### PR TITLE
fix(chat): stop streamed reply from sorting ahead of its user turn

### DIFF
--- a/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
@@ -184,6 +184,49 @@ describe("chunk handling", () => {
     expect(msgs.at(-1)?.id).toBe("m-1");
   });
 
+  test("in-flight reply sorts after its user turn despite a client-ahead clock skew", async () => {
+    // The optimistic user row is stamped with the CLIENT clock; the streamed
+    // reply arrives carrying a SERVER-clock `metadata.created_at`. If the
+    // client is ahead of the server, the reply's timestamp predates the user's
+    // and it would sort AHEAD of its own turn — pairing then shows "No response
+    // was generated" on the turn that triggered the run. Regression guard.
+    const stream = controllableStream();
+    globalThis.fetch = makeFetchMock({
+      stream: () => stream.response,
+    }) as unknown as typeof globalThis.fetch;
+
+    const conn = getOrOpenStream("acme", "thread-skew", { client: null });
+    await new Promise((r) => setTimeout(r, 20));
+
+    await conn.submit(
+      {
+        kind: "message",
+        message: {
+          id: "u-2",
+          role: "user",
+          parts: [{ type: "text", text: "hi" }],
+        },
+      },
+      baseOpts,
+    );
+
+    // Server run-start metadata 5s in the PAST relative to the just-stamped
+    // client user row — simulates a client clock running ahead of the server.
+    const serverStart = new Date(Date.now() - 5_000).toISOString();
+    stream.enqueue({
+      type: "start",
+      messageId: "m-2",
+      messageMetadata: { created_at: serverStart },
+    });
+    stream.enqueue({ type: "text-start", id: "p-2" });
+    stream.enqueue({ type: "text-delta", id: "p-2", delta: "fresh" });
+    stream.enqueue({ type: "text-end", id: "p-2" });
+    stream.enqueue({ type: "finish", finishReason: "stop" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(conn.messages.get().map((m) => m.id)).toEqual(["u-2", "m-2"]);
+  });
+
   test("observer.onFinish fires once per run", async () => {
     const stream = controllableStream();
     globalThis.fetch = makeFetchMock({

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -1122,7 +1122,10 @@ export class ThreadConnection {
           : pending;
       pending = null;
       this.messages.update((curr) =>
-        mergeAndSort(dropRedundantStubs(upsertById(curr, msg)), []),
+        mergeAndSort(
+          dropRedundantStubs(upsertById(curr, stampInflightOrder(curr, msg))),
+          [],
+        ),
       );
     };
     for await (const msg of iter) {
@@ -1456,6 +1459,40 @@ export function reconcileLatestPage(
     return Number.isFinite(t) && t <= cutoff;
   });
   return mergeAndSort(kept, fetched);
+}
+
+/**
+ * Give the in-flight streamed reply a client-clock top-level `created_at` so it
+ * sorts directly after the user turn it answers.
+ *
+ * The reply arrives carrying only a SERVER-clock `metadata.created_at` (stamped
+ * at run-start in run-stream.ts), while the optimistic user row is stamped with
+ * the CLIENT clock (`applyLocally`). Comparing the two in `mergeAndSort` mixes
+ * clock domains: if the client is ahead of the server by more than the POST
+ * latency, the reply's server timestamp predates the user's client timestamp
+ * and the reply sorts AHEAD of its own user turn — order-based `useMessagePairs`
+ * then pairs the reply with the previous turn and the current turn renders empty
+ * ("No response was generated"), until a refetch brings all-server timestamps.
+ *
+ * Stamp a client-clock timestamp strictly after everything currently in the
+ * store (same trick as `applyLocally`), keeping both rows in one clock domain.
+ * Only on the row's first appearance — later commits carry the stamp forward via
+ * `preserveCreatedAt`; a genuine DB refetch (incoming has `created_at`)
+ * overwrites it with the authoritative server value.
+ */
+function stampInflightOrder(curr: UIMessage[], m: UIMessage): UIMessage {
+  if ((m as { created_at?: unknown }).created_at != null) return m;
+  const existing = curr.find((x) => x.id === m.id) as
+    | (UIMessage & { created_at?: unknown })
+    | undefined;
+  if (existing?.created_at != null) return m;
+  let maxMs = 0;
+  for (const x of curr) {
+    const t = readTimestamp(x);
+    if (Number.isFinite(t) && t > maxMs) maxMs = t;
+  }
+  if (maxMs === 0) return m;
+  return { ...m, created_at: new Date(maxMs + 1).toISOString() } as UIMessage;
 }
 
 function readTimestamp(m: UIMessage): number {


### PR DESCRIPTION
## Summary

Fixes the intermittent bug where sending a message on an already-populated thread renders the current turn empty ("No response was generated") and attaches the streamed answer to the *previous* turn — a refresh always fixes it.

### Root cause

Two clock domains are compared in the same sort:

- The optimistic **user** row is stamped with the **client** clock (`applyLocally`, `Date.now()`).
- The streamed **assistant** reply is ordered by its **server**-stamped `metadata.created_at` (run-start, `run-stream.ts`).

When the client clock runs ahead of the server by more than the POST round-trip latency, the reply's server timestamp predates the user's client timestamp, so `mergeAndSort` places the reply *ahead* of its own user row. `useMessagePairs` is purely order-based, so it pairs the reply with the previous user turn and leaves the current turn with `assistant: null` → "No response was generated". Refresh loads all-server-clock timestamps from the DB (self-consistent) and the order is correct again.

### Fix

Stamp the in-flight reply with a client-clock top-level `created_at` strictly after everything currently in the store on its first commit — the same one-clock-domain trick `applyLocally` already uses for the user row. Both rows now live in the client clock domain, so the reply always sorts directly after the user turn it answers. A later DB refetch still overwrites this with the authoritative server value (via `preserveCreatedAt`).

## Testing

- Added a regression test that submits a user turn, then streams a reply whose run-start `metadata.created_at` is 5s in the past (client-ahead skew). Without the fix the reply sorts as `[m-2, u-2]`; with it, `[u-2, m-2]`.
- `bun test apps/mesh/src/web/components/chat/store/thread-connection.test.ts` — 70 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where a streamed assistant reply could sort ahead of the user message that triggered it, causing the turn to show "No response was generated." In‑flight replies now get a client‑clock `created_at` so they always sort after their user turn; server timestamps still replace it on refetch.

- **Bug Fixes**
  - Root cause: mixed clocks in sorting (user row uses client time; reply uses server `metadata.created_at`), so client-ahead skew made replies attach to the previous turn.
  - Fix: on the reply’s first streamed commit, `stampInflightOrder` assigns a client `created_at` strictly after the latest message; preserved across updates and overwritten by DB refetch via `preserveCreatedAt`.

<sup>Written for commit d6a40d75b48f2d1fd64aa89e6bd3e4cf5370a458. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

