### PR TITLE
refactor(typegen): prefer STUDIO_* env vars (MESH_* as fallback)

### DIFF
--- a/packages/typegen/README.md
+++ b/packages/typegen/README.md
@@ -15,9 +15,12 @@ bunx @decocms/typegen --mcp <virtual-mcp-id> --key <api-key> --output client.ts
 | Flag | Env var | Default |
 |------|---------|---------|
 | `--mcp` | — | **required** |
-| `--key` | `MESH_API_KEY` | — |
-| `--url` | `MESH_BASE_URL` | `https://studio.decocms.com` |
+| `--key` | `STUDIO_API_KEY` | — |
+| `--url` | `STUDIO_BASE_URL` | `https://studio.decocms.com` |
 | `--output` | — | `client.ts` |
+
+> The legacy `MESH_API_KEY` / `MESH_BASE_URL` env vars are still honored as a
+> fallback, so existing setups keep working.
 
 ### 2. Use the generated client
 
@@ -36,8 +39,8 @@ export interface Tools {
 
 export const client = createMeshClient<Tools>({
   mcpId: "vmc_abc123",
-  apiKey: process.env.MESH_API_KEY,
-  baseUrl: process.env.MESH_BASE_URL,
+  apiKey: process.env.STUDIO_API_KEY ?? process.env.MESH_API_KEY,
+  baseUrl: process.env.STUDIO_BASE_URL ?? process.env.MESH_BASE_URL,
 });
 ```
 
@@ -58,7 +61,7 @@ import { createMeshClient } from "@decocms/typegen";
 
 const client = createMeshClient<Tools>({
   mcpId: "vmc_abc123",   // Virtual MCP ID
-  apiKey: "sk_...",      // Falls back to process.env.MESH_API_KEY
+  apiKey: "sk_...",      // Falls back to process.env.STUDIO_API_KEY
   baseUrl: "https://...", // Falls back to https://studio.decocms.com
 });
 ```

--- a/packages/typegen/src/cli.ts
+++ b/packages/typegen/src/cli.ts
@@ -28,8 +28,13 @@ function parseArgs(argv: string[]): {
 
   return {
     mcpId,
-    apiKey: get("--key") ?? process.env.MESH_API_KEY,
-    baseUrl: get("--url") ?? process.env.MESH_BASE_URL ?? DEFAULT_BASE_URL,
+    apiKey:
+      get("--key") ?? process.env.STUDIO_API_KEY ?? process.env.MESH_API_KEY,
+    baseUrl:
+      get("--url") ??
+      process.env.STUDIO_BASE_URL ??
+      process.env.MESH_BASE_URL ??
+      DEFAULT_BASE_URL,
     output: get("--output") ?? "client.ts",
   };
 }

--- a/packages/typegen/src/codegen.ts
+++ b/packages/typegen/src/codegen.ts
@@ -202,8 +202,8 @@ ${toolsInterface}
 
 export const client = createMeshClient<Tools>({
   mcpId: "${mcpId}",
-  apiKey: process.env.MESH_API_KEY,
-  baseUrl: process.env.MESH_BASE_URL,
+  apiKey: process.env.STUDIO_API_KEY ?? process.env.MESH_API_KEY,
+  baseUrl: process.env.STUDIO_BASE_URL ?? process.env.MESH_BASE_URL,
 });
 `;
 

--- a/packages/typegen/src/index.ts
+++ b/packages/typegen/src/index.ts
@@ -11,7 +11,7 @@ export type MeshClient<T extends ToolMap> = MeshClientInstance<T> & {
 
 export interface MeshClientOptions {
   mcpId: string;
-  /** Falls back to process.env.MESH_API_KEY */
+  /** Falls back to process.env.STUDIO_API_KEY (or legacy process.env.MESH_API_KEY) */
   apiKey?: string;
   /** Falls back to https://studio.decocms.com */
   baseUrl?: string;

--- a/packages/typegen/src/runtime.ts
+++ b/packages/typegen/src/runtime.ts
@@ -25,7 +25,8 @@ export function createMeshClient<T extends ToolMap>(
 
     connectPromise = (async () => {
       const base = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
-      const apiKey = opts.apiKey ?? process.env.MESH_API_KEY;
+      const apiKey =
+        opts.apiKey ?? process.env.STUDIO_API_KEY ?? process.env.MESH_API_KEY;
       // Build URL with string concat so a path-prefixed baseUrl is preserved,
       // and encode mcpId to guard against special characters in the ID.
       const url = new URL(


### PR DESCRIPTION
## Summary

`@decocms/typegen` reads `MESH_API_KEY` / `MESH_BASE_URL` today. The product is **Studio**, so this switches the public env-var surface to `STUDIO_*`, keeping the `MESH_*` names as a **fallback** — existing setups keep working, no breaking change.

- CLI (`--key`/`--url`) → `STUDIO_API_KEY` / `STUDIO_BASE_URL`, then `MESH_*`.
- Runtime `createMeshClient` → same fallback for `apiKey`.
- Generated `client.ts` template → `process.env.STUDIO_API_KEY ?? process.env.MESH_API_KEY` (and base URL).
- README + JSDoc updated.

## Why separate / first

This is a standalone rename of an already-published package's env contract. Landing it on its own keeps it reviewable, and the follow-up feature PR (per-tool JSON Schema files + `tools`/`call` CLI) stacks on top of it.

## Testing

`bun test packages/typegen/` → 18 pass. `bun run check` clean. `bun run fmt` clean.

## Out of scope

The repo-wide `MESH_*` usage elsewhere (mesh server, dispatch) is untouched — this only covers the `@decocms/typegen` package's own public env vars.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `@decocms/typegen` to prefer `STUDIO_*` env vars with `MESH_*` as fallback across CLI, runtime, and the generated client. No breaking changes; existing setups keep working.

- **Refactors**
  - CLI `--key`/`--url` read `STUDIO_API_KEY`/`STUDIO_BASE_URL`, then `MESH_*`, then default URL.
  - Runtime `createMeshClient` applies the same fallback chain for `apiKey` and `baseUrl`.
  - Generated `client.ts` and docs updated to show the new env var order.

<sup>Written for commit 9ced704ae5546a17c3fe3f889c1d06fd502f271f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

