### PR TITLE
feat(sidebar): persist Mine/All thread scope in localStorage

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactNode } from "react";
 import { cn } from "@deco/ui/lib/utils.ts";
+import { useLocalStorage } from "@/web/hooks/use-local-storage";
 import { ScrollFade } from "./scroll-fade";
 import {
   Activity,
@@ -169,7 +170,10 @@ export function TaskGroupsList({
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
   const [groupBy, setGroupBy] = useState<GroupBy>("flat");
   const [agentsOpen, setAgentsOpen] = useState(true);
-  const [showAll, setShowAll] = useState(false);
+  const [showAll, setShowAll] = useLocalStorage<boolean>(
+    "sidebar-threads-scope-all",
+    false,
+  );
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchEverOpened, setSearchEverOpened] = useState(false);
   const [localOrderRevision, setLocalOrderRevision] = useState(0);


### PR DESCRIPTION
## Summary
The sidebar Mine/All thread-scope toggle reset to "Mine" on every reload. Now persisted across sessions.

## Change
- `task-groups-list.tsx`: swapped `useState(false)` for the existing `useLocalStorage<boolean>` hook (key `sidebar-threads-scope-all`), same one the sibling group-expanded state uses. Setter signature unchanged, so the toggle handler is untouched.

## Testing
- `bun run fmt` + typecheck (no errors in changed file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the sidebar Mine/All thread scope so it no longer resets on reload and stays the same across sessions. In `task-groups-list.tsx`, replaced `useState(false)` with `useLocalStorage<boolean>('sidebar-threads-scope-all', false)`.

<sup>Written for commit dc8eac0516c6846541b68ca313ef582d293dfc37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

