### PR TITLE
feat(sandbox): materialize org tool catalog into the workspace

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "3.112.1",
+      "version": "4.4.0",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -206,7 +206,7 @@
     },
     "packages/e2e": {
       "name": "@decocms/e2e",
-      "version": "0.10.0",
+      "version": "1.1.0",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/sandbox": "workspace:*",
@@ -228,7 +228,7 @@
     },
     "packages/harness": {
       "name": "@decocms/harness",
-      "version": "1.11.1",
+      "version": "2.0.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.85",
         "@ai-sdk/google": "^3.0.83",
@@ -251,7 +251,7 @@
     },
     "packages/mcp-utils": {
       "name": "@decocms/mcp-utils",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "dependencies": {
         "@decocms/std": "^0.1.0",
         "ajv": "^8.20.0",
@@ -268,7 +268,7 @@
     },
     "packages/mesh-sdk": {
       "name": "@decocms/mesh-sdk",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "dependencies": {
         "@decocms/bindings": "^1.1.1",
         "@decocms/mcp-utils": "workspace:*",
@@ -308,11 +308,12 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "1.12.0",
+      "version": "1.13.1",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/std": "workspace:*",
         "@kubernetes/client-node": "^1.4.0",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.0",
         "node-pty": "^1.0.0",
         "zod": "^4.0.0",
@@ -338,7 +339,7 @@
     },
     "packages/typegen": {
       "name": "@decocms/typegen",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "bin": {
         "typegen": "./dist/cli.js",
       },

--- a/packages/sandbox/daemon/daemon.tools.e2e.test.ts
+++ b/packages/sandbox/daemon/daemon.tools.e2e.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Black-box e2e for POST /_sandbox/tools/sync.
+ *
+ * Stands up a stub Virtual MCP over HTTP (in-process), points the spawned
+ * daemon at it, and asserts the daemon materializes a JSON Schema tool catalog
+ * under `<repo>/.deco/tools/`. Same black-box contract as the rest of the
+ * daemon suite — the assertions only touch HTTP + the workspace filesystem.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  type Daemon,
+  HOOK_TIMEOUT_MS,
+  jsonAuthHeaders,
+  startDaemon,
+  stopDaemon,
+  url,
+} from "./daemon.e2e.helpers";
+
+const TOOLS = [
+  {
+    name: "LIST_CUSTOMERS",
+    description: "List customers",
+    inputSchema: {
+      type: "object",
+      properties: { plan: { type: "string", enum: ["free", "pro"] } },
+    },
+    outputSchema: {
+      type: "object",
+      properties: { customers: { type: "array" } },
+      required: ["customers"],
+    },
+  },
+  {
+    name: "SEND_EMAIL",
+    description: "Send an email",
+    inputSchema: {
+      type: "object",
+      properties: { to: { type: "string" } },
+      required: ["to"],
+    },
+  },
+];
+
+let stub: ReturnType<typeof Bun.serve>;
+let stubUrl: string;
+let d: Daemon;
+
+beforeEach(async () => {
+  const server = new Server(
+    { name: "stub-mcp", version: "1.0.0" },
+    { capabilities: { tools: {} } },
+  );
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: TOOLS,
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async () => ({
+    content: [{ type: "text", text: "{}" }],
+    structuredContent: {},
+  }));
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: () => crypto.randomUUID(),
+  });
+  await server.connect(transport);
+  stub = Bun.serve({ port: 0, fetch: (req) => transport.handleRequest(req) });
+  stubUrl = `http://localhost:${stub.port}/mcp/virtual-mcp/test`;
+
+  d = await startDaemon();
+}, HOOK_TIMEOUT_MS);
+
+afterEach(async () => {
+  stub?.stop(true);
+  await stopDaemon(d);
+}, HOOK_TIMEOUT_MS);
+
+function sync(body: unknown): Promise<Response> {
+  return fetch(url(d, "/_sandbox/tools/sync"), {
+    method: "POST",
+    headers: jsonAuthHeaders(),
+    body: JSON.stringify(body),
+  });
+}
+
+const catalogPath = (file: string) =>
+  join(d.appDir, "repo", ".deco", "tools", file);
+
+describe("POST /_sandbox/tools/sync", () => {
+  test("writes one JSON Schema file per tool into the workspace", async () => {
+    const res = await sync({
+      url: stubUrl,
+      headers: { Authorization: "Bearer k" },
+    });
+    expect(res.status).toBe(200);
+    const out = await res.json();
+    expect(out.count).toBe(2);
+    expect(out.tools.sort()).toEqual(["LIST_CUSTOMERS", "SEND_EMAIL"]);
+
+    expect(existsSync(catalogPath("LIST_CUSTOMERS.json"))).toBe(true);
+    expect(existsSync(catalogPath("SEND_EMAIL.json"))).toBe(true);
+
+    const listSchema = JSON.parse(
+      readFileSync(catalogPath("LIST_CUSTOMERS.json"), "utf-8"),
+    );
+    expect(listSchema.name).toBe("LIST_CUSTOMERS");
+    expect(listSchema.description).toBe("List customers");
+    expect(listSchema.inputSchema.properties.plan.enum).toEqual([
+      "free",
+      "pro",
+    ]);
+    expect(listSchema.outputSchema.required).toEqual(["customers"]);
+  });
+
+  test("rejects a malformed body with 400", async () => {
+    const res = await sync({ headers: {} }); // missing url
+    expect(res.status).toBe(400);
+  });
+
+  test("surfaces an unreachable endpoint as 502", async () => {
+    const res = await sync({
+      url: "http://127.0.0.1:1/mcp/virtual-mcp/test",
+      headers: {},
+    });
+    expect(res.status).toBe(502);
+  });
+
+  test("requires the daemon bearer token", async () => {
+    const res = await fetch(url(d, "/_sandbox/tools/sync"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: stubUrl, headers: {} }),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/sandbox/daemon/daemon.tools.e2e.test.ts
+++ b/packages/sandbox/daemon/daemon.tools.e2e.test.ts
@@ -47,6 +47,23 @@ const TOOLS = [
       required: ["to"],
     },
   },
+  {
+    name: "LIST_EMAILS",
+    description: "List emails in the inbox",
+    inputSchema: {
+      type: "object",
+      properties: { folder: { type: "string" } },
+    },
+  },
+  {
+    name: "ARCHIVE_EMAIL",
+    description: "Archive an email by id",
+    inputSchema: {
+      type: "object",
+      properties: { emailId: { type: "string" } },
+      required: ["emailId"],
+    },
+  },
 ];
 
 let stub: ReturnType<typeof Bun.serve>;
@@ -91,6 +108,14 @@ function sync(body: unknown): Promise<Response> {
 const catalogPath = (file: string) =>
   join(d.appDir, "repo", ".deco", "tools", file);
 
+function post(path: string, body: unknown): Promise<Response> {
+  return fetch(url(d, path), {
+    method: "POST",
+    headers: jsonAuthHeaders(),
+    body: JSON.stringify(body),
+  });
+}
+
 describe("POST /_sandbox/tools/sync", () => {
   test("writes one JSON Schema file per tool into the workspace", async () => {
     const res = await sync({
@@ -99,8 +124,13 @@ describe("POST /_sandbox/tools/sync", () => {
     });
     expect(res.status).toBe(200);
     const out = await res.json();
-    expect(out.count).toBe(2);
-    expect(out.tools.sort()).toEqual(["LIST_CUSTOMERS", "SEND_EMAIL"]);
+    expect(out.count).toBe(4);
+    expect(out.tools.sort()).toEqual([
+      "ARCHIVE_EMAIL",
+      "LIST_CUSTOMERS",
+      "LIST_EMAILS",
+      "SEND_EMAIL",
+    ]);
 
     expect(existsSync(catalogPath("LIST_CUSTOMERS.json"))).toBe(true);
     expect(existsSync(catalogPath("SEND_EMAIL.json"))).toBe(true);
@@ -137,5 +167,41 @@ describe("POST /_sandbox/tools/sync", () => {
       body: JSON.stringify({ url: stubUrl, headers: {} }),
     });
     expect(res.status).toBe(401);
+  });
+});
+
+// The whole point of the catalog: a coding agent, handed "archive all my
+// emails", discovers which of the org's tools to script against straight from
+// disk — via the same glob/grep/bash routes its shell uses. No LLM needed to
+// prove the discovery contract holds end-to-end.
+describe("use case: agent discovers email tools from the catalog", () => {
+  test("glob + grep + read surface ARCHIVE_EMAIL and its input contract", async () => {
+    expect((await sync({ url: stubUrl, headers: {} })).status).toBe(200);
+
+    // 1. glob the catalog the way an agent enumerates available tools.
+    const globbed = await post("/_sandbox/glob", {
+      pattern: ".deco/tools/*.json",
+    }).then((r) => r.json());
+    expect(globbed.files).toContain(".deco/tools/ARCHIVE_EMAIL.json");
+    expect(globbed.files).toContain(".deco/tools/LIST_EMAILS.json");
+
+    // 2. grep descriptions to narrow to the email tools (POSIX grep, always
+    //    present — not the ripgrep route). LIST_CUSTOMERS must NOT match.
+    const grep = await post("/_sandbox/bash", {
+      command: "grep -il email .deco/tools/*.json | xargs -n1 basename | sort",
+    }).then((r) => r.json());
+    expect(grep.exitCode).toBe(0);
+    expect(grep.stdout.trim().split("\n")).toEqual([
+      "ARCHIVE_EMAIL.json",
+      "LIST_EMAILS.json",
+      "SEND_EMAIL.json",
+    ]);
+
+    // 3. read ARCHIVE_EMAIL's schema — the contract the agent scripts against.
+    const schema = JSON.parse(
+      readFileSync(catalogPath("ARCHIVE_EMAIL.json"), "utf-8"),
+    );
+    expect(schema.name).toBe("ARCHIVE_EMAIL");
+    expect(schema.inputSchema.required).toEqual(["emailId"]);
   });
 });

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -57,7 +57,7 @@ import { metrics, trace } from "@opentelemetry/api";
 import { makeEventsHandler } from "./routes/events-stream";
 import { makeExecHandler } from "./routes/exec";
 import { makeToolsSyncHandler } from "./routes/tools";
-import { syncToolCatalog } from "./tools-catalog";
+import { makeCatalogSync } from "./tools-catalog";
 import {
   makeReadHandler,
   makeWriteHandler,
@@ -362,6 +362,9 @@ const fsDeps = {
 };
 const readH = makeReadHandler(fsDeps);
 const toolsSyncH = makeToolsSyncHandler(fsDeps);
+// Coalesced, min-interval catalog sync for the fire-and-forget dispatch hook —
+// re-syncing on every run would be wasted work + a write race.
+const catalogSync = makeCatalogSync({ appRoot, repoDir });
 const writeH = makeWriteHandler(fsDeps);
 const unlinkH = makeUnlinkHandler(fsDeps);
 const mkdirH = makeMkdirHandler(fsDeps);
@@ -671,11 +674,7 @@ async function vmRouteH(
       lookupHarness: lookupDispatchHarness,
       allowedHosts: bootConfig.offloadAllowedHosts,
       allowSameHostDev: bootConfig.offloadAllowSameHostDev,
-      onDispatchMcp: (mcp) => {
-        void syncToolCatalog(mcp, { appRoot, repoDir }).catch((err) => {
-          console.error("[tools] catalog sync failed", err);
-        });
-      },
+      onDispatchMcp: catalogSync,
     });
   }
   if (method === "DELETE" && vmPath.startsWith("/runs/")) {

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -56,6 +56,8 @@ import type {
 import { metrics, trace } from "@opentelemetry/api";
 import { makeEventsHandler } from "./routes/events-stream";
 import { makeExecHandler } from "./routes/exec";
+import { makeToolsSyncHandler } from "./routes/tools";
+import { syncToolCatalog } from "./tools-catalog";
 import {
   makeReadHandler,
   makeWriteHandler,
@@ -359,6 +361,7 @@ const fsDeps = {
   },
 };
 const readH = makeReadHandler(fsDeps);
+const toolsSyncH = makeToolsSyncHandler(fsDeps);
 const writeH = makeWriteHandler(fsDeps);
 const unlinkH = makeUnlinkHandler(fsDeps);
 const mkdirH = makeMkdirHandler(fsDeps);
@@ -624,6 +627,7 @@ const fsH: Record<string, (req: Request) => Response | Promise<Response>> = {
   "/write_from_url": writeFromUrlH,
   "/upload_to_url": uploadToUrlH,
   "/bash": bashH,
+  "/tools/sync": toolsSyncH,
 };
 
 const gitH: Record<string, (req: Request) => Response | Promise<Response>> = {
@@ -667,6 +671,11 @@ async function vmRouteH(
       lookupHarness: lookupDispatchHarness,
       allowedHosts: bootConfig.offloadAllowedHosts,
       allowSameHostDev: bootConfig.offloadAllowSameHostDev,
+      onDispatchMcp: (mcp) => {
+        void syncToolCatalog(mcp, { appRoot, repoDir }).catch((err) => {
+          console.error("[tools] catalog sync failed", err);
+        });
+      },
     });
   }
   if (method === "DELETE" && vmPath.startsWith("/runs/")) {

--- a/packages/sandbox/daemon/git-exclude.ts
+++ b/packages/sandbox/daemon/git-exclude.ts
@@ -1,0 +1,37 @@
+import {
+  appendFile,
+  lstat,
+  mkdir,
+  readFile,
+  writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Registers `line` in `<repoDir>/.git/info/exclude` so the daemon's shutdown
+ * `git add -A` never commits daemon-managed paths onto user branches.
+ * info/exclude is local-only (unlike .gitignore), so it never leaks into the
+ * repo. No-op without a `.git` dir — the caller re-runs on every tool call, so
+ * the line lands once one exists. Never throws (best-effort).
+ */
+export async function ensureGitExclude(
+  repoDir: string,
+  line: string,
+): Promise<void> {
+  try {
+    const gitDir = join(repoDir, ".git");
+    const gitStat = await lstat(gitDir).catch(() => null);
+    if (!gitStat?.isDirectory()) return;
+    const excludePath = join(gitDir, "info", "exclude");
+    const existing = await readFile(excludePath, "utf8").catch(() => null);
+    if (existing === null) {
+      // Template-less clones (libgit2/JGit, bare templates) lack info/exclude.
+      await mkdir(join(gitDir, "info"), { recursive: true });
+      await writeFile(excludePath, `${line}\n`);
+    } else if (!existing.split("\n").includes(line)) {
+      await appendFile(excludePath, `${line}\n`);
+    }
+  } catch {
+    // Best-effort: an unwritable .git never blocks the caller.
+  }
+}

--- a/packages/sandbox/daemon/org-fs/repo-link.ts
+++ b/packages/sandbox/daemon/org-fs/repo-link.ts
@@ -10,17 +10,9 @@
  * (info/exclude is local-only, unlike .gitignore). Never throws.
  */
 
-import {
-  appendFile,
-  lstat,
-  mkdir,
-  readFile,
-  symlink,
-  writeFile,
-} from "node:fs/promises";
+import { lstat, symlink } from "node:fs/promises";
 import { join } from "node:path";
-
-const EXCLUDE_LINE = "/org";
+import { ensureGitExclude } from "../git-exclude";
 
 export async function ensureRepoOrgLink(
   repoDir: string,
@@ -37,22 +29,9 @@ export async function ensureRepoOrgLink(
     } else {
       await symlink("../org", link);
     }
-    // Keep the link out of version control (no-op without a .git dir — the
-    // hook re-runs on every tool call, so the exclude lands once one exists).
-    const gitDir = join(repoDir, ".git");
-    const gitStat = await lstat(gitDir).catch(() => null);
-    if (!gitStat?.isDirectory()) return;
-    const excludePath = join(gitDir, "info", "exclude");
-    const existing = await readFile(excludePath, "utf8").catch(() => null);
-    if (existing === null) {
-      // Template-less clones (libgit2/JGit, bare templates) lack
-      // info/exclude; without it the shutdown `git add -A` would commit the
-      // link onto the user's branch.
-      await mkdir(join(gitDir, "info"), { recursive: true });
-      await writeFile(excludePath, `${EXCLUDE_LINE}\n`);
-    } else if (!existing.split("\n").includes(EXCLUDE_LINE)) {
-      await appendFile(excludePath, `${EXCLUDE_LINE}\n`);
-    }
+    // Keep the link out of version control so the shutdown `git add -A` never
+    // commits it to user branches.
+    await ensureGitExclude(repoDir, "/org");
   } catch (err) {
     log("repo org link failed", err);
   }

--- a/packages/sandbox/daemon/routes/dispatch.ts
+++ b/packages/sandbox/daemon/routes/dispatch.ts
@@ -61,6 +61,14 @@ export interface DispatchDeps {
   /** Dev escape hatch: allow `http://` loopback offload refs (same-host
    *  MinIO). false in production. */
   allowSameHostDev: boolean;
+  /** Fire-and-forget hook called with the run's MCP endpoint right after the
+   *  input is parsed. The daemon uses it to materialize the tool catalog into
+   *  the workspace so agents can script against tools from disk. Must not
+   *  throw or block; omitted in tests. */
+  onDispatchMcp?: (mcp: {
+    url: string;
+    headers: Record<string, string>;
+  }) => void;
 }
 
 export interface CancelDeps {
@@ -302,6 +310,9 @@ export async function handleDispatchRequest(
         // (spec: "Harness Input Contract" Q4 — containment by construction).
         const rebasedInput = rebaseHarnessInput(input);
 
+        // Materialize the org tool catalog into the workspace (best-effort).
+        if (rebasedInput.mcp?.url) deps.onDispatchMcp?.(rebasedInput.mcp);
+
         // 3. Tombstone check — a cancel may have landed first. Surface it as a
         //    terminal error rather than starting a doomed harness.
         const tombstoneExpiry = tombstones.get(runId);
@@ -383,6 +394,9 @@ export async function handleDispatchRequest(
   // Rebase the symbolic workspace cwd fields onto this daemon's sandbox root
   // (spec: "Harness Input Contract" Q4 — containment by construction).
   const rebasedInput = rebaseHarnessInput(input);
+
+  // Materialize the org tool catalog into the workspace (best-effort).
+  if (rebasedInput.mcp?.url) deps.onDispatchMcp?.(rebasedInput.mcp);
 
   // Tombstone check — a cancel landed before this dispatch did. Decline
   // and let the cluster surface a clear cancellation instead of starting

--- a/packages/sandbox/daemon/routes/tools.ts
+++ b/packages/sandbox/daemon/routes/tools.ts
@@ -1,16 +1,21 @@
-import { type McpEndpoint, syncToolCatalog } from "../tools-catalog";
+import {
+  fetchToolCatalog,
+  type McpEndpoint,
+  writeToolCatalog,
+} from "../tools-catalog";
 import { jsonResponse, parseJsonBody } from "./body-parser";
 
 export interface ToolsDeps {
   appRoot: string;
   repoDir: string;
-  onWorkingTreeWrite?: (filePath: string) => void;
 }
 
 /**
  * POST /_sandbox/tools/sync — body `{ url, headers }` (the run's Virtual MCP
  * endpoint). Lists its tools and writes a JSON Schema catalog under
- * `<repo>/.deco/tools/`. Idempotent; overwrites. Returns `{ count, tools }`.
+ * `<repo>/.deco/tools/`. Idempotent; overwrites and prunes stale files.
+ * Returns `{ count, tools }`. 502 when the endpoint is unreachable/errors,
+ * 500 when the local write fails.
  */
 export function makeToolsSyncHandler(deps: ToolsDeps) {
   return async (req: Request): Promise<Response> => {
@@ -35,17 +40,31 @@ export function makeToolsSyncHandler(deps: ToolsDeps) {
       );
     }
 
+    const endpoint = {
+      url: mcp.url,
+      headers: mcp.headers as Record<string, string>,
+    };
+
+    let tools: Awaited<ReturnType<typeof fetchToolCatalog>>;
     try {
-      const result = await syncToolCatalog(
-        { url: mcp.url, headers: mcp.headers as Record<string, string> },
-        { appRoot: deps.appRoot, repoDir: deps.repoDir },
-      );
-      deps.onWorkingTreeWrite?.(".deco/tools");
-      return jsonResponse(result);
+      tools = await fetchToolCatalog(endpoint);
     } catch (err) {
       return jsonResponse(
         { error: err instanceof Error ? err.message : String(err) },
         502,
+      );
+    }
+
+    try {
+      const result = await writeToolCatalog(tools, {
+        appRoot: deps.appRoot,
+        repoDir: deps.repoDir,
+      });
+      return jsonResponse(result);
+    } catch (err) {
+      return jsonResponse(
+        { error: err instanceof Error ? err.message : String(err) },
+        500,
       );
     }
   };

--- a/packages/sandbox/daemon/routes/tools.ts
+++ b/packages/sandbox/daemon/routes/tools.ts
@@ -1,0 +1,52 @@
+import { type McpEndpoint, syncToolCatalog } from "../tools-catalog";
+import { jsonResponse, parseJsonBody } from "./body-parser";
+
+export interface ToolsDeps {
+  appRoot: string;
+  repoDir: string;
+  onWorkingTreeWrite?: (filePath: string) => void;
+}
+
+/**
+ * POST /_sandbox/tools/sync — body `{ url, headers }` (the run's Virtual MCP
+ * endpoint). Lists its tools and writes a JSON Schema catalog under
+ * `<repo>/.deco/tools/`. Idempotent; overwrites. Returns `{ count, tools }`.
+ */
+export function makeToolsSyncHandler(deps: ToolsDeps) {
+  return async (req: Request): Promise<Response> => {
+    let body: unknown;
+    try {
+      body = await parseJsonBody(req);
+    } catch {
+      return jsonResponse({ error: "invalid JSON body" }, 400);
+    }
+
+    const mcp = body as Partial<McpEndpoint>;
+    if (
+      typeof mcp?.url !== "string" ||
+      typeof mcp.headers !== "object" ||
+      mcp.headers === null
+    ) {
+      return jsonResponse(
+        {
+          error: "body must be { url: string, headers: Record<string,string> }",
+        },
+        400,
+      );
+    }
+
+    try {
+      const result = await syncToolCatalog(
+        { url: mcp.url, headers: mcp.headers as Record<string, string> },
+        { appRoot: deps.appRoot, repoDir: deps.repoDir },
+      );
+      deps.onWorkingTreeWrite?.(".deco/tools");
+      return jsonResponse(result);
+    } catch (err) {
+      return jsonResponse(
+        { error: err instanceof Error ? err.message : String(err) },
+        502,
+      );
+    }
+  };
+}

--- a/packages/sandbox/daemon/tools-catalog.test.ts
+++ b/packages/sandbox/daemon/tools-catalog.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { toolCatalogFiles } from "./tools-catalog";
+
+describe("toolCatalogFiles", () => {
+  test("emits one JSON file per tool with name, description and schemas", () => {
+    const files = toolCatalogFiles([
+      {
+        name: "SEND_EMAIL",
+        description: "Send an email",
+        inputSchema: {
+          type: "object",
+          properties: { to: { type: "string" } },
+          required: ["to"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: { id: { type: "string" } },
+        },
+      },
+    ]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].filename).toBe("SEND_EMAIL.json");
+    const parsed = JSON.parse(files[0].content);
+    expect(parsed.name).toBe("SEND_EMAIL");
+    expect(parsed.description).toBe("Send an email");
+    expect(parsed.inputSchema.properties.to.type).toBe("string");
+    expect(parsed.outputSchema.properties.id.type).toBe("string");
+  });
+
+  test("omits description/outputSchema when absent and defaults inputSchema", () => {
+    const files = toolCatalogFiles([{ name: "PING", inputSchema: undefined }]);
+    const parsed = JSON.parse(files[0].content);
+    expect("description" in parsed).toBe(false);
+    expect("outputSchema" in parsed).toBe(false);
+    expect(parsed.inputSchema).toEqual({ type: "object" });
+  });
+
+  test("sanitizes unsafe filename chars but keeps the real name inside", () => {
+    const files = toolCatalogFiles([
+      { name: "conn/../SEND", inputSchema: { type: "object" } },
+    ]);
+    // Slashes (the traversal risk) become underscores; dots are safe in a
+    // bare filename and kept. safePath clamps the write regardless.
+    expect(files[0].filename).toBe("conn_.._SEND.json");
+    expect(files[0].filename).not.toContain("/");
+    expect(JSON.parse(files[0].content).name).toBe("conn/../SEND");
+  });
+});

--- a/packages/sandbox/daemon/tools-catalog.test.ts
+++ b/packages/sandbox/daemon/tools-catalog.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, test } from "bun:test";
-import { toolCatalogFiles } from "./tools-catalog";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CATALOG_DIR,
+  makeCatalogSync,
+  type McpEndpoint,
+  toolCatalogFiles,
+  writeToolCatalog,
+} from "./tools-catalog";
 
 describe("toolCatalogFiles", () => {
   test("emits one JSON file per tool with name, description and schemas", () => {
@@ -45,5 +55,93 @@ describe("toolCatalogFiles", () => {
     expect(files[0].filename).toBe("conn_.._SEND.json");
     expect(files[0].filename).not.toContain("/");
     expect(JSON.parse(files[0].content).name).toBe("conn/../SEND");
+  });
+
+  test("disambiguates distinct tools that sanitize to the same filename", () => {
+    const files = toolCatalogFiles([
+      { name: "a/b", inputSchema: { type: "object" } },
+      { name: "a_b", inputSchema: { type: "object" } },
+    ]);
+    // Both sanitize to `a_b` — neither may be silently dropped.
+    expect(files.map((f) => f.filename)).toEqual(["a_b.json", "a_b-2.json"]);
+    expect(JSON.parse(files[0].content).name).toBe("a/b");
+    expect(JSON.parse(files[1].content).name).toBe("a_b");
+  });
+});
+
+describe("writeToolCatalog", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "catalog-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const opts = () => ({ appRoot: root, repoDir: root });
+  const dir = () => join(root, CATALOG_DIR);
+
+  test("writes one file per tool and returns the names", async () => {
+    const res = await writeToolCatalog(
+      [{ name: "LIST", inputSchema: { type: "object" } }],
+      opts(),
+    );
+    expect(res).toEqual({ count: 1, tools: ["LIST"] });
+    expect(existsSync(join(dir(), "LIST.json"))).toBe(true);
+  });
+
+  test("prunes stale *.json from a previous sync, keeps other files", async () => {
+    await writeToolCatalog(
+      [
+        { name: "OLD", inputSchema: { type: "object" } },
+        { name: "KEEP", inputSchema: { type: "object" } },
+      ],
+      opts(),
+    );
+    // A non-catalog file must survive the prune.
+    writeFileSync(join(dir(), "README.md"), "hi");
+
+    await writeToolCatalog([{ name: "KEEP", inputSchema: {} }], opts());
+
+    const left = (await readdir(dir())).sort();
+    expect(left).toEqual(["KEEP.json", "README.md"]);
+  });
+});
+
+describe("makeCatalogSync", () => {
+  const mcp: McpEndpoint = { url: "http://x/mcp", headers: {} };
+
+  test("coalesces while in flight, then respects the min interval", async () => {
+    let calls = 0;
+    let release: () => void = () => {};
+    let clock = 1000;
+    const sync = makeCatalogSync(
+      { appRoot: "/", repoDir: "/", minIntervalMs: 100 },
+      {
+        now: () => clock,
+        sync: () => {
+          calls++;
+          return new Promise<void>((r) => {
+            release = r;
+          });
+        },
+      },
+    );
+
+    sync(mcp);
+    sync(mcp); // in-flight → coalesced
+    expect(calls).toBe(1);
+
+    release();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    clock += 50; // within the interval → skipped
+    sync(mcp);
+    expect(calls).toBe(1);
+
+    clock += 100; // past the interval → runs again
+    sync(mcp);
+    expect(calls).toBe(2);
   });
 });

--- a/packages/sandbox/daemon/tools-catalog.ts
+++ b/packages/sandbox/daemon/tools-catalog.ts
@@ -6,10 +6,11 @@
  * codegen — so it pulls no prettier / json-schema-to-typescript into the daemon
  * bundle. Agents wanting the typed client run `@decocms/typegen` themselves.
  */
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { mkdir, readdir, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ensureGitExclude } from "./git-exclude";
 import { safePath } from "./paths";
 
 /** Where the catalog lands, relative to the repo root. */
@@ -36,22 +37,29 @@ export interface CatalogFile {
  * One JSON Schema file per tool: `<TOOL>.json` holding
  * `{ name, description?, inputSchema, outputSchema? }`. Pure — the caller writes
  * them. Filenames are sanitized to filesystem-safe chars while the original
- * tool name is preserved inside the file.
+ * tool name is preserved inside the file. Distinct tools whose names sanitize to
+ * the same string (e.g. `a/b` and `a_b`) get a `-2`, `-3`… suffix so no tool is
+ * silently dropped; stable for a given input order.
  */
 export function toolCatalogFiles(tools: CatalogTool[]): CatalogFile[] {
+  const used = new Set<string>();
   return tools.map((tool) => {
     const body: Record<string, unknown> = { name: tool.name };
     if (tool.description) body.description = tool.description;
     body.inputSchema = tool.inputSchema ?? { type: "object" };
     if (tool.outputSchema) body.outputSchema = tool.outputSchema;
-    return {
-      filename: `${tool.name.replace(/[^A-Za-z0-9_.-]/g, "_")}.json`,
-      content: `${JSON.stringify(body, null, 2)}\n`,
-    };
+    const base = tool.name.replace(/[^A-Za-z0-9_.-]/g, "_") || "tool";
+    let filename = `${base}.json`;
+    for (let i = 2; used.has(filename); i++) filename = `${base}-${i}.json`;
+    used.add(filename);
+    return { filename, content: `${JSON.stringify(body, null, 2)}\n` };
   });
 }
 
-/** Connect to a Virtual MCP endpoint and list its tools. */
+/**
+ * Connect to a Virtual MCP endpoint and list its tools, following the MCP
+ * pagination cursor so large orgs aren't silently truncated to the first page.
+ */
 export async function fetchToolCatalog(
   mcp: McpEndpoint,
 ): Promise<CatalogTool[]> {
@@ -65,28 +73,43 @@ export async function fetchToolCatalog(
     }),
   );
   try {
-    const { tools } = await client.listTools();
-    return tools.map((t) => ({
-      name: t.name,
-      description: t.description,
-      inputSchema: t.inputSchema,
-      outputSchema: (t as { outputSchema?: unknown }).outputSchema,
-    }));
+    const out: CatalogTool[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await client.listTools(cursor ? { cursor } : undefined);
+      for (const t of page.tools) {
+        out.push({
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+          outputSchema: (t as { outputSchema?: unknown }).outputSchema,
+        });
+      }
+      cursor = page.nextCursor;
+    } while (cursor);
+    return out;
   } finally {
     await client.close();
   }
 }
 
 /**
- * Fetch the catalog and write it under `<repoDir>/.deco/tools/`, clamped to
- * `appRoot`. Returns the tool names written.
+ * Write the catalog under `<repoDir>/.deco/tools/`, clamped to `appRoot`, and
+ * prune stale `*.json` left by a previous sync (renamed/removed tools).
+ * Registers the dir in `.git/info/exclude` so the daemon's shutdown
+ * `git add -A` never commits the catalog onto the user's branch. Returns the
+ * tool names written. Throws only on a real filesystem failure.
  */
-export async function syncToolCatalog(
-  mcp: McpEndpoint,
+export async function writeToolCatalog(
+  tools: CatalogTool[],
   opts: { appRoot: string; repoDir: string },
 ): Promise<{ count: number; tools: string[] }> {
-  const tools = await fetchToolCatalog(mcp);
   const files = toolCatalogFiles(tools);
+  const dir = safePath(opts.appRoot, opts.repoDir, CATALOG_DIR);
+  if (!dir) return { count: 0, tools: [] }; // escapes the workspace root
+  await mkdir(dir, { recursive: true });
+  await ensureGitExclude(opts.repoDir, `/${CATALOG_DIR}/`);
+
   // Async fs: this can fire during dispatch, and the daemon runs a single
   // event loop — sync writes would stall it. Writes run concurrently.
   const written = await Promise.all(
@@ -99,9 +122,65 @@ export async function syncToolCatalog(
       if (!target) return null; // escapes the workspace root — skip
       await mkdir(dirname(target), { recursive: true });
       await writeFile(target, file.content, "utf-8");
-      return tools[i].name;
+      return { filename: file.filename, name: tools[i].name };
     }),
   );
-  const names = written.filter((n): n is string => n !== null);
-  return { count: names.length, tools: names };
+  const ok = written.filter((w): w is { filename: string; name: string } =>
+    Boolean(w),
+  );
+  const keep = new Set(ok.map((w) => w.filename));
+
+  // Prune files from a previous sync that this one didn't write, so a
+  // renamed/removed tool doesn't linger as a stale catalog entry.
+  const existing = await readdir(dir).catch(() => [] as string[]);
+  await Promise.all(
+    existing
+      .filter((name) => name.endsWith(".json") && !keep.has(name))
+      .map((name) => unlink(join(dir, name)).catch(() => {})),
+  );
+
+  return { count: ok.length, tools: ok.map((w) => w.name) };
+}
+
+/** Fetch the catalog from the endpoint and write it to disk. */
+async function syncToolCatalog(
+  mcp: McpEndpoint,
+  opts: { appRoot: string; repoDir: string },
+): Promise<{ count: number; tools: string[] }> {
+  const tools = await fetchToolCatalog(mcp);
+  return writeToolCatalog(tools, opts);
+}
+
+/**
+ * Wraps `syncToolCatalog` for the fire-and-forget dispatch hook: coalesces
+ * concurrent syncs and skips re-listing the same endpoint more often than
+ * `minIntervalMs`. The catalog rarely changes within a sandbox's lifetime, so
+ * re-syncing on every single run is wasted work (and a write race). Errors are
+ * logged, never thrown. `now` is injectable for tests.
+ */
+export function makeCatalogSync(
+  opts: { appRoot: string; repoDir: string; minIntervalMs?: number },
+  deps: {
+    now?: () => number;
+    sync?: (mcp: McpEndpoint) => Promise<unknown>;
+  } = {},
+): (mcp: McpEndpoint) => void {
+  const now = deps.now ?? Date.now;
+  const sync = deps.sync ?? ((mcp: McpEndpoint) => syncToolCatalog(mcp, opts));
+  const minInterval = opts.minIntervalMs ?? 60_000;
+  const lastRun = new Map<string, number>();
+  const inFlight = new Set<string>();
+  return (mcp) => {
+    const key = mcp.url;
+    if (inFlight.has(key)) return;
+    const last = lastRun.get(key);
+    if (last !== undefined && now() - last < minInterval) return;
+    inFlight.add(key);
+    void Promise.resolve(sync(mcp))
+      .catch((err) => console.error("[tools] catalog sync failed", err))
+      .finally(() => {
+        inFlight.delete(key);
+        lastRun.set(key, now());
+      });
+  };
 }

--- a/packages/sandbox/daemon/tools-catalog.ts
+++ b/packages/sandbox/daemon/tools-catalog.ts
@@ -1,0 +1,107 @@
+/**
+ * Materializes an org's Virtual MCP tool catalog onto the sandbox filesystem so
+ * an agent can discover and script against tools from disk (see the typegen CLI
+ * / generated client). Writes one raw JSON Schema file per tool under
+ * `<repo>/.deco/tools/`. Deliberately keeps only JSON Schema — no TypeScript
+ * codegen — so it pulls no prettier / json-schema-to-typescript into the daemon
+ * bundle. Agents wanting the typed client run `@decocms/typegen` themselves.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { safePath } from "./paths";
+
+/** Where the catalog lands, relative to the repo root. */
+export const CATALOG_DIR = ".deco/tools";
+
+export interface McpEndpoint {
+  url: string;
+  headers: Record<string, string>;
+}
+
+export interface CatalogTool {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+  outputSchema?: unknown;
+}
+
+export interface CatalogFile {
+  filename: string;
+  content: string;
+}
+
+/**
+ * One JSON Schema file per tool: `<TOOL>.json` holding
+ * `{ name, description?, inputSchema, outputSchema? }`. Pure — the caller writes
+ * them. Filenames are sanitized to filesystem-safe chars while the original
+ * tool name is preserved inside the file.
+ */
+export function toolCatalogFiles(tools: CatalogTool[]): CatalogFile[] {
+  return tools.map((tool) => {
+    const body: Record<string, unknown> = { name: tool.name };
+    if (tool.description) body.description = tool.description;
+    body.inputSchema = tool.inputSchema ?? { type: "object" };
+    if (tool.outputSchema) body.outputSchema = tool.outputSchema;
+    return {
+      filename: `${tool.name.replace(/[^A-Za-z0-9_.-]/g, "_")}.json`,
+      content: `${JSON.stringify(body, null, 2)}\n`,
+    };
+  });
+}
+
+/** Connect to a Virtual MCP endpoint and list its tools. */
+export async function fetchToolCatalog(
+  mcp: McpEndpoint,
+): Promise<CatalogTool[]> {
+  const client = new Client({
+    name: "@decocms/sandbox-tools-catalog",
+    version: "1.0.0",
+  });
+  await client.connect(
+    new StreamableHTTPClientTransport(new URL(mcp.url), {
+      requestInit: { headers: mcp.headers },
+    }),
+  );
+  try {
+    const { tools } = await client.listTools();
+    return tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+      outputSchema: (t as { outputSchema?: unknown }).outputSchema,
+    }));
+  } finally {
+    await client.close();
+  }
+}
+
+/**
+ * Fetch the catalog and write it under `<repoDir>/.deco/tools/`, clamped to
+ * `appRoot`. Returns the tool names written.
+ */
+export async function syncToolCatalog(
+  mcp: McpEndpoint,
+  opts: { appRoot: string; repoDir: string },
+): Promise<{ count: number; tools: string[] }> {
+  const tools = await fetchToolCatalog(mcp);
+  const files = toolCatalogFiles(tools);
+  // Async fs: this can fire during dispatch, and the daemon runs a single
+  // event loop — sync writes would stall it. Writes run concurrently.
+  const written = await Promise.all(
+    files.map(async (file, i) => {
+      const target = safePath(
+        opts.appRoot,
+        opts.repoDir,
+        `${CATALOG_DIR}/${file.filename}`,
+      );
+      if (!target) return null; // escapes the workspace root — skip
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, file.content, "utf-8");
+      return tools[i].name;
+    }),
+  );
+  const names = written.filter((n): n is string => n !== null);
+  return { count: names.length, tools: names };
+}

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -27,6 +27,7 @@
     "@decocms/harness": "workspace:*",
     "@decocms/std": "workspace:*",
     "@kubernetes/client-node": "^1.4.0",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.0",
     "node-pty": "^1.0.0",
     "zod": "^4.0.0"


### PR DESCRIPTION
## Summary

Lets a sandboxed coding agent **discover and script against org/user tools from the filesystem**. The daemon writes a JSON Schema tool catalog under `<repo>/.deco/tools/` — one file per tool (`{ name, description, inputSchema, outputSchema }`) — sourced from the run's Virtual MCP endpoint the daemon already receives. Pairs with the `@decocms/typegen` CLI/client (an agent can read the catalog, or run typegen for a typed client).

## How it works

- **`tools-catalog.ts`** — connects to the run's Virtual MCP endpoint via the MCP SDK, lists tools, and emits one **raw JSON Schema** file per tool. Deliberately *no* TypeScript codegen, so it pulls **no prettier / json-schema-to-typescript** into the daemon bundle. The MCP SDK is already in the bundle (via `@decocms/harness`), so bundle size is unchanged (3.20 MB before and after).
- **`POST /_sandbox/tools/sync`** (token-gated) — body `{ url, headers }`; syncs the catalog on demand. Returns `{ count, tools }`.
- **Auto-sync on dispatch** — the dispatch handler already receives the per-run `mcp` endpoint; it now fires the sync **fire-and-forget** (non-blocking, errors logged) so every run populates the catalog without a separate caller. Wired via an optional `onDispatchMcp` dep, keeping `dispatch.ts` decoupled from the fs.

## Why this shape

- `mcp` reaches only the in-process harness / dispatch path, not the dev-server/exec env — so dispatch is the correct seam, not `buildDevEnv`.
- Raw JSON catalog (not the typed client) keeps the daemon lean; the typed client is a heavier, optional step an agent runs itself via `@decocms/typegen`.

## Testing

- **Unit** (`bun test`): `toolCatalogFiles` — one file per tool, optional fields omitted, filename sanitization (slashes → `_`, dots kept, `safePath` clamps regardless).
- **E2E** (`daemon.tools.e2e.test.ts`, black-box): stands up a stub Virtual MCP over HTTP, points the **spawned daemon** at it, and asserts the catalog files land in the workspace with correct content; plus 400 (malformed body), 502 (unreachable endpoint), 401 (missing token).

`bun test` for the daemon suite: tools 7 pass, dispatch e2e 8 pass, core daemon e2e 103 pass. `bun run check`, `bun run fmt`, `bun run lint` (no new warnings) clean.

## Follow-ups (not here)

- Inject `STUDIO_*` env into the agent's shell so `deco call` / the generated client run flagless (needs the `x-org-id` header story sorted for the typegen CLI).
- Optionally gate/curate which tools land in the catalog.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Materializes org/user tools into the sandbox workspace as a JSON Schema catalog under .deco/tools so agents can discover and script tools from disk. Auto-syncs on each run from the Virtual MCP and exposes a token-gated endpoint for on-demand sync.

- **New Features**
  - Writes one JSON file per tool to .deco/tools with { name, description?, inputSchema (defaults to `{ type: "object" }`), outputSchema? }; filenames are sanitized.
  - Adds `POST /_sandbox/tools/sync` (body `{ url, headers }`) to fetch via MCP; returns `{ count, tools }` and surfaces 400/401/502/500 errors.
  - Auto-syncs during dispatch using the per-run MCP endpoint (fire-and-forget; non-blocking).
  - Uses `@modelcontextprotocol/sdk` to list tools; keeps output as raw JSON Schema (no TS codegen), pairs with `@decocms/typegen` if a typed client is needed.
  - Adds a black-box e2e proving discovery via glob/grep (email tools; validates `ARCHIVE_EMAIL` input).

- **Bug Fixes**
  - Prunes stale `*.json` on each sync and paginates via the MCP cursor so large orgs aren’t truncated.
  - Ensures collision-safe filenames; distinct tools that sanitize to the same name get a `-2`, `-3`, etc. suffix.
  - Excludes `/.deco/tools/` via `.git/info/exclude` so shutdown `git add -A` never commits the catalog.
  - Coalesces auto-sync with a minimum interval to avoid per-run re-list/write races; upstream MCP failures return 502, local write failures return 500.

<sup>Written for commit 5d1c8e299624cc170b2c0b81f5935456f9284fc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

