### PR TITLE
fix(decopilot): stop dropping the auto-title on fast runs

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/nats-chunk-source.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-chunk-source.test.ts
@@ -355,7 +355,11 @@ describe("projectorChunkStream", () => {
     expect(out.map((c) => c.type)).toEqual(["start", "text-delta"]);
   });
 
-  test("closes on the AI-SDK finish chunk (ignoring a later chunk)", async () => {
+  test("does NOT close on the AI-SDK finish chunk; keeps reading to the fenced done", async () => {
+    // Background title generation emits its transient `data-title-result` chunk
+    // AFTER the assistant `finish` chunk on fast runs. The projector must run to
+    // the fenced `done` (whose finalSeq covers it) rather than closing at
+    // `finish`, or the title is dropped and the thread stays on "New chat".
     const out = await readAll(
       projectorPipeline(
         [
@@ -364,14 +368,19 @@ describe("projectorChunkStream", () => {
             p: { type: "finish", finishReason: "stop" },
           }),
           rawJson("run_1:fence_a:3", {
-            p: { type: "text-delta", id: "t", delta: "late" },
+            p: { type: "data-title-result", data: { title: "Late title" } },
           }),
+          rawJson("run_1:fence_a:done:3", { done: true, finalSeq: 3 }),
         ],
         "run_1",
         "fence_a",
       ),
     );
-    expect(out.map((c) => c.type)).toEqual(["start", "finish"]);
+    expect(out.map((c) => c.type)).toEqual([
+      "start",
+      "finish",
+      "data-title-result",
+    ]);
   });
 
   test("errors on a tail gap exposed by finalSeq", async () => {

--- a/apps/mesh/src/api/routes/decopilot/nats-chunk-source.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-chunk-source.ts
@@ -99,11 +99,13 @@ export function projectorChunkStream(
         }
         lastSeq = ev.seq ?? lastSeq;
         controller.enqueue(ev.chunk);
-        if (ev.chunk.type === "finish") {
-          await reader.cancel();
-          release();
-          controller.close();
-        }
+        // Terminate only on the fenced `done` marker, never on the assistant
+        // `finish` chunk. Background title generation emits its transient
+        // `data-title-result` chunk AFTER `finish` on fast runs; the producer
+        // gives it a seq and the fenced done's `finalSeq` covers it. Closing at
+        // `finish` raced (and dropped) that title, leaving the thread on "New
+        // chat". The idle-timeout (StreamIdleTimeoutError) is the backstop for a
+        // producer that dies before publishing its done.
         return;
       }
     },

--- a/apps/mesh/src/api/routes/decopilot/projector-chunk-stream.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-chunk-stream.test.ts
@@ -75,7 +75,12 @@ describe("createProjectorChunkStreamFromMessages", () => {
     ]);
   });
 
-  test("ignores legacy unfenced done and closes on the AI SDK finish chunk", async () => {
+  test("ignores legacy unfenced done and runs past finish to the fenced done", async () => {
+    // Background title generation emits a transient `data-title-result` chunk
+    // AFTER the assistant `finish` chunk on fast runs. The projector must keep
+    // reading to the fenced `done` (whose finalSeq covers it) rather than
+    // closing at `finish` — otherwise the title is dropped and the thread stays
+    // on "New chat".
     const stream = createProjectorChunkStreamFromMessages({
       messages: [
         msg("run_1:fence_a:1", { p: { type: "start" } }),
@@ -95,8 +100,9 @@ describe("createProjectorChunkStreamFromMessages", () => {
           p: { type: "finish", finishReason: "stop" },
         }),
         msg("run_1:fence_a:8", {
-          p: { type: "text-delta", id: "late", delta: "ignored" },
+          p: { type: "data-title-result", data: { title: "Late title" } },
         }),
+        msg("run_1:fence_a:done:8", { done: true, finalSeq: 8 }),
       ],
       runId: "run_1",
       fenceToken: "fence_a",
@@ -110,6 +116,7 @@ describe("createProjectorChunkStreamFromMessages", () => {
       "text-delta",
       "text-end",
       "finish",
+      "data-title-result",
     ]);
   });
 
@@ -200,6 +207,7 @@ describe("createProjectorChunkStreamFromMessages", () => {
         });
         await sleep(20);
         yield msg("run_1:fence_a:3", { p: { type: "finish" } });
+        yield msg("run_1:fence_a:done:3", { done: true, finalSeq: 3 });
       }
       const stream = createProjectorChunkStreamFromMessages({
         messages: trickle(),
@@ -223,6 +231,7 @@ describe("createProjectorChunkStreamFromMessages", () => {
       async function* delayedFinish(): AsyncIterable<Msg> {
         await sleep(30);
         yield msg("run_1:fence_a:1", { p: { type: "finish" } });
+        yield msg("run_1:fence_a:done:1", { done: true, finalSeq: 1 });
       }
       const stream = createProjectorChunkStreamFromMessages({
         messages: delayedFinish(),


### PR DESCRIPTION
## Summary

Chat threads were stuck on **"New chat"** on fast turns (e.g. sending "hi"), even with the OpenRouter provider. Root cause: the durable projector closed its chunk stream the instant it saw the assistant `finish` chunk.

Background title generation (`genTitle`) runs the title LLM in parallel and emits its transient `data-title-result` chunk **after** the main `finish` chunk whenever the assistant response finishes first — which is exactly what happens on short turns. The projector's early close (`if (ev.chunk.type === "finish") { … controller.close() }`, added in #4179) dropped that trailing chunk before `interceptTitleChunkStream` could persist it. Slower/longer turns resolved the title *before* `finish`, so the bug looked intermittent (older threads got titles, recent short ones didn't).

## Fix

Terminate the projector stream only on the fenced `done` marker, never on `finish`. The producer (`ingestRun`) assigns every chunk a seq — including the post-`finish` title chunk — and publishes `done` with `finalSeq` covering it, so reading through to `done` picks the title up cleanly. The existing `StreamIdleTimeoutError` remains the backstop for a producer that dies before publishing its done.

One line changed in `nats-chunk-source.ts` (removed the `finish`-triggered close); the `finish`-close was the sole cause.

## Sidebar "All" view (second ask)

This same fix restores **live title updates for teammates' threads** in the sidebar's "All" view. Persisting the title fires `onTitleUpdated` (app.ts), which emits the org-wide `decopilot.thread.status` SSE event carrying the title — already consumed by `thread-manager-store` and applied to any thread in the list. The path was fully wired; it was starved only because the title chunk never reached the projector. No sidebar code change needed.

## Testing

- Updated `projector-chunk-stream.test.ts`: the projector now reads past `finish` to the fenced `done`, and a trailing `data-title-result` chunk survives. Adjusted two idle-window tests that relied on the old `finish`-close terminal.
- Verified end-to-end against a fast-run message sequence (`start → text → finish → data-title-result → done`) piped through the real projector stream into the real `interceptTitleChunkStream`: `persistTitle` now fires with the generated title. Pre-fix, the chunk was dropped and no title was persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops dropping auto-generated chat titles on fast runs by keeping the projector stream open until the fenced `done` instead of closing on `finish`. Restores live title updates in the sidebar "All" view.

- **Bug Fixes**
  - Projector now runs until the fenced `done`, preserving post-`finish` `data-title-result` chunks.
  - Honors `finalSeq`; idle-timeout remains the safety net for stuck producers.
  - Tests updated across `nats-chunk-source` and projector streams to read past `finish`, include fenced `done`, and ignore legacy unfenced done.

<sup>Written for commit 455ff214e371b8d80771b9faca6d2c7c70729541. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

