### PR TITLE
docs: add CONTRIBUTING.md + daemon sync-ops rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -429,6 +429,7 @@ PRs should include:
 5. **Formatting**: The pre-commit hook will reject commits if code isn't formatted with Biome
 6. **Never modify knip configuration** (`knip.json`, `knip.config.ts`, etc.) to silence warnings. Knip warnings indicate dead code, unused exports, or unused dependencies—these are code smells that should be fixed by removing the unused code/export/dependency, not by adding exclusions to the knip config.
 7. **CI errors are always on your branch**. The `main` branch CI always passes. When CI fails, the problem is in the code you changed—do not assume it's a pre-existing issue or a flaky test. Investigate and fix your code.
+8. **No synchronous/blocking work in the sandbox daemon** (`packages/sandbox/daemon/**`). It runs on a single-threaded Bun event loop. Any sync fs (`readFileSync`/`writeFileSync`/`mkdirSync`), sync crypto/hashing, or CPU-bound work (huge `JSON.parse`/`stringify`, unbounded loops) blocks the loop—so the daemon stops answering its HTTP health probe. Studio polls that probe and will mark the sandbox **dead** and tear it down / trigger recovery on a single miss. Use `node:fs/promises`, `await`, stream/chunk large payloads, and offload CPU work. This is CONTRIBUTING.md rule #1 for a reason. See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ## API Path Convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,59 +1,13 @@
 # Contributing to Studio
 
-Thanks for contributing. This is the short list of things that will save you
-(and reviewers) time. Architecture, commands, and coding conventions live in
-[`AGENTS.md`](./AGENTS.md) (symlinked as `CLAUDE.md`); testing philosophy in
-[`TESTING.md`](./TESTING.md). This file is the human-facing quick start plus the
-rules that bite hardest if ignored.
-
-## The golden rules
-
-### 1. Watch out for synchronous / blocking operations — especially in the sandbox daemon
-
-The sandbox daemon (`packages/sandbox/daemon/**`) runs on a **single-threaded
-Bun event loop**. Anything synchronous or CPU-bound holds that one thread and
-**blocks the loop**:
-
-- sync fs — `readFileSync`, `writeFileSync`, `mkdirSync`, `readdirSync`, …
-- sync crypto / hashing, `execSync`, `child_process` sync variants
-- CPU-bound work — large `JSON.parse` / `JSON.stringify`, unbounded loops,
-  synchronous compression, big regex over big strings
-
-Why it's worse than "a bit slow": Studio continuously polls the daemon's HTTP
-health probe. When the loop is blocked, the probe doesn't answer, and Studio
-concludes the sandbox is **dead** — then it does crazy shit: marks the run
-crashed, tears the pod down, triggers recovery. A single missed probe can flip
-a perfectly healthy sandbox to "crashed". So a blocking write you thought was
-harmless can kill a user's live session.
-
-**Do instead:** use `node:fs/promises` and `await`; run independent I/O with
-`Promise.all`; stream or chunk large payloads; offload CPU-bound work off the
-hot path. If you must do something synchronous, prove it's bounded and tiny,
-and leave a comment saying so.
-
-This applies most sharply to the daemon, but "prefer async, never block the
-loop" is the default everywhere in the codebase.
-
-### 2. Never hand-roll async primitives
-
-Use `@decocms/std` for `sleep`, `retry`, and backoff. Do not write another
-`setTimeout` promise, retry loop, or `Math.min(base * 2 ** n, cap)` jitter
-formula. See the "Async primitives" section in [`AGENTS.md`](./AGENTS.md).
-
-### 3. Tools go through `StudioContext`
-
-Never touch env vars, HTTP objects, or the DB driver directly from a tool — all
-dependencies flow through `StudioContext`. Use `defineTool()`. See
-[`AGENTS.md`](./AGENTS.md).
-
-### 4. Don't silence the tooling
-
-Don't edit `knip.json` to hide dead-code warnings, don't disable lints to make
-them pass, don't `@ts-ignore` a real type error. Fix the underlying thing.
+Thanks for contributing. This is the quick start plus the handful of rules that
+save the most review time. Architecture, commands, and coding conventions live
+in [`AGENTS.md`](./AGENTS.md) (symlinked as `CLAUDE.md`); testing philosophy in
+[`TESTING.md`](./TESTING.md).
 
 ## Getting started
 
-Prerequisites: [Bun](https://bun.sh).
+Prerequisites: [Bun](https://bun.sh) and Node ≥ 24.
 
 ```bash
 bun install
@@ -61,40 +15,73 @@ npx lefthook install   # pre-commit hook that runs `bun run fmt`
 bun run dev            # migrations + client + server
 ```
 
+## Filing issues & opening PRs
+
+- **Bug or feature idea?** Open an issue first — templates live under
+  [`.github/ISSUE_TEMPLATE`](./.github/ISSUE_TEMPLATE). For anything large,
+  agree on the approach in the issue before writing code.
+- **Fork or branch** off `main`, then open a PR. The
+  [PR template](./.github/pull_request_template.md) tells you what to fill in:
+  what changed, how to test it, and any migration notes.
+- Keep PRs focused. Stack dependent PRs rather than bundling unrelated changes.
+
+## The rules that bite hardest
+
+### 1. Tools go through `StudioContext`
+
+Never touch env vars, HTTP objects, or the DB driver directly from a tool — all
+dependencies flow through `StudioContext`. Use `defineTool()`. See
+[`AGENTS.md`](./AGENTS.md).
+
+### 2. Never hand-roll async primitives
+
+Use `@decocms/std` for `sleep`, `retry`, and backoff. Don't write another
+`setTimeout` promise, retry loop, or `Math.min(base * 2 ** n, cap)` jitter
+formula. See the "Async primitives" section in [`AGENTS.md`](./AGENTS.md).
+
+### 3. Don't silence the tooling
+
+Don't edit `knip.json` to hide dead-code warnings, don't disable lints to make
+them pass, don't `@ts-ignore` a real type error. Fix the underlying thing.
+
+### 4. Never block the event loop — especially in the sandbox daemon
+
+`packages/sandbox/daemon/**` runs on a single Bun thread. Sync fs
+(`readFileSync`, `mkdirSync`, …), sync crypto / `execSync`, or CPU-bound work
+(large `JSON.parse` / `JSON.stringify`, unbounded loops) freezes that thread.
+Studio polls the daemon's health probe, and a **single** missed probe flips a
+healthy sandbox to "crashed" — tearing the pod down mid-session. Use
+`node:fs/promises` with `await`, stream large payloads, and keep CPU work off
+the hot path. Full detail in [`AGENTS.md`](./AGENTS.md). "Prefer async, never
+block the loop" is the default everywhere, not just the daemon.
+
 ## Before you push
 
-Run these locally — CI runs them and CI failures are always on your branch:
+Run these locally — CI runs them, and CI failures are always on your branch:
 
 ```bash
 bun run check   # TypeScript, all workspaces
 bun run lint    # oxlint + custom plugins
 bun run fmt     # Biome (also enforced by the pre-commit hook)
-bun test        # unit tests
+bun run test    # unit tests
 ```
 
 ## Testing
 
 Two tiers, no third — see [`TESTING.md`](./TESTING.md) for the full rules:
 
-- **Unit (`bun test`)** — pure logic only. No mocks, no DB, no network.
+- **Unit (`bun run test`)** — pure logic only. No mocks, no DB, no network.
   Co-located `*.test.ts` next to the source.
 - **E2E (Playwright, `packages/e2e`)** — everything else. Real Postgres + NATS.
-
-The sandbox daemon has its own black-box e2e (`packages/sandbox/daemon/*.e2e.test.ts`):
-spawn the built daemon, assert over HTTP + the workspace filesystem. Mirror
-that pattern for new daemon routes.
 
 If a test needs `vi.mock`, a stubbed `StudioContext`, or a fake `fetch`, it is
 not a unit test — move it to e2e.
 
-## Commits & pull requests
+## Commits
 
 - **Conventional commits**: `type(scope): message` (e.g.
   `fix(event-bus): handle retry-after flow`). Chores: `[chore]: ...`.
-- Keep PRs focused. Stack dependent PRs rather than bundling unrelated changes.
-- A PR should say what changed, how it was tested, and call out follow-ups.
-- Comments: explain *why*, not *what*. No narration, no paragraph essays.
-  Prefer deleting code over adding it.
+- Comments explain *why*, not *what*. Prefer deleting code over adding it.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to Studio
+
+Thanks for contributing. This is the short list of things that will save you
+(and reviewers) time. Architecture, commands, and coding conventions live in
+[`AGENTS.md`](./AGENTS.md) (symlinked as `CLAUDE.md`); testing philosophy in
+[`TESTING.md`](./TESTING.md). This file is the human-facing quick start plus the
+rules that bite hardest if ignored.
+
+## The golden rules
+
+### 1. Watch out for synchronous / blocking operations — especially in the sandbox daemon
+
+The sandbox daemon (`packages/sandbox/daemon/**`) runs on a **single-threaded
+Bun event loop**. Anything synchronous or CPU-bound holds that one thread and
+**blocks the loop**:
+
+- sync fs — `readFileSync`, `writeFileSync`, `mkdirSync`, `readdirSync`, …
+- sync crypto / hashing, `execSync`, `child_process` sync variants
+- CPU-bound work — large `JSON.parse` / `JSON.stringify`, unbounded loops,
+  synchronous compression, big regex over big strings
+
+Why it's worse than "a bit slow": Studio continuously polls the daemon's HTTP
+health probe. When the loop is blocked, the probe doesn't answer, and Studio
+concludes the sandbox is **dead** — then it does crazy shit: marks the run
+crashed, tears the pod down, triggers recovery. A single missed probe can flip
+a perfectly healthy sandbox to "crashed". So a blocking write you thought was
+harmless can kill a user's live session.
+
+**Do instead:** use `node:fs/promises` and `await`; run independent I/O with
+`Promise.all`; stream or chunk large payloads; offload CPU-bound work off the
+hot path. If you must do something synchronous, prove it's bounded and tiny,
+and leave a comment saying so.
+
+This applies most sharply to the daemon, but "prefer async, never block the
+loop" is the default everywhere in the codebase.
+
+### 2. Never hand-roll async primitives
+
+Use `@decocms/std` for `sleep`, `retry`, and backoff. Do not write another
+`setTimeout` promise, retry loop, or `Math.min(base * 2 ** n, cap)` jitter
+formula. See the "Async primitives" section in [`AGENTS.md`](./AGENTS.md).
+
+### 3. Tools go through `StudioContext`
+
+Never touch env vars, HTTP objects, or the DB driver directly from a tool — all
+dependencies flow through `StudioContext`. Use `defineTool()`. See
+[`AGENTS.md`](./AGENTS.md).
+
+### 4. Don't silence the tooling
+
+Don't edit `knip.json` to hide dead-code warnings, don't disable lints to make
+them pass, don't `@ts-ignore` a real type error. Fix the underlying thing.
+
+## Getting started
+
+Prerequisites: [Bun](https://bun.sh).
+
+```bash
+bun install
+npx lefthook install   # pre-commit hook that runs `bun run fmt`
+bun run dev            # migrations + client + server
+```
+
+## Before you push
+
+Run these locally — CI runs them and CI failures are always on your branch:
+
+```bash
+bun run check   # TypeScript, all workspaces
+bun run lint    # oxlint + custom plugins
+bun run fmt     # Biome (also enforced by the pre-commit hook)
+bun test        # unit tests
+```
+
+## Testing
+
+Two tiers, no third — see [`TESTING.md`](./TESTING.md) for the full rules:
+
+- **Unit (`bun test`)** — pure logic only. No mocks, no DB, no network.
+  Co-located `*.test.ts` next to the source.
+- **E2E (Playwright, `packages/e2e`)** — everything else. Real Postgres + NATS.
+
+The sandbox daemon has its own black-box e2e (`packages/sandbox/daemon/*.e2e.test.ts`):
+spawn the built daemon, assert over HTTP + the workspace filesystem. Mirror
+that pattern for new daemon routes.
+
+If a test needs `vi.mock`, a stubbed `StudioContext`, or a fake `fetch`, it is
+not a unit test — move it to e2e.
+
+## Commits & pull requests
+
+- **Conventional commits**: `type(scope): message` (e.g.
+  `fix(event-bus): handle retry-after flow`). Chores: `[chore]: ...`.
+- Keep PRs focused. Stack dependent PRs rather than bundling unrelated changes.
+- A PR should say what changed, how it was tested, and call out follow-ups.
+- Comments: explain *why*, not *what*. No narration, no paragraph essays.
+  Prefer deleting code over adding it.
+
+## License
+
+Sustainable Use License — see [`LICENSE.md`](./LICENSE.md). Free to self-host
+for internal use and for client projects; a commercial license is required for
+SaaS / revenue-generating production systems. Questions: contact@decocms.com.


### PR DESCRIPTION
## Summary

Adds contributor guidelines, with the hardest-biting rule front and center.

- **New `CONTRIBUTING.md`** — human-facing quick start (setup, pre-push checks, testing tiers, commit/PR conventions) that points to `AGENTS.md`/`TESTING.md` rather than duplicating them. **Golden rule #1:** watch out for synchronous / blocking operations, especially in the sandbox daemon.
- **`AGENTS.md` (aka `CLAUDE.md`) gotcha #8** — the same rule, so AI assistants and humans both see it.

## The rule

The sandbox daemon (`packages/sandbox/daemon/**`) runs on a **single-threaded Bun event loop**. Any sync fs / crypto / CPU-bound work blocks the loop → the daemon stops answering its HTTP health probe → Studio, which polls that probe, concludes the sandbox is **dead** and tears it down / triggers recovery. A single missed probe can flip a healthy sandbox to "crashed", so a stray `writeFileSync` can kill a live user session. Use `node:fs/promises`, `await`, stream/chunk large payloads, offload CPU work.

Direct motivation: the tool-catalog sync in the sandbox PR originally used `writeFileSync`; caught and moved to `fs/promises`. This writes the lesson down.

## Testing

Docs only — no code paths. Linked files (`TESTING.md`, `LICENSE.md`, `AGENTS.md`) verified to exist; `bun run fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `CONTRIBUTING.md` with a quick start, issue/PR/branch basics, and the highest-impact rules (tools via `StudioContext`, use `@decocms/std` for async, don’t silence lints, and never block the event loop—especially in `packages/sandbox/daemon/**`). Also documents pre-push checks, unit vs e2e test tiers, conventional commits, and adds the same daemon sync/blocking rule to `AGENTS.md` (gotcha #8) to prevent false “dead” health probes.

<sup>Written for commit 221ff1249338f962a85a9286e31f8305b12825f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

