### PR TITLE
fix(web): keep selected tab when flipping the Develop/Live agent toggle

### DIFF
--- a/apps/mesh/src/web/components/dev-agent/dev-agent-control.tsx
+++ b/apps/mesh/src/web/components/dev-agent/dev-agent-control.tsx
@@ -6,10 +6,10 @@
  * agent settings (see DevAgentSetup), not here.
  */
 
-import { useNavigate } from "@tanstack/react-router";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { useProjectContext, useVirtualMCPs } from "@decocms/mesh-sdk";
+import { useVirtualMCPs } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
+import { useChatNavigation } from "@/web/components/chat/hooks/use-chat-navigation";
 import { useThreadActions } from "@/web/components/chat/store/hooks";
 import { findDevPartner } from "@/web/lib/agent-capabilities";
 
@@ -19,8 +19,7 @@ export function DevAgentControl({
   virtualMcp: VirtualMCPEntity;
 }) {
   const allAgents = useVirtualMCPs();
-  const { org } = useProjectContext();
-  const navigate = useNavigate();
+  const { navigateToTask } = useChatNavigation();
   const { create } = useThreadActions();
 
   const partner = findDevPartner(virtualMcp, allAgents);
@@ -28,7 +27,8 @@ export function DevAgentControl({
 
   const isDev = partner.mode === "dev";
 
-  /** Open a fresh task on the paired counterpart. */
+  /** Open a fresh task on the paired counterpart. `navigateToTask` carries
+   *  `?main`/`?chat`, so a same-id tab stays selected across the flip. */
   const goToAgent = async (agentId: string) => {
     const taskId = crypto.randomUUID();
     try {
@@ -37,11 +37,7 @@ export function DevAgentControl({
       // The action already toasted; navigate anyway so the route loader's
       // ensure-fallback retries the thread create.
     }
-    navigate({
-      to: "/$org/$taskId",
-      params: { org: org.slug, taskId },
-      search: { virtualmcpid: agentId },
-    });
+    navigateToTask(taskId, { virtualMcpId: agentId });
   };
 
   const segment = (label: string, active: boolean) => (


### PR DESCRIPTION
## What is this contribution about?
The Develop/Live toggle in the agent shell header hand-rolled its own `navigate()` with only `?virtualmcpid` in the search, wiping the rest of the query string — so the selected main-panel tab (`?main=`) and chat state (`?chat=`) were lost on every flip. It now routes through the existing `navigateToTask` helper (`use-chat-navigation.ts`), which preserves `?main`/`?chat` while still dropping thread-scoped tabs (`file:`, `deck:`, `app:`, …) that can't carry into a fresh task. If the dev and live agents declare a tab with the same id, flipping keeps it selected.

## Screenshots/Demonstration
No visual change — behavior only (URL state preserved across the toggle).

## How to Test
1. Open an agent that has a linked dev/live partner and select a non-default tab (e.g. Settings) in the main panel.
2. Click the other side of the Develop/Live toggle in the header.
3. Expected: the new task on the partner agent opens with the same tab selected (previously it reset to the default view).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the selected main-panel tab when switching the Develop/Live agent toggle. The toggle now uses `navigateToTask` to preserve `?main`/`?chat` in the URL while dropping thread-scoped tabs, so same-id tabs stay selected across agents.

<sup>Written for commit 8f51cf97ac59d0bf49bdc9f77cf7fad2bd440d98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

