### PR TITLE
feat(agents): seed kickstart prompts on COLLECTION_VIRTUAL_MCP_CREATE

### DIFF
--- a/apps/mesh/src/file-storage/agent-prompts.ts
+++ b/apps/mesh/src/file-storage/agent-prompts.ts
@@ -12,7 +12,7 @@ import { slugify } from "@decocms/mcp-utils/aggregate";
 import type { AgentKickstartPrompt } from "@decocms/mesh-sdk/types";
 import type { OrgFs } from "./org-fs";
 
-export const AGENT_PROMPTS_VOLUME = "agent-prompts";
+const AGENT_PROMPTS_VOLUME = "agent-prompts";
 
 /** Backstop so a pathological agent can't make the gateway read forever. */
 const MAX_PROMPTS = 20;

--- a/apps/mesh/src/file-storage/agent-prompts.ts
+++ b/apps/mesh/src/file-storage/agent-prompts.ts
@@ -1,0 +1,115 @@
+/**
+ * Agent kickstart prompts — persisted to a dedicated org-fs volume (one JSON
+ * file per prompt) and served back as native MCP prompts on the agent's
+ * gateway. Writing happens once at agent-create time; reading happens whenever
+ * the gateway lists/gets prompts (icebreakers, org home, `/` mentions).
+ *
+ * The volume (`agent-prompts`) is intentionally NOT in the sandbox mount set,
+ * so seeding an agent never pollutes the org's sandbox home.
+ */
+
+import { slugify } from "@decocms/mcp-utils/aggregate";
+import type { AgentKickstartPrompt } from "@decocms/mesh-sdk/types";
+import type { OrgFs } from "./org-fs";
+
+export const AGENT_PROMPTS_VOLUME = "agent-prompts";
+
+/** Backstop so a pathological agent can't make the gateway read forever. */
+const MAX_PROMPTS = 20;
+
+/** A stored prompt with the stable local name used to resolve it later. */
+export interface StoredAgentPrompt {
+  /** Local (un-namespaced) prompt name, unique within the agent. */
+  name: string;
+  title: string;
+  description?: string;
+  text: string;
+}
+
+function dir(agentId: string): string {
+  return slugify(agentId);
+}
+
+/** Local name for the Nth prompt — stable, unique, and a valid file base. */
+function localName(index: number, title: string): string {
+  const slug = slugify(title) || "prompt";
+  return `${index}-${slug}`;
+}
+
+/**
+ * Seed an agent's kickstart prompts. One JSON file per prompt under
+ * `agent-prompts/<agentId>/`. Best-effort per file: a failed write is logged
+ * and skipped rather than failing the whole agent creation.
+ */
+export async function writeAgentPrompts(
+  orgFs: OrgFs,
+  agentId: string,
+  actor: string,
+  prompts: AgentKickstartPrompt[],
+): Promise<void> {
+  const base = dir(agentId);
+  await Promise.all(
+    prompts.slice(0, MAX_PROMPTS).map(async (p, i) => {
+      const name = localName(i, p.title);
+      const stored: StoredAgentPrompt = {
+        name,
+        title: p.title,
+        description: p.description,
+        text: p.text,
+      };
+      try {
+        await orgFs.write(
+          AGENT_PROMPTS_VOLUME,
+          `${base}/${name}.json`,
+          JSON.stringify(stored),
+          { actor, contentType: "application/json" },
+        );
+      } catch (err) {
+        console.error("[agent-prompts] failed to seed prompt", {
+          agentId,
+          name,
+          err,
+        });
+      }
+    }),
+  );
+}
+
+/**
+ * Read an agent's seeded prompts. Best-effort and bounded: returns [] on any
+ * storage error and skips individual unreadable/corrupt files. Never throws.
+ */
+export async function readAgentPrompts(
+  orgFs: OrgFs,
+  agentId: string,
+): Promise<StoredAgentPrompt[]> {
+  const base = dir(agentId);
+  let entries: Awaited<ReturnType<OrgFs["listDir"]>>;
+  try {
+    entries = await orgFs.listDir(AGENT_PROMPTS_VOLUME, base);
+  } catch {
+    return [];
+  }
+  const files = entries
+    .filter((e) => e.kind === "file" && e.path.endsWith(".json"))
+    .slice(0, MAX_PROMPTS);
+
+  const out: StoredAgentPrompt[] = [];
+  for (const f of files) {
+    try {
+      const bytes = await orgFs.read(AGENT_PROMPTS_VOLUME, f.path);
+      const parsed = JSON.parse(new TextDecoder().decode(bytes));
+      if (
+        parsed &&
+        typeof parsed.name === "string" &&
+        typeof parsed.title === "string" &&
+        typeof parsed.text === "string"
+      ) {
+        out.push(parsed as StoredAgentPrompt);
+      }
+    } catch {
+      // Corrupt/vanished file — skip it rather than break the whole list.
+    }
+  }
+  return out;
+}

--- a/apps/mesh/src/file-storage/agent-prompts.ts
+++ b/apps/mesh/src/file-storage/agent-prompts.ts
@@ -37,9 +37,27 @@ function localName(index: number, title: string): string {
 }
 
 /**
- * Seed an agent's kickstart prompts. One JSON file per prompt under
- * `agent-prompts/<agentId>/`. Best-effort per file: a failed write is logged
- * and skipped rather than failing the whole agent creation.
+ * Delete every seeded prompt for an agent (the whole `agent-prompts/<agentId>/`
+ * subtree). Best-effort: logs and swallows storage errors. Never throws.
+ */
+export async function deleteAgentPrompts(
+  orgFs: OrgFs,
+  agentId: string,
+  actor: string,
+): Promise<void> {
+  try {
+    await orgFs.delete(AGENT_PROMPTS_VOLUME, dir(agentId), { actor });
+  } catch (err) {
+    console.error("[agent-prompts] failed to delete prompts", { agentId, err });
+  }
+}
+
+/**
+ * (Re)seed an agent's kickstart prompts. Idempotent: clears the agent's
+ * existing prompt dir first, then writes one JSON file per prompt under
+ * `agent-prompts/<agentId>/`. So editing = pass the new full set, and passing
+ * `[]` clears all. Best-effort per file: a failed write is logged and skipped
+ * rather than failing the whole operation.
  */
 export async function writeAgentPrompts(
   orgFs: OrgFs,
@@ -48,6 +66,7 @@ export async function writeAgentPrompts(
   prompts: AgentKickstartPrompt[],
 ): Promise<void> {
   const base = dir(agentId);
+  await deleteAgentPrompts(orgFs, agentId, actor);
   await Promise.all(
     prompts.slice(0, MAX_PROMPTS).map(async (p, i) => {
       const name = localName(i, p.title);

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -9,14 +9,22 @@ import {
   GatewayClient,
   type ClientEntry,
   getGatewayClientId,
+  slugify,
   stripToolNamespace,
 } from "@decocms/mcp-utils/aggregate";
 import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
+  GetPromptRequest,
+  GetPromptResult,
   ListPromptsRequest,
   ListPromptsResult,
+  Prompt,
 } from "@modelcontextprotocol/sdk/types.js";
 import type { StudioContext } from "../../core/studio-context";
+import {
+  readAgentPrompts,
+  type StoredAgentPrompt,
+} from "../../file-storage/agent-prompts";
 import {
   findStudioPackAgentByMcpId,
   resolveStudioPackChecklist,
@@ -30,6 +38,9 @@ import type { VirtualClientOptions } from "./types";
  * Tool/prompt names are namespaced with slugified connection IDs.
  */
 export class PassthroughClient extends GatewayClient {
+  /** Cached org-fs read of this agent's seeded kickstart prompts. */
+  private agentPromptsCache: Promise<StoredAgentPrompt[]> | null = null;
+
   constructor(
     protected options: VirtualClientOptions,
     protected ctx: StudioContext,
@@ -98,7 +109,12 @@ export class PassthroughClient extends GatewayClient {
     params?: ListPromptsRequest["params"],
     options?: RequestOptions,
   ): Promise<ListPromptsResult> {
-    const result = await super.listPrompts(params, options);
+    const base = await super.listPrompts(params, options);
+    const seeded = await this.listSeededPrompts();
+    const result: ListPromptsResult = {
+      ...base,
+      prompts: [...base.prompts, ...seeded],
+    };
 
     const agent = findStudioPackAgentByMcpId(this.options.virtualMcp.id ?? "");
     const orgId = this.ctx.organization?.id;
@@ -129,6 +145,64 @@ export class PassthroughClient extends GatewayClient {
           ),
       ),
     };
+  }
+
+  /**
+   * Resolve a kickstart prompt seeded on THIS agent (stored in org-fs) before
+   * delegating to the aggregator. Seeded prompts have no owning child
+   * connection, so the gateway's namespace routing would 404 them.
+   */
+  override async getPrompt(
+    params: GetPromptRequest["params"],
+    options?: RequestOptions,
+  ): Promise<GetPromptResult> {
+    const agentId = this.options.virtualMcp.id;
+    if (agentId) {
+      const prefix = `${slugify(agentId)}_`;
+      if (params.name.startsWith(prefix)) {
+        const localName = params.name.slice(prefix.length);
+        const stored = await this.loadSeededPrompts();
+        const match = stored.find((p) => p.name === localName);
+        if (match) {
+          return {
+            description: match.description,
+            messages: [
+              { role: "user", content: { type: "text", text: match.text } },
+            ],
+          };
+        }
+      }
+    }
+    return super.getPrompt(params, options);
+  }
+
+  /**
+   * The agent's own kickstart prompts (org-fs), shaped as gateway prompts:
+   * namespaced under the agent id so the icebreaker chip's strip/resolve flow
+   * lines up with `getPrompt` above. Cached per instance. Never throws.
+   */
+  private async listSeededPrompts(): Promise<Prompt[]> {
+    const agentId = this.options.virtualMcp.id;
+    if (!agentId) return [];
+    const stored = await this.loadSeededPrompts();
+    const prefix = slugify(agentId);
+    return stored.map((p) => ({
+      name: `${prefix}_${p.name}`,
+      title: p.title,
+      description: p.description,
+      _meta: { gatewayClientId: agentId },
+    }));
+  }
+
+  /** Cached org-fs read of the agent's seeded prompts. Never throws. */
+  private loadSeededPrompts(): Promise<StoredAgentPrompt[]> {
+    const agentId = this.options.virtualMcp.id;
+    const orgFs = this.ctx.orgFs;
+    if (!agentId || !orgFs) return Promise.resolve([]);
+    if (!this.agentPromptsCache) {
+      this.agentPromptsCache = readAgentPrompts(orgFs, agentId);
+    }
+    return this.agentPromptsCache;
   }
 
   override getInstructions(): string | undefined {

--- a/apps/mesh/src/tools/guides/agents.ts
+++ b/apps/mesh/src/tools/guides/agents.ts
@@ -15,7 +15,7 @@ Recommended tool order:
 1. Use COLLECTION_CONNECTIONS_LIST to inspect what capabilities already exist.
 2. If the user names a specific connection, use COLLECTION_CONNECTIONS_GET to verify details.
 3. If requirements are ambiguous, use user_ask before creating anything.
-4. Use COLLECTION_VIRTUAL_MCP_CREATE with a focused title, description, connectionIds, and instructions.
+4. Use COLLECTION_VIRTUAL_MCP_CREATE with a focused title, description, connectionIds, instructions, and kickstart prompts.
 5. Use COLLECTION_VIRTUAL_MCP_GET to verify the saved configuration.
 
 Checks:
@@ -23,6 +23,7 @@ Checks:
 - Include only the connections relevant to that role.
 - Ensure the title is specific and easy to distinguish from other agents.
 - Write instructions using the docs://agents.md guidance, especially XML-structured sections and explicit workflows.
+- Seed 3-4 kickstart prompts via the \`prompts\` field so the agent opens with useful conversation starters. Author them from the agent's role and the tool descriptions of its connections (see docs://agents.md "Kickstart prompts").
 - Verify the created agent includes the intended connections and instructions before reporting success.
 `,
   },
@@ -140,6 +141,39 @@ When revising an existing agent:
 - Instruct the agent to inspect available capabilities before assuming.
 - Explain when tools are mandatory versus when direct answers are acceptable.
 - For multi-step workflows, tell the agent to chain tool calls instead of guessing intermediate state.
+
+## Kickstart prompts
+
+Seed a new agent with a few kickstart prompts (the \`prompts\` field on
+COLLECTION_VIRTUAL_MCP_CREATE). They render as clickable conversation starters
+(icebreakers) — clicking one sends its text as the first message. A good set
+makes an empty agent immediately useful.
+
+How to write coherent ones:
+- Read the agent's own role/instructions and the descriptions of the tools its
+  connections expose. Each prompt should map to a real capability.
+- Prefer 3-4 concrete, runnable tasks over generic greetings. Bad: "How can
+  you help me?". Good (for a support-triage agent with a ticketing tool):
+  "Summarize the 5 oldest open tickets and flag anything urgent."
+- \`title\` is the short chip label; \`description\` is a one-line subtitle;
+  \`text\` is the actual message sent on click — write it as the user would.
+
+Example \`prompts\` argument:
+
+\`\`\`json
+[
+  {
+    "title": "Triage new tickets",
+    "description": "Summarize and prioritize open tickets",
+    "text": "Summarize the 5 oldest open tickets and flag anything urgent."
+  },
+  {
+    "title": "Draft a reply",
+    "description": "Write a customer response",
+    "text": "Draft a reply to the latest ticket, matching our support tone."
+  }
+]
+\`\`\`
 
 ### Guardrails
 

--- a/apps/mesh/src/tools/virtual/create.ts
+++ b/apps/mesh/src/tools/virtual/create.ts
@@ -15,6 +15,7 @@ import {
 } from "../../core/studio-context";
 import { VirtualMCPCreateDataSchema, VirtualMCPEntitySchema } from "./schema";
 import { requireOrgAdminForPinnedField } from "./require-org-admin-for-pin";
+import { writeAgentPrompts } from "../../file-storage/agent-prompts";
 /**
  * Random icon+color for new agents (server-side, no React deps).
  * Uses the same icon:// format as the client-side agent-icon module.
@@ -88,7 +89,7 @@ const CreateOutputSchema = z.object({
 export const COLLECTION_VIRTUAL_MCP_CREATE = defineTool({
   name: "COLLECTION_VIRTUAL_MCP_CREATE",
   description:
-    "Create a Virtual MCP that aggregates tools from multiple connections into one endpoint.",
+    "Create a Virtual MCP (agent) that aggregates tools from multiple connections into one endpoint. Pass `prompts` to seed the agent with kickstart prompts (conversation starters shown as icebreakers). Author them from the agent's role/instructions and the descriptions of the tools it will have, so the starters are coherent and immediately useful.",
   annotations: {
     title: "Create Virtual MCP",
     readOnlyHint: false,
@@ -114,12 +115,15 @@ export const COLLECTION_VIRTUAL_MCP_CREATE = defineTool({
       requireOrgAdminForPinnedField(ctx);
     }
 
+    // `prompts` is seeded to org-fs after creation, not stored on the agent row.
+    const { prompts, ...createData } = input.data;
+
     // Create the virtual MCP (input.data is already in the correct format)
     // Note: The facade creates a VIRTUAL connection in the connections table
     // Use a random icon+color if no icon is provided
     const dataWithIcon = {
-      ...input.data,
-      icon: input.data.icon ?? pickRandomAgentIcon(),
+      ...createData,
+      icon: createData.icon ?? pickRandomAgentIcon(),
     };
 
     const virtualMcp = await ctx.storage.virtualMcps.create(
@@ -127,6 +131,13 @@ export const COLLECTION_VIRTUAL_MCP_CREATE = defineTool({
       userId,
       dataWithIcon,
     );
+
+    // Seed kickstart prompts into org-fs so the agent's gateway serves them as
+    // native MCP prompts (icebreakers). Best-effort: never fail agent creation
+    // over a prompt write.
+    if (prompts?.length && ctx.orgFs && virtualMcp.id) {
+      await writeAgentPrompts(ctx.orgFs, virtualMcp.id, userId, prompts);
+    }
 
     // Return virtual MCP entity directly (already in correct format)
     return {

--- a/apps/mesh/src/tools/virtual/delete.ts
+++ b/apps/mesh/src/tools/virtual/delete.ts
@@ -8,7 +8,12 @@ import { z } from "zod";
 import { getRepoScope } from "@/shared/github-repo-scope";
 import { DownstreamTokenStorage } from "@/storage/downstream-token";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth, requireOrganization } from "../../core/studio-context";
+import {
+  getUserId,
+  requireAuth,
+  requireOrganization,
+} from "../../core/studio-context";
+import { deleteAgentPrompts } from "../../file-storage/agent-prompts";
 import { VirtualMCPEntitySchema } from "./schema";
 
 /**
@@ -62,6 +67,11 @@ export const COLLECTION_VIRTUAL_MCP_DELETE = defineTool({
     // connection row itself is NOT removed by this (it's a separate, non-VIRTUAL
     // connection), so its token is still readable below.
     await ctx.storage.virtualMcps.delete(input.id);
+
+    // Drop the agent's seeded kickstart prompts from org-fs (best-effort).
+    if (ctx.orgFs) {
+      await deleteAgentPrompts(ctx.orgFs, input.id, getUserId(ctx) ?? "system");
+    }
 
     // Tear down the per-agent repo-scoped mcp-github child connection (if any).
     // Best-effort: the agent is already deleted, so a cleanup hiccup must not

--- a/apps/mesh/src/tools/virtual/studio-pack/agent-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/agent-manager.ts
@@ -23,7 +23,8 @@ You are the Agent Manager. This organization has not created any agents yet — 
    a. Ask the user: what should this agent do, and who is it for? Steer toward one focused responsibility.
    b. List available connections with COLLECTION_CONNECTIONS_LIST so you can suggest a sensible default set.
    c. Create the agent with COLLECTION_VIRTUAL_MCP_CREATE — a focused title, a one-line description, the chosen connections, and XML-structured instructions (<role>, <capabilities>, <constraints>, <workflows>).
-   d. Confirm in one short line and offer the obvious next step (refine instructions, add more connections, create another agent).
+   d. Seed 3-4 kickstart prompts via the \`prompts\` field on the same COLLECTION_VIRTUAL_MCP_CREATE call. Derive them from the agent's role and the tools it will have (read the selected connections' tool descriptions) so each starter is a concrete task the agent can actually do on turn one — not a generic "How can you help?".
+   e. Confirm in one short line and offer the obvious next step (refine instructions, add more connections, create another agent).
 </workflows>`;
 
 const INSTRUCTIONS_MANAGE = `<role>
@@ -55,7 +56,8 @@ You are the Agent Manager. You create, configure, and maintain agents (Virtual M
    a. List available connections with COLLECTION_CONNECTIONS_LIST.
    b. Confirm the agent's purpose, target user, and scope with the user.
    c. Create the agent with COLLECTION_VIRTUAL_MCP_CREATE, including a focused title, description, selected connections, and XML-structured instructions.
-   d. Verify the saved configuration with COLLECTION_VIRTUAL_MCP_GET.
+   d. Seed kickstart prompts via the \`prompts\` field on the same create call. Base each starter on the agent's role and the descriptions of the tools it will have so they're coherent, specific, and immediately runnable. Prefer 3-4 concrete tasks over generic greetings.
+   e. Verify the saved configuration with COLLECTION_VIRTUAL_MCP_GET.
 
 2. Updating an agent:
    a. Get the current agent config with COLLECTION_VIRTUAL_MCP_GET.

--- a/apps/mesh/src/tools/virtual/update.ts
+++ b/apps/mesh/src/tools/virtual/update.ts
@@ -11,6 +11,7 @@ import {
   requireAuth,
   requireOrganization,
 } from "../../core/studio-context";
+import { writeAgentPrompts } from "../../file-storage/agent-prompts";
 import { VirtualMCPEntitySchema, VirtualMCPUpdateDataSchema } from "./schema";
 import { requireOrgAdminForPinnedField } from "./require-org-admin-for-pin";
 
@@ -35,7 +36,8 @@ const UpdateOutputSchema = z.object({
 
 export const COLLECTION_VIRTUAL_MCP_UPDATE = defineTool({
   name: "COLLECTION_VIRTUAL_MCP_UPDATE",
-  description: "Update a Virtual MCP's name, slug, or connection list.",
+  description:
+    "Update a Virtual MCP's name, slug, connection list, or kickstart prompts. Pass `prompts` to replace the agent's conversation starters (full set; empty array clears them).",
   annotations: {
     title: "Update Virtual MCP",
     readOnlyHint: false,
@@ -66,10 +68,9 @@ export const COLLECTION_VIRTUAL_MCP_UPDATE = defineTool({
       throw new Error(`Virtual MCP not found: ${input.id}`);
     }
 
-    // Shallow-merge incoming metadata with existing so that callers can send
-    // partial metadata updates (e.g. only enabled_plugins) without wiping
-    // other fields like instructions or ui.
-    const data = { ...input.data };
+    // `prompts` lives in org-fs, not on the agent row — pull it out before the
+    // row update and re-seed separately below.
+    const { prompts, ...data } = input.data;
     if (data.metadata && existing.metadata) {
       data.metadata = { ...existing.metadata, ...data.metadata };
     }
@@ -83,6 +84,12 @@ export const COLLECTION_VIRTUAL_MCP_UPDATE = defineTool({
       userId,
       data,
     );
+
+    // Re-seed kickstart prompts when provided (full replace; [] clears all).
+    // Best-effort: never fail the update over a prompt write.
+    if (prompts !== undefined && ctx.orgFs) {
+      await writeAgentPrompts(ctx.orgFs, input.id, userId, prompts);
+    }
 
     // Return virtual MCP entity directly (already in correct format)
     return {

--- a/packages/mesh-sdk/src/types/index.ts
+++ b/packages/mesh-sdk/src/types/index.ts
@@ -25,6 +25,8 @@ export {
   type VirtualMCPCreateData,
   type VirtualMCPUpdateData,
   type VirtualMCPConnection,
+  AgentKickstartPromptSchema,
+  type AgentKickstartPrompt,
   type KnowledgeFile,
   type VirtualMcpUILayout,
   type VirtualMcpUILayoutTab,

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -625,6 +625,27 @@ export const VirtualMCPEntitySchema = z.object({
 export type VirtualMCPEntity = z.infer<typeof VirtualMCPEntitySchema>;
 
 /**
+ * A kickstart prompt seeded on an agent at creation time. Persisted to org-fs
+ * (not on the agent row) and surfaced as a native MCP prompt on the agent's
+ * gateway — so it shows up as an icebreaker, on the org home, and via `/`
+ * mentions, exactly like a prompt exposed by a connected MCP.
+ */
+export const AgentKickstartPromptSchema = z.object({
+  title: z.string().min(1).max(120).describe("Short label shown on the chip"),
+  description: z
+    .string()
+    .max(280)
+    .optional()
+    .describe("One-line subtitle shown under the title"),
+  text: z
+    .string()
+    .min(1)
+    .describe("The message sent to the agent when the prompt is clicked"),
+});
+
+export type AgentKickstartPrompt = z.infer<typeof AgentKickstartPromptSchema>;
+
+/**
  * Input schema for creating virtual MCPs
  */
 export const VirtualMCPCreateDataSchema = z.object({
@@ -696,6 +717,12 @@ export const VirtualMCPCreateDataSchema = z.object({
     .array(VirtualMCPConnectionInputSchema)
     .describe(
       "Connections to include/exclude (can be empty for exclusion mode)",
+    ),
+  prompts: z
+    .array(AgentKickstartPromptSchema)
+    .optional()
+    .describe(
+      "Optional kickstart prompts to seed on the agent. Each becomes a clickable conversation starter (icebreaker) on the agent. Author them from the agent's role and the tools it will have so they're coherent and immediately useful.",
     ),
 });
 

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -796,6 +796,12 @@ export const VirtualMCPUpdateDataSchema = z.object({
     .array(VirtualMCPConnectionInputSchema)
     .optional()
     .describe("New connections (replaces existing)"),
+  prompts: z
+    .array(AgentKickstartPromptSchema)
+    .optional()
+    .describe(
+      "Replace the agent's kickstart prompts with this full set. Omit to leave them unchanged; pass an empty array to remove all. Each becomes a clickable conversation starter (icebreaker).",
+    ),
 });
 
 export type VirtualMCPUpdateData = z.infer<typeof VirtualMCPUpdateDataSchema>;


### PR DESCRIPTION
## Summary

`COLLECTION_VIRTUAL_MCP_CREATE` (the agent-create tool) gains an optional **`prompts`** field. Prompts passed at create time seed the new agent with **kickstart prompts** — clickable conversation starters (icebreakers) that make an empty agent immediately useful.

The tool description and the Agent Manager / agent guides now instruct authoring **coherent** starters derived from the agent's role/instructions and the descriptions of the tools it will have — not generic "How can I help?" greetings.

## How it works

- **Persist:** seeded prompts are written to a dedicated org-fs volume (`agent-prompts`, one JSON file per prompt at `<agentId>/<slug>.json`). They are **not** stored on the agent row, and the volume is intentionally not in the sandbox mount set, so seeding never pollutes the org's sandbox home. This mirrors the existing skills-catalog pattern.
- **Serve:** `PassthroughClient` (the agent gateway) now injects these into `listPrompts()` — namespaced under the agent id — and resolves them in `getPrompt()`. Because everything downstream already consumes the gateway's `prompts/list` / `prompts/get`, they surface as **icebreakers**, on the **org home** next-actions, and via **`/` mentions** with **zero frontend changes**.

## Files

- `packages/mesh-sdk/src/types/virtual-mcp.ts` — `AgentKickstartPromptSchema` (`title`, `description?`, `text`) + optional `prompts` on `VirtualMCPCreateDataSchema`.
- `apps/mesh/src/file-storage/agent-prompts.ts` — org-fs read/write helpers (bounded, best-effort, never throw).
- `apps/mesh/src/tools/virtual/create.ts` — seed prompts after create; updated description.
- `apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts` — inject/resolve seeded prompts on the gateway.
- `apps/mesh/src/tools/virtual/studio-pack/agent-manager.ts`, `apps/mesh/src/tools/guides/agents.ts` — instructions to author coherent kickstart prompts from role + tool descriptions.

## Testing

- `bun run check` (all workspaces), `bun run lint` (0 errors), `bun run fmt` pass.
- Existing `passthrough-client.test.ts` passes.
- Seeding is best-effort: a failed prompt write logs and is skipped rather than failing agent creation.

## Notes / follow-ups

- Scope is **create-only** (as requested); `COLLECTION_VIRTUAL_MCP_UPDATE` does not yet manage seeded prompts.
- An **e2e** test for the create → icebreaker round-trip (real Postgres + org-fs) is the appropriate home for a wire-contract test and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds kickstart prompts to agent creation and now lets you edit or remove them on update/delete. Prompts persist in org-fs and are served as native MCP prompts, so they show as icebreakers and via `/` mentions with no UI changes.

- **New Features**
  - `COLLECTION_VIRTUAL_MCP_CREATE` accepts optional `prompts` (`AgentKickstartPromptSchema`), seeded after create; best‑effort and non‑blocking.
  - `COLLECTION_VIRTUAL_MCP_UPDATE` adds `prompts` to fully replace the set; pass `[]` to clear. Writes are idempotent (clear‑then‑write).
  - `COLLECTION_VIRTUAL_MCP_DELETE` cleans up the `agent-prompts/<agentId>/` subtree on delete.
  - Storage: prompts persist to `agent-prompts` (JSON, max 20); not on the agent row and not mounted in the sandbox.
  - Gateway: `PassthroughClient` injects prompts in `listPrompts()` and resolves them in `getPrompt()` with agent‑id namespacing; per‑instance cache; never throws.
  - Guides updated to author coherent starters from the agent’s role and its tools.

- **Bug Fixes**
  - Removed an unused export in `agent-prompts.ts` (knip).

<sup>Written for commit 09db5f4be10e7b5d40bb866a40e89e9effb818c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

