### PR TITLE
fix(pwa): drop stale install prompt after dismissal

### DIFF
--- a/apps/mesh/src/web/lib/pwa-install.test.tsx
+++ b/apps/mesh/src/web/lib/pwa-install.test.tsx
@@ -1,0 +1,35 @@
+import { setupComponentTest } from "../../test/setup";
+setupComponentTest();
+import { describe, expect, it } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+import { initPwaInstallCapture, usePwaInstall } from "./pwa-install";
+
+function dispatchBeforeInstallPrompt(outcome: "accepted" | "dismissed") {
+  const event = Object.assign(
+    new Event("beforeinstallprompt", { cancelable: true }),
+    {
+      prompt: async () => {},
+      userChoice: Promise.resolve({ outcome, platform: "web" }),
+    },
+  );
+  window.dispatchEvent(event);
+}
+
+describe("usePwaInstall", () => {
+  it("drops a dismissed prompt so a second click doesn't silently no-op", async () => {
+    initPwaInstallCapture();
+    const { result } = renderHook(() => usePwaInstall());
+
+    await act(async () => {
+      dispatchBeforeInstallPrompt("dismissed");
+    });
+    expect(result.current.canPrompt).toBe(true);
+
+    await act(async () => {
+      const outcome = await result.current.promptInstall();
+      expect(outcome).toBe("dismissed");
+    });
+
+    expect(result.current.canPrompt).toBe(false);
+  });
+});

--- a/apps/mesh/src/web/lib/pwa-install.ts
+++ b/apps/mesh/src/web/lib/pwa-install.ts
@@ -150,12 +150,14 @@ export function usePwaInstall(): PwaInstall {
     ios: isIos(),
     promptInstall: async () => {
       if (!deferredPrompt) return "unavailable";
-      await deferredPrompt.prompt();
-      const choice = await deferredPrompt.userChoice;
-      if (choice.outcome === "accepted") {
-        deferredPrompt = null;
-        emit();
-      }
+      const promptEvent = deferredPrompt;
+      await promptEvent.prompt();
+      const choice = await promptEvent.userChoice;
+      // The event fires only once — whether accepted or dismissed, it can't
+      // be reused, so it must be dropped either way or the button would look
+      // clickable but silently do nothing on a second try.
+      deferredPrompt = null;
+      emit();
       return choice.outcome;
     },
   };


### PR DESCRIPTION
## Source
Bug found reading `apps/mesh/src/web/lib/pwa-install.ts` (recently-changed file).

## Bug
`promptInstall()` only cleared `deferredPrompt` when the user accepted the native install prompt. The `beforeinstallprompt` event can only be triggered once — after the user responds at all (accept *or* dismiss), Chromium won't show the native UI again for that same captured event.

Failure scenario: user clicks the org-install button, sees the native prompt, dismisses it. `canPrompt` stays `true` (the button still renders as installable). Clicking it again calls `.prompt()` on the already-resolved event, which silently no-ops — no native UI appears, no error — until a full page reload lets a fresh `beforeinstallprompt` fire.

Fix: clear `deferredPrompt` regardless of outcome (accepted or dismissed), matching the standard once-only lifecycle of this event.

## Test
Added `apps/mesh/src/web/lib/pwa-install.test.tsx`, which dispatches a mocked `beforeinstallprompt`, resolves it as `"dismissed"`, and asserts `canPrompt` becomes `false` afterward. Verified it fails on the pre-fix code and passes after the fix.

Reviewer can confirm with:
```
bun test apps/mesh/src/web/lib/pwa-install.test.tsx
```

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` (apps/mesh) — no new errors introduced (3 pre-existing unrelated module-resolution errors in other files)
- `bun test apps/mesh/src/web/lib/pwa-install.test.tsx` — passes

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale PWA install prompt handling by clearing the captured `beforeinstallprompt` event after any user response. Prevents the install button from appearing clickable and then silently doing nothing after a dismissal.

- **Bug Fixes**
  - Clear `deferredPrompt` whether the prompt is accepted or dismissed, and emit state so `canPrompt` updates correctly.
  - Added `apps/mesh/src/web/lib/pwa-install.test.tsx` to cover the dismissal case and ensure `canPrompt` becomes false.

<sup>Written for commit f85b723f63fd1bfd14416e91259e5f05d510e37e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

