### PR TITLE
fix(decopilot): stop leaking raw JSON parts into auto-titles

### DIFF
--- a/packages/harness/src/claude-code/index.ts
+++ b/packages/harness/src/claude-code/index.ts
@@ -161,14 +161,17 @@ export const claudeCodeHarnessFactory: HarnessFactory = {
         const titleHandle = needsTitle
           ? genTitle({
               abortSignal: input.signal,
-              model: createClaudeCodeModel(
-                resolveClaudeCodeModelId("claude-code:haiku"),
-                {
-                  toolApprovalLevel: "readonly",
-                  isPlanMode: true,
-                  cwd,
-                },
-              ),
+              models: [
+                () =>
+                  createClaudeCodeModel(
+                    resolveClaudeCodeModelId("claude-code:haiku"),
+                    {
+                      toolApprovalLevel: "readonly",
+                      isPlanMode: true,
+                      cwd,
+                    },
+                  ),
+              ],
               userMessage: extractUserText(messages),
             })
           : null;

--- a/packages/harness/src/codex/index.ts
+++ b/packages/harness/src/codex/index.ts
@@ -175,7 +175,7 @@ export const codexHarnessFactory: HarnessFactory = {
                   });
                 const handle = genTitle({
                   abortSignal: input.signal,
-                  model: titleModel,
+                  models: [() => titleModel],
                   userMessage: extractUserText(messages),
                 });
                 const closed = handle.promise.finally(() =>

--- a/packages/harness/src/decopilot/run-stream.ts
+++ b/packages/harness/src/decopilot/run-stream.ts
@@ -48,6 +48,8 @@ import { makeTitleResultChunk } from "../title-chunk";
 import { shouldGenerateTitle } from "../title-merge";
 import { createLanguageModel } from "./mesh-provider";
 import { genTitle } from "../title-generator";
+import { extractUserText } from "../cli-message-prep";
+import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type { ChatMessage, HarnessStreamInput, ModelSelection } from "../types";
 import type {
   AssembledEngineHandle,
@@ -311,17 +313,36 @@ export async function* runDecopilotStream(
     currentThreadTitle: extras.currentThreadTitle,
     kind: extras.kind,
   });
-  const userMessageText = JSON.stringify(processedMessages[0]?.content ?? "");
+  // Extract the user-visible text (NOT the JSON-stringified parts array — that
+  // would leak `[{"type":"text",...}]` into the fallback title).
+  const userMessageText = extractUserText(processedMessages);
+  // Ordered fallback chain, fast/cheap first: a per-run title override, then
+  // fast → smart → thinking. Lazy factories: models are built only when
+  // genTitle actually tries them, and only when a title is needed — so a slot
+  // whose provider can't build a model just fails that attempt (rotating to
+  // the next / clean fallback) instead of crashing the whole run stream.
+  const titleModelChain = ((): Array<() => LanguageModelV3> => {
+    if (!needsTitle) return [];
+    const seen = new Set<string>();
+    const chain: Array<() => LanguageModelV3> = [];
+    const push = (
+      prov: MeshProvider,
+      sel: ModelSelection | null | undefined,
+    ) => {
+      if (!sel || seen.has(sel.id)) return;
+      seen.add(sel.id);
+      chain.push(() => createLanguageModel(prov, sel) as never);
+    };
+    push(titleProvider ?? provider, titleModel);
+    push(provider, input.models.fast);
+    push(provider, input.models.smart);
+    push(provider, input.models.thinking);
+    return chain;
+  })();
   const titleHandle = needsTitle
     ? genTitle({
         abortSignal: registrySignal,
-        model: createLanguageModel(
-          titleProvider ?? provider,
-          titleModel ??
-            input.models.fast ??
-            input.models.smart ??
-            input.models.thinking,
-        ) as never,
+        models: titleModelChain,
         userMessage: userMessageText,
       })
     : null;

--- a/packages/harness/src/title-generator.test.ts
+++ b/packages/harness/src/title-generator.test.ts
@@ -56,10 +56,65 @@ function makeHangingModel(): LanguageModelV3 {
   } as unknown as LanguageModelV3;
 }
 
+/** A model that returns a fixed title object via doGenerate. */
+function makeSucceedingModel(title: string): LanguageModelV3 {
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "ok",
+    doGenerate: async () => ({
+      content: [{ type: "text", text: JSON.stringify({ title }) }],
+      finishReason: "stop",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      warnings: [],
+    }),
+    doStream: async () => {
+      throw new Error("no stream");
+    },
+  } as unknown as LanguageModelV3;
+}
+
+describe("genTitle model fallback chain", () => {
+  test("rotates to the next model when the first keeps failing", async () => {
+    const handle = genTitle({
+      models: [
+        () => makeFailingModel(new Error("first boom")),
+        () => makeSucceedingModel("Second model title"),
+      ],
+      userMessage: "does not matter",
+    });
+    const result = await handle.promise;
+    expect(result).toBe("Second model title");
+  });
+
+  test("a factory that throws at build time fails only its attempt, then rotates", async () => {
+    const handle = genTitle({
+      models: [
+        () => {
+          throw new Error("provider has no aiSdk"); // unbuildable slot
+        },
+        () => makeSucceedingModel("Built by the second slot"),
+      ],
+      userMessage: "does not matter",
+    });
+    const result = await handle.promise;
+    expect(result).toBe("Built by the second slot");
+  });
+
+  test("empty model list falls back to clamped user message (never a broken title)", async () => {
+    const handle = genTitle({
+      models: [],
+      userMessage: "Fix the login button on mobile devices please",
+    });
+    const result = await handle.promise;
+    expect(result).toBe("Fix the login button on mobile d");
+  });
+});
+
 describe("genTitle fallback", () => {
   test("self-timeout (slow/hung model) falls back to clamped user message, not null", async () => {
     const handle = genTitle({
-      model: makeHangingModel(),
+      models: [() => makeHangingModel()],
       userMessage: "Build a complex dashboard app",
       timeoutMs: 10, // tiny self-timeout; no parent abort, no finish()
     });
@@ -72,7 +127,7 @@ describe("genTitle fallback", () => {
     const abortController = new AbortController();
     const handle = genTitle({
       abortSignal: abortController.signal,
-      model: makeFailingModel(new Error("provider boom")),
+      models: [() => makeFailingModel(new Error("provider boom"))],
       userMessage: "Fix the login button on mobile devices please",
     });
     handle.finish();
@@ -85,7 +140,7 @@ describe("genTitle fallback", () => {
     const abortController = new AbortController();
     const handle = genTitle({
       abortSignal: abortController.signal,
-      model: makeFailingModel(new Error("boom")),
+      models: [() => makeFailingModel(new Error("boom"))],
       userMessage: "  hi  ",
     });
     handle.finish();
@@ -97,7 +152,7 @@ describe("genTitle fallback", () => {
     const abortController = new AbortController();
     const handle = genTitle({
       abortSignal: abortController.signal,
-      model: makeFailingModel(new Error("boom")),
+      models: [() => makeFailingModel(new Error("boom"))],
       userMessage: "01234567890123456789012345678901",
     });
     handle.finish();
@@ -109,7 +164,7 @@ describe("genTitle fallback", () => {
     const abortController = new AbortController();
     const handle = genTitle({
       abortSignal: abortController.signal,
-      model: makeFailingModel(new Error("boom")),
+      models: [() => makeFailingModel(new Error("boom"))],
       userMessage: "",
     });
     handle.finish();
@@ -121,7 +176,7 @@ describe("genTitle fallback", () => {
     const abortController = new AbortController();
     const handle = genTitle({
       abortSignal: abortController.signal,
-      model: makeFailingModel(new Error("boom")),
+      models: [() => makeFailingModel(new Error("boom"))],
       userMessage: "!?!?.....",
     });
     handle.finish();
@@ -136,7 +191,7 @@ describe("genTitle fallback", () => {
     // instead of throwing `addEventListener of undefined`.
     const handle = genTitle({
       abortSignal: undefined,
-      model: makeFailingModel(new Error("boom")),
+      models: [() => makeFailingModel(new Error("boom"))],
       userMessage: "Fix the login button on mobile devices please",
     });
     handle.finish();
@@ -149,9 +204,12 @@ describe("genTitle fallback", () => {
     abortController.abort();
     const handle = genTitle({
       abortSignal: abortController.signal,
-      model: makeFailingModel(
-        Object.assign(new Error("aborted"), { name: "AbortError" }),
-      ),
+      models: [
+        () =>
+          makeFailingModel(
+            Object.assign(new Error("aborted"), { name: "AbortError" }),
+          ),
+      ],
       userMessage: "anything at all",
     });
     handle.finish();

--- a/packages/harness/src/title-generator.ts
+++ b/packages/harness/src/title-generator.ts
@@ -5,6 +5,7 @@
  */
 
 import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { retry } from "@decocms/std";
 import { generateObject } from "ai";
 import { z } from "zod";
 
@@ -48,20 +49,30 @@ const POST_STREAM_GRACE_MS = 10_000;
 // promptly so a title appears soon after submit.
 const TITLE_GEN_TIMEOUT_MS = 20_000;
 const FALLBACK_TITLE_MAX_CHARS = 32;
+// Total title-generation attempts before falling back. Each attempt uses the
+// next model in `models` (clamped to the last), so a fast/cheap model is tried
+// first and a slower/stronger one only if it keeps failing.
+const TITLE_GEN_MAX_ATTEMPTS = 3;
 
 export function genTitle(config: {
   /** Optional: aborts title generation when the parent stream is cancelled.
    *  Undefined on the desktop/pull path, where the harness runs from a
    *  serialized wire input that cannot carry a (non-serializable) AbortSignal. */
   abortSignal?: AbortSignal;
-  model: LanguageModelV3;
+  /** Ordered fallback chain, fast/cheap first — each entry is a lazy factory
+   *  so an unbuildable model fails only its own attempt (never at call time).
+   *  Attempt N uses `models[N]`, clamped to the last entry once exhausted. */
+  models: Array<() => LanguageModelV3>;
   userMessage: string;
   /** Override the self-timeout (ms) before falling back to the clamped user
    *  message. Defaults to {@link TITLE_GEN_TIMEOUT_MS}. Tests pass a tiny value. */
   timeoutMs?: number;
+  /** Override the attempt cap. Defaults to {@link TITLE_GEN_MAX_ATTEMPTS}. */
+  maxAttempts?: number;
 }): { promise: Promise<string | null>; finish: () => void } {
-  const { abortSignal, model, userMessage } = config;
+  const { abortSignal, models, userMessage } = config;
   const timeoutMs = config.timeoutMs ?? TITLE_GEN_TIMEOUT_MS;
+  const maxAttempts = Math.max(1, config.maxAttempts ?? TITLE_GEN_MAX_ATTEMPTS);
 
   const titleAbortController = new AbortController();
 
@@ -102,15 +113,35 @@ export function genTitle(config: {
   })();
 
   const promise = (async (): Promise<string | null> => {
+    // No model to try → deterministic fallback, never a broken title.
+    if (models.length === 0) return fallbackTitle;
     try {
-      const result = await generateObject({
-        model,
-        schema: TITLE_SCHEMA,
-        system: TITLE_GENERATOR_PROMPT,
-        messages: [{ role: "user", content: userMessage }],
-        temperature: 0.2,
-        abortSignal: titleAbortController.signal,
-      });
+      let attempt = -1;
+      const result = await retry(
+        () => {
+          attempt++;
+          // Guarded non-empty above, so this index is always in range. Build
+          // the model lazily here so a factory that throws counts as a failed
+          // attempt (retried / rotated) rather than crashing the caller.
+          const model = models[Math.min(attempt, models.length - 1)]!();
+          return generateObject({
+            model,
+            schema: TITLE_SCHEMA,
+            system: TITLE_GENERATOR_PROMPT,
+            messages: [{ role: "user", content: userMessage }],
+            temperature: 0.2,
+            abortSignal: titleAbortController.signal,
+          });
+        },
+        {
+          maxAttempts,
+          minTimeout: 200,
+          maxTimeout: 2_000,
+          // Don't retry a cancel/timeout — only genuine model failures.
+          isRetriable: (err) => (err as Error)?.name !== "AbortError",
+          signal: titleAbortController.signal,
+        },
+      );
 
       const title = result.object.title
         .replace(/[.!?]$/, "") // Remove trailing punctuation
@@ -122,7 +153,10 @@ export function genTitle(config: {
 
       return title;
     } catch (error) {
-      const err = error as Error;
+      // On exhaustion `retry` throws a RetryError wrapping the last failure in
+      // `.cause`; on abort it rethrows the AbortError directly. Unwrap so the
+      // abort-vs-failure branch below sees the real error either way.
+      const err = ((error as { cause?: unknown }).cause ?? error) as Error;
       if (err.name === "AbortError") {
         // Parent stream was cancelled (user hit stop) → do NOT title a cancelled
         // run; emit nothing.


### PR DESCRIPTION
## Problem

Auto-generated conversation titles were coming out as raw JSON, e.g.:

```
[{"type":"text","text":"hello sy
```

## Root cause

The decopilot harness stream built the title input with
`JSON.stringify(processedMessages[0].content)` (`run-stream.ts:314`).
`content` is a parts array, so:

1. The title-model prompt received serialized JSON, and
2. more damagingly, the **deterministic fallback** in `title-generator.ts`
   sliced that JSON string — so any time the title model failed or timed
   out (common on the openrouter / deco AI gateway path) the persisted
   title was the first 32 chars of `[{"type":"text",...}]`.

The CLI harnesses (Claude Code, Codex) already did this right via
`extractUserText`; only the decopilot path stringified.

## Fix

- **Extract clean text** with the existing `extractUserText` helper instead
  of stringifying. The fallback is now always plain user text — a broken
  title can no longer be persisted.
- **Fallback model chain + retries**: `genTitle` now takes an ordered
  `models` chain (fast/cheap first: `fast → smart → thinking`) and retries
  up to 3 times across it via `@decocms/std` `retry` before falling back,
  so a single flaky model no longer forces the fallback.

## Testing

- Updated + extended `title-generator.test.ts` (10 tests pass), including a
  new case proving the chain rotates to the next model on failure and that
  an empty model list still yields a clean fallback (never broken JSON).
- `bun run check` (apps/mesh + packages/harness) and `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Decopilot auto-title JSON leaks and makes title generation more reliable. Titles now use clean user text and a lazy, multi-model retry chain before falling back.

- **Bug Fixes**
  - Decopilot now builds title input with `extractUserText`; fallback titles are plain text (no `[{"type":"text"...}]`).
  - `genTitle` takes `models: Array<() => LanguageModelV3>` and retries up to 3 times via `@decocms/std` `retry` (skips `AbortError`) before falling back to a clamped user message.
  - Decopilot constructs an ordered chain: optional per-run title override, then `fast → smart → thinking` (deduped). `claude-code` and `codex` harnesses updated to pass `models`; tests cover rotation, build-time factory errors, and empty-list fallback.

<sup>Written for commit a610a9d0195cf0c5500ed3d9a0696c1b112e724a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

