### PR TITLE
fix(sandbox): make installProtectedBranchHook async

### DIFF
--- a/packages/sandbox/daemon/git/protect-branch.test.ts
+++ b/packages/sandbox/daemon/git/protect-branch.test.ts
@@ -22,10 +22,10 @@ function runHook(
 }
 
 describe("installProtectedBranchHook", () => {
-  it("installs an executable pre-push hook", () => {
+  it("installs an executable pre-push hook", async () => {
     const repoDir = mkdtempSync(join(tmpdir(), "protect-branch-"));
     try {
-      installProtectedBranchHook(repoDir);
+      await installProtectedBranchHook(repoDir);
       const hookPath = join(repoDir, ".git", "hooks", "pre-push");
       expect(statSync(hookPath).mode & 0o777).toBe(0o755);
     } finally {
@@ -33,10 +33,10 @@ describe("installProtectedBranchHook", () => {
     }
   });
 
-  it("blocks pushes to main/master and allows other branches", () => {
+  it("blocks pushes to main/master and allows other branches", async () => {
     const repoDir = mkdtempSync(join(tmpdir(), "protect-branch-"));
     try {
-      installProtectedBranchHook(repoDir);
+      await installProtectedBranchHook(repoDir);
       const hookPath = join(repoDir, ".git", "hooks", "pre-push");
 
       const main = runHook(hookPath, "refs/heads/main");

--- a/packages/sandbox/daemon/git/protect-branch.ts
+++ b/packages/sandbox/daemon/git/protect-branch.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 const HOOK = `#!/bin/sh
@@ -14,10 +14,14 @@ done
 exit 0
 `;
 
-export function installProtectedBranchHook(repoDir: string): void {
+// Sync fs here would block the daemon's single event loop long enough to
+// miss a health probe (CONTRIBUTING.md rule #4) — use the async variants.
+export async function installProtectedBranchHook(
+  repoDir: string,
+): Promise<void> {
   const hooksDir = join(repoDir, ".git", "hooks");
-  mkdirSync(hooksDir, { recursive: true });
+  await mkdir(hooksDir, { recursive: true });
   const hookPath = join(hooksDir, "pre-push");
-  writeFileSync(hookPath, HOOK, { encoding: "utf-8" });
-  chmodSync(hookPath, 0o755);
+  await writeFile(hookPath, HOOK, { encoding: "utf-8" });
+  await chmod(hookPath, 0o755);
 }

--- a/packages/sandbox/daemon/setup/orchestrator.test.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.test.ts
@@ -745,7 +745,7 @@ describe("SetupOrchestrator install-step branch protection", () => {
     try {
       const repoDir = join(dir, "repo");
       mkdirSync(repoDir);
-      installProtectedBranchHook(repoDir);
+      await installProtectedBranchHook(repoDir);
       const hookPath = join(repoDir, ".git", "hooks", "pre-push");
 
       // A separate script file avoids shell/JSON quoting entirely.

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -418,7 +418,7 @@ export class SetupOrchestrator {
     // overwrite .git/hooks/pre-push; reinstall so branch protection survives.
     if (config.repoDir) {
       try {
-        installProtectedBranchHook(config.repoDir);
+        await installProtectedBranchHook(config.repoDir);
       } catch (e) {
         this.chunk(
           `\r\n[orchestrator] warning: could not reinstall protected-branch hook: ${(e as Error).message}\r\n`,
@@ -610,7 +610,7 @@ export class SetupOrchestrator {
     }
     if (config.repoDir) {
       try {
-        installProtectedBranchHook(config.repoDir);
+        await installProtectedBranchHook(config.repoDir);
       } catch (e) {
         this.chunk(
           `\r\n[orchestrator] warning: could not install protected-branch hook: ${(e as Error).message}\r\n`,


### PR DESCRIPTION
## Source

Bug found reading recently-changed sandbox daemon code (#4440 added a second call site to `installProtectedBranchHook`).

## Why

`installProtectedBranchHook` used `mkdirSync`/`writeFileSync`/`chmodSync` (`packages/sandbox/daemon/git/protect-branch.ts`). The daemon runs on a single Bun event loop, and this repo's own `CONTRIBUTING.md` rule #4 (and `CLAUDE.md` gotcha #8) calls out sync fs in this package as a hard rule, not a style nit: a single missed health probe flips a healthy sandbox to "crashed" and tears the pod down mid-session. #4440 just added a *second* call site for this same function (reinstalling the hook right after every real `install` completes, in addition to the existing `gitSetup()` call), doubling how often this sync work runs on the hot path.

## Fix

Switch `installProtectedBranchHook` to `node:fs/promises` (`mkdir`/`writeFile`/`chmod`) and `await` it at both call sites in `orchestrator.ts` (both are already inside `async` methods with `try/catch`, so this is a drop-in change).

## Test plan

- `bun test packages/sandbox/daemon/git/protect-branch.test.ts` — 2 pass
- `bun test packages/sandbox/daemon/setup/orchestrator.test.ts` — 12 pass, including the "reinstalls the pre-push hook after an install script clobbers it" regression test added by #4440
- `bun run fmt` — clean

Full CI will validate the rest (typecheck across the monorepo needs `bun install`, which I didn't run since this diff touches no dependencies).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make branch-protection hook installation async to stop blocking the sandbox daemon’s event loop. This prevents missed health probes and improves reliability during setup and post-install.

- **Bug Fixes**
  - Converted `installProtectedBranchHook` to use `node:fs/promises` and made it `async` (`mkdir`/`writeFile`/`chmod`).
  - Awaited the hook install at both `SetupOrchestrator` call sites so reinstalling happens without blocking.
  - Updated tests to `await installProtectedBranchHook`.

<sup>Written for commit 6515f8ba275d63b3c5a6276f2f7b785f39cd3fdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

