### PR TITLE
feat(chat): back-to-previous-thread from a created agent (⌘[)

### DIFF
--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -23,6 +23,7 @@ import {
   useMatch,
   useNavigate,
   useParams,
+  useRouter,
   useSearch,
 } from "@tanstack/react-router";
 import { KEYS } from "../lib/query-keys";
@@ -218,6 +219,7 @@ function ShellLayoutContent() {
   const org = orgMatch?.params.org;
   const { taskId } = useParams({ strict: false }) as { taskId?: string };
   const [shortcutsDialogOpen, setShortcutsDialogOpen] = useState(false);
+  const router = useRouter();
 
   useQuery({
     ...homeNextActionsQueryOptions(org ?? ""),
@@ -230,17 +232,29 @@ function ShellLayoutContent() {
   const userId = session?.user?.id;
   const cachedOrg = org && userId ? readCachedOrg(userId, org) : null;
 
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect — subscribes to document keydown for ⌘K shortcuts dialog; DOM event listener has no React 19 alternative
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect — subscribes to document keydown for ⌘K / ⌘[ shortcuts; DOM event listener has no React 19 alternative
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent) => {
       if (isModKey(e) && e.code === "KeyK") {
         e.preventDefault();
         setShortcutsDialogOpen(true);
+        return;
+      }
+      // ⌘[ / Ctrl+[ — back to the previous thread. Own the chord (preventDefault)
+      // so it uses SPA history instead of a full browser navigation; skip when
+      // there's nothing to go back to so cold entry doesn't leave the app.
+      if (
+        isModKey(e) &&
+        e.code === "BracketLeft" &&
+        router.history.canGoBack()
+      ) {
+        e.preventDefault();
+        router.history.back();
       }
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, []);
+  }, [router]);
 
   const { data: activeOrg } = useSuspenseQuery({
     queryKey: KEYS.activeOrganization(org),

--- a/apps/mesh/src/web/lib/keyboard-shortcuts.ts
+++ b/apps/mesh/src/web/lib/keyboard-shortcuts.ts
@@ -18,6 +18,7 @@ interface ShortcutGroup {
 
 export const KEYBOARD_SHORTCUTS = {
   keyboardShortcuts: { keys: [MOD, "K"], description: "Keyboard shortcuts" },
+  back: { keys: [MOD, "["], description: "Back to previous" },
   focusChatInput: { keys: [MOD, "L"], description: "Focus chat input" },
   saveAndFormat: { keys: [MOD, "S"], description: "Save & format" },
   sendMessage: { keys: ["Enter"], description: "Send message" },
@@ -43,6 +44,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     label: "General",
     shortcuts: [
       KEYBOARD_SHORTCUTS.keyboardShortcuts,
+      KEYBOARD_SHORTCUTS.back,
       KEYBOARD_SHORTCUTS.newTask,
       KEYBOARD_SHORTCUTS.toggleDaemon,
     ],


### PR DESCRIPTION
## Summary

Follow-up on the `COLLECTION_VIRTUAL_MCP_CREATE` tool UI. That card's **See agent** button (`agent-create.tsx` → `useNavigateToAgent`) pushes a brand-new thread for the created agent, and `useEnsureTask` creates that thread *in place* — no `replace`, no redirect. So the creating agent's thread stays as the previous history entry.

That means **browser back** (and the browser's native keyboard back) already return to the creating thread. This PR closes the remaining gap: an **in-app keyboard shortcut** so it's discoverable and consistent.

## Changes
- `⌘[` / `Ctrl+[` → `router.history.back()`, guarded by `router.history.canGoBack()` so cold entry can't leave the app. `preventDefault()` owns the chord so it uses SPA history instead of a full browser navigation.
- Registered the shortcut in the keyboard-shortcuts dialog (General group).

No new navbar button — the toolbar logo already covers "home", and browser/keyboard back cover "previous".

## Testing
- `bun run check` (tsc) — clean
- `bun run lint` (oxlint) — no new warnings (8 pre-existing in `packages/e2e`)
- Back navigation to the previous thread verified by code path (push nav + in-place thread create); not exercised in a live browser session.