### PR TITLE
fix(harness): stop title generation hanging the run when the provider ignores abort

### DIFF
--- a/packages/harness/src/title-generator.test.ts
+++ b/packages/harness/src/title-generator.test.ts
@@ -56,6 +56,23 @@ function makeHangingModel(): LanguageModelV3 {
   } as unknown as LanguageModelV3;
 }
 
+/** A model whose doGenerate never settles and IGNORES the abort signal —
+ *  simulates a hung title app-server that black-holes the request. Without the
+ *  settlement latch, `retry` (which only observes the signal between attempts)
+ *  awaits this forever and genTitle's promise never resolves, hanging the parent
+ *  run's drain loop. The latch must cap settlement at the timeout regardless. */
+function makeUnabortableModel(): LanguageModelV3 {
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "test",
+    doGenerate: () => new Promise(() => {}), // never resolves, ignores abort
+    doStream: async () => {
+      throw new Error("no stream");
+    },
+  } as unknown as LanguageModelV3;
+}
+
 /** A model that returns a fixed title object via doGenerate. */
 function makeSucceedingModel(title: string): LanguageModelV3 {
   return {
@@ -121,6 +138,20 @@ describe("genTitle fallback", () => {
     const result = await handle.promise;
     // First 32 chars of "Build a complex dashboard app".
     expect(result).toBe("Build a complex dashboard app");
+  });
+
+  test("provider that IGNORES the abort signal still settles to the fallback (does not hang)", async () => {
+    // Regression: the self-timeout only *signals* an abort; `retry` awaits the
+    // in-flight call and can't observe the signal mid-attempt. A provider that
+    // black-holes the request would leave the promise pending forever and hang
+    // the parent run's drain loop. The settlement latch must resolve it anyway.
+    const handle = genTitle({
+      models: [() => makeUnabortableModel()],
+      userMessage: "Ship the unabortable fix",
+      timeoutMs: 10,
+    });
+    const result = await handle.promise;
+    expect(result).toBe("Ship the unabortable fix");
   });
 
   test("when the LLM throws, falls back to userMessage.slice(0, 32).trim()", async () => {

--- a/packages/harness/src/title-generator.ts
+++ b/packages/harness/src/title-generator.ts
@@ -76,31 +76,6 @@ export function genTitle(config: {
 
   const titleAbortController = new AbortController();
 
-  // Abort title generation if parent stream is aborted. `abortSignal` is
-  // optional-at-runtime: on the desktop/pull path the serialized wire input
-  // omits the (non-serializable) AbortSignal, and a caller may legitimately
-  // have nothing to tie lifetime to. Guard so a missing signal degrades to "no
-  // parent abort wiring" instead of throwing `addEventListener of undefined`.
-  const onParentAbort = () => titleAbortController.abort();
-  abortSignal?.addEventListener("abort", onParentAbort, { once: true });
-
-  let graceTimeoutId: ReturnType<typeof setTimeout> | undefined;
-
-  // Self-timeout: cap title generation so a slow/hung title model falls back to
-  // the clamped user message promptly (≈ right after submit) instead of only
-  // resolving when the main stream ends. Fires regardless of stream lifetime.
-  const selfTimeoutId = setTimeout(() => {
-    titleAbortController.abort();
-  }, timeoutMs);
-
-  // Called when the main LLM stream finishes — gives the title a grace
-  // period to complete, then aborts so onFinish doesn't hang.
-  const finish = () => {
-    graceTimeoutId = setTimeout(() => {
-      titleAbortController.abort();
-    }, POST_STREAM_GRACE_MS);
-  };
-
   // Fallback used when the LLM call errors or produces unusable output.
   // Spec: take the literal first 32 characters of the user message, trim,
   // and fall through to "New chat" if there's no usable letter/digit.
@@ -112,7 +87,53 @@ export function genTitle(config: {
     return hasUsableText(candidate) ? candidate : "New chat";
   })();
 
-  const promise = (async (): Promise<string | null> => {
+  // Guaranteed-settlement latch. The timers/parent-abort below only *signal* an
+  // abort on `titleAbortController`; whether the in-flight `generateObject`
+  // actually rejects depends on the provider honoring that signal — and `retry`
+  // observes the abort only *between* attempts, never during an in-flight call.
+  // A hung title app-server that ignores the signal would otherwise leave the
+  // returned promise pending forever, hanging the parent run's drain loop (which
+  // gates stream completion on the title settling). Racing the generation against
+  // this latch caps settlement at the timeout regardless of provider behavior.
+  // ponytail: the ignored in-flight request leaks until it settles or the process
+  // exits — acceptable; the alternative is hanging the whole run.
+  let settleLatch!: (v: string | null) => void;
+  const latch = new Promise<string | null>((resolve) => {
+    settleLatch = resolve;
+  });
+
+  // Abort title generation if parent stream is aborted. `abortSignal` is
+  // optional-at-runtime: on the desktop/pull path the serialized wire input
+  // omits the (non-serializable) AbortSignal, and a caller may legitimately
+  // have nothing to tie lifetime to. Guard so a missing signal degrades to "no
+  // parent abort wiring" instead of throwing `addEventListener of undefined`.
+  // Cancelled run → resolve the latch with null so no title is emitted.
+  const onParentAbort = () => {
+    titleAbortController.abort();
+    settleLatch(null);
+  };
+  abortSignal?.addEventListener("abort", onParentAbort, { once: true });
+
+  let graceTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  // Self-timeout: cap title generation so a slow/hung title model falls back to
+  // the clamped user message promptly (≈ right after submit) instead of only
+  // resolving when the main stream ends. Fires regardless of stream lifetime.
+  const selfTimeoutId = setTimeout(() => {
+    titleAbortController.abort();
+    settleLatch(fallbackTitle);
+  }, timeoutMs);
+
+  // Called when the main LLM stream finishes — gives the title a grace
+  // period to complete, then aborts so onFinish doesn't hang.
+  const finish = () => {
+    graceTimeoutId = setTimeout(() => {
+      titleAbortController.abort();
+      settleLatch(fallbackTitle);
+    }, POST_STREAM_GRACE_MS);
+  };
+
+  const genPromise = (async (): Promise<string | null> => {
     // No model to try → deterministic fallback, never a broken title.
     if (models.length === 0) return fallbackTitle;
     try {
@@ -185,6 +206,11 @@ export function genTitle(config: {
       abortSignal?.removeEventListener("abort", onParentAbort);
     }
   })();
+
+  // Whichever settles first wins. `genPromise` never rejects (it catches every
+  // failure and returns a value), so racing it against the latch can only ever
+  // resolve — never leave an unhandled rejection dangling.
+  const promise = Promise.race([genPromise, latch]);
 
   return { promise, finish };
 }


### PR DESCRIPTION
## Summary

Confirms and fixes a real hang: **when an agent spawns a subtask, the run can silently block forever.** The culprit is auto-title generation on the *parent* run, not the subtask (subtasks are correctly excluded from titling).

## Root cause

`genTitle` (`packages/harness/src/title-generator.ts`) runs concurrently with the whole run. Its 20s self-timeout and 10s post-stream grace **only call `titleAbortController.abort()`** — they signal an abort but never independently settle the promise. Settlement depended entirely on the provider honoring that signal, and `retry` (`packages/std/src/retry.ts`) checks the signal **only between attempts**, never during an in-flight `generateObject` call.

So a hung/slow title app-server that ignores `abortSignal` leaves the title promise pending forever → `titleDone` never flips → the parent run's drain loop (`run-stream.ts`, `while (!mainDone || !titleDone || ...)`) blocks indefinitely after the model stream already ended. Because a `subtask` tool-call runs *inside* the parent stream and can run long, this presents exactly as "calling a subtask blocks everything."

The existing `makeHangingModel` test only simulated a provider that **honors** abort — the ignore-abort case (the actual hang) was untested.

## Fix

Add a settlement latch that the timers and parent-abort resolve directly (self-timeout/grace → clamped-user-message fallback; parent abort → `null`), and race the generation promise against it. The returned promise now always settles at the timeout regardless of provider behavior. The in-flight request to a misbehaving provider leaks until it eventually settles — acceptable vs. hanging the whole run.

## Testing

- New regression test: a model whose `doGenerate` never resolves and ignores the abort signal — the promise still settles to the fallback (would hang without the fix).
- `bun test packages/harness/src/title-generator.test.ts` → 12 pass.
- `tsc --noEmit` clean; `bun run fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents runs from hanging when title generation providers ignore abort signals by guaranteeing `genTitle` settles on timeout or parent abort. Fixes the “subtask blocks the run” symptom by capping title generation.

- **Bug Fixes**
  - Added a settlement latch in `packages/harness/src/title-generator.ts` that self-timeout, post-stream grace, and parent abort resolve; raced against generation so the promise always settles (fallback title or `null`).
  - Preserved the fallback rule: first 32 chars of the user message (trimmed) or "New chat".
  - Added a regression test in `packages/harness/src/title-generator.test.ts` with an unabortable model to ensure no hang.

<sup>Written for commit 9b579e35d5e3e1e53236582e3cc35a23dc57ccb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

