### PR TITLE
fix(chat): reposition IceBreakers component in AgentHome

### DIFF
--- a/apps/mesh/src/web/components/chat/agent-home.tsx
+++ b/apps/mesh/src/web/components/chat/agent-home.tsx
@@ -60,7 +60,6 @@ export function AgentHome({
 
       {/* docked input */}
       <Chat.Footer>
-        <Chat.IceBreakers className="pb-3" />
         {/* thread list — mt-auto pushes it to the bottom of the scroll area */}
         <div className="flex-1 min-h-0 overflow-y-auto flex flex-col">
           <div className="mt-auto w-full max-w-2xl mx-auto px-2 pb-2 flex flex-col gap-0.5">
@@ -75,6 +74,7 @@ export function AgentHome({
             ))}
           </div>
         </div>
+        <Chat.IceBreakers className="pb-3" />
         <div
           data-chat-above-row="true"
           className="@container/chat-bottom pb-1 flex justify-start gap-1"


### PR DESCRIPTION
Moved the Chat.IceBreakers component to a new location within the AgentHome layout to improve the structure and maintain consistency in the chat interface.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repositioned `Chat.IceBreakers` in `AgentHome` to render at the bottom of `Chat.Footer`, below the thread list. This keeps the prompts next to the input and aligns the layout across chat views.

<sup>Written for commit dbb411febd31179accf279b876654e6f378ba3a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

