### PR TITLE
feat(chat): rename Home agent to Decopilot

### DIFF
--- a/apps/mesh/src/storage/virtual.integration.test.ts
+++ b/apps/mesh/src/storage/virtual.integration.test.ts
@@ -75,7 +75,7 @@ describe("VirtualMCPStorage.findById (Decopilot)", () => {
   test("returns the synthesized decopilot entity with NO aggregated connections", async () => {
     const decopilot = await storage.findById(getDecopilotId(orgId), orgId);
     expect(decopilot).not.toBeNull();
-    expect(decopilot?.title).toBe("Home");
+    expect(decopilot?.title).toBe("Decopilot");
     expect(decopilot?.connections).toEqual([]);
   });
 });

--- a/apps/mesh/src/web/components/chat/context-panel.tsx
+++ b/apps/mesh/src/web/components/chat/context-panel.tsx
@@ -336,7 +336,7 @@ export function ChatContextPanel({
     ? formatModelId(selectedModel.modelId)
     : "—";
 
-  const agentTitle = selectedVirtualMcp?.title ?? "Home";
+  const agentTitle = selectedVirtualMcp?.title ?? "Decopilot";
 
   const allStats: StatItem[] = [
     { label: "Session", value: activeTask?.title ?? "New chat" },

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -285,7 +285,7 @@ export function getWellKnownDecopilotVirtualMCP(
   return defineWellKnownAgentVMCP({
     id: getDecopilotId(organizationId),
     organizationId,
-    title: "Home",
+    title: "Decopilot",
     description: "Default agent that aggregates all organization connections",
     icon: "https://assets.decocache.com/decocms/fd07a578-6b1c-40f1-bc05-88a3b981695d/f7fc4ffa81aec04e37ae670c3cd4936643a7b269.png",
   });


### PR DESCRIPTION
Renames the well-known default agent's display title from **Home** to **Decopilot**.

## Changes
- `packages/mesh-sdk/src/lib/constants.ts` — `getWellKnownDecopilotVirtualMCP` title `Home` → `Decopilot` (the source of truth; all consumers derive the label from here).
- `apps/mesh/src/web/components/chat/context-panel.tsx` — updated the fallback agent title.
- `apps/mesh/src/storage/virtual.integration.test.ts` — updated the title assertion.

## Testing notes
Display-only rename; the agent id is unchanged. UI consumers read the title from the constant, so the sidebar/tab/context-panel all pick it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the default agent title from "Home" to "Decopilot". Updated `getWellKnownDecopilotVirtualMCP` (source of truth) so the UI and fallbacks reflect the change, updated tests, and kept the agent ID the same.

<sup>Written for commit ab2718082a79612295b7de46e8b1ab497d1a74a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

