### PR TITLE
feat(sidebar): agents grid view toggle + tighter list height

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/agent-icon-grid.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/agent-icon-grid.tsx
@@ -1,0 +1,71 @@
+import { useVirtualMCP } from "@decocms/mesh-sdk";
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuTrigger,
+} from "@deco/ui/components/context-menu.tsx";
+import { AgentAvatar } from "@/web/components/agent-icon";
+import { AgentGroupContextMenuItems } from "./agent-group-context-menu-items";
+import type { AgentRowProps } from "./agent-row";
+import type { TaskGroupData } from "./group-threads";
+
+/**
+ * Icons-only grid of agents — packs far more agents into the same space than
+ * the list. Name shows on hover (native title). Reuses the same open/context
+ * handlers as the list via `renderGroup`. No drag-reorder here (list view owns
+ * ordering).
+ */
+function AgentIconCell(props: AgentRowProps) {
+  const { virtualMcpId, isActive, onOpen } = props;
+  const entity = useVirtualMCP(virtualMcpId);
+  const title = entity?.title ?? "Agent";
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          type="button"
+          title={title}
+          aria-label={title}
+          onClick={() => onOpen(virtualMcpId)}
+          className={cn(
+            "flex items-center justify-center p-1 rounded-md transition-colors",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+            isActive ? "bg-accent" : "hover:bg-accent/60",
+          )}
+        >
+          <AgentAvatar icon={entity?.icon ?? null} name={title} size="xs" />
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-56">
+        <AgentGroupContextMenuItems
+          virtualMcpId={virtualMcpId}
+          isOrgPinned={props.isOrgPinned ?? false}
+          canManageOrgPin={props.canManageOrgPin ?? false}
+          onNewTaskInGroup={props.onNewTask}
+          onShowSettings={props.onShowSettings}
+          onToggleOrgPin={props.onToggleOrgPin ?? (() => {})}
+          onHideGroup={props.onHideGroup}
+        />
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+export function AgentIconGrid({
+  groups,
+  renderGroup,
+}: {
+  groups: TaskGroupData[];
+  renderGroup: (group: TaskGroupData) => AgentRowProps;
+}) {
+  return (
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(1.75rem,1fr))] gap-1 px-2 py-0.5">
+      {groups.map((group) => {
+        const props = renderGroup(group);
+        return <AgentIconCell key={props.virtualMcpId} {...props} />;
+      })}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sidebar/task-groups/agent-icon-grid.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/agent-icon-grid.tsx
@@ -5,6 +5,12 @@ import {
   ContextMenuContent,
   ContextMenuTrigger,
 } from "@deco/ui/components/context-menu.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { AgentGroupContextMenuItems } from "./agent-group-context-menu-items";
 import type { AgentRowProps } from "./agent-row";
@@ -22,34 +28,38 @@ function AgentIconCell(props: AgentRowProps) {
   const title = entity?.title ?? "Agent";
 
   return (
-    <ContextMenu>
-      <ContextMenuTrigger asChild>
-        <button
-          type="button"
-          title={title}
-          aria-label={title}
-          onClick={() => onOpen(virtualMcpId)}
-          className={cn(
-            "flex items-center justify-center p-1 rounded-md transition-colors",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-            isActive ? "bg-accent" : "hover:bg-accent/60",
-          )}
-        >
-          <AgentAvatar icon={entity?.icon ?? null} name={title} size="xs" />
-        </button>
-      </ContextMenuTrigger>
-      <ContextMenuContent className="w-56">
-        <AgentGroupContextMenuItems
-          virtualMcpId={virtualMcpId}
-          isOrgPinned={props.isOrgPinned ?? false}
-          canManageOrgPin={props.canManageOrgPin ?? false}
-          onNewTaskInGroup={props.onNewTask}
-          onShowSettings={props.onShowSettings}
-          onToggleOrgPin={props.onToggleOrgPin ?? (() => {})}
-          onHideGroup={props.onHideGroup}
-        />
-      </ContextMenuContent>
-    </ContextMenu>
+    <Tooltip>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={title}
+              onClick={() => onOpen(virtualMcpId)}
+              className={cn(
+                "flex items-center justify-center p-1 rounded-md transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+                isActive ? "bg-accent" : "hover:bg-accent/60",
+              )}
+            >
+              <AgentAvatar icon={entity?.icon ?? null} name={title} size="xs" />
+            </button>
+          </TooltipTrigger>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="w-56">
+          <AgentGroupContextMenuItems
+            virtualMcpId={virtualMcpId}
+            isOrgPinned={props.isOrgPinned ?? false}
+            canManageOrgPin={props.canManageOrgPin ?? false}
+            onNewTaskInGroup={props.onNewTask}
+            onShowSettings={props.onShowSettings}
+            onToggleOrgPin={props.onToggleOrgPin ?? (() => {})}
+            onHideGroup={props.onHideGroup}
+          />
+        </ContextMenuContent>
+      </ContextMenu>
+      <TooltipContent side="right">{title}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -61,11 +71,13 @@ export function AgentIconGrid({
   renderGroup: (group: TaskGroupData) => AgentRowProps;
 }) {
   return (
-    <div className="grid grid-cols-[repeat(auto-fill,minmax(1.75rem,1fr))] gap-1 px-2 py-0.5">
-      {groups.map((group) => {
-        const props = renderGroup(group);
-        return <AgentIconCell key={props.virtualMcpId} {...props} />;
-      })}
-    </div>
+    <TooltipProvider delayDuration={300}>
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(1.75rem,1fr))] gap-1 px-2 py-0.5">
+        {groups.map((group) => {
+          const props = renderGroup(group);
+          return <AgentIconCell key={props.virtualMcpId} {...props} />;
+        })}
+      </div>
+    </TooltipProvider>
   );
 }

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -668,23 +668,25 @@ export function TaskGroupsList({
             controlsId="sidebar-section-agents"
             actionSlot={
               <>
-                <ToolbarIconButton
-                  aria-label={
-                    agentView === "list"
-                      ? "Switch to grid view"
-                      : "Switch to list view"
-                  }
-                  title={agentView === "list" ? "Grid view" : "List view"}
-                  onClick={() =>
-                    setAgentView((v) => (v === "list" ? "grid" : "list"))
-                  }
-                >
-                  {agentView === "list" ? (
-                    <Grid01 className="size-4" />
-                  ) : (
-                    <List className="size-4" />
-                  )}
-                </ToolbarIconButton>
+                {agentsOpen && (
+                  <ToolbarIconButton
+                    aria-label={
+                      agentView === "list"
+                        ? "Switch to grid view"
+                        : "Switch to list view"
+                    }
+                    title={agentView === "list" ? "Grid view" : "List view"}
+                    onClick={() =>
+                      setAgentView((v) => (v === "list" ? "grid" : "list"))
+                    }
+                  >
+                    {agentView === "list" ? (
+                      <Grid01 className="size-4" />
+                    ) : (
+                      <List className="size-4" />
+                    )}
+                  </ToolbarIconButton>
+                )}
                 <BrowseAgentsButton compact />
               </>
             }

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -6,6 +6,8 @@ import {
   Activity,
   Edit05,
   FilterLines,
+  Grid01,
+  List,
   Rows01,
   SearchSm,
 } from "@untitledui/icons";
@@ -60,6 +62,7 @@ import {
 import { getLiveDevAgentMaps } from "@/web/lib/agent-capabilities";
 import { removeGroupFromOrder, syncOrdersOnOrgPinToggle } from "./stable-order";
 import { SortableAgentRows } from "./sortable-agent-rows";
+import { AgentIconGrid } from "./agent-icon-grid";
 import type { AgentRowProps } from "./agent-row";
 import { MyThreadsSection } from "./my-threads-section";
 import { SidebarSectionHeader } from "./sidebar-section-header";
@@ -170,6 +173,10 @@ export function TaskGroupsList({
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
   const [groupBy, setGroupBy] = useState<GroupBy>("flat");
   const [agentsOpen, setAgentsOpen] = useState(true);
+  const [agentView, setAgentView] = useLocalStorage<"list" | "grid">(
+    "sidebar-agents-view",
+    "list",
+  );
   const [showAll, setShowAll] = useLocalStorage<boolean>(
     "sidebar-threads-scope-all",
     false,
@@ -647,31 +654,64 @@ export function TaskGroupsList({
           />
         </ScrollFade>
         <div className="shrink-0 mx-2 my-2 border-b" />
-        <div className="shrink-0">
+        <div
+          className={cn(
+            "flex flex-col min-h-0",
+            agentsOpen ? "basis-[35%] shrink-0" : "shrink-0",
+          )}
+        >
           <SidebarSectionHeader
             label="Agents"
             open={agentsOpen}
             onToggle={() => setAgentsOpen((v) => !v)}
             count={agentGroups.length}
             controlsId="sidebar-section-agents"
-            actionSlot={<BrowseAgentsButton compact />}
+            actionSlot={
+              <>
+                <ToolbarIconButton
+                  aria-label={
+                    agentView === "list"
+                      ? "Switch to grid view"
+                      : "Switch to list view"
+                  }
+                  title={agentView === "list" ? "Grid view" : "List view"}
+                  onClick={() =>
+                    setAgentView((v) => (v === "list" ? "grid" : "list"))
+                  }
+                >
+                  {agentView === "list" ? (
+                    <Grid01 className="size-4" />
+                  ) : (
+                    <List className="size-4" />
+                  )}
+                </ToolbarIconButton>
+                <BrowseAgentsButton compact />
+              </>
+            }
           />
           <div
             id="sidebar-section-agents"
             aria-hidden={!agentsOpen}
-            className="grid transition-[grid-template-rows] duration-200 ease-out"
+            className="grid min-h-0 transition-[grid-template-rows] duration-200 ease-out"
             style={{ gridTemplateRows: agentsOpen ? "1fr" : "0fr" }}
           >
-            <div className="overflow-hidden">
-              <ScrollFade className="flex flex-col gap-0.5 max-h-[35vh] overflow-y-auto overscroll-contain">
-                <SortableAgentRows
-                  groups={agentGroups}
-                  orderScope={orderScope}
-                  decopilotId={decopilotId}
-                  orgPinnedIds={orgPinnedIds}
-                  onReorder={() => setLocalOrderRevision((n) => n + 1)}
-                  renderGroup={buildAgentRowProps}
-                />
+            <div className="overflow-hidden min-h-0">
+              <ScrollFade className="flex flex-col gap-0.5 h-full overflow-y-auto overscroll-contain">
+                {agentView === "grid" ? (
+                  <AgentIconGrid
+                    groups={agentGroups}
+                    renderGroup={buildAgentRowProps}
+                  />
+                ) : (
+                  <SortableAgentRows
+                    groups={agentGroups}
+                    orderScope={orderScope}
+                    decopilotId={decopilotId}
+                    orgPinnedIds={orgPinnedIds}
+                    onReorder={() => setLocalOrderRevision((n) => n + 1)}
+                    renderGroup={buildAgentRowProps}
+                  />
+                )}
               </ScrollFade>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Adds a **list/grid toggle** to the left of the Agents section's `+` button.
- **Grid view** renders icon-only agent cells (name on hover via native `title`), packing far more agents into the same space than the list. Click opens the agent; right-click keeps the same context menu.
- View choice persists in `localStorage` (`sidebar-agents-view`), defaults to `list`.
- **Height**: the Agents section is now a genuine **35%** of the sidebar via a flex-basis split (threads take the remaining ~65%), replacing the viewport-relative `max-h-[35vh]` that read closer to half on shorter sidebars.

## Changes
- `task-groups-list.tsx` — view state, toggle button in the header `actionSlot`, list/grid switch, flex-basis height split (collapse animation preserved).
- `agent-icon-grid.tsx` (new) — `AgentIconGrid` + `AgentIconCell`, reusing `AgentAvatar`, `useVirtualMCP`, and the shared agent context menu. No drag-reorder in grid (list view owns ordering).

## Testing
- `bun run fmt`, `bunx tsc --noEmit` (0 errors), `bun run lint` (0 errors on changed files) all pass.
- ⚠️ Not verified live in the browser — spinning up the full dev stack (embedded PG + auth + real agents) wasn't practical in this environment. Please sanity-check the grid layout and the 35% split visually before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a list/grid view toggle to the Agents section and size the Agents area to a true 35% of the sidebar for a denser, consistent layout.

- **New Features**
  - Toggle next to the Agents `+`; choice persists in `localStorage` (`sidebar-agents-view`, default `list`).
  - Grid view: icon-only cells with name on hover via tooltip; click opens the agent; right-click shows the same context menu. No drag-reorder in grid (ordering stays in list).
  - Agents/threads split via flex-basis: 35% Agents, ~65% threads; collapse animation preserved.

- **Bug Fixes**
  - Hide the Agents view toggle when the section is collapsed.

<sup>Written for commit 894072e7b6378d7cb4b8a62b50c0b1fea3190c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

