### PR TITLE
fix(decopilot): stream user prompt to other thread viewers

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/project-chunks.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/project-chunks.test.ts
@@ -448,7 +448,11 @@ describe("projectChunks", () => {
       chunks: (async function* () {
         yield {
           type: "data-user-message",
-          data: { id: "u-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+          data: {
+            id: "u-1",
+            role: "user",
+            parts: [{ type: "text", text: "hi" }],
+          },
         } as unknown as UIMessageChunk;
         yield { type: "start", messageId: "m-1" } as UIMessageChunk;
         yield { type: "text-start", id: "txt" } as UIMessageChunk;

--- a/apps/mesh/src/api/routes/decopilot/project-chunks.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/project-chunks.test.ts
@@ -440,4 +440,60 @@ describe("projectChunks", () => {
         }),
     ).toBe(true);
   });
+
+  test("ignores data-user-message chunks when projecting assistant parts", async () => {
+    const emitted: Array<{ id: string; parts?: unknown[] }> = [];
+
+    await projectChunks({
+      chunks: (async function* () {
+        yield {
+          type: "data-user-message",
+          data: { id: "u-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        } as unknown as UIMessageChunk;
+        yield { type: "start", messageId: "m-1" } as UIMessageChunk;
+        yield { type: "text-start", id: "txt" } as UIMessageChunk;
+        yield {
+          type: "text-delta",
+          id: "txt",
+          delta: "hello",
+        } as UIMessageChunk;
+        yield { type: "text-end", id: "txt" } as UIMessageChunk;
+        yield { type: "finish", finishReason: "stop" } as UIMessageChunk;
+      })(),
+      persistence: {
+        emitStepParts: async (message) => {
+          emitted.push({ id: message.id, parts: message.parts });
+        },
+        emitFinal: async (message) => {
+          emitted.push({ id: message.id, parts: message.parts });
+        },
+        emitError: async () => {},
+      },
+    });
+
+    // The user-message chunk must not leak into any projected assistant part,
+    // and the assistant text still folds normally.
+    expect(
+      emitted
+        .flatMap((message) => message.parts ?? [])
+        .some(
+          (part) =>
+            typeof part === "object" &&
+            part !== null &&
+            (part as { type?: unknown }).type === "data-user-message",
+        ),
+    ).toBe(false);
+    expect(emitted.some((m) => m.id === "u-1")).toBe(false);
+    expect(
+      emitted
+        .flatMap((message) => message.parts ?? [])
+        .some(
+          (part) =>
+            typeof part === "object" &&
+            part !== null &&
+            (part as { type?: unknown; text?: unknown }).type === "text" &&
+            (part as { text?: unknown }).text === "hello",
+        ),
+    ).toBe(true);
+  });
 });

--- a/apps/mesh/src/api/routes/decopilot/project-chunks.ts
+++ b/apps/mesh/src/api/routes/decopilot/project-chunks.ts
@@ -5,6 +5,15 @@ import {
   type HarnessUsage,
 } from "./consume-harness-stream";
 import { isRunStatusControlChunk } from "./run-status-stage";
+import { isUserMessageControlChunk } from "./user-message-stream";
+
+/** Transient control chunks that ride the run stream for the live UI but must
+ *  never be folded into the durable assistant projection. `fenceFilter`
+ *  already drops the fence-less ones, but filtering by type here keeps the
+ *  projection correct even if one is ever published with a run fence. */
+function isTransientControlChunk(chunk: unknown): boolean {
+  return isRunStatusControlChunk(chunk) || isUserMessageControlChunk(chunk);
+}
 
 /**
  * Title persistence for the projector. When supplied, the projector becomes the
@@ -192,7 +201,7 @@ export async function projectChunks(
       ? (async function* () {
           try {
             for await (const chunk of options.chunks!) {
-              if (isRunStatusControlChunk(chunk)) continue;
+              if (isTransientControlChunk(chunk)) continue;
               yield chunk;
             }
           } catch (e) {
@@ -207,7 +216,7 @@ export async function projectChunks(
       }).pipeThrough(
         new TransformStream<UIMessageChunk, UIMessageChunk>({
           transform(chunk, controller) {
-            if (!isRunStatusControlChunk(chunk)) controller.enqueue(chunk);
+            if (!isTransientControlChunk(chunk)) controller.enqueue(chunk);
           },
         }),
       )

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -45,6 +45,7 @@ import {
   publishRunStatusStage,
   shouldPublishClusterRunStatus,
 } from "./run-status-stage";
+import { publishUserMessage } from "./user-message-stream";
 import { wrapWithSseKeepalive } from "./sse-keepalive";
 import { resolveDispatchTarget } from "../../../links/resolve-dispatch-target";
 import {
@@ -746,6 +747,10 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         })
       ) {
         await emitter.emitRequestMessage(persistedRequestMessage);
+        // Mirror the prompt onto the run stream so OTHER viewers of a shared
+        // thread render it live, not only after a DB refetch. Best-effort and
+        // published before the run's assistant chunks so it sorts first.
+        await publishUserMessage(streamBuffer, taskId, persistedRequestMessage);
       }
 
       const serializableRequest = buildDurableDispatchInput(input, {

--- a/apps/mesh/src/api/routes/decopilot/user-message-stream.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/user-message-stream.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+import {
+  buildUserMessageChunk,
+  isUserMessageControlChunk,
+  publishUserMessage,
+  USER_MESSAGE_CHUNK_TYPE,
+} from "./user-message-stream";
+
+const MESSAGE = {
+  id: "u-1",
+  role: "user",
+  parts: [{ type: "text", text: "hello" }],
+} as unknown as UIMessage;
+
+describe("buildUserMessageChunk", () => {
+  test("wraps the message in a data-user-message chunk", () => {
+    expect(buildUserMessageChunk(MESSAGE)).toEqual({
+      type: USER_MESSAGE_CHUNK_TYPE,
+      data: MESSAGE,
+    });
+  });
+});
+
+describe("isUserMessageControlChunk", () => {
+  test("matches the control chunk and nothing else", () => {
+    expect(isUserMessageControlChunk(buildUserMessageChunk(MESSAGE))).toBe(true);
+    expect(isUserMessageControlChunk({ type: "data-run-status" })).toBe(false);
+    expect(isUserMessageControlChunk({ type: "text-delta" })).toBe(false);
+    expect(isUserMessageControlChunk(null)).toBe(false);
+    expect(isUserMessageControlChunk("data-user-message")).toBe(false);
+  });
+});
+
+describe("publishUserMessage", () => {
+  test("publishes the chunk via streamBuffer.publishRawChunk", async () => {
+    const calls: Array<{ taskId: string; chunk: unknown }> = [];
+    await publishUserMessage(
+      {
+        publishRawChunk: async (taskId, chunk) => {
+          calls.push({ taskId, chunk });
+          return true;
+        },
+      },
+      "task-1",
+      MESSAGE,
+    );
+    expect(calls).toEqual([
+      { taskId: "task-1", chunk: buildUserMessageChunk(MESSAGE) },
+    ]);
+  });
+
+  test("is a no-op without a stream buffer", async () => {
+    await expect(
+      publishUserMessage(undefined, "task-1", MESSAGE),
+    ).resolves.toBeUndefined();
+  });
+
+  test("swallows publish errors (best-effort)", async () => {
+    await expect(
+      publishUserMessage(
+        {
+          publishRawChunk: async () => {
+            throw new Error("nats down");
+          },
+        },
+        "task-1",
+        MESSAGE,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/mesh/src/api/routes/decopilot/user-message-stream.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/user-message-stream.test.ts
@@ -24,7 +24,9 @@ describe("buildUserMessageChunk", () => {
 
 describe("isUserMessageControlChunk", () => {
   test("matches the control chunk and nothing else", () => {
-    expect(isUserMessageControlChunk(buildUserMessageChunk(MESSAGE))).toBe(true);
+    expect(isUserMessageControlChunk(buildUserMessageChunk(MESSAGE))).toBe(
+      true,
+    );
     expect(isUserMessageControlChunk({ type: "data-run-status" })).toBe(false);
     expect(isUserMessageControlChunk({ type: "text-delta" })).toBe(false);
     expect(isUserMessageControlChunk(null)).toBe(false);

--- a/apps/mesh/src/api/routes/decopilot/user-message-stream.ts
+++ b/apps/mesh/src/api/routes/decopilot/user-message-stream.ts
@@ -1,0 +1,48 @@
+import type { UIMessage, UIMessageChunk } from "ai";
+import type { StreamBuffer } from "./stream-buffer";
+
+/**
+ * Live mirror of a just-posted USER prompt onto the run stream.
+ *
+ * The run's JetStream subject carries only assistant/harness output, so a
+ * SECOND viewer of a shared thread never saw the other user's prompt until a DB
+ * refetch. We publish the materialized request message as a transient control
+ * chunk at POST time (before the run's assistant chunks) so every tailing
+ * viewer renders it live. It is deliberately fence-less and NOT persisted from
+ * the stream — the durable copy is the `emitRequestMessage` DB write; the
+ * projector filters this chunk out (see `project-chunks.ts`).
+ *
+ * Large prompts are handled for free: `publishRawChunk` → `serializeChunk`
+ * fragments anything over `MAX_PUBLISH_BYTES` and drops over `MAX_CHUNKED_BYTES`.
+ */
+export const USER_MESSAGE_CHUNK_TYPE = "data-user-message";
+
+export type UserMessageChunk = Extract<
+  UIMessageChunk,
+  { type: `data-${string}` }
+> & {
+  type: typeof USER_MESSAGE_CHUNK_TYPE;
+  data: UIMessage;
+};
+
+export function buildUserMessageChunk(message: UIMessage): UserMessageChunk {
+  return { type: USER_MESSAGE_CHUNK_TYPE, data: message } as UserMessageChunk;
+}
+
+export function isUserMessageControlChunk(chunk: unknown): boolean {
+  if (!chunk || typeof chunk !== "object") return false;
+  return (chunk as { type?: unknown }).type === USER_MESSAGE_CHUNK_TYPE;
+}
+
+export async function publishUserMessage(
+  streamBuffer: Pick<StreamBuffer, "publishRawChunk"> | undefined,
+  taskId: string,
+  message: UIMessage,
+): Promise<void> {
+  if (!streamBuffer) return;
+  try {
+    await streamBuffer.publishRawChunk(taskId, buildUserMessageChunk(message));
+  } catch {
+    // Best-effort live mirror. Never fail the POST because a viewer hint failed.
+  }
+}

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -952,6 +952,15 @@ export class ThreadConnection {
       this.chunkBuffer.push(chunk);
       return;
     }
+    // A user prompt mirrored onto the run stream (see server
+    // `user-message-stream.ts`). Intercept BEFORE the assistant fold — the AI
+    // SDK reassembler hardcodes `role:"assistant"` — and upsert it by id so the
+    // author's optimistic copy dedupes while other viewers get it live.
+    if ((chunk as { type?: unknown }).type === "data-user-message") {
+      const message = (chunk as { data?: UIMessage }).data;
+      if (message) this.applyLocalMessage(message);
+      return;
+    }
     const isRunStatusControl = isRunStatusControlChunk(chunk);
     const runStatusStage = parseRunStatusStageChunk(chunk);
     if (this.waitingForNewRun) {


### PR DESCRIPTION
## Problem

We stream the LLM output server-side to multiple consumers (several users viewing the same thread). But the **user prompt** is never put on the stream — it's only written to the DB. So a second viewer of a shared thread doesn't see the other user's message until a DB refetch happens (reconnect or a `thread.status` event), which feels laggy on a live thread.

## Fix

Publish the materialized request message onto the same per-thread NATS JetStream subject as a **transient `data-user-message` control chunk**, at POST time, *before* the run's assistant chunks (so it sorts first).

Key point — **large prompts are handled for free**: the publish goes through the existing `publishRawChunk → serializeChunk` path, which already **fragments** anything over `MAX_PUBLISH_BYTES` (768 KiB) and drops over `MAX_CHUNKED_BYTES` (32 MiB). File attachments are already offloaded to object-storage URLs by `uploadFileParts`, so the payload is essentially text. No new large-payload machinery — this reuses the harness stream codec.

### Server
- `user-message-stream.ts` (new) — `buildUserMessageChunk` / `isUserMessageControlChunk` / `publishUserMessage`, mirroring `run-status-stage.ts`. Publish is best-effort (never fails the POST).
- `routes.ts` — publish right after `emitRequestMessage`, in the same `shouldPersistRequestMessage` gate.
- `project-chunks.ts` — filter the chunk out of the durable assistant projection. `fenceFilter` already drops it (it's fence-less), but the explicit type filter matches the `data-run-status` precedent and future-proofs against it ever being published with a run fence.

### Client
- `thread-connection.ts` — intercept `data-user-message` in `handleChunk` **before** the AI-SDK fold (the reassembler hardcodes `role:"assistant"`), and route it into the existing `applyLocalMessage` → `mergeAndSort`/`upsertById` path. Dedup is free: the author's optimistic row shares the same id, and a later DB refetch reconciles `created_at` via `preserveCreatedAt`.

## Testing
- New unit tests for the helpers (`user-message-stream.test.ts`).
- Extended `project-chunks.test.ts` to assert the chunk never leaks into projected assistant parts while normal assistant text still folds.
- `bun test` (affected), `tsc --noEmit` (0 errors), `bun run lint` (0 errors) all pass.

### Not covered / follow-up
Live two-viewer end-to-end wasn't driven headlessly here — worth a manual check (or an e2e in `packages/e2e`) with two sessions on one thread to confirm the prompt renders live for the non-author.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mirror the user's prompt onto the per-thread run stream so other viewers see it instantly, fixing lag in shared threads. Uses a transient `data-user-message` control chunk and keeps the durable projection unchanged.

- **Bug Fixes**
  - Server: publish a best-effort `data-user-message` chunk at POST time (before assistant chunks) via existing `publishRawChunk` fragmentation; filter it out of the assistant projection; gated with the same `shouldPersistRequestMessage` check.
  - Client: intercept `data-user-message` before the assistant fold and upsert via `applyLocalMessage` so the author's optimistic message dedupes and other viewers see it live.

<sup>Written for commit 4f24dff48890a2cd612ba9291d5e9687fe3106af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

