### PR TITLE
fix(web): stop serving stale index.html on soft reload (nginx 304 trap)

### DIFF
--- a/deploy/helm/studio/files/api-nginx.conf
+++ b/deploy/helm/studio/files/api-nginx.conf
@@ -121,6 +121,12 @@ server {
     add_header Cache-Control "no-cache" always;
     add_header X-Frame-Options "DENY" always;
     add_header Content-Security-Policy "frame-ancestors 'none'" always;
+    # Pinned build mtimes + fixed-width Vite hashes make index.html's ETag and
+    # Last-Modified identical across deploys, so `no-cache` revalidation always
+    # 304s and serves stale HTML until a hard refresh. Drop the validators ->
+    # every soft reload gets a fresh 200.
+    etag off;
+    if_modified_since off;
     try_files $uri /index.html;
   }
 }


### PR DESCRIPTION
Users only got a new frontend build after a **hard** refresh (Cmd+Shift+R); a normal reload kept serving the old bundle. Reverting the version-check dialog (#4460) did not help because the dialog’s `window.location.reload()` is the same soft request — it hit the same trap.

## Root cause

`index.html` has a **deploy-invariant validator**, so `Cache-Control: no-cache` revalidation always returns `304 Not Modified` → the browser reuses the old HTML → old asset hashes → old bundle.

Confirmed against prod:

```
$ curl -sI https://studio.decocms.com/ -H "If-Modified-Since: Sat, 26 Oct 1985 08:15:00 GMT"
HTTP/2 304
etag: "1dc09d84-e7a"
cache-control: no-cache
```

Why the validator never changes:
- nginx’s default `ETag` is `hex(mtime)-hex(size)`.
- `mtime` is **pinned** — the Docker build normalizes file timestamps (the `Sat, 26 Oct 1985` date is that sentinel, not real).
- `size` is unchanged — Vite content-hash filenames are fixed-width, so `index.html` is the same byte length every build.

Pinned mtime + constant size ⇒ identical `ETag`/`Last-Modified` across every deploy. `no-cache` faithfully revalidates, nginx faithfully 304s, the user is stuck. Hard refresh works only because it sends a `no-cache` **request** header that skips revalidation.

Cloudflare is not involved — `index.html` returns `cf-cache-status: DYNAMIC` (edge does not cache HTML).

## Fix

Disable the validators on the SPA entry so every soft reload gets a full `200`:

```nginx
location / {
  add_header Cache-Control "no-cache" always;
  ...
  etag off;
  if_modified_since off;
  try_files $uri /index.html;
}
```

`index.html` is ~3.7 KB, so re-downloading it per navigation is negligible. Hashed `/assets/*` keep their `immutable` caching (own location block, untouched).

## Notes / testing

- `deploy/helm/studio/files/api-nginx.conf` is baked into `Dockerfile.nginx`, so this takes effect on the next image rebuild + release (per the note at the top of that file).
- After deploy, verify the trap is gone:
  ```
  curl -sI https://studio.decocms.com/ -H "If-Modified-Since: Sat, 26 Oct 1985 08:15:00 GMT"
  # expect: HTTP/2 200 (no more 304), no etag header
  ```
- The existing chunk-load-error `ErrorBoundary` (`apps/mesh/src/web/components/error-boundary.tsx`) remains the reactive safety net and now actually reaches fresh HTML on its auto-reload.
- The `VersionCheckDialog` revert (#4460) can proceed independently — it was redundant with this fix and could never beat the 304.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale SPA reloads by disabling Nginx validators for `index.html` so soft reloads return 200 and pull fresh HTML. Hashed `/assets/*` caching remains unchanged.

- **Bug Fixes**
  - Turned off `etag` and `if_modified_since` for the `/` location (kept `Cache-Control: no-cache`) to prevent 304 revalidation of `index.html`.

<sup>Written for commit 8c619563aeb055f7d7fcd7630fb14872b7b47fad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

