### PR TITLE
fix(decopilot): mid-run joiners see the user prompt (publish mirror after purge)

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -97,6 +97,7 @@ import {
   publishRunStatusStage,
   shouldPublishClusterRunStatus,
 } from "./run-status-stage";
+import { publishUserMessage } from "./user-message-stream";
 import type {
   HarnessStreamConsumerHooks,
   HarnessStreamTitleOptions,
@@ -1275,6 +1276,20 @@ async function prepareRun(
             });
         }
       }
+    }
+
+    // Mirror the user prompt onto the run stream AFTER the purge above (which
+    // clears the previous run) so it survives the whole run — a viewer who
+    // JOINS mid-run replays it via `deliverPolicy: "all"`, not only viewers
+    // already connected at POST time. Best-effort and published before the
+    // run's assistant chunks so it sorts first. Uses the persisted message
+    // shape so the live chunk and a later DB refetch reconcile by id, no swap.
+    if (materializedRequestMessage) {
+      await publishUserMessage(
+        streamBuffer,
+        mem.thread.id,
+        materializedRequestMessage as UIMessage,
+      );
     }
 
     const pendingOps: Promise<void>[] = [];

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -45,7 +45,6 @@ import {
   publishRunStatusStage,
   shouldPublishClusterRunStatus,
 } from "./run-status-stage";
-import { publishUserMessage } from "./user-message-stream";
 import { wrapWithSseKeepalive } from "./sse-keepalive";
 import { resolveDispatchTarget } from "../../../links/resolve-dispatch-target";
 import {
@@ -747,10 +746,6 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
         })
       ) {
         await emitter.emitRequestMessage(persistedRequestMessage);
-        // Mirror the prompt onto the run stream so OTHER viewers of a shared
-        // thread render it live, not only after a DB refetch. Best-effort and
-        // published before the run's assistant chunks so it sorts first.
-        await publishUserMessage(streamBuffer, taskId, persistedRequestMessage);
       }
 
       const serializableRequest = buildDurableDispatchInput(input, {


### PR DESCRIPTION
## Problem

Follow-up to #4461, which mirrors a just-posted user prompt onto the run stream as a transient `data-user-message` chunk so other thread viewers render it live.

That PR published the chunk at **POST time** (`routes.ts`, right after `emitRequestMessage`). But `dispatchRun` calls `streamBuffer.purge(taskId)` at the start of every run to clear the *previous* run's tail — and that purge runs **after** the POST-time publish, so it **wipes the just-published prompt chunk too**.

Effect: a viewer **already connected** when the author posts still gets the chunk live (their consumer received it before the purge). But a viewer who **joins mid-run** subscribes with `deliverPolicy: "all"` and replays the subject from the start — where the prompt has already been purged — so they see the assistant reply forming with no prompt above it, until a DB refetch reconciles it. That's exactly the shared-thread scenario the original fix targeted.

## Fix

Move the `publishUserMessage` call out of `routes.ts` and into `dispatchRun`, **after** the `streamBuffer.purge()` and once the materialized request message is resolved (still before any assistant chunks flow, so it sorts first). The chunk now survives for the whole run, so mid-run joiners replay it.

Nice side effect: for a **queued** turn (posted behind a running turn), the prompt now appears at *dispatch* time rather than POST time — which matches the intended "tray-only until dispatch" UX for queued messages.

### Notes
- Uses `materializedRequestMessage` (the persisted DB shape), so the live chunk and a later DB refetch reconcile by id with no visible swap.
- Best-effort semantics unchanged (`publishUserMessage` swallows errors, no-ops without a stream buffer).
- Author dedup is unaffected — the optimistic row and the streamed chunk share the same id and collapse in `mergeAndSort`.
- Client interception, the `project-chunks` projection filter, and the helper unit tests are all untouched and still apply.

## Testing
- `tsc --noEmit` (0 errors)
- `bun test` on `user-message-stream.test.ts` + `project-chunks.test.ts` (19 pass)

Still worth the manual two-viewer / mid-run-join e2e that #4461 flagged as deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing user prompt for mid-run joiners by publishing the transient user-message chunk after the run purge. The prompt now persists for the whole run and appears at dispatch time for queued turns.

- **Bug Fixes**
  - Moved `publishUserMessage` from `routes.ts` (POST time) to `dispatch-run` after `streamBuffer.purge()`, before assistant chunks.
  - Uses persisted `materializedRequestMessage` so the stream and DB reconcile by id; best-effort behavior unchanged.
  - Mid-run subscribers with `deliverPolicy: "all"` now replay the prompt; queued turns display the prompt on dispatch.

<sup>Written for commit 802d1e32ac6da8a28cafc391bd36708064b4f3d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

