### PR TITLE
fix(sandbox): surface SANDBOX_START failures in the preview UI

### DIFF
--- a/apps/mesh/src/shared/github-clone-info.ts
+++ b/apps/mesh/src/shared/github-clone-info.ts
@@ -22,6 +22,10 @@ import {
   RECONNECT_ERROR,
 } from "../oauth/token-refresh";
 import { getRepoScope } from "./github-repo-scope";
+import {
+  encodeSandboxStartError,
+  SANDBOX_START_ERROR_CODES,
+} from "./sandbox-start-errors";
 
 export interface GitHubCloneInfo {
   cloneUrl: string;
@@ -83,9 +87,12 @@ export async function buildCloneInfo(
   });
   if (!tokenResult.accessToken) {
     throw new Error(
-      tokenResult.state === "refresh_failed"
-        ? RECONNECT_ERROR
-        : "No GitHub token found. Ensure the mcp-github connection is authenticated.",
+      encodeSandboxStartError(
+        SANDBOX_START_ERROR_CODES.githubNotAuthenticated,
+        tokenResult.state === "refresh_failed"
+          ? RECONNECT_ERROR
+          : "No GitHub token found. Ensure the mcp-github connection is authenticated.",
+      ),
     );
   }
 

--- a/apps/mesh/src/shared/sandbox-start-errors.test.ts
+++ b/apps/mesh/src/shared/sandbox-start-errors.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import {
+  decodeSandboxStartError,
+  encodeSandboxStartError,
+  SANDBOX_START_ERROR_CODES,
+} from "./sandbox-start-errors";
+
+const CODE = SANDBOX_START_ERROR_CODES.githubNotAuthenticated;
+
+test("round-trips a coded message", () => {
+  const encoded = encodeSandboxStartError(CODE, "No GitHub token found.");
+  expect(decodeSandboxStartError(encoded)).toEqual({
+    code: CODE,
+    message: "No GitHub token found.",
+  });
+});
+
+test("preserves ':: ' inside the message", () => {
+  const encoded = encodeSandboxStartError(CODE, "a::b::c");
+  expect(decodeSandboxStartError(encoded)).toEqual({
+    code: CODE,
+    message: "a::b::c",
+  });
+});
+
+test("plain (uncoded) text → code null, full text as message", () => {
+  expect(decodeSandboxStartError("some raw failure")).toEqual({
+    code: null,
+    message: "some raw failure",
+  });
+});
+
+test("unknown prefix is not treated as a code", () => {
+  expect(decodeSandboxStartError("NOT_A_CODE::hi")).toEqual({
+    code: null,
+    message: "NOT_A_CODE::hi",
+  });
+});

--- a/apps/mesh/src/shared/sandbox-start-errors.ts
+++ b/apps/mesh/src/shared/sandbox-start-errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Typed SANDBOX_START failure codes carried over MCP's text-only error
+ * channel. A thrown tool error only survives to the client as
+ * `content[0].text`, so the code is prefixed onto the message and parsed
+ * back on the frontend. Leaf module (no server deps) — safe to import from
+ * both the tool handler and the web bundle.
+ */
+
+export const SANDBOX_START_ERROR_CODES = {
+  /** No usable GitHub token for the connected repo — needs (re)auth. */
+  githubNotAuthenticated: "GITHUB_NOT_AUTHENTICATED",
+} as const;
+
+export type SandboxStartErrorCode =
+  (typeof SANDBOX_START_ERROR_CODES)[keyof typeof SANDBOX_START_ERROR_CODES];
+
+const MARKER = "::";
+
+export function encodeSandboxStartError(
+  code: SandboxStartErrorCode,
+  message: string,
+): string {
+  return `${code}${MARKER}${message}`;
+}
+
+export function decodeSandboxStartError(text: string): {
+  code: SandboxStartErrorCode | null;
+  message: string;
+} {
+  const i = text.indexOf(MARKER);
+  if (i > 0) {
+    const code = text.slice(0, i);
+    if ((Object.values(SANDBOX_START_ERROR_CODES) as string[]).includes(code)) {
+      return {
+        code: code as SandboxStartErrorCode,
+        message: text.slice(i + MARKER.length),
+      };
+    }
+  }
+  return { code: null, message: text };
+}

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -103,7 +103,11 @@ import {
 } from "@/web/components/sandbox/hooks/use-sandbox-start";
 import { SandboxStateCard } from "@/web/components/sandbox/preview/state-card";
 import { derivePhaseProgress } from "@/web/components/sandbox/preview/derive-phase-progress";
-import { computePreviewState } from "@/web/components/sandbox/preview/preview-state";
+import {
+  computePreviewState,
+  type SandboxStartError,
+} from "@/web/components/sandbox/preview/preview-state";
+import { decodeSandboxStartError } from "@/shared/sandbox-start-errors";
 import {
   buildDuplicatePage,
   buildEmptyPage,
@@ -319,6 +323,10 @@ export function ContentBrowser() {
     previewUrl,
     appPaused: vmEvents.status.state === "paused",
     userStopped,
+    startError:
+      startVm.isError && startVm.error
+        ? decodeSandboxStartError(startVm.error.message)
+        : null,
   });
 
   if (sandboxState.kind !== "iframe") {
@@ -328,6 +336,7 @@ export function ContentBrowser() {
         claimPhase={vmEvents.phase}
         lifecycle={vmEvents.lifecycle}
         onStart={triggerStart}
+        connectionsHref={`/${org.slug}/settings/connections`}
       />
     );
   }
@@ -2730,11 +2739,16 @@ function SandboxStateRenderer({
   claimPhase,
   lifecycle,
   onStart,
+  connectionsHref,
 }: {
-  state: { kind: "starting" } | { kind: "suspended" };
+  state:
+    | { kind: "starting" }
+    | { kind: "suspended" }
+    | { kind: "errored"; error: SandboxStartError };
   claimPhase: ReturnType<typeof useSandboxEvents>["phase"];
   lifecycle: ReturnType<typeof useSandboxEvents>["lifecycle"];
   onStart: () => void;
+  connectionsHref?: string;
 }) {
   switch (state.kind) {
     case "starting":
@@ -2747,6 +2761,15 @@ function SandboxStateRenderer({
       );
     case "suspended":
       return <SandboxStateCard kind="suspended" onResume={onStart} />;
+    case "errored":
+      return (
+        <SandboxStateCard
+          kind="errored"
+          error={state.error}
+          onRetry={onStart}
+          connectionsHref={connectionsHref}
+        />
+      );
   }
 }
 

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -144,4 +144,13 @@ describe("computeDrawerStatus", () => {
       computeDrawerStatus({ kind: "iframe", previewUrl: "https://x" }),
     ).toBe("running");
   });
+
+  test("errored → errored", () => {
+    expect(
+      computeDrawerStatus({
+        kind: "errored",
+        error: { code: null, message: "boom" },
+      }),
+    ).toBe("errored");
+  });
 });

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -76,6 +76,8 @@ export function computeDrawerStatus(state: PreviewState): DrawerStatus {
       return "running";
     case "starting":
       return "starting";
+    case "errored":
+      return "errored";
   }
 }
 
@@ -101,6 +103,7 @@ import {
 } from "./use-sandbox-start";
 import { useSandboxEvents } from "./use-sandbox-events";
 import { computePreviewState } from "@/web/components/sandbox/preview/preview-state";
+import { decodeSandboxStartError } from "@/shared/sandbox-start-errors";
 
 export interface SandboxLifecycleValue {
   branch: string | null;
@@ -201,10 +204,15 @@ export function SandboxLifecycleProvider({
     !!branch &&
     sandboxUserStop.isStopped(virtualMcpId, branch);
   const appPaused = events.status.state === "paused";
+  const startError =
+    startVm.isError && startVm.error
+      ? decodeSandboxStartError(startVm.error.message)
+      : null;
   const previewState = computePreviewState({
     previewUrl,
     appPaused,
     userStopped,
+    startError,
   });
   const status = computeDrawerStatus(previewState);
 

--- a/apps/mesh/src/web/components/sandbox/preview/preview-state.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-state.test.ts
@@ -6,6 +6,7 @@ const base: PreviewStateInput = {
   previewUrl: "http://localhost:5173",
   appPaused: false,
   userStopped: false,
+  startError: null,
 };
 
 describe("computePreviewState", () => {
@@ -32,5 +33,35 @@ describe("computePreviewState", () => {
     expect(computePreviewState({ ...base, userStopped: true })).toEqual({
       kind: "suspended",
     });
+  });
+
+  test("startError with no previewUrl → errored", () => {
+    const error = {
+      code: "GITHUB_NOT_AUTHENTICATED" as const,
+      message: "nope",
+    };
+    expect(
+      computePreviewState({ ...base, previewUrl: null, startError: error }),
+    ).toEqual({ kind: "errored", error });
+  });
+
+  test("startError but a live previewUrl → iframe (running VM wins)", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        startError: { code: null, message: "restart failed" },
+      }),
+    ).toEqual({ kind: "iframe", previewUrl: "http://localhost:5173" });
+  });
+
+  test("startError but userStopped → suspended (stop wins)", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        previewUrl: null,
+        userStopped: true,
+        startError: { code: null, message: "x" },
+      }),
+    ).toEqual({ kind: "suspended" });
   });
 });

--- a/apps/mesh/src/web/components/sandbox/preview/preview-state.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-state.ts
@@ -10,21 +10,37 @@
  * connection-refused page when the link is down) is the displayed state.
  */
 
+import type { SandboxStartErrorCode } from "@/shared/sandbox-start-errors";
+
+export interface SandboxStartError {
+  code: SandboxStartErrorCode | null;
+  message: string;
+}
+
 export interface PreviewStateInput {
   previewUrl: string | null;
   /** Daemon reported its app as paused. */
   appPaused: boolean;
   /** User explicitly stopped the sandbox. */
   userStopped: boolean;
+  /** SANDBOX_START rejected (e.g. GitHub not authenticated) with no VM yet. */
+  startError: SandboxStartError | null;
 }
 
 export type PreviewState =
   | { kind: "starting" }
   | { kind: "suspended" }
+  | { kind: "errored"; error: SandboxStartError }
   | { kind: "iframe"; previewUrl: string };
 
 export function computePreviewState(input: PreviewStateInput): PreviewState {
   if (input.appPaused || input.userStopped) return { kind: "suspended" };
+  // A start error with no live VM is terminal: show it instead of spinning
+  // on the booting overlay forever. Once a previewUrl exists the running
+  // sandbox wins (a failed restart shouldn't blank a working preview).
+  if (input.startError && !input.previewUrl) {
+    return { kind: "errored", error: input.startError };
+  }
   if (!input.previewUrl) return { kind: "starting" };
   return { kind: "iframe", previewUrl: input.previewUrl };
 }

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -1319,6 +1319,17 @@ export function PreviewContent() {
             </div>
           )}
 
+          {previewState.kind === "errored" && (
+            <div className="absolute inset-0 z-30">
+              <SandboxStateCard
+                kind="errored"
+                error={previewState.error}
+                onRetry={lifecycle.retry}
+                connectionsHref={`/${org.slug}/settings/connections`}
+              />
+            </div>
+          )}
+
           {effectiveViewMode === "visual" && !visualElement && (
             <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/90 px-3 py-1 text-xs font-medium text-white shadow-md backdrop-blur-sm pointer-events-none select-none">
               <CursorClick01 size={12} />

--- a/apps/mesh/src/web/components/sandbox/preview/state-card-helpers.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/state-card-helpers.test.ts
@@ -4,6 +4,7 @@ import { activePhaseIndex, headlineFor } from "./state-card-helpers";
 test("headlineFor maps each kind to its headline", () => {
   expect(headlineFor("starting")).toBe("Starting your sandbox");
   expect(headlineFor("suspended")).toBe("Sandbox is paused");
+  expect(headlineFor("errored")).toBe("Couldn't start the sandbox");
 });
 
 test("activePhaseIndex returns the index of the current step", () => {

--- a/apps/mesh/src/web/components/sandbox/preview/state-card-helpers.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/state-card-helpers.ts
@@ -7,6 +7,8 @@ export function headlineFor(kind: StateCardKind): string {
       return "Starting your sandbox";
     case "suspended":
       return "Sandbox is paused";
+    case "errored":
+      return "Couldn't start the sandbox";
   }
 }
 

--- a/apps/mesh/src/web/components/sandbox/preview/state-card-types.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/state-card-types.ts
@@ -1,1 +1,1 @@
-export type StateCardKind = "starting" | "suspended";
+export type StateCardKind = "starting" | "suspended" | "errored";

--- a/apps/mesh/src/web/components/sandbox/preview/state-card.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/state-card.tsx
@@ -1,8 +1,15 @@
 import { Button } from "@deco/ui/components/button.tsx";
-import { PauseCircle, Play } from "@untitledui/icons";
+import {
+  AlertTriangle,
+  PauseCircle,
+  Play,
+  RefreshCw01,
+} from "@untitledui/icons";
+import { SANDBOX_START_ERROR_CODES } from "@/shared/sandbox-start-errors";
 import { BootingVisual } from "./booting-visual";
 import type { ClaimPhase } from "../hooks/sandbox-events-context";
 import type { PhaseProgress } from "./derive-phase-progress";
+import type { SandboxStartError } from "./preview-state";
 import { headlineFor } from "./state-card-helpers";
 
 export type SandboxStateCardProps =
@@ -11,7 +18,14 @@ export type SandboxStateCardProps =
       progress: PhaseProgress;
       claimPhase: ClaimPhase | null;
     }
-  | { kind: "suspended"; onResume: () => void };
+  | { kind: "suspended"; onResume: () => void }
+  | {
+      kind: "errored";
+      error: SandboxStartError;
+      onRetry: () => void;
+      /** Link to the org's Connections page, for the GitHub-auth case. */
+      connectionsHref?: string;
+    };
 
 export function SandboxStateCard(props: SandboxStateCardProps) {
   if (props.kind === "starting") {
@@ -21,6 +35,34 @@ export function SandboxStateCard(props: SandboxStateCardProps) {
           progress={props.progress}
           claimPhase={props.claimPhase}
         />
+      </div>
+    );
+  }
+
+  if (props.kind === "errored") {
+    const needsGithubAuth =
+      props.error.code === SANDBOX_START_ERROR_CODES.githubNotAuthenticated;
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-background p-6">
+        <div className="flex w-full max-w-md flex-col items-center gap-4 text-center">
+          <AlertTriangle className="size-12 text-destructive" />
+          <h3 className="text-lg font-medium">{headlineFor("errored")}</h3>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            {needsGithubAuth
+              ? "This agent's GitHub repo isn't authenticated. Reconnect it in Connections, then retry."
+              : props.error.message}
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            {needsGithubAuth && props.connectionsHref && (
+              <Button asChild>
+                <a href={props.connectionsHref}>Reconnect GitHub</a>
+              </Button>
+            )}
+            <Button variant="outline" onClick={props.onRetry}>
+              <RefreshCw01 className="size-4" /> Retry
+            </Button>
+          </div>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Problem

Opening a thread whose sandbox fails to start (e.g. the connected GitHub repo's `mcp-github` connection isn't authenticated) left the preview stuck on **"Cloning your repo…"** indefinitely — nothing was cloned, no sandbox was ever provisioned, and the real error was only `console.error`'d:

```
POST /api/:org/tools/SANDBOX_START
{ "error": "No GitHub token found. Ensure the mcp-github connection is authenticated." }
```

The user had no way to see the error or fix it.

## Root cause

- `SANDBOX_START` throws from `buildCloneInfo` (`github-clone-info.ts`) when the downstream GitHub OAuth token is missing.
- The error propagated correctly to the mutation (`call-sandbox-tool.ts` turns `isError` → thrown), but every `onError` in `sandbox-lifecycle-context.tsx` only logged to console.
- The preview state machine had only `starting | suspended | iframe` — no failed state — so the booting overlay never cleared.

## Fix

- **Typed error code over MCP's text-only error channel.** New leaf module `sandbox-start-errors.ts` encodes a `GITHUB_NOT_AUTHENTICATED` code into the thrown message; the client decodes it (no brittle string-matching in UI logic).
- **`errored` preview state.** `computePreviewState` returns `errored` when a start fails with no live VM (a running sandbox still wins, so a failed *restart* never blanks a working preview).
- **Errored state card** with a **"Reconnect GitHub"** button (→ `/{org}/settings/connections`) for the auth case, plus **Retry** for any failure. Also surfaces in the Content tab's `SandboxStateRenderer`.
- **Drawer status.** `computeDrawerStatus` now emits `errored`, lighting up the already-present (but never-triggered) Retry toolbar control.

## Not in scope

Investigated the "`/events` called with no sandbox" report: there is **no self-heal loop** (self-heal needs a `vmEntry.sandboxHandle`, which a failed start never creates). The `/events` hit is a single transient 404 during the in-flight start that tears down on failure. Deemed not worth gate machinery.

## Testing

- New unit tests: `sandbox-start-errors.test.ts` (encode/decode round-trip + edge cases).
- Extended `preview-state.test.ts`, `state-card-helpers.test.ts`, `sandbox-lifecycle-context.test.ts` for the `errored` path.
- `bun run check`, `bun run fmt`, `bun run lint` clean.
- Not driven end-to-end in a live app; logic is covered by unit tests + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview getting stuck on “Cloning your repo…” by surfacing `SANDBOX_START` failures with a clear error state and actions (Reconnect GitHub, Retry). Adds typed error codes and an `errored` preview state so users can recover.

- **Bug Fixes**
  - Added typed start error codes (`GITHUB_NOT_AUTHENTICATED`) via `encodeSandboxStartError`/`decodeSandboxStartError`.
  - Introduced `errored` in preview state; only shown when no VM is running (running VM still wins; paused/stopped still show suspended).
  - New errored state card with message, Retry, and “Reconnect GitHub” linking to `/{org}/settings/connections`.
  - Drawer status now reports `errored` and enables the existing Retry control.
  - Tests for error encode/decode and preview state; small UI helper updates.

<sup>Written for commit 5ceb690401a26814800379b8215b1366df5cd9c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

