### PR TITLE
fix(sidebar): make the agents list scrollable

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -698,7 +698,10 @@ export function TaskGroupsList({
             style={{ gridTemplateRows: agentsOpen ? "1fr" : "0fr" }}
           >
             <div className="overflow-hidden min-h-0">
-              <ScrollFade className="flex flex-col gap-0.5 h-full overflow-y-auto overscroll-contain">
+              <ScrollFade
+                wrapperClassName="h-full min-h-0"
+                className="flex flex-col gap-0.5 h-full overflow-y-auto overscroll-contain"
+              >
                 {agentView === "grid" ? (
                   <AgentIconGrid
                     groups={agentGroups}


### PR DESCRIPTION
## Summary
The sidebar **Agents** section couldn't scroll — with many agents (e.g. 29), the list overflowed its box and the extra rows were silently clipped by the bottom user/settings bar instead of scrolling.

## Cause
The Agents section's `ScrollFade` was rendered without a `wrapperClassName`. `ScrollFade` wraps its `overflow-y-auto` child in `<div className={cn("relative", wrapperClassName)}>`. With no `wrapperClassName`, that wrapper has no bounded height, so the inner `h-full overflow-y-auto` element sizes to its content — nothing to scroll. The overflowing rows were then clipped by the `overflow-hidden` parent.

Every other `ScrollFade` in `task-groups-list.tsx` (desktop threads, mobile threads, mobile agents) passes a bounded `wrapperClassName`; the desktop agents one was the only one that didn't.

## Fix
Give the wrapper `h-full min-h-0` so the inner `overflow-y-auto` has a bounded height and scrolls.

## Testing
- `bun run fmt` passes.
- Manual: with the agents list taller than its 35%-basis box, it now scrolls (with the existing bottom fade) instead of clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar Agents list so it scrolls instead of being clipped when there are many agents. Sets `wrapperClassName="h-full min-h-0"` on the Agents `ScrollFade` so the inner `overflow-y-auto` has a bounded height and can scroll.

<sup>Written for commit f90a419debd19563bd5a26f16c2a7b7e3c8474a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

