### PR TITLE
chore(lint): enforce web ↔ server import boundary (ban-web-server-imports)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,7 +8,8 @@
     "./plugins/ban-direct-auth-client-organization.js",
     "./plugins/ban-ref-current-assignment.js",
     "./plugins/ban-cross-tree-imports.js",
-    "./plugins/ban-e2e-app-imports.js"
+    "./plugins/ban-e2e-app-imports.js",
+    "./plugins/ban-web-server-imports.js"
   ],
   "ignorePatterns": ["apps/docs/*"],
   "rules": {
@@ -24,7 +25,8 @@
     "ban-direct-auth-client-organization/ban-direct-auth-client-organization": "error",
     "ban-ref-current-assignment/ban-ref-current-assignment": "error",
     "ban-cross-tree-imports/ban-cross-tree-imports": "warn",
-    "ban-e2e-app-imports/ban-e2e-app-imports": "error"
+    "ban-e2e-app-imports/ban-e2e-app-imports": "error",
+    "ban-web-server-imports/ban-web-server-imports": "warn"
   },
   "plugins": ["react"]
 }

--- a/plugins/ban-web-server-imports.js
+++ b/plugins/ban-web-server-imports.js
@@ -1,0 +1,120 @@
+/**
+ * Lint plugin enforcing the web ↔ server boundary inside apps/mesh.
+ *
+ * The frontend (`apps/mesh/src/web/`) ships as a separate build artifact (vite →
+ * dist/client, served by the nginx `-web` container) and talks to the API over
+ * HTTP via `@decocms/mesh-sdk`. It is therefore free to import *types* from the
+ * backend (erased at build — end-to-end type safety is a feature), but must NOT
+ * make **value** imports from server-only trees: those pull server runtime code
+ * (DB drivers, secrets, provider SDKs) into the browser bundle and couple the UI
+ * to the server's internal file layout.
+ *
+ * Rule: files under `apps/mesh/src/web/` may not make a **value** import (or
+ * re-export, or dynamic import) from a `@/<server-tree>/…` specifier. `import
+ * type` / `import { type X }` are allowed. The fix is to import it `type`-only,
+ * or move the shared value (schema, constant, pure helper) into a frontend-safe
+ * location (`@/web`, `@/mcp-apps`, `@/lib`, `@/shared`) or into `@decocms/mesh-sdk`.
+ *
+ * Companion to `ban-cross-tree-imports.js` (which guards packages/ ↛ apps/mesh)
+ * and `ban-e2e-app-imports.js` (which guards the e2e black-box wall).
+ */
+
+// Second path segment of `@/<tree>/…` that is server-only. Anything not listed
+// (web, mcp-apps, lib, shared, hooks, …) is treated as frontend-safe.
+const SERVER_ONLY_TREES = new Set([
+  "storage",
+  "core",
+  "api",
+  "tools",
+  "auth",
+  "services",
+  "mcp-clients",
+  "event-bus",
+  "automations",
+  "dispatch-queue",
+  "object-storage",
+  "file-storage",
+  "monitoring",
+  "observability",
+  "database",
+  "dbos",
+  "nats",
+  "vault",
+  "encryption",
+  "oauth",
+  "link-daemon",
+  "harnesses",
+  "ai-providers",
+  "commerce-discovery",
+  "sandbox",
+  "settings",
+  "links",
+]);
+
+function inWebTree(filename) {
+  return (
+    filename.includes("/apps/mesh/src/web/") ||
+    filename.startsWith("apps/mesh/src/web/")
+  );
+}
+
+// `@/<tree>/…` → returns the server-only tree name, or null.
+function serverTreeOf(spec) {
+  if (typeof spec !== "string" || !spec.startsWith("@/")) return null;
+  const tree = spec.slice(2).split("/")[0];
+  return SERVER_ONLY_TREES.has(tree) ? tree : null;
+}
+
+// True when the whole statement is type-only (erased at build → safe).
+function isTypeOnly(node) {
+  const kind = node.importKind ?? node.exportKind;
+  if (kind === "type") return true;
+  // `import { type A, type B } from …` — value statement, but every named
+  // specifier is a type. `export * from` has no specifiers → not type-only.
+  const specs = node.specifiers;
+  if (Array.isArray(specs) && specs.length > 0) {
+    return specs.every(
+      (s) => s.importKind === "type" || s.exportKind === "type",
+    );
+  }
+  return false;
+}
+
+const banWebServerImportsRule = {
+  create(context) {
+    const filename = context.filename ?? "";
+    if (!inWebTree(filename)) return {};
+
+    const check = (node, { dynamic = false } = {}) => {
+      const src = node?.source;
+      if (!src || src.type !== "Literal" || typeof src.value !== "string")
+        return;
+      const tree = serverTreeOf(src.value);
+      if (!tree) return;
+      if (!dynamic && isTypeOnly(node)) return;
+
+      context.report({
+        node: src,
+        message:
+          `Web ↔ server boundary: "${src.value}" is a VALUE import from the server-only "@/${tree}" tree. ` +
+          `The frontend is a separate bundle — it may import types (use \`import type\`) but not runtime code, ` +
+          `which risks pulling server deps/secrets into the browser. Move the shared value into @/web, @/mcp-apps, ` +
+          `@/lib, @/shared or @decocms/mesh-sdk, or import it type-only.`,
+      });
+    };
+
+    return {
+      ImportDeclaration: (node) => check(node),
+      ExportNamedDeclaration: (node) => check(node),
+      ExportAllDeclaration: (node) => check(node),
+      ImportExpression: (node) => check(node, { dynamic: true }),
+    };
+  },
+};
+
+const plugin = {
+  meta: { name: "ban-web-server-imports" },
+  rules: { "ban-web-server-imports": banWebServerImportsRule },
+};
+
+export default plugin;

--- a/plugins/ban-web-server-imports.js
+++ b/plugins/ban-web-server-imports.js
@@ -10,46 +10,24 @@
  * to the server's internal file layout.
  *
  * Rule: files under `apps/mesh/src/web/` may not make a **value** import (or
- * re-export, or dynamic import) from a `@/<server-tree>/…` specifier. `import
- * type` / `import { type X }` are allowed. The fix is to import it `type`-only,
- * or move the shared value (schema, constant, pure helper) into a frontend-safe
- * location (`@/web`, `@/mcp-apps`, `@/lib`, `@/shared`) or into `@decocms/mesh-sdk`.
+ * re-export, or dynamic import) that resolves into an `apps/mesh/src/<tree>`
+ * OTHER than the frontend-safe trees below. This is an ALLOWLIST — a new
+ * server-only tree is guarded by default (fails closed) instead of leaking until
+ * someone remembers to blocklist it. `import type` / `import { type X }` are
+ * allowed. Both `@/…` alias imports and `../…` relative climbs are checked. The
+ * fix is to import it `type`-only, or move the shared value (schema, constant,
+ * pure helper) into a frontend-safe tree or into `@decocms/mesh-sdk`.
  *
  * Companion to `ban-cross-tree-imports.js` (which guards packages/ ↛ apps/mesh)
  * and `ban-e2e-app-imports.js` (which guards the e2e black-box wall).
  */
 
-// Second path segment of `@/<tree>/…` that is server-only. Anything not listed
-// (web, mcp-apps, lib, shared, hooks, …) is treated as frontend-safe.
-const SERVER_ONLY_TREES = new Set([
-  "storage",
-  "core",
-  "api",
-  "tools",
-  "auth",
-  "services",
-  "mcp-clients",
-  "event-bus",
-  "automations",
-  "dispatch-queue",
-  "object-storage",
-  "file-storage",
-  "monitoring",
-  "observability",
-  "database",
-  "dbos",
-  "nats",
-  "vault",
-  "encryption",
-  "oauth",
-  "link-daemon",
-  "harnesses",
-  "ai-providers",
-  "commerce-discovery",
-  "sandbox",
-  "settings",
-  "links",
-]);
+// Trees under apps/mesh/src that the browser bundle may value-import from.
+// Everything else (storage, core, api, tools, auth, ai-providers, cli, …) is
+// server-only by default.
+const FRONTEND_SAFE_TREES = new Set(["web", "mcp-apps", "lib", "shared"]);
+
+const SRC_MARKER = "/apps/mesh/src/";
 
 function inWebTree(filename) {
   return (
@@ -58,11 +36,42 @@ function inWebTree(filename) {
   );
 }
 
-// `@/<tree>/…` → returns the server-only tree name, or null.
-function serverTreeOf(spec) {
-  if (typeof spec !== "string" || !spec.startsWith("@/")) return null;
-  const tree = spec.slice(2).split("/")[0];
-  return SERVER_ONLY_TREES.has(tree) ? tree : null;
+// Test files never ship in the browser bundle, so their imports are outside
+// this rule's bundle/secret boundary (a web unit test may pull `@/test` helpers).
+function isTestFile(filename) {
+  return /\.test\.[cm]?[jt]sx?$/.test(filename);
+}
+
+// Resolve `../` / `./` segments of a relative spec against the importing file.
+function resolveRelative(fromFile, spec) {
+  const parts = fromFile.split("/");
+  parts.pop(); // drop the filename → containing directory
+  for (const seg of spec.split("/")) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") parts.pop();
+    else parts.push(seg);
+  }
+  return parts.join("/");
+}
+
+// Returns the server-only `apps/mesh/src/<tree>` a specifier resolves into, or
+// null if it stays in a frontend-safe tree / points outside apps/mesh/src (bare
+// or workspace specifier).
+function serverTreeOf(spec, filename) {
+  if (typeof spec !== "string") return null;
+  let resolved;
+  if (spec.startsWith("@/")) {
+    resolved = `${SRC_MARKER}${spec.slice(2)}`;
+  } else if (spec.startsWith(".")) {
+    resolved = resolveRelative(filename, spec);
+  } else {
+    return null; // bare / workspace-package specifier
+  }
+  const i = resolved.indexOf(SRC_MARKER);
+  if (i === -1) return null;
+  const tree = resolved.slice(i + SRC_MARKER.length).split("/")[0];
+  if (!tree) return null;
+  return FRONTEND_SAFE_TREES.has(tree) ? null : tree;
 }
 
 // True when the whole statement is type-only (erased at build → safe).
@@ -83,20 +92,20 @@ function isTypeOnly(node) {
 const banWebServerImportsRule = {
   create(context) {
     const filename = context.filename ?? "";
-    if (!inWebTree(filename)) return {};
+    if (!inWebTree(filename) || isTestFile(filename)) return {};
 
     const check = (node, { dynamic = false } = {}) => {
       const src = node?.source;
       if (!src || src.type !== "Literal" || typeof src.value !== "string")
         return;
-      const tree = serverTreeOf(src.value);
+      const tree = serverTreeOf(src.value, filename);
       if (!tree) return;
       if (!dynamic && isTypeOnly(node)) return;
 
       context.report({
         node: src,
         message:
-          `Web ↔ server boundary: "${src.value}" is a VALUE import from the server-only "@/${tree}" tree. ` +
+          `Web ↔ server boundary: "${src.value}" is a VALUE import from the server-only "${tree}" tree. ` +
           `The frontend is a separate bundle — it may import types (use \`import type\`) but not runtime code, ` +
           `which risks pulling server deps/secrets into the browser. Move the shared value into @/web, @/mcp-apps, ` +
           `@/lib, @/shared or @decocms/mesh-sdk, or import it type-only.`,

--- a/plugins/ban-web-server-imports.test.ts
+++ b/plugins/ban-web-server-imports.test.ts
@@ -106,12 +106,40 @@ describe("ban-web-server-imports", () => {
     expect((await lint(f)).length).toBe(0);
   });
 
-  test("ignores relative and workspace-package imports", async () => {
+  test("ignores in-tree relative and workspace-package imports", async () => {
     const f = fixture(
       "apps/mesh/src/web/i.ts",
       `import { a } from "./sibling";\nimport { useProjectContext } from "@decocms/mesh-sdk";\n` +
         `export const x = [a, useProjectContext];\n`,
     );
     expect((await lint(f)).length).toBe(0);
+  });
+
+  // Allowlist means any not-explicitly-safe tree is guarded by default. `cli`
+  // is server-only but was not in the old blocklist — it must be caught now.
+  test("bans a value import from an unlisted server tree (cli)", async () => {
+    const f = fixture(
+      "apps/mesh/src/web/j.ts",
+      `import { run } from "@/cli/cli-store";\nexport const x = run;\n`,
+    );
+    expect((await lint(f)).length).toBe(1);
+  });
+
+  // Web test files never ship in the browser bundle → outside this rule.
+  test("ignores web test files (not bundled)", async () => {
+    const f = fixture(
+      "apps/mesh/src/web/x.test.ts",
+      `import { render } from "@/test/render";\nexport const x = render;\n`,
+    );
+    expect((await lint(f)).length).toBe(0);
+  });
+
+  // Relative climbs out of web/ into a server tree bypass the `@/` prefix.
+  test("bans a relative climb out of web into a server tree", async () => {
+    const f = fixture(
+      "apps/mesh/src/web/components/k.ts",
+      `import { db } from "../../storage/types";\nexport const x = db;\n`,
+    );
+    expect((await lint(f)).length).toBe(1);
   });
 });

--- a/plugins/ban-web-server-imports.test.ts
+++ b/plugins/ban-web-server-imports.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+
+const ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const TMP = `${ROOT}/.ban-web-server.tmp`;
+const CONFIG = `${TMP}/.oxlintrc.json`;
+
+const CONFIG_JSON = JSON.stringify({
+  jsPlugins: ["../plugins/ban-web-server-imports.js"],
+  rules: { "ban-web-server-imports/ban-web-server-imports": "error" },
+});
+
+async function lint(relPath: string): Promise<string[]> {
+  const proc = Bun.spawn(
+    ["node_modules/.bin/oxlint", "-c", CONFIG, "-f", "json", relPath],
+    { cwd: ROOT, stdout: "pipe", stderr: "pipe" },
+  );
+  const out = await new Response(proc.stdout).text();
+  await proc.exited;
+  const parsed = JSON.parse(out) as {
+    diagnostics: { code: string; message: string }[];
+  };
+  return parsed.diagnostics
+    .filter((d) => d.code.includes("ban-web-server-imports"))
+    .map((d) => d.message);
+}
+
+function fixture(relPath: string, contents: string): string {
+  const abs = `${TMP}/${relPath}`;
+  mkdirSync(abs.slice(0, abs.lastIndexOf("/")), { recursive: true });
+  writeFileSync(abs, contents);
+  return `.ban-web-server.tmp/${relPath}`;
+}
+
+beforeAll(() => {
+  mkdirSync(TMP, { recursive: true });
+  writeFileSync(CONFIG, CONFIG_JSON);
+});
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+describe("ban-web-server-imports", () => {
+  test("bans a value import from a server-only tree", async () => {
+    const f = fixture(
+      "apps/mesh/src/web/a.ts",
+      `import { db } from "@/storage/types";\nexport const x = db;\n`,
+    );
+    expect((await lint(f)).length).toBe(1);
+  });
+
+  test("bans a value import from @/tools schema", async () => {
+    const f = fixture(
+      "apps/mesh/src/web/b.ts",
+      `import { ConnectionSchema } from "@/tools/connection/schema";\nexport const x = ConnectionSchema;\n`,
+    );
+    expect((await lint(f)).length).toBe(1);
+  });
+
+  test("allows `import type` from a server tree (erased at build)", async () => {
+    const f = fixture(
+      "apps/mesh/src/web/c.ts",
+      `import type { Thread } from "@/storage/types";\nexport type T = Thread;\n`,
+    );
+    expect((await lint(f)).length).toBe(0);
+  });
+
+  test("allows `import { type X }` inline type specifiers", async () => {
+    const f = fixture(
+      "apps/mesh/src/web/d.ts",
+      `import { type ChatMessage } from "@/api/routes/decopilot/types";\nexport type M = ChatMessage;\n`,
+    );
+    expect((await lint(f)).length).toBe(0);
+  });
+
+  test("allows value imports from frontend-safe trees (mcp-apps, web, lib)", async () => {
+    const f = fixture(
+      "apps/mesh/src/web/e.ts",
+      `import { MCPAppRenderer } from "@/mcp-apps/mcp-app-renderer.tsx";\n` +
+        `import { thing } from "@/web/lib/thing";\n` +
+        `import { util } from "@/lib/util";\n` +
+        `export const x = [MCPAppRenderer, thing, util];\n`,
+    );
+    expect((await lint(f)).length).toBe(0);
+  });
+
+  test("bans a dynamic import from a server tree", async () => {
+    const f = fixture(
+      "apps/mesh/src/web/f.ts",
+      `export const load = () => import("@/core/studio-context");\n`,
+    );
+    expect((await lint(f)).length).toBe(1);
+  });
+
+  test("bans a value re-export from a server tree", async () => {
+    const f = fixture(
+      "apps/mesh/src/web/g.ts",
+      `export { MCP_MESH_KEY } from "@/core/constants";\n`,
+    );
+    expect((await lint(f)).length).toBe(1);
+  });
+
+  test("ignores files outside the web tree", async () => {
+    const f = fixture(
+      "apps/mesh/src/api/h.ts",
+      `import { db } from "@/storage/types";\nexport const x = db;\n`,
+    );
+    expect((await lint(f)).length).toBe(0);
+  });
+
+  test("ignores relative and workspace-package imports", async () => {
+    const f = fixture(
+      "apps/mesh/src/web/i.ts",
+      `import { a } from "./sibling";\nimport { useProjectContext } from "@decocms/mesh-sdk";\n` +
+        `export const x = [a, useProjectContext];\n`,
+    );
+    expect((await lint(f)).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an oxlint plugin, **`ban-web-server-imports`**, that enforces the web ↔ server boundary inside `apps/mesh` — the cheap, enforceable version of "separate the frontend and API" (see the analysis in #4468, WI-12).

**Why not a full package split?** The frontend and API are *already* separate at build (`build:client`→`dist/client` vs `build:server`), image (nginx `-web` container vs Bun `-api` container, independent tags — `deploy/helm/studio/templates/deployment.yaml`), and runtime (SPA calling the API over HTTP via `@decocms/mesh-sdk`, 207 files). The only shared thing is the *source tree*, and the coupling there is almost entirely `import type` (erased at build — end-to-end type safety is a feature we want to keep). A full `apps/web` split would break ~240 type imports for little runtime gain. The real risk is the handful of **value** imports that reach into server-only trees.

**What the rule does.** Files under `apps/mesh/src/web/` may not make a **value** import (or re-export, or dynamic import) from a `@/<server-tree>/…` specifier (`storage`, `core`, `api`, `tools`, `auth`, `ai-providers`, `services`, `mcp-clients`, `event-bus`, `harnesses`, `sandbox`, …). It **allows**: `import type` / `import { type X }` (erased), frontend-safe trees (`@/mcp-apps`, `@/web`, `@/lib`, `@/shared`), and workspace packages (`@decocms/mesh-sdk`). This makes the bundle/secret boundary real and gives frontend-vibecoding agents a hard fence.

**Landed as `warn`** (not `error`) because there are **21 pre-existing violations across 20 files** — all genuine leaks where a Zod schema / constant / pure helper lives on the server side and gets value-imported by the UI:

| Server tree | Violations | Example |
|---|---|---|
| `@/tools/*/schema`, `registry/shared`, `registry-metadata` | 10 | `connection-sidebar.tsx` → `@/tools/connection/schema` |
| `@/ai-providers` (model lists, tiers) | 3 | `agent-models.tsx` → `CLAUDE_CODE_MODELS` |
| `@/core` (constants, `org-archived`) | 3 | `utils/constants.ts` → `@/core/constants` |
| `@/api/routes/decopilot/mesh-storage-uri` | 3 | `parseMeshStorageKey` |
| `@/file-storage`, `@/commerce-discovery` | 2 | pure helpers |

The fix for each is to move the shared value into `@/web` / `@/lib` / `@/shared` / `@decocms/mesh-sdk`, or import it type-only. Once the list is drained, flip the rule to `error`. (Confirmed the rule correctly **ignores** the 18 legit `@/mcp-apps` value imports — that tree is frontend code.)

## Testing
- `bun test plugins/ban-web-server-imports.test.ts` → **9 pass** (bans value import / tools-schema / dynamic import / value re-export; allows `import type`, inline `type` specifiers, frontend-safe trees, relative + workspace imports, non-web files).
- `bun run fmt` clean.

## Companion
Sibling to `plugins/ban-cross-tree-imports.js` (packages ↛ apps/mesh) and `plugins/ban-e2e-app-imports.js` (e2e black-box wall). Part of the audit in #4468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an oxlint plugin `ban-web-server-imports` to enforce the web ↔ server import boundary in `apps/mesh`, blocking value imports from server-only trees into the web bundle. Lands as `warn` to surface 21 violations while we move shared values; supports WI-12.

- **New Features**
  - Enforces an allowlist of frontend-safe trees (`@/web`, `@/mcp-apps`, `@/lib`, `@/shared`); bans value imports, re-exports, and dynamic imports from other `apps/mesh/src/<tree>` paths.
  - Resolves both `@/` and relative `../` climbs; skips web test files; allows `import type` and workspace packages like `@decocms/mesh-sdk`.
  - Loads the plugin in `.oxlintrc.json`; adds 12 tests.

- **Migration**
  - For violations, move shared constants/schemas/helpers to `@/web`, `@/lib`, `@/shared`, or `@decocms/mesh-sdk`, or switch to `import type`.
  - Flip the rule to `error` after cleanup.

<sup>Written for commit 20960405465f82423105808d42fb40dd80177472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

