### PR TITLE
fix(sandbox): validate remote default branch before shelling out in checkout

### DIFF
--- a/packages/sandbox/daemon/git/checkout-branch.test.ts
+++ b/packages/sandbox/daemon/git/checkout-branch.test.ts
@@ -8,6 +8,7 @@ import {
   resolveRemoteDefaultBranch,
   spawnCheckoutBranch,
 } from "./checkout-branch";
+import { InvalidRemoteBranchNameError } from "./ref-name";
 
 function setupBareRepo(): { url: string; root: string; cleanup: () => void } {
   const root = mkdtempSync(join(tmpdir(), "checkout-branch-"));
@@ -121,6 +122,34 @@ describe("spawnCheckoutBranch", () => {
       });
 
       expect(existsSync(join(repoDir, "local.txt"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("rejects a malicious origin/HEAD default branch instead of shelling it out", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = cloneWorkspace(url, root);
+      // A repo's default branch name is remote-controlled: whoever owns
+      // `origin` can point origin/HEAD anywhere. Git's ref-format rules allow
+      // shell metacharacters in ref names, so an attacker-named default
+      // branch would otherwise get interpolated straight into `sh -c`.
+      execSync(
+        `git -C ${repoDir} symbolic-ref refs/remotes/origin/HEAD 'refs/heads/pwn;touch\${IFS}${root}/INJECTED'`,
+      );
+
+      await expect(
+        spawnCheckoutBranch({
+          repoDir,
+          branch: "does-not-exist-anywhere",
+          gc: `git -C ${repoDir}`,
+          runStep: (cmd) => spawnSetupStep(cmd, () => {}),
+          log: () => {},
+        }),
+      ).rejects.toThrow(InvalidRemoteBranchNameError);
+
+      expect(existsSync(join(root, "INJECTED"))).toBe(false);
     } finally {
       cleanup();
     }

--- a/packages/sandbox/daemon/git/checkout-branch.ts
+++ b/packages/sandbox/daemon/git/checkout-branch.ts
@@ -1,4 +1,5 @@
 import { gitSync } from "./git-sync";
+import { assertValidRemoteBranchName } from "./ref-name";
 
 /** Default branch pointed to by `origin/HEAD`, falling back to `main`. */
 export function resolveRemoteDefaultBranch(repoDir: string): string {
@@ -88,6 +89,12 @@ export async function spawnCheckoutBranch(
     }
 
     const defaultBranch = resolveRemoteDefaultBranch(repoDir);
+    // `defaultBranch` comes from the remote's own `origin/HEAD` symref (set by
+    // whoever controls that remote) and is interpolated into `sh -c` git
+    // commands below — git permits shell metacharacters (`;`, `$(…)`,
+    // backticks, …) in ref names, so an unvalidated value here is a command
+    // injection vector. Reject before it ever reaches a shell string.
+    assertValidRemoteBranchName(defaultBranch);
     log(
       `[orchestrator] branch '${branch}' not on remote; creating from default branch '${defaultBranch}'\r\n`,
     );


### PR DESCRIPTION
## Source
A bug found while reading recently-changed sandbox git code (no open issue covers this).

## Payoff
Closes a command-injection vector: `spawnCheckoutBranch`'s fork-from-default-branch path reads `defaultBranch` from the remote's own `origin/HEAD` symref and interpolates it, unvalidated, into `sh -c` git commands (`fetch`/`checkout -B`). Git's ref-format rules permit shell metacharacters (`;`, `$(...)`, backticks) in ref names, so a repository whose default branch is attacker-named lets that attacker run arbitrary commands in the sandbox daemon process the moment a task requests a branch that doesn't exist locally or on the remote.

This is the same vulnerability class the team already fixed in the sibling `fetchBaseBranch` path (`packages/sandbox/daemon/setup/clone.ts`, with its own ad-hoc `isSafeRefName` allowlist and an explicit comment about the injection vector) — this file was just missed. Rather than duplicating that allowlist again, this reuses the existing `assertValidRemoteBranchName` guard already used for the same purpose in `rebase-onto-base.ts` and `routes/git.ts`.

## Failure scenario + regression test
`packages/sandbox/daemon/git/checkout-branch.test.ts` adds a case that points a cloned repo's `origin/HEAD` at `refs/heads/pwn;touch${IFS}<tmp>/INJECTED` (a syntactically valid git ref name) and requests a checkout of a branch absent from both remote and local. Before the fix, `spawnCheckoutBranch` resolves without error (i.e. it shells the malicious ref straight into `sh -c`); after the fix it rejects with `InvalidRemoteBranchNameError` before the shell ever sees it.

## Verify
```
bun test packages/sandbox/daemon/git/checkout-branch.test.ts
```

## Checks run locally
- `bun run fmt` — no changes needed
- `bun test packages/sandbox/daemon/git/checkout-branch.test.ts` — 4 pass (confirmed the new test fails on the pre-fix code, then passes after the fix)
- Full CI will run typecheck/lint across the monorepo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the remote default branch name in sandbox checkout to block command injection via attacker-controlled `origin/HEAD`. Adds a guard before shell commands and a regression test to ensure `spawnCheckoutBranch` rejects malicious refs.

- **Bug Fixes**
  - Validate `defaultBranch` in `spawnCheckoutBranch` using `assertValidRemoteBranchName` before running `git fetch`/`git checkout -B`.
  - Add test that sets `origin/HEAD` to a ref with shell metacharacters; now fails with `InvalidRemoteBranchNameError` and no commands run.

<sup>Written for commit 60815ef62e6909187333027e5d8551b8a2a344d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

