### PR TITLE
fix(sandbox): protect a repo's actual default branch, not just main/master

### DIFF
--- a/packages/sandbox/daemon/git/protect-branch.test.ts
+++ b/packages/sandbox/daemon/git/protect-branch.test.ts
@@ -52,4 +52,32 @@ describe("installProtectedBranchHook", () => {
       rmSync(repoDir, { recursive: true, force: true });
     }
   });
+
+  it("also blocks pushes to the repo's actual default branch when it isn't main/master", async () => {
+    const repoDir = mkdtempSync(join(tmpdir(), "protect-branch-"));
+    try {
+      execFileSync("git", ["init", "-q"], { cwd: repoDir });
+      execFileSync(
+        "git",
+        [
+          "symbolic-ref",
+          "refs/remotes/origin/HEAD",
+          "refs/remotes/origin/release",
+        ],
+        { cwd: repoDir },
+      );
+
+      await installProtectedBranchHook(repoDir);
+      const hookPath = join(repoDir, ".git", "hooks", "pre-push");
+
+      const release = runHook(hookPath, "refs/heads/release");
+      expect(release.status).not.toBe(0);
+      expect(release.stderr).toContain("not allowed from a sandbox");
+
+      const feature = runHook(hookPath, "refs/heads/feature/x");
+      expect(feature.status).toBe(0);
+    } finally {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/sandbox/daemon/git/protect-branch.ts
+++ b/packages/sandbox/daemon/git/protect-branch.ts
@@ -1,15 +1,17 @@
 import { chmod, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { resolveRemoteDefaultBranch } from "./checkout-branch";
 
+// The protected branch list is a plain data file, not interpolated into the
+// script, so an unusual (but valid) ref name can't inject shell syntax here.
 const HOOK = `#!/bin/sh
+protected="$(dirname "$0")/protected-branches"
 while IFS=' ' read -r _local_ref _local_sha remote_ref _remote_sha; do
   branch="\${remote_ref#refs/heads/}"
-  case "$branch" in
-    main|master)
-      echo "error: pushing to '$branch' is not allowed from a sandbox" >&2
-      exit 1
-      ;;
-  esac
+  if grep -qxF "$branch" "$protected" 2>/dev/null; then
+    echo "error: pushing to '$branch' is not allowed from a sandbox" >&2
+    exit 1
+  fi
 done
 exit 0
 `;
@@ -21,7 +23,20 @@ export async function installProtectedBranchHook(
 ): Promise<void> {
   const hooksDir = join(repoDir, ".git", "hooks");
   await mkdir(hooksDir, { recursive: true });
-  const hookPath = join(hooksDir, "pre-push");
-  await writeFile(hookPath, HOOK, { encoding: "utf-8" });
-  await chmod(hookPath, 0o755);
+  await writeFile(join(hooksDir, "pre-push"), HOOK, { encoding: "utf-8" });
+  await chmod(join(hooksDir, "pre-push"), 0o755);
+
+  // Not every repo names its default branch main/master (trunk, develop,
+  // etc.) — protect the repo's actual default too, or a sandbox push would
+  // sail straight through on those repos.
+  const branches = new Set([
+    "main",
+    "master",
+    resolveRemoteDefaultBranch(repoDir),
+  ]);
+  await writeFile(
+    join(hooksDir, "protected-branches"),
+    `${[...branches].join("\n")}\n`,
+    { encoding: "utf-8" },
+  );
 }


### PR DESCRIPTION
## Source
Bug found reading the sandbox daemon's git-safety code (`packages/sandbox/daemon/git/protect-branch.ts`), which installs a pre-push hook meant to stop a sandbox agent from pushing straight to a repo's protected branch.

## The bug
The installed hook only blocked pushes to branches literally named `main` or `master`:

```sh
case "$branch" in
  main|master)
    echo "error: pushing to '$branch' is not allowed from a sandbox" >&2
    exit 1
    ;;
esac
```

The codebase already has `resolveRemoteDefaultBranch()` (`git/checkout-branch.ts`) specifically because not every repo's default branch is `main`/`master` — it reads `origin/HEAD` and falls back to `main` only if that fails. `protect-branch.ts` never used it, so on any repo whose real default branch is e.g. `trunk`, `develop`, or `release`, a sandbox push straight to that branch would sail through unblocked — silently defeating the entire safety net this hook exists for.

## Fix
`installProtectedBranchHook` now also resolves and protects the repo's actual default branch (`resolveRemoteDefaultBranch(repoDir)`), in addition to the `main`/`master` literals. The branch list is written to a sibling data file (`protected-branches`) and matched with `grep -qxF` (fixed-string, exact-line) rather than interpolated into the shell script's `case` pattern — this avoids reintroducing a shell-injection surface from an unusual (but git-legal) branch name.

## Regression test
Added a test that fakes `origin/HEAD` pointing at `refs/remotes/origin/release` and confirms the installed hook now blocks a push to `release` (and still allows unrelated branches). Failed before the fix (only `main`/`master` were blocked), passes after.

## Verify
```
bun test packages/sandbox/daemon/git/protect-branch.test.ts
```

## Checks run locally
- `bun run fmt` (no changes)
- `bun x tsc --noEmit` in `packages/sandbox` — pre-existing unrelated errors only (confirmed identical on `main` before this change)
- `bun test packages/sandbox/daemon/git/protect-branch.test.ts` — 3 pass

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox pre-push hook to block pushes to a repo’s actual default branch, not only `main`/`master`. This closes a gap that allowed direct pushes to defaults like `trunk`, `develop`, or `release`.

- **Bug Fixes**
  - Populates `.git/hooks/protected-branches` with `main`, `master`, and the resolved default from `resolveRemoteDefaultBranch(repoDir)` in `git/checkout-branch.ts`.
  - The hook checks branches with `grep -qxF` for exact matches to avoid shell injection from unusual ref names.
  - Adds a regression test in `packages/sandbox/daemon/git/protect-branch.test.ts` that blocks `release` and allows unrelated branches.

<sup>Written for commit ae692c0f14fe5c01c0b86608d34bbada756ead24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

