### PR TITLE
fix(sandbox): validate requested branch name before shelling out in checkout

### DIFF
--- a/packages/sandbox/daemon/git/checkout-branch.test.ts
+++ b/packages/sandbox/daemon/git/checkout-branch.test.ts
@@ -154,4 +154,27 @@ describe("spawnCheckoutBranch", () => {
       cleanup();
     }
   }, 30_000);
+
+  it("rejects a malicious requested branch instead of shelling it out", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = cloneWorkspace(url, root);
+      // `branch` comes from the sandbox's git config and is interpolated
+      // into `sh -c` git commands (ls-remote/fetch/checkout) — same
+      // injection vector as origin/HEAD, just from a different source.
+      await expect(
+        spawnCheckoutBranch({
+          repoDir,
+          branch: `pwn;touch\${IFS}${root}/INJECTED`,
+          gc: `git -C ${repoDir}`,
+          runStep: (cmd) => spawnSetupStep(cmd, () => {}),
+          log: () => {},
+        }),
+      ).rejects.toThrow(InvalidRemoteBranchNameError);
+
+      expect(existsSync(join(root, "INJECTED"))).toBe(false);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
 });

--- a/packages/sandbox/daemon/git/checkout-branch.ts
+++ b/packages/sandbox/daemon/git/checkout-branch.ts
@@ -49,6 +49,11 @@ export async function spawnCheckoutBranch(
 ): Promise<void> {
   const { repoDir, branch, gc, runStep, log } = params;
 
+  // `branch` is interpolated into `sh -c` git commands below (ls-remote,
+  // fetch, checkout) — same shell-injection vector as `defaultBranch` above,
+  // so it needs the same validation before ever reaching a shell string.
+  assertValidRemoteBranchName(branch);
+
   try {
     const head = gitSync(["rev-parse", "--abbrev-ref", "HEAD"], {
       cwd: repoDir,


### PR DESCRIPTION
## Source
Bug found by reading recently-changed code around PR #4470 (fix/sandbox-checkout-default-branch-validation), which validated `defaultBranch` (from `origin/HEAD`) before interpolating it into shell commands but left the sibling `branch` parameter unvalidated in the same function.

## The bug
`spawnCheckoutBranch` in `packages/sandbox/daemon/git/checkout-branch.ts` interpolates the caller-supplied `branch` (sourced from the sandbox's `config.git.repository.branch`) directly into `sh -c` git commands — `ls-remote --heads origin ${branch}`, `checkout -B ${branch} ...` — without validation. Git ref names permit shell metacharacters, so a branch name such as `` pwn;touch${IFS}/tmp/pwned `` is a command-injection vector when the daemon shells it out (`spawnPty` runs `sh -c <cmd>`). This is the exact same vulnerability class the adjacent `defaultBranch` fix in #4470 closed, just for a different field.

## Fix
Validate `branch` with the existing `assertValidRemoteBranchName` guard (already used for `defaultBranch` in this same file) before any shell interpolation.

## Test
Added `checkout-branch.test.ts`: "rejects a malicious requested branch instead of shelling it out" — passes a branch name containing shell metacharacters and asserts `spawnCheckoutBranch` throws `InvalidRemoteBranchNameError` before ever touching a shell, with a filesystem-side-effect check (`INJECTED` file never created) proving the injection didn't fire. This test fails without the fix.

## To verify
`bun test packages/sandbox/daemon/git/checkout-branch.test.ts`

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `packages/sandbox` (pre-existing unrelated errors in `title-generator.ts`/`tools-catalog.ts`, confirmed present on `main` before this change too)
- `bun test packages/sandbox/daemon/git/checkout-branch.test.ts` — 5 pass, 0 fail

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the requested `branch` before executing git commands to prevent command injection in the sandbox checkout flow. This matches the existing `defaultBranch` validation and blocks malicious ref names.

- **Bug Fixes**
  - Added `assertValidRemoteBranchName(branch)` in `packages/sandbox/daemon/git/checkout-branch.ts` to guard before any `sh -c` calls.
  - Added `checkout-branch.test.ts` to ensure malicious branch names throw `InvalidRemoteBranchNameError` and produce no side effects.

<sup>Written for commit 242b42175ba8aa77bad70669da7baad9d691b8a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

