### PR TITLE
fix(sidebar): one new chat, retargeted — stop spawning empty chats per agent click

### DIFF
--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -383,6 +383,9 @@ export class SqlThreadStorage implements ThreadStoragePort {
     if (data.branch !== undefined) {
       updateData.branch = data.branch;
     }
+    if (data.virtual_mcp_id !== undefined) {
+      updateData.virtual_mcp_id = data.virtual_mcp_id;
+    }
     if (data.sandbox_provider_kind !== undefined) {
       updateData.sandbox_provider_kind = data.sandbox_provider_kind;
     }

--- a/apps/mesh/src/tools/thread/schema.ts
+++ b/apps/mesh/src/tools/thread/schema.ts
@@ -151,6 +151,12 @@ export const ThreadUpdateDataSchema = z.object({
     "Full replacement of the thread's metadata object",
   ),
   branch: z.string().nullish().describe("New git branch for this thread"),
+  virtual_mcp_id: z
+    .string()
+    .optional()
+    .describe(
+      "Re-point the thread at a different agent. Only meaningful for an unsent thread (changing the recipient of a new chat); the UI restricts it accordingly.",
+    ),
 });
 
 export type ThreadUpdateData = z.infer<typeof ThreadUpdateDataSchema>;

--- a/apps/mesh/src/tools/thread/update.ts
+++ b/apps/mesh/src/tools/thread/update.ts
@@ -101,6 +101,10 @@ export const COLLECTION_THREADS_UPDATE = defineTool({
       updateData.branch = data.branch;
     }
 
+    if (data.virtual_mcp_id !== undefined) {
+      updateData.virtual_mcp_id = data.virtual_mcp_id;
+    }
+
     const thread = await ctx.storage.threads.update(id, updateData);
 
     // Fire chat_archived / chat_unarchived when the hidden flag flips. Only

--- a/apps/mesh/src/web/components/chat/store/hooks.tsx
+++ b/apps/mesh/src/web/components/chat/store/hooks.tsx
@@ -99,6 +99,7 @@ export function useThreadActions() {
     hide: m.hide.bind(m),
     setStatus: m.setStatus.bind(m),
     setBranch: m.setBranch.bind(m),
+    setAgent: m.setAgent.bind(m),
     setActive: m.setActive.bind(m),
     closeActive: m.closeActive.bind(m),
   };

--- a/apps/mesh/src/web/components/chat/store/thread-manager-store.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-manager-store.ts
@@ -178,6 +178,12 @@ export class ThreadManagerStore {
     return this.optimisticUpdate(id, { branch });
   }
 
+  /** Re-point an (unsent) thread at a different agent — updates the row's
+   * virtual_mcp_id so the sidebar icon follows the selected agent. */
+  setAgent(id: string, virtualMcpId: string): Promise<void> {
+    return this.optimisticUpdate(id, { virtual_mcp_id: virtualMcpId });
+  }
+
   /**
    * Local-only patch: apply a partial Task patch in-place. No server round-trip.
    * Used for live signals that don't flow through `/watch` (e.g. titles emitted

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -152,7 +152,7 @@ export function TaskGroupsList({
     fetchNextPage,
   } = useThreads();
   const visibleThreads = allThreads.filter((thread) => !thread.hidden);
-  const { hide } = useThreadActions();
+  const { hide, setAgent } = useThreadActions();
 
   const navigate = useNavigate();
   const navigateToAgent = useNavigateToAgent();
@@ -361,6 +361,9 @@ export function TaskGroupsList({
       const active = allThreads.find((t) => t.id === activeTaskId);
       if (active?.title === "New chat" && (await isThreadEmpty(activeTaskId))) {
         closeAfterNavigation();
+        // Re-point the row at the new agent (icon follows) and swap the
+        // recipient — same thread, no new empty chat.
+        void setAgent(activeTaskId, virtualMcpId);
         setTaskId(activeTaskId, virtualMcpId);
         return;
       }

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -32,7 +32,12 @@ import {
   useVirtualMCPActions,
   useVirtualMCPs,
 } from "@decocms/mesh-sdk";
-import { useNavigate, useParams, useRouterState } from "@tanstack/react-router";
+import {
+  useNavigate,
+  useParams,
+  useRouterState,
+  useSearch,
+} from "@tanstack/react-router";
 import { authClient } from "@/web/lib/auth-client";
 import {
   useThreadActions,
@@ -155,13 +160,19 @@ export function TaskGroupsList({
   const params = useParams({ strict: false }) as {
     taskId?: string;
   };
+  const search = useSearch({ strict: false }) as { virtualmcpid?: string };
   const pathname = useRouterState({
     select: (s) => s.location.pathname,
   });
   const isOnHome = pathname === `/${org.slug}` || pathname === `/${org.slug}/`;
   const activeTaskId = params.taskId ?? null;
+  // The recipient is the URL's `virtualmcpid` (what the composer sends to),
+  // falling back to the thread row's agent. Preferring the param keeps the
+  // active-agent highlight in sync when a new chat is retargeted in place.
   const activeAgentId =
-    allThreads.find((t) => t.id === activeTaskId)?.virtual_mcp_id ?? null;
+    search.virtualmcpid ??
+    allThreads.find((t) => t.id === activeTaskId)?.virtual_mcp_id ??
+    null;
   const closeAfterNavigation = () => {
     onNavigate?.();
   };
@@ -297,6 +308,22 @@ export function TaskGroupsList({
     createNewTask(virtualMcpId);
   };
 
+  // Verify a thread has no messages (an unsent "New chat"), so we can reuse it
+  // instead of spawning another empty one. Failure → treat as non-empty.
+  const isThreadEmpty = async (threadId: string): Promise<boolean> => {
+    try {
+      const res = await client.callTool({
+        name: "COLLECTION_THREAD_MESSAGES_LIST",
+        arguments: { thread_id: threadId, limit: 1, offset: 0 },
+      });
+      const payload = ((res as { structuredContent?: unknown })
+        .structuredContent ?? res) as { items?: unknown[] };
+      return (payload.items?.length ?? 0) === 0;
+    } catch {
+      return false;
+    }
+  };
+
   // New thread: always target the currently selected agent (the active
   // thread's agent, else decopilot). To avoid piling up empties, focus an
   // existing empty "New chat" for that agent (verified to have no messages)
@@ -307,38 +334,38 @@ export function TaskGroupsList({
     const candidate = myThreadsAll.find(
       (t) => t.virtual_mcp_id === currentAgentId && t.title === "New chat",
     );
-    if (candidate) {
-      let isEmpty = false;
-      try {
-        const res = await client.callTool({
-          name: "COLLECTION_THREAD_MESSAGES_LIST",
-          arguments: { thread_id: candidate.id, limit: 1, offset: 0 },
-        });
-        const payload = ((res as { structuredContent?: unknown })
-          .structuredContent ?? res) as { items?: unknown[] };
-        isEmpty = (payload.items?.length ?? 0) === 0;
-      } catch {
-        // On lookup failure, fall through and create a fresh thread.
-      }
-      if (isEmpty) {
-        closeAfterNavigation();
-        setTaskId(candidate.id, currentAgentId);
-        return;
-      }
+    if (candidate && (await isThreadEmpty(candidate.id))) {
+      closeAfterNavigation();
+      setTaskId(candidate.id, currentAgentId);
+      return;
     }
     closeAfterNavigation();
     createNewTask(currentAgentId);
   };
 
-  // Click an agent → show the agent home (threads list + new chat input).
+  // Click an agent. There is only ever ONE new chat: if you're already sitting
+  // in an empty "New chat", clicking a different agent just re-points that chat
+  // at the new recipient (same thread, swap the agent) instead of spawning yet
+  // another empty thread. Otherwise it starts the one new chat with that agent.
   // Decopilot is the product home — clicking it navigates to /$org directly.
-  const handleOpenAgent = (virtualMcpId: string) => {
+  const handleOpenAgent = async (virtualMcpId: string) => {
     if (virtualMcpId === decopilotId) {
       closeAfterNavigation();
       navigate({ to: "/$org", params: { org: org.slug } });
       return;
     }
     track("sidebar_agent_opened", { virtual_mcp_id: virtualMcpId });
+
+    // Retarget the current empty new chat in place.
+    if (activeTaskId && activeAgentId !== virtualMcpId) {
+      const active = allThreads.find((t) => t.id === activeTaskId);
+      if (active?.title === "New chat" && (await isThreadEmpty(activeTaskId))) {
+        closeAfterNavigation();
+        setTaskId(activeTaskId, virtualMcpId);
+        return;
+      }
+    }
+
     closeAfterNavigation();
     navigateToAgent(virtualMcpId);
   };


### PR DESCRIPTION
## Problem

Clicking back and forth between agents in the sidebar spawned a **new empty "New chat" every time** — the list filled up with duplicates. Root cause: `useNavigateToAgent` mints a fresh `taskId` on every click and the destination route eagerly creates that thread row (`useEnsureTask`).

## Fix

There is only ever **one** new chat. If you're already sitting in an empty "New chat", clicking a different agent **re-points that same thread at the new recipient** (swaps the `?virtualmcpid` the composer/run sends to) instead of creating another empty thread. It only starts a fresh chat when you're not already in one.

- `handleOpenAgent`: when the active thread is an empty "New chat", reuse its `taskId` and set the recipient to the clicked agent (`setTaskId`), else `navigateToAgent` as before.
- Active-agent highlight now derives from the URL `virtualmcpid` (falling back to the thread row), so it stays correct after an in-place retarget.
- Extracted the shared `isThreadEmpty` check (also used by the new-thread button).

The send path already targets the URL param agent (`agent: { id: capturedVirtualMcpId }`), so retargeting an unsent chat routes the first message to the right agent.

## Testing

- `tsc --noEmit` clean, `bun run lint` clean, client build passes.
- Manual: verify clicking agents A→B→A while in a new chat keeps a single "New chat" row and updates the recipient; sending lands the message with the last-selected agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops creating duplicate empty "New chat" threads when switching agents. Reuses the current unsent chat, retargets its recipient, and updates the thread row’s agent icon so only one new chat exists.

- **Bug Fixes**
  - If the active thread is an empty "New chat", keep its `taskId`, retarget the recipient on agent click, and persist the new agent to the row (`setAgent` → `COLLECTION_THREADS_UPDATE`) so the sidebar icon follows; otherwise navigate as before.
  - Read active agent from the URL `virtualmcpid` (fallback to thread) to keep the sidebar highlight correct after retargeting. Uses `useSearch` from `@tanstack/react-router`.
  - Added `virtual_mcp_id` to `ThreadUpdateDataSchema` and storage/update mappings, `ThreadManagerStore.setAgent` and `useThreadActions.setAgent`, plus a shared `isThreadEmpty` check to verify unsent chats.

<sup>Written for commit 455da2cdb65aafd495846599c99c0d75f2cfab1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

