### PR TITLE
docs(agents): add first-pass review-readiness checklist (mined from ~300 PRs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,7 +420,92 @@ PRs should include:
 - Run `bun test` before requesting review
 - Flag follow-up work with TODOs linked to issues
 
+## Ship it review-ready — the first-pass checklist
+
+Auditing ~300 merged PRs shows a consistent shape: a first draft ships the **happy
+path**, then a **hardening pass** (frequently a second person — the author who
+vibecoded it opens, an engineer takes over the branch, adds commits, and merges)
+adds the *same categories of change* every time. Those categories are below. Do
+them in the **first** PR — they are the difference between "works in the demo" and
+"survives production." Each item cites a real PR.
+
+1. **Handle the variants, not just the happy path.** Cover empty / null /
+   whitespace / duplicate / oversized inputs and every schema shape, not the one
+   in front of you. *(sections-editor #4008 added `@hide`, Lazy-wrapped, and
+   blank-title cases the first pass skipped; storage #4426 had to measure payload
+   size **before** `JSON.stringify`, not after; sandbox #4445 added pagination +
+   filename-collision disambiguation + stale-file pruning to a catalog writer.)*
+
+2. **Scope by tenant and permission.** Reads/writes are scoped to the current
+   user/org; other people's data is **read-only unless owned**. A validation or
+   dedup gate must inspect the **complete** payload, not one representative slice.
+   Never reuse a cache/list/React key across two shapes, and never conflate ids.
+   *(#4230 fix: teammates' threads must be read-only in the "All" view; #4416: the
+   publish gate had to union the committed **and** working-tree diffs; #4373: list
+   keys collided across skill/prompt of the same name.)*
+
+3. **Get concurrency right — no silent data loss.** For any "start B while A is in
+   flight" path, trace what happens to A's output and B's input under
+   concurrency-1 / a latch / a retry. Make side-effecting steps **non-retriable
+   unless idempotent**, claim fences/slots at **dispatch**, not at request time,
+   and coalesce fire-and-forget writes that share a path. *(#4365: a fence claimed
+   at POST time silently dropped an in-flight run's reply; #4409: a retriable
+   agent-loop step re-ran 3× and spliced generations; #4445: per-run catalog
+   re-sync raced itself.)*
+
+4. **Test each behavior you touch — in the right tier** (see [Testing](#testing)).
+   Add a test *per fix*. When you fix a bug, find the test that encodes the **old**
+   behavior and **invert** it — don't just append a new one. `grep` **all** tiers
+   (unit **and** `packages/e2e`) for any string or wire/storage contract you
+   changed. Storage changes need a real-Postgres test (in-memory fakes accept
+   columns the `update()` whitelist silently drops). E2E must not depend on a model
+   tier/provider absent in the test org. *(#4008 shipped a test with each fix;
+   #4446/#4430 had to invert tests that asserted the bug; #4350's e2e still
+   asserted pre-redesign copy; #4355 needed real-PG; #4365's e2e depended on a
+   provider tier.)*
+
+5. **Leave no dead code.** After you change who calls a symbol, narrow its export
+   to module-private and delete the newly-orphaned helpers/components/branches in
+   the **same** PR. Run `knip` before declaring done (see Gotcha #6). *(#4230
+   deleted 297 lines of components the refactor orphaned; #4449, #4350, #4373 each
+   shipped a follow-up un-exporting a now-internal symbol knip flagged.)*
+
+6. **Complete the lifecycle and reset state.** New persisted state ships
+   **create + update + delete together**; make the writer idempotent (clear-then-write
+   for index/slug-named files); clean it up when the parent is deleted. A
+   "start/reset" transition must clear the previous cycle's terminal columns.
+   *(#4449 implemented create only — update ignored the field, delete orphaned the
+   subtree; #4355 left a stale `failure_reason` because `RUN_STARTED` didn't null
+   it.)*
+
+7. **Make risky and infra changes reversible and bounded.** Any change on a
+   boot/install/dispatch hot path gets its **own** default-off flag — never
+   piggyback on a neighbor's flag, and never let "deployed" mean "enabled." New
+   caches/artifacts need eviction (TTL + cap), bad-entry invalidation (publish only
+   **after** a health signal), and `.git/info/exclude` so they don't leak onto user
+   branches. Prefer the idle reaper to a fixed wall-clock timeout; emit heartbeats
+   during silent phases. *(#4357: golden cache shipped dormant behind
+   `GOLDEN_CACHE_ENABLED`, with GC and health-gated publish; #4445 git-excluded its
+   artifact; #4355 dropped a fixed timeout for progress-based reaping; #4409 added
+   heartbeats.)* Overstating a safety property in a comment/doc is itself a bug
+   (#4357, #4363).
+
+8. **Validate external input; don't over-engineer.** Validate URLs and user input.
+   Prefer schema-driven behavior to clever runtime inference — an engineer reverted
+   exactly that "infer from runtime data" cleverness in #4008. Use design-system
+   tokens, not raw palette (#4350: `text-emerald-600` → `text-success`), and run
+   `bun run fmt` before the first push (#4461 was a pure-format follow-up).
+
+9. **Keep type-safety at compile time.** Don't `as`-cast to read a field off a
+   union — narrow with an `in` / discriminant check so a rename is a **compile**
+   error, not a runtime regression only e2e catches (#4365). Respect
+   `noUncheckedIndexedAccess`.
+
 ## Common Gotchas
+
+> The [first-pass checklist](#ship-it-review-ready--the-first-pass-checklist) above
+> captures the review-driven gotchas mined from PR history. The list below is the
+> always-load-bearing set.
 
 1. **Never access environment variables directly in tools**—use StudioContext
 2. **Never access HTTP context in tools**—use StudioContext for all state


### PR DESCRIPTION
## Summary

Refactors `AGENTS.md` (the file `CLAUDE.md` symlinks to) with a new **"Ship it review-ready — the first-pass checklist"** section, derived from analyzing what actually changes between a PR's first proposal and its merged state.

## How this was built

Mined the last **~300 merged PRs**, looking specifically at the **diff between the first commit and the merged result** — the "review/hardening work." Findings, using the graph as a map of where churn concentrates (decopilot, sandbox, chat, sections-editor — the same hotspots the [audit](https://github.com/decocms/studio/issues/4468) flagged):

- **Inline code review is ~absent** (0 inline comments across 97 recent PRs) — review here is *self-review* + a **cross-user handoff**: a first draft ships, then a hardening pass adds fixes before merge.
- **The vibecoder→engineer pattern is real** but role-by-context, not by-person. Across 591 PRs, 22 cross-user merges: `pedrofrxncx` is the primary hardener (closes PRs from `vibegui`, `0xcucumbersalad`, `guitavano`), `tlgimenes` gatekeeps the `app/deco-cms` agent's commerce PRs. Clean examples where an engineer took over the branch and added commits: **#4230** (vibegui → rafavalls+pedrofrxncx: rewrote the impl, deleted 297 lines of dead components, fixed a *teammates'-threads-read-only* permission bug, added tests), **#4008** (JonasJesus42 → guitavano, 11 commits: every schema variant + a test per fix + URL validation + reverted an over-clever "infer from runtime data"), **#4134** (cecilia → viktormarinho added the missing tests), **#4469** (the earlier lint PR: ban-list → allowlist hardening). Notably, clean **security** PRs (#4022/#4023) were merged **as-is** — engineers don't touch what's already right.

The hardening pass adds the **same 9 categories every time**. The checklist encodes them so a coding agent does them on the first pass, each citing the PR it came from:

1. Handle the variants, not the happy path (empty/null/oversized/every schema shape)
2. Scope by tenant & permission; gate the *complete* payload; no key/id collisions
3. Concurrency — no silent data loss (non-retriable side effects, claim fences at dispatch, coalesce fire-and-forget)
4. Test each behavior in the right tier — invert bug-encoding tests, grep all tiers, real-Postgres for storage, provider-independent e2e
5. Leave no dead code (narrow exports, delete orphans, run knip)
6. Complete the lifecycle & reset state (create+update+delete together, idempotent clear-then-write)
7. Make risky/infra changes reversible & bounded (own default-off flag, TTL+cap GC, health-gated publish, git-exclude, idle reaper over fixed timeouts)
8. Validate external input; don't over-engineer (schema-driven > runtime inference; DS tokens; `fmt`)
9. Keep type-safety at compile time (no `as`-cast on unions; `noUncheckedIndexedAccess`)

It's cross-linked with the existing "Common Gotchas" list (which stays as the always-load-bearing set).

## Testing
Docs-only change to `AGENTS.md`. No code touched.

## Notes
- `CLAUDE.md` is a symlink to `AGENTS.md`, so this covers both.
- Companion to the codebase audit in #4468 and the lint-boundary PR #4469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Ship it review‑ready” first‑pass checklist to AGENTS.md to help authors ship PRs that need fewer hardening passes. The checklist distills nine recurring fix areas from ~300 merged PRs and links to real examples.

- **New Features**
  - 9-point checklist covering: edge-case/variant handling; tenant/permission scoping; concurrency/idempotency; test-per-fix in the right tier; dead code cleanup; lifecycle symmetry/state reset; reversible infra via flags/GC; input validation/DS tokens; compile-time type safety.
  - Cross-linked with “Common Gotchas”. Docs-only; CLAUDE.md (symlink) reflects the change.

<sup>Written for commit e3fb43aea5b08289e9f83c7611af7594cdb35b26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

