### PR TITLE
test(config): pin Cache-Control: no-store on /api/config

### DIFF
--- a/apps/mesh/src/api/routes/public-config.test.ts
+++ b/apps/mesh/src/api/routes/public-config.test.ts
@@ -31,6 +31,12 @@ describe("GET /api/config", () => {
     setGlobalSettings(originalSettings);
   });
 
+  it("sends Cache-Control: no-store so version-drift polling isn't defeated by caching", async () => {
+    const res = await publicConfigRoutes.request("/");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
   it("returns posthog config when POSTHOG_KEY is set", async () => {
     process.env.POSTHOG_KEY = "phc_test_key";
     delete process.env.POSTHOG_HOST;


### PR DESCRIPTION
## Source
Improvement found while reading recently-churned files (Source 3) — no open PR or issue covers this.

## Why
`public-config.ts` sets `Cache-Control: no-store` on `/api/config` specifically so `version-check-dialog.tsx`'s drift-detection poll isn't defeated by caching — the in-code comment documents the exact failure mode: a cached response returns the same stale value forever, and a hard refresh (which incidentally clears the cache) makes a stuck "new version available" dialog look like it "fixes itself" for no reason. This version-check feature has been reverted and reshipped three separate times (#4403, #4418, #4425, #4460, #4463), yet no test pinned this header — a future refactor of the route could silently drop it and reintroduce that exact confusing bug.

## What changed
Added one test asserting `res.headers.get("Cache-Control") === "no-store"` on `GET /api/config`.

## Verify
```
bun test apps/mesh/src/api/routes/public-config.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun test apps/mesh/src/api/routes/public-config.test.ts` (9 pass)

Full CI will run typecheck/lint across the monorepo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a test that asserts Cache-Control: no-store is returned by GET /api/config to keep the version-drift poll reliable. This guards against caching serving stale config and causing the “new version available” dialog to get stuck.

<sup>Written for commit 1adc3152bd7563bf6b8ac7ac6fe0cf2be5681ea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

