### PR TITLE
fix(sandbox): scope user-driven SANDBOX_START to the locked provider kind

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -4,6 +4,7 @@ import {
   shouldAutoStart,
   shouldSelfHeal,
   computeDrawerStatus,
+  buildSandboxStartArgs,
   type BranchMapEntryLike,
 } from "./sandbox-lifecycle-context";
 
@@ -127,6 +128,26 @@ describe("shouldSelfHeal", () => {
 
   test("user stopped → false", () => {
     expect(shouldSelfHeal({ ...base, userStopped: true })).toBe(false);
+  });
+});
+
+describe("buildSandboxStartArgs", () => {
+  test("includes sandboxProviderKind when the thread has a locked kind", () => {
+    // Regression: user-driven start/retry/resume used to omit
+    // sandboxProviderKind (unlike auto-start/self-heal), so retrying a
+    // failed locked-provider thread could get provisioned on the wrong
+    // provider instead of the one the preview is locked to.
+    expect(buildSandboxStartArgs("vmcp1", "main", "user-desktop")).toEqual({
+      virtualMcpId: "vmcp1",
+      branch: "main",
+      sandboxProviderKind: "user-desktop",
+    });
+  });
+
+  test("omits branch and sandboxProviderKind when absent", () => {
+    expect(buildSandboxStartArgs("vmcp1", null, null)).toEqual({
+      virtualMcpId: "vmcp1",
+    });
   });
 });
 

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -68,6 +68,21 @@ export function shouldSelfHeal(args: ShouldSelfHealArgs): boolean {
   );
 }
 
+/** Shared SANDBOX_START arg-builder so every call site (auto-start,
+ *  self-heal, user-driven start/retry/resume) scopes provisioning to the
+ *  locked provider kind identically — a caller that omits it can get
+ *  provisioned on the wrong provider. */
+export function buildSandboxStartArgs(
+  virtualMcpId: string,
+  branch: string | null,
+  sandboxProviderKind: SandboxProviderKind | null,
+): SandboxStartArgs {
+  const args: SandboxStartArgs = { virtualMcpId };
+  if (branch) args.branch = branch;
+  if (sandboxProviderKind) args.sandboxProviderKind = sandboxProviderKind;
+  return args;
+}
+
 export function computeDrawerStatus(state: PreviewState): DrawerStatus {
   switch (state.kind) {
     case "suspended":
@@ -239,9 +254,11 @@ export function SandboxLifecycleProvider({
   useEffect(() => {
     if (!autoStartEligible || !virtualMcpId) return;
     autoStartAttemptedForBranchRef.current.add(autoStartDedupKey);
-    const args: SandboxStartArgs = { virtualMcpId };
-    if (branch) args.branch = branch;
-    if (sandboxProviderKind) args.sandboxProviderKind = sandboxProviderKind;
+    const args = buildSandboxStartArgs(
+      virtualMcpId,
+      branch,
+      sandboxProviderKind,
+    );
     startVmMutate(args, {
       onSuccess: (data) => {
         if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
@@ -276,9 +293,11 @@ export function SandboxLifecycleProvider({
     if (!selfHealEligible || !deadVmId || !virtualMcpId) return;
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- record dead handle to dedup repeat 404s
     reprovisionedForVmIdRef.current = deadVmId;
-    const args: SandboxStartArgs = { virtualMcpId };
-    if (branch) args.branch = branch;
-    if (sandboxProviderKind) args.sandboxProviderKind = sandboxProviderKind;
+    const args = buildSandboxStartArgs(
+      virtualMcpId,
+      branch,
+      sandboxProviderKind,
+    );
     startVmMutate(args, {
       onSuccess: (data) => {
         if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
@@ -300,8 +319,11 @@ export function SandboxLifecycleProvider({
   // User-driven actions.
   const start = () => {
     if (!virtualMcpId) return;
-    const args: SandboxStartArgs = { virtualMcpId };
-    if (branch) args.branch = branch;
+    const args = buildSandboxStartArgs(
+      virtualMcpId,
+      branch,
+      sandboxProviderKind,
+    );
     startVmMutate(args, {
       onSuccess: (data) => {
         if (data?.branch && !branch) setCurrentTaskBranch(data.branch);


### PR DESCRIPTION
## Source
Bug found reading `sandbox-lifecycle-context.tsx` (high-churn file this run).

## What's wrong
`SandboxLifecycleProvider` receives a `sandboxProviderKind` prop specifically so "entry selection and SANDBOX_START are scoped to this kind [and] the preview never silently shows a different-provider sibling" (per the prop's own doc comment). Commit #4025 wired this through for the auto-start and self-heal effects, but the user-driven `start()` action — which `retry()` and `resume()` also call — built its `SANDBOX_START` args without `sandboxProviderKind`.

**Failure scenario:** a thread is locked to `sandboxProviderKind: "user-desktop"`. That sandbox fails to start (`errored` state, no `previewUrl` yet, no `branchMap` entry recorded). The user clicks Retry. `retry()` → `start()` calls `SANDBOX_START` with no `sandboxProviderKind`, so the server falls back to its link-or-env default provider policy instead of honoring the lock — the sandbox can come up on `agent-sandbox` instead, exactly the "different-provider sibling" the surrounding code says should never happen.

## Fix
Extracted the SANDBOX_START arg-building into one pure, exported helper (`buildSandboxStartArgs`) matching the existing tested-pure-helper pattern already used in this file (`shouldAutoStart`, `shouldSelfHeal`, `computeDrawerStatus`), and reused it at all three call sites (auto-start effect, self-heal effect, user `start()`). Added a regression test asserting the built args include `sandboxProviderKind` when the thread has a locked kind.

## To verify
`bun test apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts`

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (no new errors)
- `bun test apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts` (24 pass)

Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes user-driven SANDBOX_START to the thread’s locked provider to prevent starting on a different provider.

- **Bug Fixes**
  - Extracted `buildSandboxStartArgs` and used in auto-start, self-heal, and user `start()` so all calls include `sandboxProviderKind` when locked.
  - Added regression tests for the arg builder (includes `sandboxProviderKind` when locked; omits optional fields when absent).

<sup>Written for commit 253110f3c90a94ee6c893b51eb1ea58e1bee5203. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

