### PR TITLE
fix(sections-editor): keep array item editor open when editing its label field

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -324,13 +324,29 @@ export function ArrayField({
   // Only plain object arrays (banners, links, …) get the hide toggle. Section
   // pickers have their own hide flow, and primitive arrays can't be wrapped.
   const canHideItems = !usesSectionPicker && itemSchema?.type === "object";
+  // Index of the item the user has explicitly opened. Array items are addressed
+  // in the breadcrumb by their mutable, non-unique display label, so this lets
+  // selection stay on the opened row even when its label collides with another
+  // item's (e.g. after Duplicate, or while typing a name/alt another item uses).
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
   const selection = resolveArrayItemSelection(
     label,
     breadcrumbPath,
     items,
     itemSchema,
+    openIndex,
   );
   const selectedIndex = selection?.index ?? null;
+
+  // Keep the tracked index in step with the breadcrumb: forget it once the
+  // breadcrumb no longer opens an item here, and adopt the resolved index when
+  // navigation opened an item some other way (header/breadcrumb click, deep link).
+  if (selection === null) {
+    if (openIndex !== null) setOpenIndex(null);
+  } else if (selection.index !== openIndex) {
+    setOpenIndex(selection.index);
+  }
 
   const [entries, setEntries] = useState<ArrayEntry[]>(() =>
     createArrayEntries(items.length),
@@ -344,6 +360,7 @@ export function ArrayField({
     setPrevListKey(path);
     setPrevItemCount(items.length);
     setEntries(createArrayEntries(items.length));
+    setOpenIndex(null);
   } else if (prevItemCount !== items.length) {
     setPrevItemCount(items.length);
     setEntries((current) => resizeArrayEntries(current, items.length));
@@ -355,6 +372,7 @@ export function ArrayField({
   const openItem = (index: number) => {
     if (suppressClickRef.current) return;
     const labelText = itemLabel(items[index], index);
+    setOpenIndex(index);
     onBreadcrumbChange?.(
       buildArrayDrillDownBreadcrumb(breadcrumbPath, label, labelText),
     );
@@ -364,6 +382,7 @@ export function ArrayField({
     const next = [...items, item];
     onChange(next);
     const nextIndex = next.length - 1;
+    setOpenIndex(nextIndex);
     const labelText = getArrayItemLabel(item, nextIndex, itemSchema);
     onBreadcrumbChange?.(
       buildArrayDrillDownBreadcrumb(breadcrumbPath, label, labelText),
@@ -395,6 +414,7 @@ export function ArrayField({
     const next = [...items, defaultVal];
     onChange(next);
     const nextIndex = next.length - 1;
+    setOpenIndex(nextIndex);
     const labelText = getArrayItemLabel(defaultVal, nextIndex, itemSchema);
     onBreadcrumbChange?.(
       buildArrayDrillDownBreadcrumb(breadcrumbPath, label, labelText),

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -4,6 +4,7 @@ import {
   breadcrumbPathForActiveField,
   breadcrumbsForHeaderClick,
   buildArrayDrillDownBreadcrumb,
+  consumedBreadcrumbPrefix,
   fieldDisplayLabel,
   findBreadcrumbLabelIndex,
   isArrayDrillDownField,
@@ -311,6 +312,40 @@ describe("breadcrumbPathForActiveField", () => {
   });
 });
 
+describe("consumedBreadcrumbPrefix", () => {
+  test("returns the crumbs dropped from the front", () => {
+    expect(consumedBreadcrumbPrefix(["Banner", "Banner"], ["Banner"])).toEqual([
+      "Banner",
+    ]);
+  });
+
+  test("is empty when nothing was consumed", () => {
+    expect(consumedBreadcrumbPrefix(["Hello"], ["Hello"])).toEqual([]);
+    expect(consumedBreadcrumbPrefix([], [])).toEqual([]);
+  });
+
+  test("round-trips: prefix + relative trail reconstructs the full trail", () => {
+    const full = ["Banner", "Banner"];
+    const relative = breadcrumbPathForActiveField(
+      "banner",
+      {
+        title: "Banner",
+        type: "array",
+        items: { type: "object" },
+      } as SchemaProperty,
+      full,
+    );
+    // A child editing its own crumb reports the updated RELATIVE trail…
+    const childReported = ["Banner Sale"];
+    // …and re-prepending the consumed prefix must preserve the ancestor crumb,
+    // not collapse it (the array-label == item-label focus-loss bug).
+    expect([
+      ...consumedBreadcrumbPrefix(full, relative),
+      ...childReported,
+    ]).toEqual(["Banner", "Banner Sale"]);
+  });
+});
+
 describe("resolveArrayItemSelection", () => {
   const itemSchema = {
     type: "object",
@@ -344,6 +379,64 @@ describe("resolveArrayItemSelection", () => {
         itemSchema,
       ),
     ).toEqual({ index: 0, innerPath: ["Button"] });
+  });
+
+  test("selects item when its label equals the array label (alt-driven label)", () => {
+    // Array "Banner" whose single item is also labelled "Banner" (its label
+    // comes from `alt`). As long as the consumed prefix is preserved, the
+    // relative trail keeps the item crumb and resolution finds it.
+    const bannerItems = [{ alt: "Banner Sale" }];
+    const bannerSchema = {
+      type: "object",
+      properties: { alt: { type: "string", title: "Alt" } },
+    } as SchemaProperty;
+    expect(
+      resolveArrayItemSelection(
+        "Banner",
+        ["Banner Sale"],
+        bannerItems,
+        bannerSchema,
+        0,
+      ),
+    ).toEqual({ index: 0, innerPath: [] });
+  });
+
+  describe("duplicate labels (preferredIndex)", () => {
+    // Two items resolve to the same crumb — e.g. after Duplicate, or while
+    // editing a label field (alt/name/title) to a value a sibling already uses.
+    const dupItems = [{ title: "Hello" }, { title: "Hello" }];
+
+    test("without preferredIndex, first matching item wins", () => {
+      expect(
+        resolveArrayItemSelection("Cards", ["Hello"], dupItems, itemSchema),
+      ).toEqual({ index: 0, innerPath: [] });
+    });
+
+    test("keeps the opened item when its label collides with an earlier sibling", () => {
+      // Editing item 1 whose label just became equal to item 0's — selection
+      // must stay on 1, not snap back to 0 (the focus-loss bug).
+      expect(
+        resolveArrayItemSelection("Cards", ["Hello"], dupItems, itemSchema, 1),
+      ).toEqual({ index: 1, innerPath: [] });
+    });
+
+    test("ignores a preferredIndex whose label no longer matches the crumb", () => {
+      expect(
+        resolveArrayItemSelection(
+          "Cards",
+          ["Women's"],
+          items,
+          itemSchema,
+          0, // preferred item 0 is "Men's" — doesn't match, fall back to search
+        ),
+      ).toEqual({ index: 1, innerPath: [] });
+    });
+
+    test("ignores an out-of-range preferredIndex", () => {
+      expect(
+        resolveArrayItemSelection("Cards", ["Hello"], dupItems, itemSchema, 5),
+      ).toEqual({ index: 0, innerPath: [] });
+    });
   });
 });
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
@@ -48,6 +48,27 @@ export function buildArrayDrillDownBreadcrumb(
   return trail;
 }
 
+/**
+ * Crumbs the active field consumed — i.e. the prefix {@link breadcrumbPathForActiveField}
+ * dropped from the front of `breadcrumbPath` to produce `fieldBreadcrumbPath`.
+ *
+ * The active field receives a breadcrumb relative to itself but reports changes
+ * through an `onBreadcrumbChange` that writes the GLOBAL trail. Re-prepend this
+ * prefix to those reports so a child rebuilding the trail (e.g. ArrayField
+ * syncing an item's label while typing) doesn't silently drop the ancestor
+ * crumbs — which otherwise collapses the trail when a consumed crumb equals the
+ * child's own crumb (array labelled "Banner" + lone item labelled "Banner").
+ */
+export function consumedBreadcrumbPrefix(
+  breadcrumbPath: string[],
+  fieldBreadcrumbPath: string[],
+): string[] {
+  return breadcrumbPath.slice(
+    0,
+    breadcrumbPath.length - fieldBreadcrumbPath.length,
+  );
+}
+
 /** Drop crumbs consumed by the active field so children see a relative trail. */
 export function breadcrumbPathForActiveField(
   activeKey: string,
@@ -254,18 +275,58 @@ export function isBreadcrumbInsideObject(
   );
 }
 
+/**
+ * Find the array item whose label matches `crumb`.
+ *
+ * Array items are addressed in the breadcrumb by their (mutable, non-unique)
+ * display label, so two items can resolve to the same crumb — e.g. after
+ * duplicating an item, or when the label field (name/title/alt/…) is edited to
+ * a value another item already uses. A plain `findIndex` always returns the
+ * FIRST such item, which yanks the editor away from a later item the moment its
+ * label collides with an earlier sibling (dropping focus mid-typing).
+ *
+ * `preferredIndex` is the item the caller currently has open. When it still
+ * matches the crumb we keep it, so editing a colliding label never snaps
+ * selection to a different row.
+ */
+function findItemIndexForCrumb(
+  items: unknown[],
+  itemSchema: SchemaProperty | undefined,
+  crumb: string,
+  preferredIndex?: number | null,
+): number {
+  if (
+    preferredIndex != null &&
+    preferredIndex >= 0 &&
+    preferredIndex < items.length &&
+    labelsMatch(
+      getArrayItemLabel(items[preferredIndex], preferredIndex, itemSchema),
+      crumb,
+    )
+  ) {
+    return preferredIndex;
+  }
+  return items.findIndex((item, i) =>
+    labelsMatch(getArrayItemLabel(item, i, itemSchema), crumb),
+  );
+}
+
 export function resolveArrayItemSelection(
   label: string,
   breadcrumbPath: string[],
   items: unknown[],
   itemSchema: SchemaProperty | undefined,
+  preferredIndex?: number | null,
 ): { index: number; innerPath: string[] } | null {
   if (breadcrumbPath.length === 0) return null;
 
   for (let pi = 0; pi < breadcrumbPath.length; pi++) {
     const crumb = breadcrumbPath[pi]!;
-    const index = items.findIndex((item, i) =>
-      labelsMatch(getArrayItemLabel(item, i, itemSchema), crumb),
+    const index = findItemIndexForCrumb(
+      items,
+      itemSchema,
+      crumb,
+      preferredIndex,
     );
     if (index >= 0) {
       return { index, innerPath: breadcrumbPath.slice(pi + 1) };
@@ -277,8 +338,11 @@ export function resolveArrayItemSelection(
   );
   if (labelIndex >= 0 && breadcrumbPath.length > labelIndex + 1) {
     const itemCrumb = breadcrumbPath[labelIndex + 1]!;
-    const index = items.findIndex((item, i) =>
-      labelsMatch(getArrayItemLabel(item, i, itemSchema), itemCrumb),
+    const index = findItemIndexForCrumb(
+      items,
+      itemSchema,
+      itemCrumb,
+      preferredIndex,
     );
     if (index >= 0) {
       return { index, innerPath: breadcrumbPath.slice(labelIndex + 2) };

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -23,6 +23,7 @@ import {
 } from "./page-variants";
 import {
   breadcrumbPathForActiveField,
+  consumedBreadcrumbPrefix,
   fieldDisplayLabel,
   resolveActiveFieldKey,
 } from "./schema-form-breadcrumb";
@@ -394,6 +395,24 @@ export function SchemaForm({
     activeKey && activeSchema
       ? breadcrumbPathForActiveField(activeKey, activeSchema, breadcrumbPath)
       : breadcrumbPath;
+  // `breadcrumbPathForActiveField` hands the active field a breadcrumb RELATIVE
+  // to itself (the crumbs it consumed are dropped from the front). The child
+  // reports changes through `onBreadcrumbChange`, which writes the GLOBAL trail,
+  // so we must re-prepend the crumbs we consumed — otherwise a child that
+  // rebuilds the trail (e.g. ArrayField.updateItem syncing an item's label as
+  // you type) drops the ancestor crumbs. That silent prefix loss is usually
+  // masked by label re-matching, but breaks when a consumed crumb equals the
+  // child's own crumb (e.g. an array labelled "Banner" whose only item is also
+  // labelled "Banner" because its label comes from `alt`): editing the label
+  // then collapses the trail and kicks you back to the list.
+  const consumedPrefix = consumedBreadcrumbPrefix(
+    breadcrumbPath,
+    fieldBreadcrumbPath,
+  );
+  const fieldOnBreadcrumbChange =
+    consumedPrefix.length > 0 && onBreadcrumbChange
+      ? (next: string[]) => onBreadcrumbChange([...consumedPrefix, ...next])
+      : onBreadcrumbChange;
   return (
     <div className="min-w-0 space-y-6">
       {visibleKeys.map((key) => {
@@ -409,7 +428,7 @@ export function SchemaForm({
           path: fieldPath,
           label,
           breadcrumbPath: fieldBreadcrumbPath,
-          onBreadcrumbChange,
+          onBreadcrumbChange: fieldOnBreadcrumbChange,
           meta,
           decofile,
           onSaveReferencedBlock,


### PR DESCRIPTION
## Summary

Editing a CMS array item's label-driving field would kick you back to the array list. The clearest repro: an image **Banner** section whose single item's label comes from its **`alt`** text — typing in **Alt** immediately drops you back to the list.

Two independent root causes, both fixed here:

1. **Breadcrumb scope mismatch (`SchemaForm`).** `breadcrumbPathForActiveField` hands the active field a breadcrumb trail *relative* to itself (consumed crumbs dropped from the front), but the child reports changes through an `onBreadcrumbChange` that writes the **global** trail. When `ArrayField.updateItem` syncs the item's label as you type, the ancestor crumbs were silently dropped. This is normally masked by label re-matching, but the trail **collapses** when a consumed crumb equals the child's own crumb — e.g. an array labelled `"Banner"` whose lone item is *also* labelled `"Banner"` (its label comes from `alt`). `SchemaForm` now re-prepends the consumed prefix via the new `consumedBreadcrumbPrefix` helper.

2. **Label-based item selection with first-match-wins (`ArrayField` / `resolveArrayItemSelection`).** Selection resolved the open item by matching the item's mutable, non-unique display label, so when two items resolved to the same label (duplicated items, multiple sections of the same type, empty/identical labels), editing a later item snapped selection to an earlier sibling and unmounted the editor. `ArrayField` now tracks the opened item index and passes it as `preferredIndex`, so selection stays on the item you actually opened.

## Testing
- New unit/regression tests in `schema-form-breadcrumb.test.ts`: `consumedBreadcrumbPrefix` (including the full round-trip that preserves the ancestor crumb), array-label==item-label resolution, and item-vs-item collision (`preferredIndex`).
- `bun test` for `sections-editor/` (413 tests) passes; `bun run check` (typecheck), `bun run fmt`, and lint are clean on the changed files.

> Note: the drop-out was validated via faithful pure-logic simulation of the breadcrumb flow — React 19 + happy-dom don't propagate controlled-input edits, so component tests can't drive this interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a sections-editor bug where editing an array item's label field (e.g. a Banner image `alt`) closed the item and jumped back to the list. The item editor now stays open and breadcrumbs remain correct.

- **Bug Fixes**
  - `SchemaForm`: re-prepends the consumed breadcrumb prefix via `consumedBreadcrumbPrefix` and forwards it in `onBreadcrumbChange` to prevent ancestor crumbs from being dropped (e.g., array "Banner" + item "Banner").
  - `ArrayField`: tracks the opened item index and passes it as `preferredIndex` to `resolveArrayItemSelection`, keeping selection on the item you opened even when labels collide.

<sup>Written for commit d25927a263d545f7b7dd3e20ab1f7273a252db17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

