### PR TITLE
fix(web): equalize gap between form and preview panels

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/chat-main-panel-group.tsx
@@ -164,10 +164,16 @@ function ChatMainPanelGroupInner({
                   />
                 </div>
               </div>
-              <div
-                className="w-1 shrink-0 cursor-col-resize rounded bg-transparent hover:bg-border transition-colors"
-                {...dividerProps}
-              />
+              {/* Zero-width seam so the form↔preview gap is just the two card
+                  gutters, matching the other panel gaps. The grab-area is an
+                  absolutely positioned transparent child — it adds no layout
+                  width, so it can't widen the gap or read as a scrollbar. */}
+              <div className="relative w-0 shrink-0 bg-sidebar hover:bg-border transition-colors">
+                <div
+                  className="absolute inset-y-0 -left-1 -right-1 cursor-col-resize"
+                  {...dividerProps}
+                />
+              </div>
             </>
           )}
           <div className="h-full flex-1 min-w-0 p-0.5 pt-0.25">


### PR DESCRIPTION
## Summary

The gap between the **Form (Sections editor)** panel and the **Preview** panel read noticeably wider than the other panel gaps (chat↔form). The chat↔form seam uses a `ResizableHandle` (`w-[0.5px]`), while the form↔preview seam used a plain `w-1` (4px) divider div — so its combined gap was ~8px vs ~4.5px elsewhere.

This replaces the form↔preview divider with a **zero-width seam**: the visible element takes no layout width, and the drag hit-area is an absolutely-positioned transparent child (`-left-1 -right-1`) that adds no width and can't read as a scrollbar. The gap is now just the two card gutters, uniform across all panels.

## Testing notes

- Affected area: the CMS/agent shell 3-panel layout (chat | form/sections | preview) in `chat-main-panel-group.tsx`.
- Divider remains draggable (the `useColumnResize` `dividerProps` moved to the transparent child).
- Please verify visually with the dev server that the form's left and right gaps now match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Equalized the gap between the Form and Preview panels by replacing the 4px divider with a zero-width seam. Layout now matches the chat↔form gap, and the divider remains draggable.

- **Bug Fixes**
  - Replaced the `w-1` divider with a `relative w-0` seam and an absolutely positioned drag handle (`-left-1 -right-1`) that adds no layout width.
  - Moved `dividerProps` to the transparent child to preserve resize behavior without widening the gap.

<sup>Written for commit 334fac1e3e085b520946558b422a9dbd8862a115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

