### PR TITLE
feat(web): move agents to top, tasks to bottom in sidebar

### DIFF
--- a/apps/mesh/src/web/components/sidebar/navigation.tsx
+++ b/apps/mesh/src/web/components/sidebar/navigation.tsx
@@ -102,7 +102,7 @@ function NavigationSidebarInner({
     <Sidebar variant={variant}>
       <SidebarContent
         className={cn(
-          "flex flex-col flex-1 px-2 py-2 gap-0.5",
+          "flex flex-col flex-1 px-2 pb-2 gap-0.5",
           contentClassName,
         )}
       >
@@ -110,7 +110,7 @@ function NavigationSidebarInner({
           <SidebarSectionRenderer key={index} section={section} />
         ))}
         {additionalContent && (
-          <div className="flex flex-col flex-1 min-h-0 group-data-[state=collapsed]/sidebar:mt-1 group-data-[state=expanded]/sidebar:mt-2">
+          <div className="flex flex-col flex-1 min-h-0">
             {additionalContent}
           </div>
         )}

--- a/apps/mesh/src/web/components/sidebar/task-groups/sidebar-section-header.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/sidebar-section-header.tsx
@@ -26,7 +26,7 @@ export function SidebarSectionHeader({
   controlsId?: string;
 }) {
   return (
-    <div className="group/section flex items-center gap-1 px-2 pt-1 pb-0.5">
+    <div className="group/section flex items-center gap-1 px-2 pb-0.5">
       <button
         type="button"
         aria-expanded={open}

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -635,6 +635,74 @@ export function TaskGroupsList({
   return (
     <div className="flex flex-col h-full min-h-0">
       <SyncSidebarAgentGroupsEmpty value={agentGroups.length === 0} />
+      <div
+        className={cn(
+          "flex flex-col min-h-0",
+          agentsOpen ? "basis-[35%] shrink-0" : "shrink-0",
+        )}
+      >
+        <SidebarSectionHeader
+          label="Agents"
+          open={agentsOpen}
+          onToggle={() => setAgentsOpen((v) => !v)}
+          count={agentGroups.length}
+          controlsId="sidebar-section-agents"
+          actionSlot={
+            <>
+              {agentsOpen && (
+                <ToolbarIconButton
+                  aria-label={
+                    agentView === "list"
+                      ? "Switch to grid view"
+                      : "Switch to list view"
+                  }
+                  title={agentView === "list" ? "Grid view" : "List view"}
+                  onClick={() =>
+                    setAgentView((v) => (v === "list" ? "grid" : "list"))
+                  }
+                >
+                  {agentView === "list" ? (
+                    <Grid01 className="size-4" />
+                  ) : (
+                    <List className="size-4" />
+                  )}
+                </ToolbarIconButton>
+              )}
+              <BrowseAgentsButton compact />
+            </>
+          }
+        />
+        <div
+          id="sidebar-section-agents"
+          aria-hidden={!agentsOpen}
+          className="grid min-h-0 transition-[grid-template-rows] duration-200 ease-out"
+          style={{ gridTemplateRows: agentsOpen ? "1fr" : "0fr" }}
+        >
+          <div className="overflow-hidden min-h-0">
+            <ScrollFade
+              wrapperClassName="h-full min-h-0"
+              className="flex flex-col gap-0.5 h-full overflow-y-auto overscroll-contain"
+            >
+              {agentView === "grid" ? (
+                <AgentIconGrid
+                  groups={agentGroups}
+                  renderGroup={buildAgentRowProps}
+                />
+              ) : (
+                <SortableAgentRows
+                  groups={agentGroups}
+                  orderScope={orderScope}
+                  decopilotId={decopilotId}
+                  orgPinnedIds={orgPinnedIds}
+                  onReorder={() => setLocalOrderRevision((n) => n + 1)}
+                  renderGroup={buildAgentRowProps}
+                />
+              )}
+            </ScrollFade>
+          </div>
+        </div>
+      </div>
+      <div className="shrink-0 mx-2 my-2 border-b" />
       {toolbar(false)}
       <div className="flex-1 min-h-0 flex flex-col gap-0.5 -mr-2 pr-2">
         <ScrollFade
@@ -653,74 +721,6 @@ export function TaskGroupsList({
             onLoadMore={() => void fetchNextPage()}
           />
         </ScrollFade>
-        <div className="shrink-0 mx-2 my-2 border-b" />
-        <div
-          className={cn(
-            "flex flex-col min-h-0",
-            agentsOpen ? "basis-[35%] shrink-0" : "shrink-0",
-          )}
-        >
-          <SidebarSectionHeader
-            label="Agents"
-            open={agentsOpen}
-            onToggle={() => setAgentsOpen((v) => !v)}
-            count={agentGroups.length}
-            controlsId="sidebar-section-agents"
-            actionSlot={
-              <>
-                {agentsOpen && (
-                  <ToolbarIconButton
-                    aria-label={
-                      agentView === "list"
-                        ? "Switch to grid view"
-                        : "Switch to list view"
-                    }
-                    title={agentView === "list" ? "Grid view" : "List view"}
-                    onClick={() =>
-                      setAgentView((v) => (v === "list" ? "grid" : "list"))
-                    }
-                  >
-                    {agentView === "list" ? (
-                      <Grid01 className="size-4" />
-                    ) : (
-                      <List className="size-4" />
-                    )}
-                  </ToolbarIconButton>
-                )}
-                <BrowseAgentsButton compact />
-              </>
-            }
-          />
-          <div
-            id="sidebar-section-agents"
-            aria-hidden={!agentsOpen}
-            className="grid min-h-0 transition-[grid-template-rows] duration-200 ease-out"
-            style={{ gridTemplateRows: agentsOpen ? "1fr" : "0fr" }}
-          >
-            <div className="overflow-hidden min-h-0">
-              <ScrollFade
-                wrapperClassName="h-full min-h-0"
-                className="flex flex-col gap-0.5 h-full overflow-y-auto overscroll-contain"
-              >
-                {agentView === "grid" ? (
-                  <AgentIconGrid
-                    groups={agentGroups}
-                    renderGroup={buildAgentRowProps}
-                  />
-                ) : (
-                  <SortableAgentRows
-                    groups={agentGroups}
-                    orderScope={orderScope}
-                    decopilotId={decopilotId}
-                    orgPinnedIds={orgPinnedIds}
-                    onReorder={() => setLocalOrderRevision((n) => n + 1)}
-                    renderGroup={buildAgentRowProps}
-                  />
-                )}
-              </ScrollFade>
-            </div>
-          </div>
-        </div>
       </div>
       {searchEverOpened && (
         <GlobalSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />


### PR DESCRIPTION
## What is this contribution about?

Reorders the desktop sidebar so agents appear at the top and tasks (with their toolbar: search, filter, group-by, mine/all, new thread) appear at the bottom. Also removes the top padding above the agents section header for a tighter layout.

## Screenshots/Demonstration

Before: tasks list at top, agents section pinned at bottom.
After: agents section at top, divider, task toolbar + task list below.

## How to Test

1. Open the sidebar in the app
2. Verify agents section appears at the top
3. Verify the task toolbar (search, filter, scope toggle) and task list appear below the divider
4. Collapse/expand the agents section and confirm layout remains correct

## Migration Notes

N/A

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the desktop sidebar: Agents now appear at the top; the task toolbar and task list move to the bottom with a divider. Also removed the top padding from the Agents header and tightened container spacing for a cleaner layout.

<sup>Written for commit ca3c185f6e60daf9018ca572e3328ca2bf764743. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

