### PR TITLE
fix(sections-editor): avoid double breadcrumb prefix in module-loader unions (follow-up to #4479)

### DIFF
--- a/apps/mesh/ct/tests/array-object-drilldown.ct.tsx
+++ b/apps/mesh/ct/tests/array-object-drilldown.ct.tsx
@@ -160,6 +160,87 @@ test("editing a drilled-in item updates the correct index", async ({
     .toEqual({ cards: [{ name: "Alpha" }, { name: "Beta2" }] });
 });
 
+test("editing a label field whose value equals the array label keeps the editor open", async ({
+  mount,
+}) => {
+  // Regression: an array labelled "Banner" whose single item is ALSO labelled
+  // "Banner" (its label comes from `alt` via titleBy). The breadcrumb is
+  // ["Banner", "Banner"]; editing `alt` must not collapse the trail and kick
+  // you back to the list. Guards the SchemaForm consumed-prefix re-prepend.
+  const meta = sectionWithProps({
+    banner: {
+      type: "array",
+      title: "Banner",
+      items: {
+        type: "object",
+        title: "Banner",
+        titleBy: "alt",
+        properties: { alt: { type: "string", title: "Alt" } },
+      },
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ banner: [{ alt: "Banner" }] }}
+    />,
+  );
+
+  await component.getByRole("button", { name: "Banner", exact: true }).click();
+  await expect
+    .poll(() => readBreadcrumb(component))
+    .toEqual(["Banner", "Banner"]);
+
+  const altInput = component.getByLabel("Alt");
+  await expect(altInput).toHaveAttribute("id", "banner.0.alt");
+  await altInput.fill("Banner Sale");
+
+  // Editor stays open on the same item (does NOT drop back to the list), and
+  // the edit is applied.
+  await expect(component.getByLabel("Alt")).toHaveAttribute(
+    "id",
+    "banner.0.alt",
+  );
+  await expect(component.getByRole("button", { name: "Add item" })).toHaveCount(
+    0,
+  );
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ banner: [{ alt: "Banner Sale" }] });
+});
+
+test("editing a label to collide with an earlier sibling keeps the opened row", async ({
+  mount,
+}) => {
+  // Regression: drill into item 1, rename it to equal item 0's label. Selection
+  // must stay on index 1 (not snap to the first matching label at index 0).
+  // Guards the ArrayField openIndex/preferredIndex disambiguation.
+  const meta = sectionWithProps(cardArrayProps);
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ cards: [{ name: "Alpha" }, { name: "Beta" }] }}
+    />,
+  );
+
+  await component.getByRole("button", { name: "Beta", exact: true }).click();
+  const nameInput = component.getByLabel("Name");
+  await expect(nameInput).toHaveAttribute("id", "cards.1.name");
+
+  await nameInput.fill("Alpha");
+
+  // Still editing index 1 — not snapped to the identically-labelled index 0.
+  await expect(component.getByLabel("Name")).toHaveAttribute(
+    "id",
+    "cards.1.name",
+  );
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({ cards: [{ name: "Alpha" }, { name: "Alpha" }] });
+});
+
 test("deleting a row removes the right item from the array", async ({
   mount,
   page,

--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -178,12 +178,19 @@ export function AnyOfField({
   // both label and key, so resolution still works.
   const outerCrumb = label ?? (path.includes(".") ? path.split(".")[0]! : path);
   const safeBreadcrumbPath = breadcrumbPath ?? [];
-  const nestedBreadcrumbPath =
-    isModuleLoaderUnion && safeBreadcrumbPath[0] === outerCrumb
-      ? safeBreadcrumbPath.slice(1)
-      : safeBreadcrumbPath;
+  // Strip our own crumb only when it's actually at the head. The parent
+  // SchemaForm may have already consumed it (via breadcrumbPathForActiveField)
+  // and now re-prepends it for us (via consumedBreadcrumbPrefix). Re-prepend
+  // SYMMETRICALLY — add the crumb back only when we stripped it here; otherwise
+  // the parent's re-prepend would double it (["Página de Listagem", "Página de
+  // Listagem", …]) when this loader union is the active narrowed field.
+  const strippedOwnCrumb =
+    isModuleLoaderUnion && safeBreadcrumbPath[0] === outerCrumb;
+  const nestedBreadcrumbPath = strippedOwnCrumb
+    ? safeBreadcrumbPath.slice(1)
+    : safeBreadcrumbPath;
   const nestedOnBreadcrumbChange: ((p: string[]) => void) | undefined =
-    isModuleLoaderUnion
+    strippedOwnCrumb
       ? (newPath) => {
           onBreadcrumbChange?.([outerCrumb, ...newPath]);
         }

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -342,6 +342,15 @@ export function ArrayField({
   // Keep the tracked index in step with the breadcrumb: forget it once the
   // breadcrumb no longer opens an item here, and adopt the resolved index when
   // navigation opened an item some other way (header/breadcrumb click, deep link).
+  //
+  // This set-state-during-render reconciliation converges in one extra render
+  // because `resolveArrayItemSelection` returns `preferredIndex` only when that
+  // item still matches the winning crumb: adopting the resolved index yields a
+  // fixed point on the next render (no oscillation). `openIndex` is a raw index
+  // (not tied to the stable `entries` ids), which is safe only because every
+  // index-shifting mutation (reorder, duplicate, remove) is reachable exclusively
+  // from the list view below — where `selection` is null and `openIndex` has
+  // already been forced back to null.
   if (selection === null) {
     if (openIndex !== null) setOpenIndex(null);
   } else if (selection.index !== openIndex) {

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
@@ -69,7 +69,15 @@ export function consumedBreadcrumbPrefix(
   );
 }
 
-/** Drop crumbs consumed by the active field so children see a relative trail. */
+/**
+ * Drop crumbs consumed by the active field so children see a relative trail.
+ *
+ * NOTE: {@link consumedBreadcrumbPrefix} reconstructs the dropped prefix purely
+ * by length difference, which relies on the return value always being a
+ * front-suffix of `breadcrumbPath` (this only ever drops the leading crumb).
+ * Keep it that way — dropping from the middle or rewriting a crumb would make
+ * that reconstruction silently wrong.
+ */
 export function breadcrumbPathForActiveField(
   activeKey: string,
   schema: SchemaProperty,


### PR DESCRIPTION
## Summary

Follow-up to **#4479** (merged), addressing findings from a post-merge multi-perspective review of that PR.

**Blocker fixed — double breadcrumb prefix regression introduced by #4479.**
#4479 made `SchemaForm` re-prepend the consumed breadcrumb prefix to the active field's `onBreadcrumbChange`. But `AnyOfField` (module-loader unions, e.g. ProductListingPage loader config) *also* re-prepends its own crumb: it stripped its crumb **conditionally** (only when at the head) yet re-prepended **unconditionally**. Composed with the parent's new re-prepend, drilling into a loader config doubled the outer crumb → `["Página de Listagem", "Página de Listagem", …]`.

Fix: make `AnyOfField`'s re-prepend **symmetric** with its strip — re-prepend the crumb only when it stripped it here; otherwise let the parent's re-prepend handle it. Verified via a breadcrumb round-trip trace: current PR produced the doubled trail, the symmetric version matches the pre-#4479 single-prefix baseline.

**Testing — regression guards.**
Added Playwright CT tests in `array-object-drilldown.ct.tsx` for the two focus-loss scenarios #4479 fixed (array-label == item-label alt-driven label; editing a label to collide with an earlier sibling keeps the opened row). Reviewer flagged that a revert of #4479 left every test green.

> ⚠️ Caveat: the array drill-down CT tests do **not** execute in my local environment (they fail identically on `origin/main` there — a pre-existing local Playwright-CT harness limitation), and CT is not part of CI. These are added at the correct layer following the existing pattern, but I could not run them green. Please run `bun run --cwd=apps/mesh test:ct array-object-drilldown` in a working CT env to confirm before/at merge.

**Docs — invariants.**
Documented the `consumedBreadcrumbPrefix` ↔ `breadcrumbPathForActiveField` tail-slice coupling, and the `ArrayField` reconciliation fixed-point + "mutations are list-view-only" invariants that keep `openIndex` from desyncing.

## Testing
- `bun test` sections-editor unit suite (413) passes; `bun run check` (typecheck), `bun run fmt`, and lint clean.
- CT tests added but not executed locally (see caveat above).

## Review outcome (for reference)
- Correctness: Ready (low risk) — convergence of the render-phase reconciliation proven; `preferredIndex` cannot change which crumb wins.
- Scope/perf/dup: clean (net de-duplication).
- Architecture: the one Important finding (this double-prefix) is what this PR fixes.
- Testing: this PR adds the guards it flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes doubled breadcrumb prefixes when drilling into module‑loader unions and adds regression tests to guard focus behavior. Aligns `AnyOfField` with `SchemaForm` so prefixes are only re‑prepended when they were stripped.

- **Bug Fixes**
  - Make `AnyOfField` re‑prepend its crumb only when it stripped it, composing correctly with `SchemaForm` and fixing the double‑prefix regression from #4479.
  - Add Playwright CT regressions for breadcrumb focus cases (array label equals item label; renaming to collide with an earlier sibling) and document breadcrumb/array selection invariants.

<sup>Written for commit fad9df266a8ce2b2d3070073a4e950f273a48c53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

