### PR TITLE
fix(commerce-onboarding): don't skip site re-claim on a malformed siteUrl param

### DIFF
--- a/apps/mesh/src/commerce-discovery/site-url.test.ts
+++ b/apps/mesh/src/commerce-discovery/site-url.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeCommerceSiteUrl } from "./site-url.ts";
+import {
+  isConnectionClaimedForSite,
+  normalizeCommerceSiteUrl,
+} from "./site-url.ts";
 
 describe("normalizeCommerceSiteUrl", () => {
   test("adds https to bare hostnames", () => {
@@ -98,5 +101,38 @@ describe("normalizeCommerceSiteUrl", () => {
         error: "Enter a valid website URL.",
       });
     }
+  });
+});
+
+describe("isConnectionClaimedForSite", () => {
+  test("trusts an existing claim when no site is requested (returning session)", () => {
+    expect(isConnectionClaimedForSite("", "https://a.com")).toBe(true);
+    expect(isConnectionClaimedForSite("   ", undefined)).toBe(true);
+  });
+
+  test("matches when the requested site equals the claimed site", () => {
+    expect(
+      isConnectionClaimedForSite("https://a.com/path", "https://a.com"),
+    ).toBe(true);
+  });
+
+  test("does not match when the requested site differs from the claimed site", () => {
+    expect(isConnectionClaimedForSite("https://b.com", "https://a.com")).toBe(
+      false,
+    );
+  });
+
+  test("does not match when nothing is claimed yet", () => {
+    expect(isConnectionClaimedForSite("https://a.com", undefined)).toBe(false);
+  });
+
+  test("a malformed non-empty request is NOT treated like an empty one", () => {
+    // Regression: both "" and "not-a-url" fail normalizeCommerceSiteUrl, but
+    // only the empty case should bypass the site-match check — otherwise a
+    // garbled ?siteUrl param would silently reuse whatever site the
+    // connection happens to already be claimed for.
+    expect(isConnectionClaimedForSite("not-a-url", "https://a.com")).toBe(
+      false,
+    );
   });
 });

--- a/apps/mesh/src/commerce-discovery/site-url.ts
+++ b/apps/mesh/src/commerce-discovery/site-url.ts
@@ -72,3 +72,26 @@ export function normalizeCommerceSiteUrl(input: string): CommerceSiteUrlResult {
     value: url.origin,
   };
 }
+
+/**
+ * True when an already-provisioned Commerce Discovery connection's claimed
+ * site matches the one currently requested.
+ *
+ * An empty `requestedSite` means no site was specified (a returning session
+ * with no `?siteUrl`) — trust the existing claim. A non-empty but malformed
+ * `requestedSite` must NOT be treated the same as "no site requested": both
+ * fail `normalizeCommerceSiteUrl`, but only the empty case should bypass the
+ * match check — otherwise a garbled site param silently skips re-claiming
+ * and surfaces whatever site the connection happens to already be claimed
+ * for.
+ */
+export function isConnectionClaimedForSite(
+  requestedSite: string,
+  claimedSiteUrl: string | undefined,
+): boolean {
+  if (!requestedSite.trim()) return true;
+  const requested = normalizeCommerceSiteUrl(requestedSite);
+  if (!requested.ok || !claimedSiteUrl) return false;
+  const claimed = normalizeCommerceSiteUrl(claimedSiteUrl);
+  return claimed.ok && claimed.value === requested.value;
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -1,4 +1,7 @@
-import { normalizeCommerceSiteUrl } from "@/commerce-discovery/site-url";
+import {
+  isConnectionClaimedForSite,
+  normalizeCommerceSiteUrl,
+} from "@/commerce-discovery/site-url";
 import { AuthEntry } from "@/web/components/auth-entry";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { AuthSplitLayout } from "@/web/components/auth-split-layout";
@@ -778,14 +781,10 @@ function CommerceSetupContent({
   // requested site; when the site differs, fall through to setup (idempotent
   // re-claim) so the token + metadata.siteUrl follow the site being onboarded.
   const requestedSite = initialSiteUrl || siteUrlInput || "";
-  const requestedNormalized = normalizeCommerceSiteUrl(requestedSite);
-  const claimedNormalized = connectionSiteUrl
-    ? normalizeCommerceSiteUrl(connectionSiteUrl)
-    : null;
-  const claimedForRequestedSite =
-    !requestedNormalized.ok ||
-    (!!claimedNormalized?.ok &&
-      claimedNormalized.value === requestedNormalized.value);
+  const claimedForRequestedSite = isConnectionClaimedForSite(
+    requestedSite,
+    connectionSiteUrl,
+  );
   const setupReady = connectionExists && claimedForRequestedSite;
   const currentSiteUrl =
     initialSiteUrl || siteUrlInput || connectionSiteUrl || "";


### PR DESCRIPTION
## Source

Bug found while reading the most recently merged commit on `main` (#4439, "GitHub companion repo search + re-claim site on report open"), which added a check to re-claim the Commerce Discovery connection when the requested site differs from the one it's currently claimed for.

## The bug

`normalizeCommerceSiteUrl` returns `{ ok: false }` both for an **empty** input and for a **non-empty but malformed** one. The new check used `!requestedNormalized.ok` to mean "no site was requested, trust the existing claim" — but that condition is also true for a malformed, non-empty site param, which was never the intent.

### Failure scenario
- Org A previously onboarded for `https://a.com` (connection's claimed site = `a.com`).
- Org A opens the onboarding page with a garbled `?siteUrl=` param (e.g. a corrupted/edited link) for a different site.
- `claimedForRequestedSite` evaluates to `true` regardless of which site is actually claimed, so `setupReady` becomes `true`.
- The re-claim (`triggerInitialSetup`) never fires, and `openReport` skips the `COMMERCE_DISCOVERY_RUN` trigger entirely (since the malformed URL fails `normalizeCommerceSiteUrl` again there) — it just opens whatever report the connection happens to already point at, instead of surfacing the invalid-URL error the rest of the component already handles for this exact case (see the `initialSiteUrl` normalization branch further down).

This silently defeats the wrong-store-diagnostic fix #4439 just added.

## Fix

Extracted the check into `isConnectionClaimedForSite(requestedSite, claimedSiteUrl)` in `site-url.ts`, which explicitly distinguishes "no site requested" (empty string) from "invalid site requested" (non-empty, fails normalization) — only the former bypasses the match check.

## Test

Added `isConnectionClaimedForSite` unit tests in `site-url.test.ts`, including a regression test for the malformed-non-empty case that fails on the old inlined logic and passes with the fix.

## Verify

```
bun test apps/mesh/src/commerce-discovery/site-url.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (pre-existing unrelated errors confirmed present on `main` before this change too; no new ones introduced)
- `bun test apps/mesh/src/commerce-discovery/site-url.test.ts` — 17 pass

Full CI will run the broader suite/lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Commerce onboarding so a malformed non-empty `siteUrl` no longer bypasses site re-claim and skip `COMMERCE_DISCOVERY_RUN`. Empty `siteUrl` is treated as “no site requested,” while invalid non-empty values now trigger a re-claim or surface the existing invalid-URL error.

- **Bug Fixes**
  - Added `isConnectionClaimedForSite()` to distinguish empty vs invalid `siteUrl` and compare normalized origins.
  - Updated `commerce-onboarding.tsx` to use this helper instead of inline checks.
  - Added unit tests, including a regression test for the malformed non-empty case.

<sup>Written for commit 18a428c7d465f58c963af738ab119a6bfacad454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

