### PR TITLE
analytics: add store domain to commerce-onboarding companion-connect events

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -1,3 +1,4 @@
+import { normalizeCommerceSiteUrl } from "@/commerce-discovery/site-url";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { ScrollReveal } from "@/web/components/scroll-reveal";
 import { authClient } from "@/web/lib/auth-client";
@@ -119,6 +120,10 @@ function CompanionMcpsSectionContent({
 }) {
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id ?? "";
+  const normalizedSite = siteUrl ? normalizeCommerceSiteUrl(siteUrl) : null;
+  const siteHost = normalizedSite?.ok
+    ? new URL(normalizedSite.value).hostname
+    : undefined;
   const selfClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,
@@ -140,6 +145,8 @@ function CompanionMcpsSectionContent({
     org,
     userId,
     cdConnectionId,
+    domain: siteHost,
+    siteUrl,
   });
   const [autoOpenConfigFieldKey, setAutoOpenConfigFieldKey] = useState<
     string | null

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -121,9 +121,14 @@ function CompanionMcpsSectionContent({
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id ?? "";
   const normalizedSite = siteUrl ? normalizeCommerceSiteUrl(siteUrl) : null;
-  const siteHost = normalizedSite?.ok
-    ? new URL(normalizedSite.value).hostname
-    : undefined;
+  let siteHost: string | undefined;
+  if (normalizedSite?.ok) {
+    try {
+      siteHost = new URL(normalizedSite.value).hostname;
+    } catch {
+      siteHost = undefined;
+    }
+  }
   const selfClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
     orgId: org.id,

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
@@ -22,11 +22,15 @@ export function useConnectCompanion({
   org,
   userId,
   cdConnectionId,
+  domain,
+  siteUrl,
 }: {
   selfClient: Client;
   org: CompanionOrg;
   userId: string;
   cdConnectionId: string;
+  domain?: string;
+  siteUrl?: string;
 }) {
   const queryClient = useQueryClient();
   const [connectingFieldKey, setConnectingFieldKey] = useState<string | null>(
@@ -54,6 +58,8 @@ export function useConnectCompanion({
       app_name: card.title,
       field_key: card.fieldKey,
       organization_id: org.id,
+      domain,
+      site_url: siteUrl,
     };
     track("commerce_onboarding_companion_connect_clicked", basePayload);
     try {


### PR DESCRIPTION
## What
Adds `domain` (+ `site_url`) to the commerce-onboarding **companion-connect** analytics events:
- `commerce_onboarding_companion_connect_clicked`
- `commerce_onboarding_companion_connected`
- `commerce_onboarding_companion_connect_failed`

## Why
These events carried `organization_id` but no store `domain`, so a data-source connection couldn't be tied to the specific store's diagnostic on the **Store** front of the diagnostic PLG analytics plan. The other onboarding events (`_viewed`, `_setup_succeeded/_failed`, `_open_report_clicked`, `_site_url_submitted`) already carry `domain`; this closes the gap so the Store funnel can include "connected GA4/GSC/VTEX" as a native step.

## How
`companion-mcps-section.tsx` already receives `siteUrl`; derive the canonical host with the same `normalizeCommerceSiteUrl` helper the route uses for `commerce_onboarding_viewed` (so the `domain` value matches across events), then pass `domain` + `siteUrl` into `useConnectCompanion`, which adds them to `basePayload`. +13 lines, 2 files.

## Verification
- `tsc --noEmit` (apps/mesh): **0 errors**.
- `oxlint` changed files: 0 errors, 1 `ban-web-server-imports` warning for the `normalizeCommerceSiteUrl` value import — identical to the existing sibling import in `commerce-onboarding.tsx` (one of 22 pre-existing tolerated warnings of this rule in mesh/web; oxlint exits 0 on warnings).

## Scope note
`connection_created` (generic server event) and `mcp_app_opened` are intentionally left unchanged (domain not cleanly in scope there) — follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add store domain and site_url to commerce-onboarding companion-connect analytics so connections map to the correct store and count in the Store funnel. Also hardened URL parsing to avoid failures when deriving the domain.

- **New Features**
  - Added domain and site_url to `commerce_onboarding_companion_connect_clicked`, `_connected`, and `_failed`.
  - Derived domain from siteUrl using `normalizeCommerceSiteUrl` for consistency, and threaded both into `useConnectCompanion` payloads.

- **Bug Fixes**
  - Guarded against URL parse failures when extracting `siteHost`; falls back to undefined instead of throwing.

<sup>Written for commit 517aa0b92363663ed03027e75861f29b61fae6c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

