### PR TITLE
feat(harness): teach agents the Deco CMS content rules (.deco/blocks only)

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -24,6 +24,7 @@ import {
   type CodingWorkspacePromptInput,
 } from "@decocms/harness/coding-workspace-prompt";
 import { buildOrgFilesystemPrompt } from "@/api/routes/decopilot/constants";
+import { sandboxIsDecoSite } from "./built-in-tools/cluster-sandbox-fs";
 import type { GithubRepo } from "@decocms/mesh-sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
@@ -132,7 +133,23 @@ export async function buildAgentSystemPrompt(
     add("planMode", modeConfig.planPrompt);
   }
 
-  add("codingWorkspace", buildCodingWorkspacePrompt(opts.codingWorkspace));
+  // Resolve whether the attached sandbox is a Deco CMS site (has a `.deco/`
+  // dir) so the CMS-content rules are only appended for deco workspaces. Gated
+  // on `user + branch` — the same prerequisites the VM file tools need to exist
+  // (see `tools.ts` vmContext). Without those there are no file tools to guide,
+  // so the rules are moot and we skip the sandbox round-trip entirely.
+  let codingWorkspaceInput = opts.codingWorkspace;
+  if (codingWorkspaceInput && opts.user?.id && codingWorkspaceInput.branch) {
+    codingWorkspaceInput = {
+      ...codingWorkspaceInput,
+      isDecoSite: await sandboxIsDecoSite(opts.ctx, {
+        virtualMcpId: opts.virtualMcp.id,
+        branch: codingWorkspaceInput.branch,
+        userId: opts.user.id,
+      }),
+    };
+  }
+  add("codingWorkspace", buildCodingWorkspacePrompt(codingWorkspaceInput));
 
   // Org filesystem layout. org-fs is mounted into every sandbox now (desktop +
   // cluster), so this is unconditional. The home folder mounts at the fixed

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/cluster-sandbox-fs.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/cluster-sandbox-fs.ts
@@ -113,3 +113,36 @@ export async function buildClusterSandboxFs(
     canAutoRestart,
   });
 }
+
+/**
+ * Probe whether the attached sandbox is a Deco CMS site — i.e. its repo
+ * checkout contains a `.deco/` directory. Gates the CMS-content rules block in
+ * the coding-workspace prompt (see `DECO_CMS_CONTENT_RULES`) so non-deco repos
+ * don't carry it as dead weight.
+ *
+ * Runs `test -d .deco` from the daemon's default bash cwd (the repo root). It
+ * reuses `buildClusterSandboxFs`, so the sandbox `ensureSandbox` resolution is
+ * memoized: on an already-running sandbox (the common case for an active coding
+ * thread) this is a cheap proxied bash call; on the first turn it provisions
+ * the same sandbox the VM file tools will use moments later.
+ *
+ * Fails OPEN (returns `true`) on any error: an indeterminate probe must not
+ * strip the guardrails from a genuine deco site, whose whole failure mode is
+ * silent data loss (editing `*.gen.*` instead of `.deco/blocks/`).
+ */
+export async function sandboxIsDecoSite(
+  ctx: StudioContext,
+  vm: { virtualMcpId: string; branch: string; userId: string },
+): Promise<boolean> {
+  try {
+    const fs = await buildClusterSandboxFs(ctx, vm);
+    const { stdout } = await fs.onBash("test -d .deco && echo __DECO_SITE__");
+    return stdout.includes("__DECO_SITE__");
+  } catch (err) {
+    console.warn(
+      "[cluster-sandbox-fs] .deco probe failed; assuming deco site",
+      err,
+    );
+    return true;
+  }
+}

--- a/packages/harness/src/claude-code/index.ts
+++ b/packages/harness/src/claude-code/index.ts
@@ -37,6 +37,7 @@ import { effectiveCwd } from "../workspace-cwd";
 import { extractUserText, prepCliMessages } from "../cli-message-prep";
 import { createCliMessageMetadata } from "../cli-stream-metadata";
 import { buildCodingWorkspacePrompt } from "../coding-workspace-prompt";
+import { localWorkspaceIsDecoSite } from "../coding-workspace-deco";
 import { buildCurrentContextPrompt } from "../current-context-prompt";
 import { NO_BACKGROUND_TASKS_PROMPT } from "../no-background-tasks-prompt";
 import { mergeTitleResult, shouldGenerateTitle } from "../title-merge";
@@ -83,7 +84,14 @@ export function buildClaudeCodeSystemPrompt(input: {
   now?: Date;
 }) {
   const parts = [
-    buildCodingWorkspacePrompt(input.workspace),
+    buildCodingWorkspacePrompt(
+      input.workspace
+        ? {
+            ...input.workspace,
+            isDecoSite: localWorkspaceIsDecoSite(input.workspace.cwd),
+          }
+        : input.workspace,
+    ),
     input.agentInstructions?.trim()
       ? `<agent-instructions>\n${input.agentInstructions.trim()}\n</agent-instructions>`
       : null,

--- a/packages/harness/src/codex/index.ts
+++ b/packages/harness/src/codex/index.ts
@@ -39,6 +39,7 @@ import { streamText, type UIMessageChunk } from "ai";
 import { generateMessageId } from "../message-id";
 import { createCodexModel, resolveCodexModelId } from "./model";
 import { buildCodingWorkspacePrompt } from "../coding-workspace-prompt";
+import { localWorkspaceIsDecoSite } from "../coding-workspace-deco";
 import { effectiveCwd } from "../workspace-cwd";
 import { extractUserText, prepCliMessages } from "../cli-message-prep";
 import { createCliMessageMetadata } from "../cli-stream-metadata";
@@ -87,7 +88,14 @@ export function buildCodexDeveloperInstructions(input: {
   now?: Date;
 }): string | undefined {
   const parts = [
-    buildCodingWorkspacePrompt(input.workspace),
+    buildCodingWorkspacePrompt(
+      input.workspace
+        ? {
+            ...input.workspace,
+            isDecoSite: localWorkspaceIsDecoSite(input.workspace.cwd),
+          }
+        : input.workspace,
+    ),
     input.agentInstructions?.trim()
       ? `<agent-instructions>\n${input.agentInstructions.trim()}\n</agent-instructions>`
       : null,

--- a/packages/harness/src/coding-workspace-deco.test.ts
+++ b/packages/harness/src/coding-workspace-deco.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { localWorkspaceIsDecoSite } from "./coding-workspace-deco";
+
+describe("localWorkspaceIsDecoSite", () => {
+  test("returns false when there is no checkout (cwd: null)", () => {
+    expect(localWorkspaceIsDecoSite(null)).toBe(false);
+  });
+
+  test("detects a `.deco/` directory in process.cwd() for the /repo checkout", () => {
+    const dir = mkdtempSync(join(tmpdir(), "deco-site-"));
+    const originalCwd = process.cwd();
+    try {
+      mkdirSync(join(dir, ".deco"));
+      process.chdir(dir);
+      expect(localWorkspaceIsDecoSite("/repo")).toBe(true);
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns false for a /repo checkout without a `.deco/` directory", () => {
+    const dir = mkdtempSync(join(tmpdir(), "plain-repo-"));
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(dir);
+      expect(localWorkspaceIsDecoSite("/repo")).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/harness/src/coding-workspace-deco.ts
+++ b/packages/harness/src/coding-workspace-deco.ts
@@ -1,0 +1,30 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { WORKSPACE_CWD_REPO, type HarnessCwd } from "./workspace-cwd";
+
+/**
+ * Local-fs probe: does the attached sandbox checkout contain a `.deco/`
+ * directory? Used by the CLI harnesses (claude-code, codex), which run INSIDE
+ * the sandbox — the repo checkout is on the local filesystem, so a synchronous
+ * `existsSync` is cheap and correct. `.deco/` is the marker of a Deco CMS site;
+ * its presence gates the CMS-content rules block (see `DECO_CMS_CONTENT_RULES`
+ * in `coding-workspace-prompt.ts`).
+ *
+ * `cwd` is the symbolic wire value ("/repo" | null). No checkout (`null`) is
+ * never a deco site. For "/repo" we probe two bases because the real checkout
+ * location differs by sandbox kind: hosted containers mount it literally at
+ * `/repo`, while the desktop daemon runs the harness with the checkout as
+ * `process.cwd()` (it rebases the symbolic "/repo" onto its own sandbox root).
+ */
+export function localWorkspaceIsDecoSite(cwd: HarnessCwd): boolean {
+  if (!cwd) return false;
+  const bases =
+    cwd === WORKSPACE_CWD_REPO ? [process.cwd(), WORKSPACE_CWD_REPO] : [cwd];
+  return bases.some((base) => {
+    try {
+      return existsSync(join(base, ".deco"));
+    } catch {
+      return false;
+    }
+  });
+}

--- a/packages/harness/src/coding-workspace-prompt.test.ts
+++ b/packages/harness/src/coding-workspace-prompt.test.ts
@@ -100,6 +100,23 @@ describe("buildCodingWorkspacePrompt", () => {
     );
   });
 
+  test("includes Deco CMS content rules regardless of workspace input", () => {
+    for (const input of [
+      undefined,
+      { workspaceKind: "local" as const },
+      {
+        repo: { owner: "deco", name: "site", connectedGithub: true },
+        workspaceKind: "github" as const,
+      },
+    ]) {
+      const prompt = buildCodingWorkspacePrompt(input);
+      expect(prompt).toContain(".deco/blocks/<encoded-key>.json");
+      expect(prompt).toContain("NEVER edit generated artifacts");
+      expect(prompt).toContain("blocks.gen.json");
+      expect(prompt).toContain("AGENTS.md");
+    }
+  });
+
   test("does not include Decopilot-only tool vocabulary", () => {
     const prompt = buildCodingWorkspacePrompt({
       repo: {

--- a/packages/harness/src/coding-workspace-prompt.test.ts
+++ b/packages/harness/src/coding-workspace-prompt.test.ts
@@ -100,20 +100,42 @@ describe("buildCodingWorkspacePrompt", () => {
     );
   });
 
-  test("includes Deco CMS content rules regardless of workspace input", () => {
+  test("includes Deco CMS content rules only when isDecoSite is set", () => {
+    const decoPrompt = buildCodingWorkspacePrompt({
+      repo: { owner: "deco", name: "site", connectedGithub: true },
+      workspaceKind: "github",
+      cwd: "/repo",
+      isDecoSite: true,
+    });
+    expect(decoPrompt).toContain("This is a Deco CMS site");
+    expect(decoPrompt).toContain(".deco/blocks/<encoded-key>.json");
+    expect(decoPrompt).toContain("NEVER edit generated artifacts");
+    expect(decoPrompt).toContain("blocks.gen.json");
+    expect(decoPrompt).toContain("AGENTS.md");
+  });
+
+  test("omits Deco CMS content rules for non-deco or unverified workspaces", () => {
     for (const input of [
       undefined,
       { workspaceKind: "local" as const },
+      // A repo workspace that was NOT confirmed to be a deco site.
       {
         repo: { owner: "deco", name: "site", connectedGithub: true },
         workspaceKind: "github" as const,
+        cwd: "/repo",
+      },
+      // Explicitly not a deco site.
+      {
+        repo: { owner: "acme", name: "app", connectedGithub: true },
+        workspaceKind: "github" as const,
+        cwd: "/repo",
+        isDecoSite: false,
       },
     ]) {
       const prompt = buildCodingWorkspacePrompt(input);
-      expect(prompt).toContain(".deco/blocks/<encoded-key>.json");
-      expect(prompt).toContain("NEVER edit generated artifacts");
-      expect(prompt).toContain("blocks.gen.json");
-      expect(prompt).toContain("AGENTS.md");
+      expect(prompt).not.toContain("This is a Deco CMS site");
+      expect(prompt).not.toContain(".deco/blocks/<encoded-key>.json");
+      expect(prompt).not.toContain("NEVER edit generated artifacts");
     }
   });
 

--- a/packages/harness/src/coding-workspace-prompt.ts
+++ b/packages/harness/src/coding-workspace-prompt.ts
@@ -14,6 +14,21 @@ function line(label: string, value: string | null | undefined): string | null {
   return text ? `- ${label}: ${text}` : null;
 }
 
+/**
+ * CMS-content rules for Deco sites, rendered unconditionally (the prompt is
+ * assembled server-side, before any sandbox fs access, so the block is
+ * self-gating: "when the repository contains a `.deco/` directory"). Getting
+ * this wrong is silent data loss — `blocks.gen.json` edits render in the dev
+ * preview but are regenerated from `.deco/blocks/` on every production build,
+ * so the change never reaches the deployed site.
+ */
+const DECO_CMS_CONTENT_RULES = `When the repository contains a \`.deco/\` directory, it is a Deco CMS site and these rules apply to content changes (page copy, section props, loader config, site settings):
+
+- CMS content lives in \`.deco/blocks/<encoded-key>.json\` — one JSON file per block, filename is the URI-encoded block key. Edit ONLY the matching \`.deco/blocks/*.json\` file(s).
+- NEVER edit generated artifacts: \`blocks.gen.json\`, \`blocks.gen.ts\`, \`meta.gen.json\`, or any other \`*.gen.*\` file. They are regenerated from \`.deco/blocks/\` by the dev server and by every production build — an edit there looks correct in the preview but is silently discarded on deploy.
+- Do not touch any other file to make a content change visible: the dev server watches \`.deco/blocks/\` and hot-reloads the preview, and production builds/content syncs read \`.deco/blocks/\` directly. Committing the \`.deco/blocks/*.json\` change is all that is needed.
+- After making a CMS content change, check the repo's AGENTS.md: if it is missing or does not document these \`.deco/\` content rules, add a short "Deco CMS content" section (creating AGENTS.md if needed) so other tools working in this repo follow the same rules. If AGENTS.md already documents them, leave it untouched.`;
+
 export function buildCodingWorkspacePrompt(
   input?: CodingWorkspacePromptInput | null,
 ): string | null {
@@ -54,5 +69,7 @@ Cite files as \`path:line\` when explaining code.
 Do not re-clone the repository; it is already available in the workspace.
 Use git CLI for local working tree, branch, history, rebase, commit, and push operations.
 Use GitHub tools only for PR, review, comment, issue, or remote repository operations when available.${githubCaution}
+
+${DECO_CMS_CONTENT_RULES}
 </coding-workspace>`;
 }

--- a/packages/harness/src/coding-workspace-prompt.ts
+++ b/packages/harness/src/coding-workspace-prompt.ts
@@ -7,6 +7,15 @@ export interface CodingWorkspacePromptInput {
   branch?: string | null;
   cwd?: string | null;
   workspaceKind?: "github" | "template" | "local" | "unknown";
+  /**
+   * Whether the attached workspace is a Deco CMS site (its checkout contains a
+   * `.deco/` directory). Gates the {@link DECO_CMS_CONTENT_RULES} block — the
+   * caller resolves this against the sandbox the agent is attached to (local fs
+   * for the in-sandbox CLI harnesses, the sandbox-fs proxy for the cluster
+   * engine). Absent/false ⇒ the CMS rules are omitted, so non-deco workspaces
+   * don't carry the dead-weight instructions.
+   */
+  isDecoSite?: boolean;
 }
 
 function line(label: string, value: string | null | undefined): string | null {
@@ -15,14 +24,14 @@ function line(label: string, value: string | null | undefined): string | null {
 }
 
 /**
- * CMS-content rules for Deco sites, rendered unconditionally (the prompt is
- * assembled server-side, before any sandbox fs access, so the block is
- * self-gating: "when the repository contains a `.deco/` directory"). Getting
- * this wrong is silent data loss — `blocks.gen.json` edits render in the dev
- * preview but are regenerated from `.deco/blocks/` on every production build,
- * so the change never reaches the deployed site.
+ * CMS-content rules for Deco sites. Rendered only when the caller has confirmed
+ * the attached workspace is a Deco site (`isDecoSite` — resolved against the
+ * sandbox `.deco/` directory), so non-deco workspaces don't carry it as dead
+ * weight. Getting this wrong is silent data loss — `blocks.gen.json` edits
+ * render in the dev preview but are regenerated from `.deco/blocks/` on every
+ * production build, so the change never reaches the deployed site.
  */
-const DECO_CMS_CONTENT_RULES = `When the repository contains a \`.deco/\` directory, it is a Deco CMS site and these rules apply to content changes (page copy, section props, loader config, site settings):
+const DECO_CMS_CONTENT_RULES = `This is a Deco CMS site (its repository contains a \`.deco/\` directory). These rules apply to content changes (page copy, section props, loader config, site settings):
 
 - CMS content lives in \`.deco/blocks/<encoded-key>.json\` — one JSON file per block, filename is the URI-encoded block key. Edit ONLY the matching \`.deco/blocks/*.json\` file(s).
 - NEVER edit generated artifacts: \`blocks.gen.json\`, \`blocks.gen.ts\`, \`meta.gen.json\`, or any other \`*.gen.*\` file. They are regenerated from \`.deco/blocks/\` by the dev server and by every production build — an edit there looks correct in the preview but is silently discarded on deploy.
@@ -68,8 +77,8 @@ When asked to change code, edit the working tree directly and verify the result.
 Cite files as \`path:line\` when explaining code.
 Do not re-clone the repository; it is already available in the workspace.
 Use git CLI for local working tree, branch, history, rebase, commit, and push operations.
-Use GitHub tools only for PR, review, comment, issue, or remote repository operations when available.${githubCaution}
-
-${DECO_CMS_CONTENT_RULES}
+Use GitHub tools only for PR, review, comment, issue, or remote repository operations when available.${githubCaution}${
+    input?.isDecoSite ? `\n\n${DECO_CMS_CONTENT_RULES}` : ""
+  }
 </coding-workspace>`;
 }


### PR DESCRIPTION
## Problem

When users ask decopilot for a content change, the agent has zero guidance about which file is the source of truth. A grep for the visible text hits both `.deco/blocks/<key>.json` and the committed `.deco/blocks.gen.json` (which contains every block, so it often matches first). Editing the gen file renders correctly in the studio preview (SSR re-eval reads it) — but production builds run `generate:blocks`, which regenerates `blocks.gen.json` from `.deco/blocks/`, and the fast-deploy KV sync (`deco-sync-blocks-to-kv`) reads `.deco/blocks/*.json` directly. The edit is silently discarded on deploy: **persisted in git, never reflected in production.**

## Fix

Append a `DECO_CMS_CONTENT_RULES` block to `buildCodingWorkspacePrompt` — the single assembler shared by the decopilot engine, claude-code CLI, and codex CLI harnesses — stating:

- CMS content lives in `.deco/blocks/<encoded-key>.json`; edit **only** those files
- **never** edit `blocks.gen.json` / `blocks.gen.ts` / `meta.gen.json` / any `*.gen.*` (derived, regenerated by the dev watcher and every production build)
- no other file needs touching: the `decoVitePlugin` watcher handles preview HMR (delta → `blocks.gen.json` + POST `/.decofile` + full-reload), and production reads `.deco/blocks/` directly
- after a content edit, seed these rules into the repo's AGENTS.md **once** (create if missing, skip if already documented) so non-studio tooling follows the same contract

The block is self-gating text ("when the repository contains a `.deco/` directory…") because the prompt is assembled server-side with no sandbox fs access — inert for non-deco workspaces and prompt-cache-stable.

## Notes for reviewers

- Studio already treats `blocks.gen.json` as generated noise (`stripGeneratedFilesFromDiff`), consistent with this rule.
- The AGENTS.md seeding means a one-time extra `AGENTS.md` diff in customer repos on their next content edit. `isDecoOnlyDiff` publish gating may want to whitelist `AGENTS.md` — flagged for discussion, not changed here.

## Testing

- `bun test packages/harness/src/coding-workspace-prompt.test.ts` — 8 pass, including a new test asserting the rules render for all workspace kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach agents the correct Deco CMS content files to edit and avoid silent data loss. Edits target `.deco/blocks/*.json` only; generated artifacts like `blocks.gen.json` are off-limits. Rules are now appended only when the repo has a `.deco/` directory.

- **New Features**
  - Gate `DECO_CMS_CONTENT_RULES` on a real `.deco/` check via a new `isDecoSite` flag in `buildCodingWorkspacePrompt` (removed self-gating prose).
  - CLI harnesses (`claude-code`, `codex`): set `isDecoSite` using `localWorkspaceIsDecoSite(cwd)` (sync check for `/repo`).
  - Decopilot engine: set `isDecoSite` using `sandboxIsDecoSite` (cluster `test -d .deco` via sandbox-fs), gated on `user + branch`, and fail open on errors.
  - Tests: added `coding-workspace-deco.test.ts`; expanded `coding-workspace-prompt.test.ts` to assert inclusion only when `isDecoSite` is true.
  - Rules also seed a short note in `AGENTS.md` once if missing.

<sup>Written for commit 69e6eb5c6bbb6038522d7dcea7b1ecb5873d7a39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

