### PR TITLE
fix(web): truncate preview host label when no page name is resolved

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -942,34 +942,46 @@ export function PreviewContent() {
                         {/* Page name in focus, followed by the route path.
                             Path-template segments (`:param`/`*`) stay editable
                             inputs; plain paths render as muted text. */}
-                        <span className="shrink-0 text-[13px] font-medium text-foreground">
+                        <span
+                          className={cn(
+                            "text-[13px] font-medium text-foreground",
+                            // A real page name stays fully visible (the route
+                            // path truncates instead); the host fallback has no
+                            // path segment to shed, so it must truncate itself.
+                            currentPageName == null
+                              ? "min-w-0 flex-1 truncate"
+                              : "shrink-0",
+                          )}
+                        >
                           {currentPageName ?? previewLabel}
                         </span>
-                        {!activeGlobalSection && currentPath && (
-                          <span className="flex min-w-0 flex-1 items-center overflow-hidden whitespace-nowrap text-[12px] text-muted-foreground">
-                            {splitPathTemplate(currentPath).map((token, i) =>
-                              token.type === "text" ? (
-                                <span
-                                  key={`text-${i}`}
-                                  className={cn(
-                                    i === 0 ? "min-w-0 truncate" : "shrink-0",
-                                  )}
-                                >
-                                  {token.text}
-                                </span>
-                              ) : (
-                                <PathParamInput
-                                  key={`${currentPageKey}:${token.name}`}
-                                  name={token.name}
-                                  value={pathParamValues[token.name] ?? ""}
-                                  onCommit={(value) =>
-                                    setPathParamValue(token.name, value)
-                                  }
-                                />
-                              ),
-                            )}
-                          </span>
-                        )}
+                        {!activeGlobalSection &&
+                          currentPageName != null &&
+                          currentPath && (
+                            <span className="flex min-w-0 flex-1 items-center overflow-hidden whitespace-nowrap text-[12px] text-muted-foreground">
+                              {splitPathTemplate(currentPath).map((token, i) =>
+                                token.type === "text" ? (
+                                  <span
+                                    key={`text-${i}`}
+                                    className={cn(
+                                      i === 0 ? "min-w-0 truncate" : "shrink-0",
+                                    )}
+                                  >
+                                    {token.text}
+                                  </span>
+                                ) : (
+                                  <PathParamInput
+                                    key={`${currentPageKey}:${token.name}`}
+                                    name={token.name}
+                                    value={pathParamValues[token.name] ?? ""}
+                                    onCommit={(value) =>
+                                      setPathParamValue(token.name, value)
+                                    }
+                                  />
+                                ),
+                              )}
+                            </span>
+                          )}
                       </div>
                       <button
                         type="button"


### PR DESCRIPTION
## Summary

Fixes the preview address bar clipping the sandbox host URL when no page name is resolved.

- **Before (bug 1):** the host fallback (`previewLabel`) was rendered in a `shrink-0` span, so a long sandbox host was cut off mid-string by the container's `overflow-hidden` instead of truncating with an ellipsis.
- **Before (bug 2):** the separate route-path span still rendered in the no-page-name case. Its competing `flex-1` stole half the bar's width, forcing the host to truncate far too early — plus a redundant trailing `/`, since `previewLabel` already includes the path.
- **After:** the label span truncates (`min-w-0 flex-1 truncate`) when there's no page name and keeps `shrink-0` when a real page name is shown; the route-path span only renders when there's an actual page name.

## Testing

- `bun run fmt` clean.
- Verified visually: host now fills the bar and truncates with an ellipsis at the real edge, no stray ` /`.

## Affected areas

`apps/mesh/src/web/components/sandbox/preview/preview.tsx` (preview address bar only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview address bar so the sandbox host truncates correctly when no page name is resolved. The host now fills the bar and shows an ellipsis at the edge, with no extra slash.

- **Bug Fixes**
  - The label span truncates (`min-w-0 flex-1 truncate`) when there’s no page name, and stays `shrink-0` when a real page name exists.
  - The route-path span only renders when a page name exists, preventing width conflicts and removing the redundant trailing `/`.

<sup>Written for commit 17b3262f94b928bc3a45f016266417370236bfb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

