### PR TITLE
refactor(sections-editor): remove unreachable breadcrumb cleanup in ArrayField.removeItem

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -471,13 +471,6 @@ export function ArrayField({
 
   const removeItem = (index: number) => {
     onChange(items.filter((_, i) => i !== index));
-    if (selectedIndex === index) {
-      const itemName = itemLabel(items[index], index);
-      const itemIndex = findBreadcrumbLabelIndex(breadcrumbPath, itemName);
-      onBreadcrumbChange?.(
-        itemIndex >= 0 ? breadcrumbPath.slice(0, itemIndex) : [],
-      );
-    }
   };
 
   const updateItem = (index: number, val: unknown) => {


### PR DESCRIPTION
## Source

Bounded dead-code deletion found while reading `array-field.tsx` (a recently-churned file in the sections-editor breadcrumb-navigation area, e.g. #4479/#4482).

## What / why

`removeItem` is only wired to the row-list view's delete button (`onRemove={() => removeItem(entry.index)}`), which only renders in the branch that's reachable exclusively when `selectedIndex === null` (the component early-returns into the item editor whenever `selectedIndex !== null`). So the `if (selectedIndex === index)` breadcrumb-slicing branch inside `removeItem` can never be true — `index` is always a number and `selectedIndex` is always `null` at the only call site. It's inert code that could mislead a future reader into thinking removal has breadcrumb-cleanup behavior it doesn't.

Net: -7 / +0 lines. Behavior-preserving — the branch never executed, confirmed by tracing the only call site (`grep -rn "removeItem\|onRemove"` under `sections-editor/`) and the render-branch guard at the top of the component.

## How to verify

`cd apps/mesh && bun x tsc --noEmit` — clean.

No existing test file covers this component (`array-field.tsx` has no co-located `*.test.ts`), so the dead-code trace above plus a clean typecheck is the verification; full CI will run the rest.

## Checks run locally
- `bun run fmt` — no changes
- `cd apps/mesh && bun x tsc --noEmit` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unreachable breadcrumb cleanup in `ArrayField.removeItem` in the sections editor by deleting the `selectedIndex === index` branch that never runs. No behavior change; code is simpler and clearer.

<sup>Written for commit 4e84824a7cba180d28a0b21f3a573e82da8d1710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

