### PR TITLE
refactor(commerce-onboarding): remove dead hasConfigurationValues export

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -3,7 +3,6 @@ import {
   buildCompanionCards,
   buildRegistryWhere,
   getConfigurationSummaryEntries,
-  hasConfigurationValues,
   matchGscSite,
   mergeBindingValue,
   parseBindingRequirements,
@@ -75,21 +74,6 @@ describe("mergeBindingValue", () => {
     expect(mergeBindingValue(null, "VTEX_STORE", "vtex", "c1")).toEqual({
       VTEX_STORE: { __type: "vtex", value: "c1" },
     });
-  });
-});
-
-describe("hasConfigurationValues", () => {
-  it("treats null, empty objects, and empty scalar values as not configured", () => {
-    expect(hasConfigurationValues(null)).toBe(false);
-    expect(hasConfigurationValues({})).toBe(false);
-    expect(hasConfigurationValues({ propertyId: null })).toBe(false);
-    expect(hasConfigurationValues({ accountName: "" })).toBe(false);
-    expect(hasConfigurationValues({ accountName: "   " })).toBe(false);
-  });
-
-  it("detects nested saved values", () => {
-    expect(hasConfigurationValues({ accountName: "electrolux" })).toBe(true);
-    expect(hasConfigurationValues({ nested: { value: "123" } })).toBe(true);
   });
 });
 

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -151,12 +151,6 @@ function isMeaningfulConfigValue(value: unknown): boolean {
   return false;
 }
 
-export function hasConfigurationValues(
-  state: Record<string, unknown> | null | undefined,
-): boolean {
-  return isMeaningfulConfigValue(state);
-}
-
 function formatConfigurationKey(key: string): string {
   const labels: Record<string, string> = {
     accountName: "Nome da conta",


### PR DESCRIPTION
## Summary
- Deletes `hasConfigurationValues` from `companions-core.ts` — grep across the repo shows zero production callers; only its own test file exercised it.
- It was superseded when `companion-card.tsx` moved to `getConfigurationSummaryEntries(card.configurationState).length` for the same "has this companion been configured with real values" check (its underlying helper `isMeaningfulConfigValue` is still used by `getConfigurationSummaryEntries` and stays).
- Net: -22 / +0 lines. Behavior-preserving — this is a pure deletion of an unreachable export plus its dedicated test block, nothing else touches the file's exported surface.

## Test plan
- `grep -rn "hasConfigurationValues"` across the repo returns no matches after the change.
- `cd apps/mesh && bunx tsc --noEmit` — clean.
- `bun test apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts` — 40 pass / 0 fail (the other tests in that file, including `getConfigurationSummaryEntries`, cover the replacement path).
- Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove dead `hasConfigurationValues` from companions-core and delete its tests. It was replaced by `getConfigurationSummaryEntries(...).length` in `companion-card.tsx`, and had no remaining production callers.

<sup>Written for commit 992eb15f984065ac93204236277e07a683ebfc61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

