### PR TITLE
feat(commerce-onboarding): forward github_repo to the diagnostic run

### DIFF
--- a/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.test.ts
@@ -257,6 +257,33 @@ describe("triggerCommerceDiscoveryRun", () => {
     ]);
   });
 
+  test("forwards github_repo in the body when provided", async () => {
+    let body: unknown;
+    await triggerCommerceDiscoveryRun(
+      {
+        siteUrl: "https://example.com",
+        orgId: "org_123",
+        githubRepo: "deco-sites/fila-store",
+      },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async (input, init) => {
+          body = await new Request(input, init).json();
+          return Response.json({
+            url: "example.com",
+            scope: "private",
+            run: {},
+          });
+        },
+      },
+    );
+    expect(body).toEqual({
+      org_id: "org_123",
+      github_repo: "deco-sites/fila-store",
+    });
+  });
+
   test("treats a 409 (not upgraded yet) as a soft skip, not a throw", async () => {
     const out = await triggerCommerceDiscoveryRun(
       { siteUrl: "https://example.com", orgId: "org_123" },

--- a/apps/mesh/src/tools/commerce-discovery/auth-client.ts
+++ b/apps/mesh/src/tools/commerce-discovery/auth-client.ts
@@ -325,7 +325,7 @@ export async function bindCommerceDiscoveryResource(
  * { triggered: false } rather than thrown, so the UI can still open the report.
  */
 export async function triggerCommerceDiscoveryRun(
-  input: { siteUrl: string; orgId: string },
+  input: { siteUrl: string; orgId: string; githubRepo?: string },
   options: CommerceDiscoveryAuthOptions = {},
 ): Promise<{ triggered: boolean; reason?: string }> {
   const baseUrl = resolveBaseUrl(options);
@@ -342,7 +342,13 @@ export async function triggerCommerceDiscoveryRun(
       Authorization: `Bearer ${apiKey}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ org_id: input.orgId }),
+    // github_repo (optional) is the repo the client picked in the GitHub
+    // companion. Commerce Discovery threads it to the enriched-agent hand-off so
+    // repo-audit targets the right repo; absent ⇒ GitHub not connected.
+    body: JSON.stringify({
+      org_id: input.orgId,
+      ...(input.githubRepo ? { github_repo: input.githubRepo } : {}),
+    }),
   });
 
   if (response.status === 409) {

--- a/apps/mesh/src/tools/commerce-discovery/run.ts
+++ b/apps/mesh/src/tools/commerce-discovery/run.ts
@@ -1,3 +1,4 @@
+import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import { z } from "zod";
 import { normalizeCommerceSiteUrl } from "../../commerce-discovery/site-url";
 import { defineTool } from "../../core/define-tool";
@@ -40,9 +41,34 @@ export const COMMERCE_DISCOVERY_RUN = defineTool({
       throw new Error(normalized.error);
     }
 
+    // The repo the client picked in the GitHub companion is persisted on the CD
+    // connection's configuration_state (github_repo). Forward it so Commerce
+    // Discovery can run repo-audit against the right repo; its absence just means
+    // GitHub isn't connected and never blocks the run.
+    const cdConnectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(
+      organization.id,
+    );
+    const cdConnection = await ctx.storage.connections.findById(
+      cdConnectionId,
+      organization.id,
+    );
+    const configState = cdConnection?.configuration_state as
+      | Record<string, unknown>
+      | string
+      | null
+      | undefined;
+    const githubRepo =
+      configState &&
+      typeof configState === "object" &&
+      typeof configState.github_repo === "string" &&
+      configState.github_repo.length > 0
+        ? (configState.github_repo as string)
+        : undefined;
+
     return triggerCommerceDiscoveryRun({
       siteUrl: normalized.value,
       orgId: organization.id,
+      githubRepo,
     });
   },
 });


### PR DESCRIPTION
## Summary

`COMMERCE_DISCOVERY_RUN` now reads `github_repo` from the Commerce Discovery connection's `configuration_state` (persisted by the GitHub companion) and sends it in the `/run` body. Commerce Discovery threads it to the enriched-agent hand-off so `repo-audit` targets the client's repo.

This is the Studio half of the GitHub-tab feature; the diagnostic/report half lives in commerce-discovery#212.

## What changed

- `tools/commerce-discovery/auth-client.ts` — `triggerCommerceDiscoveryRun` accepts an optional `githubRepo` and includes it as `github_repo` in the POST body (omitted when absent).
- `tools/commerce-discovery/run.ts` — the tool loads the CD connection via `configuration_state.github_repo` and forwards it to the run.

Optional by design: no `github_repo` ⇒ body is unchanged (`{ org_id }`) and the run behaves exactly as before. GitHub never blocks the run.

## Testing

- `bun test tools/commerce-discovery/auth-client.test.ts` — 22 pass, incl. a new case asserting `github_repo` is forwarded when provided (and omitted otherwise).
- `tsc --noEmit` clean for the changed files; `oxlint` clean; `biome format` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward the selected GitHub repo from the Commerce Discovery connection into diagnostic runs so `repo-audit` targets the right repo. Runs work the same when no repo is set.

- **New Features**
  - `COMMERCE_DISCOVERY_RUN` reads `configuration_state.github_repo` from the Commerce Discovery connection (via `WellKnownOrgMCPId.COMMERCE_DISCOVERY` from `@decocms/mesh-sdk`) and sends it as `github_repo` in the `/run` body.
  - `triggerCommerceDiscoveryRun` now accepts optional `githubRepo`; `github_repo` is included only when provided.
  - Added tests to assert forwarding and omission; behavior is unchanged when GitHub isn’t connected.

<sup>Written for commit bce469a12d3defb42c461e30207facba9a615fe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

