### PR TITLE
docs: add guideline against paragraph-long workaround comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,7 @@ isolation) and is intentionally separate.
 - Components and classes: PascalCase
 - Hooks and utilities: camelCase
 - Files in shared packages: kebab-case (enforced by `plugins/enforce-kebab-case-file-names.ts`)
+- A comment that takes a paragraph to justify a workaround is a signal the code is wrong, not the comment—fix the code, don't explain it away
 
 ### React 19 Patterns
 - Uses React 19 with React Compiler (babel-plugin-react-compiler)


### PR DESCRIPTION
## Summary
- Adds one line to AGENTS.md's Style & Formatting section: a comment that needs a paragraph to justify a workaround is a signal the code is wrong, not the comment.
- Inspired by Bun's Rust rewrite retro, where they used this exact rule to instruct adversarial reviewers to reject overly-explained workarounds.

## Test plan
- [x] Docs-only change, no code affected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a style rule to AGENTS.md: if a workaround needs a paragraph-long comment, fix the code instead of explaining it. This clarifies review expectations and keeps comments focused; docs-only change.

<sup>Written for commit 3dcc89af5091f027a9b3ec15dd088daf64325a92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

