### PR TITLE
fix(sections-editor): fix row content desync after duplicating/removing a non-last array item

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/array-entries.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-entries.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+  insertEntryAfter,
+  removeEntryAt,
+  type ArrayEntry,
+} from "./array-entries";
+
+describe("insertEntryAfter", () => {
+  test("duplicating a non-last item shifts later entries instead of colliding with them", () => {
+    // items: [A, B, C]; duplicating A (index 0) yields [A, copyA, B, C].
+    const entries: ArrayEntry[] = [
+      { id: "a", index: 0 },
+      { id: "b", index: 1 },
+      { id: "c", index: 2 },
+    ];
+    const next = insertEntryAfter(entries, 0);
+    // "b" (originally B) must point at B's new position (2) — a naive
+    // append-at-the-end resize would leave it at 1, which is now the copy's
+    // slot, so the row keyed "b" would render the copy's label instead of B's.
+    expect(next.find((e) => e.id === "b")?.index).toBe(2);
+    expect(next.find((e) => e.id === "c")?.index).toBe(3);
+    expect(next.find((e) => e.id === "a")?.index).toBe(0);
+    const inserted = next.find(
+      (e) => e.id !== "a" && e.id !== "b" && e.id !== "c",
+    );
+    expect(inserted?.index).toBe(1);
+  });
+
+  test("duplicating the last item just appends", () => {
+    const entries: ArrayEntry[] = [
+      { id: "a", index: 0 },
+      { id: "b", index: 1 },
+    ];
+    const next = insertEntryAfter(entries, 1);
+    expect(next.map((e) => e.index)).toEqual([0, 1, 2]);
+  });
+});
+
+describe("removeEntryAt", () => {
+  test("removing a non-last item drops its entry and shifts later ones down", () => {
+    // items: [A, B, C]; removing A (index 0) yields [B, C].
+    const entries: ArrayEntry[] = [
+      { id: "a", index: 0 },
+      { id: "b", index: 1 },
+      { id: "c", index: 2 },
+    ];
+    const next = removeEntryAt(entries, 0);
+    expect(next.find((e) => e.id === "a")).toBeUndefined();
+    // "b" (originally B) must now point at index 0, matching B's new position.
+    expect(next.find((e) => e.id === "b")?.index).toBe(0);
+    expect(next.find((e) => e.id === "c")?.index).toBe(1);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/fields/array-entries.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-entries.ts
@@ -1,0 +1,74 @@
+/** Stable DnD id per row; item data always comes from the `items` prop. */
+export interface ArrayEntry {
+  id: string;
+  index: number;
+}
+
+export function createArrayEntries(count: number): ArrayEntry[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: crypto.randomUUID(),
+    index,
+  }));
+}
+
+export function remapEntryIndices(entries: ArrayEntry[]): ArrayEntry[] {
+  return entries.map((entry, index) => ({ ...entry, index }));
+}
+
+/** Append/truncate entries by count only — correct when items are only ever
+ * added/removed at the end. `insertEntryAfter`/`removeEntryAt` below handle
+ * the mid-array cases (duplicate, remove). */
+export function resizeArrayEntries(
+  current: ArrayEntry[],
+  nextCount: number,
+): ArrayEntry[] {
+  if (nextCount === current.length) return current;
+  if (nextCount < current.length) {
+    return remapEntryIndices(current.slice(0, nextCount));
+  }
+  const extra = Array.from(
+    { length: nextCount - current.length },
+    (_, offset) => ({
+      id: crypto.randomUUID(),
+      index: current.length + offset,
+    }),
+  );
+  return [...current, ...extra];
+}
+
+/** Insert a new entry right after the item at `itemIndex`, shifting the
+ * indices of entries after it. Used for duplicate, which inserts mid-array —
+ * unlike append, `resizeArrayEntries` can't place it (it only grows/shrinks
+ * from the end, which desyncs every entry after the insertion point). */
+export function insertEntryAfter(
+  entries: ArrayEntry[],
+  itemIndex: number,
+): ArrayEntry[] {
+  const insertAt = entries.findIndex((entry) => entry.index === itemIndex);
+  const shifted = entries.map((entry) =>
+    entry.index > itemIndex ? { ...entry, index: entry.index + 1 } : entry,
+  );
+  const newEntry: ArrayEntry = {
+    id: crypto.randomUUID(),
+    index: itemIndex + 1,
+  };
+  if (insertAt === -1) return [...shifted, newEntry];
+  return [
+    ...shifted.slice(0, insertAt + 1),
+    newEntry,
+    ...shifted.slice(insertAt + 1),
+  ];
+}
+
+/** Drop the entry for the item at `itemIndex`, shifting indices of entries
+ * after it down by one. Used for remove, which can drop from mid-array. */
+export function removeEntryAt(
+  entries: ArrayEntry[],
+  itemIndex: number,
+): ArrayEntry[] {
+  return entries
+    .filter((entry) => entry.index !== itemIndex)
+    .map((entry) =>
+      entry.index > itemIndex ? { ...entry, index: entry.index - 1 } : entry,
+    );
+}

--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -55,6 +55,14 @@ import {
   resolveArrayItemSelection,
 } from "../schema-form-breadcrumb";
 import { isSectionArrayField } from "../section-array-field";
+import {
+  type ArrayEntry,
+  createArrayEntries,
+  insertEntryAfter,
+  remapEntryIndices,
+  removeEntryAt,
+  resizeArrayEntries,
+} from "./array-entries";
 import type { FieldProps } from "./field-props";
 import { SchemaForm, renderField } from "../schema-form";
 import {
@@ -62,19 +70,6 @@ import {
   type LiveMeta,
   type SchemaProperty,
 } from "../resolve-schema";
-
-/** Stable DnD id per row; item data always comes from the `items` prop. */
-interface ArrayEntry {
-  id: string;
-  index: number;
-}
-
-function createArrayEntries(count: number): ArrayEntry[] {
-  return Array.from({ length: count }, (_, index) => ({
-    id: crypto.randomUUID(),
-    index,
-  }));
-}
 
 function itemEditorSchema(
   item: unknown,
@@ -121,28 +116,6 @@ function itemEditorSchema(
 function arrayFieldKeyFromPath(path: string): string {
   const segments = path.split(".").filter((segment) => !/^\d+$/.test(segment));
   return segments[segments.length - 1] ?? path;
-}
-
-function remapEntryIndices(entries: ArrayEntry[]): ArrayEntry[] {
-  return entries.map((entry, index) => ({ ...entry, index }));
-}
-
-function resizeArrayEntries(
-  current: ArrayEntry[],
-  nextCount: number,
-): ArrayEntry[] {
-  if (nextCount === current.length) return current;
-  if (nextCount < current.length) {
-    return remapEntryIndices(current.slice(0, nextCount));
-  }
-  const extra = Array.from(
-    { length: nextCount - current.length },
-    (_, offset) => ({
-      id: crypto.randomUUID(),
-      index: current.length + offset,
-    }),
-  );
-  return [...current, ...extra];
 }
 
 function ArrayRowContent({
@@ -458,6 +431,7 @@ export function ArrayField({
       ...items.slice(index + 1),
     ];
     onChange(next);
+    setEntries((current) => insertEntryAfter(current, index));
   };
 
   const toggleItemHidden = (index: number) => {
@@ -471,6 +445,7 @@ export function ArrayField({
 
   const removeItem = (index: number) => {
     onChange(items.filter((_, i) => i !== index));
+    setEntries((current) => removeEntryAt(current, index));
   };
 
   const updateItem = (index: number, val: unknown) => {


### PR DESCRIPTION
## Source
A bug found while reading `array-field.tsx` (top of the recently-changed-files hunting ground — 5 PRs touched this file in the last two weeks: duplicate action, hide/show toggle, breadcrumb fixes).

## The bug
`ArrayField` gives each row a stable DnD identity separate from the underlying `items` array, via an `entries` list of `{ id, index }`. That list is only ever resized from the tail (`resizeArrayEntries`: truncate/append at the end) — correct for `addItem`/`appendItem`, which only ever push to the end.

But `duplicateItem(index)` and `removeItem(index)` mutate the array at an arbitrary position. After either, every entry positioned after the mutated index still points at its *old* array index, which is now the wrong item — so that row's label/image renders as a different item's content until some other length-preserving mutation happens to paper over it.

Concretely: items `[A, B, C]`, duplicate `A` (index 0) → items become `[A, copyA, B, C]`, but the old tail-append resize just appends one new entry at the end, leaving the entry that used to point at `B` still pointing at index 1 — which is now `copyA`. The row that should show `B` shows `copyA` instead (and the row for `C` is off by one too), and the same shift happens in reverse for `removeItem` on a non-last index.

## Fix
Added `insertEntryAfter`/`removeEntryAt` (in the new `array-entries.ts`, mirroring the existing pure-logic-file convention like `array-item-hidden.ts`) which rewrite the indices of every entry after the mutated position, instead of assuming append-only mutation. `duplicateItem`/`removeItem` now call these directly.

## Regression test
`apps/mesh/src/web/components/sections-editor/fields/array-entries.test.ts` — asserts the entry pointing at `B` still resolves to `B`'s new position after duplicating an earlier item, and the same for removal. Fails on the old tail-based resize logic, passes with the fix.

## To verify
```
bun test apps/mesh/src/web/components/sections-editor/fields/array-entries.test.ts
```
Manually: open the Sections editor on any array field with 3+ items (e.g. a banner list), duplicate or delete the first item, and note the rows after it show stale content until reordered.

## Checks run locally
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` (clean)
- `bun test apps/mesh/src/web/components/sections-editor/fields/array-entries.test.ts` (3 pass)

Full CI will run lint and the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes row content desync in the Sections editor when duplicating or removing non-last array items by correctly remapping DnD entry indices. Ensures rows always display the right item after mid-array changes.

- **Bug Fixes**
  - Update `duplicateItem` and `removeItem` to use `insertEntryAfter` and `removeEntryAt` for index remapping.
  - Prevent rows after the changed index from showing the wrong label/image.

- **Refactors**
  - Extract entry helpers to `array-entries.ts` (`createArrayEntries`, `resizeArrayEntries`, `insertEntryAfter`, `removeEntryAt`, `remapEntryIndices`).
  - Add `array-entries.test.ts` to cover mid-array duplicate/remove behavior.

<sup>Written for commit 0f1350b39137164b011195782eba7bdc21ba51aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

