### PR TITLE
fix(monitoring): count tool-level isError in monitoring_logs

### DIFF
--- a/apps/mesh/src/mcp-clients/outbound/transports/monitoring.test.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/monitoring.test.ts
@@ -146,6 +146,35 @@ describe("MonitoringTransport emitMonitoringLog", () => {
     );
   });
 
+  it("should flag isError when result.isError is true (tool-level failure)", async () => {
+    const { transport, simulateResponse } = createMockTransportAndCtx();
+
+    transport.onmessage = vi.fn();
+    await transport.start();
+
+    await transport.send({
+      jsonrpc: "2.0",
+      id: 42,
+      method: "tools/call",
+      params: { name: "FAILING_TOOL", arguments: {} },
+    } as any);
+
+    // Successful JSON-RPC response, but the tool signals failure the MCP way.
+    simulateResponse({
+      jsonrpc: "2.0",
+      id: 42,
+      result: {
+        content: [{ type: "text", text: "repo not found" }],
+        isError: true,
+      },
+    } as any);
+
+    expect(mockEmitMonitoringLog).toHaveBeenCalledTimes(1);
+    const [params] = mockEmitMonitoringLog.mock.calls[0]!;
+    expect(params.isError).toBe(true);
+    expect(params.errorMessage).toBe("repo not found");
+  });
+
   it("should pass context (spanCtx) as second argument to emitMonitoringLog", async () => {
     const { transport, simulateResponse } = createMockTransportAndCtx();
 

--- a/apps/mesh/src/mcp-clients/outbound/transports/monitoring.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/monitoring.ts
@@ -159,6 +159,11 @@ export class MonitoringTransport extends WrapperTransport {
     // tools signal failure. Both must count; checking only "error" in response
     // undercounted real failures ~35x in production telemetry.
     const isError = transportError || callToolResult?.isError === true;
+    // Read response.error only inside the aliased type guard so TS narrows the
+    // JSONRPCResponse union; downstream branches use the derived string.
+    const transportErrorMessage = transportError
+      ? response.error?.message
+      : undefined;
     const errorMessage = extractCallToolErrorMessage(callToolResult) || null;
 
     // Record connection-level OpenTelemetry metrics
@@ -174,7 +179,7 @@ export class MonitoringTransport extends WrapperTransport {
         "connection.id": connectionId,
         "organization.id": organizationId,
         "tool.name": toolName,
-        error: response.error?.message ?? errorMessage ?? undefined,
+        error: transportErrorMessage ?? errorMessage ?? undefined,
       });
     } else {
       ctx.meter.createCounter("connection.proxy.requests").add(1, {
@@ -201,7 +206,7 @@ export class MonitoringTransport extends WrapperTransport {
     if (span) {
       if (isError) {
         span.recordException(
-          new Error(response.error?.message ?? errorMessage ?? "Tool error"),
+          new Error(transportErrorMessage ?? errorMessage ?? "Tool error"),
         );
       }
 

--- a/apps/mesh/src/mcp-clients/outbound/transports/monitoring.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/monitoring.ts
@@ -138,11 +138,11 @@ export class MonitoringTransport extends WrapperTransport {
     }
 
     const organizationId = ctx.organization?.id ?? "";
-    const isError = "error" in response;
-    const result = isError ? response.error : response.result;
+    const transportError = "error" in response;
+    const result = transportError ? response.error : response.result;
 
     // Convert to CallToolResult format for logging
-    const callToolResult: CallToolResult = isError
+    const callToolResult: CallToolResult = transportError
       ? {
           content: [
             {
@@ -153,6 +153,13 @@ export class MonitoringTransport extends WrapperTransport {
           isError: true,
         }
       : (result as CallToolResult);
+
+    // A tool call fails two ways: a JSON-RPC transport error, or a successful
+    // response whose CallToolResult carries isError:true — the normal way MCP
+    // tools signal failure. Both must count; checking only "error" in response
+    // undercounted real failures ~35x in production telemetry.
+    const isError = transportError || callToolResult?.isError === true;
+    const errorMessage = extractCallToolErrorMessage(callToolResult) || null;
 
     // Record connection-level OpenTelemetry metrics
     ctx.meter.createHistogram("connection.proxy.duration").record(duration, {
@@ -167,7 +174,7 @@ export class MonitoringTransport extends WrapperTransport {
         "connection.id": connectionId,
         "organization.id": organizationId,
         "tool.name": toolName,
-        error: response.error?.message,
+        error: response.error?.message ?? errorMessage ?? undefined,
       });
     } else {
       ctx.meter.createCounter("connection.proxy.requests").add(1, {
@@ -186,14 +193,16 @@ export class MonitoringTransport extends WrapperTransport {
         toolName,
         durationMs: duration,
         isError,
-        errorType: isError ? "RemoteError" : "",
+        errorType: transportError ? "RemoteError" : isError ? "ToolError" : "",
       });
     }
 
     // Enrich and end OpenTelemetry span
     if (span) {
-      if (isError && response.error) {
-        span.recordException(new Error(response.error.message));
+      if (isError) {
+        span.recordException(
+          new Error(response.error?.message ?? errorMessage ?? "Tool error"),
+        );
       }
 
       const metaProps = extractMetaProperties(toolArguments);
@@ -209,8 +218,8 @@ export class MonitoringTransport extends WrapperTransport {
           toolArguments,
           result: callToolResult,
           duration,
-          isError: Boolean(isError),
-          errorMessage: extractCallToolErrorMessage(callToolResult) || null,
+          isError,
+          errorMessage,
           userId: ctx.auth.user?.id || ctx.auth.apiKey?.userId || null,
           requestId: ctx.metadata.requestId,
           userAgent: ctx.metadata.userAgent || null,


### PR DESCRIPTION
## Problem

ClickHouse `studio_monitoring_logs` massively undercounts tool-call failures. `is_error=1` catches only ~0.3% of calls (transport-level failures), yet ~11k rows / 7d have `is_error=0` while their output payload carries `"isError":true`. MCP tools signal failure *inside* a successful JSON-RPC response (`result.isError: true`), not as a transport error — so any dashboard or alert built on `is_error` is blind to the real error rate (GitHub 404/409s, D1 SQL errors, broken queries in tenant MCP apps, etc.).

## Root cause

`MonitoringTransport.onResponseEnd` (`apps/mesh/src/mcp-clients/outbound/transports/monitoring.ts`) computed:

```ts
const isError = "error" in response; // JSON-RPC transport error only
```

`response.result` (the `CallToolResult`, carrying both `content` and `isError`) is available at that point, but its `isError` was never read for the logged flag. The correct logic already existed in `createProxyMonitoringMiddleware` (`Boolean(result.isError)`) but that middleware is unused — the transport is the live write path.

## Fix

`is_error` is now `transportError || callToolResult?.isError === true`, so tool-level failures are counted. Also:
- `errorType` distinguishes `RemoteError` (transport) vs `ToolError` (tool-level).
- The error counter and span exception fall back to the extracted tool error message when there's no transport error.

Consumers no longer need the `output ILIKE '%"isError":true%'` full-scan workaround to find real failures.

## Testing

`bun test apps/mesh/src/mcp-clients/outbound/transports/monitoring.test.ts` — added a case asserting `is_error=true` + `errorMessage` for a successful JSON-RPC response with `result.isError: true`. All pass.

## Note

Fixes reporting going forward. Historical rows stay wrong; consumers wanting a backfill can still derive truth from the `output` payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes monitoring to count tool-level failures by setting `is_error` when `result.isError` is true, not just on JSON-RPC transport errors. Dashboards and alerts now reflect real MCP tool error rates.

- **Bug Fixes**
  - Compute `is_error` as `transportError || callToolResult.isError === true`.
  - Safely narrow `JSONRPCResponse` before reading `response.error`; use `transportErrorMessage ?? extractedToolErrorMessage` for metrics and span exceptions.
  - Set `errorType` to `RemoteError` (transport) or `ToolError` (tool-level).
  - Add a test for successful JSON-RPC responses with `result.isError: true`.
  - Forward fix only; historical rows are unchanged.

<sup>Written for commit 6ecf8d5270af10c954f74e0eb87cb48e223fdd86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

