### PR TITLE
feat(proxy): actionable hints on InvalidParams tool errors

### DIFF
--- a/apps/mesh/src/mcp-clients/lazy-client.ts
+++ b/apps/mesh/src/mcp-clients/lazy-client.ts
@@ -10,6 +10,7 @@
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
   GetPromptResult,
@@ -36,6 +37,7 @@ import {
   REVALIDATE_MIN_INTERVAL_MS,
 } from "./mcp-list-cache";
 import { getMcpReadCache, type ReadCacheScope } from "./mcp-read-cache";
+import { enrichInvalidParams, type ToolInputSchema } from "./validation-hint";
 
 /**
  * A read-only tool is eligible for result caching. We trust the upstream's
@@ -211,7 +213,11 @@ export function createLazyClient(
   const cacheReads =
     connection.connection_type !== "VIRTUAL" && !isDevConnection;
 
-  placeholder.callTool = async (params, resultSchema, options) => {
+  const callToolInner: Client["callTool"] = async (
+    params,
+    resultSchema,
+    options,
+  ) => {
     const toolName = (params as { name?: unknown })?.name;
     const readOnly =
       cacheReads &&
@@ -259,6 +265,38 @@ export function createLazyClient(
     }
 
     return real.callTool(params, resultSchema, options);
+  };
+
+  // On a -32602 (InvalidParams) rejection, append a schema-derived correction
+  // so the agent can fix its arguments instead of retrying the same bad shape.
+  // Only the error path pays the cached tool-list lookup.
+  placeholder.callTool = async (params, resultSchema, options) => {
+    try {
+      return await callToolInner(params, resultSchema, options);
+    } catch (err) {
+      const toolName = (params as { name?: unknown })?.name;
+      if (
+        err instanceof McpError &&
+        err.code === ErrorCode.InvalidParams &&
+        typeof toolName === "string" &&
+        cache
+      ) {
+        const tools = await cache.get("tools", connection.id).catch(() => null);
+        const tool = tools?.find(
+          (t): t is { name: string; inputSchema?: ToolInputSchema } =>
+            typeof t === "object" &&
+            t !== null &&
+            (t as { name?: unknown }).name === toolName,
+        );
+        throw enrichInvalidParams(
+          err,
+          toolName,
+          tool?.inputSchema,
+          (params as { arguments?: Record<string, unknown> })?.arguments,
+        );
+      }
+      throw err;
+    }
   };
 
   placeholder.getPrompt = async (params, options) => {

--- a/apps/mesh/src/mcp-clients/validation-hint.test.ts
+++ b/apps/mesh/src/mcp-clients/validation-hint.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { buildValidationHint, enrichInvalidParams } from "./validation-hint";
+
+describe("buildValidationHint", () => {
+  const schema = {
+    required: ["startDate", "endDate"],
+    properties: { startDate: { type: "string" }, endDate: { type: "string" } },
+  };
+
+  it("names required params, what was sent, and what's missing", () => {
+    const hint = buildValidationHint("query_search_analytics", schema, {
+      endDate: "2026-07-01",
+    });
+    expect(hint).toBe(
+      'Invalid arguments for "query_search_analytics". Required: startDate (string), endDate (string). You sent: endDate. Missing required: startDate.',
+    );
+  });
+
+  it("reports (none) when no args were sent", () => {
+    const hint = buildValidationHint("t", schema, undefined);
+    expect(hint).toContain("You sent: (none).");
+    expect(hint).toContain("Missing required: startDate, endDate.");
+  });
+
+  it("omits missing/required clauses when schema has no required fields", () => {
+    const hint = buildValidationHint("t", { properties: {} }, { a: 1 });
+    expect(hint).toBe('Invalid arguments for "t". You sent: a.');
+  });
+});
+
+describe("enrichInvalidParams", () => {
+  const schema = { required: ["startDate"], properties: {} };
+
+  it("appends a hint to an InvalidParams McpError", () => {
+    const original = new McpError(
+      ErrorCode.InvalidParams,
+      "startDate: Required",
+    );
+    const enriched = enrichInvalidParams(original, "t", schema, {});
+    expect(enriched).toBeInstanceOf(McpError);
+    expect((enriched as McpError).code).toBe(ErrorCode.InvalidParams);
+    expect((enriched as McpError).message).toContain("startDate: Required");
+    expect((enriched as McpError).message).toContain(
+      "Missing required: startDate",
+    );
+  });
+
+  it("passes through non-InvalidParams errors untouched", () => {
+    const other = new McpError(ErrorCode.MethodNotFound, "nope");
+    expect(enrichInvalidParams(other, "t", schema, {})).toBe(other);
+    const plain = new Error("boom");
+    expect(enrichInvalidParams(plain, "t", schema, {})).toBe(plain);
+  });
+
+  it("passes through when the tool name is unknown", () => {
+    const original = new McpError(ErrorCode.InvalidParams, "bad");
+    expect(enrichInvalidParams(original, undefined, schema, {})).toBe(original);
+  });
+});

--- a/apps/mesh/src/mcp-clients/validation-hint.test.ts
+++ b/apps/mesh/src/mcp-clients/validation-hint.test.ts
@@ -44,6 +44,8 @@ describe("enrichInvalidParams", () => {
     expect((enriched as McpError).message).toContain(
       "Missing required: startDate",
     );
+    // The SDK prefix must appear exactly once, not doubled.
+    expect((enriched as McpError).message).not.toContain("-32602: MCP error");
   });
 
   it("passes through non-InvalidParams errors untouched", () => {

--- a/apps/mesh/src/mcp-clients/validation-hint.ts
+++ b/apps/mesh/src/mcp-clients/validation-hint.ts
@@ -1,0 +1,68 @@
+/**
+ * Corrective hints for invalid tool-call arguments.
+ *
+ * When an upstream MCP server rejects a `tools/call` with JSON-RPC -32602
+ * (InvalidParams), the raw error is often terse ("startDate: Required") and the
+ * agent keeps retrying with the same bad shape. Since the proxy already holds
+ * the tool's advertised `inputSchema`, we append a concrete correction so the
+ * model can fix the arguments on the next attempt.
+ */
+
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+
+export interface ToolInputSchema {
+  required?: string[];
+  properties?: Record<string, { type?: string }>;
+}
+
+/**
+ * Build a one-line correction from the tool's input schema and what the agent
+ * actually sent. Pure: given the same inputs, always the same string.
+ */
+export function buildValidationHint(
+  toolName: string,
+  schema: ToolInputSchema | undefined,
+  args: Record<string, unknown> | undefined,
+): string {
+  const sent = Object.keys(args ?? {});
+  const required = schema?.required ?? [];
+  const missing = required.filter((k) => !sent.includes(k));
+
+  const describe = (name: string) => {
+    const type = schema?.properties?.[name]?.type;
+    return type ? `${name} (${type})` : name;
+  };
+
+  const parts = [
+    `Invalid arguments for "${toolName}".`,
+    required.length ? `Required: ${required.map(describe).join(", ")}.` : "",
+    `You sent: ${sent.length ? sent.join(", ") : "(none)"}.`,
+    missing.length ? `Missing required: ${missing.join(", ")}.` : "",
+  ];
+
+  return parts.filter(Boolean).join(" ");
+}
+
+/**
+ * If `err` is an InvalidParams McpError, return a new McpError with a
+ * schema-derived correction appended to the message. Any other error (or a
+ * missing tool name) passes through unchanged.
+ */
+export function enrichInvalidParams(
+  err: unknown,
+  toolName: string | undefined,
+  schema: ToolInputSchema | undefined,
+  args: Record<string, unknown> | undefined,
+): unknown {
+  if (!(err instanceof McpError) || err.code !== ErrorCode.InvalidParams) {
+    return err;
+  }
+  if (!toolName) return err;
+
+  const hint = buildValidationHint(toolName, schema, args);
+  return new McpError(
+    ErrorCode.InvalidParams,
+    `${err.message}\n\n${hint}`,
+    err.data,
+  );
+}

--- a/apps/mesh/src/mcp-clients/validation-hint.ts
+++ b/apps/mesh/src/mcp-clients/validation-hint.ts
@@ -60,9 +60,8 @@ export function enrichInvalidParams(
   if (!toolName) return err;
 
   const hint = buildValidationHint(toolName, schema, args);
-  return new McpError(
-    ErrorCode.InvalidParams,
-    `${err.message}\n\n${hint}`,
-    err.data,
-  );
+  // McpError's constructor re-adds the "MCP error <code>: " prefix, so strip
+  // the one already on err.message to avoid a doubled header.
+  const raw = err.message.replace(/^MCP error -?\d+: /, "");
+  return new McpError(ErrorCode.InvalidParams, `${raw}\n\n${hint}`, err.data);
 }


### PR DESCRIPTION
## Problem

Telemetry (once the [isError fix](https://github.com/decocms/studio/pull/4493) made it trustworthy) shows several proxied tools failing **100%** of calls with JSON-RPC `-32602` (InvalidParams) — e.g. `query_search_analytics` (agent never sends `startDate`), `VTEX_IS_GET_PRODUCT_SEARCH` (`query` wrong type). The raw upstream error is terse and the model just retries the same bad shape, so every call is pure waste.

## What a proxy can do here

The proxy can't fix the upstream schema, but it advertises each tool's `inputSchema` and sees every error on the wire. So on a `-32602` rejection it now appends a concrete, schema-derived correction to the error the agent receives:

```
startDate: Required

Invalid arguments for "query_search_analytics". Required: startDate (string), endDate (string). You sent: endDate. Missing required: startDate.
```

The agent can act on that and retry with valid args.

## Implementation

- `apps/mesh/src/mcp-clients/validation-hint.ts` — pure `buildValidationHint()` + thin `enrichInvalidParams()` (wraps only `McpError` with code `InvalidParams`; everything else passes through).
- `lazy-client.ts` `callTool` — wrapped: on a `-32602` throw, look up the tool in the already-cached tool list and rethrow the enriched `McpError`. **Only the error path** pays the (cached) lookup; successful calls are untouched.

Deliberately conservative — it enriches the *error*, never rewrites a successful response or guesses arguments (that would hide real breakage).

## Testing

`bun test apps/mesh/src/mcp-clients/validation-hint.test.ts` — 6 cases covering the hint text (missing/sent/required, no-args, no-required) and the pass-through behavior. Typecheck + lint clean.

## Not in this PR

The `-32602` tools are the cleanest but smallest failure class (~600/wk). The bulk (~6,700/wk `get_file_contents` GitHub 404/409) is upstream/owner-fixable and needs a per-connection health signal surfaced to the owner — separate, larger PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds schema-based hints to `-32602` InvalidParams tool errors so agents can fix arguments instead of retrying. Also prevents a doubled JSON‑RPC prefix in enriched errors.

- **New Features**
  - On `-32602`, wraps `McpError` with an `inputSchema`-derived hint; other errors pass through.
  - Uses cached tool list; successful calls are untouched.
  - Adds `buildValidationHint()` and `enrichInvalidParams()` in `apps/mesh/src/mcp-clients/validation-hint.ts`.

- **Bug Fixes**
  - Strips the existing JSON-RPC prefix to avoid duplicated "MCP error -32602:" in enriched messages; tests added.

<sup>Written for commit 6c05e0348a634d5e990c61764d536c95602fd9e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

