### PR TITLE
feat(connections): surface top errors on the connection activity card

### DIFF
--- a/apps/mesh/src/web/components/details/connection/connection-activity.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-activity.tsx
@@ -8,6 +8,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@deco/ui/components/chart.tsx";
+import { computeTopErrors } from "./connection-health.ts";
 import { KEYS } from "@/web/lib/query-keys.ts";
 import { useStudioTools } from "@/web/lib/studio-tools";
 import { cn } from "@deco/ui/lib/utils.ts";
@@ -68,6 +69,11 @@ function ActivityChart({ connectionId, orgId, timeframe }: ActivityChartProps) {
   const stats = calculateStats(data?.logs ?? [], dateRange);
   const chartData = stats.data;
   const hasData = stats.totalCalls > 0;
+  const topErrors = computeTopErrors(data?.logs ?? []);
+  const errorRate =
+    stats.totalCalls > 0
+      ? Math.round((stats.totalErrors / stats.totalCalls) * 100)
+      : 0;
 
   return (
     <div>
@@ -154,6 +160,29 @@ function ActivityChart({ connectionId, orgId, timeframe }: ActivityChartProps) {
           <p className="text-sm text-muted-foreground/60">
             No activity in this period
           </p>
+        </div>
+      )}
+
+      {topErrors.length > 0 && (
+        <div className="px-5 py-4 border-t border-border">
+          <p className="text-xs font-medium text-muted-foreground mb-2">
+            Top errors{errorRate > 0 ? ` · ${errorRate}% of calls failed` : ""}
+          </p>
+          <ul className="space-y-1.5">
+            {topErrors.map((e) => (
+              <li key={e.message} className="flex items-start gap-2 text-xs">
+                <span className="tabular-nums text-destructive font-medium shrink-0">
+                  {e.count.toLocaleString()}×
+                </span>
+                <span
+                  className="text-muted-foreground truncate"
+                  title={e.message}
+                >
+                  {e.message}
+                </span>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </div>

--- a/apps/mesh/src/web/components/details/connection/connection-health.test.ts
+++ b/apps/mesh/src/web/components/details/connection/connection-health.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { computeTopErrors } from "./connection-health";
+import type { MonitoringLog } from "@/web/components/monitoring/monitoring-stats-row.tsx";
+
+const log = (over: Partial<MonitoringLog>): MonitoringLog => ({
+  id: "1",
+  connectionId: "c",
+  toolName: "t",
+  isError: false,
+  errorMessage: null,
+  durationMs: 0,
+  timestamp: "",
+  ...over,
+});
+
+describe("computeTopErrors", () => {
+  it("ranks error messages by frequency, ignoring successes", () => {
+    const top = computeTopErrors([
+      log({ isError: true, errorMessage: "repo not found" }),
+      log({ isError: true, errorMessage: "repo not found" }),
+      log({ isError: true, errorMessage: "403 forbidden" }),
+      log({ isError: false, errorMessage: null }),
+    ]);
+    expect(top).toEqual([
+      { message: "repo not found", count: 2 },
+      { message: "403 forbidden", count: 1 },
+    ]);
+  });
+
+  it("buckets empty/null messages as 'Unknown error'", () => {
+    const top = computeTopErrors([
+      log({ isError: true, errorMessage: null }),
+      log({ isError: true, errorMessage: "  " }),
+    ]);
+    expect(top).toEqual([{ message: "Unknown error", count: 2 }]);
+  });
+
+  it("caps at the requested limit", () => {
+    const logs = ["a", "b", "c", "d"].map((m) =>
+      log({ isError: true, errorMessage: m }),
+    );
+    expect(computeTopErrors(logs, 2)).toHaveLength(2);
+  });
+
+  it("returns nothing when there are no errors", () => {
+    expect(computeTopErrors([log({ isError: false })])).toEqual([]);
+  });
+});

--- a/apps/mesh/src/web/components/details/connection/connection-health.ts
+++ b/apps/mesh/src/web/components/details/connection/connection-health.ts
@@ -1,0 +1,30 @@
+import type { MonitoringLog } from "@/web/components/monitoring/monitoring-stats-row.tsx";
+
+export interface TopError {
+  message: string;
+  count: number;
+}
+
+/**
+ * Group a connection's failed calls by error message, most frequent first.
+ * This is the "what is actually failing" signal the owner needs — a raw error
+ * rate says a connection is broken; the top error says why.
+ *
+ * ponytail: computed over the already-fetched log sample (MONITORING_LOGS_LIST
+ * caps at 1000 rows), so for very high-volume connections the counts are a
+ * recent sample, not the full window — the error identity stays accurate. If
+ * exact window-wide counts are needed, upgrade to a server-side
+ * `GROUP BY error_message` query.
+ */
+export function computeTopErrors(logs: MonitoringLog[], limit = 3): TopError[] {
+  const counts = new Map<string, number>();
+  for (const log of logs) {
+    if (!log.isError) continue;
+    const message = (log.errorMessage ?? "").trim() || "Unknown error";
+    counts.set(message, (counts.get(message) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([message, count]) => ({ message, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}


### PR DESCRIPTION
## Problem

Once the [isError fix](https://github.com/decocms/studio/pull/4493) made the telemetry trustworthy, the data showed a handful of connections failing constantly — and **2 orgs account for ~half of all failures**. But only the connection owner can fix a misconfigured connection (wrong GitHub token scope, nonexistent repo, bad args).

The connection Activity card already shows the error *rate* (bars redden above 50%), but never says **what** is failing. So the owner sees "this connection is broken" with no lead on the fix.

## What this adds

Group the connection's failed calls by error message and show the top few on the same Activity card, with an "N% of calls failed" summary:

```
Top errors · 57% of calls failed
6,654×  repo not found or empty (deco-sites/...)
  858×  Resource not accessible by integration
  151×  startDate: Required
```

That's the actionable signal — "repo not found", "Resource not accessible" (→ token scope), "startDate: Required" (→ bad args) — pointed at the person who can act on it.

## Why it's small

The Activity card **already fetches** these logs (`MONITORING_LOGS_LIST`) and computes stats client-side. This reuses that data — no new tool, query, query key, or round-trip. Just a pure `computeTopErrors()` helper (unit-tested) + a section in the existing card.

The monitoring read path is ClickHouse/DuckDB-only (Postgres `monitoring_logs` has no reader), and per-connection error rate already exists server-side (`queryMetricTimeseries.connectionBreakdown`) — but **no `GROUP BY error_message` query exists anywhere**, so the "top error" was genuinely missing. I chose to derive it from the already-loaded rows rather than add a server round-trip.

## Known ceiling

Counts are over the fetched sample (list caps at 1000 rows), so for very high-volume connections they're a recent sample, not the full window — the error *identity* stays accurate, the absolute counts are a lower bound. Marked with a `ponytail:` comment; upgrade path is a server-side `GROUP BY error_message` tool if exact window-wide counts are ever needed.

## Testing

`bun test .../connection-health.test.ts` — 4 cases (ranking, null/empty bucketing, limit, no-errors). Typecheck + lint clean.

**Not driven in-app:** rendering the section needs a connection with real error telemetry (ClickHouse/DuckDB), which isn't trivial to fabricate locally. The pure ranking logic is unit-tested and the markup typechecks; the render itself is display-only. Screenshot before merge if desired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface the top error messages on the Connection Activity card with a “N% of calls failed” summary. This helps owners identify why a connection is failing and act quickly.

- New Features
  - Group existing activity logs by error message and show the top 3 with counts.
  - Display “N% of calls failed” in the section header.
  - Added `computeTopErrors` with unit tests; no new queries or round-trips.
  - Counts come from the fetched sample; identity is accurate, totals are lower bounds.

<sup>Written for commit 5aac99c497f1949536d2ab793faa1db4c729d773. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

