### PR TITLE
feat(codex): default to gpt-5.6 models

### DIFF
--- a/apps/mesh/src/ai-providers/adapters/codex-models.test.ts
+++ b/apps/mesh/src/ai-providers/adapters/codex-models.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { CODEX_MODELS } from "./codex-models";
+
+describe("CODEX_MODELS", () => {
+  it("exposes the GPT-5.6 trio in the visible Codex catalog", () => {
+    expect(CODEX_MODELS.map((model) => model.modelId)).toEqual([
+      "codex:gpt-5.6-sol",
+      "codex:gpt-5.6-terra",
+      "codex:gpt-5.6-luna",
+      "codex:gpt-5.3-codex-spark",
+    ]);
+  });
+});

--- a/apps/mesh/src/ai-providers/adapters/codex-models.ts
+++ b/apps/mesh/src/ai-providers/adapters/codex-models.ts
@@ -13,10 +13,10 @@ const CODEX_LOGO =
 export const CODEX_MODELS: ModelInfo[] = [
   {
     providerId: "codex",
-    modelId: "codex:gpt-5.5",
-    title: "GPT-5.5",
+    modelId: "codex:gpt-5.6-sol",
+    title: "GPT-5.6 Sol",
     description:
-      "Frontier model for complex coding, research, and real-world work",
+      "Frontier Codex model for deep reasoning, complex coding, and real-world work",
     capabilities: ["text", "reasoning"],
     logo: CODEX_LOGO,
     limits: null,
@@ -24,9 +24,9 @@ export const CODEX_MODELS: ModelInfo[] = [
   },
   {
     providerId: "codex",
-    modelId: "codex:gpt-5.4",
-    title: "GPT-5.4",
-    description: "Strong model for everyday coding",
+    modelId: "codex:gpt-5.6-terra",
+    title: "GPT-5.6 Terra",
+    description: "Balanced Codex model for everyday coding and agent work",
     capabilities: ["text", "reasoning"],
     logo: CODEX_LOGO,
     limits: null,
@@ -34,10 +34,9 @@ export const CODEX_MODELS: ModelInfo[] = [
   },
   {
     providerId: "codex",
-    modelId: "codex:gpt-5.4-mini",
-    title: "GPT-5.4 Mini",
-    description:
-      "Small, fast, and cost-efficient model for simpler coding tasks",
+    modelId: "codex:gpt-5.6-luna",
+    title: "GPT-5.6 Luna",
+    description: "Fast Codex model for lightweight coding tasks and titles",
     capabilities: ["text", "reasoning"],
     logo: CODEX_LOGO,
     limits: null,

--- a/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
+++ b/apps/mesh/src/web/components/chat/select-model/agent-models.tsx
@@ -50,20 +50,20 @@ const CLAUDE_CODE_TIERS: AgentTierMap = {
 
 const CODEX_TIERS: AgentTierMap = {
   fast: {
-    modelId: "codex:gpt-5.4-mini",
-    label: "GPT-5.4 Mini",
+    modelId: "codex:gpt-5.6-luna",
+    label: "GPT-5.6 Luna",
     description: "Quicker responses",
     iconNode: <CodexIcon size={16} />,
   },
   smart: {
-    modelId: "codex:gpt-5.4",
-    label: "GPT-5.4",
+    modelId: "codex:gpt-5.6-terra",
+    label: "GPT-5.6 Terra",
     description: "Balanced quality",
     iconNode: <CodexIcon size={16} />,
   },
   thinking: {
-    modelId: "codex:gpt-5.5",
-    label: "GPT-5.5",
+    modelId: "codex:gpt-5.6-sol",
+    label: "GPT-5.6 Sol",
     description: "Deeper reasoning",
     iconNode: <CodexIcon size={16} />,
   },

--- a/apps/mesh/src/web/components/chat/use-agent-mode.test.ts
+++ b/apps/mesh/src/web/components/chat/use-agent-mode.test.ts
@@ -56,14 +56,16 @@ describe("resolveTierSubtitle", () => {
   });
 
   describe("local-codex: returns the versioned model label", () => {
-    it("fast → GPT-5.4 Mini", () => {
-      expect(resolveTierSubtitle("local-codex", "fast")).toBe("GPT-5.4 Mini");
+    it("fast → GPT-5.6 Luna", () => {
+      expect(resolveTierSubtitle("local-codex", "fast")).toBe("GPT-5.6 Luna");
     });
-    it("smart → GPT-5.4", () => {
-      expect(resolveTierSubtitle("local-codex", "smart")).toBe("GPT-5.4");
+    it("smart → GPT-5.6 Terra", () => {
+      expect(resolveTierSubtitle("local-codex", "smart")).toBe("GPT-5.6 Terra");
     });
-    it("thinking → GPT-5.5", () => {
-      expect(resolveTierSubtitle("local-codex", "thinking")).toBe("GPT-5.5");
+    it("thinking → GPT-5.6 Sol", () => {
+      expect(resolveTierSubtitle("local-codex", "thinking")).toBe(
+        "GPT-5.6 Sol",
+      );
     });
   });
 

--- a/apps/mesh/src/web/lib/release-feed.ts
+++ b/apps/mesh/src/web/lib/release-feed.ts
@@ -30,6 +30,29 @@ export interface Release {
  */
 export const RELEASES: Release[] = [
   {
+    id: "codex-gpt-5-6-defaults",
+    date: "2026-07-13",
+    eyebrow: "Now Available",
+    title: "Codex defaults move to GPT-5.6",
+    bullets: [
+      {
+        icon: Stars02,
+        title: "Sol leads Thinking",
+        body: "Codex Thinking now defaults to `gpt-5.6-sol` for deeper coding and reasoning work.",
+      },
+      {
+        icon: CheckCircle,
+        title: "Terra balances Smart",
+        body: "The Smart tier now uses `gpt-5.6-terra`, replacing GPT-5.4 as the default balanced Codex model.",
+      },
+      {
+        icon: Zap,
+        title: "Luna speeds up Fast",
+        body: "The Fast tier and lightweight Codex title generation now use `gpt-5.6-luna`. Existing threads that reference older GPT-5.4 or GPT-5.5 model IDs remain supported.",
+      },
+    ],
+  },
+  {
     id: "claude-sonnet-5",
     date: "2026-06-30",
     eyebrow: "Now Available",

--- a/packages/harness/src/claude-code/model/agent-tiers.ts
+++ b/packages/harness/src/claude-code/model/agent-tiers.ts
@@ -24,9 +24,9 @@ const CLAUDE_CODE_TIERS: AgentTierMap = {
 };
 
 const CODEX_TIERS: AgentTierMap = {
-  fast: { modelId: "codex:gpt-5.4-mini", label: "GPT-5.4 Mini" },
-  smart: { modelId: "codex:gpt-5.4", label: "GPT-5.4" },
-  thinking: { modelId: "codex:gpt-5.5", label: "GPT-5.5" },
+  fast: { modelId: "codex:gpt-5.6-luna", label: "GPT-5.6 Luna" },
+  smart: { modelId: "codex:gpt-5.6-terra", label: "GPT-5.6 Terra" },
+  thinking: { modelId: "codex:gpt-5.6-sol", label: "GPT-5.6 Sol" },
 };
 
 function getAgentTiers(agent: HarnessId): AgentTierMap | null {

--- a/packages/harness/src/claude-code/model/index.test.ts
+++ b/packages/harness/src/claude-code/model/index.test.ts
@@ -46,4 +46,19 @@ describe("resolveClaudeCodeModelId", () => {
     });
     expect(resolveClaudeCodeModelId(entry!.modelId)).toBe("claude-sonnet-5");
   });
+
+  it("maps Codex desktop tiers to the GPT-5.6 default trio", () => {
+    expect(resolveAgentTier("codex", "thinking")).toEqual({
+      modelId: "codex:gpt-5.6-sol",
+      label: "GPT-5.6 Sol",
+    });
+    expect(resolveAgentTier("codex", "smart")).toEqual({
+      modelId: "codex:gpt-5.6-terra",
+      label: "GPT-5.6 Terra",
+    });
+    expect(resolveAgentTier("codex", "fast")).toEqual({
+      modelId: "codex:gpt-5.6-luna",
+      label: "GPT-5.6 Luna",
+    });
+  });
 });

--- a/packages/harness/src/codex/index.ts
+++ b/packages/harness/src/codex/index.ts
@@ -105,7 +105,7 @@ export const codexHarnessFactory: HarnessFactory = {
       id: "codex",
       async *stream(input: HarnessStreamInput): AsyncIterable<UIMessageChunk> {
         // 1. Resolve the composite `codex:<model>` id to the SDK model
-        //    name (e.g. `gpt-5.4`). Mirrors stream-core line 922.
+        //    name (e.g. `gpt-5.6-terra`). Mirrors stream-core line 922.
         const sdkModelId = resolveCodexModelId(input.models.thinking.id);
 
         // 2. Translate the workspace cwd to an SDK option. `null` means no
@@ -168,7 +168,7 @@ export const codexHarnessFactory: HarnessFactory = {
           const titleSetup = needsTitle
             ? (() => {
                 const { model: titleModel, provider: titleProvider } =
-                  createCodexModel(resolveCodexModelId("codex:gpt-5.4-mini"), {
+                  createCodexModel(resolveCodexModelId("codex:gpt-5.6-luna"), {
                     toolApprovalLevel: "readonly",
                     isPlanMode: true,
                     cwd,

--- a/packages/harness/src/codex/model/index.test.ts
+++ b/packages/harness/src/codex/model/index.test.ts
@@ -3,12 +3,18 @@ import { buildCodexDefaultSettings, resolveCodexModelId } from "./index";
 
 describe("resolveCodexModelId", () => {
   it("resolves current Codex CLI model IDs", () => {
-    expect(resolveCodexModelId("codex:gpt-5.5")).toBe("gpt-5.5");
-    expect(resolveCodexModelId("codex:gpt-5.4")).toBe("gpt-5.4");
-    expect(resolveCodexModelId("codex:gpt-5.4-mini")).toBe("gpt-5.4-mini");
+    expect(resolveCodexModelId("codex:gpt-5.6-sol")).toBe("gpt-5.6-sol");
+    expect(resolveCodexModelId("codex:gpt-5.6-terra")).toBe("gpt-5.6-terra");
+    expect(resolveCodexModelId("codex:gpt-5.6-luna")).toBe("gpt-5.6-luna");
     expect(resolveCodexModelId("codex:gpt-5.3-codex-spark")).toBe(
       "gpt-5.3-codex-spark",
     );
+  });
+
+  it("keeps previous Codex CLI model IDs resolvable for persisted threads", () => {
+    expect(resolveCodexModelId("codex:gpt-5.5")).toBe("gpt-5.5");
+    expect(resolveCodexModelId("codex:gpt-5.4")).toBe("gpt-5.4");
+    expect(resolveCodexModelId("codex:gpt-5.4-mini")).toBe("gpt-5.4-mini");
   });
 
   it("rejects removed Codex model IDs", () => {

--- a/packages/harness/src/codex/model/index.ts
+++ b/packages/harness/src/codex/model/index.ts
@@ -92,6 +92,9 @@ export function buildCodexDefaultSettings(options?: CodexModelOptions) {
 
 /** Map composite model IDs to SDK model names. */
 const CODEX_SDK_MODELS: Record<string, string> = {
+  "codex:gpt-5.6-sol": "gpt-5.6-sol",
+  "codex:gpt-5.6-terra": "gpt-5.6-terra",
+  "codex:gpt-5.6-luna": "gpt-5.6-luna",
   "codex:gpt-5.5": "gpt-5.5",
   "codex:gpt-5.4": "gpt-5.4",
   "codex:gpt-5.4-mini": "gpt-5.4-mini",

--- a/packages/mesh-sdk/src/lib/default-model.test.ts
+++ b/packages/mesh-sdk/src/lib/default-model.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import type { AiProviderKey, AiProviderModel } from "../types/ai-providers";
+import {
+  getFastModel,
+  pickSimpleModeDefaults,
+  selectDefaultModel,
+} from "./default-model";
+
+const key: AiProviderKey = {
+  id: "codex-key",
+  providerId: "codex",
+  label: "Codex",
+  presetId: null,
+  createdBy: "user-1",
+  createdAt: "2026-07-13T00:00:00.000Z",
+};
+
+function model(modelId: string, title: string): AiProviderModel {
+  return {
+    providerId: "codex",
+    modelId,
+    title,
+    description: null,
+    logo: null,
+    capabilities: ["text", "reasoning"],
+    limits: null,
+    costs: null,
+  };
+}
+
+describe("Codex default model preferences", () => {
+  const models = [
+    model("codex:gpt-5.6-sol", "GPT-5.6 Sol"),
+    model("codex:gpt-5.6-terra", "GPT-5.6 Terra"),
+    model("codex:gpt-5.6-luna", "GPT-5.6 Luna"),
+  ];
+
+  it("uses GPT-5.6 Terra as the default Codex model", () => {
+    expect(selectDefaultModel(models, "codex", key.id)).toMatchObject({
+      keyId: "codex-key",
+      modelId: "codex:gpt-5.6-terra",
+      title: "GPT-5.6 Terra",
+    });
+  });
+
+  it("uses GPT-5.6 Luna as the fast Codex model", () => {
+    expect(getFastModel("codex")).toBe("codex:gpt-5.6-luna");
+  });
+
+  it("maps simple-mode Codex tiers to Luna, Terra, and Sol", () => {
+    const defaults = pickSimpleModeDefaults([key], {
+      [key.id]: models,
+    });
+
+    expect(defaults.chat.fast).toEqual({
+      keyId: key.id,
+      modelId: "codex:gpt-5.6-luna",
+      title: "GPT-5.6 Luna",
+    });
+    expect(defaults.chat.smart).toEqual({
+      keyId: key.id,
+      modelId: "codex:gpt-5.6-terra",
+      title: "GPT-5.6 Terra",
+    });
+    expect(defaults.chat.thinking).toEqual({
+      keyId: key.id,
+      modelId: "codex:gpt-5.6-sol",
+      title: "GPT-5.6 Sol",
+    });
+  });
+});

--- a/packages/mesh-sdk/src/lib/default-model.ts
+++ b/packages/mesh-sdk/src/lib/default-model.ts
@@ -33,7 +33,7 @@ export const DEFAULT_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
       "claude-code:opus",
       "claude-code:haiku",
     ],
-    codex: ["codex:gpt-5.4"],
+    codex: ["codex:gpt-5.6-terra"],
   };
 
 /**
@@ -52,7 +52,7 @@ export const FAST_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
   llmapi: ["claude-haiku-4-5", "claude-haiku", "gpt-4o-mini"],
   google: ["gemini-2.5-flash", "gemini-3-flash"],
   "claude-code": ["claude-code:haiku", "claude-code:sonnet"],
-  codex: ["codex:gpt-5.4-mini"],
+  codex: ["codex:gpt-5.6-luna"],
 };
 
 /**
@@ -84,7 +84,7 @@ export const SMART_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> = {
   llmapi: ["claude-sonnet-4-6", "claude-sonnet"],
   google: ["gemini-3-pro", "gemini-3-flash"],
   "claude-code": ["claude-code:sonnet"],
-  codex: ["codex:gpt-5.4"],
+  codex: ["codex:gpt-5.6-terra"],
 };
 
 /**
@@ -123,7 +123,7 @@ export const THINKING_MODEL_PREFERENCES: Partial<Record<ProviderId, string[]>> =
       "claude-code:opus",
       "claude-code:sonnet",
     ],
-    codex: ["codex:gpt-5.5"],
+    codex: ["codex:gpt-5.6-sol"],
   };
 
 /**


### PR DESCRIPTION
## Summary
- Update Codex desktop tiers to use GPT-5.6 Sol, Terra, and Luna for Thinking, Smart, and Fast.
- Keep previous Codex GPT-5.5/5.4/5.4-mini IDs resolvable for persisted threads while removing them from the visible Codex picker defaults.
- Add a release-feed entry and focused coverage for resolver, catalog, and simple-mode defaults.

## Test Plan
- bun run fmt
- bun test packages/harness/src/codex/model/index.test.ts packages/harness/src/claude-code/model/index.test.ts packages/mesh-sdk/src/lib/default-model.test.ts apps/mesh/src/ai-providers/adapters/codex-models.test.ts
- bun run check
- bun run lint

## Notes
- `bun run fmt` exits 0 but Biome reports internal I/O diagnostics while walking the sibling `org` symlink; no fixes were applied.
- `bun run lint` exits 0 with warnings outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Codex defaults to GPT-5.6 Sol/Terra/Luna for Thinking/Smart/Fast across the UI, harness, and SDK. Older `gpt-5.5`/`gpt-5.4` IDs (incl. `gpt-5.4-mini`) still resolve for existing threads but are hidden from the picker.

- **New Features**
  - Updates the Codex catalog and agent tiers to Sol/Terra/Luna; title generation now uses `gpt-5.6-luna`.
  - Sets `packages/mesh-sdk` defaults to Terra (default/smart), Luna (fast), and Sol (thinking).
  - Adds a release-feed entry and expands tests for resolver, catalog visibility, tier labels, and default selection.

<sup>Written for commit a0111641e6adb177089290d274136704049b821b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

