### PR TITLE
fix(harness): bump @openai/codex to 0.144.3 for gpt-5.6 handles

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -39,13 +39,13 @@
   "optionalDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.181",
     "@duckdb/node-api": "^1.5.0-r.1",
-    "@openai/codex": "0.141.0",
-    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64",
-    "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64",
-    "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64",
-    "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64",
-    "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64",
-    "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64"
+    "@openai/codex": "0.144.3",
+    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.3-darwin-arm64",
+    "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.3-darwin-x64",
+    "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.3-linux-arm64",
+    "@openai/codex-linux-x64": "npm:@openai/codex@0.144.3-linux-x64",
+    "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.3-win32-arm64",
+    "@openai/codex-win32-x64": "npm:@openai/codex@0.144.3-win32-x64"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.85",

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "4.4.0",
+      "version": "4.15.0",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -178,13 +178,13 @@
       "optionalDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.181",
         "@duckdb/node-api": "^1.5.0-r.1",
-        "@openai/codex": "0.141.0",
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64",
+        "@openai/codex": "0.144.3",
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.3-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.3-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.3-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.3-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.3-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.3-win32-x64",
       },
     },
     "packages/bindings": {
@@ -228,7 +228,7 @@
     },
     "packages/harness": {
       "name": "@decocms/harness",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.85",
         "@ai-sdk/google": "^3.0.83",
@@ -268,7 +268,7 @@
     },
     "packages/mesh-sdk": {
       "name": "@decocms/mesh-sdk",
-      "version": "1.18.0",
+      "version": "1.21.0",
       "dependencies": {
         "@decocms/bindings": "^1.1.1",
         "@decocms/mcp-utils": "workspace:*",
@@ -308,7 +308,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "1.13.1",
+      "version": "1.14.4",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/std": "workspace:*",
@@ -420,7 +420,7 @@
   ],
   "overrides": {
     "@anthropic-ai/claude-agent-sdk": "0.3.181",
-    "@openai/codex": "0.141.0",
+    "@openai/codex": "0.144.3",
     "fast-xml-parser": "5.4.2",
   },
   "packages": {
@@ -958,19 +958,19 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@openai/codex": ["@openai/codex@0.141.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-ACpAn/Z7JwBg431040zKOLpBtNdP024ixqwC/R2YM5tPrLG0wfSmrd/AVHPUExt6hOO6fEHwxM/ixAyzFleQXw=="],
+    "@openai/codex": ["@openai/codex@0.144.3", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.3-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.3-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.3-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.144.3-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.3-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.144.3-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-8Re3wp5CdYiM7nsF4StFa5js6IT11N7srhxfvwtol7ENHDht05C+HS4e1CTmYjqkhgsUzl2R1gB27iN2pdbVnA=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.141.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BuroZvQQLJYLfQEG7MKMdxHtggDDlxeJCTot//MwEnbW8ga7P319EPos/FyOK9r/gh+E/KGxk+YAzEoHZPRGEg=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.144.3-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v/yT1wqslBcwquUvUPZvAdYyiZcCBIUL+pE4ymHpbUMVduwDJBw1EjLroOhe9FkYFDHzWGyv7YEw7iIV4k+0dA=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.141.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-kDP+egfjp3cuao1r9AdD8/skBxM7saT007VE82DB9mRUcqgKaxYHoPaHmKhlYOlFwPam0zsD6ORT6GJJhvGAKg=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.144.3-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-308U0s7AeRg3AlnxJtmJk03yRRriEplC6ceFoB3OpWh+przqt8/u6MKDVU3KHdjb+vasa0IpmDWv5VrFw3oJAw=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.141.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-jXAOSjMqAUUgfMo9ciAkioJKKAYDwOE40bLx4/2jR7Tfu4u9409X5fQlLuNLMgnlfuzUEk/UiibQE62a70bQaw=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.144.3-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-mJgDUmoPMry9a7g6ywsMQ4uQko2K0uHLqzEITUJMXiNNbCRBQKS+PxDWBlSK0bF0v72uAhWRRRGvPXslwhIdyg=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.141.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-q3xv538DT/Sb8rRq8apdKgrgA/isqs1fDfE5JhRDMmojYFA3zwDldlmdWWGdS3APtjf5UrDsqljSE9JHxnlWNA=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.144.3-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-xtDY5sWQPbYBj2lLWZJvc0jBre0XQ7ZmN4VbSEvazbQ2X7uHhm1D/0oZ7AI+SgC/VfZrUhvxRHd43/AmXSaAzA=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.141.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-87X5tvH1RmKQOHbgO5Cv+S0aXJ+saHTSSHEasJjbB1FtUoLbao29NTnkpkB2dAV3xtUJ/dmE8NgvbFEeWuMqUQ=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.144.3-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-uvgBLuBX58GIq58CquhvhEmwLlH9Lc46rLmE5/CkEf1vQiCvWqVHxL28t7P9cmWGoeMuxsrIwqJgyzmRu6wZMQ=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.141.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-4gur4DgFQIOc+DopNOI90IpNA66qBIyc5Lb5QYy66OOCXOvXpbOCpScuEFmT1xpaTzNUYhlRGA2NFWqSHQrKUQ=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.144.3-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-0o8LpbZuBvqcAdIqMh96pECFTtfkgMT2sP/Q2IKYUOOlSudq3ulvdDW6zARq04HhbOxSsU9TBYDkdqtDs2YcYQ=="],
 
     "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.9.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-okgq07Vdkro4CB5INbfhwa0e6VR1HS7sidNcfHN/MeXLJvX1JmQCff/vem6tcxwT9r1avyFrXSlfv9B28D/Pag=="],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "node-pty"
   ],
   "overrides": {
-    "@openai/codex": "0.141.0",
+    "@openai/codex": "0.144.3",
     "fast-xml-parser": "5.4.2",
     "@anthropic-ai/claude-agent-sdk": "0.3.181"
   }


### PR DESCRIPTION
## Summary
Fixes `harness_crashed: Unknown Codex model ID: codex:gpt-5.6-sol`.

The `gpt-5.6-sol`/`-terra`/`-luna` handles are **correct** — the problem was a stale Codex CLI. `@openai/codex` was pinned at **0.141.0**, whose model table stops at `gpt-5.5-pro` and has no `gpt-5.6` handles. The harness resolves `codex:gpt-5.6-*` and hands them to the CLI, which rejects them. **0.144.3** is the first release shipping `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` (verified against the binaries).

## Changes
- `package.json` — root `overrides` pin `@openai/codex` 0.141.0 → 0.144.3 (the controlling pin — forces every copy, incl. the provider's `^0.130.0` optional dep, to one version)
- `apps/mesh/package.json` — direct dep + all 6 platform packages → 0.144.3
- `bun.lock` — regenerated

## Testing
- Verified the 0.144.3 binary's model table contains `gpt-5.6-sol/terra/luna` (0.141.0 has none)
- Confirmed `ai-sdk-provider-codex-cli` now resolves `@openai/codex` → 0.144.3 via `require.resolve` from the provider's own location
- `bun test packages/harness/src/codex/model/index.test.ts` → 4 pass
- `bun.lock` has zero remaining references to 0.141.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `@openai/codex` to 0.144.3 to add support for `codex:gpt-5.6-sol/terra/luna` and stop the harness crash on “Unknown Codex model ID”. The CLI now recognizes `gpt-5.6` handles.

- **Dependencies**
  - Pin root `overrides` for `@openai/codex` to `0.144.3` to enforce a single version across the workspace.
  - Update `apps/mesh` optional deps (all platform-specific `@openai/codex-*` packages) to `0.144.3`.
  - Regenerate `bun.lock`.

<sup>Written for commit 56bf7bfb4aadd2fdcf4afbf43853f0bb550601c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

