### PR TITLE
fix(sandbox): validate requested branch name before shelling out in clone

### DIFF
--- a/packages/sandbox/daemon/git/ref-name.test.ts
+++ b/packages/sandbox/daemon/git/ref-name.test.ts
@@ -21,6 +21,7 @@ describe("assertValidRemoteBranchName", () => {
       "main/",
       "main.lock",
       "has space",
+      "a//b",
     ]) {
       expect(() => assertValidRemoteBranchName(name)).toThrow(
         InvalidRemoteBranchNameError,

--- a/packages/sandbox/daemon/git/ref-name.ts
+++ b/packages/sandbox/daemon/git/ref-name.ts
@@ -8,17 +8,23 @@ export class InvalidRemoteBranchNameError extends Error {
   }
 }
 
+/** Whether `name` is safe to interpolate as a git CLI branch/ref argument. */
+export function isValidRemoteBranchName(name: string): boolean {
+  return (
+    !!name &&
+    name.length <= 255 &&
+    !name.includes("..") &&
+    !name.includes("//") &&
+    !name.startsWith("/") &&
+    !name.endsWith("/") &&
+    !name.endsWith(".lock") &&
+    REMOTE_BRANCH_NAME.test(name)
+  );
+}
+
 /** Validates a remote branch name before passing it as a git CLI argument. */
 export function assertValidRemoteBranchName(name: string): void {
-  if (
-    !name ||
-    name.length > 255 ||
-    name.includes("..") ||
-    name.startsWith("/") ||
-    name.endsWith("/") ||
-    name.endsWith(".lock") ||
-    !REMOTE_BRANCH_NAME.test(name)
-  ) {
+  if (!isValidRemoteBranchName(name)) {
     throw new InvalidRemoteBranchNameError(name);
   }
 }

--- a/packages/sandbox/daemon/setup/clone.test.ts
+++ b/packages/sandbox/daemon/setup/clone.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { computeBranchDivergence } from "../git/branch-divergence";
 import type { Config } from "../types";
-import { isSafeRefName, spawnClone } from "./clone";
+import { spawnClone } from "./clone";
 
 /**
  * Creates a bare "origin" git repo with two branches:
@@ -90,42 +90,6 @@ function makeConfig(
     repoDir,
   } as unknown as Config;
 }
-
-describe("isSafeRefName", () => {
-  it("accepts real branch names", () => {
-    for (const name of [
-      "main",
-      "master",
-      "feature/x",
-      "release/1.0",
-      "feat-2.0_a",
-      "user/fix.bug",
-    ]) {
-      expect(isSafeRefName(name)).toBe(true);
-    }
-  });
-
-  it("rejects shell metacharacters and ref-format edge cases", () => {
-    for (const name of [
-      "x;whoami",
-      "a$(id)b",
-      "a`id`b",
-      "a|b",
-      "a&b",
-      "a>b",
-      "a b",
-      "-x",
-      "/x",
-      "x/",
-      "a..b",
-      "a//b",
-      "x.lock",
-      "",
-    ]) {
-      expect(isSafeRefName(name)).toBe(false);
-    }
-  });
-});
 
 describe("spawnClone", () => {
   it("clones the target branch directly when it exists on remote", async () => {
@@ -243,6 +207,26 @@ describe("spawnClone", () => {
           `rev-parse --verify --quiet 'refs/remotes/origin/${evil}'`,
         ),
       ).toBeNull();
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("rejects a malicious requested branch instead of shelling it out", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = join(root, "workspace");
+      // `branch` comes from tenant-supplied config and is interpolated into
+      // `sh -c` git commands (ls-remote/clone/checkout) before any other
+      // check runs — an unsafe name must be rejected before it ever reaches
+      // a shell string instead of executing as a second command.
+      const marker = join(root, "INJECTED");
+      const { code } = await spawnClone({
+        config: makeConfig(repoDir, url, `x;touch ${marker}`),
+        onChunk: () => {},
+      });
+      expect(code).not.toBe(0);
+      expect(existsSync(marker)).toBe(false);
     } finally {
       cleanup();
     }

--- a/packages/sandbox/daemon/setup/clone.ts
+++ b/packages/sandbox/daemon/setup/clone.ts
@@ -2,6 +2,7 @@ import { sleep } from "@decocms/std";
 import { existsSync, readdirSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import { isSyntheticBranch } from "../constants";
+import { isValidRemoteBranchName } from "../git/ref-name";
 import type { Config } from "../types";
 import { spawnSetupStep } from "./spawn-step";
 
@@ -97,26 +98,6 @@ async function runNetworkStep(cmd: string, deps: CloneDeps): Promise<number> {
 // through to a fork-from-default fallback.
 const LS_REMOTE_NO_MATCH = 2;
 
-/**
- * Conservative ref-name allowlist. `base` below is derived from
- * remote-controlled `ls-remote` output and interpolated into `sh -c` git
- * commands; git permits shell metacharacters (`;`, `$(…)`, backticks, `|`, …)
- * in branch names, so an untrusted remote whose HEAD points at a maliciously
- * named default branch could inject commands. Restrict to characters that
- * appear in real branch names and reject the ref-format edge cases.
- */
-export function isSafeRefName(name: string): boolean {
-  return (
-    /^[A-Za-z0-9._/-]+$/.test(name) &&
-    !name.startsWith("-") &&
-    !name.startsWith("/") &&
-    !name.endsWith("/") &&
-    !name.endsWith(".lock") &&
-    !name.includes("..") &&
-    !name.includes("//")
-  );
-}
-
 /** Like runNetworkStep but also returns the (merged stdout+stderr) output. */
 async function runNetworkStepCapture(
   cmd: string,
@@ -180,7 +161,7 @@ async function fetchBaseBranch(
   // into `sh -c` git commands below — reject anything outside a safe ref-name
   // charset to close the command-injection vector (git allows `;`, `$(…)`,
   // backticks, etc. in branch names).
-  if (!isSafeRefName(base)) {
+  if (!isValidRemoteBranchName(base)) {
     deps.onChunk(
       "setup",
       `\r\n[clone] warning: refusing unsafe base branch name ${JSON.stringify(base)}; divergence vs base unavailable until next fetch\r\n`,
@@ -266,6 +247,17 @@ export async function spawnClone(deps: CloneDeps): Promise<CloneResult> {
   let branchOnRemote: string | null = null;
   let branchToForkLocally: string | null = null;
   if (branch) {
+    // `branch` is config-supplied and interpolated into `sh -c` git commands
+    // below (ls-remote/clone/checkout) — same command-injection vector as
+    // `base` above (git permits shell metacharacters in ref names), so
+    // validate before it ever reaches a shell string.
+    if (!isValidRemoteBranchName(branch)) {
+      deps.onChunk(
+        "setup",
+        `\r\n[clone] refusing invalid branch name ${JSON.stringify(branch)}\r\n`,
+      );
+      return { code: 1 };
+    }
     const probe = await runNetworkStep(
       `${gc} ls-remote --exit-code --heads ${cloneUrl} ${branch}`,
       deps,


### PR DESCRIPTION
## Source
A bug found by reading `packages/sandbox/daemon/setup/clone.ts` while looking at recent churn in `packages/sandbox/daemon/git/checkout-branch.ts` (#4472, #4470 hardened the sibling checkout path against the same class of issue).

## The bug
`spawnClone` builds `sh -c` git commands (`ls-remote`, `clone --branch`, `checkout -B`) by interpolating the config-supplied `git.repository.branch` directly into the command string, with no validation. Git allows shell metacharacters (`;`, `$(…)`, backticks, …) in ref names, so a branch value like `x;touch pwned` runs `touch pwned` as a second shell command the moment `spawnClone` does its first `ls-remote` probe — during the very first clone of a sandbox.

The same interpolation for the *remote-controlled* default branch (`base`, read from `ls-remote --symref` output) was already guarded by a hand-rolled `isSafeRefName` allowlist in this file, and the analogous requested-branch value in the sibling checkout path (`git/checkout-branch.ts`) was already hardened in #4472/#4470 — this fixes the one remaining unguarded call site, and folds the two independent ref-name allowlists (`clone.ts`'s `isSafeRefName` and `git/ref-name.ts`'s `assertValidRemoteBranchName`) into the single validator in `git/ref-name.ts`.

## Regression test
`packages/sandbox/daemon/setup/clone.test.ts` — `"rejects a malicious requested branch instead of shelling it out"` passes a branch of `x;touch <marker>` into `spawnClone` and asserts the marker file is never created and `spawnClone` returns a non-zero code instead of running the injected command.

## To verify
```
bun test packages/sandbox/daemon/setup/clone.test.ts
bun test packages/sandbox/daemon/git/ref-name.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `packages/sandbox`
- `bun test packages/sandbox/daemon/setup/clone.test.ts` (10 pass)
- `bun test packages/sandbox/daemon/git/ref-name.test.ts` (2 pass)
- `bun test packages/sandbox/daemon/git/checkout-branch.test.ts` (5 pass, unaffected by the shared validator change)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate config‑supplied branch names in the sandbox clone path before building `sh -c` git commands. This prevents command injection via `git.repository.branch` and unifies ref-name validation in `git/ref-name.ts`.

- **Bug Fixes**
  - `spawnClone` rejects invalid/malicious branch names with `isValidRemoteBranchName` and exits non‑zero.
  - Use the same validator when inspecting the remote default branch (`base`) to avoid unsafe interpolation.
  - Added a regression test to ensure injected shell payloads (e.g., `x;touch <file>`) never execute.

- **Refactors**
  - Replaced local `isSafeRefName` with shared `isValidRemoteBranchName`/`assertValidRemoteBranchName` in `git/ref-name.ts`.
  - Expanded validator tests and edge cases (e.g., reject `a//b`).

<sup>Written for commit c94c649dd1119c58ab5d14ead8ac89a1def24b8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

