### PR TITLE
fix(release-channel): restore floating release announcement card

### DIFF
--- a/apps/mesh/src/web/components/release-channel/floating-release-card.test.tsx
+++ b/apps/mesh/src/web/components/release-channel/floating-release-card.test.tsx
@@ -56,7 +56,7 @@ mock.module("@/web/lib/auth-client", () => ({
   },
 }));
 
-import { SidebarReleaseCard } from "./sidebar-release-card";
+import { FloatingReleaseCard } from "./floating-release-card";
 
 function wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({
@@ -65,7 +65,7 @@ function wrapper({ children }: { children: ReactNode }) {
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
-describe("SidebarReleaseCard", () => {
+describe("FloatingReleaseCard", () => {
   beforeEach(() => {
     localStorage.clear();
     releasesRef.current = [];
@@ -82,28 +82,28 @@ describe("SidebarReleaseCard", () => {
   });
 
   it("renders nothing when RELEASES is empty", () => {
-    const { container } = render(<SidebarReleaseCard />, { wrapper });
+    const { container } = render(<FloatingReleaseCard />, { wrapper });
     expect(container.firstChild).toBeNull();
   });
 
   it("renders nothing when the newest release is older than 30 days", () => {
     releasesRef.current = [makeRelease({ id: "stale", date: OLD_DATE })];
-    const { container } = render(<SidebarReleaseCard />, { wrapper });
+    const { container } = render(<FloatingReleaseCard />, { wrapper });
     expect(container.firstChild).toBeNull();
   });
 
   it("renders the card when the newest release is fresh and unseen", () => {
     releasesRef.current = [makeRelease({ id: "fresh" })];
     const { getByRole, getByText, queryByRole } = render(
-      <SidebarReleaseCard />,
+      <FloatingReleaseCard />,
       { wrapper },
     );
     expect(getByText("Fresh Release")).toBeInTheDocument();
+    expect(getByRole("dialog", { name: "Release announcement" })).toHaveClass(
+      "fixed",
+    );
     expect(
-      getByRole("region", { name: "Release announcement" }),
-    ).not.toHaveClass("fixed");
-    expect(
-      queryByRole("dialog", { name: "Release announcement" }),
+      queryByRole("region", { name: "Release announcement" }),
     ).not.toBeInTheDocument();
   });
 
@@ -116,7 +116,7 @@ describe("SidebarReleaseCard", () => {
       },
     };
 
-    const { container } = render(<SidebarReleaseCard />, { wrapper });
+    const { container } = render(<FloatingReleaseCard />, { wrapper });
     expect(container.firstChild).toBeNull();
   });
 
@@ -129,7 +129,7 @@ describe("SidebarReleaseCard", () => {
       },
     };
 
-    const { getByText } = render(<SidebarReleaseCard />, { wrapper });
+    const { getByText } = render(<FloatingReleaseCard />, { wrapper });
     expect(getByText("Fresh Release")).toBeInTheDocument();
   });
 
@@ -139,13 +139,13 @@ describe("SidebarReleaseCard", () => {
       "studio.release-feed.v1",
       JSON.stringify({ fresh: { seenAt: new Date().toISOString() } }),
     );
-    const { container } = render(<SidebarReleaseCard />, { wrapper });
+    const { container } = render(<FloatingReleaseCard />, { wrapper });
     expect(container.firstChild).toBeNull();
   });
 
   it("clicking the dismiss button marks the release as seen and unmounts the card", () => {
     releasesRef.current = [makeRelease({ id: "fresh" })];
-    const { getByLabelText, queryByText } = render(<SidebarReleaseCard />, {
+    const { getByLabelText, queryByText } = render(<FloatingReleaseCard />, {
       wrapper,
     });
     fireEvent.click(getByLabelText("Dismiss release announcement"));

--- a/apps/mesh/src/web/components/release-channel/floating-release-card.tsx
+++ b/apps/mesh/src/web/components/release-channel/floating-release-card.tsx
@@ -17,7 +17,7 @@ function parseReleaseDate(date: string): number {
   return new Date(y, m - 1, d).getTime();
 }
 
-function pickSidebarCandidate(now: number) {
+function pickFloatingCandidate(now: number) {
   const latest = RELEASES[0];
   if (!latest) return null;
   const releaseTime = parseReleaseDate(latest.date);
@@ -41,11 +41,11 @@ function isUserOldEnoughForReleaseNotice(createdAt: unknown, now: number) {
   return now - createdAtTime >= MIN_USER_AGE_MS;
 }
 
-export function SidebarReleaseCard() {
+export function FloatingReleaseCard() {
   const { data: session } = authClient.useSession();
   const { isSeen, markSeen } = useReleaseSeenState();
   const now = Date.now();
-  const candidate = pickSidebarCandidate(now);
+  const candidate = pickFloatingCandidate(now);
 
   if (!candidate) return null;
   if (!isUserOldEnoughForReleaseNotice(session?.user?.createdAt, now)) {
@@ -55,15 +55,15 @@ export function SidebarReleaseCard() {
 
   return (
     <div
-      role="region"
+      role="dialog"
       aria-label="Release announcement"
-      className="relative rounded-lg border border-border bg-background p-3 shadow-sm"
+      className="fixed bottom-6 right-6 z-50 w-[min(360px,calc(100vw-3rem))] rounded-lg border border-border bg-background p-4 shadow-lg animate-in fade-in slide-in-from-bottom-2 duration-300"
     >
       <Button
         size="icon"
         variant="ghost"
         aria-label="Dismiss release announcement"
-        className="absolute right-1.5 top-1.5 size-7 text-muted-foreground"
+        className="absolute right-2 top-2 size-7 text-muted-foreground"
         onClick={() => markSeen(candidate.id)}
       >
         <XClose size={14} />

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useEffect, useState } from "react";
 import { OrgAccessGate } from "@/web/components/org-access-gate";
 import { SplashScreen } from "@/web/components/splash-screen";
-import { SidebarReleaseCard } from "@/web/components/release-channel/sidebar-release-card";
+import { FloatingReleaseCard } from "@/web/components/release-channel/floating-release-card";
 import { KeyboardShortcutsDialog } from "@/web/components/keyboard-shortcuts-dialog";
 import { VersionCheckDialog } from "@/web/components/version-check-dialog";
 import { isModKey } from "@/web/lib/keyboard-shortcuts";
@@ -369,7 +369,7 @@ function ShellLayoutContent() {
       <PostHogGroupSync activeOrg={activeOrg} />
       <Outlet />
 
-      <SidebarReleaseCard />
+      <FloatingReleaseCard />
 
       {/* Keyboard Shortcuts Dialog */}
       <KeyboardShortcutsDialog


### PR DESCRIPTION
## Summary
Restores the **floating** release-announcement card, reverting the floating→sidebar swap from #4274. The "Now Available" card renders again as a dismissible floating card pinned bottom-right instead of an inline sidebar region.

- `role="region"` → `role="dialog"`
- className → `fixed bottom-6 right-6 z-50 w-[min(360px,calc(100vw-3rem))] … shadow-lg animate-in fade-in slide-in-from-bottom-2 duration-300`
- Dismiss button back to `right-2 top-2`
- Renamed `SidebarReleaseCard` → `FloatingReleaseCard`; files renamed back to `floating-release-card.{tsx,test.tsx}` (git history preserved)

**Kept** (not part of the swap): the established-user gating (`MIN_USER_AGE_MS` + session check) and local-midnight date parsing.

## Testing
- `bun test floating-release-card.test.tsx` → 7 pass, 0 fail (behavioral assertion flipped back to expect the dialog/`fixed` form)
- `bun run fmt` clean
- No lingering `SidebarReleaseCard` / `sidebar-release-card` references

## Screenshots
_Floating card renders bottom-right for an established user when the newest release is <30 days old and unseen._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the floating release-announcement card by reverting the sidebar variant from #4274; the card now appears as a dismissible `role="dialog"` fixed bottom-right with a slide-in animation. Keeps established-user gating and local-midnight date parsing, renames `SidebarReleaseCard` to `FloatingReleaseCard`, and updates shell layout and tests accordingly.

<sup>Written for commit bfbc6027795b25d6d43e0f19511253e8c0424bd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

