### PR TITLE
feat(chat): show selected branch in empty state

### DIFF
--- a/apps/mesh/src/web/components/chat/agent-home-header.tsx
+++ b/apps/mesh/src/web/components/chat/agent-home-header.tsx
@@ -1,0 +1,40 @@
+import { IntegrationIcon } from "@/web/components/integration-icon";
+import { Users03 } from "@untitledui/icons";
+
+interface AgentHomeHeaderProps {
+  agent: {
+    icon?: string | null;
+    title: string;
+  };
+  currentBranch: string | null;
+}
+
+export function AgentHomeHeader({
+  agent,
+  currentBranch,
+}: AgentHomeHeaderProps) {
+  return (
+    <div className="w-full max-w-2xl mx-auto px-4 pt-8 pb-4 flex items-center gap-3">
+      <IntegrationIcon
+        icon={agent.icon}
+        name={agent.title}
+        size="sm"
+        fallbackIcon={<Users03 size={16} />}
+        className="size-8 min-w-8 rounded-lg shrink-0"
+      />
+      <div className="min-w-0 flex items-baseline gap-1.5">
+        <span className="min-w-0 truncate font-medium text-base text-foreground">
+          {agent.title}
+        </span>
+        {currentBranch && (
+          <>
+            <span className="text-sm text-muted-foreground">/</span>
+            <span className="min-w-0 truncate font-mono text-sm text-muted-foreground">
+              {currentBranch}
+            </span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/chat/agent-home.test.tsx
+++ b/apps/mesh/src/web/components/chat/agent-home.test.tsx
@@ -1,0 +1,41 @@
+import { setupComponentTest } from "../../../test/setup";
+setupComponentTest();
+import { describe, expect, it } from "bun:test";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { AgentHomeHeader } from "./agent-home-header";
+
+describe("AgentHomeHeader", () => {
+  it("renders the selected branch after the agent title as muted text", () => {
+    const { getByText } = render(
+      <AgentHomeHeader
+        agent={{
+          icon: null,
+          title: "Decopilot",
+        }}
+        currentBranch="feature/chat-empty-branch"
+      />,
+    );
+
+    expect(getByText("Decopilot")).toBeInTheDocument();
+    expect(getByText("/")).toHaveClass("text-muted-foreground");
+    expect(getByText("feature/chat-empty-branch")).toHaveClass(
+      "text-muted-foreground",
+    );
+  });
+
+  it("omits the branch separator when no branch is selected", () => {
+    const { queryByText } = render(
+      <AgentHomeHeader
+        agent={{
+          icon: null,
+          title: "Decopilot",
+        }}
+        currentBranch={null}
+      />,
+    );
+
+    expect(queryByText("/")).toBeNull();
+  });
+});

--- a/apps/mesh/src/web/components/chat/agent-home.tsx
+++ b/apps/mesh/src/web/components/chat/agent-home.tsx
@@ -1,4 +1,3 @@
-import { IntegrationIcon } from "@/web/components/integration-icon";
 import { useThreads } from "@/web/components/chat/store/hooks";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { TaskRow } from "@/web/layouts/tasks-panel/task-row";
@@ -7,11 +6,11 @@ import {
   useProjectContext,
   useVirtualMCP,
 } from "@decocms/mesh-sdk";
-import { Users03 } from "@untitledui/icons";
 import { authClient } from "@/web/lib/auth-client";
 import { Chat } from "./index";
-import { useChatPrefs } from "./context";
+import { useChatPrefs, useChatTask } from "./context";
 import { ChatModeRow } from "./pills/chat-mode-row";
+import { AgentHomeHeader } from "./agent-home-header";
 
 export function AgentHome({
   onOpenContextPanel,
@@ -20,6 +19,7 @@ export function AgentHome({
 }) {
   const { org } = useProjectContext();
   const { selectedVirtualMcp } = useChatPrefs();
+  const { currentBranch } = useChatTask();
   const defaultAgent = getWellKnownDecopilotVirtualMCP(org.id);
   const agent = selectedVirtualMcp ?? defaultAgent;
   const fullVm = useVirtualMCP(agent.id);
@@ -44,18 +44,7 @@ export function AgentHome({
     <>
       <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
         {/* compact agent header */}
-        <div className="w-full max-w-2xl mx-auto px-4 pt-8 pb-4 flex items-center gap-3">
-          <IntegrationIcon
-            icon={agent.icon}
-            name={agent.title}
-            size="sm"
-            fallbackIcon={<Users03 size={16} />}
-            className="size-8 min-w-8 rounded-lg shrink-0"
-          />
-          <span className="font-medium text-base text-foreground truncate">
-            {agent.title}
-          </span>
-        </div>
+        <AgentHomeHeader agent={agent} currentBranch={currentBranch} />
       </div>
 
       {/* docked input */}
@@ -79,7 +68,7 @@ export function AgentHome({
           data-chat-above-row="true"
           className="@container/chat-bottom pb-1 flex justify-start gap-1"
         >
-          <ChatModeRow virtualMcp={fullVm} currentBranch={null} />
+          <ChatModeRow virtualMcp={fullVm} currentBranch={currentBranch} />
         </div>
         <Chat.Input onOpenContextPanel={onOpenContextPanel} />
       </Chat.Footer>


### PR DESCRIPTION
## Summary

- show the selected branch beside the agent title in the chat empty state
- style the separator and branch name with muted text
- preserve the existing header when no branch is selected

## Testing

- bun test apps/mesh/src/web/components/chat/agent-home.test.tsx
- bun run check
- bun run fmt
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the selected branch next to the agent title in the chat empty state. The branch and separator use muted text, and the header stays unchanged when no branch is selected.

- **New Features**
  - Added `AgentHomeHeader` to render the agent icon/title with an optional `currentBranch`.
  - `AgentHome` now reads `currentBranch` from `useChatTask()` and passes it to `AgentHomeHeader` and `ChatModeRow`.
  - Added tests to verify header behavior with and without a selected branch.

<sup>Written for commit 5801c278e99fd77ac78b3247a1774b674d2c0ddf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

