### PR TITLE
fix(cli): render correct project/branch for freshly created sandboxes

### DIFF
--- a/apps/mesh/src/cli/link-store.test.ts
+++ b/apps/mesh/src/cli/link-store.test.ts
@@ -56,6 +56,42 @@ describe("applySandboxEvent", () => {
     expect(m.get("a")?.previewUrl).toBe("http://a.localhost:5174");
   });
 
+  it("carries projectName/branch/sandboxPath from a spawning event", () => {
+    const m = applySandboxEvent(empty(), {
+      handle: "agent-1-feat/x",
+      phase: "spawning",
+      projectName: "studio",
+      branch: "feat/x",
+      sandboxPath: "/tmp/deco/sandboxes/agent-1-feat/x",
+    });
+    expect(m.get("agent-1-feat/x")).toEqual(
+      expect.objectContaining({
+        status: "spawning",
+        projectName: "studio",
+        branch: "feat/x",
+        sandboxPath: "/tmp/deco/sandboxes/agent-1-feat/x",
+      }),
+    );
+  });
+
+  it("retains metadata across a follow-up event that omits it", () => {
+    let m = applySandboxEvent(empty(), {
+      handle: "a",
+      phase: "spawning",
+      projectName: "studio",
+      branch: "feat/x",
+    });
+    m = applySandboxEvent(m, { handle: "a", phase: "ready", port: 7 });
+    expect(m.get("a")).toEqual(
+      expect.objectContaining({
+        status: "ready",
+        port: 7,
+        projectName: "studio",
+        branch: "feat/x",
+      }),
+    );
+  });
+
   it("records the error on failure and retains the row", () => {
     let m = applySandboxEvent(empty(), { handle: "a", phase: "spawning" });
     m = applySandboxEvent(m, {

--- a/apps/mesh/src/cli/link-store.ts
+++ b/apps/mesh/src/cli/link-store.ts
@@ -100,9 +100,9 @@ export function applySandboxEvent(
     previewUrl: e.previewUrl ?? prev?.previewUrl ?? null,
     status: e.phase, // "spawning" | "ready" | "failed"
     error: e.phase === "failed" ? (e.error ?? "failed") : null,
-    projectName: prev?.projectName ?? null,
-    branch: prev?.branch ?? null,
-    sandboxPath: prev?.sandboxPath ?? null,
+    projectName: e.projectName ?? prev?.projectName ?? null,
+    branch: e.branch ?? prev?.branch ?? null,
+    sandboxPath: e.sandboxPath ?? prev?.sandboxPath ?? null,
   });
   return next;
 }

--- a/apps/mesh/src/link-daemon/user-desktop-provider.test.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.test.ts
@@ -185,6 +185,40 @@ describe("desktop sandbox provider", () => {
     }
   });
 
+  it("carries projectName/branch on spawning and ready events", async () => {
+    const dataDir = tmpDataDir();
+    try {
+      const events: SandboxEvent[] = [];
+      let portCounter = 30000;
+      const provider = createDesktopSandboxProvider({
+        dataDir,
+        spawnDaemon: () => fakeDaemonSpawner(),
+        postConfig: async () => {},
+        waitForHealth: async () => {},
+        pickPort: () => portCounter++,
+        onEvent: (e) => events.push(e),
+      });
+      await provider.ensureSandbox({
+        handle: "abc",
+        repo: {
+          cloneUrl: "https://github.com/decocms/studio.git",
+          branch: "alpha-hydrae",
+        },
+      });
+      const lifecycle = events.filter((e) => e.handle === "abc");
+      for (const phase of ["spawning", "ready"] as const) {
+        expect(lifecycle.find((e) => e.phase === phase)).toEqual(
+          expect.objectContaining({
+            branch: "alpha-hydrae",
+            projectName: "studio",
+          }),
+        );
+      }
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it("persists ready and deleted lifecycle transitions to the registry", async () => {
     const dataDir = tmpDataDir();
     try {

--- a/apps/mesh/src/link-daemon/user-desktop-provider.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.ts
@@ -39,6 +39,16 @@ export interface SandboxEvent {
   previewUrl?: string;
   /** Set on `failed`. */
   error?: string;
+  /**
+   * Registry metadata carried on create-path events so the TUI can render the
+   * correct PROJECT/BRANCH columns before the next `setPersistedSandboxes`
+   * hydration. Without these, a freshly created live row has no prior state to
+   * inherit from and falls back to the handle (which embeds the branch),
+   * showing the branch in the PROJECT column until the CLI restarts.
+   */
+  projectName?: string | null;
+  branch?: string | null;
+  sandboxPath?: string | null;
 }
 
 export interface SpawnResult {
@@ -407,7 +417,13 @@ export function createDesktopSandboxProvider(
       ...metadata,
       error: null,
     });
-    emit({ handle: input.handle, phase: "spawning" });
+    emit({
+      handle: input.handle,
+      phase: "spawning",
+      sandboxPath: workdir,
+      projectName: metadata.projectName,
+      branch: metadata.branch,
+    });
     evictIfNeeded();
     let port: number | undefined;
     let spawned: SpawnResult | null = null;
@@ -485,6 +501,9 @@ export function createDesktopSandboxProvider(
         handle: input.handle,
         phase: "failed",
         error: bringUpCauseMessage(err),
+        sandboxPath: workdir,
+        projectName: metadata.projectName,
+        branch: metadata.branch,
       });
       persist({
         handle: input.handle,
@@ -531,6 +550,9 @@ export function createDesktopSandboxProvider(
       phase: "ready",
       port,
       previewUrl,
+      sandboxPath: workdir,
+      projectName: metadata.projectName,
+      branch: metadata.branch,
     });
 
     // Watchdog: clear the map entry if the daemon process exits unexpectedly.


### PR DESCRIPTION
## Summary

In the `deco link` terminal TUI, newly created sandboxes rendered the **branch name in the PROJECT column** until the CLI was restarted.

**Root cause:** On create, the daemon `persist()`s full metadata (`projectName`, `branch`) to the SQLite registry, but the live `SandboxEvent` only carried `handle` + `phase`. `applySandboxEvent` therefore set `projectName`/`branch` to `null` for the fresh row, and the TUI's `{row.projectName ?? row.handle}` fallback printed the handle — which is `agent-<id>-<branch>`, i.e. it looks like the branch. Restart fixed it because hydration (`setPersistedSandboxes`) reads straight from the registry.

**Fix (additive):**
- Added `projectName`/`branch`/`sandboxPath` to `SandboxEvent`.
- The three create-path emits (spawning / failed / ready) now carry the metadata already in scope.
- `applySandboxEvent` prefers the event's values (`e.projectName ?? prev?.projectName ?? null`, etc.).

This keeps the event self-describing (matching its "purely additive" contract) rather than making `setPersistedSandboxes` backfill onto live rows.

## Testing
- `bun test apps/mesh/src/cli/link-store.test.ts apps/mesh/src/link-daemon/user-desktop-provider.test.ts` → 30 pass
- `bun run check` (tsc) clean, `bun run fmt` clean
- New tests: event carries metadata / metadata survives a follow-up event that omits it / repo-backed create emits `projectName`+`branch` on spawning and ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `deco link` TUI showing the branch name in the PROJECT column for new sandboxes by sending project metadata on create events and using it in the live store. New sandboxes now render correct Project/Branch immediately without a CLI restart.

- **Bug Fixes**
  - Added `projectName`, `branch`, and `sandboxPath` to `SandboxEvent`, emitted on `spawning`, `failed`, and `ready`.
  - Updated `applySandboxEvent` to prefer event metadata over previous values.

<sup>Written for commit 270847b4402c45d5d53d023a3be6dcc0e4539c34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

