### PR TITLE
fix(shell): drop dangling separator from breadcrumb

### DIFF
--- a/apps/mesh/src/web/components/header/org-switcher.tsx
+++ b/apps/mesh/src/web/components/header/org-switcher.tsx
@@ -33,7 +33,7 @@ function getOrgColorStyle(name: string): {
   };
 }
 
-export function OrgIcon({
+function OrgIcon({
   org,
   size = "sm",
 }: {

--- a/apps/mesh/src/web/components/header/org-switcher.tsx
+++ b/apps/mesh/src/web/components/header/org-switcher.tsx
@@ -33,7 +33,7 @@ function getOrgColorStyle(name: string): {
   };
 }
 
-function OrgIcon({
+export function OrgIcon({
   org,
   size = "sm",
 }: {

--- a/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
+++ b/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
@@ -33,7 +33,10 @@ import {
 } from "@decocms/mesh-sdk";
 import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
 import { AgentAvatar } from "@/web/components/agent-icon";
-import { OrgSwitcherPopover } from "@/web/components/header/org-switcher";
+import {
+  OrgIcon,
+  OrgSwitcherPopover,
+} from "@/web/components/header/org-switcher";
 import { AgentScopePicker } from "@/web/components/sidebar/agents-section";
 import { useThreads } from "@/web/components/chat/store/hooks";
 import { usePanelActions } from "@/web/layouts/shell-layout";
@@ -157,6 +160,7 @@ export function ShellBreadcrumb() {
               orgParam={org.slug}
               trigger={
                 <button type="button" className={crumbBtnClass}>
+                  <OrgIcon org={org} size="xs" />
                   <span className="truncate font-medium max-w-[10rem]">
                     {org.name}
                   </span>

--- a/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
+++ b/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
@@ -33,10 +33,7 @@ import {
 } from "@decocms/mesh-sdk";
 import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
 import { AgentAvatar } from "@/web/components/agent-icon";
-import {
-  OrgIcon,
-  OrgSwitcherPopover,
-} from "@/web/components/header/org-switcher";
+import { OrgSwitcherPopover } from "@/web/components/header/org-switcher";
 import { AgentScopePicker } from "@/web/components/sidebar/agents-section";
 import { useThreads } from "@/web/components/chat/store/hooks";
 import { usePanelActions } from "@/web/layouts/shell-layout";
@@ -160,7 +157,6 @@ export function ShellBreadcrumb() {
               orgParam={org.slug}
               trigger={
                 <button type="button" className={crumbBtnClass}>
-                  <OrgIcon org={org} size="xs" />
                   <span className="truncate font-medium max-w-[10rem]">
                     {org.name}
                   </span>
@@ -174,7 +170,9 @@ export function ShellBreadcrumb() {
           )}
         </BreadcrumbItem>
 
-        <BreadcrumbSeparator />
+        {/* Separator only when the org crumb is shown — otherwise it's just
+            `deco  agent` with no dangling divider. */}
+        {!sidebarCollapsed && <BreadcrumbSeparator />}
 
         {/* agent → avatar opens the agent home, label opens the picker */}
         <BreadcrumbItem>


### PR DESCRIPTION
## Summary

Tidies up the toolbar breadcrumb org crumb:

- **No org image** — the org crumb shows just the org name, dropping the `OrgIcon` avatar.
- **No dangling separator** — the `deco › org › agent` divider between the logo and the agent now only renders when the org crumb is visible (sidebar open). With the sidebar collapsed (org hidden) the breadcrumb reads `deco  agent`, with no stray `›`.

## Testing

- `bun run fmt` ✅
- `bun run check` (typecheck) ✅

## Screenshots

Collapsed sidebar — no separator between the logo and the agent:

`deco  Decopilot ⌄`

Open sidebar — org name (no avatar) between the logo and the agent:

`deco  <org> ⌄ › Decopilot ⌄`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the “/” separator in the toolbar breadcrumb when the sidebar is collapsed to avoid a dangling divider. The org avatar and label remain unchanged; the slash only renders when the org crumb is visible.

<sup>Written for commit a5dd730e6e57dc8520aa7d346dacac090e28f0e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

