### PR TITLE
fix(web): center route pending loader instead of left-collapsed splash

### DIFF
--- a/apps/mesh/src/web/components/splash-screen.tsx
+++ b/apps/mesh/src/web/components/splash-screen.tsx
@@ -2,7 +2,7 @@ import { Loading01 } from "@untitledui/icons";
 
 export function SplashScreen() {
   return (
-    <div className="flex items-center justify-center min-h-screen">
+    <div className="flex items-center justify-center min-h-screen w-full">
       <Loading01 size={20} className="animate-spin text-muted-foreground" />
     </div>
   );

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -11,6 +11,7 @@ import {
   redirect,
 } from "@tanstack/react-router";
 import { SplashScreen } from "@/web/components/splash-screen";
+import { ShellRouteLoading } from "@/web/layouts/shell-route-loading";
 import { ChunkErrorBoundary } from "@/web/components/error-boundary";
 import * as z from "zod";
 
@@ -231,6 +232,11 @@ const orgShellLayout = createRoute({
 const agentShellLayout = createRoute({
   getParentRoute: () => orgShellLayout,
   id: "agent-shell",
+  // Render the centered panel-area loader (matches the shell's own Suspense
+  // fallbacks) while this route loads, instead of the full-screen SplashScreen.
+  // The sidebar is already mounted by orgShellLayout, so the pending state
+  // covers only the main panel region — no off-center left flash on nav.
+  pendingComponent: ShellRouteLoading,
   component: lazyRouteComponent(
     () => import("./layouts/agent-shell-layout/index.tsx"),
   ),
@@ -286,6 +292,7 @@ const orgIndexRoute = createRoute({
   getParentRoute: () => orgShellLayout,
   path: "/",
   validateSearch: orgIndexSearchSchema,
+  pendingComponent: ShellRouteLoading,
   component: lazyRouteComponent(() => import("./layouts/org-home/index.tsx")),
 });
 
@@ -303,6 +310,7 @@ const libraryRoute = createRoute({
   getParentRoute: () => orgShellLayout,
   path: "/files",
   validateSearch: librarySearchSchema,
+  pendingComponent: ShellRouteLoading,
   component: lazyRouteComponent(() => import("./layouts/library/index.tsx")),
 });
 


### PR DESCRIPTION
## Summary

Fixes a long-standing "rogue" loading spinner that flashed **off-center to the left** and then jumped to center when navigating into the agent/home/library views.

### Root cause
TanStack Router's `defaultPendingComponent` (`SplashScreen`) renders at the org-shell `<Outlet />` while a child route's loader runs. `SplashScreen`'s wrapper (`flex items-center justify-center min-h-screen`) had **no width**, so as a flex item inside the org-shell's `flex flex-row` main-content container it collapsed to its content width (~75px) and pinned to the left, right against the sidebar. Once the route resolved and the panels mounted, their own centered loader took over — producing the "left, then center" jump.

Confirmed via a bisect: swapping `defaultPendingComponent` for a marker using SplashScreen's exact classes reproduced the left-collapsed column at `x:56, w:75` inside `relative flex-1 min-h-0 flex flex-row`.

### Changes
- **`components/splash-screen.tsx`** — add `w-full` so the splash can never collapse when used as a flex-row item (keeps `min-h-screen` so the full-screen boot splash still centers without depending on ancestor height). Defense-in-depth for the position bug.
- **`index.tsx`** — give the three org-shell child routes (`agent-shell`, org index `/`, library `/files`) a `pendingComponent` of `ShellRouteLoading` — the centered panel-area loader the shell already uses for its own Suspense fallbacks. Client-side navs now go straight to a centered loader with no left-flash-then-center jump.

## Testing
- ✅ `bun run fmt` — clean
- ✅ `bun run lint` — 0 errors
- ✅ `tsc --noEmit` (apps/mesh) — 0 errors
- Manual: reproduce by clicking into an agent from org home under a throttled network — the pending loader now renders centered over the panel area (no left flash).

## Affected areas
Route pending / loading states for `/$org`, `/$org/$taskId`, `/$org/files`. No behavioral change beyond the loading visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the off-center loading spinner by centering route pending loaders in the org shell. Navigations now show a stable, centered loader with no left-flash jump.

- **Bug Fixes**
  - Added `w-full` to `SplashScreen` to prevent flex collapse when rendered by `@tanstack/react-router` (keeps `min-h-screen` for the boot splash).
  - Set `pendingComponent` to `ShellRouteLoading` for `agent-shell`, `/`, and `/files` so the loader centers in the main panel during route loads.

<sup>Written for commit b494418bd47cc17edd41fd2ec19297778d65ddf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

