### PR TITLE
fix(sandbox): clamp absolute org-fs mount paths through path.resolve

### DIFF
--- a/packages/sandbox/daemon/org-fs/mount-manager.test.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.test.ts
@@ -126,6 +126,10 @@ describe("resolveMountPath", () => {
     expect(resolveMountPath("/ws", "/ws/org/x")).toBe("/ws/org/x");
     expect(resolveMountPath("/ws", "/etc/passwd")).toBeNull();
   });
+  it("rejects absolute paths that use .. to escape appRoot despite matching its prefix", () => {
+    expect(resolveMountPath("/ws", "/ws/../etc/passwd")).toBeNull();
+    expect(resolveMountPath("/ws", "/ws/org/../../../etc/passwd")).toBeNull();
+  });
 });
 
 describe("MountManager", () => {

--- a/packages/sandbox/daemon/org-fs/mount-manager.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.ts
@@ -126,8 +126,12 @@ function freePort(): Promise<number> {
  */
 export function resolveMountPath(appRoot: string, p: string): string | null {
   const orgRoot = join(appRoot, "org");
+  // Route absolute paths through the same resolve-then-clamp check relative
+  // paths get below — a raw `startsWith(appRoot)` never normalizes `..`
+  // segments, so e.g. "<appRoot>/../../etc" passes the prefix check while
+  // actually resolving outside appRoot.
   if (isAbsolute(p)) {
-    return p.startsWith(`${appRoot}/`) || p === appRoot ? p : null;
+    return safePath(appRoot, appRoot, p);
   }
   return safePath(appRoot, orgRoot, p);
 }


### PR DESCRIPTION
## Source
Bug found reading `packages/sandbox/daemon/org-fs/mount-manager.ts` (recently-changed org-fs area).

## Bug
`resolveMountPath`'s absolute-path branch validated the mount path with a raw `p.startsWith(\`${appRoot}/\`)` string check instead of resolving it first. That never normalizes `..` segments, so a mesh/cluster-supplied absolute mount path like `<appRoot>/../../etc/passwd` passes the prefix check (the literal string starts with `<appRoot>/`) while its actual resolved location is outside `appRoot` entirely. The relative-path branch already avoids this by going through `safePath`, which does `path.resolve` + `path.relative` before clamping — the absolute branch just never used it.

`mountPath` from this function feeds `mkdirSync(mountPath, { recursive: true })` and is handed to the OS mounter (rclone), so an untrusted/misconfigured cluster-supplied path could make the daemon create directories and mount a WebDAV volume outside the intended workspace root.

## Fix
Route the absolute-path branch through the same `safePath(appRoot, appRoot, p)` clamp already used for relative paths.

## Regression test
Added to `mount-manager.test.ts`:
```ts
expect(resolveMountPath("/ws", "/ws/../etc/passwd")).toBeNull();
expect(resolveMountPath("/ws", "/ws/org/../../../etc/passwd")).toBeNull();
```
Both fail (return the raw unresolved path) on current `main`, pass after the fix.

## Verify
```
bun test packages/sandbox/daemon/org-fs/mount-manager.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` (packages/sandbox workspace)
- `bun test packages/sandbox/daemon/org-fs/mount-manager.test.ts` (12 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened org-fs mount path resolution by normalizing and clamping absolute paths to stop path traversal outside the workspace root. Prevents creating directories or mounting volumes outside `appRoot`.

- **Bug Fixes**
  - Route absolute paths in `resolveMountPath` through `safePath(appRoot, appRoot, p)` to normalize with `path.resolve` and clamp with `path.relative`.
  - Added regression tests in `packages/sandbox/daemon/org-fs/mount-manager.test.ts` to reject paths like `/ws/../etc/passwd` and `/ws/org/../../../etc/passwd`.

<sup>Written for commit 4d1214494a77c94b089d98661d0c8f64f2c85f44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

