### PR TITLE
fix(e2e): self-healing composer typing — Tiptap drops keystroke bursts under CI load

### DIFF
--- a/packages/e2e/tests/chat-input-draft.spec.ts
+++ b/packages/e2e/tests/chat-input-draft.spec.ts
@@ -43,11 +43,30 @@ async function waitForChatInput(page: Page): Promise<void> {
  */
 async function typeInComposer(page: Page, text: string): Promise<void> {
   const input = page.locator(CHAT_INPUT);
-  await input.click();
-  await page.keyboard.type(text);
-  // Tiptap may take time to render the typed text, especially under load.
-  // Use a more generous timeout to avoid flakiness in CI.
-  await expect(input).toHaveText(text, { timeout: 15_000 });
+  // Tiptap can drop keystrokes typed while the editor re-renders under CI
+  // load (observed on main: "thread b" landing as "threa" — the tail of the
+  // burst swallowed mid-render, identically across all Playwright retries,
+  // so a longer timeout alone can't save an assertion once keys are lost).
+  // Self-heal instead: every attempt replaces the WHOLE content (select-all
+  // + delete + retype — every call site types full replacement text, never
+  // appends), verifies quickly, and only the last attempt fails the test.
+  const ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    await input.click();
+    await page.keyboard.press("ControlOrMeta+A");
+    await page.keyboard.press("Delete");
+    // A small inter-key delay yields to the event loop between keystrokes,
+    // shrinking the window where a re-render can eat the rest of the burst.
+    await page.keyboard.type(text, { delay: 10 });
+    try {
+      await expect(input).toHaveText(text, {
+        timeout: attempt < ATTEMPTS ? 3_000 : 15_000,
+      });
+      return;
+    } catch (error) {
+      if (attempt === ATTEMPTS) throw error;
+    }
+  }
 }
 
 /** Read the visible text content of the chat input. */


### PR DESCRIPTION
## Summary

Fixes the `e2e` failure on main ([run 29293699143](https://github.com/decocms/studio/actions/runs/29293699143/job/86962590229)): `chat-input-draft.spec.ts › drafts are isolated per thread`.

**Failure mechanics:** `openNewThread` types `"thread b"` into the Tiptap composer and the editor received only `"threa"` — the tail of the keystroke burst was swallowed while the editor re-rendered under CI load, **identically across all three Playwright retries**. `typeInComposer`'s existing mitigation (a generous 15s `toHaveText` timeout) can't help in this shape: once keystrokes are dropped, no amount of waiting makes the text complete.

**Fix (test-infra, in the helper all call sites share):** `typeInComposer` is now self-healing —
- each attempt replaces the *whole* content (select-all → delete → retype); safe because every call site in the spec types full replacement text, never appends;
- verification uses a short 3s timeout on early attempts and retypes on mismatch; only the final attempt keeps the 15s timeout and fails the test;
- a 10ms inter-key delay yields to the event loop between keystrokes, shrinking the window in which a re-render can eat the rest of the burst.

This spec is the only one in `packages/e2e` using `keyboard.type` against the composer, so the hardening is complete at this one helper.

## Testing

- Local Playwright run is blocked in my environment (a dev server occupies the app ports), so this PR's own `e2e` job is the verification gate — the suite that failed on main runs here unchanged apart from the helper.
- Not a product change: `packages/e2e` only, no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes e2e tests by making Tiptap composer typing self-healing. Prevents dropped keystrokes under CI load that broke draft isolation.

- **Bug Fixes**
  - Replaces the whole content on each attempt (select-all → delete → retype), never appends.
  - Verifies with a 3s timeout and retypes on mismatch; only the last attempt uses 15s and fails if needed.
  - Adds a 10ms inter-key delay to reduce burst loss during editor re-renders.

<sup>Written for commit a246405a59a2c1ca61f4ebd030a3e234dfdba1df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

