### PR TITLE
feat(shell): agents picker as a list; sidebar Invite/Add repo; breadcrumb slash

### DIFF
--- a/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
@@ -12,6 +12,7 @@ import { getMcpListCache } from "../mcp-list-cache";
 import type { StudioContext } from "../../core/studio-context";
 import type { ConnectionEntity } from "../../tools/connection/schema";
 import type { VirtualMCPEntity } from "../../tools/virtual/schema";
+import { isOrgSharedConnection } from "../../shared/github-repo-scope";
 import { PassthroughClient } from "./passthrough-client";
 import { renderSkillsCatalogBlock } from "./skills-instructions";
 import type { VirtualClientOptions } from "./types";
@@ -128,6 +129,29 @@ export async function createVirtualClientFrom(
   // aggregator's first-occurrence-wins dedup over any same-named tool.
   if (options?.additionalConnections?.length) {
     loadedConnections.unshift(...options.additionalConnections);
+  }
+
+  // Org-shared repo connections ("Add repo" in the sidebar) are available to
+  // every agent by default. Appended (not the agent's own, so all their tools
+  // are exposed), deduped, and guarded on a real org so the well-known agents
+  // (Decopilot/brand-context, which resolve with no org) don't fan them in.
+  // ponytail: one slug-filtered connections.list per client build; memoize in
+  // createRequestCachedVirtualMcps like virtualMcps.list if this path gets hot.
+  if (virtualMcp.organization_id) {
+    const existingIds = new Set(loadedConnections.map((c) => c.id));
+    const { items } = await ctx.storage.connections.list(
+      virtualMcp.organization_id,
+      { slug: "mcp-github" },
+    );
+    for (const conn of items) {
+      if (
+        conn.status === "active" &&
+        !existingIds.has(conn.id) &&
+        isOrgSharedConnection(conn)
+      ) {
+        loadedConnections.push(conn);
+      }
+    }
   }
 
   // Agent runtimes opt into the skill catalog: enumerate the org's skills now

--- a/apps/mesh/src/shared/github-repo-scope.test.ts
+++ b/apps/mesh/src/shared/github-repo-scope.test.ts
@@ -3,6 +3,7 @@ import {
   getOrgGithubConnections,
   getRepoScope,
   GITHUB_SCOPED_PERMISSIONS,
+  isOrgSharedConnection,
   type RepoScopeRecipe,
 } from "./github-repo-scope";
 
@@ -197,5 +198,23 @@ describe("getOrgGithubConnections", () => {
     expect(
       getOrgGithubConnections([scopedConn, refreshableScopedConn]),
     ).toEqual([]);
+  });
+});
+
+describe("isOrgSharedConnection", () => {
+  it("is true only when metadata.orgShared === true", () => {
+    expect(isOrgSharedConnection({ metadata: { orgShared: true } })).toBe(true);
+  });
+
+  it("is false for per-agent repo children and plain connections", () => {
+    expect(
+      isOrgSharedConnection({
+        metadata: { repoScope: { installationId: 1, owner: "a", repo: "b" } },
+      }),
+    ).toBe(false);
+    expect(isOrgSharedConnection({ metadata: null })).toBe(false);
+    expect(isOrgSharedConnection({ metadata: { orgShared: "yes" } })).toBe(
+      false,
+    );
   });
 });

--- a/apps/mesh/src/shared/github-repo-scope.ts
+++ b/apps/mesh/src/shared/github-repo-scope.ts
@@ -107,3 +107,15 @@ export function getOrgGithubConnections<
 >(connections: T[] | undefined | null): T[] {
   return (connections ?? []).filter((c) => getRepoScope(c) === null);
 }
+
+/**
+ * An org-shared repo connection ("Add repo" in the sidebar): a repo-scoped
+ * child that is deliberately NOT bound to a single agent — it's injected into
+ * every agent's toolset. Distinct from the per-agent import child, which also
+ * has `repoScope` but no `orgShared` flag and stays private to its agent.
+ */
+export function isOrgSharedConnection(connection: {
+  metadata: Record<string, unknown> | null;
+}): boolean {
+  return connection.metadata?.orgShared === true;
+}

--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -68,16 +68,25 @@ export interface GitHubImportPayload {
 export function GitHubRepoPicker({
   open,
   onOpenChange,
-  title = "Import from GitHub",
+  title,
   hideAutoRespondCheckbox = false,
   onImportComplete,
+  mode = "agent",
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title?: string;
   hideAutoRespondCheckbox?: boolean;
   onImportComplete?: (payload: GitHubImportPayload) => void;
+  /**
+   * "agent" (default): pick a repo → provision a repo-scoped connection + a new
+   * agent bound to it. "connection": provision an org-shared repo connection
+   * only (available to every agent), no agent, no automations.
+   */
+  mode?: "agent" | "connection";
 }) {
+  const resolvedTitle =
+    title ?? (mode === "connection" ? "Add repo" : "Import from GitHub");
   const [selectedInstallation, setSelectedInstallation] =
     useState<GitHubInstallation | null>(null);
 
@@ -85,7 +94,7 @@ export function GitHubRepoPicker({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[560px] h-[85svh] sm:h-[520px] p-0 gap-0 overflow-hidden flex flex-col">
         <DialogHeader className="sr-only">
-          <DialogTitle>{title}</DialogTitle>
+          <DialogTitle>{resolvedTitle}</DialogTitle>
         </DialogHeader>
         <div className="flex items-center h-12 border-b border-border px-4 gap-3 shrink-0">
           {selectedInstallation ? (
@@ -111,7 +120,7 @@ export function GitHubRepoPicker({
             <>
               <GitHubIcon className="size-4 text-foreground shrink-0" />
               <span className="text-sm font-medium text-foreground">
-                {title}
+                {resolvedTitle}
               </span>
             </>
           )}
@@ -132,8 +141,11 @@ export function GitHubRepoPicker({
               onComplete={() => onOpenChange(false)}
               selectedInstallation={selectedInstallation}
               onSelectInstallation={setSelectedInstallation}
-              hideAutoRespondCheckbox={hideAutoRespondCheckbox}
+              hideAutoRespondCheckbox={
+                hideAutoRespondCheckbox || mode === "connection"
+              }
               onImportComplete={onImportComplete}
+              mode={mode}
             />
           </Suspense>
         </div>
@@ -149,6 +161,7 @@ function PickerContent({
   onSelectInstallation,
   hideAutoRespondCheckbox,
   onImportComplete,
+  mode = "agent",
 }: {
   open: boolean;
   onComplete: () => void;
@@ -156,6 +169,7 @@ function PickerContent({
   onSelectInstallation: (inst: GitHubInstallation | null) => void;
   hideAutoRespondCheckbox?: boolean;
   onImportComplete?: (payload: GitHubImportPayload) => void;
+  mode?: "agent" | "connection";
 }) {
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
@@ -296,6 +310,29 @@ function PickerContent({
 
       const installationId = selectedInstallation.installationId;
 
+      // Connection-only ("Add repo"): provision an org-shared repo connection
+      // that every agent can use, then stop — no agent, no automations.
+      if (mode === "connection") {
+        const { childConnectionId } = await provisionRepoScopedGithubConnection(
+          {
+            orgSlug: org.slug,
+            sourceConnection: effectiveConnection,
+            installationId,
+            owner: repo.owner,
+            repo: repo.name,
+            githubCallTool: (req) => githubClient.callTool(req),
+            selfCallTool: (req) => selfClient.callTool(req),
+            orgShared: true,
+          },
+        );
+        return {
+          virtualMcpId: null,
+          repo,
+          connectionId: childConnectionId,
+          item: null,
+        };
+      }
+
       const { childConnectionId } = await provisionRepoScopedGithubConnection({
         orgSlug: org.slug,
         sourceConnection: effectiveConnection,
@@ -396,6 +433,12 @@ function PickerContent({
       }
     },
     onSuccess: ({ virtualMcpId, repo, connectionId, item }) => {
+      if (mode === "connection" || !virtualMcpId || !item) {
+        invalidateVirtualMcpQueries(queryClient, org.id);
+        toast.success(`Added ${repo.name}`);
+        onComplete();
+        return;
+      }
       queryClient.setQueryData(
         KEYS.collectionItem(
           selfClient,

--- a/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
+++ b/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
@@ -174,7 +174,12 @@ export function ShellBreadcrumb() {
           )}
         </BreadcrumbItem>
 
-        <BreadcrumbSeparator />
+        {/* Slash, not a chevron: the org's own dropdown ▾ sits right before it,
+            and two arrows in a row read as noise. A slash marks hierarchy
+            without competing with the dropdown affordance. */}
+        <BreadcrumbSeparator className="opacity-40">
+          <span className="text-sm font-normal select-none">/</span>
+        </BreadcrumbSeparator>
 
         {/* agent → avatar opens the agent home, label opens the picker */}
         <BreadcrumbItem>

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -1,5 +1,4 @@
 import { Suspense, useState, type ReactElement } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
@@ -31,7 +30,7 @@ import {
 } from "@deco/ui/components/drawer.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { CollectionSearch } from "@deco/ui/components/collection-search.tsx";
-import { Check, Globe02, Plus } from "@untitledui/icons";
+import { Check, Plus } from "@untitledui/icons";
 import {
   getWellKnownDecopilotVirtualMCP,
   isDecopilot,
@@ -39,21 +38,11 @@ import {
   useVirtualMCPs,
 } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
-import { useCreateVirtualMCP } from "@/web/hooks/use-create-virtual-mcp";
-import {
-  WEBSITE_TEMPLATE,
-  useCreateAgentFromTemplate,
-} from "@/web/hooks/use-create-website-agent";
 import { track } from "@/web/lib/posthog-client";
 import { AgentAvatar } from "@/web/components/agent-icon";
-import { GitHubIcon } from "@/web/components/icons/github-icon";
-import { ImportFromDecoDialog } from "@/web/components/import-from-deco-dialog.tsx";
-import { GitHubRepoPicker } from "@/web/components/github-repo-picker.tsx";
 import { useThreadActions } from "@/web/components/chat/store/hooks";
 import { readCachedTaskBranch } from "@/web/lib/read-cached-task-branch";
 import { authClient } from "@/web/lib/auth-client";
-import { KEYS } from "@/web/lib/query-keys";
-import { usePublicConfig } from "@/web/hooks/use-public-config";
 import { getServerPinnedIds } from "@/web/hooks/use-navigate-to-agent";
 import { getDevAgentIds } from "@/web/lib/agent-capabilities";
 import {
@@ -73,22 +62,6 @@ function BrowseAgentsEmptyHint({ children }: { children: ReactElement }) {
       </TooltipContent>
     </Tooltip>
   );
-}
-
-function useIsDecoUser() {
-  const { enableDecoImport } = usePublicConfig();
-  const { data: session } = authClient.useSession();
-  const { data } = useQuery({
-    queryKey: KEYS.decoProfile(session?.user?.email),
-    queryFn: async () => {
-      const res = await fetch("/api/deco-sites/profile");
-      if (!res.ok) return { isDecoUser: false };
-      return res.json() as Promise<{ isDecoUser: boolean }>;
-    },
-    enabled: Boolean(enableDecoImport) && Boolean(session?.user?.email),
-    staleTime: 5 * 60_000,
-  });
-  return data?.isDecoUser ?? false;
 }
 
 /**
@@ -130,7 +103,7 @@ function useNavigateToNewTaskWithBranchCarry(orgSlug: string) {
   };
 }
 
-function AgentGridItem({
+function AgentRow({
   agent,
   selected,
   onClick,
@@ -144,43 +117,35 @@ function AgentGridItem({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex flex-col items-center gap-2 p-3 rounded-xl transition-colors cursor-pointer group",
+        "flex items-center gap-2.5 px-2 py-1.5 rounded-md transition-colors cursor-pointer text-left w-full",
         selected ? "bg-accent" : "hover:bg-accent",
       )}
     >
-      <div className="relative">
-        <AgentAvatar
-          icon={agent.icon}
-          name={agent.title}
-          size="md"
-          className="transition-transform group-hover:scale-105"
-        />
-        {selected && (
-          <span className="absolute -bottom-1 -right-1 flex size-4 items-center justify-center rounded-full border border-border bg-background">
-            <Check size={10} className="text-foreground" />
-          </span>
-        )}
-      </div>
-      <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground line-clamp-2 w-full">
+      <AgentAvatar
+        icon={agent.icon}
+        name={agent.title}
+        size="xs"
+        className="shrink-0"
+      />
+      <span className="flex-1 min-w-0 truncate text-sm text-foreground">
         {agent.title}
       </span>
+      {selected && (
+        <Check size={16} className="shrink-0 text-muted-foreground" />
+      )}
     </button>
   );
 }
 
 function PinAgentPopoverContent({
   onClose,
-  onOpenImportDeco,
-  onOpenGithubImport,
   onSelectAgent,
   selectedAgentId,
 }: {
   onClose: () => void;
-  onOpenImportDeco: () => void;
-  onOpenGithubImport: () => void;
   /** When provided (breadcrumb scope picker), selecting an agent sets the
-   * sidebar scope instead of opening a new task; `null` = all agents. The grid
-   * then leads with a Decopilot tile ("all threads") and marks the active one. */
+   * sidebar scope instead of opening a new task; `null` = all agents. The list
+   * then leads with a Decopilot row ("all threads") and marks the active one. */
   onSelectAgent?: (id: string | null) => void;
   /** The currently-scoped agent, for the check mark (picker mode). */
   selectedAgentId?: string | null;
@@ -193,12 +158,6 @@ function PinAgentPopoverContent({
   const sidebarUserId = session?.user?.id ?? "anon";
   const serverPinnedIds = getServerPinnedIds(allAgents);
   const bumpOrderRevision = useBumpSidebarOrderRevision();
-  const { createVirtualMCP, isCreating } = useCreateVirtualMCP({
-    navigateOnCreate: true,
-  });
-  const { createFromTemplate, isCreating: isCreatingFromTemplate } =
-    useCreateAgentFromTemplate();
-  const isDecoUser = useIsDecoUser();
 
   const navigateToNewTask = useNavigateToNewTaskWithBranchCarry(org.slug);
 
@@ -259,90 +218,10 @@ function PinAgentPopoverContent({
             Agents
           </span>
         </div>
-        <div className="grid grid-cols-3 gap-1">
-          {/* Create new button */}
-          <button
-            type="button"
-            disabled={isCreating}
-            onClick={async () => {
-              track("agent_create_new_clicked", { source: "browse_popover" });
-              await createVirtualMCP();
-              onClose();
-            }}
-            className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <div className="w-12 h-12 rounded-xl border-2 border-dashed border-border flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
-              <Plus size={16} className="text-muted-foreground" />
-            </div>
-            <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
-              Create new
-            </span>
-          </button>
-
-          <button
-            type="button"
-            disabled={isCreatingFromTemplate}
-            onClick={async () => {
-              track("agent_create_clicked", {
-                source: "browse_popover",
-                method: "website",
-              });
-              await createFromTemplate(WEBSITE_TEMPLATE);
-              onClose();
-            }}
-            className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <div className="w-12 h-12 rounded-xl border-2 border-border flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
-              <Globe02 className="size-5 text-muted-foreground" />
-            </div>
-            <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
-              Start Website
-            </span>
-          </button>
-
-          <button
-            type="button"
-            onClick={() => {
-              track("agent_import_clicked", { source: "github" });
-              onOpenGithubImport();
-              onClose();
-            }}
-            className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group"
-          >
-            <div className="w-12 h-12 rounded-xl border-2 border-border flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
-              <GitHubIcon className="size-5 text-muted-foreground" />
-            </div>
-            <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
-              Import GitHub
-            </span>
-          </button>
-
-          {isDecoUser && (
-            <button
-              type="button"
-              onClick={() => {
-                track("agent_import_clicked", { source: "deco" });
-                onOpenImportDeco();
-                onClose();
-              }}
-              className="flex flex-col items-center gap-2 p-3 rounded-xl transition-colors hover:bg-accent cursor-pointer group"
-            >
-              <div className="w-12 h-12 rounded-xl border-2 border-border flex items-center justify-center shrink-0 transition-transform group-hover:scale-105">
-                <img
-                  src="/logos/deco%20logo.svg"
-                  alt=""
-                  className="size-5 object-contain"
-                />
-              </div>
-              <span className="text-xs leading-tight text-center text-muted-foreground group-hover:text-foreground">
-                Import deco.cx
-              </span>
-            </button>
-          )}
-
+        <div className="flex flex-col gap-0.5">
           {/* Scope-picker mode: Decopilot = all threads, every agent. */}
           {onSelectAgent && showDecopilot && decopilotAgent && (
-            <AgentGridItem
+            <AgentRow
               agent={decopilotAgent}
               selected={
                 !selectedAgentId || selectedAgentId === decopilotAgent.id
@@ -352,7 +231,7 @@ function PinAgentPopoverContent({
           )}
 
           {userAgents.map((agent) => (
-            <AgentGridItem
+            <AgentRow
               key={agent.id}
               agent={agent}
               selected={
@@ -363,7 +242,7 @@ function PinAgentPopoverContent({
           ))}
         </div>
 
-        {userAgents.length === 0 && !isCreating && (
+        {userAgents.length === 0 && (
           <div className="flex items-center justify-center py-6 text-xs text-muted-foreground">
             {search ? "No agents found" : "No agents yet"}
           </div>
@@ -403,8 +282,6 @@ function PinAgentPopover({
   align?: "start" | "center" | "end";
 } = {}) {
   const [open, setOpen] = useState(false);
-  const [importDecoOpen, setImportDecoOpen] = useState(false);
-  const [githubPickerOpen, setGithubPickerOpen] = useState(false);
   const isMobile = useIsMobile();
   const { setOpenMobile } = useSidebar();
   const highlightEmpty = useSidebarAgentGroupsEmpty();
@@ -432,11 +309,6 @@ function PinAgentPopover({
     >
       <PinAgentPopoverContent
         onClose={handleClose}
-        onOpenImportDeco={() => setImportDecoOpen(true)}
-        onOpenGithubImport={() => {
-          setGithubPickerOpen(true);
-          handleClose();
-        }}
         onSelectAgent={onSelectAgent}
         selectedAgentId={selectedAgentId}
       />
@@ -539,14 +411,6 @@ function PinAgentPopover({
           </PopoverContent>
         </Popover>
       )}
-      <ImportFromDecoDialog
-        open={importDecoOpen}
-        onOpenChange={setImportDecoOpen}
-      />
-      <GitHubRepoPicker
-        open={githubPickerOpen}
-        onOpenChange={setGithubPickerOpen}
-      />
     </>
   );
 }

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -9,6 +9,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarSeparator,
   useSidebar,
 } from "@deco/ui/components/sidebar.tsx";
 import {
@@ -17,8 +18,11 @@ import {
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
-import { ArrowLeft, Inbox01, Settings02 } from "@untitledui/icons";
+import { ArrowLeft, Inbox01, Settings02, UserPlus01 } from "@untitledui/icons";
 import { useState, type ReactNode } from "react";
+import { GitHubIcon } from "@/web/components/icons/github-icon";
+import { GitHubRepoPicker } from "@/web/components/github-repo-picker";
+import { InviteMemberDialog } from "@/web/components/invite-member-dialog";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
 import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
@@ -222,6 +226,45 @@ function SettingsIconButton() {
   );
 }
 
+/**
+ * Sidebar footer actions — org-wide entry points that aren't tied to a single
+ * agent: invite teammates, and add a repo as an org-shared GitHub connection
+ * (available to every agent). Rendered as full-width rows above the account row.
+ */
+function SidebarExtraActions() {
+  const [repoOpen, setRepoOpen] = useState(false);
+  return (
+    <>
+      <SidebarMenu className="gap-0.5">
+        <SidebarMenuItem>
+          <InviteMemberDialog
+            trigger={
+              <SidebarMenuButton tooltip="Invite members">
+                <UserPlus01 />
+                <span>Invite members</span>
+              </SidebarMenuButton>
+            }
+          />
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            tooltip="Add repo"
+            onClick={() => setRepoOpen(true)}
+          >
+            <GitHubIcon />
+            <span>Add repo</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+      <GitHubRepoPicker
+        open={repoOpen}
+        onOpenChange={setRepoOpen}
+        mode="connection"
+      />
+    </>
+  );
+}
+
 export function SidebarInboxFooter() {
   const { state } = useSidebar();
   const isCollapsed = state === "collapsed";
@@ -251,7 +294,9 @@ export function SidebarInboxFooter() {
   }
 
   return (
-    <SidebarFooter className="px-2 pb-3">
+    <SidebarFooter className="px-2 pb-3 gap-1.5">
+      <SidebarExtraActions />
+      <SidebarSeparator className="mx-0" />
       <div className="flex items-center gap-1">
         <div className="flex-1 min-w-0">
           <SidebarMenu>

--- a/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.ts
+++ b/apps/mesh/src/web/lib/provision-repo-scoped-github-connection.ts
@@ -47,6 +47,8 @@ export async function provisionRepoScopedGithubConnection(params: {
   repo: string;
   githubCallTool: McpCallTool;
   selfCallTool: McpCallTool;
+  /** Mark the connection as available to every agent ("Add repo" flow). */
+  orgShared?: boolean;
 }): Promise<{ childConnectionId: string }> {
   const {
     orgSlug,
@@ -56,6 +58,7 @@ export async function provisionRepoScopedGithubConnection(params: {
     repo,
     githubCallTool,
     selfCallTool,
+    orgShared,
   } = params;
 
   const mintRes = (await githubCallTool({
@@ -140,6 +143,7 @@ export async function provisionRepoScopedGithubConnection(params: {
         connection_type: sourceConnection.connection_type,
         connection_url: sourceConnection.connection_url,
         metadata: {
+          ...(orgShared ? { orgShared: true } : {}),
           repoScope: {
             installationId,
             repositoryId,


### PR DESCRIPTION
## What

Three shell/nav changes.

### Agents picker → an actual list
The breadcrumb agent picker was a 3-column grid of icon tiles. It's now a **vertical list of rows** (small avatar + title, check on the active one), Decopilot first — matching the "ordered list of rows" #4473 described but never actually rendered.

### Remove the four action buttons from the picker
Dropped **Create new**, **Start Website**, **Import GitHub**, **Import deco.cx** from the popover. All four still live on the **See all agents** page, so nothing is lost — the popover is just a clean agent list now. Swept the hooks/imports/state those buttons pulled in.

### Import GitHub → sidebar footer, reframed as "Add repo"
New footer actions group above the account row:
- **Invite members** — reuses the existing `InviteMemberDialog`.
- **Add repo** — `GitHubRepoPicker` in a new `mode="connection"`: same browse UI, but on select it *only* provisions a repo-scoped connection (no agent, no automations), tagged `metadata.orgShared: true`.

**Auto-availability:** at the single connection-resolution choke point (`createVirtualClientFrom`), every agent now also gets active org connections where `orgShared === true` — deduped, org-guarded, all tools exposed (same pattern as the ephemeral dev connection). New `isOrgSharedConnection()` predicate keeps these distinct from the per-agent import children (which reuse `repoScope` and stay private to their agent).

> **Security note (intended):** anyone who can run any agent can call an org-shared repo's tools through that agent's identity. That's the "any agent can use it by default" behavior. Per-agent repo imports are unaffected.

### Breadcrumb: resolve the double arrow
The org chip's dropdown **▾** butted straight into the breadcrumb separator **›** — two arrows in a row. Swapped the separator for a slash so hierarchy no longer competes with the dropdown affordance.

## Testing
- `tsc --noEmit`, `bun run lint`, `bun run fmt` — clean.
- New unit tests for `isOrgSharedConnection` (pure predicate) pass; full `github-repo-scope` suite green.
- Behavioural bits (list rendering, Add repo provisioning, org-shared tools showing up in an agent) best verified in the running app.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the agent picker as a clean vertical list and moved creation/import actions to the sidebar. Added an org-shared GitHub "Add repo" flow so any agent can use shared repos by default, and switched the breadcrumb separator to a slash for clarity.

- **New Features**
  - Agent picker: 3-column grid → vertical list with avatar + title; Decopilot first. Removed "Create new," "Start Website," "Import GitHub," and "Import deco.cx" from the popover (still on "See all agents").
  - Sidebar footer: added "Invite members" and "Add repo." `GitHubRepoPicker` supports `mode="connection"` to provision an org-shared repo-only connection (no agent). In `createVirtualClientFrom`, active org-shared repos are appended to every agent’s tools (deduped, org-guarded). New `isOrgSharedConnection` predicate with tests keeps these distinct from per-agent imports.
  - Breadcrumb: replaced chevron with a slash so it doesn’t clash with the org dropdown arrow.

<sup>Written for commit 366255061f6ca7ebfa2bb99d18e64786a5106101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

