### PR TITLE
refactor(api): replace hand-rolled setTimeout sleep with @decocms/std

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -9,6 +9,7 @@
  */
 
 import { readFileSync } from "node:fs";
+import { sleep } from "@decocms/std";
 import { jetstreamManager } from "@nats-io/jetstream";
 import { getSettings } from "../settings";
 import {
@@ -1676,9 +1677,7 @@ export async function createApp(options: CreateAppOptions = {}) {
         const REVALIDATION_TIMEOUT_MS = 30_000;
         void Promise.race([
           Promise.allSettled(revalidations),
-          new Promise((resolve) =>
-            setTimeout(resolve, REVALIDATION_TIMEOUT_MS),
-          ),
+          sleep(REVALIDATION_TIMEOUT_MS),
         ]).catch((err) =>
           console.error("[mesh] revalidation cleanup error:", err),
         );


### PR DESCRIPTION
## Source
A code-reduction cleanup found while reading recently-changed files: `apps/mesh/src/api/app.ts` still has a hand-rolled `new Promise((resolve) => setTimeout(resolve, ms))` for the revalidation-timeout race, in the request-completion middleware. This is exactly the pattern the repo already consolidated ~9 copies of into `@decocms/std`'s `sleep()` (see #4510, which fixed the other 5 remaining copies but didn't touch this file).

## Payoff
One fewer hand-rolled timer implementation to maintain; keeps this file consistent with the repo-wide `@decocms/std` convention documented in CLAUDE.md.

## Change
Behavior-preserving: `sleep(REVALIDATION_TIMEOUT_MS)` resolves after the same delay as the inline `new Promise` did, and is `await`ed the same way inside `Promise.race`. No types changed.

## Verification
- `bun run fmt`
- `cd apps/mesh && bunx tsc --noEmit` — passes clean
- No existing test file targets this specific middleware branch (it's a fire-and-forget cleanup path), so no test file to run; the diff is a 1:1 semantic-preserving substitution. Full CI will validate the rest.

Net diff: +2 / -3 (adds the import, collapses 4 lines into 1).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hand-rolled setTimeout Promise with `sleep()` from `@decocms/std` in the revalidation-timeout race in apps/mesh/src/api/app.ts. Behavior is unchanged; this reduces code and aligns the file with the shared utility.

<sup>Written for commit 98fa5d84af600ed8783e89900c8ad1e9eae4b3ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

