### PR TITLE
fix(shell): agents picker rows match org-switcher; add-connection; drop breadcrumb slash

### DIFF
--- a/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
+++ b/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
@@ -23,7 +23,6 @@ import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbList,
-  BreadcrumbSeparator,
 } from "@deco/ui/components/breadcrumb.tsx";
 import { useSidebar } from "@deco/ui/components/sidebar.tsx";
 import {
@@ -173,17 +172,6 @@ export function ShellBreadcrumb() {
             />
           )}
         </BreadcrumbItem>
-
-        {/* Slash, not a chevron: the org's own dropdown ▾ sits right before it,
-            and two arrows in a row read as noise. A slash marks hierarchy
-            without competing with the dropdown affordance. Only shown when the
-            org crumb is visible (sidebar open) — otherwise it's a dangling
-            divider between `deco` and the agent. */}
-        {!sidebarCollapsed && (
-          <BreadcrumbSeparator className="opacity-40">
-            <span className="text-sm font-normal select-none">/</span>
-          </BreadcrumbSeparator>
-        )}
 
         {/* agent → avatar opens the agent home, label opens the picker */}
         <BreadcrumbItem>

--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -117,8 +117,10 @@ function AgentRow({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex items-center gap-2.5 px-2 py-1.5 rounded-md transition-colors cursor-pointer text-left w-full",
-        selected ? "bg-accent" : "hover:bg-accent",
+        "flex items-center gap-3 px-3 py-2.5 rounded-md text-sm text-left w-full transition-colors",
+        selected
+          ? "bg-accent text-accent-foreground"
+          : "text-foreground hover:bg-accent/50",
       )}
     >
       <AgentAvatar
@@ -127,11 +129,16 @@ function AgentRow({
         size="xs"
         className="shrink-0"
       />
-      <span className="flex-1 min-w-0 truncate text-sm text-foreground">
-        {agent.title}
-      </span>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium truncate">{agent.title}</p>
+        {agent.description && (
+          <p className="text-xs text-muted-foreground truncate">
+            {agent.description}
+          </p>
+        )}
+      </div>
       {selected && (
-        <Check size={16} className="shrink-0 text-muted-foreground" />
+        <Check size={14} className="ml-auto text-muted-foreground shrink-0" />
       )}
     </button>
   );
@@ -211,36 +218,24 @@ function PinAgentPopoverContent({
       />
 
       {/* Scrollable content */}
-      <div className="overflow-y-auto flex-1 min-h-0 px-3 pb-3">
-        {/* Agents section */}
-        <div className="px-1 pt-3 pb-2">
-          <span className="text-xs font-medium text-muted-foreground">
-            Agents
-          </span>
-        </div>
-        <div className="flex flex-col gap-0.5">
-          {/* Scope-picker mode: Decopilot = all threads, every agent. */}
-          {onSelectAgent && showDecopilot && decopilotAgent && (
-            <AgentRow
-              agent={decopilotAgent}
-              selected={
-                !selectedAgentId || selectedAgentId === decopilotAgent.id
-              }
-              onClick={selectAll}
-            />
-          )}
+      <div className="overflow-y-auto flex-1 min-h-0 p-1.5 flex flex-col gap-1">
+        {/* Scope-picker mode: Decopilot = all threads, every agent. */}
+        {onSelectAgent && showDecopilot && decopilotAgent && (
+          <AgentRow
+            agent={decopilotAgent}
+            selected={!selectedAgentId || selectedAgentId === decopilotAgent.id}
+            onClick={selectAll}
+          />
+        )}
 
-          {userAgents.map((agent) => (
-            <AgentRow
-              key={agent.id}
-              agent={agent}
-              selected={
-                onSelectAgent ? selectedAgentId === agent.id : undefined
-              }
-              onClick={() => handleSelect(agent)}
-            />
-          ))}
-        </div>
+        {userAgents.map((agent) => (
+          <AgentRow
+            key={agent.id}
+            agent={agent}
+            selected={onSelectAgent ? selectedAgentId === agent.id : undefined}
+            onClick={() => handleSelect(agent)}
+          />
+        ))}
 
         {userAgents.length === 0 && (
           <div className="flex items-center justify-center py-6 text-xs text-muted-foreground">

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -18,11 +18,18 @@ import {
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
-import { ArrowLeft, Inbox01, Settings02, UserPlus01 } from "@untitledui/icons";
+import {
+  ArrowLeft,
+  Inbox01,
+  Settings02,
+  UserPlus01,
+  ZapSquare,
+} from "@untitledui/icons";
 import { useState, type ReactNode } from "react";
 import { GitHubIcon } from "@/web/components/icons/github-icon";
 import { GitHubRepoPicker } from "@/web/components/github-repo-picker";
 import { InviteMemberDialog } from "@/web/components/invite-member-dialog";
+import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
 import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
@@ -228,11 +235,13 @@ function SettingsIconButton() {
 
 /**
  * Sidebar footer actions — org-wide entry points that aren't tied to a single
- * agent: invite teammates, and add a repo as an org-shared GitHub connection
- * (available to every agent). Rendered as full-width rows above the account row.
+ * agent: invite teammates, add a repo as an org-shared GitHub connection
+ * (available to every agent), and add any connection. Rendered as full-width
+ * rows above the account row.
  */
 function SidebarExtraActions() {
   const [repoOpen, setRepoOpen] = useState(false);
+  const [connectionsOpen, setConnectionsOpen] = useState(false);
   return (
     <>
       <SidebarMenu className="gap-0.5">
@@ -255,11 +264,25 @@ function SidebarExtraActions() {
             <span>Add repo</span>
           </SidebarMenuButton>
         </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            tooltip="Add connection"
+            onClick={() => setConnectionsOpen(true)}
+          >
+            <ZapSquare />
+            <span>Add connection</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
       </SidebarMenu>
       <GitHubRepoPicker
         open={repoOpen}
         onOpenChange={setRepoOpen}
         mode="connection"
+      />
+      <AddConnectionDialog
+        open={connectionsOpen}
+        onOpenChange={setConnectionsOpen}
+        mode="browse"
       />
     </>
   );


### PR DESCRIPTION
Follow-up polish to the agents picker + sidebar footer.

## Agents picker
- **Rows reuse the org-switcher row pattern** (`gap-3 px-3 py-2.5`, icon + title/description stack, right-aligned `Check`) and the same container spacing (`p-1.5 gap-1`), so the picker and the org switcher are visually consistent.
- **Descriptions are back** as the row subtitle.
- **Dropped the "Agents" section label** — the list stands on its own.

## Sidebar footer
- Added **Add connection** below **Add repo**, opening `AddConnectionDialog` in `mode="browse"` (the org-level connections modal).

## Breadcrumb
- **Removed the slash separator** between org and agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the agents picker to match the org-switcher (stacked title/description rows, consistent spacing, no "Agents" label) and removed the org/agent slash in the breadcrumb. Added an org-wide "Add connection" action in the sidebar footer.

- **New Features**
  - Added "Add connection" below "Add repo" in the sidebar footer; opens `AddConnectionDialog` in `mode="browse"`.

<sup>Written for commit 07403fcdc5eb9ea83244cfd40f1e539f8e32319b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

