### PR TITLE
fix(sandbox): report status 'killed' for signal-terminated pipe-mode tasks

### DIFF
--- a/packages/sandbox/daemon/process/task-manager.test.ts
+++ b/packages/sandbox/daemon/process/task-manager.test.ts
@@ -42,6 +42,22 @@ describe("TaskManager intentional flag", () => {
   });
 });
 
+describe("TaskManager kill status", () => {
+  it("reports status 'killed' (not 'exited') for a pipe-mode task killed via kill()", async () => {
+    const tm = makeManager();
+    const t = await tm.spawn({
+      command: "sleep 30",
+      cwd: "/tmp",
+      mode: "pipe",
+    });
+    const finished = tm.finished(t.id)!;
+    tm.kill(t.id, "SIGTERM");
+    const result = await finished;
+    expect(result.status).toBe("killed");
+    expect(tm.get(t.id)?.status).toBe("killed");
+  });
+});
+
 describe("TaskManager replaceByLogName", () => {
   it("kills the running task with the same logName, awaits exit, then spawns", async () => {
     const tm = makeManager();

--- a/packages/sandbox/daemon/process/task-manager.ts
+++ b/packages/sandbox/daemon/process/task-manager.ts
@@ -13,6 +13,15 @@ const LOG_MAX_BYTES = 10 * 1024 * 1024;
 const DEFAULT_REAP_INTERVAL_MS = 60 * 1000;
 const DEFAULT_TTL_MS = 15 * 60 * 1000;
 const TASK_FILE_PREFIX = "task";
+// Signal name → number, shell `kill -l` convention. Used to map a
+// signal-terminated pipe-mode child to its `128 + signal` exit code.
+const SIGNAL_NUMBERS: Record<string, number> = {
+  SIGHUP: 1,
+  SIGINT: 2,
+  SIGQUIT: 3,
+  SIGKILL: 9,
+  SIGTERM: 15,
+};
 
 export type TaskStatus = "running" | "exited" | "failed" | "killed" | "timeout";
 
@@ -541,12 +550,21 @@ export class TaskManager {
       }, task.spec.timeoutMs);
     }
 
-    child.on("close", (code) => {
+    child.on("close", (code, signal) => {
       if (task.timer) clearTimeout(task.timer);
       // Reap survivors of any backgrounded children.
       killGroup("SIGKILL");
+      // A signal-terminated child (e.g. our own SIGTERM/SIGKILL via
+      // kill()/killByLogName()) reports `code: null` here — mapping that
+      // to `1` collapsed every explicit kill into status "exited" instead
+      // of "killed". Map to the shell convention (128 + signal number),
+      // matching pty mode's shellExitCode, so finalize()'s `> 128` check
+      // classifies it correctly.
+      const exitCode = signal
+        ? 128 + (SIGNAL_NUMBERS[signal] ?? 1)
+        : (code ?? 1);
       this.finalize(task, {
-        exitCode: code ?? 1,
+        exitCode,
         timedOut: task.timedOut,
       });
     });


### PR DESCRIPTION
## Source
Bug found while reading `packages/sandbox/daemon/process/task-manager.ts` (in the recently-churned sandbox daemon area).

## Payoff
Any background bash task (`mode: "pipe"`, used by `/exec` bash and dev-server-style tasks) killed via the `/tasks/:id/kill` endpoint or `killByLogName()` currently reports `status: "exited"` with `exitCode: 1` — indistinguishable from a real crash. `TaskStatus` has a dedicated `"killed"` value for exactly this case, and pty-mode tasks already get it right.

## Root cause / failure scenario
`child.on("close", (code) => ...)` only destructured `code`, discarding the `signal` argument. When a process dies from SIGTERM/SIGKILL, Node reports `code: null`, so `code ?? 1` collapsed every explicit kill into `exitCode: 1` → `status: "exited"`. Pty mode already handles this correctly via `shellExitCode` (maps `signal → 128 + signal`), but pipe mode never did.

Repro (see the new test): spawn a `mode: "pipe"` task, call `taskManager.kill(id, "SIGTERM")`, await `finished()` — before this fix, `result.status` was `"exited"`, not `"killed"`.

## Fix
Capture `signal` in the pipe-mode close handler and map it to the shell `128 + signal` convention (same as pty mode), so `finalize()`'s existing `exitCode > 128` check classifies it as `"killed"`.

## Test
Added `packages/sandbox/daemon/process/task-manager.test.ts` — "reports status 'killed' (not 'exited') for a pipe-mode task killed via kill()". Fails on `main`, passes with this fix.

Reviewer command: `bun test packages/sandbox/daemon/process/task-manager.test.ts`

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` in `packages/sandbox` (clean)
- `bun test packages/sandbox/daemon/process/task-manager.test.ts` (9 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pipe‑mode task status after explicit kills. Tasks terminated via `/tasks/:id/kill`, `TaskManager.kill()`, or `killByLogName()` now report status "killed" instead of "exited".

- **Bug Fixes**
  - Capture the `signal` in the pipe-mode `child.on("close")` handler.
  - Map signal exits to `128 + signal` (SIGHUP, SIGINT, SIGQUIT, SIGKILL, SIGTERM) so existing logic classifies them as "killed" (matching pty mode).
  - Added a test confirming a `mode: "pipe"` task killed with `SIGTERM` resolves with status "killed".

<sup>Written for commit 9a672e149bd2e65de3d55161b1b343e04e92faed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

