### PR TITLE
feat(tabs): standalone Chat/Preview/Blocks/Code tab row

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect, Suspense, lazy } from "react";
 import { createPortal } from "react-dom";
+import { useNavigate } from "@tanstack/react-router";
+import { formatCodeTabId } from "@/web/layouts/main-panel-tabs/tab-id";
+import { consumePreviewTabIntent, setPreviewTabIntent } from "./tab-intent";
 import { useInsetContext } from "@/web/layouts/agent-shell-layout";
-import { Toolbar } from "@/web/layouts/agent-shell-layout/toolbar";
 import { useSecondaryPanel } from "@/web/layouts/agent-shell-layout/secondary-panel-context";
 import { useColumnResize } from "@/web/hooks/use-column-resize";
 import { useChatTask } from "@/web/components/chat/context";
@@ -11,7 +13,6 @@ import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-life
 import {
   ChevronDown,
   Code01,
-  Code02,
   CornerDownLeft,
   CursorClick01,
   DotsHorizontal,
@@ -21,7 +22,6 @@ import {
   Plus,
   SearchLg,
   CreditCardSearch,
-  TextInput,
   Loading01,
   Monitor04,
   Phone02,
@@ -115,16 +115,10 @@ const SeoSheet = lazy(() =>
   })),
 );
 
-const FileExplorer = lazy(() =>
-  import("./file-explorer/file-explorer").then((m) => ({
-    default: m.FileExplorer,
-  })),
-);
-
 /** Delay before reloading the preview iframe after a save, giving the dev server time to pick up file changes. */
 const DEV_SERVER_SETTLE_MS = 500;
 
-type PreviewViewMode = "preview" | "visual" | "cms" | "code";
+type PreviewViewMode = "preview" | "visual" | "cms";
 type PreviewDeviceSize = "mobile" | "tablet" | "desktop";
 
 const PREVIEW_DEVICE_WIDTHS: Record<PreviewDeviceSize, number | null> = {
@@ -220,12 +214,25 @@ function withDeviceHint(url: string, device: PreviewDeviceSize): string {
   return parsed.href;
 }
 
-export function PreviewContent() {
+export function PreviewContent({
+  initialViewMode = "preview",
+}: {
+  initialViewMode?: "preview" | "cms";
+} = {}) {
   const inset = useInsetContext();
+  const navigate = useNavigate();
   const { currentBranch: branch } = useChatTask();
 
+  const goToTab = (main: string) => {
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({ ...prev, main }),
+      replace: true,
+    });
+  };
+
   // Visual editor state
-  const [viewMode, setViewMode] = useState<PreviewViewMode>("preview");
+  const [viewMode, setViewMode] = useState<PreviewViewMode>(initialViewMode);
   const [previewDeviceSize, setPreviewDeviceSize] =
     useState<PreviewDeviceSize>("desktop");
   const [visualElement, setVisualElement] =
@@ -275,8 +282,20 @@ export function PreviewContent() {
   // SEO panel state
   const [cmsInitialEditSeo, setCmsInitialEditSeo] = useState(false);
   const [siteSeoOpen, setSiteSeoOpen] = useState(false);
-  // File deep-link for "View JSON" — opens the page's block file in code mode.
-  const [codeFilePath, setCodeFilePath] = useState<string | null>(null);
+
+  // Consume the one-shot Preview→Blocks intent once on mount: "Edit SEO" from
+  // the Preview tab navigates here (Blocks) and wants the SEO panel open. Uses
+  // a useState guard (not a ref) — the render-time setState pattern used by
+  // `prevIframeBase` below — so it runs exactly once without reading a ref
+  // during render.
+  const [intentConsumed, setIntentConsumed] = useState(false);
+  if (!intentConsumed) {
+    setIntentConsumed(true);
+    const intent = consumePreviewTabIntent();
+    if (intent?.kind === "edit-seo") {
+      setCmsInitialEditSeo(true);
+    }
+  }
 
   const virtualMcpId = inset?.entity?.id ?? null;
   const { org } = useProjectContext();
@@ -640,9 +659,6 @@ export function PreviewContent() {
     const prev = viewMode;
     setViewMode(mode);
     setVisualElement(null);
-    // Leaving code mode clears the "View JSON" deep-link so re-entering code
-    // mode later opens the file tree, not the previously-viewed page JSON.
-    if (mode !== "code") setCodeFilePath(null);
     if (mode !== "cms") {
       setCmsSelectedSectionIndex(null);
       setVariantOverrideParams(null);
@@ -811,7 +827,7 @@ export function PreviewContent() {
         name: result.name,
         path: result.path,
       });
-      handleViewModeChange("cms");
+      goToTab("blocks");
     } catch (error) {
       setCreatePageError(
         error instanceof Error ? error.message : "Failed to create page",
@@ -873,8 +889,7 @@ export function PreviewContent() {
           onExitSeo={() => setCmsInitialEditSeo(false)}
           onViewJsonFile={(pageKey) => {
             try {
-              setCodeFilePath(decoBlockFileViewPath(pageKey));
-              handleViewModeChange("code");
+              goToTab(formatCodeTabId(decoBlockFileViewPath(pageKey)));
             } catch {
               toast.error("Invalid page block key");
             }
@@ -886,460 +901,362 @@ export function PreviewContent() {
 
   return (
     <div className="flex flex-col w-full h-full">
-      {/* View-mode controls live in the app toolbar (next to the chat/compose
-          toggles), portaled up out of this panel. Individual toggle buttons —
-          each flips its mode on, or back to the base `preview` view. Rendered
-          whenever the daemon is up so the user can drop into code after a
-          crash. */}
-      {daemonReady && (
-        <Toolbar.Toggles>
-          {canSectionsEdit && (
-            <Tooltip delayDuration={300}>
-              <TooltipTrigger asChild>
-                <ToolbarIconButton
-                  onClick={() => toggleViewMode("cms")}
-                  aria-pressed={viewMode === "cms"}
-                  aria-label="Sections editor"
-                  active={viewMode === "cms"}
-                >
-                  <TextInput size={16} />
-                </ToolbarIconButton>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Sections editor</TooltipContent>
-            </Tooltip>
-          )}
-          <Tooltip delayDuration={300}>
-            <TooltipTrigger asChild>
-              <ToolbarIconButton
-                onClick={() => toggleViewMode("code")}
-                aria-pressed={viewMode === "code"}
-                aria-label="Code editor"
-                active={viewMode === "code"}
-              >
-                <Code02 size={16} />
-              </ToolbarIconButton>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Code editor</TooltipContent>
-          </Tooltip>
-        </Toolbar.Toggles>
-      )}
-      {daemonReady &&
-        (previewState.kind === "iframe" ||
-          (viewMode === "code" && Boolean(repoDir))) && (
-          <div className="relative flex h-12 shrink-0 items-center gap-4 border-b border-border/60 px-3 md:px-4">
-            {/* Groups 2+3 only render when the iframe is live — they read
+      {daemonReady && previewState.kind === "iframe" && (
+        <div className="relative flex h-12 shrink-0 items-center gap-4 border-b border-border/60 px-3 md:px-4">
+          {/* Groups 2+3 only render when the iframe is live — they read
               `previewState.previewUrl` and steer the iframe directly. */}
-            {previewState.kind === "iframe" && (
-              <div
-                className={cn(
-                  "flex w-full items-center justify-center",
-                  viewMode === "code" && "hidden",
-                )}
-              >
-                {/* Centered address bar (max 500px):
+          {previewState.kind === "iframe" && (
+            <div className="flex w-full items-center justify-center">
+              {/* Centered address bar (max 500px):
                     reload · URL · open in new tab · more actions. */}
-                <div className="flex w-full max-w-[500px] items-center gap-0.5">
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={handleRefresh}
-                      >
-                        <RefreshCw01 size={14} />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">Refresh</TooltipContent>
-                  </Tooltip>
+              <div className="flex w-full max-w-[500px] items-center gap-0.5">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="ghost" size="icon" onClick={handleRefresh}>
+                      <RefreshCw01 size={14} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Refresh</TooltipContent>
+                </Tooltip>
 
-                  <div
-                    ref={pagesContainerRef}
-                    className="relative min-w-0 flex-1"
-                  >
-                    <div className="flex h-8 w-full min-w-0 items-center rounded-md border border-border bg-background transition-colors duration-200 hover:bg-accent">
-                      {/* Not a <button>: path-template pages render `:param`
+                <div
+                  ref={pagesContainerRef}
+                  className="relative min-w-0 flex-1"
+                >
+                  <div className="flex h-8 w-full min-w-0 items-center rounded-md border border-border bg-background transition-colors duration-200 hover:bg-accent">
+                    {/* Not a <button>: path-template pages render `:param`
                         inputs inline, and inputs can't nest inside a button.
                         Keyboard toggling stays on the chevron button. */}
-                      <div
-                        className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-1 pl-2 pr-1"
-                        onClick={() => setPagesOpen((prev) => !prev)}
-                      >
-                        {activeGlobalSection && (
-                          <span className="shrink-0 inline-flex items-center gap-1 rounded bg-global-section/14 px-1.5 py-0.5 text-[11px] font-medium text-global-section-fg dark:text-global-section-fg-dark">
-                            <Globe02 size={11} />
-                            Global
-                          </span>
-                        )}
-                        {/* Page name in focus, followed by the route path.
+                    <div
+                      className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-1 pl-2 pr-1"
+                      onClick={() => setPagesOpen((prev) => !prev)}
+                    >
+                      {activeGlobalSection && (
+                        <span className="shrink-0 inline-flex items-center gap-1 rounded bg-global-section/14 px-1.5 py-0.5 text-[11px] font-medium text-global-section-fg dark:text-global-section-fg-dark">
+                          <Globe02 size={11} />
+                          Global
+                        </span>
+                      )}
+                      {/* Page name in focus, followed by the route path.
                             Path-template segments (`:param`/`*`) stay editable
                             inputs; plain paths render as muted text. */}
-                        <span
-                          className={cn(
-                            "text-[13px] font-medium text-foreground",
-                            // A real page name stays fully visible (the route
-                            // path truncates instead); the host fallback has no
-                            // path segment to shed, so it must truncate itself.
-                            currentPageName == null
-                              ? "min-w-0 flex-1 truncate"
-                              : "shrink-0",
-                          )}
-                        >
-                          {currentPageName ?? previewLabel}
-                        </span>
-                        {!activeGlobalSection &&
-                          currentPageName != null &&
-                          currentPath && (
-                            <span className="flex min-w-0 flex-1 items-center overflow-hidden whitespace-nowrap text-[12px] text-muted-foreground">
-                              {splitPathTemplate(currentPath).map(
-                                (token, i) => {
-                                  if (token.type === "text") {
-                                    return (
-                                      <span
-                                        key={`text-${i}`}
-                                        className={cn(
-                                          i === 0
-                                            ? "min-w-0 truncate"
-                                            : "shrink-0",
-                                        )}
-                                      >
-                                        {token.text}
-                                      </span>
-                                    );
-                                  }
-                                  const pickerKind =
-                                    pathParamPickerKinds[token.name];
-                                  // Params with a picker render as a chip that
-                                  // opens the modal (search or free-form value);
-                                  // the rest keep the inline input.
-                                  if (pickerKind && pickerSandboxRef) {
-                                    return (
-                                      <PathParamPickerChip
-                                        key={`${currentPageKey}:${token.name}`}
-                                        kind={pickerKind}
-                                        paramName={token.name}
-                                        value={
-                                          pathParamValues[token.name] ?? ""
-                                        }
-                                        sandboxRef={pickerSandboxRef}
-                                        onCommit={(value) =>
-                                          setPathParamValue(token.name, value)
-                                        }
-                                      />
-                                    );
-                                  }
-                                  return (
-                                    <PathParamInput
-                                      key={`${currentPageKey}:${token.name}`}
-                                      name={token.name}
-                                      value={pathParamValues[token.name] ?? ""}
-                                      onCommit={(value) =>
-                                        setPathParamValue(token.name, value)
-                                      }
-                                    />
-                                  );
-                                },
-                              )}
-                            </span>
-                          )}
-                      </div>
-                      <button
-                        type="button"
-                        className="flex h-full shrink-0 items-center pl-1 pr-2"
-                        onClick={() => setPagesOpen((prev) => !prev)}
-                        aria-label="Choose page"
-                      >
-                        <ChevronDown
-                          size={12}
-                          className={cn(
-                            "shrink-0 text-muted-foreground transition-transform",
-                            pagesOpen && "rotate-180",
-                          )}
-                        />
-                      </button>
-                    </div>
-
-                    {pagesOpen && (
-                      <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-lg border bg-popover shadow-lg">
-                        <div className="px-2 h-10 flex items-center gap-2 border-b">
-                          <SearchLg
-                            size={14}
-                            className="shrink-0 text-muted-foreground"
-                            aria-hidden
-                          />
-                          <input
-                            type="text"
-                            value={pagesSearch}
-                            onChange={(e) => setPagesSearch(e.target.value)}
-                            placeholder="Search pages and components..."
-                            className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-                            autoFocus
-                          />
-                        </div>
-                        <div className="p-1.5 border-b">
-                          <button
-                            type="button"
-                            className="flex w-full items-center gap-2.5 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-                            onMouseDown={(e) => {
-                              e.preventDefault();
-                              setPagesOpen(false);
-                              setPagesSearch("");
-                              setCreatePageError(undefined);
-                              setCreatePageDialogOpen(true);
-                            }}
-                          >
-                            <Plus
-                              size={16}
-                              className="shrink-0 text-muted-foreground"
-                            />
-                            <span className="flex-1 font-medium">
-                              Create new page
-                            </span>
-                          </button>
-                        </div>
-                        {filteredPages.length === 0 &&
-                        filteredGlobalSections.length === 0 ? (
-                          <div className="px-4 py-5 text-center text-xs text-muted-foreground">
-                            {pages.length === 0 && globalSections.length === 0
-                              ? "No pages found in this site."
-                              : "No results match your search."}
-                          </div>
-                        ) : (
-                          <div className="max-h-80 overflow-y-auto overscroll-contain">
-                            {filteredPages.length > 0 && (
-                              <div className="p-1.5">
-                                {filteredPages.map((page) => (
-                                  <button
-                                    key={page.key}
-                                    type="button"
-                                    className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-                                    onMouseDown={(e) => {
-                                      e.preventDefault();
-                                      setPagesOpen(false);
-                                      setPagesSearch("");
-                                      navigatePreviewToPage(page);
-                                    }}
-                                  >
-                                    <LayoutAlt01
-                                      size={16}
-                                      className="shrink-0 text-muted-foreground"
-                                    />
-                                    <span className="min-w-0 flex-1 truncate font-medium">
-                                      {page.name}
-                                    </span>
-                                    <span className="shrink-0 text-xs text-muted-foreground">
-                                      {page.path}
-                                    </span>
-                                  </button>
-                                ))}
-                              </div>
-                            )}
-                            {filteredGlobalSections.length > 0 && (
-                              <div
-                                className={cn(
-                                  "p-1.5",
-                                  filteredPages.length > 0 && "border-t",
-                                )}
-                              >
-                                <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
-                                  Global components
-                                </div>
-                                {filteredGlobalSections.map((section) => (
-                                  <button
-                                    key={section.key}
-                                    type="button"
-                                    className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-                                    onMouseDown={(e) => {
-                                      e.preventDefault();
-                                      setPagesOpen(false);
-                                      setPagesSearch("");
-                                      navigatePreviewToGlobalSection(section);
-                                    }}
-                                  >
-                                    <Globe02
-                                      size={16}
-                                      className="shrink-0 text-muted-foreground"
-                                    />
-                                    <span className="min-w-0 flex-1 truncate font-medium">
-                                      {section.name}
-                                    </span>
-                                    <span className="shrink-0 text-xs text-muted-foreground">
-                                      {section.resolveType
-                                        .split("/")
-                                        .pop()
-                                        ?.replace(/\.tsx?$/, "")}
-                                    </span>
-                                  </button>
-                                ))}
-                              </div>
-                            )}
-                          </div>
+                      <span
+                        className={cn(
+                          "text-[13px] font-medium text-foreground",
+                          // A real page name stays fully visible (the route
+                          // path truncates instead); the host fallback has no
+                          // path segment to shed, so it must truncate itself.
+                          currentPageName == null
+                            ? "min-w-0 flex-1 truncate"
+                            : "shrink-0",
                         )}
-                      </div>
-                    )}
+                      >
+                        {currentPageName ?? previewLabel}
+                      </span>
+                      {!activeGlobalSection &&
+                        currentPageName != null &&
+                        currentPath && (
+                          <span className="flex min-w-0 flex-1 items-center overflow-hidden whitespace-nowrap text-[12px] text-muted-foreground">
+                            {splitPathTemplate(currentPath).map((token, i) => {
+                              if (token.type === "text") {
+                                return (
+                                  <span
+                                    key={`text-${i}`}
+                                    className={cn(
+                                      i === 0 ? "min-w-0 truncate" : "shrink-0",
+                                    )}
+                                  >
+                                    {token.text}
+                                  </span>
+                                );
+                              }
+                              const pickerKind =
+                                pathParamPickerKinds[token.name];
+                              // Params with a picker render as a chip that
+                              // opens the modal (search or free-form value);
+                              // the rest keep the inline input.
+                              if (pickerKind && pickerSandboxRef) {
+                                return (
+                                  <PathParamPickerChip
+                                    key={`${currentPageKey}:${token.name}`}
+                                    kind={pickerKind}
+                                    paramName={token.name}
+                                    value={pathParamValues[token.name] ?? ""}
+                                    sandboxRef={pickerSandboxRef}
+                                    onCommit={(value) =>
+                                      setPathParamValue(token.name, value)
+                                    }
+                                  />
+                                );
+                              }
+                              return (
+                                <PathParamInput
+                                  key={`${currentPageKey}:${token.name}`}
+                                  name={token.name}
+                                  value={pathParamValues[token.name] ?? ""}
+                                  onCommit={(value) =>
+                                    setPathParamValue(token.name, value)
+                                  }
+                                />
+                              );
+                            })}
+                          </span>
+                        )}
+                    </div>
+                    <button
+                      type="button"
+                      className="flex h-full shrink-0 items-center pl-1 pr-2"
+                      onClick={() => setPagesOpen((prev) => !prev)}
+                      aria-label="Choose page"
+                    >
+                      <ChevronDown
+                        size={12}
+                        className={cn(
+                          "shrink-0 text-muted-foreground transition-transform",
+                          pagesOpen && "rotate-180",
+                        )}
+                      />
+                    </button>
                   </div>
 
-                  {/* open in new tab · more actions */}
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => {
-                          const url = iframeSrc ?? previewState.previewUrl;
-                          if (url) window.open(url, "_blank", "noopener");
-                        }}
-                      >
-                        <LinkExternal01 size={14} />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      Open in new tab
-                    </TooltipContent>
-                  </Tooltip>
-                  {/* more actions — pinned to the right of the header,
+                  {pagesOpen && (
+                    <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-lg border bg-popover shadow-lg">
+                      <div className="px-2 h-10 flex items-center gap-2 border-b">
+                        <SearchLg
+                          size={14}
+                          className="shrink-0 text-muted-foreground"
+                          aria-hidden
+                        />
+                        <input
+                          type="text"
+                          value={pagesSearch}
+                          onChange={(e) => setPagesSearch(e.target.value)}
+                          placeholder="Search pages and components..."
+                          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                          autoFocus
+                        />
+                      </div>
+                      <div className="p-1.5 border-b">
+                        <button
+                          type="button"
+                          className="flex w-full items-center gap-2.5 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                          onMouseDown={(e) => {
+                            e.preventDefault();
+                            setPagesOpen(false);
+                            setPagesSearch("");
+                            setCreatePageError(undefined);
+                            setCreatePageDialogOpen(true);
+                          }}
+                        >
+                          <Plus
+                            size={16}
+                            className="shrink-0 text-muted-foreground"
+                          />
+                          <span className="flex-1 font-medium">
+                            Create new page
+                          </span>
+                        </button>
+                      </div>
+                      {filteredPages.length === 0 &&
+                      filteredGlobalSections.length === 0 ? (
+                        <div className="px-4 py-5 text-center text-xs text-muted-foreground">
+                          {pages.length === 0 && globalSections.length === 0
+                            ? "No pages found in this site."
+                            : "No results match your search."}
+                        </div>
+                      ) : (
+                        <div className="max-h-80 overflow-y-auto overscroll-contain">
+                          {filteredPages.length > 0 && (
+                            <div className="p-1.5">
+                              {filteredPages.map((page) => (
+                                <button
+                                  key={page.key}
+                                  type="button"
+                                  className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                                  onMouseDown={(e) => {
+                                    e.preventDefault();
+                                    setPagesOpen(false);
+                                    setPagesSearch("");
+                                    navigatePreviewToPage(page);
+                                  }}
+                                >
+                                  <LayoutAlt01
+                                    size={16}
+                                    className="shrink-0 text-muted-foreground"
+                                  />
+                                  <span className="min-w-0 flex-1 truncate font-medium">
+                                    {page.name}
+                                  </span>
+                                  <span className="shrink-0 text-xs text-muted-foreground">
+                                    {page.path}
+                                  </span>
+                                </button>
+                              ))}
+                            </div>
+                          )}
+                          {filteredGlobalSections.length > 0 && (
+                            <div
+                              className={cn(
+                                "p-1.5",
+                                filteredPages.length > 0 && "border-t",
+                              )}
+                            >
+                              <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
+                                Global components
+                              </div>
+                              {filteredGlobalSections.map((section) => (
+                                <button
+                                  key={section.key}
+                                  type="button"
+                                  className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                                  onMouseDown={(e) => {
+                                    e.preventDefault();
+                                    setPagesOpen(false);
+                                    setPagesSearch("");
+                                    navigatePreviewToGlobalSection(section);
+                                  }}
+                                >
+                                  <Globe02
+                                    size={16}
+                                    className="shrink-0 text-muted-foreground"
+                                  />
+                                  <span className="min-w-0 flex-1 truncate font-medium">
+                                    {section.name}
+                                  </span>
+                                  <span className="shrink-0 text-xs text-muted-foreground">
+                                    {section.resolveType
+                                      .split("/")
+                                      .pop()
+                                      ?.replace(/\.tsx?$/, "")}
+                                  </span>
+                                </button>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                {/* open in new tab · more actions */}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => {
+                        const url = iframeSrc ?? previewState.previewUrl;
+                        if (url) window.open(url, "_blank", "noopener");
+                      }}
+                    >
+                      <LinkExternal01 size={14} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Open in new tab</TooltipContent>
+                </Tooltip>
+                {/* more actions — pinned to the right of the header,
                       outside the centered address bar. */}
-                  <div className="absolute inset-y-0 right-3 flex items-center md:right-4">
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon">
-                          <DotsHorizontal size={14} />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end" className="w-44">
-                        <DropdownMenuItem onClick={handleHardReload}>
-                          Hard Reload
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={handleCopyUrl}>
-                          Copy Current URL
-                        </DropdownMenuItem>
-                        {decofile && meta && (
-                          <>
-                            <DropdownMenuSeparator />
-                            {currentPageKey && (
-                              <DropdownMenuItem
-                                onClick={() => {
-                                  setCmsInitialEditSeo(true);
-                                  handleViewModeChange("cms");
-                                }}
-                              >
-                                <CreditCardSearch size={14} />
-                                Edit SEO
-                              </DropdownMenuItem>
-                            )}
-                            {currentPageKey && (
-                              <DropdownMenuItem
-                                onClick={() => {
-                                  try {
-                                    setCodeFilePath(
-                                      decoBlockFileViewPath(currentPageKey),
-                                    );
-                                    handleViewModeChange("code");
-                                  } catch {
-                                    toast.error("Invalid page block key");
-                                  }
-                                }}
-                              >
-                                <Code01 size={14} />
-                                View JSON
-                              </DropdownMenuItem>
-                            )}
+                <div className="absolute inset-y-0 right-3 flex items-center md:right-4">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon">
+                        <DotsHorizontal size={14} />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-44">
+                      <DropdownMenuItem onClick={handleHardReload}>
+                        Hard Reload
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={handleCopyUrl}>
+                        Copy Current URL
+                      </DropdownMenuItem>
+                      {decofile && meta && (
+                        <>
+                          <DropdownMenuSeparator />
+                          {currentPageKey && (
                             <DropdownMenuItem
-                              onClick={() => setSiteSeoOpen(true)}
+                              onClick={() => {
+                                setPreviewTabIntent({
+                                  kind: "edit-seo",
+                                  pageKey: currentPageKey,
+                                });
+                                goToTab("blocks");
+                              }}
                             >
                               <CreditCardSearch size={14} />
-                              Site SEO
+                              Edit SEO
                             </DropdownMenuItem>
-                          </>
-                        )}
-                        {repoDir && (
-                          <>
-                            <DropdownMenuSeparator />
+                          )}
+                          {currentPageKey && (
                             <DropdownMenuItem
-                              onClick={() =>
-                                window.open(
-                                  `vscode://file${repoDir}?windowId=_blank`,
-                                )
-                              }
+                              onClick={() => {
+                                try {
+                                  goToTab(
+                                    formatCodeTabId(
+                                      decoBlockFileViewPath(currentPageKey),
+                                    ),
+                                  );
+                                } catch {
+                                  toast.error("Invalid page block key");
+                                }
+                              }}
                             >
-                              <img
-                                src={VSCODE_ICON_URL}
-                                alt="VSCode"
-                                width={14}
-                                height={14}
-                              />
-                              Open in VSCode
+                              <Code01 size={14} />
+                              View JSON
                             </DropdownMenuItem>
-                            <DropdownMenuItem
-                              onClick={() =>
-                                window.open(
-                                  `cursor://file${repoDir}?windowId=_blank`,
-                                )
-                              }
-                            >
-                              <img
-                                src={CURSOR_ICON_URL}
-                                alt="Cursor"
-                                width={14}
-                                height={14}
-                              />
-                              Open in Cursor
-                            </DropdownMenuItem>
-                          </>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
+                          )}
+                          <DropdownMenuItem
+                            onClick={() => setSiteSeoOpen(true)}
+                          >
+                            <CreditCardSearch size={14} />
+                            Site SEO
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                      {repoDir && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onClick={() =>
+                              window.open(
+                                `vscode://file${repoDir}?windowId=_blank`,
+                              )
+                            }
+                          >
+                            <img
+                              src={VSCODE_ICON_URL}
+                              alt="VSCode"
+                              width={14}
+                              height={14}
+                            />
+                            Open in VSCode
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() =>
+                              window.open(
+                                `cursor://file${repoDir}?windowId=_blank`,
+                              )
+                            }
+                          >
+                            <img
+                              src={CURSOR_ICON_URL}
+                              alt="Cursor"
+                              width={14}
+                              height={14}
+                            />
+                            Open in Cursor
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
               </div>
-            )}
-
-            {/* IDE buttons — visible only in code mode, right-aligned */}
-            {viewMode === "code" && repoDir && (
-              <div className="ml-auto flex shrink-0 items-center gap-0.5">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label="Open in VSCode"
-                      onClick={() =>
-                        window.open(`vscode://file${repoDir}?windowId=_blank`)
-                      }
-                    >
-                      <img
-                        src={VSCODE_ICON_URL}
-                        alt="VSCode"
-                        width={14}
-                        height={14}
-                      />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Open in VSCode</TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label="Open in Cursor"
-                      onClick={() =>
-                        window.open(`cursor://file${repoDir}?windowId=_blank`)
-                      }
-                    >
-                      <img
-                        src={CURSOR_ICON_URL}
-                        alt="Cursor"
-                        width={14}
-                        height={14}
-                      />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Open in Cursor</TooltipContent>
-                </Tooltip>
-              </div>
-            )}
-          </div>
-        )}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Desktop: portal the Sections editor into the shared secondary column
           beside the preview ([Chat | CMS | Preview]). */}
@@ -1370,7 +1287,6 @@ export function PreviewContent() {
             "flex-1 relative overflow-hidden",
             previewDeviceSize !== "desktop" &&
               previewState.kind === "iframe" &&
-              viewMode !== "code" &&
               "flex justify-center bg-muted/30",
           )}
         >
@@ -1416,7 +1332,7 @@ export function PreviewContent() {
 
           {/* Floating preview controls — a centered pill at the bottom of the
               preview (Visual editor toggle + device switcher), à la Lovable. */}
-          {canVisualEdit && viewMode !== "code" && (
+          {canVisualEdit && (
             <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2">
               <div className="flex items-center gap-0.5 rounded-full border bg-background/90 p-1 shadow-lg backdrop-blur-sm">
                 <Tooltip>
@@ -1461,43 +1377,17 @@ export function PreviewContent() {
               </div>
             </div>
           )}
-          {/* File explorer (code mode). Gated on daemon-ready, NOT on the
-              dev server: the daemon's FS endpoints (/read, /glob, …) keep
-              serving even when the dev script has crashed, so the user can
-              still browse files to debug a `start-failed`. */}
-          {viewMode === "code" && daemonReady && virtualMcpId && branch && (
-            <div className="absolute inset-0 z-10 bg-background">
-              <Suspense
-                fallback={
-                  <div className="h-full flex items-center justify-center">
-                    <Loading01
-                      size={20}
-                      className="animate-spin text-muted-foreground"
-                    />
-                  </div>
-                }
-              >
-                <FileExplorer
-                  orgSlug={org.slug}
-                  virtualMcpId={virtualMcpId}
-                  branch={branch}
-                  openPath={codeFilePath}
-                />
-              </Suspense>
-            </div>
-          )}
 
           {previewState.kind === "iframe" && iframeSrc && (
             <div
               className={cn(
                 "h-full transition-[width] duration-250 [transition-timing-function:var(--ease-in-out-cubic)]",
                 previewDeviceSize !== "desktop" &&
-                  viewMode !== "code" &&
                   "w-full max-w-full border-x border-border bg-background shadow-sm",
               )}
               style={{
                 width:
-                  previewDeviceSize === "desktop" || viewMode === "code"
+                  previewDeviceSize === "desktop"
                     ? "100%"
                     : `${PREVIEW_DEVICE_WIDTHS[previewDeviceSize]}px`,
               }}
@@ -1508,10 +1398,7 @@ export function PreviewContent() {
                 key={previewState.previewUrl}
                 ref={previewIframeRef}
                 src={iframeSrc}
-                className={cn(
-                  "w-full h-full border-0",
-                  viewMode === "code" && "invisible",
-                )}
+                className="w-full h-full border-0"
                 title="Dev Server Preview"
                 tabIndex={sectionsOpen ? -1 : undefined}
                 onLoad={() => {

--- a/apps/mesh/src/web/components/sandbox/preview/tab-intent.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/tab-intent.ts
@@ -1,0 +1,19 @@
+/**
+ * One-shot handoff for actions that originate in the Preview tab but must be
+ * applied by the freshly-mounted Blocks tab (a separate PreviewContent mount).
+ * Set right before navigating to `?main=blocks`; consumed once on mount.
+ */
+export type PreviewTabIntent = { kind: "edit-seo"; pageKey: string } | null;
+
+let pending: PreviewTabIntent = null;
+
+export function setPreviewTabIntent(intent: PreviewTabIntent): void {
+  pending = intent;
+}
+
+/** Returns the pending intent and clears it (one-shot). */
+export function consumePreviewTabIntent(): PreviewTabIntent {
+  const intent = pending;
+  pending = null;
+  return intent;
+}

--- a/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
@@ -37,16 +37,22 @@ export function ToggleButtons({
       aria-label="Chat"
       className={cn(
         // Chat is the leftmost item of the tab cluster (before Preview/Blocks/
-        // Code), rendered via the toggles portal at the front of the tab group.
-        "wco-no-drag inline-flex h-10 md:h-7 shrink-0 items-center gap-1.5 rounded-md px-2 text-sm transition-colors",
+        // Code). Match HeaderTabButton's metrics (h-8, gap, padding, icon +
+        // label sizing) so it lines up pixel-for-pixel with the tabs; keep the
+        // taller h-10 touch target on mobile.
+        "wco-no-drag inline-flex h-10 md:h-8 shrink-0 items-center gap-1.5 rounded-md px-2 transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50",
         chatOpen
           ? "bg-sidebar-accent text-sidebar-foreground"
           : "text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground",
       )}
     >
-      <MessageCircle01 size={16} />
-      <span>Chat</span>
+      <span className="flex size-5 items-center justify-center shrink-0">
+        <MessageCircle01 size={16} />
+      </span>
+      <span className="whitespace-nowrap text-sm font-medium leading-none">
+        Chat
+      </span>
     </button>
   );
 }

--- a/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
@@ -1,5 +1,5 @@
 import { MessageCircle01 } from "@untitledui/icons";
-import { cn } from "@deco/ui/lib/utils.ts";
+import { HeaderTabButton } from "@/web/layouts/main-panel-tabs/header-tab-button";
 import { track } from "@/web/lib/posthog-client";
 
 export interface ToggleButtonsProps {
@@ -13,8 +13,11 @@ export interface ToggleButtonsProps {
 }
 
 /**
- * Top-toolbar chat toggle. (The New task action lives in the sidebar toolbar,
- * next to the thread list.)
+ * Top-toolbar chat toggle. Renders through the shared HeaderTabButton so it
+ * stays pixel-identical to the Preview/Blocks/Code tabs (same height, icon and
+ * label metrics, active/hover styling) — the only extras are the PWA titlebar
+ * drag opt-out and a taller mobile touch target. (The New task action lives in
+ * the sidebar toolbar, next to the thread list.)
  */
 export function ToggleButtons({
   chatOpen,
@@ -22,37 +25,19 @@ export function ToggleButtons({
   disableChatToggle = false,
 }: ToggleButtonsProps) {
   return (
-    <button
-      type="button"
+    <HeaderTabButton
+      title="Chat"
+      icon={{ kind: "component", Component: MessageCircle01 }}
+      active={chatOpen}
+      disabled={disableChatToggle}
+      className="wco-no-drag h-10 md:h-8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50"
       onClick={() => {
-        if (disableChatToggle) return;
         track("agent_toolbar_toggled", {
           button: "chat",
           next_state: !chatOpen ? "open" : "closed",
         });
         toggleChat();
       }}
-      disabled={disableChatToggle}
-      aria-pressed={chatOpen}
-      aria-label="Chat"
-      className={cn(
-        // Chat is the leftmost item of the tab cluster (before Preview/Blocks/
-        // Code). Match HeaderTabButton's metrics (h-8, gap, padding, icon +
-        // label sizing) so it lines up pixel-for-pixel with the tabs; keep the
-        // taller h-10 touch target on mobile.
-        "wco-no-drag inline-flex h-10 md:h-8 shrink-0 items-center gap-1.5 rounded-md px-2 transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50",
-        chatOpen
-          ? "bg-sidebar-accent text-sidebar-foreground"
-          : "text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground",
-      )}
-    >
-      <span className="flex size-5 items-center justify-center shrink-0">
-        <MessageCircle01 size={16} />
-      </span>
-      <span className="whitespace-nowrap text-sm font-medium leading-none">
-        Chat
-      </span>
-    </button>
+    />
   );
 }

--- a/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
@@ -36,9 +36,9 @@ export function ToggleButtons({
       aria-pressed={chatOpen}
       aria-label="Chat"
       className={cn(
-        // Chat shares the toggles portal with the preview view-mode buttons
-        // (sections / code) — force it to the far right regardless of mount order.
-        "order-last wco-no-drag inline-flex h-10 md:h-7 shrink-0 items-center gap-1.5 rounded-md px-2 text-sm transition-colors",
+        // Chat is the leftmost item of the tab cluster (before Preview/Blocks/
+        // Code), rendered via the toggles portal at the front of the tab group.
+        "wco-no-drag inline-flex h-10 md:h-7 shrink-0 items-center gap-1.5 rounded-md px-2 text-sm transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50",
         chatOpen
           ? "bg-sidebar-accent text-sidebar-foreground"

--- a/apps/mesh/src/web/layouts/main-panel-tabs/code-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/code-tab.tsx
@@ -1,0 +1,134 @@
+/**
+ * CodeTab — standalone file-explorer main-panel tab (`?main=code` /
+ * `?main=code:<encoded path>`).
+ *
+ * Unlike the Preview/Blocks tabs it needs no live dev-server iframe: it talks
+ * to the sandbox daemon's FS endpoints directly, so it keeps working even when
+ * the dev script has crashed. Renders the IDE (VSCode/Cursor) affordances when
+ * a user-desktop sandbox exposes a local repo directory.
+ */
+
+import { Suspense, lazy } from "react";
+import { Loading01 } from "@untitledui/icons";
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { useInsetContext } from "@/web/layouts/agent-shell-layout";
+import { useChatTask } from "@/web/components/chat/context";
+import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
+import { useSandboxRepoDir } from "@/web/components/sandbox/hooks/use-sandbox-repo-dir";
+import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events";
+
+const VSCODE_ICON_URL =
+  "https://decoims.com/decocms/01b321bd-4613-4b2c-9348-35058444d210/Visual_Studio_Code_1.35_icon.svg.png";
+const CURSOR_ICON_URL =
+  "https://decoims.com/decocms/7583d3b5-81d0-4afb-becf-6a59bbb3a68e/cursor-logo-icon-freelogovectors.net_.png";
+
+const FileExplorer = lazy(() =>
+  import("@/web/components/sandbox/preview/file-explorer/file-explorer").then(
+    (m) => ({ default: m.FileExplorer }),
+  ),
+);
+
+export function CodeTab({ openPath }: { openPath: string | null }) {
+  const inset = useInsetContext();
+  const { org } = useProjectContext();
+  const { currentBranch: branch } = useChatTask();
+  const virtualMcpId = inset?.entity?.id ?? null;
+
+  const lifecycle = useSandboxLifecycle();
+  const vmEvents = useSandboxEvents();
+  const vmEntry = lifecycle.vmEntry;
+  const devServerReady = vmEvents.lifecycle.phase === "running";
+
+  const isDesktopSandbox = vmEntry?.sandboxProviderKind === "user-desktop";
+  const rawRepoDir = useSandboxRepoDir({
+    orgSlug: org.slug,
+    virtualMcpId: virtualMcpId ?? "",
+    branch: branch ?? "",
+    enabled: isDesktopSandbox && devServerReady && !!virtualMcpId && !!branch,
+  });
+  const repoDir = isDesktopSandbox ? rawRepoDir : null;
+
+  if (!virtualMcpId || !branch) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+        No sandbox to browse.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col w-full h-full">
+      {repoDir && (
+        <div className="relative flex h-12 shrink-0 items-center border-b border-border/60 px-3 md:px-4">
+          <div className="ml-auto flex shrink-0 items-center gap-0.5">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Open in VSCode"
+                  onClick={() =>
+                    window.open(`vscode://file${repoDir}?windowId=_blank`)
+                  }
+                >
+                  <img
+                    src={VSCODE_ICON_URL}
+                    alt="VSCode"
+                    width={14}
+                    height={14}
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Open in VSCode</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Open in Cursor"
+                  onClick={() =>
+                    window.open(`cursor://file${repoDir}?windowId=_blank`)
+                  }
+                >
+                  <img
+                    src={CURSOR_ICON_URL}
+                    alt="Cursor"
+                    width={14}
+                    height={14}
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Open in Cursor</TooltipContent>
+            </Tooltip>
+          </div>
+        </div>
+      )}
+      <div className="flex-1 relative overflow-hidden bg-background">
+        <Suspense
+          fallback={
+            <div className="h-full flex items-center justify-center">
+              <Loading01
+                size={20}
+                className="animate-spin text-muted-foreground"
+              />
+            </div>
+          }
+        >
+          <FileExplorer
+            orgSlug={org.slug}
+            virtualMcpId={virtualMcpId}
+            branch={branch}
+            openPath={openPath}
+          />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/header-tab-button.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/header-tab-button.tsx
@@ -17,16 +17,25 @@ export function HeaderTabButton({
   icon,
   active,
   onClick,
+  disabled = false,
+  className,
 }: {
   title: string;
   icon: TabIcon;
   active: boolean;
   onClick: () => void;
+  /** Disables the button (e.g. the Chat toggle when it's the only panel). */
+  disabled?: boolean;
+  /** Extra classes merged onto the base metrics — lets non-tab consumers
+   *  (the Chat toggle) tweak height / drag behaviour while staying pixel-
+   *  identical to the tabs. */
+  className?: string;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       aria-pressed={active}
       aria-label={title}
       className={cn(
@@ -35,6 +44,7 @@ export function HeaderTabButton({
         active
           ? "bg-sidebar-accent text-sidebar-foreground"
           : "text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground",
+        className,
       )}
     >
       <span className="flex size-5 items-center justify-center shrink-0">

--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -13,6 +13,7 @@ import { useMainPanelTabs } from "./use-main-panel-tabs";
 import { SettingsTab } from "./settings-tab";
 import { GitTab } from "@/web/components/thread/github/git-tab";
 import { PreviewTab } from "./preview-tab";
+import { CodeTab } from "./code-tab";
 import { ContentTab } from "./content-tab";
 import { AutomationTab } from "./automation-tab";
 import { AutomationsListTab } from "./automations-list-tab";
@@ -23,6 +24,7 @@ import { LibraryTab } from "./library-tab";
 import { MainPanelLoading } from "./main-panel-loading";
 import {
   isLegacySettingsTab,
+  parseCodeTabId,
   parseDeckTabId,
   parseFileTabId,
   parseLibraryFileTabId,
@@ -77,6 +79,13 @@ function TabBody({
   }
   if (activeTab === "preview") {
     return <PreviewTab virtualMcpId={virtualMcpId} />;
+  }
+  if (activeTab === "blocks") {
+    return <PreviewTab virtualMcpId={virtualMcpId} initialViewMode="cms" />;
+  }
+  const codeTab = parseCodeTabId(activeTab);
+  if (codeTab) {
+    return <CodeTab openPath={codeTab.path} />;
   }
   if (activeTab === "content") {
     return <ContentTab virtualMcpId={virtualMcpId} />;

--- a/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
@@ -3,7 +3,13 @@ import { agentHasClonableSource } from "@/web/lib/agent-capabilities";
 import { useVirtualMCP } from "@decocms/mesh-sdk";
 import { AlertCircle } from "@untitledui/icons";
 
-export function PreviewTab({ virtualMcpId }: { virtualMcpId: string }) {
+export function PreviewTab({
+  virtualMcpId,
+  initialViewMode = "preview",
+}: {
+  virtualMcpId: string;
+  initialViewMode?: "preview" | "cms";
+}) {
   const entity = useVirtualMCP(virtualMcpId);
   const hasClonableSource = agentHasClonableSource(entity?.metadata);
 
@@ -20,5 +26,5 @@ export function PreviewTab({ virtualMcpId }: { virtualMcpId: string }) {
     );
   }
 
-  return <PreviewContent />;
+  return <PreviewContent initialViewMode={initialViewMode} />;
 }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/resolve-tab-icon.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/resolve-tab-icon.test.ts
@@ -10,6 +10,25 @@ describe("SYSTEM_TAB_ICONS", () => {
     expect(SYSTEM_TAB_ICONS.automations).toBe(Lightning01);
     expect(SYSTEM_TAB_ICONS.preview).toBeDefined();
     expect(SYSTEM_TAB_ICONS.git).toBeDefined();
+    expect(SYSTEM_TAB_ICONS.blocks).toBeDefined();
+    expect(SYSTEM_TAB_ICONS.code).toBeDefined();
+  });
+});
+
+describe("blocks/code system icons", () => {
+  test("resolve to component icons", () => {
+    const blocks = resolveTabIcon({
+      kind: "system",
+      tabId: "blocks",
+      connections: [],
+    });
+    const code = resolveTabIcon({
+      kind: "system",
+      tabId: "code",
+      connections: [],
+    });
+    expect(blocks.kind).toBe("component");
+    expect(code.kind).toBe("component");
   });
 });
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/resolve-tab-icon.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/resolve-tab-icon.ts
@@ -1,11 +1,13 @@
 import type { ComponentType, SVGProps } from "react";
 import {
+  Code02,
   Edit05,
   Folder,
   GitBranch01,
   Globe01,
   LayoutAlt04,
   Lightning01,
+  TextInput,
 } from "@untitledui/icons";
 import { getIconComponent, parseIconString } from "../../components/agent-icon";
 
@@ -22,6 +24,8 @@ export type SystemTabId =
   | "settings"
   | "automations"
   | "preview"
+  | "blocks"
+  | "code"
   | "content"
   | "git"
   | "files";
@@ -30,6 +34,8 @@ export const SYSTEM_TAB_ICONS: Record<SystemTabId, IconComponent> = {
   settings: LayoutAlt04,
   automations: Lightning01,
   preview: Globe01,
+  blocks: TextInput,
+  code: Code02,
   content: Edit05,
   git: GitBranch01,
   files: Folder,

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+  FIXED_SYSTEM_TABS,
+  formatCodeTabId,
   formatDeckTabId,
   formatFileTabId,
   formatLibraryFileTabId,
+  parseCodeTabId,
   isLegacySettingsTab,
   isPerThreadTab,
   parseAutomationTabId,
@@ -421,5 +424,30 @@ describe("resolveAutomationsPillClickTarget", () => {
         mainOpen: true,
       }),
     ).toBe("automations");
+  });
+});
+
+describe("code tab id", () => {
+  test("includes blocks and code in the fixed system tabs", () => {
+    expect(FIXED_SYSTEM_TABS).toContain("blocks");
+    expect(FIXED_SYSTEM_TABS).toContain("code");
+  });
+
+  test("parses the bare code id as a null path", () => {
+    expect(parseCodeTabId("code")).toEqual({ path: null });
+  });
+
+  test("round-trips a code path with slashes", () => {
+    const id = formatCodeTabId(".deco/blocks/pages-Home.json");
+    expect(id).toBe("code:.deco%2Fblocks%2Fpages-Home.json");
+    expect(parseCodeTabId(id)).toEqual({
+      path: ".deco/blocks/pages-Home.json",
+    });
+  });
+
+  test("returns null for non-code ids", () => {
+    expect(parseCodeTabId("preview")).toBeNull();
+    expect(parseCodeTabId(undefined)).toBeNull();
+    expect(parseCodeTabId("codex")).toBeNull();
   });
 });

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
@@ -144,10 +144,38 @@ export function parseLibraryFileTabId(
   }
 }
 
+export interface CodeTabParsed {
+  /** File to open in the code tab, or null for the bare file-tree view. */
+  path: string | null;
+}
+
+/** Paths carry `/`, so the tab id encodes them to keep the
+ *  `<kind>:<rest>` grammar unambiguous in the `?main=` URL param. */
+export function formatCodeTabId(path: string): string {
+  return `code:${encodeURIComponent(path)}`;
+}
+
+export function parseCodeTabId(
+  tabId: string | undefined,
+): CodeTabParsed | null {
+  if (!tabId) return null;
+  if (tabId === "code") return { path: null };
+  if (!tabId.startsWith("code:")) return null;
+  const encoded = tabId.slice("code:".length);
+  if (!encoded) return null;
+  try {
+    return { path: decodeURIComponent(encoded) };
+  } catch {
+    return null;
+  }
+}
+
 export const FIXED_SYSTEM_TABS = [
   "settings",
   "automations",
   "preview",
+  "blocks",
+  "code",
   "content",
   "git",
 ] as const;

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -298,12 +298,23 @@ export function useMainPanelTabs(ctx: {
   // into a single detail view. On GitHub-linked vMCPs the contextual
   // work tabs (Preview, git) come first so they're closest to the panel;
   // Settings + Automations stay anchored at the right.
-  const systemTabs: Array<{ id: string; title: string }> = [];
+  // Leading work tabs, rendered first in the bar (right after the Chat toggle):
+  // Preview · Blocks · Code. Blocks (Sections editor) needs a live preview
+  // iframe to inject its CMS overlays; Code (file tree) only needs a clonable
+  // source — the daemon serves files even when the dev script has crashed.
+  const showBlocksTab = hasClonableSource && devServerReady && showContentTab;
+  const showCodeTab = hasClonableSource;
+  const leadingSystemTabs: Array<{ id: string; title: string }> = [];
   if (hasClonableSource) {
-    systemTabs.push({ id: "preview", title: "Preview" });
-    if (showContentTab) {
-      systemTabs.push({ id: "content", title: "Content" });
-    }
+    leadingSystemTabs.push({ id: "preview", title: "Preview" });
+    if (showBlocksTab)
+      leadingSystemTabs.push({ id: "blocks", title: "Blocks" });
+    if (showCodeTab) leadingSystemTabs.push({ id: "code", title: "Code" });
+  }
+
+  const systemTabs: Array<{ id: string; title: string }> = [];
+  if (hasClonableSource && showContentTab) {
+    systemTabs.push({ id: "content", title: "Content" });
   }
   if (gitTabVisible) {
     systemTabs.push({ id: "git", title: "Review changes" });
@@ -421,6 +432,16 @@ export function useMainPanelTabs(ctx: {
     : [];
 
   const tabs: Tab[] = [
+    ...leadingSystemTabs.map((t) => ({
+      id: t.id,
+      title: t.title,
+      kind: "system" as const,
+      icon: resolveTabIcon({
+        tabId: t.id,
+        kind: "system",
+        connections,
+      }),
+    })),
     ...fileTabs,
     ...deckTabs,
     ...libraryFileTabs,
@@ -476,7 +497,7 @@ export function useMainPanelTabs(ctx: {
     activeTab,
     mainOpen,
     setActiveTab,
-    systemTabs,
+    systemTabs: [...leadingSystemTabs, ...systemTabs],
     layoutTabs,
     expandedTools,
     automationTabParsed,

--- a/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/org-shell-layout/index.tsx
@@ -79,11 +79,11 @@ export default function OrgShellLayout() {
                   </Toolbar.LeftColumn>
                   <Toolbar.CenterSlot />
                   <Toolbar.RightColumn>
-                    <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] flex justify-end">
+                    <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] flex justify-end items-center gap-0.5">
+                      <Toolbar.TogglesSlot />
                       <Toolbar.TabsSlot />
                     </div>
                     <Toolbar.RightSlot />
-                    <Toolbar.TogglesSlot />
                   </Toolbar.RightColumn>
                 </Toolbar.Header>
               )}


### PR DESCRIPTION
## Summary

Restructures the agent-shell work-surface controls into one consistent tab row and promotes **Blocks** (Sections editor) and **Code** (file explorer) from icon-only in-panel toggles to first-class standalone main-panel tabs.

**Header order is now** (left→right within the tab cluster): `Chat · Preview · Blocks · Code · Content · …`

- **Chat** moved from far-right (`order-last`) to the leftmost item of the tab cluster.
- **Blocks** and **Code** now render as `HeaderTabButton`s (icon + label, same active/hover styling as Preview) instead of bare `ToolbarIconButton`s.
- **Code** (`?main=code`) is a standalone `CodeTab` — `FileExplorer` + IDE buttons, no preview iframe. "View JSON" (dropdown + sections editor) deep-links via a `code:<path>` tab id.
- **Blocks** (`?main=blocks`) mounts the Preview panel seeded to CMS mode; "Edit SEO" / create-page route here (one-shot intent carried via a small `tab-intent` module).
- Visual editor pill is unchanged.

Approach **B**: Preview/Blocks/Code are separate, independently-mounted tab bodies. Tradeoff: switching **Preview ↔ Blocks** briefly reloads the preview iframe (Blocks needs the live iframe for its CMS overlays). Code needs no iframe.

## Affected areas

Tab system (`main-panel-tabs/*`), preview panel (`sandbox/preview/preview.tsx` + new `tab-intent.ts` / `code-tab.tsx`), and header layout (`org-shell-layout`, `toggle-buttons`).

## Testing

- `bun run check` ✅ (all workspaces, 0 errors)
- `bun run lint` ✅ (0 errors; pre-existing warnings only)
- `bun test apps/mesh/src/web/layouts/main-panel-tabs/` ✅ (81 pass) — new unit tests for `code:` tab-id parsing and blocks/code icons
- `bun run fmt` ✅

**Not done:** live-UI verification in a browser (dev server needs a persistent process unavailable in the working environment). Worth a manual pass on tab ordering and the Preview↔Blocks iframe reload before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes Blocks (Sections editor) and Code (file explorer) to first-class main-panel tabs and unifies the header into a single tab row with Chat at the front. Adds deep-linking from Preview to open files directly in Code and a one-shot intent to open SEO in Blocks.

- **New Features**
  - New tab order: Chat · Preview · Blocks · Code · Content · …
  - `CodeTab` (standalone): file explorer + VSCode/Cursor buttons; open via `?main=code` or `?main=code:<encoded-path>` (`formatCodeTabId`).
  - `PreviewTab` supports CMS mode for `?main=blocks`; "Edit SEO" uses a one-shot intent to open SEO when navigating from Preview.
  - "View JSON" from Preview deep-links to Code using `formatCodeTabId`.
  - Blocks shows when the dev server is ready; Code shows whenever the source is clonable.
  - Chat toggle now renders through the shared `HeaderTabButton` for pixel-perfect alignment with the tab row. Blocks/Code have dedicated system icons.

- **Migration**
  - Removed in-panel Sections/Code toggles and Preview’s code mode; use the new tabs instead.
  - Switching Preview ↔ Blocks remounts the preview iframe and may briefly reload.
  - Please verify tab order and the Edit SEO/View JSON flows in a browser.

<sup>Written for commit 1948d20a3a95cd817149f38e56c2a11156e4df3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

