### PR TITLE
fix(sandbox): flag single-task kill()/killAll() as intentional

### DIFF
--- a/packages/sandbox/daemon/process/task-manager.test.ts
+++ b/packages/sandbox/daemon/process/task-manager.test.ts
@@ -56,6 +56,33 @@ describe("TaskManager kill status", () => {
     expect(result.status).toBe("killed");
     expect(tm.get(t.id)?.status).toBe("killed");
   });
+
+  it("flags intentional=true for a single-task kill() (the Stop-by-id route) — a dev-script task stopped this way must not be misread as a crash", async () => {
+    const tm = makeManager();
+    const t = await tm.spawn({
+      command: "sleep 30",
+      cwd: "/tmp",
+      mode: "pipe",
+      logName: "dev",
+    });
+    const finished = tm.finished(t.id)!;
+    tm.kill(t.id, "SIGTERM");
+    await finished;
+    expect(tm.get(t.id)?.intentional).toBe(true);
+  });
+
+  it("flags intentional=true on every task stopped via killAll()", async () => {
+    const tm = makeManager();
+    const t = await tm.spawn({
+      command: "sleep 30",
+      cwd: "/tmp",
+      mode: "pipe",
+    });
+    const finished = tm.finished(t.id)!;
+    tm.killAll();
+    await finished;
+    expect(tm.get(t.id)?.intentional).toBe(true);
+  });
 });
 
 describe("TaskManager replaceByLogName", () => {

--- a/packages/sandbox/daemon/process/task-manager.ts
+++ b/packages/sandbox/daemon/process/task-manager.ts
@@ -272,6 +272,11 @@ export class TaskManager {
     const t = this.tasks.get(id);
     if (!t) return false;
     if (t.status !== "running") return false;
+    // The only caller is the single-task Stop route — always a deliberate
+    // user stop, never an internal/automatic kill. Flag it so a WELL_KNOWN_STARTERS
+    // (dev script) task stopped this way isn't misread by the orchestrator's
+    // onTaskExit as a crash (see task-manager's `intentional` field docs).
+    t.intentional = true;
     t.kill(signal);
     setTimeout(() => {
       if (t.status === "running") {
@@ -303,6 +308,7 @@ export class TaskManager {
     let count = 0;
     for (const t of this.tasks.values()) {
       if (t.status === "running") {
+        t.intentional = true;
         t.kill("SIGTERM");
         count++;
       }


### PR DESCRIPTION
## Source
A bug found reading `packages/sandbox/daemon/process/task-manager.ts` (in the recently-changed hunting ground).

## The bug
`TaskManager.kill(id, signal)` (backs `POST /_sandbox/tasks/:id/kill`) and `killAll()` (backs `POST /_sandbox/tasks/kill-all`) never set `task.intentional = true`, unlike `killByLogName({ intentional: true })` (backs `POST /_sandbox/exec/:name/kill`, the dev-server Stop button). The `intentional` field's own docs say it should cover "orchestrator-driven stop, replace-by-logName, **or user Stop**" — but the generic single-task/kill-all Stop routes are the only callers of `kill()`/`killAll()`, so every call through them is exactly that "user Stop" case, and it was never flagged.

## Failure scenario
`SetupOrchestrator`'s `onTaskExit` handler (`setup/orchestrator.ts:81-106`) treats any non-intentional exit of a `WELL_KNOWN_STARTERS` task (the dev script) as a crash: it sets `status: "error"` and transitions the lifecycle to `start-failed`, which surfaces as a stuck error banner requiring manual retry. If a dev-script task is stopped via the generic `/tasks/:id/kill` or `/tasks/kill-all` routes instead of the dev-server-specific `/exec/:name/kill` route, this deliberate stop gets misclassified as a crash.

## Fix
Set `t.intentional = true` in both `kill()` and `killAll()`, matching the existing `killByLogName` behavior.

## Regression test
Added two tests to `task-manager.test.ts` asserting `intentional === true` after `kill()` and after `killAll()` — both fail on the old code (flag stays `undefined`/`false`) and pass with the fix.

## Verification
- `bun test packages/sandbox/daemon/process/task-manager.test.ts` — 11 pass, 0 fail (including the 2 new tests)
- `cd packages/sandbox && bunx tsc --noEmit` — clean
- `bun run fmt` — clean

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flagged `TaskManager.kill()` and `killAll()` as intentional stops so user-initiated stops aren’t misread as crashes. Aligns behavior with `killByLogName()` and fixes erroneous error states in the orchestrator.

- **Bug Fixes**
  - Set `t.intentional = true` in `kill()` and `killAll()` (routes: `POST /_sandbox/tasks/:id/kill`, `POST /_sandbox/tasks/kill-all`) to prevent dev-script tasks from being marked as crashed by the orchestrator.
  - Added tests to `packages/sandbox/daemon/process/task-manager.test.ts` to assert `intentional === true` after `kill()` and `killAll()`.

<sup>Written for commit 27a300e75df2bbed75b01169ba8e06890c99e132. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

