### PR TITLE
fix(sandbox): escalate kill-all to SIGKILL when a task ignores SIGTERM

### DIFF
--- a/packages/sandbox/daemon/process/task-manager.test.ts
+++ b/packages/sandbox/daemon/process/task-manager.test.ts
@@ -1,3 +1,4 @@
+import { sleep } from "@decocms/std";
 import { describe, expect, it } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -55,6 +56,28 @@ describe("TaskManager kill status", () => {
     const result = await finished;
     expect(result.status).toBe("killed");
     expect(tm.get(t.id)?.status).toBe("killed");
+  });
+});
+
+describe("TaskManager killAll", () => {
+  it("escalates to SIGKILL when a task ignores SIGTERM", async () => {
+    const tm = makeManager();
+    const t = await tm.spawn({
+      // A busy-loop builtin (no subprocess) that traps and ignores SIGTERM —
+      // only SIGKILL can end it, unlike `sleep`, which dies on TERM by default
+      // regardless of a shell trap around it.
+      command: "trap '' TERM; while true; do :; done",
+      cwd: "/tmp",
+      mode: "pipe",
+    });
+    const finished = tm.finished(t.id)!;
+    // Give the shell time to install the trap before signaling it — otherwise
+    // SIGTERM can race the trap and land while TERM is still fatal.
+    await sleep(300);
+    const count = tm.killAll();
+    expect(count).toBe(1);
+    const result = await finished;
+    expect(result.status).toBe("killed");
   });
 });
 

--- a/packages/sandbox/daemon/process/task-manager.ts
+++ b/packages/sandbox/daemon/process/task-manager.ts
@@ -304,6 +304,9 @@ export class TaskManager {
     for (const t of this.tasks.values()) {
       if (t.status === "running") {
         t.kill("SIGTERM");
+        setTimeout(() => {
+          if (t.status === "running") t.kill("SIGKILL");
+        }, 3000);
         count++;
       }
     }


### PR DESCRIPTION
## Summary
- Bug found while reading `packages/sandbox/daemon/process/task-manager.ts` (recent churn area).
- `TaskManager.kill()` and `killByLogName()` both escalate to `SIGKILL` after 3s if the task is still running post-`SIGTERM`, but `killAll()` only sent a bare `SIGTERM` with no follow-up. A task whose process ignores/traps `TERM` (a stuck subprocess, a shell that traps `TERM`) would survive a `POST /_sandbox/tasks/kill-all` call forever instead of being force-killed like every other kill path.
- Payoff: the "kill everything" endpoint is meant to be the reliable last-resort stop; without escalation it silently fails for exactly the processes it exists to handle (ones that don't respond to a polite signal).

## Failure scenario + regression test
Added `packages/sandbox/daemon/process/task-manager.test.ts`: spawns a task running `trap '' TERM; while true; do :; done` (a busy-loop shell that ignores TERM), calls `killAll()`, and asserts it ends up `killed`. On current `main` this test times out (5s) because the task never dies; with the fix it passes in ~3s (a `SIGKILL` fires after the 3s grace period).

## How to verify
```
bun test packages/sandbox/daemon/process/task-manager.test.ts
```

## Checks run locally
- `bun test packages/sandbox/daemon/process/task-manager.test.ts` — 10 pass
- `cd packages/sandbox && bun run check` (tsc --noEmit) — clean
- `bun run fmt` — clean

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escalates `TaskManager.killAll()` to send `SIGKILL` after 3s if a task ignores `SIGTERM`, matching other kill paths. This makes POST `/_sandbox/tasks/kill-all` reliably stop stuck or TERM-trapping tasks.

- **Bug Fixes**
  - In `packages/sandbox/daemon/process/task-manager.ts`, follow `SIGTERM` with `SIGKILL` after 3s when a task is still running.
  - Added a regression test in `packages/sandbox/daemon/process/task-manager.test.ts` that spawns a shell loop trapping `TERM` and asserts `killAll()` results in `killed`.

<sup>Written for commit 340a8778551d8052bccf217071fa7984be0b312d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

