### PR TITLE
fix(sandbox): resolve default branch before init+fetch clone fallback

### DIFF
--- a/packages/sandbox/daemon/setup/clone.test.ts
+++ b/packages/sandbox/daemon/setup/clone.test.ts
@@ -379,4 +379,27 @@ describe("spawnClone", () => {
       cleanup();
     }
   }, 30_000);
+
+  it("lands on the default branch (not detached HEAD) via init+fetch when no branch is requested", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = join(root, "workspace");
+      mkdirSync(repoDir);
+      // Same pre-populated-dir scenario as above, but with no branch
+      // requested — this must still land on a real local branch (`main`),
+      // matching what a plain `git clone` (no --branch) does, not a
+      // detached FETCH_HEAD checkout.
+      writeFileSync(join(repoDir, "marker.txt"), "preexisting\n");
+      const { code } = await spawnClone({
+        config: makeConfig(repoDir, url),
+        askpassPath: ASKPASS,
+        onChunk: () => {},
+      });
+      expect(code).toBe(0);
+      expect(currentBranch(repoDir)).toBe("main");
+      expect(existsSync(join(repoDir, "marker.txt"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
 });

--- a/packages/sandbox/daemon/setup/clone.ts
+++ b/packages/sandbox/daemon/setup/clone.ts
@@ -357,8 +357,27 @@ export async function spawnClone(deps: CloneDeps): Promise<CloneResult> {
       const code = await runStep(step, deps);
       if (code !== 0) return { code };
     }
-    const fetchRef = branchOnRemote
-      ? `+refs/heads/${branchOnRemote}:refs/remotes/origin/${branchOnRemote}`
+    // When no branch was requested (and none needs forking locally), `git
+    // clone` would land on the remote's default branch as a real local
+    // branch. Mirror that here by resolving the default branch name first —
+    // otherwise `checkout FETCH_HEAD` below leaves the working tree in
+    // detached HEAD, unlike the normal clone path (see clone.test.ts).
+    let defaultBranch: string | null = null;
+    if (!branchOnRemote && !branchToForkLocally) {
+      const { code: symrefCode, output } = await runNetworkStepCapture(
+        git(["ls-remote", "--symref", cloneUrl, "HEAD"], askpassPath),
+        deps,
+      );
+      const resolved =
+        symrefCode === 0
+          ? (output.match(/ref:\s+refs\/heads\/(\S+)\s+HEAD/)?.[1] ?? null)
+          : null;
+      if (resolved && isValidRemoteBranchName(resolved))
+        defaultBranch = resolved;
+    }
+    const branchToTrack = branchOnRemote ?? defaultBranch;
+    const fetchRef = branchToTrack
+      ? `+refs/heads/${branchToTrack}:refs/remotes/origin/${branchToTrack}`
       : "HEAD";
     const fetchCode = await runNetworkStep(
       git(["fetch", "--depth", "1", "origin", fetchRef], askpassPath, {
@@ -374,14 +393,14 @@ export async function spawnClone(deps: CloneDeps): Promise<CloneResult> {
     // overwritten"). Force lets the committed branch content win; only files
     // that collide with tracked paths are overwritten — `.decocms/daemon.json`
     // (not tracked on the branch) is left in place.
-    const checkoutCmd = branchOnRemote
+    const checkoutCmd = branchToTrack
       ? git(
           [
             "checkout",
             "-f",
             "-B",
-            branchOnRemote,
-            `refs/remotes/origin/${branchOnRemote}`,
+            branchToTrack,
+            `refs/remotes/origin/${branchToTrack}`,
           ],
           askpassPath,
           { cwd: dir },
@@ -401,7 +420,7 @@ export async function spawnClone(deps: CloneDeps): Promise<CloneResult> {
     }
     return {
       code: 0,
-      ...(branchOnRemote ? { fetchBase: deferBaseFetch(branchOnRemote) } : {}),
+      ...(branchToTrack ? { fetchBase: deferBaseFetch(branchToTrack) } : {}),
     };
   }
 


### PR DESCRIPTION
## Source
Bug found reading `packages/sandbox/daemon/setup/clone.ts` (top of the recently-churned-files list for this repo).

## The bug
`spawnClone` has two ways to acquire a repo working tree:
1. Normal path: `git clone` — lands on the remote's default branch as a real local branch.
2. Fallback path (`isNonEmptyWithoutGit`): used when `repoDir` already has files but no `.git` (the daemon can write `.decocms/daemon.json` into `repoDir` before the first clone). This does `git init` + `git fetch origin HEAD` + `git checkout -f FETCH_HEAD`.

When no branch is explicitly requested, path 2's `checkout FETCH_HEAD` leaves the working tree in **detached HEAD** instead of on a real local branch (e.g. `main`) — unlike path 1. Any code assuming a checked-out branch (branch-divergence header, later commits/pushes, PR creation) sees a broken/`HEAD` branch name in this specific but real scenario.

Repro (fails on current `main`, passes after the fix):
```
bun test packages/sandbox/daemon/setup/clone.test.ts -t "lands on the default branch"
```

## Fix
In the init+fetch fallback, when no branch was requested (and none needs forking locally), resolve the remote's default branch name via `ls-remote --symref` (same technique already used by `fetchBaseBranch`), then fetch + checkout onto that named local branch instead of detached `FETCH_HEAD` — matching what `git clone` does by default.

## Verification
- `bun run fmt`
- `cd packages/sandbox && bun x tsc --noEmit` (clean)
- `bun test packages/sandbox/daemon/setup/clone.test.ts` — 13/13 pass, including the new regression test
- Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the init+fetch clone fallback so sandboxes land on the remote’s default branch as a real local branch, not detached HEAD, when no branch is requested. This matches `git clone` behavior and avoids broken `HEAD` branch names in later operations.

- **Bug Fixes**
  - In `packages/sandbox/daemon/setup/clone.ts`, `spawnClone` resolves the default branch via `git ls-remote --symref` and fetches/checks out `refs/remotes/origin/<branch>` with `-B <branch>` instead of using `FETCH_HEAD`.
  - Added a regression test in `packages/sandbox/daemon/setup/clone.test.ts` to verify the fallback lands on `main` and preserves preexisting files.

<sup>Written for commit fd456ca8aa5242019d5aea81c6e69ee40874fa20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

