### PR TITLE
refactor(sandbox): consolidate duplicated SIGTERM->SIGKILL escalation in TaskManager

### DIFF
--- a/packages/sandbox/daemon/process/task-manager.ts
+++ b/packages/sandbox/daemon/process/task-manager.ts
@@ -172,10 +172,7 @@ export class TaskManager {
       for (const t of this.tasks.values()) {
         if (t.status !== "running" || t.spec.logName !== spec.logName) continue;
         t.intentional = true;
-        t.kill("SIGTERM");
-        setTimeout(() => {
-          if (t.status === "running") t.kill("SIGKILL");
-        }, 3000);
+        this.killWithEscalation(t, "SIGTERM");
         waiters.push(t.finishedPromise);
       }
       if (waiters.length > 0) await Promise.all(waiters);
@@ -277,12 +274,7 @@ export class TaskManager {
     // (dev script) task stopped this way isn't misread by the orchestrator's
     // onTaskExit as a crash (see task-manager's `intentional` field docs).
     t.intentional = true;
-    t.kill(signal);
-    setTimeout(() => {
-      if (t.status === "running") {
-        t.kill("SIGKILL");
-      }
-    }, 3000);
+    this.killWithEscalation(t, signal);
     return true;
   }
 
@@ -295,10 +287,7 @@ export class TaskManager {
     for (const t of this.tasks.values()) {
       if (t.status !== "running" || t.spec.logName !== logName) continue;
       if (opts?.intentional) t.intentional = true;
-      t.kill(signal);
-      setTimeout(() => {
-        if (t.status === "running") t.kill("SIGKILL");
-      }, 3000);
+      this.killWithEscalation(t, signal);
       count++;
     }
     return count;
@@ -309,14 +298,20 @@ export class TaskManager {
     for (const t of this.tasks.values()) {
       if (t.status === "running") {
         t.intentional = true;
-        t.kill("SIGTERM");
-        setTimeout(() => {
-          if (t.status === "running") t.kill("SIGKILL");
-        }, 3000);
+        this.killWithEscalation(t, "SIGTERM");
         count++;
       }
     }
     return count;
+  }
+
+  /** Signal a task, then escalate to SIGKILL after 3s if it's still running
+   *  (a stuck subprocess or a shell with a trap can ignore the first signal). */
+  private killWithEscalation(t: TaskInternal, signal: NodeJS.Signals): void {
+    t.kill(signal);
+    setTimeout(() => {
+      if (t.status === "running") t.kill("SIGKILL");
+    }, 3000);
   }
 
   delete(id: string): boolean {


### PR DESCRIPTION
## Summary
- `TaskManager` had the same "signal, then escalate to SIGKILL after 3s if still running" block copy-pasted 4 times: `spawn()`'s replaceByLogName path, `kill()`, `killByLogName()`, and `killAll()` (the last of those escalation blocks was added just now in #4516). Each copy is 3-6 lines of identical `setTimeout`/status-check logic.
- Collapsed all 4 into one private `killWithEscalation(t, signal)` helper. No behavior change — same 3000ms delay, same running-status guard, same signal passed through.
- Net: -18 / +13 lines in one file, one concern.

## Verification
- `bun run fmt` — clean
- `cd packages/sandbox && bunx tsc --noEmit` — clean
- `bun test packages/sandbox/daemon/process/task-manager.test.ts` — 12 pass / 0 fail, including the "escalates to SIGKILL when a task ignores SIGTERM" integration test that actually spawns a SIGTERM-trapping process and asserts on the real escalation path.

Reviewer can confirm with the same test command above. Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated the SIGTERM→SIGKILL escalation logic in `TaskManager` into a single helper to reduce duplication and keep shutdown behavior consistent. No behavior change; still escalates to `SIGKILL` after 3s if a task is still running.

- **Refactors**
  - Added private `killWithEscalation(t, signal)` to send the signal, then escalate to `SIGKILL` after 3s if needed.
  - Replaced duplicate blocks in spawn’s replace-by-logName path, `kill()`, `killByLogName()`, and `killAll()`.
  - Kept the same 3000ms delay and running-status guard.

<sup>Written for commit 6d235edbc0e875aa7dbdb94192db51c6d9d94d2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

