### PR TITLE
feat(web): repo switcher in sidebar "Add repo"

### DIFF
--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -15,7 +15,10 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
+import {
+  invalidateConnectionQueries,
+  invalidateVirtualMcpQueries,
+} from "@/web/lib/query-keys";
 import {
   useProjectContext,
   useMCPClient,
@@ -435,6 +438,7 @@ function PickerContent({
     onSuccess: ({ virtualMcpId, repo, connectionId, item }) => {
       if (mode === "connection" || !virtualMcpId || !item) {
         invalidateVirtualMcpQueries(queryClient, org.id);
+        invalidateConnectionQueries(queryClient, org.id);
         toast.success(`Added ${repo.name}`);
         onComplete();
         return;

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -26,8 +26,7 @@ import {
   ZapSquare,
 } from "@untitledui/icons";
 import { useState, type ReactNode } from "react";
-import { GitHubIcon } from "@/web/components/icons/github-icon";
-import { GitHubRepoPicker } from "@/web/components/github-repo-picker";
+import { RepoSwitcher } from "@/web/components/sidebar/footer/repo-switcher";
 import { InviteMemberDialog } from "@/web/components/invite-member-dialog";
 import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
 import { useProjectContext } from "@decocms/mesh-sdk";
@@ -240,7 +239,6 @@ function SettingsIconButton() {
  * rows above the account row.
  */
 function SidebarExtraActions() {
-  const [repoOpen, setRepoOpen] = useState(false);
   const [connectionsOpen, setConnectionsOpen] = useState(false);
   return (
     <>
@@ -256,13 +254,7 @@ function SidebarExtraActions() {
           />
         </SidebarMenuItem>
         <SidebarMenuItem>
-          <SidebarMenuButton
-            tooltip="Add repo"
-            onClick={() => setRepoOpen(true)}
-          >
-            <GitHubIcon />
-            <span>Add repo</span>
-          </SidebarMenuButton>
+          <RepoSwitcher />
         </SidebarMenuItem>
         <SidebarMenuItem>
           <SidebarMenuButton
@@ -274,11 +266,6 @@ function SidebarExtraActions() {
           </SidebarMenuButton>
         </SidebarMenuItem>
       </SidebarMenu>
-      <GitHubRepoPicker
-        open={repoOpen}
-        onOpenChange={setRepoOpen}
-        mode="connection"
-      />
       <AddConnectionDialog
         open={connectionsOpen}
         onOpenChange={setConnectionsOpen}

--- a/apps/mesh/src/web/components/sidebar/footer/repo-switcher.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/repo-switcher.tsx
@@ -1,0 +1,233 @@
+/**
+ * Sidebar "Add repo" entry. Once the org has at least one added repo (an
+ * org-shared repo-scoped GitHub connection), this upgrades from a plain
+ * "add a repo to the org" button into a switcher over those repos.
+ *
+ * Picking a repo depends on which agent is in view:
+ *   - a real custom agent → writes `metadata.githubRepo` on it (a top-level
+ *     shallow merge, so `ui`/`instructions`/`connections` survive) and opens
+ *     its Preview tab in place. The org-shared connection is already injected
+ *     into every agent's toolset, so no connection wiring is needed —
+ *     SANDBOX_START reads `metadata.githubRepo` and boots the sandbox from it.
+ *   - Decopilot (the synthetic default agent, which can't persist a repo) or no
+ *     agent → creates, or reuses, a dedicated agent bound to that repo and
+ *     opens its Preview.
+ */
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import { SidebarMenuButton } from "@deco/ui/components/sidebar.tsx";
+import { Check, Plus } from "@untitledui/icons";
+import { Suspense, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { toast } from "sonner";
+import {
+  isDecopilot,
+  SELF_MCP_ALIAS_ID,
+  useConnections,
+  useMCPClient,
+  useProjectContext,
+  useVirtualMCP,
+  useVirtualMCPs,
+} from "@decocms/mesh-sdk";
+import type { ConnectionEntity } from "@decocms/mesh-sdk";
+import {
+  getRepoScope,
+  isOrgSharedConnection,
+} from "@/shared/github-repo-scope";
+import { GitHubIcon } from "@/web/components/icons/github-icon";
+import { GitHubRepoPicker } from "@/web/components/github-repo-picker";
+import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
+import { invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
+
+type GithubRepoMeta = { owner?: string; name?: string; connectionId?: string };
+
+function AddRepoButton({ onClick }: { onClick: () => void }) {
+  return (
+    <SidebarMenuButton tooltip="Add repo" onClick={onClick}>
+      <GitHubIcon />
+      <span>Add repo</span>
+    </SidebarMenuButton>
+  );
+}
+
+function RepoSwitcherInner({ onAddNew }: { onAddNew: () => void }) {
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const navigateToAgent = useNavigateToAgent();
+  const search = useSearch({ strict: false }) as { virtualmcpid?: string };
+  const currentAgentId = search.virtualmcpid ?? null;
+  // Decopilot is synthetic and can't hold a persisted repo, so treat it (and
+  // the no-agent home) as "create/reuse a repo agent" rather than attach.
+  const isRealAgent = !!currentAgentId && !isDecopilot(currentAgentId);
+
+  const connections = useConnections({ slug: "mcp-github" });
+  const repos = connections.filter(
+    (c) => getRepoScope(c) !== null && isOrgSharedConnection(c),
+  );
+
+  const agents = useVirtualMCPs();
+  const currentAgent = useVirtualMCP(isRealAgent ? currentAgentId : null);
+  const currentRepoConnId =
+    (currentAgent?.metadata?.githubRepo as GithubRepoMeta | undefined)
+      ?.connectionId ?? null;
+
+  const selfClient = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+
+  // Nothing added yet: fall back to the plain "add a repo to the org" flow so
+  // the first repo can still be added from here.
+  if (repos.length === 0) {
+    return <AddRepoButton onClick={onAddNew} />;
+  }
+
+  const attachToCurrent = async (
+    githubRepo: Record<string, unknown>,
+    label: string,
+  ) => {
+    await selfClient.callTool({
+      name: "COLLECTION_VIRTUAL_MCP_UPDATE",
+      arguments: { id: currentAgentId, data: { metadata: { githubRepo } } },
+    });
+    invalidateVirtualMcpQueries(queryClient, org.id);
+    toast.success(`Previewing ${label}`);
+    // ponytail: projectRef is keyed on agent+branch, not repo — switching repos
+    // on an agent with a live sandbox reuses it; tear the sandbox down first if
+    // that turns out to matter.
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({ ...prev, main: "preview" }),
+      replace: true,
+    });
+  };
+
+  const openOrCreateRepoAgent = async (
+    githubRepo: Record<string, unknown> & { owner: string; name: string },
+    connectionId: string,
+    label: string,
+  ) => {
+    const existing = agents.find((a) => {
+      const r = a.metadata?.githubRepo as GithubRepoMeta | undefined;
+      return (
+        r?.owner?.toLowerCase() === githubRepo.owner.toLowerCase() &&
+        r?.name?.toLowerCase() === githubRepo.name.toLowerCase()
+      );
+    });
+    if (existing) {
+      navigateToAgent(existing.id, { search: { main: "preview" } });
+      return;
+    }
+    const result = (await selfClient.callTool({
+      name: "COLLECTION_VIRTUAL_MCP_CREATE",
+      arguments: {
+        data: {
+          title: githubRepo.name,
+          description: `Imported from ${label}`,
+          status: "active",
+          pinned: false,
+          icon: null,
+          connections: [{ connection_id: connectionId }],
+          metadata: {
+            githubRepo,
+            instructions: null,
+            ui: {
+              pinnedViews: null,
+              layout: {
+                defaultMainView: { type: "preview" },
+                chatDefaultOpen: true,
+              },
+            },
+          },
+        },
+      },
+    })) as { structuredContent?: { item?: { id?: string } } };
+    const createdId = result.structuredContent?.item?.id;
+    invalidateVirtualMcpQueries(queryClient, org.id);
+    if (!createdId) throw new Error("Failed to create the repo agent");
+    toast.success(`Created ${label}`);
+    navigateToAgent(createdId, { search: { main: "preview" } });
+  };
+
+  const pick = async (repo: ConnectionEntity) => {
+    const scope = getRepoScope(repo);
+    if (!scope) return;
+    const label = `${scope.owner}/${scope.repo}`;
+    const githubRepo = {
+      owner: scope.owner,
+      name: scope.repo,
+      url: `https://github.com/${scope.owner}/${scope.repo}`,
+      installationId: scope.installationId,
+      connectionId: repo.id,
+    };
+    try {
+      if (isRealAgent) {
+        await attachToCurrent(githubRepo, label);
+      } else {
+        await openOrCreateRepoAgent(githubRepo, repo.id, label);
+      }
+    } catch (err) {
+      toast.error(
+        "Failed to set preview repo: " +
+          (err instanceof Error ? err.message : "Unknown error"),
+      );
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <SidebarMenuButton>
+          <GitHubIcon />
+          <span>Add repo</span>
+        </SidebarMenuButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" side="right" className="w-56">
+        {repos.map((repo) => {
+          const scope = getRepoScope(repo);
+          if (!scope) return null;
+          return (
+            <DropdownMenuItem key={repo.id} onSelect={() => pick(repo)}>
+              <GitHubIcon className="size-4 text-muted-foreground" />
+              <span className="flex-1 truncate">
+                {scope.owner}/{scope.repo}
+              </span>
+              {repo.id === currentRepoConnId && <Check className="size-4" />}
+            </DropdownMenuItem>
+          );
+        })}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onAddNew}>
+          <Plus className="size-4" />
+          Add new repo…
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function RepoSwitcher() {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  return (
+    <>
+      <Suspense
+        fallback={<AddRepoButton onClick={() => setPickerOpen(true)} />}
+      >
+        <RepoSwitcherInner onAddNew={() => setPickerOpen(true)} />
+      </Suspense>
+      <GitHubRepoPicker
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        mode="connection"
+      />
+    </>
+  );
+}

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -534,3 +534,19 @@ export function invalidateVirtualMcpQueries(
     },
   });
 }
+
+export function invalidateConnectionQueries(
+  queryClient: import("@tanstack/react-query").QueryClient,
+  orgId?: string,
+) {
+  queryClient.invalidateQueries({
+    predicate: (query) => {
+      const key = query.queryKey;
+      return (
+        (!orgId || key[1] === orgId) &&
+        key[3] === "collection" &&
+        key[4] === "CONNECTIONS"
+      );
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Turns the sidebar **Add repo** button into a repo switcher once the org has at least one added repo (an org-shared repo-scoped GitHub connection).

- **0 repos** → unchanged: plain "Add repo" opens the add-to-org GitHub picker.
- **≥1 repo** → dropdown of the org's added repos + an **"Add new repo…"** item:
  - **Real custom agent in view** → picking writes `metadata.githubRepo` on that agent (top-level shallow merge, so `ui`/`instructions`/`connections` survive) and opens its Preview tab in place. The org-shared connection is already injected into every agent's toolset, so `SANDBOX_START` boots the sandbox from the repo with no extra connection wiring. The current repo is checkmarked.
  - **Decopilot / no agent** → Decopilot is a synthetic default agent that can't persist a repo (`findById` short-circuits it to a constant), so picking instead **creates — or reuses, matched by owner/name — a dedicated agent** bound to the repo and opens its Preview.

Also fixes a staleness bug: the add-to-org flow only invalidated `VIRTUAL_MCP` queries, so a freshly added repo didn't appear in the switcher. Added `invalidateConnectionQueries` and call it from the picker's connection-mode success path.

## Changes
- `components/sidebar/footer/repo-switcher.tsx` (new) — the adaptive Add repo entry.
- `components/github-repo-picker.tsx` — invalidate `CONNECTIONS` queries after adding a repo.
- `lib/query-keys.ts` — add `invalidateConnectionQueries` (mirrors `invalidateVirtualMcpQueries`).
- `components/sidebar/footer/inbox.tsx` — mount `<RepoSwitcher />`, drop the old item/state/imports.

## Testing
- `bun run check` (apps/mesh), `bun run lint`, `bun run fmt` — clean (no new warnings).
- Manually verified in the running app.

## Notes
- Known limitation (marked with a `ponytail:` comment): switching repos on a real agent that already has a **live** sandbox reuses the same `projectRef` (keyed on agent+branch, not repo) — a fresh clone may need the old sandbox torn down. Left as-is; primary flow is first-attach.
- Making Decopilot *itself* preview a repo was considered but rejected here — it needs a core change to default-agent resolution (materialize + make `findById` merge a DB row) with blast radius across chat/gateway/monitoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns the sidebar "Add repo" button into a repo switcher when the org has at least one repo, making it faster to preview and switch repos. Newly added repos now appear immediately in the switcher.

- **New Features**
  - When the org has ≥1 repo, the button becomes a dropdown with the org’s repos and an “Add new repo…” item.
  - On a real agent, picking a repo saves `metadata.githubRepo` and opens Preview. On Decopilot or no agent, it creates or reuses a repo-bound agent and opens Preview.
  - With 0 repos, the button still opens the GitHub picker.

- **Bug Fixes**
  - Invalidate `CONNECTIONS` queries after adding a repo so it shows up in the switcher right away.

<sup>Written for commit aab59c15a4c9fa2af446bb4ce5d45b38745acda4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

