### PR TITLE
fix(web): reconnect button when GitHub accounts fail to load

### DIFF
--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -23,8 +23,11 @@ import {
   useProjectContext,
   useMCPClient,
   useConnections,
+  useConnectionActions,
   SELF_MCP_ALIAS_ID,
 } from "@decocms/mesh-sdk";
+import { Button } from "@deco/ui/components/button.tsx";
+import { authenticateAndPersistOAuth } from "@/web/lib/authenticate-and-persist-oauth";
 import type { ConnectionEntity } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
 import { toast } from "sonner";
@@ -593,11 +596,51 @@ function InstallationPicker({
     orgId,
     orgSlug,
   });
+  const queryClient = useQueryClient();
+  const connectionActions = useConnectionActions();
 
   const installationsQuery = useQuery({
     queryKey: KEYS.githubUserOrgs(orgId, connectionId),
     queryFn: () =>
       fetchGithubInstallations((req) => selfClient.callTool(req), connectionId),
+  });
+
+  // The load failure is usually an expired/revoked GitHub token. Re-run OAuth
+  // for this connection (authenticateAndPersistOAuth no-ops when the token is
+  // still valid, so it doubles as a plain retry), then refetch.
+  const reconnect = useMutation({
+    mutationFn: async () => {
+      const auth = await authenticateAndPersistOAuth({
+        connectionId,
+        orgId,
+        orgSlug,
+        persistFallback: (token) =>
+          connectionActions.update
+            .mutateAsync({
+              id: connectionId,
+              data: { connection_token: token },
+            })
+            .then(() => undefined),
+      });
+      if (auth.ran && !auth.ok) {
+        throw new Error(auth.error ?? "no token received");
+      }
+      const mcpProxyUrl = new URL(
+        `/api/${orgSlug}/mcp/${connectionId}`,
+        window.location.origin,
+      );
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
+      });
+      await queryClient.invalidateQueries({ queryKey: KEYS.mcpClientPrefix() });
+      await installationsQuery.refetch();
+    },
+    onError: (err) => {
+      toast.error(
+        "Failed to reconnect GitHub: " +
+          (err instanceof Error ? err.message : "Unknown error"),
+      );
+    },
   });
 
   if (installationsQuery.isLoading) {
@@ -610,10 +653,27 @@ function InstallationPicker({
 
   if (installationsQuery.isError) {
     return (
-      <div className="flex-1 flex items-center justify-center">
+      <div className="flex-1 flex flex-col items-center justify-center gap-3 px-6 text-center">
         <p className="text-sm text-destructive">
           Failed to load GitHub accounts
         </p>
+        <p className="text-xs text-muted-foreground max-w-[280px] leading-relaxed">
+          Your GitHub connection may have expired. Reconnect to restore access.
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => reconnect.mutate()}
+          disabled={reconnect.isPending}
+        >
+          {reconnect.isPending ? (
+            <Loading01 size={14} className="animate-spin" />
+          ) : (
+            <GitHubIcon className="size-3.5" />
+          )}
+          Reconnect GitHub
+        </Button>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

When the org's GitHub connection token is expired/revoked, the **Add repo** picker's account list showed a dead-end **"Failed to load GitHub accounts"** message with no way to recover.

This surfaces a **"Reconnect GitHub"** button that re-authenticates the errored connection, reusing the existing OAuth path — `authenticateAndPersistOAuth` (the same helper `useAutoInstallGitHub` and the connection detail view's `handleAuthenticateForId` use). After reconnecting it invalidates the auth (`isMCPAuthenticated`) and MCP-client caches and refetches the account list.

Because `authenticateAndPersistOAuth` no-ops when the token is actually still valid, the same button doubles as a plain retry for transient (non-auth) failures — so a single action covers both cases.

## Changes
- `components/github-repo-picker.tsx` — replace the static error text in `InstallationPicker` with an explanatory message + a "Reconnect GitHub" button backed by a reconnect mutation.

## Testing
- `bun run check` (apps/mesh), `bun run lint`, `bun run fmt` — clean (no new warnings).

## Screenshot context
Repro: `studio-stg.decocms.com`, Decopilot → **Add repo** with an expired GitHub connection → "Failed to load GitHub accounts". Now shows a Reconnect button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Reconnect GitHub" button to the Add repo picker so users can re-auth expired connections and retry loading accounts instead of hitting a dead end. Reuses the existing OAuth flow and refreshes caches to display accounts after reconnect.

- **Bug Fixes**
  - Show a "Reconnect GitHub" button in `InstallationPicker` when account loading fails, with a brief help message.
  - Reuse `authenticateAndPersistOAuth` and persist via `useConnectionActions.update` when needed.
  - Invalidate `isMCPAuthenticated` and MCP client queries, then refetch installations after reconnect.
  - Button also works as a retry for transient errors, with loading state and error toast.

<sup>Written for commit b65474e1f3d56db4cfb836529560ab3e778e2242. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

