### PR TITLE
fix(sandbox): fix TaskSummary.truncated to account for ring-buffer drops

### DIFF
--- a/packages/sandbox/daemon/process/ring-buffer.ts
+++ b/packages/sandbox/daemon/process/ring-buffer.ts
@@ -38,6 +38,10 @@ export class RingBuffer {
     return { data: this.chunks.join(""), truncated: this.dropped };
   }
 
+  isTruncated(): boolean {
+    return this.dropped;
+  }
+
   byteLength(): number {
     return this.size;
   }

--- a/packages/sandbox/daemon/process/task-manager.test.ts
+++ b/packages/sandbox/daemon/process/task-manager.test.ts
@@ -108,6 +108,22 @@ describe("TaskManager killAll", () => {
   });
 });
 
+describe("TaskManager summary truncation", () => {
+  it("flags summary.truncated when output exceeds the ring buffer but not the tee cap", async () => {
+    const tm = makeManager();
+    // Ring buffer caps at 256KB per stream; the on-disk tee caps at 10MB.
+    // 300KB of output overflows the former but not the latter, so
+    // summarize() must reflect the ring buffer's drop, not just the tee's.
+    const t = await tm.spawn({
+      command: "yes | head -c 300000",
+      cwd: "/tmp",
+      mode: "pipe",
+    });
+    await tm.finished(t.id);
+    expect(tm.get(t.id)?.truncated).toBe(true);
+  });
+});
+
 describe("TaskManager replaceByLogName", () => {
   it("kills the running task with the same logName, awaits exit, then spawns", async () => {
     const tm = makeManager();

--- a/packages/sandbox/daemon/process/task-manager.ts
+++ b/packages/sandbox/daemon/process/task-manager.ts
@@ -653,7 +653,8 @@ function summarize(t: TaskInternal): TaskSummary {
     startedAt: t.startedAt,
     finishedAt: t.finishedAt,
     timedOut: t.timedOut,
-    truncated: t.tee.isTruncated(),
+    truncated:
+      t.stdout.isTruncated() || t.stderr.isTruncated() || t.tee.isTruncated(),
     logName: t.spec.logName,
     intentional: t.intentional,
   };


### PR DESCRIPTION
## Source
A real bug found while reading `packages/sandbox/daemon/process/task-manager.ts` (top of the recently-changed-files list, following the recent SIGTERM/SIGKILL escalation refactors in that file).

## Bug
`TaskManager.output(id)` correctly derives `truncated` by OR-ing the two in-memory ring buffers (`stdout`/`stderr`, capped at 256KB each) with the on-disk tee (capped at 10MB):

```ts
truncated: stdout.truncated || stderr.truncated || t.tee.isTruncated(),
```

But `summarize()` — which produces the `TaskSummary` returned by `TaskManager.list()` and embedded in `TaskManager.get()` — only checked the tee:

```ts
truncated: t.tee.isTruncated(),
```

## Failure scenario
A task that emits more than 256KB but less than 10MB of combined stdout/stderr (e.g. a noisy build script) has its ring buffers silently drop early output while the on-disk tee is nowhere near its cap. `GET /_sandbox/tasks` (list endpoint, used to broadcast the active-tasks summary) then reports `truncated: false` even though the buffered output the client would read back is already incomplete. (`GET /_sandbox/tasks/:id` happens to be correct today only because its route handler separately overwrites the field with `output()`'s value — the underlying `TaskSummary.truncated` itself was still wrong.)

## Fix
Added a cheap `RingBuffer.isTruncated()` accessor (mirrors `LogTee.isTruncated()`, avoids joining chunks just to check the flag) and used it in `summarize()` alongside the tee check.

## Regression test
`packages/sandbox/daemon/process/task-manager.test.ts` — spawns a task producing 300KB of output (over the ring-buffer cap, under the tee cap) and asserts `tm.get(t.id)?.truncated` is `true`. Fails on current `main`, passes with the fix.

## Verify
```
bun test packages/sandbox/daemon/process/task-manager.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `packages/sandbox`
- `bun test packages/sandbox/daemon/process/task-manager.test.ts` (13 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `TaskSummary.truncated` in the sandbox to account for ring-buffer drops. Task summaries now report truncation when stdout/stderr exceed the 256KB in-memory buffers, even if the 10MB on-disk tee is not truncated.

- **Bug Fixes**
  - Added `RingBuffer.isTruncated()` to expose drop state.
  - Updated `summarize()` to OR `stdout.isTruncated()`, `stderr.isTruncated()`, and `t.tee.isTruncated()`.
  - Added a regression test emitting ~300KB that asserts `tm.get(id)?.truncated` is `true`.

<sup>Written for commit cbe6d92c63cc16fa61fad23bf36d50f65c46b7ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

