### PR TITLE
refactor(sandbox): dedupe signal-name-to-number map into signal-numbers.ts

### DIFF
--- a/packages/sandbox/daemon/process/pty-spawn.ts
+++ b/packages/sandbox/daemon/process/pty-spawn.ts
@@ -44,6 +44,7 @@ import {
   type StructuredCommand,
 } from "./structured-command";
 import { resolveShell } from "./resolve-shell";
+import { SIGNAL_NUMBERS } from "./signal-numbers";
 
 export { ShellNotFoundError } from "./structured-command";
 
@@ -410,15 +411,7 @@ function spawnFallback(opts: PtySpawnOpts): PtyHandle {
   child.stderr?.on("data", emit);
 
   child.on("exit", (code, signal) => {
-    // Map signal name to number via kill -l convention (best-effort).
-    const sigMap: Record<string, number> = {
-      SIGHUP: 1,
-      SIGINT: 2,
-      SIGQUIT: 3,
-      SIGKILL: 9,
-      SIGTERM: 15,
-    };
-    const sigNum = signal ? (sigMap[signal] ?? 1) : 0;
+    const sigNum = signal ? (SIGNAL_NUMBERS[signal] ?? 1) : 0;
     const exitCode = sigNum > 0 ? 128 + sigNum : (code ?? 0);
     for (const l of exitListeners) l(exitCode);
   });

--- a/packages/sandbox/daemon/process/signal-numbers.ts
+++ b/packages/sandbox/daemon/process/signal-numbers.ts
@@ -1,0 +1,9 @@
+/** Signal name → number, shell `kill -l` convention. Used to map a
+ *  signal-terminated child to its `128 + signal` exit code. */
+export const SIGNAL_NUMBERS: Record<string, number> = {
+  SIGHUP: 1,
+  SIGINT: 2,
+  SIGQUIT: 3,
+  SIGKILL: 9,
+  SIGTERM: 15,
+};

--- a/packages/sandbox/daemon/process/task-manager.ts
+++ b/packages/sandbox/daemon/process/task-manager.ts
@@ -6,6 +6,7 @@ import { LogTee } from "./log-tee";
 import { spawnPty } from "./pty-spawn";
 import { resolveShell } from "./resolve-shell";
 import { RingBuffer } from "./ring-buffer";
+import { SIGNAL_NUMBERS } from "./signal-numbers";
 import type { PhaseManager } from "./phase-manager";
 
 const RING_BUFFER_BYTES = 256 * 1024;
@@ -13,15 +14,6 @@ const LOG_MAX_BYTES = 10 * 1024 * 1024;
 const DEFAULT_REAP_INTERVAL_MS = 60 * 1000;
 const DEFAULT_TTL_MS = 15 * 60 * 1000;
 const TASK_FILE_PREFIX = "task";
-// Signal name → number, shell `kill -l` convention. Used to map a
-// signal-terminated pipe-mode child to its `128 + signal` exit code.
-const SIGNAL_NUMBERS: Record<string, number> = {
-  SIGHUP: 1,
-  SIGINT: 2,
-  SIGQUIT: 3,
-  SIGKILL: 9,
-  SIGTERM: 15,
-};
 
 export type TaskStatus = "running" | "exited" | "failed" | "killed" | "timeout";
 


### PR DESCRIPTION
## Summary
`task-manager.ts` and `pty-spawn.ts`'s `spawnFallback` each hand-rolled the exact same `SIGHUP/SIGINT/SIGQUIT/SIGKILL/SIGTERM` → number map used to compute the `128 + signal` shell exit-code convention. Extracted the map into a new `packages/sandbox/daemon/process/signal-numbers.ts` and imported it from both call sites — net -7 lines (-18/+3 in the two existing files, +8 for the new shared module).

Two independent copies of the same lookup table risk silently drifting apart (e.g. a future signal added to one map but not the other), which would misclassify a task's exit status.

## Why
Source: duplication found while reading `task-manager.ts` (top churned file this run) and its neighbor `pty-spawn.ts`. Behavior-preserving — both maps were byte-identical, so this is a pure extract-and-import with no logic change.

## Test plan
- [x] `bun run fmt`
- [x] `cd packages/sandbox && bun x tsc --noEmit` (clean)
- [x] `bun test packages/sandbox/daemon/process/task-manager.test.ts` — 13 pass
- [x] `bun test packages/sandbox/daemon/process/pty-spawn.test.ts` — 3 pass

Reviewer can confirm with the same two test commands above. Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated the signal name-to-number map into `packages/sandbox/daemon/process/signal-numbers.ts` and reused it in `task-manager.ts` and `pty-spawn.ts` to standardize the 128+signal exit-code calculation. No behavior change; reduces duplication and drift risk.

- **Refactors**
  - Added shared `SIGNAL_NUMBERS` in `signal-numbers.ts` (`kill -l` convention).
  - Replaced inline maps in `task-manager.ts` and `pty-spawn.ts` with the shared export.

<sup>Written for commit f5bf616e94b33f7a1a29e5ab7338ab0182e02765. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

