### PR TITLE
feat(harness): raise agent-loop step limits to 60/30

### DIFF
--- a/packages/harness/src/decopilot/prompt-constants.ts
+++ b/packages/harness/src/decopilot/prompt-constants.ts
@@ -2,12 +2,12 @@ import type { GithubRepo } from "@decocms/mesh-sdk";
 export { DEFAULT_THREAD_TITLE } from "../thread-title";
 
 export const DEFAULT_WINDOW_SIZE = 50;
-export const PARENT_STEP_LIMIT = 30;
+export const PARENT_STEP_LIMIT = 60;
 
 /** Step budget for a delegated `subtask`/subagent run. Lives here (a `@/*`-free
  *  harnesses leaf) so the portable core + the daemon (Task 18 desktop subtask)
  *  can bundle it; re-exported from the route constants for the cluster. */
-export const SUBAGENT_STEP_LIMIT = 15;
+export const SUBAGENT_STEP_LIMIT = 30;
 
 export function buildBasePlatformPrompt(): string {
   return `<platform>


### PR DESCRIPTION
## Summary
Raises the default agent-loop step caps so runs continue longer before the AI SDK returns `finishReason: "tool-calls"` and the UI shows the "Response paused after tool execution…" (Response incomplete) banner.

- `PARENT_STEP_LIMIT`: 30 → 60
- `SUBAGENT_STEP_LIMIT`: 15 → 30

These feed `runAgentLoop`'s `stopWhen: stepCountIs(...)` in `apps/mesh/src/harnesses/decopilot/run-agent-loop.ts` via the `kind === "agent"` vs subagent fallback.

## Notes
- Only changes the **defaults**. Automations/monitors passing explicit `maxAgentSteps` (e.g. `monitor-run-start.ts` `?? 15`) still override and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the default agent-loop step limits so runs continue longer before pausing on tool calls, reducing the “Response paused after tool execution…” banner. Explicit `maxAgentSteps` overrides are unchanged.

- **New Features**
  - Parent step limit: 60 (was 30)
  - Subagent step limit: 30 (was 15)

<sup>Written for commit e928f8aef4a970416352aa8352fd80eefbd723eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

