### PR TITLE
feat(web): align Blocks tab with Preview availability

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview-surface.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-surface.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { canToggleVisualEditor, viewModeForSurface } from "./preview-surface";
+
+describe("preview surface", () => {
+  test("Preview owns preview mode and its visual editor toggle", () => {
+    expect(viewModeForSurface("preview", "preview")).toBe("preview");
+    expect(viewModeForSurface("preview", "visual")).toBe("visual");
+    expect(canToggleVisualEditor("preview")).toBe(true);
+  });
+
+  test("Blocks owns CMS mode and cannot toggle into Preview", () => {
+    expect(viewModeForSurface("blocks", "preview")).toBe("cms");
+    expect(viewModeForSurface("blocks", "visual")).toBe("cms");
+    expect(canToggleVisualEditor("blocks")).toBe(false);
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/preview/preview-surface.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-surface.ts
@@ -1,0 +1,14 @@
+export type PreviewSurface = "preview" | "blocks";
+export type PreviewInteractiveViewMode = "preview" | "visual";
+export type PreviewViewMode = PreviewInteractiveViewMode | "cms";
+
+export function viewModeForSurface(
+  surface: PreviewSurface,
+  interactiveViewMode: PreviewInteractiveViewMode,
+): PreviewViewMode {
+  return surface === "blocks" ? "cms" : interactiveViewMode;
+}
+
+export function canToggleVisualEditor(surface: PreviewSurface): boolean {
+  return surface === "preview";
+}

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -76,6 +76,13 @@ import {
   type VisualEditorPayload,
 } from "./visual-editor-script";
 import { CMS_EDITOR_SCRIPT, CmsEditorPayloadSchema } from "./cms-editor-script";
+import {
+  canToggleVisualEditor,
+  viewModeForSurface,
+  type PreviewInteractiveViewMode,
+  type PreviewSurface,
+  type PreviewViewMode,
+} from "./preview-surface";
 import { VisualEditorPrompt } from "./visual-editor-prompt";
 import {
   useSandboxEvents,
@@ -119,7 +126,6 @@ const SeoSheet = lazy(() =>
 /** Delay before reloading the preview iframe after a save, giving the dev server time to pick up file changes. */
 const DEV_SERVER_SETTLE_MS = 500;
 
-type PreviewViewMode = "preview" | "visual" | "cms";
 type PreviewDeviceSize = "mobile" | "tablet" | "desktop";
 
 const PREVIEW_DEVICE_WIDTHS: Record<PreviewDeviceSize, number | null> = {
@@ -216,9 +222,9 @@ function withDeviceHint(url: string, device: PreviewDeviceSize): string {
 }
 
 export function PreviewContent({
-  initialViewMode = "preview",
+  surface = "preview",
 }: {
-  initialViewMode?: "preview" | "cms";
+  surface?: PreviewSurface;
 } = {}) {
   const inset = useInsetContext();
   const navigate = useNavigate();
@@ -233,7 +239,9 @@ export function PreviewContent({
   };
 
   // Visual editor state
-  const [viewMode, setViewMode] = useState<PreviewViewMode>(initialViewMode);
+  const [interactiveViewMode, setInteractiveViewMode] =
+    useState<PreviewInteractiveViewMode>("preview");
+  const viewMode = viewModeForSurface(surface, interactiveViewMode);
   const [previewDeviceSize, setPreviewDeviceSize] =
     useState<PreviewDeviceSize>("desktop");
   const [visualElement, setVisualElement] =
@@ -656,18 +664,15 @@ export function PreviewContent({
     win.postMessage({ type: "cms-editor::deactivate" }, "*");
   };
 
-  const handleViewModeChange = (mode: PreviewViewMode) => {
+  const handleViewModeChange = (mode: PreviewInteractiveViewMode) => {
     const prev = viewMode;
-    setViewMode(mode);
+    setInteractiveViewMode(mode);
     setVisualElement(null);
-    if (mode !== "cms") {
-      setCmsSelectedSectionIndex(null);
-      setVariantOverrideParams(null);
-    }
+    setCmsSelectedSectionIndex(null);
+    setVariantOverrideParams(null);
     if (prev === "visual") deactivateVisualEditor();
     if (prev === "cms") deactivateCmsEditor();
     if (mode === "visual") injectVisualEditor();
-    if (mode === "cms") injectCmsEditor();
   };
 
   const handleRefresh = () => {
@@ -836,14 +841,13 @@ export function PreviewContent({
     }
   };
 
-  // visual + cms require a live iframe (they inject overlays into the dev
-  // server). `preview` is the base interactive view — the toggle buttons
-  // below flip a mode on, or back to `preview` when their mode is already
-  // active, so there is no dedicated "interactive" button.
-  const canVisualEdit = previewState.kind === "iframe";
+  // Visual mode belongs only to the Preview surface and requires a live
+  // iframe. The Blocks surface remains fixed in CMS mode.
+  const canVisualEdit =
+    previewState.kind === "iframe" && canToggleVisualEditor(surface);
   const canSectionsEdit =
     previewState.kind === "iframe" && hasEditableDecoContent(decofile, meta);
-  const toggleViewMode = (mode: PreviewViewMode) =>
+  const toggleViewMode = (mode: PreviewInteractiveViewMode) =>
     handleViewModeChange(viewMode === mode ? "preview" : mode);
 
   // Keep the shared secondary column in sync with whether the Sections editor

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
@@ -34,9 +34,9 @@ describe("resolveBlocksTabState", () => {
   });
 
   test("renders content when editable Deco content is available", () => {
-    expect(
-      resolveBlocksTabState(input({ hasEditableContent: true })),
-    ).toEqual({ kind: "content" });
+    expect(resolveBlocksTabState(input({ hasEditableContent: true }))).toEqual({
+      kind: "content",
+    });
   });
 
   test("renders empty after both resources settle without editable content", () => {

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveBlocksTabState,
+  type BlocksTabStateInput,
+} from "./blocks-tab-state";
+
+const success = { status: "success" as const, hasData: true };
+
+function input(
+  overrides: Partial<BlocksTabStateInput> = {},
+): BlocksTabStateInput {
+  return {
+    lifecyclePhase: "running",
+    decofile: success,
+    meta: success,
+    hasEditableContent: false,
+    ...overrides,
+  };
+}
+
+describe("resolveBlocksTabState", () => {
+  test("loads while the sandbox is progressing", () => {
+    expect(
+      resolveBlocksTabState(input({ lifecyclePhase: "installing" })),
+    ).toEqual({ kind: "loading" });
+  });
+
+  test("loads while initial Deco data is pending", () => {
+    expect(
+      resolveBlocksTabState(
+        input({ decofile: { status: "pending", hasData: false } }),
+      ),
+    ).toEqual({ kind: "loading" });
+  });
+
+  test("renders content when editable Deco content is available", () => {
+    expect(
+      resolveBlocksTabState(input({ hasEditableContent: true })),
+    ).toEqual({ kind: "content" });
+  });
+
+  test("renders empty after both resources settle without editable content", () => {
+    expect(resolveBlocksTabState(input())).toEqual({ kind: "empty" });
+  });
+
+  test.each([
+    "clone-failed",
+    "install-failed",
+    "start-failed",
+    "crashed",
+  ] as const)("renders a sandbox error for %s", (lifecyclePhase) => {
+    expect(resolveBlocksTabState(input({ lifecyclePhase }))).toEqual({
+      kind: "error",
+      source: "sandbox",
+    });
+  });
+
+  test("renders a data error when an initial request fails", () => {
+    expect(
+      resolveBlocksTabState(
+        input({ meta: { status: "error", hasData: false } }),
+      ),
+    ).toEqual({ kind: "error", source: "data" });
+  });
+
+  test("keeps cached editable content during a failed background refetch", () => {
+    expect(
+      resolveBlocksTabState(
+        input({
+          meta: { status: "error", hasData: true },
+          hasEditableContent: true,
+        }),
+      ),
+    ).toEqual({ kind: "content" });
+  });
+});

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
@@ -1,0 +1,48 @@
+import type { LifecycleState } from "@decocms/sandbox/shared";
+
+type QueryStatus = "pending" | "error" | "success";
+
+export interface BlocksQueryState {
+  status: QueryStatus;
+  hasData: boolean;
+}
+
+export interface BlocksTabStateInput {
+  lifecyclePhase: LifecycleState["phase"];
+  decofile: BlocksQueryState;
+  meta: BlocksQueryState;
+  hasEditableContent: boolean;
+}
+
+export type BlocksTabState =
+  | { kind: "loading" }
+  | { kind: "content" }
+  | { kind: "empty" }
+  | { kind: "error"; source: "sandbox" | "data" };
+
+const TERMINAL_LIFECYCLE_PHASES = new Set<LifecycleState["phase"]>([
+  "clone-failed",
+  "install-failed",
+  "start-failed",
+  "crashed",
+]);
+
+export function resolveBlocksTabState(
+  input: BlocksTabStateInput,
+): BlocksTabState {
+  if (TERMINAL_LIFECYCLE_PHASES.has(input.lifecyclePhase)) {
+    return { kind: "error", source: "sandbox" };
+  }
+  if (input.lifecyclePhase !== "running") return { kind: "loading" };
+
+  const initialDataFailed =
+    (input.decofile.status === "error" && !input.decofile.hasData) ||
+    (input.meta.status === "error" && !input.meta.hasData);
+  if (initialDataFailed) return { kind: "error", source: "data" };
+
+  if (!input.decofile.hasData || !input.meta.hasData) {
+    return { kind: "loading" };
+  }
+
+  return input.hasEditableContent ? { kind: "content" } : { kind: "empty" };
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-states.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-states.tsx
@@ -1,0 +1,48 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import { AlertCircle, Box, LinkExternal01 } from "@untitledui/icons";
+import { EmptyState } from "@/web/components/empty-state";
+
+const BLOCKS_DOCS_URL = "https://github.com/decocms/blocks";
+
+export function BlocksEmptyState() {
+  return (
+    <EmptyState
+      image={<Box size={48} className="text-muted-foreground" />}
+      title="No editable Blocks found"
+      description="This project does not expose editable Blocks content yet. Learn how to add Blocks to your project."
+      actions={
+        <Button variant="outline" size="sm" asChild>
+          <a href={BLOCKS_DOCS_URL} target="_blank" rel="noreferrer">
+            View Blocks docs
+            <LinkExternal01 size={14} />
+          </a>
+        </Button>
+      }
+    />
+  );
+}
+
+export function BlocksErrorState({
+  source,
+  onRetry,
+}: {
+  source: "sandbox" | "data";
+  onRetry: () => void;
+}) {
+  const description =
+    source === "sandbox"
+      ? "The project preview could not start. Retry to make Blocks available."
+      : "Studio could not load this project's Blocks metadata.";
+  return (
+    <EmptyState
+      image={<AlertCircle size={48} className="text-muted-foreground" />}
+      title="Blocks unavailable"
+      description={description}
+      actions={
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+      }
+    />
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab.test.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab.test.tsx
@@ -1,0 +1,33 @@
+import { setupComponentTest } from "../../../test/setup";
+setupComponentTest();
+
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, test } from "bun:test";
+import { BlocksEmptyState, BlocksErrorState } from "./blocks-tab-states";
+
+describe("Blocks tab states", () => {
+  test("links the empty state to the Blocks documentation", () => {
+    const { getByRole } = render(<BlocksEmptyState />);
+    const link = getByRole("link", { name: "View Blocks docs" });
+
+    expect(link).toHaveAttribute("href", "https://github.com/decocms/blocks");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noreferrer");
+  });
+
+  test("retries from the error state", () => {
+    let retryCount = 0;
+    const { getByRole } = render(
+      <BlocksErrorState
+        source="data"
+        onRetry={() => {
+          retryCount += 1;
+        }}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Retry" }));
+    expect(retryCount).toBe(1);
+  });
+});

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab.tsx
@@ -5,9 +5,9 @@ import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-life
 import { useDecofile } from "@/web/components/sections-editor/use-decofile";
 import { useLiveMeta } from "@/web/components/sections-editor/use-live-meta";
 import { hasEditableDecoContent } from "@/web/components/sections-editor/page-list";
+import { PreviewContent } from "@/web/components/sandbox/preview/preview";
 import { resolveBlocksTabState } from "./blocks-tab-state";
 import { MainPanelLoading } from "./main-panel-loading";
-import { PreviewTab } from "./preview-tab";
 import { BlocksEmptyState, BlocksErrorState } from "./blocks-tab-states";
 
 export function BlocksTab({ virtualMcpId }: { virtualMcpId: string }) {
@@ -39,7 +39,7 @@ export function BlocksTab({ virtualMcpId }: { virtualMcpId: string }) {
 
   if (state.kind === "loading") return <MainPanelLoading />;
   if (state.kind === "content") {
-    return <PreviewTab virtualMcpId={virtualMcpId} initialViewMode="cms" />;
+    return <PreviewContent surface="blocks" />;
   }
   if (state.kind === "empty") return <BlocksEmptyState />;
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab.tsx
@@ -1,0 +1,54 @@
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useChatTask } from "@/web/components/chat/context";
+import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events";
+import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
+import { useDecofile } from "@/web/components/sections-editor/use-decofile";
+import { useLiveMeta } from "@/web/components/sections-editor/use-live-meta";
+import { hasEditableDecoContent } from "@/web/components/sections-editor/page-list";
+import { resolveBlocksTabState } from "./blocks-tab-state";
+import { MainPanelLoading } from "./main-panel-loading";
+import { PreviewTab } from "./preview-tab";
+import { BlocksEmptyState, BlocksErrorState } from "./blocks-tab-states";
+
+export function BlocksTab({ virtualMcpId }: { virtualMcpId: string }) {
+  const { org } = useProjectContext();
+  const { currentBranch } = useChatTask();
+  const sandboxEvents = useSandboxEvents();
+  const lifecycle = useSandboxLifecycle();
+  const devServerReady = sandboxEvents.lifecycle.phase === "running";
+  const fetchParams =
+    currentBranch && devServerReady
+      ? {
+          orgSlug: org.slug,
+          virtualMcpId,
+          branch: currentBranch,
+          previewUrl: lifecycle.previewUrl,
+        }
+      : null;
+  const decofile = useDecofile(fetchParams, { fetchEnabled: devServerReady });
+  const meta = useLiveMeta(fetchParams, { fetchEnabled: devServerReady });
+  const state = resolveBlocksTabState({
+    lifecyclePhase: sandboxEvents.lifecycle.phase,
+    decofile: {
+      status: decofile.status,
+      hasData: decofile.data !== undefined,
+    },
+    meta: { status: meta.status, hasData: meta.data !== undefined },
+    hasEditableContent: hasEditableDecoContent(decofile.data, meta.data),
+  });
+
+  if (state.kind === "loading") return <MainPanelLoading />;
+  if (state.kind === "content") {
+    return <PreviewTab virtualMcpId={virtualMcpId} initialViewMode="cms" />;
+  }
+  if (state.kind === "empty") return <BlocksEmptyState />;
+
+  const retry = () => {
+    if (state.source === "sandbox") {
+      lifecycle.retry();
+      return;
+    }
+    void Promise.all([decofile.refetch(), meta.refetch()]);
+  };
+  return <BlocksErrorState source={state.source} onRetry={retry} />;
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/index.tsx
@@ -13,6 +13,7 @@ import { useMainPanelTabs } from "./use-main-panel-tabs";
 import { SettingsTab } from "./settings-tab";
 import { GitTab } from "@/web/components/thread/github/git-tab";
 import { PreviewTab } from "./preview-tab";
+import { BlocksTab } from "./blocks-tab";
 import { CodeTab } from "./code-tab";
 import { ContentTab } from "./content-tab";
 import { AutomationTab } from "./automation-tab";
@@ -81,7 +82,7 @@ function TabBody({
     return <PreviewTab virtualMcpId={virtualMcpId} />;
   }
   if (activeTab === "blocks") {
-    return <PreviewTab virtualMcpId={virtualMcpId} initialViewMode="cms" />;
+    return <BlocksTab virtualMcpId={virtualMcpId} />;
   }
   const codeTab = parseCodeTabId(activeTab);
   if (codeTab) {

--- a/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
@@ -3,13 +3,7 @@ import { agentHasClonableSource } from "@/web/lib/agent-capabilities";
 import { useVirtualMCP } from "@decocms/mesh-sdk";
 import { AlertCircle } from "@untitledui/icons";
 
-export function PreviewTab({
-  virtualMcpId,
-  initialViewMode = "preview",
-}: {
-  virtualMcpId: string;
-  initialViewMode?: "preview" | "cms";
-}) {
+export function PreviewTab({ virtualMcpId }: { virtualMcpId: string }) {
   const entity = useVirtualMCP(virtualMcpId);
   const hasClonableSource = agentHasClonableSource(entity?.metadata);
 
@@ -26,5 +20,5 @@ export function PreviewTab({
     );
   }
 
-  return <PreviewContent initialViewMode={initialViewMode} />;
+  return <PreviewContent surface="preview" />;
 }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/source-system-tabs.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/source-system-tabs.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { getSourceSystemTabs } from "./source-system-tabs";
+
+describe("getSourceSystemTabs", () => {
+  test("returns Preview, Blocks, and Code for clonable source", () => {
+    expect(getSourceSystemTabs(true)).toEqual([
+      { id: "preview", title: "Preview" },
+      { id: "blocks", title: "Blocks" },
+      { id: "code", title: "Code" },
+    ]);
+  });
+
+  test("returns no source tabs without clonable source", () => {
+    expect(getSourceSystemTabs(false)).toEqual([]);
+  });
+});

--- a/apps/mesh/src/web/layouts/main-panel-tabs/source-system-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/source-system-tabs.ts
@@ -1,0 +1,16 @@
+export interface SourceSystemTab {
+  id: "preview" | "blocks" | "code";
+  title: string;
+}
+
+const SOURCE_SYSTEM_TABS: readonly SourceSystemTab[] = [
+  { id: "preview", title: "Preview" },
+  { id: "blocks", title: "Blocks" },
+  { id: "code", title: "Code" },
+];
+
+export function getSourceSystemTabs(
+  hasClonableSource: boolean,
+): SourceSystemTab[] {
+  return hasClonableSource ? [...SOURCE_SYSTEM_TABS] : [];
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
@@ -324,6 +324,23 @@ describe("resolveTabClickTarget", () => {
     ).toBe("preview");
   });
 
+  test("Preview and Blocks switch to their own tab ids", () => {
+    expect(
+      resolveTabClickTarget({
+        clickedId: "blocks",
+        activeTab: "preview",
+        mainOpen: true,
+      }),
+    ).toBe("blocks");
+    expect(
+      resolveTabClickTarget({
+        clickedId: "preview",
+        activeTab: "blocks",
+        mainOpen: true,
+      }),
+    ).toBe("preview");
+  });
+
   test("clicking any tab while panel closed → clicked id (open it)", () => {
     expect(
       resolveTabClickTarget({

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -58,6 +58,7 @@ import {
   type AutomationTabParsed,
 } from "./tab-id";
 import { resolveTabIcon, type TabIcon, type TabKind } from "./resolve-tab-icon";
+import { getSourceSystemTabs } from "./source-system-tabs";
 
 export type AgentTabDef = {
   id: string;
@@ -298,19 +299,9 @@ export function useMainPanelTabs(ctx: {
   // into a single detail view. On GitHub-linked vMCPs the contextual
   // work tabs (Preview, git) come first so they're closest to the panel;
   // Settings + Automations stay anchored at the right.
-  // Leading work tabs, rendered first in the bar (right after the Chat toggle):
-  // Preview · Blocks · Code. Blocks (Sections editor) needs a live preview
-  // iframe to inject its CMS overlays; Code (file tree) only needs a clonable
-  // source — the daemon serves files even when the dev script has crashed.
-  const showBlocksTab = hasClonableSource && devServerReady && showContentTab;
-  const showCodeTab = hasClonableSource;
-  const leadingSystemTabs: Array<{ id: string; title: string }> = [];
-  if (hasClonableSource) {
-    leadingSystemTabs.push({ id: "preview", title: "Preview" });
-    if (showBlocksTab)
-      leadingSystemTabs.push({ id: "blocks", title: "Blocks" });
-    if (showCodeTab) leadingSystemTabs.push({ id: "code", title: "Code" });
-  }
+  // Leading source tabs share one capability gate. Blocks resolves whether the
+  // current project supports CMS editing inside its own tab body.
+  const leadingSystemTabs = getSourceSystemTabs(hasClonableSource);
 
   const systemTabs: Array<{ id: string; title: string }> = [];
   if (hasClonableSource && showContentTab) {

--- a/docs/superpowers/specs/2026-07-14-blocks-tab-availability-design.md
+++ b/docs/superpowers/specs/2026-07-14-blocks-tab-availability-design.md
@@ -1,0 +1,76 @@
+# Blocks Tab Availability Design
+
+## Goal
+
+Make the Blocks tab visible whenever Preview is visible, then explain the
+Blocks feature's actual availability inside the tab with distinct loading,
+content, empty, and error states.
+
+## Tab visibility
+
+Preview, Blocks, and Code are source tabs. All three appear when the current
+agent has clonable source, as determined by `agentHasClonableSource`. Blocks no
+longer waits for the sandbox dev server or Deco metadata before appearing.
+
+The Content tab keeps its existing, stricter availability condition.
+
+## Blocks tab states
+
+A dedicated `BlocksTab` reads the sandbox lifecycle and the existing
+`.decofile` and `/live/_meta` React Query resources. It resolves one of four
+states in this order:
+
+1. **Error:** The sandbox reaches `clone-failed`, `install-failed`,
+   `start-failed`, or `crashed`, or an initial Deco data request fails without
+   cached data. The tab shows an error message and a Retry action. Sandbox
+   errors retry the lifecycle; data errors refetch the Deco resources.
+2. **Loading:** The sandbox is progressing toward `running`, or an initial Deco
+   data request is still pending. The tab renders `MainPanelLoading`.
+3. **Content:** The sandbox is running and `hasEditableDecoContent(decofile,
+   meta)` is true. The tab renders the existing `PreviewTab` with
+   `initialViewMode="cms"`.
+4. **Empty:** The sandbox is running, both Deco data requests have settled, and
+   the editable-content condition is false. The tab explains that the project
+   does not expose editable Blocks content and links to
+   <https://github.com/decocms/blocks> in a new tab.
+
+Background refetches do not replace usable cached content with a loading or
+error state.
+
+## Components and data flow
+
+- A small pure helper builds the source-tab list so the shared Preview/Blocks
+  visibility rule is directly testable.
+- A small pure state resolver converts lifecycle and query snapshots into the
+  four Blocks states. `BlocksTab` remains responsible only for calling hooks
+  and rendering the selected state.
+- Existing `useDecofile` and `useLiveMeta` query keys remain unchanged. The tab
+  bar, Content tab, Preview, and Blocks therefore share cached responses and
+  deduplicate concurrent requests.
+- The current Preview/CMS implementation remains unchanged; it is mounted only
+  for the content state.
+
+## Error and empty-state presentation
+
+The error state uses the established full-panel empty-state layout with an
+alert icon, concise failure copy, and a Retry button. The empty state uses the
+same layout with a `View Blocks docs` action. External navigation uses
+`target="_blank"` and `rel="noreferrer"`.
+
+## Testing
+
+Pure unit tests cover:
+
+- source agents receiving Preview, Blocks, and Code together;
+- non-source agents receiving none of those source tabs;
+- forward lifecycle and initial query work resolving to loading;
+- editable Deco data resolving to content;
+- settled non-editable data resolving to empty;
+- terminal lifecycle and initial query failures resolving to error;
+- cached usable data remaining content during background refetches.
+
+A lightweight render test covers the empty state's documentation link. Tests
+use real pure functions/components and no mocked application hooks.
+
+After implementation, run the focused tests, formatting, type checking, and
+linting required by the repository.


### PR DESCRIPTION
## Summary

- show Blocks whenever the Preview source capability is available
- resolve Blocks content, loading, empty, and error states from sandbox/deco data
- keep Blocks fixed to its CMS surface and Preview fixed to its own preview/visual surface
- link the empty state to the Blocks documentation
- add focused state, rendering, routing, and surface-mode tests

## Testing

- focused Blocks and main-panel tab tests: 74 passed
- bun run check
- bun run lint (0 errors; 30 existing warnings)
- bun run fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the Blocks tab with Preview availability and resolved its actual availability inside the tab with clear loading, content, empty, and error states. Also split Preview and Blocks into separate surfaces so the visual editor only affects Preview while Blocks stays in CMS mode.

- **New Features**
  - Show Preview, Blocks, and Code together for clonable sources via getSourceSystemTabs.
  - Added a dedicated BlocksTab that resolves loading/content/empty/error from sandbox and Deco data, with Retry actions and a link to the Blocks docs.
  - Render Preview with surface="preview" and Blocks with surface="blocks" to keep each on its own surface.

- **Refactors**
  - Introduced preview-surface helpers to compute view mode and visual-toggle capability; Blocks can’t toggle into Preview’s visual editor.
  - Moved Blocks visibility gating out of the tab bar; availability is resolved inside BlocksTab.

<sup>Written for commit e75b31b25b4982312bfce8e409ea4a4838371010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

