### PR TITLE
[chore]: relicense project under MIT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,10 +454,5 @@ stable.
 
 ## License
 
-Sustainable Use License (SUL):
-- ✅ Free to self-host for internal use
-- ✅ Free for client projects (agencies, SIs)
-- ⚠️ Commercial license required for SaaS or revenue-generating production systems
-
-See LICENSE.md for details. Questions: contact@decocms.com
+MIT License — see LICENSE.md for details.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,4 @@ not a unit test — move it to e2e.
 
 ## License
 
-Sustainable Use License — see [`LICENSE.md`](./LICENSE.md). Free to self-host
-for internal use and for client projects; a commercial license is required for
-SaaS / revenue-generating production systems. Questions: contact@decocms.com.
+MIT — see [`LICENSE.md`](./LICENSE.md).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,120 +1,21 @@
-# **Deco CMS Sustainable Use License v1.1**
+MIT License
 
 Copyright © 2025 Deco CMS and contributors.
-All rights reserved.
 
----
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-### **1. Definitions**
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-1.1 **“Software”** means the source code, object code, documentation, templates, components, and any related files of Deco CMS (including Deco Studio, Deco Chat, or other Deco-branded modules) made available under this License.
-
-1.2 **“Internal Use”** means use of the Software solely within your organization for your own business purposes, without providing or offering the Software (or derivative works) as a product or service to third parties, and without charging for access to it.
-
-1.3 **“Commercial Use”** means any use of the Software other than Internal Use, including but not limited to:
-(a) operating the Software as a multi-tenant or hosted service (SaaS) for external users, whether for a fee or not;
-(b) white-labeling, re-branding, or embedding the Software (or substantial portions of its functionality) in a product offered to third parties;
-(c) offering hosted instances or managed versions of the Software to customers as a service;
-(d) selling or charging for access to the Software as your own product;
-(e) any use where Deco CMS itself is the primary commercial value delivered.
-
-1.4 **“You”** (or **“Your”**) means the individual or legal entity exercising the rights granted by this License.
-**“Company”** includes any entity that controls, is controlled by, or is under common control with You, where “control” means ownership of at least 50 % of the voting interests or the ability to direct management policies.
-
----
-
-### **2. License Grant**
-
-Subject to the terms and conditions of this License, Deco CMS grants You a worldwide, royalty-free, non-exclusive, non-transferable right to use, modify, and distribute the Software for Internal Use and non-commercial purposes.
-
-You may copy and modify the Software to build applications, agents, workflows, and interfaces for your own business needs.
-
----
-
-### **3. Commercial Use Requires a Commercial License**
-
-3.1 If You engage in Commercial Use of the Software, You must obtain a separate commercial license from Deco CMS before such use begins.
-
-3.2 Examples of Commercial Use include, but are not limited to:
-
-(a) Operating the Software as a multi-tenant SaaS platform for external users, whether for a fee or not.
-(b) White-labeling or re-branding the Software (and/or core functionality) and offering it as Your own product.
-(c) Offering hosted instances or managed installations of the Software to customers as a service.
-(d) Embedding the Software as the primary product offering in a commercial application (e.g., “Your AI Agent Platform powered by Deco CMS”).
-
-3.3 The following uses are **not** considered Commercial Use:
-
-(a) Using the Software internally within Your organization, regardless of scale.
-(b) Agencies, consultancies, or system integrators building custom applications for clients using the Software, provided the clients use those applications internally.
-(c) Creating or selling modules, components, integrations, or extensions for use with the Software (see Section 9).
-(d) Academic, research, educational, or non-profit use.
-
-3.4 Commercial licenses are available from Deco CMS at [https://decocms.com/](https://decocms.com/) or by contacting [contact@decocms.com](mailto:contact@decocms.com).
-
----
-
-### **4. Distribution and Modification**
-
-4.1 You may distribute original or modified copies of the Software for non-commercial purposes, provided that You include a copy of this License and retain all copyright and license notices.
-
-4.2 If You modify the Software, You must clearly document those changes in the source files.
-
-4.3 You may not remove or obscure any copyright, patent, or trademark notices from the Software.
-
----
-
-### **5. Attribution**
-
-5.1 Attribution is appreciated but not required.
-
-5.2 If You redistribute the Software in original or modified form, You must retain all copyright notices and license terms in the source code and documentation.
-
----
-
-### **6. Intellectual Property and Trademarks**
-
-This License does not grant You any rights in the Deco name, logo, or trademarks.
-You may not use the Deco branding or confusingly similar marks without prior written permission.
-Forks or derivatives must use distinct branding to avoid confusion.
-
----
-
-### **7. Termination**
-
-7.1 This License terminates automatically if You violate its terms and fail to cure the violation within 30 days of notice from Deco CMS.
-
-7.2 Upon termination, You must cease all use and distribution of the Software, except that Internal Use rights for already-deployed instances may continue at Deco’s discretion.
-
----
-
-### **8. Warranty Disclaimer and Limitation of Liability**
-
-THE SOFTWARE IS PROVIDED “AS IS,” WITHOUT ANY WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING FROM THE SOFTWARE OR ITS USE.
-
----
-
-### **9. Store and Extensions**
-
-9.1 You may create, distribute, and sell modules, components, integrations, templates, or extensions (“Extensions”) for use with the Software, through the Deco Store or independently.
-
-9.2 Creating or selling Extensions does **not** constitute Commercial Use of the Software if:
-(a) the Extension adds substantial functionality beyond the core Software capabilities; and
-(b) You are not redistributing the core Software itself as a stand-alone product or service.
-
-9.3 Extensions may be licensed under any terms You choose. Deco CMS may apply a transaction fee for Extensions sold through the official Deco Store.
-
----
-
-### **10. Right to Audit and Compliance (Commercial Licensees Only)**
-
-For holders of a commercial license, Deco CMS may reasonably request records to verify compliance with the license terms. Such requests will not include access to source code or confidential data and will be limited to verifying commercial deployment scope.
-
----
-
-### **11. Governing Law**
-
-This License is governed by the laws of the State of Delaware, USA, without regard to conflict-of-laws principles. Disputes shall be resolved in the state or federal courts located in Delaware.
-
----
-
-**END OF LICENSE**
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -267,11 +267,7 @@ No vendor lock-in. Runs on Docker, Kubernetes, AWS, GCP, or local runtimes.
 
 ## License
 
-**Sustainable Use License (SUL)** — see [LICENSE.md](./LICENSE.md).
-
-- Free to self-host for internal use
-- Free for client projects (agencies, SIs)
-- Commercial license required for SaaS or revenue-generating production systems
+**MIT** — see [LICENSE.md](./LICENSE.md).
 
 Questions? [builders@decocms.com](mailto:builders@decocms.com)
 

--- a/apps/mesh/README.md
+++ b/apps/mesh/README.md
@@ -245,11 +245,7 @@ Product docs: [docs.decocms.com](https://docs.decocms.com/).
 
 ## License
 
-[Deco CMS Sustainable Use License v1.1](../../LICENSE.md).
-
-- Free to self-host for internal use
-- Free for client projects (agencies, SIs)
-- Commercial license required for SaaS or revenue-generating production systems
+[MIT License](../../LICENSE.md).
 
 Questions: [builders@decocms.com](mailto:builders@decocms.com)
 

--- a/decostudio-alias/README.md
+++ b/decostudio-alias/README.md
@@ -214,11 +214,7 @@ No vendor lock-in. Runs on Docker, Kubernetes, AWS, GCP, or local runtimes.
 
 ## License
 
-**Sustainable Use License (SUL)** — see the [project repository](https://github.com/decocms/studio) for full terms.
-
-- Free to self-host for internal use
-- Free for client projects (agencies, SIs)
-- Commercial license required for SaaS or revenue-generating production systems
+**MIT** — see the [project repository](https://github.com/decocms/studio) for full terms.
 
 Questions? [builders@decocms.com](mailto:builders@decocms.com)
 


### PR DESCRIPTION
## Summary
- Replace the Deco CMS Sustainable Use License with the standard MIT license in `LICENSE.md`
- Update license references in `README.md`, `apps/mesh/README.md`, `decostudio-alias/README.md`, `CONTRIBUTING.md`, and `AGENTS.md`/`CLAUDE.md`
- All workspace `package.json` files already declared `"license": "MIT"`, so no changes needed there

## Test plan
- [x] `bun run fmt` (no changes needed)
- [ ] Confirm no other docs/legal references to the old license remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relicense the project under MIT by replacing the SUL in `LICENSE.md` and updating license references across READMEs and CONTRIBUTING/AGENTS docs. No changes to `package.json` licenses (already set to "MIT").

<sup>Written for commit 9ff80c46b4683c7cce1681b78e74555f0fa2a4ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

