### PR TITLE
fix(sandbox): harden shutdown publish against non-repo and tokenless origin

### DIFF
--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -10,6 +10,7 @@ import {
   makeGitPublishHandler,
   makeGitRebaseHandler,
   makeGitStatusHandler,
+  publish,
 } from "./git";
 
 function initRepo(): { appRoot: string; repoDir: string } {
@@ -347,6 +348,29 @@ describe("git routes", () => {
       return;
     }
     expect(res.status).toBe(200);
+  });
+
+  it("publish() skips cleanly on a never-cloned dir (shutdown path)", () => {
+    const appRoot = mkdtempSync(join(tmpdir(), "git-route-root-"));
+    const repoDir = join(appRoot, "app");
+    mkdirSync(repoDir, { recursive: true });
+    // The shutdown handler calls publish() directly, bypassing the handler's
+    // isGitRepo() guard — it must not throw "not a git repository".
+    expect(publish({ appRoot, repoDir }, "shutdown sync")).toEqual({
+      pushed: false,
+    });
+  });
+
+  it("publish() rejects a tokenless github origin with a clear error", () => {
+    const { appRoot, repoDir } = initRepo();
+    gitSync(["remote", "add", "origin", "https://github.com/owner/repo.git"], {
+      cwd: repoDir,
+      asUser: false,
+    });
+    writeFileSync(join(repoDir, "README.md"), "changed\n");
+    expect(() => publish({ appRoot, repoDir }, "no creds")).toThrow(
+      /authenticated clone URL/,
+    );
   });
 
   it("publish skips failing pre-commit hooks", async () => {

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -484,6 +484,12 @@ function pushBranch(repoDir: string, branch: string): void {
 
 export function publish(deps: GitDeps, message: string): { pushed: boolean } {
   const repoDir = deps.repoDir;
+  // The HTTP route guards with isGitRepo(); the shutdown handler calls publish()
+  // directly, so a never-cloned/empty dir would throw 128 ("not a git
+  // repository") on the rev-parse below. Nothing to publish — skip cleanly.
+  if (!isGitRepo(repoDir)) {
+    return { pushed: false };
+  }
   const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (!branch || branch === "HEAD") {
     throw new Error("Cannot publish from a detached HEAD");
@@ -524,16 +530,15 @@ export function publish(deps: GitDeps, message: string): { pushed: boolean } {
   const cloneUrl = deps.getCloneUrl?.();
   if (typeof cloneUrl === "string" && cloneUrl.length > 0) {
     syncOriginRemote(repoDir, cloneUrl);
-  } else {
-    const originUrl = tryGit(repoDir, ["remote", "get-url", "origin"]) ?? "";
-    if (
-      originUrl.includes("github.com") &&
-      !cloneUrlHasCredentials(originUrl)
-    ) {
-      throw new Error(
-        "GitHub push requires an authenticated clone URL. Connect GitHub for this project and restart the sandbox.",
-      );
-    }
+  }
+  // Guard the *effective* origin. syncOriginRemote no-ops on a credential-less
+  // cloneUrl, so a non-empty-but-tokenless cloneUrl used to fall straight
+  // through to pushBranch and fail with an opaque "Invalid username or token".
+  const originUrl = tryGit(repoDir, ["remote", "get-url", "origin"]) ?? "";
+  if (originUrl.includes("github.com") && !cloneUrlHasCredentials(originUrl)) {
+    throw new Error(
+      "GitHub push requires an authenticated clone URL. Connect GitHub for this project and restart the sandbox.",
+    );
   }
 
   pushBranch(repoDir, branch);


### PR DESCRIPTION
## Summary

The sandbox daemon's SIGTERM handler calls `publish()` to push the user's in-progress edits to their branch **before the pod dies** — it's the only thing that persists work when a pod is torn down (spot reclaim, idle reap, node churn). In prod that push is **failing ~100% of the time**, so users lose edits when their sandbox goes away.

This PR fixes two of the failure modes (both observed live in `agent-sandbox-system`, us-west-2):

### 1. Non-repo dir → `not a git repository` (128)
The HTTP publish route guards with `isGitRepo()`, but the **shutdown handler calls `publish()` directly**, bypassing that guard. On a never-cloned / ephemeral pod, `git rev-parse --abbrev-ref HEAD` throws 128. Fix: guard inside `publish()` so every caller skips cleanly (`{ pushed: false }`) when there's no repo — nothing to publish.

### 2. Tokenless origin → opaque `Invalid username or token`
The credential guard only ran in the `else` branch. A non-empty-but-**tokenless** `cloneUrl` took the `if` branch, `syncOriginRemote` silently no-op'd (it returns early when the URL has no credentials), and the code pushed against a bare `github.com` origin — failing with an unactionable auth error. Fix: check the **effective** origin after `syncOriginRemote`, so a missing credential fails loudly with the "connect GitHub / restart the sandbox" message.

## Scope / follow-up

This does **not** fix the expired-token case (origin *has* credentials but the ~1h GitHub App installation token has lapsed) — that's the failure that lost real customer work and is a separate, more architectural fix. Investigating that now; a second PR will follow.

## Testing
- `bun test packages/sandbox/daemon/routes/git.test.ts` — 20 pass (2 new: non-repo skip on the direct `publish()` path, tokenless-github-origin rejection).
- `bun run fmt`, sandbox `tsc --noEmit`, and `bun run lint` (0 errors) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened sandbox shutdown publishing to prevent lost edits by guarding `publish()` against non-repo dirs and rejecting tokenless GitHub origins with a clear error.

- **Bug Fixes**
  - `publish()` now checks `isGitRepo()` and returns `{ pushed: false }` if the repo doesn’t exist, avoiding 128 errors on shutdown.
  - After `syncOriginRemote`, the effective `origin` is validated; if a GitHub URL lacks credentials, we throw an actionable “connect GitHub and restart the sandbox” message instead of failing with “Invalid username or token.”

<sup>Written for commit f302ba9046d7cd1bd87cda34218da434f765925a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

