### PR TITLE
test(sandbox): verify SIGTERM triggers a graceful publish before exit

### DIFF
--- a/packages/sandbox/daemon/daemon.git.e2e.test.ts
+++ b/packages/sandbox/daemon/daemon.git.e2e.test.ts
@@ -146,7 +146,10 @@ describe("daemon e2e: git (cloned repo)", () => {
     expect(((await res.json()) as { pushed: boolean }).pushed).toBe(true);
   });
 
-  it(
+  // Windows Node can't deliver a catchable SIGTERM — kill("SIGTERM") tears the
+  // process down abruptly, so the shutdown handler never runs. Graceful
+  // termination is a POSIX/k8s concern (the daemon runs on Linux in prod).
+  it.skipIf(process.platform === "win32")(
     "SIGTERM triggers a graceful publish to origin before exit",
     async () => {
       await writeRepoFile(d, "graceful.txt", "saved on shutdown\n");

--- a/packages/sandbox/daemon/daemon.git.e2e.test.ts
+++ b/packages/sandbox/daemon/daemon.git.e2e.test.ts
@@ -5,6 +5,7 @@
  * against a local bare git repo (file:// — hermetic, no network) and waits for
  * the setup orchestrator to drain. Black-box throughout (see helpers).
  */
+import { execSync } from "node:child_process";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import {
@@ -144,6 +145,37 @@ describe("daemon e2e: git (cloned repo)", () => {
     expect(res.status).toBe(200);
     expect(((await res.json()) as { pushed: boolean }).pushed).toBe(true);
   });
+
+  it(
+    "SIGTERM triggers a graceful publish to origin before exit",
+    async () => {
+      await writeRepoFile(d, "graceful.txt", "saved on shutdown\n");
+
+      // origin has no `sandbox-work` branch until the shutdown publish pushes.
+      const remoteRef = () =>
+        execSync(`git ls-remote ${repo.url} refs/heads/sandbox-work`, {
+          encoding: "utf8",
+        }).trim();
+      expect(remoteRef()).toBe("");
+
+      // Real OS signal — the same SIGTERM k8s delivers on a spot drain / node
+      // eviction (~120s grace). shutdown() must commit + push before exit(0),
+      // or the user's in-progress work dies with the pod.
+      const start = Date.now();
+      const exited = new Promise<void>((resolve) =>
+        d.proc.once("exit", () => resolve()),
+      );
+      d.proc.kill("SIGTERM");
+      await exited;
+      const elapsedMs = Date.now() - start;
+
+      // Well under the graceful-termination budget; a local push is ~instant.
+      expect(elapsedMs).toBeLessThan(30_000);
+      // The change reached origin — work survived the pod dying.
+      expect(remoteRef()).not.toBe("");
+    },
+    SETUP_TIMEOUT_MS,
+  );
 });
 
 // --- setup routes ------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a CI guard for the sandbox persistence contract: **work survives a pod dying only if the shutdown push lands.** The daemon relies on a SIGTERM handler to commit + push the user's in-progress edits to their branch before the pod is torn down (spot reclaim, node drain, idle reap). AWS gives ~120s notice → k8s sends SIGTERM → the daemon has that window to publish.

This test emits a **real `SIGTERM`** to the running daemon process — the same signal k8s delivers, so it exercises the exact graceful-shutdown path (a signal is a signal, container or k8s) — and asserts:

1. `origin` has no `sandbox-work` branch before shutdown,
2. after SIGTERM, `shutdown()` commits + pushes the working-tree change to the file:// origin **before `exit(0)`**,
3. it completes well under the graceful-termination budget (asserts < 30s; runs in ~2s).

Reuses the existing hermetic bare-repo harness in `daemon.git.e2e.test.ts` (file:// remote, no network).

## Context

Prod incident: sandbox pods on spot nodes were losing users' in-progress CMS edits because the shutdown `git push` was failing. This test locks in that the graceful SIGTERM → publish path works, so regressions are caught in CI rather than by customers.

Related: #4530 (shutdown-publish hardening). The remaining expired-token AUTH fix is a separate follow-up PR.

## Testing
`bun test packages/sandbox/daemon/daemon.git.e2e.test.ts -t SIGTERM` — passes (~2s). `fmt` + sandbox `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an e2e test that sends a real SIGTERM to the sandbox daemon and verifies it commits and pushes in-progress edits to `origin` before exit, using the hermetic file:// repo harness. Ensures sandbox work survives pod shutdown, completes under 30s, and skips on Windows where Node can’t deliver a catchable SIGTERM.

<sup>Written for commit 0a418b956d21fca9f2239a92946bcac4ac1dee87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

