### PR TITLE
refactor(sandbox): remove dead RingBuffer.byteLength()

### DIFF
--- a/packages/sandbox/daemon/process/ring-buffer.ts
+++ b/packages/sandbox/daemon/process/ring-buffer.ts
@@ -41,8 +41,4 @@ export class RingBuffer {
   isTruncated(): boolean {
     return this.dropped;
   }
-
-  byteLength(): number {
-    return this.size;
-  }
 }


### PR DESCRIPTION
## Summary
`RingBuffer.byteLength()` has zero callers anywhere in the repo — `RingBuffer` is only instantiated in `task-manager.ts` for stdout/stderr capture, and that code never calls `byteLength()`. Confirmed via `grep -rn "RingBuffer" .` and `grep -rn "\.byteLength(" .` (the only `.byteLength(` matches in the repo are unrelated `Buffer.byteLength` calls).

Dead code removal — a maintainer scanning this file shouldn't have to wonder whether some caller depends on it.

## Test plan
- Behavior-preserving: no callers exist, so removing the method changes nothing at runtime.
- `bun run fmt` — clean.
- `bunx tsc --noEmit` in `packages/sandbox` — clean, no type errors.
- Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `byteLength()` method from the sandbox `RingBuffer` to reduce dead code. No runtime change, as the method had no callers.

<sup>Written for commit ade42885c56f683e69a75c26f904fc0ae8cc5e4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

