### PR TITLE
fix(sandbox): re-mint clone credential on autonomous recovery

### DIFF
--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -19,6 +19,10 @@ import type { Kysely } from "kysely";
 import { meter } from "@/observability";
 import type { Database as DatabaseSchema } from "@/storage/types";
 import { KyselySandboxProviderStateStore } from "@/storage/sandbox-runner-state";
+import { buildCloneInfo } from "@/shared/github-clone-info";
+import { CredentialVault } from "@/encryption/credential-vault";
+import { getSettings } from "@/settings";
+import { parseGithubOwnerRepo } from "@/sandbox/parse-github-clone-url";
 
 // Stashed on globalThis so they survive Bun's `--hot` reload. The preview
 // reverse-proxy registered at the top of `apps/mesh/src/index.ts` is wired
@@ -149,6 +153,10 @@ async function instantiate(
       // `meter` is reassigned by initObservability() after sdk.start(); read
       // it at provider construction (post-init) so we get the real instruments
       // not the no-op evaluated at module load.
+      // Ambient vault (encryption key only, no request ctx) so the runner can
+      // re-mint a fresh clone credential on autonomous recovery instead of
+      // replaying the expired token baked into the persisted cloneUrl.
+      const vault = new CredentialVault(getSettings().encryptionKey);
       return new AgentSandboxProvider({
         stateStore,
         previewUrlPattern,
@@ -157,6 +165,23 @@ async function instantiate(
         previewGateway: readPreviewGateway(),
         sentinelToken: readSandboxSentinelToken(),
         meter,
+        mintCloneUrl: async (repo) => {
+          // Only connection-backed clones can be re-minted; buildCloneInfo
+          // refreshes standard OAuth GitHub connections from db + vault alone.
+          // Legacy repo-scoped tokens throw here (need an org-scoped ctx) and
+          // the runner falls back to the persisted URL.
+          if (!repo.connectionId) return null;
+          const parsed = parseGithubOwnerRepo(repo.cloneUrl);
+          if (!parsed) return null;
+          const { cloneUrl } = await buildCloneInfo(
+            repo.connectionId,
+            parsed.owner,
+            parsed.name,
+            db,
+            vault,
+          );
+          return cloneUrl;
+        },
       });
     }
     case "user-desktop": {

--- a/apps/mesh/src/sandbox/parse-github-clone-url.test.ts
+++ b/apps/mesh/src/sandbox/parse-github-clone-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { parseGithubOwnerRepo } from "./parse-github-clone-url";
+
+describe("parseGithubOwnerRepo", () => {
+  it("parses a credentialed clone URL", () => {
+    expect(
+      parseGithubOwnerRepo(
+        "https://x-access-token:ghs_abc@github.com/deco-sites/casaevideo-tanstack.git",
+      ),
+    ).toEqual({ owner: "deco-sites", name: "casaevideo-tanstack" });
+  });
+
+  it("parses an anonymous clone URL without .git", () => {
+    expect(parseGithubOwnerRepo("https://github.com/owner/repo")).toEqual({
+      owner: "owner",
+      name: "repo",
+    });
+  });
+
+  it("returns null when owner or name is missing", () => {
+    expect(parseGithubOwnerRepo("https://github.com/owner")).toBeNull();
+    expect(parseGithubOwnerRepo("https://github.com/")).toBeNull();
+  });
+
+  it("returns null for a non-URL string", () => {
+    expect(parseGithubOwnerRepo("git@github.com:owner/repo.git")).toBeNull();
+  });
+});

--- a/apps/mesh/src/sandbox/parse-github-clone-url.ts
+++ b/apps/mesh/src/sandbox/parse-github-clone-url.ts
@@ -1,0 +1,14 @@
+/** Parse `owner`/`name` from a GitHub clone URL (credentialed or anonymous). */
+export function parseGithubOwnerRepo(
+  cloneUrl: string,
+): { owner: string; name: string } | null {
+  try {
+    const [owner, rest] = new URL(cloneUrl).pathname
+      .replace(/^\//, "")
+      .split("/");
+    const name = rest?.replace(/\.git$/, "");
+    return owner && name ? { owner, name } : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -297,6 +297,7 @@ async function provisionSandbox(
   let repoOpts:
     | {
         cloneUrl: string;
+        connectionId?: string;
         userName: string;
         userEmail: string;
         branch: string;
@@ -376,6 +377,10 @@ async function provisionSandbox(
 
     repoOpts = {
       cloneUrl,
+      // Persisted so the runner can re-mint on recovery; absent for anonymous.
+      ...(githubRepo.connectionId
+        ? { connectionId: githubRepo.connectionId }
+        : {}),
       userName: gitUserName,
       userEmail: gitUserEmail,
       branch,

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -367,6 +367,20 @@ export interface AgentSandboxProviderOptions {
     name: string;
     namespace: string;
   };
+  /**
+   * Re-mint a fresh credentialed clone URL for a repo. The cloneUrl persisted
+   * in `ensureOpts` embeds a ~55min GitHub App token from first provision; on
+   * autonomous recovery (a warm-pool pod recreated under a live claim without a
+   * new SANDBOX_START) that token has usually lapsed, so replaying it would
+   * clone/push with a dead credential — the cause of "Invalid username or
+   * token" on shutdown. The runner calls this before re-cloning / rotating
+   * origin on recovery. Returns null when it can't re-mint (no connection,
+   * legacy repo-scoped token needing an org-scoped context, mint error); the
+   * runner then falls back to the persisted URL. Must never throw.
+   */
+  mintCloneUrl?: (
+    repo: NonNullable<EnsureOptions["repo"]>,
+  ) => Promise<string | null>;
 }
 
 export class AgentSandboxProvider implements SandboxProvider {
@@ -405,6 +419,8 @@ export class AgentSandboxProvider implements SandboxProvider {
    * silently flip modes with an unusable token.
    */
   private readonly sentinelToken: string | null;
+  /** See {@link AgentSandboxProviderOptions.mintCloneUrl}. */
+  private readonly mintCloneUrl: AgentSandboxProviderOptions["mintCloneUrl"];
   private closed = false;
   /** Aborts the background SandboxClaim-deletion watch on `close()`. */
   private readonly claimWatchAbort = new AbortController();
@@ -432,6 +448,7 @@ export class AgentSandboxProvider implements SandboxProvider {
         : null;
     const trimmedSentinel = opts.sentinelToken?.trim() ?? "";
     this.sentinelToken = trimmedSentinel.length > 0 ? trimmedSentinel : null;
+    this.mintCloneUrl = opts.mintCloneUrl;
     this.startClaimReaper();
   }
 
@@ -1364,6 +1381,31 @@ export class AgentSandboxProvider implements SandboxProvider {
   }
 
   /**
+   * Return `repo` with a freshly-minted credentialed cloneUrl, or unchanged
+   * when no minter is wired or it declines. The persisted cloneUrl embeds a
+   * ~55min GitHub App token from first provision; on recovery (pod recreation
+   * under a live claim) that token has usually lapsed, so replaying it clones /
+   * pushes with a dead credential. Best-effort — a mint failure must not block
+   * recovery, so this falls back to the persisted URL.
+   */
+  private async withFreshCloneUrl(
+    repo: NonNullable<EnsureOptions["repo"]>,
+  ): Promise<NonNullable<EnsureOptions["repo"]>> {
+    if (!this.mintCloneUrl) return repo;
+    try {
+      const fresh = await this.mintCloneUrl(repo);
+      return fresh ? { ...repo, cloneUrl: fresh } : repo;
+    } catch (err) {
+      console.warn(
+        `[${LOG_LABEL}] clone credential re-mint failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return repo;
+    }
+  }
+
+  /**
    * Warm-pool re-bootstrap. A pool pod recreated under a live claim (operator
    * rebind, node churn, idle-TTL reap) boots back on the SandboxTemplate
    * sentinel and is "unclaimed": it rejects our persisted per-claim token and
@@ -1575,10 +1617,18 @@ export class AgentSandboxProvider implements SandboxProvider {
     // so a bootId change there is informational only.
     if (state.daemonBootId && state.daemonBootId !== live.bootId) {
       if (this.sentinelToken !== null) {
+        // Re-clone with a live credential — the persisted cloneUrl's token has
+        // usually lapsed by the time a pool pod is recreated under the claim.
+        const rebootstrapOpts: EnsureOptions | null = state.ensureOpts?.repo
+          ? {
+              ...state.ensureOpts,
+              repo: await this.withFreshCloneUrl(state.ensureOpts.repo),
+            }
+          : (state.ensureOpts ?? null);
         const ok = await this.rebootstrapDaemon(
           live.daemonUrl,
           state.token,
-          state.ensureOpts ?? null,
+          rebootstrapOpts,
         );
         if (!ok) {
           this.closeForwarder(live.daemonForward);
@@ -1759,11 +1809,20 @@ export class AgentSandboxProvider implements SandboxProvider {
     if (!row) return null;
     const persistedOpts = (row.state as Partial<PersistedK8sState>).ensureOpts;
     if (!persistedOpts) return null;
+    // The persisted cloneUrl carries the first-provision token, long expired by
+    // now. Re-mint so the reprovision (and the downstream credential rotation)
+    // uses a live credential instead of the dead one.
+    const opts: EnsureOptions = persistedOpts.repo
+      ? {
+          ...persistedOpts,
+          repo: await this.withFreshCloneUrl(persistedOpts.repo),
+        }
+      : persistedOpts;
     // ensure() is idempotent + advisory-locked, so concurrent resurrections
     // for the same handle collapse to a single provision. The lock is keyed
     // on (userId, projectRef, kind), the same identity our state-store row
     // is keyed on.
-    await this.ensure(row.id, persistedOpts);
+    await this.ensure(row.id, opts);
     return this.records.get(handle) ?? null;
   }
 

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -67,6 +67,13 @@ export interface EnsureOptions {
      * `origin` in place rather than leaving a stale token.
      */
     cloneUrl: string;
+    /**
+     * GitHub connection backing `cloneUrl`. Persisted so the runner can
+     * re-mint a fresh credential on autonomous recovery (pod recreation
+     * under a live claim) instead of replaying the stale token baked into
+     * `cloneUrl` at first provision. Absent for anonymous/public clones.
+     */
+    connectionId?: string;
     userName: string;
     userEmail: string;
     branch?: string;


### PR DESCRIPTION
## Summary

Fixes the prod data-loss bug where sandbox pods lost users' in-progress edits: the shutdown `git push` (the mechanism that persists work to the user's branch) was failing with **`Invalid username or token`**.

### Root cause

The credentialed `cloneUrl` — which embeds a **~55min GitHub App token** — is snapshotted **verbatim** into the persisted `ensureOpts` state-store blob at first provision, with **no TTL and no re-mint**. On **autonomous recovery** (a warm-pool pod recreated under a live claim *without* a new `SANDBOX_START` — i.e. node churn / spot reclaim), `resurrectByHandle` and `rehydrate`→`rebootstrapDaemon` replay that stale blob:

1. they re-clone with the (already-expired) token, **and**
2. they feed the *same* stale URL to `refreshDaemonGitCredential`, which the daemon classifies as unchanged → **no-op**.

So a freshly-recreated pod (observed live at 15–20 min old) ends up holding a token minted 40+ min earlier at the original provision. It survives the recovery re-clone, then **expires before the shutdown push**, which dies — taking the user's edits with it. Confirmed live: pods failing at `shutdown publish` with `Invalid username or token`, across ~15 users, correlated with spot-node reclaim.

### Fix

Add a `mintCloneUrl` callback to the agent-sandbox runner, wired from mesh (`lifecycle.ts` → `buildCloneInfo`, which refreshes standard OAuth GitHub connections from `db` + an ambient `CredentialVault` — no request context needed). The runner calls it via `withFreshCloneUrl` before **both** recovery consumers of the persisted URL: the `rebootstrapDaemon` re-clone and the `resurrectByHandle` reprovision (which then feeds `refreshDaemonGitCredential` a live token to rotate `origin`).

`connectionId` is now persisted in `EnsureOptions.repo` so the callback can resolve the connection at recovery time.

**Best-effort by design:** if the mint declines or throws, `withFreshCloneUrl` falls back to the persisted URL — so nothing regresses relative to today.

### Known gaps (tracked as follow-ups, not regressions)

- **Legacy repo-scoped `ghs_` connections** can't be re-minted in this ambient callback (`MINT_REPO_TOKEN` needs an org-scoped `StudioContext`). They fall back to prior behavior. The modern repo-connect flow uses standard OAuth, which is fully covered.
- **A pod alive >55min with no recovery event** still expires the token in place — no recovery hook fires, so nothing re-mints. That needs a *periodic* refresh (daemon-side timer or server-side push), which is a separate mechanism. Flagged for a follow-up PR.

## Testing
- New unit test for the clone-URL parser (`parse-github-clone-url.test.ts`).
- `packages/sandbox` + `apps/mesh` `tsc --noEmit` clean; existing provider unit tests pass; `fmt` + `lint` (0 errors).
- The runner recovery paths themselves are k8s-integration territory (no unit harness); the change is fail-safe (falls back to prior behavior on any mint issue).

Stacked on: #4530 (shutdown-publish hardening), #4532 (SIGTERM graceful-publish CI guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-mints a fresh GitHub credential for sandbox clones during autonomous recovery to stop shutdown pushes failing with "Invalid username or token" and prevent data loss. Pods now use a live token when re-cloning and rotating origin.

- **Bug Fixes**
  - Added `mintCloneUrl` in `packages/sandbox` runner, wired from `apps/mesh` via `buildCloneInfo` + `CredentialVault`; used before `rebootstrapDaemon` and `resurrectByHandle`; falls back to the persisted URL on errors.
  - Persisted `connectionId` in `EnsureOptions.repo` so the runner can resolve and re-mint the credential on recovery.
  - Added `parseGithubOwnerRepo` and tests to safely extract owner/repo from credentialed or anonymous clone URLs.

<sup>Written for commit 5304972f76619ae3e3109aae3939e925f0836440. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

