### PR TITLE
feat(sections-editor): add text alignment to rich-text field

### DIFF
--- a/apps/mesh/package.json
+++ b/apps/mesh/package.json
@@ -70,6 +70,7 @@
     "@openrouter/ai-sdk-provider": "^2.9.1",
     "@opentelemetry/core": "^2.6.0",
     "@tanstack/react-virtual": "3.13.24",
+    "@tiptap/extension-text-align": "3.20.2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "embedded-postgres": "^18.3.0-beta.16",

--- a/apps/mesh/src/web/components/sections-editor/fields/rich-text-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/rich-text-field.tsx
@@ -1,5 +1,9 @@
 import { useRef } from "react";
 import {
+  AlignCenter,
+  AlignJustify,
+  AlignLeft,
+  AlignRight,
   Bold01,
   Heading01,
   Heading02,
@@ -11,6 +15,7 @@ import {
 } from "@untitledui/icons";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
+import TextAlign from "@tiptap/extension-text-align";
 import { Label } from "@deco/ui/components/label.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
 import type { FieldProps } from "./field-props";
@@ -63,6 +68,9 @@ export function RichTextField({
     extensions: [
       StarterKit.configure({
         heading: { levels: [1, 2, 3] },
+      }),
+      TextAlign.configure({
+        types: ["heading", "paragraph"],
       }),
     ],
     content: strValue || "",
@@ -180,6 +188,37 @@ export function RichTextField({
             }}
           >
             <Link01 size={14} />
+          </ToolbarButton>
+
+          <div className="mx-0.5 h-4 w-px bg-border" />
+
+          <ToolbarButton
+            active={editor.isActive({ textAlign: "left" })}
+            label="Align left"
+            onClick={() => editor.chain().focus().setTextAlign("left").run()}
+          >
+            <AlignLeft size={14} />
+          </ToolbarButton>
+          <ToolbarButton
+            active={editor.isActive({ textAlign: "center" })}
+            label="Align center"
+            onClick={() => editor.chain().focus().setTextAlign("center").run()}
+          >
+            <AlignCenter size={14} />
+          </ToolbarButton>
+          <ToolbarButton
+            active={editor.isActive({ textAlign: "right" })}
+            label="Align right"
+            onClick={() => editor.chain().focus().setTextAlign("right").run()}
+          >
+            <AlignRight size={14} />
+          </ToolbarButton>
+          <ToolbarButton
+            active={editor.isActive({ textAlign: "justify" })}
+            label="Justify"
+            onClick={() => editor.chain().focus().setTextAlign("justify").run()}
+          >
+            <AlignJustify size={14} />
           </ToolbarButton>
         </div>
         <EditorContent editor={editor} />

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
     },
     "apps/mesh": {
       "name": "decocms",
-      "version": "4.15.0",
+      "version": "4.22.3",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -65,6 +65,7 @@
         "@openrouter/ai-sdk-provider": "^2.9.1",
         "@opentelemetry/core": "^2.6.0",
         "@tanstack/react-virtual": "3.13.24",
+        "@tiptap/extension-text-align": "3.20.2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "embedded-postgres": "^18.3.0-beta.16",
@@ -206,7 +207,7 @@
     },
     "packages/e2e": {
       "name": "@decocms/e2e",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/sandbox": "workspace:*",
@@ -228,7 +229,7 @@
     },
     "packages/harness": {
       "name": "@decocms/harness",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.85",
         "@ai-sdk/google": "^3.0.83",
@@ -308,7 +309,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "1.14.4",
+      "version": "1.15.7",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/std": "workspace:*",
@@ -1633,6 +1634,8 @@
     "@tiptap/extension-strike": ["@tiptap/extension-strike@3.20.2", "", { "peerDependencies": { "@tiptap/core": "^3.20.2" } }, "sha512-Jivcc5Hgw2moIDfVoLEuJumDtw38k2mzEMYt3oZQnvE5d0ttXhWWR0LbLm5LBX3oxlc74I3NSi+Q4ixQHiDtvA=="],
 
     "@tiptap/extension-text": ["@tiptap/extension-text@3.20.2", "", { "peerDependencies": { "@tiptap/core": "^3.20.2" } }, "sha512-I1rVt6JTi/itgsFqXp+JfxWn9fEewIxiIaaaMUmaCJ6HChQSvYlVWy1B/RixmbCCPaL/FxybEa/Tg9MugyOJYA=="],
+
+    "@tiptap/extension-text-align": ["@tiptap/extension-text-align@3.20.2", "", { "peerDependencies": { "@tiptap/core": "^3.20.2" } }, "sha512-ior4BAu+F0dn4ErqWlAmkyy/qTaIiaJ72VBwSvEUEuuXgX8Htyg9hfE38O8MXZw/KLpL2X7i0P6VbDHhaAWA4Q=="],
 
     "@tiptap/extension-underline": ["@tiptap/extension-underline@3.20.2", "", { "peerDependencies": { "@tiptap/core": "^3.20.2" } }, "sha512-oVszIGkRtg8NLhop/t5kco6suWlDUKW9cqhL6wwd19aLztr+tMU/u8+kPG2cjjYZ+XoMZOoKfkOt7he2iU5/0A=="],
 


### PR DESCRIPTION
## Summary
The CMS rich-text widget (`rich-text-field.tsx`) had no way to align text. This adds left / center / right / justify alignment.

## Changes
- Add `@tiptap/extension-text-align@3.20.2` dependency to `apps/mesh`.
- Register `TextAlign` targeting `heading` and `paragraph` nodes.
- Add 4 alignment buttons (left, center, right, justify) to the toolbar in a dedicated group after the Link button, each reflecting active state via `editor.isActive({ textAlign })`.

## Notes
- Only touches the sections-editor field editor. The blog inline "Paragraph" block editor (`rich-text-block.tsx`) is marks-only and was left unchanged.
- Alignment is persisted as `style="text-align: ..."` in the generated HTML; the rendering surface must honor that style (the editor's `prose` preview already does).

## Testing
- `bun run --cwd=apps/mesh check` (tsc) passes.
- `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add text alignment controls (left, center, right, justify) to the CMS sections editor rich‑text field. Only affects the sections editor; the blog inline Paragraph block is unchanged.

- **New Features**
  - Alignment for `heading` and `paragraph` via `@tiptap/extension-text-align`.
  - Toolbar buttons added after Link with active state.
  - Alignment persists as inline `style="text-align: ..."` and is reflected in the preview.

- **Dependencies**
  - Add `@tiptap/extension-text-align@3.20.2` to `apps/mesh`.

<sup>Written for commit b401da82ccec9be7fcd81a01bc7d4cfffdf3e9da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

