### PR TITLE
fix(sandbox): periodically refresh git credential in long-lived pods

### DIFF
--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -165,7 +165,7 @@ async function instantiate(
         previewGateway: readPreviewGateway(),
         sentinelToken: readSandboxSentinelToken(),
         meter,
-        mintCloneUrl: async (repo) => {
+        mintCloneUrl: async (repo, mintOpts) => {
           // Only connection-backed clones can be re-minted; buildCloneInfo
           // refreshes standard OAuth GitHub connections from db + vault alone.
           // Legacy repo-scoped tokens throw here (need an org-scoped ctx) and
@@ -179,6 +179,7 @@ async function instantiate(
             parsed.name,
             db,
             vault,
+            { bufferMs: mintOpts?.bufferMs },
           );
           return cloneUrl;
         },

--- a/apps/mesh/src/shared/github-clone-info.ts
+++ b/apps/mesh/src/shared/github-clone-info.ts
@@ -79,11 +79,21 @@ export async function buildCloneInfo(
   name: string,
   db: Kysely<Database>,
   vault: CredentialVault,
+  opts?: {
+    /**
+     * Refresh the token when it has less than this many ms of life left.
+     * Callers that need a proactively-fresh token (e.g. a periodic refresh of
+     * long-lived sandboxes) pass a large value so the token is re-minted well
+     * before its ~55min expiry; omit for the default near-expiry buffer.
+     */
+    bufferMs?: number;
+  },
 ): Promise<GitHubCloneInfo> {
   const tokenStorage = new DownstreamTokenStorage(db, vault);
   const tokenResult = await getValidDownstreamAccessToken({
     connectionId,
     tokenStorage,
+    bufferMs: opts?.bufferMs,
   });
   if (!tokenResult.accessToken) {
     throw new Error(

--- a/packages/sandbox/server/provider/agent-sandbox/credential-refresh.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/credential-refresh.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { refreshCredentialsByConnection } from "./credential-refresh";
+
+type Item = { id: string; conn?: string };
+
+// Deterministic scheduler-yield so "concurrent" callbacks actually interleave
+// without wall-clock timers.
+const tick = () => Promise.resolve();
+
+describe("refreshCredentialsByConnection", () => {
+  it("processes items sharing a connection sequentially (no overlap)", async () => {
+    const active = new Map<string, number>();
+    let maxPerConn = 0;
+    const items: Item[] = [
+      { id: "a1", conn: "A" },
+      { id: "a2", conn: "A" },
+      { id: "a3", conn: "A" },
+    ];
+    await refreshCredentialsByConnection(
+      items,
+      (i) => i.conn,
+      async (i) => {
+        const n = (active.get(i.conn!) ?? 0) + 1;
+        active.set(i.conn!, n);
+        maxPerConn = Math.max(maxPerConn, n);
+        await tick();
+        await tick();
+        active.set(i.conn!, active.get(i.conn!)! - 1);
+      },
+    );
+    // Never two of connection A's items in flight at once.
+    expect(maxPerConn).toBe(1);
+  });
+
+  it("runs distinct connections in parallel", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items: Item[] = [
+      { id: "a", conn: "A" },
+      { id: "b", conn: "B" },
+      { id: "c", conn: "C" },
+    ];
+    await refreshCredentialsByConnection(
+      items,
+      (i) => i.conn,
+      async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await tick();
+        inFlight--;
+      },
+    );
+    expect(maxInFlight).toBe(3);
+  });
+
+  it("skips items with no connection id", async () => {
+    const seen: string[] = [];
+    await refreshCredentialsByConnection(
+      [{ id: "a", conn: "A" }, { id: "b" }, { id: "c", conn: "C" }] as Item[],
+      (i) => i.conn,
+      async (i) => {
+        seen.push(i.id);
+      },
+    );
+    expect(seen.sort()).toEqual(["a", "c"]);
+  });
+
+  it("isolates a failing item — others still run", async () => {
+    const done: string[] = [];
+    await refreshCredentialsByConnection(
+      [
+        { id: "a", conn: "A" },
+        { id: "b", conn: "B" },
+      ] as Item[],
+      (i) => i.conn,
+      async (i) => {
+        if (i.id === "a") throw new Error("boom");
+        done.push(i.id);
+      },
+    );
+    expect(done).toEqual(["b"]);
+  });
+});

--- a/packages/sandbox/server/provider/agent-sandbox/credential-refresh.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/credential-refresh.ts
@@ -1,0 +1,30 @@
+/**
+ * Fan out a per-item credential refresh, grouped by connection.
+ *
+ * Refreshing an OAuth token rotates its refresh_token, so two concurrent
+ * refreshes for the *same* connection race (the second uses a spent refresh
+ * token and fails). Items sharing a connection id are therefore processed
+ * sequentially — the first refresh mints, the rest see the token already fresh
+ * and no-op — while distinct connections run in parallel. Items with no
+ * connection id are skipped. Best-effort: one item's failure never blocks the
+ * others (`allSettled`), so `refreshOne` should surface its own errors.
+ */
+export async function refreshCredentialsByConnection<T>(
+  items: Iterable<T>,
+  connectionIdOf: (item: T) => string | undefined,
+  refreshOne: (item: T) => Promise<void>,
+): Promise<void> {
+  const byConnection = new Map<string, T[]>();
+  for (const item of items) {
+    const connectionId = connectionIdOf(item);
+    if (!connectionId) continue;
+    const group = byConnection.get(connectionId);
+    if (group) group.push(item);
+    else byConnection.set(connectionId, [item]);
+  }
+  await Promise.allSettled(
+    [...byConnection.values()].map(async (group) => {
+      for (const item of group) await refreshOne(item);
+    }),
+  );
+}

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -26,6 +26,7 @@
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import * as net from "node:net";
 import { PassThrough } from "node:stream";
+import { sleep } from "@decocms/std";
 import {
   type KubeConfig,
   KubeConfig as KubeConfigClass,
@@ -84,6 +85,7 @@ import {
   SandboxError,
 } from "./constants";
 import { watchClaimDeletions, watchClaimLifecycle } from "./lifecycle-watcher";
+import { refreshCredentialsByConnection } from "./credential-refresh";
 import type { ClaimPhase } from "../lifecycle-types";
 
 const RUNNER_KIND = "agent-sandbox" as const;
@@ -146,6 +148,15 @@ const RESERVED_ENV_KEYS = new Set([
 ]);
 
 const DEFAULT_IDLE_TTL_MS = 15 * 60 * 1000;
+
+// Periodic git-credential refresh for long-lived sandboxes. The clone token
+// expires ~55min after it's minted; a pod that stays alive that long with no
+// recovery event would otherwise push with a dead credential on shutdown and
+// lose the user's work. The sweep re-mints well before expiry: BUFFER > INTERVAL
+// guarantees a token entering the refresh window is re-minted within one sweep,
+// so the daemon's origin token never ages past ~(INTERVAL + a bit) < 55min.
+const CREDENTIAL_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
+const CREDENTIAL_REFRESH_BUFFER_MS = 30 * 60 * 1000;
 
 /**
  * Handle shape: `<slug>-<hash5>` when a branch is supplied, `<hash5>`
@@ -377,9 +388,14 @@ export interface AgentSandboxProviderOptions {
    * origin on recovery. Returns null when it can't re-mint (no connection,
    * legacy repo-scoped token needing an org-scoped context, mint error); the
    * runner then falls back to the persisted URL. Must never throw.
+   *
+   * `opts.bufferMs` asks the minter to refresh the token when it has less than
+   * that many ms of life left — the periodic refresher passes a large value to
+   * keep long-lived sandboxes ahead of the ~55min expiry; recovery omits it.
    */
   mintCloneUrl?: (
     repo: NonNullable<EnsureOptions["repo"]>,
+    opts?: { bufferMs?: number },
   ) => Promise<string | null>;
 }
 
@@ -450,6 +466,7 @@ export class AgentSandboxProvider implements SandboxProvider {
     this.sentinelToken = trimmedSentinel.length > 0 ? trimmedSentinel : null;
     this.mintCloneUrl = opts.mintCloneUrl;
     this.startClaimReaper();
+    this.startCredentialRefresher();
   }
 
   /**
@@ -1390,10 +1407,14 @@ export class AgentSandboxProvider implements SandboxProvider {
    */
   private async withFreshCloneUrl(
     repo: NonNullable<EnsureOptions["repo"]>,
+    bufferMs?: number,
   ): Promise<NonNullable<EnsureOptions["repo"]>> {
     if (!this.mintCloneUrl) return repo;
     try {
-      const fresh = await this.mintCloneUrl(repo);
+      const fresh = await this.mintCloneUrl(
+        repo,
+        bufferMs !== undefined ? { bufferMs } : undefined,
+      );
       return fresh ? { ...repo, cloneUrl: fresh } : repo;
     } catch (err) {
       console.warn(
@@ -1403,6 +1424,68 @@ export class AgentSandboxProvider implements SandboxProvider {
       );
       return repo;
     }
+  }
+
+  /**
+   * Keep the git credential fresh in long-lived sandboxes this replica serves.
+   * A pod alive past the clone token's ~55min expiry with no recovery event
+   * would push a dead credential on shutdown and lose the user's work; recovery
+   * (resume/adopt/resurrect) only re-mints on a claim/pod event, so a
+   * continuously-editing pod is otherwise never refreshed. Runs off the request
+   * path (zero hot-path cost); cancelled via `claimWatchAbort` on `close()`.
+   *
+   * Coverage is per-replica (`this.records` = sandboxes this replica holds
+   * warm). That's the replica whose port-forward drives the shutdown push too,
+   * so it's the right one in practice — a pod served only by another replica is
+   * refreshed by that replica instead.
+   */
+  private startCredentialRefresher(): void {
+    // No minter wired (tests / non-agent-sandbox deploys) → nothing to refresh.
+    if (!this.mintCloneUrl) return;
+    const { signal } = this.claimWatchAbort;
+    void (async () => {
+      while (!signal.aborted) {
+        await sleep(CREDENTIAL_REFRESH_INTERVAL_MS, { signal }).catch(() => {});
+        if (signal.aborted) break;
+        try {
+          await this.refreshAllGitCredentials();
+        } catch (err) {
+          console.warn(
+            `[${LOG_LABEL}] periodic credential refresh failed: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
+    })();
+  }
+
+  /**
+   * Re-mint + rotate the git credential for every cached sandbox with a
+   * connection-backed repo. Grouping/serialization is in
+   * `refreshCredentialsByConnection`; this just supplies the per-record work.
+   */
+  private async refreshAllGitCredentials(): Promise<void> {
+    await refreshCredentialsByConnection(
+      this.records.values(),
+      (rec) => rec.ensureOpts?.repo?.connectionId,
+      async (rec) => {
+        if (this.claimWatchAbort.signal.aborted) return;
+        const repo = rec.ensureOpts?.repo;
+        if (!repo) return;
+        const fresh = await this.withFreshCloneUrl(
+          repo,
+          CREDENTIAL_REFRESH_BUFFER_MS,
+        );
+        await this.refreshDaemonGitCredential(rec, {
+          ...rec.ensureOpts,
+          repo: fresh,
+        });
+        // Keep the record's URL current so the next sweep sees the fresh token
+        // (a no-op) rather than re-deriving the stale one.
+        rec.ensureOpts = { ...rec.ensureOpts, repo: fresh };
+      },
+    );
   }
 
   /**

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -152,9 +152,10 @@ const DEFAULT_IDLE_TTL_MS = 15 * 60 * 1000;
 // Periodic git-credential refresh for long-lived sandboxes. The clone token
 // expires ~55min after it's minted; a pod that stays alive that long with no
 // recovery event would otherwise push with a dead credential on shutdown and
-// lose the user's work. The sweep re-mints well before expiry: BUFFER > INTERVAL
-// guarantees a token entering the refresh window is re-minted within one sweep,
-// so the daemon's origin token never ages past ~(INTERVAL + a bit) < 55min.
+// lose the user's work. The sweep re-mints well before expiry: a token entering
+// the BUFFER window is re-minted within one INTERVAL, so the daemon's origin
+// token always keeps ≥ ~(BUFFER - INTERVAL) of life — never near the ~55min
+// expiry at an unpredictable SIGTERM. Requires BUFFER > INTERVAL.
 const CREDENTIAL_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
 const CREDENTIAL_REFRESH_BUFFER_MS = 30 * 60 * 1000;
 


### PR DESCRIPTION
## Summary

Follow-up to #4535 (re-mint on recovery). That fix only re-mints the GitHub clone credential on a **claim/pod event** (resume / adopt / resurrect). A pod that stays alive past the token's **~55min expiry with no such event** — e.g. a sandbox being edited continuously for an hour — never re-mints, so its `origin` token lapses **in place** and the shutdown `git push` still fails, losing the user's in-progress work. This closes that gap.

## What it does

Adds a periodic background sweep on the agent-sandbox runner that re-mints + rotates the git credential for every cached sandbox **before** the token expires:

- **Off the request path** — a background loop (mirrors `startClaimReaper`), cancelled via the existing `claimWatchAbort` on `close()`. Zero hot-path latency (the proxy/preview path is a cache read and must not pay a refresh cost).
- **Reuses the #4535 machinery** — `withFreshCloneUrl` + `refreshDaemonGitCredential`. The daemon no-ops when the token is unchanged, so most sweeps are cheap.
- **Timing invariant:** interval `15min` < refresh buffer `30min` < token lifetime `55min`. A token entering the 30-min-remaining window is re-minted within one sweep, so the daemon's `origin` token never ages past ~40min → always valid at an unpredictable SIGTERM (spot reclaim).
- **`buildCloneInfo` gains an optional `bufferMs`** so the periodic path forces a proactive refresh; recovery keeps the default near-expiry buffer.

## Correctness: no refresh-token races

Refreshing an OAuth token rotates its `refresh_token`, so two concurrent refreshes for the *same* connection race (the second uses a spent token and fails). The grouping/serialization is a **pure, unit-tested** helper `refreshCredentialsByConnection`: records sharing a connection are refreshed **sequentially** (the first mints, the rest see it fresh and no-op), while **distinct connections run in parallel**; items with no connection are skipped; one failure never blocks the others.

## Coverage / limits

- **Per-replica:** refreshes the sandboxes *this* replica holds warm (`this.records`) — which is the same replica whose port-forward drives that pod's shutdown push, so it's the right one in practice. A pod served only by another replica is refreshed by that replica.
- **Legacy repo-scoped connections** still can't be re-minted ambiently (needs an org-scoped `StudioContext`) — unchanged from #4535; they fall back to prior behavior.

## Testing
- New unit test `credential-refresh.test.ts` — 4 cases covering sequential-within-connection, parallel-across-connections, skip-no-connection, and fault isolation.
- `packages/sandbox` + `apps/mesh` `tsc --noEmit` clean; 72 provider tests pass; `fmt` + `lint` (0 errors).

Completes the sandbox-persistence hardening: #4530 (shutdown-publish guards) → #4532 (SIGTERM CI guard) → #4535 (re-mint on recovery) → this (re-mint for long-lived pods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Periodically refresh GitHub clone credentials in long‑lived sandboxes to prevent shutdown push failures and lost work. Runs off the hot path in the `agent-sandbox` runner and keeps tokens fresh well before expiry.

- **Bug Fixes**
  - Added a background sweep to re-mint clone tokens for cached sandboxes (15m interval, 30m buffer), canceled via the existing abort; no request-path latency. Corrected the timing‑invariant comment.
  - Introduced `refreshCredentialsByConnection` to serialize refreshes per connection and run different connections in parallel (unit-tested) to avoid refresh_token races.
  - Enabled proactive refresh by adding `bufferMs` to `buildCloneInfo` and `mintCloneUrl(repo, { bufferMs })`; rotates the daemon’s `origin` credential and updates in-memory records; scope is per-replica.

<sup>Written for commit ac6f76f894c18faa2f9c11bf063f62b7b443fcf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

