### PR TITLE
fix(sandbox): unref kill-escalation timer to avoid holding the daemon alive

### DIFF
--- a/packages/sandbox/daemon/process/task-manager.test.ts
+++ b/packages/sandbox/daemon/process/task-manager.test.ts
@@ -108,6 +108,40 @@ describe("TaskManager killAll", () => {
   });
 });
 
+describe("TaskManager kill escalation timer", () => {
+  it("unrefs the SIGKILL escalation timer so a clean kill doesn't keep the process alive for 3s", async () => {
+    const tm = makeManager();
+    const t = await tm.spawn({
+      command: "sleep 30",
+      cwd: "/tmp",
+      mode: "pipe",
+    });
+    const finished = tm.finished(t.id)!;
+
+    const originalSetTimeout = globalThis.setTimeout;
+    let escalationTimer: ReturnType<typeof setTimeout> | undefined;
+    // @ts-expect-error test-only monkeypatch to capture the escalation timer
+    globalThis.setTimeout = (
+      fn: TimerHandler,
+      ms?: number,
+      ...args: unknown[]
+    ) => {
+      const timer = originalSetTimeout(fn as never, ms, ...args);
+      if (ms === 3000) escalationTimer = timer;
+      return timer;
+    };
+    try {
+      tm.kill(t.id, "SIGTERM");
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+
+    await finished;
+    expect(escalationTimer).toBeDefined();
+    expect(escalationTimer?.hasRef()).toBe(false);
+  });
+});
+
 describe("TaskManager summary truncation", () => {
   it("flags summary.truncated when output exceeds the ring buffer but not the tee cap", async () => {
     const tm = makeManager();

--- a/packages/sandbox/daemon/process/task-manager.ts
+++ b/packages/sandbox/daemon/process/task-manager.ts
@@ -301,9 +301,10 @@ export class TaskManager {
    *  (a stuck subprocess or a shell with a trap can ignore the first signal). */
   private killWithEscalation(t: TaskInternal, signal: NodeJS.Signals): void {
     t.kill(signal);
-    setTimeout(() => {
+    const escalate = setTimeout(() => {
       if (t.status === "running") t.kill("SIGKILL");
     }, 3000);
+    escalate.unref?.();
   }
 
   delete(id: string): boolean {


### PR DESCRIPTION
## Source
Bug found reading `packages/sandbox/daemon/process/task-manager.ts` (high-churn file this run).

## The bug
`TaskManager.killWithEscalation()` (called by every `kill()`, `killByLogName()`, and `killAll()`) schedules a 3-second `setTimeout` that escalates to `SIGKILL` if the task is still running. That timer is never `.unref()`'d.

Every other timer/interval in this file *is* explicitly unref'd for this exact reason (see the `reaper` interval in the constructor). This one was missed — so a task that exits cleanly right after its first `SIGTERM` still leaves a live, ref'd timer around for up to 3s, holding the daemon's event loop open longer than necessary.

## Failure scenario
Spawn a task, call `tm.kill(id, "SIGTERM")`, the subprocess exits immediately. The escalation timer keeps the process alive for up to 3 more seconds even though there's no more work to do.

## Fix
`.unref()` the escalation timer, same as the existing reaper interval.

## Regression test
`packages/sandbox/daemon/process/task-manager.test.ts` — "unrefs the SIGKILL escalation timer so a clean kill doesn't keep the process alive for 3s". It monkeypatches `setTimeout` to capture the escalation timer and asserts `hasRef() === false`. Verified it fails on the prior code (`hasRef()` returns `true`) and passes with the fix.

## Verify
```
bun test packages/sandbox/daemon/process/task-manager.test.ts
```

## Checked locally
- `bun run fmt`
- `cd packages/sandbox && bun x tsc --noEmit`
- `bun test packages/sandbox/daemon/process/task-manager.test.ts` (14 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unrefs the SIGKILL escalation timer in the sandbox task manager so a clean kill doesn’t keep the daemon alive for ~3s. Adds a regression test to ensure the timer is unref’d.

- **Bug Fixes**
  - In `packages/sandbox/daemon/process/task-manager.ts`, store the 3s escalation timer and call `.unref()` in `killWithEscalation`, preventing the event loop from being held open after a clean exit.
  - Added `packages/sandbox/daemon/process/task-manager.test.ts` to capture the escalation timer and assert `hasRef() === false`.

<sup>Written for commit 9f9217f63eb36575b53835ecd4fcc2ca3029a001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

