### PR TITLE
feat(sidebar): hide Studio Pack default agents from browse dropdown

### DIFF
--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -34,6 +34,7 @@ import { Check, Plus } from "@untitledui/icons";
 import {
   getWellKnownDecopilotVirtualMCP,
   isDecopilot,
+  isStudioPackAgent,
   useProjectContext,
   useVirtualMCPs,
 } from "@decocms/mesh-sdk";
@@ -175,6 +176,9 @@ function PinAgentPopoverContent({
   const userAgents = agents
     .filter((s) => !isDecopilot(s.id))
     .filter((s) => !devAgentIds.has(s.id))
+    // Studio Pack default agents (Usage/Automation/Agent/Connection/Store/Brand
+    // Manager) live only on the agents page, not this browse list.
+    .filter((s) => !isStudioPackAgent(s.id))
     .filter((s) => !search || s.title.toLowerCase().includes(lowerSearch));
 
   // Decopilot — the "all threads / every agent" option in scope-picker mode.
@@ -182,6 +186,9 @@ function PinAgentPopoverContent({
   const decopilotAgent = getWellKnownDecopilotVirtualMCP(org.id);
   const showDecopilot =
     !search || decopilotAgent.title.toLowerCase().includes(lowerSearch);
+  // Decopilot only renders in scope-picker mode; when it's shown the list is
+  // never truly empty, so the "No agents yet" hint would be misleading.
+  const decopilotRowShown = Boolean(onSelectAgent && showDecopilot);
 
   const selectAll = () => {
     onSelectAgent?.(null);
@@ -237,7 +244,7 @@ function PinAgentPopoverContent({
           />
         ))}
 
-        {userAgents.length === 0 && (
+        {userAgents.length === 0 && !decopilotRowShown && (
           <div className="flex items-center justify-center py-6 text-xs text-muted-foreground">
             {search ? "No agents found" : "No agents yet"}
           </div>


### PR DESCRIPTION
## Summary
- Hide Studio Pack default agents (Usage Manager, Automation Manager, Agent Manager, Connection Manager, Store Manager, Brand Manager) from the agent browse/scope-picker dropdown in the sidebar. They now live only on the agents page (`/$org/settings/agents`).
- Suppress the "No agents yet" empty state when the Decopilot row is being shown (scope-picker mode), since the list is never truly empty in that case.

## Details
- `agents-section.tsx`: added `isStudioPackAgent` filter to the `userAgents` list feeding the dropdown (matches the well-known `studio-<name>-manager_<orgId>` id prefixes). This mirrors the existing Decopilot / dev-agent filters.
- The agents page uses the unfiltered `useVirtualMCPs()` list, so all agents remain fully visible there.

## Testing
- `bun run fmt` ✅
- Verified Studio Pack agents are seeded with `pinned: false`, so they never appeared in the sidebar's pinned list — only in this browse dropdown.

## Screenshots
Before: default agents (Usage/Automation/Agent/Connection/Store/Brand Manager) appeared in the browse dropdown. After: only user agents + Decopilot appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide Studio Pack default agents from the sidebar browse/scope-picker dropdown so only user agents and Decopilot appear. Also suppress the "No agents yet" message when Decopilot is visible.

- **New Features**
  - Filter dropdown with `isStudioPackAgent(...)`; Studio Pack agents stay on `/$org/settings/agents` (agents page uses unfiltered `useVirtualMCPs()`).
  - Hide the empty-state hint when Decopilot is shown in scope-picker mode to avoid a misleading message.

<sup>Written for commit a67db40abfc5d4d9298b0b51b1f4f0a305418d38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

