### PR TITLE
feat(task-board): add due date, redesign card & detail dialog

### DIFF
--- a/apps/mesh/migrations/127-task-board-due-date.ts
+++ b/apps/mesh/migrations/127-task-board-due-date.ts
@@ -1,0 +1,19 @@
+import { type Kysely } from "kysely";
+
+/**
+ * Adds `due_date` (nullable) to `task_board_items` so cards can carry an
+ * explicit deadline instead of stuffing "Prazo: ..." into description text.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_items")
+    .addColumn("due_date", "timestamptz")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_items")
+    .dropColumn("due_date")
+    .execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -125,6 +125,7 @@ import * as migration123connectioncredentialvault from "./123-connection-credent
 import * as migration124dropthreadprojectedseq from "./124-drop-thread-projected-seq.ts";
 import * as migration125githubchildsingleparent from "./125-github-child-single-parent.ts";
 import * as migration126taskboard from "./126-task-board.ts";
+import * as migration127taskboardduedate from "./127-task-board-due-date.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -275,6 +276,7 @@ const migrations: Record<string, Migration> = {
   "124-drop-thread-projected-seq": migration124dropthreadprojectedseq,
   "125-github-child-single-parent": migration125githubchildsingleparent,
   "126-task-board": migration126taskboard,
+  "127-task-board-due-date": migration127taskboardduedate,
 };
 
 export default migrations;

--- a/apps/mesh/src/storage/task-board.ts
+++ b/apps/mesh/src/storage/task-board.ts
@@ -48,6 +48,7 @@ export class TaskBoardStorage {
     status?: TaskBoardItemStatus;
     priority?: TaskBoardItemPriority;
     assigneeId?: string | null;
+    dueDate?: string | null;
     by: string;
   }): Promise<TaskBoardItem> {
     const id = generatePrefixedId("board");
@@ -63,6 +64,7 @@ export class TaskBoardStorage {
         status: params.status ?? "triage",
         priority: params.priority ?? "medium",
         assignee_id: params.assigneeId ?? null,
+        due_date: params.dueDate ?? null,
         created_by: params.by,
         created_at: now,
         updated_by: params.by,
@@ -83,6 +85,7 @@ export class TaskBoardStorage {
       status?: TaskBoardItemStatus;
       priority?: TaskBoardItemPriority;
       assigneeId?: string | null;
+      dueDate?: string | null;
     },
     by: string,
   ): Promise<TaskBoardItem> {
@@ -98,6 +101,7 @@ export class TaskBoardStorage {
         ...(data.assigneeId !== undefined
           ? { assignee_id: data.assigneeId }
           : {}),
+        ...(data.dueDate !== undefined ? { due_date: data.dueDate } : {}),
         updated_by: by,
         updated_at: new Date().toISOString(),
       })
@@ -125,6 +129,7 @@ export class TaskBoardStorage {
     status: string;
     priority: string;
     assignee_id: string | null;
+    due_date: string | Date | null;
     created_by: string;
     created_at: string | Date;
     updated_by: string;
@@ -138,6 +143,10 @@ export class TaskBoardStorage {
       status: row.status as TaskBoardItemStatus,
       priority: row.priority as TaskBoardItemPriority,
       assigneeId: row.assignee_id,
+      dueDate:
+        row.due_date instanceof Date
+          ? row.due_date.toISOString()
+          : row.due_date,
       createdBy: row.created_by,
       createdAt:
         row.created_at instanceof Date

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -1507,6 +1507,11 @@ export interface TaskBoardItemTable {
     string
   >;
   assignee_id: string | null;
+  due_date: ColumnType<
+    Date | null,
+    Date | string | null | undefined,
+    Date | string | null
+  >;
   created_by: string;
   created_at: ColumnType<Date, Date | string | undefined, never>;
   updated_by: string;
@@ -1521,6 +1526,7 @@ export interface TaskBoardItem {
   status: TaskBoardItemStatus;
   priority: TaskBoardItemPriority;
   assigneeId: string | null;
+  dueDate: string | null;
   createdBy: string;
   createdAt: string;
   updatedBy: string;

--- a/apps/mesh/src/tools/task-board/create.ts
+++ b/apps/mesh/src/tools/task-board/create.ts
@@ -25,6 +25,7 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
     status: TaskBoardItemStatusSchema.optional(),
     priority: TaskBoardItemPrioritySchema.optional(),
     assigneeId: z.string().nullable().optional(),
+    dueDate: z.string().datetime().nullable().optional(),
   }),
   outputSchema: z.object({ item: TaskBoardItemSchema }),
   handler: async (input, ctx) => {
@@ -51,6 +52,7 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
       status: input.status,
       priority: input.priority,
       assigneeId: input.assigneeId ?? null,
+      dueDate: input.dueDate ?? null,
       by: getUserId(ctx)!,
     });
 

--- a/apps/mesh/src/tools/task-board/schema.ts
+++ b/apps/mesh/src/tools/task-board/schema.ts
@@ -23,6 +23,7 @@ export const TaskBoardItemSchema = z.object({
   status: TaskBoardItemStatusSchema,
   priority: TaskBoardItemPrioritySchema,
   assigneeId: z.string().nullable(),
+  dueDate: z.string().datetime().nullable(),
   createdBy: z.string(),
   createdAt: z.string().datetime(),
   updatedBy: z.string(),

--- a/apps/mesh/src/tools/task-board/update.ts
+++ b/apps/mesh/src/tools/task-board/update.ts
@@ -27,6 +27,7 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     status: TaskBoardItemStatusSchema.optional(),
     priority: TaskBoardItemPrioritySchema.optional(),
     assigneeId: z.string().nullable().optional(),
+    dueDate: z.string().datetime().nullable().optional(),
   }),
   outputSchema: z.object({ item: TaskBoardItemSchema }),
   handler: async (input, ctx) => {
@@ -55,6 +56,7 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
         status: input.status,
         priority: input.priority,
         assigneeId: input.assigneeId,
+        dueDate: input.dueDate,
       },
       getUserId(ctx)!,
     );

--- a/apps/mesh/src/web/layouts/task-board/config.tsx
+++ b/apps/mesh/src/web/layouts/task-board/config.tsx
@@ -65,22 +65,26 @@ export const PRIORITIES: TaskBoardItemPriority[] = [
 
 export const PRIORITY_CONFIG: Record<
   TaskBoardItemPriority,
-  { label: string; badgeClassName: string }
+  { label: string; badgeClassName: string; flagClassName: string }
 > = {
   low: {
     label: "Low",
     badgeClassName: "bg-muted text-muted-foreground",
+    flagClassName: "text-muted-foreground",
   },
   medium: {
     label: "Medium",
     badgeClassName: "bg-blue-500/10 text-blue-600",
+    flagClassName: "text-blue-500",
   },
   high: {
     label: "High",
     badgeClassName: "bg-orange-500/10 text-orange-600",
+    flagClassName: "text-orange-500",
   },
   urgent: {
     label: "Urgent",
     badgeClassName: "bg-red-500/10 text-red-600",
+    flagClassName: "text-red-500",
   },
 };

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -9,7 +9,15 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Badge } from "@deco/ui/components/badge.tsx";
-import { Columns03, List, Loading01, Plus } from "@untitledui/icons";
+import {
+  Calendar,
+  Columns03,
+  Flag01,
+  List,
+  Loading01,
+  Plus,
+  User01,
+} from "@untitledui/icons";
 import { useMembers } from "@/web/hooks/use-members";
 import {
   useTaskBoardItemActions,
@@ -48,6 +56,34 @@ function getInitials(name?: string | null) {
     .join("")
     .toUpperCase()
     .slice(0, 2);
+}
+
+const DATE_FMT = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+});
+
+function formatDueDate(iso: string): { label: string; overdue: boolean } {
+  const d = new Date(iso);
+  const overdue = d.getTime() < Date.now();
+  return { label: DATE_FMT.format(d), overdue };
+}
+
+function DueDatePill({ iso }: { iso: string }) {
+  const { label, overdue } = formatDueDate(iso);
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px]",
+        overdue
+          ? "bg-red-500/10 text-red-600"
+          : "bg-muted text-muted-foreground",
+      )}
+    >
+      <Calendar size={10} />
+      {label}
+    </span>
+  );
 }
 
 function TaskBoardPage() {
@@ -279,6 +315,9 @@ function TaskCard({
   assignee?: Member;
   onOpen: () => void;
 }) {
+  const priorityConfig = PRIORITY_CONFIG[item.priority];
+  const due = item.dueDate ? formatDueDate(item.dueDate) : null;
+
   return (
     <button
       type="button"
@@ -288,35 +327,76 @@ function TaskCard({
         e.dataTransfer.effectAllowed = "move";
       }}
       onClick={onOpen}
-      className="flex cursor-grab flex-col gap-3 rounded-[10px] border border-border bg-card px-3.5 py-3 text-left transition-colors hover:border-ring/40 active:cursor-grabbing"
+      className="flex cursor-grab flex-col gap-2.5 rounded-[10px] border border-border bg-card px-3.5 py-3 text-left transition-colors hover:border-ring/40 active:cursor-grabbing"
     >
-      <div className="flex items-start gap-2">
-        <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-snug text-foreground">
-          {item.title}
-        </span>
-        {assignee && (
-          <Avatar
-            url={assignee.user?.image ?? undefined}
-            fallback={getInitials(assignee.user?.name)}
-            shape="circle"
-            size="2xs"
-          />
-        )}
+      <span className="min-w-0 truncate text-[13px] font-medium leading-snug text-foreground">
+        {item.title}
+      </span>
+
+      <div className="flex flex-col gap-1.5 text-[12px] text-muted-foreground">
+        <CardMetaRow
+          icon={
+            assignee ? (
+              <Avatar
+                url={assignee.user?.image ?? undefined}
+                fallback={getInitials(assignee.user?.name)}
+                shape="circle"
+                size="2xs"
+              />
+            ) : (
+              <User01 size={13} className="text-muted-foreground/60" />
+            )
+          }
+          value={assignee?.user?.name}
+        />
+        <CardMetaRow
+          icon={
+            <Calendar
+              size={13}
+              className={cn(
+                due?.overdue ? "text-red-500" : "text-muted-foreground/60",
+              )}
+            />
+          }
+          value={due?.label}
+          valueClassName={due?.overdue ? "text-red-600" : undefined}
+        />
+        <CardMetaRow
+          icon={<Flag01 size={13} className={priorityConfig.flagClassName} />}
+          value={priorityConfig.label}
+        />
       </div>
-      <div className="flex items-center gap-2">
-        <Badge
-          className={cn(
-            "text-[10px]",
-            PRIORITY_CONFIG[item.priority].badgeClassName,
-          )}
-        >
-          {PRIORITY_CONFIG[item.priority].label}
-        </Badge>
-        <span className="text-[11px] text-muted-foreground/70">
-          {formatTimeAgo(new Date(item.createdAt))}
-        </span>
-      </div>
+
+      <span className="text-[10px] text-muted-foreground/60">
+        {formatTimeAgo(new Date(item.createdAt))}
+      </span>
     </button>
+  );
+}
+
+function CardMetaRow({
+  icon,
+  value,
+  valueClassName,
+}: {
+  icon: React.ReactNode;
+  value?: string | null;
+  valueClassName?: string;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="flex size-4 shrink-0 items-center justify-center">
+        {icon}
+      </span>
+      <span
+        className={cn(
+          "min-w-0 truncate",
+          value ? valueClassName : "text-muted-foreground/50",
+        )}
+      >
+        {value ?? "—"}
+      </span>
+    </div>
   );
 }
 
@@ -349,6 +429,7 @@ function ListRow({
       >
         {PRIORITY_CONFIG[item.priority].label}
       </Badge>
+      {item.dueDate && <DueDatePill iso={item.dueDate} />}
       {assignee && (
         <Avatar
           url={assignee.user?.image ?? undefined}

--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
-import { Sheet, SheetContent, SheetTitle } from "@deco/ui/components/sheet.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -134,17 +138,17 @@ export function TaskBoardItemDialog({
   const assignee = members.find((m) => m.userId === assigneeId);
 
   return (
-    <Sheet open={open} onOpenChange={(next) => !next && close()}>
-      <SheetContent
-        side="right"
-        className="flex w-full flex-col gap-0 p-0 sm:!max-w-[640px]"
+    <Dialog open={open} onOpenChange={(next) => !next && close()}>
+      <DialogContent
+        className="flex h-[85vh] max-h-[720px] flex-col gap-0 overflow-hidden p-0 sm:max-w-[820px]"
+        closeButtonClassName="hidden"
       >
-        <SheetTitle className="sr-only">
+        <DialogTitle className="sr-only">
           {item ? "Edit task" : "New task"}
-        </SheetTitle>
+        </DialogTitle>
 
         <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-          <div className="flex flex-col gap-4 border-b border-border px-6 pt-14 pb-5">
+          <div className="flex flex-col gap-4 border-b border-border px-6 pt-6 pb-5">
             <input
               value={title}
               onChange={(e) => setTitle(e.target.value)}
@@ -345,7 +349,7 @@ export function TaskBoardItemDialog({
             {item ? "Save" : "Create task"}
           </Button>
         </div>
-      </SheetContent>
-    </Sheet>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -1,25 +1,30 @@
 import { useState } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from "@deco/ui/components/dialog.tsx";
+import { Sheet, SheetContent, SheetTitle } from "@deco/ui/components/sheet.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deco/ui/components/popover.tsx";
+import { Calendar as DayPickerCalendar } from "@deco/ui/components/calendar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
-import { ChevronDown, Trash01, User01 } from "@untitledui/icons";
+import { Calendar, ChevronDown, Trash01, User01, X } from "@untitledui/icons";
 import { useMembers } from "@/web/hooks/use-members";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   PRIORITIES,
   PRIORITY_CONFIG,
+  STATUS_CONFIG,
+  STATUSES,
   type TaskBoardItem,
   type TaskBoardItemPriority,
+  type TaskBoardItemStatus,
   type Member,
 } from "./config";
 
@@ -32,6 +37,30 @@ function getInitials(name?: string | null) {
     .toUpperCase()
     .slice(0, 2);
 }
+
+// ponytail: pinned to end-of-day so "due today" doesn't flip to overdue
+// mid-morning. Local zone in, UTC out.
+function toEndOfDayIso(d: Date): string {
+  return new Date(
+    d.getFullYear(),
+    d.getMonth(),
+    d.getDate(),
+    23,
+    59,
+    59,
+  ).toISOString();
+}
+
+function parseIsoDate(iso: string | null | undefined): Date | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+const DUE_DATE_FMT = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+});
 
 export function TaskBoardItemDialog({
   open,
@@ -48,8 +77,10 @@ export function TaskBoardItemDialog({
   onSubmit: (input: {
     title: string;
     description: string | null;
+    status: TaskBoardItemStatus;
     priority: TaskBoardItemPriority;
     assigneeId: string | null;
+    dueDate: string | null;
   }) => void;
   onDelete?: () => void;
   isSaving?: boolean;
@@ -59,18 +90,27 @@ export function TaskBoardItemDialog({
 
   const [title, setTitle] = useState(item?.title ?? "");
   const [description, setDescription] = useState(item?.description ?? "");
+  const [status, setStatus] = useState<TaskBoardItemStatus>(
+    item?.status ?? "triage",
+  );
   const [priority, setPriority] = useState<TaskBoardItemPriority>(
     item?.priority ?? "medium",
   );
   const [assigneeId, setAssigneeId] = useState<string | null>(
     item?.assigneeId ?? null,
   );
+  const [dueDate, setDueDate] = useState<Date | null>(
+    parseIsoDate(item?.dueDate),
+  );
+  const [dueOpen, setDueOpen] = useState(false);
 
   const reset = () => {
     setTitle(item?.title ?? "");
     setDescription(item?.description ?? "");
+    setStatus(item?.status ?? "triage");
     setPriority(item?.priority ?? "medium");
     setAssigneeId(item?.assigneeId ?? null);
+    setDueDate(parseIsoDate(item?.dueDate));
   };
 
   const close = () => {
@@ -84,113 +124,212 @@ export function TaskBoardItemDialog({
     onSubmit({
       title: trimmed,
       description: description.trim() || null,
+      status,
       priority,
       assigneeId,
+      dueDate: dueDate ? toEndOfDayIso(dueDate) : null,
     });
   };
 
   const assignee = members.find((m) => m.userId === assigneeId);
 
   return (
-    <Dialog open={open} onOpenChange={(next) => !next && close()}>
-      <DialogContent
-        className="gap-0 overflow-hidden p-0 sm:max-w-[560px]"
-        closeButtonClassName="hidden"
+    <Sheet open={open} onOpenChange={(next) => !next && close()}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col gap-0 p-0 sm:!max-w-[640px]"
       >
-        <DialogTitle className="sr-only">
+        <SheetTitle className="sr-only">
           {item ? "Edit task" : "New task"}
-        </DialogTitle>
+        </SheetTitle>
 
-        <div className="flex flex-col gap-3 px-4 pt-4">
-          <input
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="Task title"
-            autoFocus
-            className="w-full border-0 bg-transparent text-base font-medium text-foreground outline-none placeholder:text-muted-foreground/70"
-          />
-          <textarea
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Add a description…"
-            className="min-h-[96px] w-full resize-none border-0 bg-transparent text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/70"
-          />
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+          <div className="flex flex-col gap-4 border-b border-border px-6 pt-14 pb-5">
+            <input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Task title"
+              autoFocus
+              className="w-full border-0 bg-transparent text-xl font-semibold text-foreground outline-none placeholder:text-muted-foreground/70"
+            />
+
+            <div className="flex flex-wrap items-center gap-2">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground transition-colors hover:bg-muted"
+                  >
+                    {(() => {
+                      const Icon = STATUS_CONFIG[status].icon;
+                      return (
+                        <Icon
+                          size={13}
+                          className={STATUS_CONFIG[status].iconClassName}
+                        />
+                      );
+                    })()}
+                    {STATUS_CONFIG[status].label}
+                    <ChevronDown size={12} className="text-muted-foreground" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-44">
+                  {STATUSES.map((s) => {
+                    const Icon = STATUS_CONFIG[s].icon;
+                    return (
+                      <DropdownMenuItem
+                        key={s}
+                        onSelect={() => setStatus(s)}
+                        className="gap-2"
+                      >
+                        <Icon
+                          size={13}
+                          className={STATUS_CONFIG[s].iconClassName}
+                        />
+                        {STATUS_CONFIG[s].label}
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground transition-colors hover:bg-muted"
+                  >
+                    <span
+                      className={cn(
+                        "size-2 rounded-full",
+                        PRIORITY_CONFIG[priority].badgeClassName,
+                      )}
+                    />
+                    {PRIORITY_CONFIG[priority].label}
+                    <ChevronDown size={12} className="text-muted-foreground" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-40">
+                  {PRIORITIES.map((p) => (
+                    <DropdownMenuItem key={p} onSelect={() => setPriority(p)}>
+                      {PRIORITY_CONFIG[p].label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground transition-colors hover:bg-muted"
+                  >
+                    {assignee ? (
+                      <Avatar
+                        url={assignee.user?.image ?? undefined}
+                        fallback={getInitials(assignee.user?.name)}
+                        shape="circle"
+                        size="2xs"
+                      />
+                    ) : (
+                      <User01 size={13} className="text-muted-foreground" />
+                    )}
+                    {assignee?.user?.name ?? "Unassigned"}
+                    <ChevronDown size={12} className="text-muted-foreground" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-56">
+                  <DropdownMenuItem onSelect={() => setAssigneeId(null)}>
+                    Unassigned
+                  </DropdownMenuItem>
+                  {members.map((m) => (
+                    <DropdownMenuItem
+                      key={m.userId}
+                      onSelect={() => setAssigneeId(m.userId)}
+                      className="gap-2"
+                    >
+                      <Avatar
+                        url={m.user?.image ?? undefined}
+                        fallback={getInitials(m.user?.name)}
+                        shape="circle"
+                        size="2xs"
+                      />
+                      <span className="truncate">
+                        {m.user?.name ?? m.userId}
+                      </span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <Popover open={dueOpen} onOpenChange={setDueOpen}>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground transition-colors hover:bg-muted"
+                  >
+                    <Calendar size={13} className="text-muted-foreground" />
+                    {dueDate ? DUE_DATE_FMT.format(dueDate) : "Due date"}
+                    {dueDate ? (
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        aria-label="Clear due date"
+                        className="-mr-0.5 ml-0.5 flex size-4 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setDueDate(null);
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setDueDate(null);
+                          }
+                        }}
+                      >
+                        <X size={12} />
+                      </span>
+                    ) : (
+                      <ChevronDown
+                        size={12}
+                        className="text-muted-foreground"
+                      />
+                    )}
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <DayPickerCalendar
+                    mode="single"
+                    selected={dueDate ?? undefined}
+                    onSelect={(next) => {
+                      setDueDate(next ?? null);
+                      if (next) setDueOpen(false);
+                    }}
+                    initialFocus
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+          </div>
+
+          <div className="flex flex-1 flex-col px-6 py-5">
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Add a description…"
+              className="min-h-[320px] w-full flex-1 resize-none border-0 bg-transparent text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/70"
+            />
+          </div>
         </div>
 
-        <div className="flex items-center gap-2 border-t border-border px-4 py-3">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground transition-colors hover:bg-muted"
-              >
-                <span
-                  className={cn(
-                    "size-2 rounded-full",
-                    PRIORITY_CONFIG[priority].badgeClassName,
-                  )}
-                />
-                {PRIORITY_CONFIG[priority].label}
-                <ChevronDown size={12} className="text-muted-foreground" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-40">
-              {PRIORITIES.map((p) => (
-                <DropdownMenuItem key={p} onSelect={() => setPriority(p)}>
-                  {PRIORITY_CONFIG[p].label}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground transition-colors hover:bg-muted"
-              >
-                {assignee ? (
-                  <Avatar
-                    url={assignee.user?.image ?? undefined}
-                    fallback={getInitials(assignee.user?.name)}
-                    shape="circle"
-                    size="2xs"
-                  />
-                ) : (
-                  <User01 size={13} className="text-muted-foreground" />
-                )}
-                {assignee?.user?.name ?? "Unassigned"}
-                <ChevronDown size={12} className="text-muted-foreground" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-56">
-              <DropdownMenuItem onSelect={() => setAssigneeId(null)}>
-                Unassigned
-              </DropdownMenuItem>
-              {members.map((m) => (
-                <DropdownMenuItem
-                  key={m.userId}
-                  onSelect={() => setAssigneeId(m.userId)}
-                  className="gap-2"
-                >
-                  <Avatar
-                    url={m.user?.image ?? undefined}
-                    fallback={getInitials(m.user?.name)}
-                    shape="circle"
-                    size="2xs"
-                  />
-                  <span className="truncate">{m.user?.name ?? m.userId}</span>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
+        <div className="flex items-center gap-2 border-t border-border px-6 py-3">
           {item && onDelete && (
             <Button
               variant="ghost"
               size="icon"
               aria-label="Delete task"
-              className="ml-0 text-muted-foreground hover:text-destructive"
+              className="text-muted-foreground hover:text-destructive"
               onClick={onDelete}
             >
               <Trash01 size={14} />
@@ -206,7 +345,7 @@ export function TaskBoardItemDialog({
             {item ? "Save" : "Create task"}
           </Button>
         </div>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   );
 }


### PR DESCRIPTION
## Summary

- New nullable `due_date` column on `task_board_items` surfaced through storage, schema, and the `TASK_BOARD_ITEM_*` tool inputs — tasks can now carry an explicit deadline instead of stuffing "Prazo: ..." into the description.
- Board cards restacked vertically (assignee / due / priority flag) for legibility; overdue dates highlighted in red.
- Task detail moved from the cramped compact popup to a centered dialog (820px × 85vh) with room for long descriptions, plus chips for **status**, priority, assignee, and a proper `react-day-picker` popover for the due date (no more native `<input type="date">`).

## Files touched

- `apps/mesh/migrations/127-task-board-due-date.ts` (new)
- `apps/mesh/src/storage/{types,task-board}.ts`
- `apps/mesh/src/tools/task-board/{schema,create,update}.ts`
- `apps/mesh/src/web/layouts/task-board/{index,task-dialog,config}.tsx`

## Screenshots

<!-- drag the images into GitHub here after opening the PR -->

Card:

<!-- attach card screenshot -->

Detail dialog:

<!-- attach detail dialog screenshot -->

## Test plan

- [ ] Run `bun run --cwd=apps/mesh migrate` locally — confirms migration 127 applies.
- [ ] Enable `task_board_enabled` in org settings, open `/<org>/board`, create a task with a due date.
- [ ] Card shows the due-date pill; set a date in the past and confirm it turns red.
- [ ] Open the task, change status via the new chip, confirm it moves lanes on save.
- [ ] Clear the due date via the `×` on the chip; confirm it round-trips as `null`.
- [ ] `bun run --cwd=apps/mesh check` and `bun run fmt` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds due dates to task-board items and refreshes the UI: cards now show assignee, due date, and priority clearly, and the task detail opens in a centered dialog with a calendar picker. Overdue dates are highlighted for quick scanning.

- **New Features**
  - Data layer: adds nullable `due_date` to `task_board_items`; exposes `dueDate` on storage/types, `TaskBoardItem` schema, and `TASK_BOARD_ITEM_CREATE`/`TASK_BOARD_ITEM_UPDATE` inputs.
  - Cards: vertical meta layout (assignee, due, priority); due-date pill with red state when overdue.
  - Dialog: centered 820px × 85vh modal with room for long descriptions; chips for status/priority/assignee; due date set/clear via calendar popover.

- **Migration**
  - Run `bun run --cwd=apps/mesh migrate` to apply `127-task-board-due-date`; existing tasks keep `due_date = null`.
  - Tool users may pass/read optional ISO `dueDate` on create/update and item payloads.

<sup>Written for commit 9b4e11fdf2a0ea21ee95ac8a7594c510ac65c5b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

