### PR TITLE
feat(sandbox): instant loading feedback when selecting a preview page

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -289,6 +289,26 @@ export function PreviewContent({
     Record<string, Record<string, string>>
   >({});
 
+  // Instant click feedback: set the moment a page/section is picked, cleared
+  // when the iframe's onLoad fires. Without this the click has no visible
+  // effect until the new page finishes fetching, so it feels unresponsive.
+  const [navigating, setNavigating] = useState(false);
+  const navTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const beginNavigation = () => {
+    setNavigating(true);
+    if (navTimerRef.current) clearTimeout(navTimerRef.current);
+    // Safety net: clear the indicator even if onLoad never fires (network
+    // failure, cross-origin redirect) so it can't get stuck on forever.
+    navTimerRef.current = setTimeout(() => setNavigating(false), 15000);
+  };
+  const endNavigation = () => {
+    if (navTimerRef.current) {
+      clearTimeout(navTimerRef.current);
+      navTimerRef.current = null;
+    }
+    setNavigating(false);
+  };
+
   // SEO panel state
   const [cmsInitialEditSeo, setCmsInitialEditSeo] = useState(false);
   const [siteSeoOpen, setSiteSeoOpen] = useState(false);
@@ -752,7 +772,13 @@ export function PreviewContent({
   const navigatePreviewToPage = (page: PageEntry) => {
     // The iframe loads the template with any stored param values filled in.
     const params = pathParamsByPage[page.key] ?? {};
-    intendedPathRef.current = fillPathTemplate(page.path, params);
+    const target = fillPathTemplate(page.path, params);
+    // Show the loading indicator only when the iframe will actually reload —
+    // re-selecting the current page leaves `iframeSrc` unchanged (no onLoad).
+    if (activeGlobalSection || normPath(target) !== normPath(resolvedPath)) {
+      beginNavigation();
+    }
+    intendedPathRef.current = target;
     setActiveGlobalSection(null);
     setDirectPreviewUrl(null);
     setPinnedPageKey(page.key);
@@ -777,6 +803,7 @@ export function PreviewContent({
       toast.error("Preview metadata not ready yet");
       return;
     }
+    beginNavigation();
     intendedPathRef.current = null;
     const livePageRt = findLivePageResolveType(meta);
     const url = buildGlobalSectionPreviewUrl(
@@ -1292,6 +1319,12 @@ export function PreviewContent({
               "flex justify-center bg-muted/30",
           )}
         >
+          {navigating && previewState.kind === "iframe" && (
+            <div className="absolute inset-x-0 top-0 z-40 h-0.5 overflow-hidden bg-primary/15">
+              <div className="absolute inset-y-0 w-2/5 rounded-full bg-primary animate-preview-nav" />
+            </div>
+          )}
+
           {showBootingOverlay && (
             <div className="absolute inset-0 z-30">
               <SandboxStateCard
@@ -1404,6 +1437,9 @@ export function PreviewContent({
                 title="Dev Server Preview"
                 tabIndex={sectionsOpen ? -1 : undefined}
                 onLoad={() => {
+                  // The page finished loading — always clear the navigation
+                  // indicator first, before any of the early returns below.
+                  endNavigation();
                   // This is the VM dev-server preview (sandboxed running app),
                   // NOT an MCP app. MCP apps render via <MCPAppRenderer/>.
                   track("vm_preview_loaded", {

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -279,6 +279,7 @@
     infinite;
   --animate-connection-arrive: connection-arrive 2.6s var(--ease-out-cubic)
     infinite;
+  --animate-preview-nav: preview-nav 1.1s var(--ease-in-out-cubic) infinite;
 }
 
 /* Animations */
@@ -353,7 +354,32 @@
   }
 }
 
+/* Indeterminate top progress bar shown the instant a page/section is selected,
+   until the preview iframe finishes loading — immediate click feedback. */
+@keyframes preview-nav {
+  0% {
+    left: -40%;
+    width: 40%;
+  }
+  50% {
+    width: 55%;
+  }
+  100% {
+    left: 100%;
+    width: 40%;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
+  /* Park it as a static full-width bar — still signals loading, no motion. */
+  @keyframes preview-nav {
+    0%,
+    100% {
+      left: 0%;
+      width: 100%;
+    }
+  }
+
   @keyframes device-icon-pop {
     from {
       opacity: 0;


### PR DESCRIPTION
## Summary

Selecting a page in the preview URL-bar page picker only swapped the iframe `src` and waited for `onLoad`, so nothing visible happened until the new page finished fetching. It felt like the click did nothing.

This adds **instant click feedback**: a thin indeterminate progress bar appears at the top of the preview the moment a page (or global section) is selected, and clears when the iframe finishes loading.

## Changes

- **`apps/mesh/src/web/components/sandbox/preview/preview.tsx`**
  - New `navigating` state + `beginNavigation()` / `endNavigation()` helpers. `beginNavigation()` sets the loading flag synchronously on click (immediate feedback) and arms a 15s safety timer so the bar never gets stuck if `onLoad` never fires (network failure / cross-origin redirect).
  - `navigatePreviewToPage()` triggers feedback — guarded so re-selecting the already-open page (iframe won't reload, no `onLoad`) doesn't leave the bar spinning.
  - `navigatePreviewToGlobalSection()` triggers feedback too.
  - The iframe `onLoad` calls `endNavigation()` first, before the existing early-returns, so it always clears.
  - Progress bar rendered at the top of the preview container (`z-40`, above the iframe).
- **`packages/ui/src/styles/global.css`**
  - New `preview-nav` keyframe + `--animate-preview-nav` design-system token, matching the existing animation-token pattern.
  - `prefers-reduced-motion` variant: static full-width bar, no motion.

## Scope note

This covers the **preview** page picker (URL-bar dropdown) — the "select page → preview updates" flow. The Content/Blocks sidebar page list is a separate surface that drives the sections editor, not the iframe, and is not touched here.

## Testing

- `bun run fmt` ✅
- `bun run check` (tsc) ✅
- `bun run lint` ✅ (0 errors; pre-existing unrelated warnings only)
- Manual: not exercised end-to-end in this environment. Recommend verifying with `bun run dev` → open preview → switch pages → bar should appear instantly at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds instant click feedback when selecting a preview page or global section in the sandbox. A thin top progress bar appears immediately and clears when the iframe finishes loading.

- **New Features**
  - Show an indeterminate progress bar on page/section selection; clear it on iframe `onLoad`.
  - Guard for re-selecting the current page (no reload, no bar) and a 15s safety timeout to prevent a stuck indicator.
  - Adds `--animate-preview-nav` and `preview-nav` keyframes in `packages/ui`; respects `prefers-reduced-motion`.

<sup>Written for commit c0473f4760e3721d8f58dc870f2fbfb380217b81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

