### PR TITLE
fix(sidebar): show org actions when sidebar is collapsed

### DIFF
--- a/apps/mesh/src/web/components/header/linked-desktop-indicator.tsx
+++ b/apps/mesh/src/web/components/header/linked-desktop-indicator.tsx
@@ -5,6 +5,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
+import { SidebarMenuButton } from "@deco/ui/components/sidebar.tsx";
 import { useCurrentLink } from "@/web/hooks/use-current-link";
 import {
   ConnectDesktopDialog,
@@ -12,11 +13,21 @@ import {
 } from "@/web/components/chat/connect-desktop-dialog";
 import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
 
-export function LinkedDesktopIndicator() {
+/**
+ * `icon` (default) renders the compact toolbar button used in the header and
+ * collapsed sidebar. `full` renders a full-width sidebar row with a label, for
+ * the expanded sidebar footer.
+ */
+export function LinkedDesktopIndicator({
+  variant = "icon",
+}: {
+  variant?: "icon" | "full";
+} = {}) {
   const link = useCurrentLink();
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const labels = visibleCapabilities(link.capabilities);
+  const label = link.online ? "Desktop linked" : "Connect desktop";
   const tooltipContent = link.online ? (
     <div className="flex flex-col gap-0.5 text-xs">
       <span className="font-medium">
@@ -31,6 +42,29 @@ export function LinkedDesktopIndicator() {
   ) : (
     <span className="text-xs">Desktop disconnected</span>
   );
+
+  if (variant === "full") {
+    return (
+      <>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <SidebarMenuButton
+              tooltip={label}
+              onClick={() => setDialogOpen(true)}
+            >
+              <Monitor01 />
+              <span>{label}</span>
+              {link.online && (
+                <span className="ml-auto size-2 rounded-full bg-success animate-pulse" />
+              )}
+            </SidebarMenuButton>
+          </TooltipTrigger>
+          <TooltipContent side="right">{tooltipContent}</TooltipContent>
+        </Tooltip>
+        <ConnectDesktopDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+      </>
+    );
+  }
 
   return (
     <>

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -283,6 +283,7 @@ export function SidebarInboxFooter() {
     return (
       <SidebarFooter className="px-2 pb-3 gap-1">
         <SidebarTopActions />
+        <SidebarExtraActions />
         <SidebarMenu>
           <SidebarMenuItem>
             <div className="flex justify-center">

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -9,14 +9,8 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarSeparator,
   useSidebar,
 } from "@deco/ui/components/sidebar.tsx";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
   ArrowLeft,
@@ -31,17 +25,13 @@ import { InviteMemberDialog } from "@/web/components/invite-member-dialog";
 import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useNavigate } from "@tanstack/react-router";
-import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
 import { LinkedDesktopIndicator } from "@/web/components/header/linked-desktop-indicator";
 import { InvitationItem } from "@/web/components/sidebar/footer/invitation-item";
 import { JoinRequestItem } from "@/web/components/sidebar/footer/join-request-item";
 import { InboxReleaseItem } from "@/web/components/release-channel/inbox-release-item";
 import { ReleaseCard } from "@/web/components/release-channel/release-card";
 import { useInboxFeed } from "@/web/hooks/use-inbox-feed";
-import {
-  SidebarTopActions,
-  SidebarTopActionsInline,
-} from "@/web/components/sidebar/top-actions";
+import { SidebarTopActions } from "@/web/components/sidebar/top-actions";
 
 function InboxPopover({ children }: { children: ReactNode }) {
   const { items, markReleaseSeen } = useInboxFeed();
@@ -169,27 +159,6 @@ function InboxFullButton() {
   );
 }
 
-function InboxIconButton() {
-  const hasUnread = useHasUnreadInbox();
-  return (
-    <InboxPopover>
-      <Tooltip delayDuration={300}>
-        <PopoverTrigger asChild>
-          <TooltipTrigger asChild>
-            <ToolbarIconButton aria-label="Inbox">
-              <Inbox01 className="size-4" />
-              {hasUnread && (
-                <span className="absolute top-0.5 right-0.5 size-2 rounded-full bg-red-500 pointer-events-none" />
-              )}
-            </ToolbarIconButton>
-          </TooltipTrigger>
-        </PopoverTrigger>
-        <TooltipContent side="top">Inbox</TooltipContent>
-      </Tooltip>
-    </InboxPopover>
-  );
-}
-
 function SettingsFullButton() {
   const navigate = useNavigate();
   const { org } = useProjectContext();
@@ -206,29 +175,6 @@ function SettingsFullButton() {
       <Settings02 />
       <span>Settings</span>
     </SidebarMenuButton>
-  );
-}
-
-function SettingsIconButton() {
-  const navigate = useNavigate();
-  const { org } = useProjectContext();
-  return (
-    <Tooltip delayDuration={300}>
-      <TooltipTrigger asChild>
-        <ToolbarIconButton
-          aria-label="Settings"
-          onClick={() =>
-            navigate({
-              to: "/$org/settings",
-              params: { org: org.slug },
-            })
-          }
-        >
-          <Settings02 className="size-4" />
-        </ToolbarIconButton>
-      </TooltipTrigger>
-      <TooltipContent side="top">Settings</TooltipContent>
-    </Tooltip>
   );
 }
 
@@ -305,22 +251,23 @@ export function SidebarInboxFooter() {
   }
 
   return (
-    <SidebarFooter className="px-2 pb-3 gap-1.5">
+    <SidebarFooter className="px-2 pb-3 gap-0.5">
       <SidebarExtraActions />
-      <SidebarSeparator className="mx-0" />
-      <div className="flex items-center gap-1">
-        <div className="flex-1 min-w-0">
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <AccountPopover />
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </div>
-        <SettingsIconButton />
-        <InboxIconButton />
-        <LinkedDesktopIndicator />
-        <SidebarTopActionsInline />
-      </div>
+      <SidebarTopActions />
+      <SidebarMenu className="gap-0.5">
+        <SidebarMenuItem>
+          <InboxFullButton />
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SettingsFullButton />
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <LinkedDesktopIndicator variant="full" />
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <AccountPopover />
+        </SidebarMenuItem>
+      </SidebarMenu>
     </SidebarFooter>
   );
 }

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -228,16 +228,16 @@ export function SidebarInboxFooter() {
   if (isCollapsed) {
     return (
       <SidebarFooter className="px-2 pb-3 gap-1">
-        <SidebarTopActions />
         <SidebarExtraActions />
+        <SidebarTopActions />
         <SidebarMenu>
+          <SidebarMenuItem>
+            <InboxFullButton />
+          </SidebarMenuItem>
           <SidebarMenuItem>
             <div className="flex justify-center">
               <LinkedDesktopIndicator />
             </div>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <InboxFullButton />
           </SidebarMenuItem>
           <SidebarMenuItem>
             <SettingsFullButton />
@@ -259,10 +259,10 @@ export function SidebarInboxFooter() {
           <InboxFullButton />
         </SidebarMenuItem>
         <SidebarMenuItem>
-          <SettingsFullButton />
+          <LinkedDesktopIndicator variant="full" />
         </SidebarMenuItem>
         <SidebarMenuItem>
-          <LinkedDesktopIndicator variant="full" />
+          <SettingsFullButton />
         </SidebarMenuItem>
         <SidebarMenuItem>
           <AccountPopover />

--- a/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/inbox.tsx
@@ -228,12 +228,14 @@ export function SidebarInboxFooter() {
   if (isCollapsed) {
     return (
       <SidebarFooter className="px-2 pb-3 gap-1">
-        <SidebarExtraActions />
-        <SidebarTopActions />
         <SidebarMenu>
           <SidebarMenuItem>
             <InboxFullButton />
           </SidebarMenuItem>
+        </SidebarMenu>
+        <SidebarExtraActions />
+        <SidebarTopActions />
+        <SidebarMenu>
           <SidebarMenuItem>
             <div className="flex justify-center">
               <LinkedDesktopIndicator />
@@ -252,12 +254,14 @@ export function SidebarInboxFooter() {
 
   return (
     <SidebarFooter className="px-2 pb-3 gap-0.5">
-      <SidebarExtraActions />
-      <SidebarTopActions />
       <SidebarMenu className="gap-0.5">
         <SidebarMenuItem>
           <InboxFullButton />
         </SidebarMenuItem>
+      </SidebarMenu>
+      <SidebarExtraActions />
+      <SidebarTopActions />
+      <SidebarMenu className="gap-0.5">
         <SidebarMenuItem>
           <LinkedDesktopIndicator variant="full" />
         </SidebarMenuItem>

--- a/apps/mesh/src/web/components/sidebar/footer/repo-switcher.tsx
+++ b/apps/mesh/src/web/components/sidebar/footer/repo-switcher.tsx
@@ -185,7 +185,7 @@ function RepoSwitcherInner({ onAddNew }: { onAddNew: () => void }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <SidebarMenuButton>
+        <SidebarMenuButton tooltip="Add repo">
           <GitHubIcon />
           <span>Add repo</span>
         </SidebarMenuButton>

--- a/apps/mesh/src/web/components/sidebar/top-actions.tsx
+++ b/apps/mesh/src/web/components/sidebar/top-actions.tsx
@@ -11,12 +11,6 @@ import { useNavigate } from "@tanstack/react-router";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useDecoCredits } from "@/web/hooks/use-deco-credits";
 import { cn } from "@deco/ui/lib/utils.ts";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
 
 class SilentErrorBoundary extends Component<
   { children: ReactNode },
@@ -81,46 +75,6 @@ export function SidebarTopActions() {
     <SilentErrorBoundary>
       <Suspense fallback={null}>
         <CreditChip />
-      </Suspense>
-    </SilentErrorBoundary>
-  );
-}
-
-function CreditChipInline() {
-  const navigate = useNavigate();
-  const { org } = useProjectContext();
-  const { hasDecoKey, balanceDollars } = useDecoCredits();
-  if (!hasDecoKey) return null;
-  const tooltipLabel =
-    balanceDollars != null
-      ? `Credits: $${balanceDollars.toFixed(2)}`
-      : "Credits";
-  return (
-    <Tooltip delayDuration={300}>
-      <TooltipTrigger asChild>
-        <ToolbarIconButton
-          aria-label={tooltipLabel}
-          onClick={() =>
-            navigate({
-              to: "/$org/settings/ai-providers",
-              params: { org: org.slug },
-            })
-          }
-          className={cn(balanceDollars != null && creditColor(balanceDollars))}
-        >
-          <Coins04 className="size-4" />
-        </ToolbarIconButton>
-      </TooltipTrigger>
-      <TooltipContent side="top">{tooltipLabel}</TooltipContent>
-    </Tooltip>
-  );
-}
-
-export function SidebarTopActionsInline() {
-  return (
-    <SilentErrorBoundary>
-      <Suspense fallback={null}>
-        <CreditChipInline />
       </Suspense>
     </SilentErrorBoundary>
   );


### PR DESCRIPTION
## Summary

The **Invite members**, **Add repo**, and **Add connection** actions disappeared when the sidebar was collapsed. They live in `SidebarExtraActions`, which was only rendered in the *expanded* branch of `SidebarInboxFooter` — the collapsed branch early-returns a different layout that omitted the group entirely.

## Changes

- `inbox.tsx` — render `<SidebarExtraActions />` in the collapsed footer branch too. The buttons already carry `tooltip` props, so the design-system sidebar collapses them to icon-only buttons with hover tooltips.
- `repo-switcher.tsx` — add `tooltip="Add repo"` to the dropdown-trigger variant (used once the org has repos), matching the plain `AddRepoButton` fallback, so it has a label in collapsed mode.

## Testing

Visual: collapse the sidebar and confirm the three action icons appear with tooltips, and the "Add repo" dropdown still opens when repos exist. `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores org actions in the collapsed sidebar, moves Inbox to the top of the footer, and switches expanded mode to labeled rows for clarity. Adds tooltips so actions stay discoverable and standardizes action order.

- **Bug Fixes**
  - Collapsed: show Inbox first; render org actions and credits; add “Add repo” tooltip on the repo switcher trigger.
  - Expanded: render Inbox, Linked desktop, and Settings as full-width rows via a new full variant of the desktop indicator; remove icon-only buttons and the separator.
  - Order: unify both modes to Inbox → Invite/Repo/Connection → credits → Desktop → Settings → Account.

<sup>Written for commit 3b626206d17ba3466be5430d0beafe55ced6f7c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

