### PR TITLE
fix(sandbox): don't let one item's failure block its connection's queue in credential refresh

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/credential-refresh.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/credential-refresh.test.ts
@@ -80,4 +80,21 @@ describe("refreshCredentialsByConnection", () => {
     );
     expect(done).toEqual(["b"]);
   });
+
+  it("keeps processing later items in the same connection's queue after an earlier one throws", async () => {
+    const done: string[] = [];
+    await refreshCredentialsByConnection(
+      [
+        { id: "a1", conn: "A" },
+        { id: "a2", conn: "A" },
+        { id: "a3", conn: "A" },
+      ] as Item[],
+      (i) => i.conn,
+      async (i) => {
+        if (i.id === "a1") throw new Error("boom");
+        done.push(i.id);
+      },
+    );
+    expect(done).toEqual(["a2", "a3"]);
+  });
 });

--- a/packages/sandbox/server/provider/agent-sandbox/credential-refresh.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/credential-refresh.ts
@@ -7,7 +7,8 @@
  * sequentially — the first refresh mints, the rest see the token already fresh
  * and no-op — while distinct connections run in parallel. Items with no
  * connection id are skipped. Best-effort: one item's failure never blocks the
- * others (`allSettled`), so `refreshOne` should surface its own errors.
+ * others — including later items *in the same connection's queue* — so
+ * `refreshOne` should surface its own errors.
  */
 export async function refreshCredentialsByConnection<T>(
   items: Iterable<T>,
@@ -24,7 +25,11 @@ export async function refreshCredentialsByConnection<T>(
   }
   await Promise.allSettled(
     [...byConnection.values()].map(async (group) => {
-      for (const item of group) await refreshOne(item);
+      for (const item of group) {
+        // A throw here must not stop the rest of this connection's queue —
+        // `refreshOne` is expected to log its own errors (see docstring).
+        await refreshOne(item).catch(() => {});
+      }
     }),
   );
 }


### PR DESCRIPTION
## Source
A bug found while reading `packages/sandbox/server/provider/agent-sandbox/credential-refresh.ts` (recently-changed file).

## The bug
`refreshCredentialsByConnection` groups items by connection id and processes each group sequentially with a plain `for (const item of group) await refreshOne(item);` loop. If `refreshOne` throws for the first item in a connection's group, every later item queued behind it for that *same connection* is silently skipped for the rest of the sweep — contradicting the function's own docstring: "Best-effort: one item's failure never blocks the others."

Concrete failure scenario: connection `A` has three cached sandbox records; `refreshOne` throws for the first. Before this fix, the other two records for connection `A` never get their git credential refreshed in that sweep (see the new regression test `keeps processing later items in the same connection's queue after an earlier one throws`, which fails on current `main` and passes after the fix).

The one current caller (`refreshAllGitCredentials` in `runner.ts`) happens to swallow all its own errors today, so this isn't yet observable in production — but it's a real trap in the shared helper: any future caller (or a removed try/catch upstream) would silently stop refreshing git credentials for every other sandbox sharing that connection after the first failure, which is exactly the "stale credential pushed on shutdown" failure mode this refresher exists to prevent.

## Fix
Catch per-item inside the sequential loop so a throw only affects that one item, matching the documented contract.

## To verify
```
bun test packages/sandbox/server/provider/agent-sandbox/credential-refresh.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun test packages/sandbox/server/provider/agent-sandbox/credential-refresh.test.ts` (5 pass)

No types changed, so no targeted `tsc` was needed. Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a single item's failure from blocking other items on the same connection during credential refresh. Ensures best-effort processing across all items sharing a connection.

- **Bug Fixes**
  - Wrap per-item calls with a no-op catch inside the per-connection loop in `packages/sandbox/server/provider/agent-sandbox/credential-refresh.ts`.
  - Add a regression test in `packages/sandbox/server/provider/agent-sandbox/credential-refresh.test.ts` to verify later items still run after an earlier failure.

<sup>Written for commit 50b3afa93cfe68a18af6bebf35c78d122920571e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

