### PR TITLE
fix(sandbox): lazy-detach org-fs mounts so sidecar exits 0

### DIFF
--- a/packages/sandbox/daemon/org-fs/detach-mount.test.ts
+++ b/packages/sandbox/daemon/org-fs/detach-mount.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+import { detachCommands } from "./detach-mount";
+
+// The whole point of the change: teardown must use non-blocking (lazy) detach
+// so several unmounts can't serialize past the pod's terminationGracePeriod.
+test("linux detach uses lazy flags", () => {
+  expect(detachCommands("/app/org/home", false)).toEqual([
+    ["fusermount", "-uz", "/app/org/home"],
+    ["umount", "-l", "/app/org/home"],
+  ]);
+});
+
+test("macos detach uses force flag", () => {
+  expect(detachCommands("/app/org/home", true)).toEqual([
+    ["umount", "-f", "/app/org/home"],
+  ]);
+});

--- a/packages/sandbox/daemon/org-fs/detach-mount.ts
+++ b/packages/sandbox/daemon/org-fs/detach-mount.ts
@@ -1,4 +1,24 @@
 /**
+ * Detach commands to try, in order, for `mountPath`. Pure so the flag choice is
+ * unit-testable without spawning. Every command is the NON-BLOCKING variant:
+ * Linux `fusermount -uz` / `umount -l` and macOS `umount -f` all return
+ * immediately and let the kernel finish cleanup once references drop. A plain
+ * `fusermount -u` / `umount` instead blocks in-kernel while the FUSE server
+ * flushes (up to the spawnSync timeout below). That matters because MountManager
+ * unmounts run this synchronously with no internal await, so several blocking
+ * detaches serialize and can overrun the pod's terminationGracePeriod → the
+ * sidecar is SIGKILLed (exit 137) instead of exiting 0.
+ */
+export function detachCommands(mountPath: string, isMac: boolean): string[][] {
+  return isMac
+    ? [["umount", "-f", mountPath]]
+    : [
+        ["fusermount", "-uz", mountPath],
+        ["umount", "-l", mountPath],
+      ];
+}
+
+/**
  * Force-detach whatever is mounted at `mountPath` (best-effort, never throws).
  * Used both to tear down our own mount and to reclaim a stale ghost left by a
  * previously-killed session before mounting fresh. On a path that isn't a mount
@@ -11,18 +31,9 @@ export function detachMount(mountPath: string, isMac: boolean): void {
   // for every tracked mount path). No-op rather than spawn a binary that
   // doesn't exist.
   if (process.platform === "win32") return;
-  // NFS + FUSE both unmount via `umount`; on Linux `fusermount -u` is the
-  // unprivileged path, so try it first there.
-  const cmds: string[][] = isMac
-    ? [["umount", "-f", mountPath]]
-    : [
-        ["fusermount", "-u", mountPath],
-        ["umount", mountPath],
-      ];
-  for (const cmd of cmds) {
-    // `umount -f` is the non-blocking force path, but bound it anyway: this
-    // runs on every mount (reclaim) and at shutdown, and a wedged kernel
-    // unmount must never hang the daemon.
+  for (const cmd of detachCommands(mountPath, isMac)) {
+    // Keep the timeout as a backstop even though every command is lazy: a
+    // wedged kernel must never hang the daemon.
     const p = Bun.spawnSync(cmd, {
       stdout: "ignore",
       stderr: "ignore",


### PR DESCRIPTION
Diagnosis of `agent-sandbox-system` pods stuck in `Error`: the `sandbox` container exits `0` but `orgfs-sidecar` exits **137 (SIGKILL)**, which flips the whole pod to `phase=Failed`.

On SIGTERM the sidecar unmounts its 5 `fuse.rclone` volumes before `process.exit(0)`, but `detachMount` used the **blocking** unmount variants (`fusermount -u` / `umount`). Those block in-kernel while the FUSE server flushes, and since `MountManager.stop()` runs each unmount synchronously (no internal `await` before the blocking `Bun.spawnSync`), the "parallel" detaches actually serialize — up to `5 × (5s + 5s)` of blocking, overrunning the pod`s 30s `terminationGracePeriod`.

**Fix:** switch Linux to lazy detach (`fusermount -uz` / `umount -l`). Both return immediately and let the kernel finish cleanup once references drop, so teardown never blocks. macOS `umount -f` is unchanged. Added a small unit test locking in the lazy flags.

Primary fix of a 3-PR series (the other two harden the same teardown path and GC the leftover Failed pods); independent and mergeable on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch org-fs teardown to lazy unmount on Linux so the sidecar exits 0 and pods no longer get marked Failed during shutdown.

- **Bug Fixes**
  - Use lazy detach on Linux: `fusermount -uz` then `umount -l`; macOS stays `umount -f`.
  - Prevents blocking unmounts during SIGTERM that caused exit 137 and Failed pods.
  - Adds a unit test to lock in the lazy flags.

<sup>Written for commit 20b2401e2cc3a1fecbb202f3e6a48544c3754e0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

