### PR TITLE
fix(sandbox): bound rclone teardown so a stuck flush can't wedge shutdown

### DIFF
--- a/packages/sandbox/daemon/org-fs/mounter.ts
+++ b/packages/sandbox/daemon/org-fs/mounter.ts
@@ -211,8 +211,13 @@ async function waitForMount(
   throw new Error(`rclone ${subcommand} not ready for ${mountPath} in time`);
 }
 
+/** Cap on how long we wait for rclone to exit after SIGTERM before SIGKILLing.
+ *  Well under the pod's terminationGracePeriod so all mounts can drain in
+ *  parallel and still leave slack. */
+const RCLONE_EXIT_TIMEOUT_MS = 5_000;
+
 function makeHandle(
-  proc: { kill: () => void; exited: Promise<number> },
+  proc: { kill: (signal?: number) => void; exited: Promise<number> },
   mountPath: string,
   isMac: boolean,
 ): MountHandle {
@@ -228,7 +233,25 @@ function makeHandle(
       } catch {
         // already gone
       }
-      await proc.exited.catch(() => {});
+      // rclone flushes its --vfs-cache-mode full write-back cache on SIGTERM;
+      // against a slow or unreachable mesh that flush can outlast the pod's
+      // terminationGracePeriod and hang shutdown → the sidecar is SIGKILLed
+      // (exit 137). Bound the wait, then SIGKILL rclone so teardown always
+      // makes progress. Unflushed writes at teardown are best-effort anyway.
+      const exited = proc.exited.catch(() => {});
+      const timeout = Symbol("timeout");
+      const outcome = await Promise.race([
+        exited.then(() => null),
+        sleep(RCLONE_EXIT_TIMEOUT_MS).then(() => timeout),
+      ]);
+      if (outcome === timeout) {
+        try {
+          proc.kill(9);
+        } catch {
+          // already gone
+        }
+        await exited;
+      }
     },
   };
 }


### PR DESCRIPTION
Part of the org-fs sidecar exit-137 fix series (independent of the others).

On unmount the sidecar SIGTERMs the foreground rclone child and `await proc.exited`. rclone flushes its `--vfs-cache-mode full` write-back cache on SIGTERM; against a slow/unreachable mesh that flush can outlast the pod`s 30s `terminationGracePeriod`, so `await proc.exited` hangs and the sidecar is SIGKILLed (exit 137) → pod `Failed`.

**Fix:** bound the exit wait (5s), then `SIGKILL` rclone so teardown always makes progress well within the grace window. Unflushed writes at teardown are best-effort regardless.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound `rclone` teardown on unmount to prevent shutdown hangs that caused the sidecar to be SIGKILLed (exit 137). After SIGTERM we wait up to 5s; if it’s still running we send SIGKILL so teardown completes within the pod’s `terminationGracePeriod`.

<sup>Written for commit 252d453d81f32f98cd01763e79cd529ed62cd9ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

