### PR TITLE
fix(sandbox-housekeeper): reap Failed sandbox pods orphaned by deleted Sandbox

### DIFF
--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
@@ -320,4 +320,22 @@ if [ "$selector_mismatch" -eq 0 ]; then
   done < "$ROUTES_FILE"
 fi
 
-log "heartbeat ok claims=$total reaped=$reaped skipped=$skipped orphan_routes=$orphan_routes"
+# === Failed pod GC ===
+# A sandbox pod whose orgfs-sidecar can't unmount within terminationGracePeriod
+# is SIGKILLed (exit 137), flipping the whole pod to phase=Failed. Its owner
+# Sandbox is already gone by then, so nothing garbage-collects it and Failed
+# pods pile up for hours. Reap them here — Failed is terminal, so a delete can't
+# race a live workload. Gated on selector_mismatch (same caution as routes).
+failed_pods=0
+if [ "$selector_mismatch" -eq 0 ]; then
+  for POD in $(kubectl get pods -n "$NS" -l "$POD_SELECTOR" \
+      --field-selector=status.phase=Failed \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null); do
+    [ -z "$POD" ] && continue
+    log "failed-pod-gc pod=$POD"
+    kubectl delete pod "$POD" -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
+    failed_pods=$((failed_pods + 1))
+  done
+fi
+
+log "heartbeat ok claims=$total reaped=$reaped skipped=$skipped orphan_routes=$orphan_routes failed_pods=$failed_pods"

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -36,9 +36,11 @@ rules:
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxclaims"]
     verbs: ["get", "list", "patch", "delete"]
+  # list = idle-probe pod-IP lookup; delete = Failed-pod GC (sidecar SIGKILL
+  # leaves an orphaned phase=Failed pod its deleted Sandbox can't reap).
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["list"]
+    verbs: ["list", "delete"]
   # Reap events outlive the claim object — used for post-mortem.
   # events.k8s.io/v1 is the current API; legacy `[""] events` is deprecated.
   # `kubectl get events` aggregates from both, so consumers are unaffected.


### PR DESCRIPTION
Part of the org-fs sidecar exit-137 fix series (independent of the others).

When `orgfs-sidecar` is SIGKILLed on teardown (exit 137) the pod goes `phase=Failed`. By then its owner `Sandbox` CR is already deleted, so nothing garbage-collects the pod — Failed pods pile up in `agent-sandbox-system` for hours (observed some ~19–20h old).

**Fix:** add a Failed-pod GC pass to the housekeeper sweep. `Failed` is terminal, so the delete can`t race a live workload; gated on `selector_mismatch` like the orphan-route GC. Grants the housekeeper Role `delete` on pods and adds a `failed_pods` count to the heartbeat log.

This addresses the *accumulation*; the two sibling PRs stop the sidecar from being SIGKILLed in the first place.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reap `Failed` sandbox pods orphaned when `orgfs-sidecar` is SIGKILLed on teardown. This prevents failed pods from piling up in `agent-sandbox-system`.

- Bug Fixes
  - Added GC pass in housekeeper sweep to delete pods with `status.phase=Failed` matching the sandbox label selector; gated by `selector_mismatch` and safe since `Failed` is terminal.
  - Granted housekeeper Role `delete` on `pods`.
  - Heartbeat log now includes `failed_pods` count.

<sup>Written for commit 6f68d9a9cd5c327279243db524ee6082083ad83a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

