### PR TITLE
feat(helm): ClusterIP Service for the worker Deployment

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/worker-service.yaml
+++ b/deploy/helm/studio/templates/worker-service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.worker.enabled }}
+# ClusterIP Service for the worker Deployment. NOT for LB/HTTP traffic —
+# workers still get none of that (see worker-deployment.yaml). This exists
+# purely so an in-cluster poller (e.g. a KEDA metrics-api trigger against
+# /dbos-queue-depth/*) has a stable DNS name instead of an ephemeral pod IP.
+# Queue depth is global DBOS/Postgres state, so any worker pod answers
+# identically — round-robin across replicas is fine.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart-deco-studio.fullname" . }}-worker
+  labels:
+    app.kubernetes.io/name: {{ include "chart-deco-studio.name" . }}-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "chart-deco-studio.chart" . }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "chart-deco-studio.name" . }}-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.configMap.meshConfig.PORT | default "3000" | int }}
+      targetPort: {{ .Values.configMap.meshConfig.PORT | default "3000" | int }}
+{{- end }}


### PR DESCRIPTION
## Summary
Adds `worker-service.yaml`: a `ClusterIP` Service in front of the worker Deployment (previously deliberately unexposed — see the comment in `worker-deployment.yaml`, "workers never get LB/HTTP traffic").

This changes nothing about that — no LB, no Gateway route, no ingress. It exists purely so an in-cluster poller has a **stable DNS name** to hit instead of an ephemeral pod IP: specifically, a KEDA `metrics-api` trigger against `/dbos-queue-depth/:queueName` (studio#4380), which needs *some* fixed address to poll. Queue depth is global DBOS/Postgres state, so it doesn't matter which worker pod answers — round-robin across replicas is fine.

Chart bumped 0.12.0 → 0.12.1 (`publish-chart.yml` only republishes on a `Chart.yaml` change).

## Test plan
- [x] `helm template` renders the new Service correctly (selector matches the worker Deployment's pod labels, port matches `configMap.meshConfig.PORT`)
- [ ] After merge + chart publish, confirm `deco-apps-cd`'s `chart-deco-studio` dependency bump picks it up and the Service comes up selecting the running worker pods

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a ClusterIP Service for the worker Deployment to provide a stable in-cluster DNS for KEDA polling. Workers remain unexposed externally; this only enables round-robin access to the queue depth endpoint.

- **New Features**
  - Add ClusterIP Service for workers; selects existing worker labels and exposes `meshConfig.PORT`.
  - Enables KEDA metrics-api to poll `/dbos-queue-depth/:queueName` via stable DNS (supports Linear studio#4380).
  - No LB, Gateway route, or Ingress added.

- **Dependencies**
  - Bump `chart-deco-studio` to 0.12.1 for publish.

<sup>Written for commit a199c027b00b930a03b5f57e9a8a699d38cce0d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

