### PR TITLE
chore(sandbox-env): bump chart to 0.9.5 to publish Failed-pod GC

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,10 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.9.5: housekeeper reaps orphaned phase=Failed sandbox pods (left when the
+# orgfs-sidecar is SIGKILLed on teardown and its Sandbox CR is already gone) +
+# grants the housekeeper Role `delete` on pods. Additive; existing reap paths
+# unchanged.
 # 0.9.4: default studio-sandbox image tag bumped to 1.12.0 (Node.js 26).
 # 0.9.3: opt-in HPA for the warm pool (warmPool.autoscaling.*, default off) —
 # scales SandboxWarmPool via its native scale subresource. No default metric
@@ -32,7 +36,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.4
+version: 0.9.5
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.12.0"
 kubeVersion: ">=1.30.0-0"


### PR DESCRIPTION
Follow-up to #4549. That PR merged with the housekeeper `failed-pod-gc` sweep + RBAC change but on chart version `0.9.4` — a version bump I pushed landed on the branch *after* the merge, so it never reached main.

Since the publish workflow skips already-published versions (see the Chart.yaml changelog — this is the exact 0.9.2 postmortem), main`s `0.9.4` change would ship nothing. This bumps to `0.9.5` so #4549 actually publishes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `sandbox-env` Helm chart to 0.9.5 to publish the housekeeper Failed-pod GC and pod delete RBAC from #4549. 0.9.4 was already published and skipped by the workflow, so this ships the change.

<sup>Written for commit 542cca862b43561dbdb987872405dc16ecfb15ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

