### PR TITLE
ci(publish-chart): dispatch studio-chart-bump to deco-apps-cd

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -13,6 +13,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      version: ${{ steps.chart.outputs.version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -35,3 +37,36 @@ jobs:
 
       - name: Summary
         run: echo "Published ghcr.io/decocms/chart-deco-studio:${{ steps.chart.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+
+  # ---------------------------------------------------------------------------
+  # GitOps: tell deco-apps-cd to bump the chart version. Mirrors the image path
+  # in release-mesh.yaml — we do NOT write into that repo from here, we fire a
+  # `studio-chart-bump` repository_dispatch and its own bump-studio-chart.yml
+  # self-commits (rewriting Chart.yaml + regenerating Chart.lock + the vendored
+  # tgz). Without this, chart bumps were manual and stranded the lock/tgz,
+  # stalling Argo's `helm dependency build`.
+  # ---------------------------------------------------------------------------
+  bump-deco-apps-cd:
+    name: Trigger deco-apps-cd chart bump
+    needs: publish
+    runs-on: ubuntu-latest
+    # Reuses DEPLOY_REPO_TOKEN (decobot PAT, admin on decocms/deco-apps-cd) —
+    # same token/mechanism as the image bump. The bump is a convenience and must
+    # never fail this workflow: no token → the step no-ops and the job passes.
+    env:
+      DISPATCH_TOKEN: ${{ secrets.DEPLOY_REPO_TOKEN }}
+    steps:
+      - name: Skip notice (dispatch token not configured)
+        if: env.DISPATCH_TOKEN == ''
+        run: echo "::notice::DEPLOY_REPO_TOKEN not set — skipping the deco-apps-cd chart bump."
+      - name: Dispatch studio-chart-bump to deco-apps-cd
+        if: env.DISPATCH_TOKEN != ''
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DEPLOY_REPO_TOKEN }}
+          repository: decocms/deco-apps-cd
+          event-type: studio-chart-bump
+          client-payload: '{"version": "${{ needs.publish.outputs.version }}"}'
+      - name: Summary
+        if: env.DISPATCH_TOKEN != ''
+        run: echo "Dispatched \`studio-chart-bump\` (version ${{ needs.publish.outputs.version }}) to decocms/deco-apps-cd" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Companion to decocms/deco-apps-cd#140.

`publish-chart.yml` publishes `chart-deco-studio` to GHCR and stops — nothing tells deco-apps-cd to bump the chart version, unlike the image path (`release-mesh.yaml` fires `studio-image-bump`). So chart bumps were manual, and the manual path stranded `Chart.lock`/tgz → Argo stall (the stg c5094f8 incident).

This adds a `bump-deco-apps-cd` job that fires a `studio-chart-bump` repository_dispatch with the published version, mirroring the image dispatch exactly (same `DEPLOY_REPO_TOKEN`, same no-op-if-absent guard). The receiver is `bump-studio-chart.yml` in deco-apps-cd#140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
After publishing `chart-deco-studio` to GHCR, the workflow now dispatches `studio-chart-bump` to `decocms/deco-apps-cd` to auto-bump the chart and regenerate `Chart.lock`/tgz, preventing Argo stalls. Mirrors the `studio-image-bump` path and safely no-ops if `DEPLOY_REPO_TOKEN` is unset.

<sup>Written for commit 53fe4de73a41af30757c40dfb518c2bb13b19555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

