### PR TITLE
fix(commerce-onboarding): gate report on a connected data source

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -377,7 +377,14 @@ function CommerceOnboardingContent({
             <OrganizationChoice
               organizations={activeOrganizations}
               selectLabel="Continuar"
-              onSelected={(organization) => setSelectedOrg(organization)}
+              onSelected={(organization) =>
+                // Persisted in the URL (not local state) so a refresh doesn't
+                // lose the pick and force reselecting among active orgs.
+                navigate({
+                  to: "/commerce-onboarding",
+                  search: { org: organization.slug, siteUrl },
+                })
+              }
             />
           </ScrollReveal>
         </div>
@@ -1042,6 +1049,10 @@ function CommerceDiscoveryReady({
   meetingVisual: ReactNode;
   siteUrl?: string;
 }) {
+  // Starts false (blocked) until the companions section reports whether any
+  // data source is connected — see onReadinessChange below.
+  const [hasConnectedSource, setHasConnectedSource] = useState(false);
+
   return (
     <CommerceOnboardingLayout align="fill" visual={meetingVisual}>
       {/* align="fill" hands us a flex column sized to the visible viewport, so we
@@ -1054,6 +1065,7 @@ function CommerceDiscoveryReady({
           org={org}
           cdConnectionId={reportApp.connectionId}
           siteUrl={siteUrl}
+          onReadinessChange={setHasConnectedSource}
         />
         <div className="flex shrink-0 flex-col gap-3 md:mt-8">
           {/* Right-side ScheduleMeetingVisual is hidden on mobile, so the human
@@ -1069,7 +1081,9 @@ function CommerceDiscoveryReady({
             size="xl"
             className="w-full rounded-2xl text-base font-medium"
             onClick={onOpenReport}
-            disabled={isSubmitting || !reportApp.virtualMcpId}
+            disabled={
+              isSubmitting || !reportApp.virtualMcpId || !hasConnectedSource
+            }
           >
             {isSubmitting ? "Abrindo relatório..." : "Ver relatório completo"}
             {!isSubmitting ? <ArrowRight size={18} /> : null}

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -1049,9 +1049,11 @@ function CommerceDiscoveryReady({
   meetingVisual: ReactNode;
   siteUrl?: string;
 }) {
-  // Starts false (blocked) until the companions section reports whether any
-  // data source is connected — see onReadinessChange below.
-  const [hasConnectedSource, setHasConnectedSource] = useState(false);
+  // Fails open: stays true (and the CTA usable) unless the companions section
+  // positively confirms there are required sources still unconnected. A
+  // section load error shouldn't be able to permanently trap the user behind
+  // a disabled button — see onReadinessChange below.
+  const [hasConnectedSource, setHasConnectedSource] = useState(true);
 
   return (
     <CommerceOnboardingLayout align="fill" visual={meetingVisual}>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -86,6 +86,9 @@ export function CompanionMcpsSection(props: {
   org: CompanionOrg;
   cdConnectionId: string;
   siteUrl?: string;
+  /** Called once cards resolve with whether at least one is connected (or
+   *  none are required). Lets the report CTA above this section gate on it. */
+  onReadinessChange?: (hasConnectedSource: boolean) => void;
 }) {
   return (
     <QueryErrorResetBoundary>
@@ -113,10 +116,12 @@ function CompanionMcpsSectionContent({
   org,
   cdConnectionId,
   siteUrl,
+  onReadinessChange,
 }: {
   org: CompanionOrg;
   cdConnectionId: string;
   siteUrl?: string;
+  onReadinessChange?: (hasConnectedSource: boolean) => void;
 }) {
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id ?? "";
@@ -156,6 +161,11 @@ function CompanionMcpsSectionContent({
   const [autoOpenConfigFieldKey, setAutoOpenConfigFieldKey] = useState<
     string | null
   >(null);
+
+  // Nothing required, or at least one connected → the report CTA may proceed.
+  // Called during render (derived from query data, not an effect) so the
+  // parent's button re-enables the same render pass a source connects.
+  onReadinessChange?.(cards.length === 0 || cards.some((c) => c.satisfied));
 
   // Empty: nothing to connect → render nothing (the parent footer still shows
   // the report CTA).


### PR DESCRIPTION
## What is this contribution about?
On `/commerce-onboarding`, the "Ver relatório completo" button could be clicked before connecting any companion data source. It's now disabled until at least one is connected (or none are required). Also, picking an org from the multi-org list now writes the choice to the `org` URL search param instead of local state, so refreshing the page doesn't force reselecting.

## Screenshots/Demonstration
N/A (behavior-only change, no visual changes).

## How to Test
1. Go through `/commerce-onboarding` for a site with companion data sources required, and confirm "Ver relatório completo" is disabled until you connect at least one.
2. As a user with 2+ active orgs, pick one from the org list, then refresh the page — you should land back on the same org instead of being asked to pick again.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the "Ver relatório completo" button behind at least one connected companion data source, failing open if readiness can't be determined. Also persist the selected org in the URL so it survives refresh.

- **Bug Fixes**
  - Gate the CTA until a companion source is connected (or none are required), defaulting to enabled and only disabling after `CompanionMcpsSection` confirms an unmet requirement via `onReadinessChange`.
  - Persist org selection by writing `org` to the URL search params via `navigate` (keeps `siteUrl`), so a refresh doesn’t force reselecting.

<sup>Written for commit 6f9d5601108f9d7c51e6f88f0626cacca36eef13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

