### PR TITLE
refactor(web): dedupe getInitials into a shared helper

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useState } from "react";
+import { getInitials } from "@/web/lib/get-initials";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
@@ -46,16 +47,6 @@ export default function TaskBoard() {
       </div>
     </div>
   );
-}
-
-function getInitials(name?: string | null) {
-  if (!name) return "?";
-  return name
-    .split(" ")
-    .map((n) => n[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
 }
 
 const DATE_FMT = new Intl.DateTimeFormat(undefined, {

--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -20,6 +20,7 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Calendar, ChevronDown, Trash01, User01, X } from "@untitledui/icons";
 import { useMembers } from "@/web/hooks/use-members";
+import { getInitials } from "@/web/lib/get-initials";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
   PRIORITIES,
@@ -31,16 +32,6 @@ import {
   type TaskBoardItemStatus,
   type Member,
 } from "./config";
-
-function getInitials(name?: string | null) {
-  if (!name) return "?";
-  return name
-    .split(" ")
-    .map((n) => n[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
-}
 
 // ponytail: pinned to end-of-day so "due today" doesn't flip to overdue
 // mid-morning. Local zone in, UTC out.

--- a/apps/mesh/src/web/lib/get-initials.ts
+++ b/apps/mesh/src/web/lib/get-initials.ts
@@ -1,0 +1,9 @@
+export function getInitials(name?: string | null): string {
+  if (!name) return "?";
+  return name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}

--- a/apps/mesh/src/web/routes/orgs/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/members.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from "@/web/components/error-boundary";
 import { InviteMemberDialog } from "@/web/components/invite-member-dialog";
 import { JoinRequestsSection } from "@/web/components/settings/join-requests-section";
 import { track } from "@/web/lib/posthog-client";
+import { getInitials } from "@/web/lib/get-initials";
 import { useMembers } from "@/web/hooks/use-members";
 import {
   useInvitations,
@@ -96,16 +97,6 @@ const BUILTIN_ROLE_COLORS: Record<string, string> = {
   admin: "bg-blue-500",
   user: "bg-green-500",
 };
-
-function getInitials(name?: string) {
-  if (!name) return "?";
-  return name
-    .split(" ")
-    .map((n) => n[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
-}
 
 // Create a Map for O(1) role color lookups
 function createRoleColorMap(

--- a/apps/mesh/src/web/views/settings/org-role-detail.tsx
+++ b/apps/mesh/src/web/views/settings/org-role-detail.tsx
@@ -9,6 +9,7 @@ import { ToolSetSelector } from "@/web/components/tool-set-selector.tsx";
 import { useMembers } from "@/web/hooks/use-members";
 import { type OrganizationRole } from "@/web/hooks/use-organization-roles";
 import { useOrgAuthClient } from "@/web/hooks/use-org-auth-client";
+import { getInitials } from "@/web/lib/get-initials";
 import { KEYS } from "@/web/lib/query-keys";
 import { track } from "@/web/lib/posthog-client";
 import {
@@ -142,16 +143,6 @@ const roleFormSchema = z.object({
 });
 
 type RoleFormData = z.infer<typeof roleFormSchema>;
-
-function getInitials(name: string | undefined | null): string {
-  if (!name) return "?";
-  return name
-    .split(" ")
-    .map((part) => part[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
-}
 
 // ============================================================================
 // Organization Permissions Tab


### PR DESCRIPTION
## Summary
- The identical name-to-initials logic was hand-rolled in four separate files: `apps/mesh/src/web/layouts/task-board/index.tsx`, `task-board/task-dialog.tsx`, `apps/mesh/src/web/routes/orgs/members.tsx`, and `apps/mesh/src/web/views/settings/org-role-detail.tsx`.
- Consolidated into one shared `apps/mesh/src/web/lib/get-initials.ts` (widest existing signature: `string | null | undefined`), and updated all four call sites to import it instead.
- Net: -36 / +13 (one new 8-line file, four call sites trimmed). Pure dedup, no behavior change — verified by `grep -rn "function getInitials"` returning zero remaining duplicates and a clean targeted typecheck.

## Test plan
- [x] `bun run fmt` — clean
- [x] `bunx tsc --noEmit` in `apps/mesh` — no new errors (only a pre-existing, unrelated missing-dependency error in `rich-text-field.tsx`)
- [x] `grep -rn "function getInitials" apps/mesh/src` — confirms only the one shared definition remains
- No test file needed: pure deletion/consolidation of identical logic, not new behavior. Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated duplicate name-to-initials logic into a shared `getInitials` helper at apps/mesh/src/web/lib/get-initials.ts. Updated four call sites to use it; behavior unchanged.

- **Refactors**
  - Added `getInitials(name?: string | null): string` with two-letter uppercase output and "?" fallback.
  - Replaced inline implementations in: layouts/task-board/index.tsx, layouts/task-board/task-dialog.tsx, routes/orgs/members.tsx, views/settings/org-role-detail.tsx.

<sup>Written for commit 401c4317544465817d942e5d90a2bdbdbe3edd40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

