### PR TITLE
fix(sections-editor): resolve $ref-based Location|Map unions as inline-union

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
@@ -974,47 +974,110 @@ describe("resolveSchema – inline object unions (A | B) render as a choice", ()
   });
 });
 
-describe("resolveSchema – inline-union negative cases (paths left untouched)", () => {
-  test("anyOf of $refs stays block-ref, not inline-union", () => {
-    const meta: LiveMeta = {
+describe("resolveSchema – inline object unions behind $refs (real deco shape)", () => {
+  // deco emits data unions like `(Location | Map)[]` as an anyOf of *$refs* to
+  // bare object defs (no `__resolveType`, no saved-block title, no `type`
+  // discriminator) — NOT as inlined object branches. Before the fix these fell
+  // into the block-ref path, found no resolveType on either branch, dropped both,
+  // and returned an empty block-ref that rendered as `[object Object]`.
+  // deco base64-encodes def keys (they embed a jsdelivr URL), so real refs are
+  // slash-free single-segment keys. Mirror that with plain keys here.
+  function locationMatcherMeta(): LiveMeta {
+    return {
       manifest: {
         blocks: {
-          sections: {
-            "site/sections/Test.tsx": {
-              type: "object",
-              properties: {
-                card: {
-                  anyOf: [
-                    { $ref: "#/definitions/ImageCard" },
-                    { $ref: "#/definitions/TextCard" },
-                  ],
-                },
-              },
-            } as unknown as { $ref?: string; namespace?: string },
+          matchers: {
+            "website/matchers/location.ts": {
+              $ref: "#/definitions/LocationMatcher",
+              namespace: "website",
+            },
           },
         },
       },
       schema: {
         definitions: {
-          ImageCard: {
+          LocationMatcher: {
+            title: "Location",
             type: "object",
-            title: "ImageCard",
-            properties: { src: { type: "string" } },
+            allOf: [{ $ref: "#/definitions/LocationProps" }],
+            required: ["__resolveType"],
+            properties: {
+              __resolveType: {
+                type: "string",
+                enum: ["website/matchers/location.ts"],
+                default: "website/matchers/location.ts",
+              },
+            },
           },
-          TextCard: {
+          LocationProps: {
             type: "object",
-            title: "TextCard",
-            properties: { text: { type: "string" } },
+            properties: {
+              includeLocations: {
+                $ref: "#/definitions/LocationMapArray",
+                title: "Include Locations",
+              },
+            },
           },
+          LocationMapArray: {
+            type: "array",
+            items: { $ref: "#/definitions/LocationMapUnion" },
+            title: "[Location|Map]",
+          },
+          LocationMapUnion: {
+            anyOf: [
+              { $ref: "#/definitions/LocationBranch" },
+              { $ref: "#/definitions/MapBranch" },
+            ],
+            title: "Location|Map",
+          },
+          LocationBranch: {
+            type: "object",
+            title: "Location",
+            properties: {
+              city: { type: ["string", "null"], title: "City" },
+              regionCode: { type: ["string", "null"], title: "Region Code" },
+              country: { type: ["string", "null"], title: "Country" },
+            },
+          },
+          MapBranch: {
+            type: "object",
+            title: "Map",
+            properties: {
+              coordinates: {
+                $ref: "#/definitions/MapWidget",
+                title: "Area selection",
+              },
+            },
+          },
+          MapWidget: { type: "string", format: "map", title: "MapWidget" },
         },
       },
     };
-    const card = resolveSchema("site/sections/Test.tsx", meta)?.properties
-      ?.card;
-    expect(card?.type).toBe("block-ref");
-    expect(card?.type).not.toBe("inline-union");
-  });
+  }
 
+  test("(Location | Map)[] with $ref branches resolves to an inline-union", () => {
+    const items = resolveSchema(
+      "website/matchers/location.ts",
+      locationMatcherMeta(),
+    )?.properties?.includeLocations?.items;
+    expect(items?.type).toBe("inline-union");
+    const branches = items?.inlineUnionBranches ?? [];
+    expect(branches.map((b) => b.title)).toEqual(["Location", "Map"]);
+    // Location branch keeps its {city, regionCode, country} fields.
+    expect(Object.keys(branches[0]?.schema?.properties ?? {}).sort()).toEqual([
+      "city",
+      "country",
+      "regionCode",
+    ]);
+    // Map branch keeps its coordinates @format map (deref'd through MapWidget).
+    expect(branches[1]?.schema?.properties?.coordinates?.format).toBe("map");
+    // Plain data branches carry no const discriminators.
+    expect(branches[0]?.discriminators).toBeUndefined();
+    expect(branches[1]?.discriminators).toBeUndefined();
+  });
+});
+
+describe("resolveSchema – inline-union negative cases (paths left untouched)", () => {
   test("mixed primitive|object union does NOT become inline-union", () => {
     const meta = metaWithSchema({
       type: "object",

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -732,9 +732,58 @@ export function resolveSchema(
           };
         }
 
+        // A union branch is a real module/block (loader, section, saved block)
+        // only when its resolved def carries a `__resolveType` or a saved-block
+        // title. Deco also emits plain *data* unions (e.g. `Location | Map`) as
+        // an anyOf of `$ref`s to bare object defs with none of those — those must
+        // render as an inline branch selector, NOT as a block picker (which would
+        // find no resolveType, drop every branch at the `continue` below, and
+        // return an empty block-ref that renders as `[object Object]`).
+        const branchHasModuleIdentity = (branch: RawSchema): boolean => {
+          const def = resolveBranchDef(branch);
+          if (
+            typeof def.title === "string" &&
+            parseSavedBlockSchemaTitle(def.title)
+          ) {
+            return true;
+          }
+          const rtEnum = (
+            (def.properties as RawSchema | undefined)?.__resolveType as
+              | RawSchema
+              | undefined
+          )?.enum;
+          if (Array.isArray(rtEnum) && typeof rtEnum[0] === "string") {
+            return true;
+          }
+          if (Array.isArray(def.allOf)) {
+            for (const part of def.allOf as RawSchema[]) {
+              const e = (
+                (part.properties as RawSchema | undefined)?.__resolveType as
+                  | RawSchema
+                  | undefined
+              )?.enum;
+              if (Array.isArray(e) && typeof e[0] === "string") return true;
+            }
+          }
+          return false;
+        };
+        // A plain-data union (Location | Map): every branch — inline or behind a
+        // `$ref` — resolves to a bare object with no module identity.
+        const branchIsPlainDataObject = (branch: RawSchema): boolean => {
+          if (branchHasModuleIdentity(branch)) return false;
+          const def = resolveBranchDef(branch);
+          return def.type === "object" || Boolean(def.properties);
+        };
+        const isChoiceUnion =
+          Array.isArray(resolved.anyOf) || Array.isArray(resolved.oneOf);
+        const isPlainDataUnion =
+          isChoiceUnion &&
+          depth < MAX_BUILD_PROPERTY_DEPTH &&
+          nonNull.every(branchIsPlainDataObject);
+
         // All branches are $refs to block/loader defs
         const allRefs = nonNull.every((a) => typeof a.$ref === "string");
-        if (allRefs) {
+        if (allRefs && !isPlainDataUnion) {
           const anyOfRefs: SchemaAnyOfRef[] = [];
           for (const branch of nonNull) {
             const def = resolveRef(branch.$ref as string);
@@ -814,18 +863,10 @@ export function resolveSchema(
         //
         // Only `anyOf`/`oneOf` are choices — `allOf` is an intersection meant to
         // MERGE all branches, so it must fall through to the object-merge path.
-        const isChoiceUnion =
-          Array.isArray(resolved.anyOf) || Array.isArray(resolved.oneOf);
-        const allInlineObjects = nonNull.every(
-          (b) =>
-            typeof b.$ref !== "string" &&
-            (b.type === "object" || Boolean(b.properties)),
-        );
-        if (
-          isChoiceUnion &&
-          allInlineObjects &&
-          depth < MAX_BUILD_PROPERTY_DEPTH
-        ) {
+        // `isPlainDataUnion` (computed above) already requires a choice union of
+        // bare object branches (inline or behind a `$ref`) with no module
+        // identity — exactly the `Location | Map` / const-tagged-union shape.
+        if (isPlainDataUnion) {
           const constValue = (
             p: RawSchema,
           ): string | number | boolean | undefined => {
@@ -849,7 +890,8 @@ export function resolveSchema(
           };
           const inlineUnionBranches = nonNull.map((branch, index) => {
             const branchProps =
-              (branch.properties as RawSchema | undefined) ?? {};
+              (resolveBranchDef(branch).properties as RawSchema | undefined) ??
+              {};
             const discriminators: Record<string, string | number | boolean> =
               {};
             for (const [key, prop] of Object.entries(branchProps)) {


### PR DESCRIPTION
## Summary

The **Variant rule → Include Locations → Location|Map** field rendered `[object Object]` instead of the location/map picker on real deco sites (e.g. `eurorelogios.com.br`).


### Root cause

Deco emits the `(Location | Map)[]` matcher union as an `anyOf` of **`$ref`s** to bare data-object defs (`@Location` = `{city, regionCode, country}`, `@Map` = `{coordinates}`), neither of which carries a `__resolveType`.

`resolve-schema.ts` had an `allRefs` branch that assumed *any* union whose branches are all `$ref`s is a **module/block picker**. It looked for a `__resolveType` on each branch, found none, `continue`d past both, and returned an **empty `block-ref`** — which renders as `[object Object]`.

The inline-union path that *should* handle `Location | Map` only fired for **inlined** object branches (`typeof b.$ref !== "string"`) — exactly the shape the existing unit test used, so the test passed while every real deco site hit the bug.

### Fix

- Add `branchHasModuleIdentity()` — a branch is a real block only if its resolved def has a `__resolveType` (via `properties` or `allOf`) or a saved-block title.
- Add `branchIsPlainDataObject()` / `isPlainDataUnion` — a choice union whose every branch (inline **or behind a `$ref`**) resolves to a bare object with no module identity.
- Guard the block-ref path with `if (allRefs && !isPlainDataUnion)` and route plain-data unions to the inline branch selector, dereferencing `$ref` branches for titles, nested schema, and const discriminators.

Now `Include Locations` items resolve to an `inline-union` with a **Location** branch (country→region→city cascade, Brazil map) and a **Map** branch (`@format map` coordinate picker).

## Testing

- Added a regression test using the real `$ref`-based deco shape (the prior test only covered inlined branches, which never reproduced the bug).
- Updated the "anyOf of $refs stays block-ref" test — it was pinning the buggy empty-block-ref behavior for plain-data objects; it now correctly expects an inline-union.
- `bun test` sections-editor: **416 pass, 0 fail**
- `bun run --cwd apps/mesh check` clean · `bun run fmt` applied

## Affected areas

Client-side schema resolution — corrects the location matcher widget for **all** deco sites, not just the reported one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Location|Map matcher in the sections editor. `$ref`-based `anyOf` data unions now resolve as an inline union, restoring the Location and Map pickers on Deco sites.

- **Bug Fixes**
  - Treat plain data unions (inline or `$ref`) as inline-union; only use block pickers when branches have `__resolveType` or a saved-block title.
  - Dereference `$ref` branches to expose titles, nested properties, and const discriminators. Added a regression test for the real Deco `$ref` shape and updated expectations; all sections-editor tests pass.

<sup>Written for commit 5f0351395360d6e5155e736d9754bb89fa56ec4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

