### PR TITLE
feat(web): move branch selector into the toolbar breadcrumb

### DIFF
--- a/apps/mesh/src/web/components/chat/agent-home.tsx
+++ b/apps/mesh/src/web/components/chat/agent-home.tsx
@@ -5,7 +5,7 @@ import {
 } from "@decocms/mesh-sdk";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { Chat } from "./index";
-import { useChatPrefs, useChatTask } from "./context";
+import { useChatPrefs } from "./context";
 import { ChatModeRow } from "./pills/chat-mode-row";
 
 export function AgentHome({
@@ -15,7 +15,6 @@ export function AgentHome({
 }) {
   const { org } = useProjectContext();
   const { selectedVirtualMcp } = useChatPrefs();
-  const { currentBranch } = useChatTask();
   const defaultAgent = getWellKnownDecopilotVirtualMCP(org.id);
   const agent = selectedVirtualMcp ?? defaultAgent;
   const fullVm = useVirtualMCP(agent.id);
@@ -53,11 +52,7 @@ export function AgentHome({
           data-chat-above-row="true"
           className="@container/chat-bottom pb-1 flex justify-start gap-1"
         >
-          <ChatModeRow
-            virtualMcp={fullVm}
-            currentBranch={currentBranch}
-            showRuntimeLabel
-          />
+          <ChatModeRow virtualMcp={fullVm} showRuntimeLabel />
         </div>
         <Chat.Input onOpenContextPanel={onOpenContextPanel} />
       </Chat.Footer>

--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -670,14 +670,10 @@ export function ChatInput({
                       )}
                     </div>
 
-                    {/* Right Actions (branch/mode, model, mic, send) */}
+                    {/* Right Actions (runtime, model, mic, send). The branch
+                        selector now lives in the toolbar breadcrumb. */}
                     <div className="flex items-center gap-1.5 min-w-0">
-                      {showInlineModeRow && (
-                        <ChatModeRow
-                          virtualMcp={fullVm}
-                          currentBranch={taskCtx?.currentBranch ?? null}
-                        />
-                      )}
+                      {showInlineModeRow && <ChatModeRow virtualMcp={fullVm} />}
                       <TierTrigger />
 
                       {/* Microphone button — always enabled; the composer has

--- a/apps/mesh/src/web/components/chat/pills/branch-pill.test.tsx
+++ b/apps/mesh/src/web/components/chat/pills/branch-pill.test.tsx
@@ -11,24 +11,7 @@ mock.module("../../thread/github/branch-picker", () => ({
   BranchPicker: () => <button type="button">branch-picker</button>,
 }));
 
-import { ChatModeRowPure } from "./chat-mode-row";
 import { BranchPill } from "./branch-pill";
-
-describe("ChatModeRowPure", () => {
-  it("returns null when the branch pill is null", () => {
-    const { container } = render(<ChatModeRowPure branchPill={null} />);
-    expect(container.firstChild).toBeNull();
-  });
-
-  it("renders the BranchPill when present", () => {
-    const { getByTestId } = render(
-      <ChatModeRowPure
-        branchPill={<span data-testid="branch-pill">branch</span>}
-      />,
-    );
-    expect(getByTestId("branch-pill")).toBeInTheDocument();
-  });
-});
 
 const BRANCH_PILL_PROPS = {
   orgId: "org-1",

--- a/apps/mesh/src/web/components/chat/pills/branch-pill.tsx
+++ b/apps/mesh/src/web/components/chat/pills/branch-pill.tsx
@@ -4,7 +4,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
 import { GitBranch01 } from "@untitledui/icons";
 import { BranchPicker } from "../../thread/github/branch-picker";
 
@@ -21,22 +20,17 @@ interface Props {
   value: string | null | undefined;
   onChange: (branch: string) => void;
   locked: boolean;
-  placement?: "chat" | "header";
 }
 
 /**
- * Thin wrapper over `BranchPicker` that maps the chat-level `locked`
- * flag onto the picker's `disabled` prop. The picker still renders its
- * Button + Tooltip when disabled — the user just can't open the
- * popover.
+ * Thin wrapper over `BranchPicker` used by the toolbar breadcrumb
+ * (`ShellBreadcrumb` → `BranchCrumb`).
  *
- * When `locked` is true (chat has messages or is a thread-locked thread)
- * we replace the picker with a non-clickable lock chip so the user can
- * see the active branch without being able to change it.
+ * When `locked` is true (the thread's runtime is pinned — `harness_id` set) we
+ * replace the interactive picker with a non-clickable lock chip so the user can
+ * still see the active branch without being able to change it.
  */
-export function BranchPill({ locked, placement, value, ...props }: Props) {
-  const isHeader = placement === "header";
-
+export function BranchPill({ locked, value, ...props }: Props) {
   if (locked) {
     const branchLabel = value ?? "(no branch)";
     return (
@@ -45,21 +39,10 @@ export function BranchPill({ locked, placement, value, ...props }: Props) {
           <span
             data-testid="branch-picker-locked"
             aria-disabled="true"
-            className={cn(
-              "inline-flex items-center rounded-md font-mono text-xs",
-              "text-muted-foreground cursor-default min-w-0 max-w-[200px]",
-              isHeader ? "h-8 gap-1.5 px-2.5" : "h-9 gap-0 px-2",
-            )}
+            className="inline-flex items-center h-8 gap-1.5 px-2.5 rounded-md font-mono text-xs text-muted-foreground cursor-default min-w-0 max-w-[200px]"
           >
             <GitBranch01 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-            <span
-              className={cn(
-                "min-w-0 truncate",
-                isHeader ? "" : "max-w-0 opacity-0",
-              )}
-            >
-              {branchLabel}
-            </span>
+            <span className="min-w-0 truncate">{branchLabel}</span>
           </span>
         </TooltipTrigger>
         <TooltipContent>
@@ -70,5 +53,5 @@ export function BranchPill({ locked, placement, value, ...props }: Props) {
     );
   }
 
-  return <BranchPicker {...props} value={value} placement={placement} />;
+  return <BranchPicker {...props} value={value} />;
 }

--- a/apps/mesh/src/web/components/chat/pills/branch-pill.tsx
+++ b/apps/mesh/src/web/components/chat/pills/branch-pill.tsx
@@ -48,9 +48,7 @@ export function BranchPill({ locked, placement, value, ...props }: Props) {
             className={cn(
               "inline-flex items-center rounded-md font-mono text-xs",
               "text-muted-foreground cursor-default min-w-0 max-w-[200px]",
-              isHeader
-                ? "h-8 gap-1.5 border border-input bg-background px-2.5"
-                : "h-9 gap-0 px-2",
+              isHeader ? "h-8 gap-1.5 px-2.5" : "h-9 gap-0 px-2",
             )}
           >
             <GitBranch01 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />

--- a/apps/mesh/src/web/components/chat/pills/chat-mode-row.tsx
+++ b/apps/mesh/src/web/components/chat/pills/chat-mode-row.tsx
@@ -6,31 +6,10 @@ import {
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
 import type { HarnessId } from "@/harnesses";
-import { useOptionalChatStream, useOptionalChatTask } from "../context";
-import { BranchPill } from "./branch-pill";
+import { useOptionalChatTask } from "../context";
 import { RuntimeSwitcher } from "./runtime-switcher";
 import { ClaudeCodeIcon, CodexIcon } from "../agent-icons";
 import { getActiveGithubRepo } from "@/web/lib/github-repo";
-import { useProjectContext } from "@decocms/mesh-sdk";
-import { authClient } from "@/web/lib/auth-client";
-
-interface PureProps {
-  branchPill: ReactNode;
-}
-
-/**
- * Pure layout — used by tests. Renders the branch pill (when present) in the
- * parent flex flow. Returns null when there is nothing to show.
- *
- * This pure component only handles the branch pill. The smart `ChatModeRow`
- * below renders the sandbox-backed agent's `RuntimeSwitcher` (Cloud sandbox vs
- * This device) alongside it; the chat model runtime itself is still chosen in
- * the model selector.
- */
-export function ChatModeRowPure({ branchPill }: PureProps) {
-  if (!branchPill) return null;
-  return <>{branchPill}</>;
-}
 
 const LOCAL_RUNTIME: Partial<
   Record<HarnessId, { label: string; icon: ReactNode }>
@@ -69,31 +48,26 @@ function LockedRuntimeChip({ harness }: { harness: HarnessId }) {
 
 interface SmartProps {
   virtualMcp: VirtualMCPEntity | null | undefined;
-  currentBranch: string | null;
   /** Show the runtime switcher's full label. On for the spacious empty-chat
    *  landing; off (default) for the dense in-conversation composer row. */
   showRuntimeLabel?: boolean;
 }
 
 /**
- * Smart wrapper. Renders the BranchPill for agents imported from GitHub —
- * `metadata.githubRepo` exists AND has an attached `connectionId` (an
- * authenticated user repo, not a public-template clone). Start Website agents
- * populate `metadata.githubRepo.url` for the template but leave `connectionId`
- * unset; branches aren't meaningful there.
+ * Smart wrapper for the composer's runtime affordance. Sandbox-backed agents
+ * (imported from a GitHub repo) get the `RuntimeSwitcher` — Cloud sandbox vs
+ * This device — so you can pick where it runs even before the sandbox starts.
+ * Non-sandbox threads show a read-only locked-runtime chip once they're bound
+ * to a local coding agent.
  *
- * Locked flag is derived from `useOptionalChatStream().messages.length > 0`.
+ * The branch selector no longer lives here — it moved to the toolbar
+ * breadcrumb (see `ShellBreadcrumb` → `BranchCrumb`).
  */
 export function ChatModeRow({
   virtualMcp,
-  currentBranch,
   showRuntimeLabel = false,
 }: SmartProps) {
-  const stream = useOptionalChatStream();
   const taskCtx = useOptionalChatTask();
-  const locked =
-    (stream?.messages ?? []).length > 0 || (taskCtx?.isThreadLocked ?? false);
-  const setCurrentTaskBranch = taskCtx?.setCurrentTaskBranch;
 
   // Once a thread is locked to a local coding agent, the model selector hides
   // its runtime toggle — surface a read-only chip so the binding stays legible.
@@ -102,48 +76,13 @@ export function ChatModeRow({
       <LockedRuntimeChip harness={taskCtx.lockedHarness} />
     ) : null;
 
-  const githubRepo = getActiveGithubRepo(virtualMcp);
-  const connectionId = githubRepo?.connectionId;
-  // Sandbox-backed agents (imported from a repo) get the runtime switcher —
-  // Cloud sandbox vs This device — right next to the branch pill, so you can
-  // pick where it runs even before the sandbox starts. It also renders the
-  // locked-runtime state itself, so it supersedes the LockedRuntimeChip here.
-  const hasSandbox = !!githubRepo;
+  // Sandbox-backed agents get the runtime switcher, which also renders the
+  // locked-runtime state itself, so it supersedes the LockedRuntimeChip.
+  const hasSandbox = !!getActiveGithubRepo(virtualMcp);
 
-  const { data: session } = authClient.useSession();
-  const userId = session?.user?.id ?? "";
-  const userLabel = session?.user?.name ?? session?.user?.email?.split("@")[0];
-  const { org } = useProjectContext();
-
-  const branchPill =
-    githubRepo && connectionId ? (
-      <BranchPill
-        orgId={org.id}
-        orgSlug={org.slug}
-        userId={userId}
-        userLabel={userLabel}
-        virtualMcpId={virtualMcp?.id ?? ""}
-        connectionId={connectionId}
-        owner={githubRepo.owner}
-        repo={githubRepo.name}
-        sandboxMap={virtualMcp?.metadata?.sandboxMap}
-        value={currentBranch}
-        onChange={(next) => {
-          if (setCurrentTaskBranch) void setCurrentTaskBranch(next);
-        }}
-        locked={locked}
-        placement="chat"
-      />
-    ) : null;
-
-  return (
-    <>
-      {hasSandbox ? (
-        <RuntimeSwitcher showLabel={showRuntimeLabel} />
-      ) : (
-        lockedRuntime
-      )}
-      <ChatModeRowPure branchPill={branchPill} />
-    </>
+  return hasSandbox ? (
+    <RuntimeSwitcher showLabel={showRuntimeLabel} />
+  ) : (
+    lockedRuntime
   );
 }

--- a/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
+++ b/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
@@ -113,12 +113,19 @@ function AgentCrumb({
  * Branch crumb — the last segment (`… › agent › branch`), shown only inside a
  * thread whose agent is a sandbox agent (imported from GitHub with an attached
  * connection). Non-sandbox agents have no branch concept, so this renders
- * nothing. Reuses the chat's `BranchPill` with `placement="header"`.
+ * nothing. Reuses `BranchPill` (header-styled ghost chip).
  *
  * The breadcrumb lives above the `ChatContextProvider`, so it can't read the
  * chat task context. It resolves the active thread's branch + lock state from
  * the ThreadManager store instead (`harness_id != null` ⇒ runtime pinned ⇒
  * branch locked, matching `ChatTaskContextValue.isThreadLocked`).
+ *
+ * That store only holds the panel-visible page (page 0). A thread opened by
+ * direct link / refresh beyond page 0 — or an archived one — isn't in it, and
+ * such threads are always locked (harness pinned). Rather than render a wrong
+ * "unlocked, no branch" picker (and let `setBranch` prepend a phantom row for
+ * an off-list id), we render nothing until the thread is in the store. Fresh,
+ * unlocked threads are always in page 0, so the interactive path is unaffected.
  */
 function BranchCrumb({ agentId, taskId }: { agentId: string; taskId: string }) {
   const entity = useVirtualMCP(agentId);
@@ -132,6 +139,8 @@ function BranchCrumb({ agentId, taskId }: { agentId: string; taskId: string }) {
   if (!githubRepo || !connectionId) return null;
 
   const activeTask = threads.find((t) => t.id === taskId);
+  if (!activeTask) return null;
+
   const userLabel = session?.user?.name ?? session?.user?.email?.split("@")[0];
 
   return (
@@ -146,10 +155,9 @@ function BranchCrumb({ agentId, taskId }: { agentId: string; taskId: string }) {
         owner={githubRepo.owner}
         repo={githubRepo.name}
         sandboxMap={entity?.metadata?.sandboxMap}
-        value={activeTask?.branch ?? null}
+        value={activeTask.branch ?? null}
         onChange={(next) => void setBranch(taskId, next)}
-        locked={activeTask?.harness_id != null}
-        placement="header"
+        locked={activeTask.harness_id != null}
       />
     </BreadcrumbItem>
   );

--- a/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
+++ b/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
@@ -38,7 +38,13 @@ import {
   OrgSwitcherPopover,
 } from "@/web/components/header/org-switcher";
 import { AgentScopePicker } from "@/web/components/sidebar/agents-section";
-import { useThreads } from "@/web/components/chat/store/hooks";
+import { BranchPill } from "@/web/components/chat/pills/branch-pill";
+import {
+  useThreadActions,
+  useThreads,
+} from "@/web/components/chat/store/hooks";
+import { getActiveGithubRepo } from "@/web/lib/github-repo";
+import { authClient } from "@/web/lib/auth-client";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { findReusableNewChat } from "@/web/lib/reusable-new-chat";
 import { usePendingInvitations } from "@/web/hooks/use-pending-invitations";
@@ -100,6 +106,52 @@ function AgentCrumb({
         }
       />
     </div>
+  );
+}
+
+/**
+ * Branch crumb — the last segment (`… › agent › branch`), shown only inside a
+ * thread whose agent is a sandbox agent (imported from GitHub with an attached
+ * connection). Non-sandbox agents have no branch concept, so this renders
+ * nothing. Reuses the chat's `BranchPill` with `placement="header"`.
+ *
+ * The breadcrumb lives above the `ChatContextProvider`, so it can't read the
+ * chat task context. It resolves the active thread's branch + lock state from
+ * the ThreadManager store instead (`harness_id != null` ⇒ runtime pinned ⇒
+ * branch locked, matching `ChatTaskContextValue.isThreadLocked`).
+ */
+function BranchCrumb({ agentId, taskId }: { agentId: string; taskId: string }) {
+  const entity = useVirtualMCP(agentId);
+  const { threads } = useThreads();
+  const { setBranch } = useThreadActions();
+  const { org } = useProjectContext();
+  const { data: session } = authClient.useSession();
+
+  const githubRepo = getActiveGithubRepo(entity);
+  const connectionId = githubRepo?.connectionId;
+  if (!githubRepo || !connectionId) return null;
+
+  const activeTask = threads.find((t) => t.id === taskId);
+  const userLabel = session?.user?.name ?? session?.user?.email?.split("@")[0];
+
+  return (
+    <BreadcrumbItem>
+      <BranchPill
+        orgId={org.id}
+        orgSlug={org.slug}
+        userId={session?.user?.id ?? ""}
+        userLabel={userLabel}
+        virtualMcpId={agentId}
+        connectionId={connectionId}
+        owner={githubRepo.owner}
+        repo={githubRepo.name}
+        sandboxMap={entity?.metadata?.sandboxMap}
+        value={activeTask?.branch ?? null}
+        onChange={(next) => void setBranch(taskId, next)}
+        locked={activeTask?.harness_id != null}
+        placement="header"
+      />
+    </BreadcrumbItem>
   );
 }
 
@@ -210,6 +262,13 @@ export function ShellBreadcrumb() {
             />
           </Suspense>
         </BreadcrumbItem>
+
+        {/* branch → only inside a thread on a sandbox agent; hidden otherwise */}
+        {params.taskId && (
+          <Suspense fallback={null}>
+            <BranchCrumb agentId={activeAgentId} taskId={params.taskId} />
+          </Suspense>
+        )}
       </BreadcrumbList>
     </Breadcrumb>
   );

--- a/apps/mesh/src/web/components/thread/github/branch-picker.tsx
+++ b/apps/mesh/src/web/components/thread/github/branch-picker.tsx
@@ -139,14 +139,14 @@ export function BranchPicker({
           <span className="inline-flex min-w-0 shrink">
             <PopoverTrigger asChild>
               <Button
-                variant={isHeader ? "outline" : "ghost"}
+                variant="ghost"
                 size={isHeader ? "sm" : "default"}
                 aria-label={label}
                 disabled={disabled}
                 className={cn(
                   "font-mono shrink min-w-0 max-w-[200px]",
                   isHeader
-                    ? "gap-1.5 text-xs"
+                    ? "gap-1.5 text-xs text-foreground hover:bg-accent/60"
                     : cn(
                         "text-xs text-muted-foreground hover:text-foreground transition-[gap] duration-200",
                         disabled

--- a/apps/mesh/src/web/components/thread/github/branch-picker.tsx
+++ b/apps/mesh/src/web/components/thread/github/branch-picker.tsx
@@ -1,7 +1,6 @@
 import { type UIEvent, useRef, useState } from "react";
 import type { SandboxMap } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
 import {
   Command,
   CommandEmpty,
@@ -42,8 +41,6 @@ interface Props {
   /** When true, the trigger is disabled — the user can't open the
    *  picker. The tooltip still surfaces the current branch on hover. */
   disabled?: boolean;
-  /** Chat input uses responsive label collapse; header always shows the name. */
-  placement?: "chat" | "header";
 }
 
 /**
@@ -66,9 +63,7 @@ export function BranchPicker({
   value,
   onChange,
   disabled = false,
-  placement = "chat",
 }: Props) {
-  const isHeader = placement === "header";
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [isSearchingRemote, setIsSearchingRemote] = useState(false);
@@ -140,42 +135,15 @@ export function BranchPicker({
             <PopoverTrigger asChild>
               <Button
                 variant="ghost"
-                size={isHeader ? "sm" : "default"}
+                size="sm"
                 aria-label={label}
                 disabled={disabled}
-                className={cn(
-                  "font-mono shrink min-w-0 max-w-[200px]",
-                  isHeader
-                    ? "gap-1.5 text-xs text-foreground hover:bg-accent/60"
-                    : cn(
-                        "text-xs text-muted-foreground hover:text-foreground transition-[gap] duration-200",
-                        disabled
-                          ? "gap-0"
-                          : "gap-0 @[320px]/chat-bottom:gap-1.5",
-                      ),
-                )}
+                className="font-mono shrink min-w-0 max-w-[200px] gap-1.5 text-xs text-foreground hover:bg-accent/60"
               >
                 <GitBranch01 className="h-3.5 w-3.5 shrink-0" />
-                <span
-                  className={cn(
-                    "min-w-0 truncate",
-                    isHeader
-                      ? ""
-                      : "transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[320px]/chat-bottom:max-w-[200px] @[320px]/chat-bottom:opacity-100",
-                  )}
-                >
-                  {label}
-                </span>
+                <span className="min-w-0 truncate">{label}</span>
                 {!disabled && (
-                  <ChevronDown
-                    size={12}
-                    className={cn(
-                      "opacity-60 shrink-0",
-                      isHeader
-                        ? ""
-                        : "hidden @[320px]/chat-bottom:inline-block",
-                    )}
-                  />
+                  <ChevronDown size={12} className="opacity-60 shrink-0" />
                 )}
               </Button>
             </PopoverTrigger>

--- a/packages/e2e/tests/chat-locked-thread.spec.ts
+++ b/packages/e2e/tests/chat-locked-thread.spec.ts
@@ -304,15 +304,14 @@ test.describe("Thread runtime is locked after first message", () => {
       );
 
       // Note: the branch-picker-locked chip is intentionally not asserted
-      // here. `ChatModeRow` gates `BranchPill` on
-      // `githubRepo && connectionId`, and this fixture deliberately omits
-      // `connectionId` (a public-clone-mode repo is enough to flip
-      // `agentHasClonableSource` for the mode picker, but the branch
-      // pill needs a real GH connection to mount). Covering the locked
-      // branch chip requires a fixture with an authenticated GH
-      // connection — out of scope for this test. The locked-state lookup
-      // itself is exercised by `BranchPill`'s own logic and by the
-      // server-side lock test above.
+      // here. The branch pill now lives in the toolbar breadcrumb
+      // (`BranchCrumb`), which gates on `githubRepo && connectionId`, and this
+      // fixture deliberately omits `connectionId` (a public-clone-mode repo is
+      // enough to flip `agentHasClonableSource` for the mode picker, but the
+      // branch pill needs a real GH connection to mount). Covering the locked
+      // branch chip requires a fixture with an authenticated GH connection —
+      // out of scope for this test. The locked-state lookup itself is exercised
+      // by `BranchPill`'s own logic and by the server-side lock test above.
 
       // Hard reload — locked affordance must survive a fresh mount.
       await page.reload();


### PR DESCRIPTION
## Summary

Moves the GitHub branch selector out of the chat composer and into the shell breadcrumb, so the toolbar reads `deco › org › agent › branch`.

- **New `BranchCrumb`** in `shell-breadcrumb.tsx`, rendered after the agent crumb. Shows **only inside a thread whose agent is a sandbox agent** (GitHub repo with an attached connection). Non-sandbox agents (e.g. Decopilot) get no branch crumb.
- The breadcrumb lives **above** `ChatContextProvider`, so it can't read the chat task context — `BranchCrumb` resolves the active thread's branch + lock state from the `ThreadManager` store instead (`harness_id != null` ⇒ runtime pinned ⇒ branch locked, matching `ChatTaskContextValue.isThreadLocked`).
- Reuses the existing `BranchPill` with `placement="header"`, restyled **ghost** (no border/bg, `hover:bg-accent/60`) to match the agent crumb.
- Drops the `ChatModeRow` wrapper: the chat composer (`input.tsx`) and agent home (`agent-home.tsx`) now render `ModePicker` directly. `BranchPill` tests moved to their own `branch-pill.test.tsx`.

## Testing

- `bun run check` ✅
- `bun run lint` ✅ (0 errors)
- `bun test apps/mesh/src/web/components/chat/` ✅ (366 pass)

## Notes / follow-up

- **Lock timing:** in the chat the branch locked as soon as messages existed; in the breadcrumb it locks when `harness_id` is pinned (first send). There's a brief window where the branch stays editable until the runtime is actually pinned — which is arguably the more correct semantic.
- Worth a visual check on **mobile**, where the breadcrumb row is tight; the chip truncates at `max-w-[200px]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the GitHub branch selector from the chat composer into the toolbar breadcrumb so it reads “org › agent › branch”. It shows only in sandbox-agent threads and avoids rendering for off-list/archived threads.

- **New Features**
  - Added `BranchCrumb` in `shell-breadcrumb.tsx` that renders `BranchPill`. Lock state comes from the ThreadManager store (`harness_id != null`), and updates use `useThreadActions.setBranch`.
  - `BranchCrumb` gates on the active thread being present in the panel store; off-list/archived threads render nothing to avoid an unlocked, branch-less picker and phantom “New chat” rows.

- **Refactors**
  - Removed `placement` from `BranchPill`/`BranchPicker`; always render a ghost, header-styled chip with a visible label. Simplified styles and removed responsive label collapse.
  - `ChatModeRow` now only renders the `RuntimeSwitcher` or the locked-runtime chip; removed branch pill composition and `ChatModeRowPure`. Callers in `input.tsx` and `agent-home.tsx` updated.

<sup>Written for commit 8416e38dd7aa2d5562c48bf906bfec15c63c9813. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

