### PR TITLE
test(sandbox): pin RingBuffer truncation invariant

### DIFF
--- a/packages/sandbox/daemon/process/ring-buffer.test.ts
+++ b/packages/sandbox/daemon/process/ring-buffer.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { RingBuffer } from "./ring-buffer";
+
+// Regression coverage for #4522: TaskSummary.truncated silently stayed false
+// after this buffer had already dropped bytes, because nothing pinned the
+// drop-tracking invariant below. Any regression here re-hides real output
+// loss from the tasks-list endpoint.
+describe("RingBuffer", () => {
+  it("keeps all data and reports no truncation while under capacity", () => {
+    const buf = new RingBuffer(10);
+    buf.append("ab");
+    buf.append("cd");
+    expect(buf.read()).toEqual({ data: "abcd", truncated: false });
+    expect(buf.isTruncated()).toBe(false);
+  });
+
+  it("does not truncate when total size exactly equals capacity", () => {
+    const buf = new RingBuffer(4);
+    buf.append("ab");
+    buf.append("cd");
+    expect(buf.read()).toEqual({ data: "abcd", truncated: false });
+  });
+
+  it("keeps only the tail and flags truncated when a single append exceeds capacity", () => {
+    const buf = new RingBuffer(5);
+    buf.append("0123456789");
+    expect(buf.read()).toEqual({ data: "56789", truncated: true });
+  });
+
+  it("drops whole oldest chunks then trims the next one, keeping exactly the tail", () => {
+    const buf = new RingBuffer(5);
+    buf.append("ab");
+    buf.append("cd");
+    buf.append("efgh");
+    // Full stream was "abcdefgh" (8 chars); only the last 5 must survive.
+    expect(buf.read()).toEqual({ data: "defgh", truncated: true });
+  });
+
+  it("ignores empty appends without affecting size or truncation state", () => {
+    const buf = new RingBuffer(5);
+    buf.append("abc");
+    buf.append("");
+    expect(buf.read()).toEqual({ data: "abc", truncated: false });
+  });
+
+  it("isTruncated stays true once data has been dropped, even after more appends", () => {
+    const buf = new RingBuffer(3);
+    buf.append("abcd");
+    expect(buf.isTruncated()).toBe(true);
+    buf.append("e");
+    expect(buf.isTruncated()).toBe(true);
+    expect(buf.read().data).toBe("cde");
+  });
+});


### PR DESCRIPTION
## Summary
`RingBuffer` (the in-memory tail of task stdout/stderr in the sandbox daemon) had zero dedicated unit tests despite its drop-tracking logic already causing a real production bug: #4522 fixed `TaskSummary.truncated` silently staying `false` after this exact buffer had dropped bytes, hiding real output loss from the tasks-list endpoint.

This adds a focused unit test file pinning the core invariant directly on the class — appends beyond capacity must keep exactly the tail and flag `truncated`/`isTruncated()` — so a regression here fails fast instead of resurfacing as a misleading `truncated: false` downstream (as it did in #4522).

## Test plan
- `bun test packages/sandbox/daemon/process/ring-buffer.test.ts` — 6 new tests, all passing.
- `bun x tsc --noEmit` in `packages/sandbox` — clean.
- Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `RingBuffer` truncation to ensure overflow keeps the tail and sets `truncated`/`isTruncated()` correctly. Prevents regressions like #4522 where `TaskSummary.truncated` stayed false after drops.

- **Bug Fixes**
  - Pins truncation invariant with 6 tests in `packages/sandbox/daemon/process/ring-buffer.test.ts`.
  - Covers tail retention, exact-capacity writes, multi-chunk drops, empty appends, and sticky truncation state.

<sup>Written for commit 5da27286692ecc612664f23229068df4017ce60a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

