### PR TITLE
fix(web): Super Agent follow-ups — live New-chat reuse, invite decline, agent-switch view reset

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -1180,6 +1180,40 @@ export function ActiveTaskProvider({
       setChatMode("default");
     }
 
+    const submitSettings = resolveSubmitSettings({
+      thread: activeTask
+        ? {
+            harness_id: activeTask.harness_id ?? null,
+            sandbox_provider_kind: activeTask.sandbox_provider_kind ?? null,
+            branch: activeTask.branch ?? null,
+          }
+        : null,
+      globals: {
+        harnessId: pendingHarnessId ?? undefined,
+        sandboxProviderKind: pendingSandboxProviderKind ?? undefined,
+        branch: currentBranch,
+      },
+    });
+
+    // First message on an unlocked thread: the server pins harness_id /
+    // sandbox_provider_kind on receipt, but that write never flows back through
+    // `/watch` (RowPatch carries it, the SSE event does not). Mirror it into the
+    // store now so `findReusableNewChat` stops treating the (now non-empty,
+    // often just-failed) thread as an empty "New chat" and dropping the user
+    // back onto it. When the user hasn't explicitly picked a runtime the client
+    // sends no harnessId and the server pins its default ("decopilot", per
+    // resolveHarnessId's fallback for non-CLI providers) — mirror that so this
+    // covers the common brand-new-thread case, not just explicit picks. LIST is
+    // authoritative on reload; this only keeps the live view correct meanwhile.
+    if (!activeTask?.harness_id) {
+      manager.patchThread({
+        id: capturedTaskId,
+        harness_id: submitSettings.harnessId ?? "decopilot",
+        sandbox_provider_kind: submitSettings.sandboxProviderKind ?? null,
+        updated_at: new Date().toISOString(),
+      });
+    }
+
     const requestOptions: RequestOptions = {
       tier: activeTier,
       mode: modeToSend,
@@ -1188,20 +1222,7 @@ export function ActiveTaskProvider({
       system: system || undefined,
       agent: { id: capturedVirtualMcpId },
       thread_id: capturedTaskId,
-      ...resolveSubmitSettings({
-        thread: activeTask
-          ? {
-              harness_id: activeTask.harness_id ?? null,
-              sandbox_provider_kind: activeTask.sandbox_provider_kind ?? null,
-              branch: activeTask.branch ?? null,
-            }
-          : null,
-        globals: {
-          harnessId: pendingHarnessId ?? undefined,
-          sandboxProviderKind: pendingSandboxProviderKind ?? undefined,
-          branch: currentBranch,
-        },
-      }),
+      ...submitSettings,
     };
 
     // A run is already streaming (this thread) or in progress (hosted): this

--- a/apps/mesh/src/web/components/chat/task/types.ts
+++ b/apps/mesh/src/web/components/chat/task/types.ts
@@ -47,6 +47,8 @@ export type RowPatch = Pick<Task, "id"> &
       | "created_by"
       | "trigger_id"
       | "virtual_mcp_id"
+      | "harness_id"
+      | "sandbox_provider_kind"
       | "metadata"
     >
   >;

--- a/apps/mesh/src/web/components/header/org-switcher.tsx
+++ b/apps/mesh/src/web/components/header/org-switcher.tsx
@@ -8,7 +8,6 @@
  */
 import { type ReactNode, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   Popover,
@@ -79,9 +78,16 @@ export function OrgIcon({
  * navigates there. This is where invitations live now (the old global "inbox"
  * was removed); org-admin join-requests still live in Settings.
  */
-function InvitationRow({ invitation }: { invitation: Invitation }) {
+function InvitationRow({
+  invitation,
+  onChanged,
+}: {
+  invitation: Invitation;
+  /** Refresh the invitation list after a decline so the row + breadcrumb dot
+   *  clear. Accept hard-navigates, so it doesn't need this. */
+  onChanged: () => void;
+}) {
   const [busy, setBusy] = useState(false);
-  const queryClient = useQueryClient();
   const name = invitation.organizationName ?? "Unknown organization";
 
   const accept = async () => {
@@ -128,7 +134,10 @@ function InvitationRow({ invitation }: { invitation: Invitation }) {
         return;
       }
       toast.success("Invitation declined");
-      queryClient.invalidateQueries();
+      // Re-enable in case the refetch keeps the row briefly, and refresh the
+      // invitation list so the declined row (and the breadcrumb dot) clear.
+      setBusy(false);
+      onChanged();
     } catch {
       toast.error("Failed to decline invitation");
       setBusy(false);
@@ -183,7 +192,8 @@ function OrganizationsPanel({
   // deferred until the switcher is actually opened — it no longer fires on
   // every page load.
   const { data: organizations } = useActiveOrganizations();
-  const pendingInvitations = usePendingInvitations();
+  const { invitations: pendingInvitations, refetch: refetchInvitations } =
+    usePendingInvitations();
   const sortedOrgs = [...(organizations ?? [])].sort((a, b) => {
     if (a.slug === orgParam) return -1;
     if (b.slug === orgParam) return 1;
@@ -227,7 +237,11 @@ function OrganizationsPanel({
             click. Hidden while searching (they're not "your" orgs to filter). */}
         {!query &&
           pendingInvitations.map((invitation) => (
-            <InvitationRow key={invitation.id} invitation={invitation} />
+            <InvitationRow
+              key={invitation.id}
+              invitation={invitation}
+              onChanged={refetchInvitations}
+            />
           ))}
         {filtered.length === 0 && (
           <p className="px-3 py-4 text-sm text-muted-foreground/60 text-center">

--- a/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
+++ b/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
@@ -113,7 +113,7 @@ export function ShellBreadcrumb() {
   const { setTaskId, createNewTask } = usePanelActions();
   // Pending cross-org invitations surface inside the org switcher; show a dot on
   // its trigger so they're noticed without opening it.
-  const hasPendingInvites = usePendingInvitations().length > 0;
+  const hasPendingInvites = usePendingInvitations().invitations.length > 0;
 
   const decopilot = getWellKnownDecopilotVirtualMCP(org.id);
   const decopilotId = decopilot.id;

--- a/apps/mesh/src/web/hooks/use-pending-invitations.ts
+++ b/apps/mesh/src/web/hooks/use-pending-invitations.ts
@@ -4,11 +4,16 @@ import type { Invitation } from "@/web/components/sidebar/types";
 
 export type { Invitation };
 
-export function usePendingInvitations(): Invitation[] {
+export function usePendingInvitations(): {
+  invitations: Invitation[];
+  /** Re-fetch the underlying invitation list — call after accept/decline so
+   *  the row (and the breadcrumb dot) clear without a full page reload. */
+  refetch: () => void;
+} {
   const authUi = useContext(AuthUIContext);
-  const { data } = authUi.hooks.useListUserInvitations();
-  const invitations = (data ?? []) as Invitation[];
-  return invitations.filter(
+  const { data, refetch } = authUi.hooks.useListUserInvitations();
+  const invitations = ((data ?? []) as Invitation[]).filter(
     (inv) => inv.status === "pending" && new Date(inv.expiresAt) > new Date(),
   );
+  return { invitations, refetch: () => refetch?.() };
 }

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -130,11 +130,18 @@ export function usePanelActions() {
         // "overview" onto a repo agent, or "preview" onto the Super Agent
         // ("No source to preview"), is exactly the stuck-view bug. Leaving
         // `main` unset lets the new agent's own defaultMainView resolve.
-        const targetVmcp = virtualMcpId ?? prev.virtualmcpid;
-        const isAgentSwitch =
-          typeof prev.virtualmcpid === "string" &&
-          typeof targetVmcp === "string" &&
-          targetVmcp !== prev.virtualmcpid;
+        // The Super Agent is the default agent when the URL carries no
+        // `virtualmcpid`, so treat an absent id as the Super Agent on BOTH
+        // sides. Otherwise switching FROM the param-less Super Agent TO a repo
+        // agent isn't detected as a switch and wrongly carries "overview" onto
+        // an agent that has no Overview tab.
+        const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
+        const prevVmcp =
+          typeof prev.virtualmcpid === "string"
+            ? prev.virtualmcpid
+            : decopilotId;
+        const targetVmcp = virtualMcpId ?? prevVmcp;
+        const isAgentSwitch = targetVmcp !== prevVmcp;
         // Explicit main tab takes priority (e.g. home tile → pinned view).
         if (opts?.main) {
           next.main = opts.main;


### PR DESCRIPTION
Follow-up to #4531 (already merged). A second-look review of that PR surfaced three issues that didn't block the merge but should land before they bite in prod.

## 1. `findReusableNewChat` didn't actually skip failed threads in-session
#4531 added a `!harness_id` gate so a thread whose first message already ran (a failed first message keeps the `"New chat"` title forever) wouldn't be reused as if it were an empty "New chat". That fixed the **cross-session** case (`COLLECTION_THREADS_LIST` returns `harness_id`), but not the live one: the server pins `harness_id` on first-message dispatch, and that write **never flows back through `/watch`** — so in-session the store row still shows `harness_id: null` and the broken thread got reused anyway (dropping the user back onto it until a reload).

Fix: mirror the pin into the store at send time (`RowPatch` now carries `harness_id`/`sandbox_provider_kind`, alongside the existing title/status live-patches). When no runtime was explicitly picked the client sends no `harnessId` and the server pins its default (`decopilot`, per `resolveHarnessId`), so we mirror that too — covering the common brand-new-thread case, not just explicit picks. `LIST` stays authoritative on reload.

## 2. Declining an org invitation left the row frozen and stale
`InvitationRow.decline` never called `setBusy(false)` on success (both error paths do), so the buttons stayed disabled; and `invalidateQueries()` doesn't touch the invitation list (it comes from better-auth-ui's store, not TanStack Query), so the declined row and the breadcrumb dot lingered until reload. Now `usePendingInvitations` exposes `refetch`, and decline re-enables + refetches.

## 3. Overview leaked onto repo agents from the param-less Super Agent
`isAgentSwitch` required `prev.virtualmcpid` to be a string, but the Super Agent is the *default* agent when the URL has no `virtualmcpid`. Switching from it to a repo agent then wasn't detected as a switch, so `main=overview` was carried onto an agent with no Overview tab. Now an absent id is treated as the Super Agent on both sides.

## Testing
- `bun run check`, `bun run lint`, and unit tests pass.
- Fixes 1 and 3 are live-view/navigation behavior (two-tier policy → e2e territory, not unit); the pure `findReusableNewChat` helper is already unit-covered from #4531.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Super Agent UX bugs: stop live reuse of failed "New chat" threads, clear UI after declining org invites, and reset the view when switching from the param-less Super Agent.

- **Bug Fixes**
  - Mirror the server’s first-message runtime pin into the thread store (`harness_id`/`sandbox_provider_kind`) so live `findReusableNewChat` no longer reuses a non-empty thread.
  - Declining an org invitation re-enables buttons and refreshes the list via `usePendingInvitations().refetch`, clearing the row and breadcrumb dot.
  - Treat a missing `virtualmcpid` as the Super Agent when detecting switches, so moving to a repo agent clears `main` and avoids a stuck Overview.

<sup>Written for commit 4dab748c542a316001ecc7d5fd09ede7258d3c7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

