### PR TITLE
fix(web): align invitation badge with sidebar state

### DIFF
--- a/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
+++ b/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
@@ -24,6 +24,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
+import { useSidebar } from "@deco/ui/components/sidebar.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
 import {
   getWellKnownDecopilotVirtualMCP,
   useProjectContext,
@@ -103,6 +105,7 @@ function AgentCrumb({
 
 export function ShellBreadcrumb() {
   const { org } = useProjectContext();
+  const { state: sidebarState, isMobile } = useSidebar();
   const navigate = useNavigate();
   const params = useParams({ strict: false }) as {
     org?: string;
@@ -114,6 +117,7 @@ export function ShellBreadcrumb() {
   // Pending cross-org invitations surface inside the org switcher; show a dot on
   // its trigger so they're noticed without opening it.
   const hasPendingInvites = usePendingInvitations().invitations.length > 0;
+  const isSidebarCollapsed = sidebarState === "collapsed" || isMobile;
 
   const decopilot = getWellKnownDecopilotVirtualMCP(org.id);
   const decopilotId = decopilot.id;
@@ -169,7 +173,14 @@ export function ShellBreadcrumb() {
                     <span className="relative inline-flex">
                       <OrgIcon org={org} size="sm" />
                       {hasPendingInvites && (
-                        <span className="absolute -top-1 -right-1 size-2.5 rounded-full bg-destructive ring-2 ring-background" />
+                        <span
+                          className={cn(
+                            "absolute -right-1 size-2.5 rounded-full bg-destructive ring-2 ring-background",
+                            isSidebarCollapsed
+                              ? "-top-1"
+                              : "top-1/2 -translate-y-1/2",
+                          )}
+                        />
                       )}
                     </span>
                     <ChevronDown


### PR DESCRIPTION
## Summary

- position the pending-invitation badge based on the sidebar state
- keep the corner placement for collapsed/mobile layouts and vertically center it when expanded

## Testing

- `bunx biome format apps/mesh/src/web/components/header/shell-breadcrumb.tsx`
- `bun run lint` (passes with existing repository warnings)
- `bun run check`
- `bun test` (unit portion passed; stopped when the Docker-dependent resilience suite waited for an unavailable Studio service)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the pending invitation badge on the org switcher with the sidebar state. Keeps the dot in the corner on collapsed/mobile and vertically centers it when expanded for consistent placement.

- **Bug Fixes**
  - Use `useSidebar` to detect collapsed/mobile state and set `isSidebarCollapsed`.
  - Toggle badge positioning with `cn`: corner (`-top-1`) when collapsed, centered (`top-1/2 -translate-y-1/2`) when expanded.

<sup>Written for commit 7c08dc10cbd66315216053c06acc77ddd2003daf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

