### PR TITLE
fix(sandbox): make the SIGTERM git-sync survive to completion

### DIFF
--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -55,6 +55,10 @@ spec:
         # dashboards filter by absence-of-handle instead.
     spec:
       automountServiceAccountToken: false
+      # Room for the daemon's SIGTERM git-sync (commit + push, push bounded at
+      # 30s) before SIGKILL — the pushed branch is the only durable copy of the
+      # user's work. See values.yaml.
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -55,6 +55,17 @@ resources:
     memory: 4Gi
     ephemeral-storage: 10Gi
 
+# ── shutdown grace period ──────────────────────────────────────────────
+# On SIGTERM (rollout, spot reclaim, idle eviction) the daemon commits and
+# pushes the working tree to git — the only durable copy of the user's work
+# (the pod's /app is ephemeral emptyDir). That push self-limits at 30s
+# (git-sync.ts DEFAULT_GIT_TIMEOUT_MS); K8s must not SIGKILL the pod before it
+# finishes, so the grace period has to clear the push + commit + unmount with
+# margin. The K8s default (30s) is too tight and drops unsynced work. 90s fits
+# a 30s-bounded push comfortably and still sits inside AWS spot's 120s
+# reclaim notice.
+terminationGracePeriodSeconds: 90
+
 # ── netinit / sandbox egress enforcement ──────────────────────────────
 # Sandbox pods run user code and must not reach in-cluster services.
 # Enforcement is via an iptables init container rather than a Kubernetes

--- a/packages/sandbox/daemon/daemon.git.e2e.test.ts
+++ b/packages/sandbox/daemon/daemon.git.e2e.test.ts
@@ -6,6 +6,8 @@
  * the setup orchestrator to drain. Black-box throughout (see helpers).
  */
 import { execSync } from "node:child_process";
+import { chmodSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import {
@@ -141,6 +143,25 @@ describe("daemon e2e: git (cloned repo)", () => {
       method: "POST",
       headers: jsonAuthHeaders(),
       body: toBody({ message: "test publish" }),
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { pushed: boolean }).pushed).toBe(true);
+  });
+
+  it("POST /git/publish pushes past a failing pre-push hook", async () => {
+    // A repo's own pre-push hook must never block the sync: the shutdown
+    // publish shares this path and can't wait out a hanging/failing hook before
+    // the pod's grace period elapses and SIGKILL drops the unsynced work. The
+    // push runs --no-verify, so a hook that would abort the push is skipped.
+    const hook = join(d.appDir, "repo", ".git", "hooks", "pre-push");
+    writeFileSync(hook, "#!/bin/sh\nexit 1\n");
+    chmodSync(hook, 0o755);
+
+    await writeRepoFile(d, "past-hook.txt", "survived the hook\n");
+    const res = await fetch(url(d, "/_sandbox/git/publish"), {
+      method: "POST",
+      headers: jsonAuthHeaders(),
+      body: toBody({ message: "publish past a failing hook" }),
     });
     expect(res.status).toBe(200);
     expect(((await res.json()) as { pushed: boolean }).pushed).toBe(true);

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -916,13 +916,10 @@ async function shutdown(): Promise<void> {
   shuttingDown = true;
   taskManager.shutdown();
   branchStatus.stop();
-  // Best-effort unmount before exit (rclone --daemon detaches, so it would
-  // otherwise outlive us). A truly abrupt SIGKILL skips this — the sync `exit`
-  // handler below and the next boot's reclaim are the backstops.
-  if (mountManager) {
-    await mountManager.stop().catch(() => {});
-  }
-  // Reuse the same publish() path as POST /_sandbox/git/publish so the
+  // Publish BEFORE unmount: syncing the user's work is the only irrecoverable
+  // step. A stale mount is backstopped (sync `exit` handler + next-boot
+  // reclaim), so a hanging unmount must never eat the push's slice of the grace
+  // period. Reuse the same publish() path as POST /_sandbox/git/publish so the
   // shutdown sync inherits credentialed-remote setup, hook-skipping, and
   // non-interactive push — the blind add/commit/push it replaced silently
   // failed on GitHub repos whose origin URL lacked embedded credentials and
@@ -937,6 +934,11 @@ async function shutdown(): Promise<void> {
     } catch (err) {
       console.warn("[daemon] shutdown publish failed", err);
     }
+  }
+  // rclone --daemon detaches, so an unmount here stops it from outliving us.
+  // Best-effort: a truly abrupt SIGKILL skips it and the backstops above cover.
+  if (mountManager) {
+    await mountManager.stop().catch(() => {});
   }
   process.exit(0);
 }

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -467,6 +467,11 @@ function pushBranch(repoDir: string, branch: string): void {
       "-c",
       "safe.directory=*",
       "push",
+      // Skip native pre-push hooks (parity with the --no-verify commit above).
+      // A repo's pre-push script can fail or hang the push, and the shutdown
+      // sync — which shares this path — has no room to wait it out before the
+      // pod's grace period elapses and SIGKILL drops the unsynced work.
+      "--no-verify",
       "-u",
       "origin",
       branch,


### PR DESCRIPTION
## Summary

On SIGTERM (rollout, spot reclaim, idle eviction) the sandbox daemon commits + pushes the working tree to git. That pushed branch is the **only durable copy of the user's work** — the pod's `/app` is ephemeral `emptyDir`. Three ways the sync could silently drop hours of work:

1. **Unmount ran before publish.** `shutdown()` awaited `mountManager.stop()` first, so a hanging rclone unmount could eat the push's slice of the grace period. → Publish first; unmount moved after (best-effort, already backstopped by the sync `exit` handler + next-boot reclaim).
2. **Push didn't skip hooks.** The commit already runs `--no-verify`, but the push didn't — a repo's native `pre-push` hook could fail or hang it. → `--no-verify` on the push too.
3. **No `terminationGracePeriodSeconds`.** The pod used the K8s default (30s), too tight to clear commit + the 30s-bounded push (`git-sync.ts` `DEFAULT_GIT_TIMEOUT_MS`) + unmount → SIGKILL mid-sync. → Set to `90s` (chart value + template), comfortably inside AWS spot's 120s reclaim notice.

## Testing

- New e2e: `POST /git/publish pushes past a failing pre-push hook` — installs a `pre-push` that `exit 1`s and asserts the push still lands. **Verified discriminating**: fails (500) without `--no-verify`, passes with it.
- Full `daemon.git.e2e.test.ts` green (17/17), including the existing `SIGTERM triggers a graceful publish` test after the reorder.
- `helm template` renders `terminationGracePeriodSeconds: 90` on the `SandboxTemplate`.
- `tsc` clean, `bun run lint` 0 errors, formatted.

## Notes / follow-up

This hardens the *graceful* path. It does **not** cover a hard kill with no SIGTERM (OOM, node loss, non-graceful spot) — that still loses since the last push. A periodic/debounced background push during the session would close that gap; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the sandbox completes its SIGTERM git sync so user work is pushed before the pod is killed. We publish before unmount, skip `pre-push` hooks, and extend the pod’s shutdown window to 90s.

- **Bug Fixes**
  - Run publish before unmount on shutdown; unmount is best-effort to avoid blocking the push.
  - Use `git push --no-verify` to bypass repo `pre-push` hooks that could fail or hang.
  - Set `terminationGracePeriodSeconds: 90` in Helm to cover commit + 30s-bounded push within AWS spot’s 120s notice.
  - Add e2e test that confirms publish succeeds past a failing `pre-push` hook; existing SIGTERM publish test remains green.

<sup>Written for commit e39e6c27d78d6dca6ffb6c19a45eacb7d22d3071. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

