### PR TITLE
feat(sections-editor): add make global / detach actions for loaders

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx
@@ -1,5 +1,11 @@
 import { useState, type ReactNode } from "react";
-import { ChevronDown, ChevronRight, Globe01 } from "@untitledui/icons";
+import {
+  ChevronDown,
+  ChevronRight,
+  DotsHorizontal,
+  Globe01,
+  LayoutAlt01,
+} from "@untitledui/icons";
 import {
   Select,
   SelectContent,
@@ -7,6 +13,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@deco/ui/components/select.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
 import {
   Tooltip,
@@ -27,9 +40,12 @@ import {
   isEmbeddedUnionResolveType,
 } from "../block-type-utils";
 import { labelFromResolveType } from "../section-types";
+import { suggestBlockId, validateBlockId } from "../page-sections";
 import type { SchemaProperty } from "../resolve-schema";
 import type { FieldProps } from "./field-props";
 
+import { toast } from "sonner";
+import { MakeReusableModal } from "../make-reusable-modal";
 import { SchemaForm } from "../schema-form";
 import { unwrapBlockReference } from "../unwrap-section";
 
@@ -78,6 +94,8 @@ function CollapsibleLoaderConfig({
   nested,
   nestedBlockRef,
   globalBlockKey,
+  onDetach,
+  onMakeGlobal,
 }: {
   path: string;
   open: boolean;
@@ -86,6 +104,8 @@ function CollapsibleLoaderConfig({
   nested: ReactNode;
   nestedBlockRef?: boolean;
   globalBlockKey?: string;
+  onDetach?: () => void;
+  onMakeGlobal?: () => void;
 }) {
   const contentId = `${path}-loader-config`;
 
@@ -96,23 +116,54 @@ function CollapsibleLoaderConfig({
         nestedBlockRef && "ml-1",
       )}
     >
-      <button
-        type="button"
-        aria-expanded={open}
-        aria-controls={contentId}
-        onClick={() => onOpenChange(!open)}
-        className="group flex w-full min-w-0 items-center gap-2 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-accent/50"
-      >
-        <span className="flex size-6 shrink-0 items-center justify-center text-muted-foreground transition-colors group-hover:text-foreground">
-          {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-        </span>
-        <span className="flex min-w-0 items-center gap-2">
-          <span className="truncate text-xs font-medium tracking-wide text-muted-foreground uppercase">
-            {title}
+      <div className="group flex w-full min-w-0 items-center gap-1 rounded-lg pr-2 transition-colors hover:bg-accent/50">
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={contentId}
+          onClick={() => onOpenChange(!open)}
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-3 py-2.5 text-left"
+        >
+          <span className="flex size-6 shrink-0 items-center justify-center text-muted-foreground transition-colors group-hover:text-foreground">
+            {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
           </span>
-          {globalBlockKey && <GlobalLoaderBadge blockKey={globalBlockKey} />}
-        </span>
-      </button>
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              {title}
+            </span>
+            {globalBlockKey && <GlobalLoaderBadge blockKey={globalBlockKey} />}
+          </span>
+        </button>
+        {(onDetach || onMakeGlobal) && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Loader actions"
+                className="h-7 w-7 shrink-0 text-muted-foreground"
+              >
+                <DotsHorizontal size={16} />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              {globalBlockKey && onDetach && (
+                <DropdownMenuItem onClick={onDetach}>
+                  <LayoutAlt01 className="h-4 w-4" />
+                  Detach
+                </DropdownMenuItem>
+              )}
+              {!globalBlockKey && onMakeGlobal && (
+                <DropdownMenuItem onClick={onMakeGlobal}>
+                  <Globe01 className="h-4 w-4" />
+                  Make global
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
       {open && (
         <div
           id={contentId}
@@ -205,6 +256,7 @@ export function AnyOfField({
   const [loaderConfigOpen, setLoaderConfigOpen] = useState(() =>
     blockRefLoaderConfigHasData(editorValue, savedRef?.blockKey),
   );
+  const [makeGlobalOpen, setMakeGlobalOpen] = useState(false);
 
   // ── block-ref mode (anyOfRefs from schema resolution) ─────────────
   if (refs.length > 0) {
@@ -310,6 +362,52 @@ export function AnyOfField({
 
     const isNestedBlockRef = path.includes(".");
 
+    // Detach: convert a global (saved-block) loader into a local, inline copy.
+    // Mirrors the section-level "Detach" — the resolved block data is written
+    // back inline (minus the saved block's `name`), so edits no longer touch
+    // the shared decofile entry referenced elsewhere on the site.
+    const handleDetach = savedRef
+      ? () => {
+          const { name: _name, ...inlineData } = savedRef.data;
+          onChange(inlineData);
+        }
+      : undefined;
+
+    // Make global: save the current inline loader as a reusable decofile block
+    // and point this field at it. Mirrors the section-level "Save as global".
+    // Only offered for a local module loader (not already global, not a Lazy
+    // wrapper, and an actual module resolveType — not an embedded union variant).
+    const canMakeGlobal =
+      !savedRef &&
+      !lazyInner &&
+      !!onSaveReferencedBlock &&
+      isModuleLoaderUnion &&
+      !isEmbeddedUnionResolveType(activeRt) &&
+      activeRt.includes("/");
+    const currentLoaderData =
+      boundValue && typeof boundValue === "object" && !Array.isArray(boundValue)
+        ? (boundValue as Record<string, unknown>)
+        : {};
+    const handleMakeGlobalSubmit = (blockId: string) => {
+      if (!onSaveReferencedBlock) return;
+      const trimmed = blockId.trim();
+      const validationError = decofile
+        ? validateBlockId(trimmed, decofile)
+        : null;
+      if (validationError) {
+        toast.error(validationError);
+        return;
+      }
+      onSaveReferencedBlock(trimmed, {
+        ...currentLoaderData,
+        __resolveType: activeRt,
+        name: trimmed,
+      });
+      onChange({ __resolveType: trimmed });
+      setMakeGlobalOpen(false);
+      toast.success(`Saved global block "${trimmed}"`);
+    };
+
     return (
       <div className="space-y-3">
         <div className="space-y-1.5">
@@ -353,10 +451,22 @@ export function AnyOfField({
               nested={nestedProps}
               nestedBlockRef={isNestedBlockRef}
               globalBlockKey={savedRef?.blockKey}
+              onDetach={handleDetach}
+              onMakeGlobal={
+                canMakeGlobal ? () => setMakeGlobalOpen(true) : undefined
+              }
             />
           ) : (
             nestedProps
           ))}
+        {canMakeGlobal && (
+          <MakeReusableModal
+            open={makeGlobalOpen}
+            onOpenChange={setMakeGlobalOpen}
+            defaultBlockId={suggestBlockId(labelFromResolveType(activeRt))}
+            onSubmit={handleMakeGlobalSubmit}
+          />
+        )}
       </div>
     );
   }

--- a/apps/mesh/src/web/components/sections-editor/page-sections.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-sections.test.ts
@@ -79,6 +79,8 @@ describe("page-sections", () => {
       "Must start with a letter",
     );
     expect(validateBlockId("MyNewBlock", decofile)).toBeNull();
+    // Block keys may contain spaces (see deco-block-key.ts).
+    expect(validateBlockId("PLP Air Fryer", decofile)).toBeNull();
   });
 
   it("canMakeSectionReusable rejects saved, multivariate, and hidden sections", () => {
@@ -90,7 +92,9 @@ describe("page-sections", () => {
 
   it("suggestBlockId sanitizes labels", () => {
     expect(suggestBlockId("Hero")).toBe("Hero");
-    expect(suggestBlockId("Variants of Hero")).toBe("VariantsofHero");
-    expect(suggestBlockId("FAQ Section")).toBe("FAQSection");
+    expect(suggestBlockId("Variants of Hero")).toBe("Variants of Hero");
+    expect(suggestBlockId("FAQ Section")).toBe("FAQ Section");
+    // Disallowed characters are stripped; spaces are collapsed and trimmed.
+    expect(suggestBlockId("  PLP / Air  Fryer!  ")).toBe("PLP Air Fryer");
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/page-sections.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-sections.ts
@@ -46,9 +46,14 @@ export function canMakeSectionReusable(section: {
 }
 
 export function suggestBlockId(label: string): string {
-  const cleaned = label.replace(/[^A-Za-z0-9_-]/g, "");
+  // Block keys may contain spaces (see deco-block-key.ts), so keep them for a
+  // readable default name — only strip characters that aren't allowed.
+  const cleaned = label
+    .replace(/[^A-Za-z0-9_ -]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
   if (/^[A-Za-z]/.test(cleaned)) return cleaned;
-  if (cleaned) return `Block${cleaned}`;
+  if (cleaned) return `Block ${cleaned}`;
   return "";
 }
 
@@ -64,8 +69,8 @@ export function validateBlockId(
   if (Object.hasOwn(decofile, trimmed)) {
     return "A block with this name already exists.";
   }
-  if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(trimmed)) {
-    return "Use letters, numbers, hyphens, or underscores. Must start with a letter.";
+  if (!/^[A-Za-z][A-Za-z0-9_ -]*$/.test(trimmed)) {
+    return "Use letters, numbers, spaces, hyphens, or underscores. Must start with a letter.";
   }
   return null;
 }


### PR DESCRIPTION
## Summary

The loader configuration in the sections editor now supports converting between **global** (a reusable decofile block referenced across the site) and **local** (inline) loaders, in both directions — previously only the section list had these actions.

A three-dots menu was added to the loader config header:

- **Detach** (global → local): converts a global loader into an inline copy for that section only. Edits no longer affect other places referencing the block. Mirrors the section-level "Detach".
- **Make global** (local → global): saves the current inline loader as a reusable decofile block and points the field at it. Reuses the existing "Save as global" modal.

The kebab menu is always visible (chosen over hover-only buttons for discoverability).

## Block name validation

While testing "Make global", human-friendly names like `PLP Air Fryer` were rejected by the block-name validator even though block keys support spaces at the storage layer (see `deco-block-key.ts`). Relaxed `validateBlockId` to allow spaces and updated `suggestBlockId` to keep them (collapsed + trimmed) for a readable default.

## Testing

- `bun run --cwd=apps/mesh check` (tsc) ✅
- `bun run lint` ✅
- `bun test apps/mesh/src/web/components/sections-editor/` ✅ 416 pass
- Not yet exercised end-to-end in the running app — the flows were validated via unit tests and type/lint checks only.

## Affected areas

- `apps/mesh/src/web/components/sections-editor/fields/any-of-field.tsx` — loader config menu, detach & make-global handlers
- `apps/mesh/src/web/components/sections-editor/page-sections.ts` — allow spaces in block names
- `apps/mesh/src/web/components/sections-editor/page-sections.test.ts` — updated expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “Make global” and “Detach” actions to loader configs in the sections editor, enabling easy conversion between local and global loaders. Also relax block-name rules to allow spaces and improve suggested names.

- **New Features**
  - Added a three-dots menu in the loader config header with:
    - Detach (global → local) to inline a shared loader.
    - Make global (local → global) using the existing “Save as global” modal.
  - Menu is always visible; “Make global” only appears for inline module loaders.

- **Bug Fixes**
  - Allowed spaces in block names by updating `validateBlockId`; improved `suggestBlockId` to keep collapsed, trimmed spaces.
  - Updated tests to cover the new naming rules.

<sup>Written for commit 33a365e65c71d10997d5d0fe28d34a9140850d94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

