### PR TITLE
fix(tabs): scope open code-tab paths to their originating task

### DIFF
--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
@@ -477,4 +477,9 @@ describe("code tab id", () => {
     expect(parseCodeTabId(undefined)).toBeNull();
     expect(parseCodeTabId("codex")).toBeNull();
   });
+
+  test("an open code path is per-thread (scoped to the task's sandbox/branch), but the bare tab is not", () => {
+    expect(isPerThreadTab(formatCodeTabId("src/index.ts"))).toBe(true);
+    expect(isPerThreadTab("code")).toBe(false);
+  });
 });

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
@@ -191,6 +191,9 @@ const FIXED_SYSTEM_TAB_SET = new Set<string>(FIXED_SYSTEM_TABS);
  *   - "file:<encoded key>"            (ephemeral thread-output file preview)
  *   - "deck:<encoded path>"           (ephemeral HTML-artifact preview/editor)
  *   - "library-file:<encoded path>"   (ephemeral org Library file preview)
+ *   - "code:<encoded path>"           (open file in the Code tab's file explorer,
+ *     scoped to the task's branch/sandbox — the bare "code" tab id is NOT
+ *     per-thread, only a specific open path is)
  */
 export function isPerThreadTab(tabId: string): boolean {
   return (
@@ -198,7 +201,8 @@ export function isPerThreadTab(tabId: string): boolean {
     tabId.startsWith("automation:") ||
     tabId.startsWith("file:") ||
     tabId.startsWith("deck:") ||
-    tabId.startsWith("library-file:")
+    tabId.startsWith("library-file:") ||
+    tabId.startsWith("code:")
   );
 }
 


### PR DESCRIPTION
## Source
Bug found reading recently-changed files (`apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts`), not tied to an open issue.

## Payoff
Prevents the Code tab from showing a broken/unrelated file after starting a new task, which otherwise looks like data corruption to the user.

## The bug
`isPerThreadTab()` decides which `?main=` tab ids must NOT be carried over when navigating to a new task (`shell-layout.tsx` / `use-chat-navigation.ts`). It already lists `file:`, `deck:`, and `library-file:` — all tab kinds that encode a path meaningful only in the originating thread — but `code:<path>` (added in #4514) was missing.

`CodeTab` (`code-tab.tsx`) resolves its file explorer against the *current task's* branch and virtualMcpId (`useChatTask().currentBranch`, `inset.entity.id`). So:

1. Open a file in the Code tab on task A (`?main=code:src%2Ffoo.ts`).
2. Start a new task (different agent/branch/sandbox) via `createNewTask`.
3. Because `code:` wasn't per-thread, the stale path carries into the new task's URL, pointing the file explorer at a path from an unrelated sandbox/branch.

The bare `code` tab (no open path) is intentionally unaffected — it's a fixed system tab and correctly still carries over.

## Fix + regression test
Added `code:` to `isPerThreadTab()`, matching the existing pattern for `file:`/`deck:`/`library-file:`. Added a test in `tab-id.test.ts` (mirrors the "tabs are per-thread" tests already there for the other kinds) that fails on the old code and passes now.

## Verify
```
bun test apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts
```

## Checked locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (pre-existing, unrelated `@tiptap/extension-text-align` errors only — nothing in the touched files)
- `bun test apps/mesh/src/web/layouts/main-panel-tabs/tab-id.test.ts` — 60 pass

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes open Code tab paths to their originating task so starting a new task no longer shows a stale/unrelated file. The bare `code` tab still carries over as a fixed system tab.

- **Bug Fixes**
  - Add `code:` to `isPerThreadTab()` so `code:<path>` is per-thread.
  - Add a unit test to cover path scoping and the bare `code` tab behavior.

<sup>Written for commit 343195ff02bebacd9349eba89ba56bb13b9e6642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

