### PR TITLE
fix(task-board): validate assignee membership by exact userId, not a page

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -383,6 +383,8 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
                 organizationId: options.organizationId,
                 limit: options.limit,
                 offset: options.offset,
+                filterField: options.filterField,
+                filterValue: options.filterValue,
               }
             : undefined,
         });

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -142,6 +142,8 @@ export interface BoundAuthClient {
       organizationId?: string;
       limit?: number;
       offset?: number;
+      filterField?: string;
+      filterValue?: string;
     }): Promise<ListMembersResult>;
 
     updateMemberRole(data: {

--- a/apps/mesh/src/tools/task-board/validate-assignee.test.ts
+++ b/apps/mesh/src/tools/task-board/validate-assignee.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression coverage: `assertValidAssignee` used to list members with no
+ * filter, so it relied on Better Auth's default page (capped at 100 rows) to
+ * happen to contain the assignee. In an organization with more than 100
+ * members, a legitimate assignee outside that first page was wrongly
+ * rejected. The fix filters server-side on the exact userId.
+ *
+ * `listMembers` is mocked as the single boundary this internal validator
+ * calls through (see TESTING.md's narrow one-boundary-mock exception) — the
+ * assertion is on the JS behavior (throw vs. not, and the query it issues),
+ * not a wire response.
+ */
+import { describe, expect, it, mock } from "bun:test";
+import type { StudioContext } from "@/core/studio-context";
+import { assertValidAssignee } from "./validate-assignee";
+
+function ctxWithListMembers(
+  listMembers: (options?: {
+    organizationId?: string;
+    filterField?: string;
+    filterValue?: string;
+  }) => Promise<{ members: { userId: string }[] }>,
+): StudioContext {
+  return {
+    boundAuth: { organization: { listMembers } },
+  } as unknown as StudioContext;
+}
+
+describe("assertValidAssignee", () => {
+  it("resolves when the filtered lookup returns the assignee", async () => {
+    const ctx = ctxWithListMembers(async () => ({
+      members: [{ userId: "user-101" }],
+    }));
+    await expect(
+      assertValidAssignee(ctx, "org-1", "user-101"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws when the filtered lookup returns no match", async () => {
+    const ctx = ctxWithListMembers(async () => ({ members: [] }));
+    await expect(assertValidAssignee(ctx, "org-1", "user-999")).rejects.toThrow(
+      "assigneeId is not a member of the organization",
+    );
+  });
+
+  it("filters server-side on the exact userId instead of paging every member", async () => {
+    const listMembers = mock(async () => ({
+      members: [{ userId: "user-101" }],
+    }));
+    const ctx = ctxWithListMembers(listMembers);
+    await assertValidAssignee(ctx, "org-1", "user-101");
+    // Without this filter, an org with >100 members could hide a valid
+    // assignee behind Better Auth's default page and this call would wrongly
+    // throw — see the docstring above.
+    expect(listMembers).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      filterField: "userId",
+      filterValue: "user-101",
+    });
+  });
+});

--- a/apps/mesh/src/tools/task-board/validate-assignee.ts
+++ b/apps/mesh/src/tools/task-board/validate-assignee.ts
@@ -6,8 +6,14 @@ export async function assertValidAssignee(
   organizationId: string,
   assigneeId: string,
 ): Promise<void> {
+  // Filter server-side on the exact userId rather than paging through every
+  // member — an unfiltered listMembers() caps at 100 rows (Better Auth's
+  // default membershipLimit), so it would silently miss a valid assignee in
+  // an organization with more than 100 members.
   const { members } = await ctx.boundAuth.organization.listMembers({
     organizationId,
+    filterField: "userId",
+    filterValue: assigneeId,
   });
   if (
     !members.some((member: { userId: string }) => member.userId === assigneeId)


### PR DESCRIPTION
## Source
A bug found while reading the new task-board tools (`apps/mesh/src/tools/task-board/`).

## The bug
`assertValidAssignee` (used by `TASK_BOARD_ITEM_CREATE`/`TASK_BOARD_ITEM_UPDATE`) checks whether a task's `assigneeId` is a member of the organization by calling `ctx.boundAuth.organization.listMembers({ organizationId })` with no `limit`. Better Auth's `listMembers` defaults to a 100-row page (`options?.membershipLimit || 100`) when no limit is passed, and no `orderBy` is applied.

**Failure scenario:** in an organization with more than 100 members, assigning/updating a task board item with an `assigneeId` that happens to fall outside that first page throws `"assigneeId is not a member of the organization"` even though the user genuinely is a member — a false-negative validation that blocks a legitimate operation.

## The fix
Better Auth's `listMembers` already supports `filterField`/`filterValue` server-side filtering. `assertValidAssignee` now filters directly on `userId`, so the check no longer depends on paging through the full membership list. Plumbed `filterField`/`filterValue` through `BoundAuthClient.organization.listMembers` (`studio-context.ts` type + `context-factory.ts` wrapper), which previously dropped them.

## Regression test
`apps/mesh/src/tools/task-board/validate-assignee.test.ts` — verified it fails on the pre-fix code (the `listMembers` call args assertion) and passes after the fix. `listMembers` is mocked as the single boundary this validator calls through, per TESTING.md's narrow one-boundary-mock exception (assertion is on JS behavior/call args, not a wire response) — a full e2e repro would need an org with >100 real members, which isn't practical to set up here.

## To verify
```
bun test apps/mesh/src/tools/task-board/validate-assignee.test.ts
```

## Checks run locally
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` (confirmed identical pre-existing unrelated errors on main, none introduced)
- `bun test apps/mesh/src/tools/task-board/validate-assignee.test.ts` (3 pass)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false negatives when assigning tasks in large orgs by validating assignees via a server-side `userId` filter instead of relying on the first 100-member page. Plumbs `filterField`/`filterValue` through the bound auth client to `organization.listMembers` and adds a regression test.

<sup>Written for commit 1bde90ba4f1ba2547dc1b4ee69b8de265a45ded9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

