### PR TITLE
refactor(sandbox): use @decocms/std sleep in waitForClaimAdoptedSandbox

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/client.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.ts
@@ -510,7 +510,7 @@ export async function waitForClaimAdoptedSandbox(
     );
     const name = claim?.status?.sandbox?.name;
     if (name) return name;
-    await new Promise((r) => setTimeout(r, intervalMs));
+    await sleep(intervalMs);
   }
   throw new SandboxTimeoutError(
     `SandboxClaim ${claimName} did not record an adopted Sandbox (status.sandbox.name) within ${timeoutSeconds}s`,


### PR DESCRIPTION
## Summary
`waitForClaimAdoptedSandbox`'s poll loop hand-rolled `new Promise((r) => setTimeout(r, intervalMs))` instead of the `sleep()` helper from `@decocms/std` that this exact same file already imports and uses one function above (`waitForSandboxClaimGone`, line 411) for the identical poll-with-interval shape.

This repo already consolidated ~9 hand-rolled `sleep` copies into `@decocms/std` — this is a straggler in a file that otherwise follows the convention.

## Behavior
No-op change: `sleep(ms)` (no `signal` passed) resolves after `ms` exactly like the replaced `setTimeout` promise — same net line count, purely a dedup within one file.

## Test plan
- [x] `bun run fmt` — no changes
- [x] `cd packages/sandbox && bun x tsc --noEmit` — clean
- [x] `bun test packages/sandbox/server/provider/agent-sandbox/client.test.ts` — 29 pass, 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor: use `sleep()` from `@decocms/std` in waitForClaimAdoptedSandbox instead of a local setTimeout promise. No behavior change; matches the pattern used in waitForSandboxClaimGone and removes the last hand-rolled sleep in this file.

<sup>Written for commit 373b0d0f5d9e658c34c4ddcf0f0719c47f2ddbbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

