### PR TITLE
fix(decopilot): terminal-not-retry when a redelivered projection meets a truncated or settled stream

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -169,6 +169,7 @@ import {
   THREAD_GATE_QUEUE,
 } from "../dispatch-queue";
 import { setProjectorWorkflowRuntime } from "./routes/decopilot/projector-workflow";
+import { synthesizedErrorMessageId } from "./routes/decopilot/message-ids";
 import { backfillStudioPackForAllOrgs } from "../auth/install-studio-pack-workflow";
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import {
@@ -1501,6 +1502,17 @@ export async function createApp(options: CreateAppOptions = {}) {
       );
       emitTerminalThreadStatus(sseHub, orgId, runId, flipped);
       return flipped;
+    },
+    clearSynthesizedError: async (runId, fenceToken) => {
+      // Replace-with-empty = delete the synthesized error message a prior
+      // interrupted attempt persisted for this fence (deterministic id).
+      await projectorThreadStorage
+        .messageParts()
+        .replaceMessageParts(
+          runId,
+          synthesizedErrorMessageId(runId, fenceToken),
+          [],
+        );
     },
     persistTitle: (runId, orgId, title) =>
       projectorThreadStorage.update(runId, orgId, { title }),

--- a/apps/mesh/src/api/routes/decopilot/nats-chunk-source.ts
+++ b/apps/mesh/src/api/routes/decopilot/nats-chunk-source.ts
@@ -21,6 +21,32 @@ export class StreamIdleTimeoutError extends Error {
   }
 }
 
+/**
+ * Thrown when the fenced chunk sequence has a hole: the subject no longer
+ * retains a chunk the projection needs (retention discard — the stream's 4GB
+ * `DiscardPolicy.Old` / 24h age caps — or a purge racing a redelivery).
+ * Distinguishable via `instanceof` from a genuine projection bug because the
+ * caller must treat it differently: redelivery can NEVER succeed (the data is
+ * gone), so the projector maps this to a clean terminal failure instead of
+ * rethrowing into DBOS step retries that are pure burn (see
+ * `runProjectorWorkflowBody`'s catch in `projector-workflow.ts`).
+ * `gotSeq === null` means the fenced done arrived before `expectedSeq` was
+ * ever delivered (tail truncation under the done's `finalSeq`).
+ */
+export class StreamGapError extends Error {
+  constructor(
+    public readonly expectedSeq: number,
+    public readonly gotSeq: number | null,
+  ) {
+    super(
+      gotSeq === null
+        ? `missing seq ${expectedSeq} (stream ended at the fenced done)`
+        : `missing seq ${expectedSeq} (next delivered is ${gotSeq})`,
+    );
+    this.name = "StreamGapError";
+  }
+}
+
 export function fenceFilter(
   runId: string,
   fenceToken: string,
@@ -50,7 +76,7 @@ export function assertContiguousAndDedup(): TransformStream<
       }
       if (ev.seq < nextSeq) return; // dedup replay (resend past the dedup window)
       if (ev.seq > nextSeq) {
-        controller.error(new Error(`missing seq ${nextSeq}`));
+        controller.error(new StreamGapError(nextSeq, ev.seq));
         return;
       }
       nextSeq++;
@@ -89,7 +115,7 @@ export function projectorChunkStream(
           if (ev.envelopeFinalSeq !== lastSeq) {
             await reader.cancel();
             release();
-            controller.error(new Error(`missing seq ${lastSeq + 1}`));
+            controller.error(new StreamGapError(lastSeq + 1, null));
             return;
           }
           await reader.cancel();

--- a/apps/mesh/src/api/routes/decopilot/projector-redelivery.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-redelivery.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Redelivery behavior of the durable projector (the `consumeRunProjection`
+ * step) — the invariants that make DBOS re-running an interrupted projection
+ * attempt safe, and the terminal behavior when redelivery can no longer
+ * succeed because the JetStream subject lost data.
+ *
+ * Context (stg incident 2026-07-14, thread d9ef33e5): a gate workflow orphaned
+ * on a dead executor was recovered hours late. Recovery re-runs the WHOLE
+ * consume step from seq 1 (`DeliverPolicy.All`, no journaled cursor). That is
+ * safe — parts persist incrementally at step boundaries with idempotent row
+ * ids — but only while the subject still retains every chunk. The stream has
+ * a 4GB `DiscardPolicy.Old` cap, a 24h age cap, and `purgeRun` on terminal:
+ * a late re-attempt can meet a truncated (or fully purged) subject, which
+ * today surfaces as a generic contiguity error → misleading
+ * `failed(projection)` + pointless DBOS step retries that can never succeed.
+ *
+ * Three groups:
+ *  1. Churn convergence — pins the existing invariant: interrupt + full
+ *     redelivery from seq 1 converges to the exact same rows (no dup, no loss).
+ *  2. Truncated redelivery — typed `StreamGapError` instead of a generic
+ *     error, and the workflow body maps it to a clean, NON-retried terminal.
+ *  3. Idle timeout on an already-terminal same-fence run — clean no-op
+ *     (crash between terminal-write and step-journal + purge race), not a
+ *     spurious liveness re-fail.
+ */
+import { describe, expect, test } from "bun:test";
+import type { UIMessageChunk } from "ai";
+import type { SqlThreadMessagePartStorage } from "@/storage/thread-message-parts";
+import { createProjectorChunkStreamFromMessages } from "./projector-chunk-stream";
+import { StreamGapError, StreamIdleTimeoutError } from "./nats-chunk-source";
+import { projectChunks } from "./project-chunks";
+import { createRunPersistence } from "./run-persistence";
+import { synthesizedErrorMessageId } from "./message-ids";
+import {
+  runProjectorWorkflowBody,
+  type ProjectorWorkflowInput,
+  type ProjectorWorkflowRuntime,
+} from "./projector-workflow";
+
+const RUN_ID = "run_1";
+const FENCE = "fence_a";
+const enc = new TextEncoder();
+
+type Msg = {
+  subject: string;
+  data: Uint8Array;
+  headers?: { get(name: string): string | undefined };
+};
+
+function msg(msgId: string, payload: unknown): Msg {
+  const all: Record<string, string> = { "Nats-Msg-Id": msgId };
+  return {
+    subject: `decopilot.stream.${RUN_ID}`,
+    data: enc.encode(JSON.stringify(payload)),
+    headers: { get: (name) => all[name] },
+  };
+}
+
+/** Producer-side encode: chunks at fence seqs 1..n, then the fenced done. */
+function encodeRun(chunks: UIMessageChunk[], startSeq = 1): Msg[] {
+  const msgs = chunks.map((chunk, i) =>
+    msg(`${RUN_ID}:${FENCE}:${startSeq + i}`, { p: chunk }),
+  );
+  const finalSeq = startSeq + chunks.length - 1;
+  msgs.push(
+    msg(`${RUN_ID}:${FENCE}:done:${finalSeq}`, { done: true, finalSeq }),
+  );
+  return msgs;
+}
+
+/** A two-step assistant turn — step boundaries make `emitStepParts` fire
+ *  mid-fold, which is the incremental durable checkpoint under test. */
+function twoStepTurn(): UIMessageChunk[] {
+  return [
+    { type: "start", messageId: "msg_a" },
+    { type: "start-step" },
+    { type: "text-start", id: "t1" },
+    { type: "text-delta", id: "t1", delta: "hello" },
+    { type: "text-end", id: "t1" },
+    { type: "finish-step" },
+    { type: "start-step" },
+    { type: "text-start", id: "t2" },
+    { type: "text-delta", id: "t2", delta: " world" },
+    { type: "text-end", id: "t2" },
+    { type: "finish-step" },
+    { type: "finish", finishReason: "stop" },
+  ] as UIMessageChunk[];
+}
+
+interface FakeRow {
+  id: string;
+  message_id: string;
+  created_at: string;
+  [key: string]: unknown;
+}
+
+/** ON-CONFLICT-faithful in-memory storage: `appendParts` keeps the FIRST
+ *  write per row id (`ON CONFLICT DO NOTHING`), `replaceMessageParts`
+ *  deletes-then-inserts the message's rows — the two behaviors redelivery
+ *  correctness rests on. */
+function fakeStorage() {
+  const rows = new Map<string, FakeRow>();
+  const storage = {
+    maxCreatedAtMsForMessage: async () => null,
+    maxCreatedAtMsForRun: async () => {
+      let max: number | null = null;
+      for (const r of rows.values()) {
+        const t = new Date(r.created_at).getTime();
+        if (max === null || t > max) max = t;
+      }
+      return max;
+    },
+    appendParts: async (incoming: FakeRow[]) => {
+      for (const r of incoming) if (!rows.has(r.id)) rows.set(r.id, r);
+    },
+    replaceMessageParts: async (
+      _threadId: string,
+      messageId: string,
+      incoming: FakeRow[],
+    ) => {
+      for (const [id, r] of rows)
+        if (r.message_id === messageId) rows.delete(id);
+      for (const r of incoming) rows.set(r.id, r);
+    },
+  } as unknown as SqlThreadMessagePartStorage;
+  return { rows, storage };
+}
+
+/** One projection attempt, exactly as `projectFromJetStreamStep` wires it:
+ *  fresh persistence (fresh emitter/base), full pipeline from the delivered
+ *  messages, `replaceFinal: true`. */
+async function projectionAttempt(
+  messages: AsyncIterable<Msg> | Iterable<Msg>,
+  storage: SqlThreadMessagePartStorage,
+) {
+  const persistence = await createRunPersistence({
+    messageParts: storage,
+    orgId: "org_1",
+    runId: RUN_ID,
+    replaceFinal: true,
+  });
+  return projectChunks({
+    chunkStream: createProjectorChunkStreamFromMessages({
+      messages,
+      runId: RUN_ID,
+      fenceToken: FENCE,
+    }),
+    persistence,
+    originalMessages: [],
+    // Production-faithful: the projector passes the deterministic per-fence
+    // error id so re-attempts dedupe the synthesized error part.
+    errorMessageId: synthesizedErrorMessageId(RUN_ID, FENCE),
+  });
+}
+
+/** Rows keyed by id with volatile ordering fields stripped, for convergence
+ *  comparison across attempts (created_at bases legitimately differ between
+ *  a first write and a redelivered one — first write wins per row). */
+function snapshot(rows: Map<string, FakeRow>) {
+  return [...rows.values()]
+    .map(({ id, message_id, ...rest }) => ({
+      id,
+      message_id,
+      part: JSON.stringify(rest.part ?? rest.content ?? null),
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+describe("projector redelivery — churn convergence (existing invariant)", () => {
+  test("interrupt mid-fold + full redelivery from seq 1 converges to identical rows", async () => {
+    // Control: one uninterrupted projection.
+    const control = fakeStorage();
+    const controlResult = await projectionAttempt(
+      encodeRun(twoStepTurn()),
+      control.storage,
+    );
+    expect(controlResult.finishReason).toBe("stop");
+    expect(control.rows.size).toBeGreaterThan(0);
+
+    // Churn: attempt 1 dies mid-step (executor killed) after step 1 finished.
+    const churn = fakeStorage();
+    const all = encodeRun(twoStepTurn());
+    const dyingSource = (async function* () {
+      // Deliver through the first finish-step (chunk seq 6), then die.
+      yield* all.slice(0, 6);
+      throw new Error("executor died");
+    })();
+    await expect(projectionAttempt(dyingSource, churn.storage)).rejects.toThrow(
+      "executor died",
+    );
+    // The durable checkpoint: step-1 parts persisted BEFORE the crash.
+    expect(churn.rows.size).toBeGreaterThan(0);
+
+    // Attempt 2: DBOS recovery re-runs the step; JetStream redelivers ALL
+    // retained messages from seq 1.
+    const second = await projectionAttempt(all, churn.storage);
+    expect(second.finishReason).toBe("stop");
+
+    // Attempt 3: crash-after-completion-before-journal → one more full replay.
+    const third = await projectionAttempt(all, churn.storage);
+    expect(third.finishReason).toBe("stop");
+
+    // CONTENT rows converge exactly (no dup, no loss). The synthesized error
+    // message attempt 1 persisted is excluded here — its cleanup is the
+    // workflow body's job on a successful terminal (clearSynthesizedError,
+    // asserted below), not the fold's.
+    const errorMessageId = synthesizedErrorMessageId(RUN_ID, FENCE);
+    const contentRows = (rows: Map<string, FakeRow>) =>
+      new Map([...rows].filter(([, r]) => r.message_id !== errorMessageId));
+    expect(snapshot(contentRows(churn.rows))).toEqual(
+      snapshot(contentRows(control.rows)),
+    );
+    // The interrupted attempt DID leave the synthesized error message behind
+    // at this layer — the reason the workflow-level cleanup below must exist.
+    expect(
+      [...churn.rows.values()].some((r) => r.message_id === errorMessageId),
+    ).toBe(true);
+  });
+});
+
+describe("projector redelivery — truncated subject", () => {
+  test("head-truncated redelivery surfaces a typed StreamGapError", async () => {
+    // Retention (4GB DiscardOld / 24h age) discarded seqs 1-2 before a late
+    // re-attempt: delivery starts at seq 3.
+    const { storage } = fakeStorage();
+    const truncated = encodeRun(twoStepTurn()).slice(2);
+    const err = await projectionAttempt(truncated, storage).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(StreamGapError);
+    expect((err as StreamGapError).expectedSeq).toBe(1);
+    expect((err as StreamGapError).gotSeq).toBe(3);
+  });
+
+  test("done whose finalSeq exceeds the last delivered chunk is a gap too", async () => {
+    const { storage } = fakeStorage();
+    const chunks = twoStepTurn();
+    const msgs = encodeRun(chunks);
+    // Drop the tail chunks but keep the done (tail truncation mid-subject).
+    const truncatedTail = [...msgs.slice(0, 4), msgs[msgs.length - 1]!];
+    const err = await projectionAttempt(truncatedTail, storage).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(StreamGapError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workflow-body mapping — injected-runtime-fake style (projector-workflow.test)
+// ---------------------------------------------------------------------------
+
+interface FakeCall {
+  kind: string;
+  reason?: string;
+  failKind?: string;
+}
+
+function makeRuntime(opts: { status: string }) {
+  const calls: FakeCall[] = [];
+  const rt: ProjectorWorkflowRuntime = {
+    getJetStream: () => null as never,
+    getJetStreamManager: async () => null as never,
+    resolveRun: async () => ({
+      orgId: "org_1",
+      createdBy: "user_1",
+      version: 2,
+      status: opts.status,
+      runFenceToken: FENCE,
+      title: null,
+    }),
+    messageParts: null as never,
+    completeRunIfNotCompleted: async () => {
+      calls.push({ kind: "complete" });
+      return { status: "completed" };
+    },
+    markRunRequiresAction: async () => {
+      calls.push({ kind: "requires-action" });
+      return { status: "requires_action" };
+    },
+    markRunFailed: async (_runId, _orgId, reason, kind) => {
+      calls.push({ kind: "fail", reason, failKind: kind });
+      return { status: "failed" };
+    },
+    persistTitle: async () => {},
+    onTitleUpdated: async () => {},
+    bumpProgress: async () => {},
+    recordCompleted: async () => {
+      calls.push({ kind: "record-complete" });
+    },
+    recordFailed: async ({ reason, kind }) => {
+      calls.push({ kind: "record-fail", reason, failKind: kind });
+    },
+    purgeRun: async () => {
+      calls.push({ kind: "purge" });
+    },
+    clearSynthesizedError: async () => {
+      calls.push({ kind: "clear-error" });
+    },
+  };
+  return { rt, calls };
+}
+
+const input: ProjectorWorkflowInput = { runId: RUN_ID, fenceToken: FENCE };
+
+describe("projector workflow — StreamGapError terminal mapping", () => {
+  test("truncation fails the run cleanly WITHOUT rethrowing (no retry burn)", async () => {
+    const { rt, calls } = makeRuntime({ status: "in_progress" });
+    const projectFn = async () => {
+      throw new StreamGapError(1, 3);
+    };
+    // Resolves — the step must SUCCEED: redelivery can never reconstruct a
+    // truncated subject, so retrying is pure burn. (A successful projection
+    // of a failed run, same shape as the in-band harness-error branch.)
+    await expect(
+      runProjectorWorkflowBody(input, rt, projectFn),
+    ).resolves.toBeUndefined();
+    const fail = calls.find((c) => c.kind === "fail");
+    expect(fail?.failKind).toBe("projection");
+    expect(fail?.reason).toMatch(/truncated/);
+    expect(calls.some((c) => c.kind === "record-fail")).toBe(true);
+    expect(calls.some((c) => c.kind === "purge")).toBe(true);
+  });
+});
+
+describe("projector workflow — stale synthesized error cleanup", () => {
+  test("successful terminal clears the prior attempt's synthesized error", async () => {
+    const { rt, calls } = makeRuntime({ status: "in_progress" });
+    const projectFn = async () => ({
+      chunkCount: 1,
+      attempts: 1,
+      outcome: {
+        failed: false,
+        finishReason: "stop",
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        finalParts: [],
+      },
+    });
+    await runProjectorWorkflowBody(input, rt, projectFn);
+    expect(calls.some((c) => c.kind === "clear-error")).toBe(true);
+  });
+
+  test("failed terminal keeps the error part (it IS the run's content)", async () => {
+    const { rt, calls } = makeRuntime({ status: "in_progress" });
+    const projectFn = async () => ({
+      chunkCount: 1,
+      attempts: 1,
+      outcome: {
+        failed: true,
+        finishReason: undefined,
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        finalParts: [],
+      },
+    });
+    await runProjectorWorkflowBody(input, rt, projectFn);
+    expect(calls.some((c) => c.kind === "clear-error")).toBe(false);
+    expect(calls.some((c) => c.kind === "fail")).toBe(true);
+  });
+});
+
+describe("projector workflow — idle timeout on an already-terminal run", () => {
+  test("same-fence terminal run: clean no-op, no spurious liveness fail", async () => {
+    // Crash between terminal-write and step-journal (or purge raced): the
+    // re-attempt reads an empty subject → idle timeout — but the run is
+    // already settled. Must return cleanly, not re-fail it.
+    const { rt, calls } = makeRuntime({ status: "completed" });
+    const projectFn = async () => {
+      throw new StreamIdleTimeoutError(600_000);
+    };
+    await expect(
+      runProjectorWorkflowBody(input, rt, projectFn),
+    ).resolves.toBeUndefined();
+    expect(calls.filter((c) => c.kind === "fail")).toEqual([]);
+    expect(calls.some((c) => c.kind === "purge")).toBe(true);
+  });
+
+  test("in_progress run: liveness failure + rethrow unchanged", async () => {
+    const { rt, calls } = makeRuntime({ status: "in_progress" });
+    const projectFn = async () => {
+      throw new StreamIdleTimeoutError(600_000);
+    };
+    await expect(
+      runProjectorWorkflowBody(input, rt, projectFn),
+    ).rejects.toThrow(/no output/);
+    const fail = calls.find((c) => c.kind === "fail");
+    expect(fail?.failKind).toBe("liveness");
+  });
+});

--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts
@@ -75,7 +75,8 @@ interface FakeCall {
     | "fail"
     | "record-complete"
     | "record-fail"
-    | "purge";
+    | "purge"
+    | "clear-error";
   runId?: string;
   orgId?: string;
   distinctId?: string;
@@ -132,6 +133,9 @@ function makeRuntime(): { rt: ProjectorWorkflowRuntime; calls: FakeCall[] } {
     },
     purgeRun: async (runId, fenceToken) => {
       calls.push({ kind: "purge", runId, fenceToken });
+    },
+    clearSynthesizedError: async (runId, fenceToken) => {
+      calls.push({ kind: "clear-error", runId, fenceToken });
     },
   };
 

--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
@@ -3,7 +3,7 @@ import type { SqlThreadMessagePartStorage } from "@/storage/thread-message-parts
 import type { ProjectChunksResult } from "./project-chunks";
 import { projectChunks } from "./project-chunks";
 import { createProjectorChunkStream } from "./projector-chunk-stream";
-import { StreamIdleTimeoutError } from "./nats-chunk-source";
+import { StreamGapError, StreamIdleTimeoutError } from "./nats-chunk-source";
 import { createRunPersistence } from "./run-persistence";
 import { recordPoison } from "./projector-metrics";
 import { ProgressBumpThrottle, tapProgressStream } from "./progress-bump";
@@ -97,6 +97,15 @@ export interface ProjectorWorkflowRuntime {
     kind: "harness" | "projection" | "liveness";
   }): Promise<void>;
   purgeRun(runId: string, fenceToken: string): Promise<void>;
+  /**
+   * Delete the synthesized error message a PRIOR interrupted projection
+   * attempt persisted for this `(runId, fenceToken)` (deterministic id — see
+   * `synthesizedErrorMessageId`). Called only on a SUCCESSFUL terminal
+   * (completed / requires_action), where a lingering "Error: …" bubble from a
+   * retried attempt is stale by definition. On a failed terminal the error
+   * part IS the run's content and must stay.
+   */
+  clearSynthesizedError(runId: string, fenceToken: string): Promise<void>;
 }
 
 let runtime: ProjectorWorkflowRuntime | null = null;
@@ -271,6 +280,7 @@ export async function runProjectorWorkflowBody(
       // Tool-approval pause: flip to requires_action so the client can
       // re-engage. No completion analytics for a pause.
       await rt.markRunRequiresAction(input.runId, orgId);
+      await rt.clearSynthesizedError(input.runId, input.fenceToken);
     } else {
       // completed
       const flipped = await rt.completeRunIfNotCompleted(input.runId, orgId);
@@ -286,12 +296,50 @@ export async function runProjectorWorkflowBody(
           },
         });
       }
+      // A PRIOR attempt of this same fence may have thrown mid-fold and
+      // persisted the synthesized error message before DBOS retried into
+      // this successful pass — that stale "Error: …" bubble would otherwise
+      // sit above the successful reply forever (redelivery repro,
+      // projector-redelivery.test.ts).
+      await rt.clearSynthesizedError(input.runId, input.fenceToken);
     }
     // Purge JetStream subject on ALL terminal outcomes (completed + harness-failed
     // + requires_action). The run is terminal — no re-projection is expected — so
     // purging is safe.
     await rt.purgeRun(input.runId, input.fenceToken);
   } catch (error) {
+    // A gapped subject (StreamGapError — retention discarded chunks under a
+    // late redelivery, or a purge raced it) can NEVER be reconstructed by
+    // retrying: the data is gone from the stream. Mark the run failed with an
+    // honest reason and let the step SUCCEED — a successful projection of a
+    // failed run, the same shape as the in-band harness-error branch above.
+    // Rethrowing (the pre-fix behavior) burned DBOS step retries/recovery on
+    // a hopeless replay and recorded the misleading generic reason
+    // "missing seq N" (stg incident 2026-07-14 follow-up; repro in
+    // projector-redelivery.test.ts).
+    if (error instanceof StreamGapError) {
+      const reason = `stream truncated before projection could replay it: ${error.message}`;
+      recordPoison(input.runId, orgId);
+      const flipped = await rt.markRunFailed(
+        input.runId,
+        orgId,
+        reason,
+        "projection",
+      );
+      if (flipped) {
+        await rt.recordFailed({
+          runId: input.runId,
+          orgId,
+          distinctId,
+          reason,
+          kind: "projection",
+        });
+      }
+      // Terminal — no re-projection is expected (and the subject is already
+      // partially discarded), so purging matches the try-path's policy.
+      await rt.purgeRun(input.runId, input.fenceToken);
+      return;
+    }
     // A silent subject (StreamIdleTimeoutError, thrown by natsChunkSource —
     // see nats-chunk-source.ts) is a LIVENESS breach, not a projection bug:
     // the executor died (or never started) before publishing anything, so
@@ -299,7 +347,25 @@ export async function runProjectorWorkflowBody(
     // plane T4) gives the thread a legible `failure_reason` instead of the
     // generic (and misleading) "projection" catch-all every other thrown
     // error still gets.
+    //
+    // One idle case is NOT a breach: the run already reached a terminal for
+    // THIS fence (a prior attempt crashed between its terminal write and the
+    // DBOS step journal, or `purgeRun` raced the redelivery) — the subject is
+    // silent because the run is finished, not because the producer died.
+    // Return cleanly instead of re-failing a settled run and rethrowing into
+    // retries that would idle-wait the full window again each time.
     const isLivenessBreach = error instanceof StreamIdleTimeoutError;
+    if (isLivenessBreach) {
+      const row = await rt.resolveRun(input.runId).catch(() => null);
+      const settled =
+        row !== null &&
+        row.runFenceToken === input.fenceToken &&
+        ["completed", "failed", "requires_action"].includes(row.status);
+      if (settled) {
+        await rt.purgeRun(input.runId, input.fenceToken);
+        return;
+      }
+    }
     const reason = isLivenessBreach
       ? livenessFailureReason((error as StreamIdleTimeoutError).idleTimeoutMs)
       : error instanceof Error


### PR DESCRIPTION
## Context

Follow-up to the stg 2026-07-14 stuck-thread incident (thread `d9ef33e5…`). The root cause there was conductor-side — a gate workflow orphaned `PENDING` on a dead executor, never recovered (fixed in [studio-dbos-conductor#2](https://github.com/decocms/studio-dbos-conductor/pull/2)). This PR fixes what a **late recovery** would have met on the mesh side.

## Verification that preceded this fix

Before changing anything, the projector's redelivery behavior was verified end-to-end against the real code (probe scripts + DB evidence from stg):

- **The feared "Sisyphus loop" does not exist.** Parts persist incrementally at step boundaries (`onStepFinish → emitStepParts`) with idempotent row ids (`ON CONFLICT DO NOTHING`), and every re-attempt reseeds from `loadWindow`. An interrupted `consumeRunProjection` step re-run from seq 1 is a fast catch-up that converges to byte-identical rows. **This invariant is now pinned by a regression test** (churn-convergence in `projector-redelivery.test.ts`) instead of being an unstated assumption.
- What was actually broken is what happens when the replay-from-seq-1 assumption fails — the stream no longer holds what redelivery needs. The `DECOPILOT_STREAMS` stream has a **4GB `DiscardPolicy.Old` cap, 24h `max_age`, and `purgeRun` on terminal** — all three can leave a late re-attempt facing a truncated or empty subject.

## The three bugs (each reproduced, then fixed)

**1. Truncated subject → misleading failure + retry burn.** Redelivery starting above the fence's seq 1 threw a generic `Error("missing seq N")` → run marked `failed(projection, "missing seq 1")` **and rethrown** into DBOS step retries that can never succeed (the chunks are gone).
→ Typed `StreamGapError` (head gap, mid gap, and done-`finalSeq` mismatch) now maps to a clean terminal failure with an honest reason (`stream truncated before projection could replay it: …`) and the step **succeeds** — a successful projection of a failed run, same shape as the in-band harness-error branch.

**2. Idle timeout on an already-settled run.** A crash between the terminal DB write and the DBOS step journal (or `purgeRun` racing a redelivery) left the re-attempt idle-waiting the full 10-minute window, then **re-failing a finished run** and rethrowing into more 10-minute waits.
→ On `StreamIdleTimeoutError`, the run is re-resolved: same-fence terminal status ⇒ clean no-op. A still-`in_progress` run keeps the exact pre-fix liveness behavior (regression-tested).

**3. Stale synthesized error bubble.** An interrupted attempt persists the deterministic `error-{runId}:{fence}` message; a later successful redelivery left that "Error: executor died" bubble sitting above the successful reply forever.
→ New `ProjectorWorkflowRuntime.clearSynthesizedError` — called on **successful** terminals only (completed / requires_action); on failed terminals the error part *is* the run's content and stays. Prod impl: `replaceMessageParts(runId, errorId, [])`.

## DBOS compatibility

All changes are logic **inside** the existing `consumeRunProjection` step — no step added/removed/reordered, no recorded I/O contract change ⇒ **no `DBOS_WORKFLOW_VERSION` bump** (per `workflow-version.ts` rules), fully recovery-compatible with in-flight v4 gates.

## Testing

- New `projector-redelivery.test.ts` (7 tests): churn-convergence invariant (control vs interrupted+redelivered rows identical, checkpoint rows present before the crash), head + tail truncation → typed `StreamGapError`, workflow mapping resolves-without-rethrow with honest reason + purge, idle-on-settled no-op, idle-on-in_progress unchanged, error-cleanup on success, error-kept on failure.
- Reproduction record: all three bugs demonstrated on unmodified code (generic `missing seq 1` + rethrow; `fail(liveness)` + rethrow on a completed run; stale error rows surviving a successful redelivery), then the same probes verified green post-fix.
- `bun test apps/mesh/src/api/routes/decopilot/` — 501 pass; the 15 failures are the pre-existing infra-bound (real Postgres) integration tests, identical set on unmodified `main`.
- `bun run check` clean across all workspaces, `bun run lint` identical to `main` (0 errors), `bun run fmt` applied.
- Not exercised: a live end-to-end truncation (would require forcing NATS retention discard mid-run); the in-memory harness drives the exact same pipeline (`createProjectorChunkStreamFromMessages` → `projectChunks`) production uses.

## Not doing (deliberately)

- No projection cursor / durable consumer / partitioned projector group (the DBOS-free projector design) — the verification showed incremental part persistence already provides durable progress; that larger design remains future work with this PR's regression suite as its safety net.
- No retry of a gapped stream — retrying is provably hopeless, which is the point of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents pointless retries when projector redelivery meets a truncated stream or an already-settled run, and cleans up stale synthesized errors. Adds a typed `StreamGapError`, improves terminal handling, and keeps workflow compatibility.

- Bug Fixes
  - Map `StreamGapError` (stream gaps/truncation) to a clean failed(projection) with a clear reason; do not rethrow; purge the subject.
  - On `StreamIdleTimeoutError`, if the same-fence run is already terminal, return cleanly and purge; keep liveness fail/throw for in-progress runs unchanged.
  - Clear the synthesized error message on successful terminals only via `clearSynthesizedError`; keep it for failed terminals.
  - Added `projector-redelivery.test.ts` to pin redelivery invariants and gap handling; changes stay inside the existing `consumeRunProjection` step (no `DBOS_WORKFLOW_VERSION` bump).

<sup>Written for commit 69faf11644612eff8ab25edc59cbf895bb9817f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

