### PR TITLE
fix(chat): lock harness choice and show its icon on locked threads

### DIFF
--- a/apps/mesh/src/web/components/chat/agent-icons.tsx
+++ b/apps/mesh/src/web/components/chat/agent-icons.tsx
@@ -1,9 +1,11 @@
 /**
- * Brand glyphs for the desktop-CLI agents shown in the chat-input
- * tier popover and the settings-flow model selector. Lifted out of
+ * Brand identity (name + glyph) for the desktop-CLI agents shown in the
+ * chat-input tier popover and the settings-flow model selector. Lifted out of
  * `select-model/agent-models.tsx` so the same paths can be reused
  * by `tier-trigger.tsx` without duplicating the SVG data.
  */
+import type { ReactNode } from "react";
+import type { HarnessId } from "@/harnesses";
 
 export function ClaudeCodeIcon({ size = 16 }: { size?: number }) {
   return (
@@ -41,4 +43,29 @@ export function CodexIcon({ size = 16 }: { size?: number }) {
       />
     </svg>
   );
+}
+
+/**
+ * Product name + glyph for each desktop CLI harness — the one place these live,
+ * so the locked runtime chip, the runtime switcher and the tier popover can't
+ * drift on what a harness is called or what it looks like. `Icon` is the
+ * component (not rendered JSX) so each call site picks its own size.
+ *
+ * Keyed by the harnesses that *have* a brand: `decopilot` is deliberately
+ * absent — it's the cloud runtime, described by where it runs rather than by a
+ * CLI name, so callers fall back to their runtime glyph for it.
+ */
+const LOCAL_HARNESS_BRAND: Partial<
+  Record<
+    HarnessId,
+    { label: string; Icon: (props: { size?: number }) => ReactNode }
+  >
+> = {
+  "claude-code": { label: "Claude Code", Icon: ClaudeCodeIcon },
+  codex: { label: "Codex", Icon: CodexIcon },
+};
+
+/** Brand for a harness, or null when it has none (cloud / unknown / legacy). */
+export function localHarnessBrand(harness: HarnessId | null | undefined) {
+  return (harness && LOCAL_HARNESS_BRAND[harness]) ?? null;
 }

--- a/apps/mesh/src/web/components/chat/pills/chat-mode-row.tsx
+++ b/apps/mesh/src/web/components/chat/pills/chat-mode-row.tsx
@@ -9,7 +9,7 @@ import type { HarnessId } from "@/harnesses";
 import { useOptionalChatStream, useOptionalChatTask } from "../context";
 import { BranchPill } from "./branch-pill";
 import { RuntimeSwitcher } from "./runtime-switcher";
-import { ClaudeCodeIcon, CodexIcon } from "../agent-icons";
+import { localHarnessBrand } from "../agent-icons";
 import { getActiveGithubRepo } from "@/web/lib/github-repo";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { authClient } from "@/web/lib/auth-client";
@@ -32,13 +32,6 @@ export function ChatModeRowPure({ branchPill }: PureProps) {
   return <>{branchPill}</>;
 }
 
-const LOCAL_RUNTIME: Partial<
-  Record<HarnessId, { label: string; icon: ReactNode }>
-> = {
-  "claude-code": { label: "Claude Code", icon: <ClaudeCodeIcon size={14} /> },
-  codex: { label: "Codex", icon: <CodexIcon size={14} /> },
-};
-
 /**
  * Read-only chip shown once a thread is locked to a local coding agent. The
  * runtime is normally chosen (and re-chosen) inside the model selector, but a
@@ -47,9 +40,10 @@ const LOCAL_RUNTIME: Partial<
  * Only local CLIs surface it; a cloud thread stays chrome-free.
  */
 function LockedRuntimeChip({ harness }: { harness: HarnessId }) {
-  const runtime = LOCAL_RUNTIME[harness];
-  if (!runtime) return null;
-  const message = `This chat is using ${runtime.label}. Start a new chat to use a different runtime.`;
+  const brand = localHarnessBrand(harness);
+  if (!brand) return null;
+  const { label, Icon } = brand;
+  const message = `This chat is using ${label}. Start a new chat to use a different runtime.`;
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -58,8 +52,8 @@ function LockedRuntimeChip({ harness }: { harness: HarnessId }) {
           aria-label={message}
           className="inline-flex items-center gap-1.5 shrink-0 text-xs text-muted-foreground"
         >
-          {runtime.icon}
-          <span className="truncate">{runtime.label}</span>
+          <Icon size={14} />
+          <span className="truncate">{label}</span>
         </span>
       </TooltipTrigger>
       <TooltipContent>{message}</TooltipContent>

--- a/apps/mesh/src/web/components/chat/pills/runtime-switcher.tsx
+++ b/apps/mesh/src/web/components/chat/pills/runtime-switcher.tsx
@@ -40,6 +40,7 @@ import {
 import type { SandboxProviderKind } from "@decocms/mesh-sdk";
 import { useChatPrefs, useChatTask } from "../context";
 import { useAgentOptionAvailability } from "../use-agent-availability";
+import { localHarnessBrand } from "../agent-icons";
 import { preferredLocalAgentOption } from "./agent-options";
 import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
 
@@ -107,7 +108,7 @@ export function RuntimeSwitcher({
   showLabel?: boolean;
 } = {}) {
   const { pendingSandboxProviderKind, setPendingAgentOption } = useChatPrefs();
-  const { isThreadLocked, lockedSandbox } = useChatTask();
+  const { isThreadLocked, lockedHarness, lockedSandbox } = useChatTask();
   const { vmEntry } = useSandboxLifecycle();
   const availability = useAgentOptionAvailability();
 
@@ -131,9 +132,18 @@ export function RuntimeSwitcher({
   const current = runtimeMeta(currentSandbox);
   const CurrentIcon = current.Icon;
 
+  // Once the thread locks, the harness is settled — name and draw *which* agent
+  // is pinned rather than the generic runtime glyph. Cloud has no CLI brand, so
+  // it keeps falling back to the runtime icon and reads as just its location.
+  const brand = isThreadLocked ? localHarnessBrand(lockedHarness) : null;
+  const BrandIcon = brand?.Icon;
+  const lockedRuntimeName = brand
+    ? `${brand.label} on ${current.label.toLowerCase()}`
+    : current.label.toLowerCase();
+
   const iconGlyph = (
     <span className="relative inline-flex items-center justify-center">
-      <CurrentIcon size={16} />
+      {BrandIcon ? <BrandIcon size={16} /> : <CurrentIcon size={16} />}
       {isThreadLocked && (
         <Lock01
           size={9}
@@ -152,7 +162,7 @@ export function RuntimeSwitcher({
           <span
             data-testid="runtime-switcher-locked"
             aria-disabled="true"
-            aria-label={`Runtime: ${current.label} (locked)`}
+            aria-label={`Runtime: ${lockedRuntimeName} (locked)`}
             className={cn(
               "inline-flex cursor-default items-center rounded-md text-muted-foreground",
               showLabel
@@ -165,8 +175,8 @@ export function RuntimeSwitcher({
           </span>
         </TooltipTrigger>
         <TooltipContent side="bottom">
-          Locked to {current.label.toLowerCase()} for this chat. Start a new
-          chat to change.
+          Locked to {lockedRuntimeName} for this chat. Start a new chat to
+          change.
         </TooltipContent>
       </Tooltip>
     );

--- a/apps/mesh/src/web/components/chat/tier-trigger.tsx
+++ b/apps/mesh/src/web/components/chat/tier-trigger.tsx
@@ -316,12 +316,17 @@ export function TierTrigger() {
 
   let groups: TierGroup[];
   if (isLocal) {
-    // Show a CLI's group when it's detected, or when it's the active runtime
-    // (so the popover never renders empty if detection lags behind a locked
-    // thread's harness). Label the groups only when both are shown.
-    const showClaude =
-      availability.claudeCode || pendingHarnessId === "claude-code";
-    const showCodex = availability.codex || pendingHarnessId === "codex";
+    // A locked thread is pinned to one harness for its lifetime, so only that
+    // CLI's group is real — listing the other would offer a switch that can't
+    // happen. Otherwise show a CLI when it's detected, or when it's the active
+    // runtime (so the popover never renders empty if detection lags). Label the
+    // groups only when both are shown.
+    const showClaude = locked
+      ? pendingHarnessId === "claude-code"
+      : availability.claudeCode || pendingHarnessId === "claude-code";
+    const showCodex = locked
+      ? pendingHarnessId === "codex"
+      : availability.codex || pendingHarnessId === "codex";
     const bothShown = showClaude && showCodex;
     const built: TierGroup[] = [];
     if (showClaude) {


### PR DESCRIPTION
## Summary

A chat thread locks to a `(harness, sandbox)` pair on its first message, but two bits of the chat UI kept behaving as though the choice were still open.

**The tier popover offered a switch that can't happen.** It showed a CLI's tier group whenever the availability probe detected it (`availability.claudeCode || pendingHarnessId === "claude-code"`), so a locked thread still listed both Claude and Codex. On a locked thread it now builds only the pinned harness's group. The unlocked path is untouched.

**The locked runtime pill showed the wrong icon.** Its glyph came from `runtimeMeta()`, which only knows the sandbox — so a desktop thread always drew the `Monitor01` desktop glyph no matter which CLI was actually running. It now draws the pinned harness's brand glyph, and the tooltip and `aria-label` name it too ("Locked to Claude Code on this device for this chat. Start a new chat to change."), so the icon and the text agree. Cloud has no CLI brand and still falls back to its runtime icon.

**Consolidated the harness name+glyph map.** Naming the harness in the tooltip needed a label that already existed in `chat-mode-row`'s `LOCAL_RUNTIME`. Rather than duplicate it, that map moved to `agent-icons.tsx` (already the canonical home for these glyphs) as `localHarnessBrand()`. It stores `Icon` as a component reference, not rendered JSX, so each call site picks its own size (the chip uses 14, the switcher 16). `LockedRuntimeChip` now reads from it too.

## Affected areas

- `apps/mesh/src/web/components/chat/tier-trigger.tsx` — locked-thread group gating
- `apps/mesh/src/web/components/chat/pills/runtime-switcher.tsx` — locked glyph + tooltip/aria-label
- `apps/mesh/src/web/components/chat/agent-icons.tsx` — new shared `localHarnessBrand()`
- `apps/mesh/src/web/components/chat/pills/chat-mode-row.tsx` — reads the shared map

## Testing

- `bun test` on `tier-trigger.test.tsx` + `chat-mode-row.test.tsx` — 9 pass, 0 fail
- `bun run check` (mesh) — clean
- Biome formatting — clean on all four files

Checked by reading the render path: `mode` and `pendingHarnessId` both derive from the same `effectiveAgentOption` (`chat-context.tsx:621-627`), so whenever `isLocal` is true the harness is necessarily `claude-code` or `codex` and exactly one group survives — a locked thread can't render an empty popover. An unmappable locked pair yields `null` and falls into the cloud branch.

## Notes for the reviewer

**No screenshots — this change was not visually verified.** It's a purely visual change verified by unit tests and by reading the render path; I never drove the app. Worth a human eye on two judgment calls:

1. In the `showLabel` variant the pill now reads *[Claude glyph] This device* — icon answers *which agent*, text answers *where it runs*. Intentional, but it's a split worth agreeing with.
2. The tier popover keeps its own shorter `"Claude"` / `"Codex"` group headings rather than the shared `"Claude Code"`. Those are side-by-side headings where the short form reads better; folding them in would have changed visible copy beyond this fix's scope.

There is no test file for `runtime-switcher.tsx`, so the icon/tooltip change isn't covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat UI for locked threads. The tier popover now respects the pinned harness, and the locked runtime chip shows the correct harness icon and name.

- **Bug Fixes**
  - Tier popover: on locked threads, only builds the pinned harness’s tier group; unlocked behavior unchanged.
  - Runtime switcher: when locked, shows the harness brand icon and names it in the tooltip/aria-label; cloud falls back to the runtime icon.

- **Refactors**
  - Centralized harness brand map in `agent-icons.tsx` as `localHarnessBrand()`, and updated `chat-mode-row` and `runtime-switcher` to use it.

<sup>Written for commit 5e07dbf1968117e0177ec09bdf007c632dac6011. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

