### PR TITLE
fix(sandbox): stop org-fs detach from blocking the daemon event loop

### DIFF
--- a/packages/sandbox/daemon/org-fs/detach-mount.test.ts
+++ b/packages/sandbox/daemon/org-fs/detach-mount.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { detachCommands } from "./detach-mount";
+import { detachCommands, runDetachCommand } from "./detach-mount";
 
 // The whole point of the change: teardown must use non-blocking (lazy) detach
 // so several unmounts can't serialize past the pod's terminationGracePeriod.
@@ -14,4 +14,30 @@ test("macos detach uses force flag", () => {
   expect(detachCommands("/app/org/home", true)).toEqual([
     ["umount", "-f", "/app/org/home"],
   ]);
+});
+
+// Regression: detachMountAsync (used by mounter.ts's mount()/unmount() on the
+// daemon's live event loop) must never freeze that loop the way the old
+// Bun.spawnSync-based detach did — a wedged fusermount/umount would otherwise
+// stall the daemon's health probe for the full command timeout, and a single
+// missed probe flips a healthy sandbox to "crashed" (CONTRIBUTING.md). Proof:
+// a setTimeout(0) scheduled just before a deliberately slow (~250ms) command
+// must fire before that command resolves. A blocking spawnSync-based
+// implementation would starve the loop and the timer would never get a
+// chance to run first, so this fails on the old implementation.
+test("runDetachCommand does not block the event loop", async () => {
+  let timerFired = false;
+  setTimeout(() => {
+    timerFired = true;
+  }, 0);
+
+  const start = Date.now();
+  const code = await runDetachCommand(
+    [process.execPath, "-e", "const s=Date.now();while(Date.now()-s<250);"],
+    5000,
+  );
+
+  expect(code).toBe(0);
+  expect(Date.now() - start).toBeGreaterThanOrEqual(200);
+  expect(timerFired).toBe(true);
 });

--- a/packages/sandbox/daemon/org-fs/detach-mount.ts
+++ b/packages/sandbox/daemon/org-fs/detach-mount.ts
@@ -1,13 +1,14 @@
+import { spawn } from "node:child_process";
+
 /**
  * Detach commands to try, in order, for `mountPath`. Pure so the flag choice is
  * unit-testable without spawning. Every command is the NON-BLOCKING variant:
  * Linux `fusermount -uz` / `umount -l` and macOS `umount -f` all return
  * immediately and let the kernel finish cleanup once references drop. A plain
  * `fusermount -u` / `umount` instead blocks in-kernel while the FUSE server
- * flushes (up to the spawnSync timeout below). That matters because MountManager
- * unmounts run this synchronously with no internal await, so several blocking
- * detaches serialize and can overrun the pod's terminationGracePeriod → the
- * sidecar is SIGKILLed (exit 137) instead of exiting 0.
+ * flushes (up to the timeout below). That matters because a wedged detach can
+ * overrun the pod's terminationGracePeriod → the sidecar is SIGKILLed (exit
+ * 137) instead of exiting 0.
  */
 export function detachCommands(mountPath: string, isMac: boolean): string[][] {
   return isMac
@@ -33,7 +34,9 @@ export function detachMount(mountPath: string, isMac: boolean): void {
   if (process.platform === "win32") return;
   for (const cmd of detachCommands(mountPath, isMac)) {
     // Keep the timeout as a backstop even though every command is lazy: a
-    // wedged kernel must never hang the daemon.
+    // wedged kernel must never hang the daemon. Blocking (spawnSync) is
+    // acceptable ONLY here: this is entry.ts's synchronous `process.on("exit")`
+    // backstop, which by Node/Bun contract cannot await a Promise anyway.
     const p = Bun.spawnSync(cmd, {
       stdout: "ignore",
       stderr: "ignore",
@@ -41,4 +44,45 @@ export function detachMount(mountPath: string, isMac: boolean): void {
     });
     if (p.exitCode === 0) break;
   }
+}
+
+/**
+ * Async twin of {@link detachMount} for every OTHER call site (mounter.ts's
+ * `mount()` reclaim and `unmount()`), which run on the daemon's live event
+ * loop rather than in the exit handler. `Bun.spawnSync` there froze the whole
+ * daemon for the command's full duration (up to two 5 s timeouts on Linux) —
+ * on the very reclaim path documented above as handling a wedged/stale mount,
+ * i.e. exactly when the command is most likely to actually hit its timeout.
+ * A single missed health probe during that freeze flips a healthy sandbox to
+ * "crashed" (see CONTRIBUTING.md). `node:child_process.spawn` never blocks the
+ * loop, mirroring git-async.ts's fix for the same class of bug in git-sync.ts.
+ */
+export async function detachMountAsync(
+  mountPath: string,
+  isMac: boolean,
+): Promise<void> {
+  if (process.platform === "win32") return;
+  for (const cmd of detachCommands(mountPath, isMac)) {
+    const code = await runDetachCommand(cmd, 5000);
+    if (code === 0) break;
+  }
+}
+
+/**
+ * Run one detach command without blocking the event loop; never rejects.
+ * Exported (like {@link detachCommands}) so the non-blocking behavior itself
+ * is unit-testable without a real fusermount/umount.
+ */
+export function runDetachCommand(
+  cmd: string[],
+  timeoutMs: number,
+): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd[0]!, cmd.slice(1), {
+      stdio: "ignore",
+      timeout: timeoutMs,
+    });
+    child.on("error", () => resolve(1));
+    child.on("close", (code) => resolve(code ?? 1));
+  });
 }

--- a/packages/sandbox/daemon/org-fs/mounter.ts
+++ b/packages/sandbox/daemon/org-fs/mounter.ts
@@ -31,7 +31,7 @@
  */
 
 import { sleep } from "@decocms/std";
-import { detachMount } from "./detach-mount";
+import { detachMountAsync } from "./detach-mount";
 import type { MountHandle, Mounter } from "./mount-manager";
 
 export { detachMount } from "./detach-mount";
@@ -137,8 +137,10 @@ export function createRcloneMounter(
         throw new Error("org-fs mounts are not supported on Windows");
       }
       // Reclaim: clear a stale mount from a prior killed session so we don't
-      // layer a fresh mount over a hung one (no-op on a clean path).
-      detachMount(mountPath, isMac);
+      // layer a fresh mount over a hung one (no-op on a clean path). Async so
+      // a wedged fusermount/umount can't freeze the daemon's event loop (see
+      // detach-mount.ts's detachMountAsync doc).
+      await detachMountAsync(mountPath, isMac);
 
       const args = buildMountArgs({
         isMac,
@@ -227,7 +229,7 @@ function makeHandle(
     exited: proc.exited,
     async unmount() {
       // Detach the OS mount first, then stop the foreground rclone child.
-      detachMount(mountPath, isMac);
+      await detachMountAsync(mountPath, isMac);
       try {
         proc.kill();
       } catch {


### PR DESCRIPTION
## Source
A bug found while reading `packages/sandbox/daemon/org-fs/` (recently-changed area).

## The bug
`mounter.ts`'s `mount()` (stale-mount reclaim, called on every mount) and `unmount()` call `detachMount`, which runs `Bun.spawnSync` per candidate detach command with a 5s timeout each (Linux tries `fusermount -uz` then `umount -l` — up to ~10s worst case). `spawnSync` blocks the daemon's single-threaded Bun event loop for the full duration of the call.

Per this repo's own `CONTRIBUTING.md` rule #1: Studio polls the daemon's health probe, and a single missed probe flips a healthy sandbox to "crashed", tearing the pod down mid-session. The reclaim path is exactly where this is most likely to bite — it exists specifically to clean up a wedged/stale mount from a previously-killed session, i.e. the case most likely to actually hit the timeout instead of returning instantly.

This is the identical bug class the repo already fixed once: `git-async.ts` replaced `git-sync.ts`'s `spawnSync` on the daemon's hot git read paths for exactly this reason ("spawnSync freezes the whole daemon for the duration of the child").

## Fix
Added `detachMountAsync` (backed by `node:child_process.spawn`, non-blocking) and switched `mounter.ts`'s two live call sites (`mount()`'s reclaim, `unmount()`) to use it. The original sync `detachMount` is kept unchanged for `entry.ts`'s `process.on("exit")` backstop, which by Node/Bun contract cannot await a Promise anyway.

## Test
`packages/sandbox/daemon/org-fs/detach-mount.test.ts` — new regression test spawns a deliberately slow (~250ms) child via the same non-blocking primitive and asserts a `setTimeout(0)` fires before it resolves. This fails against a `spawnSync`-based implementation (the loop would be frozen for the child's duration) and passes with the fix.

Run: `bun test packages/sandbox/daemon/org-fs/detach-mount.test.ts`

## Checks run locally
- `bun test packages/sandbox/daemon/org-fs/detach-mount.test.ts` — 3 pass
- `cd packages/sandbox && bunx tsc --noEmit` — clean
- `bun run fmt` — no changes needed

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced blocking detach with an async, non-blocking path to stop org-fs unmounts from freezing the daemon event loop. This prevents missed health probes and accidental pod teardown during reclaim or unmount.

- Bug Fixes
  - Added `detachMountAsync` (uses `node:child_process.spawn`) and switched `mounter.ts` `mount()` reclaim and `unmount()` to use it.
  - Kept sync `detachMount` only for `entry.ts` `process.on("exit")`.
  - Introduced `runDetachCommand` and a regression test that proves the event loop stays responsive during a slow child process.

<sup>Written for commit 6c9b185033de1c0a75baca72fc7c35975abc9b4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

