### PR TITLE
fix(dispatch-queue): cap per-worker DBOS concurrency on heavy queues

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -163,6 +163,7 @@ import {
 import {
   HOSTED_HARNESS_PARTITION_CONCURRENCY,
   HOSTED_HARNESS_QUEUE,
+  HOSTED_HARNESS_WORKER_CONCURRENCY,
   setHostedHarnessRuntime,
   setThreadGateRuntime,
   THREAD_GATE_PARTITION_CONCURRENCY,
@@ -795,6 +796,7 @@ import { type SSEEvent, sseHub } from "../event-bus";
 import {
   BACKGROUND_TOOLS_PARTITION_CONCURRENCY,
   BACKGROUND_TOOLS_QUEUE,
+  BACKGROUND_TOOLS_WORKER_CONCURRENCY,
   setBackgroundToolRuntime,
 } from "@/harnesses/decopilot/background-tool-workflow";
 import { abortBackgroundJobs } from "@/harnesses/decopilot/background-abort-registry";
@@ -2147,15 +2149,19 @@ export async function createApp(options: CreateAppOptions = {}) {
     // Hosted-harness child workflow queue. Partition key = threadId, concurrency 1
     // (mirrors THREAD_GATE_QUEUE: one active run per thread, different threads
     // progress in parallel). Worker pods dequeue this alongside the parent gate.
+    // workerConcurrency bounds how many agent loops one pod runs at once so a
+    // burst spills to new pods (KEDA queue depth) instead of OOMing one.
     await DBOS.registerQueue(HOSTED_HARNESS_QUEUE, {
       partitionQueue: true,
       concurrency: HOSTED_HARNESS_PARTITION_CONCURRENCY,
+      workerConcurrency: HOSTED_HARNESS_WORKER_CONCURRENCY,
     });
     // Slow backgroundable built-ins (generate_image) run here, partitioned by
     // orgId for per-org fairness. The reaction turn hops to the thread-gate.
     await DBOS.registerQueue(BACKGROUND_TOOLS_QUEUE, {
       partitionQueue: true,
       concurrency: BACKGROUND_TOOLS_PARTITION_CONCURRENCY,
+      workerConcurrency: BACKGROUND_TOOLS_WORKER_CONCURRENCY,
     });
     await reconcileAutomationSchedules(automationsStorage);
 

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,9 +1,9 @@
 {
   "auth/install-studio-pack-workflow.ts": "8aa255710fe562a3a0a86373ba60c9bfb53b34a9b17539083a22866e734fdede",
   "automations/dbos-workflow.ts": "76f03ce0e787209aacbe2ac128cb50c6d12eb513b7e0c7ae463401544de43127",
-  "dispatch-queue/hosted-harness-workflow.ts": "0b394f56423c5efe4cf3ec8ff95fc78ffb51ab266b5dde0272bca6347af3f390",
+  "dispatch-queue/hosted-harness-workflow.ts": "2912df344e8682c0290b325810e7b67124db1b0e19014bcaab5750ad0eaee52a",
   "dispatch-queue/thread-gate-workflow.ts": "2e63fcff27fb5109f2264d31d455dbbfb1b3f18ce46c0eb3075ca6b0266fe379",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",
-  "harnesses/decopilot/background-tool-workflow.ts": "b75384d08b2293a101da50f0dfc63c23fc27f4b5636d2a9ada3cc22d2f61202b",
+  "harnesses/decopilot/background-tool-workflow.ts": "63c5d84ee7956739c19223f5508e6ffaf2e00f1f842bca78c1075328b87fa432",
   "monitoring/dbos-retention-workflow.ts": "b43e3596b386b53faf372b140d9137a12252565987543640d17f7798504b8dbb"
 }

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
@@ -117,6 +117,18 @@ export type StudioContextFactory = (
 export const HOSTED_HARNESS_PARTITION_CONCURRENCY = 1;
 
 /**
+ * Max concurrent hosted runs a SINGLE worker pod executes (global per-process
+ * cap, orthogonal to the per-thread partition cap above). Each run drives an
+ * in-process agent loop (LLM streaming + tool calls) whose working set is
+ * ~300MB typical with occasional multi-hundred-MB JSON.parse spikes; without a
+ * per-worker cap one pod can dequeue as many runs as there are active threads
+ * and OOM (2Gi limit). 3 keeps a loaded pod near ~1GB and makes backlog spill
+ * to new pods (KEDA queue-depth) instead of piling onto one.
+ * ponytail: raise if per-pod memory headroom grows or throughput caps out.
+ */
+export const HOSTED_HARNESS_WORKER_CONCURRENCY = 3;
+
+/**
  * Serializable input to a hosted harness run. Everything needed to (re)run the
  * in-process agent loop from a DBOS-replayed workflow journal — the
  * non-serializable `abortSignal` is excluded (the run constructs its own from

--- a/apps/mesh/src/dispatch-queue/index.ts
+++ b/apps/mesh/src/dispatch-queue/index.ts
@@ -12,6 +12,7 @@ export {
 export {
   cancelHostedHarness,
   HOSTED_HARNESS_PARTITION_CONCURRENCY,
+  HOSTED_HARNESS_WORKER_CONCURRENCY,
   HOSTED_HARNESS_QUEUE,
   setHostedHarnessRuntime,
   type HostedHarnessInput,

--- a/apps/mesh/src/harnesses/decopilot/background-tool-workflow.ts
+++ b/apps/mesh/src/harnesses/decopilot/background-tool-workflow.ts
@@ -45,6 +45,13 @@ import { BACKGROUND_TOOLS_QUEUE } from "@/dispatch-queue/queue-names";
 /** Per-org (per-partition) concurrency cap for heavy background tool runs. */
 export const BACKGROUND_TOOLS_PARTITION_CONCURRENCY = 5;
 
+/**
+ * Max concurrent background-tool runs a SINGLE worker pod executes (global
+ * per-process cap). Same rationale as the hosted-harness worker cap: bound
+ * per-pod memory and let backlog spill to new pods via KEDA queue depth.
+ */
+export const BACKGROUND_TOOLS_WORKER_CONCURRENCY = 4;
+
 /** Serializable thread snapshot carried so the reaction turn can be rebuilt on
  *  any pod. Models are re-resolved in-workflow, not carried. */
 export interface BackgroundToolSnapshot {


### PR DESCRIPTION
## Summary

The hosted-harness and background-tools DBOS queues set only **per-partition** concurrency (`1` per thread, `5` per org). Nothing bounded how many workflows a **single worker pod** dequeues across all active partitions — so one pod could run an unbounded number of concurrent agent loops.

Measured impact on prod (`deco-studio`, 7d): worker working-set is ~300MB median but the tail reaches **677 / 921 / 1794 MB** — the 1.8GB pod sat right under the 2Gi limit and OOM-restarted. It also defeats the new KEDA queue-depth autoscaler: backlog piles onto existing pods instead of spilling to new ones.

## Change

Add `workerConcurrency` (a per-process cap, orthogonal to the per-partition cap) to the two memory-heavy queues:
- `decopilot-hosted-harness` → **3** (the in-process agent loop: LLM streaming + tool calls)
- `background-tools` → **4** (generate_image et al.)

thread-gate and automations are left uncapped — they're light dispatch/gate workflows that spawn children and await.

At `workerConcurrency=3` a loaded hosted-harness pod stays near ~1GB, and bursts beyond that trigger KEDA to add pods.

## Testing
- `tsc --noEmit` passes
- `biome format` clean
- No runtime behavior change under low concurrency; the cap only engages when a single pod would otherwise run >3 hosted runs at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap per-worker DBOS concurrency on heavy queues to prevent pod OOMs and let bursts trigger KEDA queue-depth scale-out. This bounds concurrent agent loops per pod while keeping per-partition fairness.

- **Bug Fixes**
  - Add `workerConcurrency` for `HOSTED_HARNESS_QUEUE` and `BACKGROUND_TOOLS_QUEUE`.
  - Set `HOSTED_HARNESS_WORKER_CONCURRENCY = 3` and `BACKGROUND_TOOLS_WORKER_CONCURRENCY = 4`; export and wire into registration.
  - Keep existing per-partition caps (`1` per thread, `5` per org); thread-gate and automations remain uncapped.
  - Stabilizes per-pod memory (~1 GB under load) and spreads backlog to new pods; no change at low concurrency.
  - Re-baseline DBOS workflow source snapshot; only top-level constants added, no workflow-body changes, recovery-compatible (no version bump).

<sup>Written for commit f56eccd957fca4bdc1ca6a031714527fcd8d3a9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

