### PR TITLE
feat(chat): brand local model tiers

### DIFF
--- a/apps/mesh/src/web/components/chat/agent-icons.tsx
+++ b/apps/mesh/src/web/components/chat/agent-icons.tsx
@@ -1,8 +1,8 @@
 /**
  * Brand identity (name + glyph) for the desktop-CLI agents shown in the
  * chat-input tier popover and the settings-flow model selector. Lifted out of
- * `select-model/agent-models.tsx` so the same paths can be reused
- * by `tier-trigger.tsx` without duplicating the SVG data.
+ * `select-model/agent-models.tsx` so the same paths can be reused by the tier
+ * trigger without duplicating the SVG data.
  */
 import type { ReactNode } from "react";
 import type { HarnessId } from "@/harnesses";
@@ -47,9 +47,9 @@ export function CodexIcon({ size = 16 }: { size?: number }) {
 
 /**
  * Product name + glyph for each desktop CLI harness — the one place these live,
- * so the locked runtime chip, the runtime switcher and the tier popover can't
- * drift on what a harness is called or what it looks like. `Icon` is the
- * component (not rendered JSX) so each call site picks its own size.
+ * so the tier trigger and popover can't drift on what a harness is called or
+ * what it looks like. `Icon` is the component (not rendered JSX) so each call
+ * site picks its own size.
  *
  * Keyed by the harnesses that *have* a brand: `decopilot` is deliberately
  * absent — it's the cloud runtime, described by where it runs rather than by a

--- a/apps/mesh/src/web/components/chat/pills/chat-mode-row.tsx
+++ b/apps/mesh/src/web/components/chat/pills/chat-mode-row.tsx
@@ -1,15 +1,8 @@
 import type { ReactNode } from "react";
 import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
-import type { HarnessId } from "@/harnesses";
 import { useOptionalChatStream, useOptionalChatTask } from "../context";
 import { BranchPill } from "./branch-pill";
 import { RuntimeSwitcher } from "./runtime-switcher";
-import { localHarnessBrand } from "../agent-icons";
 import { getActiveGithubRepo } from "@/web/lib/github-repo";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { authClient } from "@/web/lib/auth-client";
@@ -30,35 +23,6 @@ interface PureProps {
 export function ChatModeRowPure({ branchPill }: PureProps) {
   if (!branchPill) return null;
   return <>{branchPill}</>;
-}
-
-/**
- * Read-only chip shown once a thread is locked to a local coding agent. The
- * runtime is normally chosen (and re-chosen) inside the model selector, but a
- * locked thread can't switch runtimes — this tells the user which local agent
- * the chat is bound to and why the model selector no longer offers the toggle.
- * Only local CLIs surface it; a cloud thread stays chrome-free.
- */
-function LockedRuntimeChip({ harness }: { harness: HarnessId }) {
-  const brand = localHarnessBrand(harness);
-  if (!brand) return null;
-  const { label, Icon } = brand;
-  const message = `This chat is using ${label}. Start a new chat to use a different runtime.`;
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          data-testid="mode-picker-locked"
-          aria-label={message}
-          className="inline-flex items-center gap-1.5 shrink-0 text-xs text-muted-foreground"
-        >
-          <Icon size={14} />
-          <span className="truncate">{label}</span>
-        </span>
-      </TooltipTrigger>
-      <TooltipContent>{message}</TooltipContent>
-    </Tooltip>
-  );
 }
 
 interface SmartProps {
@@ -89,19 +53,12 @@ export function ChatModeRow({
     (stream?.messages ?? []).length > 0 || (taskCtx?.isThreadLocked ?? false);
   const setCurrentTaskBranch = taskCtx?.setCurrentTaskBranch;
 
-  // Once a thread is locked to a local coding agent, the model selector hides
-  // its runtime toggle — surface a read-only chip so the binding stays legible.
-  const lockedRuntime =
-    taskCtx?.isThreadLocked && taskCtx.lockedHarness ? (
-      <LockedRuntimeChip harness={taskCtx.lockedHarness} />
-    ) : null;
-
   const githubRepo = getActiveGithubRepo(virtualMcp);
   const connectionId = githubRepo?.connectionId;
   // Sandbox-backed agents (imported from a repo) get the runtime switcher —
   // Cloud sandbox vs This device — right next to the branch pill, so you can
-  // pick where it runs even before the sandbox starts. It also renders the
-  // locked-runtime state itself, so it supersedes the LockedRuntimeChip here.
+  // pick where it runs even before the sandbox starts. Once the thread is
+  // locked, RuntimeSwitcher hides itself because there is no longer a choice.
   const hasSandbox = !!githubRepo;
 
   const { data: session } = authClient.useSession();
@@ -132,11 +89,7 @@ export function ChatModeRow({
 
   return (
     <>
-      {hasSandbox ? (
-        <RuntimeSwitcher showLabel={showRuntimeLabel} />
-      ) : (
-        lockedRuntime
-      )}
+      {hasSandbox && <RuntimeSwitcher showLabel={showRuntimeLabel} />}
       <ChatModeRowPure branchPill={branchPill} />
     </>
   );

--- a/apps/mesh/src/web/components/chat/pills/runtime-switcher.tsx
+++ b/apps/mesh/src/web/components/chat/pills/runtime-switcher.tsx
@@ -12,17 +12,10 @@
  * selector exposes as "Cloud / This device" — it writes through the same
  * `pendingAgentOption`, so the two never disagree.
  *
- * The runtime locks to a thread on its first message. On a locked thread the
- * trigger is a disabled indicator; the tooltip explains a new chat is required
- * to change it.
+ * The runtime locks to a thread on its first message, at which point this
+ * control disappears instead of occupying space with a disabled indicator.
  */
-import {
-  Check,
-  ChevronDown,
-  Cloud01,
-  Lock01,
-  Monitor01,
-} from "@untitledui/icons";
+import { Check, ChevronDown, Cloud01, Monitor01 } from "@untitledui/icons";
 import type { ComponentType, ReactNode, SVGProps } from "react";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
@@ -40,7 +33,6 @@ import {
 import type { SandboxProviderKind } from "@decocms/mesh-sdk";
 import { useChatPrefs, useChatTask } from "../context";
 import { useAgentOptionAvailability } from "../use-agent-availability";
-import { localHarnessBrand } from "../agent-icons";
 import { preferredLocalAgentOption } from "./agent-options";
 import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
 
@@ -108,9 +100,13 @@ export function RuntimeSwitcher({
   showLabel?: boolean;
 } = {}) {
   const { pendingSandboxProviderKind, setPendingAgentOption } = useChatPrefs();
-  const { isThreadLocked, lockedHarness, lockedSandbox } = useChatTask();
+  const { isThreadLocked } = useChatTask();
   const { vmEntry } = useSandboxLifecycle();
   const availability = useAgentOptionAvailability();
+
+  // The persisted thread state remains the source of truth after the first
+  // message, so there is no useful action or status for this control to show.
+  if (isThreadLocked) return null;
 
   // "This device" only exists via a local CLI harness (there's no cloud-brain-
   // on-desktop option), so it's gated on a linked desktop with Claude Code or
@@ -123,64 +119,15 @@ export function RuntimeSwitcher({
   // "Cloud sandbox" (the null default) even where cloud can't run.
   const currentSandbox: SandboxProviderKind | null =
     (vmEntry?.sandboxProviderKind as SandboxProviderKind | null | undefined) ??
-    (isThreadLocked ? lockedSandbox : pendingSandboxProviderKind) ??
+    pendingSandboxProviderKind ??
     (availability.agentSandbox
       ? "agent-sandbox"
       : localOption
         ? "user-desktop"
         : null);
+
   const current = runtimeMeta(currentSandbox);
   const CurrentIcon = current.Icon;
-
-  // Once the thread locks, the harness is settled — name and draw *which* agent
-  // is pinned rather than the generic runtime glyph. Cloud has no CLI brand, so
-  // it keeps falling back to the runtime icon and reads as just its location.
-  const brand = isThreadLocked ? localHarnessBrand(lockedHarness) : null;
-  const BrandIcon = brand?.Icon;
-  const lockedRuntimeName = brand
-    ? `${brand.label} on ${current.label.toLowerCase()}`
-    : current.label.toLowerCase();
-
-  const iconGlyph = (
-    <span className="relative inline-flex items-center justify-center">
-      {BrandIcon ? <BrandIcon size={16} /> : <CurrentIcon size={16} />}
-      {isThreadLocked && (
-        <Lock01
-          size={9}
-          className="absolute -bottom-1 -right-1.5 rounded-full bg-background"
-        />
-      )}
-    </span>
-  );
-
-  // Locked: the runtime can't change for this thread, so the trigger is just a
-  // disabled indicator — the tooltip explains why. No menu to open.
-  if (isThreadLocked) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            data-testid="runtime-switcher-locked"
-            aria-disabled="true"
-            aria-label={`Runtime: ${lockedRuntimeName} (locked)`}
-            className={cn(
-              "inline-flex cursor-default items-center rounded-md text-muted-foreground",
-              showLabel
-                ? "h-9 gap-1.5 px-2 text-xs font-medium"
-                : "size-9 justify-center",
-            )}
-          >
-            {iconGlyph}
-            {showLabel && <span className="truncate">{current.label}</span>}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          Locked to {lockedRuntimeName} for this chat. Start a new chat to
-          change.
-        </TooltipContent>
-      </Tooltip>
-    );
-  }
 
   return (
     <DropdownMenu>
@@ -196,7 +143,7 @@ export function RuntimeSwitcher({
                 showLabel ? "h-9 gap-1.5 px-2 text-xs font-medium" : "size-9",
               )}
             >
-              {iconGlyph}
+              <CurrentIcon size={16} />
               {showLabel && (
                 <>
                   <span className="truncate">{current.label}</span>

--- a/apps/mesh/src/web/components/chat/tier-trigger.test.tsx
+++ b/apps/mesh/src/web/components/chat/tier-trigger.test.tsx
@@ -41,6 +41,20 @@ describe("TierTriggerPure", () => {
     expect(queryByText(/Sonnet/)).toBeNull();
   });
 
+  it("uses the local harness name for the closed pill when provided", () => {
+    const { getByRole } = render(
+      <TierTriggerPure
+        tier="smart"
+        pillIcon={<svg data-testid="claude-code-icon" />}
+        pillLabel="Claude Code Smart"
+        groups={[cloudGroup()]}
+      />,
+    );
+    expect(
+      getByRole("button", { name: "Claude Code Smart" }),
+    ).toBeInTheDocument();
+  });
+
   it("popover shows one row per group entry with its subtitle", () => {
     const { getByRole } = render(
       <TierTriggerPure tier="smart" groups={[cloudGroup()]} />,
@@ -94,7 +108,7 @@ describe("TierTriggerPure", () => {
     const groups = [
       {
         key: "claude-code",
-        label: "Claude",
+        label: "Claude Code",
         rows: [
           {
             key: "claude-smart",
@@ -125,7 +139,7 @@ describe("TierTriggerPure", () => {
     fireEvent.click(getByRole("button", { name: /Smart/i }));
     // Both groups expose a "Smart" row — the group label disambiguates them.
     expect(
-      getByRole("menuitem", { name: "Claude Smart" }).textContent,
+      getByRole("menuitem", { name: "Claude Code Smart" }).textContent,
     ).toContain("Sonnet 5");
     expect(
       getByRole("menuitem", { name: "Codex Smart" }).textContent,

--- a/apps/mesh/src/web/components/chat/tier-trigger.tsx
+++ b/apps/mesh/src/web/components/chat/tier-trigger.tsx
@@ -34,7 +34,7 @@ import {
   type AgentOption,
   preferredLocalAgentOption,
 } from "./pills/agent-options";
-import { ClaudeCodeIcon, CodexIcon } from "./agent-icons";
+import { ClaudeCodeIcon, CodexIcon, localHarnessBrand } from "./agent-icons";
 
 const TIER_ORDER: ChatTier[] = ["fast", "smart", "thinking"];
 const TIER_LABELS: Record<ChatTier, string> = {
@@ -55,13 +55,12 @@ interface TierRow {
 
 /**
  * A labelled cluster of rows. The `label` is the small-font runtime heading
- * (e.g. "Claude", "Codex") rendered above its tiers; omit it for a single
+ * (e.g. "Claude Code", "Codex") rendered above its tiers; omit it for a single
  * ungrouped list (Cloud, or a lone local CLI).
  */
 interface TierGroup {
   key: string;
   label?: string;
-  labelIcon?: ReactNode;
   rows: TierRow[];
 }
 
@@ -70,6 +69,8 @@ interface PureProps {
   tier: ChatTier;
   /** Optional glyph rendered on the closed pill next to the tier label. */
   pillIcon?: ReactNode;
+  /** Accessible label and tooltip for the closed pill. Defaults to the tier. */
+  pillLabel?: string;
   /** Runtime × tier options, grouped by runtime. */
   groups: TierGroup[];
   /** Optional content rendered above the groups (the runtime toggle). */
@@ -84,7 +85,13 @@ interface PureProps {
  * block per group (optional heading + its rows). Selecting a row runs its
  * `onSelect` and closes the popover.
  */
-export function TierTriggerPure({ tier, pillIcon, groups, header }: PureProps) {
+export function TierTriggerPure({
+  tier,
+  pillIcon,
+  pillLabel = TIER_LABELS[tier],
+  groups,
+  header,
+}: PureProps) {
   const [open, setOpen] = useState(false);
   const handleSelect = (row: TierRow) => {
     row.onSelect();
@@ -101,7 +108,7 @@ export function TierTriggerPure({ tier, pillIcon, groups, header }: PureProps) {
                 type="button"
                 variant="ghost"
                 size="default"
-                aria-label={TIER_LABELS[tier]}
+                aria-label={pillLabel}
                 className={cn(
                   "text-muted-foreground hover:text-foreground transition-[gap] duration-200 shrink min-w-0",
                   "gap-0 @[320px]/chat-bottom:gap-1.5",
@@ -124,7 +131,7 @@ export function TierTriggerPure({ tier, pillIcon, groups, header }: PureProps) {
             </PopoverTrigger>
           </span>
         </TooltipTrigger>
-        <TooltipContent>{TIER_LABELS[tier]}</TooltipContent>
+        <TooltipContent>{pillLabel}</TooltipContent>
       </Tooltip>
       <PopoverContent align="end" className="p-1 w-64">
         {header && (
@@ -135,7 +142,6 @@ export function TierTriggerPure({ tier, pillIcon, groups, header }: PureProps) {
             <div key={group.key} className="flex flex-col">
               {group.label && (
                 <div className="flex items-center gap-1.5 px-2 pt-1.5 pb-0.5 text-xs font-medium text-muted-foreground">
-                  {group.labelIcon}
                   <span className="truncate">{group.label}</span>
                 </div>
               )}
@@ -180,10 +186,9 @@ export function TierTriggerPure({ tier, pillIcon, groups, header }: PureProps) {
 }
 
 /**
- * Per-tier intent glyph (Lightning / Stars / Atom). The same affordance
- * lands on every tier row regardless of the active runtime — the brand
- * glyph for the harness (Claude, Codex) rides on the group heading, not the
- * row.
+ * Per-tier intent glyph (Lightning / Stars / Atom) used by the cloud runtime.
+ * Local runtimes use their harness glyph on every tier instead, keeping the
+ * active runtime legible from both the closed trigger and each menu row.
  */
 function tierIconFor(tier: ChatTier): ReactNode {
   if (tier === "fast") return <Lightning01 size={16} />;
@@ -270,7 +275,7 @@ function RuntimeToggle() {
 function localGroup(params: {
   key: string;
   label: string | undefined;
-  labelIcon: ReactNode;
+  icon: ReactNode;
   mode: AgentMode;
   option: AgentOption;
   isActiveRuntime: boolean;
@@ -281,10 +286,9 @@ function localGroup(params: {
   return {
     key: params.key,
     label: params.label,
-    labelIcon: params.labelIcon,
     rows: TIER_ORDER.map((t) => ({
       key: `${params.key}-${t}`,
-      icon: tierIconFor(t),
+      icon: params.icon,
       title: TIER_LABELS[t],
       subtitle: resolveTierSubtitle(params.mode, t),
       active: params.isActiveRuntime && params.currentTier === t,
@@ -333,8 +337,8 @@ export function TierTrigger() {
       built.push(
         localGroup({
           key: "claude-code",
-          label: bothShown ? "Claude" : undefined,
-          labelIcon: <ClaudeCodeIcon size={14} />,
+          label: bothShown ? "Claude Code" : undefined,
+          icon: <ClaudeCodeIcon size={16} />,
           mode: "local-claude-code",
           option: "claude-code-desktop",
           isActiveRuntime: pendingHarnessId === "claude-code",
@@ -349,7 +353,7 @@ export function TierTrigger() {
         localGroup({
           key: "codex",
           label: bothShown ? "Codex" : undefined,
-          labelIcon: <CodexIcon size={14} />,
+          icon: <CodexIcon size={16} />,
           mode: "local-codex",
           option: "codex-desktop",
           isActiveRuntime: pendingHarnessId === "codex",
@@ -376,10 +380,20 @@ export function TierTrigger() {
     ];
   }
 
+  const localBrand = isLocal ? localHarnessBrand(pendingHarnessId) : null;
+  const LocalBrandIcon = localBrand?.Icon;
+
   return (
     <TierTriggerPure
       tier={tier}
-      pillIcon={tierIconFor(tier)}
+      pillIcon={
+        LocalBrandIcon ? <LocalBrandIcon size={16} /> : tierIconFor(tier)
+      }
+      pillLabel={
+        localBrand
+          ? `${localBrand.label} ${TIER_LABELS[tier]}`
+          : TIER_LABELS[tier]
+      }
       groups={groups}
       header={hasLocal && !locked ? <RuntimeToggle /> : undefined}
     />

--- a/packages/e2e/tests/chat-locked-thread.spec.ts
+++ b/packages/e2e/tests/chat-locked-thread.spec.ts
@@ -13,10 +13,9 @@
  *     pinned row values. We assert the row stays at the first-message values
  *     after sending a conflicting body.
  *
- *   - Task 5 / Task 6 (UI affordance): on a locked thread the runtime
- *     indicator and branch chip render as `runtime-switcher-locked` /
- *     `branch-picker-locked` with the original values, and the same is true
- *     after a hard reload.
+ *   - Task 5 / Task 6 (UI affordance): on a locked local thread the redundant
+ *     runtime indicator disappears and the tier selector carries the harness
+ *     identity. The same is true after a hard reload.
  *
  * Driven via the real /api/:org/decopilot/threads/:threadId/messages route —
  * same pattern as decopilot-messages.spec.ts. We avoid the UI for the submit
@@ -242,7 +241,7 @@ test.describe("Thread runtime is locked after first message", () => {
     }
   });
 
-  test("locked-state chips render on the thread page after first message", async ({
+  test("locked local runtime is represented by the tier selector", async ({
     authedPage,
   }) => {
     const { page, orgSlug, user } = authedPage;
@@ -252,10 +251,8 @@ test.describe("Thread runtime is locked after first message", () => {
       "claude-code",
     ]);
     try {
-      // Seed an AI provider key so the thread route renders the
-      // composer instead of `NoAiProviderEmptyState`. Without this,
-      // `runtime-switcher-locked` never mounts because the chat input
-      // itself is short-circuited away.
+      // Seed an AI provider key so the thread route renders the composer
+      // instead of `NoAiProviderEmptyState`.
       await seedAiProviderKey(api, orgSlug);
 
       const { agentId, threadId } = await createAgentAndThread(api, orgSlug);
@@ -277,7 +274,7 @@ test.describe("Thread runtime is locked after first message", () => {
       );
       expect(first.status()).toBe(202);
 
-      // Navigate to the thread URL and confirm the locked chips render.
+      // Navigate to the thread URL and confirm the locked UI renders.
       // Include `?virtualmcpid=` so `useChatNavigation` resolves the
       // chat input against THIS agent (with its `metadata.githubRepo`)
       // instead of falling back to the well-known decopilot agent,
@@ -285,20 +282,14 @@ test.describe("Thread runtime is locked after first message", () => {
       // harness/branch pickers entirely.
       await page.goto(`/${orgSlug}/${threadId}?virtualmcpid=${agentId}`);
 
-      // A sandbox-backed agent (this fixture has a `githubRepo`) renders the
-      // RuntimeSwitcher, which supersedes the plain LockedRuntimeChip. Its
-      // locked state is a disabled indicator keyed by the runtime kind
-      // ("This device" for user-desktop), not the harness name — the harness
-      // picker was collapsed into a single Cloud/This-device runtime control.
-      const lockedRuntime = page.getByTestId("runtime-switcher-locked");
-      await expect(lockedRuntime).toBeVisible({ timeout: 60_000 });
-      await expect(lockedRuntime).toHaveAccessibleName(/this device/i);
-
-      // The unlocked-state switcher trigger must NOT be present — that would
-      // mean the lock indicator is shadowed by the live (enabled) control. The
-      // locked indicator is a disabled <span> (no button role); the unlocked
-      // switcher is a real dropdown-trigger button labelled "Runtime: …", so
-      // asserting no such button exists enforces the intent.
+      // The tier selector now owns the local harness identity for every tier,
+      // so the separate locked runtime indicator and the unlocked runtime
+      // trigger should both be absent.
+      const tierSelector = page.getByRole("button", {
+        name: /^Claude Code (Fast|Smart|Thinking)$/,
+      });
+      await expect(tierSelector).toBeVisible({ timeout: 60_000 });
+      await expect(page.getByTestId("runtime-switcher-locked")).toHaveCount(0);
       await expect(page.getByRole("button", { name: /^Runtime:/ })).toHaveCount(
         0,
       );
@@ -314,11 +305,10 @@ test.describe("Thread runtime is locked after first message", () => {
       // itself is exercised by `BranchPill`'s own logic and by the
       // server-side lock test above.
 
-      // Hard reload — locked affordance must survive a fresh mount.
+      // Hard reload — the consolidated affordance must survive a fresh mount.
       await page.reload();
-      await expect(page.getByTestId("runtime-switcher-locked")).toBeVisible({
-        timeout: 60_000,
-      });
+      await expect(tierSelector).toBeVisible({ timeout: 60_000 });
+      await expect(page.getByTestId("runtime-switcher-locked")).toHaveCount(0);
     } finally {
       await daemon.close();
     }


### PR DESCRIPTION
## Summary

- show Claude Code and Codex branding on the local tier trigger and every local tier row
- keep runtime group headings text-only and remove locked runtime indicators
- add accessible harness-aware tier labels and update the locked-thread contract

## Testing

- `bun test apps/mesh/src/web/components/chat/tier-trigger.test.tsx`
- `bun run --cwd=apps/mesh check`
- `bun run --cwd=packages/e2e check`
- focused `bun run lint` on changed files
- browser E2E not run locally because NATS was unavailable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brands local model tiers in the chat UI by showing Claude Code and Codex on the tier trigger and each local tier row, and removes the locked runtime indicator in favor of clearer tier labeling. The runtime switcher now hides on locked threads, reducing UI noise.

- **New Features**
  - Tier trigger shows the harness icon and accessible label (e.g., "Claude Code Smart"); added `pillLabel` to `TierTriggerPure`.
  - Local tier rows carry the harness glyph; runtime group headings are text-only.
  - `RuntimeSwitcher` disappears once the thread locks; the tier selector represents the locked local runtime.
  - Removed the locked runtime chip from the chat header; updated E2E to assert the new behavior.

<sup>Written for commit 9ba9012bac583aa453ba8c04f904df7cd2d0e1be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

