### PR TITLE
feat(dispatch-queue): cap concurrent hosted agent-loop runs per pod

### DIFF
--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,7 +1,7 @@
 {
   "auth/install-studio-pack-workflow.ts": "8aa255710fe562a3a0a86373ba60c9bfb53b34a9b17539083a22866e734fdede",
   "automations/dbos-workflow.ts": "76f03ce0e787209aacbe2ac128cb50c6d12eb513b7e0c7ae463401544de43127",
-  "dispatch-queue/hosted-harness-workflow.ts": "0b394f56423c5efe4cf3ec8ff95fc78ffb51ab266b5dde0272bca6347af3f390",
+  "dispatch-queue/hosted-harness-workflow.ts": "4caf3a360104c5ba7b0559895208234f39e819157d0ac31955f64ed94a88ed95",
   "dispatch-queue/thread-gate-workflow.ts": "2e63fcff27fb5109f2264d31d455dbbfb1b3f18ce46c0eb3075ca6b0266fe379",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",
   "harnesses/decopilot/background-tool-workflow.ts": "b75384d08b2293a101da50f0dfc63c23fc27f4b5636d2a9ada3cc22d2f61202b",

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
@@ -85,6 +85,7 @@ import type { StudioContext } from "@/core/studio-context";
 
 export { HOSTED_HARNESS_QUEUE } from "./queue-names";
 import { HOSTED_HARNESS_QUEUE } from "./queue-names";
+import { acquireHostedRunSlot } from "./hosted-run-concurrency";
 
 // These types mirror the thread-gate runtime's shapes. They're defined locally
 // (rather than imported from `./thread-gate-workflow`) to avoid an import cycle
@@ -209,11 +210,19 @@ export async function runHostedHarness(
   // explicit cancellation and the reaper's force-fail.
   const abortController = new AbortController();
 
-  await rt.dispatchRunFn(
-    { ...request, abortSignal: abortController.signal },
-    meshCtx,
-    rt.deps,
-  );
+  // Cap concurrent agent loops per pod (see hosted-run-concurrency.ts). The
+  // slot is held only for the loop itself, not the ctx resolution above; excess
+  // runs park here until a slot frees.
+  const releaseSlot = await acquireHostedRunSlot();
+  try {
+    await rt.dispatchRunFn(
+      { ...request, abortSignal: abortController.signal },
+      meshCtx,
+      rt.deps,
+    );
+  } finally {
+    releaseSlot();
+  }
 }
 
 /**

--- a/apps/mesh/src/dispatch-queue/hosted-run-concurrency.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-run-concurrency.ts
@@ -1,0 +1,34 @@
+/**
+ * Process-wide gate on concurrent hosted agent-loop runs.
+ *
+ * Each hosted run (hostedHarnessWorkflow → runHostedHarness → dispatchRunFn)
+ * drives a full in-process agent loop — LLM streaming + tool calls, ~300MB
+ * working set with multi-hundred-MB JSON.parse spikes. The DBOS queue's
+ * per-partition concurrency=1 only serializes ONE thread; nothing bounds how
+ * many DISTINCT threads' runs a single worker pod executes at once, so a burst
+ * can pile up unbounded loops and OOM the pod (2Gi limit). This caps concurrent
+ * top-level runs per process — excess park and start as slots free (KEDA's CPU
+ * trigger adds pods as the running load grows).
+ *
+ * DBOS `workerConcurrency` can't express this: in dbos-sdk it's enforced
+ * per-partition (same scope as `concurrency`), not per-process across threads,
+ * and it's rejected outright on the concurrency=1 queue. Mirrors the subagent
+ * gate (subagent-concurrency.ts) and reuses its factory; the two gates compose
+ * — subagent fan-out is bounded independently.
+ *
+ * The acquire sits INSIDE the DBOS step (`runHostedHarness`), so a parked run
+ * just delays that step — the workflow's step sequence and recorded I/O are
+ * unchanged (recovery-compatible; no DBOS_WORKFLOW_VERSION bump).
+ *
+ * DRAFT: limit is read from the environment with a conservative default. If we
+ * keep this, move it into Settings (resolve-config.ts) so it's tunable per
+ * deployment without an env redeploy.
+ */
+
+import { createConcurrencyGate } from "@/harnesses/decopilot/built-in-tools/subagent-concurrency";
+
+const gate = createConcurrencyGate(
+  Number(process.env.DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS ?? 3),
+);
+
+export const acquireHostedRunSlot = (): Promise<() => void> => gate.acquire();

--- a/apps/mesh/src/dispatch-queue/hosted-run-concurrency.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-run-concurrency.ts
@@ -27,8 +27,22 @@
 
 import { createConcurrencyGate } from "@/harnesses/decopilot/built-in-tools/subagent-concurrency";
 
-const gate = createConcurrencyGate(
-  Number(process.env.DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS ?? 3),
-);
+// A non-finite / non-positive env value would make the gate never block (fail
+// OPEN — the exact unbounded OOM this file prevents), so guard the default.
+const parsed = Number(process.env.DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS);
+const MAX = Number.isFinite(parsed) && parsed > 0 ? parsed : 3;
 
-export const acquireHostedRunSlot = (): Promise<() => void> => gate.acquire();
+const gate = createConcurrencyGate(MAX);
+
+export const acquireHostedRunSlot = (): Promise<() => void> => {
+  // Log when a run parks so a saturating pod is visible in prod — the whole
+  // point of the cap. (gate exposes active/pending for exactly this.)
+  if (gate.active >= MAX) {
+    console.log("[hostedHarness] run parked at concurrency cap", {
+      active: gate.active,
+      pending: gate.pending,
+      max: MAX,
+    });
+  }
+  return gate.acquire();
+};


### PR DESCRIPTION
## Summary

The one real *code* optimization from the worker-sizing investigation: bound how many hosted agent loops a single worker pod runs at once.

Each hosted run (`hostedHarnessWorkflow` → `runHostedHarness` → `dispatchRunFn`) drives a full in-process agent loop — LLM streaming + tool calls, **~300MB working set with spikes to ~1.8GB** (measured on prod `deco-studio`, 7d). The DBOS queue's per-partition `concurrency=1` only serializes **one thread**; nothing bounded how many *distinct* threads' runs a pod executes concurrently, so a burst piled up unbounded loops and OOM'd the pod against the 2Gi limit.

DBOS `workerConcurrency` **can't** express this — in dbos-sdk it's enforced per-partition (same scope as `concurrency`), not per-process across threads, and it's rejected outright on the `concurrency=1` queue (see the closed studio#4573).

## Change

Gate the agent loop with a process-wide `ConcurrencyGate`, **reusing the existing subagent-gate factory** (`createConcurrencyGate`). Env-tunable via `DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS` (default **3**); excess runs park until a slot frees. The two gates compose — subagent fan-out is bounded independently.

The `acquire` sits **inside** the existing DBOS step (`runHostedHarness`), holding a slot only for the loop itself (not ctx resolution). So:
- Step sequence + recorded I/O unchanged → **recovery-compatible, no `DBOS_WORKFLOW_VERSION` bump** (source-guard snapshot re-baselined only).
- A parked run just delays its step — cheap, and that's the intended backpressure.

## Trade-off
Per-process gating means a saturated pod parks new runs behind in-flight ones (head-of-line). That's acceptable: the alternative is OOM, KEDA's CPU trigger adds pods as load grows, and the limit is env-tunable. The subagent gate made the same call.

## Testing
- `tsc`, `biome`, `oxlint` (0 errors) clean
- `hosted-harness-workflow.test.ts` + `subagent-concurrency.test.ts` (the gate factory's own tests) pass — 25/0
- workflow-source-guard re-baselined + passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps concurrent hosted agent-loop runs per pod to prevent OOMs and smooth bursts. Adds a process-wide gate in the hosted harness workflow, tunable via `DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS` (default 3).

- **New Features**
  - Process-wide gate for hosted runs; slot held only during the agent loop in runHostedHarness.
  - Excess runs wait for a free slot; logs when parked to surface saturation; composes with the existing subagent gate to bound fan-out.
  - Workflow behavior unchanged and recovery-safe (no DBOS_WORKFLOW_VERSION change).

<sup>Written for commit 01813bf5f1759f26a1cfcd31b016dabd02f042bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

