### PR TITLE
refactor(web): remove dead toggleMain from usePanelActions

### DIFF
--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -207,24 +207,11 @@ export function usePanelActions() {
       main: tabId,
     }));
 
-  const toggleMain = () =>
-    nav((prev) => {
-      const isOpen =
-        prev.main !== undefined && prev.main !== 0 && prev.main !== "0";
-      if (isOpen) {
-        return { ...prev, main: 0 };
-      }
-      const next: Record<string, unknown> = { ...prev };
-      delete next.main;
-      return next;
-    });
-
   return {
     setChatOpen,
     setTaskId,
     createNewTask,
     openTab,
-    toggleMain,
   };
 }
 


### PR DESCRIPTION
## Summary

Source: dead-code cleanup found while reading recently-churned files in `apps/mesh/src/web/layouts/`.

`toggleMain` in `usePanelActions()` (`shell-layout.tsx`) was added alongside the standalone workspace panel work but has no caller — every `usePanelActions()` call site in the repo destructures only `setChatOpen` / `setTaskId` / `createNewTask` / `openTab`. The actual Main-panel toggle in use today goes through `useChatMainPanelState`'s own `toggleMain` in `use-layout-state.ts`, which is a different (guarded, `canCloseWorkspacePanel`-aware) implementation. This one was simply never wired up.

Net diff: **-13 / +0**, one file, no behavior change.

## Verification

- `grep -rn "usePanelActions()" apps/mesh/src` — confirmed no call site destructures `toggleMain`.
- `grep -rn "toggleMain" apps/mesh/src` (outside `use-layout-state.ts`) — confirmed the only other reference was the deleted declaration itself.
- `bun run fmt` — no changes.
- `bun x tsc --noEmit` in `apps/mesh` — no new errors (pre-existing, unrelated `@tiptap/extension-text-align` module errors remain, present before this change too).

A reviewer can confirm by re-running the same greps, or just checking that CI's typecheck/build stay green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `toggleMain` from `usePanelActions` to clean up dead code. The Main panel toggle already uses `useChatMainPanelState.toggleMain`, so there’s no behavior change.

<sup>Written for commit 902a75dbc8f052eff851dd39df87c5355807087a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

