### PR TITLE
feat(dispatch-queue): observability + /hosted-run-pending for the hosted-run gate

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -168,6 +168,7 @@ import {
   THREAD_GATE_PARTITION_CONCURRENCY,
   THREAD_GATE_QUEUE,
 } from "../dispatch-queue";
+import { hostedRunStats } from "../dispatch-queue/hosted-run-concurrency";
 import { setProjectorWorkflowRuntime } from "./routes/decopilot/projector-workflow";
 import { synthesizedErrorMessageId } from "./routes/decopilot/message-ids";
 import { backfillStudioPackForAllOrgs } from "../auth/install-studio-pack-workflow";
@@ -1236,6 +1237,16 @@ export async function createApp(options: CreateAppOptions = {}) {
       status: "ENQUEUED",
     });
     return c.json({ queue_length: queued.length });
+  });
+
+  // Hosted-run gate backlog on THIS pod, for a KEDA metrics-api trigger:
+  // `{ "pending": <n> }`. Distinct from /dbos-queue-depth (ENQUEUED count) —
+  // gate-parked runs are already DEQUEUED (PENDING) and pinned to this pod, so
+  // queue depth can't see them (see hosted-run-concurrency.ts). Per-pod, so the
+  // trigger must aggregate across worker pods.
+  app.get(SYSTEM_PATHS.HOSTED_RUN_PENDING, (c) => {
+    const { active, pending, max } = hostedRunStats();
+    return c.json({ pending, active, max });
   });
 
   // ============================================================================

--- a/apps/mesh/src/api/utils/paths.test.ts
+++ b/apps/mesh/src/api/utils/paths.test.ts
@@ -17,3 +17,13 @@ describe("DBOS queue-depth path", () => {
     expect(shouldSkipStudioContext("/dbos-queue-depth")).toBe(false);
   });
 });
+
+describe("hosted-run-pending path", () => {
+  test("skips StudioContext for the hosted-run-pending endpoint", () => {
+    expect(shouldSkipStudioContext(SYSTEM_PATHS.HOSTED_RUN_PENDING)).toBe(true);
+  });
+
+  test("does not match the API-prefixed variant", () => {
+    expect(shouldSkipStudioContext("/api/hosted-run-pending")).toBe(false);
+  });
+});

--- a/apps/mesh/src/api/utils/paths.ts
+++ b/apps/mesh/src/api/utils/paths.ts
@@ -18,6 +18,11 @@ export const SYSTEM_PATHS = {
   // neither), so it only answers on the pod's own port — for a KEDA
   // metrics-api trigger or similar in-cluster poller.
   DBOS_QUEUE_DEPTH_PREFIX: "/dbos-queue-depth/",
+  // Cluster-internal only (same as DBOS_QUEUE_DEPTH_PREFIX): parked-run backlog
+  // for a KEDA metrics-api trigger. The queue-depth endpoint counts ENQUEUED
+  // only, but the gate parks DEQUEUED (PENDING) runs — so this is the signal
+  // that reflects a saturated pod.
+  HOSTED_RUN_PENDING: "/hosted-run-pending",
 } as const;
 
 /** Path prefixes for different route types (internal use only) */
@@ -50,7 +55,8 @@ function isSystemPath(path: string): boolean {
     path === SYSTEM_PATHS.HEALTH_READY ||
     path === SYSTEM_PATHS.METRICS ||
     path.startsWith(PATH_PREFIXES.WELL_KNOWN) ||
-    path.startsWith(SYSTEM_PATHS.DBOS_QUEUE_DEPTH_PREFIX)
+    path.startsWith(SYSTEM_PATHS.DBOS_QUEUE_DEPTH_PREFIX) ||
+    path === SYSTEM_PATHS.HOSTED_RUN_PENDING
   );
 }
 

--- a/apps/mesh/src/dispatch-queue/hosted-run-concurrency.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-run-concurrency.ts
@@ -26,13 +26,48 @@
  */
 
 import { createConcurrencyGate } from "@/harnesses/decopilot/built-in-tools/subagent-concurrency";
+import { meter } from "@/observability";
 
 // A non-finite / non-positive env value would make the gate never block (fail
 // OPEN — the exact unbounded OOM this file prevents), so guard the default.
+// Default 3: prod worker is 768Mi request / 2Gi limit, run working set p90
+// ~450MB — 3×450≈1.35GB stays under the limit, 4-5 would OOM on p90 alone, and
+// a lower cap just parks more (which the KEDA queue-depth trigger can't see —
+// parked runs are PENDING, not ENQUEUED). The 1.8GB JSON.parse tail can still
+// OOM at any cap≥2; that's recovery's job, not this gate's.
 const parsed = Number(process.env.DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS);
 const MAX = Number.isFinite(parsed) && parsed > 0 ? parsed : 3;
 
 const gate = createConcurrencyGate(MAX);
+
+// The gate caps memory, which flattens the CPU/memory signals a plain HPA scales
+// on — so the backlog of PARKED runs is the only thing that reflects saturation.
+// Export it as a gauge so a queue-depth/KEDA trigger can add workers when runs
+// start waiting (parked runs are pinned to this pod; scaling relieves the queue,
+// not the in-flight backlog).
+meter
+  .createObservableGauge("hosted_runs.active", {
+    description: "Hosted agent-loop runs executing on this pod",
+    unit: "{runs}",
+  })
+  .addCallback((r) => r.observe(gate.active));
+meter
+  .createObservableGauge("hosted_runs.pending", {
+    description: "Hosted agent-loop runs parked waiting for a slot on this pod",
+    unit: "{runs}",
+  })
+  .addCallback((r) => r.observe(gate.pending));
+
+/**
+ * Live gate stats for the `/hosted-run-pending` metrics-api endpoint (KEDA).
+ * `pending` is the scale signal: parked runs are DBOS-PENDING (dequeued), so
+ * they're invisible to the ENQUEUED-only queue-depth endpoint.
+ */
+export const hostedRunStats = (): {
+  active: number;
+  pending: number;
+  max: number;
+} => ({ active: gate.active, pending: gate.pending, max: MAX });
 
 export const acquireHostedRunSlot = (): Promise<() => void> => {
   // Log when a run parks so a saturating pod is visible in prod — the whole


### PR DESCRIPTION
Follow-up to #4575 (merged). Hardens the per-pod hosted-run concurrency gate and adds the signal needed to eventually scale on it.

## Changes

**Fail-closed default** — a non-finite / ≤0 `DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS` previously made the gate never block (`Math.max(1, NaN)` → `NaN` → `active >= NaN` always false), i.e. it failed **open** into the exact unbounded-concurrency OOM the gate exists to prevent. Now guarded with `Number.isFinite` → default 3.

**Observability** — OTel gauges `hosted_runs.active` / `hosted_runs.pending` and a `run parked at concurrency cap` log line, so a saturating pod is visible in prod (dashboards + VictoriaLogs).

**`/hosted-run-pending` metrics-api endpoint** — sibling to `/dbos-queue-depth`, returns `{ pending, active, max }` from the gate. Cluster-internal, unauthenticated system path (same treatment as queue-depth).

## Why a new endpoint and not the existing queue-depth trigger

`/dbos-queue-depth` counts `status: "ENQUEUED"` only. The hosted-harness queue is **concurrency=1 per threadId**, so a cross-thread burst (the pod-saturation case the gate parks) is dequeued immediately → `PENDING` → parked **in-memory** on the pod → invisible to the ENQUEUED count. So the existing KEDA queue-depth trigger cannot see gate saturation. `pending` is the signal that can.

## Scope

Endpoint + observability **only** — no KEDA trigger wired. The `workerKeda` thresholds in deco-apps-cd are already admitted to be un-measured guesses; I'd rather watch `hosted_runs.pending` in prod first, then wire a metrics-api trigger (aggregated across worker pods — this endpoint is per-pod) with a real threshold. Related: deco-apps-cd#146 corrects the worker-memory comment that credited the reverted #4573.

## Testing
- `paths.test.ts` extended (skip-StudioContext for the new endpoint); 4/4 pass
- `tsc`, `biome`, `oxlint` clean (0 errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the hosted-run concurrency gate and adds per-pod observability, including a new `/hosted-run-pending` endpoint, so we can see and scale on gate saturation.

- **New Features**
  - Added gauges `hosted_runs.active` and `hosted_runs.pending`.
  - Added cluster-internal `/hosted-run-pending` endpoint returning `{ pending, active, max }` (per pod).
  - Log when a run is parked at the concurrency cap.

- **Bug Fixes**
  - Validates `DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS`; non-finite/non-positive now defaults to 3 instead of disabling the gate.

<sup>Written for commit 2ad72d0ae9052446919a416809d4acf01d5d080e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

