### PR TITLE
feat(preview): loader-based, multi-app path-param picker + auto-select

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/runnable-catalog.ts
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-catalog.ts
@@ -59,6 +59,27 @@ export function isManifestRunnableResolveType(
 }
 
 /**
+ * All manifest resolveTypes of the given runnable kind (loaders/actions). Unlike
+ * {@link listAvailableRunnables} this is the raw set — no hidden/preview
+ * filtering — for callers that need to pattern-match against every registered
+ * loader (e.g. discovering a store's product-search loader dynamically).
+ */
+export function manifestLoaderResolveTypes(
+  meta: LiveMeta,
+  kind: RunnableKind,
+): Set<string> {
+  const resolveTypes = new Set<string>();
+  const blocks = meta.manifest?.blocks ?? {};
+  for (const [blockType, blockMap] of Object.entries(blocks)) {
+    if (!blockType.includes(kind)) continue;
+    for (const resolveType of Object.keys(blockMap)) {
+      resolveTypes.add(resolveType);
+    }
+  }
+  return resolveTypes;
+}
+
+/**
  * Tanstack manifests register most modules twice: a bare invoke-by-key alias
  * (`site/loaders/CheckStock`) plus the real module path
  * (`site/loaders/CheckStock.ts`). Only the suffixed entry carries the

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
@@ -65,7 +65,7 @@ async function invokeLoader(
  * tree, filtered locally) so their key ignores the term; both the chip's modal
  * query and preview.tsx's auto-fill query use this, sharing one cache entry.
  */
-export function pickerInvokeKey(
+function pickerInvokeKey(
   ref: RunBlockSandboxRef,
   source: OptionSource,
   term: string,
@@ -81,7 +81,7 @@ export function pickerInvokeKey(
  * calls (e.g. product ids + name query); they run in parallel and merge in
  * order, deduped. Partial failures are tolerated as long as one call succeeds.
  */
-export async function fetchOptions(
+async function fetchOptions(
   ref: RunBlockSandboxRef,
   source: OptionSource,
   term: string,

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
@@ -15,23 +15,28 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
+import { fillPathTemplate } from "@/web/components/sections-editor/page-path-utils";
 import { KEYS } from "@/web/lib/query-keys";
 import {
   buildPreviewInvokePath,
   type RunBlockSandboxRef,
 } from "@/web/components/sandbox/content/use-run-block";
 import {
-  categoryOptionsFromPayload,
   filterPickerOptions,
   mergePickerOptions,
-  pickerLoaderRequests,
-  productOptionsFromPayload,
+  type OptionPayloadContext,
+  type OptionSource,
+  type PathParamKind,
   type PathParamOption,
-  type PathParamPickerKind,
   type PickerLoaderRequest,
 } from "./path-param-picker";
 
 const PICKER_FETCH_TIMEOUT_MS = 10_000;
+
+const KIND_LABELS: Record<PathParamKind, { noun: string; heading: string }> = {
+  product: { noun: "product", heading: "Products" },
+  category: { noun: "category", heading: "Categories" },
+};
 
 /**
  * Invoke a loader via the mesh preview-invoke proxy (same-origin,
@@ -56,16 +61,34 @@ async function invokeLoader(
 }
 
 /**
- * A term can fan out to several loader calls (e.g. product ids + name query);
- * they run in parallel and merge in order, deduped. Partial failures are
- * tolerated as long as at least one call succeeds.
+ * react-query key for a source + term. clientFilter sources fetch once (whole
+ * tree, filtered locally) so their key ignores the term; both the chip's modal
+ * query and preview.tsx's auto-fill query use this, sharing one cache entry.
  */
-async function fetchPickerOptions(
+export function pickerInvokeKey(
   ref: RunBlockSandboxRef,
-  kind: PathParamPickerKind,
+  source: OptionSource,
   term: string,
+) {
+  return KEYS.sandboxInvoke(
+    `${ref.orgSlug}/${ref.virtualMcpId}/${ref.branch}`,
+    `path-param-${source.id}:${source.clientFilter ? "" : term}`,
+  );
+}
+
+/**
+ * Fetch and map options for one source. A term can fan out to several loader
+ * calls (e.g. product ids + name query); they run in parallel and merge in
+ * order, deduped. Partial failures are tolerated as long as one call succeeds.
+ */
+export async function fetchOptions(
+  ref: RunBlockSandboxRef,
+  source: OptionSource,
+  term: string,
+  ctx: OptionPayloadContext,
 ): Promise<PathParamOption[]> {
-  const requests = pickerLoaderRequests(kind, term);
+  const requests = source.buildRequests(term);
+  if (requests.length === 0) return [];
   const settled = await Promise.allSettled(
     requests.map((request) => invokeLoader(ref, request)),
   );
@@ -81,29 +104,113 @@ async function fetchPickerOptions(
     throw failed ? failed.reason : new Error("Failed to fetch options");
   }
   return mergePickerOptions(
-    payloads.map((payload) =>
-      kind === "product"
-        ? productOptionsFromPayload(payload)
-        : categoryOptionsFromPayload(payload),
-    ),
+    payloads.map((payload) => source.optionsFromPayload(payload, ctx)),
+  );
+}
+
+/** One source's fetched options rendered as a labelled command group. */
+function PickerSourceGroup({
+  source,
+  sandboxRef,
+  template,
+  paramName,
+  open,
+  search,
+  debouncedSearch,
+  showHeading,
+  onSelect,
+}: {
+  source: OptionSource;
+  sandboxRef: RunBlockSandboxRef;
+  template: string;
+  paramName: string;
+  open: boolean;
+  search: string;
+  debouncedSearch: string;
+  showHeading: boolean;
+  onSelect: (value: string) => void;
+}) {
+  const query = useQuery({
+    queryKey: pickerInvokeKey(sandboxRef, source, debouncedSearch),
+    queryFn: () =>
+      fetchOptions(sandboxRef, source, debouncedSearch, {
+        template,
+        paramName,
+      }),
+    enabled: open,
+    staleTime: 60_000,
+    retry: 1,
+  });
+
+  const { noun, heading } = KIND_LABELS[source.kind];
+  const options = source.clientFilter
+    ? filterPickerOptions(query.data ?? [], search)
+    : (query.data ?? []);
+
+  const status = query.isLoading
+    ? `Loading ${noun}…`
+    : query.isError
+      ? "Couldn't load — is the dev server running?"
+      : null;
+
+  if (!status && options.length === 0) return null;
+
+  return (
+    <CommandGroup heading={showHeading ? heading : undefined}>
+      {status ? (
+        <div className="px-2 py-2 text-xs text-muted-foreground">{status}</div>
+      ) : (
+        options.map((opt) => (
+          <CommandItem
+            key={`${source.id}:${opt.value}`}
+            value={`${source.id}:${opt.value}`}
+            className="gap-3 py-2"
+            onSelect={() => onSelect(opt.value)}
+          >
+            {source.kind === "product" && (
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-muted">
+                {opt.image ? (
+                  <img
+                    src={opt.image}
+                    alt=""
+                    referrerPolicy="no-referrer"
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <SearchSm size={14} className="text-muted-foreground" />
+                )}
+              </span>
+            )}
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm">{opt.label}</span>
+              <span className="block truncate text-xs text-muted-foreground">
+                {fillPathTemplate(template, { [paramName]: opt.value })}
+              </span>
+            </span>
+          </CommandItem>
+        ))
+      )}
+    </CommandGroup>
   );
 }
 
 /**
- * Path-param chip whose click opens a centered picker modal: search real
- * store entities (VTEX products for PDP params, categories for the PLP
- * catch-all) or commit the typed text as a free-form value. Replaces the
- * inline input for params that have a picker; committing goes through
- * `onCommit`, the same flow free typing uses elsewhere.
+ * Path-param chip whose click opens a centered picker modal: search real store
+ * entities (products / categories, driven by whatever loaders the running site
+ * ships) or commit the typed text as a free-form value. Replaces the inline
+ * input for params that have at least one option source; committing goes
+ * through `onCommit`, the same flow free typing uses elsewhere.
  */
 export function PathParamPickerChip({
-  kind,
+  sources,
+  template,
   paramName,
   value,
   sandboxRef,
   onCommit,
 }: {
-  kind: PathParamPickerKind;
+  sources: OptionSource[];
+  template: string;
   paramName: string;
   value: string;
   sandboxRef: RunBlockSandboxRef;
@@ -114,14 +221,16 @@ export function PathParamPickerChip({
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const noun = kind === "product" ? "product" : "category";
-  const paramLabel = paramName === "*" ? "*" : `:${paramName}`;
+  // The `*` catch-all reads badly in the URL bar; show a friendly word instead.
+  const paramLabel = paramName === "*" ? "path" : `:${paramName}`;
+  const nouns = [...new Set(sources.map((s) => KIND_LABELS[s.kind].noun))];
+  const placeholder = `Search ${nouns.join(" or ")} or enter a value…`;
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     // Opening seeds the search with the current value so editing an existing
-    // slug is one click; closing resets so a reopen starts clean.
+    // value is one click; closing resets so a reopen starts clean.
     setSearch(next ? value : "");
     setDebouncedSearch(next ? value : "");
   };
@@ -139,26 +248,10 @@ export function PathParamPickerChip({
     handleOpenChange(false);
   };
 
-  // The category tree is term-independent (fetched once, filtered locally),
-  // so its query key ignores the search term.
-  const query = useQuery({
-    queryKey: KEYS.sandboxInvoke(
-      `${sandboxRef.orgSlug}/${sandboxRef.virtualMcpId}/${sandboxRef.branch}`,
-      `path-param-${kind}:${kind === "product" ? debouncedSearch : ""}`,
-    ),
-    queryFn: () => fetchPickerOptions(sandboxRef, kind, debouncedSearch),
-    enabled: open,
-    staleTime: 60_000,
-    retry: 1,
-  });
-
-  const options =
-    kind === "product"
-      ? (query.data ?? [])
-      : filterPickerOptions(query.data ?? [], search);
-
-  const rawTerm = search.trim();
-  const rawPath = kind === "product" ? `/${rawTerm}/p` : `/${rawTerm}`;
+  // Strip surrounding slashes so a typed `/sabonetes/x` fills as `sabonetes/x`
+  // (the template supplies the leading slash; a `*` value keeps inner slashes).
+  const rawTerm = search.trim().replace(/^\/+|\/+$/g, "");
+  const rawPath = fillPathTemplate(template, { [paramName]: rawTerm });
 
   return (
     <>
@@ -166,7 +259,7 @@ export function PathParamPickerChip({
           chip must not let clicks bubble. */}
       <button
         type="button"
-        title={`Value for ${paramLabel} — click to pick a ${noun}`}
+        title={`Value for ${paramLabel} — click to pick`}
         className="max-w-64 shrink-0 cursor-pointer truncate rounded-sm bg-violet-500/15 px-1 py-0.5 text-[12px] text-violet-600 hover:bg-violet-500/25 dark:text-violet-400"
         onClick={(e) => {
           e.stopPropagation();
@@ -184,14 +277,12 @@ export function PathParamPickerChip({
           onClick={(e) => e.stopPropagation()}
         >
           <DialogHeader className="sr-only">
-            <DialogTitle>
-              Pick a {noun} or enter a value for {paramLabel}
-            </DialogTitle>
+            <DialogTitle>Pick a value for {paramLabel}</DialogTitle>
           </DialogHeader>
           <div className="flex h-12 shrink-0 items-center gap-3 border-b border-border px-4">
             <SearchSm size={16} className="shrink-0 text-foreground" />
             <span className="text-sm font-medium text-foreground">
-              Pick a {noun} for{" "}
+              Pick a value for{" "}
               <span className="rounded-sm bg-violet-500/15 px-1 py-0.5 font-mono text-[12px] text-violet-600 dark:text-violet-400">
                 {paramLabel}
               </span>
@@ -200,22 +291,12 @@ export function PathParamPickerChip({
           <Command shouldFilter={false} className="min-h-0 flex-1">
             <CommandInput
               autoFocus
-              placeholder={
-                kind === "product"
-                  ? "Search products or enter a slug..."
-                  : "Search categories or enter a path..."
-              }
+              placeholder={placeholder}
               value={search}
               onValueChange={handleSearchChange}
             />
             <CommandList className="max-h-none flex-1">
-              <CommandEmpty>
-                {query.isLoading
-                  ? "Loading..."
-                  : query.isError
-                    ? "Couldn't load — is the dev server running?"
-                    : "No results."}
-              </CommandEmpty>
+              <CommandEmpty>No results.</CommandEmpty>
               {rawTerm && (
                 <CommandGroup>
                   <CommandItem
@@ -237,46 +318,64 @@ export function PathParamPickerChip({
                   </CommandItem>
                 </CommandGroup>
               )}
-              <CommandGroup>
-                {options.map((opt) => (
-                  <CommandItem
-                    key={opt.value}
-                    value={opt.value}
-                    className="gap-3 py-2"
-                    onSelect={() => commit(opt.value)}
-                  >
-                    {kind === "product" && (
-                      <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-muted">
-                        {opt.image ? (
-                          <img
-                            src={opt.image}
-                            alt=""
-                            referrerPolicy="no-referrer"
-                            className="h-full w-full object-cover"
-                          />
-                        ) : (
-                          <SearchSm
-                            size={14}
-                            className="text-muted-foreground"
-                          />
-                        )}
-                      </span>
-                    )}
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate text-sm">
-                        {opt.label}
-                      </span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        /{kind === "product" ? `${opt.value}/p` : opt.value}
-                      </span>
-                    </span>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
+              {sources.map((source) => (
+                <PickerSourceGroup
+                  key={source.id}
+                  source={source}
+                  sandboxRef={sandboxRef}
+                  template={template}
+                  paramName={paramName}
+                  open={open}
+                  search={search}
+                  debouncedSearch={debouncedSearch}
+                  showHeading={sources.length > 1}
+                  onSelect={commit}
+                />
+              ))}
             </CommandList>
           </Command>
         </DialogContent>
       </Dialog>
     </>
   );
+}
+
+/**
+ * Renders nothing; fetches the first option for a picker param that has no
+ * value yet and commits it, so navigating to a bare dynamic-route template
+ * lands on a real entity instead of an empty page. Mounted by preview.tsx only
+ * while the param is empty (unmounts the instant the value is filled), so it
+ * never overwrites a user/restored value and can't loop. Shares the chip's
+ * react-query cache (same key/fetch).
+ */
+export function PathParamAutoFill({
+  source,
+  template,
+  paramName,
+  sandboxRef,
+  onFill,
+}: {
+  source: OptionSource;
+  template: string;
+  paramName: string;
+  sandboxRef: RunBlockSandboxRef;
+  onFill: (value: string) => void;
+}) {
+  const query = useQuery({
+    queryKey: pickerInvokeKey(sandboxRef, source, ""),
+    queryFn: () =>
+      fetchOptions(sandboxRef, source, "", { template, paramName }),
+    staleTime: 60_000,
+    retry: 1,
+  });
+  // Render-time guard (the codebase's run-once pattern). Setting own state
+  // during render is allowed; the parent commit is deferred to a microtask so
+  // it doesn't update a different component mid-render.
+  const [filled, setFilled] = useState(false);
+  if (!filled && query.data && query.data.length > 0) {
+    setFilled(true);
+    const value = query.data[0]!.value;
+    queueMicrotask(() => onFill(value));
+  }
+  return null;
 }

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker.test.ts
@@ -1,85 +1,391 @@
 import { describe, expect, test } from "bun:test";
 import {
   categoryOptionsFromPayload,
-  detectPickerKind,
+  classifyParamKinds,
+  collectPageLoaderResolveTypes,
+  commercePlatformsFromLoaders,
   filterPickerOptions,
   mergePickerOptions,
-  pickerLoaderRequests,
   productOptionsFromPayload,
-  productSlugFromUrl,
+  resolveOptionSources,
+  valueFromEntityUrl,
+  type PathParamKind,
 } from "./path-param-picker";
 
-describe("detectPickerKind", () => {
-  test("param followed by /p at the end is a product", () => {
-    expect(detectPickerKind("/:slug/p", "slug")).toBe("product");
-    expect(detectPickerKind("/foo/:id/p", "id")).toBe("product");
+const VTEX_PRODUCT = "vtex/loaders/intelligentSearch/productList.ts";
+const VTEX_TREE = "vtex/loaders/categories/tree.ts";
+const ALGOLIA_LIST = "site/loaders/algolia/products/list.ts";
+const MAGENTO_PDP = "magento/loaders/product/detailsPageGQL.ts";
+const MAGENTO_PLP = "magento/loaders/product/listingPage.ts";
+
+const kinds = (...k: PathParamKind[]) => new Set<PathParamKind>(k);
+const pdpCtx = { template: "/:slug/p", paramName: "slug" };
+
+describe("classifyParamKinds", () => {
+  test("VTEX URL shapes classify without page loaders", () => {
+    expect([...classifyParamKinds("/:slug/p", "slug", new Set())]).toEqual([
+      "product",
+    ]);
+    expect([...classifyParamKinds("/foo/:id/p", "id", new Set())]).toEqual([
+      "product",
+    ]);
+    expect([...classifyParamKinds("/*", "*", new Set())]).toEqual(["category"]);
+    expect([...classifyParamKinds("/c/*", "*", new Set())]).toEqual([
+      "category",
+    ]);
   });
 
-  test("trailing slash is normalized away", () => {
-    expect(detectPickerKind("/:slug/p/", "slug")).toBe("product");
+  test("only the param right before /p is a product", () => {
+    expect([...classifyParamKinds("/:a/:b/p", "b", new Set())]).toEqual([
+      "product",
+    ]);
+    expect([...classifyParamKinds("/:a/:b/p", "a", new Set())]).toEqual([]);
   });
 
-  test("only the param right before /p gets the product picker", () => {
-    expect(detectPickerKind("/:a/:b/p", "b")).toBe("product");
-    expect(detectPickerKind("/:a/:b/p", "a")).toBeNull();
+  test("loader-based: a detailsPage loader classifies product (no /p needed)", () => {
+    // Magento PDP: /granado/:slug with a detailsPageGQL loader, no trailing /p.
+    expect([
+      ...classifyParamKinds("/:slug", "slug", new Set([MAGENTO_PDP])),
+    ]).toEqual(["product"]);
+    expect([
+      ...classifyParamKinds(
+        "/:slug",
+        "slug",
+        new Set(["vtex/loaders/productDetailsPage.ts"]),
+      ),
+    ]).toEqual(["product"]);
   });
 
-  test("params not followed by a trailing /p get no picker", () => {
-    expect(detectPickerKind("/blog/:slug", "slug")).toBeNull();
-    expect(detectPickerKind("/:slug/p/x", "slug")).toBeNull();
+  test("loader-based: a listingPage loader classifies category", () => {
+    expect([
+      ...classifyParamKinds("/produtos/:slug", "slug", new Set([MAGENTO_PLP])),
+    ]).toEqual(["category"]);
   });
 
-  test("catch-all is a category", () => {
-    expect(detectPickerKind("/*", "*")).toBe("category");
-    expect(detectPickerKind("/c/*", "*")).toBe("category");
+  test("a catch-all wiring both detail and listing loaders is both", () => {
+    // Granado's `$` route resolves PDP or PLP at runtime → both.
+    expect(
+      classifyParamKinds("/*", "*", new Set([MAGENTO_PDP, MAGENTO_PLP])),
+    ).toEqual(kinds("product", "category"));
   });
 
-  test("catch-all name on a template without * gets no picker", () => {
-    expect(detectPickerKind("/:slug/p", "*")).toBeNull();
+  test("classifies by loader/block name (PDP → product, PLP → category)", () => {
+    expect(
+      classifyParamKinds("/*", "*", new Set(["PDP Magento loader (GQL)"])),
+    ).toEqual(kinds("product", "category")); // + category from the `*` shape
+    expect([
+      ...classifyParamKinds("/:slug", "slug", new Set(["PDP Custom Loader"])),
+    ]).toEqual(["product"]);
+    expect([
+      ...classifyParamKinds("/:slug", "slug", new Set(["PLP Custom Loader"])),
+    ]).toEqual(["category"]);
+  });
+
+  test("params with no loader and no shape get nothing", () => {
+    expect([...classifyParamKinds("/blog/:slug", "slug", new Set())]).toEqual(
+      [],
+    );
   });
 });
 
-describe("pickerLoaderRequests", () => {
-  const PRODUCT_LOADER = "vtex/loaders/intelligentSearch/productList.ts";
+describe("resolveOptionSources", () => {
+  test("binds the VTEX product loader present in the manifest", () => {
+    const [source] = resolveOptionSources(
+      kinds("product"),
+      new Set([VTEX_PRODUCT]),
+    );
+    expect(source?.kind).toBe("product");
+    expect(source?.resolveType).toBe(VTEX_PRODUCT);
+    expect(source?.clientFilter).toBe(false);
+  });
 
-  test("plain product term is a single name query", () => {
-    expect(pickerLoaderRequests("product", "torrada integral")).toEqual([
+  test("VTEX product requests: numeric term also tries ids, ids first", () => {
+    const [source] = resolveOptionSources(
+      kinds("product"),
+      new Set([VTEX_PRODUCT]),
+    );
+    expect(source?.buildRequests("123")).toEqual([
+      { resolveType: VTEX_PRODUCT, props: { ids: ["123"] } },
+      { resolveType: VTEX_PRODUCT, props: { query: "123", count: 10 } },
+    ]);
+    expect(source?.buildRequests("torrada-multigraos")).toEqual([
       {
-        resolveType: PRODUCT_LOADER,
-        props: { query: "torrada integral", count: 10 },
+        resolveType: VTEX_PRODUCT,
+        props: { query: "torrada multigraos", count: 10 },
       },
     ]);
   });
 
-  test("numeric term also tries product ids, ids first", () => {
-    expect(pickerLoaderRequests("product", "123")).toEqual([
-      { resolveType: PRODUCT_LOADER, props: { ids: ["123"] } },
-      { resolveType: PRODUCT_LOADER, props: { query: "123", count: 10 } },
-    ]);
-  });
-
-  test("slug-like term is de-hyphenated so its words match the name", () => {
-    expect(pickerLoaderRequests("product", "torrada-multigraos-142g")).toEqual([
+  test("falls back to the site's Algolia search loader when no VTEX loader", () => {
+    const [source] = resolveOptionSources(
+      kinds("product"),
+      new Set([ALGOLIA_LIST]),
+    );
+    expect(source?.resolveType).toBe(ALGOLIA_LIST);
+    expect(source?.buildRequests("torrada")).toEqual([
       {
-        resolveType: PRODUCT_LOADER,
-        props: { query: "torrada multigraos 142g", count: 10 },
+        resolveType: ALGOLIA_LIST,
+        props: { term: "torrada", hitsPerPage: 10 },
       },
     ]);
   });
 
-  test("hyphenated term with spaces is kept as typed", () => {
-    expect(pickerLoaderRequests("product", "kit caixa-presente")).toEqual([
+  test("candidate order is priority: VTEX wins over Algolia", () => {
+    const [source] = resolveOptionSources(
+      kinds("product"),
+      new Set([ALGOLIA_LIST, VTEX_PRODUCT]),
+    );
+    expect(source?.resolveType).toBe(VTEX_PRODUCT);
+  });
+
+  test("category binds a tree loader as a client-filtered source", () => {
+    const [source] = resolveOptionSources(
+      kinds("category"),
+      new Set([VTEX_TREE]),
+    );
+    expect(source?.kind).toBe("category");
+    expect(source?.clientFilter).toBe(true);
+    expect(source?.buildRequests("anything")).toEqual([
+      { resolveType: VTEX_TREE, props: {} },
+    ]);
+  });
+
+  test("prefers the page platform's own search loader over a neutral index", () => {
+    // Magento page with both its native product search AND Algolia present:
+    // Magento's public GraphQL search wins (no external index dependency).
+    const magentoList = "magento/loaders/product/list.ts";
+    const [product] = resolveOptionSources(
+      kinds("product"),
+      new Set([ALGOLIA_LIST, magentoList]),
+      new Set(["magento"]),
+    );
+    expect(product?.resolveType).toBe(magentoList);
+    expect(product?.buildRequests("sabonete")).toEqual([
       {
-        resolveType: PRODUCT_LOADER,
-        props: { query: "kit caixa-presente", count: 10 },
+        resolveType: magentoList,
+        props: { props: { search: "sabonete", pageSize: 10, currentPage: 1 } },
       },
     ]);
   });
 
-  test("category fetches the whole tree, term-independent", () => {
-    expect(pickerLoaderRequests("category", "hats")).toEqual([
-      { resolveType: "vtex/loaders/categories/tree.ts", props: {} },
+  test("skips a competing vendor's loader for the page's platform", () => {
+    // Magento store that also has the VTEX app installed: product must resolve
+    // to the neutral Algolia loader, NOT vtex; category must NOT invoke a vtex
+    // category-tree loader that merely exists in the manifest.
+    const magento = new Set(["magento"]);
+    const [product] = resolveOptionSources(
+      kinds("product"),
+      new Set([VTEX_PRODUCT, ALGOLIA_LIST]),
+      magento,
+    );
+    expect(product?.resolveType).toBe(ALGOLIA_LIST);
+    expect(
+      resolveOptionSources(
+        kinds("category"),
+        new Set(["vtex/loaders/catalog/getCategoryTree"]),
+        magento,
+      ),
+    ).toEqual([]);
+  });
+
+  test("commercePlatformsFromLoaders picks vendor namespaces only", () => {
+    expect(
+      commercePlatformsFromLoaders([
+        MAGENTO_PDP,
+        ALGOLIA_LIST,
+        "PDP Magento loader (GQL)",
+        "site/loaders/features.ts",
+      ]),
+    ).toEqual(new Set(["magento"]));
+  });
+
+  test("a kind with no available loader yields no source", () => {
+    // Granado: product (Algolia) resolves, category has no tree loader.
+    const sources = resolveOptionSources(
+      kinds("product", "category"),
+      new Set([ALGOLIA_LIST]),
+    );
+    expect(sources.map((s) => s.kind)).toEqual(["product"]);
+    expect(resolveOptionSources(kinds("product"), new Set())).toEqual([]);
+  });
+});
+
+describe("valueFromEntityUrl", () => {
+  test("VTEX /p shape strips the trailing /p", () => {
+    expect(
+      valueFromEntityUrl("https://store.com/apple-watch/p", "/:slug/p", "slug"),
+    ).toBe("apple-watch");
+    expect(valueFromEntityUrl("/apple-watch/p", "/:slug/p", "slug")).toBe(
+      "apple-watch",
+    );
+    expect(valueFromEntityUrl("/apple-watch/p/", "/:slug/p", "slug")).toBe(
+      "apple-watch",
+    );
+    expect(
+      valueFromEntityUrl(
+        "https://store.com/tv-4k/p?skuId=12",
+        "/:slug/p",
+        "slug",
+      ),
+    ).toBe("tv-4k");
+  });
+
+  test("Magento catch-all (no /p) keeps the whole path, multi-segment ok", () => {
+    expect(valueFromEntityUrl("/eau-de-toilette-spritz-100ml", "/*", "*")).toBe(
+      "eau-de-toilette-spritz-100ml",
+    );
+    expect(valueFromEntityUrl("/granado/campanhas/produtos", "/*", "*")).toBe(
+      "granado/campanhas/produtos",
+    );
+  });
+
+  test("static prefix in the template is stripped", () => {
+    expect(
+      valueFromEntityUrl("/granado/spritz-100ml", "/granado/:slug", "slug"),
+    ).toBe("spritz-100ml");
+  });
+
+  test("decodes percent-encoded values", () => {
+    expect(valueFromEntityUrl("/caf%C3%A9/p", "/:slug/p", "slug")).toBe("café");
+  });
+
+  test("rejects non-string, unparseable, and empty results", () => {
+    expect(valueFromEntityUrl(undefined, "/:slug/p", "slug")).toBeNull();
+    expect(valueFromEntityUrl(42, "/:slug/p", "slug")).toBeNull();
+    expect(valueFromEntityUrl("", "/:slug/p", "slug")).toBeNull();
+    expect(valueFromEntityUrl("/p", "/:slug/p", "slug")).toBeNull();
+    expect(valueFromEntityUrl("/x/p", "/*", "missing")).toBeNull();
+  });
+});
+
+describe("productOptionsFromPayload", () => {
+  test("maps a Product[] with label precedence and image", () => {
+    const payload = [
+      {
+        url: "https://store.com/tv-4k/p",
+        name: "TV 4K 55in",
+        isVariantOf: { name: "TV 4K" },
+        image: [{ url: "https://img.com/tv.jpg" }],
+      },
+      { url: "/mouse/p", name: "Mouse" },
+      { url: "/keyboard/p" },
+    ];
+    expect(productOptionsFromPayload(payload, pdpCtx)).toEqual([
+      { value: "tv-4k", label: "TV 4K", image: "https://img.com/tv.jpg" },
+      { value: "mouse", label: "Mouse", image: undefined },
+      { value: "keyboard", label: "keyboard", image: undefined },
     ]);
+  });
+
+  test("accepts a ProductListingPage ({ products })", () => {
+    const payload = { products: [{ url: "/tv/p", name: "TV" }] };
+    expect(productOptionsFromPayload(payload, pdpCtx)).toEqual([
+      { value: "tv", label: "TV", image: undefined },
+    ]);
+  });
+
+  test("accepts a ProductList ({ list }) — e.g. the Algolia loader", () => {
+    const payload = {
+      "@type": "ProductList",
+      list: [{ url: "/tv/p", name: "TV" }],
+    };
+    expect(productOptionsFromPayload(payload, pdpCtx)).toEqual([
+      { value: "tv", label: "TV", image: undefined },
+    ]);
+  });
+
+  test("catch-all template derives the full-path value", () => {
+    const payload = [{ url: "/eau-de-toilette-100ml", name: "Spritz" }];
+    expect(
+      productOptionsFromPayload(payload, { template: "/*", paramName: "*" }),
+    ).toEqual([
+      { value: "eau-de-toilette-100ml", label: "Spritz", image: undefined },
+    ]);
+  });
+
+  test("skips items without an extractable value and dedupes", () => {
+    const payload = [
+      { url: "/tv/p", name: "TV" },
+      { url: "/tv/p", name: "TV duplicate" },
+      { url: "/p", name: "Nope" },
+      { name: "No url" },
+      null,
+      "garbage",
+    ];
+    expect(productOptionsFromPayload(payload, pdpCtx)).toEqual([
+      { value: "tv", label: "TV", image: undefined },
+    ]);
+  });
+
+  test("non-array, non-listing payloads yield no options", () => {
+    expect(productOptionsFromPayload(null, pdpCtx)).toEqual([]);
+    expect(productOptionsFromPayload({}, pdpCtx)).toEqual([]);
+    expect(productOptionsFromPayload("x", pdpCtx)).toEqual([]);
+  });
+});
+
+describe("collectPageLoaderResolveTypes", () => {
+  const isLoader = (rt: string) => rt.includes("/loaders/");
+
+  test("collects nested inline loader resolveTypes, ignores sections and non-loaders", () => {
+    const page = {
+      __resolveType: "website/pages/Page.tsx",
+      sections: [
+        {
+          __resolveType: "site/sections/ProductDetails.tsx",
+          page: { __resolveType: MAGENTO_PDP, props: { slug: "x" } },
+        },
+        { __resolveType: "site/sections/Shelf.tsx" },
+      ],
+      loader: { __resolveType: MAGENTO_PLP },
+    };
+    expect(
+      [...collectPageLoaderResolveTypes(page, {}, isLoader)].sort(),
+    ).toEqual([MAGENTO_PDP, MAGENTO_PLP].sort());
+  });
+
+  test("follows __resolveType block references and keeps the block name", () => {
+    // Granado wires loaders as saved blocks referenced by key, not inline.
+    const decofile = {
+      "PDP Magento loader (GQL)": { __resolveType: MAGENTO_PDP, foo: 1 },
+      "PLP Magento loader": { __resolveType: MAGENTO_PLP },
+      // A non-loader block with a PDP-ish name is NOT kept as a signal.
+      "PDP Shelf": { __resolveType: "site/sections/Product/Shelf.tsx" },
+    };
+    const page = {
+      __resolveType: "website/pages/Page.tsx",
+      sections: [
+        { page: { __resolveType: "PDP Magento loader (GQL)" } },
+        { page: { __resolveType: "PLP Magento loader" } },
+        { shelf: { __resolveType: "PDP Shelf" } },
+      ],
+    };
+    expect(
+      [...collectPageLoaderResolveTypes(page, decofile, isLoader)].sort(),
+    ).toEqual(
+      [
+        MAGENTO_PDP,
+        MAGENTO_PLP,
+        "PDP Magento loader (GQL)",
+        "PLP Magento loader",
+      ].sort(),
+    );
+  });
+
+  test("tolerates cycles and malformed input", () => {
+    const decofile = { a: { __resolveType: "b" }, b: { __resolveType: "a" } };
+    expect([
+      ...collectPageLoaderResolveTypes(
+        { __resolveType: "a" },
+        decofile,
+        isLoader,
+      ),
+    ]).toEqual([]);
+    expect([...collectPageLoaderResolveTypes(null, {}, isLoader)]).toEqual([]);
+    expect([...collectPageLoaderResolveTypes("x", {}, isLoader)]).toEqual([]);
+    expect([
+      ...collectPageLoaderResolveTypes([{ a: 1 }], {}, isLoader),
+    ]).toEqual([]);
   });
 });
 
@@ -99,81 +405,6 @@ describe("mergePickerOptions", () => {
   test("empty lists merge to empty", () => {
     expect(mergePickerOptions([])).toEqual([]);
     expect(mergePickerOptions([[], []])).toEqual([]);
-  });
-});
-
-describe("productSlugFromUrl", () => {
-  test("extracts the segment before /p", () => {
-    expect(productSlugFromUrl("https://store.com/apple-watch/p")).toBe(
-      "apple-watch",
-    );
-    expect(productSlugFromUrl("/apple-watch/p")).toBe("apple-watch");
-    expect(productSlugFromUrl("/apple-watch/p/")).toBe("apple-watch");
-    expect(productSlugFromUrl("https://store.com/tv-4k/p?skuId=12")).toBe(
-      "tv-4k",
-    );
-  });
-
-  test("decodes percent-encoded slugs", () => {
-    expect(productSlugFromUrl("/caf%C3%A9/p")).toBe("café");
-  });
-
-  test("rejects urls without the /p suffix or with extra segments", () => {
-    expect(productSlugFromUrl("https://store.com/apple-watch")).toBeNull();
-    expect(productSlugFromUrl("/a/b/p")).toBeNull();
-    expect(productSlugFromUrl("/p")).toBeNull();
-  });
-
-  test("rejects non-string and unparseable values", () => {
-    expect(productSlugFromUrl(undefined)).toBeNull();
-    expect(productSlugFromUrl(42)).toBeNull();
-    expect(productSlugFromUrl("")).toBeNull();
-    expect(productSlugFromUrl("http://")).toBeNull();
-  });
-});
-
-describe("productOptionsFromPayload", () => {
-  test("maps products to options with label precedence and image", () => {
-    const payload = [
-      {
-        url: "https://store.com/tv-4k/p",
-        name: "TV 4K 55in",
-        isVariantOf: { name: "TV 4K" },
-        image: [{ url: "https://img.com/tv.jpg" }],
-      },
-      { url: "/mouse/p", name: "Mouse" },
-      { url: "/keyboard/p" },
-    ];
-    expect(productOptionsFromPayload(payload)).toEqual([
-      { value: "tv-4k", label: "TV 4K", image: "https://img.com/tv.jpg" },
-      { value: "mouse", label: "Mouse", image: undefined },
-      { value: "keyboard", label: "keyboard", image: undefined },
-    ]);
-  });
-
-  test("skips items without an extractable slug and dedupes", () => {
-    const payload = [
-      { url: "/tv/p", name: "TV" },
-      { url: "/tv/p", name: "TV duplicate" },
-      { url: "/not-a-product", name: "Nope" },
-      { name: "No url" },
-      null,
-      "garbage",
-    ];
-    expect(productOptionsFromPayload(payload)).toEqual([
-      { value: "tv", label: "TV", image: undefined },
-    ]);
-  });
-
-  test("non-string image entries are dropped", () => {
-    const payload = [{ url: "/tv/p", name: "TV", image: [{ url: 42 }] }];
-    expect(productOptionsFromPayload(payload)[0]?.image).toBeUndefined();
-  });
-
-  test("non-array payloads yield no options", () => {
-    expect(productOptionsFromPayload(null)).toEqual([]);
-    expect(productOptionsFromPayload({})).toEqual([]);
-    expect(productOptionsFromPayload("x")).toEqual([]);
   });
 });
 
@@ -200,10 +431,7 @@ describe("categoryOptionsFromPayload", () => {
 
   test("nodes without a url still recurse into children", () => {
     const payload = [
-      {
-        name: "Root",
-        children: [{ name: "Leaf", url: "/root/leaf" }],
-      },
+      { name: "Root", children: [{ name: "Leaf", url: "/root/leaf" }] },
     ];
     expect(categoryOptionsFromPayload(payload)).toEqual([
       { value: "root/leaf", label: "Root › Leaf" },

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker.ts
@@ -3,8 +3,8 @@ import {
   splitPathTemplate,
 } from "@/web/components/sections-editor/page-path-utils";
 
-/** Entity kind a path param can be filled from. VTEX-only for now. */
-export type PathParamPickerKind = "product" | "category";
+/** Entity kind a path param can be filled from. */
+export type PathParamKind = "product" | "category";
 
 export interface PathParamOption {
   /** Committed into the param — never has a leading slash. */
@@ -13,77 +13,344 @@ export interface PathParamOption {
   image?: string;
 }
 
-/** Loader each kind invokes — also the manifest-gating key. VTEX-only for now. */
-export const PICKER_LOADER_RESOLVE_TYPE: Record<PathParamPickerKind, string> = {
-  product: "vtex/loaders/intelligentSearch/productList.ts",
-  category: "vtex/loaders/categories/tree.ts",
-};
-
-/**
- * Which picker (if any) a param of a path template gets:
- *
- * - the `*` catch-all → "category" (PLP-style pages, e.g. `/*`)
- * - a `:param` immediately followed by a literal `/p` at the END of the
- *   template → "product" (PDP-style pages, e.g. `/:slug/p`)
- * - everything else → null (free typing only)
- */
-export function detectPickerKind(
-  template: string,
-  paramName: string,
-): PathParamPickerKind | null {
-  const tokens = splitPathTemplate(normalizePagePath(template));
-  if (paramName === "*") {
-    return tokens.some((t) => t.type === "param" && t.name === "*")
-      ? "category"
-      : null;
-  }
-  const last = tokens[tokens.length - 1];
-  const prev = tokens[tokens.length - 2];
-  return last?.type === "text" &&
-    last.text === "/p" &&
-    prev?.type === "param" &&
-    prev.name === paramName
-    ? "product"
-    : null;
-}
-
 export interface PickerLoaderRequest {
   resolveType: string;
   props: Record<string, unknown>;
 }
 
+/** Context a payload mapper needs to derive param values relative to the route. */
+export interface OptionPayloadContext {
+  template: string;
+  paramName: string;
+}
+
 /**
- * Loader calls for a kind and search term — results are merged in order.
- *
- * Products search server-side and must match by name, id, and slug:
- * intelligent search's `query` only matches names, so a numeric term also
- * tries `ids` (the same productList variant the blog blocks use), and a
- * slug-like term (hyphenated, no spaces) is de-hyphenated so its words match
- * the product name. The category tree is fetched once (term-independent) and
- * filtered client-side.
+ * A concrete way to enumerate options for one kind: the manifest loader to
+ * invoke, the requests to build from a search term, and how to map the payload.
+ * Bound to a specific `resolveType` discovered in the running site's manifest.
  */
-export function pickerLoaderRequests(
-  kind: PathParamPickerKind,
+export interface OptionSource {
+  kind: PathParamKind;
+  /** Stable id — also the react-query cache-key discriminator. */
+  id: string;
+  /** Loader invoked to enumerate options (present in the manifest). */
+  resolveType: string;
+  /** Options fetched once (term-independent) and filtered client-side. */
+  clientFilter: boolean;
+  buildRequests: (term: string) => PickerLoaderRequest[];
+  optionsFromPayload: (
+    payload: unknown,
+    ctx: OptionPayloadContext,
+  ) => PathParamOption[];
+}
+
+/**
+ * Loaders whose presence on a page classify its dynamic param. Matched against
+ * the loader module resolveTypes AND the descriptive saved-block names the page
+ * references (both surfaced by {@link collectPageLoaderResolveTypes}), so
+ * detection is app-agnostic: it catches the `detailsPage`/`listingPage` module
+ * convention (VTEX `productDetailsPage`, Magento `detailsPageGQL`, …) as well as
+ * blocks a site simply named `PDP …` / `PLP …`. URL-shape is a complementary
+ * fallback (see {@link classifyParamKinds}).
+ */
+const DETAIL_LOADER_RE = /details?page|\bpdp\b/i;
+const LISTING_LOADER_RE = /listingpage|\bplp\b/i;
+
+/**
+ * Kinds a path param can be filled from, derived from BOTH the loaders the
+ * current page uses and the template shape:
+ *
+ * - loader-based (primary, app-agnostic): a `*detailsPage*` loader → product, a
+ *   `*listingPage*` loader → category. A catch-all page that wires both (e.g.
+ *   Magento's runtime PDP/PLP router) yields both.
+ * - URL-shape (fallback, keeps VTEX zero-config): a `:param` right before a
+ *   trailing `/p` → product; the `*` catch-all → category.
+ */
+export function classifyParamKinds(
+  template: string,
+  paramName: string,
+  pageLoaders: ReadonlySet<string>,
+): Set<PathParamKind> {
+  const kinds = new Set<PathParamKind>();
+  for (const rt of pageLoaders) {
+    if (DETAIL_LOADER_RE.test(rt)) kinds.add("product");
+    if (LISTING_LOADER_RE.test(rt)) kinds.add("category");
+  }
+  const tokens = splitPathTemplate(normalizePagePath(template));
+  const last = tokens[tokens.length - 1];
+  const prev = tokens[tokens.length - 2];
+  if (
+    last?.type === "text" &&
+    last.text === "/p" &&
+    prev?.type === "param" &&
+    prev.name === paramName
+  ) {
+    kinds.add("product");
+  }
+  if (
+    paramName === "*" &&
+    tokens.some((t) => t.type === "param" && t.name === "*")
+  ) {
+    kinds.add("category");
+  }
+  return kinds;
+}
+
+/**
+ * VTEX intelligent-search product requests: numeric terms also try the `ids`
+ * variant (ids first), slug-like terms are de-hyphenated so their words match
+ * the product name. `query`/`count` is the VTEX convention.
+ */
+function vtexProductRequests(
+  resolveType: string,
   term: string,
 ): PickerLoaderRequest[] {
-  if (kind === "category") {
-    return [{ resolveType: PICKER_LOADER_RESOLVE_TYPE.category, props: {} }];
-  }
   const trimmed = term.trim();
   const requests: PickerLoaderRequest[] = [];
   if (/^\d+$/.test(trimmed)) {
-    requests.push({
-      resolveType: PICKER_LOADER_RESOLVE_TYPE.product,
-      props: { ids: [trimmed] },
-    });
+    requests.push({ resolveType, props: { ids: [trimmed] } });
   }
   const slugLike = trimmed.includes("-") && !/\s/.test(trimmed);
   const query = slugLike ? trimmed.replace(/-+/g, " ") : trimmed;
-  requests.push({
-    resolveType: PICKER_LOADER_RESOLVE_TYPE.product,
-    props: { query, count: 10 },
-  });
+  requests.push({ resolveType, props: { query, count: 10 } });
   return requests;
+}
+
+/**
+ * Ordered candidate loaders per kind. Resolution ({@link resolveOptionSources})
+ * scans the running site's manifest and binds the FIRST candidate present — so
+ * the loader is discovered dynamically, not hardcoded per app (a Magento PDP
+ * page classified as "product" is searched via whatever product-search loader
+ * the site actually ships, e.g. Algolia). Adding an app = adding a candidate.
+ */
+interface OptionSourceCandidate {
+  kind: PathParamKind;
+  /** Whether a manifest loader resolveType can serve this candidate. */
+  test: (resolveType: string) => boolean;
+  clientFilter: boolean;
+  buildRequests: (resolveType: string, term: string) => PickerLoaderRequest[];
+  optionsFromPayload: (
+    payload: unknown,
+    ctx: OptionPayloadContext,
+  ) => PathParamOption[];
+}
+
+/**
+ * First-segment app namespaces that are commerce providers. Used to avoid
+ * invoking one provider's loader on a site running another — e.g. a Magento
+ * store often also has the VTEX app installed, so `vtex/loaders/...` exists in
+ * the manifest and would otherwise be picked, hitting the wrong backend.
+ * Neutral namespaces (`site`, `commerce`, `algolia`, …) are NOT listed and are
+ * always allowed.
+ */
+const COMMERCE_VENDOR_NAMESPACES = new Set([
+  "vtex",
+  "shopify",
+  "shopify-mcp",
+  "magento",
+  "wake",
+  "linx",
+  "linx-impulse",
+  "nuvemshop",
+  "vnda",
+  "wap",
+  "salesforce",
+]);
+
+function loaderVendor(resolveType: string): string {
+  return resolveType.split("/")[0] ?? "";
+}
+
+/** Commerce platform namespaces a page uses, from its loader resolveTypes. */
+export function commercePlatformsFromLoaders(
+  loaders: Iterable<string>,
+): Set<string> {
+  const platforms = new Set<string>();
+  for (const rt of loaders) {
+    const vendor = loaderVendor(rt);
+    if (COMMERCE_VENDOR_NAMESPACES.has(vendor)) platforms.add(vendor);
+  }
+  return platforms;
+}
+
+/**
+ * Whether a loader may serve an option source given the page's platforms. A
+ * loader from a commerce vendor NOT among the page's platforms is a competing
+ * backend and rejected; neutral loaders (site/commerce/algolia/…) and the
+ * page's own platform are allowed. No detected platform → no restriction.
+ */
+function allowedForPlatforms(
+  resolveType: string,
+  platforms: ReadonlySet<string>,
+): boolean {
+  const vendor = loaderVendor(resolveType);
+  if (!COMMERCE_VENDOR_NAMESPACES.has(vendor)) return true;
+  if (platforms.size === 0) return true;
+  return platforms.has(vendor);
+}
+
+const OPTION_SOURCE_CANDIDATES: OptionSourceCandidate[] = [
+  // Product search — must accept a free-text term.
+  {
+    kind: "product",
+    test: (rt) => rt === "vtex/loaders/intelligentSearch/productList.ts",
+    clientFilter: false,
+    buildRequests: vtexProductRequests,
+    optionsFromPayload: productOptionsFromPayload,
+  },
+  {
+    // Magento full-text product search (`products(search:)`) — the platform's
+    // own public GraphQL, preferred over a neutral search index when the page
+    // is Magento (see the platform-priority pass in resolveOptionSources). Its
+    // props are nested under `props` (a `TermProps`); `currentPage` is required
+    // alongside `search`/`pageSize`.
+    kind: "product",
+    test: (rt) => /magento\/.*products?\/list(\.tsx?)?$/i.test(rt),
+    clientFilter: false,
+    buildRequests: (resolveType, term) => [
+      {
+        resolveType,
+        props: { props: { search: term.trim(), pageSize: 10, currentPage: 1 } },
+      },
+    ],
+    optionsFromPayload: productOptionsFromPayload,
+  },
+  {
+    // Algolia product search (site-local or app), `term`/`hitsPerPage`.
+    kind: "product",
+    test: (rt) =>
+      /algolia\/.*products?\/(list|suggestions)(\.tsx?)?$/i.test(rt),
+    clientFilter: false,
+    buildRequests: (resolveType, term) => [
+      { resolveType, props: { term: term.trim(), hitsPerPage: 10 } },
+    ],
+    optionsFromPayload: productOptionsFromPayload,
+  },
+  {
+    // Generic product-list fallback. Passes both prop conventions; Zod strips
+    // the unknown ones, so a loader taking either shape still works.
+    kind: "product",
+    test: (rt) => /products?\/list(\.tsx?)?$/i.test(rt),
+    clientFilter: false,
+    buildRequests: (resolveType, term) => [
+      {
+        resolveType,
+        props: {
+          query: term.trim(),
+          term: term.trim(),
+          count: 10,
+          hitsPerPage: 10,
+        },
+      },
+    ],
+    optionsFromPayload: productOptionsFromPayload,
+  },
+  // Category — a term-independent tree, filtered client-side.
+  {
+    kind: "category",
+    test: (rt) =>
+      rt === "vtex/loaders/categories/tree.ts" ||
+      /categor(y|ies).*tree/i.test(rt),
+    clientFilter: true,
+    buildRequests: (resolveType) => [{ resolveType, props: {} }],
+    optionsFromPayload: categoryOptionsFromPayload,
+  },
+];
+
+/**
+ * For each requested kind, bind the first candidate loader present in the
+ * manifest into a concrete {@link OptionSource}. Kinds with no available loader
+ * are dropped (the free-text "Use …" row and the plain inline input still let
+ * the user type a value). Preserves candidate order = priority.
+ */
+export function resolveOptionSources(
+  kinds: ReadonlySet<PathParamKind>,
+  manifestLoaders: ReadonlySet<string>,
+  platforms: ReadonlySet<string> = new Set(),
+): OptionSource[] {
+  const loaders = [...manifestLoaders];
+  const sources: OptionSource[] = [];
+  for (const kind of ["product", "category"] as const) {
+    if (!kinds.has(kind)) continue;
+    // Collect every candidate that resolves to an allowed loader, in candidate
+    // order, then prefer one from the page's own platform (Magento's native
+    // search over a neutral Algolia index) — otherwise take the first.
+    const matches: { cand: OptionSourceCandidate; resolveType: string }[] = [];
+    for (const cand of OPTION_SOURCE_CANDIDATES) {
+      if (cand.kind !== kind) continue;
+      const resolveType = loaders.find(
+        (rt) => cand.test(rt) && allowedForPlatforms(rt, platforms),
+      );
+      if (resolveType) matches.push({ cand, resolveType });
+    }
+    const chosen =
+      matches.find((m) => platforms.has(loaderVendor(m.resolveType))) ??
+      matches[0];
+    if (!chosen) continue;
+    const { cand, resolveType } = chosen;
+    sources.push({
+      kind,
+      id: `${kind}:${resolveType}`,
+      resolveType,
+      clientFilter: cand.clientFilter,
+      buildRequests: (term) => cand.buildRequests(resolveType, term),
+      optionsFromPayload: cand.optionsFromPayload,
+    });
+  }
+  return sources;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Loader signals reachable from a page block, for {@link classifyParamKinds}.
+ * Detail/listing loaders sit either inline in section props OR — as in the CMS
+ * — behind a `__resolveType` that names another decofile block (e.g.
+ * `"PDP Magento loader (GQL)"` whose block holds
+ * `magento/loaders/product/detailsPageGQL.ts`). Both are followed: a
+ * `__resolveType` that is a manifest loader is collected; one that is a decofile
+ * key is resolved and walked (guarded against cycles). When a followed
+ * reference points at a loader block, the **descriptive block key** (`"PDP …"`)
+ * is collected too, so a param can be classified by the loader's name even when
+ * its module doesn't follow the `detailsPage`/`listingPage` convention.
+ */
+export function collectPageLoaderResolveTypes(
+  pageBlock: unknown,
+  decofile: Record<string, unknown>,
+  isLoader: (resolveType: string) => boolean,
+): Set<string> {
+  const found = new Set<string>();
+  const visited = new Set<string>();
+  const walk = (node: unknown) => {
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    const rec = asRecord(node);
+    if (!rec) return;
+    const rt = rec.__resolveType;
+    if (typeof rt === "string") {
+      if (isLoader(rt)) found.add(rt);
+      // Block reference: `__resolveType` names another block — follow it so
+      // loaders wired as saved blocks (not inline) are still discovered.
+      else if (rt in decofile && !visited.has(rt)) {
+        visited.add(rt);
+        const targetRt = asRecord(decofile[rt])?.__resolveType;
+        // Keep the human-readable block name as a classification signal, but
+        // only for blocks that actually are loaders (avoids matching a section
+        // that merely happens to be named "PDP …").
+        if (typeof targetRt === "string" && isLoader(targetRt)) found.add(rt);
+        walk(decofile[rt]);
+      }
+    }
+    for (const value of Object.values(rec)) walk(value);
+  };
+  walk(pageBlock);
+  return found;
 }
 
 /** Merge option lists in order, dropping later duplicates by value. */
@@ -102,12 +369,6 @@ export function mergePickerOptions(
   return merged;
 }
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
 /** Percent-decode, tolerating malformed sequences (returns the raw string). */
 function safeDecode(value: string): string {
   try {
@@ -118,11 +379,23 @@ function safeDecode(value: string): string {
 }
 
 /**
- * Slug from a product URL: the single pathname segment before the trailing
- * `/p` (e.g. `https://store.com/apple-watch/p` → `apple-watch`). Accepts
- * relative or absolute URLs; null when the shape doesn't match.
+ * The value to commit into `paramName` for an entity URL, derived RELATIVE to
+ * the page template — no `/p` or provider-specific shape assumed. The template's
+ * static text before and after the param is stripped from the entity pathname;
+ * the remainder is the value:
+ *
+ * - `/apple-watch/p`            on `/:slug/p`        → `apple-watch`
+ * - `/eau-de-toilette-100ml`    on `/*`              → `eau-de-toilette-100ml`
+ * - `/granado/x`                on `/granado/:slug`  → `x`
+ *
+ * Catch-all values keep internal slashes (multi-segment). Returns null when the
+ * URL is unusable.
  */
-export function productSlugFromUrl(url: unknown): string | null {
+export function valueFromEntityUrl(
+  url: unknown,
+  template: string,
+  paramName: string,
+): string | null {
   if (typeof url !== "string" || !url) return null;
   let pathname: string;
   try {
@@ -130,33 +403,71 @@ export function productSlugFromUrl(url: unknown): string | null {
   } catch {
     return null;
   }
-  const slug = pathname.match(/^\/([^/]+)\/p\/?$/)?.[1];
-  return slug ? safeDecode(slug) : null;
+  // Drop a trailing slash so it matches the normalized template's static text.
+  pathname = pathname.replace(/\/+$/, "");
+  const tokens = splitPathTemplate(normalizePagePath(template));
+  const idx = tokens.findIndex(
+    (t) => t.type === "param" && t.name === paramName,
+  );
+  if (idx === -1) return null;
+  const before = tokens
+    .slice(0, idx)
+    .map((t) => (t.type === "text" ? t.text : ""))
+    .join("");
+  const after = tokens
+    .slice(idx + 1)
+    .map((t) => (t.type === "text" ? t.text : ""))
+    .join("");
+  // Strip the trailing static text first, then the leading — a shared boundary
+  // slash (e.g. `/p` after `/:slug`) must not be consumed twice.
+  let rest = pathname;
+  if (after && rest.endsWith(after)) {
+    rest = rest.slice(0, rest.length - after.length);
+  }
+  rest =
+    before && rest.startsWith(before)
+      ? rest.slice(before.length)
+      : rest.replace(/^\/+/, "");
+  rest = rest.replace(/^\/+|\/+$/g, "");
+  return rest ? safeDecode(rest) : null;
 }
 
 /**
- * Options from a `productList` payload (`Product[] | null`). Items without an
- * extractable slug are skipped; duplicate slugs are deduped.
+ * Options from a product-search payload — accepts the schema.org shapes commerce
+ * list/search loaders return: a bare `Product[]`, a `ProductListingPage`
+ * (`{ products }`), or a `ProductList` (`{ list }`, e.g. the Algolia loader).
+ * Items without an extractable value are skipped; duplicate values are deduped.
+ * Label prefers `isVariantOf.name`.
  */
-export function productOptionsFromPayload(data: unknown): PathParamOption[] {
-  if (!Array.isArray(data)) return [];
+export function productOptionsFromPayload(
+  data: unknown,
+  ctx: OptionPayloadContext,
+): PathParamOption[] {
+  const rec = asRecord(data);
+  const items = Array.isArray(data)
+    ? data
+    : Array.isArray(rec?.products)
+      ? (rec.products as unknown[])
+      : Array.isArray(rec?.list)
+        ? (rec.list as unknown[])
+        : [];
   const options: PathParamOption[] = [];
   const seen = new Set<string>();
-  for (const item of data) {
+  for (const item of items) {
     const rec = asRecord(item);
     if (!rec) continue;
-    const slug = productSlugFromUrl(rec.url);
-    if (!slug || seen.has(slug)) continue;
-    seen.add(slug);
+    const value = valueFromEntityUrl(rec.url, ctx.template, ctx.paramName);
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
     const variant = asRecord(rec.isVariantOf);
     const label =
       (typeof variant?.name === "string" && variant.name) ||
       (typeof rec.name === "string" && rec.name) ||
-      slug;
+      value;
     const imageEntry = Array.isArray(rec.image) ? asRecord(rec.image[0]) : null;
     const image =
       typeof imageEntry?.url === "string" ? imageEntry.url : undefined;
-    options.push({ value: slug, label, image });
+    options.push({ value, label, image });
   }
   return options;
 }

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -98,12 +98,17 @@ import {
 import { derivePhaseProgress } from "./derive-phase-progress";
 import { ideDeepLink } from "../ide-deep-link";
 import {
-  detectPickerKind,
-  PICKER_LOADER_RESOLVE_TYPE,
-  type PathParamPickerKind,
+  classifyParamKinds,
+  collectPageLoaderResolveTypes,
+  commercePlatformsFromLoaders,
+  resolveOptionSources,
+  type OptionSource,
 } from "./path-param-picker";
-import { PathParamPickerChip } from "./path-param-picker-chip";
-import { isManifestRunnableResolveType } from "@/web/components/sandbox/content/runnable-catalog";
+import {
+  PathParamAutoFill,
+  PathParamPickerChip,
+} from "./path-param-picker-chip";
+import { manifestLoaderResolveTypes } from "@/web/components/sandbox/content/runnable-catalog";
 import { track } from "@/web/lib/posthog-client";
 import { useSandboxRepoDir } from "../hooks/use-sandbox-repo-dir";
 
@@ -159,7 +164,7 @@ function PathParamInput({
   const [draft, setDraft] = useState(value);
   const [focused, setFocused] = useState(false);
   const cancelledRef = useRef(false);
-  const label = name === "*" ? "*" : `:${name}`;
+  const label = name === "*" ? "path" : `:${name}`;
   const sizer = draft || label;
   return (
     <>
@@ -400,25 +405,27 @@ export function PreviewContent({
     (currentPageKey ? pathParamsByPage[currentPageKey] : undefined) ?? {};
   const resolvedPath = fillPathTemplate(currentPath, pathParamValues);
 
-  // Special selectors for path params: PDP-style params get a product picker,
-  // the PLP catch-all a category picker — only when the running site's
-  // manifest actually has the VTEX loader the picker invokes.
-  const pathParamPickerKinds: Record<string, PathParamPickerKind> = {};
-  if (devServerReady && previewUrl && meta) {
+  // Special selectors for path params: each `:param`/`*` is classified from the
+  // loaders the current page uses (product/category, app-agnostic) and bound to
+  // whatever product-search / category loader the running site actually ships.
+  // A param with no resolvable source keeps the plain inline input.
+  const pathParamSources: Record<string, OptionSource[]> = {};
+  if (devServerReady && previewUrl && meta && decofile) {
+    const manifestLoaders = manifestLoaderResolveTypes(meta, "loaders");
+    const pageBlock = currentPageKey ? decofile[currentPageKey] : undefined;
+    const pageLoaders = collectPageLoaderResolveTypes(
+      pageBlock,
+      decofile,
+      (rt) => manifestLoaders.has(rt),
+    );
+    // The page's commerce platform (e.g. magento) — so option sources don't
+    // invoke a competing vendor's loader that merely exists in the manifest.
+    const platforms = commercePlatformsFromLoaders(pageLoaders);
     for (const token of splitPathTemplate(currentPath)) {
       if (token.type !== "param") continue;
-      const name = token.name;
-      const kind = detectPickerKind(currentPath, name);
-      if (
-        kind &&
-        isManifestRunnableResolveType(
-          meta,
-          PICKER_LOADER_RESOLVE_TYPE[kind],
-          "loaders",
-        )
-      ) {
-        pathParamPickerKinds[name] = kind;
-      }
+      const kinds = classifyParamKinds(currentPath, token.name, pageLoaders);
+      const sources = resolveOptionSources(kinds, manifestLoaders, platforms);
+      if (sources.length > 0) pathParamSources[token.name] = sources;
     }
   }
   const pickerSandboxRef =
@@ -952,6 +959,22 @@ export function PreviewContent({
 
   return (
     <div className="flex flex-col w-full h-full">
+      {/* Auto-select the first entity for a picker param with no value yet, so
+          navigating to a bare dynamic-route template lands on a real page.
+          Each helper renders nothing and unmounts once its param is filled. */}
+      {pickerSandboxRef &&
+        Object.entries(pathParamSources).map(([name, sources]) =>
+          (pathParamValues[name] ?? "") === "" ? (
+            <PathParamAutoFill
+              key={`${currentPageKey}:${name}`}
+              source={sources[0]!}
+              template={currentPath}
+              paramName={name}
+              sandboxRef={pickerSandboxRef}
+              onFill={(value) => setPathParamValue(name, value)}
+            />
+          ) : null,
+        )}
       {daemonReady && previewState.kind === "iframe" && (
         <div className="relative flex h-12 shrink-0 items-center gap-4 border-b border-border/60 px-3 md:px-4">
           {/* Groups 2+3 only render when the iframe is live — they read
@@ -1021,16 +1044,16 @@ export function PreviewContent({
                                   </span>
                                 );
                               }
-                              const pickerKind =
-                                pathParamPickerKinds[token.name];
-                              // Params with a picker render as a chip that
+                              const sources = pathParamSources[token.name];
+                              // Params with option sources render as a chip that
                               // opens the modal (search or free-form value);
                               // the rest keep the inline input.
-                              if (pickerKind && pickerSandboxRef) {
+                              if (sources && pickerSandboxRef) {
                                 return (
                                   <PathParamPickerChip
                                     key={`${currentPageKey}:${token.name}`}
-                                    kind={pickerKind}
+                                    sources={sources}
+                                    template={currentPath}
                                     paramName={token.name}
                                     value={pathParamValues[token.name] ?? ""}
                                     sandboxRef={pickerSandboxRef}

--- a/apps/mesh/src/web/components/sections-editor/page-path-utils.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-path-utils.test.ts
@@ -99,6 +99,17 @@ describe("page-path-utils", () => {
     );
   });
 
+  it("expands optional `{x}?` segments (always present) in split and fill", () => {
+    expect(splitPathTemplate("/{granado/}?*")).toEqual([
+      { type: "text", text: "/granado/" },
+      { type: "param", name: "*" },
+    ]);
+    expect(fillPathTemplate("/{granado/}?*", { "*": "eau-de-toilette" })).toBe(
+      "/granado/eau-de-toilette",
+    );
+    expect(fillPathTemplate("/bf{/70-off}?", {})).toBe("/bf/70-off");
+  });
+
   it("fillPathTemplate fills `*` keeping `/` separators, encoding segments", () => {
     expect(fillPathTemplate("/*", { "*": "category/shoes" })).toBe(
       "/category/shoes",

--- a/apps/mesh/src/web/components/sections-editor/page-path-utils.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-path-utils.ts
@@ -43,8 +43,19 @@ export type PathToken =
   | { type: "text"; text: string }
   | { type: "param"; name: string };
 
+/**
+ * Expand optional literal segments `{x}?` to their inner literal, treated as
+ * always present (e.g. `/{granado/}?*` → `/granado/*`, `/bf{/70-off}?` →
+ * `/bf/70-off`). Deco/TanStack route templates use this for optional path
+ * segments; the preview always renders the fuller form so the URL resolves.
+ */
+function expandOptionalSegments(path: string): string {
+  return path.replace(/\{([^{}]*)\}\?/g, "$1");
+}
+
 /** Split a path template into static text and `:param`/`*` tokens, in order. */
 export function splitPathTemplate(path: string): PathToken[] {
+  path = expandOptionalSegments(path);
   const tokens: PathToken[] = [];
   let last = 0;
   for (const match of path.matchAll(PATH_PARAM_RE)) {
@@ -65,18 +76,21 @@ export function fillPathTemplate(
   path: string,
   values: Record<string, string>,
 ): string {
-  return path.replace(PATH_PARAM_RE, (token, name?: string) => {
-    const value = values[name ?? "*"]?.trim();
-    if (!value) return token;
-    if (name !== undefined) return encodeURIComponent(value);
-    // The `*` catch-all may span multiple segments (e.g. `category/shoes`):
-    // keep `/` separators, encode each segment, drop empty ones (leading or
-    // doubled slashes in the typed value).
-    const filled = value
-      .split("/")
-      .filter(Boolean)
-      .map(encodeURIComponent)
-      .join("/");
-    return filled || token;
-  });
+  return expandOptionalSegments(path).replace(
+    PATH_PARAM_RE,
+    (token, name?: string) => {
+      const value = values[name ?? "*"]?.trim();
+      if (!value) return token;
+      if (name !== undefined) return encodeURIComponent(value);
+      // The `*` catch-all may span multiple segments (e.g. `category/shoes`):
+      // keep `/` separators, encode each segment, drop empty ones (leading or
+      // doubled slashes in the typed value).
+      const filled = value
+        .split("/")
+        .filter(Boolean)
+        .map(encodeURIComponent)
+        .join("/");
+      return filled || token;
+    },
+  );
 }


### PR DESCRIPTION
## What is this contribution about?
Generalizes the sandbox preview URL path-param picker (from #4432) beyond VTEX and URL-shape heuristics: each `:param`/`*` is classified from the loaders the page actually uses — following decofile block-key references and `PDP`/`PLP` block names, not just `/p`/`*` — then bound to whatever product/category loader the running site ships (VTEX intelligentSearch, Magento `products(search:)`, Algolia, …), scoped to the page's commerce platform so a competing vendor's loader that merely exists in the manifest (e.g. VTEX on a Magento store) is never invoked. Param values are derived relative to the route (no `/p` assumption; TanStack `{seg}?` optional segments expand so URLs resolve), the catch-all renders as a friendly "path" chip, typed values are slash-trimmed, and navigating a bare template auto-selects the first entity so the preview lands on a real page.

## Screenshots/Demonstration
Verified end-to-end against real Magento data (Granado): the picker resolves the Magento search loader, maps the `ProductList` response to options (e.g. "Arranjo Flores M" → `/granado/arranjo-flores-m`), and fills the catch-all correctly.

## How to Test
1. Open a site with a running dev server in the sandbox preview; go to a dynamic-route page (e.g. `/:slug/p`, `/*`, or a Magento catch-all).
2. The `:param`/`path` chip opens a picker that searches real store entities (or accepts a free-form value); the URL preview reflects the resolved path.
3. Expected: the correct loader for the site's platform is invoked, the first entity auto-fills on navigation, and picking navigates the preview to the real entity URL.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the sandbox preview path-param picker loader-driven and multi-platform, so each `:param`/`*` is classified from the page’s loaders and bound to whatever product/category loader the site ships. Also auto-selects the first entity for empty params and improves URL handling, making previews land on real pages.

- New Features
  - Classify params by page loaders and URL shape; supports VTEX, Magento, Algolia, and generic `products/list` loaders.
  - Resolve option sources from the manifest and scope to the page’s commerce platform to avoid cross-vendor loaders.
  - Product search builds sensible requests per loader; category trees fetch once and filter client-side.
  - Derive values relative to the route (no `/p` assumption), expand `{seg}?` optional segments, and label `*` as “path”.
  - Auto-fill: when a picker param is empty, fetch the first option and commit it so preview opens on a real entity.
  - Shared react-query cache between chip modal and auto-fill; friendly loading/error states.

- Refactors
  - Added `manifestLoaderResolveTypes` and page-walker to collect inline and referenced loader resolveTypes (keeps descriptive PDP/PLP block names).
  - Consolidated picker logic into `OptionSource` with request builders and payload mappers; added robust mappers for `Product[]`, `ProductListingPage`, and `ProductList`.
  - Enhanced path utils to expand optional segments and improved fill/split behavior. Added comprehensive tests for classification, source resolution, mapping, and URL/value derivation.
  - Made `pickerInvokeKey` and `fetchOptions` module-local and removed unused exports flagged by `knip`.

<sup>Written for commit fb5344b4216a0612073a89dcbe053fe7e154efb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

