### PR TITLE
fix(concurrency-gate): hand off released slot to earliest waiter atomically

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts
@@ -62,6 +62,40 @@ describe("createConcurrencyGate", () => {
     expect(gate.active).toBe(1);
   });
 
+  it("hands a released slot to the earliest waiter, not a fresh acquire racing in the same tick", async () => {
+    const gate = createConcurrencyGate(1);
+    const r1 = await gate.acquire(); // active = 1
+
+    const order: string[] = [];
+    const p2 = gate.acquire().then((r) => {
+      order.push("p2");
+      return r;
+    });
+
+    r1(); // frees the slot — must hand off to p2, not to whoever asks next
+
+    // A brand-new acquire issued in the same synchronous tick, before p2's
+    // continuation (a microtask) gets to run. It must queue behind p2, not
+    // steal the slot out from under it.
+    const p3 = gate.acquire().then((r) => {
+      order.push("p3");
+      return r;
+    });
+
+    const r2 = await p2;
+    expect(gate.active).toBe(1);
+    expect(gate.pending).toBe(1);
+    expect(order).toEqual(["p2"]);
+
+    r2();
+    const r3 = await p3;
+    expect(order).toEqual(["p2", "p3"]);
+    expect(gate.active).toBe(1);
+
+    r3();
+    expect(gate.active).toBe(0);
+  });
+
   it("coerces a sub-1 max up to 1", async () => {
     const gate = createConcurrencyGate(0);
     await gate.acquire();

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
@@ -34,17 +34,24 @@ export function createConcurrencyGate(max: number): ConcurrencyGate {
 
   return {
     async acquire() {
-      if (active >= limit) {
+      if (active < limit) {
+        active++;
+      } else {
+        // Parked: the eventual release() hands this slot off directly
+        // (active is never decremented for it), so no increment here either.
         await new Promise<void>((resolve) => waiters.push(resolve));
       }
-      active++;
 
       let released = false;
       return () => {
         if (released) return;
         released = true;
-        active--;
-        waiters.shift()?.();
+        const next = waiters.shift();
+        if (next) {
+          next();
+        } else {
+          active--;
+        }
       };
     },
     get active() {


### PR DESCRIPTION
## Source
A real bug found reading recently-changed code: `apps/mesh/src/dispatch-queue/hosted-run-concurrency.ts` (merged in #4575/#4577) reuses `createConcurrencyGate` from `subagent-concurrency.ts` to cap concurrent hosted agent-loop runs per pod and avoid OOM. The shared gate has a race that lets it exceed its own cap.

## The bug
`release()` freed a slot in two separate steps — decrement `active`, *then* signal the next waiter:

```ts
active--;
waiters.shift()?.();
```

If a brand-new `acquire()` call lands in the same synchronous tick (before the waiter's `await` resumes as a microtask), it sees the already-decremented `active` and grabs the slot itself. When the waiter's continuation later runs, it increments `active` again — so both the new caller and the queued waiter end up holding a slot, exceeding `max`.

Reproduced directly against the unpatched code:
```ts
const gate = createConcurrencyGate(1);
const r1 = await gate.acquire();       // active = 1
const p2 = gate.acquire();             // parked
r1();                                  // active-- (0), signals p2's resolver
const r3 = await gate.acquire();       // sees active=0 < 1, grabs the slot itself
const r2 = await p2;                   // p2 resumes, active++ → 2 (over cap!)
```

For `hosted-run-concurrency.ts` specifically, exceeding the cap under load is exactly the multi-hundred-MB-per-run OOM scenario the gate exists to prevent.

## Fix
Hand the slot directly to the queued waiter without ever touching `active` for it — the count stays representing the same logical slot throughout the handoff, closing the window. Falls back to a normal decrement only when there's no waiter.

## Regression test
Added `apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts`: `hands a released slot to the earliest waiter, not a fresh acquire racing in the same tick`. Confirmed it fails on the pre-fix code (`active` reaches 2 with `max=1`) and passes after the fix.

## To verify
```
bun test apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun test apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts` (6 pass)
- Skipped whole-workspace `tsc --noEmit` — repo already has an unrelated pre-existing type error in `rich-text-field.tsx` (missing `@tiptap/extension-text-align` types); this change touches no type signatures. Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `createConcurrencyGate` that let `active` exceed `max` by assigning released slots to new callers in the same tick. The gate now hands the slot to the earliest waiter atomically, keeping the hosted run cap accurate and avoiding OOM risk.

- **Bug Fixes**
  - Make handoff atomic: only increment `active` for immediate `acquire()`, and on release give the slot to the next waiter; decrement only if no waiters.
  - Add a regression test that fails on the old behavior and confirms the waiter receives the slot over a same-tick fresh `acquire()`.

<sup>Written for commit e8c147908a4be15518f223e6606315311797e97d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

