### PR TITLE
fix(concurrency-gate): clamp non-finite max to 1 instead of deadlocking

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts
@@ -96,6 +96,16 @@ describe("createConcurrencyGate", () => {
     expect(gate.active).toBe(0);
   });
 
+  it("coerces a non-finite max (e.g. an unparsed env value) up to 1 instead of deadlocking", async () => {
+    const gate = createConcurrencyGate(Number("not-a-number"));
+    await gate.acquire();
+    expect(gate.active).toBe(1);
+    let admitted = false;
+    void gate.acquire().then(() => (admitted = true));
+    await Promise.resolve();
+    expect(admitted).toBe(false);
+  });
+
   it("coerces a sub-1 max up to 1", async () => {
     const gate = createConcurrencyGate(0);
     await gate.acquire();

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
@@ -28,7 +28,11 @@ export interface ConcurrencyGate {
 }
 
 export function createConcurrencyGate(max: number): ConcurrencyGate {
-  const limit = Math.max(1, max);
+  // A NaN/Infinity `max` (e.g. from an unguarded env parse) must not reach
+  // `Math.max` here: Math.max(1, NaN) is NaN, and `active < NaN` is always
+  // false, so every acquire() would park forever — a total deadlock instead
+  // of the intended cap.
+  const limit = Number.isFinite(max) ? Math.max(1, max) : 1;
   let active = 0;
   const waiters: Array<() => void> = [];
 


### PR DESCRIPTION
## Source
Bug found reading `subagent-concurrency.ts` (recently touched by #4579), while checking the sibling `hosted-run-concurrency.ts` gate — which explicitly guards its env parse against non-finite values, a guard the shared gate factory itself lacks.

## Payoff
`createConcurrencyGate` is the process-wide gate bounding concurrent subagent fan-out (and, via the same factory, hosted agent-loop runs). A misconfigured `DECOPILOT_MAX_CONCURRENT_SUBAGENTS` env var silently deadlocks every subagent call on the pod instead of falling back to a sane default.

## Failure scenario
`createConcurrencyGate(max)` fed `max` straight into `Math.max(1, max)`. If `max` is `NaN` (e.g. `Number(process.env.DECOPILOT_MAX_CONCURRENT_SUBAGENTS)` when that env var is set to a non-numeric string), `Math.max(1, NaN)` is `NaN`, and `active < NaN` is always `false` — so every `acquire()` parks forever, hanging all subagent fan-out on that pod (not a crash, a silent deadlock).

Fix: treat a non-finite `max` the same as the existing sub-1 coercion — clamp to 1 rather than letting it reach `Math.max`.

Regression test added: `createConcurrencyGate(Number("not-a-number"))` — times out (deadlocks) on the old code, passes after the fix.

## Verify
```
bun test apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts
```

## Checks run locally
- `bun run fmt` (no changes)
- `bunx tsc --noEmit` in `apps/mesh` (no new errors — pre-existing unrelated errors in an unrelated file)
- `bun test apps/mesh/src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts` — 7 pass

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents subagent fan-out from deadlocking when `DECOPILOT_MAX_CONCURRENT_SUBAGENTS` is misconfigured. The concurrency gate now clamps non‑finite limits (NaN/Infinity) to 1.

- **Bug Fixes**
  - Clamp non-finite `max` to 1 in `createConcurrencyGate` to avoid a silent deadlock.
  - Add a regression test for NaN input.

<sup>Written for commit 1c2d9606082dc39f1cc7929121d7aef073d9ea9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

