### PR TITLE
fix(commerce-onboarding): reset github_repo on GitHub (re)connect

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
@@ -139,6 +139,14 @@ export function useConnectCompanion({
         card.bindingType,
         id,
       );
+      // GitHub carries a free-standing github_repo string on the CD state that is
+      // NOT tied to this connection id (unlike the binding value). A stale repo
+      // left over from a previous store would silently leak into the next run's
+      // report, so (re)connecting GitHub resets it — the user re-picks the repo in
+      // the config form against the just-connected account.
+      if (card.bindingType === "github") {
+        delete merged.github_repo;
+      }
       await updateConnection(cdConnectionId, { configuration_state: merged });
 
       // Step 3: refresh (flip to Connected).


### PR DESCRIPTION
## What is this contribution about?

Prevents a stale GitHub repo from leaking across diagnostic runs in the same org.

`github_repo` is a free-standing string on the Commerce Discovery connection's `configuration_state`, decoupled from the GitHub connection id and only ever merged, never cleared. A repo picked for one store therefore survived into the next run in the same org, leaking a stale repo into the report (e.g. a `fila.com.br` run auditing `deco-sites/granadobr`).

The GitHub companion now clears `github_repo` whenever it is (re)connected, so the config form starts empty and the user re-selects the repo against the just-connected account.

> Note: the `github_repo` forwarding to the run (`reports/run.ts` + `auth-client.ts`) already landed on `main`; this PR is scoped to the reset fix only.

## Screenshots/Demonstration

N/A — no visual changes; behavior change is in the connect flow.

## How to Test

1. In Commerce onboarding for an org, connect the GitHub companion and pick a repo (e.g. `owner/repo-a`). Confirm it is saved on the CD connection's `configuration_state.github_repo`.
2. Re-open the GitHub companion and reconnect it. Confirm `github_repo` is cleared from `configuration_state` and the repo picker starts empty.
3. Pick a different repo (`owner/repo-b`), run again, and confirm the run forwards `owner/repo-b` — no leakage of the previous value.
4. Connecting a non-GitHub companion (GA4/GSC/VTEX) must leave `github_repo` untouched.

## Migration Notes

N/A — no database migrations or configuration changes.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes