### PR TITLE
feat(preview): navigate to page on Enter when path matches exactly

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -885,6 +885,21 @@ export function PreviewContent() {
                           type="text"
                           value={pagesSearch}
                           onChange={(e) => setPagesSearch(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key !== "Enter") return;
+                            const query = pagesSearch.trim();
+                            if (!query) return;
+                            // Enter only navigates when the typed path matches an
+                            // existing page exactly; otherwise it does nothing.
+                            const target = filteredPages.find(
+                              (p) => normPath(p.path) === normPath(query),
+                            );
+                            if (!target) return;
+                            e.preventDefault();
+                            setPagesOpen(false);
+                            setPagesSearch("");
+                            navigatePreviewToPage(target);
+                          }}
                           placeholder="Search pages and components..."
                           className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
                           autoFocus


### PR DESCRIPTION
## Summary

In the CMS page selector search (preview URL bar), pressing **Enter** now navigates to a page when the typed path matches an existing page exactly — behaving as if the user had clicked that page in the list.

Previously the search `<input>` had no keyboard handling and no wrapping form, so Enter did nothing.

## Behavior

- Enter navigates **only** when the typed path exactly matches an existing page's path (compared via `normalizePagePath`).
- No fuzzy fallbacks: no match-by-name, no "first result", no global-component selection, and it does not trigger "Create new page".
- Empty input or no exact match → Enter does nothing.

## Testing notes

- Manual: open the page selector, type an existing page path (e.g. `/offline`) and press Enter → navigates to that page.
- Typing a non-existent path and pressing Enter does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pressing Enter in the preview page selector now navigates only when the typed path exactly matches an existing page. This adds keyboard support without changing selection behavior.

- **New Features**
  - Exact-match navigation on Enter (normalized path comparison).
  - No fuzzy fallback; empty or non-matching input does nothing.

<sup>Written for commit c3b2d5baf2dab7c67e1cd987904e54cc019cb2a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

