### PR TITLE
fix(web): stop gating main-panel tabs on runtime setup

### DIFF
--- a/apps/mesh/src/web/components/chat/use-needs-runtime-setup.ts
+++ b/apps/mesh/src/web/components/chat/use-needs-runtime-setup.ts
@@ -8,10 +8,9 @@ import { useAgentOptionAvailability } from "./use-agent-availability";
  * a valid runtime, so once the user picks one (and it's actually available)
  * this flips to false.
  *
- * Two surfaces read this so they stay in lockstep:
- *  - the chat panel shows the provider-setup empty state, and
- *  - the main-panel view tabs (Overview / Settings / …) are disabled — you
- *    can't browse the app until a runtime exists.
+ * Read only by the chat side panel, which shows the provider-setup empty state
+ * when true. The main-panel view tabs stay navigable regardless — browsing the
+ * app (Overview / Content / Settings / …) is never gated on runtime setup.
  */
 export function useNeedsRuntimeSetup(): boolean {
   const allKeys = useAiProviderKeys();

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -540,8 +540,9 @@ function AgentInsetProvider() {
             sandboxMap={entity?.metadata?.sandboxMap}
           >
             {/* The toggles, tabs, header, and main panel all render inside
-                ActiveTaskProvider via DesktopTaskWorkspace so a single
-                locked-aware useNeedsRuntimeSetup() gates them together. */}
+                ActiveTaskProvider via DesktopTaskWorkspace. The runtime-setup
+                prompt lives only in the chat side panel; the tabs stay
+                navigable regardless. */}
             <Chat.ActiveTaskProvider key={layout.taskId} taskId={layout.taskId}>
               <Suspense fallback={<Chat.Skeleton />}>
                 <DesktopTaskWorkspace

--- a/apps/mesh/src/web/layouts/main-panel-tabs/header-tab-button.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/header-tab-button.tsx
@@ -18,14 +18,20 @@ export function HeaderTabButton({
   active,
   onClick,
   disabled = false,
+  locked = false,
   className,
 }: {
   title: string;
   icon: TabIcon;
   active: boolean;
   onClick: () => void;
-  /** Disables the button (e.g. the Chat toggle when it's the only panel). */
+  /** Disables the button and dims it (e.g. every tab while the org still
+   *  needs runtime setup — the view is a genuine dead-end). */
   disabled?: boolean;
+  /** Blocks interaction WITHOUT dimming — for the active tab when clicking it
+   *  would close the only visible panel. It must still read as the selected
+   *  tab (full-opacity accent), just not respond to clicks. */
+  locked?: boolean;
   /** Extra classes merged onto the base metrics — lets non-tab consumers
    *  (the Chat toggle) tweak height / drag behaviour while staying pixel-
    *  identical to the tabs. */
@@ -37,11 +43,13 @@ export function HeaderTabButton({
       onClick={onClick}
       disabled={disabled}
       aria-pressed={active}
+      aria-disabled={locked || undefined}
       aria-label={title}
       className={cn(
         "shrink-0 flex items-center gap-1.5 h-8 rounded-md px-2",
         "[transition:background-color_180ms_ease,color_180ms_ease]",
         "disabled:opacity-40 disabled:pointer-events-none",
+        locked && "pointer-events-none",
         active
           ? "bg-sidebar-accent text-sidebar-foreground"
           : "text-sidebar-foreground/60 hover:bg-sidebar-accent hover:text-sidebar-foreground",

--- a/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-tabs-bar.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-tabs-bar.tsx
@@ -27,7 +27,6 @@ import { selectTabSlots } from "./select-tab-slots";
 import { HeaderTabButton } from "./header-tab-button";
 import { TabOverflowMenu } from "./tab-overflow-menu";
 import { track } from "@/web/lib/posthog-client";
-import { useNeedsRuntimeSetup } from "@/web/components/chat/use-needs-runtime-setup";
 
 const MAX_VISIBLE_TABS = 6;
 
@@ -45,11 +44,6 @@ export function MainPanelTabsBar({
     virtualMcpId,
     taskId,
   });
-
-  // While the org has no usable runtime, you can't open any view — the app is
-  // gated behind connecting a provider (or picking a local coding agent) in the
-  // chat panel. Disable the whole tab strip so it isn't a dead-end open.
-  const needsSetup = useNeedsRuntimeSetup();
 
   const automationsActive = isAutomationsPillActive({ activeTab, mainOpen });
 
@@ -104,11 +98,11 @@ export function MainPanelTabsBar({
           title={tab.title}
           icon={tab.icon}
           active={isTabActive(tab)}
-          disabled={needsSetup || (disableActiveMainToggle && isTabActive(tab))}
+          locked={disableActiveMainToggle && isTabActive(tab)}
           onClick={() => handleSelect(tab.id)}
         />
       ))}
-      {overflow.length > 0 && !needsSetup && (
+      {overflow.length > 0 && (
         <TabOverflowMenu overflow={overflow} onSelect={handleSelect} />
       )}
     </div>

--- a/apps/mesh/src/web/layouts/main-panel-tabs/overview-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/overview-tab.tsx
@@ -21,8 +21,6 @@ import {
 } from "@/web/components/home/home-edit-context";
 import { HomeGrid } from "@/web/components/home/home-grid";
 import { AddTileDrawer } from "@/web/components/home/add-tile-drawer";
-import { useNeedsRuntimeSetup } from "@/web/components/chat/use-needs-runtime-setup";
-import { NoAiProviderEmptyState } from "@/web/components/chat/no-ai-provider-empty-state";
 
 function CustomizeToolbar({
   isEditMode,
@@ -118,19 +116,9 @@ function OverviewBoard() {
 }
 
 export function OverviewTab() {
-  // The Overview board is only meaningful once the org can run a chat — with no
-  // AI provider (and no usable local CLI) it'd be a board behind a wall. Swap
-  // it for the provider-setup prompt. Sandbox-backed views (Preview/Settings/
-  // Deck) don't gate this way; they render regardless. A locked historical
-  // thread early-returns false from the hook, so it's never gated.
-  const needsSetup = useNeedsRuntimeSetup();
-  if (needsSetup) {
-    return (
-      <div className="h-full overflow-y-auto flex items-center justify-center p-6">
-        <NoAiProviderEmptyState />
-      </div>
-    );
-  }
+  // The board renders regardless of runtime setup — the tabs are always
+  // navigable. The provider-setup prompt lives solely in the chat side panel
+  // (side-panel-chat.tsx), so browsing the app is never a dead-end.
   return (
     <HomeEditProvider>
       <OverviewBoard />


### PR DESCRIPTION
## Summary

Two related fixes to the agent-shell header tabs (Preview / Code / Content / Automations / Settings).

**1. Tabs are no longer gated on runtime setup.** Previously the whole tab strip was disabled whenever the org had no AI provider *and* no local runtime — coupling data/config browsing (CMS, Settings) to an AI runtime it doesn't actually need. This funneled new orgs into a dead-end where they couldn't even look at the app. The provider-setup prompt now lives **solely in the chat side panel**; the tabs stay navigable regardless.
   - Removed `useNeedsRuntimeSetup` from `main-panel-tabs-bar.tsx` (tabs + overflow menu always render).
   - `overview-tab.tsx` renders the board unconditionally instead of swapping to `NoAiProviderEmptyState`.

**2. Decoupled the active-tab click guard from the disabled *visual* state.** The active tab (when clicking it would close the only visible panel) was rendered with the `disabled` attribute, so `disabled:opacity-40` faded the selected pill to 40% — making the selected tab look different depending on whether the chat panel was open. It now uses a new `locked` state on `HeaderTabButton` that blocks interaction (`pointer-events-none` + `aria-disabled`) without dimming. The click was already a no-op via the early return in `handleSelect`, so behavior is unchanged — only appearance is fixed.

`disabled` on `HeaderTabButton` remains in use by the Chat/Blocks toggles (when a toggle is the only visible panel).

## Testing

- `bun run fmt`, `bun run check` (tsc), `bun run lint` all pass with no errors on the changed files.
- `NoAiProviderEmptyState` confirmed still used by the chat panel and model selector (not dead code).
- ⚠️ Not exercised end-to-end — reproducing requires an org with no AI provider and no local CLI. The Overview board / CMS query storage (not an LLM), so they render without a runtime; worth a manual visual check in that state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ungates main-panel tabs from runtime setup so users can browse without a provider. Also keeps the selected tab at full opacity by blocking clicks with a new locked state instead of dimming.

- **Bug Fixes**
  - Removed runtime-setup gating from the tabs bar; overflow menu always available.
  - `overview-tab` always renders; provider-setup prompt now only in the chat side panel.
  - Added `locked` to `HeaderTabButton` (aria-disabled + pointer-events) and kept `disabled` for true disabled cases.

<sup>Written for commit 163b84cbe68493219cb5961a9899d4b1b85a0937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

