### PR TITLE
feat(decopilot): support connection-scoped subagents

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/decopilot/context-and-tasks.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/decopilot/context-and-tasks.mdx
@@ -77,11 +77,13 @@ Subtasks can't ask you questions and can't create additional subtasks — they r
 
 **Parallel work** — if two pieces of work don't depend on each other, run them as separate subtasks at the same time.
 
-### Using specialist agents in subtasks
+### Using specialist agents and connections in subtasks
 
 You can run a subtask with a specific [agent](/en/studio/agents) — one configured for a particular domain. The agent brings its own focused toolset and instructions without affecting your main conversation.
 
-**Example**: Your main task is coordinating order fulfillment. You start subtasks using an **Inventory Agent** to check stock, a **Shipping Agent** to plan logistics, and a **Customer Service Agent** to prepare support notes. Each runs independently; your main task gets the summaries and coordinates the outcome.
+You can also target a concrete MCP connection directly. Decopilot creates an ephemeral subagent for that run with the connection's tools, so you don't need to create a dedicated agent first.
+
+**Example**: Your main task is coordinating order fulfillment. You start subtasks using an **Inventory Agent** to check stock, a ShipStation MCP connection directly to plan logistics, and a **Customer Service Agent** to prepare support notes. Each runs independently; your main task gets the summaries and coordinates the outcome.
 
 ---
 

--- a/apps/docs/client/src/content/deco-studio/en/studio/decopilot/overview.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/decopilot/overview.mdx
@@ -57,7 +57,7 @@ Decopilot works with multiple AI providers — Anthropic, Google, OpenRouter, th
 
 ## Agents and subtasks
 
-When a task needs focused work — a customer-support question, a research pass, a data analysis — Decopilot can hand it off to a specialist [agent](/en/studio/agents) in a **subtask**. The subtask runs independently with its own clean context, then reports a summary back. Your main conversation stays clean.
+When a task needs focused work — a customer-support question, a research pass, a data analysis — Decopilot can hand it off to a specialist [agent](/en/studio/agents) or directly to a concrete MCP connection in a **subtask**. A connection target runs as an ephemeral subagent, so it doesn't require a dedicated agent configuration. The subtask runs independently with its own clean context, then reports a summary back. Your main conversation stays clean.
 
 ## Built-in tools
 
@@ -65,7 +65,7 @@ Decopilot ships with tools for coordinating work across any scope:
 
 | Tool | What it does |
 |---|---|
-| `subtask` | Delegates work to a specialist agent |
+| `subtask` | Delegates work to a specialist agent or concrete MCP connection |
 | `user_ask` | Asks you a question when it needs clarification |
 | `enable_tool` | Activates a scope tool for use in subsequent steps |
 | `read_resource` | Reads documentation or guidelines available in scope |

--- a/apps/docs/client/src/content/deco-studio/en/studio/decopilot/tools.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/decopilot/tools.mdx
@@ -20,7 +20,7 @@ These are the tools the Decopilot agent uses internally to manage its own work â
 
 | Tool | Available in subtasks | What it does |
 |---|:---:|---|
-| `subtask` | No | Start a subtask, optionally with a specific agent |
+| `subtask` | No | Start a subtask with a cloned agent, another agent, or an ephemeral agent scoped to a concrete MCP connection |
 | `user_ask` | No | Ask you a question when it needs input |
 | `enable_tool` | Yes | Activate a scope tool so it can be called next step |
 | `read_resource` | Yes | Read documentation or guidelines from the current scope |

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -4,6 +4,6 @@
   "dispatch-queue/hosted-harness-workflow.ts": "4caf3a360104c5ba7b0559895208234f39e819157d0ac31955f64ed94a88ed95",
   "dispatch-queue/thread-gate-workflow.ts": "2e63fcff27fb5109f2264d31d455dbbfb1b3f18ce46c0eb3075ca6b0266fe379",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",
-  "harnesses/decopilot/background-tool-workflow.ts": "b75384d08b2293a101da50f0dfc63c23fc27f4b5636d2a9ada3cc22d2f61202b",
+  "harnesses/decopilot/background-tool-workflow.ts": "16ef60a6df35498b877ed27ca3a41046dbb165089075cabdcb48aed54512e4f8",
   "monitoring/dbos-retention-workflow.ts": "b43e3596b386b53faf372b140d9137a12252565987543640d17f7798504b8dbb"
 }

--- a/apps/mesh/src/harnesses/decopilot/background-tool-workflow.ts
+++ b/apps/mesh/src/harnesses/decopilot/background-tool-workflow.ts
@@ -369,7 +369,7 @@ async function runSubtaskStep(
     ...(models.webSearch ? { webSearch: models.webSearch } : {}),
     ...(models.deepResearch ? { deepResearch: models.deepResearch } : {}),
   };
-  const { mcpClient, targetRef } = await resolveSubagent(
+  const { mcpClient, targetKind, targetRef } = await resolveSubagent(
     meshCtx,
     ctx.orgId,
     targetId,
@@ -404,16 +404,20 @@ async function runSubtaskStep(
     isPlanMode: false,
     passthroughClient: mcpClient as never,
     pendingImages: [],
-    // Self-clone shares the parent's sandbox (same virtualMcpId/branch/userId);
-    // a cross-agent delegate has a different sandbox identity but the same keying.
-    vmContext: {
-      virtualMcpId: targetRef.id,
-      branch: targetRef.repo
-        ? (ctx.branch ?? `thread:${ctx.threadId}`)
-        : "ephemeral",
-      userId: ctx.userId,
-      threadId: ctx.threadId,
-    },
+    // Persisted agents may own a sandbox. A concrete MCP target is deliberately
+    // connection-only: provisioning VM tools would reintroduce the Virtual MCP
+    // row requirement this ephemeral path is designed to remove.
+    vmContext:
+      targetKind === "virtual-mcp"
+        ? {
+            virtualMcpId: targetRef.id,
+            branch: targetRef.repo
+              ? (ctx.branch ?? `thread:${ctx.threadId}`)
+              : "ephemeral",
+            userId: ctx.userId,
+            threadId: ctx.threadId,
+          }
+        : null,
     taskId: ctx.threadId,
     agentId: targetRef.id,
     // Depth-1: a backgrounded subagent can't itself background/re-delegate.
@@ -438,6 +442,7 @@ async function runSubtaskStep(
       provider,
       models: harnessModels,
       messages: [{ role: "user", content: input.prompt }],
+      systemAgentInstructions: targetRef.instructions,
       abortSignal: abort.signal,
       stepLimit: SUBAGENT_STEP_LIMIT,
       toolApprovalLevel: "auto",

--- a/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -74,6 +74,7 @@ export interface BuildAgentSystemPromptOptions {
     id: string;
     instructions?: string;
     repo?: GithubRepo;
+    delegationTargetIds?: string[] | null;
   };
   kind: "agent" | "subagent";
   planMode: boolean;
@@ -196,10 +197,21 @@ export async function buildAgentSystemPrompt(
     await listPromptsBlock(opts.ctx, opts.organization, opts.passthroughClient),
   );
 
-  if (opts.kind === "agent" && opts.userContext?.agents) {
+  if (
+    opts.kind === "agent" &&
+    (opts.userContext?.agents || opts.connectionsData?.tools.length)
+  ) {
+    const connectionIds = opts.connectionsData?.tools.map(
+      (tool) => tool.connectionId,
+    );
     add(
       "agents",
-      buildAgentsBlock(opts.userContext.agents, opts.virtualMcp.id),
+      buildAgentsBlock(
+        opts.userContext?.agents ?? [],
+        opts.virtualMcp.id,
+        opts.virtualMcp.delegationTargetIds,
+        connectionIds,
+      ),
     );
   }
 

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.test.ts
@@ -43,6 +43,15 @@ describe("SubtaskInputSchema", () => {
       expect(result.success).toBe(true);
     });
 
+    test("accepts a concrete MCP connection id as agent_id", () => {
+      const result = SubtaskInputSchema.safeParse({
+        prompt: "Inspect the latest orders",
+        agent_id: "conn_orders",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
     test("accepts prompt at max length boundary", () => {
       const input = {
         prompt: "a".repeat(50_000),

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -36,9 +36,10 @@ export const SubtaskInputSchema = z.object({
     .max(128)
     .optional()
     .describe(
-      "The ID of the agent (Virtual MCP) to delegate to. Must exist and be " +
-        "active in the current organization. OMIT to clone yourself — a fresh " +
-        "subagent with your exact tools and instructions but an empty context.",
+      "The ID of an agent (Virtual MCP) or concrete MCP connection to delegate " +
+        "to. A concrete connection creates an ephemeral subagent scoped to that " +
+        "connection. OMIT to clone yourself — a fresh subagent with your exact " +
+        "tools and instructions but an empty context.",
     ),
 });
 
@@ -51,7 +52,8 @@ const SUBTASK_DESCRIPTION =
   "context on the digging and hands back just the answer, keeping yours focused and cheap. A single, " +
   "targeted lookup you already know the shape of stays inline.\n\n" +
   "OMIT agent_id to clone yourself (a fresh subagent with your exact tools and instructions, empty context). " +
-  "Pass agent_id to delegate to a different, specialized agent instead.\n\n" +
+  "Pass agent_id to delegate to a different specialized agent, or to create an ephemeral subagent for a " +
+  "concrete MCP connection. Use IDs exactly as listed in <available-agents> or <available-connections>.\n\n" +
   "Usage notes:\n" +
   "- Every subtask call starts FRESH — no conversation history, no prior runs. Always include full context in the prompt and state exactly what to return (the specific answer/list/paths you need, not a raw dump); never use continuation phrases like 'continue' or 'as before'.\n" +
   "- Clearly tell the subagent whether you expect it to take action or just research.\n" +
@@ -215,9 +217,11 @@ export function createSubtaskTool(
         return;
       }
 
-      // 1. Enforce the caller's sub-agent allowlist for cross-agent delegation
-      //    BEFORE resolving the target. Self-clones are always allowed (isSelf
-      //    short-circuits). An empty/absent allowlist means "all agents".
+      // 1. Enforce the caller's delegation allowlist BEFORE resolving the
+      //    target. It may contain persisted agent ids or concrete MCP
+      //    connection ids. Self-clones are always allowed (isSelf
+      //    short-circuits). An empty array means self-only; absent means all
+      //    active organization targets.
       if (!isSelf && self) {
         const caller = await ctx.storage.virtualMcps.findById(
           self.id,
@@ -225,27 +229,27 @@ export function createSubtaskTool(
         );
         const allow = caller?.metadata?.subAgents;
         // An allowlist array (even empty = itself only) gates cross-agent
-        // delegation. A null/absent allowlist means all agents are allowed.
+        // delegation. A null/absent allowlist means all targets are allowed.
         if (Array.isArray(allow) && !allow.includes(targetId)) {
-          // Point at the catalog ONLY when the allowlist permits some other
-          // agent. An empty allowlist (self-only) has no <available-agents>
-          // table, so directing the model there just makes it invent ids.
+          // Point at the catalogs ONLY when the allowlist permits some other
+          // target. An empty allowlist (self-only) has no delegable catalog,
+          // so directing the model there just makes it invent ids.
           const catalogHint =
             allow.length > 0
-              ? " Or pass an agent id from <available-agents>."
+              ? " Or pass an id from <available-agents> or <available-connections>."
               : "";
           yield {
             text: "",
-            error: `Agent '${targetId}' is not in this agent's delegation allowlist (allow=${JSON.stringify(allow)}).${cloneHint}${catalogHint}`,
+            error: `Target '${targetId}' is not in this agent's delegation allowlist (allow=${JSON.stringify(allow)}).${cloneHint}${catalogHint}`,
             finishReason: "error",
           };
           return;
         }
       }
 
-      // 2. Validate the target and open its passthrough client. A self-clone
-      //    uses superUser so its tool scope mirrors the parent loop. Resolution
-      //    errors ("Agent not found" / "not active") are also recoverable.
+      // 2. Validate the agent/connection target and open its passthrough
+      //    client. A self-clone uses superUser so its tool scope mirrors the
+      //    parent loop. Resolution errors are recoverable.
       let resolved: Awaited<ReturnType<typeof resolveSubagent>>;
       try {
         resolved = await resolveSubagent(ctx, organization.id, targetId, {
@@ -301,6 +305,7 @@ export function createSubtaskTool(
           provider,
           models,
           messages: [{ role: "user", content: prompt }],
+          systemAgentInstructions: targetRef.instructions,
           abortSignal: abortSignal ?? new AbortController().signal,
           stepLimit: SUBAGENT_STEP_LIMIT,
           toolApprovalLevel: "auto",

--- a/apps/mesh/src/harnesses/decopilot/resolve-subagent.ts
+++ b/apps/mesh/src/harnesses/decopilot/resolve-subagent.ts
@@ -1,21 +1,23 @@
 /**
- * Shared delegation-target resolution for the two `subtask` surfaces:
- * the in-process `subtask` built-in (`built-in-tools/subtask.ts`) and the
- * cluster-side `SUBTASK_MCP` tool (`tools/decopilot-mcp/subtask-tool.ts`).
+ * Shared delegation-target resolution for the inline `subtask` built-in and
+ * the durable background-subtask workflow.
  *
- * Both validate the target Virtual MCP identically (existence + org scope +
- * active status), open a passthrough client, and build the `targetRef` that
- * `runAgentLoop` expects. Keeping it here stops the two surfaces from drifting
- * on the error strings (`"Agent not found"` / `"Agent is not active"`) or the
- * targetRef shape.
+ * A target may be a persisted Virtual MCP or a concrete MCP connection. The
+ * latter becomes an ephemeral subagent whose MCP scope contains exactly that
+ * connection; no Virtual MCP row is created. Both paths enforce organization
+ * scope + active status and return the same runtime target shape.
  */
 import type { GithubRepo } from "@decocms/mesh-sdk";
 import type { StudioContext } from "@/core/studio-context";
-import { createVirtualClientFrom } from "@/mcp-clients/virtual-mcp";
+import {
+  createConnectionClient,
+  createVirtualClientFrom,
+} from "@/mcp-clients/virtual-mcp";
 import type { PassthroughClient } from "@/mcp-clients/virtual-mcp/passthrough-client";
 
 export interface ResolvedSubagent {
   mcpClient: PassthroughClient;
+  targetKind: "virtual-mcp" | "connection";
   targetRef: {
     id: string;
     instructions: string | undefined;
@@ -26,42 +28,69 @@ export interface ResolvedSubagent {
 /**
  * Validate a delegation target, open a passthrough client for it, and build the
  * targetRef. `superUser` mirrors the parent loop's passthrough scope (used by
- * self-clones); leave it false for cross-agent delegation.
+ * self-clones); leave it false for cross-target delegation.
  *
- * @throws Error("Agent not found") when the id doesn't resolve in the org.
- * @throws Error("Agent is not active") when the agent exists but is inactive.
+ * @throws when the id doesn't resolve to an agent or concrete connection in
+ * the organization, or when the resolved target is inactive.
  */
 export async function resolveSubagent(
   ctx: StudioContext,
   organizationId: string,
-  agentId: string,
+  targetId: string,
   { superUser = false }: { superUser?: boolean } = {},
 ): Promise<ResolvedSubagent> {
   const virtualMcp = await ctx.storage.virtualMcps.findById(
-    agentId,
+    targetId,
     organizationId,
   );
-  if (!virtualMcp || virtualMcp.organization_id !== organizationId) {
-    throw new Error("Agent not found");
-  }
-  if (virtualMcp.status !== "active") {
-    throw new Error("Agent is not active");
+  if (virtualMcp?.organization_id === organizationId) {
+    if (virtualMcp.status !== "active") {
+      throw new Error("Agent is not active");
+    }
+
+    const mcpClient = await createVirtualClientFrom(
+      virtualMcp,
+      ctx,
+      "passthrough",
+      superUser,
+      { includeSkillsCatalog: true },
+    );
+
+    return {
+      mcpClient,
+      targetKind: "virtual-mcp",
+      targetRef: {
+        id: virtualMcp.id,
+        instructions: mcpClient.getInstructions(),
+        repo: virtualMcp.metadata?.githubRepo ?? undefined,
+      },
+    };
   }
 
-  const mcpClient = await createVirtualClientFrom(
-    virtualMcp,
-    ctx,
-    "passthrough",
-    superUser,
-    { includeSkillsCatalog: true },
+  const connection = await ctx.storage.connections.findById(
+    targetId,
+    organizationId,
   );
+  if (
+    !connection ||
+    connection.organization_id !== organizationId ||
+    connection.connection_type === "VIRTUAL"
+  ) {
+    throw new Error("Agent or MCP connection not found");
+  }
+  if (connection.status !== "active") {
+    throw new Error("MCP connection is not active");
+  }
+
+  const mcpClient = createConnectionClient(connection, ctx, superUser);
 
   return {
     mcpClient,
+    targetKind: "connection",
     targetRef: {
-      id: virtualMcp.id,
+      id: connection.id,
       instructions: mcpClient.getInstructions(),
-      repo: virtualMcp.metadata?.githubRepo ?? undefined,
+      repo: undefined,
     },
   };
 }

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
@@ -55,6 +55,7 @@ export interface RunAgentLoopOptions {
     id: string;
     instructions?: string;
     repo?: GithubRepo;
+    delegationTargetIds?: string[] | null;
   };
   mcpClient: Client;
   provider: MeshProvider;

--- a/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
@@ -176,5 +176,42 @@ export async function createVirtualClientFrom(
   return new PassthroughClient(clientOptions, ctx);
 }
 
+/**
+ * Create the tool gateway for an ephemeral subagent backed by one concrete
+ * MCP connection. No Virtual MCP row is created or required: the connection
+ * itself supplies the subagent's complete MCP scope for this run.
+ */
+export function createConnectionClient(
+  connection: ConnectionEntity,
+  ctx: StudioContext,
+  superUser = false,
+  options?: { listTimeoutMs?: number },
+): PassthroughClient {
+  if (connection.connection_type === "VIRTUAL") {
+    throw new Error(
+      `Concrete MCP connection required, received Virtual MCP: ${connection.id}`,
+    );
+  }
+
+  const description = connection.description?.trim();
+  const instructions = [
+    `You are an ephemeral specialist for the "${connection.title}" MCP connection (ID: ${connection.id}).`,
+    description || undefined,
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join("\n\n");
+
+  return new PassthroughClient(
+    {
+      connections: [connection],
+      superUser,
+      mcpListCache: getMcpListCache() ?? undefined,
+      listTimeoutMs: options?.listTimeoutMs,
+      instructions,
+    },
+    ctx,
+  );
+}
+
 // Re-export types and utilities
 export { type VirtualClientOptions } from "./types";

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.test.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.test.ts
@@ -259,6 +259,24 @@ describe("PassthroughClient", () => {
   });
 
   describe("getInstructions", () => {
+    it("supports an ephemeral connection-scoped identity without a virtual MCP", () => {
+      const conn = makeConnection("conn_ephemeral", "Orders");
+      mockCreateLazyClient.mockReturnValue(makeMockClient() as any);
+
+      const pt = new PassthroughClient(
+        {
+          connections: [conn],
+          instructions: "Ephemeral Orders specialist",
+        },
+        mockCtx,
+      );
+
+      expect(pt.getInstructions()).toBe("Ephemeral Orders specialist");
+      expect(pt.getConnectionTitleMap()).toEqual(
+        new Map([["conn_ephemeral", "Orders"]]),
+      );
+    });
+
     it("returns instructions from virtualMcp metadata", () => {
       const conn = makeConnection("conn_ins", "Ins");
       mockCreateLazyClient.mockReturnValue(makeMockClient() as any);

--- a/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.ts
@@ -47,7 +47,7 @@ export class PassthroughClient extends GatewayClient {
   ) {
     // Build VirtualMCP connection lookup for per-client selection
     const vmcpConnMap = new Map(
-      options.virtualMcp.connections.map((c) => [c.connection_id, c]),
+      (options.virtualMcp?.connections ?? []).map((c) => [c.connection_id, c]),
     );
 
     // Build ClientEntry record
@@ -116,7 +116,7 @@ export class PassthroughClient extends GatewayClient {
       prompts: [...base.prompts, ...seeded],
     };
 
-    const agent = findStudioPackAgentByMcpId(this.options.virtualMcp.id ?? "");
+    const agent = findStudioPackAgentByMcpId(this.options.virtualMcp?.id ?? "");
     const orgId = this.ctx.organization?.id;
     if (!agent || !orgId) return result;
 
@@ -156,7 +156,7 @@ export class PassthroughClient extends GatewayClient {
     params: GetPromptRequest["params"],
     options?: RequestOptions,
   ): Promise<GetPromptResult> {
-    const agentId = this.options.virtualMcp.id;
+    const agentId = this.options.virtualMcp?.id;
     if (agentId) {
       const prefix = `${slugify(agentId)}_`;
       if (params.name.startsWith(prefix)) {
@@ -182,7 +182,7 @@ export class PassthroughClient extends GatewayClient {
    * lines up with `getPrompt` above. Cached per instance. Never throws.
    */
   private async listSeededPrompts(): Promise<Prompt[]> {
-    const agentId = this.options.virtualMcp.id;
+    const agentId = this.options.virtualMcp?.id;
     if (!agentId) return [];
     const stored = await this.loadSeededPrompts();
     const prefix = slugify(agentId);
@@ -196,7 +196,7 @@ export class PassthroughClient extends GatewayClient {
 
   /** Cached org-fs read of the agent's seeded prompts. Never throws. */
   private loadSeededPrompts(): Promise<StoredAgentPrompt[]> {
-    const agentId = this.options.virtualMcp.id;
+    const agentId = this.options.virtualMcp?.id;
     const orgFs = this.ctx.orgFs;
     if (!agentId || !orgFs) return Promise.resolve([]);
     if (!this.agentPromptsCache) {
@@ -210,10 +210,12 @@ export class PassthroughClient extends GatewayClient {
     // they reach the model on every run path (cluster engine AND sandbox
     // daemon both read instructions; only the cluster runs the richer
     // buildAgentSystemPrompt).
-    const base = withKnowledge(
-      this.options.virtualMcp.metadata?.instructions ?? undefined,
-      this.options.virtualMcp.metadata?.knowledge,
-    );
+    const base = this.options.virtualMcp
+      ? withKnowledge(
+          this.options.virtualMcp.metadata?.instructions ?? undefined,
+          this.options.virtualMcp.metadata?.knowledge,
+        )
+      : this.options.instructions;
     // Append the pre-rendered <available-skills> catalog (built async in the
     // factory). Same seam, same both-paths guarantee as the knowledge block.
     const skills = this.options.skillsBlock;

--- a/apps/mesh/src/mcp-clients/virtual-mcp/types.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/types.ts
@@ -11,7 +11,13 @@ import type { McpListCache } from "../../mcp-clients/mcp-list-cache";
 /** Options for creating an aggregator */
 export interface VirtualClientOptions {
   connections: ConnectionEntity[];
-  virtualMcp: VirtualMCPEntity;
+  /**
+   * Persisted agent configuration. Concrete-connection subagents omit this:
+   * they use the same gateway over one connection with an ephemeral identity.
+   */
+  virtualMcp?: VirtualMCPEntity;
+  /** Instructions for an ephemeral, connection-scoped subagent. */
+  instructions?: string;
   /** Whether to use superuser mode for background processes (bypasses auth checks on sub-clients) */
   superUser?: boolean;
   /** Cross-pod NATS KV cache for MCP lists (avoids MCP handshake on listTools/listResources/listPrompts) */

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/subtask.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/subtask.tsx
@@ -10,7 +10,7 @@ import {
 } from "@deco/ui/components/sheet.tsx";
 import type { ToolSubtaskMetadata } from "../../use-filter-parts.ts";
 import { IntegrationIcon } from "@/web/components/integration-icon";
-import { useVirtualMCP, type ToolDefinition } from "@decocms/mesh-sdk";
+import { useConnection, type ToolDefinition } from "@decocms/mesh-sdk";
 import { ArrowUpRight, Tool02, Users03 } from "@untitledui/icons";
 import type { TextUIPart } from "ai";
 import type { SubtaskToolPart } from "../../../types.ts";
@@ -440,11 +440,13 @@ export function SubtaskPartFallback(props: SubtaskPartProps) {
 }
 
 /**
- * Suspends on the agent fetch (useVirtualMCP). MUST be wrapped in
+ * Suspends on the delegation-target fetch. Agents are stored as VIRTUAL
+ * connections, so the connection collection resolves both persisted agents
+ * and concrete MCP targets through one query. MUST be wrapped in
  * <Suspense fallback={<SubtaskPartFallback ... />}> by the caller.
  */
 export function SubtaskPart(props: SubtaskPartProps) {
-  const agent = useVirtualMCP(props.part.input?.agent_id);
+  const target = useConnection(props.part.input?.agent_id);
   if (isBackgroundStart(props.part.output))
     return <BackgroundSubtaskCard {...props} />;
   const { fallbackTitle, summary, usage, state } = buildSubtaskRowConfig(props);
@@ -453,14 +455,14 @@ export function SubtaskPart(props: SubtaskPartProps) {
     <SubtaskCard
       icon={
         <IntegrationIcon
-          icon={agent?.icon}
-          name={agent?.title ?? "Subtask"}
+          icon={target?.icon}
+          name={target?.title ?? "Subtask"}
           size="2xs"
           className="rounded-xs"
           fallbackIcon={<Users03 />}
         />
       }
-      title={agent?.title ?? fallbackTitle}
+      title={target?.title ?? fallbackTitle}
       summary={summary}
       state={state}
       usage={usage}

--- a/packages/harness/src/decopilot/agents-block.test.ts
+++ b/packages/harness/src/decopilot/agents-block.test.ts
@@ -140,4 +140,30 @@ describe("buildAgentsBlock", () => {
     expect(result).toContain("subtask");
     expect(result).toContain("full context");
   });
+
+  test("documents ephemeral delegation when only a concrete connection is available", () => {
+    const result = buildAgentsBlock(
+      [entry("vmcp_self", "Self", "Self")],
+      "vmcp_self",
+      undefined,
+      ["conn_orders"],
+    );
+
+    expect(result).not.toContain("<available-agents>");
+    expect(result).toContain("<available-connections>");
+    expect(result).toContain("ephemeral subagent");
+    expect(result).not.toContain("NEVER pass agent_id");
+  });
+
+  test("applies the delegation allowlist to concrete connection ids", () => {
+    const result = buildAgentsBlock(
+      [entry("vmcp_self", "Self", "Self")],
+      "vmcp_self",
+      [],
+      ["conn_orders"],
+    );
+
+    expect(result).toContain("NEVER pass agent_id");
+    expect(result).not.toContain("ephemeral subagent");
+  });
 });

--- a/packages/harness/src/decopilot/agents-block.ts
+++ b/packages/harness/src/decopilot/agents-block.ts
@@ -4,8 +4,9 @@
  * Each decopilot run executes inside a single Virtual MCP. The usage
  * guidance is ALWAYS emitted because every agent can delegate to itself
  * (`subtask({ prompt })` clones the current agent with a fresh context).
- * When other active Virtual MCPs exist in the organization they are also
- * listed so the model can delegate cross-agent work via `subtask({ agent_id })`.
+ * When other active Virtual MCPs or concrete MCP connections are available,
+ * the usage block explains how `agent_id` selects either a persisted agent or
+ * an ephemeral connection-scoped subagent.
  *
  * The block is stable per organization so the prompt prefix can be
  * cached across steps.
@@ -32,17 +33,26 @@ Launch multiple subtask calls in one message to run independent searches in
 parallel.
 </agents-usage>`;
 
-// Emitted when other delegable agents exist: documents both the self-clone and
-// the cross-agent form, and points at the <available-agents> catalog below.
-const FULL_USAGE = `<agents-usage>
+function buildDelegationUsage(
+  hasAgents: boolean,
+  hasConnections: boolean,
+): string {
+  const targetDescription =
+    hasAgents && hasConnections
+      ? "delegate to a DIFFERENT agent from <available-agents>, or create an ephemeral subagent scoped to a concrete MCP connection id from <available-connections>."
+      : hasAgents
+        ? "delegate to a DIFFERENT agent from <available-agents>, which has its own tools and instructions."
+        : "create an ephemeral subagent scoped to a concrete MCP connection id from <available-connections>.";
+
+  return `<agents-usage>
 Delegate self-contained work to a subagent with the subtask tool.
 
 - subtask({ prompt }) — clone YOURSELF: a fresh subagent with your exact tools
   and instructions but an empty context window.
-- subtask({ agent_id, prompt }) — delegate to a DIFFERENT agent (see
-  <available-agents>), which has its own tools and instructions.
+- subtask({ agent_id, prompt }) — ${targetDescription}
 
 ${USAGE_TAIL}`;
+}
 
 // Emitted when there is NO catalog (self-only). Must NOT reference
 // <available-agents> or the agent_id form — that block isn't in context, and a
@@ -74,6 +84,7 @@ export function buildAgentsBlock(
   agents: AgentsBlockEntry[],
   currentVirtualMcpId: string,
   allowedIds?: string[] | null,
+  connectionIds: string[] = [],
 ): string {
   let others = agents.filter(
     (a) => a.id !== currentVirtualMcpId && a.status === "active",
@@ -85,12 +96,16 @@ export function buildAgentsBlock(
   if (allowedIds) {
     const allow = new Set(allowedIds);
     others = others.filter((a) => allow.has(a.id));
+    connectionIds = connectionIds.filter((id) => allow.has(id));
   }
 
-  // Self-delegation is always available, so the usage guidance is always
-  // emitted. The <available-agents> table is added only when other active
-  // agents exist to delegate to.
-  if (others.length === 0) {
+  const concreteConnectionIds = [...new Set(connectionIds)].filter(
+    (id) => id !== currentVirtualMcpId,
+  );
+
+  // Self-delegation is always available. The strict self-only wording is valid
+  // only when neither an agent nor a concrete connection can be targeted.
+  if (others.length === 0 && concreteConnectionIds.length === 0) {
     return `\n\n${SELF_ONLY_USAGE}`;
   }
 
@@ -99,8 +114,13 @@ export function buildAgentsBlock(
     return `${csvField(a.id)},${csvField(a.name)},${csvField(desc)}`;
   });
 
-  return (
-    `\n\n<available-agents>\nid,name,description\n${rows.join("\n")}\n</available-agents>` +
-    `\n\n${FULL_USAGE}`
-  );
+  const agentsCatalog =
+    rows.length > 0
+      ? `\n\n<available-agents>\nid,name,description\n${rows.join("\n")}\n</available-agents>`
+      : "";
+
+  return `${agentsCatalog}\n\n${buildDelegationUsage(
+    others.length > 0,
+    concreteConnectionIds.length > 0,
+  )}`;
 }

--- a/packages/harness/src/decopilot/built-in-tools/local-subtask.test.ts
+++ b/packages/harness/src/decopilot/built-in-tools/local-subtask.test.ts
@@ -65,6 +65,15 @@ describe("SubtaskInputSchema", () => {
       SubtaskInputSchema.safeParse({ prompt: "go", agent_id: "vir_x" }).success,
     ).toBe(true);
   });
+
+  test("accepts a concrete MCP connection id", () => {
+    expect(
+      SubtaskInputSchema.safeParse({
+        prompt: "go",
+        agent_id: "conn_orders",
+      }).success,
+    ).toBe(true);
+  });
   test("accepts missing agent_id (self-clone)", () => {
     expect(SubtaskInputSchema.safeParse({ prompt: "go" }).success).toBe(true);
   });

--- a/packages/harness/src/decopilot/built-in-tools/local-subtask.ts
+++ b/packages/harness/src/decopilot/built-in-tools/local-subtask.ts
@@ -39,9 +39,10 @@ export const SubtaskInputSchema = z.object({
     .max(128)
     .optional()
     .describe(
-      "The ID of the agent (Virtual MCP) to delegate to. Must exist and be " +
-        "active in the current organization. OMIT to clone yourself — a fresh " +
-        "subagent with your exact tools and instructions but an empty context.",
+      "The ID of an agent (Virtual MCP) or concrete MCP connection to delegate " +
+        "to. A concrete connection creates an ephemeral subagent scoped to that " +
+        "connection. OMIT to clone yourself — a fresh subagent with your exact " +
+        "tools and instructions but an empty context.",
     ),
 });
 
@@ -54,7 +55,8 @@ const SUBTASK_DESCRIPTION =
   "context on the digging and hands back just the answer, keeping yours focused and cheap. A single, " +
   "targeted lookup you already know the shape of stays inline.\n\n" +
   "OMIT agent_id to clone yourself (a fresh subagent with your exact tools and instructions, empty context). " +
-  "Pass agent_id to delegate to a different, specialized agent instead.\n\n" +
+  "Pass agent_id to delegate to a different specialized agent, or to create an ephemeral subagent for a " +
+  "concrete MCP connection. Use IDs exactly as listed in <available-agents> or <available-connections>.\n\n" +
   "Usage notes:\n" +
   "- Every subtask call starts FRESH — no conversation history, no prior runs. Always include full context in the prompt and state exactly what to return (the specific answer/list/paths you need, not a raw dump); never use continuation phrases like 'continue' or 'as before'.\n" +
   "- Clearly tell the subagent whether you expect it to take action or just research.\n" +

--- a/packages/harness/src/decopilot/connections-block.test.ts
+++ b/packages/harness/src/decopilot/connections-block.test.ts
@@ -31,9 +31,9 @@ describe("buildConnectionsBlock", () => {
       ]),
     );
     expect(result).toContain("<available-connections>");
-    expect(result).toContain("name,tools");
-    expect(result).toContain(`Gmail,"send_email; list_inbox"`);
-    expect(result).toContain(`Slack,post_message`);
+    expect(result).toContain("id,name,tools");
+    expect(result).toContain(`conn_gmail,Gmail,"send_email; list_inbox"`);
+    expect(result).toContain(`conn_slack,Slack,post_message`);
     expect(result).toContain("<connections-usage>");
     expect(result).toContain("enable_tool");
   });
@@ -49,8 +49,8 @@ describe("buildConnectionsBlock", () => {
         ["conn_outlook", "Outlook"],
       ]),
     );
-    expect(result).toContain(`Gmail,conn_gmail_send_email`);
-    expect(result).toContain(`Outlook,conn_outlook_send_email`);
+    expect(result).toContain(`conn_gmail,Gmail,conn_gmail_send_email`);
+    expect(result).toContain(`conn_outlook,Outlook,conn_outlook_send_email`);
   });
 
   test("falls back to the connection id when no title is mapped", () => {
@@ -58,7 +58,7 @@ describe("buildConnectionsBlock", () => {
       [tool("ping", "ping", "conn_unknown")],
       titleMap([]),
     );
-    expect(result).toContain(`conn_unknown,ping`);
+    expect(result).toContain(`conn_unknown,conn_unknown,ping`);
   });
 
   test("sorts connections lexicographically by title for cache stability", () => {
@@ -88,9 +88,9 @@ describe("buildConnectionsBlock", () => {
         ["conn_c", "C\nnewline"],
       ]),
     );
-    expect(result).toContain(`"A, comma",send`);
-    expect(result).toContain(`"B ""quote""",post`);
-    expect(result).toContain(`"C\nnewline",call`);
+    expect(result).toContain(`conn_a,"A, comma",send`);
+    expect(result).toContain(`conn_b,"B ""quote""",post`);
+    expect(result).toContain(`conn_c,"C\nnewline",call`);
   });
 
   test("does not split tool names that contain underscores", () => {
@@ -101,6 +101,8 @@ describe("buildConnectionsBlock", () => {
       ],
       titleMap([["conn_slack", "Slack"]]),
     );
-    expect(result).toContain(`Slack,"delete_message; list_channels"`);
+    expect(result).toContain(
+      `conn_slack,Slack,"delete_message; list_channels"`,
+    );
   });
 });

--- a/packages/harness/src/decopilot/connections-block.ts
+++ b/packages/harness/src/decopilot/connections-block.ts
@@ -1,8 +1,8 @@
 /**
  * Builds the <available-connections> + <connections-usage> system-prompt
- * block. Lists the current Virtual MCP's connections and the safe names
- * of every tool each one exposes. The usage block teaches the model how
- * to activate them via enable_tool.
+ * block. Lists each concrete connection's id, title, and safe tool names. The
+ * id is also a valid subtask delegation target: Decopilot can create an
+ * ephemeral subagent scoped to that connection without a persisted agent.
  *
  * Returns null when there are no tools to expose so the caller can drop
  * the block from the prompt entirely.
@@ -59,12 +59,15 @@ export function buildConnectionsBlock(
 ): string | null {
   if (tools.length === 0) return null;
 
-  const groups = new Map<string, { title: string; toolNames: string[] }>();
+  const groups = new Map<
+    string,
+    { id: string; title: string; toolNames: string[] }
+  >();
   for (const t of tools) {
     const title = connectionTitleMap.get(t.connectionId) ?? t.connectionId;
     let group = groups.get(t.connectionId);
     if (!group) {
-      group = { title, toolNames: [] };
+      group = { id: t.connectionId, title, toolNames: [] };
       groups.set(t.connectionId, group);
     }
     // Emit the safe name verbatim — this is the exact identifier the
@@ -78,13 +81,13 @@ export function buildConnectionsBlock(
     a.title.localeCompare(b.title),
   );
 
-  const rows = sorted.map(({ title, toolNames }) => {
+  const rows = sorted.map(({ id, title, toolNames }) => {
     const joined = toolNames.join("; ");
-    return `${csvField(title)},${csvField(joined)}`;
+    return `${csvField(id)},${csvField(title)},${csvField(joined)}`;
   });
 
   return (
-    `\n\n<available-connections>\nname,tools\n${rows.join("\n")}\n</available-connections>` +
+    `\n\n<available-connections>\nid,name,tools\n${rows.join("\n")}\n</available-connections>` +
     `\n\n${USAGE}`
   );
 }

--- a/packages/harness/src/decopilot/engine.ts
+++ b/packages/harness/src/decopilot/engine.ts
@@ -90,7 +90,11 @@ export interface HarnessAssembledTools {
  */
 export interface RunEngineArgs {
   kind: "agent" | "subagent";
-  virtualMcp: { id: string; repo?: GithubRepo };
+  virtualMcp: {
+    id: string;
+    repo?: GithubRepo;
+    delegationTargetIds?: string[] | null;
+  };
   mcpClient: Client;
   provider: MeshProvider;
   models: ModelsConfig;

--- a/packages/harness/src/decopilot/run-stream.ts
+++ b/packages/harness/src/decopilot/run-stream.ts
@@ -443,6 +443,7 @@ export async function* runDecopilotStream(
   const vmMetadata = runContext?.virtualMcp.metadata as
     | {
         githubRepo?: import("@decocms/mesh-sdk").GithubRepo | null;
+        subAgents?: string[] | null;
       }
     | undefined;
   const codingWorkspace =
@@ -459,6 +460,7 @@ export async function* runDecopilotStream(
     virtualMcp: {
       id: input.agent.id,
       repo: vmMetadata?.githubRepo ?? undefined,
+      delegationTargetIds: vmMetadata?.subAgents,
     },
     mcpClient: tools.passthroughClient,
     provider,

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -581,7 +581,7 @@ export const VirtualMCPEntitySchema = z.object({
         .nullable()
         .optional()
         .describe(
-          "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
+          "Allowlist of Virtual MCP (agent) or concrete MCP connection IDs this agent may delegate to via subtask. Concrete connections create ephemeral subagents. null/absent = all active org targets; empty array = itself only.",
         ),
       liveAgentId: z
         .string()
@@ -679,7 +679,7 @@ export const VirtualMCPCreateDataSchema = z.object({
         .nullable()
         .optional()
         .describe(
-          "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
+          "Allowlist of Virtual MCP (agent) or concrete MCP connection IDs this agent may delegate to via subtask. Concrete connections create ephemeral subagents. null/absent = all active org targets; empty array = itself only.",
         ),
       liveAgentId: z
         .string()
@@ -758,7 +758,7 @@ export const VirtualMCPUpdateDataSchema = z.object({
         .nullable()
         .optional()
         .describe(
-          "Allowlist of Virtual MCP (agent) IDs this agent may delegate to via subtask. null/absent = all active org agents; empty array = itself only (no cross-agent delegation).",
+          "Allowlist of Virtual MCP (agent) or concrete MCP connection IDs this agent may delegate to via subtask. Concrete connections create ephemeral subagents. null/absent = all active org targets; empty array = itself only.",
         ),
       liveAgentId: z
         .string()


### PR DESCRIPTION
## Summary

- allow subtask delegation targets to be persisted Virtual MCP agents or concrete MCP connection IDs
- create ephemeral one-connection subagents without requiring a Virtual MCP row
- apply delegation allowlists to both target kinds and expose connection IDs in the prompt catalog
- support inline and background execution paths, update chat target rendering, and document the behavior

## Testing

- bun test packages/harness/src/decopilot/connections-block.test.ts packages/harness/src/decopilot/agents-block.test.ts packages/harness/src/decopilot/built-in-tools/local-subtask.test.ts packages/harness/src/decopilot/run-core.test.ts apps/mesh/src/harnesses/decopilot/build-agent-system-prompt.test.ts apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.test.ts apps/mesh/src/mcp-clients/virtual-mcp/passthrough-client.test.ts
- bun run check
- bun run --cwd=apps/mesh check
- bun run lint
- bun run fmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds connection-scoped subagents to Decopilot. `subtask` can now delegate to a persisted agent or directly to a concrete MCP connection ID, with allowlists, prompt, runtime, and UI updates to support this.

- **New Features**
  - `subtask` accepts agent IDs or MCP connection IDs; connection targets run as ephemeral one-connection subagents (no Virtual MCP row needed).
  - Delegation allowlists now cover agent and connection IDs; enforced for inline and background subtasks.
  - Prompts/catalogs: `<available-connections>` lists id,name,tools; usage explains ephemeral delegation; agent prompts include allowed target IDs.
  - Runtime: pass target instructions into the loop; only persisted agents get a VM sandbox; added `createConnectionClient`; `PassthroughClient` supports ephemeral mode.
  - UI/docs/tests: chat resolves subtask targets via `useConnection`; docs updated; workflow snapshot refreshed; tests added.

<sup>Written for commit 92006a23fab8cc13df62bcb7f76cc28c23664008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

