### PR TITLE
refactor(web): dedupe panel-width normalize/localStorage logic

### DIFF
--- a/apps/mesh/src/web/hooks/use-blocks-panel-width.ts
+++ b/apps/mesh/src/web/hooks/use-blocks-panel-width.ts
@@ -1,27 +1,11 @@
-import { useLocalStorage } from "@/web/hooks/use-local-storage";
+import { usePanelWidthPercent } from "@/web/hooks/use-panel-width-percent";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 
 const DEFAULT_BLOCKS_PANEL_WIDTH = 40;
 
-function normalizePanelSizePercent(
-  value: unknown,
-  fallback = DEFAULT_BLOCKS_PANEL_WIDTH,
-): number {
-  const numeric = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(numeric) || numeric <= 0 || numeric >= 100) {
-    return fallback;
-  }
-  return numeric;
-}
-
-function blocksPanelWidthInitializer(existing: number | undefined): number {
-  return normalizePanelSizePercent(existing);
-}
-
 export function useBlocksPanelWidth(): [number, (width: number) => void] {
-  const [stored, setStored] = useLocalStorage(
+  return usePanelWidthPercent(
     LOCALSTORAGE_KEYS.blocksPanelWidth(),
-    blocksPanelWidthInitializer,
+    DEFAULT_BLOCKS_PANEL_WIDTH,
   );
-  return [normalizePanelSizePercent(stored), setStored];
 }

--- a/apps/mesh/src/web/hooks/use-chat-panel-width.ts
+++ b/apps/mesh/src/web/hooks/use-chat-panel-width.ts
@@ -1,4 +1,4 @@
-import { useLocalStorage } from "@/web/hooks/use-local-storage";
+import { usePanelWidthPercent } from "@/web/hooks/use-panel-width-percent";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 
 // Chat takes ~1/3 by default so the main panel (the agent's app / the Super
@@ -6,25 +6,9 @@ import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 // persisted width.
 const DEFAULT_CHAT_PANEL_WIDTH = 33;
 
-/** react-resizable-panels requires numeric defaultSize; localStorage may hold strings. */
-function normalizePanelSizePercent(
-  value: unknown,
-  fallback = DEFAULT_CHAT_PANEL_WIDTH,
-): number {
-  const n = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(n) || n <= 0 || n >= 100) return fallback;
-  return n;
-}
-
-function chatPanelWidthInitializer(existing: number | undefined): number {
-  return normalizePanelSizePercent(existing, DEFAULT_CHAT_PANEL_WIDTH);
-}
-
 export function useChatPanelWidth(): [number, (width: number) => void] {
-  const [stored, setStored] = useLocalStorage(
+  return usePanelWidthPercent(
     LOCALSTORAGE_KEYS.decoChatPanelWidth(),
-    chatPanelWidthInitializer,
+    DEFAULT_CHAT_PANEL_WIDTH,
   );
-  const width = normalizePanelSizePercent(stored, DEFAULT_CHAT_PANEL_WIDTH);
-  return [width, setStored];
 }

--- a/apps/mesh/src/web/hooks/use-panel-width-percent.ts
+++ b/apps/mesh/src/web/hooks/use-panel-width-percent.ts
@@ -1,0 +1,20 @@
+import { useLocalStorage } from "@/web/hooks/use-local-storage";
+
+/** react-resizable-panels requires numeric defaultSize; localStorage may hold strings. */
+function normalizePanelSizePercent(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n) || n <= 0 || n >= 100) return fallback;
+  return n;
+}
+
+export function usePanelWidthPercent(
+  key: string,
+  defaultWidth: number,
+): [number, (width: number) => void] {
+  const [stored, setStored] = useLocalStorage(
+    key,
+    (existing: number | undefined) =>
+      normalizePanelSizePercent(existing, defaultWidth),
+  );
+  return [normalizePanelSizePercent(stored, defaultWidth), setStored];
+}


### PR DESCRIPTION
## Summary
`use-chat-panel-width.ts` and `use-blocks-panel-width.ts` (both touched in #4588) each defined an identical `normalizePanelSizePercent` helper plus an identical localStorage-initializer pattern, differing only in their default width value. Extracted the shared logic into a new `usePanelWidthPercent(key, defaultWidth)` hook; both call sites now just supply their key and default.

Net: -32 / +20 (two files shrink by 38/22 lines combined, new shared file adds 20).

## Why
One canonical place to fix/extend the percent-clamping logic for resizable panel widths, instead of two copies that would silently drift if one is edited and the other isn't.

## Verification
- Behavior-preserving: same clamping logic (`0 < n < 100` else fallback), same localStorage read/initializer flow via `useLocalStorage`, same public `[number, setter]` return shape for both `useChatPanelWidth` and `useBlocksPanelWidth`.
- `bun run fmt` — clean.
- `bunx tsc --noEmit` in `apps/mesh` — no new errors (pre-existing unrelated `rich-text-field.tsx` / `@tiptap/extension-text-align` errors are untouched by this change).
- No existing test file covers these hooks, so no test was added or removed.

Reviewer can confirm with `bunx tsc --noEmit` in `apps/mesh`; full CI will run lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated panel width normalization and localStorage logic into a single reusable hook to reduce duplication and keep behavior consistent for chat and blocks panels.

- **Refactors**
  - Added `usePanelWidthPercent(key, defaultWidth)` to handle clamping and storage initialization.
  - Updated `useChatPanelWidth` and `useBlocksPanelWidth` to use the new hook.
  - Preserves clamping (0 < n < 100) and the `[number, setter]` return shape.

<sup>Written for commit 97557b280687da84aa74220ad1609f4ceddc0c10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

