### PR TITLE
feat(sections-editor): add back arrow to editor breadcrumb navigation

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -2542,6 +2542,22 @@ export function SectionsEditor({
             )}
           >
             <div className="flex min-w-0 items-center gap-2 overflow-hidden">
+              {headerCrumbs.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => handleBreadcrumbClick(headerCrumbs.length - 2)}
+                  title="Back"
+                  aria-label="Back"
+                  className={cn(
+                    "shrink-0 inline-flex size-6 items-center justify-center rounded-md transition-colors",
+                    showGlobalBanner
+                      ? "text-foreground/80 hover:bg-global-section/15"
+                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                  )}
+                >
+                  <ChevronLeft className="size-4" />
+                </button>
+              )}
               {!isGlobalBlockMode && hasMultipleVariants && activeVariant && (
                 <button
                   type="button"


### PR DESCRIPTION
## Summary

Adds a **back-arrow button** to the CMS sections editor breadcrumb bar. Clicking it navigates **up one level** per click, making it easy to step out of deeply-nested content (e.g. editing an image field several levels deep) without having to target the tiny breadcrumb links.

The button reuses the existing `handleBreadcrumbClick` logic, so it works correctly across every mode: section editing, nested fields (arrays/objects/images), variants, SEO, and global blocks. It navigates to the second-to-last crumb (`headerCrumbs.length - 2`) and is only shown when there is somewhere to go back to (`headerCrumbs.length > 1`).

## Testing notes

- `bun run fmt` ✅
- `bun run --cwd=apps/mesh check` (tsc) ✅
- Behavior: the arrow steps back one level per click; the breadcrumb remains for larger jumps.

## Affected areas

- `apps/mesh/src/web/components/sections-editor/sections-editor.tsx` — breadcrumb bar UI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a back arrow to the sections editor breadcrumb so users can step up one level per click, making it easier to exit deep nested fields.
The button only shows when there’s a level to go back to and reuses the existing breadcrumb click handler, working across section, field, variant, SEO, and global block modes.

<sup>Written for commit c019f55c4e7cb8d0fcaf119aad1e55af314d1cc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

