### PR TITLE
fix(commerce-onboarding): don't link repo-scoped github children as companion

### DIFF
--- a/apps/mesh/src/shared/github-repo-scope.ts
+++ b/apps/mesh/src/shared/github-repo-scope.ts
@@ -63,7 +63,7 @@ function parsePositiveInteger(raw: unknown): number | undefined {
  * malformed) so callers can branch on it safely.
  */
 export function getRepoScope(connection: {
-  metadata: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
 }): RepoScopeRecipe | null {
   const raw = connection.metadata?.repoScope as
     | Partial<RepoScopeRecipe>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -142,6 +142,40 @@ describe("resolveCandidate", () => {
   it("returns null when nothing matches", () => {
     expect(resolveCandidate(conns, "shopify", "deco/shopify")).toBeNull();
   });
+  it("skips repo-scoped github children, preferring the org-level connection", () => {
+    const github = [
+      {
+        id: "c_repo_child",
+        app_id: "deco/mcp-github",
+        status: "active",
+        updated_at: "2026-03-01",
+        metadata: {
+          repoScope: { installationId: 1, owner: "deco", repo: "site" },
+        },
+      },
+      {
+        id: "c_org",
+        app_id: "deco/mcp-github",
+        status: "active",
+        updated_at: "2026-02-01",
+      },
+    ];
+    expect(resolveCandidate(github, "github", "deco/mcp-github")).toBe("c_org");
+  });
+  it("returns null when the only github match is repo-scoped", () => {
+    const github = [
+      {
+        id: "c_repo_child",
+        app_id: "deco/mcp-github",
+        status: "active",
+        updated_at: "2026-03-01",
+        metadata: {
+          repoScope: { installationId: 1, owner: "deco", repo: "site" },
+        },
+      },
+    ];
+    expect(resolveCandidate(github, "github", "deco/mcp-github")).toBeNull();
+  });
 });
 
 describe("unwrapToolResult", () => {

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -1,4 +1,5 @@
 import { getGitHubAvatarUrl } from "@deco/ui/lib/github.ts";
+import { getRepoScope } from "@/shared/github-repo-scope";
 import type { CompanionCopy } from "./companions.ts";
 
 export interface BindingRequirement {
@@ -13,6 +14,7 @@ export interface CandidateConnection {
   connection_token?: string | null;
   oauth_config?: unknown | null;
   configuration_state?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
   status?: string | null;
   updated_at?: string | null;
 }
@@ -214,8 +216,12 @@ export function resolveCandidate(
 ): string | null {
   const matches = connections.filter(
     (c) =>
-      c.app_name === bindingType ||
-      (!!registryAppId && c.app_id === registryAppId),
+      (c.app_name === bindingType ||
+        (!!registryAppId && c.app_id === registryAppId)) &&
+      // Repo-scoped github children (per-agent import / "Add repo") share the
+      // deco/mcp-github identity but can't list installations — linking one
+      // breaks the repo picker. Only org-level connections are valid candidates.
+      getRepoScope(c) === null,
   );
   if (matches.length === 0) return null;
   matches.sort((a, b) => {


### PR DESCRIPTION
## Summary

During commerce onboarding the GitHub repo picker was failing with:

> Repo-scoped connections cannot list installations — use an org-level mcp-github connection

`GITHUB_LIST_USER_ORGS` (which the picker calls to enumerate installations before searching repos) rejects any connection carrying `metadata.repoScope`. The bug is in candidate resolution: `resolveCandidate` matched **any** `deco/mcp-github` connection — including per-agent **repo-scoped children** created by agent import or the sidebar "Add repo" feature. When one of those got picked as the GitHub companion candidate, OAuth reused it, it got linked on the commerce-discovery connection, and every subsequent `GITHUB_LIST_USER_ORGS` call for the picker threw.

## Fix

Exclude repo-scoped connections from `resolveCandidate`, mirroring the existing `getOrgGithubConnections` helper — only org-level connections qualify as companion candidates. `getRepoScope` returns `null` for every non-github connection, so this is a no-op for the other bindings (vtex, ga4, gsc, …).

- `companions-core.ts`: filter `getRepoScope(c) === null` in `resolveCandidate`; add `metadata` to `CandidateConnection` (already returned by `COLLECTION_CONNECTIONS_LIST`).
- `github-repo-scope.ts`: widen `getRepoScope` param `metadata` to optional (runtime already used `?.`).

## Testing

- `bun test companions-core.test.ts` — 42 pass, incl. two new cases: org-level preferred over repo-scoped child, and null when the only github match is repo-scoped.
- `bun run check` (mesh) + `bun run fmt` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub repo picker in commerce onboarding by excluding repo-scoped GitHub connections from being linked as the companion. Only org-level `deco/mcp-github` connections are now considered, restoring repo search.

- **Bug Fixes**
  - In `resolveCandidate`, filter candidates with `getRepoScope(c) === null` to exclude repo-scoped GitHub children.
  - Add `metadata` to `CandidateConnection` and make `getRepoScope` accept optional `metadata`.

<sup>Written for commit f347aa4046b13746cc90caf3b39d8537d4c9293b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

