### PR TITLE
fix(preview): fix path-param value extraction for multi-param templates

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker.test.ts
@@ -256,6 +256,23 @@ describe("valueFromEntityUrl", () => {
     expect(valueFromEntityUrl("/p", "/:slug/p", "slug")).toBeNull();
     expect(valueFromEntityUrl("/x/p", "/*", "missing")).toBeNull();
   });
+
+  test("a leading dynamic param doesn't bleed into a later param's value", () => {
+    expect(
+      valueFromEntityUrl(
+        "/electronics/apple-watch/p",
+        "/:category/:slug/p",
+        "slug",
+      ),
+    ).toBe("apple-watch");
+    expect(
+      valueFromEntityUrl(
+        "/electronics/apple-watch/p",
+        "/:category/:slug/p",
+        "category",
+      ),
+    ).toBe("electronics");
+  });
 });
 
 describe("productOptionsFromPayload", () => {

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker.ts
@@ -1,6 +1,7 @@
 import {
   normalizePagePath,
   splitPathTemplate,
+  type PathToken,
 } from "@/web/components/sections-editor/page-path-utils";
 
 /** Entity kind a path param can be filled from. */
@@ -378,18 +379,48 @@ function safeDecode(value: string): string {
   }
 }
 
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Builds a regex that matches a template's tokens against a real pathname,
+ * capturing each param/catch-all in token order. A non-catch-all param
+ * matches one path segment (`[^/]+`); the catch-all matches the rest
+ * (`.+`, so it keeps internal slashes). Anchored to the whole pathname, so
+ * an earlier param in the template consumes exactly its own segment(s)
+ * instead of bleeding into a later param's match.
+ */
+function templateMatcher(tokens: PathToken[]): {
+  pattern: RegExp;
+  order: string[];
+} {
+  const order: string[] = [];
+  let source = "^";
+  for (const token of tokens) {
+    if (token.type === "text") {
+      source += escapeRegExp(token.text);
+    } else {
+      order.push(token.name);
+      source += token.name === "*" ? "(.+)" : "([^/]+)";
+    }
+  }
+  return { pattern: new RegExp(`${source}$`), order };
+}
+
 /**
  * The value to commit into `paramName` for an entity URL, derived RELATIVE to
- * the page template — no `/p` or provider-specific shape assumed. The template's
- * static text before and after the param is stripped from the entity pathname;
- * the remainder is the value:
+ * the page template — no `/p` or provider-specific shape assumed. Matches the
+ * entity pathname against the whole template (every param/catch-all consumes
+ * its own segment), then reads out `paramName`'s captured group:
  *
- * - `/apple-watch/p`            on `/:slug/p`        → `apple-watch`
- * - `/eau-de-toilette-100ml`    on `/*`              → `eau-de-toilette-100ml`
- * - `/granado/x`                on `/granado/:slug`  → `x`
+ * - `/apple-watch/p`             on `/:slug/p`             → `apple-watch`
+ * - `/eau-de-toilette-100ml`     on `/*`                   → `eau-de-toilette-100ml`
+ * - `/granado/x`                 on `/granado/:slug`       → `x`
+ * - `/electronics/apple-watch/p` on `/:category/:slug/p`   → `apple-watch`
  *
  * Catch-all values keep internal slashes (multi-segment). Returns null when the
- * URL is unusable.
+ * URL is unusable or the pathname doesn't match the template's shape.
  */
 export function valueFromEntityUrl(
   url: unknown,
@@ -406,29 +437,12 @@ export function valueFromEntityUrl(
   // Drop a trailing slash so it matches the normalized template's static text.
   pathname = pathname.replace(/\/+$/, "");
   const tokens = splitPathTemplate(normalizePagePath(template));
-  const idx = tokens.findIndex(
-    (t) => t.type === "param" && t.name === paramName,
-  );
-  if (idx === -1) return null;
-  const before = tokens
-    .slice(0, idx)
-    .map((t) => (t.type === "text" ? t.text : ""))
-    .join("");
-  const after = tokens
-    .slice(idx + 1)
-    .map((t) => (t.type === "text" ? t.text : ""))
-    .join("");
-  // Strip the trailing static text first, then the leading — a shared boundary
-  // slash (e.g. `/p` after `/:slug`) must not be consumed twice.
-  let rest = pathname;
-  if (after && rest.endsWith(after)) {
-    rest = rest.slice(0, rest.length - after.length);
-  }
-  rest =
-    before && rest.startsWith(before)
-      ? rest.slice(before.length)
-      : rest.replace(/^\/+/, "");
-  rest = rest.replace(/^\/+|\/+$/g, "");
+  const { pattern, order } = templateMatcher(tokens);
+  const paramIdx = order.indexOf(paramName);
+  if (paramIdx === -1) return null;
+  const match = pathname.match(pattern);
+  if (!match) return null;
+  const rest = match[paramIdx + 1]?.replace(/^\/+|\/+$/g, "");
   return rest ? safeDecode(rest) : null;
 }
 


### PR DESCRIPTION
## Source
Bug found while reading recently-changed code in `apps/mesh/src/web/components/sandbox/preview/` (the path-param picker backing the Preview URL bar's `:param` auto-fill/chip UI).

## What's wrong
`valueFromEntityUrl` extracted a `:param`'s value by stripping the template's static text *before* and *after* the param from the entity's pathname. That only works when there's exactly one dynamic segment in the template. When another `:param` appears earlier in the template (e.g. a two-segment commerce URL like `/:category/:slug/p`), the "before" text is just the literal static characters — it has no way to account for the actual (variable-length) value of the earlier param — so it leaks into the extracted value.

**Failure scenario:** template `/:category/:slug/p`, entity URL `/electronics/apple-watch/p`. Extracting `slug` returns `"electronics/apple-watch"` instead of `"apple-watch"`. This value is what gets committed as the picker's selection, so picking a product on such a page would fill the wrong value into the URL and navigate to the wrong path.

## Fix
Replaced the prefix/suffix string-stripping with a regex built from the *entire* token sequence (every param becomes its own capture group — `[^/]+` for a normal param, `.+` for the catch-all). Each param then consumes exactly its own segment(s) regardless of how many other params precede it.

Added a regression test (`a leading dynamic param doesn't bleed into a later param's value`) that fails on the old implementation and passes now.

## Verify
```
bun test apps/mesh/src/web/components/sandbox/preview/path-param-picker.test.ts
```

## Checks run locally
- `bun run fmt` (no changes)
- `bun x tsc --noEmit -p apps/mesh` (no new errors — pre-existing unrelated tiptap type errors only)
- `bun test apps/mesh/src/web/components/sandbox/preview/path-param-picker.test.ts` — 40 pass

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes path-param extraction in the Preview URL bar so multi-param templates (e.g., `/:category/:slug/p`) resolve the correct value and navigate to the right path.

- **Bug Fixes**
  - Switched from prefix/suffix stripping to a full-template regex, capturing each param separately (`[^/]+` for params, `.+` for catch-alls).
  - Added a regression test to prevent earlier dynamic segments from leaking into later param values.

<sup>Written for commit 7cd6fd0a4ca0854d78bfa6f48fe64b10764d299a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

