### PR TITLE
fix(blocks): restore variant-aware preview override in standalone panel

### DIFF
--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
@@ -125,6 +125,7 @@ export function BlocksPanel({ virtualMcpId }: { virtualMcpId: string }) {
           }
           onExitSeo={workspace.consumeEditSeo}
           onSaved={workspace.notifySaved}
+          onVariantPreviewOverride={workspace.setVariantOverride}
         />
       </Suspense>
     </div>

--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-context.tsx
@@ -12,6 +12,7 @@ interface BlocksPreviewWorkspaceContextValue {
   editSeo: (target: Extract<BlocksTarget, { kind: "page" }>) => void;
   consumeEditSeo: () => void;
   notifySaved: () => void;
+  setVariantOverride: (params: string[] | null) => void;
 }
 
 const BlocksPreviewWorkspaceContext =
@@ -35,6 +36,8 @@ export function BlocksPreviewWorkspaceProvider({
         editSeo: (target) => dispatch({ type: "edit-seo", target }),
         consumeEditSeo: () => dispatch({ type: "consume-edit-seo" }),
         notifySaved: () => dispatch({ type: "saved" }),
+        setVariantOverride: (params) =>
+          dispatch({ type: "variant-override", params }),
       }}
     >
       {children}

--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-state.test.ts
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-state.test.ts
@@ -59,6 +59,38 @@ describe("blocksPreviewWorkspaceReducer", () => {
       target: { kind: "page", key: "pages-home", path: "/" },
       editSeoPageKey: null,
       previewRevision: 0,
+      variantOverride: null,
     });
+  });
+
+  test("records variant override params for the preview iframe", () => {
+    const next = blocksPreviewWorkspaceReducer(
+      INITIAL_BLOCKS_PREVIEW_WORKSPACE,
+      {
+        type: "variant-override",
+        params: ["pages-home@sections.variants.1.rule=1"],
+      },
+    );
+
+    expect(next.variantOverride).toEqual([
+      "pages-home@sections.variants.1.rule=1",
+    ]);
+  });
+
+  test("selecting a new target clears a stale variant override", () => {
+    const withOverride = blocksPreviewWorkspaceReducer(
+      INITIAL_BLOCKS_PREVIEW_WORKSPACE,
+      {
+        type: "variant-override",
+        params: ["pages-home@sections.variants.1.rule=1"],
+      },
+    );
+
+    const next = blocksPreviewWorkspaceReducer(withOverride, {
+      type: "select",
+      target: { kind: "page", key: "pages-about", path: "/about" },
+    });
+
+    expect(next.variantOverride).toBeNull();
   });
 });

--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-state.ts
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-state.ts
@@ -6,6 +6,12 @@ export interface BlocksPreviewWorkspaceState {
   target: BlocksTarget | null;
   editSeoPageKey: string | null;
   previewRevision: number;
+  /**
+   * `x-deco-matchers-override` params published by the Blocks panel so the
+   * (independent) Preview iframe renders the variant currently selected in the
+   * sections editor. `null` clears any prior override.
+   */
+  variantOverride: string[] | null;
 }
 
 export type BlocksPreviewWorkspaceAction =
@@ -15,12 +21,14 @@ export type BlocksPreviewWorkspaceAction =
       target: Extract<BlocksTarget, { kind: "page" }>;
     }
   | { type: "consume-edit-seo" }
-  | { type: "saved" };
+  | { type: "saved" }
+  | { type: "variant-override"; params: string[] | null };
 
 export const INITIAL_BLOCKS_PREVIEW_WORKSPACE: BlocksPreviewWorkspaceState = {
   target: null,
   editSeoPageKey: null,
   previewRevision: 0,
+  variantOverride: null,
 };
 
 export function blocksPreviewWorkspaceReducer(
@@ -29,7 +37,9 @@ export function blocksPreviewWorkspaceReducer(
 ): BlocksPreviewWorkspaceState {
   switch (action.type) {
     case "select":
-      return { ...state, target: action.target };
+      // A new target's variant override is unknown until the editor emits it;
+      // drop the previous target's params so they don't bleed across pages.
+      return { ...state, target: action.target, variantOverride: null };
     case "edit-seo":
       return {
         ...state,
@@ -40,5 +50,7 @@ export function blocksPreviewWorkspaceReducer(
       return { ...state, editSeoPageKey: null };
     case "saved":
       return { ...state, previewRevision: state.previewRevision + 1 };
+    case "variant-override":
+      return { ...state, variantOverride: action.params };
   }
 }

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -40,6 +40,7 @@ import {
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
 import { useDecofile } from "@/web/components/sections-editor/use-decofile";
+import { withVariantMatcherOverride } from "@/web/components/sections-editor/variant-matcher-override";
 import { useLiveMeta } from "@/web/components/sections-editor/use-live-meta";
 import {
   extractGlobalSections,
@@ -413,10 +414,13 @@ export function PreviewContent() {
 
   const iframeSrc =
     previewState.kind === "iframe"
-      ? withDeviceHint(
-          directPreviewUrl ??
-            new URL(resolvedPath, previewState.previewUrl).href,
-          previewDeviceSize,
+      ? withVariantMatcherOverride(
+          withDeviceHint(
+            directPreviewUrl ??
+              new URL(resolvedPath, previewState.previewUrl).href,
+            previewDeviceSize,
+          ),
+          workspace.state.variantOverride ?? [],
         )
       : null;
 


### PR DESCRIPTION
## Summary

Clicking a page/section variant in the **Blocks** panel stopped updating the **Preview** iframe. This restores the variant → preview wiring.

**Regression origin:** #4566 (`feat(blocks): add standalone workspace panel`) split Preview and Blocks into independent panels. In doing so, the override plumbing was dropped:
- `blocks-panel.tsx` rendered `<SectionsEditor>` **without** `onVariantPreviewOverride`, so the callback was `undefined` and the computed override params went nowhere.
- `preview.tsx` built `iframeSrc` **without** `withVariantMatcherOverride`, so the deco runtime's `x-deco-matchers-override` query param never reached the iframe.
- `withVariantMatcherOverride` remained exported but had **no callers**.

## Fix

Restore the channel through the shared `BlocksPreviewWorkspace` context (the mechanism the independent panels already use to communicate):

- `blocks-preview-workspace-state.ts` — new `variantOverride: string[] | null` state, `variant-override` action, and reset-on-`select` so params from one page don't bleed into another.
- `blocks-preview-workspace-context.tsx` — `setVariantOverride` method.
- `blocks-panel.tsx` — passes `onVariantPreviewOverride={workspace.setVariantOverride}`.
- `preview.tsx` — wraps `iframeSrc` with `withVariantMatcherOverride(..., workspace.state.variantOverride ?? [])`.

## Scope note

The **Content** tab (`content-browser.tsx`) also renders `SectionsEditor`, but it was never wired to an iframe override (even before #4566 only `preview.tsx` consumed it), so it's intentionally left out.

## Testing

- `bun run check` (mesh) — clean.
- `bun test` reducer suite — 6/6 pass, including two new tests covering the override action and the reset-on-target-change.
- Manual check recommended: open Blocks + Preview side by side on a multivariate page and click between variants to confirm the iframe re-renders the selected variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes variant clicks in the Blocks panel not updating the Preview iframe. Restores the variant → preview override so the iframe renders the selected variant.

- **Bug Fixes**
  - Reintroduced the override channel via `BlocksPreviewWorkspace` context.
  - Added `variantOverride` state and `variant-override` action; cleared on target change.
  - Wired Blocks to publish with `onVariantPreviewOverride` and Preview to consume via `withVariantMatcherOverride` when building `iframeSrc`.
  - Added reducer tests covering override recording and reset behavior.

<sup>Written for commit 801ba39f8f4188ab616bc3e89e7526f9d9902137. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

