### PR TITLE
fix(sidebar): open adjacent thread after archive

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/archive-fallback.test.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/archive-fallback.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import type { Task } from "@/web/components/chat/task/types";
+import { findArchiveFallback } from "./archive-fallback";
+
+const task = (id: string, createdBy: string, agentId: string): Task => ({
+  id,
+  title: id,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  created_by: createdBy,
+  virtual_mcp_id: agentId,
+});
+
+describe("findArchiveFallback", () => {
+  it("selects the next owned row even when it belongs to another agent", () => {
+    const threads = [
+      task("current", "me", "agent-a"),
+      task("next", "me", "agent-b"),
+    ];
+
+    expect(findArchiveFallback(threads, "current", "me")?.id).toBe("next");
+  });
+
+  it("skips teammate rows while scanning downward", () => {
+    const threads = [
+      task("current", "me", "agent-a"),
+      task("teammate", "them", "agent-b"),
+      task("mine", "me", "agent-c"),
+    ];
+
+    expect(findArchiveFallback(threads, "current", "me")?.id).toBe("mine");
+  });
+
+  it("falls back to the closest owned row above", () => {
+    const threads = [
+      task("mine", "me", "agent-a"),
+      task("teammate", "them", "agent-b"),
+      task("current", "me", "agent-c"),
+    ];
+
+    expect(findArchiveFallback(threads, "current", "me")?.id).toBe("mine");
+  });
+
+  it("returns no fallback when only teammate rows remain", () => {
+    const threads = [
+      task("current", "me", "agent-a"),
+      task("teammate", "them", "agent-b"),
+    ];
+
+    expect(findArchiveFallback(threads, "current", "me")).toBeUndefined();
+  });
+});

--- a/apps/mesh/src/web/components/sidebar/task-groups/archive-fallback.ts
+++ b/apps/mesh/src/web/components/sidebar/task-groups/archive-fallback.ts
@@ -1,0 +1,32 @@
+import type { Task } from "@/web/components/chat/task/types";
+
+/**
+ * Pick the closest thread the current user owns in the sidebar's rendered
+ * order. Prefer the row below the archived thread, then scan upward when there
+ * is no eligible row below it. Team threads stay manually selectable but are
+ * never opened automatically.
+ */
+export function findArchiveFallback(
+  threads: Task[],
+  archivedThreadId: string,
+  currentUserId: string | null | undefined,
+): Task | undefined {
+  if (!currentUserId) return undefined;
+
+  const archivedIndex = threads.findIndex(
+    (thread) => thread.id === archivedThreadId,
+  );
+  if (archivedIndex === -1) return undefined;
+
+  for (let index = archivedIndex + 1; index < threads.length; index++) {
+    const thread = threads[index];
+    if (thread?.created_by === currentUserId) return thread;
+  }
+
+  for (let index = archivedIndex - 1; index >= 0; index--) {
+    const thread = threads[index];
+    if (thread?.created_by === currentUserId) return thread;
+  }
+
+  return undefined;
+}

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -53,6 +53,7 @@ import { AgentAvatar } from "@/web/components/agent-icon";
 import { SidebarTriggerButton } from "@/web/layouts/shell-controls";
 import { MyThreadsSection } from "./my-threads-section";
 import type { SidebarFilters } from "./next-page-offset";
+import { findArchiveFallback } from "./archive-fallback";
 
 type TypeFilter = "all" | "manual" | "automation";
 type GroupBy = "flat" | "status";
@@ -237,9 +238,12 @@ export function TaskGroupsList({
     const wasActive = task.id === activeTaskId;
     hide(task.id);
     if (!wasActive) return;
-    // Land only on the caller's own threads — never teleport into a teammate's.
-    const next = myThreadsAll.find(
-      (t) => t.id !== task.id && t.virtual_mcp_id === task.virtual_mcp_id,
+    // Follow the sidebar's current filtered order across agents, while keeping
+    // teammate threads opt-in even when Team scope renders them.
+    const next = findArchiveFallback(
+      visibleScopedThreads,
+      task.id,
+      currentUserId,
     );
     closeAfterNavigation();
     if (next) {


### PR DESCRIPTION
## What is this contribution about?

When the active sidebar thread is archived, open the closest visible thread owned by the current user instead of falling back to the org home and creating a Decopilot thread.

The fallback follows sidebar order: it prefers the next row, then the previous row. It can cross agent boundaries, skips teammate-owned threads in Team scope, and leaves the existing final-thread archive guard unchanged.

## Screenshots/Demonstration

Not applicable; this changes navigation behavior without visual changes.

## How to Test

1. Open a thread with another owned thread visible below it, using a different agent.
2. Archive the active thread.
3. Confirm the adjacent owned thread opens and no new Decopilot thread is created.
4. In Team scope, confirm teammate threads are skipped as automatic fallbacks.
5. Confirm the final loaded thread still has no archive affordance.

Automated checks:

- `bun test apps/mesh/src/web/components/sidebar/task-groups/*.test.ts --dots` (52 passed)
- `bun run fmt:check`
- `bun run check`
- `bun run lint` (0 errors)

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (not needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Archiving the active sidebar thread now opens the closest visible thread you own instead of jumping to org home and creating a new Decopilot thread. It follows sidebar order, crosses agents, and keeps teammate threads opt-in.

- **Bug Fixes**
  - Added `findArchiveFallback` to select the next owned row, then the previous.
  - Skips teammate-owned threads in Team scope; final-thread archive guard unchanged.
  - Wired into `TaskGroupsList` and added unit tests for cross-agent and skip-teammate cases.

<sup>Written for commit 62c6cac63216e73a1487ed4047607a4884240583. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

