### PR TITLE
fix(commerce-onboarding): resilient integrations section + disconnect to revalidate

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -17,7 +17,12 @@ import {
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { useMCPClient } from "@decocms/mesh-sdk";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { CheckCircle, Loading01, Settings01 } from "@untitledui/icons";
+import {
+  CheckCircle,
+  LinkBroken01,
+  Loading01,
+  Settings01,
+} from "@untitledui/icons";
 import { Suspense, useState } from "react";
 import { toast } from "sonner";
 import type { CompanionCardModel } from "./companions-core.ts";
@@ -56,8 +61,10 @@ const AREA_BADGE_CLASS =
 export function CompanionCard({
   card,
   connecting,
+  disconnecting,
   disabled,
   onConnect,
+  onDisconnect,
   org,
   selfClient,
   siteUrl,
@@ -66,8 +73,10 @@ export function CompanionCard({
 }: {
   card: CompanionCardModel;
   connecting: boolean;
+  disconnecting: boolean;
   disabled: boolean;
   onConnect: () => void;
+  onDisconnect: () => void;
   org: { id: string; slug: string };
   selfClient: Client;
   siteUrl?: string;
@@ -116,6 +125,28 @@ export function CompanionCard({
             onAutoOpenHandled={onAutoOpenConfigHandled}
           />
         </Suspense>
+        {/* Unlink to revalidate: reverts the card to "Conectar" so a wrong or
+            stale link (e.g. a repo-scoped GitHub connection) can be replaced. */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="shrink-0 text-muted-foreground hover:text-destructive"
+              disabled={disabled || disconnecting}
+              onClick={onDisconnect}
+              aria-label={`Desconectar ${card.title}`}
+            >
+              {disconnecting ? (
+                <Loading01 size={16} className="animate-spin" />
+              ) : (
+                <LinkBroken01 size={16} />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Desconectar</TooltipContent>
+        </Tooltip>
       </div>
     ) : (
       <Button

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -149,6 +149,8 @@ function CompanionMcpsSectionContent({
   const {
     connect,
     connectingFieldKey,
+    disconnect,
+    disconnectingFieldKey,
     error: connectError,
   } = useConnectCompanion({
     selfClient,
@@ -173,7 +175,7 @@ function CompanionMcpsSectionContent({
     return null;
   }
 
-  const busy = connectingFieldKey !== null;
+  const busy = connectingFieldKey !== null || disconnectingFieldKey !== null;
 
   return (
     // Mobile: fill the parent's remaining height — the header + intro copy stay
@@ -208,7 +210,12 @@ function CompanionMcpsSectionContent({
                 key={card.fieldKey}
                 card={card}
                 connecting={connectingFieldKey === card.fieldKey}
-                disabled={busy && connectingFieldKey !== card.fieldKey}
+                disconnecting={disconnectingFieldKey === card.fieldKey}
+                disabled={
+                  busy &&
+                  connectingFieldKey !== card.fieldKey &&
+                  disconnectingFieldKey !== card.fieldKey
+                }
                 org={org}
                 selfClient={selfClient}
                 siteUrl={siteUrl}
@@ -219,6 +226,7 @@ function CompanionMcpsSectionContent({
                   )
                 }
                 onConnect={() => void handleConnect()}
+                onDisconnect={() => void disconnect(card)}
               />
             );
           })}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -95,6 +95,27 @@ export function parseBindingRequirements(
   return reqs;
 }
 
+/**
+ * Static binding requirements for the four Commerce Discovery companions — a
+ * fallback for when the CD connection's live MCP_CONFIGURATION schema can't be
+ * fetched (e.g. the CD proxy returns 401 because the connection lost its
+ * credential to reach commerce-skills). Without this the schema fetch is a hard
+ * dependency: one 401 collapses the whole integrations section to an error and
+ * the user can neither connect nor disconnect anything.
+ *
+ * `fieldKey` is the CD `configuration_state` key and `bindingType` is the
+ * binding `__type` (== the curated COMMERCE_COMPANION_MCPS key). Kept in sync
+ * with commerce-discovery's CONNECTION_PROVIDERS (vtex/ga4/gsc/github); if the
+ * CD schema gains a binding it still appears via the live schema — this
+ * fallback only applies when the schema is unreachable.
+ */
+export const FALLBACK_COMPANION_REQUIREMENTS: BindingRequirement[] = [
+  { fieldKey: "vtex", bindingType: "vtex" },
+  { fieldKey: "ga4", bindingType: "google-analytics" },
+  { fieldKey: "gsc", bindingType: "google-search-console" },
+  { fieldKey: "github", bindingType: "github" },
+];
+
 /** Build a registry LIST `where` matching items by id-set OR server-name-set.
  * `["id"]` is the top-level column; `["name"]` maps to the virtual server_json->>'name'. */
 export function buildRegistryWhere(

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-commerce-companions.ts
@@ -12,6 +12,7 @@ import { COMMERCE_COMPANION_MCPS } from "./companions.ts";
 import {
   buildCompanionCards,
   buildRegistryWhere,
+  FALLBACK_COMPANION_REQUIREMENTS,
   parseBindingRequirements,
   type SaBindings,
   unwrapToolResult,
@@ -59,7 +60,12 @@ export function useCommerceCompanions({
     orgId: org.id,
     orgSlug: org.slug,
   });
-  const schemaQuery = useSuspenseQuery({
+  // Soft (non-suspense) on purpose: this call proxies to the CD origin
+  // (commerce-skills) and can 401 when the connection lost its credential. As a
+  // hard Suspense dependency, that 401 threw and collapsed the whole section —
+  // no cards, no connect, no disconnect. Now a failure just drops us to the
+  // static requirements below so the integrations still render.
+  const schemaQuery = useQuery({
     queryKey: KEYS.commerceDiscoveryCompanionSchema(org.id, cdConnectionId),
     queryFn: async () => {
       const result = await cdClient.callTool({
@@ -70,11 +76,18 @@ export function useCommerceCompanions({
         result,
       );
     },
+    retry: false,
   });
 
-  const requirements = parseBindingRequirements(
-    schemaQuery.data?.stateSchema ?? { type: "object", properties: {} },
-  );
+  const schemaRequirements = schemaQuery.data?.stateSchema
+    ? parseBindingRequirements(schemaQuery.data.stateSchema)
+    : null;
+  // Live schema wins; fall back to the known companion set while it loads or
+  // when it's unreachable, so the section is never empty due to a CD proxy 401.
+  const requirements =
+    schemaRequirements && schemaRequirements.length > 0
+      ? schemaRequirements
+      : FALLBACK_COMPANION_REQUIREMENTS;
   const bindingTypes = requirements.map((r) => r.bindingType);
   const registryAppIds = requirements
     .map((r) => COMMERCE_COMPANION_MCPS[r.bindingType]?.registryAppId)

--- a/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/use-connect-companion.ts
@@ -36,6 +36,9 @@ export function useConnectCompanion({
   const [connectingFieldKey, setConnectingFieldKey] = useState<string | null>(
     null,
   );
+  const [disconnectingFieldKey, setDisconnectingFieldKey] = useState<
+    string | null
+  >(null);
   const [error, setError] = useState<string | null>(null);
 
   const updateConnection = async (
@@ -170,5 +173,63 @@ export function useConnectCompanion({
     }
   }
 
-  return { connect, connectingFieldKey, error };
+  // Unlink a companion so the user can revalidate: drop its binding from the CD
+  // configuration_state (read-modify-write), which reverts the card to
+  // "Conectar". We intentionally DON'T delete the underlying connection — a
+  // subsequent connect re-links a fresh/org-level one (repo-scoped children are
+  // excluded from candidates) and re-runs OAuth. GitHub's free-standing
+  // github_repo is cleared too, so the repo is re-picked against the next link.
+  async function disconnect(card: CompanionCardModel): Promise<boolean> {
+    setDisconnectingFieldKey(card.fieldKey);
+    setError(null);
+    const basePayload = {
+      app_name: card.title,
+      field_key: card.fieldKey,
+      organization_id: org.id,
+      domain,
+      site_url: siteUrl,
+    };
+    track("commerce_onboarding_companion_disconnect_clicked", basePayload);
+    try {
+      const cdGet = await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_GET",
+        arguments: { id: cdConnectionId },
+      });
+      const currentState =
+        unwrapToolResult<{
+          item: { configuration_state?: Record<string, unknown> | null } | null;
+        }>(cdGet).item?.configuration_state ?? null;
+      const next = { ...(currentState ?? {}) };
+      delete next[card.fieldKey];
+      if (card.bindingType === "github") {
+        delete next.github_repo;
+      }
+      await updateConnection(cdConnectionId, { configuration_state: next });
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.commerceDiscoveryConnection(org.id, cdConnectionId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.commerceDiscoveryCompanionConnectionsPrefix(org.id),
+      });
+      track("commerce_onboarding_companion_disconnected", basePayload);
+      return true;
+    } catch (err) {
+      track("commerce_onboarding_companion_disconnect_failed", {
+        ...basePayload,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setError(err instanceof Error ? err.message : String(err));
+      return false;
+    } finally {
+      setDisconnectingFieldKey(null);
+    }
+  }
+
+  return {
+    connect,
+    connectingFieldKey,
+    disconnect,
+    disconnectingFieldKey,
+    error,
+  };
 }


### PR DESCRIPTION
## What is this contribution about?

On `https://studio.decocms.com/commerce-onboarding?org=…&siteUrl=…` the integrations section could collapse to *"Não foi possível carregar as integrações complementares"*, leaving the user unable to see, connect, or disconnect anything.

**Root cause (confirmed on prod network):** `useCommerceCompanions` fetched the Commerce Discovery connection's live `MCP_CONFIGURATION` schema as a **hard Suspense dependency**. That call proxies to the CD origin (commerce-skills) and returns `401` when the connection lacks a valid credential for it — the oauth-proxy then responds `{"error":"unauthorized","message":"Authentication required but server does not support OAuth"}`. A single 401 threw and the section's ErrorBoundary swallowed the whole thing. (`COLLECTION_CONNECTIONS_GET`/`VIRTUAL_MCP_GET` returned 200 — only the CD proxy tool call failed.)

## Changes

1. **Render independently of the CD schema** — the schema fetch is now a soft `useQuery` (`retry:false`); on failure or while loading it falls back to a static requirements set (`vtex`/`ga4`/`gsc`/`github`, matching commerce-discovery's `CONNECTION_PROVIDERS`). Cards always render; the live schema still wins when available.
2. **Disconnect to revalidate** — connected (OAuth-linked) cards get a Desconectar action that unlinks the binding from the CD `configuration_state`, reverting the card to "Conectar". This lets a wrong/stale link (e.g. a repo-scoped GitHub connection mislinked as the companion — see #4592) be replaced. The underlying connection is left intact; reconnecting re-links a fresh org-level one and re-runs OAuth. GitHub's `github_repo` is cleared too so the repo is re-picked.

## Screenshots/Demonstration

N/A (behavioral). The integrations grid now renders with a broken CD schema, and connected cards show a Desconectar (link-broken) button next to the config gear.

## How to Test

1. Open commerce onboarding for an org whose CD connection can't be reached for `MCP_CONFIGURATION` (or simulate a 401 on `POST /api/:org/mcp/:cdConnectionId`). The four integration cards still render instead of the section error.
2. Connect GitHub (or VTEX) → the card shows "Conectado" with a config gear and a Desconectar button.
3. Click Desconectar → the card reverts to "Conectar"; `configuration_state[fieldKey]` (and `github_repo` for GitHub) is removed on the CD connection.
4. Reconnect → links a fresh org-level connection.

## Migration Notes

N/A — no database migrations or configuration changes.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Commerce Onboarding integrations section render even when the CD schema fetch fails (e.g., proxy 401). Adds a Disconnect action so users can unlink and revalidate companion connections.

- **Bug Fixes**
  - Fetch the CD schema softly and fall back to static requirements (`vtex`, `ga4`, `gsc`, `github`) when unavailable, so the cards always render.

- **New Features**
  - Add a Disconnect button on connected cards to unlink the binding from `configuration_state` (and clear `github_repo` for GitHub) without deleting the underlying connection.

<sup>Written for commit 5d10f4a1e027f45f9dbf385f90d975eaeb3a71bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

