### PR TITLE
refactor(decopilot): dedupe connections-block csvField into shared csv.ts

### DIFF
--- a/packages/harness/src/decopilot/connections-block.ts
+++ b/packages/harness/src/decopilot/connections-block.ts
@@ -8,6 +8,8 @@
  * the block from the prompt entirely.
  */
 
+import { csvField } from "./csv";
+
 export interface ConnectionsBlockTool {
   /** Original MCP tool name (with gateway prefix). */
   rawName: string;
@@ -39,19 +41,6 @@ On errors:
   call enable_tool again if the tool is not present there at all.
 - Schema validation — re-check the tool's input schema
 </connections-usage>`;
-
-function csvField(s: string | null | undefined): string {
-  if (s == null || s === "") return "";
-  if (
-    s.includes(",") ||
-    s.includes('"') ||
-    s.includes("\n") ||
-    s.includes(";")
-  ) {
-    return `"${s.replaceAll('"', '""')}"`;
-  }
-  return s;
-}
 
 export function buildConnectionsBlock(
   tools: ConnectionsBlockTool[],


### PR DESCRIPTION
## Source
Source 4 — code duplication found while reading recently-changed harness files (`connections-block.ts` landed in #4589).

## What & why
`connections-block.ts` defined its own local `csvField` helper that is byte-for-byte identical to the canonical `csvField` already exported from `csv.ts` in the same directory — the one `prompts-block.ts` and `skills-block.ts` both import. This change deletes the duplicate and imports the shared implementation instead, so there's one place to fix RFC-4180 escaping bugs instead of three.

Net line delta: -13 / +2.

## Behavior
No behavior change: the removed function and the shared one have identical bodies (same delimiter checks, same quoting logic). Confirmed via:
- `grep -rn "csvField"` — only `connections-block.ts` and `agents-block.ts` had local copies; `agents-block.ts`'s version differs (no `;` check) so it was left untouched to avoid a real behavior change there.
- `bunx tsc --noEmit` in `packages/harness` — clean.
- `bun test packages/harness/src/decopilot/connections-block.test.ts` — all 7 existing tests pass unchanged, including the CSV-escaping test.

## Reviewer check
```
cd packages/harness && bunx tsc --noEmit
bun test packages/harness/src/decopilot/connections-block.test.ts
```

Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated `csvField` in `connections-block.ts` by importing the shared helper from `./csv` to remove duplication and centralize CSV escaping.
Behavior is unchanged and now aligns with `prompts-block.ts` and `skills-block.ts` for easier maintenance.

<sup>Written for commit 8a3168f4e03bfef5346dcc830994816b3ecc8457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

