### PR TITLE
fix(home): wire up mock tile connect buttons

### DIFF
--- a/apps/mesh/src/web/components/home/native-tiles.tsx
+++ b/apps/mesh/src/web/components/home/native-tiles.tsx
@@ -10,7 +10,7 @@
  * the user to connect the backing integration). Recent conversations is still
  * available but `defaultHidden` — re-add it from Customize.
  */
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
@@ -30,6 +30,7 @@ import { useMembers } from "@/web/hooks/use-members";
 import { useTaskBoardItems } from "@/web/hooks/use-task-board-items";
 import { STATUS_CONFIG } from "@/web/layouts/task-board/config";
 import { GitHubIcon } from "@/web/components/icons/github-icon";
+import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
 import { KEYS } from "@/web/lib/query-keys";
 
 const TASKS_TILE_ID = "tasks";
@@ -264,19 +265,26 @@ function TasksTileBody() {
 
 // ---------------------------------------------------------------------------
 // Mock tiles — Coding / Analytics / Sales. Static sample data; a hover overlay
-// invites the user to connect the real integration (not wired yet).
+// opens the connection catalog pre-filtered to the backing integration.
 // ---------------------------------------------------------------------------
 
 function MockConnectOverlay({
   label,
   icon,
+  onConnect,
 }: {
   label: string;
   icon: React.ReactNode;
+  onConnect: () => void;
 }) {
   return (
     <div className="absolute inset-0 flex items-center justify-center bg-background/70 opacity-0 backdrop-blur-sm transition-opacity duration-150 group-hover/mock:opacity-100">
-      <Button size="sm" variant="secondary" className="gap-2 shadow-sm">
+      <Button
+        size="sm"
+        variant="secondary"
+        className="gap-2 shadow-sm"
+        onClick={onConnect}
+      >
         {icon}
         {label}
       </Button>
@@ -284,19 +292,34 @@ function MockConnectOverlay({
   );
 }
 
+/** Opens the connection catalog pre-filtered to the tile's integration. */
 function MockTile({
   children,
   connectLabel,
   connectIcon,
+  connectSearch,
 }: {
   children: React.ReactNode;
   connectLabel: string;
   connectIcon: React.ReactNode;
+  connectSearch: string;
 }) {
+  const [open, setOpen] = useState(false);
   return (
     <div className="group/mock relative flex h-full flex-col overflow-hidden">
       <div className="flex flex-1 flex-col p-3">{children}</div>
-      <MockConnectOverlay label={connectLabel} icon={connectIcon} />
+      <MockConnectOverlay
+        label={connectLabel}
+        icon={connectIcon}
+        onConnect={() => setOpen(true)}
+      />
+      <AddConnectionDialog
+        mode="browse"
+        open={open}
+        onOpenChange={setOpen}
+        defaultTab="all"
+        initialSearch={connectSearch}
+      />
     </div>
   );
 }
@@ -341,6 +364,7 @@ function CodingTileBody() {
     <MockTile
       connectLabel="Connect GitHub"
       connectIcon={<GitHubIcon className="size-4" />}
+      connectSearch="GitHub"
     >
       <ContributionsGrid />
       <div className="mt-3 flex flex-col gap-1.5">
@@ -405,6 +429,7 @@ function AnalyticsTileBody() {
     <MockTile
       connectLabel="Connect Google Analytics"
       connectIcon={<BarChart10 className="size-4" />}
+      connectSearch="Google Analytics"
     >
       <div className="flex gap-6">
         <StatNumber value="12.4k" label="Pageviews" />
@@ -438,6 +463,7 @@ function SalesTileBody() {
     <MockTile
       connectLabel="Connect VTEX or Shopify"
       connectIcon={<ShoppingCart01 className="size-4" />}
+      connectSearch="Shopify"
     >
       <div className="flex gap-6">
         <StatNumber value="$8,240" label="Revenue" />


### PR DESCRIPTION
## Summary
The **Coding**, **Analytics**, and **Sales** tiles on the org home board are visual mocks with a hover "Connect" CTA (Connect GitHub / Connect Google Analytics / Connect VTEX or Shopify). The button was a static element with no `onClick` — clicking it did nothing.

This wires each button to open the existing connection catalog (`AddConnectionDialog` in `mode="browse"`, `defaultTab="all"`), pre-filtered via `initialSearch` to the tile's backing integration:

| Tile | Search term |
|------|-------------|
| Coding | `GitHub` |
| Analytics | `Google Analytics` |
| Sales | `Shopify` |

No new connect flow was built — this reuses the same dialog the sidebar footer and chat input already use, so create + OAuth is handled end-to-end.

## Changes
- `apps/mesh/src/web/components/home/native-tiles.tsx` — thread an `onConnect`/`connectSearch` through `MockTile` → `MockConnectOverlay` → the button; open `AddConnectionDialog` on click.

## Testing
- `bun run check` (typecheck) passes
- `bun run fmt` / `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Connect buttons on the Coding, Analytics, and Sales tiles work. Clicking now opens the connection catalog filtered to the right integration.

- **Bug Fixes**
  - Opens AddConnectionDialog in browse mode (default tab: all) with initial search set to "GitHub", "Google Analytics", or "Shopify".
  - Reuses the existing connect and OAuth flow; no new flow added.

<sup>Written for commit 9ea7240b2a3b9e9fdedf1c1efe8752331e975e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

