### PR TITLE
refactor(web): remove dead LOCALSTORAGE_KEYS entries

### DIFF
--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -6,12 +6,6 @@ import type { ProjectLocator } from "@decocms/mesh-sdk";
  * This is used to avoid inline key definitions and to ensure consistency.
  */
 export const LOCALSTORAGE_KEYS = {
-  assistantChatTasks: (locator: ProjectLocator) =>
-    `mesh:assistant-chat:tasks:${locator}`,
-  messages: (locator: ProjectLocator, taskId: string) =>
-    `mesh:messages:${locator}:${taskId}`,
-  chatSelectedMode: (locator: ProjectLocator) =>
-    `mesh:chat:selectedMode:${locator}`,
   chatSelectedImageModel: (locator: ProjectLocator) =>
     `mesh:chat:selectedImageModel:${locator}`,
   chatSelectedWebSearchModel: (locator: ProjectLocator) =>
@@ -26,17 +20,10 @@ export const LOCALSTORAGE_KEYS = {
     `mesh:chat:autosend:${locator}:${taskId}`,
   chatDraft: (locator: ProjectLocator | string, taskKey: string) =>
     `mesh:chat:draft:${locator}:${taskKey}`,
-  assistantChatActiveTask: (locator: ProjectLocator) =>
-    `mesh:assistant-chat:active-task:${locator}`,
   decoChatPanelWidth: () => `mesh:decochat:panel-width`,
   blocksPanelWidth: () => `mesh:blocks:panel-width`,
-  tasksPanelWidth: () => `mesh:tasks-panel:width`,
   sidebarOpen: () => `mesh:sidebar-open`,
-  orgHomeQuickstart: (org: string) => `mesh:org-home:quickstart:${org}`,
-  storeShowStdio: () => `mesh:store:show-stdio`,
   preferences: () => `mesh:user:preferences`,
-  pluginConnection: (org: string, pluginId: string) =>
-    `mesh:plugin:connection:${org}:${pluginId}`,
   lastOrgSlug: () => `mesh:last-org-slug`,
   lastLocation: () => `mesh:last-location`,
   connectionsTab: (org: string) => `mesh:connections:tab:${org}`,
@@ -44,5 +31,4 @@ export const LOCALSTORAGE_KEYS = {
     `mesh:chat:task-last-viewed:${locator}`,
   sidebarGroupOrder: (orgId: string, userId: string) =>
     `sidebar.group-order.${orgId}.${userId}`,
-  sidebarOrgPinnedOrder: (orgId: string) => `sidebar.org-pinned-order.${orgId}`,
 } as const;


### PR DESCRIPTION
## Summary
- Grepped every `LOCALSTORAGE_KEYS.<key>` accessor and every key's literal string value across `apps/` and `packages/` (no `LOCALSTORAGE_KEYS[...]` dynamic access, no destructuring, no `keyof`/`typeof` usage exists on this object either) and found 9 of the 25 entries have zero remaining call sites: `assistantChatTasks`, `messages`, `chatSelectedMode`, `assistantChatActiveTask`, `tasksPanelWidth`, `orgHomeQuickstart`, `storeShowStdio`, `pluginConnection`, `sidebarOrgPinnedOrder`.
- These are leftovers from earlier feature refactors (tasks panel, org-home quickstart, plugin connections, etc.) that removed the consuming code but never cleaned up the key definitions in this shared file.
- Net diff: -14 lines, 0 additions. Purely a deletion — no behavior change since nothing reads these keys.

## Test plan
- [x] `bun run fmt`
- [x] `bun test apps/mesh/src/web/lib/chat-draft.test.ts` (the one existing test file that imports `LOCALSTORAGE_KEYS`) — 18 pass
- Reviewer can confirm no references remain: `grep -rn "LOCALSTORAGE_KEYS\.\(assistantChatTasks\|messages\|chatSelectedMode\|assistantChatActiveTask\|tasksPanelWidth\|orgHomeQuickstart\|storeShowStdio\|pluginConnection\|sidebarOrgPinnedOrder\)" apps packages` returns nothing.
- Full CI will run typecheck/lint across the whole repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed 9 unused keys from `LOCALSTORAGE_KEYS` to clean up dead code and reduce maintenance surface. Pure deletion in `apps/mesh/src/web/lib/localstorage-keys.ts` with no behavior change since nothing referenced these keys.

<sup>Written for commit 1c25b1ad906bd633c7a0ec3d25e68972abd4eabe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

