### PR TITLE
fix(web): scope reusable "New chat" to current user

### DIFF
--- a/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
+++ b/apps/mesh/src/web/components/header/shell-breadcrumb.tsx
@@ -41,6 +41,7 @@ import { AgentScopePicker } from "@/web/components/sidebar/agents-section";
 import { useThreads } from "@/web/components/chat/store/hooks";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { findReusableNewChat } from "@/web/lib/reusable-new-chat";
+import { authClient } from "@/web/lib/auth-client.ts";
 import { usePendingInvitations } from "@/web/hooks/use-pending-invitations";
 
 const crumbBtnClass =
@@ -113,6 +114,7 @@ export function ShellBreadcrumb() {
   };
   const search = useSearch({ strict: false }) as { virtualmcpid?: string };
   const { threads } = useThreads();
+  const { data: session } = authClient.useSession();
   const { setTaskId, createNewTask } = usePanelActions();
   // Pending cross-org invitations surface inside the org switcher; show a dot on
   // its trigger so they're noticed without opening it.
@@ -137,7 +139,7 @@ export function ShellBreadcrumb() {
     // Reuse this agent's existing empty "New chat" if it has one, else start
     // one — so re-selecting the same agent focuses the empty chat instead of
     // piling up duplicates. See findReusableNewChat for why status isn't gated.
-    const existing = findReusableNewChat(threads, id);
+    const existing = findReusableNewChat(threads, id, session?.user?.id);
     if (existing) {
       setTaskId(existing.id, id);
     } else {

--- a/apps/mesh/src/web/hooks/use-navigate-to-agent.ts
+++ b/apps/mesh/src/web/hooks/use-navigate-to-agent.ts
@@ -58,7 +58,8 @@ export function useNavigateToAgent() {
     // Focus the agent's existing empty chat if it has one; otherwise a fresh id
     // (the route loader's ensure-fallback creates the thread on landing).
     const taskId =
-      findReusableNewChat(threads, virtualMcpId)?.id ?? crypto.randomUUID();
+      findReusableNewChat(threads, virtualMcpId, session?.user?.id)?.id ??
+      crypto.randomUUID();
     navigate({
       to: "/$org/$taskId",
       params: { org: org.slug, taskId },

--- a/apps/mesh/src/web/layouts/org-home/index.tsx
+++ b/apps/mesh/src/web/layouts/org-home/index.tsx
@@ -16,6 +16,7 @@ import {
   useProjectContext,
 } from "@decocms/mesh-sdk";
 import { useThreads } from "@/web/components/chat/store/hooks";
+import { authClient } from "@/web/lib/auth-client.ts";
 import { useReportsOnlyGate } from "@/web/hooks/use-organization-settings";
 import { ShellRouteLoading } from "@/web/layouts/shell-route-loading";
 import { findReusableNewChat } from "@/web/lib/reusable-new-chat";
@@ -24,6 +25,7 @@ export default function OrgHome() {
   const { org } = useProjectContext();
   const reportsOnly = useReportsOnlyGate();
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
+  const { data: session } = authClient.useSession();
   const { threads, status } = useThreads();
   // Stable id for this mount, used only when there's no reusable "New chat".
   const [freshId] = useState(() => crypto.randomUUID());
@@ -42,7 +44,7 @@ export default function OrgHome() {
 
   // Reuse the Super Agent's existing empty "New chat" so revisiting `/$org`
   // doesn't pile up duplicates (see findReusableNewChat).
-  const existing = findReusableNewChat(threads, decopilotId);
+  const existing = findReusableNewChat(threads, decopilotId, session?.user?.id);
   const taskId = existing?.id ?? freshId;
 
   return (

--- a/apps/mesh/src/web/lib/reusable-new-chat.test.ts
+++ b/apps/mesh/src/web/lib/reusable-new-chat.test.ts
@@ -2,34 +2,51 @@ import { describe, expect, it } from "bun:test";
 import type { Task } from "@/web/components/chat/task/types";
 import { findReusableNewChat } from "./reusable-new-chat";
 
+const USER = "user-1";
+
 const task = (over: Partial<Task>): Task => ({
   id: over.id ?? crypto.randomUUID(),
   title: over.title ?? "New chat",
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
   virtual_mcp_id: "agent-1",
+  created_by: USER,
   ...over,
 });
 
 describe("findReusableNewChat", () => {
   it("reuses an empty New chat for the agent", () => {
     const t = task({ id: "a" });
-    expect(findReusableNewChat([t], "agent-1")?.id).toBe("a");
+    expect(findReusableNewChat([t], "agent-1", USER)?.id).toBe("a");
   });
 
   it("does not reuse a chat belonging to another agent", () => {
     const t = task({ id: "a", virtual_mcp_id: "agent-2" });
-    expect(findReusableNewChat([t], "agent-1")).toBeUndefined();
+    expect(findReusableNewChat([t], "agent-1", USER)).toBeUndefined();
+  });
+
+  // The incident this guard exists for: the thread list is org-wide (includes
+  // teammates' threads), so without scoping to the current user, landing on
+  // `/$org` reused a teammate's empty "New chat" and stranded the user on a
+  // read-only thread that wasn't theirs.
+  it("does not reuse a New chat created by another user", () => {
+    const t = task({ id: "a", created_by: "user-2" });
+    expect(findReusableNewChat([t], "agent-1", USER)).toBeUndefined();
+  });
+
+  it("does not reuse any thread when the user is unknown", () => {
+    const t = task({ id: "a" });
+    expect(findReusableNewChat([t], "agent-1", undefined)).toBeUndefined();
   });
 
   it("does not reuse a titled (already-run) chat", () => {
     const t = task({ id: "a", title: "Fix the login bug" });
-    expect(findReusableNewChat([t], "agent-1")).toBeUndefined();
+    expect(findReusableNewChat([t], "agent-1", USER)).toBeUndefined();
   });
 
   it("does not reuse a hidden chat", () => {
     const t = task({ id: "a", hidden: true });
-    expect(findReusableNewChat([t], "agent-1")).toBeUndefined();
+    expect(findReusableNewChat([t], "agent-1", USER)).toBeUndefined();
   });
 
   // The regression this guard exists for: a first message that FAILED leaves
@@ -38,12 +55,14 @@ describe("findReusableNewChat", () => {
   // conversation.
   it("does not reuse a New chat whose first message pinned a harness", () => {
     const t = task({ id: "a", harness_id: "decopilot" });
-    expect(findReusableNewChat([t], "agent-1")).toBeUndefined();
+    expect(findReusableNewChat([t], "agent-1", USER)).toBeUndefined();
   });
 
   it("picks the empty New chat over a failed same-titled one", () => {
     const failed = task({ id: "failed", harness_id: "claude-code" });
     const fresh = task({ id: "fresh" });
-    expect(findReusableNewChat([failed, fresh], "agent-1")?.id).toBe("fresh");
+    expect(findReusableNewChat([failed, fresh], "agent-1", USER)?.id).toBe(
+      "fresh",
+    );
   });
 });

--- a/apps/mesh/src/web/lib/reusable-new-chat.ts
+++ b/apps/mesh/src/web/lib/reusable-new-chat.ts
@@ -1,7 +1,8 @@
 import type { Task } from "@/web/components/chat/task/types";
 
 /**
- * The agent's existing empty "New chat" thread, or undefined if it has none.
+ * The current user's existing empty "New chat" thread for this agent, or
+ * undefined if they have none.
  *
  * `"New chat"` is the marker of a never-auto-titled thread — a thread gets
  * titled once it completes a *successful* turn. We do NOT gate on `status`
@@ -12,19 +13,24 @@ import type { Task } from "@/web/components/chat/task/types";
  * non-empty, runtime-locked thread — stranding the user on a broken
  * conversation. `harness_id` is pinned on the first message, so `!harness_id`
  * means the thread is genuinely empty. That excludes failed/in-flight threads
- * while still reusing real empty chats. Every entry point that navigates to an
- * agent (the breadcrumb picker, the org-home resolver, the repo switcher, …)
- * reuses this so re-selecting an agent focuses its empty chat instead of
- * minting another.
+ * while still reusing real empty chats. `created_by` scopes the match to the
+ * current user — the thread list is org-wide (it includes teammates' threads
+ * for the activity view), so without this we'd reuse a teammate's empty "New
+ * chat" and strand the user on a read-only thread that isn't theirs. Every
+ * entry point that navigates to an agent (the breadcrumb picker, the org-home
+ * resolver, the repo switcher, …) reuses this so re-selecting an agent focuses
+ * its empty chat instead of minting another.
  */
 export function findReusableNewChat(
   threads: Task[],
   agentId: string,
+  userId: string | undefined,
 ): Task | undefined {
   return threads.find(
     (t) =>
       !t.hidden &&
       t.virtual_mcp_id === agentId &&
+      t.created_by === userId &&
       t.title === "New chat" &&
       !t.harness_id,
   );


### PR DESCRIPTION
## Summary

Fixes the incident where landing on an org (e.g. navigating back from **Connections** to the org) drops you into a **read-only, empty Super Agent thread that isn't yours** ("Read only - you're viewing someone else's thread").

### Root cause

The `/$org` landing resolver (`org-home`) reuses an existing empty Super Agent "New chat" thread instead of minting a duplicate, via `findReusableNewChat`. But the thread list feeding it is **org-wide** — it includes teammates' threads for the activity view — and `findReusableNewChat` filtered by agent + title + emptiness, **not by owner**. So it could return a teammate's empty "New chat", redirect there, and `input.tsx` then flags it read-only because `task.created_by !== userId`.

### Fix

- `findReusableNewChat` takes a required `userId` and matches on `created_by`.
- Thread the current user's id through all three callers: the org-home resolver, the breadcrumb agent picker, and `useNavigateToAgent`.

An unknown/unloaded user matches nothing (mints a fresh id) rather than reusing a stranger's thread.

## Testing

- `bun test apps/mesh/src/web/lib/reusable-new-chat.test.ts` — added cases for "another user's New chat" and "unknown user", all 8 pass.
- `bun run --cwd=apps/mesh check` — typecheck passes.
- `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes reuse of empty “New chat” threads to the current user to stop routing into a teammate’s thread. Fixes the read-only “you’re viewing someone else’s thread” incident when landing on an org or picking an agent.

- **Bug Fixes**
  - `findReusableNewChat(threads, agentId, userId)` now requires `userId` and matches on `created_by`; unknown user does not reuse.
  - Thread the current user id through org home resolver, breadcrumb agent picker, and `useNavigateToAgent`.
  - Added tests for “another user’s New chat” and “unknown user”; preserved reuse for truly empty threads.

<sup>Written for commit e22a1bdc062bf0649ec7386b4d39ced35500a32c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

