### PR TITLE
fix(home): connect GitHub and Analytics tiles directly

### DIFF
--- a/apps/mesh/src/web/components/home/native-tiles.tsx
+++ b/apps/mesh/src/web/components/home/native-tiles.tsx
@@ -21,6 +21,7 @@ import {
   BarChart10,
   CheckCircle,
   GitBranch01,
+  Loading01,
   MessageChatCircle,
   ShoppingCart01,
 } from "@untitledui/icons";
@@ -31,6 +32,7 @@ import { useTaskBoardItems } from "@/web/hooks/use-task-board-items";
 import { STATUS_CONFIG } from "@/web/layouts/task-board/config";
 import { GitHubIcon } from "@/web/components/icons/github-icon";
 import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
+import { useConnectApp } from "@/web/hooks/use-connect-app";
 import { KEYS } from "@/web/lib/query-keys";
 
 const TASKS_TILE_ID = "tasks";
@@ -265,17 +267,20 @@ function TasksTileBody() {
 
 // ---------------------------------------------------------------------------
 // Mock tiles — Coding / Analytics / Sales. Static sample data; a hover overlay
-// opens the connection catalog pre-filtered to the backing integration.
+// connects the backing integration. GitHub / Google Analytics connect directly
+// (single known app); Sales opens the catalog (VTEX or Shopify — user picks).
 // ---------------------------------------------------------------------------
 
 function MockConnectOverlay({
   label,
   icon,
   onConnect,
+  pending,
 }: {
   label: string;
   icon: React.ReactNode;
   onConnect: () => void;
+  pending?: boolean;
 }) {
   return (
     <div className="absolute inset-0 flex items-center justify-center bg-background/70 opacity-0 backdrop-blur-sm transition-opacity duration-150 group-hover/mock:opacity-100">
@@ -284,41 +289,37 @@ function MockConnectOverlay({
         variant="secondary"
         className="gap-2 shadow-sm"
         onClick={onConnect}
+        disabled={pending}
       >
-        {icon}
+        {pending ? <Loading01 className="size-4 animate-spin" /> : icon}
         {label}
       </Button>
     </div>
   );
 }
 
-/** Opens the connection catalog pre-filtered to the tile's integration. */
+/** Presentational mock-tile shell: sample content + hover connect overlay. */
 function MockTile({
   children,
   connectLabel,
   connectIcon,
-  connectSearch,
+  onConnect,
+  pending,
 }: {
   children: React.ReactNode;
   connectLabel: string;
   connectIcon: React.ReactNode;
-  connectSearch: string;
+  onConnect: () => void;
+  pending?: boolean;
 }) {
-  const [open, setOpen] = useState(false);
   return (
     <div className="group/mock relative flex h-full flex-col overflow-hidden">
       <div className="flex flex-1 flex-col p-3">{children}</div>
       <MockConnectOverlay
         label={connectLabel}
         icon={connectIcon}
-        onConnect={() => setOpen(true)}
-      />
-      <AddConnectionDialog
-        mode="browse"
-        open={open}
-        onOpenChange={setOpen}
-        defaultTab="all"
-        initialSearch={connectSearch}
+        onConnect={onConnect}
+        pending={pending}
       />
     </div>
   );
@@ -360,11 +361,13 @@ const MOCK_PRS = [
 ];
 
 function CodingTileBody() {
+  const { connect, isConnecting } = useConnectApp("deco/mcp-github");
   return (
     <MockTile
       connectLabel="Connect GitHub"
       connectIcon={<GitHubIcon className="size-4" />}
-      connectSearch="GitHub"
+      onConnect={connect}
+      pending={isConnecting}
     >
       <ContributionsGrid />
       <div className="mt-3 flex flex-col gap-1.5">
@@ -425,11 +428,13 @@ function StatNumber({ value, label }: { value: string; label: string }) {
 }
 
 function AnalyticsTileBody() {
+  const { connect, isConnecting } = useConnectApp("deco/google-analytics");
   return (
     <MockTile
       connectLabel="Connect Google Analytics"
       connectIcon={<BarChart10 className="size-4" />}
-      connectSearch="Google Analytics"
+      onConnect={connect}
+      pending={isConnecting}
     >
       <div className="flex gap-6">
         <StatNumber value="12.4k" label="Pageviews" />
@@ -459,20 +464,32 @@ function BarChartMock() {
 }
 
 function SalesTileBody() {
+  // VTEX or Shopify — the user picks, so open the catalog rather than
+  // connecting a single app directly.
+  const [open, setOpen] = useState(false);
   return (
-    <MockTile
-      connectLabel="Connect VTEX or Shopify"
-      connectIcon={<ShoppingCart01 className="size-4" />}
-      connectSearch="Shopify"
-    >
-      <div className="flex gap-6">
-        <StatNumber value="$8,240" label="Revenue" />
-        <StatNumber value="142" label="Orders" />
-      </div>
-      <div className="mt-auto pt-3">
-        <BarChartMock />
-      </div>
-    </MockTile>
+    <>
+      <MockTile
+        connectLabel="Connect VTEX or Shopify"
+        connectIcon={<ShoppingCart01 className="size-4" />}
+        onConnect={() => setOpen(true)}
+      >
+        <div className="flex gap-6">
+          <StatNumber value="$8,240" label="Revenue" />
+          <StatNumber value="142" label="Orders" />
+        </div>
+        <div className="mt-auto pt-3">
+          <BarChartMock />
+        </div>
+      </MockTile>
+      <AddConnectionDialog
+        mode="browse"
+        open={open}
+        onOpenChange={setOpen}
+        defaultTab="all"
+        initialSearch="Shopify"
+      />
+    </>
   );
 }
 

--- a/apps/mesh/src/web/hooks/use-connect-app.ts
+++ b/apps/mesh/src/web/hooks/use-connect-app.ts
@@ -1,0 +1,90 @@
+/**
+ * Click-triggered "connect this app" flow: fetch the registry app by id,
+ * create a connection, and run OAuth — no dialog. Generalized from
+ * use-auto-install-github.ts (which auto-fires); this one exposes a `connect()`
+ * you call on a button press.
+ *
+ * ponytail: no dedup — a repeat click on an already-connected app creates
+ * another instance (same as the catalog "Connect" button). Add a slug lookup
+ * if duplicates become a problem.
+ */
+
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useConnectionActions, useProjectContext } from "@decocms/mesh-sdk";
+import { authenticateAndPersistOAuth } from "@/web/lib/authenticate-and-persist-oauth";
+import { authClient } from "@/web/lib/auth-client";
+import { useRegistryApp } from "@/web/hooks/use-registry-app";
+import { extractConnectionData } from "@/web/utils/extract-connection-data";
+import { invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
+
+export function useConnectApp(appId: string) {
+  const { org } = useProjectContext();
+  const { data: session } = authClient.useSession();
+  const actions = useConnectionActions();
+  const queryClient = useQueryClient();
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  // Deferred — the tile shouldn't hit the registry on every home render. The
+  // registry GET is kicked off on click via refetch() (which ignores `enabled`).
+  const registry = useRegistryApp(appId, { enabled: false });
+
+  const connect = async () => {
+    if (isConnecting || !session?.user?.id || !org) return;
+    setIsConnecting(true);
+    try {
+      const item = registry.data ?? (await registry.refetch()).data;
+      if (!item) {
+        toast.error("Could not find this integration in the registry");
+        return;
+      }
+
+      const connectionData = extractConnectionData(
+        item,
+        org.id,
+        session.user.id,
+        {
+          remoteIndex: 0,
+        },
+      );
+      if (!connectionData.connection_url) {
+        toast.error("This integration has no connection method available");
+        return;
+      }
+
+      const { id } = await actions.create.mutateAsync(connectionData);
+
+      const auth = await authenticateAndPersistOAuth({
+        connectionId: id,
+        orgId: org.id,
+        orgSlug: org.slug,
+        persistFallback: (token) =>
+          actions.update
+            .mutateAsync({ id, data: { connection_token: token } })
+            .then(() => undefined),
+      });
+
+      if (auth.ran && !auth.ok) {
+        try {
+          await actions.delete.mutateAsync(id);
+        } catch {
+          // best-effort cleanup
+        }
+        toast.error(`Authentication failed: ${auth.error ?? "no token"}`);
+        return;
+      }
+
+      invalidateVirtualMcpQueries(queryClient, org.id);
+      toast.success("Connected successfully");
+    } catch (error) {
+      toast.error(
+        `Failed to connect: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  return { connect, isConnecting };
+}


### PR DESCRIPTION
## Summary
Follow-up to #4598. The **Coding** (GitHub) and **Analytics** (Google Analytics) home tiles previously opened the connection catalog when you clicked the hover "Connect" button. Each maps to a single known registry app, so this connects them **directly** instead — no modal:

1. Fetch the registry app by id (`deco/mcp-github`, `deco/google-analytics`)
2. Create the connection
3. Run OAuth (`authenticateAndPersistOAuth`)

The button shows a spinner while connecting and toasts success/failure.

**Sales** still opens the catalog — it's a choice between VTEX and Shopify, not a single app.

## Changes
- `apps/mesh/src/web/hooks/use-connect-app.ts` (new) — click-triggered connect flow, generalized from `use-auto-install-github.ts` (which auto-fires). Registry lookup is deferred and kicked off on click via `refetch()`.
- `apps/mesh/src/web/components/home/native-tiles.tsx` — `MockTile` is now presentational (`onConnect` + `pending`); Coding/Analytics use `useConnectApp`, Sales keeps the catalog dialog.

## Notes
- No dedup: a repeat click on an already-connected app creates another instance (same behavior as the catalog "Connect" button). Marked with a `ponytail:` comment.

## Testing
- `bun run check`, `bun run lint`, `bun run fmt` all pass.
- Not yet driven live in the browser (OAuth flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connect GitHub and Google Analytics tiles directly from the home view. Clicking Connect looks up the registry app (`deco/mcp-github`, `deco/google-analytics`), creates the connection, and runs OAuth; Sales still opens the catalog for VTEX or Shopify.

- **New Features**
  - New `use-connect-app` hook with deferred registry lookup, connection creation, and OAuth.
  - Home buttons show a spinner, disable during connect, and toast success/failure.
  - No dedup; repeat connects create another instance.

<sup>Written for commit 68e64c4af187c819090e050e148612ce7cd2dbdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

