### PR TITLE
feat(connections): multi-keyword search in the connect modal

### DIFF
--- a/apps/mesh/src/web/hooks/use-merged-store-discovery.ts
+++ b/apps/mesh/src/web/hooks/use-merged-store-discovery.ts
@@ -56,20 +56,22 @@ function isCommunityRegistry(registry: RegistrySource): boolean {
 /**
  * Build a where expression for server-side search on registry items.
  * Searches title, description, name (server.name), and server.title.
+ *
+ * The search is split on whitespace into keywords, each OR'd across every
+ * field — so "vtex shopify" surfaces items matching either (union), letting a
+ * caller open the catalog pre-filtered to several providers at once.
  */
 function buildRegistrySearchWhere(
   search: string | undefined,
 ): Record<string, unknown> | undefined {
-  const trimmed = search?.trim();
-  if (!trimmed) return undefined;
+  const tokens = search?.trim().split(/\s+/).filter(Boolean) ?? [];
+  if (tokens.length === 0) return undefined;
+  const fields = [["title"], ["description"], ["name"], ["server", "title"]];
   return {
     operator: "or",
-    conditions: [
-      { field: ["title"], operator: "contains", value: trimmed },
-      { field: ["description"], operator: "contains", value: trimmed },
-      { field: ["name"], operator: "contains", value: trimmed },
-      { field: ["server", "title"], operator: "contains", value: trimmed },
-    ],
+    conditions: tokens.flatMap((token) =>
+      fields.map((field) => ({ field, operator: "contains", value: token })),
+    ),
   };
 }
 

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -142,23 +142,24 @@ function ConnectionDialogContent({
     orgSlug: org.slug,
   });
 
-  const where = deferredSearch?.trim()
-    ? {
-        operator: "or" as const,
-        conditions: [
-          {
-            field: ["title"],
-            operator: "contains" as const,
-            value: deferredSearch.trim(),
-          },
-          {
-            field: ["description"],
-            operator: "contains" as const,
-            value: deferredSearch.trim(),
-          },
-        ],
-      }
-    : undefined;
+  // Split on whitespace into keywords, each OR'd across title/description — so
+  // "vtex shopify" matches connections for either provider (union).
+  const searchTokens =
+    deferredSearch?.trim().split(/\s+/).filter(Boolean) ?? [];
+  const where =
+    searchTokens.length > 0
+      ? {
+          operator: "or" as const,
+          conditions: searchTokens.flatMap((token) => [
+            { field: ["title"], operator: "contains" as const, value: token },
+            {
+              field: ["description"],
+              operator: "contains" as const,
+              value: token,
+            },
+          ]),
+        }
+      : undefined;
 
   const toolArguments = {
     ...(where && { where }),
@@ -265,7 +266,10 @@ function ConnectionDialogContent({
           .filter(Boolean)
           .join(" ")
           .toLowerCase();
-        return haystack.includes(searchLower);
+        // Match any keyword (union), mirroring the server-side where clause.
+        return searchTokens.some((token) =>
+          haystack.includes(token.toLowerCase()),
+        );
       })
     : [];
 


### PR DESCRIPTION
## Summary
The connection catalog / connect modal searched by the **whole literal string** — so opening it (or typing) `vtex shopify` ran a single `contains "vtex shopify"`, which matches nothing.

Now the search is split on whitespace into keywords, and each keyword is OR'd across every searchable field (union). `vtex shopify` surfaces results for **both** providers.

## Changes
- `apps/mesh/src/web/hooks/use-merged-store-discovery.ts` — `buildRegistrySearchWhere` tokenizes the search; every token × field becomes an OR condition (server-side registry query).
- `apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx`
  - the connections `where` clause tokenizes the same way (title/description).
  - the client-side catalog haystack filter matches on `some(token)` instead of the full string.

## Behavior note
Semantics are **OR/union** across keywords (that's the requested "show from both"). A side effect: a two-word app name like `google analytics` now also matches items containing just `google` or just `analytics`, broadening those results slightly. That's the tradeoff for the union behavior.

## Testing
- `bun run check`, `bun run lint`, `bun run fmt` pass.
- Not driven live in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-keyword search to the Connect modal. Search terms are split on spaces and matched with OR across fields, so "vtex shopify" shows results for both providers.

- **New Features**
  - Server-side registry search now tokenizes input and ORs tokens across `title`, `description`, `name`, and `server.title`.
  - The modal uses the same tokenization in its `where` clause and client-side filter, matching any token.
  - Note: Union matching can broaden results (e.g., "google analytics" may match items with only "google" or only "analytics").

<sup>Written for commit cafc839ceaa7bb96e475714ea4022422596a92aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

