### PR TITLE
fix(sections-editor): render variant UI for section-multivariate blocks

### DIFF
--- a/apps/mesh/ct/tests/section-multivariate-block.ct.tsx
+++ b/apps/mesh/ct/tests/section-multivariate-block.ct.tsx
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+
+/**
+ * A saved/global block whose content is `website/flags/multivariate/section.ts`
+ * (a section wrapped in variants) must render the VARIANT editor — a rule
+ * matcher + per-variant inner field — not the generic "Item 1 / Item 2" array
+ * editor. Regression net for the section-multivariate wrapper dispatch in
+ * SchemaForm.
+ */
+
+const SECTION_MULTIVARIATE = "website/flags/multivariate/section.ts";
+const HEADER = "site/sections/Header.tsx";
+
+/**
+ * Meta with the section-multivariate flag schema plus the inner section it
+ * wraps. The flag's variant `value` type is left unresolved (a bare object) —
+ * mirroring how schema depth limits often leave the nested section type
+ * unresolved — so the inner field is resolved from the value's own
+ * `__resolveType` (the realistic path).
+ */
+function multivariateMeta(): LiveMeta {
+  return {
+    manifest: {
+      blocks: {
+        sections: {
+          [SECTION_MULTIVARIATE]: {
+            type: "object",
+            properties: {
+              variants: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    value: { type: "object" },
+                    rule: { type: "object", properties: {} },
+                  },
+                },
+              },
+            },
+          },
+          [HEADER]: {
+            type: "object",
+            properties: { title: { type: "string", title: "Heading" } },
+          },
+        },
+      },
+    },
+    schema: {},
+  };
+}
+
+const wrapperValue = {
+  __resolveType: SECTION_MULTIVARIATE,
+  variants: [
+    {
+      value: { __resolveType: HEADER, title: "Semana Granado" },
+      rule: { __resolveType: "website/matchers/date.ts" },
+    },
+    {
+      value: { __resolveType: HEADER, title: "Default" },
+      rule: { __resolveType: "website/matchers/always.ts" },
+    },
+  ],
+};
+
+test("section-multivariate wrapper → variant editor (rule + inner field)", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <SchemaFormHarness
+      meta={multivariateMeta()}
+      resolveType={SECTION_MULTIVARIATE}
+      initialValue={wrapperValue}
+    />,
+  );
+
+  // Variant editor chrome: the per-variant "Rule" matcher label.
+  await expect(component.getByText("Rule", { exact: true })).toBeVisible();
+
+  // The inner variant value renders as its own field (first variant selected).
+  const heading = component.getByLabel("Heading");
+  await expect(heading).toBeVisible();
+  await expect(heading).toHaveValue("Semana Granado");
+});
+
+test("section-multivariate wrapper → NOT the generic array editor", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <SchemaFormHarness
+      meta={multivariateMeta()}
+      resolveType={SECTION_MULTIVARIATE}
+      initialValue={wrapperValue}
+    />,
+  );
+
+  // Generic ArrayField would surface an "Add item" button and "Item N" rows.
+  await expect(component.getByRole("button", { name: "Add item" })).toHaveCount(
+    0,
+  );
+  await expect(component.getByText("Item 1", { exact: true })).toHaveCount(0);
+});

--- a/apps/mesh/ct/tests/section-multivariate-block.ct.tsx
+++ b/apps/mesh/ct/tests/section-multivariate-block.ct.tsx
@@ -21,29 +21,31 @@ const HEADER = "site/sections/Header.tsx";
  * `__resolveType` (the realistic path).
  */
 function multivariateMeta(): LiveMeta {
+  const flagSchema: Record<string, unknown> = {
+    type: "object",
+    properties: {
+      variants: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            value: { type: "object" },
+            rule: { type: "object", properties: {} },
+          },
+        },
+      },
+    },
+  };
+  const headerSchema: Record<string, unknown> = {
+    type: "object",
+    properties: { title: { type: "string", title: "Heading" } },
+  };
   return {
     manifest: {
       blocks: {
         sections: {
-          [SECTION_MULTIVARIATE]: {
-            type: "object",
-            properties: {
-              variants: {
-                type: "array",
-                items: {
-                  type: "object",
-                  properties: {
-                    value: { type: "object" },
-                    rule: { type: "object", properties: {} },
-                  },
-                },
-              },
-            },
-          },
-          [HEADER]: {
-            type: "object",
-            properties: { title: { type: "string", title: "Heading" } },
-          },
+          [SECTION_MULTIVARIATE]: flagSchema,
+          [HEADER]: headerSchema,
         },
       },
     },

--- a/apps/mesh/src/web/components/sections-editor/page-variants.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-variants.test.ts
@@ -5,12 +5,56 @@ import {
   countSavedMatcherBlockReferences,
   getPageVariantCount,
   getPageVariantSectionsAt,
+  isSectionMultivariateWrapperValue,
   parsePageVariants,
   unwrapMultivariateArrayValue,
   variantHasRule,
   wrapMultivariateArrayValue,
 } from "./page-variants";
-import { PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE } from "./section-types";
+import {
+  PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
+  SECTION_MULTIVARIATE_RESOLVE_TYPE,
+} from "./section-types";
+
+describe("isSectionMultivariateWrapperValue", () => {
+  it("matches a section-level multivariate flag wrapper", () => {
+    expect(
+      isSectionMultivariateWrapperValue({
+        __resolveType: SECTION_MULTIVARIATE_RESOLVE_TYPE,
+        variants: [
+          { value: { __resolveType: "site/sections/Header.tsx" }, rule: {} },
+          { value: { __resolveType: "site/sections/Header.tsx" }, rule: {} },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects the page-level multivariate flag wrapper", () => {
+    expect(
+      isSectionMultivariateWrapperValue({
+        __resolveType: PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
+        variants: [{ value: [], rule: {} }],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects plain arrays, primitives, and non-wrapper objects", () => {
+    expect(isSectionMultivariateWrapperValue([])).toBe(false);
+    expect(isSectionMultivariateWrapperValue(null)).toBe(false);
+    expect(isSectionMultivariateWrapperValue("x")).toBe(false);
+    expect(
+      isSectionMultivariateWrapperValue({
+        __resolveType: SECTION_MULTIVARIATE_RESOLVE_TYPE,
+      }),
+    ).toBe(false);
+    expect(
+      isSectionMultivariateWrapperValue({
+        __resolveType: "site/sections/Header.tsx",
+        variants: [],
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("page-variants", () => {
   it("unwraps multivariate global section arrays", () => {

--- a/apps/mesh/src/web/components/sections-editor/page-variants.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-variants.ts
@@ -8,6 +8,7 @@ import type { RawSection } from "./section-types";
 import {
   defaultVariantRule,
   PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE,
+  SECTION_MULTIVARIATE_RESOLVE_TYPE,
 } from "./section-types";
 
 const PAGE_RESOLVE_TYPES = new Set([
@@ -31,6 +32,26 @@ export function isPageMultivariateSectionArrayField(
         ref.schema?.properties?.variants?.items?.properties?.value;
       return valueField?.type === "array";
     }) ?? false
+  );
+}
+
+/**
+ * True when a value is a section-level multivariate flag wrapper —
+ * `{ __resolveType: "website/flags/multivariate/section.ts", variants: [...] }`.
+ *
+ * This is the shape a saved/global block takes when it wraps a single section
+ * in variants (each `{ value: Section, rule: Matcher }`). It must render with
+ * the variant editor, not the generic array editor.
+ */
+export function isSectionMultivariateWrapperValue(value: unknown): value is {
+  __resolveType: string;
+  variants: Array<Record<string, unknown>>;
+} {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    obj.__resolveType === SECTION_MULTIVARIATE_RESOLVE_TYPE &&
+    Array.isArray(obj.variants)
   );
 }
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+import { resolveSchema } from "./resolve-schema";
 import type { LiveMeta, SchemaProperty } from "./resolve-schema";
 import type { FieldProps } from "./fields/field-props";
 import { StringField } from "./fields/string-field";
@@ -18,6 +20,7 @@ import { isSecretBlock, SecretField } from "./fields/secret-field";
 import {
   isMultivariateArrayWrapper,
   isPageMultivariateSectionArrayField,
+  isSectionMultivariateWrapperValue,
   unwrapMultivariateArrayValue,
   wrapMultivariateArrayValue,
 } from "./page-variants";
@@ -324,6 +327,62 @@ export function renderField(props: FieldProps) {
   }
 }
 
+/**
+ * Render the value of a single multivariate variant (its `value` field).
+ *
+ * Section variants hold a full section; render it through the normal
+ * block-ref/section editor (breadcrumbs + drill-down keep working). When the
+ * flag's `value` type couldn't be resolved (schema depth limits), fall back to
+ * resolving the concrete value's own `__resolveType`.
+ */
+function renderMultivariateInnerField(
+  props: FieldProps,
+  variantValueSchema: SchemaProperty | undefined,
+): ReactNode {
+  if (
+    variantValueSchema &&
+    (variantValueSchema.type === "block-ref" ||
+      variantValueSchema.anyOfRefs ||
+      variantValueSchema.properties)
+  ) {
+    return renderField({ ...props, schema: variantValueSchema });
+  }
+
+  const value = props.value;
+  if (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).__resolveType === "string" &&
+    props.meta
+  ) {
+    const innerSchema = resolveSchema(
+      (value as Record<string, unknown>).__resolveType as string,
+      props.meta,
+    );
+    if (innerSchema) {
+      return (
+        <SchemaForm
+          schema={innerSchema}
+          value={value}
+          onChange={props.onChange}
+          basePath={props.path}
+          breadcrumbPath={props.breadcrumbPath}
+          onBreadcrumbChange={props.onBreadcrumbChange}
+          meta={props.meta}
+          decofile={props.decofile}
+          onSaveReferencedBlock={props.onSaveReferencedBlock}
+          sandbox={props.sandbox}
+        />
+      );
+    }
+  }
+
+  return renderField(
+    variantValueSchema ? { ...props, schema: variantValueSchema } : props,
+  );
+}
+
 export function SchemaForm({
   schema,
   value,
@@ -358,6 +417,38 @@ export function SchemaForm({
 }) {
   const properties = schema.properties;
   if (!properties) return null;
+
+  // A section-level multivariate flag (`website/flags/multivariate/section.ts`)
+  // opened directly — e.g. a saved/global block that wraps a section in
+  // variants. Its schema is `{ variants: Variant<Section>[] }`, so the generic
+  // object form would render `variants` as a plain "Item 1 / Item 2" array.
+  // Render the variant editor (rule matcher + per-variant section form) instead.
+  if (isSectionMultivariateWrapperValue(value) && properties.variants) {
+    const variantValueSchema = properties.variants.items?.properties?.value;
+    return (
+      <MultivariateFieldWrapper
+        key={basePath}
+        schema={schema}
+        value={value}
+        onChange={onChange}
+        path={basePath}
+        label={schema.title ?? ""}
+        breadcrumbPath={breadcrumbPath}
+        onBreadcrumbChange={onBreadcrumbChange}
+        meta={meta}
+        decofile={decofile}
+        onSaveReferencedBlock={onSaveReferencedBlock}
+        previewBaseUrl={previewBaseUrl}
+        onAddSectionItem={onAddSectionItem}
+        onRequestAddSection={onRequestAddSection}
+        sandbox={sandbox}
+        multivariateResolveType={value.__resolveType}
+        renderInnerField={(fieldProps) =>
+          renderMultivariateInnerField(fieldProps, variantValueSchema)
+        }
+      />
+    );
+  }
 
   const objValue =
     value != null && typeof value === "object" && !Array.isArray(value)


### PR DESCRIPTION
## Summary

A saved/global block whose content is `website/flags/multivariate/section.ts` (a single section wrapped in variants, each `{ value: Section, rule: Matcher }`) rendered in the CMS as the **generic array editor** ("Variants 2 → Item 1 / Item 2 / Add item") instead of the **variant editor**.

Root cause: the widget dispatcher (`renderField` in `schema-form.tsx`) only recognized multivariate flags in two ways — a value already shaped as a wrapper inside a *section slot*, or a *block-ref* loader union (`isMultivariateBlockRef`). When such a block is opened directly (as a saved/global block), the wrapper reaches `SchemaForm` as the **form root**, its schema is `{ variants: Variant<T>[] }`, and the `variants` prop falls straight through to `ArrayField`. Nothing inspected the `{ value, rule }` item shape to promote it to the variant editor.

Note: the section-level (`website/flags/multivariate/section.ts`) and page-level (`website/flags/multivariate.ts`) flags share the exact same `MultivariateProps<T>` type — the variant UI is driven by the same shape, so both should get it.

## Fix

- `schema-form.tsx`: detect the section-multivariate wrapper at the `SchemaForm` root and render `MultivariateFieldWrapper` (variant list + matcher/rule picker + per-variant inner field) instead of the generic object/array form. Each variant's `value` is a full section, so the inner field resolves that section's own schema (`renderMultivariateInnerField`).
- `page-variants.ts`: new pure helper `isSectionMultivariateWrapperValue()`, scoped to the section-level resolve type so it doesn't interfere with the page-level multivariate handling.

The change is additive: the new branch only fires for values whose `__resolveType` is `website/flags/multivariate/section.ts` — a shape that currently produces the buggy generic render — so it can't regress non-multivariate fields.

## Testing

- `bun run check` (tsc): clean
- Unit: `page-variants.test.ts` +3 cases (420 pass across the folder)
- Component (Playwright ct): new `ct/tests/section-multivariate-block.ct.tsx` — asserts the variant editor renders (rule matcher + inner section field showing the first variant's value) and that the generic "Add item" / "Item 1" array editor no longer appears
- `bun run fmt` / `bun run lint`: no errors in changed files (2 pre-existing `NumberField` ct failures and existing lint warnings are on `main`, confirmed via `git stash`)

## Follow-up to validate manually

- Open the block in the CMS and confirm the variant tabs + date matcher + full section form per variant render as expected.
- Edge case: "remove all variants" (flatten) on a saved multivariate block collapses to the single variant value — worth confirming the save persists as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CMS rendering for section-level multivariate saved/global blocks to use the variant editor (rule picker + per-variant section form) instead of the generic array editor. Only applies to `website/flags/multivariate/section.ts`; page-level arrays are unchanged.

- **Bug Fixes**
  - Detect the wrapper at `SchemaForm` root and render `MultivariateFieldWrapper`; resolve each variant’s value schema from its `__resolveType` when needed.
  - Add `isSectionMultivariateWrapperValue()` for dispatch; unit + CT tests cover the path.
  - Fix CT meta typing by building block schemas as `Record<string, unknown>` to satisfy typecheck.

<sup>Written for commit 9e30597dcdff1b181abed45e6cfbbe58adb258be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

