### PR TITLE
fix(deploy): keep nginx serving during target deregistration

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.12.1
+version: 0.12.2
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -91,17 +91,11 @@ spec:
             periodSeconds: 5
           lifecycle:
             preStop:
-              # `nginx -s quit` closes the listen socket and drains open
-              # keep-alive connections immediately, so a pod mid-rollout stops
-              # serving its (stale) baked SPA build right away instead of
-              # continuing to answer normally for the whole grace window. The
-              # sleep after gives that drain time to finish before kubelet's
-              # SIGTERM lands and force-kills it mid-shutdown.
+              # Keep the listener open while external load balancers remove the
+              # terminating pod from their targets. After the hook completes,
+              # the nginx image's STOPSIGNAL (SIGQUIT) drains open connections.
               exec:
-                command:
-                  - /bin/sh
-                  - -c
-                  - "nginx -s quit; sleep {{ .Values.nginx.preStopSleepSeconds | default 15 }}"
+                command: ["sleep", "{{ .Values.nginx.preStopSleepSeconds | default 15 }}"]
           {{- with .Values.nginx.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## What is this contribution about?

Keeps nginx listening during the existing 15-second `preStop` delay so AWS NLB deregistration can propagate before the listener closes.

The current hook runs `nginx -s quit` before sleeping. During that sleep, the terminating pod is still an NLB target but no longer accepts new connections, producing rollout connection resets and Cloudflare 5xx/520 responses.

This restores the sleep-only hook. After it completes, the nginx base image `STOPSIGNAL SIGQUIT` performs the normal graceful shutdown and drains open connections. It also bumps the Helm chart to `0.12.2` so the chart publish and GitOps bump workflows run after merge.

## Screenshots/Demonstration

Not applicable; deployment lifecycle change only.

## How to Test

1. Run `helm lint deploy/helm/studio --set secret.secretName=studio-test`.
2. Render with `helm template studio deploy/helm/studio --namespace studio --set secret.secretName=studio-test`.
3. Confirm the nginx lifecycle renders `command: ["sleep", "15"]`.
4. Package the chart and confirm `chart-deco-studio-0.12.2.tgz` is produced.

Validation performed:

- Helm lint passed.
- Helm template rendered the expected lifecycle hook.
- Helm package succeeded.
- `bun run fmt -- apps packages deploy plugins scripts tests .github` passed.
- `bun run lint` completed with 0 errors.
- `git diff --check` passed.

## Migration Notes

No database or application configuration migration. Merging publishes chart `0.12.2` and dispatches the `studio-chart-bump` GitOps workflow.

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated where behavior is described inline
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep nginx serving during the `preStop` delay so AWS NLB can deregister the pod before the listener closes. Prevents rollout connection resets and Cloudflare 5xx; bumps Helm chart to `0.12.2`.

- **Bug Fixes**
  - Replace `nginx -s quit; sleep` with `sleep {{ .Values.nginx.preStopSleepSeconds | default 15 }}` in `preStop`.
  - Rely on nginx image `STOPSIGNAL SIGQUIT` to gracefully drain connections after the hook.

- **Dependencies**
  - Update `chart-deco-studio` to `0.12.2`.

<sup>Written for commit c85927b71c4eb18c3a7f06a9dc39605428583044. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

