### PR TITLE
feat(decopilot): give Super Agent built-in thread search tools

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -33,6 +33,9 @@ const BUILTIN_TOOL_ANNOTATIONS: Record<
   enable_tool: { readOnly: true, destructive: false },
   todo_write: { readOnly: false, destructive: false },
   update_interests: { readOnly: false, destructive: false },
+  search_threads: { readOnly: true, destructive: false },
+  get_thread: { readOnly: true, destructive: false },
+  list_thread_messages: { readOnly: true, destructive: false },
 };
 import { createReadToolOutputTool } from "@decocms/harness/decopilot/built-in-tools/read-tool-output";
 import { type VirtualClient } from "@decocms/harness/decopilot/built-in-tools/sandbox";
@@ -57,6 +60,7 @@ import {
 import { createScrapeUrlTool } from "@decocms/harness/decopilot/built-in-tools/scrape-url";
 import { createInspectPageTool } from "@decocms/harness/decopilot/built-in-tools/inspect-page";
 import { buildPortableBuiltInTools } from "@decocms/harness/decopilot/built-in-tools/portable-built-ins";
+import { createThreadTools } from "./thread-tools";
 import { BROWSERLESS_BASE_URL } from "@decocms/harness/decopilot/built-in-tools/constants";
 import type { ModelsConfig } from "@decocms/harness/types";
 import type { MeshProvider } from "@/ai-providers/types";
@@ -202,6 +206,9 @@ async function buildAllTools(
       userId,
     });
   }
+  // Thread search built-ins — always available so the Super Agent can recall
+  // past org conversations regardless of the passthrough MCP allowlist.
+  Object.assign(tools, createThreadTools(ctx));
   // VM file tools — six LLM-visible tools (read/write/edit/grep/glob/bash)
   // always registered when a vmContext is provided. The handle is resolved
   // lazily on the first tool invocation: `ensureSandbox` either reuses

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/thread-tools.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/thread-tools.ts
@@ -1,0 +1,37 @@
+/**
+ * Thread search built-ins
+ *
+ * Exposes the org's read-only thread tools (search/list, get, messages) to the
+ * Super Agent as always-available built-ins, so it can recall past
+ * conversations without depending on the passthrough MCP allowlist.
+ *
+ * Imported from the concrete tool files (not the `@/tools/thread` barrel):
+ * the barrel pulls in background-tool-start, which imports back into this
+ * harness and would form an import cycle.
+ */
+
+import { tool, zodSchema, type ToolSet } from "ai";
+import type { StudioContext } from "@/core/studio-context";
+import { COLLECTION_THREADS_LIST } from "@/tools/thread/list";
+import { COLLECTION_THREADS_GET } from "@/tools/thread/get";
+import { COLLECTION_THREAD_MESSAGES_LIST } from "@/tools/thread/list-messages";
+
+export function createThreadTools(ctx: StudioContext): ToolSet {
+  return {
+    search_threads: tool({
+      description: COLLECTION_THREADS_LIST.description,
+      inputSchema: zodSchema(COLLECTION_THREADS_LIST.inputSchema),
+      execute: (input) => COLLECTION_THREADS_LIST.execute(input, ctx),
+    }),
+    get_thread: tool({
+      description: COLLECTION_THREADS_GET.description,
+      inputSchema: zodSchema(COLLECTION_THREADS_GET.inputSchema),
+      execute: (input) => COLLECTION_THREADS_GET.execute(input, ctx),
+    }),
+    list_thread_messages: tool({
+      description: COLLECTION_THREAD_MESSAGES_LIST.description,
+      inputSchema: zodSchema(COLLECTION_THREAD_MESSAGES_LIST.inputSchema),
+      execute: (input) => COLLECTION_THREAD_MESSAGES_LIST.execute(input, ctx),
+    }),
+  };
+}


### PR DESCRIPTION
## Summary

Exposes the org's read-only thread tools to the **Super Agent** (decopilot) as always-available built-ins, so it can search and recall past org conversations without relying on the passthrough MCP allowlist:

- `search_threads` → `COLLECTION_THREADS_LIST` (full-text title search + filtering/sort/pagination)
- `get_thread` → `COLLECTION_THREADS_GET`
- `list_thread_messages` → `COLLECTION_THREAD_MESSAGES_LIST`

Each is a thin AI-SDK `tool()` bound to the run's `StudioContext`, reusing the existing `defineTool` schema, description, access check, and tracing (`.execute(input, ctx)`).

## Implementation notes

- **New:** `built-in-tools/thread-tools.ts` — the three adapters.
- **Wired** into `buildAllTools` (`Object.assign(tools, createThreadTools(ctx))`, always-on/read-only), registered in `BUILTIN_TOOL_ANNOTATIONS`, and added to the return-type cast.
- Tools imported from their **concrete source files**, not the `@/tools/thread` barrel — the barrel drags in `background-tool-start` → back into the harness, forming an import cycle.
- `createThreadTools` has an explicit `ToolSet` return type — the inferred return otherwise cycles through `CoreTools` and cascades `implicitly any` errors across `io-types.ts`.

## Testing

- `bun run check` clean for the changed files.
- `bun run fmt` / `bun run lint` clean.
- Not yet exercised end-to-end via a live chat run.

## Scope

- Read set only — CREATE/UPDATE/DELETE and `GLOBAL_SEARCH` intentionally excluded.
- If an agent's allowlist already includes `COLLECTION_THREADS_LIST` via passthrough, the tool may appear twice — benign, not a conflict.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds always-on, read-only thread search tools to the Super Agent so it can recall past org conversations without relying on the passthrough MCP allowlist. Introduces `search_threads`, `get_thread`, and `list_thread_messages` bound to the run’s `StudioContext`.

- **New Features**
  - Registered as built-ins in `buildAllTools` and annotated in `BUILTIN_TOOL_ANNOTATIONS` (readOnly).
  - Each wraps `COLLECTION_THREADS_LIST`, `COLLECTION_THREADS_GET`, `COLLECTION_THREAD_MESSAGES_LIST` via `ai` `tool()` with `zodSchema`.
  - Imported from concrete tool files (not `@/tools/thread` barrel) to avoid an import cycle.

<sup>Written for commit a5f8d1193b82151adb009955129f86f9e901096e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

