### PR TITLE
fix(home): Sales tile opens catalog for both VTEX and Shopify

### DIFF
--- a/apps/mesh/src/web/components/home/native-tiles.tsx
+++ b/apps/mesh/src/web/components/home/native-tiles.tsx
@@ -487,7 +487,7 @@ function SalesTileBody() {
         open={open}
         onOpenChange={setOpen}
         defaultTab="all"
-        initialSearch="Shopify"
+        initialSearch="shopify vtex"
       />
     </>
   );


### PR DESCRIPTION
## Summary
The Sales tile's "Connect VTEX or Shopify" button opened the connection catalog pre-filtered to `"Shopify"` only, so VTEX didn't show. Changed the `initialSearch` to `"shopify vtex"` — the modal's multi-keyword search then surfaces **both** providers.

## Changes
- `apps/mesh/src/web/components/home/native-tiles.tsx` — `initialSearch="Shopify"` → `"shopify vtex"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Sales tile “Connect VTEX or Shopify” button to open the catalog with both providers visible. Sets the catalog modal’s initialSearch to "shopify vtex" so the multi-keyword search returns VTEX and Shopify.

<sup>Written for commit 6dddeeb937678b0599b9e38573f65a31dfe6bada. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

