### PR TITLE
fix(commerce-onboarding): match sc-domain GSC sites with www consistently

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -421,6 +421,13 @@ describe("matchGscSite", () => {
   it("returns null when sites is empty", () => {
     expect(matchGscSite("example.com", [])).toBeNull();
   });
+  it("matches a www sc-domain site against a non-www https site (www stripping must apply to both formats)", () => {
+    const site = matchGscSite("sc-domain:www.example.com", [
+      { siteUrl: "https://example.com/" },
+      { siteUrl: "https://other.com/" },
+    ]);
+    expect(site).toBe("https://example.com/");
+  });
   it("falls back to the raw string instead of throwing on an unparseable siteUrl", () => {
     const site = matchGscSite("not a valid url", [
       { siteUrl: "not a valid url" },

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -362,18 +362,20 @@ export function matchGscSite(
   if (!contextSiteUrl) return null;
 
   const normalize = (url: string): string => {
-    // Strip sc-domain: prefix
-    if (url.startsWith("sc-domain:")) return url.substring(10);
-    // Parse URL and extract hostname
-    try {
-      const parsed = new URL(url.startsWith("http") ? url : `https://${url}`);
-      let host = parsed.hostname || "";
-      // Remove leading www.
-      if (host.startsWith("www.")) host = host.substring(4);
-      return host;
-    } catch {
-      return url;
-    }
+    // Strip sc-domain: prefix, then fall through to the same www-stripping
+    // as the URL branch below so both formats compare equal.
+    const host = url.startsWith("sc-domain:")
+      ? url.substring(10)
+      : (() => {
+          try {
+            return new URL(url.startsWith("http") ? url : `https://${url}`)
+              .hostname;
+          } catch {
+            return null;
+          }
+        })();
+    if (host === null) return url;
+    return host.startsWith("www.") ? host.substring(4) : host;
   };
 
   const contextNorm = normalize(contextSiteUrl);


### PR DESCRIPTION
## Source
Bug found reading `apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts` (a recently-churned file).

## Payoff
`matchGscSite` auto-links a store's Search Console property during commerce onboarding. Its `normalize()` helper strips a leading `www.` only in the `https://` branch — the `sc-domain:` branch returns the host as-is. So a domain property registered as `sc-domain:www.example.com` never matches the site's `https://example.com/` (or vice versa), and the onboarding flow silently fails to auto-select a GSC property the user actually owns, forcing a manual pick.

## Failure scenario + fix
- `matchGscSite("sc-domain:www.example.com", [{ siteUrl: "https://example.com/" }])` returned `null` before this fix — same domain, missed match.
- Fixed `normalize()` to extract the host for both formats first, then apply the `www.` strip once, uniformly.
- Regression test added in `companions-core.test.ts` (fails on the old code, passes now).

## Verify
```
bun test apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun test apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts` (43 pass)
- Confirmed the new test fails on `main` and passes with the fix
- Full-repo `tsc --noEmit` was run for context; it surfaced pre-existing, unrelated errors in `rich-text-field.tsx` (missing `@tiptap/extension-text-align` types) not touched by this change. Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GSC auto-linking in commerce onboarding by normalizing `www` handling for both `sc-domain:` and `https://` site formats. `sc-domain:www.example.com` now matches `https://example.com/`, so the correct property auto-selects.

- **Bug Fixes**
  - Updated `matchGscSite` to extract the host for both formats and strip leading `www.` uniformly; falls back to the raw string on parse errors.
  - Added a regression test to cover the `sc-domain:www.example.com` vs `https://example.com/` match.

<sup>Written for commit eb8e2ad79c5b6fa4359d0524f6b707415d27c66c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

