### PR TITLE
feat(home): real GitHub PRs when connected + connected-state for tiles

### DIFF
--- a/apps/mesh/src/web/components/home/native-tiles.tsx
+++ b/apps/mesh/src/web/components/home/native-tiles.tsx
@@ -25,7 +25,9 @@ import {
   MessageChatCircle,
   ShoppingCart01,
 } from "@untitledui/icons";
-import { useProjectContext } from "@decocms/mesh-sdk";
+import { useConnections, useProjectContext } from "@decocms/mesh-sdk";
+import { getOrgGithubConnections } from "@/shared/github-repo-scope";
+import { useGithubRecentPrs } from "@/web/hooks/use-github-recent-prs";
 import { useStudioTools } from "@/web/lib/studio-tools";
 import { useMembers } from "@/web/hooks/use-members";
 import { useTaskBoardItems } from "@/web/hooks/use-task-board-items";
@@ -266,10 +268,37 @@ function TasksTileBody() {
 }
 
 // ---------------------------------------------------------------------------
-// Mock tiles — Coding / Analytics / Sales. Static sample data; a hover overlay
-// connects the backing integration. GitHub / Google Analytics connect directly
-// (single known app); Sales opens the catalog (VTEX or Shopify — user picks).
+// Product tiles — Coding / Analytics / Sales.
+//
+// Disconnected: sample data behind a hover "Connect" overlay (GitHub / Google
+// Analytics connect directly; Sales opens the catalog for VTEX or Shopify).
+// Connected: Coding shows real recent PRs; Analytics / Sales show a "live data
+// coming soon" placeholder until their reporting tools are wired.
 // ---------------------------------------------------------------------------
+
+function TileSkeleton() {
+  return (
+    <div className="flex flex-col gap-2 p-3">
+      {Array.from({ length: 4 }, (_, i) => (
+        <div
+          key={`tile-skeleton-${i}`}
+          className="h-6 w-full animate-pulse rounded-md bg-muted/40"
+        />
+      ))}
+    </div>
+  );
+}
+
+function ComingSoonPanel({ label }: { label: string }) {
+  return (
+    <div className="flex h-full flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
+      <CheckCircle className="size-6 text-success/60" />
+      <p className="text-xs text-muted-foreground">
+        {label} connected. Live data coming soon.
+      </p>
+    </div>
+  );
+}
 
 function MockConnectOverlay({
   label,
@@ -361,6 +390,25 @@ const MOCK_PRS = [
 ];
 
 function CodingTileBody() {
+  return (
+    <Suspense fallback={<TileSkeleton />}>
+      <CodingTileInner />
+    </Suspense>
+  );
+}
+
+function CodingTileInner() {
+  const connection = getOrgGithubConnections(
+    useConnections({ slug: "mcp-github" }),
+  )[0];
+  return connection ? (
+    <CodingConnected connectionId={connection.id} />
+  ) : (
+    <CodingMock />
+  );
+}
+
+function CodingMock() {
   const { connect, isConnecting } = useConnectApp("deco/mcp-github");
   return (
     <MockTile
@@ -389,6 +437,45 @@ function CodingTileBody() {
         ))}
       </div>
     </MockTile>
+  );
+}
+
+function CodingConnected({ connectionId }: { connectionId: string }) {
+  const { data, isLoading } = useGithubRecentPrs(connectionId);
+  if (isLoading) return <TileSkeleton />;
+  if (!data || data.prs.length === 0) return <ComingSoonPanel label="Coding" />;
+  return (
+    <div className="flex h-full flex-col overflow-y-auto p-3">
+      {data.repo && (
+        <div className="mb-2 truncate text-xs text-muted-foreground">
+          {data.repo}
+        </div>
+      )}
+      <div className="flex flex-col gap-0.5">
+        {data.prs.map((pr) => (
+          <a
+            key={pr.number}
+            href={pr.htmlUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-2 rounded-md px-1.5 py-1 text-xs transition-colors hover:bg-accent/60"
+          >
+            <GitBranch01 className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="truncate text-foreground">{pr.title}</span>
+            <span
+              className={cn(
+                "ml-auto shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
+                pr.merged
+                  ? "bg-success/10 text-success"
+                  : "bg-muted text-muted-foreground",
+              )}
+            >
+              #{pr.number}
+            </span>
+          </a>
+        ))}
+      </div>
+    </div>
   );
 }
 
@@ -428,6 +515,19 @@ function StatNumber({ value, label }: { value: string; label: string }) {
 }
 
 function AnalyticsTileBody() {
+  return (
+    <Suspense fallback={<TileSkeleton />}>
+      <AnalyticsTileInner />
+    </Suspense>
+  );
+}
+
+function AnalyticsTileInner() {
+  const connected = useConnections({ slug: "google-analytics" }).length > 0;
+  return connected ? <ComingSoonPanel label="Analytics" /> : <AnalyticsMock />;
+}
+
+function AnalyticsMock() {
   const { connect, isConnecting } = useConnectApp("deco/google-analytics");
   return (
     <MockTile
@@ -464,6 +564,22 @@ function BarChartMock() {
 }
 
 function SalesTileBody() {
+  return (
+    <Suspense fallback={<TileSkeleton />}>
+      <SalesTileInner />
+    </Suspense>
+  );
+}
+
+function SalesTileInner() {
+  // Sales is backed by either provider — connected if either is present.
+  const vtex = useConnections({ slug: "vtex" });
+  const shopify = useConnections({ slug: "shopify" });
+  const connected = vtex.length > 0 || shopify.length > 0;
+  return connected ? <ComingSoonPanel label="Sales" /> : <SalesMock />;
+}
+
+function SalesMock() {
   // VTEX or Shopify — the user picks, so open the catalog rather than
   // connecting a single app directly.
   const [open, setOpen] = useState(false);

--- a/apps/mesh/src/web/hooks/use-github-recent-prs.ts
+++ b/apps/mesh/src/web/hooks/use-github-recent-prs.ts
@@ -1,0 +1,93 @@
+/**
+ * Fetches a few recent pull requests for the org's GitHub connection, for the
+ * home Coding tile. Chains the proven-wired github-mcp-server tools: resolve the
+ * installation (GITHUB_LIST_USER_ORGS) → list its repos (search_repositories) →
+ * pull requests of the most-recently-updated repo (list_pull_requests). There is
+ * no org-wide "all my PRs" tool wired, so we scope to the busiest repo.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
+import { fetchGithubInstallations } from "@/web/lib/github-installations";
+import { extractPullRequestList } from "@/web/components/thread/github/github-pr-api";
+import { KEYS } from "@/web/lib/query-keys";
+
+export interface RecentPr {
+  number: number;
+  title: string;
+  merged: boolean;
+  state: "open" | "closed";
+  htmlUrl: string;
+}
+
+interface RepoSummary {
+  full_name: string;
+  updated_at: string;
+}
+
+export function useGithubRecentPrs(connectionId: string) {
+  const { org } = useProjectContext();
+  const self = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const github = useMCPClient({
+    connectionId,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+
+  return useQuery({
+    queryKey: KEYS.homeGithubRecentPrs(org.id, connectionId),
+    queryFn: async (): Promise<{ prs: RecentPr[]; repo: string | null }> => {
+      const { installations } = await fetchGithubInstallations(
+        (req) => self.callTool(req),
+        connectionId,
+      );
+      const inst = installations[0];
+      if (!inst) return { prs: [], repo: null };
+
+      const qualifier = inst.type === "User" ? "user" : "org";
+      const reposRes = await github.callTool({
+        name: "search_repositories",
+        arguments: {
+          query: `${qualifier}:${inst.login}`,
+          page: 1,
+          perPage: 30,
+        },
+      });
+      const reposText = (reposRes as { content?: Array<{ text?: string }> })
+        .content?.[0]?.text;
+      const repos: RepoSummary[] = reposText
+        ? ((JSON.parse(reposText).items ?? []) as RepoSummary[])
+        : [];
+      const top = [...repos].sort((a, b) =>
+        (b.updated_at ?? "").localeCompare(a.updated_at ?? ""),
+      )[0];
+      if (!top?.full_name) return { prs: [], repo: null };
+
+      const [owner, repo] = top.full_name.split("/");
+      const prsRes = await github.callTool({
+        name: "list_pull_requests",
+        arguments: { owner, repo, state: "all", perPage: 5 },
+      });
+      const prs = extractPullRequestList(prsRes)
+        .map((p) => ({
+          number: (p.number as number) ?? 0,
+          title: (p.title as string) ?? "",
+          merged: (p.merged_at as string | null) != null,
+          state: p.state === "closed" ? ("closed" as const) : ("open" as const),
+          htmlUrl: (p.html_url as string) ?? "",
+        }))
+        .filter((p) => p.number > 0);
+
+      return { prs, repo: top.full_name };
+    },
+    staleTime: 60_000,
+  });
+}

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -41,6 +41,9 @@ export const KEYS = {
   taskBoardItems: (locator: ProjectLocator) =>
     [locator, "task-board-items"] as const,
 
+  homeGithubRecentPrs: (orgId: string, connectionId: string) =>
+    ["home-github-recent-prs", orgId, connectionId] as const,
+
   // Connections (scoped by project)
   connections: (locator: ProjectLocator) => [locator, "connections"] as const,
   connectionsByBinding: (locator: ProjectLocator, binding: string) =>


### PR DESCRIPTION
## Summary
The Coding / Analytics / Sales home tiles were always static mocks — even after the backing integration was connected (the "I have GitHub connected but it still shows Connect" bug). Now each tile reacts to connection state.

**Coding (GitHub)** — when an org GitHub connection exists, shows **real recent pull requests**:
resolve the installation (`GITHUB_LIST_USER_ORGS`) → list its repos (`search_repositories`) → PRs of the most-recently-updated repo (`list_pull_requests`). All three are already used elsewhere in the app (repo picker / PR hooks), so no new/unverified tools. New hook: `use-github-recent-prs.ts`.

**Analytics (GA) & Sales (VTEX/Shopify)** — show a **"live data coming soon"** placeholder once connected. Their reporting tools aren't wired anywhere in the repo (onboarding only *connects* the sources; reports are generated by an external service), so real numbers are a follow-up.

**All tiles** — disconnected state is unchanged: sample data + hover Connect CTA.

## How it works
- Connection detection: `useConnections({ slug })` — `"mcp-github"` (+ `getOrgGithubConnections` to drop repo-scoped children), `"google-analytics"`, `"vtex"`/`"shopify"`. Each tile body is wrapped in `<Suspense>`.
- GitHub PR fetch degrades gracefully: no installation / no repos / no PRs → the "coming soon" placeholder, never a crash.

## Notes / limitations
- No org-wide "all my PRs" tool is wired, so Coding scopes to the busiest repo. The contributions heatmap has no backing tool and stays decorative in the sample.
- GA/VTEX/Shopify slugs for connected-detection are best-effort (`google-analytics`, `vtex`, `shopify`); if an app's `app_name` differs, that tile simply keeps showing the sample.
- Not driven live (needs real connected GitHub/GA/commerce instances); `bun run check` + `lint` + `fmt` pass.

## Follow-up to make Analytics/Sales real
Requires discovering each app's own reporting tools at runtime (`tools/list`) — e.g. GA4 `runReport`, VTEX orders — which aren't referenced in this repo, plus per-app config (GA property id, store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Home tiles now reflect connection state. Coding shows recent GitHub PRs when connected; Analytics and Sales show a “live data coming soon” state; disconnected tiles keep sample data with a Connect CTA.

- **New Features**
  - Connection detection via `useConnections` for `mcp-github`, `google-analytics`, `vtex`, `shopify`; GitHub uses `getOrgGithubConnections` to ignore repo-scoped children.
  - New `use-github-recent-prs` hook: resolve installation (`GITHUB_LIST_USER_ORGS`) → `search_repositories` → `list_pull_requests`, cached via React Query key `homeGithubRecentPrs` (60s stale).
  - UI: Suspense-wrapped tiles with skeletons; linked PR list in Coding; graceful fallback to “Live data coming soon” when no installation/repos/PRs.

<sup>Written for commit 4e7514d3ffb9208735d2a60ceabc066688867a47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

