### PR TITLE
fix(home): immediate fallback on GitHub recent-PRs error

### DIFF
--- a/apps/mesh/src/web/hooks/use-github-recent-prs.ts
+++ b/apps/mesh/src/web/hooks/use-github-recent-prs.ts
@@ -89,5 +89,6 @@ export function useGithubRecentPrs(connectionId: string) {
       return { prs, repo: top.full_name };
     },
     staleTime: 60_000,
+    retry: false,
   });
 }


### PR DESCRIPTION
Follow-up to #4612. Reviewed the four nits from that PR; only one turned out to be a real, safely-fixable change.

## Fixed
- **`use-github-recent-prs.ts`: `retry: false`.** On a hard error the query retried 3x with backoff before the Coding tile fell to the "coming soon" placeholder, holding the skeleton up. Now the fallback is immediate — and consistent with the sibling `useCollectionList` query.

## Deliberately not changed
- **Per-tile error boundary** — already handled: `NativeTile` is wrapped in `TileErrorBoundary` by `tile-board.tsx`, so a failed `useConnections` shows the per-tile crash placeholder, not a blank board.
- **"Busiest repo" scoped to first 30 `search_repositories` results** — the github-mcp `search_repositories` tool isn't wired to accept `sort`/`order` anywhere in the repo; the client-side `updated_at` sort here is the same established pattern used in `github-config-form.tsx`. Adding an unverified `sort` arg risks a validation rejection for no guaranteed gain. Documented limitation, not a bug.
- **PR badge colors** (open vs closed-unmerged both muted) — cosmetic, left as-is.

`bun run check` + `oxlint` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable retries for the GitHub recent PRs query. The Coding tile now falls back immediately on errors instead of holding the loading skeleton.

- **Bug Fixes**
  - Set `retry: false` in `use-github-recent-prs.ts` to avoid 3x backoff retries and match the `useCollectionList` query behavior.

<sup>Written for commit aa84e0e7bbb358838674f9041126e61b0412ed69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

