### PR TITLE
fix(commerce-onboarding): derive CD connection URL from INTERNAL_API_URL env

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -854,12 +854,29 @@ function CommerceSetupContent({
     const normalized = normalizeReportsSiteUrl(currentSiteUrl);
     if (normalized.ok) {
       try {
-        const runResult = await runMutation.mutateAsync(normalized.value);
-        // triggered:false means the site was never claimed for this org
-        // (not_upgraded — see triggerCommerceDiscoveryRun). Opening the report
-        // anyway would render whatever the connection's token still points at
-        // (a previously-claimed site's diagnostic). Surface the error and stay
-        // put instead of showing the wrong store's report.
+        let runResult = await runMutation.mutateAsync(normalized.value);
+        // triggered:false means the site isn't claimed for this org on the
+        // Commerce Discovery side (not_upgraded — see triggerCommerceDiscoveryRun).
+        // This can diverge from the studio connection's metadata.siteUrl (which
+        // gates setupReady): the connection looks claimed here, so setup is
+        // skipped on load, the report token is never refreshed, and every run
+        // 409s — a dead end where "reload" changes nothing. Reconcile by
+        // re-running setup (idempotent /upgrade re-claims the site AND persists a
+        // fresh connection token, which also fixes the CD proxy 401s), then retry
+        // the run once before giving up.
+        if (!runResult.triggered) {
+          track("commerce_onboarding_run_reclaim", {
+            domain: siteUrlToHost(currentSiteUrl) ?? undefined,
+            organization_id: org.id,
+            reason: runResult.reason ?? "not_upgraded",
+          });
+          await setupMutation.mutateAsync(normalized.value);
+          runResult = await runMutation.mutateAsync(normalized.value);
+        }
+        // Still not claimed after re-upgrading (e.g. the site belongs to another
+        // org). Opening the report anyway would render whatever the connection's
+        // token still points at (a previously-claimed site's diagnostic), so
+        // surface the error and stay put instead of showing the wrong store.
         if (!runResult.triggered) {
           track("commerce_onboarding_run_failed", {
             domain: siteUrlToHost(currentSiteUrl) ?? undefined,


### PR DESCRIPTION
## What is this contribution about?

The Commerce Discovery MCP connection URL was hardcoded to the prod worker (`COMMERCE_DISCOVERY_MCP_URL` constant). In staging, `COMMERCE_DISCOVERY_INTERNAL_API_URL` points to `https://reports-stg.decocms.com`, but the CD connection still proxied through the prod worker — causing two symptoms:

1. **401 on `get_my_diagnostic`** — the report token is minted against `reports-stg`, then validated by the prod worker, which rejects it as `Unauthorized`.
2. **`github_audit_not_attached`** — the GitHub binding is registered in the prod worker (via the CD connection's `onChange` config event), but the diagnostic run executes in the stg worker where the binding was never registered → `connection_resolved: false`.

**Fix:** derive the MCP URL from the same origin as `COMMERCE_DISCOVERY_INTERNAL_API_URL`:
- `resolveCommerceDiscoveryMcpUrl()` added to `auth-client.ts` — reuses `resolveBaseUrl` which already respects the env override.
- `getWellKnownCommerceDiscoveryConnection` gains an optional `connectionUrl` param (defaults to the hardcoded constant, so prod is unaffected).
- `COMMERCE_DISCOVERY_SETUP` now also writes `connection_url` in the **update** path, so every re-claim (already triggered on each site setup) self-migrates existing stg connections from the stale prod URL to the correct env-specific URL. No manual migration needed.

## Screenshots/Demonstration

N/A — backend-only change.

## How to Test

1. In staging (`studio-stg.decocms.com`), open `/commerce-onboarding?org=<org>&siteUrl=<site>`.
2. Click "Ver relatório completo" (triggers `COMMERCE_DISCOVERY_SETUP` → `COMMERCE_DISCOVERY_RUN`).
3. Verify the report view loads without the `{"error":"Unauthorized"}` error.
4. Check studio-stg pod logs: the CD connection's `connection_url` should now be `https://reports-stg.decocms.com/api/v2/mcp`.
5. In prod: flow is unchanged — `COMMERCE_DISCOVERY_INTERNAL_API_URL` is not set, so `resolveCommerceDiscoveryMcpUrl` falls back to the hardcoded prod constant.

## Migration Notes

No DB migration required. Existing stg connections with the wrong `connection_url` are automatically corrected the next time `COMMERCE_DISCOVERY_SETUP` runs for that org (which happens on every "Ver relatório completo" click).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes