### PR TITLE
chore: rename mesh -> studio in comments and log messages

### DIFF
--- a/apps/mesh/migrations/001-initial-schema.ts
+++ b/apps/mesh/migrations/001-initial-schema.ts
@@ -1,7 +1,7 @@
 /**
  * Initial Database Schema
  *
- * Creates all tables for MCP Mesh:
+ * Creates all tables for Studio:
  * - users (managed by Better Auth)
  * - connections (organization-scoped)
  * - api_keys (managed by Better Auth)

--- a/apps/mesh/migrations/008-event-bus.ts
+++ b/apps/mesh/migrations/008-event-bus.ts
@@ -1,7 +1,7 @@
 /**
  * Event Bus Tables Migration
  *
- * Creates the events and subscriptions tables for the MCP Mesh event bus.
+ * Creates the events and subscriptions tables for the Studio event bus.
  * - events: Stores CloudEvents with delivery status tracking and cron support
  * - event_subscriptions: Links subscriber connections to event type patterns
  * - event_deliveries: Tracks per-subscription delivery status with retry support

--- a/apps/mesh/migrations/058-trigger-callback-tokens.ts
+++ b/apps/mesh/migrations/058-trigger-callback-tokens.ts
@@ -2,7 +2,7 @@
  * Migration 052: Trigger Callback Tokens
  *
  * Stores hashed callback tokens that external MCPs use to call back
- * to Mesh when a trigger fires (e.g., GitHub webhook → Mesh automation).
+ * to Studio when a trigger fires (e.g., GitHub webhook → Studio automation).
  * One token per connection+organization pair.
  */
 

--- a/apps/mesh/migrations/069-sandbox-runner-state.ts
+++ b/apps/mesh/migrations/069-sandbox-runner-state.ts
@@ -1,5 +1,5 @@
 /**
- * Persistent sandbox runner state — survives mesh restarts so we can
+ * Persistent sandbox runner state — survives studio restarts so we can
  * recover or terminate live sandboxes. `state` jsonb is opaque: each
  * runner serialises its own shape (e.g. docker: {token, hostPort, ...}).
  */

--- a/apps/mesh/migrations/084-drop-host-sandbox-rows.ts
+++ b/apps/mesh/migrations/084-drop-host-sandbox-rows.ts
@@ -3,7 +3,7 @@
  * runner.
  *
  * The `host` SandboxProvider was the local-dev shortcut that spawned the
- * sandbox daemon as a child of the mesh process. It has been retired in
+ * sandbox daemon as a child of the studio process. It has been retired in
  * favor of the laptop-side `deco link` daemon (auto-spawned by
  * `bun run dev --local-sandbox-provider`), which exercises the same
  * remote-cli + desktop code paths production uses.

--- a/apps/mesh/migrations/097-drop-local-docker-sandbox-state.ts
+++ b/apps/mesh/migrations/097-drop-local-docker-sandbox-state.ts
@@ -4,7 +4,7 @@
  *
  * The Docker sandbox provider has been removed. Any persisted `local-docker`
  * rows/cells are orphaned pointers to containers that no longer exist (and
- * don't survive a mesh restart), and the strict readers
+ * don't survive a studio restart), and the strict readers
  * (`parseBranchMap` / `parseSandboxRecord`) no longer accept the kind — Zod
  * skips/throws on it. Two idempotent steps:
  *

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -129,7 +129,7 @@ import * as migration127taskboardduedate from "./127-task-board-due-date.ts";
 import * as migration128reportsonly from "./128-reports-only.ts";
 
 /**
- * Core migrations for the Mesh application.
+ * Core migrations for the Studio application.
  *
  * These are managed by Kysely's migrator and run in alphabetical order.
  */

--- a/apps/mesh/scripts/bundle-server-script.ts
+++ b/apps/mesh/scripts/bundle-server-script.ts
@@ -82,7 +82,7 @@ const ALWAYS_INCLUDE = [
   //     won; fix: list better-auth + @better-auth/sso here so nft sees the
   //     1.4.22 chain and nests it under better-auth/)
   //
-  // Listing each better-auth-family package mesh imports here turns them
+  // Listing each better-auth-family package studio imports here turns them
   // into nft root entries (nft starts from the resolved file, skipping the
   // broken exports map walk), so each version they need ends up in the
   // trace. The version-conflict handler in pruneNodeModules then hoists one
@@ -255,7 +255,7 @@ async function copyPackage(
 async function pruneNodeModules(): Promise<Set<string>> {
   console.log(`🔍 Tracing dependencies for server and migration scripts...`);
 
-  // Resolve migration entry points from mesh app root
+  // Resolve migration entry points from studio app root
   const migrateEntryPointPaths: string[] = [];
   for (const entryPoint of ALWAYS_INCLUDE) {
     try {
@@ -400,7 +400,7 @@ async function pruneNodeModules(): Promise<Set<string>> {
     //
     // Because workspace deps (e.g. @decocms/harness) are inlined from source
     // rather than read from npm at runtime, the published `decocms` CLI only
-    // picks up a harness change when mesh itself re-releases and re-bundles.
+    // picks up a harness change when studio itself re-releases and re-bundles.
     // A harness-only version bump does NOT reach `decocms@latest` on its own.
     if (
       packageName.startsWith("@decocms/") &&

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -1,5 +1,5 @@
 /**
- * MCP Mesh API Server
+ * Studio API Server
  *
  * Main Hono application with:
  * - Better Auth integration
@@ -257,7 +257,7 @@ let currentDecopilotCleanup: (() => void | Promise<void>) | null = null;
  * Get project_locator from the Deco Store registry connection.
  * Returns the locator string or null if not found/configured.
  *
- * @param ctx - The mesh context
+ * @param ctx - The studio context
  * @param organizationId - The organization ID to search for the registry connection
  */
 async function getDecoStoreProjectLocator(
@@ -1607,7 +1607,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     },
   });
 
-  // Background-tool jobs reuse the same mesh-context factory to rebuild the
+  // Background-tool jobs reuse the same studio-context factory to rebuild the
   // org context + re-resolve models on whatever pod runs the job. Wired before
   // DBOS.launch() like the others (module-level pointer, no DBOS API calls).
   setBackgroundToolRuntime({
@@ -1659,7 +1659,7 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Orphan/crash recovery is owned by the external DBOS Conductor now: it
   // recovers a dead executor's PENDING workflows (incl. the thread-gate
-  // workflows backing decopilot runs) onto a live executor. Mesh no longer
+  // workflows backing decopilot runs) onto a live executor. Studio no longer
   // runs its own boot sweep or pod-death recovery. The reaper (RunRegistry)
   // still force-fails runs with no progress as a zombie backstop.
 
@@ -1725,7 +1725,7 @@ export async function createApp(options: CreateAppOptions = {}) {
           Promise.allSettled(revalidations),
           sleep(REVALIDATION_TIMEOUT_MS),
         ]).catch((err) =>
-          console.error("[mesh] revalidation cleanup error:", err),
+          console.error("[studio] revalidation cleanup error:", err),
         );
       }
     }
@@ -1971,7 +1971,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // OpenAI-compatible LLM API routes
   app.route("/api", openaiCompatRoutes);
 
-  // Trigger callback endpoint (external MCPs → Mesh automations).
+  // Trigger callback endpoint (external MCPs → Studio automations).
   // Legacy mount at /api/trigger-callback with deprecation log; the new
   // /api/:org/trigger-callback mount is wired in a later task.
   const legacyTriggerCallback = new Hono<{

--- a/apps/mesh/src/api/index.ts
+++ b/apps/mesh/src/api/index.ts
@@ -1,5 +1,5 @@
 /**
- * MCP Mesh API Server - Main Entry Point
+ * Studio API Server - Main Entry Point
  *
  * Re-exports createApp and provides a default app instance for production.
  * Tests should import { createApp } from "./app" to avoid side effects.

--- a/apps/mesh/src/api/org-scoped.integration.test.ts
+++ b/apps/mesh/src/api/org-scoped.integration.test.ts
@@ -177,7 +177,7 @@ describe("org-scoped API coexistence", () => {
     // /.well-known/oauth-protected-resource/api/:org/mcp/:connectionId — this
     // path lives at the *root* (the well-known prefix is anchored there), not
     // under the /api/:org sub-app. Without a top-level mount the SDK gets a
-    // 404 here and falls back to treating the mesh root as the auth server,
+    // 404 here and falls back to treating the studio root as the auth server,
     // breaking every OAuth-gated MCP (GitHub import-from-repo, Cursor, etc.).
 
     // Mock the origin: well-known endpoints 404, but the initialize probe

--- a/apps/mesh/src/api/routes/decopilot/constants.ts
+++ b/apps/mesh/src/api/routes/decopilot/constants.ts
@@ -12,7 +12,7 @@ export { generateMessageId } from "@decocms/harness/message-id";
  * mount points. The home folder mounts at the fixed `org/home/` (same path for
  * every org), so this block is identical across orgs and fully cache-stable.
  *
- * Portable pure function kept mesh-side (consumed by the cluster
+ * Portable pure function kept studio-side (consumed by the cluster
  * `build-agent-system-prompt`). org-fs is mounted into every sandbox now, so it
  * is emitted unconditionally.
  */

--- a/apps/mesh/src/api/routes/decopilot/file-materializer.ts
+++ b/apps/mesh/src/api/routes/decopilot/file-materializer.ts
@@ -483,7 +483,7 @@ export async function resolveStorageRefs(
   // Generate fresh presigned URLs for all file-part keys.
   //
   // DEV-ONLY branch: local rigs presign plain-http URLs (DevObjectStorage
-  // mesh URLs, local MinIO — no TLS on a laptop) and Anthropic rejects
+  // studio URLs, local MinIO — no TLS on a laptop) and Anthropic rejects
   // non-https file URLs outright. There — and only there — inline the
   // bytes as base64 instead. Gated on local mode, not just the URL scheme,
   // so production can never silently fall into base64-bloated requests; a

--- a/apps/mesh/src/api/routes/decopilot/ingest-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/ingest-run.ts
@@ -1,7 +1,7 @@
 /**
  * The ONE shared ingest unit (spec §unified-pipeline / Phase B).
  *
- * Both execution paths — agent-sandbox (in-mesh) and user-desktop (relay) —
+ * Both execution paths — agent-sandbox (in-studio) and user-desktop (relay) —
  * route through `ingestRun`. It does two things, in lockstep, per chunk:
  *
  *  1. **Publish** the raw chunk to `DECOPILOT_STREAMS` with a seq-keyed

--- a/apps/mesh/src/api/routes/decopilot/progress-bump.ts
+++ b/apps/mesh/src/api/routes/decopilot/progress-bump.ts
@@ -53,7 +53,7 @@ export class ProgressBumpThrottle {
  *
  * This is the run's liveness heartbeat for BOTH topologies: desktop chunks
  * go daemon → NATS directly, so the projector's live chunk consumption is
- * the only mesh component that ever sees them; hosted runs are also
+ * the only studio component that ever sees them; hosted runs are also
  * live-tailed by the projector post-unification, so this one tap covers
  * both — see the reaper's `RUN_IDLE_TIMEOUT_MS` in run-registry.ts.
  */

--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
@@ -133,7 +133,7 @@ export function getProjectorWorkflowRuntime(): ProjectorWorkflowRuntime {
  * Process-wide progress-bump throttle for the projector's live chunk
  * consumption (Task 9, A1/A2) — the SOLE liveness heartbeat for both
  * topologies (unified-control-plane). Desktop chunks go daemon → NATS
- * directly (no mesh HTTP hop), so this tap on the JetStream-sourced
+ * directly (no studio HTTP hop), so this tap on the JetStream-sourced
  * chunkStream is the only place a desktop run's progress gets recorded.
  * Hosted runs are live-tailed the same way post-unification (dispatch-run.ts
  * no longer has its own tap — its wrapped stream never enqueued a chunk, so

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -83,7 +83,7 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
   switch (event.type) {
     case "RUN_STARTED": {
       // Single-execution is guaranteed by the DBOS thread-gate queue
-      // (concurrency=1 per threadId partition), so there is no mesh-level
+      // (concurrency=1 per threadId partition), so there is no studio-level
       // run-owner claim to win/lose here — just record the run as active.
       await storage.update(event.taskId, event.orgId, {
         status: "in_progress",

--- a/apps/mesh/src/api/routes/files.ts
+++ b/apps/mesh/src/api/routes/files.ts
@@ -2,7 +2,7 @@
  * Files Route
  *
  * Serves org-scoped storage files via a stable, non-expiring URL.
- * Proxies the object bytes through mesh on every request (presigning
+ * Proxies the object bytes through studio on every request (presigning
  * internally), so the caller never sees storage URLs or manages expiry.
  *
  * Route: GET /api/:org/files/:key
@@ -45,7 +45,7 @@ const FORWARDED_RESPONSE_HEADERS = [
 ] as const;
 
 /** Now that bytes are served same-origin (no more redirect to the storage
- * domain), member-authored active content must not run with mesh's origin.
+ * domain), member-authored active content must not run with studio's origin.
  * CSP-sandbox it so scripts get an opaque origin and can't make credentialed
  * same-origin calls (same posture as the org-fs /read route). */
 function applyContentPolicy(headers: Headers, contentType: string): void {
@@ -112,7 +112,7 @@ app.get("/:org/files/*", async (c) => {
     return new Response(bytes, { status: 200, headers });
   }
 
-  // Proxy the object through mesh instead of redirecting: the storage origin
+  // Proxy the object through studio instead of redirecting: the storage origin
   // and signed URLs never reach the client.
   const upstreamHeaders = new Headers();
   for (const name of FORWARDED_REQUEST_HEADERS) {

--- a/apps/mesh/src/api/routes/oauth-proxy.integration.test.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * MCP OAuth Proxy E2E Tests
  *
- * Tests the Mesh OAuth proxy against real MCP servers.
+ * Tests the Studio OAuth proxy against real MCP servers.
  * All servers in mcp-test-servers.json must pass all tests.
  *
  * Run with: bun test oauth-proxy.e2e.test.ts

--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -591,7 +591,7 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
   });
 
   // Read a file: `?presign=1` returns a presigned URL (the mount's byte path);
-  // otherwise the bytes are streamed through mesh (convenient for the UI/dev).
+  // otherwise the bytes are streamed through studio (convenient for the UI/dev).
   //
   // Share fast-path: resolveOrgFromPath binds ctx.orgFs and lets anonymous /
   // non-member callers reach this route (its public-share carve-out). A

--- a/apps/mesh/src/api/routes/registry/public-mcp-server.ts
+++ b/apps/mesh/src/api/routes/registry/public-mcp-server.ts
@@ -207,7 +207,7 @@ export function createPublicMCPHandler(
     });
 
     // Forward request to MCP server with a minimal env that satisfies DefaultEnv.
-    // This is a public endpoint (no Mesh proxy), so we provide stub values for
+    // This is a public endpoint (no Studio proxy), so we provide stub values for
     // the required fields that are only used by authenticated/internal flows.
     const env = {
       organizationId: org.id,

--- a/apps/mesh/src/api/routes/sandbox-events-handler.ts
+++ b/apps/mesh/src/api/routes/sandbox-events-handler.ts
@@ -43,7 +43,7 @@ const NO_CLAIM_MAX_MS = 90_000;
 const HEARTBEAT_MS = 15_000;
 
 /**
- * Budget for the "lifecycle says ready but mesh hasn't finished its
+ * Budget for the "lifecycle says ready but studio hasn't finished its
  * post-Ready bookkeeping" race.
  */
 const PROXY_OPEN_RETRY_BUDGET_MS = 60_000;

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -51,7 +51,7 @@ import {
 
 interface VmClaim {
   claimName: string;
-  /** Null when no sandbox runner is configured on this mesh instance. */
+  /** Null when no sandbox runner is configured on this studio instance. */
   runner: SandboxProvider | null;
   virtualMcpId: string;
   branch: string;
@@ -591,7 +591,7 @@ export const createSandboxRoutes = () => {
           data: JSON.stringify({
             kind: "failed",
             reason: "unknown",
-            message: "No sandbox runner configured on this mesh.",
+            message: "No sandbox runner configured on this studio instance.",
           } satisfies ClaimPhase),
         });
       });

--- a/apps/mesh/src/api/routes/self.ts
+++ b/apps/mesh/src/api/routes/self.ts
@@ -1,7 +1,7 @@
 /**
  * Self MCP Server
  *
- * Exposes MCP Mesh management tools via MCP protocol at /mcp/self endpoint
+ * Exposes Studio management tools via MCP protocol at /mcp/self endpoint
  * Tools: PROJECT_CREATE, PROJECT_LIST, CONNECTION_CREATE, etc.
  */
 import { Hono } from "hono";

--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -13,7 +13,7 @@
  *      lifecycle reaches `ready`. Wire format is preserved verbatim by raw
  *      byte-piping the upstream body, so daemon and client speak the same
  *      protocol they always have.
- *   3. `event: gone` — synthetic. Mesh's upstream daemon fetch returned 404
+ *   3. `event: gone` — synthetic. Studio's upstream daemon fetch returned 404
  *      (sandbox handle missing → operator evicted on idle TTL, etc). Client
  *      maps to `notFound` and triggers self-heal via SANDBOX_START.
  *   4. `event: keepalive` — heartbeat. 15s matches the existing daemon SSE.
@@ -27,10 +27,10 @@
  *     compute a different handle.
  *
  * Why one stream instead of two: prior design had the browser open
- * `/api/vm-lifecycle` (mesh) plus a direct EventSource to the daemon's public
+ * `/api/vm-lifecycle` (studio) plus a direct EventSource to the daemon's public
  * `/_sandbox/events`. The daemon endpoint is unauthenticated (Vercel-style
  * "URL is the secret") and putting two long-lived SSEs in every tab burned
- * the EventSource budget. Routing through mesh authenticates the surface and
+ * the EventSource budget. Routing through studio authenticates the surface and
  * collapses to one connection per session.
  */
 
@@ -165,7 +165,7 @@ export const createVmEventsRoutes = () => {
             reason: "unknown",
             message:
               resolveError?.message ??
-              "No sandbox runner configured on this mesh.",
+              "No sandbox runner configured on this studio instance.",
           } satisfies ClaimPhase),
         });
       });
@@ -256,7 +256,7 @@ async function isStaleHandle(
  * rehydrate path (which would chase a dead port-forward and timeout) and
  * falls through to fresh provision. The state-store delete alone wasn't
  * enough — when `provider.alive` returns false because the operator's
- * housekeeper reaped the claim out from under us, mesh's `records` map
+ * housekeeper reaped the claim out from under us, studio's `records` map
  * still held the K8sRecord pointing at the now-deleted pod, and the
  * deterministic preview port stayed bound to that dead pod's WS forwarder
  * until process restart. Calling `provider.delete` invalidates both.
@@ -388,7 +388,7 @@ async function emitLifecycle(args: {
 }
 
 /**
- * Budget for the "lifecycle says ready but mesh hasn't finished its
+ * Budget for the "lifecycle says ready but studio hasn't finished its
  * post-Ready bookkeeping" race. The Sandbox CR Ready=True signal fires the
  * moment the operator's reconciliation completes; `runner.ensure()` then
  * does Service-patch + HTTPRoute-mint + port-forward + daemon health probe

--- a/apps/mesh/src/api/watch.test.ts
+++ b/apps/mesh/src/api/watch.test.ts
@@ -4,7 +4,7 @@
  * The handler emits only a `connected` frame on connect followed by live
  * events. Clients use `COLLECTION_THREADS_LIST` for their initial state.
  * The handler logic itself lives in `app.ts`; we mount it directly on an
- * inline Hono app so the test doesn't have to bootstrap the full mesh
+ * inline Hono app so the test doesn't have to bootstrap the full studio
  * application.
  */
 

--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -437,7 +437,7 @@ export const auth = betterAuth({
   secret: settings.betterAuthSecret || "deco-default-secret-k7x9m2p4q8w3n5v6",
 
   // customAPIKeyGetter probes every `Authorization: Bearer …` as an API key,
-  // so OAuth tokens, mesh JWTs and stale keys routinely miss and Better Auth
+  // so OAuth tokens, studio JWTs and stale keys routinely miss and Better Auth
   // logs an ERROR + full source-mapped stack on each one — flooding prod logs.
   // Drop only that expected 401; forward everything else with the same format.
   logger: {

--- a/apps/mesh/src/auth/jwt.test.ts
+++ b/apps/mesh/src/auth/jwt.test.ts
@@ -1,7 +1,7 @@
 /**
  * JWT Authentication Integration Tests
  *
- * Tests for the mesh JWT token system:
+ * Tests for the studio JWT token system:
  * - Token issuance with custom payloads
  * - Token verification
  * - Token decoding (without verification)

--- a/apps/mesh/src/auth/jwt.ts
+++ b/apps/mesh/src/auth/jwt.ts
@@ -1,5 +1,5 @@
 /**
- * JWT Utility for Mesh Proxy Tokens
+ * JWT Utility for Studio Proxy Tokens
  *
  * Uses HMAC SHA-256 (HS256) for signing JWTs that can be:
  * - Decoded directly by downstream services to read payload
@@ -40,7 +40,7 @@ function getSecret(): Uint8Array {
 }
 
 /**
- * Mesh proxy token payload
+ * Studio proxy token payload
  */
 export interface MeshTokenPayload {
   /** User ID who initiated the request */
@@ -56,7 +56,7 @@ export interface MeshTokenPayload {
   metadata?: {
     /** Configuration state */
     state?: Record<string, unknown>;
-    /** Mesh instance URL */
+    /** Studio instance URL */
     meshUrl: string;
     /** Connection ID this token was issued for */
     connectionId: string;
@@ -74,7 +74,7 @@ export interface MeshTokenPayload {
 export type MeshJwtPayload = JWTPayload & MeshTokenPayload;
 
 /**
- * Issue a signed JWT with mesh token payload
+ * Issue a signed JWT with studio token payload
  *
  * @param payload - The token payload
  * @param expiresIn - Expiration time (default: 5 minutes)
@@ -94,7 +94,7 @@ export async function issueMeshToken(
 }
 
 /**
- * Verify and decode a mesh token
+ * Verify and decode a studio token
  *
  * @param token - JWT string to verify
  * @returns Decoded payload if valid, undefined if invalid
@@ -112,7 +112,7 @@ export async function verifyMeshToken(
 }
 
 /**
- * Mint a gateway-compatible Mesh JWT for the given user.
+ * Mint a gateway-compatible Studio JWT for the given user.
  *
  * Uses the same MESH_JWT_SECRET and payload shape that the AI Gateway's
  * verifyMeshJwt() expects: { iss: "mesh", sub: userId }.

--- a/apps/mesh/src/automations/dbos-sync.ts
+++ b/apps/mesh/src/automations/dbos-sync.ts
@@ -1,7 +1,7 @@
 /**
- * Thin sync layer between mesh's `automation_triggers` table and DBOS schedules.
+ * Thin sync layer between studio's `automation_triggers` table and DBOS schedules.
  *
- * Mesh treats `automation_triggers` as the source of truth (it carries
+ * Studio treats `automation_triggers` as the source of truth (it carries
  * user-facing config: cron expression, params, etc.). DBOS owns the actual
  * scheduling, recovery, and concurrency.
  *
@@ -19,7 +19,7 @@ import {
   type FireAutomationOutcome,
 } from "./dbos-workflow";
 
-/** Build the DBOS schedule name from a mesh trigger row. */
+/** Build the DBOS schedule name from a studio trigger row. */
 export function scheduleNameForTrigger(triggerId: string): string {
   return `auto-trigger-${triggerId}`;
 }

--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -96,7 +96,7 @@ export async function startDevServer(
   const { baseUrl, noTui } = options;
 
   // Sandbox preview: the daemon injects PORT and proxies the preview to it,
-  // expecting HTML at /. Mesh's dev front door is Vite (it serves the app and
+  // expecting HTML at /. Studio's dev front door is Vite (it serves the app and
   // proxies /api → the Bun server); the Bun server alone 404s at / in dev. So
   // in a sandbox we bind Vite to the injected PORT and move the Bun server to
   // an internal port (Vite's proxy target follows PORT). The daemon sets
@@ -131,9 +131,9 @@ export async function startDevServer(
   const repoRoot = join(import.meta.dir, "..", "..", "..", "..", "..");
 
   // Pre-compute the link's data dir. The dir lives in tmpdir — NOT under
-  // settings.dataDir, which is inside the mesh repo. Sandbox clones go into
+  // settings.dataDir, which is inside the studio repo. Sandbox clones go into
   // `<DATA_DIR>/sandboxes/<handle>/repo`; when that parent is itself a git
-  // repo (e.g. `~/code/mesh/...`) git's parent-walk hits the outer .git,
+  // repo (e.g. `~/code/studio/...`) git's parent-walk hits the outer .git,
   // refuses to clone, and the daemon crashes mid-bootstrap. Keying by
   // workspace slug isolates concurrent worktrees.
   const slug =
@@ -141,7 +141,7 @@ export async function startDevServer(
     process.env.CONDUCTOR_WORKSPACE_NAME ??
     "default";
   // Local mode mints an API-key session into an isolated tmpdir so sandbox
-  // clones never nest inside the mesh repo's .git. Non-local mode reuses
+  // clones never nest inside the studio repo's .git. Non-local mode reuses
   // DECOCMS_HOME so the auto-spawned link registers as the same OAuth user
   // logged into the browser (e.g. tavano@deco.cx).
   const linkDataDir = options.localMode
@@ -280,7 +280,7 @@ export async function startDevServer(
   // The link is tracked like postgres/nats: dynamic port, state file at
   // <home>/services/link/state.json, owned-process verification on
   // shutdown. `services down` (or our shutdown handler below) tears it
-  // down. The DATA_DIR lives OUTSIDE the mesh repo: the daemon clones
+  // down. The DATA_DIR lives OUTSIDE the studio repo: the daemon clones
   // user repos into `<DATA_DIR>/sandboxes/<handle>/repo`, and if that
   // path is nested under another git repo (this one) git's parent-walk
   // hits the outer .git, refuses to clone, and the daemon crashes

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -1,5 +1,5 @@
 /**
- * Access Control for MCP Mesh
+ * Access Control for Studio
  *
  * Uses Better Auth's permission system for authorization.
  * Follows a grant-based model:
@@ -184,7 +184,7 @@ export class AccessControl {
     // Two kinds of principal, each with its OWN self-contained rule:
     //   - API key   → the key's stored allowlist is the whole decision. It is a
     //     capability, not a member: no role, no basic-usage, no Better Auth.
-    //   - everyone else (session / MCP OAuth / mesh JWT) → membership floor +
+    //   - everyone else (session / MCP OAuth / studio JWT) → membership floor +
     //     admin/owner bypass + Better Auth grants.
     return this.boundAuth?.isApiKeyPrincipal
       ? this.checkApiKeyAccess(resource)
@@ -205,7 +205,7 @@ export class AccessControl {
   }
 
   /**
-   * Member authorization (session / MCP OAuth / mesh JWT).
+   * Member authorization (session / MCP OAuth / studio JWT).
    *
    * Basic-usage tools are granted to every authenticated org MEMBER regardless
    * of role — resolved here, not baked into each role, so the set evolves with

--- a/apps/mesh/src/core/constants.ts
+++ b/apps/mesh/src/core/constants.ts
@@ -1,10 +1,10 @@
 /**
- * Shared constants for MCP Mesh
+ * Shared constants for Studio
  *
  * Constants used by both server-side and web code.
  */
 
-/** MCP Mesh metadata key in tool _meta */
+/** Studio metadata key in tool _meta */
 export const MCP_MESH_KEY = "mcp.mesh";
 
 /**

--- a/apps/mesh/src/core/context-factory.bound-auth.test.ts
+++ b/apps/mesh/src/core/context-factory.bound-auth.test.ts
@@ -63,7 +63,7 @@ describe("createBoundAuthClient — API-key authorization", () => {
       auth: stubAuth,
       headers: new Headers(),
       role: "admin",
-      permissions: { self: ["ORGANIZATION_GET"] }, // e.g. a mesh JWT payload
+      permissions: { self: ["ORGANIZATION_GET"] }, // e.g. a studio JWT payload
       // no apiKeyId — not an API key principal
     });
 

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -212,7 +212,7 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
   // admin/owner role never widens it, or a "read-only" key minted by an admin
   // would silently act with full org power. A full-access key carries an
   // explicit wildcard. Only genuine API keys (apiKeyId present) are gated this
-  // way; browser sessions, MCP OAuth, and mesh JWTs keep the role-based path.
+  // way; browser sessions, MCP OAuth, and studio JWTs keep the role-based path.
   const isApiKeyPrincipal = !!apiKeyId;
 
   // Get hasPermission from Better Auth's organization plugin (for browser sessions)
@@ -574,7 +574,7 @@ async function resolveAndCacheRole(
 /**
  * Resolve the on-behalf-of user for a self/loopback call.
  *
- * When mesh calls its own management server (the `<org>_self` connection — e.g.
+ * When studio calls its own management server (the `<org>_self` connection — e.g.
  * a Studio Pack agent invoking COLLECTION_VIRTUAL_MCP_CREATE), the outbound
  * request authenticates with that connection's API key (owned by the org
  * creator) but ALSO forwards the REAL acting user in an `x-mesh-token` JWT (see
@@ -582,7 +582,7 @@ async function resolveAndCacheRole(
  * Studio Pack agent is attributed to the org creator instead of the user who
  * actually acted (wrong `created_by`/`updated_by`).
  *
- * `x-mesh-token` is only ever set by mesh's own outbound header builder, so an
+ * `x-mesh-token` is only ever set by studio's own outbound header builder, so an
  * inbound API-key request carrying one is always a self/loopback call. We use
  * the forwarded user for IDENTITY/attribution; the API key's permissions remain
  * the authorizing capability (the caller keeps `permissions`/`apiKeyId`).
@@ -748,13 +748,13 @@ async function authenticateRequest(
     console.error("[Auth] OAuth session check failed:", err);
   }
 
-  // Try Mesh JWT or API Key authentication (Bearer token)
+  // Try Studio JWT or API Key authentication (Bearer token)
   // These use the same header but different validation
   if (authHeader?.startsWith("Bearer ")) {
     const token = authHeader.replace("Bearer ", "").trim();
 
-    // First, try to verify as Mesh JWT token
-    // These are issued by mesh for downstream services calling back
+    // First, try to verify as Studio JWT token
+    // These are issued by studio for downstream services calling back
     try {
       const meshJwtPayload = await timings.measure("auth_verify_mesh_jwt", () =>
         verifyMeshToken(token),
@@ -825,7 +825,7 @@ async function authenticateRequest(
         };
       }
     } catch {
-      // Not a valid mesh JWT, continue to API key check
+      // Not a valid studio JWT, continue to API key check
     }
 
     // Try API Key authentication
@@ -933,7 +933,7 @@ async function authenticateRequest(
 
   try {
     // Strip the Authorization header before calling getSession.
-    // We've already tried all Bearer-based auth (Mesh JWT, API key) above.
+    // We've already tried all Bearer-based auth (Studio JWT, API key) above.
     // If we pass the Bearer token to getSession, Better Auth's API key plugin
     // will attempt to validate it as an API key and throw INVALID_API_KEY,
     // flooding logs with false-positive errors.
@@ -1366,7 +1366,7 @@ export async function createStudioContextFactory(
       : { user: undefined };
 
     // Resolve caller connection ID: explicit header takes priority, then fall
-    // back to the connectionId embedded in the mesh JWT. This ensures that
+    // back to the connectionId embedded in the studio JWT. This ensures that
     // management tools on _self see the caller's connection ID even when the
     // runtime doesn't set x-caller-id.
     const connectionId =

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -96,7 +96,7 @@ export interface BoundAuthClient {
    * authorized SOLELY by the key's stored allowlist — it must NOT inherit the
    * owner's admin/owner role. Both `hasPermission` here and the role bypass in
    * `AccessControl.checkResource` read this single flag so every call site
-   * (REST + MCP) agrees. Absent/false for browser sessions, MCP OAuth, and mesh
+   * (REST + MCP) agrees. Absent/false for browser sessions, MCP OAuth, and studio
    * JWTs, which keep the role-based behavior.
    */
   isApiKeyPrincipal?: boolean;

--- a/apps/mesh/src/database/index.ts
+++ b/apps/mesh/src/database/index.ts
@@ -1,5 +1,5 @@
 /**
- * Database Factory for MCP Mesh
+ * Database Factory for Studio
  *
  * Creates a configured Kysely instance backed by PostgreSQL.
  * Returns a StudioDatabase that includes the Kysely instance and the

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -4,6 +4,6 @@
   "dispatch-queue/hosted-harness-workflow.ts": "cba081506ab82e6c546cc55f13ef03ea23567a612f5d9f5c8856f5dca876119e",
   "dispatch-queue/thread-gate-workflow.ts": "674cd393ad3b06806e967389dfe7e87bd0de6ba933fd54df1e5cd24a08b99e43",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",
-  "harnesses/decopilot/background-tool-workflow.ts": "a47d58f9dc4850c45cc3fbea65666e9beea6a3d61081934b984fd8b34c4798e3",
+  "harnesses/decopilot/background-tool-workflow.ts": "14fc3a7d09dc68e347fa32c176f261f5b277e6bca48b14f912e27670641347e7",
   "monitoring/dbos-retention-workflow.ts": "b43e3596b386b53faf372b140d9137a12252565987543640d17f7798504b8dbb"
 }

--- a/apps/mesh/src/file-storage/mount/api.ts
+++ b/apps/mesh/src/file-storage/mount/api.ts
@@ -1,7 +1,7 @@
 /**
  * The minimal filesystem surface the WebDAV serve layer needs. Two
  * implementations exist:
- *   - `OrgFsClient` (client.ts) — talks to the mesh `/api/:org/fs/:volume/*`
+ *   - `OrgFsClient` (client.ts) — talks to the studio `/api/:org/fs/:volume/*`
  *     HTTP contract; this is what the daemon uses (it has no DB/storage).
  *   - a direct adapter over the in-process `OrgFs` service — used by tests and
  *     the end-to-end mount harness.
@@ -29,7 +29,7 @@ export interface OrgFsApi {
   /**
    * Stream a file read straight from the byte store (presigned URL), pushing
    * an optional `Range` header down so only the requested bytes move — where
-   * `read()` buffers every byte through the mesh and this process. Returns
+   * `read()` buffers every byte through the studio and this process. Returns
    * null when no streamable URL is available (presign failed, or dev storage's
    * inline `data:` URLs); callers then fall back to `read()`. Throws
    * OrgFsApiError(404) for a missing file.

--- a/apps/mesh/src/file-storage/mount/client.test.ts
+++ b/apps/mesh/src/file-storage/mount/client.test.ts
@@ -3,7 +3,7 @@ import { OrgFsClient } from "./client";
 
 describe("OrgFsClient.readResponse", () => {
   it("falls back (null) when the presigned host is unreachable", async () => {
-    // The mesh fetch is injected and presigns to a port nothing listens on —
+    // The studio fetch is injected and presigns to a port nothing listens on —
     // a real refused connection, like a cluster pod given a localhost MinIO
     // URL. Found by the Stage-2 kind e2e: a propagated error here makes
     // rclone retry-loop forever instead of using the buffered path.

--- a/apps/mesh/src/file-storage/mount/client.ts
+++ b/apps/mesh/src/file-storage/mount/client.ts
@@ -7,7 +7,7 @@ export type FetchLike = (
 ) => Promise<Response>;
 
 export interface OrgFsClientOptions {
-  /** Mesh base URL, e.g. https://cluster.deco.host (no trailing slash needed). */
+  /** Studio base URL, e.g. https://cluster.deco.host (no trailing slash needed). */
   baseUrl: string;
   /** Immutable org slug (the `:org` path segment). */
   orgSlug: string;
@@ -51,7 +51,7 @@ export interface OrgFsChangePage {
 }
 
 /**
- * Daemon-side client for the mesh org-fs HTTP contract. One instance per
+ * Daemon-side client for the studio org-fs HTTP contract. One instance per
  * (org, volume). Used by the WebDAV serve layer; never touches the DB.
  */
 export class OrgFsClient implements OrgFsApi {
@@ -121,14 +121,14 @@ export class OrgFsClient implements OrgFsApi {
     // Dev storage presigns to inline `data:` URLs (the full base64 payload) —
     // no push-down win there; the buffered path is strictly cheaper.
     if (!/^https?:/i.test(url)) return null;
-    // Global fetch on purpose: the presigned URL is external to the mesh (the
-    // injected fetch only routes the mesh contract).
+    // Global fetch on purpose: the presigned URL is external to the studio (the
+    // injected fetch only routes the studio contract).
     let res: Response;
     try {
       res = await fetch(url, range ? { headers: { range } } : undefined);
     } catch {
       // Presigned host unreachable from THIS network (e.g. a cluster pod or
-      // remote desktop vs a localhost MinIO endpoint) — the mesh can still
+      // remote desktop vs a localhost MinIO endpoint) — the studio can still
       // reach it, so fall back to the buffered read instead of erroring.
       return null;
     }

--- a/apps/mesh/src/file-storage/mount/provisioning.ts
+++ b/apps/mesh/src/file-storage/mount/provisioning.ts
@@ -1,5 +1,5 @@
 /**
- * Builds the `ORGFS_CONFIG` payload the mesh pushes to a sandbox daemon (as a
+ * Builds the `ORGFS_CONFIG` payload the studio pushes to a sandbox daemon (as a
  * boot env var) to turn on org-fs mounting. The daemon's `parseOrgFsConfig`
  * (packages/sandbox/daemon/org-fs/config.ts) validates this shape.
  *
@@ -20,7 +20,7 @@
  *     subtree of the org-wide `outputs` volume (the share-files-back flow).
  *   - `uploads` → mounted at `<appRoot>/org/.uploads` (hidden); same per-run
  *     symlink trick (`org/upload → .uploads/<threadId>`) in the inbound
- *     direction — chat attachments the mesh writes to the thread's uploads
+ *     direction — chat attachments the studio writes to the thread's uploads
  *     folder appear in the sandbox with no copy step.
  */
 

--- a/apps/mesh/src/file-storage/mount/webdav.integration.test.ts
+++ b/apps/mesh/src/file-storage/mount/webdav.integration.test.ts
@@ -1,6 +1,6 @@
 /**
  * WebDAV serve layer — integration tier. Exercises the FULL daemon read path
- * with no mocks: WebDAV handler → OrgFsClient → (in-process) mesh
+ * with no mocks: WebDAV handler → OrgFsClient → (in-process) studio
  * `/api/:org/fs/*` routes + real `resolveOrgFromPath` → real `OrgFs` (real
  * Postgres + DevObjectStorage). Only the NFS kernel mount is out of scope here
  * (covered by the manual end-to-end harness `.context/webdav-nfs-smoke`).

--- a/apps/mesh/src/file-storage/mount/webdav.ts
+++ b/apps/mesh/src/file-storage/mount/webdav.ts
@@ -199,7 +199,7 @@ export function createWebdavHandler(
           }
           // Push the read down to the byte store when the backend can stream
           // it: presigned URL + Range forwarded, so rclone's chunked reads of
-          // big files don't buffer whole objects through the mesh (or here).
+          // big files don't buffer whole objects through the studio (or here).
           if (api.readResponse) {
             const upstream = await api.readResponse(
               path,

--- a/apps/mesh/src/harnesses/cross-tree-guard.test.ts
+++ b/apps/mesh/src/harnesses/cross-tree-guard.test.ts
@@ -15,12 +15,12 @@ import { Glob } from "bun";
 // `@decocms/harness` specifiers in the later package-move slice, not here.
 //
 // Excludes:
-//  - *.integration.test.ts (DB-backed; stays mesh-side, not packaged)
-//  - local-dispatch.ts / index.ts (mesh-only, folded into InProcessSandboxClient)
+//  - *.integration.test.ts (DB-backed; stays studio-side, not packaged)
+//  - local-dispatch.ts / index.ts (studio-only, folded into InProcessSandboxClient)
 const EXCLUDED = new Set([
   "local-dispatch.ts",
   "local-dispatch.test.ts",
-  "index.ts", // top-level mesh barrel
+  "index.ts", // top-level studio barrel
 ]);
 const CROSS_TREE =
   /from\s+["'](?:\.\.\/)+(?:api\/routes\/decopilot|ai-providers|shared)\//;

--- a/apps/mesh/src/harnesses/decopilot/background-tool-workflow.ts
+++ b/apps/mesh/src/harnesses/decopilot/background-tool-workflow.ts
@@ -178,7 +178,7 @@ async function requireMeshContext(
   );
   if (!studioCtx) {
     throw new Error(
-      `[background-tool] mesh context unavailable for org ${ctx.orgId} user ${ctx.userId}`,
+      `[background-tool] studio context unavailable for org ${ctx.orgId} user ${ctx.userId}`,
     );
   }
   return studioCtx;
@@ -653,7 +653,7 @@ export async function deliverBackgroundSubtaskResult(args: {
 }
 
 /** Resolve the reaction turn's target + harness from the thread row. Returns
- *  null only when the mesh context can't be rebuilt. */
+ *  null only when the studio context can't be rebuilt. */
 async function resolveReactionTargetStep(
   ctx: BackgroundToolContext,
 ): Promise<{ target: DispatchTarget; harnessId: HarnessId | null } | null> {

--- a/apps/mesh/src/harnesses/in-process-sandbox-client.ts
+++ b/apps/mesh/src/harnesses/in-process-sandbox-client.ts
@@ -7,13 +7,13 @@ import type { StudioContext } from "../core/studio-context";
 /**
  * InProcessSandboxClient — the cluster (in-process) SandboxClient (spec §5.2/§5.3).
  *
- * MESH-OWNED: it closes over StudioContext, so it cannot live in
+ * STUDIO-OWNED: it closes over StudioContext, so it cannot live in
  * @decocms/sandbox. `dispatch(input)` runs the harness IN-PROCESS — a direct
  * call, no HTTP, no wire, no serialization (the cluster fast path is preserved).
  *
  * STEP 1a (this commit): a behavior-preserving wrapper. It delegates to the
  * existing `localDispatch(harnessId, input, ctx)` path UNCHANGED and returns the
- * same AsyncIterable<UIMessageChunk>, which mesh's consumeHarnessStream consumes
+ * same AsyncIterable<UIMessageChunk>, which studio's consumeHarnessStream consumes
  * with no adapter. The HarnessDeps merge (fs-hooks from AgentSandboxProvider,
  * cluster hooks built from StudioContext) is layered in later sub-steps (1b…);
  * `localDispatch` is then folded fully into this client (§5.4).

--- a/apps/mesh/src/harnesses/index.ts
+++ b/apps/mesh/src/harnesses/index.ts
@@ -26,7 +26,7 @@ registerClusterEnvironmentBuilder((args) => {
 //
 // CLI harnesses (claude-code, codex) are also imported by the desktop link
 // daemon; decopilot pulls in cluster-only modules (RunRegistry, run-stream,
-// mesh tools) and is only usable on the cluster side.
+// studio tools) and is only usable on the cluster side.
 registerHarnessFactory(decopilotHarnessFactory);
 registerHarnessFactory(claudeCodeHarnessFactory);
 registerHarnessFactory(codexHarnessFactory);

--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * MCP Mesh Server Entry Point
+ * Studio Server Entry Point
  *
  * Bundled server entry point for production.
  * Start with: bun run index.js
@@ -31,14 +31,14 @@ const settings = getSettings();
 // ensures every `meter.createX()` call hits the real MeterProvider.
 initObservability();
 
-// DBOS shares mesh's Postgres database and owns the `dbos` schema. Sharing
+// DBOS shares studio's Postgres database and owns the `dbos` schema. Sharing
 // the DB (vs. a sibling one) is what lets future workflow-ified CRUD
-// commit mesh writes and DBOS step-output records in a single transaction
+// commit studio writes and DBOS step-output records in a single transaction
 // via a DBOS data source. The `dbos` schema is auto-created on launch.
 // setConfig must run before any module registers workflows; launch happens
 // after the app graph is loaded so all DBOS.registerWorkflow calls are in.
 const { DBOS, DBOSClient } = await import("@dbos-inc/dbos-sdk");
-// DBOS uses its own pg client (separate from mesh's pool), so the `sslmode`
+// DBOS uses its own pg client (separate from studio's pool), so the `sslmode`
 // must travel in the URL. RDS's pg_hba.conf rejects unencrypted connections
 // with `no pg_hba.conf entry for host ... no encryption` when this is missing.
 // Use `verify-full` explicitly: pg-connection-string v2 silently upgrades
@@ -141,7 +141,7 @@ function withSecurityHeaders(res: Response): Response {
 
 // Sandbox preview reverse-proxy (agent-sandbox only). The base domain is parsed at
 // boot from STUDIO_SANDBOX_PREVIEW_URL_PATTERN; null disables the proxy and
-// preview-host requests fall through to the normal mesh routing (which 404s
+// preview-host requests fall through to the normal studio routing (which 404s
 // because nothing matches). The Bun-level WS handler is registered
 // unconditionally — when previewBaseDomain is null, no upgrade path runs it.
 const {
@@ -203,7 +203,7 @@ const server = Bun.serve({
   fetch: async (request, server) => {
     // Sandbox preview proxy: matched by Host header. Runs *before* assets
     // and the Hono app so a `<handle>.preview.<base>` request never hits
-    // mesh's static-file handler (which would 404 on the dev server's
+    // studio's static-file handler (which would 404 on the dev server's
     // bundle paths). WS upgrades short-circuit Bun.serve's fetch by
     // returning undefined; HTTP returns a Response.
     if (previewBaseDomain) {
@@ -340,7 +340,7 @@ let shuttingDown = false;
  * Runs AFTER `DBOS.shutdown()` on purpose: once this executor's queue poller is
  * stopped, a re-enqueued gate can only be claimed by a LIVE executor, so we
  * can't re-grab (and re-orphan) our own gates in a shutdown race. Uses a
- * standalone `DBOSClient` (its own sysdb connection) because mesh's DBOS
+ * standalone `DBOSClient` (its own sysdb connection) because studio's DBOS
  * executor is already torn down at this point.
  *
  * Best-effort: any failure is logged and swallowed so shutdown still completes.
@@ -443,7 +443,7 @@ async function gracefulShutdown(signal: string) {
     // and it's what our workflow rows are stamped with. See
     // handOffInFlightThreadGates for why this matters.
     const executorId = DBOS.executorID;
-    // Drain DBOS before app.shutdown closes mesh's pg pool — in-flight steps use it.
+    // Drain DBOS before app.shutdown closes studio's pg pool — in-flight steps use it.
     await DBOS.shutdown();
     // Re-enqueue our own in-flight thread-gate gates so a live pod adopts them
     // instead of stranding them PENDING on this dead executor (which bricks the

--- a/apps/mesh/src/lib/loopback-preview.ts
+++ b/apps/mesh/src/lib/loopback-preview.ts
@@ -5,7 +5,7 @@
  * User-desktop sandboxes serve their preview on `http://<handle>.localhost:
  * <ingressPort>`. Browsers (and curl) special-case `.localhost` subdomains to
  * loopback, but server-side fetch resolves them through getaddrinfo, which
- * returns NXDOMAIN on macOS — so the mesh's preview proxy routes
+ * returns NXDOMAIN on macOS — so the studio's preview proxy routes
  * (`preview-fetch` / `preview-invoke`) could never reach a linked sandbox.
  * Dialing 127.0.0.1 directly while preserving the original host lets the
  * ingress (`link-daemon/local-ingress.ts`) route by Host as usual.

--- a/apps/mesh/src/link-daemon/outbox-imports.test.ts
+++ b/apps/mesh/src/link-daemon/outbox-imports.test.ts
@@ -1,7 +1,7 @@
 /**
  * Guard: the durable-outbox core must stay cluster-free so the link daemon
  * bundle (`bunx decocms@latest link`, distributed to users) never drags in cluster
- * code (StudioContext, storage, API routes, @decocms/sandbox). The mesh
+ * code (StudioContext, storage, API routes, @decocms/sandbox). The studio
  * cross-tree guard (src/harnesses/cross-tree-guard.test.ts) covers only the
  * @decocms/harness package tree — NOT src/link-daemon — so this is the
  * dedicated guard for the outbox slice. The outbox may import only:

--- a/apps/mesh/src/mcp-clients/client.ts
+++ b/apps/mesh/src/mcp-clients/client.ts
@@ -19,7 +19,7 @@ import { createVirtualClient } from "./virtual-mcp";
  * - STDIO, HTTP, Websocket, SSE: Creates an outbound client
  *
  * @param connection - Connection entity from database
- * @param ctx - Mesh context for creating clients
+ * @param ctx - Studio context for creating clients
  * @param superUser - Whether to use superuser mode for background processes
  * @returns Client instance connected to the MCP server
  */

--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -46,7 +46,7 @@ function stripBindingMetadata(
  * Handles configuration token issuance and OAuth token refresh
  *
  * @param connection - Connection entity from database
- * @param ctx - Mesh context
+ * @param ctx - Studio context
  * @param superUser - Whether to use superuser mode for background processes
  * @returns Headers object ready to be used in HTTP requests
  */

--- a/apps/mesh/src/mcp-clients/outbound/index.ts
+++ b/apps/mesh/src/mcp-clients/outbound/index.ts
@@ -32,7 +32,7 @@ const stdioPool = createClientPool();
  * Create an MCP client for outbound connections (STDIO, HTTP, Websocket, SSE)
  *
  * @param connection - Connection entity from database
- * @param ctx - Mesh context for creating clients
+ * @param ctx - Studio context for creating clients
  * @param superUser - Whether to use superuser mode for background processes
  * @returns Client instance connected to the downstream MCP server
  */

--- a/apps/mesh/src/mcp-clients/server.ts
+++ b/apps/mesh/src/mcp-clients/server.ts
@@ -49,7 +49,7 @@ const DEFAULT_SERVER_CAPABILITIES = {
  * connection cost entirely on cache hits.
  *
  * @param connection - The connection entity to create a server for
- * @param ctx - Mesh context with storage and organization info
+ * @param ctx - Studio context with storage and organization info
  * @param superUser - Whether to create with super-user privileges (cross-org access)
  * @returns An MCP Server ready to be connected to a transport
  *

--- a/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/index.ts
@@ -34,7 +34,7 @@ function isSelfReferencingVirtual(
  * Create a virtual MCP client from a connection entity
  *
  * @param connection - Connection entity with VIRTUAL type
- * @param ctx - Mesh context for creating proxies
+ * @param ctx - Studio context for creating proxies
  * @param superUser - Whether to use superuser mode for background processes
  * @returns Client instance with aggregated tools, resources, and prompts
  */
@@ -61,7 +61,7 @@ export async function createVirtualClient(
  * Uses inclusion mode: only connections specified in virtualMcp.connections are included
  *
  * @param virtualMcp - Virtual MCP entity from database
- * @param ctx - Mesh context for creating proxies
+ * @param ctx - Studio context for creating proxies
  * @param _strategy - Kept for backward compatibility, always uses passthrough
  * @param superUser - Whether to use superuser mode for background processes
  * @returns Client instance with aggregated tools, resources, and prompts

--- a/apps/mesh/src/object-storage/key-utils.ts
+++ b/apps/mesh/src/object-storage/key-utils.ts
@@ -63,7 +63,7 @@ export function buildS3Prefix(orgId: string, prefix?: string): string {
 /**
  * Build the stable, non-expiring URL the UI / tools use to read an object by
  * key. Backed by `GET /api/:org/files/*`, which proxies the object bytes
- * through mesh (presigning internally). Single source of truth for this
+ * through studio (presigning internally). Single source of truth for this
  * route shape.
  */
 export function toFilesUrl(

--- a/apps/mesh/src/observability/index.ts
+++ b/apps/mesh/src/observability/index.ts
@@ -2,7 +2,7 @@
  * OpenTelemetry Observability Setup
  *
  * Provides distributed tracing, metrics collection, and logging
- * for the MCP Mesh.
+ * for the Studio.
  */
 
 import {

--- a/apps/mesh/src/observability/middleware.ts
+++ b/apps/mesh/src/observability/middleware.ts
@@ -2,7 +2,7 @@
  * OpenTelemetry Tracing Middleware for Hono
  *
  * Provides request-level tracing with common HTTP attributes
- * and mesh-specific context.
+ * and studio-specific context.
  */
 
 import type { MiddlewareHandler } from "hono";
@@ -48,7 +48,7 @@ const durationHistogram = (): Histogram =>
 
 /**
  * Tracing middleware that creates a span for each request
- * with common HTTP attributes and mesh-specific context.
+ * with common HTTP attributes and studio-specific context.
  */
 export const tracingMiddleware: MiddlewareHandler<Env> = async (c, next) => {
   if (isHealthPath(c.req.path)) {
@@ -107,7 +107,7 @@ export const tracingMiddleware: MiddlewareHandler<Env> = async (c, next) => {
         });
         span.setAttribute("http.response.status_code", status);
 
-        // Add mesh-specific attributes if available
+        // Add studio-specific attributes if available
         const studioContext = c.get("studioContext");
         if (studioContext) {
           if (studioContext.auth.user?.id) {

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -44,7 +44,7 @@ const lifecycleGlobal = globalThis as unknown as LifecycleGlobal;
 const runners: Partial<Record<SandboxProviderKind, SandboxProvider>> =
   (lifecycleGlobal[RUNNERS_KEY] ??= {});
 // In-flight instantiate() promises, memoized per kind. Two concurrent
-// callers on a cold mesh would otherwise both miss the resolved-runner
+// callers on a cold studio would otherwise both miss the resolved-runner
 // cache and both call instantiate(); memoizing the promise (and only
 // promoting to `runners` once it resolves) collapses them to a single
 // build. Cleared on failure so a retry can take a fresh swing.
@@ -81,7 +81,7 @@ function readPreviewUrlPattern(): string | undefined {
 
 // Per-env SandboxTemplate name. The sandbox-env Helm chart suffixes the
 // template name with envName so multiple envs share `agent-sandbox-system`
-// without collisions; mesh in this env must point its claims at the
+// without collisions; studio in this env must point its claims at the
 // matching suffixed name. Empty/unset → AgentSandboxProvider's built-in
 // default ("studio-sandbox") so single-env installs that didn't suffix
 // keep working.
@@ -96,7 +96,7 @@ function readEnvName(): string | undefined {
 }
 
 // Shared bearer baked into the SandboxTemplate's pod env via the
-// sandbox-env helm chart's Secret. Set on the mesh side from the same
+// sandbox-env helm chart's Secret. Set on the studio side from the same
 // Secret so both ends agree on what the warm-pool sentinel is.
 //
 // Presence flips AgentSandboxProvider into warm-pool mode (claims with
@@ -108,9 +108,9 @@ function readSandboxSentinelToken(): string | undefined {
 }
 
 // Per-claim HTTPRoute attaches to this Gateway. When NAME + NAMESPACE are
-// set alongside STUDIO_SANDBOX_PREVIEW_URL_PATTERN, mesh mints one
+// set alongside STUDIO_SANDBOX_PREVIEW_URL_PATTERN, studio mints one
 // HTTPRoute per SandboxClaim so the wildcard Gateway can route directly
-// to each sandbox's Service:9000 (mesh leaves the data path).
+// to each sandbox's Service:9000 (studio leaves the data path).
 //
 // Both required — no default — because the provider is Gateway-API-generic
 // (Istio, Envoy Gateway, Cilium, Kong, ...) and there's no portable
@@ -118,7 +118,7 @@ function readSandboxSentinelToken(): string | undefined {
 // ambient prefers a separate `istio-ingress`/`gateway` ns, and other
 // implementations vary. A wrong default would silently write routes that
 // fail to attach (parentRef → non-existent Gateway) and the failure mode
-// is a 404 from the gateway with no log on the mesh side.
+// is a 404 from the gateway with no log on the studio side.
 //
 // Both unset → provider falls back to in-process preview proxying (legacy).
 // Half-configured (one set, the other not) → fail fast at boot rather

--- a/apps/mesh/src/sandbox/preview-proxy.ts
+++ b/apps/mesh/src/sandbox/preview-proxy.ts
@@ -2,7 +2,7 @@
  * Sandbox preview reverse-proxy.
  *
  * Inbound requests to `<handle>.preview.<base-domain>` are routed to the
- * matching sandbox's daemon at port 9000. Mesh stays in the request path
+ * matching sandbox's daemon at port 9000. Studio stays in the request path
  * for the first ship; long-term plan is per-claim HTTPRoute objects (see
  * the K8s sandbox plan), but this keeps DNS + RBAC simple while we ship.
  *
@@ -27,7 +27,7 @@ import {
  * Cap on frames buffered between client upgrade and upstream WS open. Vite
  * HMR sends ~1 frame per file event, so 256 covers a normal cold start with
  * room to spare while preventing a slow/blackholed upstream from exhausting
- * mesh memory.
+ * studio memory.
  */
 const MAX_PENDING_FRAMES = 256;
 
@@ -95,8 +95,8 @@ export function parsePreviewBaseDomain(
 /**
  * Pulls the sandbox handle out of a request Host header. Returns null when
  * the host doesn't match `<handle>.<baseDomain>` (meaning the request isn't
- * for a mesh sandbox preview and should fall through to the rest of the
- * mesh API).
+ * for a studio sandbox preview and should fall through to the rest of the
+ * studio API).
  */
 export function extractHandleFromHost(
   host: string | null | undefined,
@@ -117,7 +117,7 @@ export function extractHandleFromHost(
 
 export interface PreviewProxyDeps {
   /**
-   * Lazy runner accessor. Returns null when the mesh isn't configured for
+   * Lazy runner accessor. Returns null when the studio isn't configured for
    * the agent-sandbox runner — the caller treats null as "not a preview
    * deployment" and falls through.
    */
@@ -130,7 +130,7 @@ export interface PreviewProxyDeps {
  * otherwise null (caller should fall through to its normal routing).
  *
  * 503 is returned when the runner isn't ready yet — preview traffic hit the
- * mesh before any sandbox tool initialized the runner. The browser will
+ * studio before any sandbox tool initialized the runner. The browser will
  * retry; by then the runner should be up.
  */
 export async function tryHandlePreviewHttp(

--- a/apps/mesh/src/settings/index.ts
+++ b/apps/mesh/src/settings/index.ts
@@ -1,5 +1,5 @@
 /**
- * Settings accessor for MCP Mesh.
+ * Settings accessor for Studio.
  *
  * getSettings() returns the frozen Settings object constructed by the
  * startup pipeline. Throws if called before buildSettings() completes.

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -1,5 +1,5 @@
 /**
- * Settings type definition for MCP Mesh.
+ * Settings type definition for Studio.
  *
  * Constructed once by the startup pipeline, frozen, and available
  * via getSettings() for the lifetime of the process.

--- a/apps/mesh/src/storage/trigger-callback-tokens.ts
+++ b/apps/mesh/src/storage/trigger-callback-tokens.ts
@@ -2,7 +2,7 @@
  * Trigger Callback Tokens Storage
  *
  * Manages opaque callback tokens that external MCPs use to authenticate
- * trigger callbacks to Mesh. Tokens are stored as SHA-256 hashes;
+ * trigger callbacks to Studio. Tokens are stored as SHA-256 hashes;
  * plaintext is only returned once at creation time.
  */
 

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -1,5 +1,5 @@
 /**
- * Database Types for MCP Mesh
+ * Database Types for Studio
  *
  * These TypeScript interfaces define the database schema using Kysely's type-only approach.
  * PostgreSQL database schema types.
@@ -1658,7 +1658,7 @@ export interface Database {
   automations: AutomationTable;
   automation_triggers: AutomationTriggerTable;
 
-  // Trigger callback tokens (for external MCP → Mesh callbacks)
+  // Trigger callback tokens (for external MCP → Studio callbacks)
   trigger_callback_tokens: TriggerCallbackTokenTable;
 
   // Organization SSO tables

--- a/apps/mesh/src/tools/automations/configure-trigger.ts
+++ b/apps/mesh/src/tools/automations/configure-trigger.ts
@@ -3,7 +3,7 @@
  *
  * Calls TRIGGER_CONFIGURE on the target connection to enable/disable
  * an event trigger. When enabling, generates a callback token and URL
- * so the external MCP can call back to Mesh when the trigger fires.
+ * so the external MCP can call back to Studio when the trigger fires.
  */
 
 import type { StudioContext } from "@/core/studio-context";

--- a/apps/mesh/src/tools/connection/dev-assets.ts
+++ b/apps/mesh/src/tools/connection/dev-assets.ts
@@ -32,7 +32,7 @@ const DEV_ASSETS_TOOLS: ToolDefinition[] = OBJECT_STORAGE_BINDING.map(
 );
 
 /**
- * True when this mesh instance falls back to DevObjectStorage (local
+ * True when this studio instance falls back to DevObjectStorage (local
  * filesystem) because no external S3 bucket is configured. The dev-assets
  * pseudo-connection must be visible whenever this is true so that tools
  * depending on the OBJECT_STORAGE binding still resolve.

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -1,7 +1,7 @@
 /**
  * Tool Registry
  *
- * Central export for all MCP Mesh management tools.
+ * Central export for all Studio management tools.
  * Types are inferred from CORE_TOOLS — this is the source of truth.
  */
 

--- a/apps/mesh/src/tools/registry/schema.test.ts
+++ b/apps/mesh/src/tools/registry/schema.test.ts
@@ -13,7 +13,7 @@ import { RegistryGetOutputSchema, RegistryListOutputSchema } from "./schema";
  * Cause: the item output schema was a closed object, advertised as JSON Schema
  * with `additionalProperties: false`. The deco store validates output with Zod
  * (which strips unknown keys, so the response is returned), but MCP clients —
- * e.g. the mesh proxy via `client.callTool` — re-validate `structuredContent`
+ * e.g. the studio proxy via `client.callTool` — re-validate `structuredContent`
  * with Ajv, which rejects items carrying fields not modeled in the schema
  * (`is_unlisted`, unmodeled `server.json` keys, etc.). `SEARCH` was unaffected
  * because it returns a slim, exactly-projected object.
@@ -61,7 +61,7 @@ describe("registry output schema – proxy round-trip validation", () => {
     ]);
 
     try {
-      // The mesh proxy lists tools (caching each tool's advertised output
+      // The studio proxy lists tools (caching each tool's advertised output
       // schema), then calls the tool. The SDK client only validates output for
       // tools whose schema was cached via listTools().
       await client.listTools();

--- a/apps/mesh/src/tools/registry/schema.ts
+++ b/apps/mesh/src/tools/registry/schema.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 // `server_json`/`meta_json` verbatim, and those mirror a full MCP `server.json`
 // (carrying many fields this schema does not model — `$schema`, `status`,
 // package transport details, etc.). The deco store validates output with Zod
-// (which strips unknown keys and passes), but MCP clients — e.g. the mesh proxy
+// (which strips unknown keys and passes), but MCP clients — e.g. the studio proxy
 // via `client.callTool` — re-validate the structuredContent with Ajv, which
 // enforces `additionalProperties: false` and rejects the extra fields with
 // `-32602: Structured content does not match the tool's output schema`.

--- a/apps/mesh/src/web/components/file-preview.tsx
+++ b/apps/mesh/src/web/components/file-preview.tsx
@@ -5,7 +5,7 @@
  * (toolbar, close) and data fetching.
  *
  * Rendering strategy by extension:
- *   - image → <img> (same-origin URL, bytes proxied by mesh; no CORS needed)
+ *   - image → <img> (same-origin URL, bytes proxied by studio; no CORS needed)
  *   - pdf   → <iframe> (browser-native viewer; NOT sandboxed — a sandbox
  *             without allow-scripts would disable Chrome's PDF plugin)
  *   - html  → <iframe sandbox="allow-scripts"> (untrusted; opaque-origin sandbox)

--- a/apps/mesh/src/web/components/sandbox/content/use-run-block.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/use-run-block.test.ts
@@ -4,7 +4,7 @@ import { buildInvokeRunUrl, buildPreviewInvokePath } from "./use-run-block";
 const NOW_MS = 1_751_500_000_000;
 
 describe("buildPreviewInvokePath", () => {
-  it("builds the org-scoped mesh proxy path", () => {
+  it("builds the org-scoped studio proxy path", () => {
     expect(
       buildPreviewInvokePath({
         orgSlug: "acme",

--- a/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
+++ b/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
@@ -5,7 +5,7 @@ interface RunBlockInput {
   props: Record<string, unknown>;
 }
 
-/** Sandbox coordinates the mesh preview-invoke proxy route is keyed by. */
+/** Sandbox coordinates the studio preview-invoke proxy route is keyed by. */
 export interface RunBlockSandboxRef {
   orgSlug: string;
   virtualMcpId: string;
@@ -16,12 +16,12 @@ export interface RunBlockSandboxRef {
 const RUN_TIMEOUT_MS = 30_000;
 
 /**
- * Mesh proxy path for a preview invoke:
+ * Studio proxy path for a preview invoke:
  * `POST /api/:org/sandbox/:virtualMcpId/:branch/preview-invoke` with a
  * block-ref body (`{ __resolveType, ...props }`). The proxy re-issues it as
  * `POST <preview>/deco/invoke/<resolveType>` with the props as JSON body.
  *
- * Going through the mesh (same-origin) instead of fetching the preview
+ * Going through the studio (same-origin) instead of fetching the preview
  * directly keeps the browser out of CORS territory — previews don't send
  * `Access-Control-Allow-Origin` for `/deco/invoke`.
  */
@@ -110,7 +110,7 @@ async function invokeBlock(
 }
 
 /**
- * Invoke a loader/action against the running sandbox preview (via the mesh
+ * Invoke a loader/action against the running sandbox preview (via the studio
  * preview-invoke proxy) and return its structured result.
  */
 export function useRunBlock(ref: RunBlockSandboxRef) {

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -1,7 +1,7 @@
 /**
- * Single SSE connection to mesh's `/api/:org/sandbox/:virtualMcpId/:branch/events`, fanned out via context.
+ * Single SSE connection to studio's `/api/:org/sandbox/:virtualMcpId/:branch/events`, fanned out via context.
  *
- * Keyed on `(virtualMcpId, branch)` — mesh derives the userId from the
+ * Keyed on `(virtualMcpId, branch)` — studio derives the userId from the
  * authenticated session and composes the same claim handle a racing
  * SANDBOX_START would. The stream emits in two phases on one connection:
  *
@@ -12,7 +12,7 @@
  *      passthrough from the in-pod daemon's `/_sandbox/events`. Types
  *      come from `@decocms/sandbox/shared`.
  *
- *   3. `event: gone` — synthetic. Mesh's upstream daemon fetch returned 404
+ *   3. `event: gone` — synthetic. Studio's upstream daemon fetch returned 404
  *      (sandbox handle missing → operator-evicted on idle TTL). Mapped to
  *      `notFound` which preview.tsx's self-heal flow turns into a SANDBOX_START.
  *
@@ -255,7 +255,7 @@ export function SandboxEventsProvider({
 
     const handleGone = () => {
       // The sandbox is gone (idle-evicted, SANDBOX_DELETE'd, or its pod terminated
-      // and mesh has stopped finding the handle). Everything we've cached is
+      // and studio has stopped finding the handle). Everything we've cached is
       // about to be stale, so reset.
       setNotFound(true);
       setPhase(null);

--- a/apps/mesh/src/web/components/sandbox/preview/drawer/drawer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/drawer/drawer.tsx
@@ -73,7 +73,7 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
     if (!props.open) props.onOpenChange(true);
   };
 
-  // Mesh's sandbox proxy route requires virtualMcpId+branch in the path to
+  // Studio's sandbox proxy route requires virtualMcpId+branch in the path to
   // compute the per-user claim handle. Without them the request 400s
   // before reaching the daemon.
   const execScript = (name: string) => {

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
@@ -39,7 +39,7 @@ const KIND_LABELS: Record<PathParamKind, { noun: string; heading: string }> = {
 };
 
 /**
- * Invoke a loader via the mesh preview-invoke proxy (same-origin,
+ * Invoke a loader via the studio preview-invoke proxy (same-origin,
  * authenticated) — the same route useRunBlock uses. Fetching the preview
  * origin directly would hit CORS: previews don't send
  * `Access-Control-Allow-Origin` for `/deco/invoke`.

--- a/apps/mesh/src/web/components/sandbox/runtime-card/env-vars-field.tsx
+++ b/apps/mesh/src/web/components/sandbox/runtime-card/env-vars-field.tsx
@@ -70,7 +70,7 @@ export interface EnvVarsFieldProps<T extends FieldValues> {
 
 /**
  * Form-bound env editor for `metadata.runtime.env` on a virtual MCP.
- * Mesh resolves secret entries against the credential vault on every
+ * Studio resolves secret entries against the credential vault on every
  * SANDBOX_START; literal entries are sent inline.
  *
  * The secret list is read via Suspense; the wrapper renders a skeleton

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -234,7 +234,7 @@ function PublishDialogBody({
       try {
         await loadGitState();
       } catch (error) {
-        // Preview can stay live via the gateway while mesh's daemon proxy
+        // Preview can stay live via the gateway while studio's daemon proxy
         // still holds a stale handle. Re-provision once, then retry — same
         // self-heal path as preview.tsx's notFound → SANDBOX_START flow.
         if (isSandboxUnreachable(error) && !reprovisionAttemptedRef.current) {

--- a/apps/mesh/src/web/hooks/use-file-picker.ts
+++ b/apps/mesh/src/web/hooks/use-file-picker.ts
@@ -76,10 +76,10 @@ export interface UploadResult {
 }
 
 /**
- * Upload a file to a configured bucket via the mesh proxy endpoint. We
+ * Upload a file to a configured bucket via the studio proxy endpoint. We
  * don't presign + PUT directly from the browser because that requires
  * per-bucket CORS configuration on every customer bucket (S3, GCS, R2),
- * which is too much friction for a CMS. The proxy streams through mesh
+ * which is too much friction for a CMS. The proxy streams through studio
  * once and avoids the cross-origin problem entirely.
  *
  * The file is sent as the raw POST body (NOT multipart) so the server

--- a/apps/mesh/src/web/layouts/library/skill.ts
+++ b/apps/mesh/src/web/layouts/library/skill.ts
@@ -1,6 +1,6 @@
 /**
  * SKILL.md parsing for the Library — re-exported from the shared harness
- * module (`@decocms/harness/skills/skill-md`) so the web UI and the mesh
+ * module (`@decocms/harness/skills/skill-md`) so the web UI and the studio
  * server-side skill catalog parse identically.
  */
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/preview-drawer-host.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/preview-drawer-host.tsx
@@ -20,7 +20,7 @@ import { PreviewDrawer } from "@/web/components/sandbox/preview/drawer/drawer";
 
 const STORAGE_KEY = (id: string) => `preview-drawer:${id}`;
 
-// Clone aborts (exit 128) when the GitHub token mesh handed the orchestrator is
+// Clone aborts (exit 128) when the GitHub token studio handed the orchestrator is
 // stale/invalid. A restart re-mints a fresh installation token, so auto
 // stop+start once per VM to recover. Match the auth-specific lines, not the
 // bare exit code (which covers unrelated git failures).

--- a/apps/mesh/src/web/lib/localstorage-keys.ts
+++ b/apps/mesh/src/web/lib/localstorage-keys.ts
@@ -1,7 +1,7 @@
 import type { ProjectLocator } from "@decocms/mesh-sdk";
 
 /**
- * Known localStorage keys for the mesh app.
+ * Known localStorage keys for the studio app.
  * When adding a new use of useLocalStorage, add the key to this object.
  * This is used to avoid inline key definitions and to ensure consistency.
  */

--- a/packages/bindings/src/well-known/event-subscriber.ts
+++ b/packages/bindings/src/well-known/event-subscriber.ts
@@ -3,7 +3,7 @@
  *
  * Defines the interface for MCP connections that can receive events.
  * Any MCP that implements this binding can receive batched CloudEvents
- * from the MCP Mesh event bus.
+ * from the Studio event bus.
  *
  * This binding includes:
  * - ON_EVENTS: Receive a batch of CloudEvents
@@ -34,7 +34,7 @@ export const CloudEventSchema = z.object({
     .describe("Unique identifier for this event (UUID recommended)"),
 
   /**
-   * Source of the event - in MCP Mesh, this is the connection ID of the publisher.
+   * Source of the event - in Studio, this is the connection ID of the publisher.
    * Format: URI-reference identifying the context in which an event happened.
    */
   source: z.string().describe("Connection ID of the event publisher"),

--- a/packages/e2e/fixtures/commerce-upgrade-mock.ts
+++ b/packages/e2e/fixtures/commerce-upgrade-mock.ts
@@ -1,13 +1,13 @@
 /**
  * Standalone mock of the commerce-skills internal upgrade API.
  *
- * Launched as a Playwright `webServer` so the mesh server can complete
+ * Launched as a Playwright `webServer` so the studio server can complete
  * `COMMERCE_DISCOVERY_SETUP` end-to-end without reaching the real production
- * reports service (https://reports.decocms.com). The mesh server is
+ * reports service (https://reports.decocms.com). The studio server is
  * pointed here via `COMMERCE_DISCOVERY_INTERNAL_API_URL` in the Playwright
  * config.
  *
- * Black-box: the mesh server reaches this over HTTP only — no app imports.
+ * Black-box: the studio server reaches this over HTTP only — no app imports.
  * Uses `node:http` (NOT `Bun.serve`) so it typechecks under the suite's Node
  * types and runs under either node or bun.
  *

--- a/packages/e2e/fixtures/mcp-tools.ts
+++ b/packages/e2e/fixtures/mcp-tools.ts
@@ -1,7 +1,7 @@
 /**
  * Call management MCP tools from a Playwright test via JSON-RPC.
  *
- * Mesh exposes built-in tools (CONNECTION_*, PROJECT_*, etc.) over the
+ * Studio exposes built-in tools (CONNECTION_*, PROJECT_*, etc.) over the
  * MCP protocol at `/api/:org/mcp/self`. From a spec, we sometimes need to
  * exercise them as setup — e.g., create a connection that points at a
  * test MCP server (see `test-mcp-server.ts`). This module wraps the
@@ -49,7 +49,7 @@ export async function callSelfMcpTool<T = unknown>(
     // MCP's Streamable HTTP transport requires advertising both response
     // types per spec — the server picks JSON for self-contained calls,
     // SSE for streams. Without both, the transport responds 406 Not
-    // Acceptable. (See mesh's self.ts enableJsonResponse check.)
+    // Acceptable. (See studio's self.ts enableJsonResponse check.)
     headers: { Accept: "application/json, text/event-stream" },
   });
   if (!res.ok()) {

--- a/packages/e2e/fixtures/test-mcp-server.ts
+++ b/packages/e2e/fixtures/test-mcp-server.ts
@@ -3,9 +3,9 @@
  *
  * Spins up a tiny HTTP MCP server on a random port using `node:http` (NOT
  * `Bun.serve` — Playwright runs specs under Node, not Bun) so a test can
- * create a real mesh connection that points at something real but
+ * create a real studio connection that points at something real but
  * controlled. Uses the SDK's `StreamableHTTPServerTransport` (Node
- * wrapper around the same Web-Standard transport mesh uses internally),
+ * wrapper around the same Web-Standard transport studio uses internally),
  * so the wire protocol matches production exactly.
  *
  * Why not Docker (like tests/resilience/everything-server)? Per-test
@@ -40,7 +40,7 @@ export interface TestMcpTool {
    * handler's (object) return value is ALSO surfaced as `structuredContent`
    * on the MCP result — the SDK only emits/validates structuredContent for
    * tools that declare an outputSchema. Consumers that read
-   * `result.structuredContent` (e.g. mesh's MINT_REPO_TOKEN caller) need
+   * `result.structuredContent` (e.g. studio's MINT_REPO_TOKEN caller) need
    * this; plain text-only tools can omit it.
    */
   outputSchema?: Record<string, z.ZodTypeAny>;
@@ -72,7 +72,7 @@ export interface RecordedRequest {
 }
 
 export interface TestMcpServer {
-  /** Base URL ending in `/`. Pass this as the connection URL in mesh. */
+  /** Base URL ending in `/`. Pass this as the connection URL in studio. */
   url: string;
   /** Every JSON-RPC request the server saw, in arrival order. */
   requests: ReadonlyArray<RecordedRequest>;
@@ -114,7 +114,7 @@ export async function startTestMcpServer(
   const recorded: RecordedRequest[] = [];
 
   // Build a fresh server per request — the streamable transport is designed
-  // to be one-shot in stateless mode, mirroring how mesh's /mcp/self mounts
+  // to be one-shot in stateless mode, mirroring how studio's /mcp/self mounts
   // (see apps/mesh/src/api/routes/self.ts).
   const buildServer = (): McpServer => {
     const server = new McpServer({ name: "test-mcp", version: "1.0.0" });
@@ -185,7 +185,7 @@ export async function startTestMcpServer(
         }
 
         const server = buildServer();
-        // Stateless mode so each request stands alone — matches mesh's
+        // Stateless mode so each request stands alone — matches studio's
         // per-request server pattern in self.ts.
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: undefined,

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -5,7 +5,7 @@ const appPort = process.env.VITE_PORT || "4000";
 const appOrigin = process.env.BASE_URL || `http://localhost:${appPort}`;
 
 // Commerce Discovery setup mints a one-time client token by calling the
-// commerce-skills internal upgrade API. We point the mesh server at a local
+// commerce-skills internal upgrade API. We point the studio server at a local
 // mock (commerce-upgrade-mock.ts, started as a webServer below) so onboarding
 // specs exercise the real setup path without hitting the production worker.
 const commerceMockPort = process.env.COMMERCE_MOCK_PORT || "4100";
@@ -67,7 +67,7 @@ export default defineConfig({
   ],
   webServer: [
     {
-      // Mock commerce-skills upgrade API. Started before the mesh server so
+      // Mock commerce-skills upgrade API. Started before the studio server so
       // COMMERCE_DISCOVERY_SETUP can mint a token over HTTP without reaching
       // the production worker. Standalone process (no app imports).
       command: `COMMERCE_MOCK_PORT=${commerceMockPort} bun run fixtures/commerce-upgrade-mock.ts`,

--- a/packages/e2e/tests/decopilot-unified-control-plane.spec.ts
+++ b/packages/e2e/tests/decopilot-unified-control-plane.spec.ts
@@ -21,7 +21,7 @@
  *      of the daemon process dying mid-stream: the consume step only ever
  *      observes the JetStream subject, never the daemon's process liveness
  *      directly, so "publishes then goes silent" and "daemon crashed" are
- *      indistinguishable from the mesh's point of view.
+ *      indistinguishable from the studio's point of view.
  *
  * ## Environment facts this suite depends on
  *
@@ -350,7 +350,7 @@ test.describe("decopilot desktop — executor death mid-run reaches a liveness t
       // event, nothing. The consume step only ever watches the JetStream
       // subject, not the daemon's process itself, so this is the faithful
       // black-box equivalent of "the desktop daemon process dies mid-run":
-      // from the mesh's point of view the two are indistinguishable —
+      // from the studio's point of view the two are indistinguishable —
       // both are "no more events on the subject."
       const assistantMessageId = `msg_liveness_${Date.now()}`;
       const textId = `${assistantMessageId}-text-0`;

--- a/packages/e2e/tests/file-serving.spec.ts
+++ b/packages/e2e/tests/file-serving.spec.ts
@@ -1,13 +1,13 @@
 /**
  * End-to-end coverage for the stable file-serving route
- * (`GET /api/:org/files/*`), which proxies object bytes through mesh instead
+ * (`GET /api/:org/files/*`), which proxies object bytes through studio instead
  * of 302-redirecting to a presigned S3 URL.
  *
  * The route has two byte-delivery paths and this spec exercises both depending
  * on how the running app is configured (see e2e.yml):
- *   - **dev (no S3):** DevObjectStorage hands back a `data:` URL → mesh decodes
+ *   - **dev (no S3):** DevObjectStorage hands back a `data:` URL → studio decodes
  *     it and serves the bytes inline.
- *   - **S3 (CI MinIO):** mesh presigns a GET internally, fetches it, and streams
+ *   - **S3 (CI MinIO):** studio presigns a GET internally, fetches it, and streams
  *     the body back — the signed URL / storage origin never reach the client.
  *
  * Bytes-back, content-type, CSP and auth assertions run in BOTH backends so the
@@ -111,7 +111,7 @@ test.describe("File serving (/api/:org/files/*)", () => {
     });
     expect(res.status()).toBe(200);
     expect(res.headers()["content-type"]).toContain("text/html");
-    // Now that HTML is served from mesh's own origin (not the storage origin
+    // Now that HTML is served from studio's own origin (not the storage origin
     // after a redirect), it must run with an opaque origin so its scripts
     // can't make credentialed same-origin calls.
     expect(res.headers()["content-security-policy"]).toContain("sandbox");

--- a/packages/e2e/tests/mcp-proxy-roundtrip.spec.ts
+++ b/packages/e2e/tests/mcp-proxy-roundtrip.spec.ts
@@ -1,17 +1,17 @@
 /**
- * End-to-end smoke test for mesh's MCP proxy.
+ * End-to-end smoke test for studio's MCP proxy.
  *
  * Stands up a tiny test MCP server (../fixtures/test-mcp-server.ts),
- * creates a real connection in mesh that points at it, then exercises the
+ * creates a real connection in studio that points at it, then exercises the
  * proxy mount at /api/:org/mcp/:connectionId. Validates the whole chain:
  *
  *   Playwright APIRequestContext
- *     → /api/:org/mcp/:connectionId (mesh proxy)
+ *     → /api/:org/mcp/:connectionId (studio proxy)
  *       → connection lookup + auth
  *         → outbound HTTP to the test MCP server
  *           → tool handler returns
  *         ← MCP response
- *       ← mesh forwards
+ *       ← studio forwards
  *     ← client gets JSON-RPC tools/call result
  *
  * Also serves as the first runtime use of:
@@ -56,7 +56,7 @@ test.describe("MCP proxy roundtrip", () => {
     const ctx = await newApiContext(playwright);
     const user = await signUpViaApi(ctx);
 
-    // Create a real connection in mesh pointing at the test MCP server.
+    // Create a real connection in studio pointing at the test MCP server.
     // This also exercises `callSelfMcpTool` indirectly via the helper.
     const connection = await createHttpConnection(ctx, user.orgSlug, {
       title: `Test MCP ${Date.now()}`,

--- a/packages/e2e/tests/object-storage-roundtrip.spec.ts
+++ b/packages/e2e/tests/object-storage-roundtrip.spec.ts
@@ -1,5 +1,5 @@
 /**
- * End-to-end roundtrip for mesh's object storage tools against real S3.
+ * End-to-end roundtrip for studio's object storage tools against real S3.
  *
  * In CI (e2e.yml) the running app is configured with S3_* env vars pointing at
  * a MinIO container, so the OBJECT_STORAGE binding resolves to the production

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -4,7 +4,7 @@
     "noEmit": true,
     "baseUrl": ".",
     // Drop the root "@deco/*" alias so the suite cannot resolve into
-    // packages/*/src, and so the "@/" mesh alias never resolves here either.
+    // packages/*/src, and so the "@/" studio alias never resolves here either.
     // This is the type-checker half of the deny-by-default isolation; the
     // oxlint rule (ban-e2e-app-imports) is the lint half.
     "paths": {}

--- a/packages/harness/src/claude-code/index.ts
+++ b/packages/harness/src/claude-code/index.ts
@@ -4,7 +4,7 @@
  *
  * Unlike Decopilot, this harness:
  *  - Does NOT register built-in tools (the CLI manages its own tools and
- *    reaches mesh's MCP endpoint directly).
+ *    reaches studio's MCP endpoint directly).
  *  - Does NOT build a Decopilot-style system prompt or tool catalog; it only
  *    appends CLI-safe workspace/instruction context through the SDK's
  *    `systemPrompt` preset.

--- a/packages/harness/src/claude-code/model/index.ts
+++ b/packages/harness/src/claude-code/model/index.ts
@@ -30,7 +30,7 @@ export function createClaudeCodeModel(
           preset: "claude_code";
           append?: string;
         };
-    /** Working directory for Claude Code's subprocess. Defaults to mesh's cwd. */
+    /** Working directory for Claude Code's subprocess. Defaults to studio's cwd. */
     cwd?: string;
   },
 ): LanguageModelV3 {

--- a/packages/harness/src/cli-message-prep.ts
+++ b/packages/harness/src/cli-message-prep.ts
@@ -4,7 +4,7 @@
  * CLI harnesses don't run the full decopilot `processConversation` pipeline
  * (which handles `toModelOutput` truncation, todo-write stripping, pending-
  * approval denial, system-prompt splitting, etc.) — they don't carry
- * mesh-side tools into the CLI binary, so most of that work is irrelevant.
+ * studio-side tools into the CLI binary, so most of that work is irrelevant.
  *
  * They DO, however, need basic `UIMessage` -> `ModelMessage` conversion.
  * `input.messages` is typed as `ChatMessage[]` (a `UIMessage` with
@@ -22,7 +22,7 @@
  * prior turn left a tool call without a corresponding result (e.g. the
  * stream was aborted mid-tool), we drop it rather than fail conversion.
  *
- * No `tools` option is passed: CLI harnesses don't register mesh-side
+ * No `tools` option is passed: CLI harnesses don't register studio-side
  * tools, so there's no `toModelOutput` for the conversion to call.
  */
 

--- a/packages/harness/src/codex/index.ts
+++ b/packages/harness/src/codex/index.ts
@@ -4,7 +4,7 @@
  *
  * Unlike Decopilot, this harness:
  *  - Does NOT register built-in tools (the CLI manages its own tools and
- *    reaches mesh's MCP endpoint directly).
+ *    reaches studio's MCP endpoint directly).
  *  - Does NOT build a system prompt (the CLI has its own).
  *  - Supports resume: each turn spawns a fresh codex app-server process, but
  *    `resume: input.harness.sessionId` reloads the on-disk thread (the app

--- a/packages/harness/src/codex/model/index.ts
+++ b/packages/harness/src/codex/model/index.ts
@@ -28,7 +28,7 @@ export function createCodexModel(
     /** Chat mode plan — stricter approval policy */
     isPlanMode?: boolean;
     /** Working directory for Codex's app-server subprocess. Defaults to
-     *  mesh's cwd — mirrors `createClaudeCodeModel`. Without this, the
+     *  studio's cwd — mirrors `createClaudeCodeModel`. Without this, the
      *  codex CLI runs in the daemon's own cwd (typically the app root)
      *  instead of the cloned repo, so file edits land in the wrong tree. */
     cwd?: string;

--- a/packages/harness/src/decopilot/built-in-tools/vm-tools/types.ts
+++ b/packages/harness/src/decopilot/built-in-tools/vm-tools/types.ts
@@ -52,7 +52,7 @@ export interface VmToolsParams {
    */
   readonly pendingImages: PendingImage[];
   /**
-   * Mesh context for tools that resolve the org id / object storage for
+   * Studio context for tools that resolve the org id / object storage for
    * stable file URLs (and the deck fast-path mirror).
    */
   readonly ctx: VmToolContext;

--- a/packages/harness/src/decopilot/built-in-tools/web-search.ts
+++ b/packages/harness/src/decopilot/built-in-tools/web-search.ts
@@ -6,7 +6,7 @@
  * progress event to the UI, and shapes the terminal `ResearchResult` into the
  * tool result. All provider/DB coupling (streaming Perplexity path, durable
  * Gemini Deep Research lifecycle over `async_research_jobs`) lives in the
- * cluster's `researchJob` hook impl (mesh-owned; see
+ * cluster's `researchJob` hook impl (studio-owned; see
  * `createClusterResearchJob` in `cluster-research-job.ts`).
  *
  * Capability gating = hook absence: when `deps.researchJob` is undefined

--- a/packages/harness/src/decopilot/index.ts
+++ b/packages/harness/src/decopilot/index.ts
@@ -40,7 +40,7 @@ import type { DecopilotTelemetry } from "./run-stream";
 /** True when the injected context is a full cluster context (it carries
  *  `storage`/`db`, absent from the bare `HarnessContext` the daemon builds).
  *  The cluster's richer `StudioContext` is structurally assignable to
- *  `HarnessContext`; the mesh-side registered builder casts it back. */
+ *  `HarnessContext`; the studio-side registered builder casts it back. */
 function isClusterContext(ctx: HarnessContext): boolean {
   return "storage" in ctx;
 }
@@ -49,7 +49,7 @@ function isClusterContext(ctx: HarnessContext): boolean {
 // The factory looks the cluster deps builder up from a module-scoped registry
 // instead of statically importing the `@/`-coupled cluster assembler
 // (`apps/mesh/src/harnesses/decopilot/harness-deps`). That keeps this package
-// entry free of `@/` imports; the mesh barrel registers the implementation.
+// entry free of `@/` imports; the studio barrel registers the implementation.
 export interface ClusterEnvironmentBuilderArgs {
   ctx: HarnessContext;
   modelRuntime: ModelRuntime;

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @decocms/harness — public barrel (the `.` export).
  *
- * Re-exports the portable harness surface shared across the monorepo (mesh +
+ * Re-exports the portable harness surface shared across the monorepo (studio +
  * the sandbox daemon). The subpath entries (./types, ./registry, ./claude-code,
  * ./codex, ./decopilot, ./sources) expose those modules directly; this barrel
  * aggregates the commonly-imported symbols plus a few deep leaves the 7-entry

--- a/packages/harness/src/message-id.ts
+++ b/packages/harness/src/message-id.ts
@@ -2,9 +2,9 @@ import { nanoid } from "nanoid";
 
 /** Message ID generator shared by ALL harnesses (decopilot, codex, claude-code).
  *  Pass to `toUIMessageStream({ generateMessageId })` so each message's `start`
- *  chunk carries a stable `msg_…` id. The mesh projection consumes that id
+ *  chunk carries a stable `msg_…` id. The studio projection consumes that id
  *  verbatim (single id authority); without it `toUIMessageStream` emits
- *  `start.messageId: undefined` and the mesh cannot keep a stable id across
+ *  `start.messageId: undefined` and the studio cannot keep a stable id across
  *  re-folds. Lives at the package root (not under `decopilot/`) so the CLI
  *  harnesses can import it without crossing the decopilot import boundary
  *  (`cli-import-boundary.test.ts`). Portable harness leaf — no cluster imports. */

--- a/packages/harness/src/no-cross-tree.test.ts
+++ b/packages/harness/src/no-cross-tree.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "bun:test";
 import { Glob } from "bun";
 
 // Extraction exit gate: @decocms/harness is the portable harness package and
-// MUST stay free of the mesh app tree. Any `@/` alias or relative reach into
+// MUST stay free of the studio app tree. Any `@/` alias or relative reach into
 // `apps/mesh` would re-couple the package to the cluster and (since the package
 // tsconfig has no `@/` paths) break `tsc` — this guard catches it explicitly,
 // including transitive relative escapes that a path-alias check would miss.
 //
 // `@decocms/*` workspace deps are allowed (declared in package.json). The
 // package is also `@decocms/sandbox`-free by design — the sandbox glue lives in
-// mesh (cluster-sandbox-fs.ts) / the daemon, never here.
+// studio (cluster-sandbox-fs.ts) / the daemon, never here.
 const BANNED =
   /from\s+["'](?:@\/|(?:\.\.\/)+(?:apps\/mesh|app\/)|@decocms\/sandbox)/;
 

--- a/packages/harness/src/skills/skill-md.ts
+++ b/packages/harness/src/skills/skill-md.ts
@@ -5,7 +5,7 @@
  * so everything degrades: name falls back to the dir name (caller's job),
  * description falls back to the first body paragraph.
  *
- * Pure and zero-dependency so it is shared by the mesh server (skill
+ * Pure and zero-dependency so it is shared by the studio server (skill
  * catalog) and the web Library, with no DOM/Node coupling.
  */
 

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -132,7 +132,7 @@ export interface PromptAgentSummary {
   status: "active" | "inactive" | "error";
 }
 
-/** Pre-resolved per-user prompt data, read agent-side (mesh) before dispatch
+/** Pre-resolved per-user prompt data, read agent-side (studio) before dispatch
  *  and rendered by the portable prompt builder. Each sub-block is independently
  *  optional; absent ⇒ the corresponding prompt section is skipped (desktop). */
 export interface HarnessUserContext {

--- a/packages/mcp-utils/src/shared-schema-validator.ts
+++ b/packages/mcp-utils/src/shared-schema-validator.ts
@@ -3,13 +3,13 @@ import addFormats from "ajv-formats";
 
 /**
  * Shared, content-memoized JSON-schema validator for all MCP Client/Server
- * instances in the mesh.
+ * instances in the studio.
  *
  * Why this exists — a multi-hour leak hunt: MCP SDK ≥1.27 validates tool I/O
  * with Ajv. Two compounding behaviours made this leak unboundedly under load:
  *
  *   1. Each `Client`/`Server` constructs its OWN `new AjvJsonSchemaValidator()`
- *      when none is injected. The mesh builds these per request / per Decopilot
+ *      when none is injected. The studio builds these per request / per Decopilot
  *      turn (proxy routes, passthrough aggregator, management server), so the
  *      Ajv instances pile up.
  *   2. Ajv's `compile()` keeps every compiled schema in its internal cache

--- a/packages/runtime/src/agents.ts
+++ b/packages/runtime/src/agents.ts
@@ -6,7 +6,7 @@ import { MCPClient } from "./mcp.ts";
  *
  * An "agent" in Studio is a Virtual MCP (a curated bundle of connections +
  * tools, optionally with instructions). `createAgent` is typed sugar over the
- * mesh self-endpoint tools COLLECTION_VIRTUAL_MCP_CREATE + AUTOMATION_CREATE +
+ * studio self-endpoint tools COLLECTION_VIRTUAL_MCP_CREATE + AUTOMATION_CREATE +
  * AUTOMATION_TRIGGER_ADD via the self-client pattern.
  *
  * Exposed to MCP authors through `configuration.onInstall`, which fires once on
@@ -108,7 +108,7 @@ interface VirtualMcpItem {
 }
 
 /**
- * Hand-rolled client for the mesh self-endpoint tools used by createAgent.
+ * Hand-rolled client for the studio self-endpoint tools used by createAgent.
  *
  * TODO: Replace with a generated client once these collection/automation tools
  * are covered by a binding. Until then, a rename of a tool or field on the
@@ -203,7 +203,7 @@ function triggerArgs(automationId: string, trigger: AutomationTrigger) {
 }
 
 /**
- * Builds the `createAgent` helper bound to a mesh self-endpoint.
+ * Builds the `createAgent` helper bound to a studio self-endpoint.
  *
  * Idempotent by title: if a Virtual MCP with the same title already exists, the
  * call is a no-op that returns the existing id. This keeps a cleared-then-

--- a/packages/runtime/src/bindings.ts
+++ b/packages/runtime/src/bindings.ts
@@ -76,7 +76,7 @@ export function injectBindingSchemas(
  * Function that returns Zod Schema for a binding field.
  *
  * When `binding` is provided, the tool definitions are embedded as `__binding`
- * in the JSON Schema so the Mesh UI can filter connections by tool capabilities.
+ * in the JSON Schema so the Studio UI can filter connections by tool capabilities.
  *
  * @example
  * ```ts

--- a/packages/runtime/src/trigger-storage.ts
+++ b/packages/runtime/src/trigger-storage.ts
@@ -1,18 +1,18 @@
 /**
  * Built-in TriggerStorage implementations.
  *
- * - StudioKV: Persists to Mesh/Studio's KV API (recommended for production)
+ * - StudioKV: Persists to Studio's KV API (recommended for production)
  * - JsonFileStorage: Persists to a local JSON file (for dev/simple deployments)
  */
 
 import type { TriggerStorage } from "./triggers.ts";
 
 // ============================================================================
-// StudioKV — backed by Mesh's /api/kv endpoint
+// StudioKV — backed by Studio's /api/kv endpoint
 // ============================================================================
 
 interface StudioKVOptions {
-  /** Mesh/Studio base URL (e.g., "https://studio.example.com") */
+  /** Studio base URL (e.g., "https://studio.example.com") */
   url: string;
   /** API key created in the Studio org */
   apiKey: string;
@@ -21,7 +21,7 @@ interface StudioKVOptions {
 }
 
 /**
- * TriggerStorage backed by Mesh/Studio's org-scoped KV API.
+ * TriggerStorage backed by Studio's org-scoped KV API.
  *
  * @example
  * ```typescript

--- a/packages/runtime/src/triggers.ts
+++ b/packages/runtime/src/triggers.ts
@@ -53,8 +53,8 @@ interface Triggers<TDefs extends TriggerDef[]> {
   tools(): CreatedTool[];
 
   /**
-   * Notify Mesh that an event occurred.
-   * The SDK matches it to stored callback credentials and POSTs to Mesh.
+   * Notify Studio that an event occurred.
+   * The SDK matches it to stored callback credentials and POSTs to Studio.
    * Fire-and-forget — errors are logged, not thrown.
    */
   notify<T extends TDefs[number]["type"]>(

--- a/packages/sandbox/daemon/activity.ts
+++ b/packages/sandbox/daemon/activity.ts
@@ -1,6 +1,6 @@
 let lastActivityAt = Date.now();
 // false until the first successful POST /_sandbox/config. Warm-pool pods
-// boot with a sentinel token and sit unclaimed until mesh delivers a workload
+// boot with a sentinel token and sit unclaimed until studio delivers a workload
 // via postConfig; the housekeeper uses this flag to skip such pods so it
 // never reaps a pod that was never given a workload.
 let claimed = false;

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -40,7 +40,7 @@ import {
   makeConfigUpdateHandler,
 } from "./routes/config";
 import { handleCancelRequest, handleDispatchRequest } from "./routes/dispatch";
-// Import harness factories from their subpaths (rather than the mesh barrel).
+// Import harness factories from their subpaths (rather than the studio barrel).
 // The daemon runs desktop CLI harnesses only; Decopilot remains cluster-side.
 import { claudeCodeHarnessFactory } from "@decocms/harness/claude-code/index";
 import { codexHarnessFactory } from "@decocms/harness/codex/index";
@@ -113,7 +113,7 @@ const bootConfig = {
   // whether http:// loopback is permitted for local dev. They come from the
   // daemon's boot env, NEVER from the request frame.
   //
-  // CONTRACT: mesh must populate these when spawning the daemon —
+  // CONTRACT: studio must populate these when spawning the daemon —
   //   OFFLOAD_ALLOWED_HOSTS      comma-separated hostnames (object-store host(s))
   //   OFFLOAD_ALLOW_SAME_HOST_DEV "1" to allow http:// loopback (dev only)
   // The default is an EMPTY allowlist, which fails CLOSED: with no env wired,
@@ -134,7 +134,7 @@ const TMP_DIR = join(APP_ROOT, "tmp");
 
 const broadcaster = new Broadcaster(REPLAY_BYTES);
 
-// `application.port` is what mesh told the dev script to use, but plenty of
+// `application.port` is what studio told the dev script to use, but plenty of
 // frameworks (vite included) ignore PORT env and pick their own — and on the
 // host runner two sandboxes can race for the same default port, leaving the
 // loser on a fallback. Sniff the actual bind announcement from starter
@@ -319,7 +319,7 @@ resetProbeState = () => {
 kickProbe = probeCheckNow;
 
 // HTTP/WS proxy forwards to the same port the probe is HEAD-checking.
-// `application.port` is what mesh configured, but vite/etc. routinely
+// `application.port` is what studio configured, but vite/etc. routinely
 // pick a fallback when the configured one is busy — using the sniffed
 // announce-port keeps the proxy aligned with what the dev script
 // actually bound to. Falls back to the configured value when nothing has
@@ -781,11 +781,11 @@ Bun.serve<WsProxyData, never>({
 });
 
 // --- Org-filesystem mounts ---------------------------------------------------
-// Desktop links: the mesh sets ORGFS_CONFIG (a JSON OrgFsMountConfig) +
+// Desktop links: the studio sets ORGFS_CONFIG (a JSON OrgFsMountConfig) +
 // ORGFS_RCLONE_PATH at spawn — as boot env, like OFFLOAD_ALLOWED_HOSTS, so the
 // daemon itself mounts here at boot.
 // Cluster pods: this container can't mount (locked-down securityContext); a
-// privileged sidecar does (org-fs/sidecar.ts). The mesh runner POSTs the
+// privileged sidecar does (org-fs/sidecar.ts). The studio runner POSTs the
 // config to /_sandbox/orgfs-config post-bind (warm-pool claims reject
 // spec.env) and the handler relays it onto the shared control volume the
 // sidecar watches. Both paths are inert unless their env is set; every step
@@ -898,7 +898,7 @@ async function repointOutputLinkForRun(threadId: string): Promise<boolean> {
   await ensureRepoOrgLink(bootConfig.repoDir, orgFsLog);
   // Uploads link is best-effort: sandboxes provisioned before the uploads
   // volume existed have no .uploads mount, and inbound attachments flow
-  // through the mesh regardless — never fail the run over it.
+  // through the studio regardless — never fail the run over it.
   const uploadsMountPath = join(bootConfig.appRoot, "org", ".uploads");
   if (mounts.some((m) => m.mountPath === uploadsMountPath)) {
     await repointUploadLink(bootConfig.appRoot, threadId, orgFsLog);

--- a/packages/sandbox/daemon/org-fs/config.ts
+++ b/packages/sandbox/daemon/org-fs/config.ts
@@ -13,9 +13,9 @@ export interface OrgFsVolumeMount {
   readonly readonly?: boolean;
 }
 
-/** Mesh-pushed config that turns on org-fs mounting for a sandbox. */
+/** Studio-pushed config that turns on org-fs mounting for a sandbox. */
 export interface OrgFsMountConfig {
-  /** Mesh base URL the daemon calls (e.g. https://cluster.example). */
+  /** Studio base URL the daemon calls (e.g. https://cluster.example). */
   readonly baseUrl: string;
   /** Immutable org slug (the `:org` path segment). */
   readonly orgSlug: string;
@@ -26,7 +26,7 @@ export interface OrgFsMountConfig {
 
 /**
  * Parse the daemon's `ORGFS_CONFIG` boot env (a JSON `OrgFsMountConfig`). The
- * mesh sets it at spawn (like `OFFLOAD_ALLOWED_HOSTS`) rather than via a
+ * studio sets it at spawn (like `OFFLOAD_ALLOWED_HOSTS`) rather than via a
  * post-boot config push, so it's available when the daemon reads it at boot.
  * Returns null for absent/malformed/empty config (mounting is then skipped).
  */

--- a/packages/sandbox/daemon/org-fs/invalidator.ts
+++ b/packages/sandbox/daemon/org-fs/invalidator.ts
@@ -3,7 +3,7 @@
  *
  * WebDAV has no ChangeNotify, so rclone can't learn about *external* writes on
  * its own — its only lever is the dir-cache TTL (a blunt time bound). This
- * closes that gap: poll the mesh change feed (`/api/:org/fs/:volume/changes`,
+ * closes that gap: poll the studio change feed (`/api/:org/fs/:volume/changes`,
  * a single indexed query — NOT a directory re-listing) and, for every changed
  * path, tell rclone via its rc API to `vfs/refresh` that path's parent dir.
  * That re-lists only that dir, picking up adds/deletes and (via the refreshed
@@ -22,7 +22,7 @@
  * long-poll isn't available (NATS down) — so the loop degrades to timer polling
  * instead of busy-looping.
  *
- * Deps are injected so the loop is unit-testable without a real mesh or rclone.
+ * Deps are injected so the loop is unit-testable without a real studio or rclone.
  */
 
 import { sleep } from "@decocms/std";
@@ -65,7 +65,7 @@ export async function runInvalidator(deps: InvalidatorDeps): Promise<void> {
     try {
       page = await deps.changes(since);
     } catch (err) {
-      // rclone rc not up yet, transient mesh error, etc. — back off and retry.
+      // rclone rc not up yet, transient studio error, etc. — back off and retry.
       log("change-feed poll failed", err);
       await sleep(pollMs, { signal: deps.signal }).catch(() => {});
       continue;

--- a/packages/sandbox/daemon/org-fs/mount-manager.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.ts
@@ -3,7 +3,7 @@
  * ones (Claude Code, Codex) that only read real files — sees them at
  * `<appRoot>/org/<volume>`, kext-free.
  *
- * Per volume: serve the WebDAV layer (over the mesh `/api/:org/fs` client) on a
+ * Per volume: serve the WebDAV layer (over the studio `/api/:org/fs` client) on a
  * loopback port, then hand that URL to a `Mounter` which has the OS mount it
  * (rclone nfsmount on macOS / rclone mount on Linux — see mounter.ts). The
  * `Mounter` is injected so this orchestration is unit-testable without a real
@@ -11,7 +11,7 @@
  *
  * Boot-safety: a mount is purely additive. Every step is wrapped so a failure
  * logs and is skipped — it never breaks the daemon, the dev server, the fs
- * routes, or the harnesses. Mounting only happens when the mesh pushes
+ * routes, or the harnesses. Mounting only happens when the studio pushes
  * `TenantConfig.orgFs` (it won't for cluster pods, whose security posture
  * blocks mounts — desktop links are the target).
  */
@@ -20,7 +20,7 @@ import { mkdirSync } from "node:fs";
 import * as net from "node:net";
 import { join, isAbsolute } from "node:path";
 import { safePath } from "../paths";
-// Portable serve-layer leaves from the mesh workspace (same cross-package
+// Portable serve-layer leaves from the studio workspace (same cross-package
 // import style entry.ts uses for harness factories).
 import { OrgFsClient } from "../../../../apps/mesh/src/file-storage/mount/client";
 import { createWebdavHandler } from "../../../../apps/mesh/src/file-storage/mount/webdav";
@@ -63,7 +63,7 @@ export interface VolumeInvalidator {
 /**
  * Starts near-realtime invalidation for a freshly-mounted volume. Injected so
  * MountManager's orchestration is unit-testable without a real rclone rc or
- * mesh (mirrors the `Mounter` seam).
+ * studio (mirrors the `Mounter` seam).
  */
 export type InvalidatorFactory = (opts: {
   client: OrgFsClient;

--- a/packages/sandbox/daemon/org-fs/mounter.ts
+++ b/packages/sandbox/daemon/org-fs/mounter.ts
@@ -53,11 +53,11 @@ const READY_POLL_MS = 200;
  *    healthy it answers in microseconds, dead it refuses the connection — so
  *    this only ever trips when rclone is genuinely gone, turning the classic NFS
  *    hard-mount hang (+ persistent reconnect dialog) into a fast, recoverable
- *    error. Writes land in rclone's local VFS cache first, so a slow mesh never
+ *    error. Writes land in rclone's local VFS cache first, so a slow studio never
  *    makes a write slow enough to trip this.
  *  - timeo=100 (tenths of a sec → 10s) / retrans=2: generous per-request
  *    headroom so a legitimately slow read (first open of a large uncached file
- *    that rclone must fetch whole from the mesh) is not killed, while still
+ *    that rclone must fetch whole from the studio) is not killed, while still
  *    bounding a dead-server hang to ~tens of seconds. Tuning knob: lower timeo
  *    for snappier dead-mount recovery only if large-read tests still pass.
  *  - nobrowse: keep the volume out of the Finder sidebar/desktop, reducing the
@@ -236,7 +236,7 @@ function makeHandle(
         // already gone
       }
       // rclone flushes its --vfs-cache-mode full write-back cache on SIGTERM;
-      // against a slow or unreachable mesh that flush can outlast the pod's
+      // against a slow or unreachable studio that flush can outlast the pod's
       // terminationGracePeriod and hang shutdown → the sidecar is SIGKILLed
       // (exit 137). Bound the wait, then SIGKILL rclone so teardown always
       // makes progress. Unflushed writes at teardown are best-effort anyway.

--- a/packages/sandbox/daemon/persistence.ts
+++ b/packages/sandbox/daemon/persistence.ts
@@ -17,7 +17,7 @@ export type ReadOutcome =
 
 /**
  * Reads `<repoDir>/.decocms/daemon.json` as a read-only fallback for fields
- * the mesh didn't supply (package manager, runtime, port). The daemon
+ * the studio didn't supply (package manager, runtime, port). The daemon
  * never writes this file; it exists only if a tenant committed one to the
  * repo themselves.
  */

--- a/packages/sandbox/daemon/process/port-sniffer.ts
+++ b/packages/sandbox/daemon/process/port-sniffer.ts
@@ -7,7 +7,7 @@ import { WELL_KNOWN_STARTERS } from "../constants";
  *   bun:   `Listening on http://localhost:3000`
  *   fresh: `Listening on http://0.0.0.0:8000/`
  *
- * The probe needs a port to HEAD-check. Mesh sets `application.port` and
+ * The probe needs a port to HEAD-check. Studio sets `application.port` and
  * exports it as `PORT`, but most frameworks (vite included) ignore that
  * env unless the project's config reads it explicitly. Worse, on the host
  * runner two sandboxes can race for the same default port — vite then

--- a/packages/sandbox/daemon/proxy.ts
+++ b/packages/sandbox/daemon/proxy.ts
@@ -37,7 +37,7 @@ export function makeProxyHandler({ broadcaster, getDevPort }: ProxyDeps) {
     // preview origin (e.g. `<handle>.localhost:5174`) rather than the loopback
     // socket. Bun's fetch honors an explicit Host header (unlike the WHATWG
     // "forbidden header" rule), so keeping it here propagates through Vite
-    // (changeOrigin:false) to the app server — which lets mesh advertise the
+    // (changeOrigin:false) to the app server — which lets studio advertise the
     // correct OAuth protected-resource URL instead of `https://[::1]:<port>`.
     outHeaders.delete("transfer-encoding");
     outHeaders.delete("content-length");

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -8,7 +8,7 @@ import { parseJsonBody, jsonResponse } from "./body-parser";
 
 /**
  * Wall-clock cap for fetches in write_from_url / upload_to_url.
- * Both endpoints only ever talk to mesh-minted presigned S3/R2 URLs,
+ * Both endpoints only ever talk to studio-minted presigned S3/R2 URLs,
  * so the model has no path to influence the destination — the cap is
  * just defense against a hung S3 endpoint tying up a request slot.
  */
@@ -484,8 +484,8 @@ export function makeGrepHandler(deps: FsDeps) {
 
 /**
  * GET a remote URL (typically a presigned S3 URL) and stream the bytes to
- * a path on the sandbox FS. Mesh mints the URL and asks the daemon to
- * fetch it directly so bytes never round-trip through mesh.
+ * a path on the sandbox FS. Studio mints the URL and asks the daemon to
+ * fetch it directly so bytes never round-trip through studio.
  *
  * Body: { path: string; url: string }
  */
@@ -503,7 +503,7 @@ export function makeWriteFromUrlHandler(deps: FsDeps) {
     const filePath = safePath(deps.appRoot, deps.repoDir, body.path ?? "");
     if (!filePath) return jsonResponse({ error: "Path escapes app root" }, 400);
 
-    // The URL here is mesh-minted (presigned GET to S3/R2) — the model
+    // The URL here is studio-minted (presigned GET to S3/R2) — the model
     // can't supply arbitrary URLs through copy_to_sandbox, so SSRF +
     // DNS-rebinding defenses aren't needed. Plain fetch with a wall-
     // clock deadline is enough.
@@ -589,8 +589,8 @@ export function makeWriteFromUrlHandler(deps: FsDeps) {
 
 /**
  * Read a file from the sandbox FS and PUT it to a remote URL (typically
- * a presigned S3 URL). Mesh mints the URL and asks the daemon to upload
- * directly so bytes never round-trip through mesh.
+ * a presigned S3 URL). Studio mints the URL and asks the daemon to upload
+ * directly so bytes never round-trip through studio.
  *
  * Body: { path: string; url: string; contentType?: string }
  */
@@ -651,7 +651,7 @@ export function makeUploadToUrlHandler(deps: FsDeps) {
         body: Bun.file(filePath).stream(),
         headers,
         signal: abortController.signal,
-        // No SSRF revalidation here — the URL is mesh-minted (presigned
+        // No SSRF revalidation here — the URL is studio-minted (presigned
         // PUT to S3/R2), so the model can't influence where bytes go.
         // upload PUTs don't redirect under S3/R2 semantics anyway.
       });

--- a/packages/sandbox/daemon/routes/orgfs-config.ts
+++ b/packages/sandbox/daemon/routes/orgfs-config.ts
@@ -3,7 +3,7 @@
  *
  * Cluster pods can't get ORGFS_CONFIG as boot env (warm-pool claims reject
  * `spec.env`), and TenantConfig is the wrong vehicle (an orgFs-only patch
- * classifies as no-op and is dropped). So the mesh runner POSTs it here right
+ * classifies as no-op and is dropped). So the studio runner POSTs it here right
  * after `/config`, and the daemon relays it to the privileged org-fs sidecar
  * by writing a file on the shared control volume — the sidecar (which does
  * the actual mounting; this container can't) is watching for it.

--- a/packages/sandbox/daemon/setup/install.test.ts
+++ b/packages/sandbox/daemon/setup/install.test.ts
@@ -103,7 +103,7 @@ describe("depsCacheEnv", () => {
   });
 
   it("is stable across git token refresh (github x-access-token form)", () => {
-    // Mesh embeds a short-lived OAuth token in the cloneUrl userinfo
+    // Studio embeds a short-lived OAuth token in the cloneUrl userinfo
     // (github-clone-info.ts: https://x-access-token:<token>@github.com/...)
     // and rotates it via git-credential-refresh. The cache key must not
     // move when the token does, or every refresh orphans the cache.

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -529,7 +529,7 @@ export class SetupOrchestrator {
 
   /**
    * Fill missing application fields (packageManager, runtime, port) from
-   * `.decocms/daemon.json` then from lockfile autodetect. Mesh-supplied
+   * `.decocms/daemon.json` then from lockfile autodetect. Studio-supplied
    * config always wins; this only patches gaps.
    *
    * Goes through `store.applyInternal` (not `apply`) so a fresh

--- a/packages/sandbox/daemon/types.ts
+++ b/packages/sandbox/daemon/types.ts
@@ -51,14 +51,14 @@ export interface PackageManagerConfig {
 export interface Application {
   readonly packageManager?: PackageManagerConfig;
   readonly runtime?: RuntimeName;
-  /** Port the dev script binds to (set as PORT env). Mesh always supplies this. */
+  /** Port the dev script binds to (set as PORT env). Studio always supplies this. */
   readonly port?: number;
 }
 
 /**
  * User-intent state for a sandboxed application. The daemon never writes this
  * file — `<repoDir>/.decocms/daemon.json` is read at boot as a fallback for
- * fields the mesh didn't supply, and any further refinements (lockfile-based
+ * fields the studio didn't supply, and any further refinements (lockfile-based
  * package manager / runtime detection) happen in memory only. The file lives
  * in the repo iff a tenant chose to commit it themselves.
  */

--- a/packages/sandbox/dispatch/sandbox-client.ts
+++ b/packages/sandbox/dispatch/sandbox-client.ts
@@ -3,11 +3,11 @@ import type { HarnessStreamInput } from "@decocms/harness/types";
 
 /**
  * SandboxClient — owns "merge the HarnessDeps bag + run the harness" (spec
- * §5.2/§5.3). Impl: InProcessSandboxClient (mesh, direct call).
+ * §5.2/§5.3). Impl: InProcessSandboxClient (studio, direct call).
  */
 export interface SandboxClient {
   /** Yields raw UIMessageChunk — byte-identical to today's localDispatch
-   *  return, consumed by mesh's consumeHarnessStream with NO adapter/framing. */
+   *  return, consumed by studio's consumeHarnessStream with NO adapter/framing. */
   dispatch(input: HarnessStreamInput): AsyncIterable<UIMessageChunk>;
   /** Sandbox-related info, as the daemon already exposes. */
   getPreviewUrl?(): Promise<string | null>;

--- a/packages/sandbox/server/provider/agent-sandbox/client.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.ts
@@ -296,7 +296,7 @@ async function ensureOk(resp: Response, action: string): Promise<void> {
 
 /**
  * Issue a kube call where 404 is *not* an error (the resource was already
- * gone; mesh's next ensure() recreates it). On 404, returns `null`. On 2xx,
+ * gone; studio's next ensure() recreates it). On 404, returns `null`. On 2xx,
  * returns the parsed JSON body — or `null` for callers that don't need it.
  * All other errors are wrapped in `SandboxError` with `wrapMessage` as the
  * surfaced label.
@@ -361,7 +361,7 @@ export async function createSandboxClaim(
   );
   // 409 is split out so the runner can wait for the still-terminating prior
   // claim to drain finalizers and retry. This is the canonical race when the
-  // operator's idle-TTL just reaped a claim and mesh's next ensure() hits
+  // operator's idle-TTL just reaped a claim and studio's next ensure() hits
   // before the resource is fully GC'd. Stuck-finalizer cases also surface as
   // 409 but never recover from a wait — those need operator intervention.
   if (resp.status === 409) {
@@ -421,14 +421,14 @@ function claimPath(namespace: string, claimName: string): string {
  * `spec.lifecycle.shutdownTime` with `shutdownPolicy: Delete`: once the
  * wall clock passes `shutdownTime`, the operator deletes the claim + pod.
  *
- * Mesh calls this on every `ensure()` hit so an active sandbox continuously
+ * Studio calls this on every `ensure()` hit so an active sandbox continuously
  * pushes its deadline forward; an abandoned one hits the deadline and the
- * operator reaps it. No mesh-side cron/reconcile needed.
+ * operator reaps it. No studio-side cron/reconcile needed.
  *
  * Uses merge-patch (RFC 7396), which is the documented patch format for
  * CRDs — strategic-merge only works on built-in types that ship merge
  * keys. 404 is swallowed because a deleted-since-lookup claim is not an
- * error from mesh's perspective; the caller's next ensure() will
+ * error from studio's perspective; the caller's next ensure() will
  * re-provision.
  */
 export async function patchSandboxClaimShutdown(
@@ -485,7 +485,7 @@ export async function getSandboxClaim(
  * the bound Sandbox's name. The operator (v0.4.x) writes this in two paths:
  * cold-start (claim's own template-rendered Sandbox, name == claim name)
  * and warm-pool adoption (an existing pool Sandbox, name = pool pod's
- * generated name). Mesh must use this value, not the claim name, because
+ * generated name). Studio must use this value, not the claim name, because
  * the v0.4.x adoption reconciler has a status-update conflict race that
  * sometimes also creates a stray same-named cold-path Sandbox alongside
  * the adopted pool one — only `status.sandbox.name` points at the
@@ -650,7 +650,7 @@ export const HTTPROUTE_CONSTANTS = {
 /**
  * Field-manager identity asserted on Server-Side Apply calls. K8s tracks
  * ownership per-field by this string; reusing it across calls (and across
- * mesh restarts) is what lets the second SSA see "I already own ports[]"
+ * studio restarts) is what lets the second SSA see "I already own ports[]"
  * and treat it as a no-op rather than a conflict.
  */
 const SSA_FIELD_MANAGER = "mesh-sandbox-runner";
@@ -671,7 +671,7 @@ const SSA_FIELD_MANAGER = "mesh-sandbox-runner";
  * error (because the empty 500 also has no `access-control-allow-origin`).
  *
  * Why SSA over strategic-merge-patch:
- *   - SSA establishes mesh as the *owner* of `spec.ports`. If a future
+ *   - SSA establishes studio as the *owner* of `spec.ports`. If a future
  *     operator revision performs a full Update of the Service (Get →
  *     mutate → Put), the API server rejects the conflicting write unless
  *     the operator explicitly forces — which would surface in operator

--- a/packages/sandbox/server/provider/agent-sandbox/constants.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/constants.ts
@@ -40,7 +40,7 @@ export class SandboxTimeoutError extends SandboxError {
 /**
  * Surfaced when the API server rejects a SandboxClaim create with 409
  * AlreadyExists — typically because the operator's idle-TTL deletion of a
- * prior claim is still draining finalizers when mesh tries to recreate.
+ * prior claim is still draining finalizers when studio tries to recreate.
  * Callers wait for the resource to fully disappear and retry.
  */
 export class SandboxAlreadyExistsError extends SandboxError {

--- a/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
@@ -32,7 +32,7 @@
  *   claiming           – Default: SandboxClaim posted, no Pod yet.
  *
  * Container name `sandbox` and pod label `studio.decocms.com/sandbox-handle`
- * are mesh conventions verified against the running cluster — do not rely
+ * are studio conventions verified against the running cluster — do not rely
  * on operator-set labels (e.g. `agents.x-k8s.io/sandbox-name`), which exist
  * only as truncated `-hash` variants.
  */
@@ -57,7 +57,7 @@ const DEFAULT_SCHEDULING_TIMEOUT_MS = 5 * 60 * 1000;
 export interface WatchClaimLifecycleOptions {
   kc: KubeConfig;
   namespace: string;
-  /** SandboxClaim name. Mesh convention: pod name === claim name. */
+  /** SandboxClaim name. Studio convention: pod name === claim name. */
   claimName: string;
   signal?: AbortSignal;
   /**
@@ -521,7 +521,7 @@ async function watchPod(
   now: () => number,
   onPodName: (name: string) => void,
 ): Promise<void> {
-  // labelSelector pins to mesh-managed claims; fieldSelector by name is
+  // labelSelector pins to studio-managed claims; fieldSelector by name is
   // belt-and-suspenders (operator names pod after the claim).
   const path =
     `/api/v1/namespaces/${encodeURIComponent(namespace)}/pods` +
@@ -683,7 +683,7 @@ async function watchEvents(
 }
 
 /**
- * Namespace-wide watch of mesh-managed SandboxClaims that invokes `onDelete`
+ * Namespace-wide watch of studio-managed SandboxClaims that invokes `onDelete`
  * with the claim handle (== claim `metadata.name`) whenever a claim is removed.
  * The long-lived runner uses this to drop its cached record + close the
  * port-forwarder the instant the operator idle-reaps the backing pod, instead

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -2,7 +2,7 @@
  * Agent-sandbox runner.
  *
  * Provisions one SandboxClaim per (user, projectRef) against the
- * kubernetes-sigs/agent-sandbox operator. Mesh runs outside the cluster
+ * kubernetes-sigs/agent-sandbox operator. Studio runs outside the cluster
  * (Stage 1 / local-dev via kind), so traffic reaches the pod via a single
  * lazily-opened 127.0.0.1 TCP listener that tunnels each inbound connection
  * to the daemon container port through the apiserver as a fresh WebSocket.
@@ -110,7 +110,7 @@ function errMsg(err: unknown): string {
 /**
  * Response-header marker on the preview-proxy's "sandbox not ready" envelopes
  * (404 "sandbox not found" in dev, 502 "sandbox daemon unreachable" in prod).
- * The mesh edge (`apps/mesh/src/sandbox/preview-proxy.ts`) swaps these for an
+ * The studio edge (`apps/mesh/src/sandbox/preview-proxy.ts`) swaps these for an
  * auto-reloading "connecting" page on top-level document navigations.
  */
 export const PREVIEW_NOT_READY_HEADER = "x-sandbox-preview-not-ready";
@@ -121,7 +121,7 @@ const DEFAULT_NAMESPACE = "agent-sandbox-system";
 const DEFAULT_TEMPLATE_NAME = "studio-sandbox";
 
 const DAEMON_CONTAINER_PORT = 9000;
-// In-pod port the daemon's reverse proxy targets. Mesh never connects here
+// In-pod port the daemon's reverse proxy targets. Studio never connects here
 // directly — everything funnels through the daemon container port — but the
 // value is propagated to the daemon via DEV_PORT so it knows where the dev
 // server will bind.
@@ -132,7 +132,7 @@ const DEFAULT_WORKDIR = "/app";
 const DAEMON_TOKEN_BYTES = 32;
 
 /**
- * Env keys mesh owns and a caller's `opts.env` MUST NOT shadow. DAEMON_TOKEN
+ * Env keys studio owns and a caller's `opts.env` MUST NOT shadow. DAEMON_TOKEN
  * is the secrecy boundary; the rest configure the daemon's bootstrap (paths
  * + ports) — silently overriding any of them would break daemon startup.
  *
@@ -203,8 +203,8 @@ const PREVIEW_STRIP_RESPONSE_HEADERS = [
 ];
 
 // Deterministic local-port range for port-forward listeners. Same
-// (handle, containerPort) pair → same host port across mesh restarts, so
-// `previewUrl` cached in the thread's sandboxMap stays valid when the mesh
+// (handle, containerPort) pair → same host port across studio restarts, so
+// `previewUrl` cached in the thread's sandboxMap stays valid when the studio
 // process recycles. Birthday-collision probability stays <1% up to ~140
 // concurrent forwarders. EADDRINUSE walks the range forward until bind.
 const PORT_RANGE_START = 40000;
@@ -241,7 +241,7 @@ interface K8sRecord {
    * `claim.status.sandbox.name`. Equals `handle` on cold-start (operator
    * names cold Sandboxes after the claim) but diverges on warm-pool
    * adoption — pool sandboxes carry their generated names like
-   * `studio-sandbox-kind-abcde`. Mesh routes preview traffic via the
+   * `studio-sandbox-kind-abcde`. Studio routes preview traffic via the
    * Service named after this (the operator-managed Service that targets
    * the *actually-bound* pod), not via the same-named cold-path
    * duplicate the v0.4.x adoption race occasionally leaves behind.
@@ -255,10 +255,10 @@ interface K8sRecord {
   daemonForward: PortForwarder;
   workload: Workload | null;
   /**
-   * Per-boot UUID the daemon reports on /health. Generated mesh-side and
+   * Per-boot UUID the daemon reports on /health. Generated studio-side and
    * injected via env; re-read from /health on rehydrate so we pick up
    * pod restarts (the daemon's orchestrator handles resume-on-restart
-   * itself, this is purely informational on the mesh side).
+   * itself, this is purely informational on the studio side).
    */
   daemonBootId: string;
   /**
@@ -314,7 +314,7 @@ export interface AgentSandboxProviderOptions {
    * warm-pool mode:
    *   - claims are created with `warmpool: "default"` and `spec.env: []`
    *     (the operator rejects per-claim env when warmpool != "none"),
-   *   - mesh's first contact with the daemon authenticates with the
+   *   - studio's first contact with the daemon authenticates with the
    *     sentinel and rotates to a per-claim token via
    *     `auth.rotateToken` on POST /_sandbox/config,
    *   - subsequent calls use the per-claim token (persisted in
@@ -327,7 +327,7 @@ export interface AgentSandboxProviderOptions {
    * Trust window: between pod boot and the first rotation call, the
    * sentinel is the only auth on the daemon. NetworkPolicy is the
    * secrecy boundary in that window — same boundary that gates every
-   * other mesh→daemon request.
+   * other studio→daemon request.
    */
   sentinelToken?: string;
   /**
@@ -352,7 +352,7 @@ export interface AgentSandboxProviderOptions {
    * OpenTelemetry meter for runner-level metrics (active gauge, ensure
    * outcome counter, proxy duration histogram). Optional — when absent,
    * runner is fully functional but emits no metrics. Tests typically pass
-   * undefined; mesh wires `metrics.getMeter("mesh", "1.0.0")`.
+   * undefined; studio wires `metrics.getMeter("mesh", "1.0.0")`.
    */
   meter?: Meter;
   /**
@@ -371,9 +371,9 @@ export interface AgentSandboxProviderOptions {
    *
    * When unset (or `previewUrlPattern` unset), the runner does NOT touch
    * HTTPRoute resources. Preview traffic still works in that mode through
-   * mesh's in-process proxy (the previous design), provided someone else
+   * studio's in-process proxy (the previous design), provided someone else
    * (the chart, an operator, hand-rolled YAML) has wired a wildcard
-   * HTTPRoute backed by mesh.
+   * HTTPRoute backed by studio.
    */
   previewGateway?: {
     name: string;
@@ -430,7 +430,7 @@ export class AgentSandboxProvider implements SandboxProvider {
   /**
    * Non-null = warm-pool mode (see `AgentSandboxProviderOptions.sentinelToken`).
    * Treated as the bearer token for the *first* daemon contact only;
-   * mesh rotates to a per-claim token via `auth.rotateToken` immediately
+   * studio rotates to a per-claim token via `auth.rotateToken` immediately
    * after, and persists the new token. Empty/whitespace strings are
    * collapsed to null at construction so a misconfigured env var doesn't
    * silently flip modes with an unusable token.
@@ -554,7 +554,7 @@ export class AgentSandboxProvider implements SandboxProvider {
 
   /**
    * Stream of phase transitions for a SandboxClaim's pre-Ready lifecycle.
-   * Used by mesh's lifecycle SSE route to surface what's happening between
+   * Used by studio's lifecycle SSE route to surface what's happening between
    * `SANDBOX_START` posting a claim and the daemon SSE coming online.
    *
    * Generator closes on terminal phase (`ready`/`failed`) or on
@@ -689,8 +689,8 @@ export class AgentSandboxProvider implements SandboxProvider {
   }
 
   /**
-   * Repopulate mesh's records cache from a SandboxClaim that already exists
-   * in the cluster. Preview gateway traffic can keep serving while mesh's
+   * Repopulate studio's records cache from a SandboxClaim that already exists
+   * in the cluster. Preview gateway traffic can keep serving while studio's
    * daemon/git proxy still holds a cold cache or missing state-store row.
    */
   async adoptLiveClaim(id: SandboxId, handle: string): Promise<boolean> {
@@ -729,18 +729,18 @@ export class AgentSandboxProvider implements SandboxProvider {
 
   /**
    * Resolves the HTTP base URL for a sandbox's daemon. Used by the preview
-   * reverse-proxy at the mesh edge.
+   * reverse-proxy at the studio edge.
    *
    * Two modes:
-   * 1. `previewUrlPattern` set (Stage 3 / in-cluster mesh): synthesize the
+   * 1. `previewUrlPattern` set (Stage 3 / in-cluster studio): synthesize the
    *    in-cluster Service URL straight from the handle. No record lookup, no
    *    port-forward, no health probe — the cluster DNS + downstream fetch
-   *    are the source of truth. Crucially this means a cold mesh pod (or one
+   *    are the source of truth. Crucially this means a cold studio pod (or one
    *    that just restarted with an empty records map) still serves preview
    *    traffic without first having to rehydrate every claim. If the Service
    *    doesn't exist for that handle, the downstream fetch fails and the
    *    caller surfaces a 502.
-   * 2. `previewUrlPattern` unset (dev / mesh-outside-cluster): fall back to
+   * 2. `previewUrlPattern` unset (dev / studio-outside-cluster): fall back to
    *    the 127.0.0.1 port-forwarder opened by `getRecord`. Returns null when
    *    the record can't be found or rehydrated — the caller surfaces 404.
    *
@@ -756,7 +756,7 @@ export class AgentSandboxProvider implements SandboxProvider {
       // on warm-pool adoption this is the pool pod's Service (e.g.
       // `studio-sandbox-kind-abcde`), NOT the same-named cold-path
       // orphan the v0.4.x adoption race occasionally leaves alongside.
-      // Records cache hit is O(1); cache miss (cold mesh) falls through to
+      // Records cache hit is O(1); cache miss (cold studio) falls through to
       // a single state-store row read, then to `handle` as a last resort.
       // We deliberately don't pre-validate that the claim is still alive
       // — every preview request would pay a K8s API call. When the
@@ -784,7 +784,7 @@ export class AgentSandboxProvider implements SandboxProvider {
    * Cache layers, cheapest first: in-memory records map, then state-store
    * (one DB row), then a `handle` fallback. Falling back to `handle` is
    * wrong for a warm-pool sandbox (it points at the cold-path duplicate's
-   * Service), but the only path that lands here is "mesh just restarted
+   * Service), but the only path that lands here is "studio just restarted
    * AND state-store doesn't have the row" — at which point the downstream
    * fetch will fail and `proxyPreviewRequest`'s catch arm runs the
    * resurrection flow, which repopulates records with the right name.
@@ -820,7 +820,7 @@ export class AgentSandboxProvider implements SandboxProvider {
    *   - **Non-GET** (POST/PUT/DELETE/etc) is rejected as defense-in-depth.
    *     The daemon enforces bearer auth on the mutating endpoints
    *     (read/write/edit/grep/glob/bash/exec/kill), but the only legitimate
-   *     caller for those is mesh itself via the internal port-forward; the
+   *     caller for those is studio itself via the internal port-forward; the
    *     preview surface should never see them.
    */
   async proxyPreviewRequest(
@@ -830,7 +830,7 @@ export class AgentSandboxProvider implements SandboxProvider {
     const start = performance.now();
     // In-memory cache only — preview is the hot path; a state-store hit per
     // request would dominate latency. Tenant attribution is best-effort: when
-    // the records map is cold (mesh just restarted) the metric still records
+    // the records map is cold (studio just restarted) the metric still records
     // duration with empty tenant attrs. cAdvisor on the pod side covers
     // bandwidth attribution authoritatively via pod labels.
     const cachedRec = this.records.get(handle) ?? null;
@@ -876,7 +876,7 @@ export class AgentSandboxProvider implements SandboxProvider {
       } catch (err) {
         // Truncate to host+pathname — query strings can carry secrets
         // (magic-link tokens, signed URLs) and would otherwise end up in
-        // mesh stdout → kubectl logs → log aggregator.
+        // studio stdout → kubectl logs → log aggregator.
         const safeTarget = `${upstreamBase}${reqUrl.pathname}`;
         console.warn(
           `[${LOG_LABEL}] preview fetch to ${safeTarget} failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -1101,7 +1101,7 @@ export class AgentSandboxProvider implements SandboxProvider {
       this.metrics.ensureOutcome.add(1, { ...attrs, outcome });
       // Only increment the active gauge on first observation to avoid
       // double-counting when the same handle is rehydrated multiple times
-      // (mesh-process internal cache hit; ensureLocked is invoked again).
+      // (studio-process internal cache hit; ensureLocked is invoked again).
       if (!wasCached) this.metrics.active.add(1, attrs);
     }
     return this.toSandbox(rec);
@@ -1138,7 +1138,7 @@ export class AgentSandboxProvider implements SandboxProvider {
     boot: { token: string; daemonBootId: string; workdir: string },
   ): SandboxClaim {
     // Warm-pool mode: the operator rejects claim.spec.env outright when
-    // warmpool != "none". Mesh delivers the per-claim secret post-bind via
+    // warmpool != "none". Studio delivers the per-claim secret post-bind via
     // POST /_sandbox/config + auth.rotateToken instead.
     const warmPoolMode = this.sentinelToken !== null;
     const envEntries = warmPoolMode
@@ -1213,7 +1213,7 @@ export class AgentSandboxProvider implements SandboxProvider {
     } catch (err) {
       // ensureLocked already waits for a known-terminating prior claim before
       // falling through here. This catch covers the residual races: a
-      // concurrent ensure() from another mesh replica raced ours to create,
+      // concurrent ensure() from another studio replica raced ours to create,
       // or an external delete (operator TTL, kubectl) finished after we
       // checked but before our POST landed. Wait for the resource to fully
       // disappear and retry exactly once — re-raising AlreadyExists straight
@@ -1301,7 +1301,7 @@ export class AgentSandboxProvider implements SandboxProvider {
     const daemonUrl = `http://127.0.0.1:${daemonForward.localPort}`;
     const configPayload = this.workloadConfigPayload(opts);
     // Warm-pool path: pod boots with the SandboxTemplate's sentinel token;
-    // mesh authenticates the first /config call with the sentinel and
+    // studio authenticates the first /config call with the sentinel and
     // rotates to `token` (per-claim) atomically with the workload patch.
     // After this call returns, only `token` is accepted on the daemon.
     //
@@ -1550,7 +1550,7 @@ export class AgentSandboxProvider implements SandboxProvider {
    * for the *adopted* Sandbox. The agent-sandbox operator (v0.4.x) ships
    * Services with empty `spec.ports`, which makes Istio refuse to register
    * an upstream cluster — `ensureServicePort` doc has the full rationale.
-   * Idempotent: once mesh owns `spec.ports[name=daemon]` (first SSA),
+   * Idempotent: once studio owns `spec.ports[name=daemon]` (first SSA),
    * subsequent calls with the same body are recorded as no-ops by the API
    * server.
    *
@@ -1766,7 +1766,7 @@ export class AgentSandboxProvider implements SandboxProvider {
     // When the state-store is wiped (the trigger that brings us into
     // adopt), there's no way to retrieve it. Returning null falls through
     // to delete + reprovision; the pool releases the pod, the operator
-    // allocates a fresh one, and mesh rotates a new token onto it.
+    // allocates a fresh one, and studio rotates a new token onto it.
     if (this.sentinelToken !== null) return null;
     const token = readClaimDaemonToken(claim);
     if (!token) return null;
@@ -1820,7 +1820,7 @@ export class AgentSandboxProvider implements SandboxProvider {
       // sandboxes when this code rolls out).
       tenant,
       // Adopt happens when the state-store is empty but a claim with our
-      // deterministic name still exists in the cluster (e.g. mesh restart
+      // deterministic name still exists in the cluster (e.g. studio restart
       // without state-store, or state-store wipe). The original opts aren't
       // recoverable from the claim alone, so resurrection on this record
       // can't autonomously re-provision; falls back to the caller's
@@ -2148,17 +2148,17 @@ function buildRunnerMetrics(meter: Meter): RunnerMetrics {
   return {
     active: meter.createUpDownCounter("studio.sandbox.active", {
       description:
-        "Active sandbox count, by runner kind and owning org. Cross-checks the cAdvisor-derived count from the cluster — divergence between the two indicates orphaned claims (mesh deleted but K8s didn't reap) or unattributed pods.",
+        "Active sandbox count, by runner kind and owning org. Cross-checks the cAdvisor-derived count from the cluster — divergence between the two indicates orphaned claims (studio deleted but K8s didn't reap) or unattributed pods.",
       unit: "{sandbox}",
     }),
     ensureOutcome: meter.createCounter("studio.sandbox.ensure.outcome", {
       description:
-        "Outcome of each ensure() call: fresh provision, resume from state-store after restart, or adopt of a cluster-side claim mesh didn't know about. Cold-start ratio is the primary input for warm-pool sizing.",
+        "Outcome of each ensure() call: fresh provision, resume from state-store after restart, or adopt of a cluster-side claim studio didn't know about. Cold-start ratio is the primary input for warm-pool sizing.",
       unit: "{call}",
     }),
     proxyDurationMs: meter.createHistogram("studio.sandbox.proxy.duration_ms", {
       description:
-        "Wall-clock latency of mesh-mediated requests to the sandbox daemon: tool exec proxies (source=daemon) and preview iframe traffic (source=preview).",
+        "Wall-clock latency of studio-mediated requests to the sandbox daemon: tool exec proxies (source=daemon) and preview iframe traffic (source=preview).",
       unit: "ms",
     }),
   };
@@ -2211,7 +2211,7 @@ function jsonResponse(status: number, body: unknown): Response {
   });
 }
 
-// K8s label keys mesh attaches. Centralized so writers (buildTenantLabels)
+// K8s label keys studio attaches. Centralized so writers (buildTenantLabels)
 // and the reader (readClaimTenant) can't drift.
 const LABEL_KEYS = {
   role: "studio.decocms.com/role",
@@ -2237,7 +2237,7 @@ const ANNOTATION_KEYS = {
 } as const;
 
 // K8s label values: ≤63 chars, must match `(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?`.
-// Org/user IDs are UUIDs in mesh and pass through unchanged; the regex check
+// Org/user IDs are UUIDs in studio and pass through unchanged; the regex check
 // + truncation is defensive against future ID-shape changes (the operator will
 // reject the claim outright if a label value is invalid).
 const LABEL_VALUE_RE = /^([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?$/;
@@ -2259,7 +2259,7 @@ function normalizeEnvName(raw: string | undefined): string | null {
   if (trimmed === "") return null;
   if (!ENV_NAME_RE.test(trimmed)) {
     throw new Error(
-      `AgentSandboxProvider: envName=${JSON.stringify(trimmed)} is not a valid DNS-label-safe environment name (lowercase alphanumeric or '-', starts with a letter, ends alphanumeric, ≤32 chars). Mesh sets this from STUDIO_ENV; check the studio chart's configMap.`,
+      `AgentSandboxProvider: envName=${JSON.stringify(trimmed)} is not a valid DNS-label-safe environment name (lowercase alphanumeric or '-', starts with a letter, ends alphanumeric, ≤32 chars). Studio sets this from STUDIO_ENV; check the studio chart's configMap.`,
     );
   }
   return trimmed;

--- a/packages/sandbox/server/provider/index.ts
+++ b/packages/sandbox/server/provider/index.ts
@@ -26,7 +26,7 @@ export {
   sandboxIdKey,
   sandboxProviderKindSchema,
 } from "./types";
-// Needed by mesh callers (decopilot dispatch-run) that compute handles
+// Needed by studio callers (decopilot dispatch-run) that compute handles
 // directly. Re-exported here so consumers don't dig into shared/.
 export { computeHandle } from "./shared";
 export type {

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -191,13 +191,13 @@ export interface SandboxProvider {
 
   /**
    * Repopulate in-process routing state from a claim that already exists in
-   * the cluster (preview gateway traffic can outlive mesh's records cache).
+   * the cluster (preview gateway traffic can outlive studio's records cache).
    * Optional — only agent-sandbox implements this today.
    */
   adoptLiveClaim?(id: SandboxId, handle: string): Promise<boolean>;
 
   /**
-   * Stream of phase transitions for the pre-Ready lifecycle. Used by mesh's
+   * Stream of phase transitions for the pre-Ready lifecycle. Used by studio's
    * unified `/api/vm-events` SSE so the UI can show meaningful progress
    * between SANDBOX_START and the daemon SSE coming online.
    *

--- a/packages/sandbox/shared.ts
+++ b/packages/sandbox/shared.ts
@@ -42,7 +42,7 @@ export {
 /**
  * Injected into proxied dev-server HTML. Two jobs:
  * 1. WebSocket rewriter — Vite/Fresh/Next/Webpack/Bun bake the dev WS URL
- *    (container-internal host:port) at startup; inside mesh's iframe under
+ *    (container-internal host:port) at startup; inside studio's iframe under
  *    `/api/sandbox/.../preview/<port>/` those URLs don't route. We patch
  *    `WebSocket` so loopback/same-hostname-different-port URLs are rewritten
  *    to the iframe origin + same proxy prefix, so HMR lands on the daemon.


### PR DESCRIPTION
## Summary

Task 02 of the de-mesh migration: prose-only rename of "mesh" to "studio" in comments, JSDoc, log/error message strings and test descriptions across `apps/mesh` and `packages/` (132 files, 311 lines).

**Zero behavior change.** Untouched on purpose:
- Identifiers (`meshContext`, `createMeshClient`, `MeshProvider`, ...), env vars (`MESH_*`), headers (`x-mesh-token`, `x-mesh-client`)
- Persisted/wire values: localStorage `mesh:*` keys, NATS subjects (`mesh.sse.broadcast`, `mesh.decopilot.cancel`), `pg_notify('mesh_events')`, `mesh-storage:` URI scheme, OTel meter name, `_meta["mcp.mesh"]`, the persisted "Mesh MCP" connection title in migration 042
- Paths/URLs (`apps/mesh`, `github.com/decocms/mesh`, test fixture URLs), `packages/mesh-sdk` (task 08), `apps/docs` (task 01, #4607), READMEs/package.json descriptions

Display-only strings changed: two "No sandbox runner configured..." error messages, the `[mesh]` console prefix in `app.ts`, one background-tool log line, three OTel metric descriptions, one test name. Verified nothing greps/asserts on the old strings.

## Testing

- `bun run fmt`, `bun run lint` (29 warnings, same as main baseline), `bun run check` — all pass
- `bun test`: 5127 pass / 361 fail / 41 errors on this branch vs **5129 pass / 359 fail / 41 errors on main** in the same environment — the failures are pre-existing/environmental (DB-backed integration tests), not introduced here (±2 flaky)
- All 10 touched unit-test files pass in isolation: 59 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed “mesh” to “studio” in comments, JSDoc, log/error message strings, and test descriptions across the codebase. No runtime, API, or persisted/wire data changes.

- **Refactors**
  - Updated prose-only references across `apps/mesh` and `packages/*`; left identifiers, env vars (`MESH_*`), headers (`x-mesh-token`, `x-mesh-client`), persisted keys/subjects/URIs, and URLs unchanged.
  - Tweaked display-only strings (console/error prefixes like “[studio]”, “No sandbox runner configured…” messages, select OTel metric descriptions, a few test names).
  - Re-baselined the DBOS workflow source snapshot after comment-only edits; confirmed formatting/lint/type checks and touched unit tests pass.

<sup>Written for commit e0406f11977cb51611feef99caee8987dd806916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

