### PR TITLE
fix(connections): resolve package-only registry items to STDIO connections

### DIFF
--- a/apps/mesh/src/web/utils/extract-connection-data.test.ts
+++ b/apps/mesh/src/web/utils/extract-connection-data.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { extractConnectionData } from "./extract-connection-data";
+import type { RegistryItem } from "@/web/components/store/types";
+
+const packageOnlyItem: RegistryItem = {
+  id: "reg-1",
+  title: "Jira MCP",
+  server: {
+    name: "jira-mcp",
+    packages: [{ identifier: "mcp-jira-server" }],
+  },
+};
+
+describe("extractConnectionData", () => {
+  // Every real caller (use-connect-app, add-connection-dialog, ...) invokes
+  // this with only `remoteIndex: 0` — never `packageIndex`. A package-only
+  // registry item (no `remotes`) must still resolve to a usable STDIO
+  // connection instead of falling through to the empty-URL "Fallback" branch.
+  it("resolves a package-only item to a STDIO connection when called the way every caller calls it", () => {
+    const data = extractConnectionData(packageOnlyItem, "org-1", "user-1", {
+      remoteIndex: 0,
+    });
+
+    expect(data.connection_type).toBe("STDIO");
+    expect(data.connection_headers).toMatchObject({
+      command: "npx",
+      args: ["-y", "mcp-jira-server"],
+    });
+  });
+
+  it("still prefers the remote when both remotes and packages are present", () => {
+    const item: RegistryItem = {
+      ...packageOnlyItem,
+      server: {
+        ...packageOnlyItem.server,
+        remotes: [{ type: "http", url: "https://example.com/mcp" }],
+      },
+    };
+
+    const data = extractConnectionData(item, "org-1", "user-1", {
+      remoteIndex: 0,
+    });
+
+    expect(data.connection_type).toBe("HTTP");
+    expect(data.connection_url).toBe("https://example.com/mcp");
+  });
+});

--- a/apps/mesh/src/web/utils/extract-connection-data.ts
+++ b/apps/mesh/src/web/utils/extract-connection-data.ts
@@ -132,8 +132,13 @@ export function extractConnectionData(
   const packageIndex = options?.packageIndex ?? 0;
   const remoteIndex = options?.remoteIndex ?? 0;
 
-  // If packageIndex is specified and packages exist, use package (STDIO)
-  const usePackage = packages.length > 0 && options?.packageIndex !== undefined;
+  // Use a package (STDIO) when the caller explicitly picked one, or when
+  // there's no remote to fall back to — otherwise a package-only registry
+  // item (no `remotes`) always fell through to the empty-URL "Fallback"
+  // branch below, since no caller passes `packageIndex`.
+  const usePackage =
+    packages.length > 0 &&
+    (options?.packageIndex !== undefined || remotes.length === 0);
   const selectedPackage = usePackage ? packages[packageIndex] : null;
   const selectedRemote = !usePackage ? remotes[remoteIndex] : null;
 


### PR DESCRIPTION
## Source
A bug found while reading `apps/mesh/src/web/utils/extract-connection-data.ts`, which is exercised by several recently-changed one-click connect flows (`use-connect-app.ts`, home tiles, commerce onboarding).

## The bug
`extractConnectionData` only resolves a registry `packages` entry (STDIO/npx) into a usable connection when the caller explicitly passes `packageIndex`. No caller in the codebase does this — `use-connect-app.ts`, `add-connection-dialog.tsx`, `use-auto-install-github.ts`, `use-install-from-registry.ts`, and `use-connect-companion.ts` all call it with only `{ remoteIndex: 0 }` (or nothing).

**Failure scenario:** a registry item that has `server.packages` but no `server.remotes` (a legitimate STDIO-only MCP server). Every install flow falls through to the "Fallback" branch (`connectionType: "HTTP"`, `connection_url: ""`), so the user sees "no connection method available" even though `add-connection-dialog.tsx` explicitly branches on `isStdioConnection`/`hasStdioConfig` expecting this case to succeed (that code path is currently unreachable).

## Fix
Use the package when the caller explicitly indexed one, OR when there's no remote to fall back to:
```ts
const usePackage =
  packages.length > 0 &&
  (options?.packageIndex !== undefined || remotes.length === 0);
```
This preserves existing behavior when both packages and remotes exist (still needs explicit `packageIndex`), and only changes behavior for the previously-broken package-only case.

## Regression test
Added `apps/mesh/src/web/utils/extract-connection-data.test.ts`:
- fails on the old code (`connection_type` was `"HTTP"` with an empty URL for a package-only item), passes with the fix (`connection_type: "STDIO"` with proper npx args)
- also asserts remotes still take priority when both are present

## Verify
```
bun test apps/mesh/src/web/utils/extract-connection-data.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (pre-existing unrelated error in `rich-text-field.tsx`, confirmed present on `main` via `git stash`)
- `bun test apps/mesh/src/web/utils/extract-connection-data.test.ts` (2 pass)

Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes STDIO connection resolution for registry items that only define packages, so one-click connect works for STDIO-only MCP servers. If no remotes exist, we now use the first `packages` entry; behavior is unchanged when both remotes and packages exist.

- **Bug Fixes**
  - Use a package when `packageIndex` is provided or when `remotes` is empty, producing an STDIO/`npx` connection.
  - Added regression tests for package-only and mixed cases.

<sup>Written for commit de912406ed39788848c07fef9b9b28bf28292b83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

