### PR TITLE
refactor: rename mesh* internal identifiers to studio*

### DIFF
--- a/apps/mesh/spec/001.md
+++ b/apps/mesh/spec/001.md
@@ -375,7 +375,7 @@ Tools must explicitly authorize operations using the improved access control API
 // api/middlewares/inject-context.ts
 app.use('*', async (c, next) => {
   const ctx: StudioContext = await createStudioContext(c);
-  c.set('meshContext', ctx);
+  c.set('studioContext', ctx);
   await next();
 });
 ```
@@ -385,7 +385,7 @@ app.use('*', async (c, next) => {
 ```typescript
 // api/middlewares/authorization.ts
 app.use('/mcp/tools/*', async (c, next) => {
-  const ctx = c.get('meshContext');
+  const ctx = c.get('studioContext');
   const toolName = extractToolName(c.req.path);
   
   // Check if user has policies that MIGHT allow this tool
@@ -719,7 +719,7 @@ app.use('*', async (c, next) => {
   await next();
   
   // After tool execution, verify authorization was handled
-  const ctx = c.get('meshContext');
+  const ctx = c.get('studioContext');
   
   if (!ctx.access.granted()) {
     // Tool forgot to call grant() - if not granted, access is denied
@@ -1231,7 +1231,7 @@ app.post('/mcp/:connectionId', async (c) => {
   // - session.accessToken: Access token details
   
   const connectionId = c.req.param('connectionId');
-  const ctx = c.get('meshContext');
+  const ctx = c.get('studioContext');
   
   // Check authorization for this specific connection
   await ctx.access.check(connectionId);
@@ -1291,7 +1291,7 @@ app.use('/mcp/*', requireMcpAuth());
 app.post('/mcp/:connectionId', async (c) => {
   const session = c.get('mcpSession');
   const connectionId = c.req.param('connectionId');
-  const ctx = c.get('meshContext');
+  const ctx = c.get('studioContext');
   
   await ctx.access.check(connectionId);
   
@@ -1330,7 +1330,7 @@ app.post('/mcp/:connectionId', async (c) => {
   }
   
   const connectionId = c.req.param('connectionId');
-  const ctx = c.get('meshContext');
+  const ctx = c.get('studioContext');
   
   // Check authorization
   await ctx.access.check(connectionId);
@@ -1676,7 +1676,7 @@ When proxying to downstream MCPs, Studio obtains and uses proper tokens:
 // Proxy MCP request with OAuth token
 app.post('/mcp/:connectionId', requireMcpAuth(), async (c) => {
   const { connectionId } = c.req.param();
-  const ctx = c.get('meshContext');
+  const ctx = c.get('studioContext');
   
   // Start trace span
   return await ctx.tracer.startActiveSpan('mcp.proxy', async (span) => {
@@ -2111,7 +2111,7 @@ oauthCallbackRouter.get('/oauth/callback', async (c) => {
   }
   
   // Get connection details using Kysely
-  const ctx = c.get('meshContext') as StudioContext;
+  const ctx = c.get('studioContext') as StudioContext;
   const connection = await ctx.db
     .selectFrom('connections')
     .selectAll()
@@ -3208,7 +3208,7 @@ import { mcpServer } from '../utils/mcp';
 const app = new Hono();
 
 app.post('/', async (c) => {
-  const ctx = c.get('meshContext');
+  const ctx = c.get('studioContext');
 
   // Convert tools to MCP format
   const tools = ALL_TOOLS.map(tool => ({
@@ -3247,7 +3247,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 app.post('/:connectionId', async (c) => {
   const connectionId = c.req.param('connectionId');
-  const ctx = c.get('meshContext');
+  const ctx = c.get('studioContext');
   
   // Get connection from database
   const connection = await ctx.storage.connections.findById(connectionId);

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -333,10 +333,10 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
   const endpoint = pathParts[pathParts.length - 1];
 
   // Get or create context
-  let ctx = c.get("meshContext");
+  let ctx = c.get("studioContext");
   if (!ctx) {
     ctx = await ContextFactory.create(c.req.raw);
-    c.set("meshContext", ctx);
+    c.set("studioContext", ctx);
   }
 
   const orgScope = c.req.param("org") ? ctx.organization?.id : undefined;
@@ -697,15 +697,16 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
  * Clients use `COLLECTION_THREADS_LIST` for their initial state.
  */
 export const watchHandler: MiddlewareHandler<Env> = async (c) => {
-  const meshContext = c.var.meshContext;
+  const studioContext = c.var.studioContext;
 
   // Require authentication (user session or API key)
-  const userId = meshContext.auth.user?.id ?? meshContext.auth.apiKey?.userId;
+  const userId =
+    studioContext.auth.user?.id ?? studioContext.auth.apiKey?.userId;
   if (!userId) {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  const orgId = meshContext.organization?.id;
+  const orgId = studioContext.organization?.id;
   if (!orgId) {
     return c.json({ error: "organization id missing" }, 400);
   }
@@ -1429,7 +1430,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // runtime now — automations invoke its shared `runDispatchSteps` body.
   setAutomationRuntime({
     storage: automationsStorage,
-    meshContextFactory: automationContextFactory,
+    studioContextFactory: automationContextFactory,
   });
 
   // The per-thread gate now STARTS the run (hosted: fire-and-forget enqueue of
@@ -1438,7 +1439,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // so it no longer needs a `dispatchRunFn` or a status-poll cap. Wiring happens
   // before `DBOS.launch()` for the same reasons as automations.
   setThreadGateRuntime({
-    meshContextFactory: automationContextFactory,
+    studioContextFactory: automationContextFactory,
     deps: {
       runRegistry,
       cancelBroadcast,
@@ -1460,7 +1461,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // consume step, which writes terminal status for both hosted and desktop runs.
   setHostedHarnessRuntime({
     dispatchRunFn: dispatchRunAndWait,
-    meshContextFactory: automationContextFactory,
+    studioContextFactory: automationContextFactory,
     deps: {
       runRegistry,
       cancelBroadcast,
@@ -1610,7 +1611,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // org context + re-resolve models on whatever pod runs the job. Wired before
   // DBOS.launch() like the others (module-level pointer, no DBOS API calls).
   setBackgroundToolRuntime({
-    meshContextFactory: automationContextFactory,
+    studioContextFactory: automationContextFactory,
     systemDatabaseUrl: withSslmode(
       getSettings().databaseUrl,
       getSettings().databasePgSsl,
@@ -1707,9 +1708,9 @@ export async function createApp(options: CreateAppOptions = {}) {
       },
     };
 
-    const meshCtx = await ContextFactory.create(c.req.raw, { timings });
-    meshCtx.automationRunner = automationRunner;
-    c.set("meshContext", meshCtx);
+    const studioCtx = await ContextFactory.create(c.req.raw, { timings });
+    studioCtx.automationRunner = automationRunner;
+    c.set("studioContext", studioCtx);
 
     try {
       await next();
@@ -1717,7 +1718,7 @@ export async function createApp(options: CreateAppOptions = {}) {
       // Fire-and-forget: await pending SWR revalidations with a timeout.
       // Keeps ctx (and its client pool) alive via closure while revalidations complete.
       // No pool disposal — pool was never disposed and SSE/streaming connections depend on it.
-      const revalidations = meshCtx.pendingRevalidations;
+      const revalidations = studioCtx.pendingRevalidations;
       if (revalidations.length > 0) {
         const REVALIDATION_TIMEOUT_MS = 30_000;
         void Promise.race([
@@ -1763,7 +1764,7 @@ export async function createApp(options: CreateAppOptions = {}) {
       return next();
     }
 
-    const ctx = c.get("meshContext") as StudioContext | undefined;
+    const ctx = c.get("studioContext") as StudioContext | undefined;
     if (!ctx?.organization?.id || !ctx?.auth?.user?.id) {
       return next();
     }
@@ -1793,7 +1794,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Legacy mount at /api/org-sso with deprecation log; the new
   // /api/:org/org-sso mount is wired in a later task.
   const legacyOrgSso = new Hono<{
-    Variables: { meshContext: StudioContext };
+    Variables: { studioContext: StudioContext };
   }>();
   legacyOrgSso.use(
     "*",
@@ -1825,9 +1826,9 @@ export async function createApp(options: CreateAppOptions = {}) {
   });
 
   const mcpAuth: MiddlewareHandler<Env> = async (c, next) => {
-    const meshContext = c.var.meshContext;
+    const studioContext = c.var.studioContext;
     // Require either user or API key authentication
-    if (!meshContext.auth.user?.id && !meshContext.auth.apiKey?.id) {
+    if (!studioContext.auth.user?.id && !studioContext.auth.apiKey?.id) {
       const url = new URL(c.req.url);
       return (c.res = new Response(null, {
         status: 401,
@@ -1905,7 +1906,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // GET /api/links/me — presence-read for the current user's link claim.
   // Used by the `deco link` CLI preflight and by presence checks.
   // Dual-auth: Bearer token (CLI — OAuth MCP session or a Better Auth API key)
-  // or the session cookie (browser/e2e via meshContext).
+  // or the session cookie (browser/e2e via studioContext).
   app.get("/api/links/me", async (c) => {
     try {
       const authHeader = c.req.header("authorization") ?? "";
@@ -1920,7 +1921,7 @@ export async function createApp(options: CreateAppOptions = {}) {
           auth.api as unknown as LinkBearerAuthApi,
         );
       } else {
-        const ctx = (c.get as (key: string) => unknown)("meshContext") as
+        const ctx = (c.get as (key: string) => unknown)("studioContext") as
           | { auth?: { user?: { id?: string } } }
           | undefined;
         userSub = ctx?.auth?.user?.id ?? null;
@@ -1938,7 +1939,7 @@ export async function createApp(options: CreateAppOptions = {}) {
       // Presence is best-effort: a failing probe / bearer-resolver / transport
       // must read as "no link" (200 null), never a 500. The bearer path
       // already degrades to null when offline; this keeps the cookie path
-      // (whose org-scoped meshContext can surface transient failures) in lock-
+      // (whose org-scoped studioContext can surface transient failures) in lock-
       // step instead of bubbling an empty-body 500 to the UI poller.
       console.error(
         "[links/me] presence probe failed; reporting offline:",
@@ -1958,7 +1959,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Legacy mount at /api/* with deprecation log; the new /api/:org/* mount
   // is wired in a later task.
   const legacyThreadOutputsRoutes = new Hono<{
-    Variables: { meshContext: StudioContext };
+    Variables: { studioContext: StudioContext };
   }>();
   legacyThreadOutputsRoutes.use(
     "*",
@@ -1974,7 +1975,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Legacy mount at /api/trigger-callback with deprecation log; the new
   // /api/:org/trigger-callback mount is wired in a later task.
   const legacyTriggerCallback = new Hono<{
-    Variables: { meshContext: StudioContext };
+    Variables: { studioContext: StudioContext };
   }>();
   legacyTriggerCallback.use(
     "*",
@@ -2000,7 +2001,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Legacy mount at /api/* with deprecation log; the new /api/:org/* mount
   // is wired in a later task.
   const legacyDownstreamTokenRoutes = new Hono<{
-    Variables: { meshContext: StudioContext };
+    Variables: { studioContext: StudioContext };
   }>();
   legacyDownstreamTokenRoutes.use(
     "*",
@@ -2009,7 +2010,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   legacyDownstreamTokenRoutes.route("/", createDownstreamTokenRoutes());
   app.route("/api", legacyDownstreamTokenRoutes);
 
-  // Deco.cx sites list (requires meshContext / auth)
+  // Deco.cx sites list (requires studioContext / auth)
   // /profile is user-scoped (no org), stays mounted permanently — no
   // deprecation log.
   app.route("/api/deco-sites", createDecoSitesUserRoutes());
@@ -2019,7 +2020,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // at /api/deco-sites with a deprecation log; the new /api/:org/deco-sites
   // mount is wired in a later task.
   const legacyDecoSitesOrg = new Hono<{
-    Variables: { meshContext: StudioContext };
+    Variables: { studioContext: StudioContext };
   }>();
   legacyDecoSitesOrg.use(
     "*",
@@ -2035,7 +2036,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Legacy mount at /api/vm-events with deprecation log; the new
   // /api/:org/vm-events mount is wired in a later task.
   const legacyVmEvents = new Hono<{
-    Variables: { meshContext: StudioContext };
+    Variables: { studioContext: StudioContext };
   }>();
   legacyVmEvents.use(
     "*",

--- a/apps/mesh/src/api/hono-env.ts
+++ b/apps/mesh/src/api/hono-env.ts
@@ -4,7 +4,7 @@ import type { StudioContext } from "../core/studio-context";
 
 // Define Hono variables type
 type Variables = TimingVariables & {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
   rootSpan: Span;
 };
 

--- a/apps/mesh/src/api/middleware/log-deprecated-route.test.ts
+++ b/apps/mesh/src/api/middleware/log-deprecated-route.test.ts
@@ -6,13 +6,13 @@ import {
   logDeprecatedRoute,
 } from "./log-deprecated-route";
 
-type Variables = { meshContext: StudioContext };
+type Variables = { studioContext: StudioContext };
 
 const setStudioContext = async (
   c: import("hono").Context<{ Variables: Variables }>,
   next: () => Promise<void>,
 ) => {
-  c.set("meshContext", {
+  c.set("studioContext", {
     organization: { slug: "acme" },
     auth: { user: { id: "user-1" } },
   } as unknown as StudioContext);
@@ -93,7 +93,7 @@ describe("createLogDeprecatedRoute suppression logic", () => {
         header: () => "test-agent",
       },
       get: (key: string) =>
-        key === "meshContext"
+        key === "studioContext"
           ? {
               organization: { slug: "acme" },
               auth: { user: { id: "user-1" } },

--- a/apps/mesh/src/api/middleware/log-deprecated-route.ts
+++ b/apps/mesh/src/api/middleware/log-deprecated-route.ts
@@ -3,7 +3,7 @@ import type { StudioContext } from "../../core/studio-context";
 
 /**
  * Attribution set by token-authenticated legacy handlers (e.g.
- * `/api/trigger-callback`) that don't resolve a session-based `meshContext`,
+ * `/api/trigger-callback`) that don't resolve a session-based `studioContext`,
  * so their org/connection can still appear in the deprecation log. The handler
  * sets this via `c.set("deprecatedRouteAttribution", ...)` after validating its
  * own token; the middleware reads it after `next()`.
@@ -14,7 +14,7 @@ export interface DeprecatedRouteAttribution {
 }
 
 type Variables = {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
   deprecatedRouteAttribution?: DeprecatedRouteAttribution;
 };
 
@@ -84,7 +84,7 @@ const buildLogDeprecatedRoute =
       return;
     }
 
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const attribution = c.get("deprecatedRouteAttribution");
     console.log("deprecated route", {
       route: c.req.routePath,

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.integration.test.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.integration.test.ts
@@ -9,7 +9,7 @@ import {
 import type { StudioDatabase } from "../../database";
 import { resolveOrgFromPath } from "./resolve-org-from-path";
 
-type Variables = { meshContext: StudioContext };
+type Variables = { studioContext: StudioContext };
 
 interface FakeAuth {
   user?: { id: string };
@@ -36,7 +36,7 @@ const buildApp = (
     // rebind, any thread-touching route on the new path family throws
     // "OrgScopedThreadStorage: thread operations require an authenticated organization".
     const threadOrgIds: (string | undefined)[] = [];
-    c.set("meshContext", {
+    c.set("studioContext", {
       auth,
       db: db.db,
       baseUrl: "http://test",
@@ -65,7 +65,7 @@ const buildApp = (
   });
   app.use("/api/:org/*", resolveOrgFromPath);
   app.get("/api/:org/probe", (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     return c.json({
       orgId: ctx.organization?.id,
       orgSlug: ctx.organization?.slug,
@@ -199,7 +199,7 @@ describe("resolveOrgFromPath", () => {
     // when the session's active org differs from the URL org.
     const app = new Hono<{ Variables: Variables }>();
     app.use("*", async (c, next) => {
-      c.set("meshContext", {
+      c.set("studioContext", {
         auth: { user: { id: "user-1" } },
         db: db.db,
         baseUrl: "http://test",
@@ -217,7 +217,7 @@ describe("resolveOrgFromPath", () => {
     });
     app.use("/api/:org/*", resolveOrgFromPath);
     app.get("/api/:org/role", (c) => {
-      const ctx = c.get("meshContext");
+      const ctx = c.get("studioContext");
       return c.json({ role: ctx.organization?.role });
     });
     const res = await app.request("/api/acme/role");
@@ -238,7 +238,7 @@ describe("resolveOrgFromPath", () => {
 
   it("rebinds storage.threads + objectStorage to the path-resolved org", async () => {
     // Regression: when the new /api/:org path is hit without an x-org-id
-    // header, meshContext is created with org=undefined, so OrgScopedThreadStorage
+    // header, studioContext is created with org=undefined, so OrgScopedThreadStorage
     // and objectStorage start out unbound. resolveOrgFromPath must rebind both
     // after looking up the org from the slug, otherwise thread routes throw
     // "thread operations require an authenticated organization".
@@ -251,7 +251,7 @@ describe("resolveOrgFromPath", () => {
   });
 
   it("rebinds objectStorage even when it was prebound to a stale org", async () => {
-    // Regression: meshContext is built eagerly from the session's
+    // Regression: studioContext is built eagerly from the session's
     // activeOrganizationId. When the URL targets a different org (e.g. session
     // active=A, path=B), the eagerly-bound objectStorage points at A. The
     // middleware must replace it so /api/:org/files/* reads from B's tenant

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -22,16 +22,16 @@ function isPublicSharePath(c: Context): boolean {
 }
 
 export const resolveOrgFromPath: MiddlewareHandler<{
-  Variables: { meshContext: StudioContext };
+  Variables: { studioContext: StudioContext };
 }> = async (c, next) => {
   const slug = c.req.param("org");
   if (!slug) {
     return c.json({ error: "org slug missing in path" }, 400);
   }
 
-  const ctx = c.get("meshContext");
+  const ctx = c.get("studioContext");
   if (!ctx?.db) {
-    return c.json({ error: "meshContext not initialized" }, 500);
+    return c.json({ error: "studioContext not initialized" }, 500);
   }
   const db = ctx.db;
 

--- a/apps/mesh/src/api/routes/admin.ts
+++ b/apps/mesh/src/api/routes/admin.ts
@@ -98,7 +98,7 @@ function auditAdminAction(action: string, props: Record<string, unknown>) {
 
 /**
  * The REAL actor for audit purposes. Under impersonation the session user (and
- * meshContext.auth.user) is the impersonation TARGET — an admin impersonating
+ * studioContext.auth.user) is the impersonation TARGET — an admin impersonating
  * a fellow admin can reach every /api/_admin route, and attributing their
  * actions to the impersonated identity would defeat the audit trail. The
  * original admin's id lives in `session.impersonatedBy`.
@@ -108,7 +108,7 @@ async function getAuditActor(
 ): Promise<{ actorId?: string; impersonatedBy?: string }> {
   const session = await auth.api.getSession({ headers: c.req.raw.headers });
   return {
-    actorId: c.get("meshContext").auth.user?.id,
+    actorId: c.get("studioContext").auth.user?.id,
     impersonatedBy: (
       session?.session as { impersonatedBy?: string } | undefined
     )?.impersonatedBy,
@@ -119,7 +119,7 @@ async function requireDeploymentAdmin(
   c: Context<Env>,
   next: () => Promise<void>,
 ) {
-  const user = c.get("meshContext").auth.user;
+  const user = c.get("studioContext").auth.user;
   if (!user) {
     return c.json({ error: "Unauthorized" }, 401);
   }
@@ -146,7 +146,7 @@ export function createAdminRoutes(): Hono<Env> {
 
   // The middleware IS the check — the UI gate just probes this.
   app.get("/me", (c) => {
-    const email = c.get("meshContext").auth.user?.email;
+    const email = c.get("studioContext").auth.user?.email;
     if (!email) return c.json({ error: "Unauthorized" }, 401);
     return c.json({ email });
   });
@@ -218,7 +218,7 @@ export function createAdminRoutes(): Hono<Env> {
     }
     // The UI disables the button for the current user, but the server is the
     // trust boundary — self-impersonation would set impersonatedBy = self.
-    if (userId === c.get("meshContext").auth.user?.id) {
+    if (userId === c.get("studioContext").auth.user?.id) {
       return c.json({ error: "Cannot impersonate yourself" }, 400);
     }
 
@@ -243,7 +243,7 @@ export function createAdminRoutes(): Hono<Env> {
     });
 
     if (res.ok) {
-      const actorId = c.get("meshContext").auth.user?.id;
+      const actorId = c.get("studioContext").auth.user?.id;
       auditAdminAction("impersonate", {
         actor_user_id: actorId,
         target_user_id: userId,

--- a/apps/mesh/src/api/routes/automation-webhooks.ts
+++ b/apps/mesh/src/api/routes/automation-webhooks.ts
@@ -141,7 +141,7 @@ export function createAutomationWebhookRoutes() {
   });
 
   const handle = async (c: Context<Env>, pathToken: string | undefined) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     if (!ctx?.organization) {
       return c.json({ error: "Organization context missing" }, 500);
     }

--- a/apps/mesh/src/api/routes/credential-vault.ts
+++ b/apps/mesh/src/api/routes/credential-vault.ts
@@ -9,7 +9,7 @@ import {
 import { DownstreamTokenStorage } from "@/storage/downstream-token";
 
 type Variables = {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
 };
 
 function bearerToken(value: string | undefined): string | null {
@@ -71,7 +71,7 @@ async function authorizeVaultRequest(
     return { ok: false, response: c.json({ error: "Unauthorized" }, 401) };
   }
 
-  const ctx = c.get("meshContext");
+  const ctx = c.get("studioContext");
   const organizationId = ctx.organization?.id;
   if (!organizationId) {
     return {

--- a/apps/mesh/src/api/routes/deco-apps.test.ts
+++ b/apps/mesh/src/api/routes/deco-apps.test.ts
@@ -43,9 +43,9 @@ describe("mapSupabaseAppRows", () => {
 
 describe("createDecoAppsRoutes", () => {
   test("returns 401 when unauthenticated", async () => {
-    const root = new Hono<{ Variables: { meshContext: StudioContext } }>();
+    const root = new Hono<{ Variables: { studioContext: StudioContext } }>();
     root.use("*", async (c, next) => {
-      c.set("meshContext", {
+      c.set("studioContext", {
         auth: { user: null },
       } as unknown as StudioContext);
       await next();

--- a/apps/mesh/src/api/routes/deco-apps.ts
+++ b/apps/mesh/src/api/routes/deco-apps.ts
@@ -7,7 +7,7 @@ import { Hono } from "hono";
 import type { StudioContext } from "../../core/studio-context";
 import { getSettings } from "../../settings";
 
-type Variables = { meshContext: StudioContext };
+type Variables = { studioContext: StudioContext };
 
 export interface SupabaseAppRow {
   name: string;
@@ -76,7 +76,7 @@ const requireAuth = async (
   c: import("hono").Context<{ Variables: Variables }>,
   next: () => Promise<void>,
 ) => {
-  const ctx = c.get("meshContext");
+  const ctx = c.get("studioContext");
   if (!ctx.auth.user?.id) {
     return c.json({ error: "Unauthorized" }, 401);
   }

--- a/apps/mesh/src/api/routes/deco-sites.ts
+++ b/apps/mesh/src/api/routes/deco-sites.ts
@@ -18,7 +18,7 @@ import { fetchToolsFromMCP } from "../../tools/connection/fetch-tools";
 import { tenantStorageDescriptor } from "../../file-storage/tenant-credentials";
 import { isValidSiteSlug } from "../../shared/site-slug";
 
-type Variables = { meshContext: StudioContext };
+type Variables = { studioContext: StudioContext };
 
 interface SupabaseSite {
   name: string;
@@ -313,7 +313,7 @@ const requireAuth = async (
   c: import("hono").Context<{ Variables: Variables }>,
   next: () => Promise<void>,
 ) => {
-  const ctx = c.get("meshContext");
+  const ctx = c.get("studioContext");
   if (!ctx.auth.user?.id) {
     return c.json({ error: "Unauthorized" }, 401);
   }
@@ -424,7 +424,7 @@ export const createDecoSitesUserRoutes = () => {
    * Used to conditionally show deco.cx onboarding UI without fetching all sites.
    */
   app.get("/profile", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const email = ctx.auth.user?.email;
     if (!email) return c.json({ error: "Unauthorized" }, 401);
 
@@ -462,7 +462,7 @@ export const createDecoSitesOrgRoutes = () => {
    * The deco.cx API key is intentionally NOT returned — it remains server-side.
    */
   app.get("/", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
 
     const email = ctx.auth.user?.email;
     if (!email) {
@@ -517,7 +517,7 @@ export const createDecoSitesOrgRoutes = () => {
    * project-linking tool calls can reference it without an extra round-trip.
    */
   app.post("/connection", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const organization = requireOrganization(ctx);
 
     const email = ctx.auth.user?.email;

--- a/apps/mesh/src/api/routes/decopilot/helpers.ts
+++ b/apps/mesh/src/api/routes/decopilot/helpers.ts
@@ -26,9 +26,9 @@ export {
  * Ensure organization context exists and matches route param
  */
 export function ensureOrganization(
-  c: Context<{ Variables: { meshContext: StudioContext } }>,
+  c: Context<{ Variables: { studioContext: StudioContext } }>,
 ): OrganizationScope {
-  const organization = c.get("meshContext").organization;
+  const organization = c.get("studioContext").organization;
   if (!organization) {
     throw new Error("Organization context is required");
   }
@@ -44,9 +44,9 @@ export function ensureOrganization(
  * Use this for read-only / observability endpoints (e.g. stream).
  */
 export async function validateThreadAccess(
-  c: Context<{ Variables: { meshContext: StudioContext } }>,
+  c: Context<{ Variables: { studioContext: StudioContext } }>,
 ) {
-  const ctx = c.get("meshContext");
+  const ctx = c.get("studioContext");
   const userId = ctx.auth?.user?.id;
   if (!userId) {
     throw new HTTPException(401, { message: "Unauthorized" });
@@ -72,7 +72,7 @@ export async function validateThreadAccess(
  * should be allowed to act.
  */
 export async function validateThreadOwnership(
-  c: Context<{ Variables: { meshContext: StudioContext } }>,
+  c: Context<{ Variables: { studioContext: StudioContext } }>,
 ) {
   const result = await validateThreadAccess(c);
   if (result.thread.created_by !== result.userId) {

--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -131,7 +131,7 @@ export function shouldPersistRequestMessage(input: {
 // ============================================================================
 
 async function validateRequest(
-  c: Context<{ Variables: { meshContext: StudioContext } }>,
+  c: Context<{ Variables: { studioContext: StudioContext } }>,
 ) {
   const organization = ensureOrganization(c);
   const rawPayload = await c.req.json();
@@ -381,7 +381,7 @@ export function applyThreadLock(args: {
  * Legacy callers that supply the id in the body alone are unaffected.
  */
 async function validate(
-  c: Context<{ Variables: { meshContext: StudioContext } }>,
+  c: Context<{ Variables: { studioContext: StudioContext } }>,
   threadIdParam: string | undefined,
 ): Promise<
   DispatchRunInput & {
@@ -389,7 +389,7 @@ async function validate(
     harnessId?: HarnessId | null;
   }
 > {
-  const ctx = c.get("meshContext");
+  const ctx = c.get("studioContext");
 
   const {
     organization,
@@ -508,7 +508,7 @@ export interface DecopilotDeps {
 
 export function createDecopilotRoutes(deps: DecopilotDeps) {
   const { cancelBroadcast, streamBuffer, runRegistry } = deps;
-  const app = new Hono<{ Variables: { meshContext: StudioContext } }>();
+  const app = new Hono<{ Variables: { studioContext: StudioContext } }>();
 
   // ============================================================================
   // Allowed Models Endpoint
@@ -516,7 +516,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
 
   app.get("/:org/decopilot/allowed-models", async (c) => {
     try {
-      const ctx = c.get("meshContext");
+      const ctx = c.get("studioContext");
       const organization = ensureOrganization(c);
       const role = ctx.auth.user?.role;
 
@@ -563,7 +563,7 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
 
   app.post("/:org/decopilot/threads/:threadId/messages", async (c) => {
     try {
-      const ctx = c.get("meshContext");
+      const ctx = c.get("studioContext");
       const input = await validate(c, c.req.param("threadId"));
       const taskId = input.taskId;
       if (!taskId) {

--- a/apps/mesh/src/api/routes/dev-assets-mcp.ts
+++ b/apps/mesh/src/api/routes/dev-assets-mcp.ts
@@ -67,7 +67,7 @@ interface FileObject {
 
 // Define Hono variables type
 type Variables = {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
 };
 
 const app = new Hono<{ Variables: Variables }>();
@@ -590,7 +590,7 @@ export async function callDevAssetsTool(
  * Implements OBJECT_STORAGE_BINDING for local filesystem storage
  */
 app.all("/", async (c) => {
-  const ctx = c.get("meshContext");
+  const ctx = c.get("studioContext");
 
   // Get base URL for presigned URLs
   const url = new URL(c.req.url);

--- a/apps/mesh/src/api/routes/dev-assets.ts
+++ b/apps/mesh/src/api/routes/dev-assets.ts
@@ -128,12 +128,12 @@ export function getContentType(key: string): string {
 // Routes
 // ============================================================================
 
-type DevAssetsVariables = { meshContext: StudioContext };
+type DevAssetsVariables = { studioContext: StudioContext };
 
 interface CreateDevAssetsRoutesOptions {
   /**
    * When `true`, the routes are mounted at `/*` and the org id is read from
-   * `meshContext.organization.id` (set by the `resolveOrgFromPath` middleware).
+   * `studioContext.organization.id` (set by the `resolveOrgFromPath` middleware).
    * When `false`, the routes are mounted at `/:orgId/*` and the org id is read
    * from the path param — preserves the legacy `/api/dev-assets/:orgId/*`
    * behaviour.
@@ -157,7 +157,7 @@ export const createDevAssetsRoutes = (opts: CreateDevAssetsRoutesOptions) => {
    */
   app.get(path, async (c) => {
     const orgId = opts.orgFromPath
-      ? c.get("meshContext")?.organization?.id
+      ? c.get("studioContext")?.organization?.id
       : c.req.param("orgId");
 
     if (!orgId) {
@@ -237,7 +237,7 @@ export const createDevAssetsRoutes = (opts: CreateDevAssetsRoutesOptions) => {
    */
   app.put(path, async (c) => {
     const orgId = opts.orgFromPath
-      ? c.get("meshContext")?.organization?.id
+      ? c.get("studioContext")?.organization?.id
       : c.req.param("orgId");
 
     if (!orgId) {

--- a/apps/mesh/src/api/routes/dev-only.ts
+++ b/apps/mesh/src/api/routes/dev-only.ts
@@ -45,7 +45,7 @@ export function mountDevRoutes(
     mcpAuth,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async (c: Context<any>) => {
-      const ctx = c.get("meshContext") as StudioContext;
+      const ctx = c.get("studioContext") as StudioContext;
       const url = new URL(c.req.url);
       const baseUrl = `${url.protocol}//${url.host}`;
       return handleDevAssetsMcpRequest(c.req.raw, ctx, baseUrl);
@@ -58,7 +58,7 @@ export function mountDevRoutes(
     mcpAuth,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async (c: Context<any>) => {
-      const ctx = c.get("meshContext") as StudioContext;
+      const ctx = c.get("studioContext") as StudioContext;
       const url = new URL(c.req.url);
       const baseUrl = `${url.protocol}//${url.host}`;
       const toolName = c.req.param("toolName");

--- a/apps/mesh/src/api/routes/downstream-token.integration.test.ts
+++ b/apps/mesh/src/api/routes/downstream-token.integration.test.ts
@@ -13,7 +13,7 @@ import { createDownstreamTokenRoutes } from "./downstream-token";
 
 describe("Downstream Token Routes", () => {
   let database: StudioDatabase;
-  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
+  let app: Hono<{ Variables: { studioContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -45,7 +45,7 @@ describe("Downstream Token Routes", () => {
 
     app = new Hono();
     app.use("*", async (c, next) => {
-      c.set("meshContext", ctx);
+      c.set("studioContext", ctx);
       await next();
     });
     app.route("/", createDownstreamTokenRoutes());

--- a/apps/mesh/src/api/routes/downstream-token.ts
+++ b/apps/mesh/src/api/routes/downstream-token.ts
@@ -15,7 +15,7 @@ import {
 
 // Define Hono variables type
 type Variables = {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
 };
 
 export const createDownstreamTokenRoutes = () => {
@@ -28,7 +28,7 @@ export const createDownstreamTokenRoutes = () => {
    * Called from frontend after OAuth flow completes.
    */
   app.post("/connections/:connectionId/oauth-token", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const connectionId = c.req.param("connectionId");
 
     // Require authentication
@@ -141,7 +141,7 @@ export const createDownstreamTokenRoutes = () => {
    * Delete OAuth token for a connection.
    */
   app.delete("/connections/:connectionId/oauth-token", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const connectionId = c.req.param("connectionId");
 
     const userId = ctx.auth.user?.id ?? ctx.auth.apiKey?.userId ?? null;
@@ -175,7 +175,7 @@ export const createDownstreamTokenRoutes = () => {
    * Check if there's a valid cached token for a connection.
    */
   app.get("/connections/:connectionId/oauth-token/status", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const connectionId = c.req.param("connectionId");
 
     const userId = ctx.auth.user?.id ?? ctx.auth.apiKey?.userId ?? null;

--- a/apps/mesh/src/api/routes/file-uploads.ts
+++ b/apps/mesh/src/api/routes/file-uploads.ts
@@ -34,13 +34,13 @@ import {
   buildObjectKey,
 } from "@/file-storage/upload-policy";
 
-type Variables = { meshContext: StudioContext };
+type Variables = { studioContext: StudioContext };
 
 export const createFileUploadRoutes = () => {
   const app = new Hono<{ Variables: Variables }>();
 
   app.post("/file-configs/:id/upload", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const userId = ctx.auth?.user?.id;
     if (!userId) {
       throw new HTTPException(401, { message: "Unauthorized" });

--- a/apps/mesh/src/api/routes/files.ts
+++ b/apps/mesh/src/api/routes/files.ts
@@ -22,7 +22,7 @@ import { generatePresignedGetUrl } from "./decopilot/file-materializer";
 import { usesLocalObjectStorage } from "@/tools/connection/dev-assets";
 import { isBrowserNavigation } from "../utils/browser-navigation";
 
-type Variables = { meshContext: StudioContext };
+type Variables = { studioContext: StudioContext };
 
 const app = new Hono<{ Variables: Variables }>();
 
@@ -62,7 +62,7 @@ function applyContentPolicy(headers: Headers, contentType: string): void {
 }
 
 app.get("/:org/files/*", async (c) => {
-  const ctx = c.get("meshContext");
+  const ctx = c.get("studioContext");
 
   const orgId = ctx.organization?.id;
 

--- a/apps/mesh/src/api/routes/home-next-actions.ts
+++ b/apps/mesh/src/api/routes/home-next-actions.ts
@@ -31,7 +31,7 @@ const MAX_PROMPTS_PER_AGENT = 10;
 const LIST_PROMPTS_TIMEOUT_MS = 5000;
 
 type Variables = {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
 };
 interface PromptEntry {
   agentId: string;
@@ -195,7 +195,7 @@ export function createHomeNextActionsRoutes() {
   const app = new Hono<{ Variables: Variables }>();
 
   app.get("/home-next-actions", async (c) => {
-    const mesh = c.get("meshContext");
+    const mesh = c.get("studioContext");
     const orgId = mesh.organization?.id;
     if (!orgId) return c.json({ error: "Organization required" }, 400);
 

--- a/apps/mesh/src/api/routes/kv.ts
+++ b/apps/mesh/src/api/routes/kv.ts
@@ -12,7 +12,7 @@ import type { KVStorage } from "@/storage/kv";
 import { INTERESTS_KEY_PREFIX } from "@/storage/interests";
 
 type Variables = {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
 };
 
 interface KVRouteDeps {
@@ -33,8 +33,8 @@ export function createKVRoutes(deps: KVRouteDeps) {
   const app = new Hono<{ Variables: Variables }>();
 
   app.get("/kv/:key", async (c) => {
-    const meshContext = c.get("meshContext");
-    const orgId = meshContext.organization?.id;
+    const studioContext = c.get("studioContext");
+    const orgId = studioContext.organization?.id;
     if (!orgId) {
       return c.json({ error: "Organization required" }, 400);
     }
@@ -59,8 +59,8 @@ export function createKVRoutes(deps: KVRouteDeps) {
       onError: (c) => c.json({ error: "Payload too large" }, 413),
     }),
     async (c) => {
-      const meshContext = c.get("meshContext");
-      const orgId = meshContext.organization?.id;
+      const studioContext = c.get("studioContext");
+      const orgId = studioContext.organization?.id;
       if (!orgId) {
         return c.json({ error: "Organization required" }, 400);
       }
@@ -83,8 +83,8 @@ export function createKVRoutes(deps: KVRouteDeps) {
   );
 
   app.delete("/kv/:key", async (c) => {
-    const meshContext = c.get("meshContext");
-    const orgId = meshContext.organization?.id;
+    const studioContext = c.get("studioContext");
+    const orgId = studioContext.organization?.id;
     if (!orgId) {
       return c.json({ error: "Organization required" }, 400);
     }

--- a/apps/mesh/src/api/routes/links/session.test.ts
+++ b/apps/mesh/src/api/routes/links/session.test.ts
@@ -29,9 +29,9 @@ function withSettings(overrides: Partial<Settings>): void {
 }
 
 function createApp(userId: string | null) {
-  const app = new Hono<{ Variables: { meshContext: StudioContext } }>();
+  const app = new Hono<{ Variables: { studioContext: StudioContext } }>();
   app.use("*", async (c, next) => {
-    c.set("meshContext", {
+    c.set("studioContext", {
       auth: userId ? { user: { id: userId } } : undefined,
     } as unknown as StudioContext);
     await next();

--- a/apps/mesh/src/api/routes/links/session.ts
+++ b/apps/mesh/src/api/routes/links/session.ts
@@ -10,7 +10,7 @@ import {
 import { issueNatsCredentials } from "@/links/nats-credentials";
 
 type Variables = {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
 };
 
 const unavailable = () => ({ error: "link session unavailable" });
@@ -33,7 +33,7 @@ export function createLinkSessionRoutes() {
   const app = new Hono<{ Variables: Variables }>();
 
   app.post("/links/session", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const userId = ctx.auth?.user?.id;
 
     if (!userId) {

--- a/apps/mesh/src/api/routes/oauth-proxy.ts
+++ b/apps/mesh/src/api/routes/oauth-proxy.ts
@@ -33,7 +33,7 @@ import {
 
 // Define Hono variables type
 type Variables = {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
 };
 
 type HonoEnv = { Variables: Variables };
@@ -221,13 +221,13 @@ async function getOriginAuthServer(
  */
 async function ensureContext(c: {
   req: { raw: Request };
-  get: (key: "meshContext") => StudioContext | undefined;
-  set: (key: "meshContext", value: StudioContext) => void;
+  get: (key: "studioContext") => StudioContext | undefined;
+  set: (key: "studioContext", value: StudioContext) => void;
 }): Promise<StudioContext> {
-  let ctx = c.get("meshContext");
+  let ctx = c.get("studioContext");
   if (!ctx) {
     ctx = await ContextFactory.create(c.req.raw);
-    c.set("meshContext", ctx);
+    c.set("studioContext", ctx);
   }
   return ctx;
 }
@@ -335,8 +335,8 @@ export const protectedResourceMetadataHandler = async (c: {
     raw: Request;
     url: string;
   };
-  get: (key: "meshContext") => StudioContext | undefined;
-  set: (key: "meshContext", value: StudioContext) => void;
+  get: (key: "studioContext") => StudioContext | undefined;
+  set: (key: "studioContext", value: StudioContext) => void;
   json: (data: unknown, status?: number) => Response;
 }) => {
   const connectionId = c.req.param("connectionId");
@@ -354,7 +354,7 @@ export const protectedResourceMetadataHandler = async (c: {
   //    `activeOrganizationId`, and multi-org users hitting another org's URL
   //    silently lookup against their active org and 404.
   // 2. `ctx.organization?.slug` — set by `resolveOrgFromPath` for routes
-  //    inside the `/api/:org` sub-app, or by the meshContext factory from
+  //    inside the `/api/:org` sub-app, or by the studioContext factory from
   //    the session's active org. Used only when the path doesn't carry a
   //    slug (legacy `/mcp/:id/.well-known/...` mount).
   // 3. undefined — legacy routes have no slug; the prefix is empty and
@@ -661,8 +661,8 @@ export async function fetchAuthorizationServerMetadata(
  */
 const authServerMetadataHandler = async (c: {
   req: { param: (key: string) => string; raw: Request; url: string };
-  get: (key: "meshContext") => StudioContext | undefined;
-  set: (key: "meshContext", value: StudioContext) => void;
+  get: (key: "studioContext") => StudioContext | undefined;
+  set: (key: "studioContext", value: StudioContext) => void;
   json: (data: unknown, status?: number) => Response;
 }) => {
   const connectionId = c.req.param("connectionId");

--- a/apps/mesh/src/api/routes/object-storage.test.ts
+++ b/apps/mesh/src/api/routes/object-storage.test.ts
@@ -5,9 +5,9 @@ import type { BoundObjectStorage } from "@/object-storage/bound-object-storage";
 import { createObjectStorageRoutes } from "./object-storage";
 
 function createApp(objectStorage: BoundObjectStorage | null) {
-  const app = new Hono<{ Variables: { meshContext: StudioContext } }>();
+  const app = new Hono<{ Variables: { studioContext: StudioContext } }>();
   app.use("*", async (c, next) => {
-    c.set("meshContext", {
+    c.set("studioContext", {
       auth: { user: { id: "user-1" } },
       organization: { id: "org-1", slug: "acme" },
       objectStorage,

--- a/apps/mesh/src/api/routes/object-storage.ts
+++ b/apps/mesh/src/api/routes/object-storage.ts
@@ -3,7 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import type { StudioContext } from "@/core/studio-context";
 import { detectContentType, sanitizeKey } from "@/object-storage/key-utils";
 
-type Variables = { meshContext: StudioContext };
+type Variables = { studioContext: StudioContext };
 
 const DEFAULT_EXPIRES_IN = 3600;
 
@@ -69,7 +69,7 @@ export const createObjectStorageRoutes = () => {
   });
 
   app.post("/object-storage/presigned-get/*", async (c) => {
-    const storage = requireStorage(c.get("meshContext"));
+    const storage = requireStorage(c.get("studioContext"));
     const key = keyFromPath(c.req.path, "/object-storage/presigned-get/");
     const body = parsePresignBody(await c.req.json().catch(() => ({})));
     const url = await storage.presignedGetUrl(key, body.expiresIn);
@@ -77,7 +77,7 @@ export const createObjectStorageRoutes = () => {
   });
 
   app.post("/object-storage/presigned-put/*", async (c) => {
-    const storage = requireStorage(c.get("meshContext"));
+    const storage = requireStorage(c.get("studioContext"));
     const key = keyFromPath(c.req.path, "/object-storage/presigned-put/");
     const body = parsePresignBody(await c.req.json().catch(() => ({})));
     const url = await storage.presignedPutUrl(
@@ -89,7 +89,7 @@ export const createObjectStorageRoutes = () => {
   });
 
   app.put("/object-storage/*", async (c) => {
-    const storage = requireStorage(c.get("meshContext"));
+    const storage = requireStorage(c.get("studioContext"));
     const key = keyFromPath(c.req.path, "/object-storage/");
     const bytes = new Uint8Array(await c.req.arrayBuffer());
     const result = await storage.put(key, bytes, {
@@ -99,7 +99,7 @@ export const createObjectStorageRoutes = () => {
   });
 
   app.get("/object-storage/*", async (c) => {
-    const storage = requireStorage(c.get("meshContext"));
+    const storage = requireStorage(c.get("studioContext"));
     const key = keyFromPath(c.req.path, "/object-storage/");
     const [head, bytes] = await Promise.all([
       storage.head(key),
@@ -116,7 +116,7 @@ export const createObjectStorageRoutes = () => {
   });
 
   app.on("HEAD", "/object-storage/*", async (c) => {
-    const storage = requireStorage(c.get("meshContext"));
+    const storage = requireStorage(c.get("studioContext"));
     const key = keyFromPath(c.req.path, "/object-storage/");
     const head = await storage.head(key);
     return c.body(null, 200, {

--- a/apps/mesh/src/api/routes/openai-compat.integration.test.ts
+++ b/apps/mesh/src/api/routes/openai-compat.integration.test.ts
@@ -28,7 +28,7 @@ const ENDPOINT = `/${MOCK_ORG_SLUG}/v1/chat/completions`;
 
 describe("OpenAI-compat: Schema Validation", () => {
   let database: StudioDatabase;
-  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
+  let app: Hono<{ Variables: { studioContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -50,7 +50,7 @@ describe("OpenAI-compat: Schema Validation", () => {
 
     app = new Hono();
     app.use("*", async (c, next) => {
-      c.set("meshContext", ctx);
+      c.set("studioContext", ctx);
       await next();
     });
     app.route("/", openaiCompatRoutes);
@@ -182,7 +182,7 @@ describe("OpenAI-compat: Schema Validation", () => {
 
 describe("OpenAI-compat: Authentication", () => {
   let database: StudioDatabase;
-  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
+  let app: Hono<{ Variables: { studioContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -208,7 +208,7 @@ describe("OpenAI-compat: Authentication", () => {
 
     app = new Hono();
     app.use("*", async (c, next) => {
-      c.set("meshContext", ctx);
+      c.set("studioContext", ctx);
       await next();
     });
     app.route("/", openaiCompatRoutes);
@@ -244,7 +244,7 @@ describe("OpenAI-compat: Authentication", () => {
 
     app = new Hono();
     app.use("*", async (c, next) => {
-      c.set("meshContext", ctx);
+      c.set("studioContext", ctx);
       await next();
     });
     app.route("/", openaiCompatRoutes);
@@ -279,7 +279,7 @@ describe("OpenAI-compat: Authentication", () => {
 
     app = new Hono();
     app.use("*", async (c, next) => {
-      c.set("meshContext", ctx);
+      c.set("studioContext", ctx);
       await next();
     });
     app.route("/", openaiCompatRoutes);
@@ -308,7 +308,7 @@ describe("OpenAI-compat: Authentication", () => {
 
 describe("OpenAI-compat: Authorization", () => {
   let database: StudioDatabase;
-  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
+  let app: Hono<{ Variables: { studioContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -334,7 +334,7 @@ describe("OpenAI-compat: Authorization", () => {
 
     app = new Hono();
     app.use("*", async (c, next) => {
-      c.set("meshContext", ctx);
+      c.set("studioContext", ctx);
       await next();
     });
     app.route("/", openaiCompatRoutes);
@@ -364,7 +364,7 @@ describe("OpenAI-compat: Authorization", () => {
 
 describe("OpenAI-compat: Tools Schema", () => {
   let database: StudioDatabase;
-  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
+  let app: Hono<{ Variables: { studioContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -383,7 +383,7 @@ describe("OpenAI-compat: Tools Schema", () => {
 
     app = new Hono();
     app.use("*", async (c, next) => {
-      c.set("meshContext", ctx);
+      c.set("studioContext", ctx);
       await next();
     });
     app.route("/", openaiCompatRoutes);
@@ -478,7 +478,7 @@ describe("OpenAI-compat: Tools Schema", () => {
 
 describe("OpenAI-compat: Response Format", () => {
   let database: StudioDatabase;
-  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
+  let app: Hono<{ Variables: { studioContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -497,7 +497,7 @@ describe("OpenAI-compat: Response Format", () => {
 
     app = new Hono();
     app.use("*", async (c, next) => {
-      c.set("meshContext", ctx);
+      c.set("studioContext", ctx);
       await next();
     });
     app.route("/", openaiCompatRoutes);
@@ -581,7 +581,7 @@ describe("OpenAI-compat: Response Format", () => {
 
 describe("OpenAI-compat: Message Formats", () => {
   let database: StudioDatabase;
-  let app: Hono<{ Variables: { meshContext: StudioContext } }>;
+  let app: Hono<{ Variables: { studioContext: StudioContext } }>;
 
   beforeEach(async () => {
     database = await connectTestPgDatabase();
@@ -600,7 +600,7 @@ describe("OpenAI-compat: Message Formats", () => {
 
     app = new Hono();
     app.use("*", async (c, next) => {
-      c.set("meshContext", ctx);
+      c.set("studioContext", ctx);
       await next();
     });
     app.route("/", openaiCompatRoutes);

--- a/apps/mesh/src/api/routes/openai-compat.ts
+++ b/apps/mesh/src/api/routes/openai-compat.ts
@@ -412,10 +412,10 @@ function convertFinishReason(
 // Route Handler
 // ============================================================================
 
-const app = new Hono<{ Variables: { meshContext: StudioContext } }>();
+const app = new Hono<{ Variables: { studioContext: StudioContext } }>();
 
 app.post("/:org/v1/chat/completions", async (c) => {
-  const ctx = c.get("meshContext");
+  const ctx = c.get("studioContext");
   const orgSlug = c.req.param("org");
 
   try {

--- a/apps/mesh/src/api/routes/org-fs.integration.test.ts
+++ b/apps/mesh/src/api/routes/org-fs.integration.test.ts
@@ -42,7 +42,7 @@ const USER = "user_fs_api";
 const ASSETS_DIR = `./data/assets/${ORG}`;
 const BASE = `/api/${SLUG}/fs`;
 
-type Variables = { meshContext: StudioContext };
+type Variables = { studioContext: StudioContext };
 
 function buildApp(
   db: StudioDatabase,
@@ -63,7 +63,7 @@ function buildApp(
     );
   }
   app.use("*", async (c, next) => {
-    c.set("meshContext", {
+    c.set("studioContext", {
       auth: authed ? { user: { id: USER } } : {},
       db: db.db,
       baseUrl: "http://test",

--- a/apps/mesh/src/api/routes/org-fs.ts
+++ b/apps/mesh/src/api/routes/org-fs.ts
@@ -61,7 +61,7 @@ import {
 import { buildSkillCatalog } from "@/file-storage/skill-catalog";
 import { detectContentType } from "@/object-storage/key-utils";
 
-type Variables = { meshContext: StudioContext };
+type Variables = { studioContext: StudioContext };
 type Ctx = Context<{ Variables: Variables }>;
 
 /** Hard ceiling on a single uploaded body (matches the per-file quota). */
@@ -379,7 +379,7 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
     volume: string,
     permission: "ORG_FS_READ" | "ORG_FS_WRITE",
   ): Promise<Resolved> => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     if (!ctx.auth?.user?.id) {
       return { ok: false, res: c.json({ error: "Unauthorized" }, 401) };
     }
@@ -417,7 +417,7 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
   // The deployment's configured public skill sets (names only — the UI's
   // root listing). Member-gated like any read.
   app.get("/public-sets", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     if (!ctx.auth?.user?.id) {
       return c.json({ error: "Unauthorized" }, 401);
     }
@@ -428,7 +428,7 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
   // Library page's "Recently added" feed. Volume-less by design, so it
   // lives above the `/:volume/*` routes.
   app.get("/recent", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     if (!ctx.auth?.user?.id) {
       return c.json({ error: "Unauthorized" }, 401);
     }
@@ -457,7 +457,7 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
   // first — the Library's search box. Volume-less by design, so it lives
   // above the `/:volume/*` routes.
   app.get("/search", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     if (!ctx.auth?.user?.id) {
       return c.json({ error: "Unauthorized" }, 401);
     }
@@ -507,7 +507,7 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
   // the agent link picker and the run can never drift on what "a skill" is.
   // Volume-less; lives above the `/:volume/*` routes. Member-gated read.
   app.get("/skills", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     if (!ctx.auth?.user?.id) {
       return c.json({ error: "Unauthorized" }, 401);
     }
@@ -603,7 +603,7 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
   app.get("/:volume/read", async (c) => {
     const volume = c.req.param("volume");
     const path = c.req.query("path") ?? "";
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
 
     let access: ReadAccess = { access: "private" };
     if (
@@ -876,7 +876,7 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
     async (c) => {
       const volume = c.req.param("volume");
       const path = c.req.query("path") ?? "";
-      const ctx = c.get("meshContext");
+      const ctx = c.get("studioContext");
       const orgId = ctx.organization?.id;
       const orgSlug = ctx.organization?.slug ?? "";
       if (

--- a/apps/mesh/src/api/routes/org-sso.ts
+++ b/apps/mesh/src/api/routes/org-sso.ts
@@ -15,7 +15,7 @@ import type { StudioContext } from "../../core/studio-context";
 import { ADMIN_ROLES } from "../../auth/roles";
 
 type Variables = {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
 };
 
 export const createSsoRoutes = () => {
@@ -37,7 +37,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: GET /api/org-sso/status?orgId=<id>
    */
   app.get("/status", async (c) => {
-    const ctx = c.get("meshContext") as StudioContext;
+    const ctx = c.get("studioContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }
@@ -81,7 +81,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: GET /api/org-sso/authorize?orgId=<id>
    */
   app.get("/authorize", async (c) => {
-    const ctx = c.get("meshContext") as StudioContext;
+    const ctx = c.get("studioContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }
@@ -152,7 +152,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: GET /api/org-sso/callback
    */
   app.get("/callback", async (c) => {
-    const ctx = c.get("meshContext") as StudioContext;
+    const ctx = c.get("studioContext") as StudioContext;
 
     const code = c.req.query("code");
     const state = c.req.query("state");
@@ -297,7 +297,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: GET /api/org-sso/config
    */
   app.get("/config", async (c) => {
-    const ctx = c.get("meshContext") as StudioContext;
+    const ctx = c.get("studioContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }
@@ -329,7 +329,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: POST /api/org-sso/config
    */
   app.post("/config", async (c) => {
-    const ctx = c.get("meshContext") as StudioContext;
+    const ctx = c.get("studioContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }
@@ -408,7 +408,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: POST /api/org-sso/config/enforce
    */
   app.post("/config/enforce", async (c) => {
-    const ctx = c.get("meshContext") as StudioContext;
+    const ctx = c.get("studioContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }
@@ -441,7 +441,7 @@ function registerSsoRoutes(app: SsoApp) {
    * Route: DELETE /api/org-sso/config
    */
   app.delete("/config", async (c) => {
-    const ctx = c.get("meshContext") as StudioContext;
+    const ctx = c.get("studioContext") as StudioContext;
     if (!ctx.auth.user) {
       return c.json({ error: "Authentication required" }, 401);
     }

--- a/apps/mesh/src/api/routes/proxy.ts
+++ b/apps/mesh/src/api/routes/proxy.ts
@@ -41,7 +41,7 @@ export { toServerClient, type MCPProxyClient } from "./mcp-proxy-factory";
 
 // Define Hono variables type
 type Variables = {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
 };
 
 type ProxyEnv = { Variables: Variables };
@@ -97,7 +97,7 @@ export const createProxyRoutes = () => {
    * an iframe `srcDoc` (CSP already injected here).
    */
   app.get("/:connectionId/ui-resource", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const connectionId = c.req.param("connectionId");
     const uri = c.req.query("uri");
     if (!uri) return c.json({ error: "uri query param is required" }, 400);
@@ -182,7 +182,7 @@ export const createProxyRoutes = () => {
    */
   app.all("/:connectionId", async (c) => {
     const connectionId = c.req.param("connectionId");
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
 
     // SELF MCP connections ({orgId}_self) route to the management MCP server
     // instead of creating an outbound client connection
@@ -463,7 +463,7 @@ export const createProxyRoutes = () => {
   app.all("/:connectionId/call-tool/:toolName", async (c) => {
     const connectionId = c.req.param("connectionId");
     const toolName = c.req.param("toolName");
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
 
     try {
       // Fetch connection and create client directly

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -123,7 +123,7 @@ function quickFileOpSignal(c: Context<VmEnv>): AbortSignal {
  * that case; other handlers return 503 JSON via `requireRunner()`.
  */
 const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
-  const ctx = c.var.meshContext;
+  const ctx = c.var.studioContext;
   try {
     requireAuth(ctx);
   } catch {
@@ -552,11 +552,11 @@ export const createSandboxRoutes = () => {
     if (step === "start") {
       const claim = c.get("vmClaim");
       if (claim.runner) {
-        const organization = requireOrganization(c.var.meshContext);
+        const organization = requireOrganization(c.var.studioContext);
         const entries = readValidatedRuntimeEnv(claim.virtualMcpMetadata);
         try {
           await resolveAndPushEnv({
-            ctx: c.var.meshContext,
+            ctx: c.var.studioContext,
             runner: claim.runner,
             handle: claim.claimName,
             orgId: organization.id,
@@ -598,7 +598,7 @@ export const createSandboxRoutes = () => {
     }
 
     return handleVmEvents(c as unknown as Context<Env>, {
-      ctx: c.var.meshContext,
+      ctx: c.var.studioContext,
       claimName: claim.claimName,
       runner: claim.runner,
       virtualMcpId: claim.virtualMcpId,
@@ -640,7 +640,7 @@ export const createSandboxRoutes = () => {
     if (runner instanceof Response) return runner;
 
     const { claimName, virtualMcpMetadata, connectionIds } = c.get("vmClaim");
-    const ctx = c.var.meshContext;
+    const ctx = c.var.studioContext;
 
     try {
       await patchSandboxOperator(ctx, runner, claimName);
@@ -675,7 +675,7 @@ export const createSandboxRoutes = () => {
     if (runner instanceof Response) return runner;
 
     const { claimName } = c.get("vmClaim");
-    const ctx = c.var.meshContext;
+    const ctx = c.var.studioContext;
 
     try {
       await patchSandboxOperator(ctx, runner, claimName);
@@ -705,7 +705,7 @@ export const createSandboxRoutes = () => {
       if (runner instanceof Response) return runner;
 
       const { claimName, userId, projectRef } = c.get("vmClaim");
-      const ctx = c.var.meshContext;
+      const ctx = c.var.studioContext;
 
       try {
         const body = (await c.req.json().catch(() => ({}))) as {

--- a/apps/mesh/src/api/routes/self.ts
+++ b/apps/mesh/src/api/routes/self.ts
@@ -12,7 +12,7 @@ import { serveMcpRequest } from "../utils/serve-mcp";
 
 // Define Hono variables type
 type Variables = {
-  meshContext: StudioContext;
+  studioContext: StudioContext;
 };
 
 type SelfEnv = { Variables: Variables };
@@ -27,7 +27,7 @@ export const createSelfRoutes = () => {
    * Exposes all PROJECT_* and CONNECTION_* tools via MCP protocol
    */
   app.all("/", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const server = await managementMCP(ctx);
     const transport = new WebStandardStreamableHTTPServerTransport({
       enableJsonResponse:

--- a/apps/mesh/src/api/routes/thread-outputs.ts
+++ b/apps/mesh/src/api/routes/thread-outputs.ts
@@ -8,7 +8,7 @@
  *
  * Route: GET /api/threads/:threadId/outputs
  *
- * Auth: standard `meshContext` user-session middleware. The thread
+ * Auth: standard `studioContext` user-session middleware. The thread
  * lookup uses `OrgScopedThreadStorage` so an authenticated user can
  * only see threads belonging to their org.
  */
@@ -17,13 +17,13 @@ import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { StudioContext } from "@/core/studio-context";
 
-type Variables = { meshContext: StudioContext };
+type Variables = { studioContext: StudioContext };
 
 export const createThreadOutputsRoutes = () => {
   const app = new Hono<{ Variables: Variables }>();
 
   app.get("/threads/:threadId/outputs", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const userId = ctx.auth?.user?.id;
     if (!userId) {
       throw new HTTPException(401, { message: "Unauthorized" });

--- a/apps/mesh/src/api/routes/tools-rest.ts
+++ b/apps/mesh/src/api/routes/tools-rest.ts
@@ -48,7 +48,7 @@ export const createToolsRestRoutes = () => {
 
   // POST /api/:org/tools/:toolName — call a builtin tool.
   app.post("/:toolName", async (c) => {
-    const ctx = c.get("meshContext");
+    const ctx = c.get("studioContext");
     const toolName = c.req.param("toolName");
 
     // Manual tool-identifier check: 404 if the name isn't part of the builtin

--- a/apps/mesh/src/api/routes/trigger-callback.ts
+++ b/apps/mesh/src/api/routes/trigger-callback.ts
@@ -56,7 +56,7 @@ export function createTriggerCallbackRoutes(deps: TriggerCallbackDeps) {
       }
 
       // Attribute the legacy-route deprecation log to the token's
-      // org/connection — this route has no session-based meshContext.
+      // org/connection — this route has no session-based studioContext.
       c.set("deprecatedRouteAttribution", {
         organizationId: context.organizationId,
         connectionId: context.connectionId,

--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -33,7 +33,7 @@ import { serveMcpRequest } from "../utils/serve-mcp";
 
 export async function handleVirtualMcpRequest(
   c: {
-    get: (key: "meshContext") => StudioContext;
+    get: (key: "studioContext") => StudioContext;
     req: {
       header: (name: string) => string | undefined;
       param: (name: string) => string | undefined;
@@ -44,7 +44,7 @@ export async function handleVirtualMcpRequest(
   },
   virtualMcpId: string | undefined,
 ) {
-  const ctx = c.get("meshContext");
+  const ctx = c.get("studioContext");
 
   try {
     // Prefer x-org-id header (no DB lookup) over x-org-slug (requires DB lookup)

--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -71,7 +71,7 @@ const HEARTBEAT_MS = 15_000;
 export const createVmEventsRoutes = () => {
   const app = new Hono<Env>();
   app.get("/", async (c) => {
-    const ctx = c.var.meshContext;
+    const ctx = c.var.studioContext;
     try {
       requireAuth(ctx);
     } catch {

--- a/apps/mesh/src/api/watch.test.ts
+++ b/apps/mesh/src/api/watch.test.ts
@@ -45,7 +45,7 @@ function makeWatchApp(opts?: {
 
   const app = new Hono<Env>();
   app.use("*", async (c, next) => {
-    c.set("meshContext", ctx);
+    c.set("studioContext", ctx);
     await next();
   });
   app.get("/watch", watchHandler);

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -123,7 +123,7 @@ export async function cleanupOrphanedOrgQueues(pool: Pool): Promise<void> {
 
 export interface AutomationRuntime {
   storage: AutomationsStorage;
-  meshContextFactory: StudioContextFactory;
+  studioContextFactory: StudioContextFactory;
 }
 
 let runtime: AutomationRuntime | null = null;
@@ -204,11 +204,11 @@ async function prepareFireStep(
   if (!automation) return { skip: "not_found" };
   if (!automation.active) return { skip: "inactive" };
 
-  const meshCtx = await rt.meshContextFactory(
+  const studioCtx = await rt.studioContextFactory(
     automation.organization_id,
     automation.created_by,
   );
-  if (!meshCtx) {
+  if (!studioCtx) {
     console.warn(
       `[fireAutomationWorkflow] deactivating "${automation.name}" — creator ${automation.created_by} no longer in org ${automation.organization_id}`,
     );
@@ -245,11 +245,11 @@ async function prepareFireStep(
   // even when the org has Perplexity/Gemini Deep Research configured.
   const [resolved, image, webSearch, deepResearch] = await Promise.all([
     pinned
-      ? resolveSpecificModel(meshCtx, pinned.credentialId, pinned.modelId)
-      : resolveTier(meshCtx, tier),
-    tryResolveTier(meshCtx, "image"),
-    tryResolveTier(meshCtx, "web_search"),
-    tryResolveTier(meshCtx, "deep_research"),
+      ? resolveSpecificModel(studioCtx, pinned.credentialId, pinned.modelId)
+      : resolveTier(studioCtx, tier),
+    tryResolveTier(studioCtx, "image"),
+    tryResolveTier(studioCtx, "web_search"),
+    tryResolveTier(studioCtx, "deep_research"),
   ]);
   const toModel = (r: Awaited<ReturnType<typeof resolveTier>>) => ({
     id: r.modelId,
@@ -342,11 +342,11 @@ async function buildDispatchRequestStep(
 ): Promise<BuildDispatchRequestOutcome> {
   const rt = requireRuntime();
 
-  const meshCtx = await rt.meshContextFactory(
+  const studioCtx = await rt.studioContextFactory(
     automation.organization_id,
     automation.created_by,
   );
-  if (!meshCtx) {
+  if (!studioCtx) {
     return { ok: false, reason: "creator membership lost mid-fire" };
   }
 

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -244,10 +244,10 @@ export class AccessControl {
     try {
       const meta = await this.getToolMeta();
       if (!meta) return false;
-      const meshMeta = meta[MCP_MESH_KEY] as
+      const studioMeta = meta[MCP_MESH_KEY] as
         | Record<string, unknown>
         | undefined;
-      const value = meshMeta?.public_tool;
+      const value = studioMeta?.public_tool;
       return value === true || value === "true";
     } catch {
       return false;

--- a/apps/mesh/src/core/context-factory.integration.test.ts
+++ b/apps/mesh/src/core/context-factory.integration.test.ts
@@ -118,14 +118,14 @@ describe("createStudioContextFactory", () => {
         headers: {}, // No Authorization
       });
 
-      const meshCtx = await factory(request);
+      const studioCtx = await factory(request);
 
-      expect(meshCtx).toBeDefined();
-      expect(meshCtx.auth).toBeDefined();
-      expect(meshCtx.storage).toBeDefined();
-      expect(meshCtx.access).toBeDefined();
-      expect(meshCtx.baseUrl).toBe("https://mesh.example.com");
-      expect(meshCtx.metadata.requestId).toBeDefined();
+      expect(studioCtx).toBeDefined();
+      expect(studioCtx.auth).toBeDefined();
+      expect(studioCtx.storage).toBeDefined();
+      expect(studioCtx.access).toBeDefined();
+      expect(studioCtx.baseUrl).toBe("https://mesh.example.com");
+      expect(studioCtx.metadata.requestId).toBeDefined();
     });
 
     it("should derive base URL from request", async () => {
@@ -146,9 +146,9 @@ describe("createStudioContextFactory", () => {
         headers: {},
       });
 
-      const meshCtx = await factory(request);
+      const studioCtx = await factory(request);
 
-      expect(meshCtx.baseUrl).toBe("http://localhost:3000");
+      expect(studioCtx.baseUrl).toBe("http://localhost:3000");
     });
 
     it("should populate request metadata", async () => {
@@ -172,11 +172,11 @@ describe("createStudioContextFactory", () => {
         },
       });
 
-      const meshCtx = await factory(request);
+      const studioCtx = await factory(request);
 
-      expect(meshCtx.metadata.userAgent).toBe("Test/1.0");
-      expect(meshCtx.metadata.ipAddress).toBe("192.168.1.1");
-      expect(meshCtx.metadata.timestamp).toBeInstanceOf(Date);
+      expect(studioCtx.metadata.userAgent).toBe("Test/1.0");
+      expect(studioCtx.metadata.ipAddress).toBe("192.168.1.1");
+      expect(studioCtx.metadata.timestamp).toBeInstanceOf(Date);
     });
   });
 
@@ -196,12 +196,12 @@ describe("createStudioContextFactory", () => {
 
       const request = createMockRequest();
 
-      const meshCtx = await factory(request);
+      const studioCtx = await factory(request);
 
-      expect(meshCtx.organization).toBeDefined();
-      expect(meshCtx.organization?.id).toBe("org_123");
-      expect(meshCtx.organization?.slug).toBe("test-org");
-      expect(meshCtx.organization?.name).toBe("Test Organization");
+      expect(studioCtx.organization).toBeDefined();
+      expect(studioCtx.organization?.id).toBe("org_123");
+      expect(studioCtx.organization?.slug).toBe("test-org");
+      expect(studioCtx.organization?.name).toBe("Test Organization");
     });
 
     it("should work without organization (system-level)", async () => {
@@ -233,9 +233,9 @@ describe("createStudioContextFactory", () => {
       });
 
       const request = createMockRequest();
-      const meshCtx = await factory(request);
+      const studioCtx = await factory(request);
 
-      expect(meshCtx.organization).toBeUndefined();
+      expect(studioCtx.organization).toBeUndefined();
     });
   });
 
@@ -258,10 +258,10 @@ describe("createStudioContextFactory", () => {
         headers: {},
       });
 
-      const meshCtx = await factory(request);
+      const studioCtx = await factory(request);
 
-      expect(meshCtx.storage.connections).toBeDefined();
-      expect(meshCtx.storage.organizationSettings).toBeDefined();
+      expect(studioCtx.storage.connections).toBeDefined();
+      expect(studioCtx.storage.organizationSettings).toBeDefined();
     });
   });
 
@@ -284,12 +284,12 @@ describe("createStudioContextFactory", () => {
         headers: {},
       });
 
-      const meshCtx = await factory(request);
+      const studioCtx = await factory(request);
 
-      expect(meshCtx.access).toBeDefined();
-      expect(meshCtx.access.granted).toBeDefined();
-      expect(meshCtx.access.check).toBeDefined();
-      expect(meshCtx.access.grant).toBeDefined();
+      expect(studioCtx.access).toBeDefined();
+      expect(studioCtx.access.granted).toBeDefined();
+      expect(studioCtx.access.check).toBeDefined();
+      expect(studioCtx.access.grant).toBeDefined();
     });
   });
 
@@ -334,13 +334,13 @@ describe("createStudioContextFactory", () => {
         headers: { Authorization: "Bearer api_key_org_a" },
       });
 
-      const meshCtx = await factory(request);
+      const studioCtx = await factory(request);
 
       // Organization should be extracted from API key metadata
-      expect(meshCtx.organization).toBeDefined();
-      expect(meshCtx.organization?.id).toBe("org_a");
-      expect(meshCtx.organization?.slug).toBe("org-a");
-      expect(meshCtx.organization?.name).toBe("Organization A");
+      expect(studioCtx.organization).toBeDefined();
+      expect(studioCtx.organization?.id).toBe("org_a");
+      expect(studioCtx.organization?.slug).toBe("org-a");
+      expect(studioCtx.organization?.name).toBe("Organization A");
     });
 
     it("should have undefined organization when API key has no org metadata", async () => {
@@ -376,10 +376,10 @@ describe("createStudioContextFactory", () => {
         headers: { Authorization: "Bearer api_key_no_org" },
       });
 
-      const meshCtx = await factory(request);
+      const studioCtx = await factory(request);
 
       // Organization should be undefined when not in API key metadata
-      expect(meshCtx.organization).toBeUndefined();
+      expect(studioCtx.organization).toBeUndefined();
     });
 
     it("should set different organizations for different API keys", async () => {

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -1385,12 +1385,12 @@ export async function createStudioContextFactory(
     });
 
     // Build auth object for StudioContext
-    const meshAuth: StudioContext["auth"] = {
+    const studioAuth: StudioContext["auth"] = {
       user: authResult.user,
     };
 
     if (authResult.apiKeyId) {
-      meshAuth.apiKey = {
+      studioAuth.apiKey = {
         id: authResult.apiKeyId,
         name: "", // Not needed for access control
         userId: "", // Not needed for access control
@@ -1407,7 +1407,7 @@ export async function createStudioContextFactory(
 
     // Create AccessControl instance with bound auth client
     const access = new AccessControl(
-      meshAuth.user?.id,
+      studioAuth.user?.id,
       undefined, // toolName set later by defineTool
       boundAuth, // Bound auth client for permission checks
       authResult.role, // Role from session (for built-in role bypass)
@@ -1460,7 +1460,7 @@ export async function createStudioContextFactory(
 
     const ctx: StudioContext = {
       timings,
-      auth: meshAuth,
+      auth: studioAuth,
       connectionId,
       organization,
       storage,

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,9 +1,9 @@
 {
   "auth/install-studio-pack-workflow.ts": "a0bc8a8c62a62c7978c11676d67397f7116b3903579091e9b85ef7ef67b04ce5",
-  "automations/dbos-workflow.ts": "76f03ce0e787209aacbe2ac128cb50c6d12eb513b7e0c7ae463401544de43127",
-  "dispatch-queue/hosted-harness-workflow.ts": "4caf3a360104c5ba7b0559895208234f39e819157d0ac31955f64ed94a88ed95",
-  "dispatch-queue/thread-gate-workflow.ts": "2e63fcff27fb5109f2264d31d455dbbfb1b3f18ce46c0eb3075ca6b0266fe379",
+  "automations/dbos-workflow.ts": "18471f9fda4e16afda73f11a894f48eb8e7f2eb4539eed195c5563a63082a82c",
+  "dispatch-queue/hosted-harness-workflow.ts": "cba081506ab82e6c546cc55f13ef03ea23567a612f5d9f5c8856f5dca876119e",
+  "dispatch-queue/thread-gate-workflow.ts": "674cd393ad3b06806e967389dfe7e87bd0de6ba933fd54df1e5cd24a08b99e43",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",
-  "harnesses/decopilot/background-tool-workflow.ts": "16ef60a6df35498b877ed27ca3a41046dbb165089075cabdcb48aed54512e4f8",
+  "harnesses/decopilot/background-tool-workflow.ts": "a47d58f9dc4850c45cc3fbea65666e9beea6a3d61081934b984fd8b34c4798e3",
   "monitoring/dbos-retention-workflow.ts": "b43e3596b386b53faf372b140d9137a12252565987543640d17f7798504b8dbb"
 }

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.test.ts
@@ -173,7 +173,7 @@ describe("hostedHarnessWorkflowFn's try/catch contract (Finding 1)", () => {
     } as unknown as NonNullable<HostedHarnessRuntime["deps"]["streamBuffer"]>;
     const rt: HostedHarnessRuntime = {
       dispatchRunFn,
-      meshContextFactory: async () => null,
+      studioContextFactory: async () => null,
       deps: {
         runRegistry: {} as HostedHarnessRuntime["deps"]["runRegistry"],
         cancelBroadcast: {} as HostedHarnessRuntime["deps"]["cancelBroadcast"],
@@ -249,7 +249,7 @@ describe("half-terminal invariant (T9 proof obligation 1): done is never publish
     } as unknown as NonNullable<HostedHarnessRuntime["deps"]["streamBuffer"]>;
     setHostedHarnessRuntime({
       dispatchRunFn: mock(() => Promise.resolve({ taskId: "t" })),
-      meshContextFactory: async () => null,
+      studioContextFactory: async () => null,
       deps: {
         runRegistry: {} as HostedHarnessRuntime["deps"]["runRegistry"],
         cancelBroadcast: {} as HostedHarnessRuntime["deps"]["cancelBroadcast"],
@@ -273,7 +273,7 @@ describe("half-terminal invariant (T9 proof obligation 1): done is never publish
     } as unknown as NonNullable<HostedHarnessRuntime["deps"]["streamBuffer"]>;
     setHostedHarnessRuntime({
       dispatchRunFn: mock(() => Promise.resolve({ taskId: "t" })),
-      meshContextFactory: async () => null,
+      studioContextFactory: async () => null,
       deps: {
         runRegistry: {} as HostedHarnessRuntime["deps"]["runRegistry"],
         cancelBroadcast: {} as HostedHarnessRuntime["deps"]["cancelBroadcast"],
@@ -298,7 +298,7 @@ describe("half-terminal invariant (T9 proof obligation 1): done is never publish
     } as unknown as NonNullable<HostedHarnessRuntime["deps"]["streamBuffer"]>;
     setHostedHarnessRuntime({
       dispatchRunFn: mock(() => Promise.reject(dispatchErr)),
-      meshContextFactory: async () => null,
+      studioContextFactory: async () => null,
       deps: {
         runRegistry: {} as HostedHarnessRuntime["deps"]["runRegistry"],
         cancelBroadcast: {} as HostedHarnessRuntime["deps"]["cancelBroadcast"],

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
@@ -139,7 +139,7 @@ export interface HostedHarnessRuntime {
   /** The hosted in-process agent loop — `dispatchRunAndWait` in production. */
   dispatchRunFn: DispatchRunAndWaitFn;
   /** Resolves a StudioContext for an (org, user) pair (membership-checked). */
-  meshContextFactory: StudioContextFactory;
+  studioContextFactory: StudioContextFactory;
   deps: Pick<
     DispatchRunDeps,
     "runRegistry" | "cancelBroadcast" | "streamBuffer" | "sseHub"
@@ -189,10 +189,10 @@ export async function runHostedHarness(
   const rt = requireRuntime();
   const { request } = input;
 
-  const meshCtx =
+  const studioCtx =
     ctx ??
-    (await rt.meshContextFactory(request.organizationId, request.userId));
-  if (!meshCtx) {
+    (await rt.studioContextFactory(request.organizationId, request.userId));
+  if (!studioCtx) {
     // Throw so DBOS records the step (and the workflow) as failed. Swallowing
     // would mark it SUCCESS and break retry / failure tooling.
     throw new Error("user membership lost mid-dispatch");
@@ -201,7 +201,7 @@ export async function runHostedHarness(
   // Carry per-run metadata (from a webhook trigger's run_metadata) onto the run
   // context so every downstream MCP tool call forwards it as x-mesh-run-metadata.
   if (request.runMetadata) {
-    meshCtx.metadata.runMetadata = request.runMetadata;
+    studioCtx.metadata.runMetadata = request.runMetadata;
   }
 
   // No wall-clock cap: a hosted run lives as long as it makes progress. The
@@ -217,7 +217,7 @@ export async function runHostedHarness(
   try {
     await rt.dispatchRunFn(
       { ...request, abortSignal: abortController.signal },
-      meshCtx,
+      studioCtx,
       rt.deps,
     );
   } finally {

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.test.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.test.ts
@@ -21,7 +21,7 @@ describe("threadGateWorkflow plumbing", () => {
 
   it("setThreadGateRuntime accepts a runtime shape", () => {
     const rt: ThreadGateRuntime = {
-      meshContextFactory: async () => null,
+      studioContextFactory: async () => null,
       deps: {
         runRegistry: {} as ThreadGateRuntime["deps"]["runRegistry"],
         cancelBroadcast: {} as ThreadGateRuntime["deps"]["cancelBroadcast"],

--- a/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/thread-gate-workflow.ts
@@ -161,7 +161,7 @@ export type StudioContextFactory = (
 ) => Promise<StudioContext | null>;
 
 export interface ThreadGateRuntime {
-  meshContextFactory: StudioContextFactory;
+  studioContextFactory: StudioContextFactory;
   deps: Pick<
     DispatchRunDeps,
     "runRegistry" | "cancelBroadcast" | "streamBuffer" | "sseHub"
@@ -271,11 +271,11 @@ async function dispatchRunAndWaitStep(
     await publishRunStatusStage(rt.deps.streamBuffer, taskId, "starting-run");
   }
 
-  const meshCtx = await rt.meshContextFactory(
+  const studioCtx = await rt.studioContextFactory(
     request.organizationId,
     request.userId,
   );
-  if (!meshCtx) {
+  if (!studioCtx) {
     // Throw so DBOS records the step (and the workflow) as failed.
     // Swallowing into `{error}` would mark the workflow SUCCESS and
     // break retry / failure tooling.
@@ -307,7 +307,7 @@ async function dispatchRunAndWaitStep(
   const { runFenceToken, claimedRequest, shouldPersistFence } =
     claimRunFenceForDispatch(request);
   if (shouldPersistFence) {
-    await meshCtx.storage.threads.setRunFence(fenceThreadId, runFenceToken);
+    await studioCtx.storage.threads.setRunFence(fenceThreadId, runFenceToken);
   }
 
   if (executionSite === "cluster") {
@@ -362,7 +362,7 @@ async function dispatchRunAndWaitStep(
       orgSlug,
     } = await rt.prepareLinkWorkFn!(
       { ...claimedRequest, abortSignal: abortController.signal },
-      meshCtx,
+      studioCtx,
       rt.deps,
     );
     if (linkFenceToken !== runFenceToken) {
@@ -420,7 +420,7 @@ async function dispatchRunAndWaitStep(
         `[thread-gate] link work publish failed for run=${taskId}; marking failed`,
         err,
       );
-      await meshCtx.storage.threads.forceFailIfInProgress(taskId);
+      await studioCtx.storage.threads.forceFailIfInProgress(taskId);
       return { runFenceToken };
     }
 

--- a/apps/mesh/src/file-storage/mount/webdav.integration.test.ts
+++ b/apps/mesh/src/file-storage/mount/webdav.integration.test.ts
@@ -41,12 +41,12 @@ const VOLUME = "skills";
 const ASSETS_DIR = `./data/assets/${ORG}`;
 const HOOK_TIMEOUT_MS = 30_000;
 
-type Variables = { meshContext: StudioContext };
+type Variables = { studioContext: StudioContext };
 
 function buildMeshApp(db: StudioDatabase) {
   const app = new Hono<{ Variables: Variables }>();
   app.use("*", async (c, next) => {
-    c.set("meshContext", {
+    c.set("studioContext", {
       auth: { user: { id: USER } },
       db: db.db,
       baseUrl: "http://test",

--- a/apps/mesh/src/harnesses/decopilot/background-tool-workflow.ts
+++ b/apps/mesh/src/harnesses/decopilot/background-tool-workflow.ts
@@ -69,7 +69,7 @@ export interface BackgroundToolContext extends BackgroundToolSnapshot {
 }
 
 export interface BackgroundToolRuntime {
-  meshContextFactory: StudioContextFactory;
+  studioContextFactory: StudioContextFactory;
   /** Enqueue via a decoupled `DBOSClient` — `DBOS.startWorkflow` is illegal
    *  inside the agent-loop step that fires the backgroundable tool. */
   systemDatabaseUrl: string;
@@ -136,13 +136,13 @@ function toModelInfo(
 /** Re-resolve the org's chat ("smart") + image + web_search + deep_research
  *  tiers into a `ModelsConfig`, same as the interactive chat path. */
 async function resolveReactionModels(
-  meshCtx: StudioContext,
+  studioCtx: StudioContext,
 ): Promise<ModelsConfig> {
   const [chat, image, webSearch, deepResearch] = await Promise.all([
-    resolveTier(meshCtx, "smart"),
-    tryResolveTier(meshCtx, "image"),
-    tryResolveTier(meshCtx, "web_search"),
-    tryResolveTier(meshCtx, "deep_research"),
+    resolveTier(studioCtx, "smart"),
+    tryResolveTier(studioCtx, "image"),
+    tryResolveTier(studioCtx, "web_search"),
+    tryResolveTier(studioCtx, "deep_research"),
   ]);
   return {
     credentialId: chat.credentialId,
@@ -172,16 +172,16 @@ async function resolveReactionModels(
 async function requireMeshContext(
   ctx: BackgroundToolContext,
 ): Promise<StudioContext> {
-  const meshCtx = await requireRuntime().meshContextFactory(
+  const studioCtx = await requireRuntime().studioContextFactory(
     ctx.orgId,
     ctx.userId,
   );
-  if (!meshCtx) {
+  if (!studioCtx) {
     throw new Error(
       `[background-tool] mesh context unavailable for org ${ctx.orgId} user ${ctx.userId}`,
     );
   }
-  return meshCtx;
+  return studioCtx;
 }
 
 /** Resolve a thread row's dispatch target + harness (hosted vs desktop link). */
@@ -250,7 +250,7 @@ interface BackgroundProducer {
 /** Workflow-provided context + parts sink handed to each producer. */
 interface BackgroundJob {
   ctx: BackgroundToolContext;
-  meshContext(): Promise<StudioContext>;
+  studioContext(): Promise<StudioContext>;
   /** Append the job's terminal assistant message as a recorded step. */
   emitFinal(parts: AnyMessage["parts"]): Promise<void>;
 }
@@ -258,7 +258,7 @@ interface BackgroundJob {
 function makeJob(ctx: BackgroundToolContext): BackgroundJob {
   return {
     ctx,
-    meshContext: () => requireMeshContext(ctx),
+    studioContext: () => requireMeshContext(ctx),
     emitFinal: (parts) =>
       DBOS.runStep(() => appendPartsStep(ctx, parts), { name: "appendResult" }),
   };
@@ -346,8 +346,8 @@ function extractAssistantText(
 async function runSubtaskStep(
   ctx: BackgroundToolContext,
 ): Promise<{ report: string; finishReason: string; models: ModelsConfig }> {
-  const meshCtx = await requireMeshContext(ctx);
-  const organization = meshCtx.organization;
+  const studioCtx = await requireMeshContext(ctx);
+  const organization = studioCtx.organization;
   if (!organization) {
     throw new Error(
       `[background-tool] organization context unavailable for subtask (org ${ctx.orgId})`,
@@ -356,8 +356,8 @@ async function runSubtaskStep(
   const input = ctx.input as { prompt: string; agent_id?: string };
   const isSelf = !input.agent_id || input.agent_id === ctx.agentId;
   const targetId = isSelf ? ctx.agentId : input.agent_id!;
-  const models = await resolveReactionModels(meshCtx);
-  const provider = await meshCtx.aiProviders.activate(
+  const models = await resolveReactionModels(studioCtx);
+  const provider = await studioCtx.aiProviders.activate(
     models.credentialId,
     ctx.orgId,
   );
@@ -370,7 +370,7 @@ async function runSubtaskStep(
     ...(models.deepResearch ? { deepResearch: models.deepResearch } : {}),
   };
   const { mcpClient, targetKind, targetRef } = await resolveSubagent(
-    meshCtx,
+    studioCtx,
     ctx.orgId,
     targetId,
     { superUser: isSelf },
@@ -385,13 +385,16 @@ async function runSubtaskStep(
   const webSearchInfo = harnessModels.webSearch;
   const deepInfo = harnessModels.deepResearch;
   const imageProvider = imageInfo?.credentialId
-    ? await meshCtx.aiProviders.activate(imageInfo.credentialId, ctx.orgId)
+    ? await studioCtx.aiProviders.activate(imageInfo.credentialId, ctx.orgId)
     : null;
   const webSearchProvider = webSearchInfo?.credentialId
-    ? await meshCtx.aiProviders.activate(webSearchInfo.credentialId, ctx.orgId)
+    ? await studioCtx.aiProviders.activate(
+        webSearchInfo.credentialId,
+        ctx.orgId,
+      )
     : null;
   const deepResearchProvider = deepInfo?.credentialId
-    ? await meshCtx.aiProviders.activate(deepInfo.credentialId, ctx.orgId)
+    ? await studioCtx.aiProviders.activate(deepInfo.credentialId, ctx.orgId)
     : null;
   const subagentBuiltInParams = {
     provider,
@@ -435,7 +438,7 @@ async function runSubtaskStep(
   try {
     const handle = await runAgentLoop({
       kind: "subagent",
-      ctx: meshCtx,
+      ctx: studioCtx,
       organization,
       virtualMcp: targetRef,
       mcpClient: mcpClient as never,
@@ -487,7 +490,7 @@ async function runSubtaskStep(
     // Persist under runId=jobId but thread_id=the originating thread, so the
     // rows belong to the thread yet group under the job for nesting.
     const emitter = new PartEmitter({
-      storage: meshCtx.storage.threads.messageParts(),
+      storage: studioCtx.storage.threads.messageParts(),
       orgId: ctx.orgId,
       threadId: ctx.threadId,
       runId: ctx.jobId,
@@ -528,13 +531,13 @@ async function runSubtaskStep(
 async function runGenerateImageStep(
   job: BackgroundJob,
 ): Promise<{ result: GenerateImageResult; models: ModelsConfig }> {
-  const meshCtx = await job.meshContext();
-  const models = await resolveReactionModels(meshCtx);
+  const studioCtx = await job.studioContext();
+  const models = await resolveReactionModels(studioCtx);
   const image = models.image;
   if (!image?.credentialId) {
     throw new Error("[background-tool] no image model configured for org");
   }
-  const provider = await meshCtx.aiProviders.activate(
+  const provider = await studioCtx.aiProviders.activate(
     image.credentialId,
     job.ctx.orgId,
   );
@@ -548,7 +551,7 @@ async function runGenerateImageStep(
       {
         provider,
         imageModelInfo: { id: image.id },
-        objectStorage: meshCtx.objectStorage,
+        objectStorage: studioCtx.objectStorage,
         allowHttpExternalUrls: getSettings().localMode,
         abortSignal: ac.signal,
       },
@@ -565,13 +568,13 @@ async function appendPartsStep(
   ctx: BackgroundToolContext,
   parts: AnyMessage["parts"],
 ): Promise<void> {
-  const meshCtx = await requireMeshContext(ctx);
-  const thread = await meshCtx.storage.threads.get(ctx.threadId);
+  const studioCtx = await requireMeshContext(ctx);
+  const thread = await studioCtx.storage.threads.get(ctx.threadId);
   if (!thread) {
     throw new Error(`[background-tool] thread ${ctx.threadId} not found`);
   }
   const emitter = new PartEmitter({
-    storage: meshCtx.storage.threads.messageParts(),
+    storage: studioCtx.storage.threads.messageParts(),
     orgId: ctx.orgId,
     threadId: ctx.threadId,
     runId: ctx.jobId,
@@ -605,12 +608,12 @@ export async function deliverBackgroundSubtaskResult(args: {
     input: {},
     toolCallId: `${jobId}:deliver`,
   };
-  const meshCtx = await requireMeshContext(ctx);
+  const studioCtx = await requireMeshContext(ctx);
   const hasReport = report.trim().length > 0;
 
   // 1. Persist the report nested under the subtask card (metadata.subtaskJobId).
   const emitter = new PartEmitter({
-    storage: meshCtx.storage.threads.messageParts(),
+    storage: studioCtx.storage.threads.messageParts(),
     orgId: snapshot.orgId,
     threadId: snapshot.threadId,
     runId: jobId,
@@ -629,9 +632,9 @@ export async function deliverBackgroundSubtaskResult(args: {
   } as any);
 
   // 2. Enqueue the reaction turn, carrying the report in the nudge.
-  const models = await resolveReactionModels(meshCtx);
+  const models = await resolveReactionModels(studioCtx);
   const { target, harnessId } = resolveThreadTarget(
-    await meshCtx.storage.threads.get(snapshot.threadId),
+    await studioCtx.storage.threads.get(snapshot.threadId),
   );
   const nudge = hasReport
     ? `The background subtask you started has completed. Its result:\n\n${report}\n\nUse this to continue with the user's request — do NOT call subtask again for this.`
@@ -654,12 +657,12 @@ export async function deliverBackgroundSubtaskResult(args: {
 async function resolveReactionTargetStep(
   ctx: BackgroundToolContext,
 ): Promise<{ target: DispatchTarget; harnessId: HarnessId | null } | null> {
-  const meshCtx = await requireRuntime().meshContextFactory(
+  const studioCtx = await requireRuntime().studioContextFactory(
     ctx.orgId,
     ctx.userId,
   );
-  if (!meshCtx) return null;
-  return resolveThreadTarget(await meshCtx.storage.threads.get(ctx.threadId));
+  if (!studioCtx) return null;
+  return resolveThreadTarget(await studioCtx.storage.threads.get(ctx.threadId));
 }
 
 /** Re-enter the per-thread gate so the agent reacts to the delivered result.

--- a/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
+++ b/apps/mesh/src/mcp-clients/outbound/transports/auth.ts
@@ -190,8 +190,8 @@ export class AuthTransport extends WrapperTransport {
       return false;
     }
 
-    const meshMeta = tool._meta[MCP_MESH_KEY];
-    return meshMeta?.public_tool === true;
+    const studioMeta = tool._meta[MCP_MESH_KEY];
+    return studioMeta?.public_tool === true;
   }
 
   private stripMetaFromArguments(request: JSONRPCRequest): void {

--- a/apps/mesh/src/observability/middleware.ts
+++ b/apps/mesh/src/observability/middleware.ts
@@ -108,18 +108,21 @@ export const tracingMiddleware: MiddlewareHandler<Env> = async (c, next) => {
         span.setAttribute("http.response.status_code", status);
 
         // Add mesh-specific attributes if available
-        const meshContext = c.get("meshContext");
-        if (meshContext) {
-          if (meshContext.auth.user?.id) {
-            span.setAttribute("studio.user.id", meshContext.auth.user.id);
+        const studioContext = c.get("studioContext");
+        if (studioContext) {
+          if (studioContext.auth.user?.id) {
+            span.setAttribute("studio.user.id", studioContext.auth.user.id);
           }
-          if (meshContext.auth.apiKey?.id) {
-            span.setAttribute("studio.api_key.id", meshContext.auth.apiKey.id);
+          if (studioContext.auth.apiKey?.id) {
+            span.setAttribute(
+              "studio.api_key.id",
+              studioContext.auth.apiKey.id,
+            );
           }
-          if (meshContext.organization?.id) {
+          if (studioContext.organization?.id) {
             span.setAttribute(
               "studio.organization.id",
-              meshContext.organization.id,
+              studioContext.organization.id,
             );
           }
         }

--- a/apps/mesh/src/storage/registry/registry-item.ts
+++ b/apps/mesh/src/storage/registry/registry-item.ts
@@ -52,7 +52,7 @@ function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
   }
 }
 
-function getMeshMeta(meta?: RegistryItemMeta): MeshRegistryMeta {
+function getStudioMeta(meta?: RegistryItemMeta): MeshRegistryMeta {
   return meta?.["mcp.mesh"] ?? {};
 }
 
@@ -215,9 +215,9 @@ export class RegistryItemStorage {
   ): Promise<PrivateRegistryItemEntity> {
     const now = new Date().toISOString();
     const meta = input._meta ?? {};
-    const meshMeta = getMeshMeta(meta);
-    const tags = normalizeStringList(meshMeta.tags);
-    const categories = normalizeStringList(meshMeta.categories);
+    const studioMeta = getStudioMeta(meta);
+    const tags = normalizeStringList(studioMeta.tags);
+    const categories = normalizeStringList(studioMeta.categories);
 
     const row: Insertable<PrivateRegistryDatabase["private_registry_item"]> = {
       id: input.id,
@@ -289,9 +289,9 @@ export class RegistryItemStorage {
     }
 
     const mergedMeta = input._meta ?? current._meta ?? {};
-    const meshMeta = getMeshMeta(mergedMeta);
-    const tags = normalizeStringList(meshMeta.tags);
-    const categories = normalizeStringList(meshMeta.categories);
+    const studioMeta = getStudioMeta(mergedMeta);
+    const tags = normalizeStringList(studioMeta.tags);
+    const categories = normalizeStringList(studioMeta.categories);
 
     const update: Updateable<PrivateRegistryDatabase["private_registry_item"]> =
       {

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -54,7 +54,7 @@ export class OrgScopedThreadStorage {
   /**
    * Rebind this storage to a different org id.
    * Called by `resolveOrgFromPath` middleware after the org is resolved from
-   * the URL slug — meshContext is constructed eagerly, so when no `x-org-id`
+   * the URL slug — studioContext is constructed eagerly, so when no `x-org-id`
    * header is present the storage starts with `organizationId = undefined`
    * and must be updated in-place once the path-resolved org is known.
    */

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -548,12 +548,12 @@ function CatalogItemCard({
 
   const appName = getRegistryItemAppName(item) ?? "";
   const isConnected = connectedAppNames.has(appName);
-  const meshMeta = item._meta?.["mcp.mesh"] as
+  const studioMeta = item._meta?.["mcp.mesh"] as
     | Record<string, string>
     | undefined;
   const title =
-    meshMeta?.friendlyName ||
-    meshMeta?.friendly_name ||
+    studioMeta?.friendlyName ||
+    studioMeta?.friendly_name ||
     item.server?.title ||
     item.title ||
     item.server?.name ||

--- a/apps/mesh/src/web/utils/extract-connection-data.ts
+++ b/apps/mesh/src/web/utils/extract-connection-data.ts
@@ -21,8 +21,8 @@ import { generatePrefixedId } from "@/shared/utils/generate-id";
 export function getRegistryItemAppName(
   item: Pick<RegistryItem, "_meta" | "server">,
 ): string | null {
-  const meshMeta = item._meta?.["mcp.mesh"];
-  return meshMeta?.appName || item.server?.name || null;
+  const studioMeta = item._meta?.["mcp.mesh"];
+  return studioMeta?.appName || item.server?.name || null;
 }
 
 /**
@@ -76,12 +76,12 @@ export function extractConnectionData(
   options?: ExtractConnectionDataOptions,
 ) {
   const server = item.server as MCPRegistryServer["server"] | undefined;
-  const meshMeta = item._meta?.[MCP_MESH_DECOCMS_KEY];
+  const studioMeta = item._meta?.[MCP_MESH_DECOCMS_KEY];
   const now = new Date().toISOString();
 
   const baseName =
-    meshMeta?.friendlyName ||
-    meshMeta?.friendly_name ||
+    studioMeta?.friendlyName ||
+    studioMeta?.friendly_name ||
     item.title ||
     server?.title ||
     server?.name ||
@@ -93,7 +93,7 @@ export function extractConnectionData(
   const icon =
     server?.icons?.[0]?.src || getGitHubAvatarUrl(server?.repository) || null;
 
-  const rawOauthConfig = meshMeta?.oauth_config as
+  const rawOauthConfig = studioMeta?.oauth_config as
     | Record<string, unknown>
     | null
     | undefined;
@@ -108,11 +108,11 @@ export function extractConnectionData(
       ? (rawOauthConfig as unknown as OAuthConfig)
       : null;
 
-  const configState = meshMeta?.configuration_state as
+  const configState = studioMeta?.configuration_state as
     | Record<string, unknown>
     | null
     | undefined;
-  const configScopes = meshMeta?.configuration_scopes as
+  const configScopes = studioMeta?.configuration_scopes as
     | string[]
     | null
     | undefined;
@@ -199,7 +199,7 @@ export function extractConnectionData(
     description,
     icon,
     app_name: getRegistryItemAppName(item),
-    app_id: meshMeta?.id || item.id || null,
+    app_id: studioMeta?.id || item.id || null,
     connection_type: connectionType,
     connection_url: connectionUrl,
     connection_token: null as string | null,
@@ -210,10 +210,10 @@ export function extractConnectionData(
     metadata: {
       source: "store",
       registry_item_id: item.id,
-      verified: meshMeta?.verified ?? false,
-      scopeName: meshMeta?.scopeName ?? null,
-      toolsCount: meshMeta?.tools?.length ?? 0,
-      publishedAt: meshMeta?.publishedAt ?? null,
+      verified: studioMeta?.verified ?? false,
+      scopeName: studioMeta?.scopeName ?? null,
+      toolsCount: studioMeta?.tools?.length ?? 0,
+      publishedAt: studioMeta?.publishedAt ?? null,
       repository,
     },
     created_at: now,

--- a/apps/mesh/src/web/views/registry/registry-requests-page.tsx
+++ b/apps/mesh/src/web/views/registry/registry-requests-page.tsx
@@ -84,12 +84,12 @@ function getReadmeMeta(request: PublishRequest): {
   readmeContent: string;
   readmeUrl: string;
 } {
-  const meshMeta = request._meta?.["mcp.mesh"];
+  const studioMeta = request._meta?.["mcp.mesh"];
   return {
-    hasReadmeContent: Boolean(meshMeta?.readme?.trim()),
-    hasReadmeLink: Boolean(meshMeta?.readme_url?.trim()),
-    readmeContent: meshMeta?.readme?.trim() ?? "",
-    readmeUrl: meshMeta?.readme_url?.trim() ?? "",
+    hasReadmeContent: Boolean(studioMeta?.readme?.trim()),
+    hasReadmeLink: Boolean(studioMeta?.readme_url?.trim()),
+    readmeContent: studioMeta?.readme?.trim() ?? "",
+    readmeUrl: studioMeta?.readme_url?.trim() ?? "",
   };
 }
 

--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -252,7 +252,7 @@ function ConnectionDialogContent({
         const appName = getRegistryItemAppName(item);
         if (appName && connectedAppNames.has(appName)) return false;
         if (!searchLower) return true;
-        const meshMeta = item._meta?.["mcp.mesh"];
+        const studioMeta = item._meta?.["mcp.mesh"];
         const haystack = [
           item.title,
           item.description,
@@ -260,8 +260,8 @@ function ConnectionDialogContent({
           item.server?.title,
           item.server?.description,
           item.server?.name,
-          meshMeta?.friendly_name,
-          meshMeta?.friendlyName,
+          studioMeta?.friendly_name,
+          studioMeta?.friendlyName,
         ]
           .filter(Boolean)
           .join(" ")
@@ -391,10 +391,10 @@ function ConnectionDialogContent({
 
   // Render a catalog item card — no instances yet
   const renderCatalogItem = (item: RegistryItem) => {
-    const meshMeta = item._meta?.["mcp.mesh"];
+    const studioMeta = item._meta?.["mcp.mesh"];
     const title =
-      meshMeta?.friendlyName ||
-      meshMeta?.friendly_name ||
+      studioMeta?.friendlyName ||
+      studioMeta?.friendly_name ||
       item.server?.title ||
       item.title ||
       item.server?.name ||
@@ -406,9 +406,9 @@ function ConnectionDialogContent({
       item.server?.icons?.[0]?.src ||
       getGitHubAvatarUrl(item.server?.repository) ||
       null;
-    const isOfficial = meshMeta?.official === true;
-    const isVerified = meshMeta?.verified === true;
-    const isMadeByDeco = meshMeta?.owner === "deco";
+    const isOfficial = studioMeta?.official === true;
+    const isVerified = studioMeta?.verified === true;
+    const isMadeByDeco = studioMeta?.owner === "deco";
 
     return (
       <ConnectionCard
@@ -465,7 +465,7 @@ function ConnectionDialogContent({
                   action: "connect_new",
                   registry_item_id: item.id,
                   app_name:
-                    meshMeta?.friendlyName ||
+                    studioMeta?.friendlyName ||
                     item.server?.name ||
                     item.name ||
                     null,


### PR DESCRIPTION
## Summary

Task 03 of the de-mesh migration: renames camelCase `mesh*` identifiers that are pure in-process code (never serialized to DB, HTTP, JWT, or NATS).

**Renamed** (61 files, mechanical rename):
- `meshContext` -> `studioContext` — Hono context variable (`c.get`/`c.set` key + `hono-env.ts` Variables type). The key only lives inside the Hono request object, never on the wire.
- `meshCtx` -> `studioCtx` — local variables in workflows/tests.
- `meshContextFactory` -> `studioContextFactory` — property on in-process runtime objects injected via `set*Runtime()` setters (DBOS serializes workflow inputs, not these runtime objects).
- `meshMeta` -> `studioMeta` — local variables holding `_meta["mcp.mesh"]`; the `mcp.mesh` key itself is untouched.
- `meshAuth` -> `studioAuth`, `getMeshMeta` -> `getStudioMeta` — local var / private helper.

**Deliberately NOT renamed** (verified wire contracts or other tasks' scope):
- `mcp.mesh` / `MCP_MESH_KEY` / `MCP_MESH_DECOCMS_KEY` — `_meta` keys sent over MCP.
- `meshUrl` — serialized into JWT metadata and `MESH_REQUEST_CONTEXT`.
- `meshJwt*` / `meshToken` / `issueMeshToken` — task 04.
- `meshStorage*` / `meshKey` / `parseMeshStorageKey` — task 05.
- `packages/mesh-sdk` — task 08.
- `configMap.meshConfig` in helm/docs — external deploy contract, task 09.
- `MeshRegistryMeta` type — names the schema of the (kept) `mcp.mesh` wire key.

No breaking changes: no serialized key, route, env var, or published API is affected.

## Testing

- `bun run fmt`, `bun run lint` (0 errors), `bun run check` (all workspaces pass).
- `bun test` on all touched test files/dirs (middleware, deco-apps, links/session, object-storage, watch, dispatch-queue, storage/registry): 62 pass, 0 fail. Full local suite has ~359 pre-existing DB-backed failures on main, so touched-area runs are the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed internal mesh* identifiers to studio* across the app to advance de‑mesh migration. No wire or public API changes.

- **Refactors**
  - Replaced `meshContext` with `studioContext` everywhere (Hono `Variables`, `c.get`/`c.set`, `c.var`, middleware, routes, tests, and spec examples).
  - Renamed factories/locals: `meshCtx` → `studioCtx`, `meshContextFactory` → `studioContextFactory` across automations, thread-gate, hosted-harness, and background-tool workflows.
  - Updated helpers/vars: `meshMeta`/`getMeshMeta` → `studioMeta`/`getStudioMeta`, `meshAuth` → `studioAuth`; applied in access control, outbound auth transport, registry storage, and web UI.
  - Adjusted observability middleware to read `studioContext` and emit `studio.*` trace attributes.
  - Re-baselined DBOS workflow source-guard snapshot; workflow/step names unchanged (recovery-compatible).
  - Kept wire/public identifiers unchanged: `_meta["mcp.mesh"]`/`MCP_MESH_KEY` (and `MCP_MESH_DECOCMS_KEY`), JWT `meshUrl` and `meshJwt*`, storage `mesh*` keys, Helm `configMap.meshConfig`, and `packages/mesh-sdk`.

<sup>Written for commit b402ba4e05e2bf3ba5c0c8ffb604558b80ded143. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

