### PR TITLE
Default Commerce Discovery URL to reports.decocms.com (decouple from workers.dev)

### DIFF
--- a/packages/e2e/fixtures/commerce-upgrade-mock.ts
+++ b/packages/e2e/fixtures/commerce-upgrade-mock.ts
@@ -3,7 +3,7 @@
  *
  * Launched as a Playwright `webServer` so the mesh server can complete
  * `COMMERCE_DISCOVERY_SETUP` end-to-end without reaching the real production
- * worker (https://commerce-skills.deco-cx.workers.dev). The mesh server is
+ * reports service (https://reports.decocms.com). The mesh server is
  * pointed here via `COMMERCE_DISCOVERY_INTERNAL_API_URL` in the Playwright
  * config.
  *

--- a/packages/e2e/tests/commerce-onboarding.spec.ts
+++ b/packages/e2e/tests/commerce-onboarding.spec.ts
@@ -298,7 +298,7 @@ test.describe("Commerce onboarding route isolation", () => {
       [connectionId],
     );
     expect(concrete.rows[0]).toMatchObject({
-      connection_url: "https://commerce-skills.deco-cx.workers.dev/api/v2/mcp",
+      connection_url: "https://reports.decocms.com/api/v2/mcp",
       connection_type: "HTTP",
       title: "Store Report",
     });

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -35,8 +35,16 @@ export const WellKnownOrgMCPId = {
   COMMERCE_DISCOVERY: (org: string) => `${org}_commerce-discovery`,
 };
 
+// Public origin for the Commerce Discovery (reports) service. Deliberately the
+// stable custom domain, NOT the Cloudflare `workers.dev` URL, so the service can
+// move off Workers later by just repointing DNS — no code change or data
+// migration. Feeds two things: the write/claim path default (auth-client.ts uses
+// its .origin, overridable per-deploy via COMMERCE_DISCOVERY_INTERNAL_API_URL)
+// and the read-path "Store Report" connection URL (getWellKnownCommerceDiscovery
+// Connection below), which is not env-configurable — so keeping this a domain we
+// control is what keeps the whole integration portable.
 export const COMMERCE_DISCOVERY_MCP_URL =
-  "https://commerce-skills.deco-cx.workers.dev/api/v2/mcp";
+  "https://reports.decocms.com/api/v2/mcp";
 export const COMMERCE_DISCOVERY_REPORT_TOOL_NAME = "get_my_diagnostic";
 export const COMMERCE_DISCOVERY_ICON = "https://github.com/decocms.png";
 


### PR DESCRIPTION
## What
`COMMERCE_DISCOVERY_MCP_URL` pointed at the Cloudflare `workers.dev` hostname (`commerce-skills.deco-cx.workers.dev`). This change points it at the stable custom domain **`reports.decocms.com`** instead.

## Why
The `workers.dev` URL hard-couples the reports/Commerce Discovery integration to Cloudflare Workers. Using a domain we own means the reports service can later run **anywhere** (off Workers) by just repointing DNS — no code change, no data migration. Prepping for that now so it's never a painful cutover.

## Scope / effect
The constant feeds two consumers, both covered:
- **Write/claim path** (`auth-client.ts` `resolveBaseUrl` → `.origin`): default only, still overridable per-deploy via `COMMERCE_DISCOVERY_INTERNAL_API_URL`.
- **Read path** ("Store Report" HTTP connection, `getWellKnownCommerceDiscoveryConnection`): `connection_url` now the custom domain.

**Prod:** studio has no `COMMERCE_DISCOVERY_INTERNAL_API_URL` override, so it transparently switches to the custom domain. Same worker today (workers.dev stays live), so no behavioral change — just no longer hard-wired to the workers.dev identity.

Updated the e2e expectation (`commerce-onboarding.spec.ts`) and the mock's doc comment to match.

## Follow-up (not in this PR)
The read-path connection URL is still a single global constant (not env-configurable), so a non-prod studio (staging/previews) that runs setup gets a Store Report connection pointing at this default. Making that per-env configurable (mirroring the write-path env var) would let each env's read path target its own worker — worth doing if we want staging report views to render against staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaulted Commerce Discovery MCP URL to `https://reports.decocms.com/api/v2/mcp` to decouple from Cloudflare `workers.dev` and keep the service portable. No behavioral change in prod; both domains route to the same worker today.

- **Refactors**
  - Pointed `COMMERCE_DISCOVERY_MCP_URL` to the `reports.decocms.com` custom domain.
  - Both write default and read-path "Store Report" connection use this domain; write path remains overridable via `COMMERCE_DISCOVERY_INTERNAL_API_URL`.
  - Updated e2e test expectation and mock comment.

<sup>Written for commit f4cb0544b242143131030e7421418a152d40b987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

