### PR TITLE
feat(preview): move Blocks into preview editing modes

### DIFF
--- a/apps/mesh/src/web/components/chat/hooks/use-chat-navigation.ts
+++ b/apps/mesh/src/web/components/chat/hooks/use-chat-navigation.ts
@@ -44,11 +44,7 @@ export function useChatNavigation(): ChatNavigation {
           !isPerThreadTab(prevMain)
         )
           next.main = prevMain;
-        if (
-          prev.sidepanel === "chat" ||
-          prev.sidepanel === "blocks" ||
-          prev.sidepanel === 0
-        ) {
+        if (prev.sidepanel === "chat" || prev.sidepanel === 0) {
           next.sidepanel = prev.sidepanel;
         }
         if (opts?.autosend) next.autosend = AUTOSEND_QUERY_VALUE;

--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
@@ -67,8 +67,8 @@ export function BlocksPanel({ virtualMcpId }: { virtualMcpId: string }) {
     return <BlocksErrorState source={state.source} onRetry={retry} />;
   }
 
-  // Blocks edits whatever page Preview is on. The shared workspace target is
-  // published by Preview; when Preview hasn't run yet (e.g. Main showing Code),
+  // Blocks edits whatever page its sibling Preview canvas is on. The shared
+  // workspace target is published by Preview; when Preview hasn't run yet,
   // fall back to the last visited page persisted for this project + branch.
   const target = workspace.state.target;
   const saved =

--- a/apps/mesh/src/web/components/sandbox/preview/editing-mode.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/editing-mode.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { togglePreviewEditorMode } from "./editing-mode";
+
+describe("togglePreviewEditorMode", () => {
+  test("activates an editor from the neutral preview", () => {
+    expect(togglePreviewEditorMode("preview", "visual")).toBe("visual");
+    expect(togglePreviewEditorMode("preview", "blocks")).toBe("blocks");
+  });
+
+  test("turns off the active editor", () => {
+    expect(togglePreviewEditorMode("visual", "visual")).toBe("preview");
+    expect(togglePreviewEditorMode("blocks", "blocks")).toBe("preview");
+  });
+
+  test("switches directly between mutually exclusive editors", () => {
+    expect(togglePreviewEditorMode("visual", "blocks")).toBe("blocks");
+    expect(togglePreviewEditorMode("blocks", "visual")).toBe("visual");
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/preview/editing-mode.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/editing-mode.ts
@@ -1,0 +1,10 @@
+export type PreviewEditingMode = "preview" | "visual" | "blocks";
+
+export type PreviewEditorMode = Exclude<PreviewEditingMode, "preview">;
+
+export function togglePreviewEditorMode(
+  current: PreviewEditingMode,
+  requested: PreviewEditorMode,
+): PreviewEditingMode {
+  return current === requested ? "preview" : requested;
+}

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -2,10 +2,10 @@ import { sleep } from "@decocms/std";
 import { useState, useRef, useEffect, Suspense, lazy } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { formatCodeTabId } from "@/web/layouts/main-panel-tabs/tab-id";
-import { useInsetContext } from "@/web/layouts/agent-shell-layout";
 import { useChatTask } from "@/web/components/chat/context";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
+import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 
 import {
   ChevronDown,
@@ -19,6 +19,7 @@ import {
   Plus,
   SearchLg,
   CreditCardSearch,
+  TextInput,
   Monitor04,
   Phone02,
   RefreshCw01,
@@ -95,6 +96,18 @@ import { manifestLoaderResolveTypes } from "@/web/components/sandbox/content/run
 import { track } from "@/web/lib/posthog-client";
 import { useSandboxRepoDir } from "../hooks/use-sandbox-repo-dir";
 import { useBlocksPreviewWorkspace } from "@/web/components/sandbox/blocks/blocks-preview-workspace-context";
+import { BlocksPanel } from "@/web/components/sandbox/blocks/blocks-panel";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+  type ImperativePanelHandle,
+} from "@/web/components/resizable";
+import {
+  togglePreviewEditorMode,
+  type PreviewEditingMode,
+  type PreviewEditorMode,
+} from "./editing-mode";
 
 const VSCODE_ICON_URL =
   "https://decoims.com/decocms/01b321bd-4613-4b2c-9348-35058444d210/Visual_Studio_Code_1.35_icon.svg.png";
@@ -111,7 +124,6 @@ const SeoSheet = lazy(() =>
 const DEV_SERVER_SETTLE_MS = 500;
 
 type PreviewDeviceSize = "mobile" | "tablet" | "desktop";
-type PreviewViewMode = "preview" | "visual";
 
 const PREVIEW_DEVICE_WIDTHS: Record<PreviewDeviceSize, number | null> = {
   mobile: 375,
@@ -206,8 +218,8 @@ function withDeviceHint(url: string, device: PreviewDeviceSize): string {
   return parsed.href;
 }
 
-export function PreviewContent() {
-  const inset = useInsetContext();
+export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
+  const isMobile = useIsMobile();
   const navigate = useNavigate();
   const { currentBranch: branch } = useChatTask();
   const workspace = useBlocksPreviewWorkspace();
@@ -220,13 +232,15 @@ export function PreviewContent() {
     });
   };
 
-  // Visual editor state
-  const [viewMode, setViewMode] = useState<PreviewViewMode>("preview");
+  // Editing mode is singular: Visual editor and Blocks cannot be active
+  // together. Device size is independent and survives mode switches.
+  const [editingMode, setEditingMode] = useState<PreviewEditingMode>("preview");
   const [previewDeviceSize, setPreviewDeviceSize] =
     useState<PreviewDeviceSize>("desktop");
   const [visualElement, setVisualElement] =
     useState<VisualEditorPayload | null>(null);
   const previewIframeRef = useRef<HTMLIFrameElement>(null);
+  const blocksPanelRef = useRef<ImperativePanelHandle>(null);
 
   // Pages dropdown in URL bar
   const [pagesOpen, setPagesOpen] = useState(false);
@@ -271,7 +285,6 @@ export function PreviewContent() {
   // SEO panel state
   const [siteSeoOpen, setSiteSeoOpen] = useState(false);
 
-  const virtualMcpId = inset?.entity?.id ?? null;
   const { org } = useProjectContext();
 
   const vmEvents = useSandboxEvents();
@@ -538,11 +551,12 @@ export function PreviewContent() {
     !appPaused &&
     (claimPhase?.kind === "ready" || lifecyclePhase !== "idle");
 
-  // Visual mode requires a live iframe. When it is gone, fall back to Preview.
-  const effectiveViewMode: PreviewViewMode =
-    previewState.kind !== "iframe" && viewMode === "visual"
+  // Visual mode requires a live iframe. Blocks can stay open while the
+  // sandbox restarts so its loading/error state remains actionable.
+  const effectiveEditingMode: PreviewEditingMode =
+    previewState.kind !== "iframe" && editingMode === "visual"
       ? "preview"
-      : viewMode;
+      : editingMode;
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — DOM event subscription
   useEffect(() => {
@@ -593,12 +607,20 @@ export function PreviewContent() {
     win.postMessage({ type: "visual-editor::deactivate" }, "*");
   };
 
-  const handleViewModeChange = (mode: PreviewViewMode) => {
-    const prev = viewMode;
-    setViewMode(mode);
+  const activateEditingMode = (mode: PreviewEditingMode) => {
+    const previousMode = editingMode;
+    if (!isMobile && mode !== previousMode) {
+      if (mode === "blocks") blocksPanelRef.current?.resize(40);
+      else blocksPanelRef.current?.collapse();
+    }
+    setEditingMode(mode);
     setVisualElement(null);
-    if (prev === "visual") deactivateVisualEditor();
+    if (previousMode === "visual") deactivateVisualEditor();
     if (mode === "visual") injectVisualEditor();
+  };
+
+  const toggleEditingMode = (mode: PreviewEditorMode) => {
+    activateEditingMode(togglePreviewEditorMode(editingMode, mode));
   };
 
   const handleRefresh = () => {
@@ -770,14 +792,7 @@ export function PreviewContent() {
         name: result.name,
         path: result.path,
       });
-      navigate({
-        to: ".",
-        search: (prev: Record<string, unknown>) => ({
-          ...prev,
-          sidepanel: "blocks" as const,
-        }),
-        replace: true,
-      });
+      activateEditingMode("blocks");
     } catch (error) {
       setCreatePageError(
         error instanceof Error ? error.message : "Failed to create page",
@@ -786,8 +801,63 @@ export function PreviewContent() {
   };
 
   const canVisualEdit = previewState.kind === "iframe";
-  const toggleViewMode = (mode: PreviewViewMode) =>
-    handleViewModeChange(viewMode === mode ? "preview" : mode);
+  const floatingPreviewControls =
+    canVisualEdit || editingMode === "blocks" ? (
+      <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2">
+        <div className="flex items-center gap-0.5 rounded-full border bg-background/90 p-1 shadow-lg backdrop-blur-sm">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <ToolbarIconButton
+                onClick={() => toggleEditingMode("visual")}
+                aria-pressed={editingMode === "visual"}
+                aria-label="Visual editor"
+                active={editingMode === "visual"}
+                disabled={!canVisualEdit}
+              >
+                <CursorClick01 size={16} />
+              </ToolbarIconButton>
+            </TooltipTrigger>
+            <TooltipContent side="top">Visual editor</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <ToolbarIconButton
+                data-testid="preview-blocks-toggle"
+                onClick={() => toggleEditingMode("blocks")}
+                aria-pressed={editingMode === "blocks"}
+                aria-label="Blocks editor"
+                active={editingMode === "blocks"}
+              >
+                <TextInput size={16} />
+              </ToolbarIconButton>
+            </TooltipTrigger>
+            <TooltipContent side="top">Blocks editor</TooltipContent>
+          </Tooltip>
+          <div className="mx-0.5 h-5 w-px bg-border" />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <ToolbarIconButton
+                onClick={handleDeviceToggle}
+                aria-label={DEVICE_LABELS[previewDeviceSize]}
+                disabled={!canVisualEdit}
+              >
+                <span
+                  key={previewDeviceSize}
+                  className="flex items-center justify-center animate-device-icon-pop"
+                >
+                  {previewDeviceSize === "mobile" && <Phone02 size={16} />}
+                  {previewDeviceSize === "tablet" && <Tablet01 size={16} />}
+                  {previewDeviceSize === "desktop" && <Monitor04 size={16} />}
+                </span>
+              </ToolbarIconButton>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {DEVICE_LABELS[previewDeviceSize]}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+    ) : null;
 
   return (
     <div className="flex flex-col w-full h-full">
@@ -1103,14 +1173,7 @@ export function PreviewContent() {
                                   key: currentPageKey,
                                   path: currentPath,
                                 });
-                                navigate({
-                                  to: ".",
-                                  search: (prev: Record<string, unknown>) => ({
-                                    ...prev,
-                                    sidepanel: "blocks" as const,
-                                  }),
-                                  replace: true,
-                                });
+                                activateEditingMode("blocks");
                               }}
                             >
                               <CreditCardSearch size={14} />
@@ -1183,182 +1246,179 @@ export function PreviewContent() {
         </div>
       )}
 
-      <div className="flex-1 flex overflow-hidden">
-        <div
-          className={cn(
-            "flex-1 relative overflow-hidden",
-            previewDeviceSize !== "desktop" &&
-              previewState.kind === "iframe" &&
-              "flex justify-center bg-muted/30",
-          )}
-        >
-          {navigating && previewState.kind === "iframe" && (
-            <div className="absolute inset-x-0 top-0 z-40 h-0.5 overflow-hidden bg-primary/15">
-              <div className="absolute inset-y-0 w-2/5 rounded-full bg-primary animate-preview-nav" />
-            </div>
-          )}
-
-          {showBootingOverlay && (
-            <div className="absolute inset-0 z-30">
-              <SandboxStateCard
-                kind="starting"
-                progress={progress}
-                claimPhase={claimPhase}
-              />
-            </div>
-          )}
-
-          {previewState.kind === "suspended" && (
-            <div className="absolute inset-0 z-30">
-              <SandboxStateCard kind="suspended" onResume={lifecycle.resume} />
-            </div>
-          )}
-
-          {previewState.kind === "errored" && (
-            <div className="absolute inset-0 z-30">
-              <SandboxStateCard
-                kind="errored"
-                error={previewState.error}
-                onRetry={lifecycle.retry}
-                connectionsHref={`/${org.slug}/settings/connections`}
-              />
-            </div>
-          )}
-
-          {effectiveViewMode === "visual" && !visualElement && (
-            <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/90 px-3 py-1 text-xs font-medium text-white shadow-md backdrop-blur-sm pointer-events-none select-none">
-              <CursorClick01 size={12} />
-              Click any element to ask the AI
-            </div>
-          )}
-          {effectiveViewMode === "visual" && visualElement && (
-            <VisualEditorPrompt
-              element={visualElement}
-              onDismiss={() => setVisualElement(null)}
-            />
-          )}
-
-          {/* Floating preview controls — a centered pill at the bottom of the
-              preview (Visual editor toggle + device switcher), à la Lovable. */}
-          {canVisualEdit && (
-            <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2">
-              <div className="flex items-center gap-0.5 rounded-full border bg-background/90 p-1 shadow-lg backdrop-blur-sm">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <ToolbarIconButton
-                      onClick={() => toggleViewMode("visual")}
-                      aria-pressed={viewMode === "visual"}
-                      aria-label="Visual editor"
-                      active={viewMode === "visual"}
-                    >
-                      <CursorClick01 size={16} />
-                    </ToolbarIconButton>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">Visual editor</TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <ToolbarIconButton
-                      onClick={handleDeviceToggle}
-                      aria-label={DEVICE_LABELS[previewDeviceSize]}
-                    >
-                      <span
-                        key={previewDeviceSize}
-                        className="flex items-center justify-center animate-device-icon-pop"
-                      >
-                        {previewDeviceSize === "mobile" && (
-                          <Phone02 size={16} />
-                        )}
-                        {previewDeviceSize === "tablet" && (
-                          <Tablet01 size={16} />
-                        )}
-                        {previewDeviceSize === "desktop" && (
-                          <Monitor04 size={16} />
-                        )}
-                      </span>
-                    </ToolbarIconButton>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">
-                    {DEVICE_LABELS[previewDeviceSize]}
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-            </div>
-          )}
-
-          {previewState.kind === "iframe" && iframeSrc && (
-            <div
+      <div className="flex-1 overflow-hidden">
+        {isMobile && effectiveEditingMode === "blocks" ? (
+          <div className="relative h-full min-h-0 overflow-hidden">
+            <BlocksPanel virtualMcpId={virtualMcpId} />
+            {floatingPreviewControls}
+          </div>
+        ) : (
+          <ResizablePanelGroup direction="horizontal">
+            <ResizablePanel
+              ref={blocksPanelRef}
+              id="preview-blocks-editor"
+              order={1}
+              defaultSize={effectiveEditingMode === "blocks" ? 40 : 0}
+              minSize={30}
+              collapsible
+              collapsedSize={0}
               className={cn(
-                "h-full transition-[width] duration-250 [transition-timing-function:var(--ease-in-out-cubic)]",
-                previewDeviceSize !== "desktop" &&
-                  "w-full max-w-full border-x border-border bg-background shadow-sm",
+                "overflow-hidden",
+                effectiveEditingMode === "blocks" ? "min-w-[320px]" : "min-w-0",
               )}
-              style={{
-                width:
-                  previewDeviceSize === "desktop"
-                    ? "100%"
-                    : `${PREVIEW_DEVICE_WIDTHS[previewDeviceSize]}px`,
-              }}
             >
-              <iframe
-                // Key on previewUrl: remount when the VM base URL changes (branch
-                // switch). Path navigation is driven by `iframeSrc` state.
-                key={previewState.previewUrl}
-                ref={previewIframeRef}
-                src={iframeSrc}
-                className="w-full h-full border-0"
-                title="Dev Server Preview"
-                onLoad={() => {
-                  // The page finished loading — always clear the navigation
-                  // indicator first, before any of the early returns below.
-                  endNavigation();
-                  // This is the VM dev-server preview (sandboxed running app),
-                  // NOT an MCP app. MCP apps render via <MCPAppRenderer/>.
-                  track("vm_preview_loaded", {
-                    view_mode: viewMode,
-                    vm_id: vmEntry?.sandboxHandle ?? null,
-                    // Intentionally excluding the full previewUrl — it can contain
-                    // ephemeral tokens / user data in the query string.
-                  });
-                  // Sync currentPath when the user navigates inside the iframe.
-                  // Skip while a programmatic navigation is pending — stale
-                  // onLoad events from the previous URL would reset us to "/".
-                  if (!activeGlobalSection) {
-                    try {
-                      const iframePath =
-                        previewIframeRef.current?.contentWindow?.location
-                          ?.pathname;
-                      if (!iframePath) return;
-                      const intended = intendedPathRef.current;
-                      if (intended !== null) {
-                        intendedPathRef.current = null;
-                        // Stale onLoad from the previous URL — ignore.
-                        if (normPath(iframePath) !== normPath(intended)) {
-                          return;
+              {effectiveEditingMode === "blocks" && (
+                <BlocksPanel virtualMcpId={virtualMcpId} />
+              )}
+            </ResizablePanel>
+            <ResizableHandle
+              withHandle
+              className={cn(effectiveEditingMode !== "blocks" && "hidden")}
+            />
+            <ResizablePanel
+              id="preview-canvas"
+              order={2}
+              defaultSize={effectiveEditingMode === "blocks" ? 60 : 100}
+              minSize={35}
+              className="min-w-0 overflow-hidden"
+            >
+              <div
+                className={cn(
+                  "h-full relative overflow-hidden",
+                  previewDeviceSize !== "desktop" &&
+                    previewState.kind === "iframe" &&
+                    "flex justify-center bg-muted/30",
+                )}
+              >
+                {navigating && previewState.kind === "iframe" && (
+                  <div className="absolute inset-x-0 top-0 z-40 h-0.5 overflow-hidden bg-primary/15">
+                    <div className="absolute inset-y-0 w-2/5 rounded-full bg-primary animate-preview-nav" />
+                  </div>
+                )}
+
+                {showBootingOverlay && (
+                  <div className="absolute inset-0 z-30">
+                    <SandboxStateCard
+                      kind="starting"
+                      progress={progress}
+                      claimPhase={claimPhase}
+                    />
+                  </div>
+                )}
+
+                {previewState.kind === "suspended" && (
+                  <div className="absolute inset-0 z-30">
+                    <SandboxStateCard
+                      kind="suspended"
+                      onResume={lifecycle.resume}
+                    />
+                  </div>
+                )}
+
+                {previewState.kind === "errored" && (
+                  <div className="absolute inset-0 z-30">
+                    <SandboxStateCard
+                      kind="errored"
+                      error={previewState.error}
+                      onRetry={lifecycle.retry}
+                      connectionsHref={`/${org.slug}/settings/connections`}
+                    />
+                  </div>
+                )}
+
+                {effectiveEditingMode === "visual" && !visualElement && (
+                  <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/90 px-3 py-1 text-xs font-medium text-white shadow-md backdrop-blur-sm pointer-events-none select-none">
+                    <CursorClick01 size={12} />
+                    Click any element to ask the AI
+                  </div>
+                )}
+                {effectiveEditingMode === "visual" && visualElement && (
+                  <VisualEditorPrompt
+                    element={visualElement}
+                    onDismiss={() => setVisualElement(null)}
+                  />
+                )}
+
+                {floatingPreviewControls}
+
+                {previewState.kind === "iframe" && iframeSrc && (
+                  <div
+                    className={cn(
+                      "h-full transition-[width] duration-250 [transition-timing-function:var(--ease-in-out-cubic)]",
+                      previewDeviceSize !== "desktop" &&
+                        "w-full max-w-full border-x border-border bg-background shadow-sm",
+                    )}
+                    style={{
+                      width:
+                        previewDeviceSize === "desktop"
+                          ? "100%"
+                          : `${PREVIEW_DEVICE_WIDTHS[previewDeviceSize]}px`,
+                    }}
+                  >
+                    <iframe
+                      // Key on previewUrl: remount when the VM base URL changes (branch
+                      // switch). Path navigation is driven by `iframeSrc` state.
+                      key={previewState.previewUrl}
+                      ref={previewIframeRef}
+                      src={iframeSrc}
+                      className="w-full h-full border-0"
+                      title="Dev Server Preview"
+                      onLoad={() => {
+                        // The page finished loading — always clear the navigation
+                        // indicator first, before any of the early returns below.
+                        endNavigation();
+                        // This is the VM dev-server preview (sandboxed running app),
+                        // NOT an MCP app. MCP apps render via <MCPAppRenderer/>.
+                        track("vm_preview_loaded", {
+                          view_mode: editingMode,
+                          vm_id: vmEntry?.sandboxHandle ?? null,
+                          // Intentionally excluding the full previewUrl — it can contain
+                          // ephemeral tokens / user data in the query string.
+                        });
+                        // Sync currentPath when the user navigates inside the iframe.
+                        // Skip while a programmatic navigation is pending — stale
+                        // onLoad events from the previous URL would reset us to "/".
+                        if (!activeGlobalSection) {
+                          try {
+                            const iframePath =
+                              previewIframeRef.current?.contentWindow?.location
+                                ?.pathname;
+                            if (!iframePath) return;
+                            const intended = intendedPathRef.current;
+                            if (intended !== null) {
+                              intendedPathRef.current = null;
+                              // Stale onLoad from the previous URL — ignore.
+                              if (normPath(iframePath) !== normPath(intended)) {
+                                return;
+                              }
+                            }
+                            // Keep the template as currentPath when the loaded
+                            // path is just the template with params filled in —
+                            // otherwise the page match and param inputs are lost.
+                            if (
+                              normPath(iframePath) === normPath(resolvedPath)
+                            ) {
+                              return;
+                            }
+                            setCurrentPath(iframePath);
+                            persistLastPage({
+                              path: iframePath,
+                              pageKey: pinnedPageKey,
+                              params: pathParamValues,
+                            });
+                          } catch {
+                            // Cross-origin — can't read, keep current value
+                          }
                         }
-                      }
-                      // Keep the template as currentPath when the loaded
-                      // path is just the template with params filled in —
-                      // otherwise the page match and param inputs are lost.
-                      if (normPath(iframePath) === normPath(resolvedPath)) {
-                        return;
-                      }
-                      setCurrentPath(iframePath);
-                      persistLastPage({
-                        path: iframePath,
-                        pageKey: pinnedPageKey,
-                        params: pathParamValues,
-                      });
-                    } catch {
-                      // Cross-origin — can't read, keep current value
-                    }
-                  }
-                  if (viewMode === "visual") injectVisualEditor();
-                }}
-              />
-            </div>
-          )}
-        </div>
+                        if (editingMode === "visual") injectVisualEditor();
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        )}
       </div>
       <CreatePageModal
         open={createPageDialogOpen}

--- a/apps/mesh/src/web/hooks/use-layout-state.test.ts
+++ b/apps/mesh/src/web/hooks/use-layout-state.test.ts
@@ -57,13 +57,13 @@ describe("resolveDefaultPanelState", () => {
       resolveDefaultPanelState({
         entityMetadata: {
           defaultMainView: { type: "overview" },
-          chatDefaultOpen: true,
+          chatDefaultOpen: false,
         },
         mainParamPresent: false,
         sidePanelParamPresent: true,
-        sidePanelParamValue: "blocks",
+        sidePanelParamValue: "chat",
       }),
-    ).toEqual({ sidePanel: "blocks", mainOpen: true });
+    ).toEqual({ sidePanel: "chat", mainOpen: true });
   });
 
   test("sidepanel=0 keeps a non-Chat default Main-only", () => {
@@ -91,18 +91,6 @@ describe("resolveDefaultPanelState", () => {
     ).toEqual({ sidePanel: "chat", mainOpen: true });
   });
 
-  test("sidepanel=blocks&main=0 produces a Blocks-only workspace", () => {
-    expect(
-      resolveDefaultPanelState({
-        entityMetadata: null,
-        mainParamPresent: true,
-        mainParamValue: 0,
-        sidePanelParamPresent: true,
-        sidePanelParamValue: "blocks",
-      }),
-    ).toEqual({ sidePanel: "blocks", mainOpen: false });
-  });
-
   test("an all-closed state falls back to Chat", () => {
     expect(
       resolveDefaultPanelState({
@@ -126,7 +114,7 @@ describe("canCloseWorkspacePanel", () => {
   test("does not allow closing the final open panel", () => {
     expect(
       canCloseWorkspacePanel("side", {
-        sidePanel: "blocks",
+        sidePanel: "chat",
         mainOpen: false,
       }),
     ).toBe(false);
@@ -137,13 +125,13 @@ describe("canCloseWorkspacePanel", () => {
 });
 
 describe("resolveWorkspacePanelAction", () => {
-  test("switches the shared side panel directly between Chat and Blocks", () => {
+  test("opens Chat when only Main is visible", () => {
     expect(
       resolveWorkspacePanelAction(
-        { type: "toggleSidePanel", sidePanel: "blocks" },
-        { sidePanel: "chat", mainOpen: false },
+        { type: "toggleSidePanel", sidePanel: "chat" },
+        { sidePanel: null, mainOpen: true },
       ),
-    ).toEqual({ sidepanel: "blocks" });
+    ).toEqual({ sidepanel: "chat" });
   });
 
   test("closes the active side panel when Main remains open", () => {
@@ -158,8 +146,8 @@ describe("resolveWorkspacePanelAction", () => {
   test("refuses to close the active side panel when it is the final panel", () => {
     expect(
       resolveWorkspacePanelAction(
-        { type: "toggleSidePanel", sidePanel: "blocks" },
-        { sidePanel: "blocks", mainOpen: false },
+        { type: "toggleSidePanel", sidePanel: "chat" },
+        { sidePanel: "chat", mainOpen: false },
       ),
     ).toBeNull();
   });
@@ -185,7 +173,7 @@ describe("resolveWorkspacePanelAction", () => {
     ).toBeNull();
   });
 
-  test("openSidePanel is idempotent and can switch side-panel content", () => {
+  test("openSidePanel is idempotent and opens Chat when it is closed", () => {
     expect(
       resolveWorkspacePanelAction(
         { type: "openSidePanel", sidePanel: "chat" },
@@ -195,7 +183,7 @@ describe("resolveWorkspacePanelAction", () => {
     expect(
       resolveWorkspacePanelAction(
         { type: "openSidePanel", sidePanel: "chat" },
-        { sidePanel: "blocks", mainOpen: true },
+        { sidePanel: null, mainOpen: true },
       ),
     ).toEqual({ sidepanel: "chat" });
   });
@@ -208,7 +196,7 @@ describe("computeWorkspacePanelSizes", () => {
       { side: 100, main: 0 },
     ],
     [
-      { sidePanel: "blocks" as const, mainOpen: true },
+      { sidePanel: "chat" as const, mainOpen: true },
       { side: 33, main: 67 },
     ],
     [
@@ -224,10 +212,6 @@ describe("mobileSurfaceSearch", () => {
   test("selects exactly one mobile surface", () => {
     expect(mobileSurfaceSearch("chat", "preview")).toEqual({
       sidepanel: "chat",
-      main: 0,
-    });
-    expect(mobileSurfaceSearch("blocks", "preview")).toEqual({
-      sidepanel: "blocks",
       main: 0,
     });
     expect(mobileSurfaceSearch("main", "preview")).toEqual({

--- a/apps/mesh/src/web/hooks/use-layout-state.ts
+++ b/apps/mesh/src/web/hooks/use-layout-state.ts
@@ -3,7 +3,7 @@
  * panel and the tabbed main panel.
  *
  * URL model:
- *   ?sidepanel=chat|blocks  side panel open with that view selected
+ *   ?sidepanel=chat         chat side panel open
  *   ?sidepanel=0            side panel closed
  *   ?sidepanel absent       agent-configured default
  *   ?main=<tabId>           main panel open, tab active
@@ -23,7 +23,7 @@ import { useThreadActions } from "@/web/components/chat/store/hooks";
 // Types
 // ---------------------------------------------------------------------------
 
-export type SidePanelKind = "chat" | "blocks";
+export type SidePanelKind = "chat";
 
 export interface EntityLayoutMetadata {
   defaultMainView?: {

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -282,7 +282,7 @@ const agentShellLayout = createRoute({
 const unifiedChatSearchSchema = z.object({
   virtualmcpid: z.string().optional(),
   tab: z.string().optional(),
-  sidepanel: z.union([z.enum(["chat", "blocks"]), z.literal(0)]).optional(),
+  sidepanel: z.union([z.literal("chat"), z.literal(0)]).optional(),
   main: z.union([z.string(), z.literal(0)]).optional(),
   /** Open the Library file-preview overlay over the chat (browse-grammar path
    *  "<volume>/<path…>"). Set by clickable org-file refs in agent messages. */

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -75,7 +75,6 @@ import { ShellRouteLoading } from "@/web/layouts/shell-route-loading";
 import { OrgFilePreviewMount } from "./org-file-preview";
 import { OrgFileOpenProvider } from "@/web/components/chat/org-file-open-context";
 import { BlocksPreviewWorkspaceProvider } from "@/web/components/sandbox/blocks/blocks-preview-workspace-context";
-import { agentHasClonableSource } from "@/web/lib/agent-capabilities";
 import { SidePanel } from "./side-panel";
 
 // ---------------------------------------------------------------------------
@@ -237,7 +236,6 @@ function DesktopTaskWorkspace({
         <ToggleButtons
           sidePanel={layout.sidePanel}
           toggleSidePanel={layout.toggleSidePanel}
-          blocksAvailable={agentHasClonableSource(entity.metadata)}
           disableActiveSidePanelToggle={!layout.mainOpen}
         />
       </Toolbar.Toggles>
@@ -272,12 +270,10 @@ function MobileTaskWorkspace({
   virtualMcpId,
   layout,
   onNewTaskRef,
-  blocksAvailable,
 }: {
   virtualMcpId: string;
   layout: TaskLayout;
   onNewTaskRef: React.MutableRefObject<(() => void) | null>;
-  blocksAvailable: boolean;
 }) {
   const mobileSurface = layout.mainOpen ? "main" : (layout.sidePanel ?? "chat");
 
@@ -287,7 +283,6 @@ function MobileTaskWorkspace({
         <ToggleButtons
           sidePanel={mobileSurface === "main" ? null : mobileSurface}
           toggleSidePanel={layout.setMobileSurface}
-          blocksAvailable={blocksAvailable}
           disableActiveSidePanelToggle={mobileSurface !== "main"}
         />
       </Toolbar.Toggles>
@@ -330,11 +325,7 @@ function MobileTaskWorkspace({
               </Suspense>
             </ErrorBoundary>
           ) : (
-            <SidePanel
-              kind={mobileSurface}
-              virtualMcpId={virtualMcpId}
-              chatContent={<ActiveTaskBoundary />}
-            />
+            <SidePanel chatContent={<ActiveTaskBoundary />} />
           )}
         </div>
       </Suspense>
@@ -385,8 +376,6 @@ function AgentInsetProvider() {
     : null;
 
   const hasActiveGithubRepo = !!(entity && getActiveGithubRepo(entity));
-  const hasClonableSource = agentHasClonableSource(entity?.metadata);
-
   const layout = useWorkspaceLayoutState(entityMetadata, {
     virtualMcpId,
     orgSlug,
@@ -494,7 +483,6 @@ function AgentInsetProvider() {
                     virtualMcpId={chatVirtualMcpId}
                     layout={layout}
                     onNewTaskRef={onNewTask}
-                    blocksAvailable={hasClonableSource}
                   />
                 </Suspense>
               </Chat.ActiveTaskProvider>

--- a/apps/mesh/src/web/layouts/agent-shell-layout/side-panel.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/side-panel.tsx
@@ -1,24 +1,6 @@
 import { ChatSidePanel } from "@/web/components/chat/side-panel-chat";
-import { BlocksPanel } from "@/web/components/sandbox/blocks/blocks-panel";
-import type { SidePanelKind } from "@/web/hooks/use-layout-state";
 
-export function SidePanel({
-  kind,
-  virtualMcpId,
-  chatContent,
-}: {
-  kind: SidePanelKind;
-  virtualMcpId: string;
-  chatContent?: React.ReactNode;
-}) {
-  if (kind === "blocks") {
-    return (
-      <div data-testid="blocks-panel-shell" className="h-full min-h-0">
-        <BlocksPanel virtualMcpId={virtualMcpId} />
-      </div>
-    );
-  }
-
+export function SidePanel({ chatContent }: { chatContent?: React.ReactNode }) {
   return (
     <div data-testid="chat-panel" className="h-full min-h-0">
       {chatContent ?? <ChatSidePanel />}

--- a/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/toggle-buttons.tsx
@@ -1,4 +1,4 @@
-import { MessageCircle01, TextInput } from "@untitledui/icons";
+import { MessageCircle01 } from "@untitledui/icons";
 import { useReportsOnly } from "@/web/hooks/use-organization-settings";
 import { HeaderTabButton } from "@/web/layouts/main-panel-tabs/header-tab-button";
 import { track } from "@/web/lib/posthog-client";
@@ -9,7 +9,6 @@ import type { SidePanelKind } from "@/web/hooks/use-layout-state";
 export interface ToggleButtonsProps {
   sidePanel: SidePanelKind | null;
   toggleSidePanel: (sidePanel: SidePanelKind) => void;
-  blocksAvailable?: boolean;
   /**
    * When true, the active side-panel toggle is disabled because closing it
    * would leave a blank content area.
@@ -27,7 +26,6 @@ export interface ToggleButtonsProps {
 export function ToggleButtons({
   sidePanel,
   toggleSidePanel,
-  blocksAvailable = false,
   disableActiveSidePanelToggle = false,
 }: ToggleButtonsProps) {
   // Reports-only orgs collapse the toolbar to just the chat toggle.
@@ -48,22 +46,6 @@ export function ToggleButtons({
           toggleSidePanel("chat");
         }}
       />
-      {!reportsOnly && blocksAvailable && (
-        <HeaderTabButton
-          title="Blocks"
-          icon={{ kind: "component", Component: TextInput }}
-          active={sidePanel === "blocks"}
-          disabled={disableActiveSidePanelToggle && sidePanel === "blocks"}
-          className="wco-no-drag h-10 md:h-8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50"
-          onClick={() => {
-            track("agent_toolbar_toggled", {
-              button: "blocks",
-              next_state: sidePanel === "blocks" ? "closed" : "open",
-            });
-            toggleSidePanel("blocks");
-          }}
-        />
-      )}
       {/* Tasks and Library are agent-independent overlays; hidden for
           reports-only orgs along with everything else but Chat. */}
       {!reportsOnly && (

--- a/apps/mesh/src/web/layouts/agent-shell-layout/workspace-panel-group.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/workspace-panel-group.tsx
@@ -90,13 +90,7 @@ export function WorkspacePanelGroup({
         }
       >
         <PanelCard testId="side-panel">
-          {sidePanel !== null && (
-            <SidePanel
-              kind={sidePanel}
-              virtualMcpId={virtualMcpId}
-              chatContent={chatContent}
-            />
-          )}
+          {sidePanel !== null && <SidePanel chatContent={chatContent} />}
         </PanelCard>
       </ResizablePanel>
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
@@ -20,5 +20,5 @@ export function PreviewTab({ virtualMcpId }: { virtualMcpId: string }) {
     );
   }
 
-  return <PreviewContent />;
+  return <PreviewContent virtualMcpId={virtualMcpId} />;
 }

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -302,7 +302,7 @@ export function useMainPanelTabs(ctx: {
   // The Overview view (the Super Agent's default) leads the bar so it reads as
   // the agent's home. Data-driven off the configured default view — no
   // per-agent special-case. Source tabs (Preview · Code) share one capability
-  // gate via getSourceSystemTabs; Blocks is a peer workspace panel.
+  // gate via getSourceSystemTabs; Blocks is an editing mode inside Preview.
   const leadingSystemTabs: Array<{ id: string; title: string }> = [];
   // Library is agent-independent, so it lives in the LEFT toolbar group next to
   // the Chat toggle (see LibraryToggle), NOT in this per-agent tab bar.

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -111,7 +111,7 @@ export function usePanelActions() {
     replace = true,
   ) => navWith(currentTaskId, searchFn, replace);
 
-  const openSidePanel = (sidePanel: "chat" | "blocks") =>
+  const openSidePanel = (sidePanel: "chat") =>
     nav((prev) => ({ ...prev, sidepanel: sidePanel }));
 
   const setTaskId = (

--- a/packages/e2e/tests/standalone-blocks-panel.spec.ts
+++ b/packages/e2e/tests/standalone-blocks-panel.spec.ts
@@ -45,10 +45,10 @@ async function createClonableAgent(
   return { agentId: agent.item.id, threadId: thread.item.id };
 }
 
-test.describe("standalone Blocks panel", () => {
+test.describe("Blocks preview mode", () => {
   test.setTimeout(90_000);
 
-  test("Chat and Blocks share the side panel beside Main on desktop", async ({
+  test("desktop keeps Chat independent and removes Blocks from the workspace toolbar", async ({
     authedPage,
   }) => {
     const { page, orgSlug } = authedPage;
@@ -61,58 +61,21 @@ test.describe("standalone Blocks panel", () => {
     );
 
     const chat = page.getByTestId("chat-panel");
-    const blocks = page.getByTestId("blocks-panel-shell");
     const main = page.getByTestId("main-panel");
-    const blocksToggle = page.getByRole("button", {
+    const legacyBlocksToggle = page.getByRole("button", {
       name: "Blocks",
       exact: true,
     });
 
-    await expect(blocksToggle).toBeVisible({ timeout: 30_000 });
     await expect(chat).toBeVisible({ timeout: 30_000 });
     await expect(main).toBeVisible();
-    await expect(blocks).toHaveCount(0);
-
-    await blocksToggle.click();
-    await expect(page).toHaveURL(/sidepanel=blocks/);
-    await expect(page).toHaveURL(/main=settings/);
-    await expect(chat).toHaveCount(0);
-    await expect(blocks).toBeVisible();
-    await expect(main).toBeVisible();
+    await expect(legacyBlocksToggle).toHaveCount(0);
+    await expect(page.getByTestId("blocks-panel")).toHaveCount(0);
 
     await page.getByRole("button", { name: "Preview", exact: true }).click();
     await expect(page).toHaveURL(/main=preview/);
-    await expect(blocks).toBeVisible();
-
-    await blocksToggle.click();
-    await expect(page).toHaveURL(/sidepanel=0/);
+    await expect(chat).toBeVisible();
     await expect(main).toBeVisible();
-    await expect(blocks).toHaveCount(0);
-  });
-
-  test("a Blocks-only workspace preserves the final visible panel guard", async ({
-    authedPage,
-  }) => {
-    const { page, orgSlug } = authedPage;
-    const { agentId, threadId } = await createClonableAgent(
-      page.context().request,
-      orgSlug,
-    );
-    await page.goto(
-      `/${orgSlug}/${threadId}?virtualmcpid=${agentId}&sidepanel=blocks&main=0`,
-    );
-
-    const blocksToggle = page.getByRole("button", {
-      name: "Blocks",
-      exact: true,
-    });
-    await expect(blocksToggle).toBeVisible({ timeout: 30_000 });
-    await expect(page.getByTestId("blocks-panel-shell")).toBeVisible({
-      timeout: 30_000,
-    });
-    await expect(page.getByTestId("chat-panel")).toBeHidden();
-    await expect(page.getByTestId("main-panel")).toBeHidden();
-    await expect(blocksToggle).toBeDisabled();
   });
 
   test("mobile renders one workspace surface at a time", async ({
@@ -139,26 +102,14 @@ test.describe("standalone Blocks panel", () => {
     await expect(page).toHaveURL(/main=0/);
     await expect(chatToggle).toHaveAttribute("aria-pressed", "true");
     await expect(chatToggle).toBeDisabled();
-    await expect(page.getByTestId("blocks-panel-shell")).toHaveCount(0);
+    await expect(page.getByTestId("blocks-panel")).toHaveCount(0);
     await expect(page.getByTestId("main-panel")).toHaveCount(0);
-
-    const blocksToggle = page.getByRole("button", {
-      name: "Blocks",
-      exact: true,
-    });
-    await blocksToggle.click();
-    await expect(page).toHaveURL(/sidepanel=blocks/);
-    await expect(chatToggle).toHaveAttribute("aria-pressed", "false");
-    await expect(blocksToggle).toHaveAttribute("aria-pressed", "true");
-    await expect(blocksToggle).toBeDisabled();
-    await expect(page.getByTestId("blocks-panel-shell")).toBeVisible();
 
     await page.getByRole("combobox", { name: "Main panel tab" }).click();
     await page.getByRole("option", { name: "Settings" }).click();
     await expect(page).toHaveURL(/sidepanel=0/);
     await expect(page).toHaveURL(/main=settings/);
-    await expect(blocksToggle).toHaveAttribute("aria-pressed", "false");
     await expect(page.getByTestId("main-panel")).toBeVisible();
-    await expect(page.getByTestId("blocks-panel-shell")).toHaveCount(0);
+    await expect(page.getByTestId("blocks-panel")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

- move Blocks from the outer workspace side panel into Preview
- make Visual editor and Blocks mutually exclusive while keeping viewport selection independent
- render Blocks beside the iframe on desktop and as the Preview surface on mobile
- update shell state, routing, unit tests, and black-box E2E coverage

## Verification

- bun run fmt:check
- bun run lint (0 errors)
- bun run --cwd=apps/mesh check
- bun run --cwd=apps/mesh build:client
- bun test apps/mesh/src/web/components/sandbox/preview/editing-mode.test.ts apps/mesh/src/web/hooks/use-layout-state.test.ts
- bun run --cwd=packages/e2e check
- Playwright spec discovery for standalone-blocks-panel.spec.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved Blocks into Preview as a first-class editing mode and removed it from the workspace side panel. Visual editor and Blocks are mutually exclusive; the device toggle remains independent.

- New Features
  - Added Preview editing modes: preview-only, visual, and blocks (mutually exclusive).
  - Floating bottom controls in Preview: Visual, Blocks, and device toggles.
  - Desktop: resizable split shows Blocks beside the iframe; mobile: Blocks becomes the Preview surface.
  - Blocks tracks the active Preview page and remains usable during sandbox restarts.
  - Added unit tests for mode toggling and updated E2E to cover the new flow.

- Migration
  - Removed `blocks` from the side panel: `?sidepanel` now supports only `chat` or `0`.
  - `SidePanelKind` narrowed to `"chat"`; `SidePanel` no longer renders Blocks.
  - `PreviewContent` now requires a `virtualMcpId` prop.
  - Removed the Blocks toggle from the workspace toolbar; use the in-Preview toggle instead.

<sup>Written for commit bf8dff13673fd32f18bc7a25a74ded8ef068ae29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

