### PR TITLE
fix(cli): report occupied link port

### DIFF
--- a/apps/mesh/src/cli/commands/link.ts
+++ b/apps/mesh/src/cli/commands/link.ts
@@ -16,6 +16,12 @@ import { join } from "node:path";
 import { ensureSession } from "../lib/ensure-session";
 import { startLinkDaemon, type LinkDaemonMonitor } from "../../link-daemon";
 import { formatLogLine } from "../format-log-line";
+import { isPortInUse } from "../lib/port-wait";
+import {
+  formatPortInUseMessage,
+  isAddressInUseError,
+  PortInUseError,
+} from "../lib/port-in-use";
 import {
   openLinkSandboxRegistry,
   registryPathForDataDir,
@@ -137,6 +143,10 @@ export async function runLinkCommand(
     }
   };
   try {
+    if (await isPortInUse(port, "127.0.0.1")) {
+      throw new PortInUseError(port);
+    }
+
     const sandboxRoot = join(dataDir, "sandboxes");
     registry = openLinkSandboxRegistry({
       path: registryPathForDataDir(dataDir),
@@ -248,7 +258,13 @@ export async function runLinkCommand(
     // Restore BEFORE printing so a fatal error is visible on real stderr,
     // not swallowed into the TUI footer.
     restoreConsole?.();
-    console.error(err instanceof Error ? err.message : String(err));
+    console.error(
+      isAddressInUseError(err)
+        ? formatPortInUseMessage(port)
+        : err instanceof Error
+          ? err.message
+          : String(err),
+    );
     return 1;
   } finally {
     // Backstop: console must never leak patched, regardless of exit path.

--- a/apps/mesh/src/cli/lib/port-in-use.test.ts
+++ b/apps/mesh/src/cli/lib/port-in-use.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatPortInUseMessage,
+  isAddressInUseError,
+  PortInUseError,
+  portTerminationCommand,
+} from "./port-in-use";
+
+describe("portTerminationCommand", () => {
+  it("returns the cmd command on Windows", () => {
+    expect(portTerminationCommand(5174, "win32")).toBe(
+      'for /f "tokens=5" %P in (\'netstat -ano ^| findstr /R /C:":5174 .*LISTENING"\') do taskkill /F /PID %P',
+    );
+  });
+
+  it("returns the POSIX command on Linux and macOS", () => {
+    const command = "kill -9 $(lsof -ti tcp:5174)";
+    expect(portTerminationCommand(5174, "linux")).toBe(command);
+    expect(portTerminationCommand(5174, "darwin")).toBe(command);
+  });
+});
+
+describe("formatPortInUseMessage", () => {
+  it("renders only the command for the current platform", () => {
+    const windowsMessage = formatPortInUseMessage(5174, "win32");
+    expect(windowsMessage).toContain("netstat -ano");
+    expect(windowsMessage).toContain("taskkill /F /PID %P");
+    expect(windowsMessage).not.toContain("lsof");
+
+    const posixMessage = formatPortInUseMessage(5174, "darwin");
+    expect(posixMessage).toContain("lsof -ti tcp:5174");
+    expect(posixMessage).not.toContain("netstat -ano");
+  });
+});
+
+describe("isAddressInUseError", () => {
+  it("recognizes preflight and Bun listen errors", () => {
+    expect(isAddressInUseError(new PortInUseError(5174))).toBe(true);
+    expect(isAddressInUseError({ code: "EADDRINUSE" })).toBe(true);
+    expect(isAddressInUseError(new Error("unrelated"))).toBe(false);
+  });
+});

--- a/apps/mesh/src/cli/lib/port-in-use.ts
+++ b/apps/mesh/src/cli/lib/port-in-use.ts
@@ -1,0 +1,40 @@
+export class PortInUseError extends Error {
+  readonly code = "EADDRINUSE";
+
+  constructor(readonly port: number) {
+    super(`Port ${port} is already in use.`);
+    this.name = "PortInUseError";
+  }
+}
+
+export function isAddressInUseError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "EADDRINUSE"
+  );
+}
+
+export function portTerminationCommand(
+  port: number,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return `for /f "tokens=5" %P in ('netstat -ano ^| findstr /R /C:":${port} .*LISTENING"') do taskkill /F /PID %P`;
+  }
+
+  return `kill -9 $(lsof -ti tcp:${port})`;
+}
+
+export function formatPortInUseMessage(
+  port: number,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return [
+    `Port ${port} is already in use.`,
+    "Run this command to stop the process listening on it, then retry `decocms link`:",
+    "",
+    `  ${portTerminationCommand(port, platform)}`,
+  ].join("\n");
+}

--- a/apps/mesh/src/cli/lib/port-wait.ts
+++ b/apps/mesh/src/cli/lib/port-wait.ts
@@ -10,7 +10,7 @@ const LOCALHOST_ENDPOINTS = ["localhost", "127.0.0.1", "0.0.0.0"];
  */
 export async function findRunningAddr(port: number): Promise<string | null> {
   for (const host of LOCALHOST_ENDPOINTS) {
-    const inUse = await isInUse(host, port);
+    const inUse = await isPortInUse(port, host);
     if (inUse) return host;
   }
   return null;
@@ -34,7 +34,7 @@ export async function waitForPort(
   }
 }
 
-function isInUse(host: string, port: number): Promise<boolean> {
+export function isPortInUse(port: number, host: string): Promise<boolean> {
   return new Promise((resolve) => {
     const srv = createServer();
     srv.once("error", (err: NodeJS.ErrnoException) => {


### PR DESCRIPTION
## Summary

- exit decocms link early when its local ingress port is occupied
- print only the platform-appropriate process termination command
- use CMD on Windows and lsof/kill on Linux and macOS

## Testing

- bun test apps/mesh/src/cli/lib/port-in-use.test.ts
- bun test apps/mesh/src/cli/lib/port-wait.test.ts
- bun run check
- bun run lint (0 errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exits `decocms link` early when the local ingress port is occupied and shows a single, OS-specific command to free the port. This prevents confusing startup failures and guides users to resolve conflicts fast.

- **Bug Fixes**
  - Added preflight port check on 127.0.0.1; throws `PortInUseError` and exits.
  - Prints platform-appropriate termination command (Windows: `netstat`/`taskkill`; Linux/macOS: `lsof`/`kill`).
  - Exported `isPortInUse(port, host)` from port wait utils and updated callers; added tests for messaging and OS commands.

<sup>Written for commit b2e075d99d41b0ccf9d7e4e2b63b226a9751cc9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

