### PR TITLE
fix(preview): move blocks control into topbar

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -801,63 +801,48 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   };
 
   const canVisualEdit = previewState.kind === "iframe";
-  const floatingPreviewControls =
-    canVisualEdit || editingMode === "blocks" ? (
-      <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2">
-        <div className="flex items-center gap-0.5 rounded-full border bg-background/90 p-1 shadow-lg backdrop-blur-sm">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ToolbarIconButton
-                onClick={() => toggleEditingMode("visual")}
-                aria-pressed={editingMode === "visual"}
-                aria-label="Visual editor"
-                active={editingMode === "visual"}
-                disabled={!canVisualEdit}
+  const floatingPreviewControls = canVisualEdit ? (
+    <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2">
+      <div className="flex items-center gap-0.5 rounded-full border bg-background/90 p-1 shadow-lg backdrop-blur-sm">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <ToolbarIconButton
+              onClick={() => toggleEditingMode("visual")}
+              aria-pressed={editingMode === "visual"}
+              aria-label="Visual editor"
+              active={editingMode === "visual"}
+              disabled={!canVisualEdit}
+            >
+              <CursorClick01 size={16} />
+            </ToolbarIconButton>
+          </TooltipTrigger>
+          <TooltipContent side="top">Visual editor</TooltipContent>
+        </Tooltip>
+        <div className="mx-0.5 h-5 w-px bg-border" />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <ToolbarIconButton
+              onClick={handleDeviceToggle}
+              aria-label={DEVICE_LABELS[previewDeviceSize]}
+              disabled={!canVisualEdit}
+            >
+              <span
+                key={previewDeviceSize}
+                className="flex items-center justify-center animate-device-icon-pop"
               >
-                <CursorClick01 size={16} />
-              </ToolbarIconButton>
-            </TooltipTrigger>
-            <TooltipContent side="top">Visual editor</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ToolbarIconButton
-                data-testid="preview-blocks-toggle"
-                onClick={() => toggleEditingMode("blocks")}
-                aria-pressed={editingMode === "blocks"}
-                aria-label="Blocks editor"
-                active={editingMode === "blocks"}
-              >
-                <TextInput size={16} />
-              </ToolbarIconButton>
-            </TooltipTrigger>
-            <TooltipContent side="top">Blocks editor</TooltipContent>
-          </Tooltip>
-          <div className="mx-0.5 h-5 w-px bg-border" />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ToolbarIconButton
-                onClick={handleDeviceToggle}
-                aria-label={DEVICE_LABELS[previewDeviceSize]}
-                disabled={!canVisualEdit}
-              >
-                <span
-                  key={previewDeviceSize}
-                  className="flex items-center justify-center animate-device-icon-pop"
-                >
-                  {previewDeviceSize === "mobile" && <Phone02 size={16} />}
-                  {previewDeviceSize === "tablet" && <Tablet01 size={16} />}
-                  {previewDeviceSize === "desktop" && <Monitor04 size={16} />}
-                </span>
-              </ToolbarIconButton>
-            </TooltipTrigger>
-            <TooltipContent side="top">
-              {DEVICE_LABELS[previewDeviceSize]}
-            </TooltipContent>
-          </Tooltip>
-        </div>
+                {previewDeviceSize === "mobile" && <Phone02 size={16} />}
+                {previewDeviceSize === "tablet" && <Tablet01 size={16} />}
+                {previewDeviceSize === "desktop" && <Monitor04 size={16} />}
+              </span>
+            </ToolbarIconButton>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            {DEVICE_LABELS[previewDeviceSize]}
+          </TooltipContent>
+        </Tooltip>
       </div>
-    ) : null;
+    </div>
+  ) : null;
 
   return (
     <div className="flex flex-col w-full h-full">
@@ -879,13 +864,21 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
         )}
       {daemonReady && previewState.kind === "iframe" && (
         <div className="relative flex h-12 shrink-0 items-center gap-4 border-b border-border/60 px-3 md:px-4">
-          {/* Groups 2+3 only render when the iframe is live — they read
-              `previewState.previewUrl` and steer the iframe directly. */}
           {previewState.kind === "iframe" && (
-            <div className="flex w-full items-center justify-center">
-              {/* Centered address bar (max 500px):
-                    reload · URL · open in new tab · more actions. */}
-              <div className="flex w-full max-w-[500px] items-center gap-0.5">
+            <div className="grid h-full w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-2">
+              <Button
+                variant={editingMode === "blocks" ? "secondary" : "ghost"}
+                size="sm"
+                data-testid="preview-blocks-toggle"
+                onClick={() => toggleEditingMode("blocks")}
+                aria-pressed={editingMode === "blocks"}
+                aria-label="Blocks editor"
+              >
+                <TextInput size={14} />
+                Blocks
+              </Button>
+
+              <div className="flex w-full min-w-0 max-w-[500px] items-center gap-0.5 justify-self-center">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button variant="ghost" size="icon" onClick={handleRefresh}>
@@ -1129,8 +1122,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                     </div>
                   )}
                 </div>
-
-                {/* open in new tab · more actions */}
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
@@ -1146,9 +1137,8 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                   </TooltipTrigger>
                   <TooltipContent side="bottom">Open in new tab</TooltipContent>
                 </Tooltip>
-                {/* more actions — pinned to the right of the header,
-                      outside the centered address bar. */}
-                <div className="absolute inset-y-0 right-3 flex items-center md:right-4">
+
+                <div className="flex shrink-0 items-center">
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button variant="ghost" size="icon">


### PR DESCRIPTION
## Summary

- move the Blocks editor toggle from the floating preview controls to the left edge of the preview topbar
- render Blocks as an icon and label button with an active state
- keep the external-link and overflow actions in normal layout flow so they do not overlap while resizing

## Testing

- `bunx biome check apps/mesh/src/web/components/sandbox/preview/preview.tsx`
- `bun run --cwd=apps/mesh check`
- `bun run lint`
- `bun test apps/mesh/src/web/components/sandbox/preview/editing-mode.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the Blocks editor toggle into the preview topbar and fix header action overlap during resize. The Blocks control is now an icon+label button with an active state; the floating bar keeps only visual mode and device toggles.

- **Bug Fixes**
  - Switched the topbar to a 2-column grid: Blocks on the left, address bar centered with a max width.
  - Removed absolute positioning for the overflow menu; actions stay in normal flow to prevent overlap.

<sup>Written for commit d6b5f7f2889268665c8553e4ba9c3285a1f4ae52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

