### PR TITLE
refactor(mesh-sdk): remove dead getWellKnownMcpStudioConnection

### DIFF
--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -237,7 +237,6 @@ export {
   getWellKnownCommunityRegistryConnection,
   getWellKnownSelfConnection,
   getWellKnownDevAssetsConnection,
-  getWellKnownMcpStudioConnection,
   getWellKnownCommerceDiscoveryConnection,
   // Virtual MCP factory functions
   getWellKnownDecopilotVirtualMCP,

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -190,31 +190,6 @@ export function getWellKnownDevAssetsConnection(
 }
 
 /**
- * Get well-known connection definition for MCP Studio.
- * Used by agents and workflows pages to offer installation when no provider is connected.
- */
-export function getWellKnownMcpStudioConnection(): ConnectionCreateData {
-  return {
-    title: "MCP Studio",
-    description: "An app that allows you to create and manage MCPs",
-    icon: "https://assets.decocache.com/mcp/09e44283-f47d-4046-955f-816d227c626f/app.png",
-    app_name: "mcp-studio",
-    app_id: "65a1b407-b6af-41e2-a89f-ce9450c05bbc",
-    connection_type: "HTTP",
-    connection_url: "https://sites-vibemcp.decocache.com/mcp",
-    connection_token: null,
-    connection_headers: null,
-    oauth_config: null,
-    configuration_state: null,
-    configuration_scopes: null,
-    metadata: {
-      isDefault: false,
-      type: "mcp-studio",
-    },
-  };
-}
-
-/**
  * Build a paired `{ is, get }` helper for an org-scoped well-known agent id
  * of shape `${prefix}${orgId}`. Centralizes the trivial check/slice/format
  * logic that every well-known agent used to hand-roll.


### PR DESCRIPTION
## Summary
- Source: dead code found while reading `@decocms/mesh-sdk`'s well-known-connection factories (no injected issue/PR covers this).
- `getWellKnownMcpStudioConnection` is exported from the package's public API (`packages/mesh-sdk/src/index.ts`) but has zero callers anywhere in the repo — `grep -rn "getWellKnownMcpStudioConnection"` only matches its own definition and the re-export. Its last real caller was removed years ago (around the "Gateways as assistants" rework); it's been dead weight on every build/re-export since.
- Payoff: -26 lines, one less unused symbol shipped in the mesh-sdk public API surface.

## Verification
- `bun run fmt` — clean.
- `cd packages/mesh-sdk && bunx tsc --noEmit` — passes, no type errors.
- `grep -rn "getWellKnownMcpStudioConnection" .` (repo-wide) — no remaining references after the deletion.
- No existing test covered this function (it returns a static object literal), so the grep-proof of zero references plus a green targeted typecheck is the verification; full CI will run the rest.

Reviewer check: `grep -rn getWellKnownMcpStudioConnection .` should return nothing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `getWellKnownMcpStudioConnection` from `@decocms/mesh-sdk` to slim the public API and drop dead code. No behavior changes.

<sup>Written for commit 6c82d3b2b6dc4685916b96d14c0daf1c358aeba2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

