### PR TITLE
fix(web): read committed .deco snapshots so CMS works without dev server

### DIFF
--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
@@ -33,15 +33,17 @@ export function BlocksPanel({ virtualMcpId }: { virtualMcpId: string }) {
   const workspace = useBlocksPreviewWorkspace();
   const devServerReady = sandboxEvents.lifecycle.phase === "running";
   const previewUrl = lifecycle.previewUrl;
-  const fetchParams =
-    currentBranch && devServerReady
-      ? {
-          orgSlug: org.slug,
-          virtualMcpId,
-          branch: currentBranch,
-          previewUrl,
-        }
-      : null;
+  // Not gated on the dev server: when it's down (crashed/paused) we read the
+  // committed `.deco/*.gen.json` snapshot so the Blocks form editor still opens
+  // (block edits persist to the FS). The live routes take over once it's up.
+  const fetchParams = currentBranch
+    ? {
+        orgSlug: org.slug,
+        virtualMcpId,
+        branch: currentBranch,
+        previewUrl,
+      }
+    : null;
   const decofile = useDecofile(fetchParams, { fetchEnabled: devServerReady });
   const meta = useLiveMeta(fetchParams, { fetchEnabled: devServerReady });
   const state = resolveBlocksTabState({

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -372,6 +372,7 @@ export function ContentBrowser({ mode = "content" }: ContentBrowserProps) {
       branch={branch}
       previewUrl={previewUrl}
       mode={mode}
+      devServerReady={vmEvents.lifecycle.phase === "running"}
     />
   );
 }
@@ -400,17 +401,21 @@ function ContentBrowserReady({
   branch,
   previewUrl,
   mode,
+  devServerReady,
 }: {
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
   previewUrl: string | null;
   mode: "content" | "blocks";
+  devServerReady: boolean;
 }) {
   const workspace = useBlocksPreviewWorkspace();
   const fetchParams = { orgSlug, virtualMcpId, branch, previewUrl };
-  const { data: decofile, isLoading: decofileLoading } =
-    useDecofile(fetchParams);
+  const { data: decofile, isLoading: decofileLoading } = useDecofile(
+    fetchParams,
+    { fetchEnabled: devServerReady },
+  );
 
   const [activeCollection, setActiveCollection] =
     useState<CollectionId>("pages");
@@ -508,6 +513,7 @@ function ContentBrowserReady({
     isLoading: metaLoading,
     isFetching: metaFetching,
   } = useLiveMeta(fetchParams, {
+    fetchEnabled: devServerReady,
     refetchInterval: (query) => {
       const currentMeta = query.state.data;
 

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -232,6 +232,10 @@ export function SandboxEventsProvider({
     let decofileDebounceTimer: ReturnType<typeof setTimeout> | null = null;
     let studioEs: EventSource | null = null;
     let directEs: EventSource | null = null;
+    // Tracks the dev-server lifecycle so we can invalidate the CMS queries once
+    // it comes up (switching them from the committed `.deco/*.gen.json` snapshot
+    // to the live `/.decofile` + `/live/_meta` routes).
+    let prevLifecyclePhase: string | null = null;
 
     const handleClaimPhase = (e: MessageEvent) => {
       try {
@@ -299,6 +303,27 @@ export function SandboxEventsProvider({
           case "lifecycle": {
             const lp = payload as DaemonEventPayload<"lifecycle">;
             setLifecycle(lp.state);
+            // Dev server just came up: swap the CMS queries off the committed
+            // `.deco/*.gen.json` snapshot and onto the live routes. This is the
+            // trigger they rely on (they're enabled as soon as the daemon is up,
+            // so the `enabled` flip no longer does it) — see use-decofile /
+            // use-live-meta.
+            if (
+              lp.state.phase === "running" &&
+              prevLifecyclePhase !== "running"
+            ) {
+              const cacheKey = `${org.slug}/${virtualMcpId}/${branch}`;
+              void queryClient.invalidateQueries({
+                queryKey: KEYS.decofile(cacheKey),
+              });
+              void queryClient.invalidateQueries({
+                predicate: (query) =>
+                  query.queryKey[0] === "live-meta" &&
+                  typeof query.queryKey[1] === "string" &&
+                  query.queryKey[1].startsWith(`${cacheKey}/`),
+              });
+            }
+            prevLifecyclePhase = lp.state.phase;
             // Detect dev server port change (running phase carries port);
             // reload iframe so it picks up the new backend.
             const newPort = lp.state.phase === "running" ? lp.state.port : null;

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -269,13 +269,16 @@ export function flattenTree(
 /**
  * Strip the line-number prefix from the daemon's read endpoint.
  * The daemon returns content in `"1\tcontent\n2\tcontent"` format.
+ *
+ * Uses `replace` rather than a `(.*)` capture: `.` does not match `\r`,
+ * \u2028, or \u2029, so a capture group would truncate any line containing
+ * one of those (e.g. a JSON string value with an embedded line separator),
+ * silently corrupting large files. `replace` drops only the `<n>\t` prefix
+ * and keeps the rest of the line verbatim.
  */
 export function stripLineNumbers(content: string): string {
   return content
     .split("\n")
-    .map((line) => {
-      const match = line.match(/^\d+\t(.*)/);
-      return match ? match[1] : line;
-    })
+    .map((line) => line.replace(/^\d+\t/, ""))
     .join("\n");
 }

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -306,9 +306,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // agent-sandbox, whose daemon reports a container-internal path ("/app/repo").
   const repoDir = isDesktopSandbox ? rawRepoDir : null;
 
-  // Decofile pages for the URL bar dropdown — fetch only after dev server is up.
+  // Decofile pages/global sections for the URL bar dropdown. Not gated on the
+  // dev server: when it's down we read the committed `.deco/*.gen.json` snapshot
+  // so the dropdown still lists pages; the live routes take over once it's up.
+  // (The inline CMS overlay still needs the dev server — it edits the page
+  // rendered inside the iframe, which the dev server serves.)
   const decofileParams =
-    virtualMcpId && branch && devServerReady
+    virtualMcpId && branch
       ? { orgSlug: org.slug, virtualMcpId, branch, previewUrl }
       : null;
   const { data: decofile } = useDecofile(decofileParams, {

--- a/apps/mesh/src/web/components/sections-editor/read-committed-file.ts
+++ b/apps/mesh/src/web/components/sections-editor/read-committed-file.ts
@@ -1,0 +1,48 @@
+import { stripLineNumbers } from "@/web/components/sandbox/preview/file-explorer/utils";
+
+interface RepoFileParams {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+}
+
+/**
+ * Read a JSON file committed to the repo working tree via the sandbox daemon's
+ * file-read proxy. Unlike `/.decofile` and `/live/_meta` (served by the dev
+ * server), this works as soon as the daemon is up — before the dev script boots
+ * or even when it has crashed — so the CMS can be read (and, since block writes
+ * go straight to the FS, edited) without a working preview.
+ *
+ * Returns `null` when the file is absent (daemon 400) or unparseable; throws on
+ * transient daemon-unreachable errors so the caller's query retries.
+ */
+export async function readCommittedJson<T>(
+  params: RepoFileParams,
+  path: string,
+): Promise<T | null> {
+  const url = `/api/${params.orgSlug}/sandbox/${encodeURIComponent(
+    params.virtualMcpId,
+  )}/${encodeURIComponent(params.branch)}/read`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ path, full: true }),
+  });
+  // 400 = file not found: the repo simply doesn't commit this artifact, so
+  // there is no committed source to fall back to. Don't retry.
+  if (res.status === 400) return null;
+  if (!res.ok) {
+    const err = new Error(`Failed to read ${path}: ${res.status}`);
+    (err as { status?: number }).status = res.status;
+    throw err;
+  }
+  // The daemon returns line-number-prefixed content ("1\t...\n2\t..."), even
+  // with `full: true`, so strip it before parsing.
+  const data = (await res.json()) as { content?: string };
+  if (typeof data.content !== "string") return null;
+  try {
+    return JSON.parse(stripLineNumbers(data.content)) as T;
+  } catch {
+    return null;
+  }
+}

--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { exponentialBackoffWithJitter } from "@decocms/std";
 import { KEYS } from "@/web/lib/query-keys";
 import { buildDecofileFetchUrl } from "./preview-fetch-url";
+import { readCommittedJson } from "./read-committed-file";
 
 interface UseDecofileParams {
   orgSlug: string;
@@ -17,25 +18,48 @@ export function useDecofile(
   const key = params
     ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}`
     : "";
+  // `fetchEnabled` means the dev server is up, so the live `/.decofile` route is
+  // worth hitting. When it's down we read the committed `.deco/blocks.gen.json`
+  // straight from the working tree — a single source of truth for KEYS.decofile,
+  // so optimistic block writes (which persist to the FS) operate on a full base
+  // and the CMS stays editable even if the preview never comes up.
   const fetchEnabled = options?.fetchEnabled ?? true;
   return useQuery({
     queryKey: KEYS.decofile(key),
     queryFn: async () => {
-      const res = await fetch(buildDecofileFetchUrl(params!), {
-        cache: "no-store",
-      });
-      if (!res.ok) {
-        const err = new Error(`Failed to fetch decofile: ${res.status}`);
-        (err as { status?: number }).status = res.status;
+      const readCommitted = () =>
+        readCommittedJson<Record<string, unknown>>(
+          params!,
+          ".deco/blocks.gen.json",
+        );
+      if (fetchEnabled) {
+        const res = await fetch(buildDecofileFetchUrl(params!), {
+          cache: "no-store",
+        }).catch(() => null);
+        if (res?.ok) return (await res.json()) as Record<string, unknown>;
+        // Dev server reported ready but the route failed (e.g. dev script
+        // crashed): fall back to the committed snapshot so editing still works.
+        const committed = await readCommitted();
+        if (committed) return committed;
+        const err = new Error(
+          `Failed to fetch decofile: ${res?.status ?? "network error"}`,
+        );
+        (err as { status?: number }).status = res?.status ?? 502;
         throw err;
       }
-      return (await res.json()) as Record<string, unknown>;
+      const committed = await readCommitted();
+      if (committed) return committed;
+      const err = new Error(
+        "decofile unavailable (preview down, no committed snapshot)",
+      );
+      (err as { status?: number }).status = 502;
+      throw err;
     },
-    enabled: !!params && fetchEnabled,
+    enabled: !!params,
     staleTime: 30_000,
-    // 502 = preview unreachable (sandbox starting or down). The SSE lifecycle
-    // re-enables this query when the preview is back, so retrying just hammers
-    // a known-down endpoint and spams 5xx logs.
+    // 502 = preview unreachable / nothing available yet. The sandbox lifecycle
+    // re-invalidates this query when the dev server comes up (see
+    // sandbox-events-context), so retrying just hammers a known-down endpoint.
     retry: (failureCount, error) =>
       (error as { status?: number }).status !== 502 && failureCount < 2,
     retryDelay: (attempt) =>

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
@@ -1,6 +1,7 @@
 import { type Query, useQuery } from "@tanstack/react-query";
 import { exponentialBackoffWithJitter } from "@decocms/std";
 import { KEYS } from "@/web/lib/query-keys";
+import { readCommittedJson } from "./read-committed-file";
 import type { LiveMeta } from "./resolve-schema";
 
 interface UseLiveMetaParams {
@@ -28,22 +29,38 @@ export function useLiveMeta(
   return useQuery({
     queryKey: KEYS.liveMeta(key),
     queryFn: async () => {
-      const url = new URL("/live/_meta", previewUrl!).href;
-      const res = await fetch(url, { cache: "no-store" });
-      if (!res.ok) {
-        const err = new Error(`Failed to fetch live meta: ${res.status}`);
-        (err as { status?: number }).status = res.status;
+      const readCommitted = () =>
+        readCommittedJson<LiveMeta>(params!, ".deco/meta.gen.json");
+      // Prefer the live `/live/_meta` when the dev server is up; otherwise (or on
+      // failure) read the committed `.deco/meta.gen.json` snapshot so the CMS
+      // schema is available even without a working preview.
+      if (fetchEnabled && previewUrl) {
+        const url = new URL("/live/_meta", previewUrl).href;
+        const res = await fetch(url, { cache: "no-store" }).catch(() => null);
+        if (res?.ok) return (await res.json()) as LiveMeta;
+        const committed = await readCommitted();
+        if (committed) return committed;
+        const err = new Error(
+          `Failed to fetch live meta: ${res?.status ?? "network error"}`,
+        );
+        (err as { status?: number }).status = res?.status ?? 502;
         throw err;
       }
-      return (await res.json()) as LiveMeta;
+      const committed = await readCommitted();
+      if (committed) return committed;
+      const err = new Error(
+        "live meta unavailable (preview down, no committed snapshot)",
+      );
+      (err as { status?: number }).status = 502;
+      throw err;
     },
-    enabled: !!params && !!previewUrl && fetchEnabled,
+    enabled: !!params,
     refetchInterval: options?.refetchInterval,
     refetchIntervalInBackground: false,
     staleTime: 300_000,
-    // 502 = preview unreachable (sandbox starting or down). The SSE lifecycle
-    // re-enables this query when the preview is back, so retrying just hammers
-    // a known-down endpoint and spams 5xx logs.
+    // 502 = preview unreachable / nothing available yet. The sandbox lifecycle
+    // re-invalidates this query when the dev server comes up (see
+    // sandbox-events-context), so retrying just hammers a known-down endpoint.
     retry: (failureCount, error) =>
       (error as { status?: number }).status !== 502 && failureCount < 3,
     retryDelay: (attempt) =>

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
@@ -43,16 +43,36 @@ describe("resolveBlocksTabState", () => {
     expect(resolveBlocksTabState(input())).toEqual({ kind: "empty" });
   });
 
-  test.each([
-    "clone-failed",
-    "install-failed",
-    "start-failed",
-    "crashed",
-  ] as const)("renders a sandbox error for %s", (lifecyclePhase) => {
-    expect(resolveBlocksTabState(input({ lifecyclePhase }))).toEqual({
-      kind: "error",
-      source: "sandbox",
-    });
+  test.each(["clone-failed", "install-failed", "start-failed"] as const)(
+    "renders a sandbox error for %s",
+    (lifecyclePhase) => {
+      expect(resolveBlocksTabState(input({ lifecyclePhase }))).toEqual({
+        kind: "error",
+        source: "sandbox",
+      });
+    },
+  );
+
+  test("renders editable content from the committed snapshot when crashed", () => {
+    // Dev server paused/crashed but the committed `.deco/*.gen.json` is still
+    // readable, so the Blocks editor stays available for FS-backed edits.
+    expect(
+      resolveBlocksTabState(
+        input({ lifecyclePhase: "crashed", hasEditableContent: true }),
+      ),
+    ).toEqual({ kind: "content" });
+  });
+
+  test("loads while crashed and the committed snapshot is still pending", () => {
+    expect(
+      resolveBlocksTabState(
+        input({
+          lifecyclePhase: "crashed",
+          decofile: { status: "pending", hasData: false },
+          meta: { status: "pending", hasData: false },
+        }),
+      ),
+    ).toEqual({ kind: "loading" });
   });
 
   test("renders a data error when an initial request fails", () => {

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
@@ -30,10 +30,21 @@ const TERMINAL_LIFECYCLE_PHASES = new Set<LifecycleState["phase"]>([
 export function resolveBlocksTabState(
   input: BlocksTabStateInput,
 ): BlocksTabState {
-  if (TERMINAL_LIFECYCLE_PHASES.has(input.lifecyclePhase)) {
+  // `crashed` = the dev server was running and stopped responding (paused or
+  // died). The committed `.deco/*.gen.json` is still readable from the daemon,
+  // so treat it like `running` here and let the data drive the state: the user
+  // can still edit blocks (writes persist to the FS), only the live preview is
+  // broken until the dev server is back. Genuine setup failures stay terminal.
+  const devUpOrRecoverable =
+    input.lifecyclePhase === "running" || input.lifecyclePhase === "crashed";
+
+  if (
+    TERMINAL_LIFECYCLE_PHASES.has(input.lifecyclePhase) &&
+    input.lifecyclePhase !== "crashed"
+  ) {
     return { kind: "error", source: "sandbox" };
   }
-  if (input.lifecyclePhase !== "running") return { kind: "loading" };
+  if (!devUpOrRecoverable) return { kind: "loading" };
 
   const initialDataFailed =
     (input.decofile.status === "error" && !input.decofile.hasData) ||

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -255,8 +255,10 @@ export function useMainPanelTabs(ctx: {
           previewUrl,
         }
       : null;
-  // Subscribe to the same query keys as Preview; only fetch after the dev
-  // server is running, but still re-render when Preview warms the cache.
+  // Subscribe to the same query keys as Preview. The committed `.deco/*.gen.json`
+  // snapshots are read as soon as the daemon is up (before the dev server), so
+  // the Content tab can show without waiting; the live route fetch stays gated
+  // behind `devServerReady` and takes over once the preview warms up.
   const { data: decofile } = useDecofile(decofileFetchParams, {
     fetchEnabled: devServerReady,
   });


### PR DESCRIPTION
## Summary

Makes the **Content tab (CMS)** available and editable without a running dev server, by reading the committed `.deco/` snapshots straight from the sandbox working tree, and fixes a latent `stripLineNumbers` bug that was silently truncating large file reads.

### CMS without the dev server
- `useDecofile` / `useLiveMeta` now read the committed `.deco/blocks.gen.json` (decofile) and `.deco/meta.gen.json` (live meta) via the daemon file-read proxy (`/read`) when the dev server is down, falling back to it even when the route errors (crashed dev script). The live `/.decofile` + `/live/_meta` routes still win once the dev server is up.
- Single cache per key (`KEYS.decofile` / `KEYS.liveMeta`): the committed snapshot seeds it, so the existing optimistic block writes (which already persist to the FS via `/write` + `/unlink`) operate on a full base.
- On the sandbox lifecycle `running` transition, the CMS queries are re-invalidated so they swap from the committed snapshot to the live routes.
- `content-browser` passes `fetchEnabled: devServerReady` so it prefers committed while the dev server is down.

### `stripLineNumbers` truncation fix
The daemon's `/read` returns line-number-prefixed content. `stripLineNumbers` used a `(.*)` capture whose `.` does **not** match `\r`, U+2028, or U+2029. A single-line minified JSON payload with an embedded line separator (common in pasted rich-text content) was truncated at the first such char — an ~11MB decofile was cut in half, breaking `JSON.parse`. Switched to a prefix-only `replace` that preserves the rest of each line verbatim. This also fixes the same latent corruption in the file explorer.

## Testing
- `tsc`, `lint`, `fmt` clean.
- Verified end-to-end in the app: with the dev server paused, the 11MB `.deco/blocks.gen.json` now parses fully and the Content tab appears (diagnosed via temporary logging, since removed).

## Notes / known limits
- Requires the sandbox **daemon** to be reachable. A fully **paused/suspended** sandbox (pod frozen) still can't serve `/read`, so the tab won't show until resume — separate follow-up (read committed files from git directly).
- Read source is the aggregate `blocks.gen.json`, which the dev server regenerates; while the dev server is down, a reload won't reflect just-written blocks until it regenerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the CMS Content and Blocks editors, plus the preview URL-bar pages/global list, work without the dev server by reading committed `.deco` snapshots. Also fixes a file-read bug that could corrupt large JSON files.

- **New Features**
  - Read committed `.deco/blocks.gen.json` and `.deco/meta.gen.json` when the preview is down or live routes fail; used for the Content tab, Blocks editor, and Preview URL-bar lists before the dev server is up.
  - Added `readCommittedJson`; `useDecofile`/`useLiveMeta` prefer committed data until `devServerReady`, and the lifecycle `running` transition now invalidates queries to swap to live routes.
  - Treat `crashed` as recoverable so the Blocks editor stays available; ungated fetch params in Blocks panel and Preview while keeping `fetchEnabled: devServerReady` for live routes.

- **Bug Fixes**
  - `stripLineNumbers` now uses a prefix-only `replace` to avoid truncating lines with `\r`, U+2028, or U+2029`, fixing corruption in large files.

<sup>Written for commit caf2f49ca495836d9a0cf506317c32febc5db22a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

