### PR TITLE
feat(sandbox): flip to running the instant the dev server announces its port

### DIFF
--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -141,9 +141,13 @@ const broadcaster = new Broadcaster(REPLAY_BYTES);
 // stdout and feed THAT to the probe; the configured port stays as a
 // fallback for tools that do honor PORT.
 const portSniffer = createPortSniffer();
+// Assigned once the probe is started below; the moment the sniffer locks a
+// port (dev server announced its bind URL = ready) we kick the probe so it
+// confirms and flips to `running` immediately instead of on its next tick.
+let kickProbe = (): void => {};
 const broadcastChunkRaw = broadcaster.broadcastChunk.bind(broadcaster);
 broadcaster.broadcastChunk = (source, data, opts) => {
-  portSniffer.observe(source, data);
+  if (portSniffer.observe(source, data)) kickProbe();
   broadcastChunkRaw(source, data, opts);
 };
 
@@ -248,7 +252,7 @@ let baselineTimer: ReturnType<typeof setTimeout> | null = null;
 // sibling sandbox on the same host) so we hold at `crashed` and require
 // an explicit restart.
 let lastRunningPort: number | null = null;
-const lastProbe = startUpstreamProbe({
+const { state: lastProbe, checkNow: probeCheckNow } = startUpstreamProbe({
   getPort: () =>
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
     portSniffer.current() ?? store.read()?.application?.port ?? null,
@@ -312,6 +316,7 @@ resetProbeState = () => {
   lastProbe.port = null;
   lastProbe.htmlSupport = false;
 };
+kickProbe = probeCheckNow;
 
 // HTTP/WS proxy forwards to the same port the probe is HEAD-checking.
 // `application.port` is what mesh configured, but vite/etc. routinely

--- a/packages/sandbox/daemon/probe.ts
+++ b/packages/sandbox/daemon/probe.ts
@@ -121,12 +121,23 @@ async function head(
   }
 }
 
-/**
- * Returns a live `ProbeState` reference — the fields are mutated in place
- * on every change so the SSE handshake (`getLastStatus`) sees fresh values
- * without a getter.
- */
-export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
+export interface ProbeHandle {
+  /**
+   * Live `ProbeState` reference — the fields are mutated in place on every
+   * change so the SSE handshake (`getLastStatus`) sees fresh values without a
+   * getter.
+   */
+  state: ProbeState;
+  /**
+   * Run a probe tick right now instead of waiting for the next scheduled one.
+   * Called when the port sniffer catches a dev server's bind announcement, so
+   * we confirm-and-go-online within a loopback round-trip rather than up to
+   * PROBE_FAST_MS later.
+   */
+  checkNow: () => void;
+}
+
+export function startUpstreamProbe(deps: ProbeDeps): ProbeHandle {
   const state: ProbeState = {
     status: "booting",
     port: null,
@@ -211,5 +222,11 @@ export function startUpstreamProbe(deps: ProbeDeps): ProbeState {
   }
 
   schedule();
-  return state;
+  return {
+    state,
+    checkNow: () => {
+      if (timer) clearTimeout(timer);
+      void tick();
+    },
+  };
 }

--- a/packages/sandbox/daemon/process/port-sniffer.test.ts
+++ b/packages/sandbox/daemon/process/port-sniffer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { createPortSniffer } from "./port-sniffer";
+
+const VITE_READY = `  VITE v7.3.2  ready in 315 ms\n\n  ➜  Local:   http://localhost:3000/\n`;
+
+describe("createPortSniffer", () => {
+  test("returns true only on the chunk that first locks the port", () => {
+    const s = createPortSniffer();
+    expect(s.observe("dev", VITE_READY)).toBe(true);
+    expect(s.current()).toBe(3000);
+    // Already locked — later lines never retarget or re-signal.
+    expect(s.observe("dev", "fetch http://localhost:9999/api")).toBe(false);
+    expect(s.current()).toBe(3000);
+  });
+
+  test("ignores non-starter sources", () => {
+    const s = createPortSniffer();
+    expect(s.observe("task3", VITE_READY)).toBe(false);
+    expect(s.current()).toBeNull();
+  });
+
+  test("no bind URL → no lock, no signal", () => {
+    const s = createPortSniffer();
+    expect(s.observe("dev", "compiling...")).toBe(false);
+    expect(s.current()).toBeNull();
+  });
+
+  test("reset re-arms detection", () => {
+    const s = createPortSniffer();
+    s.observe("dev", VITE_READY);
+    s.reset();
+    expect(s.current()).toBeNull();
+    expect(s.observe("start", "Listening on http://0.0.0.0:8000/")).toBe(true);
+    expect(s.current()).toBe(8000);
+  });
+});

--- a/packages/sandbox/daemon/process/port-sniffer.ts
+++ b/packages/sandbox/daemon/process/port-sniffer.ts
@@ -32,8 +32,11 @@ export interface PortSniffer {
   /**
    * Inspect a log chunk. No-op when not a starter source, when a port is
    * already locked in, or when the chunk has no recognizable bind URL.
+   * Returns true only on the chunk that first locks a port in — that bind
+   * announcement is the dev server telling us it's ready, so the caller can
+   * kick the probe immediately instead of waiting for its next poll tick.
    */
-  observe(source: string, data: string): void;
+  observe(source: string, data: string): boolean;
   /** Currently sniffed port, or null if nothing's been detected. */
   current(): number | null;
   /** Drop the locked-in port — the next observe() can sniff again. */
@@ -44,19 +47,21 @@ export function createPortSniffer(): PortSniffer {
   let port: number | null = null;
   return {
     observe(source, data) {
-      if (port !== null) return;
+      if (port !== null) return false;
       if (
         !WELL_KNOWN_STARTERS.includes(
           source as (typeof WELL_KNOWN_STARTERS)[number],
         )
       )
-        return;
+        return false;
       const stripped = data.replace(ANSI, "");
       const match = stripped.match(URL_PATTERN);
-      if (!match) return;
+      if (!match) return false;
       const parsed = Number(match[1]);
-      if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) return;
+      if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535)
+        return false;
       port = parsed;
+      return true;
     },
     current() {
       return port;


### PR DESCRIPTION
## Summary

When a dev server boots, mesh waits for the daemon's HEAD probe to report the port responding before flipping the sandbox to `running` (and reloading the preview iframe). The probe only picks up a freshly-bound port on its **next scheduled tick** — up to `PROBE_FAST_MS` (1s) after the server was already up.

But the port sniffer already parses the bind URL these frameworks print *the moment they're ready*:

```
  VITE v7.3.2  ready in 315 ms
  ➜  Local:   http://localhost:3000/
```

That announcement *is* the "dev server is ready, here's the port" signal. This PR uses it to kick an immediate probe instead of waiting for the poll interval.

## Changes

- `port-sniffer.ts` — `observe()` now returns `true` on the chunk that first locks a port in.
- `probe.ts` — `startUpstreamProbe()` returns `{ state, checkNow }`; `checkNow()` runs a probe tick immediately.
- `entry.ts` — on the sniffer's first lock, call `checkNow()`.

The HEAD probe stays the source of truth for readiness + `htmlSupport` — we just stop waiting a poll interval to run it. If the kick fires before the server truly accepts connections, the immediate HEAD simply misses and normal `booting` polling continues (no false-crash escalation).

## Testing

- New `port-sniffer.test.ts` covers the newly-locked return contract (first-lock, already-locked, non-starter source, no-URL, reset re-arm).
- Existing `probe.test.ts` passes.
- `bun run check` / `bun run lint` clean; daemon bundle builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flip the sandbox to running the moment the dev server prints its bind URL, triggering an immediate HEAD probe instead of waiting up to `PROBE_FAST_MS` (~1s). This removes the startup delay and refreshes the preview faster without changing readiness rules.

- **New Features**
  - `port-sniffer.observe()` now returns `true` only on the chunk that first locks a port; we use this to kick a probe immediately.
  - `startUpstreamProbe()` now returns `{ state, checkNow }`; `checkNow()` runs a probe tick right away.
  - Wired the sniffer’s first-lock signal to `checkNow()` in the daemon entry. If the server isn’t actually accepting yet, the immediate HEAD just misses and normal polling continues.

<sup>Written for commit 13ae773120313869ca8cad14f173e24a45d62e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

