### PR TITLE
fix(github): fetch a renamed PR file's old content from its previous path

### DIFF
--- a/apps/mesh/src/web/components/thread/github/github-pr-diff.test.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-diff.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   countGitDiffFiles,
   decodeGithubFileContent,
+  fetchGithubPrDiff,
 } from "./github-pr-diff.ts";
 
 describe("github-pr-diff", () => {
@@ -47,5 +48,64 @@ describe("github-pr-diff", () => {
 
   it("decodeGithubFileContent returns null for tool errors", () => {
     expect(decodeGithubFileContent({ isError: true })).toBeNull();
+  });
+
+  it("fetchGithubPrDiff reads a renamed file's old content from its previous path", async () => {
+    const fileContentByPath: Record<string, string> = {
+      "old.ts": "old content",
+      "new.ts": "new content",
+    };
+    const calls: Array<{ name: string; arguments: Record<string, unknown> }> =
+      [];
+    const client = {
+      callTool: async (req: {
+        name: string;
+        arguments: Record<string, unknown>;
+      }) => {
+        calls.push(req);
+        if (req.name === "pull_request_read") {
+          return {
+            structuredContent: [
+              {
+                filename: "new.ts",
+                previous_filename: "old.ts",
+                status: "renamed",
+                additions: 1,
+                deletions: 1,
+                changes: 2,
+              },
+            ],
+          };
+        }
+        const path = req.arguments.path as string;
+        return {
+          content: [
+            {
+              type: "resource",
+              resource: {
+                text: JSON.stringify(fileContentByPath[path] ?? null),
+              },
+            },
+          ],
+        };
+      },
+    };
+
+    const result = await fetchGithubPrDiff(client, {
+      owner: "acme",
+      repo: "widgets",
+      pullNumber: 1,
+      base: "main",
+      headSha: "headsha",
+    });
+
+    expect(result.diffs["new.ts"]).toEqual({
+      from: "old content",
+      to: "new content",
+    });
+    const fromCall = calls.find(
+      (c) => c.name === "get_file_contents" && c.arguments.ref === "main",
+    );
+    expect(fromCall?.arguments.path).toBe("old.ts");
   });
 });

--- a/apps/mesh/src/web/components/thread/github/github-pr-diff.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-diff.ts
@@ -75,6 +75,8 @@ function parsePrFiles(result: unknown): PrFile[] {
       additions,
       deletions,
       blobUrl: typeof f.blob_url === "string" ? f.blob_url : null,
+      previousFilename:
+        typeof f.previous_filename === "string" ? f.previous_filename : null,
     };
   });
 }
@@ -154,10 +156,13 @@ export async function fetchGithubPrDiff(
       return;
     }
 
+    // A renamed file's old content lives at `previousFilename`, not `path`
+    // (the new name) — fetching `path` at the base ref 404s there instead.
+    const fromPath = file.previousFilename ?? path;
     const [from, to] = await Promise.all([
       getFileAtRef(
         client,
-        { owner: args.owner, repo: args.repo, path },
+        { owner: args.owner, repo: args.repo, path: fromPath },
         fromRef,
       ),
       getFileAtRef(

--- a/apps/mesh/src/web/components/thread/github/use-pr-data.ts
+++ b/apps/mesh/src/web/components/thread/github/use-pr-data.ts
@@ -57,6 +57,8 @@ export interface PrFile {
   additions: number;
   deletions: number;
   blobUrl: string | null;
+  /** Path before the rename, when `status === "renamed"`. */
+  previousFilename: string | null;
 }
 
 export interface CheckRun {


### PR DESCRIPTION
## Source
Bug found while reading `apps/mesh/src/web/components/thread/github/github-pr-diff.ts` (the fallback diff-fetch path used when the sandbox's shallow clone can't resolve a merge-base).

## Why
`fetchGithubPrDiff` builds the diff for each changed PR file by fetching its content at the base ref and at the head SHA. For a renamed file, GitHub's `get_files` response reports the file under its *new* name (`filename`) but the content at the base ref only exists under the *old* name (`previous_filename`). The code always fetched both sides at `filename`, so for renames it silently fetched the new path at the base ref instead of the old one.

## Failure scenario
A PR renames `old.ts` → `new.ts` (with or without content edits). Opening the "Review changes" diff panel for that PR (when the sandbox merge-base fallback kicks in) shows identical "before"/"after" content instead of the actual rename/diff, because the "from" fetch 404s (or in a mocked/misbehaving backend, silently returns the wrong file).

## Fix
`parsePrFiles` now also captures `previous_filename` on each `PrFile`; `fetchGithubPrDiff` fetches the "from" side at `previousFilename` (falling back to the current path when absent, i.e. every non-renamed status).

## Regression test
Added `github-pr-diff.test.ts > fetchGithubPrDiff reads a renamed file's old content from its previous path` — a mock client asserts the "from" fetch targets the old path and that `from`/`to` content differ. Confirmed it fails on the old code (both sides resolve to the same content) and passes after the fix.

## Verify
`bun test apps/mesh/src/web/components/thread/github/github-pr-diff.test.ts`

## Checks run locally
- `bun run fmt` — clean, no changes
- `bunx tsc --noEmit` in `apps/mesh` — no new errors (pre-existing, unrelated `@tiptap/extension-text-align` module-resolution errors are present on `main` too)
- The regression test above, in both directions

Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect diffs for renamed files by fetching the base ref content from the file’s old path (`previous_filename`). This restores accurate “from/to” content in the Review changes panel when the merge-base fallback runs.

- **Bug Fixes**
  - `parsePrFiles` now stores `previous_filename` as `previousFilename`.
  - `fetchGithubPrDiff` reads the base side from `previousFilename` (falls back to current path for non-renames).
  - Added a regression test to ensure the base fetch targets the old path and the diff shows correct changes.

<sup>Written for commit d3b01babff677523ddb06b5ffe88b01ae5e04263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

