### PR TITLE
feat(decopilot): add load_repo built-in tool to switch an agent's repo

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-events-handler.ts
+++ b/apps/mesh/src/api/routes/sandbox-events-handler.ts
@@ -23,6 +23,11 @@ import {
   removeSandboxMapEntry,
   resolveVm,
 } from "../../tools/sandbox/sandbox-map";
+import {
+  getThreadSandboxMap,
+  removeThreadSandboxMapEntry,
+  threadIdFromBranch,
+} from "../../tools/sandbox/thread-repo";
 import type { Env } from "../hono-env";
 
 /**
@@ -76,17 +81,12 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
   } = args;
   const providerKind = resolveSandboxProviderKindFromEnv();
 
-  const existingVmEntry = resolveVm(
-    readSandboxMap(virtualMcpMetadata),
-    userId,
-    branch,
-    providerKind,
-  );
-  const expectingHandle = existingVmEntry?.sandboxHandle === claimName;
-  // Post-migration 091 the field is already canonical. Just narrow against
-  // null/undefined for the cleanup call site below.
-  const existingProviderKind: SandboxProviderKind | null =
-    existingVmEntry?.sandboxProviderKind ?? null;
+  // The agent row is a no-op sandbox store for the synthetic Decopilot agent —
+  // its records live on the THREAD (see `setThreadSandboxMapEntry`). Resolve the
+  // thread id from the branch so the stale-handle check below covers thread-
+  // scoped sandboxes too; otherwise a dead thread claim never emits `gone` and
+  // the preview loops on `claiming` forever with no self-heal.
+  const threadId = threadIdFromBranch(branch);
 
   c.header("X-Accel-Buffering", "no");
   c.header("Content-Encoding", "identity");
@@ -104,7 +104,28 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
     });
 
     try {
-      if (expectingHandle) {
+      // Prefer the agent entry; fall back to the thread entry (thread-scoped
+      // branches). `fromThread` steers cleanup to the right store.
+      let vmEntry = resolveVm(
+        readSandboxMap(virtualMcpMetadata),
+        userId,
+        branch,
+        providerKind,
+      );
+      let fromThread = false;
+      if (!vmEntry && threadId) {
+        vmEntry = resolveVm(
+          await getThreadSandboxMap(ctx, threadId),
+          userId,
+          branch,
+          providerKind,
+        );
+        fromThread = !!vmEntry;
+      }
+      const existingProviderKind: SandboxProviderKind | null =
+        vmEntry?.sandboxProviderKind ?? null;
+
+      if (vmEntry?.sandboxHandle === claimName) {
         const stale = await isStaleHandle(runner, claimName);
         if (stale) {
           await cleanupStaleEntry({
@@ -116,6 +137,7 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
             userId,
             projectRef,
             sandboxProviderKind: existingProviderKind ?? providerKind,
+            threadId: fromThread ? threadId : null,
           });
           await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
           return;
@@ -170,6 +192,9 @@ async function cleanupStaleEntry(args: {
   userId: string;
   projectRef: string;
   sandboxProviderKind: SandboxProviderKind;
+  /** Set when the stale entry was found on the thread (synthetic agent) — clear
+   *  it there instead of / in addition to the agent row. */
+  threadId: string | null;
 }): Promise<void> {
   const {
     ctx,
@@ -180,20 +205,32 @@ async function cleanupStaleEntry(args: {
     userId,
     projectRef,
     sandboxProviderKind,
+    threadId,
   } = args;
   // Drop the sandboxMap entry first. Without this the dangling `sandboxHandle`
-  // stays in the virtualmcp metadata, so every client SSE reconnect re-enters
-  // this stale path and re-issues a DELETE against the already-gone claim — a
-  // 404 flood that only stops when the tab closes. Mirrors SANDBOX_DELETE.
+  // stays in metadata, so every client SSE reconnect re-enters this stale path
+  // and re-issues a DELETE against the already-gone claim — a 404 flood that
+  // only stops when the tab closes. Clear whichever store held it (thread for
+  // the synthetic agent, else the agent row). Mirrors SANDBOX_DELETE.
   try {
-    await removeSandboxMapEntry(
-      ctx.storage.virtualMcps,
-      virtualMcpId,
-      userId,
-      userId,
-      branch,
-      sandboxProviderKind,
-    );
+    if (threadId) {
+      await removeThreadSandboxMapEntry(
+        ctx,
+        threadId,
+        userId,
+        branch,
+        sandboxProviderKind,
+      );
+    } else {
+      await removeSandboxMapEntry(
+        ctx.storage.virtualMcps,
+        virtualMcpId,
+        userId,
+        userId,
+        branch,
+        sandboxProviderKind,
+      );
+    }
   } catch (err) {
     console.warn(
       `[vm-events] sandboxMap cleanup failed for ${virtualMcpId}/${branch}/${sandboxProviderKind}: ${

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -66,14 +66,21 @@ type VmEnv = Env & { Variables: Env["Variables"] & { vmClaim: VmClaim } };
 const SANDBOX_BRANCH_NAME = /^[a-zA-Z0-9][a-zA-Z0-9/._-]*$/;
 
 function assertSandboxBranchParam(branch: string): void {
+  // "thread:<id>" is a synthetic sandbox-identity branch (bound by `load_repo`
+  // for thread-scoped repos) — the daemon accepts it and never checks it out as
+  // a git ref, so the ':' is legal here even though the git-ref charset below
+  // forbids it. Validate the id part after the prefix.
+  const ref = branch.startsWith("thread:")
+    ? branch.slice("thread:".length)
+    : branch;
   if (
-    !branch ||
-    branch.length > 255 ||
-    branch.includes("..") ||
-    branch.startsWith("/") ||
-    branch.endsWith("/") ||
-    branch.endsWith(".lock") ||
-    !SANDBOX_BRANCH_NAME.test(branch)
+    !ref ||
+    ref.length > 255 ||
+    ref.includes("..") ||
+    ref.startsWith("/") ||
+    ref.endsWith("/") ||
+    ref.endsWith(".lock") ||
+    !SANDBOX_BRANCH_NAME.test(ref)
   ) {
     throw new Error(`Invalid branch name: ${branch}`);
   }

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -244,16 +244,16 @@ async function buildAllTools(
       virtualMcpId: vmContext.virtualMcpId,
     }) as ToolSet;
     Object.assign(tools, vmTools);
-    // Repo switcher — dynamic description lists the org's imported repos, and
-    // calling it rewrites `githubRepo` + tears down the sandbox so the next VM
-    // tool call re-provisions against the newly selected repo. Omitted entirely
-    // when the org has no imported repos (nothing to switch between).
+    // Repo switcher — dynamic description lists the org's imported repos; calling
+    // it binds the repo to the thread, eagerly clones its sandbox, and opens the
+    // Preview. Omitted when the org has no imported repos (nothing to switch).
     const loadRepo = await createLoadRepoTool({
       ctx,
       orgId: organization.id,
       virtualMcpId: vmContext.virtualMcpId,
-      branch: vmContext.branch,
       userId: vmContext.userId,
+      threadId: vmContext.threadId,
+      writer,
     });
     if (loadRepo) tools.load_repo = loadRepo;
   }

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -33,6 +33,7 @@ const BUILTIN_TOOL_ANNOTATIONS: Record<
   enable_tool: { readOnly: true, destructive: false },
   todo_write: { readOnly: false, destructive: false },
   update_interests: { readOnly: false, destructive: false },
+  load_repo: { readOnly: false, destructive: true },
   search_threads: { readOnly: true, destructive: false },
   get_thread: { readOnly: true, destructive: false },
   list_thread_messages: { readOnly: true, destructive: false },
@@ -42,6 +43,7 @@ import { type VirtualClient } from "@decocms/harness/decopilot/built-in-tools/sa
 import { createVmTools } from "@decocms/harness/decopilot/built-in-tools/vm-tools/index";
 import type { HtmlArtifactBuffer } from "@decocms/harness/decopilot/built-in-tools/vm-tools/types";
 import { buildClusterSandboxFs } from "./cluster-sandbox-fs";
+import { createLoadRepoTool } from "./load-repo";
 import { createSubtaskTool, SubtaskInputSchema } from "./subtask";
 import { userAskTool } from "@decocms/harness/decopilot/built-in-tools/user-ask";
 import { todoWriteTool } from "@decocms/harness/decopilot/built-in-tools/todo-write";
@@ -242,6 +244,16 @@ async function buildAllTools(
       virtualMcpId: vmContext.virtualMcpId,
     }) as ToolSet;
     Object.assign(tools, vmTools);
+    // Repo switcher — dynamic description lists the org's imported repos, and
+    // calling it rewrites `githubRepo` + tears down the sandbox so the next VM
+    // tool call re-provisions against the newly selected repo.
+    tools.load_repo = await createLoadRepoTool({
+      ctx,
+      orgId: organization.id,
+      virtualMcpId: vmContext.virtualMcpId,
+      branch: vmContext.branch,
+      userId: vmContext.userId,
+    });
   }
   // subtask requires a provider (LLM calls) — skip when provider is null (Claude Code).
   if (provider) {

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -246,14 +246,16 @@ async function buildAllTools(
     Object.assign(tools, vmTools);
     // Repo switcher — dynamic description lists the org's imported repos, and
     // calling it rewrites `githubRepo` + tears down the sandbox so the next VM
-    // tool call re-provisions against the newly selected repo.
-    tools.load_repo = await createLoadRepoTool({
+    // tool call re-provisions against the newly selected repo. Omitted entirely
+    // when the org has no imported repos (nothing to switch between).
+    const loadRepo = await createLoadRepoTool({
       ctx,
       orgId: organization.id,
       virtualMcpId: vmContext.virtualMcpId,
       branch: vmContext.branch,
       userId: vmContext.userId,
     });
+    if (loadRepo) tools.load_repo = loadRepo;
   }
   // subtask requires a provider (LLM calls) — skip when provider is null (Claude Code).
   if (provider) {

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
@@ -12,8 +12,3 @@ test("buildDescription lists each repo with its connectionId", () => {
   expect(desc).toContain("connectionId of the repo to load");
 });
 
-test("buildDescription handles the empty case without listing", () => {
-  const desc = buildDescription([]);
-  expect(desc).toContain("No repositories have been imported");
-  expect(desc).not.toContain("connectionId:");
-});

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import { buildDescription } from "./load-repo";
+
+test("buildDescription lists each repo with its connectionId", () => {
+  const desc = buildDescription([
+    { connectionId: "conn_a", owner: "acme", repo: "web", installationId: 1 },
+    { connectionId: "conn_b", owner: "acme", repo: "api", installationId: 2 },
+  ]);
+  expect(desc).toContain("acme/web (connectionId: conn_a)");
+  expect(desc).toContain("acme/api (connectionId: conn_b)");
+  // The model is told to pass a connectionId.
+  expect(desc).toContain("connectionId of the repo to load");
+});
+
+test("buildDescription handles the empty case without listing", () => {
+  const desc = buildDescription([]);
+  expect(desc).toContain("No repositories have been imported");
+  expect(desc).not.toContain("connectionId:");
+});

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
@@ -23,12 +23,19 @@ const repoScope = (owner: string, repo: string) => ({
   permissions: {},
 });
 
-test("selectLoadableRepos keeps active org-shared repo connections", () => {
+test("selectLoadableRepos lists every imported repo — org-shared AND per-agent", () => {
+  // Both are the user's own org repos; both are loadable. `orgShared` only
+  // governs auto-injection into other agents' toolsets, not load_repo's list.
   const repos = selectLoadableRepos([
     {
       id: "conn_shared",
       status: "active",
       metadata: { orgShared: true, repoScope: repoScope("acme", "web") },
+    },
+    {
+      id: "conn_peragent",
+      status: "active",
+      metadata: { repoScope: repoScope("acme", "api") },
     },
   ]);
   expect(repos).toEqual([
@@ -38,18 +45,13 @@ test("selectLoadableRepos keeps active org-shared repo connections", () => {
       repo: "web",
       installationId: 7,
     },
-  ]);
-});
-
-test("selectLoadableRepos excludes per-agent-private repos (no orgShared)", () => {
-  const repos = selectLoadableRepos([
     {
-      id: "conn_private",
-      status: "active",
-      metadata: { repoScope: repoScope("acme", "secret") },
+      connectionId: "conn_peragent",
+      owner: "acme",
+      repo: "api",
+      installationId: 7,
     },
   ]);
-  expect(repos).toEqual([]);
 });
 
 test("selectLoadableRepos excludes inactive and non-repo connections", () => {
@@ -57,9 +59,9 @@ test("selectLoadableRepos excludes inactive and non-repo connections", () => {
     {
       id: "conn_inactive",
       status: "inactive",
-      metadata: { orgShared: true, repoScope: repoScope("acme", "web") },
+      metadata: { repoScope: repoScope("acme", "web") },
     },
-    // Base org mcp-github connection — org-shared marker absent AND no repoScope.
+    // Base org mcp-github connection — no repoScope.
     { id: "conn_base", status: "active", metadata: {} },
   ]);
   expect(repos).toEqual([]);

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test";
-import { buildDescription } from "./load-repo";
+import {
+  buildDescription,
+  parseCloneProbe,
+  selectLoadableRepos,
+} from "./load-repo";
 
 test("buildDescription lists each repo with its connectionId", () => {
   const desc = buildDescription([
@@ -10,4 +14,79 @@ test("buildDescription lists each repo with its connectionId", () => {
   expect(desc).toContain("acme/api (connectionId: conn_b)");
   // The model is told to pass a connectionId.
   expect(desc).toContain("connectionId of the repo to load");
+});
+
+const repoScope = (owner: string, repo: string) => ({
+  installationId: 7,
+  owner,
+  repo,
+  permissions: {},
+});
+
+test("selectLoadableRepos keeps active org-shared repo connections", () => {
+  const repos = selectLoadableRepos([
+    {
+      id: "conn_shared",
+      status: "active",
+      metadata: { orgShared: true, repoScope: repoScope("acme", "web") },
+    },
+  ]);
+  expect(repos).toEqual([
+    {
+      connectionId: "conn_shared",
+      owner: "acme",
+      repo: "web",
+      installationId: 7,
+    },
+  ]);
+});
+
+test("selectLoadableRepos excludes per-agent-private repos (no orgShared)", () => {
+  const repos = selectLoadableRepos([
+    {
+      id: "conn_private",
+      status: "active",
+      metadata: { repoScope: repoScope("acme", "secret") },
+    },
+  ]);
+  expect(repos).toEqual([]);
+});
+
+test("selectLoadableRepos excludes inactive and non-repo connections", () => {
+  const repos = selectLoadableRepos([
+    {
+      id: "conn_inactive",
+      status: "inactive",
+      metadata: { orgShared: true, repoScope: repoScope("acme", "web") },
+    },
+    // Base org mcp-github connection — org-shared marker absent AND no repoScope.
+    { id: "conn_base", status: "active", metadata: {} },
+  ]);
+  expect(repos).toEqual([]);
+});
+
+test("parseCloneProbe reports cloned when the marker is present", () => {
+  const { cloned, listing } = parseCloneProbe(
+    "__CLONED__\npackage.json\nsrc\n.git\n",
+  );
+  expect(cloned).toBe(true);
+  expect(listing).toBe("package.json\nsrc");
+});
+
+test("parseCloneProbe never leaks the marker into the listing", () => {
+  // Marker without a trailing newline must not appear as a file entry.
+  const { cloned, listing } = parseCloneProbe("__CLONED__");
+  expect(cloned).toBe(true);
+  expect(listing).toBe("");
+});
+
+test("parseCloneProbe reports cloned when files exist without the marker", () => {
+  const { cloned, listing } = parseCloneProbe("README.md\n");
+  expect(cloned).toBe(true);
+  expect(listing).toBe("README.md");
+});
+
+test("parseCloneProbe reports not-cloned for empty or .git-only output", () => {
+  expect(parseCloneProbe("")).toEqual({ cloned: false, listing: "" });
+  expect(parseCloneProbe(".git\n")).toEqual({ cloned: false, listing: "" });
 });

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
@@ -11,4 +11,3 @@ test("buildDescription lists each repo with its connectionId", () => {
   // The model is told to pass a connectionId.
   expect(desc).toContain("connectionId of the repo to load");
 });
-

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -1,28 +1,36 @@
 /**
- * `load_repo` built-in — switch the calling agent's active GitHub repository.
+ * `load_repo` built-in — bind a GitHub repository to the current conversation.
  *
- * The agent's repo binding lives at `virtualMcp.metadata.githubRepo`, and the
- * sandbox that runs it is derived from `(orgId, virtualMcpId, branch)` — not the
- * repo. So switching repos means: rewrite `githubRepo`, then tear the current
- * sandbox down so the next file/bash tool call re-provisions a fresh sandbox
- * that clones the newly selected repo.
+ * Why thread-scoped: the Decopilot super-agent (the common caller) is a
+ * SYNTHETIC virtual MCP — `virtualMcps.findById` returns an in-memory object
+ * with no `connections` row, so a repo can't be persisted on the agent and its
+ * sandbox branch is the shared, repo-less `"ephemeral"`. Instead we bind the
+ * repo to the THREAD (`threads.metadata.githubRepo` + a dedicated
+ * `thread:<id>` branch — real, persisted columns). Sandbox provisioning
+ * (`ensureSandbox`) and the fs-tool binding (`tools.ts`) both prefer the
+ * thread's repo, so the thread gets its own repo-cloned sandbox. For real
+ * repo-agents this is a per-conversation override.
  *
- * The tool DESCRIPTION is built dynamically at `buildAllTools` time from the
- * org's imported repos (active `mcp-github` connections carrying a
- * `repoScope` recipe), so the model learns which repos exist just by reading
- * the tool — no extra listing round-trip.
+ * The tool clones EAGERLY and waits: it provisions the repo sandbox and blocks
+ * until the git checkout is present before returning, then signals the client
+ * to open the Preview panel. File tools the model calls in the SAME turn are
+ * still bound to the pre-load branch (the turn's binding is fixed at
+ * turn-start); they pick up the repo from the next message — by which point the
+ * eager clone has it hot. The returned root listing lets the model confirm the
+ * repo without a same-turn `bash`.
  *
- * CLUSTER-GLUE: `@/`-coupled (storage + sandbox provisioning), same tier as
- * `cluster-sandbox-fs.ts`.
+ * CLUSTER-GLUE: `@/`-coupled, same tier as `cluster-sandbox-fs.ts`.
  */
 
-import { tool, zodSchema } from "ai";
+import { sleep } from "@decocms/std";
+import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
 import type { StudioContext } from "@/core/studio-context";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import { getRepoScope } from "@/shared/github-repo-scope";
-import { SANDBOX_DELETE } from "@/tools/sandbox/delete";
-import type { VirtualMCPUpdateData } from "@/tools/virtual/schema";
+import { ensureSandbox } from "@/tools/sandbox/start";
+import { threadBranch } from "@/tools/sandbox/thread-repo";
+import { buildClusterSandboxFs } from "./cluster-sandbox-fs";
 
 type RepoOption = {
   connectionId: string;
@@ -31,11 +39,10 @@ type RepoOption = {
   installationId: number;
 };
 
-/**
- * List the org's imported repos: active `mcp-github` connections that carry a
- * `repoScope` recipe (per-agent import children AND org-shared "Add repo"
- * connections both qualify — both are repo-scoped).
- */
+/** Wait at most this long for the clone to land before returning anyway. */
+const CLONE_TIMEOUT_MS = 120_000;
+const CLONE_POLL_MS = 1_500;
+
 async function listOrgRepos(
   ctx: StudioContext,
   orgId: string,
@@ -60,11 +67,13 @@ async function listOrgRepos(
 
 export function buildDescription(repos: RepoOption[]): string {
   const base =
-    "Load a GitHub repository into this agent's sandbox so the file tools " +
-    "(read/write/edit/bash/grep/glob) and dev server operate on that repo. " +
-    "Calling this switches the active repo: it stops the current sandbox and " +
-    "the next file/bash tool call boots a fresh sandbox that clones the " +
-    "selected repo — the switch takes effect on the following message.";
+    "Load a GitHub repository into this conversation's sandbox so the file " +
+    "tools (read/write/edit/bash/grep/glob) and dev server operate on that " +
+    "repo, and open its live Preview. Waits until the repo is cloned before " +
+    "returning. Calling it again switches the repo. File tools operate on the " +
+    "loaded repo from your NEXT message (this turn's tools are still bound to " +
+    "the previous workspace), so after loading, prefer the file listing this " +
+    "tool returns over re-running bash in the same turn.";
   const list = repos
     .map((r) => `- ${r.owner}/${r.repo} (connectionId: ${r.connectionId})`)
     .join("\n");
@@ -75,10 +84,11 @@ export async function createLoadRepoTool(opts: {
   ctx: StudioContext;
   orgId: string;
   virtualMcpId: string;
-  branch: string;
   userId: string;
+  threadId: string;
+  writer: UIMessageStreamWriter;
 }) {
-  const { ctx, orgId, virtualMcpId, branch, userId } = opts;
+  const { ctx, orgId, virtualMcpId, userId, threadId, writer } = opts;
   const repos = await listOrgRepos(ctx, orgId);
   // Nothing to switch between — don't expose the tool at all.
   if (repos.length === 0) return null;
@@ -106,40 +116,85 @@ export async function createLoadRepoTool(opts: {
         };
       }
 
-      // 1. Switch the agent's repo binding.
-      const vm = await ctx.storage.virtualMcps.findById(virtualMcpId);
-      if (!vm) return { success: false, error: "Agent not found." };
-      const meta = (vm.metadata ?? {}) as Record<string, unknown>;
-      await ctx.storage.virtualMcps.update(virtualMcpId, userId, {
-        metadata: {
-          ...meta,
-          githubRepo: {
-            url: `https://github.com/${repo.owner}/${repo.repo}`,
-            owner: repo.owner,
-            name: repo.repo,
-            installationId: repo.installationId,
-            connectionId: repo.connectionId,
-          },
-        } as VirtualMCPUpdateData["metadata"],
+      const branch = threadBranch(threadId);
+      const githubRepo = {
+        url: `https://github.com/${repo.owner}/${repo.repo}`,
+        owner: repo.owner,
+        name: repo.repo,
+        installationId: repo.installationId,
+        connectionId: repo.connectionId,
+      };
+
+      // 1. Bind the repo to the thread (the only place it persists for the
+      //    synthetic Decopilot agent). Merge into existing metadata.
+      const thread = await ctx.storage.threads.get(threadId);
+      await ctx.storage.threads.update(threadId, {
+        metadata: { ...(thread?.metadata ?? {}), githubRepo },
+        branch,
+        updated_by: userId,
       });
 
-      // 2. Tear down the current sandbox so the next fs call re-provisions with
-      //    the new repo. Resolve the provider kind so SANDBOX_DELETE locates the
-      //    right sandboxMap entry.
+      // 2. Eagerly provision the repo sandbox on the thread branch. `ensureSandbox`
+      //    reads the thread repo we just wrote (it prefers thread over agent).
+      //    Resolve the kind so it matches how the fs tools bind next turn.
       const { kind } = await resolveSandboxProvider(ctx, {
         userId,
         branch,
-        virtualMcpMetadata: meta,
+        virtualMcpMetadata: null,
       });
-      await SANDBOX_DELETE.execute(
+      const entry = await ensureSandbox(
         { virtualMcpId, branch, sandboxProviderKind: kind },
         ctx,
       );
 
+      // 3. Poll until the checkout is present. Provisioning starts the clone
+      //    async in the daemon, so `ensureSandbox` returning isn't proof the
+      //    files are there. Reuses the fs hooks (idempotent re-`ensure`).
+      const fs = await buildClusterSandboxFs(ctx, {
+        virtualMcpId,
+        branch,
+        userId,
+      });
+      const deadline = Date.now() + CLONE_TIMEOUT_MS;
+      let listing = "";
+      let cloned = false;
+      while (Date.now() < deadline) {
+        const { stdout } = await fs
+          .onBash(
+            "if git -C /app/repo rev-parse HEAD >/dev/null 2>&1; then echo __CLONED__; fi; ls -A /app/repo 2>/dev/null",
+          )
+          .catch(() => ({ stdout: "" }) as { stdout: string });
+        const entries = stdout
+          .replace("__CLONED__\n", "")
+          .split("\n")
+          .map((l) => l.trim())
+          .filter((l) => l && l !== ".git");
+        if (stdout.includes("__CLONED__") || entries.length > 0) {
+          cloned = true;
+          listing = entries.join("\n");
+          break;
+        }
+        await sleep(CLONE_POLL_MS);
+      }
+
+      // 4. Tell the client to open the Preview panel (mirrors `data-deck-updated`).
+      writer.write({
+        type: "data-open-preview",
+        id: threadId,
+        data: { previewUrl: entry.previewUrl ?? null },
+      } as Parameters<UIMessageStreamWriter["write"]>[0]);
+
       return {
         success: true,
         repo: `${repo.owner}/${repo.repo}`,
-        message: `Loaded ${repo.owner}/${repo.repo}. The sandbox was reset; the next file or bash tool call will boot a fresh sandbox for this repo.`,
+        previewUrl: entry.previewUrl ?? null,
+        cloned,
+        files: listing,
+        message: cloned
+          ? `Loaded ${repo.owner}/${repo.repo} and opened the Preview. The repo is cloned and its dev server is booting. Your file tools operate on it from your next message.`
+          : `Loaded ${repo.owner}/${repo.repo} and opened the Preview, but the clone did not finish within ${Math.round(
+              CLONE_TIMEOUT_MS / 1000,
+            )}s. It may still be in progress — your file tools will use it next message.`,
       };
     },
   });

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -65,9 +65,6 @@ export function buildDescription(repos: RepoOption[]): string {
     "Calling this switches the active repo: it stops the current sandbox and " +
     "the next file/bash tool call boots a fresh sandbox that clones the " +
     "selected repo — the switch takes effect on the following message.";
-  if (repos.length === 0) {
-    return `${base} No repositories have been imported into this organization yet; import one from the app first.`;
-  }
   const list = repos
     .map((r) => `- ${r.owner}/${r.repo} (connectionId: ${r.connectionId})`)
     .join("\n");
@@ -83,6 +80,8 @@ export async function createLoadRepoTool(opts: {
 }) {
   const { ctx, orgId, virtualMcpId, branch, userId } = opts;
   const repos = await listOrgRepos(ctx, orgId);
+  // Nothing to switch between — don't expose the tool at all.
+  if (repos.length === 0) return null;
   const byConnId = new Map(repos.map((r) => [r.connectionId, r]));
 
   return tool({

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -27,7 +27,10 @@ import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
 import type { StudioContext } from "@/core/studio-context";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
-import { getRepoScope } from "@/shared/github-repo-scope";
+import {
+  getRepoScope,
+  isOrgSharedConnection,
+} from "@/shared/github-repo-scope";
 import { ensureSandbox } from "@/tools/sandbox/start";
 import { threadBranch } from "@/tools/sandbox/thread-repo";
 import { buildClusterSandboxFs } from "./cluster-sandbox-fs";
@@ -39,20 +42,37 @@ type RepoOption = {
   installationId: number;
 };
 
+/** Minimal connection shape the repo selection needs (keeps the pure helper
+ *  testable without the full `ConnectionEntity`). */
+type RepoConnection = {
+  id: string;
+  status: string;
+  metadata: Record<string, unknown> | null;
+};
+
 /** Wait at most this long for the clone to land before returning anyway. */
 const CLONE_TIMEOUT_MS = 120_000;
 const CLONE_POLL_MS = 1_500;
+/** Give up early if the sandbox can't answer the probe at all this many times
+ *  in a row (a broken/partitioned runner) — no point polling a dead link for
+ *  the full timeout. */
+const CLONE_MAX_CONSECUTIVE_FAILURES = 5;
 
-async function listOrgRepos(
-  ctx: StudioContext,
-  orgId: string,
-): Promise<RepoOption[]> {
-  const { items } = await ctx.storage.connections.list(orgId, {
-    slug: "mcp-github",
-  });
+/**
+ * The repos `load_repo` offers: active `mcp-github` connections that are
+ * **org-shared** ("Add repo" in the sidebar — injected into every agent, see
+ * `mcp-clients/virtual-mcp`). Per-agent import children also carry a
+ * `repoScope` but stay private to their agent, so they're deliberately excluded
+ * — otherwise the tool would surface a repo imported for a different agent.
+ * Pure so it's unit-testable without a DB.
+ */
+export function selectLoadableRepos(
+  connections: RepoConnection[],
+): RepoOption[] {
   const repos: RepoOption[] = [];
-  for (const conn of items) {
+  for (const conn of connections) {
     if (conn.status !== "active") continue;
+    if (!isOrgSharedConnection(conn)) continue;
     const scope = getRepoScope(conn);
     if (!scope) continue;
     repos.push({
@@ -63,6 +83,33 @@ async function listOrgRepos(
     });
   }
   return repos;
+}
+
+async function listOrgRepos(
+  ctx: StudioContext,
+  orgId: string,
+): Promise<RepoOption[]> {
+  const { items } = await ctx.storage.connections.list(orgId, {
+    slug: "mcp-github",
+  });
+  return selectLoadableRepos(items);
+}
+
+/**
+ * Interpret the clone-probe stdout (`echo __CLONED__` marker + `ls -A`).
+ * `cloned` is true once git has a HEAD or any non-`.git` entry appears; the
+ * listing is the repo root minus `.git`. Pure so it's unit-testable.
+ */
+export function parseCloneProbe(stdout: string): {
+  cloned: boolean;
+  listing: string;
+} {
+  const entries = stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l && l !== ".git" && l !== "__CLONED__");
+  const cloned = stdout.includes("__CLONED__") || entries.length > 0;
+  return { cloned, listing: cloned ? entries.join("\n") : "" };
 }
 
 export function buildDescription(repos: RepoOption[]): string {
@@ -192,20 +239,26 @@ export async function createLoadRepoTool(opts: {
       const deadline = Date.now() + CLONE_TIMEOUT_MS;
       let listing = "";
       let cloned = false;
+      let consecutiveFailures = 0;
       while (Date.now() < deadline) {
-        const { stdout } = await fs
+        const probe = await fs
           .onBash(
             "if git -C /app/repo rev-parse HEAD >/dev/null 2>&1; then echo __CLONED__; fi; ls -A /app/repo 2>/dev/null",
           )
-          .catch(() => ({ stdout: "" }) as { stdout: string });
-        const entries = stdout
-          .replace("__CLONED__\n", "")
-          .split("\n")
-          .map((l) => l.trim())
-          .filter((l) => l && l !== ".git");
-        if (stdout.includes("__CLONED__") || entries.length > 0) {
+          .then((r) => ({ ok: true as const, stdout: r.stdout }))
+          .catch(() => ({ ok: false as const, stdout: "" }));
+        if (!probe.ok) {
+          // The runner itself couldn't answer — a dead/partitioned link won't
+          // recover mid-poll, so bail instead of burning the full timeout.
+          if (++consecutiveFailures >= CLONE_MAX_CONSECUTIVE_FAILURES) break;
+          await sleep(CLONE_POLL_MS);
+          continue;
+        }
+        consecutiveFailures = 0;
+        const result = parseCloneProbe(probe.stdout);
+        if (result.cloned) {
           cloned = true;
-          listing = entries.join("\n");
+          listing = result.listing;
           break;
         }
         await sleep(CLONE_POLL_MS);

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -160,9 +160,38 @@ export async function createLoadRepoTool(opts: {
         ctx,
       );
 
-      // 4. Poll until the checkout is present. Provisioning starts the clone
-      //    async in the daemon, so `ensureSandbox` returning isn't proof the
-      //    files are there. Reuses the fs hooks (idempotent re-`ensure`).
+      // 4. Persist the sandbox record on the thread and open the Preview NOW —
+      //    before the (up-to-2min) clone poll — so the preview renders its
+      //    normal booting state immediately and survives an interrupted turn.
+      //    `previewUrl` is known the moment `ensureSandbox` returns; the clone
+      //    finishing is separate. The synthetic agent's sandboxMap never
+      //    persists, so the frontend reads this thread-scoped entry instead,
+      //    keyed the same 3-level way ([userId][branch][kind]).
+      const sandboxMap = {
+        [userId]: { [branch]: { [kind]: entry } },
+      };
+      await ctx.storage.threads.update(threadId, {
+        metadata: { ...(thread?.metadata ?? {}), githubRepo, sandboxMap },
+        updated_by: userId,
+      });
+      // Open the Preview panel + patch the client's local thread row (branch +
+      // repo + sandbox) so `activeTask` reflects the switch without a refetch
+      // (mirrors the `data-deck-updated` path).
+      writer.write({
+        type: "data-open-preview",
+        id: threadId,
+        data: {
+          previewUrl: entry.previewUrl ?? null,
+          branch,
+          githubRepo,
+          sandboxMap,
+          sandboxProviderKind: kind,
+        },
+      } as Parameters<UIMessageStreamWriter["write"]>[0]);
+
+      // 5. Poll until the checkout is present, only to enrich the return
+      //    message/listing. Provisioning starts the clone async in the daemon,
+      //    so `ensureSandbox` returning isn't proof the files are there.
       const fs = await buildClusterSandboxFs(ctx, {
         virtualMcpId,
         branch,
@@ -189,34 +218,6 @@ export async function createLoadRepoTool(opts: {
         }
         await sleep(CLONE_POLL_MS);
       }
-
-      // 5. Persist the sandbox record on the thread so the Preview panel can
-      //    resolve `previewUrl` (the synthetic agent's sandboxMap never
-      //    persists, and the frontend reads the sandbox entry from thread
-      //    metadata for thread-scoped repos). Keyed the same 3-level way the
-      //    agent sandboxMap is: [userId][branch][kind].
-      const sandboxMap = {
-        [userId]: { [branch]: { [kind]: entry } },
-      };
-      await ctx.storage.threads.update(threadId, {
-        metadata: { ...(thread?.metadata ?? {}), githubRepo, sandboxMap },
-        updated_by: userId,
-      });
-
-      // 6. Tell the client to open the Preview panel and patch its local thread
-      //    row (branch + repo + sandbox) so `activeTask` reflects the switch
-      //    without waiting for a refetch (mirrors the `data-deck-updated` path).
-      writer.write({
-        type: "data-open-preview",
-        id: threadId,
-        data: {
-          previewUrl: entry.previewUrl ?? null,
-          branch,
-          githubRepo,
-          sandboxMap,
-          sandboxProviderKind: kind,
-        },
-      } as Parameters<UIMessageStreamWriter["write"]>[0]);
 
       return {
         success: true,

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -25,7 +25,9 @@
 import { sleep } from "@decocms/std";
 import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
+import { composeSandboxRef } from "@decocms/sandbox/provider";
 import type { StudioContext } from "@/core/studio-context";
+import { computeClaimHandle } from "@/sandbox/claim-handle";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import { getRepoScope } from "@/shared/github-repo-scope";
 import { ensureSandbox } from "@/tools/sandbox/start";
@@ -134,20 +136,31 @@ export async function createLoadRepoTool(opts: {
         updated_by: userId,
       });
 
-      // 2. Eagerly provision the repo sandbox on the thread branch. `ensureSandbox`
-      //    reads the thread repo we just wrote (it prefers thread over agent).
-      //    Resolve the kind so it matches how the fs tools bind next turn.
-      const { kind } = await resolveSandboxProvider(ctx, {
+      // 2. Tear down any sandbox already on this thread branch. The branch is
+      //    stable per thread, so its sandbox handle is deterministic — without
+      //    an explicit teardown a repo SWITCH would re-`ensure` the SAME handle
+      //    and the daemon adopts the existing checkout instead of re-cloning
+      //    (the "still on the previous repo" bug). Delete by computed handle
+      //    because the synthetic agent's sandboxMap never persists, so
+      //    SANDBOX_DELETE's entry lookup finds nothing.
+      const { provider: runner, kind } = await resolveSandboxProvider(ctx, {
         userId,
         branch,
         virtualMcpMetadata: null,
       });
+      const projectRef = composeSandboxRef({ orgId, virtualMcpId, branch });
+      const handle = computeClaimHandle({ userId, projectRef }, branch);
+      await runner.delete(handle).catch(() => {});
+      await runner.forgetHandle?.(handle).catch(() => {});
+
+      // 3. Eagerly provision the repo sandbox on the thread branch. `ensureSandbox`
+      //    reads the thread repo we just wrote (it prefers thread over agent).
       const entry = await ensureSandbox(
         { virtualMcpId, branch, sandboxProviderKind: kind },
         ctx,
       );
 
-      // 3. Poll until the checkout is present. Provisioning starts the clone
+      // 4. Poll until the checkout is present. Provisioning starts the clone
       //    async in the daemon, so `ensureSandbox` returning isn't proof the
       //    files are there. Reuses the fs hooks (idempotent re-`ensure`).
       const fs = await buildClusterSandboxFs(ctx, {
@@ -177,11 +190,32 @@ export async function createLoadRepoTool(opts: {
         await sleep(CLONE_POLL_MS);
       }
 
-      // 4. Tell the client to open the Preview panel (mirrors `data-deck-updated`).
+      // 5. Persist the sandbox record on the thread so the Preview panel can
+      //    resolve `previewUrl` (the synthetic agent's sandboxMap never
+      //    persists, and the frontend reads the sandbox entry from thread
+      //    metadata for thread-scoped repos). Keyed the same 3-level way the
+      //    agent sandboxMap is: [userId][branch][kind].
+      const sandboxMap = {
+        [userId]: { [branch]: { [kind]: entry } },
+      };
+      await ctx.storage.threads.update(threadId, {
+        metadata: { ...(thread?.metadata ?? {}), githubRepo, sandboxMap },
+        updated_by: userId,
+      });
+
+      // 6. Tell the client to open the Preview panel and patch its local thread
+      //    row (branch + repo + sandbox) so `activeTask` reflects the switch
+      //    without waiting for a refetch (mirrors the `data-deck-updated` path).
       writer.write({
         type: "data-open-preview",
         id: threadId,
-        data: { previewUrl: entry.previewUrl ?? null },
+        data: {
+          previewUrl: entry.previewUrl ?? null,
+          branch,
+          githubRepo,
+          sandboxMap,
+          sandboxProviderKind: kind,
+        },
       } as Parameters<UIMessageStreamWriter["write"]>[0]);
 
       return {

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -36,7 +36,7 @@ type RepoOption = {
  * `repoScope` recipe (per-agent import children AND org-shared "Add repo"
  * connections both qualify — both are repo-scoped).
  */
-export async function listOrgRepos(
+async function listOrgRepos(
   ctx: StudioContext,
   orgId: string,
 ): Promise<RepoOption[]> {

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -31,6 +31,10 @@ import {
   getRepoScope,
   isOrgSharedConnection,
 } from "@/shared/github-repo-scope";
+import {
+  mergeSandboxMapEntry,
+  readSandboxMap,
+} from "@/tools/sandbox/sandbox-map";
 import { ensureSandbox } from "@/tools/sandbox/start";
 import { threadBranch } from "@/tools/sandbox/thread-repo";
 import { buildClusterSandboxFs } from "./cluster-sandbox-fs";
@@ -199,20 +203,22 @@ export async function createLoadRepoTool(opts: {
         ctx,
       );
 
-      // 3. Persist the sandbox record on the thread and open the Preview NOW —
-      //    before the (up-to-2min) clone poll — so the preview renders its
-      //    normal booting state immediately and survives an interrupted turn.
-      //    `previewUrl` is known the moment `ensureSandbox` returns; the clone
-      //    finishing is separate. The synthetic agent's sandboxMap never
-      //    persists, so the frontend reads this thread-scoped entry instead,
-      //    keyed the same 3-level way ([userId][branch][kind]).
-      const sandboxMap = {
-        [userId]: { [branch]: { [kind]: entry } },
-      };
-      await ctx.storage.threads.update(threadId, {
-        metadata: { ...(thread?.metadata ?? {}), githubRepo, sandboxMap },
-        updated_by: userId,
-      });
+      // 3. `ensureSandbox` already persisted the sandbox record on the thread
+      //    (provisionSandbox → setThreadSandboxMapEntry — the single writer), so
+      //    we don't re-write it: a second write from the pre-provision snapshot
+      //    would clobber a sibling repo's entry when switching repos. We only
+      //    open the Preview NOW — before the (up-to-2min) clone poll — so it
+      //    renders its booting state immediately and survives an interrupted
+      //    turn. `previewUrl` is known the moment `ensureSandbox` returns.
+      //    Send the merged map (snapshot + this entry, via the shared helper) so
+      //    the client patches its local thread without dropping sibling repos.
+      const sandboxMap = mergeSandboxMapEntry(
+        readSandboxMap(thread?.metadata),
+        userId,
+        branch,
+        kind,
+        entry,
+      );
       // Open the Preview panel + patch the client's local thread row (branch +
       // repo + sandbox) so `activeTask` reflects the switch without a refetch
       // (mirrors the `data-deck-updated` path).

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -25,9 +25,7 @@
 import { sleep } from "@decocms/std";
 import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
-import { composeSandboxRef } from "@decocms/sandbox/provider";
 import type { StudioContext } from "@/core/studio-context";
-import { computeClaimHandle } from "@/sandbox/claim-handle";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import { getRepoScope } from "@/shared/github-repo-scope";
 import { ensureSandbox } from "@/tools/sandbox/start";
@@ -118,7 +116,11 @@ export async function createLoadRepoTool(opts: {
         };
       }
 
-      const branch = threadBranch(threadId);
+      // Branch is repo-specific (includes the connection id) so switching repos
+      // yields a distinct sandbox + previewUrl — that's what makes the preview
+      // UI react to a switch, and it sidesteps stale-checkout entirely (each
+      // repo gets its own sandbox; re-loading one adopts its existing sandbox).
+      const branch = threadBranch(threadId, repo.connectionId);
       const githubRepo = {
         url: `https://github.com/${repo.owner}/${repo.repo}`,
         owner: repo.owner,
@@ -136,31 +138,21 @@ export async function createLoadRepoTool(opts: {
         updated_by: userId,
       });
 
-      // 2. Tear down any sandbox already on this thread branch. The branch is
-      //    stable per thread, so its sandbox handle is deterministic — without
-      //    an explicit teardown a repo SWITCH would re-`ensure` the SAME handle
-      //    and the daemon adopts the existing checkout instead of re-cloning
-      //    (the "still on the previous repo" bug). Delete by computed handle
-      //    because the synthetic agent's sandboxMap never persists, so
-      //    SANDBOX_DELETE's entry lookup finds nothing.
-      const { provider: runner, kind } = await resolveSandboxProvider(ctx, {
+      // 2. Eagerly provision the repo sandbox on the repo-specific branch.
+      //    `ensureSandbox` reads the thread repo we just wrote (it prefers
+      //    thread over agent). Resolve the kind so the frontend + fs tools bind
+      //    to the same sandbox.
+      const { kind } = await resolveSandboxProvider(ctx, {
         userId,
         branch,
         virtualMcpMetadata: null,
       });
-      const projectRef = composeSandboxRef({ orgId, virtualMcpId, branch });
-      const handle = computeClaimHandle({ userId, projectRef }, branch);
-      await runner.delete(handle).catch(() => {});
-      await runner.forgetHandle?.(handle).catch(() => {});
-
-      // 3. Eagerly provision the repo sandbox on the thread branch. `ensureSandbox`
-      //    reads the thread repo we just wrote (it prefers thread over agent).
       const entry = await ensureSandbox(
         { virtualMcpId, branch, sandboxProviderKind: kind },
         ctx,
       );
 
-      // 4. Persist the sandbox record on the thread and open the Preview NOW —
+      // 3. Persist the sandbox record on the thread and open the Preview NOW —
       //    before the (up-to-2min) clone poll — so the preview renders its
       //    normal booting state immediately and survives an interrupted turn.
       //    `previewUrl` is known the moment `ensureSandbox` returns; the clone
@@ -189,7 +181,7 @@ export async function createLoadRepoTool(opts: {
         },
       } as Parameters<UIMessageStreamWriter["write"]>[0]);
 
-      // 5. Poll until the checkout is present, only to enrich the return
+      // 4. Poll until the checkout is present, only to enrich the return
       //    message/listing. Provisioning starts the clone async in the daemon,
       //    so `ensureSandbox` returning isn't proof the files are there.
       const fs = await buildClusterSandboxFs(ctx, {

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -1,0 +1,147 @@
+/**
+ * `load_repo` built-in — switch the calling agent's active GitHub repository.
+ *
+ * The agent's repo binding lives at `virtualMcp.metadata.githubRepo`, and the
+ * sandbox that runs it is derived from `(orgId, virtualMcpId, branch)` — not the
+ * repo. So switching repos means: rewrite `githubRepo`, then tear the current
+ * sandbox down so the next file/bash tool call re-provisions a fresh sandbox
+ * that clones the newly selected repo.
+ *
+ * The tool DESCRIPTION is built dynamically at `buildAllTools` time from the
+ * org's imported repos (active `mcp-github` connections carrying a
+ * `repoScope` recipe), so the model learns which repos exist just by reading
+ * the tool — no extra listing round-trip.
+ *
+ * CLUSTER-GLUE: `@/`-coupled (storage + sandbox provisioning), same tier as
+ * `cluster-sandbox-fs.ts`.
+ */
+
+import { tool, zodSchema } from "ai";
+import { z } from "zod";
+import type { StudioContext } from "@/core/studio-context";
+import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
+import { getRepoScope } from "@/shared/github-repo-scope";
+import { SANDBOX_DELETE } from "@/tools/sandbox/delete";
+import type { VirtualMCPUpdateData } from "@/tools/virtual/schema";
+
+type RepoOption = {
+  connectionId: string;
+  owner: string;
+  repo: string;
+  installationId: number;
+};
+
+/**
+ * List the org's imported repos: active `mcp-github` connections that carry a
+ * `repoScope` recipe (per-agent import children AND org-shared "Add repo"
+ * connections both qualify — both are repo-scoped).
+ */
+export async function listOrgRepos(
+  ctx: StudioContext,
+  orgId: string,
+): Promise<RepoOption[]> {
+  const { items } = await ctx.storage.connections.list(orgId, {
+    slug: "mcp-github",
+  });
+  const repos: RepoOption[] = [];
+  for (const conn of items) {
+    if (conn.status !== "active") continue;
+    const scope = getRepoScope(conn);
+    if (!scope) continue;
+    repos.push({
+      connectionId: conn.id,
+      owner: scope.owner,
+      repo: scope.repo,
+      installationId: scope.installationId,
+    });
+  }
+  return repos;
+}
+
+export function buildDescription(repos: RepoOption[]): string {
+  const base =
+    "Load a GitHub repository into this agent's sandbox so the file tools " +
+    "(read/write/edit/bash/grep/glob) and dev server operate on that repo. " +
+    "Calling this switches the active repo: it stops the current sandbox and " +
+    "the next file/bash tool call boots a fresh sandbox that clones the " +
+    "selected repo — the switch takes effect on the following message.";
+  if (repos.length === 0) {
+    return `${base} No repositories have been imported into this organization yet; import one from the app first.`;
+  }
+  const list = repos
+    .map((r) => `- ${r.owner}/${r.repo} (connectionId: ${r.connectionId})`)
+    .join("\n");
+  return `${base}\n\nRepositories imported into this organization:\n${list}\n\nPass the connectionId of the repo to load.`;
+}
+
+export async function createLoadRepoTool(opts: {
+  ctx: StudioContext;
+  orgId: string;
+  virtualMcpId: string;
+  branch: string;
+  userId: string;
+}) {
+  const { ctx, orgId, virtualMcpId, branch, userId } = opts;
+  const repos = await listOrgRepos(ctx, orgId);
+  const byConnId = new Map(repos.map((r) => [r.connectionId, r]));
+
+  return tool({
+    description: buildDescription(repos),
+    inputSchema: zodSchema(
+      z.object({
+        connectionId: z
+          .string()
+          .describe(
+            "connectionId of the imported repository to load (see the list in this tool's description).",
+          ),
+      }),
+    ),
+    execute: async ({ connectionId }: { connectionId: string }) => {
+      const repo = byConnId.get(connectionId);
+      if (!repo) {
+        return {
+          success: false,
+          error: `No imported repository found for connectionId "${connectionId}". Available: ${
+            repos.map((r) => r.connectionId).join(", ") || "none"
+          }.`,
+        };
+      }
+
+      // 1. Switch the agent's repo binding.
+      const vm = await ctx.storage.virtualMcps.findById(virtualMcpId);
+      if (!vm) return { success: false, error: "Agent not found." };
+      const meta = (vm.metadata ?? {}) as Record<string, unknown>;
+      await ctx.storage.virtualMcps.update(virtualMcpId, userId, {
+        metadata: {
+          ...meta,
+          githubRepo: {
+            url: `https://github.com/${repo.owner}/${repo.repo}`,
+            owner: repo.owner,
+            name: repo.repo,
+            installationId: repo.installationId,
+            connectionId: repo.connectionId,
+          },
+        } as VirtualMCPUpdateData["metadata"],
+      });
+
+      // 2. Tear down the current sandbox so the next fs call re-provisions with
+      //    the new repo. Resolve the provider kind so SANDBOX_DELETE locates the
+      //    right sandboxMap entry.
+      const { kind } = await resolveSandboxProvider(ctx, {
+        userId,
+        branch,
+        virtualMcpMetadata: meta,
+      });
+      await SANDBOX_DELETE.execute(
+        { virtualMcpId, branch, sandboxProviderKind: kind },
+        ctx,
+      );
+
+      return {
+        success: true,
+        repo: `${repo.owner}/${repo.repo}`,
+        message: `Loaded ${repo.owner}/${repo.repo}. The sandbox was reset; the next file or bash tool call will boot a fresh sandbox for this repo.`,
+      };
+    },
+  });
+}

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -27,10 +27,7 @@ import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
 import type { StudioContext } from "@/core/studio-context";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
-import {
-  getRepoScope,
-  isOrgSharedConnection,
-} from "@/shared/github-repo-scope";
+import { getRepoScope } from "@/shared/github-repo-scope";
 import {
   mergeSandboxMapEntry,
   readSandboxMap,
@@ -63,12 +60,11 @@ const CLONE_POLL_MS = 1_500;
 const CLONE_MAX_CONSECUTIVE_FAILURES = 5;
 
 /**
- * The repos `load_repo` offers: active `mcp-github` connections that are
- * **org-shared** ("Add repo" in the sidebar — injected into every agent, see
- * `mcp-clients/virtual-mcp`). Per-agent import children also carry a
- * `repoScope` but stay private to their agent, so they're deliberately excluded
- * — otherwise the tool would surface a repo imported for a different agent.
- * Pure so it's unit-testable without a DB.
+ * The repos `load_repo` offers: every active `mcp-github` connection carrying a
+ * `repoScope` — i.e. each repo imported into the org (the "Code Agents" list in
+ * the UI). This includes both org-shared imports and per-agent imports; they're
+ * all the user's own org repos and all loadable. The base org-level `mcp-github`
+ * connection has no `repoScope`, so it's skipped. Pure so it's unit-testable.
  */
 export function selectLoadableRepos(
   connections: RepoConnection[],
@@ -76,7 +72,6 @@ export function selectLoadableRepos(
   const repos: RepoOption[] = [];
   for (const conn of connections) {
     if (conn.status !== "active") continue;
-    if (!isOrgSharedConnection(conn)) continue;
     const scope = getRepoScope(conn);
     if (!scope) continue;
     repos.push({

--- a/apps/mesh/src/harnesses/decopilot/tools.ts
+++ b/apps/mesh/src/harnesses/decopilot/tools.ts
@@ -298,7 +298,7 @@ export async function assembleDecopilotTools(
       ? {
           virtualMcpId: input.agent.id,
           branch: threadRepo
-            ? threadBranch(extras.threadId)
+            ? threadBranch(extras.threadId, threadRepo.connectionId)
             : isEphemeralAgent
               ? "ephemeral"
               : (runContext.branch ?? `thread:${extras.threadId}`),

--- a/apps/mesh/src/harnesses/decopilot/tools.ts
+++ b/apps/mesh/src/harnesses/decopilot/tools.ts
@@ -22,6 +22,7 @@
 import type { ToolSet, UIMessageStreamWriter } from "ai";
 import type { GithubRepo } from "@decocms/mesh-sdk";
 import type { StudioContext } from "@/core/studio-context";
+import { getThreadGithubRepo, threadBranch } from "@/tools/sandbox/thread-repo";
 import type { PassthroughClient } from "@/mcp-clients/virtual-mcp/passthrough-client";
 import type { MeshProvider } from "@/ai-providers/types";
 import type { BackgroundDispatcher } from "@decocms/harness/decopilot/built-in-tools/backgroundable";
@@ -286,13 +287,21 @@ export async function assembleDecopilotTools(
     const vmMetadata = runContext.virtualMcp.metadata as {
       githubRepo?: GithubRepo | null;
     };
-    const isEphemeralAgent = !vmMetadata.githubRepo;
+    // A thread-scoped repo (set by `load_repo`) wins: it's the only place a repo
+    // can persist for the synthetic Decopilot agent, and a per-conversation
+    // override for real repo-agents. When present it pins the thread to a
+    // dedicated `thread:<id>` sandbox branch (not the shared "ephemeral" one).
+    const threadRepo = await getThreadGithubRepo(ctx, extras.threadId);
+    const effectiveRepo = threadRepo ?? vmMetadata.githubRepo;
+    const isEphemeralAgent = !effectiveRepo;
     const vmContext: VmContext | null = input.user.id
       ? {
           virtualMcpId: input.agent.id,
-          branch: isEphemeralAgent
-            ? "ephemeral"
-            : (runContext.branch ?? `thread:${extras.threadId}`),
+          branch: threadRepo
+            ? threadBranch(extras.threadId)
+            : isEphemeralAgent
+              ? "ephemeral"
+              : (runContext.branch ?? `thread:${extras.threadId}`),
           userId: input.user.id,
           // Used by share_with_user to scope artifacts under
           // model-outputs/<threadId>/. Cannot be derived from the

--- a/apps/mesh/src/tools/sandbox/sandbox-map.test.ts
+++ b/apps/mesh/src/tools/sandbox/sandbox-map.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, test } from "bun:test";
 import type { SandboxRecord } from "@decocms/mesh-sdk";
 
-import { readSandboxMap, resolveVm } from "./sandbox-map";
+import { mergeSandboxMapEntry, readSandboxMap, resolveVm } from "./sandbox-map";
 
 const ENTRY_A: SandboxRecord = {
   sandboxHandle: "vm-1",
@@ -121,6 +121,67 @@ describe("resolveVm", () => {
     expect(resolveVm(sandboxMap, "user-1", "main", "agent-sandbox")).toEqual(
       ENTRY_B,
     );
+  });
+});
+
+describe("mergeSandboxMapEntry", () => {
+  test("preserves sibling branches when adding a new one (switch repos)", () => {
+    // Regression: load_repo used to overwrite the whole map, wiping the first
+    // repo's entry when a second repo was loaded on the same thread.
+    const current = {
+      u: { "thread:t/conn_a": { "agent-sandbox": ENTRY_A } },
+    };
+    const next = mergeSandboxMapEntry(
+      current,
+      "u",
+      "thread:t/conn_b",
+      "agent-sandbox",
+      ENTRY_B,
+    );
+    expect(resolveVm(next, "u", "thread:t/conn_a", "agent-sandbox")).toEqual(
+      ENTRY_A,
+    );
+    expect(resolveVm(next, "u", "thread:t/conn_b", "agent-sandbox")).toEqual(
+      ENTRY_B,
+    );
+  });
+
+  test("preserves sibling kinds on the same branch", () => {
+    const current = { u: { b: { "user-desktop": ENTRY_A } } };
+    const next = mergeSandboxMapEntry(
+      current,
+      "u",
+      "b",
+      "agent-sandbox",
+      ENTRY_B,
+    );
+    expect(resolveVm(next, "u", "b", "user-desktop")).toEqual(ENTRY_A);
+    expect(resolveVm(next, "u", "b", "agent-sandbox")).toEqual(ENTRY_B);
+  });
+
+  test("does not mutate the input map", () => {
+    const current = { u: { b: { "agent-sandbox": ENTRY_A } } };
+    const snapshot = JSON.stringify(current);
+    mergeSandboxMapEntry(current, "u", "b", "user-desktop", ENTRY_B);
+    expect(JSON.stringify(current)).toBe(snapshot);
+  });
+
+  test("normalizes a legacy stringified branch cell instead of corrupting it", () => {
+    // parseBranchMap treats a non-object (stringified) cell as empty, so the
+    // merge drops the unreadable cell rather than a raw spread exploding it into
+    // character-indexed keys ("0","1",...).
+    const current = {
+      u: { b: JSON.stringify({ "agent-sandbox": ENTRY_A }) },
+    } as unknown as Parameters<typeof mergeSandboxMapEntry>[0];
+    const next = mergeSandboxMapEntry(
+      current,
+      "u",
+      "b",
+      "user-desktop",
+      ENTRY_B,
+    );
+    expect(resolveVm(next, "u", "b", "user-desktop")).toEqual(ENTRY_B);
+    expect(next.u?.b).not.toHaveProperty("0");
   });
 });
 

--- a/apps/mesh/src/tools/sandbox/sandbox-map.test.ts
+++ b/apps/mesh/src/tools/sandbox/sandbox-map.test.ts
@@ -5,7 +5,12 @@
 import { describe, expect, test } from "bun:test";
 import type { SandboxRecord } from "@decocms/mesh-sdk";
 
-import { mergeSandboxMapEntry, readSandboxMap, resolveVm } from "./sandbox-map";
+import {
+  deleteSandboxMapEntry,
+  mergeSandboxMapEntry,
+  readSandboxMap,
+  resolveVm,
+} from "./sandbox-map";
 
 const ENTRY_A: SandboxRecord = {
   sandboxHandle: "vm-1",
@@ -182,6 +187,33 @@ describe("mergeSandboxMapEntry", () => {
     );
     expect(resolveVm(next, "u", "b", "user-desktop")).toEqual(ENTRY_B);
     expect(next.u?.b).not.toHaveProperty("0");
+  });
+});
+
+describe("deleteSandboxMapEntry", () => {
+  test("returns null when the entry is absent (no-op write)", () => {
+    expect(deleteSandboxMapEntry({}, "u", "b", "agent-sandbox")).toBeNull();
+    const other = { u: { b: { "user-desktop": ENTRY_A } } };
+    expect(deleteSandboxMapEntry(other, "u", "b", "agent-sandbox")).toBeNull();
+  });
+
+  test("removes the entry and prunes empty branch + user buckets", () => {
+    const current = { u: { b: { "agent-sandbox": ENTRY_A } } };
+    const next = deleteSandboxMapEntry(current, "u", "b", "agent-sandbox");
+    expect(next).toEqual({});
+  });
+
+  test("keeps sibling kinds and sibling branches", () => {
+    const current = {
+      u: {
+        b: { "agent-sandbox": ENTRY_A, "user-desktop": ENTRY_B },
+        other: { "agent-sandbox": ENTRY_A },
+      },
+    };
+    const next = deleteSandboxMapEntry(current, "u", "b", "agent-sandbox");
+    expect(resolveVm(next!, "u", "b", "user-desktop")).toEqual(ENTRY_B);
+    expect(resolveVm(next!, "u", "other", "agent-sandbox")).toEqual(ENTRY_A);
+    expect(resolveVm(next!, "u", "b", "agent-sandbox")).toBeNull();
   });
 });
 

--- a/apps/mesh/src/tools/sandbox/sandbox-map.ts
+++ b/apps/mesh/src/tools/sandbox/sandbox-map.ts
@@ -102,25 +102,20 @@ export async function setSandboxMapEntry(
 }
 
 /**
- * Read-modify-write: removes sandboxMap[userId][branch][kind].
- * Drops the branch bucket if no kinds remain; drops the user bucket if no
- * branches remain.
+ * Pure removal: returns a copy of `current` without sandboxMap[userId][branch]
+ * [kind]. Prunes the branch bucket when no kinds remain and the user bucket when
+ * no branches remain. Returns `null` when the entry wasn't present (so callers
+ * can skip a no-op write). Shared by the agent-scoped (`removeSandboxMapEntry`)
+ * and thread-scoped (`removeThreadSandboxMapEntry`) removers.
  */
-export async function removeSandboxMapEntry(
-  storage: VirtualMCPStoragePort,
-  virtualMcpId: string,
-  actingUserId: string,
+export function deleteSandboxMapEntry(
+  current: SandboxMap,
   targetUserId: string,
   branch: string,
   sandboxProviderKind: SandboxProviderKind,
-): Promise<void> {
-  const virtualMcp = await storage.findById(virtualMcpId);
-  if (!virtualMcp) return;
-
-  const meta = (virtualMcp.metadata ?? {}) as Record<string, unknown>;
-  const current = readSandboxMap(meta);
+): SandboxMap | null {
   const branchMap = parseBranchMap(current[targetUserId]?.[branch]);
-  if (!branchMap[sandboxProviderKind]) return;
+  if (!branchMap[sandboxProviderKind]) return null;
 
   const nextBranchMap = { ...branchMap };
   delete nextBranchMap[sandboxProviderKind];
@@ -138,6 +133,33 @@ export async function removeSandboxMapEntry(
   } else {
     next[targetUserId] = userMap;
   }
+  return next;
+}
+
+/**
+ * Read-modify-write: removes sandboxMap[userId][branch][kind].
+ * Drops the branch bucket if no kinds remain; drops the user bucket if no
+ * branches remain.
+ */
+export async function removeSandboxMapEntry(
+  storage: VirtualMCPStoragePort,
+  virtualMcpId: string,
+  actingUserId: string,
+  targetUserId: string,
+  branch: string,
+  sandboxProviderKind: SandboxProviderKind,
+): Promise<void> {
+  const virtualMcp = await storage.findById(virtualMcpId);
+  if (!virtualMcp) return;
+
+  const meta = (virtualMcp.metadata ?? {}) as Record<string, unknown>;
+  const next = deleteSandboxMapEntry(
+    readSandboxMap(meta),
+    targetUserId,
+    branch,
+    sandboxProviderKind,
+  );
+  if (!next) return;
 
   await storage.update(virtualMcpId, actingUserId, {
     metadata: {

--- a/apps/mesh/src/tools/sandbox/sandbox-map.ts
+++ b/apps/mesh/src/tools/sandbox/sandbox-map.ts
@@ -40,6 +40,34 @@ export function resolveVm(
 }
 
 /**
+ * Pure merge: returns a copy of `current` with sandboxMap[userId][branch][kind]
+ * set to `entry`. Creates intermediate buckets as needed and preserves any
+ * sibling users, branches, and kinds. Normalizes the target branch cell through
+ * `parseBranchMap` so a legacy stringified cell can't corrupt the spread. The
+ * single source of truth for both the agent-scoped (`setSandboxMapEntry`) and
+ * thread-scoped (`setThreadSandboxMapEntry`) writers.
+ */
+export function mergeSandboxMapEntry(
+  current: SandboxMap,
+  targetUserId: string,
+  branch: string,
+  sandboxProviderKind: SandboxProviderKind,
+  entry: SandboxRecord,
+): SandboxMap {
+  const currentBranchMap = parseBranchMap(current[targetUserId]?.[branch]);
+  return {
+    ...current,
+    [targetUserId]: {
+      ...(current[targetUserId] ?? {}),
+      [branch]: {
+        ...currentBranchMap,
+        [sandboxProviderKind]: entry,
+      } as SandboxMap[string][string],
+    },
+  };
+}
+
+/**
  * Read-modify-write: sets sandboxMap[userId][branch][kind] = entry on the
  * virtualmcp. Creates intermediate buckets as needed. Preserves any
  * sibling-kind entries already present at sandboxMap[userId][branch][*].
@@ -57,18 +85,13 @@ export async function setSandboxMapEntry(
   if (!virtualMcp) return;
 
   const meta = (virtualMcp.metadata ?? {}) as Record<string, unknown>;
-  const current = readSandboxMap(meta);
-  const currentBranchMap = parseBranchMap(current[targetUserId]?.[branch]);
-  const next: SandboxMap = {
-    ...current,
-    [targetUserId]: {
-      ...(current[targetUserId] ?? {}),
-      [branch]: {
-        ...currentBranchMap,
-        [sandboxProviderKind]: entry,
-      } as SandboxMap[string][string],
-    },
-  };
+  const next = mergeSandboxMapEntry(
+    readSandboxMap(meta),
+    targetUserId,
+    branch,
+    sandboxProviderKind,
+    entry,
+  );
 
   await storage.update(virtualMcpId, actingUserId, {
     metadata: {

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -152,7 +152,18 @@ export const SANDBOX_START = defineTool({
       providerKind,
     );
 
-    const githubRepo = (metadata as GithubRepoMeta).githubRepo ?? null;
+    // Thread-scoped repo (bound by `load_repo`) wins over the agent's repo — the
+    // same rule as `ensureSandbox`. Without this the frontend's auto-start
+    // provisions a repo-LESS sandbox for the synthetic Decopilot agent (whose
+    // metadata has no repo), so nothing clones and the dev server stays idle.
+    // Derive the thread id from the branch since this path has no
+    // `ctx.metadata.threadId`.
+    const threadRepo = await getThreadGithubRepo(
+      ctx,
+      threadIdFromBranch(resolvedBranch) ?? ctx.metadata?.threadId,
+    );
+    const githubRepo =
+      threadRepo ?? (metadata as GithubRepoMeta).githubRepo ?? null;
 
     const { entry, isNewVm } = await provisionSandbox({
       ctx,

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -43,7 +43,7 @@ import {
 import { generateBranchName } from "../../shared/branch-name";
 import { PACKAGE_MANAGER_CONFIG } from "../../shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
-import { getThreadGithubRepo } from "./thread-repo";
+import { getThreadGithubRepo, threadIdFromBranch } from "./thread-repo";
 import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
 import { getSettings } from "../../settings";
 import { getPublicUrl } from "../../core/server-constants";
@@ -249,7 +249,13 @@ export async function ensureSandbox(
   // Thread-scoped repo wins over the agent's own repo: `load_repo` binds a repo
   // to the thread (the only place it can persist for the synthetic Decopilot
   // agent), and it's the per-conversation override for real repo-agents too.
-  const threadRepo = await getThreadGithubRepo(ctx, ctx.metadata?.threadId);
+  // Recover the thread id from the branch (`thread:<id>[/<conn>]`) so the
+  // repo binding is found even on the frontend's SANDBOX_START auto-start path,
+  // which doesn't set `ctx.metadata.threadId`. Falls back to the ctx value.
+  const threadRepo = await getThreadGithubRepo(
+    ctx,
+    threadIdFromBranch(input.branch) ?? ctx.metadata?.threadId,
+  );
   const githubRepo =
     threadRepo ?? (metadata as GithubRepoMeta).githubRepo ?? null;
   const { entry } = await provisionSandbox({

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -43,6 +43,7 @@ import {
 import { generateBranchName } from "../../shared/branch-name";
 import { PACKAGE_MANAGER_CONFIG } from "../../shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
+import { getThreadGithubRepo } from "./thread-repo";
 import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
 import { getSettings } from "../../settings";
 import { getPublicUrl } from "../../core/server-constants";
@@ -245,7 +246,12 @@ export async function ensureSandbox(
     });
   }
 
-  const githubRepo = (metadata as GithubRepoMeta).githubRepo ?? null;
+  // Thread-scoped repo wins over the agent's own repo: `load_repo` binds a repo
+  // to the thread (the only place it can persist for the synthetic Decopilot
+  // agent), and it's the per-conversation override for real repo-agents too.
+  const threadRepo = await getThreadGithubRepo(ctx, ctx.metadata?.threadId);
+  const githubRepo =
+    threadRepo ?? (metadata as GithubRepoMeta).githubRepo ?? null;
   const { entry } = await provisionSandbox({
     ctx,
     userId,

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -43,7 +43,11 @@ import {
 import { generateBranchName } from "../../shared/branch-name";
 import { PACKAGE_MANAGER_CONFIG } from "../../shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
-import { getThreadGithubRepo, threadIdFromBranch } from "./thread-repo";
+import {
+  getThreadGithubRepo,
+  setThreadSandboxMapEntry,
+  threadIdFromBranch,
+} from "./thread-repo";
 import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
 import { getSettings } from "../../settings";
 import { getPublicUrl } from "../../core/server-constants";
@@ -546,6 +550,21 @@ async function provisionSandbox(
     params.providerKind,
     entry,
   );
+  // Thread-scoped branch: the agent write above is a no-op for the synthetic
+  // Decopilot agent, so also persist the record on the thread — the only place
+  // the frontend reads previewUrl/handle from for these sandboxes. Applies to
+  // EVERY provisioning path (load_repo, SANDBOX_START auto-start, fs tools).
+  const threadId = threadIdFromBranch(branch);
+  if (threadId) {
+    await setThreadSandboxMapEntry(
+      ctx,
+      threadId,
+      userId,
+      branch,
+      params.providerKind,
+      entry,
+    );
+  }
 
   // Different handle = new sandbox (stale entry / orphan recovery / state miss).
   const isNewVm = !existing || existing.sandboxHandle !== sandbox.handle;

--- a/apps/mesh/src/tools/sandbox/thread-repo.test.ts
+++ b/apps/mesh/src/tools/sandbox/thread-repo.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { threadBranch, threadIdFromBranch } from "./thread-repo";
+
+test("threadBranch round-trips through threadIdFromBranch", () => {
+  const id = "f3ef4465-b187-4e8d-b71a-a36cf4035046";
+  expect(threadIdFromBranch(threadBranch(id))).toBe(id);
+  expect(
+    threadIdFromBranch(threadBranch(id, "conn_6-MnS2eSZ3z-2BBVwFQrR")),
+  ).toBe(id);
+});
+
+test("threadBranch encodes the connection id so repos get distinct branches", () => {
+  const id = "t1";
+  expect(threadBranch(id, "conn_a")).not.toBe(threadBranch(id, "conn_b"));
+  expect(threadBranch(id, "conn_a")).toBe("thread:t1/conn_a");
+});
+
+test("threadIdFromBranch ignores non-thread branches", () => {
+  expect(threadIdFromBranch("ephemeral")).toBeNull();
+  expect(threadIdFromBranch("main")).toBeNull();
+  expect(threadIdFromBranch(null)).toBeNull();
+});

--- a/apps/mesh/src/tools/sandbox/thread-repo.ts
+++ b/apps/mesh/src/tools/sandbox/thread-repo.ts
@@ -11,8 +11,9 @@
  */
 
 import type { StudioContext } from "@/core/studio-context";
-import type { GithubRepo, SandboxMap, SandboxRecord } from "@decocms/mesh-sdk";
+import type { GithubRepo, SandboxRecord } from "@decocms/mesh-sdk";
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
+import { mergeSandboxMapEntry, readSandboxMap } from "./sandbox-map";
 
 /**
  * Per-thread sandbox branch for a loaded repo. Includes the repo's connection
@@ -49,27 +50,37 @@ export function threadIdFromBranch(
   return id || null;
 }
 
-/** Read the repo bound to a thread, or null. Never throws. `ctx.storage.threads`
- *  is already org-scoped, so only the thread id is needed. */
+/** Read a thread's metadata JSON. Returns `null` only when the thread is
+ *  absent (so writers can skip a non-existent row); an existing thread with a
+ *  null metadata column returns `{}`. Never throws. `ctx.storage.threads` is
+ *  already org-scoped, so only the thread id is needed. */
+async function getThreadMeta(
+  ctx: StudioContext,
+  threadId: string | undefined | null,
+): Promise<Record<string, unknown> | null> {
+  if (!threadId) return null;
+  const thread = await ctx.storage.threads.get(threadId).catch(() => null);
+  if (!thread) return null;
+  return (thread.metadata as Record<string, unknown> | null) ?? {};
+}
+
+/** Read the repo bound to a thread, or null. Never throws. */
 export async function getThreadGithubRepo(
   ctx: StudioContext,
   threadId: string | undefined | null,
 ): Promise<GithubRepo | null> {
-  if (!threadId) return null;
-  const thread = await ctx.storage.threads.get(threadId).catch(() => null);
-  const repo = (thread?.metadata as { githubRepo?: GithubRepo } | undefined)
-    ?.githubRepo;
-  return repo ?? null;
+  const meta = await getThreadMeta(ctx, threadId);
+  return (meta as { githubRepo?: GithubRepo } | null)?.githubRepo ?? null;
 }
 
 /**
  * Persist a sandbox record on the THREAD's `metadata.sandboxMap`
- * ([userId][branch][kind]), mirroring the agent-scoped `setSandboxMapEntry`.
- * The synthetic Decopilot agent's sandboxMap write is a no-op, so for
- * thread-scoped branches this is the only place the frontend can read the
- * live `previewUrl`/handle from. Called from `provisionSandbox` so every
- * provisioning path (load_repo, the frontend's SANDBOX_START auto-start, the
- * fs tools) persists it — not just `load_repo`. Never throws.
+ * ([userId][branch][kind]) via the shared {@link mergeSandboxMapEntry}. The
+ * synthetic Decopilot agent's sandboxMap write is a no-op, so for thread-scoped
+ * branches this is the only place the frontend reads the live `previewUrl`/
+ * handle from. Called from `provisionSandbox` so every provisioning path
+ * (load_repo, the frontend's SANDBOX_START auto-start, the fs tools) persists
+ * it — not just `load_repo`. Never throws.
  */
 export async function setThreadSandboxMapEntry(
   ctx: StudioContext,
@@ -79,16 +90,15 @@ export async function setThreadSandboxMapEntry(
   kind: SandboxProviderKind,
   entry: SandboxRecord,
 ): Promise<void> {
-  const thread = await ctx.storage.threads.get(threadId).catch(() => null);
-  if (!thread) return;
-  const meta = (thread.metadata ?? {}) as Record<string, unknown>;
-  const current = (meta.sandboxMap ?? {}) as SandboxMap;
-  const userMap = { ...(current[userId] ?? {}) } as Record<
-    string,
-    Record<string, SandboxRecord>
-  >;
-  userMap[branch] = { ...(userMap[branch] ?? {}), [kind]: entry };
-  const next = { ...current, [userId]: userMap } as SandboxMap;
+  const meta = await getThreadMeta(ctx, threadId);
+  if (!meta) return;
+  const next = mergeSandboxMapEntry(
+    readSandboxMap(meta),
+    userId,
+    branch,
+    kind,
+    entry,
+  );
   await ctx.storage.threads
     .update(threadId, { metadata: { ...meta, sandboxMap: next } })
     .catch((err) =>

--- a/apps/mesh/src/tools/sandbox/thread-repo.ts
+++ b/apps/mesh/src/tools/sandbox/thread-repo.ts
@@ -11,7 +11,8 @@
  */
 
 import type { StudioContext } from "@/core/studio-context";
-import type { GithubRepo } from "@decocms/mesh-sdk";
+import type { GithubRepo, SandboxMap, SandboxRecord } from "@decocms/mesh-sdk";
+import type { SandboxProviderKind } from "@decocms/sandbox/provider";
 
 /**
  * Per-thread sandbox branch for a loaded repo. Includes the repo's connection
@@ -59,4 +60,38 @@ export async function getThreadGithubRepo(
   const repo = (thread?.metadata as { githubRepo?: GithubRepo } | undefined)
     ?.githubRepo;
   return repo ?? null;
+}
+
+/**
+ * Persist a sandbox record on the THREAD's `metadata.sandboxMap`
+ * ([userId][branch][kind]), mirroring the agent-scoped `setSandboxMapEntry`.
+ * The synthetic Decopilot agent's sandboxMap write is a no-op, so for
+ * thread-scoped branches this is the only place the frontend can read the
+ * live `previewUrl`/handle from. Called from `provisionSandbox` so every
+ * provisioning path (load_repo, the frontend's SANDBOX_START auto-start, the
+ * fs tools) persists it — not just `load_repo`. Never throws.
+ */
+export async function setThreadSandboxMapEntry(
+  ctx: StudioContext,
+  threadId: string,
+  userId: string,
+  branch: string,
+  kind: SandboxProviderKind,
+  entry: SandboxRecord,
+): Promise<void> {
+  const thread = await ctx.storage.threads.get(threadId).catch(() => null);
+  if (!thread) return;
+  const meta = (thread.metadata ?? {}) as Record<string, unknown>;
+  const current = (meta.sandboxMap ?? {}) as SandboxMap;
+  const userMap = { ...(current[userId] ?? {}) } as Record<
+    string,
+    Record<string, SandboxRecord>
+  >;
+  userMap[branch] = { ...(userMap[branch] ?? {}), [kind]: entry };
+  const next = { ...current, [userId]: userMap } as SandboxMap;
+  await ctx.storage.threads
+    .update(threadId, { metadata: { ...meta, sandboxMap: next } })
+    .catch((err) =>
+      console.warn("[thread-repo] setThreadSandboxMapEntry failed", err),
+    );
 }

--- a/apps/mesh/src/tools/sandbox/thread-repo.ts
+++ b/apps/mesh/src/tools/sandbox/thread-repo.ts
@@ -1,0 +1,32 @@
+/**
+ * Thread-scoped repo binding.
+ *
+ * The Decopilot super-agent (and other ephemeral agents) has no persistent
+ * `connections` row — its `virtualMcps.findById` returns a synthetic object, so
+ * a repo can't be persisted on the agent. `load_repo` instead binds the chosen
+ * repo to the current THREAD (`threads.metadata.githubRepo` + `threads.branch`,
+ * both real, persisted columns), and sandbox provisioning prefers the thread's
+ * repo over the agent's. This is also the natural per-conversation override for
+ * real repo-agents.
+ */
+
+import type { StudioContext } from "@/core/studio-context";
+import type { GithubRepo } from "@decocms/mesh-sdk";
+
+/** Stable, per-thread sandbox branch used when a repo is loaded into a thread. */
+export function threadBranch(threadId: string): string {
+  return `thread:${threadId}`;
+}
+
+/** Read the repo bound to a thread, or null. Never throws. `ctx.storage.threads`
+ *  is already org-scoped, so only the thread id is needed. */
+export async function getThreadGithubRepo(
+  ctx: StudioContext,
+  threadId: string | undefined | null,
+): Promise<GithubRepo | null> {
+  if (!threadId) return null;
+  const thread = await ctx.storage.threads.get(threadId).catch(() => null);
+  const repo = (thread?.metadata as { githubRepo?: GithubRepo } | undefined)
+    ?.githubRepo;
+  return repo ?? null;
+}

--- a/apps/mesh/src/tools/sandbox/thread-repo.ts
+++ b/apps/mesh/src/tools/sandbox/thread-repo.ts
@@ -11,9 +11,13 @@
  */
 
 import type { StudioContext } from "@/core/studio-context";
-import type { GithubRepo, SandboxRecord } from "@decocms/mesh-sdk";
+import type { GithubRepo, SandboxMap, SandboxRecord } from "@decocms/mesh-sdk";
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
-import { mergeSandboxMapEntry, readSandboxMap } from "./sandbox-map";
+import {
+  deleteSandboxMapEntry,
+  mergeSandboxMapEntry,
+  readSandboxMap,
+} from "./sandbox-map";
 
 /**
  * Per-thread sandbox branch for a loaded repo. Includes the repo's connection
@@ -103,5 +107,42 @@ export async function setThreadSandboxMapEntry(
     .update(threadId, { metadata: { ...meta, sandboxMap: next } })
     .catch((err) =>
       console.warn("[thread-repo] setThreadSandboxMapEntry failed", err),
+    );
+}
+
+/** The thread's sandboxMap ([userId][branch][kind]). `{}` when absent. Never
+ *  throws. This is where the synthetic Decopilot agent's sandbox records live,
+ *  so backend existence checks (the events handler) must read it here — the
+ *  agent row is a no-op store for those. */
+export async function getThreadSandboxMap(
+  ctx: StudioContext,
+  threadId: string | undefined | null,
+): Promise<SandboxMap> {
+  return readSandboxMap(await getThreadMeta(ctx, threadId));
+}
+
+/** Remove sandboxMap[userId][branch][kind] from the thread via the shared
+ *  {@link deleteSandboxMapEntry}. No-op when the thread or entry is absent.
+ *  Never throws. Mirrors the agent-scoped `removeSandboxMapEntry`. */
+export async function removeThreadSandboxMapEntry(
+  ctx: StudioContext,
+  threadId: string,
+  userId: string,
+  branch: string,
+  kind: SandboxProviderKind,
+): Promise<void> {
+  const meta = await getThreadMeta(ctx, threadId);
+  if (!meta) return;
+  const next = deleteSandboxMapEntry(
+    readSandboxMap(meta),
+    userId,
+    branch,
+    kind,
+  );
+  if (!next) return;
+  await ctx.storage.threads
+    .update(threadId, { metadata: { ...meta, sandboxMap: next } })
+    .catch((err) =>
+      console.warn("[thread-repo] removeThreadSandboxMapEntry failed", err),
     );
 }

--- a/apps/mesh/src/tools/sandbox/thread-repo.ts
+++ b/apps/mesh/src/tools/sandbox/thread-repo.ts
@@ -33,6 +33,21 @@ export function threadBranch(
     : `thread:${threadId}`;
 }
 
+/**
+ * Extract the thread id from a synthetic sandbox branch
+ * (`thread:<id>` or `thread:<id>/<connectionId>`), or null for non-thread
+ * branches. Lets provisioning recover the thread repo from the branch alone,
+ * without relying on `ctx.metadata.threadId` (absent on the frontend's
+ * SANDBOX_START auto-start path).
+ */
+export function threadIdFromBranch(
+  branch: string | null | undefined,
+): string | null {
+  if (!branch || !branch.startsWith("thread:")) return null;
+  const id = branch.slice("thread:".length).split("/")[0];
+  return id || null;
+}
+
 /** Read the repo bound to a thread, or null. Never throws. `ctx.storage.threads`
  *  is already org-scoped, so only the thread id is needed. */
 export async function getThreadGithubRepo(

--- a/apps/mesh/src/tools/sandbox/thread-repo.ts
+++ b/apps/mesh/src/tools/sandbox/thread-repo.ts
@@ -13,9 +13,24 @@
 import type { StudioContext } from "@/core/studio-context";
 import type { GithubRepo } from "@decocms/mesh-sdk";
 
-/** Stable, per-thread sandbox branch used when a repo is loaded into a thread. */
-export function threadBranch(threadId: string): string {
-  return `thread:${threadId}`;
+/**
+ * Per-thread sandbox branch for a loaded repo. Includes the repo's connection
+ * id so switching repos yields a DISTINCT sandbox (handle + previewUrl), which
+ * is what makes the preview UI react to a switch — the whole preview/lifecycle
+ * machinery keys on the previewUrl changing. Falls back to a bare
+ * `thread:<id>` (no repo / public clone) which stays stable.
+ *
+ * The daemon treats any `thread:`-prefixed branch as synthetic (never a git
+ * ref), and the sandbox-proxy validator strips the prefix before its git-ref
+ * charset check — so the extra `/` segment is safe.
+ */
+export function threadBranch(
+  threadId: string,
+  connectionId?: string | null,
+): string {
+  return connectionId
+    ? `thread:${threadId}/${connectionId}`
+    : `thread:${threadId}`;
 }
 
 /** Read the repo bound to a thread, or null. Never throws. `ctx.storage.threads`

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -1028,10 +1028,40 @@ export function ActiveTaskProvider({
           });
           return;
         }
-        // `load_repo` finished cloning a repo into the thread's sandbox and
-        // wants the live Preview shown — open the "preview" main-panel tab.
+        // `load_repo` finished cloning a repo into the thread's sandbox. Patch
+        // the local thread row (branch + repo + sandbox record) so the preview
+        // resolves without a refetch, then open the "preview" main-panel tab.
         if (chunk.type === "data-open-preview") {
+          const data = (
+            chunk as unknown as {
+              data: {
+                branch?: string | null;
+                githubRepo?: unknown;
+                sandboxMap?: unknown;
+                sandboxProviderKind?: string | null;
+              };
+            }
+          ).data;
           const cb = cbRef.current;
+          const id = cb.taskId;
+          if (id) {
+            const current = cb.manager.threads.get().find((t) => t.id === id);
+            cb.manager.patchThread({
+              id,
+              ...(data?.branch ? { branch: data.branch } : {}),
+              ...(data?.sandboxProviderKind
+                ? {
+                    sandbox_provider_kind:
+                      data.sandboxProviderKind as Task["sandbox_provider_kind"],
+                  }
+                : {}),
+              metadata: {
+                ...(current?.metadata ?? {}),
+                ...(data?.githubRepo ? { githubRepo: data.githubRepo } : {}),
+                ...(data?.sandboxMap ? { sandboxMap: data.sandboxMap } : {}),
+              } as Task["metadata"],
+            });
+          }
           cb.navigate({
             to: ".",
             search: (prev: Record<string, unknown>) => ({

--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -1028,6 +1028,20 @@ export function ActiveTaskProvider({
           });
           return;
         }
+        // `load_repo` finished cloning a repo into the thread's sandbox and
+        // wants the live Preview shown — open the "preview" main-panel tab.
+        if (chunk.type === "data-open-preview") {
+          const cb = cbRef.current;
+          cb.navigate({
+            to: ".",
+            search: (prev: Record<string, unknown>) => ({
+              ...prev,
+              main: "preview",
+            }),
+            replace: true,
+          });
+          return;
+        }
       },
       onFinish: (message, _messages, finishReason) => {
         const cb = cbRef.current;

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -49,6 +49,7 @@ import {
   parseBranchMap,
 } from "@decocms/mesh-sdk";
 import type { VirtualMCPEntity, SandboxMap } from "@decocms/mesh-sdk/types";
+import { agentHasClonableSource } from "@/web/lib/agent-capabilities";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useIsSandboxStartPending } from "@/web/components/sandbox/hooks/use-sandbox-start";
 import { useStatusSounds } from "../../hooks/use-status-sounds";
@@ -147,10 +148,30 @@ function VmEventsBridge({
   sandboxMap: SandboxMap | undefined;
   children: ReactNode;
 }) {
-  const { currentBranch } = useChatTask();
+  const { currentBranch, activeTask } = useChatTask();
   const { pendingSandboxProviderKind } = useChatPrefs();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
+
+  // Overlay the thread's own sandbox record for the current branch. `load_repo`
+  // binds a repo to the thread and persists its sandbox there (the ephemeral
+  // Decopilot agent's sandboxMap never persists), so the preview must read the
+  // thread's entry, not just the agent's.
+  const threadSandboxMap = activeTask?.metadata?.sandboxMap as
+    | SandboxMap
+    | undefined;
+  const effectiveSandboxMap: SandboxMap | undefined =
+    userId && currentBranch && threadSandboxMap?.[userId]?.[currentBranch]
+      ? {
+          ...(sandboxMap ?? {}),
+          [userId]: {
+            ...(sandboxMap?.[userId] ?? {}),
+            [currentBranch]: threadSandboxMap[userId]![currentBranch]!,
+          },
+        }
+      : sandboxMap;
+  const effectiveHasGithubRepo =
+    hasActiveGithubRepo || agentHasClonableSource(activeTask?.metadata);
 
   // Open the events stream only when a sandbox actually exists or a start is
   // in flight — NOT merely because the agent has a GitHub repo configured.
@@ -164,10 +185,9 @@ function VmEventsBridge({
   );
   const branchMap =
     userId && currentBranch
-      ? (parseBranchMap(sandboxMap?.[userId]?.[currentBranch]) as Record<
-          string,
-          BranchMapEntryLike
-        >)
+      ? (parseBranchMap(
+          effectiveSandboxMap?.[userId]?.[currentBranch],
+        ) as Record<string, BranchMapEntryLike>)
       : {};
   // Use the resolved provider kind to pick the matching entry — same logic as
   // SandboxLifecycleProvider so the SSE previewUrl and the lifecycle vmEntry
@@ -191,8 +211,8 @@ function VmEventsBridge({
         virtualMcpId={virtualMcpId}
         branch={currentBranch ?? null}
         userId={userId ?? null}
-        hasActiveGithubRepo={hasActiveGithubRepo}
-        sandboxMap={sandboxMap}
+        hasActiveGithubRepo={effectiveHasGithubRepo}
+        sandboxMap={effectiveSandboxMap}
         sandboxProviderKind={pendingSandboxProviderKind}
       >
         <BlocksPreviewWorkspaceProvider

--- a/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-with-drawer.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-with-drawer.tsx
@@ -4,6 +4,7 @@
  * `hasClonableSource` so non-cloneable agents (e.g. decopilot) don't see it.
  */
 
+import { useChatTask } from "@/web/components/chat/chat-context";
 import { useInsetContext } from "@/web/layouts/agent-shell-layout";
 import { agentHasClonableSource } from "@/web/lib/agent-capabilities";
 import { MainPanelContent } from "@/web/layouts/main-panel-tabs";
@@ -17,7 +18,12 @@ export function MainPanelWithDrawer({
   taskId: string;
 }) {
   const inset = useInsetContext();
-  const hasClonableSource = agentHasClonableSource(inset?.entity?.metadata);
+  const { activeTask } = useChatTask();
+  // Thread-scoped repo (bound by `load_repo`) also gets the drawer + dev
+  // terminal, not just agents with their own repo.
+  const hasClonableSource =
+    agentHasClonableSource(inset?.entity?.metadata) ||
+    agentHasClonableSource(activeTask?.metadata);
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
@@ -1,3 +1,4 @@
+import { useChatTask } from "@/web/components/chat/chat-context";
 import { PreviewContent } from "@/web/components/sandbox/preview/preview";
 import { agentHasClonableSource } from "@/web/lib/agent-capabilities";
 import { useVirtualMCP } from "@decocms/mesh-sdk";
@@ -5,7 +6,12 @@ import { AlertCircle } from "@untitledui/icons";
 
 export function PreviewTab({ virtualMcpId }: { virtualMcpId: string }) {
   const entity = useVirtualMCP(virtualMcpId);
-  const hasClonableSource = agentHasClonableSource(entity?.metadata);
+  const { activeTask } = useChatTask();
+  // A thread-scoped repo (bound by `load_repo`) is previewable even when the
+  // agent itself has no clonable source (e.g. the ephemeral Decopilot agent).
+  const hasClonableSource =
+    agentHasClonableSource(entity?.metadata) ||
+    agentHasClonableSource(activeTask?.metadata);
 
   if (!hasClonableSource) {
     return (

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -185,7 +185,12 @@ export function useMainPanelTabs(ctx: {
   const devConnId = entity?.id ? getDevConnectionId(entity.id) : null;
   const expandedTools: ThreadExpandedTool[] = metadata?.expanded_tools ?? [];
   const hasActiveGithubRepo = agentHasConnectedGithub(entity);
-  const hasClonableSource = agentHasClonableSource(entity?.metadata);
+  // A thread-scoped repo (bound by `load_repo`) makes the source tabs
+  // (Preview, Code) available even when the agent itself has no repo — e.g.
+  // the ephemeral Decopilot agent.
+  const hasClonableSource =
+    agentHasClonableSource(entity?.metadata) ||
+    agentHasClonableSource(metadata);
   const { granted: canManageAgents } = useCapability("agents:manage");
   const connections = useConnections({ includeVirtual: true });
 


### PR DESCRIPTION
## Summary

Adds a new decopilot built-in tool, **`load_repo`**, that lets an agent switch (or set) the GitHub repository its sandbox operates on. After calling it, the agent's file tools (read/write/edit/bash/grep/glob) and dev server work against the newly selected repo.

An agent's repo binding lives at `virtualMcp.metadata.githubRepo`, and its sandbox identity is *derived* from `(orgId, virtualMcpId, branch)` — not from the repo. So switching repos means: rewrite `githubRepo`, then tear the current sandbox down so the next VM tool call re-provisions a fresh sandbox that clones the new repo.

### Behavior
- **Dynamic description**: built per-turn in `buildAllTools` from the org's imported repos (active `mcp-github` connections carrying a `repoScope` recipe). The model learns which repos exist — and their `connectionId` — just by reading the tool, no extra listing round-trip.
- **Input**: `connectionId` of the repo to load (unambiguous; the description maps `owner/repo → connectionId`).
- **Execute**: resolves the repo from that connection's `repoScope`, writes `metadata.githubRepo`, then calls `SANDBOX_DELETE` (resolving the provider kind first) to reset the sandbox. Reusing `SANDBOX_DELETE` keeps teardown behavior identical to the existing delete path.
- **Timing**: takes effect on the following message — the next file/bash tool call boots the fresh sandbox. (Within the same turn the fs hooks' handle is memoized and not exposed for invalidation.)

Registered only when a `vmContext` is present (i.e. the agent has VM/file tools), alongside the other sandbox-backed built-ins. Annotated `{ readOnly: false, destructive: true }` for analytics parity.

## Files
- `load-repo.ts` — the tool (cluster-glue tier, same as `cluster-sandbox-fs.ts`).
- `index.ts` — import, registration in the `vmContext` block, annotation.
- `load-repo.test.ts` — pure unit test for the dynamic description (populated + empty cases).

## Testing
- `bun test .../load-repo.test.ts` — 2 pass.
- `bun run check` — no new type errors (pre-existing `ct/` errors are unrelated, missing Playwright-CT deps).
- `bun run fmt` / `bun run lint` — clean (0 errors).

Not yet exercised end-to-end against a live agent + sandbox; the repo-switch → sandbox-reset path would benefit from a manual run before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `load_repo` built-in that lets a Decopilot agent load or switch the GitHub repo for a conversation. It binds the repo to the thread, provisions a repo-specific sandbox and Preview immediately, and file/dev tools use it from the next message.

- **New Features**
  - `load_repo` binds a GitHub repo to the thread (`threads.metadata.githubRepo` + `thread:<id>/<connectionId>`), eagerly provisions via `ensureSandbox`, waits for clone, returns root files + `previewUrl`, and emits `data-open-preview`.
  - Exposed only when VM tools are available and the org has imported repos from `mcp-github`; the description lists all imported repos (org‑shared and per‑agent) as `owner/repo (connectionId)`. Annotated `{ readOnly: false, destructive: true }`.

- **Bug Fixes**
  - Switching repos produces a distinct sandbox and `previewUrl` (branch encodes the `connectionId`), so Preview updates reliably and avoids stale checkouts.
  - Preview opens immediately; `ensureSandbox` persists the thread‑scoped sandbox record and the client patches the thread via `data-open-preview`. The clone poll only enriches the return listing and bails on repeated probe failures.
  - All provisions (`load_repo`, `SANDBOX_START`, fs tools) honor the thread‑scoped repo and persist its sandbox under the thread; the UI shows Preview/Code tabs and the dev terminal for thread‑bound repos.
  - Sandbox proxy accepts `thread:<id>[/<connectionId>]`; auto-start derives the thread id from the branch to re‑provision the correct repo.
  - VM events handler falls back to the thread’s sandboxMap for thread‑scoped branches; stale claims are cleaned up there and emit `gone` so the client self‑heals.
  - New: `mergeSandboxMapEntry` is the single read‑modify‑write path for sandbox maps (agent + thread). It prevents `load_repo` from clobbering sibling entries and fixes legacy stringified branch cells; covered by new unit tests.

<sup>Written for commit d6cd0dbe5fd689985392e465ce6a3ffafe90be3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

