### PR TITLE
refactor(mesh-sdk): dedupe Studio Pack agent id prefixes

### DIFF
--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -403,15 +403,27 @@ export function getWellKnownCommerceDiscoveryVirtualMCP(
 }
 
 /**
+ * Studio Pack agent ID prefixes (org-scoped), keyed the same as StudioPackAgentId below.
+ */
+const studioPackAgentPrefixes = {
+  AGENT_MANAGER: createWellKnownAgentPrefix("studio-agent-manager_"),
+  AUTOMATION_MANAGER: createWellKnownAgentPrefix("studio-automation-manager_"),
+  CONNECTION_MANAGER: createWellKnownAgentPrefix("studio-connection-manager_"),
+  STORE_MANAGER: createWellKnownAgentPrefix("studio-store-manager_"),
+  BRAND_MANAGER: createWellKnownAgentPrefix("studio-brand-manager_"),
+  USAGE_MANAGER: createWellKnownAgentPrefix("studio-usage-manager_"),
+} as const;
+
+/**
  * Studio Pack agent ID generators (org-scoped)
  */
 export const StudioPackAgentId = {
-  AGENT_MANAGER: (orgId: string) => `studio-agent-manager_${orgId}`,
-  AUTOMATION_MANAGER: (orgId: string) => `studio-automation-manager_${orgId}`,
-  CONNECTION_MANAGER: (orgId: string) => `studio-connection-manager_${orgId}`,
-  STORE_MANAGER: (orgId: string) => `studio-store-manager_${orgId}`,
-  BRAND_MANAGER: (orgId: string) => `studio-brand-manager_${orgId}`,
-  USAGE_MANAGER: (orgId: string) => `studio-usage-manager_${orgId}`,
+  AGENT_MANAGER: studioPackAgentPrefixes.AGENT_MANAGER.get,
+  AUTOMATION_MANAGER: studioPackAgentPrefixes.AUTOMATION_MANAGER.get,
+  CONNECTION_MANAGER: studioPackAgentPrefixes.CONNECTION_MANAGER.get,
+  STORE_MANAGER: studioPackAgentPrefixes.STORE_MANAGER.get,
+  BRAND_MANAGER: studioPackAgentPrefixes.BRAND_MANAGER.get,
+  USAGE_MANAGER: studioPackAgentPrefixes.USAGE_MANAGER.get,
 } as const;
 
 /**
@@ -419,13 +431,8 @@ export const StudioPackAgentId = {
  */
 export function isStudioPackAgent(id: string | null | undefined): boolean {
   if (!id) return false;
-  return (
-    id.startsWith("studio-agent-manager_") ||
-    id.startsWith("studio-automation-manager_") ||
-    id.startsWith("studio-connection-manager_") ||
-    id.startsWith("studio-store-manager_") ||
-    id.startsWith("studio-brand-manager_") ||
-    id.startsWith("studio-usage-manager_")
+  return Object.values(studioPackAgentPrefixes).some(
+    (prefix) => prefix.is(id) !== null,
   );
 }
 


### PR DESCRIPTION
## Source
Source 4 (net code reduction / duplication) — found while reading `packages/mesh-sdk/src/lib/constants.ts` (recently-changed file).

## Why
`StudioPackAgentId` and `isStudioPackAgent` hand-rolled the same check/slice/format logic that `createWellKnownAgentPrefix` already centralizes a few lines above in the same file for the decopilot / brand-context-setup / site-diagnostics / commerce-discovery agent ids. Each of the six Studio Pack prefix strings (`studio-agent-manager_`, etc.) was duplicated — once as a template literal in `StudioPackAgentId`, once as a `startsWith` literal in `isStudioPackAgent`. Now each prefix string is written exactly once, and adding a new Studio Pack manager only means adding one line instead of two that have to stay in sync.

Behavior-preserving for all real inputs (org ids are always non-empty in practice, and the existing test suite covers the same cases before/after).

## Verify
```
bun test packages/mesh-sdk/src/lib/constants.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` in `packages/mesh-sdk` (clean)
- `bun test packages/mesh-sdk/src/lib/constants.test.ts` (4 pass)

Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors Studio Pack agent ID generation and detection in `mesh-sdk` to reuse `createWellKnownAgentPrefix`. This removes duplicate prefix strings and centralizes logic with no behavior changes.

- **Refactors**
  - Added `studioPackAgentPrefixes` using `createWellKnownAgentPrefix`.
  - Updated `StudioPackAgentId` to use `.get` from the shared prefixes.
  - Simplified `isStudioPackAgent` to check via `.is` across the shared prefixes.

<sup>Written for commit 92fa5f600e6448e635276849867dd2dc72487d33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

