### PR TITLE
refactor(cli): dedupe stripAnsi helper shared by dev and serve commands

### DIFF
--- a/apps/mesh/src/cli/commands/dev.ts
+++ b/apps/mesh/src/cli/commands/dev.ts
@@ -17,6 +17,7 @@ import {
 } from "../cli-store";
 import { findAvailablePort } from "../find-available-port";
 import { waitForPort } from "../lib/port-wait";
+import { stripAnsi } from "../strip-ansi";
 
 export interface DevOptions {
   port: string;
@@ -34,13 +35,6 @@ export interface DevOptions {
   hotReload?: boolean;
   /** Dev-only: route managed user-desktop link traffic through ToxiProxy. */
   devLinkToxiProxy?: boolean;
-}
-
-// Strip ANSI escape codes from a string
-function stripAnsi(str: string): string {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI codes requires matching control chars
-  // oxlint-disable-next-line no-control-regex
-  return str.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
 /**

--- a/apps/mesh/src/cli/commands/serve.ts
+++ b/apps/mesh/src/cli/commands/serve.ts
@@ -14,6 +14,7 @@ import {
   updateService,
 } from "../cli-store";
 import { findAvailablePort } from "../find-available-port";
+import { stripAnsi } from "../strip-ansi";
 
 export interface ServeOptions {
   port: string;
@@ -21,13 +22,6 @@ export interface ServeOptions {
   skipMigrations: boolean;
   localMode: boolean;
   noTui?: boolean;
-}
-
-// Strip ANSI escape codes from a string
-function stripAnsi(str: string): string {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI codes requires matching control chars
-  // oxlint-disable-next-line no-control-regex
-  return str.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
 /**

--- a/apps/mesh/src/cli/strip-ansi.test.ts
+++ b/apps/mesh/src/cli/strip-ansi.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import { stripAnsi } from "./strip-ansi";
+
+describe("stripAnsi", () => {
+  it("removes color escape codes", () => {
+    expect(stripAnsi("\x1b[32mok\x1b[0m")).toBe("ok");
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(stripAnsi("plain text")).toBe("plain text");
+  });
+});

--- a/apps/mesh/src/cli/strip-ansi.ts
+++ b/apps/mesh/src/cli/strip-ansi.ts
@@ -1,0 +1,6 @@
+// Strip ANSI escape codes from a string.
+export function stripAnsi(str: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI codes requires matching control chars
+  // oxlint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, "");
+}


### PR DESCRIPTION
## Summary
- `apps/mesh/src/cli/commands/dev.ts` and `apps/mesh/src/cli/commands/serve.ts` each defined a byte-for-byte identical `stripAnsi` function (same regex `/\x1b\[[0-9;]*m/g`, same lint-suppress comments) copy-pasted between the two files.
- Extracted the shared logic into `apps/mesh/src/cli/strip-ansi.ts` and updated both call sites to import it. Net line delta: -8 across `dev.ts`/`serve.ts`, +18 for the new module + its unit test (one less hand-rolled copy to keep in sync going forward).
- Behavior-preserving: same regex, same output for both call sites. No existing test previously covered this logic (no `*.test.ts` in `apps/mesh/src/cli/commands/`), so I added `strip-ansi.test.ts` covering the escape-stripping and pass-through cases.

## Test plan
- `bun test apps/mesh/src/cli/strip-ansi.test.ts` — 2 pass
- `bun run fmt` — clean
- `bunx tsc --noEmit` in `apps/mesh` shows only pre-existing, unrelated errors in `rich-text-field.tsx` (confirmed identical on `main` before this change — a missing `@tiptap/extension-text-align` package in this local install)
- Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the duplicate `stripAnsi` helper into `apps/mesh/src/cli/strip-ansi.ts` and updated the `dev` and `serve` CLI commands to import it. Behavior is unchanged; added `strip-ansi.test.ts` to cover color-stripping and pass-through cases.

<sup>Written for commit cb5de2813590aa17375a1835252ae657ed1cb074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

