### PR TITLE
fix(sandbox): require a bind-banner phrase before locking the sniffed port

### DIFF
--- a/packages/sandbox/daemon/process/port-sniffer.test.ts
+++ b/packages/sandbox/daemon/process/port-sniffer.test.ts
@@ -33,4 +33,11 @@ describe("createPortSniffer", () => {
     expect(s.observe("start", "Listening on http://0.0.0.0:8000/")).toBe(true);
     expect(s.current()).toBe(8000);
   });
+
+  test("ignores an unrelated localhost URL from a sibling process preceding the real bind line", () => {
+    const s = createPortSniffer();
+    const interleaved = `API ready on http://localhost:4000/graphql\n\n${VITE_READY}`;
+    expect(s.observe("dev", interleaved)).toBe(true);
+    expect(s.current()).toBe(3000);
+  });
 });

--- a/packages/sandbox/daemon/process/port-sniffer.ts
+++ b/packages/sandbox/daemon/process/port-sniffer.ts
@@ -19,9 +19,18 @@ import { WELL_KNOWN_STARTERS } from "../constants";
  * locked-in port from a later log line, so a log message that happens to
  * contain another `http://localhost:N/` (e.g. an outbound fetch) can't
  * retarget the probe.
+ *
+ * The match requires one of the banner phrases above on the same line as
+ * the URL — a bare `http://localhost:N` isn't enough. `dev`/`start` often
+ * run more than one process (e.g. `concurrently "vite" "node server.js"`),
+ * and their stdout interleaves on the same stream; without the phrase gate
+ * an unrelated URL logged by a sibling process (a backend's own "listening"
+ * line, a proxied fetch, ...) could win the lock before the real bind line
+ * ever arrives.
  */
 
-const URL_PATTERN = /\bhttps?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d+)/;
+const URL_PATTERN =
+  /(?:Local:|Listening on)[^\n]*?\bhttps?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d+)/;
 
 /** ANSI color/cursor escape regex shared with the booting overlay. */
 // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control chars


### PR DESCRIPTION
## Source
Bug found reading `packages/sandbox/daemon/process/port-sniffer.ts` (recently added in #4631).

## The bug
`createPortSniffer()` locks onto the first `http://localhost:N` it sees in the `dev`/`start` task's stdout, with no check that the match is actually a bind announcement. Once locked, it never re-evaluates (`observe()` short-circuits while `port !== null`).

`dev`/`start` scripts frequently run more than one process on the same stdout stream (e.g. `"dev": "concurrently \"vite\" \"node server.js\""`). If a sibling process logs its own `http://localhost:N` (its own "listening" line, a proxied fetch, a health check, ...) before the frontend's real ready banner arrives, the sniffer locks onto that wrong port. Since `entry.ts` feeds `portSniffer.current()` straight into the upstream probe (preferred over the configured port), the sandbox's preview probe ends up polling the wrong service — the preview never comes up (or worse, comes up against an unrelated port that happens to answer).

## Fix
Require the matched URL to sit on the same line as one of the four documented banner phrases (`Local:` / `Listening on`) instead of matching any bare `http://localhost:N` anywhere in the chunk.

## Regression test
`packages/sandbox/daemon/process/port-sniffer.test.ts`: a chunk with an unrelated `http://localhost:4000` line followed by the real Vite ready banner. Fails on current code (locks port 4000), passes after the fix (locks 3000).

## Verify
```
bun test packages/sandbox/daemon/process/port-sniffer.test.ts
```

## Checks run locally
- `bun run fmt`
- `cd packages/sandbox && bun x tsc --noEmit` — clean
- `bun test packages/sandbox/daemon/process/port-sniffer.test.ts` — 5/5 pass

Full CI will cover the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox port sniffer to only lock onto a port when the URL appears with a bind-banner phrase. This prevents false locks from sibling process logs in multi-process `dev`/`start` scripts.

- **Bug Fixes**
  - Tightened URL match: require `Local:` or `Listening on` on the same line as `http://localhost:N` to lock the port.
  - Added a regression test to ensure unrelated `localhost` URLs logged before the real banner are ignored.
  - Prevents the preview probe from polling the wrong service when outputs interleave.

<sup>Written for commit 8d5cb36f7cee02ffcb80c9043a140d52cafb6eef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

