### PR TITLE
fix(sandbox): decode pipe-mode task output with a stateful UTF-8 decoder

### DIFF
--- a/packages/sandbox/daemon/process/task-manager.test.ts
+++ b/packages/sandbox/daemon/process/task-manager.test.ts
@@ -43,6 +43,21 @@ describe("TaskManager intentional flag", () => {
   });
 });
 
+describe("TaskManager pipe-mode output decoding", () => {
+  it("does not corrupt a multi-byte UTF-8 character split across separate stdout chunks", async () => {
+    const tm = makeManager();
+    const t = await tm.spawn({
+      // Two separate writes with a gap: the ✓ (0xE2 0x9C 0x93) arrives as
+      // one stdout 'data' event with a dangling lead byte, then the rest.
+      command: "printf '\\xe2\\x9c'; sleep 0.05; printf '\\x93 ok\\n'",
+      cwd: "/tmp",
+      mode: "pipe",
+    });
+    await tm.finished(t.id);
+    expect(tm.output(t.id)?.stdout).toBe("✓ ok\n");
+  });
+});
+
 describe("TaskManager kill status", () => {
   it("reports status 'killed' (not 'exited') for a pipe-mode task killed via kill()", async () => {
     const tm = makeManager();

--- a/packages/sandbox/daemon/process/task-manager.ts
+++ b/packages/sandbox/daemon/process/task-manager.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn as nodeSpawn } from "node:child_process";
 import { readdirSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { appLogPath } from "../paths";
 import { LogTee } from "./log-tee";
 import { spawnPty } from "./pty-spawn";
@@ -497,6 +498,12 @@ export class TaskManager {
     );
     task.pid = child.pid;
     task.pgid = child.pid;
+    // A multi-byte UTF-8 character can straddle two separate stdout/stderr
+    // 'data' events — decoding each Buffer chunk independently below would
+    // mangle it into replacement characters. StringDecoder carries the
+    // dangling bytes over to the next chunk instead.
+    const stdoutDecoder = new StringDecoder("utf-8");
+    const stderrDecoder = new StringDecoder("utf-8");
 
     const killGroup = (signal: NodeJS.Signals) => {
       if (task.pgid === undefined) return;
@@ -527,13 +534,13 @@ export class TaskManager {
     task.kill = (signal) => killGroup(signal ?? "SIGTERM");
 
     child.stdout?.on("data", (chunk: Buffer) => {
-      const data = chunk.toString("utf-8");
+      const data = stdoutDecoder.write(chunk);
       task.stdout.append(data);
       task.tee.write(data);
       this.fanOut(task, { stream: "stdout", data });
     });
     child.stderr?.on("data", (chunk: Buffer) => {
-      const data = chunk.toString("utf-8");
+      const data = stderrDecoder.write(chunk);
       task.stderr.append(data);
       task.tee.write(data);
       this.fanOut(task, { stream: "stderr", data });


### PR DESCRIPTION
## Source
Bug found reading `packages/sandbox/daemon/process/task-manager.ts` (churned recently alongside the port-sniffer bind-banner fix).

## Problem
In `TaskManager.startPipe`, `child.stdout`/`child.stderr` 'data' handlers call `chunk.toString("utf-8")` on each raw `Buffer` independently. Node delivers stdout/stderr as a byte stream — a multi-byte UTF-8 character (any non-ASCII output: `✓`, accented characters, emoji, unicode filenames in command output) can land split across two separate `data` events. Decoding each chunk on its own corrupts the split character into U+FFFD replacement characters in the task's stdout/stderr (visible in the on-disk log tee, the SSE fan-out, and any command output shown in the UI).

## Fix
Use `node:string_decoder`'s `StringDecoder` (one instance per stream, per task) instead of `Buffer.toString`. It buffers a dangling partial multi-byte sequence and prepends it to the next chunk, so split characters decode correctly regardless of where the chunk boundary falls.

## Regression test
Added to `task-manager.test.ts`: spawns a real `pipe`-mode task that writes `✓` (`0xE2 0x9C 0x93`) across two separate `printf` calls with a `sleep` between them (forcing two distinct stdout `data` events), then asserts the reassembled output is `"✓ ok\n"`.

Confirmed this fails on the pre-fix code (`"�� ok\n"`) and passes after the fix.

## To verify
```
bun test packages/sandbox/daemon/process/task-manager.test.ts
```

## Checks run locally
- `bun run fmt`
- `tsc --noEmit` in `packages/sandbox` (clean)
- `bun test packages/sandbox/daemon/process/task-manager.test.ts` (15 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes corrupted Unicode in pipe-mode task output by decoding stdout/stderr with a stateful UTF-8 decoder. Non-ASCII characters split across chunks now render correctly in logs, SSE, and the UI.

- **Bug Fixes**
  - Use `StringDecoder` from `node:string_decoder` per stream in `TaskManager.startPipe` instead of `Buffer.toString('utf-8')`.
  - Add a test that splits "✓" across two writes and verifies the output is "✓ ok\n".

<sup>Written for commit 80fc005796babce187ab12cdc8fe4fc03680b7fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

