### PR TITLE
fix(sandbox): carry partial bind-line across PTY chunks in port sniffer

### DIFF
--- a/packages/sandbox/daemon/process/port-sniffer.test.ts
+++ b/packages/sandbox/daemon/process/port-sniffer.test.ts
@@ -40,4 +40,13 @@ describe("createPortSniffer", () => {
     expect(s.observe("dev", interleaved)).toBe(true);
     expect(s.current()).toBe(3000);
   });
+
+  test("locks the port when the bind line is split across two PTY chunks", () => {
+    const s = createPortSniffer();
+    const splitAt = VITE_READY.indexOf("http://localhost:3000") + 15;
+    expect(s.observe("dev", VITE_READY.slice(0, splitAt))).toBe(false);
+    expect(s.current()).toBeNull();
+    expect(s.observe("dev", VITE_READY.slice(splitAt))).toBe(true);
+    expect(s.current()).toBe(3000);
+  });
 });

--- a/packages/sandbox/daemon/process/port-sniffer.ts
+++ b/packages/sandbox/daemon/process/port-sniffer.ts
@@ -37,6 +37,16 @@ const URL_PATTERN =
 // oxlint-disable-next-line no-control-regex
 const ANSI = /\[[0-9;?]*[a-zA-Z]/g;
 
+/**
+ * PTY reads (`child.onData`) aren't line-buffered — a chunk boundary can
+ * land mid bind-line (e.g. "...Local:   http://localhost:30" | "00/\n").
+ * Matching each chunk in isolation would miss the announcement forever.
+ * Carry a bounded tail per source across calls so a split line still
+ * matches once its continuation arrives. The longest phrase+URL we need
+ * to span is well under 100 chars, so 200 leaves headroom.
+ */
+const CARRY_LIMIT = 200;
+
 export interface PortSniffer {
   /**
    * Inspect a log chunk. No-op when not a starter source, when a port is
@@ -54,6 +64,7 @@ export interface PortSniffer {
 
 export function createPortSniffer(): PortSniffer {
   let port: number | null = null;
+  const carry = new Map<string, string>();
   return {
     observe(source, data) {
       if (port !== null) return false;
@@ -63,12 +74,18 @@ export function createPortSniffer(): PortSniffer {
         )
       )
         return false;
-      const stripped = data.replace(ANSI, "");
-      const match = stripped.match(URL_PATTERN);
-      if (!match) return false;
-      const parsed = Number(match[1]);
-      if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535)
+      const combined = (carry.get(source) ?? "") + data.replace(ANSI, "");
+      const match = combined.match(URL_PATTERN);
+      if (!match) {
+        carry.set(source, combined.slice(-CARRY_LIMIT));
         return false;
+      }
+      const parsed = Number(match[1]);
+      if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+        carry.set(source, combined.slice(-CARRY_LIMIT));
+        return false;
+      }
+      carry.delete(source);
       port = parsed;
       return true;
     },
@@ -77,6 +94,7 @@ export function createPortSniffer(): PortSniffer {
     },
     reset() {
       port = null;
+      carry.clear();
     },
   };
 }


### PR DESCRIPTION
## Source
Bug found reading `packages/sandbox/daemon/process/port-sniffer.ts`, one of the files with the most recent churn in the sandbox daemon.

## The bug
`createPortSniffer().observe(source, data)` matches the dev-server ready-banner (`Local: http://localhost:3000/`, `Listening on http://...`) against each `data` chunk in isolation. But the caller feeds it PTY output via `child.onData`, which is not line-buffered — the OS can hand back a partial line, so the banner can be split across two chunks (e.g. `"...Local:   http://localhost:30"` then `"00/\n"`). Neither chunk alone matches `URL_PATTERN`, so the port is never sniffed, and the health probe falls back to the (possibly wrong, due to the port-race this sniffer exists to catch) configured port for the sandbox's whole lifetime.

## Fix
Buffer a bounded (200-char) tail per source across `observe()` calls, so a chunk that only completes a match once combined with the previous chunk's tail still locks the port. Cleared on lock and on `reset()`.

## Regression test
Added `"locks the port when the bind line is split across two PTY chunks"` to `port-sniffer.test.ts` — feeds the vite-ready banner split mid-URL across two `observe()` calls. Fails on current `main` (`current()` stays `null`), passes with the fix.

## Verify
```
bun test packages/sandbox/daemon/process/port-sniffer.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` in `packages/sandbox` (clean)
- `bun test packages/sandbox/daemon/process/port-sniffer.test.ts` (6 pass, confirmed the new test fails against the pre-fix source)

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the port sniffer missing the dev-server ready banner when it’s split across PTY chunks. We now buffer a short per-source tail so split lines still match and the correct port is locked.

- **Bug Fixes**
  - Carry a bounded 200-char tail per source across `observe()` calls in `packages/sandbox/daemon/process/port-sniffer.ts`; clear on lock and `reset()`.
  - Added test to verify a split bind line across two chunks locks the port in `packages/sandbox/daemon/process/port-sniffer.test.ts`.

<sup>Written for commit a9e2b209379a70df449ed35ad1531c3085763916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

