### PR TITLE
feat(sections-editor): editable Monaco editor for Page JSON dialog

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -1424,6 +1424,9 @@ function ContentBrowserReady({
           }}
           pageKey={jsonPageKey}
           decofile={decofile}
+          onSave={(data) =>
+            saveBlock.mutateAsync({ blockKey: jsonPageKey, data })
+          }
         />
       )}
 

--- a/apps/mesh/src/web/components/sections-editor/page-json-dialog.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-json-dialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Copy01, CheckCircle } from "@untitledui/icons";
+import { toast } from "sonner";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
   Dialog,
@@ -7,13 +8,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
-import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import { MonacoCodeEditor } from "@/web/components/monaco-editor";
 
 interface PageJsonDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   pageKey: string;
   decofile: Record<string, unknown>;
+  /** Persist edited page JSON. Omit to render read-only. */
+  onSave?: (data: unknown) => Promise<unknown>;
 }
 
 export function PageJsonDialog({
@@ -21,42 +24,92 @@ export function PageJsonDialog({
   onOpenChange,
   pageKey,
   decofile,
+  onSave,
 }: PageJsonDialogProps) {
-  const [copied, setCopied] = useState(false);
   const pageData = decofile[pageKey];
+  const missing = pageData === undefined;
   // A missing key would otherwise stringify to the literal "undefined".
-  const json =
-    pageData === undefined
-      ? "// Page not found."
-      : JSON.stringify(pageData, null, 2);
+  const initialJson = missing ? "" : JSON.stringify(pageData, null, 2);
+
+  const [copied, setCopied] = useState(false);
+  const [value, setValue] = useState(initialJson);
+  const [saving, setSaving] = useState(false);
+  const readOnly = !onSave || missing;
+  const dirty = value !== initialJson;
 
   const handleCopy = () => {
-    void navigator.clipboard.writeText(json).then(() => {
+    void navigator.clipboard.writeText(value).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
   };
 
+  const handleSave = async (next: string) => {
+    if (!onSave || saving) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(next);
+    } catch {
+      toast.error("Invalid JSON — fix the syntax before saving.");
+      return;
+    }
+    setSaving(true);
+    try {
+      await onSave(parsed);
+      toast.success("Page JSON saved.");
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(
+        `Save failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl p-0 gap-0">
+      <DialogContent className="max-w-3xl p-0 gap-0">
         <DialogHeader className="px-4 py-3 border-b flex-row items-center justify-between space-y-0">
           <DialogTitle className="text-sm font-semibold">Page JSON</DialogTitle>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleCopy}
-            className="h-7 gap-1.5 text-xs"
-          >
-            {copied ? <CheckCircle size={12} /> : <Copy01 size={12} />}
-            {copied ? "Copied" : "Copy"}
-          </Button>
+          <div className="flex items-center gap-2 mr-8">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleCopy}
+              className="h-7 gap-1.5 text-xs"
+            >
+              {copied ? <CheckCircle size={12} /> : <Copy01 size={12} />}
+              {copied ? "Copied" : "Copy"}
+            </Button>
+            {!readOnly && (
+              <Button
+                size="sm"
+                onClick={() => handleSave(value)}
+                disabled={!dirty || saving}
+                className="h-7 text-xs"
+              >
+                {saving ? "Saving…" : "Save"}
+              </Button>
+            )}
+          </div>
         </DialogHeader>
-        <ScrollArea className="max-h-[70vh]">
-          <pre className="p-4 text-xs font-mono text-foreground/90 whitespace-pre overflow-auto">
-            {json}
-          </pre>
-        </ScrollArea>
+        {missing ? (
+          <div className="p-4 text-xs font-mono text-foreground/60">
+            // Page not found.
+          </div>
+        ) : (
+          <div className="h-[70vh]">
+            <MonacoCodeEditor
+              code={initialJson}
+              language="json"
+              readOnly={readOnly}
+              height="100%"
+              onChange={(v) => setValue(v ?? "")}
+              onSave={(v) => void handleSave(v)}
+            />
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
The **Page JSON** dialog previously rendered page data in a static, read-only `<pre>` (which looked broken for large payloads). This makes it an editable Monaco editor.

- Replaces the `<pre>` with `MonacoCodeEditor` (`language="json"`, syntax highlighting, folding).
- **Editable** with a **Save** button (enabled only when dirty) and **Cmd/Ctrl+S**.
- Validates JSON before saving (toast on invalid syntax), persists via the existing `useSaveBlock` write path (`POST /api/:org/sandbox/:vmcp/:branch/write`) with optimistic decofile cache update — same mechanism as the other block editors.
- Success/error toasts; closes the dialog on save.
- Keeps the **Copy** button; falls back to read-only when a page is missing or no `onSave` is provided.
- Fixed the header layout so **Copy/Save** no longer overlap the dialog's built-in close **X** (`mr-8` to reserve space).

## Testing
- `bun run --cwd=apps/mesh check` (tsc) passes
- `bun run fmt` clean
- Not yet driven visually in the running app — recommend opening the dialog in `bun run dev` to confirm Monaco loads and Save persists.

## Screenshots
Before: static broken-looking JSON `<pre>`. After: editable Monaco with Save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the Page JSON dialog editable with a Monaco JSON editor, adding save support and a cleaner UI. Changes persist through the existing write path and show helpful feedback.

- New Features
  - Replaced the static <pre> with `MonacoCodeEditor` (JSON highlighting).
  - Made JSON editable with Save and Cmd/Ctrl+S; validates JSON, shows success/error toasts, closes on success; read-only if the page is missing or no `onSave`.
  - Wired `onSave` from the content browser to persist via `useSaveBlock` (`POST /api/:org/sandbox/:vmcp/:branch/write`).

- Bug Fixes
  - Fixed header spacing so Copy/Save no longer overlap the dialog close button.

<sup>Written for commit 374f947a2e76107a8684cc13f3fa79c84f1bdb1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

