### PR TITLE
fix(commerce-onboarding): derive CD connection URL from INTERNAL_API_URL env

### DIFF
--- a/apps/mesh/src/tools/reports/auth-client.ts
+++ b/apps/mesh/src/tools/reports/auth-client.ts
@@ -67,6 +67,18 @@ function resolveBaseUrl(options: CommerceDiscoveryAuthOptions): string {
   ).replace(/\/+$/, "");
 }
 
+/**
+ * Resolve the Commerce Discovery MCP endpoint URL from env settings, so the
+ * CD connection's `connection_url` always targets the same instance as the
+ * internal API (prod vs. stg). Falls back to the hardcoded constant when no
+ * COMMERCE_DISCOVERY_INTERNAL_API_URL override is set.
+ */
+export function resolveCommerceDiscoveryMcpUrl(
+  options: CommerceDiscoveryAuthOptions = {},
+): string {
+  return `${resolveBaseUrl(options)}/api/v2/mcp`;
+}
+
 function resolveApiKey(options: CommerceDiscoveryAuthOptions): string {
   const apiKey =
     options.apiKey ??

--- a/apps/mesh/src/tools/reports/setup.test.ts
+++ b/apps/mesh/src/tools/reports/setup.test.ts
@@ -16,6 +16,8 @@ const fetchAuthMock = mock(
 
 mock.module("./auth-client", () => ({
   fetchCommerceDiscoveryAuth: fetchAuthMock,
+  resolveCommerceDiscoveryMcpUrl: () =>
+    "https://commerce-skills.deco-cx.workers.dev/api/v2/mcp",
 }));
 
 const { COMMERCE_DISCOVERY_SETUP } = await import("./setup");

--- a/apps/mesh/src/tools/reports/setup.ts
+++ b/apps/mesh/src/tools/reports/setup.ts
@@ -18,7 +18,10 @@ import {
 } from "../../core/studio-context";
 import { ConnectionEntitySchema } from "../connection/schema";
 import { VirtualMCPEntitySchema } from "../virtual/schema";
-import { fetchCommerceDiscoveryAuth } from "./auth-client";
+import {
+  fetchCommerceDiscoveryAuth,
+  resolveCommerceDiscoveryMcpUrl,
+} from "./auth-client";
 
 const REPORT_TOOL_NAME =
   COMMERCE_DISCOVERY_REPORT_TOOL_NAME as "get_my_diagnostic";
@@ -168,6 +171,11 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
       ...claimContact,
     });
 
+    // The MCP URL must target the same instance as the internal API — in
+    // staging COMMERCE_DISCOVERY_INTERNAL_API_URL overrides the host, so the
+    // CD connection must point there too, not at the hardcoded prod constant.
+    const mcpUrl = resolveCommerceDiscoveryMcpUrl();
+
     if (connection) {
       console.log("[commerce-discovery] syncing connection to claimed site", {
         orgId: organization.id,
@@ -175,6 +183,7 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
         connectionId,
       });
       connection = await ctx.storage.connections.update(connection.id, {
+        connection_url: mcpUrl,
         connection_token: auth.authorizationToken,
         metadata: { ...(connection.metadata ?? {}), siteUrl: normalized.value },
       });
@@ -189,6 +198,7 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
         const base = getWellKnownCommerceDiscoveryConnection(
           organization.id,
           auth.authorizationToken,
+          mcpUrl,
         );
         connection = await ctx.storage.connections.create({
           ...base,

--- a/packages/e2e/tests/commerce-onboarding.spec.ts
+++ b/packages/e2e/tests/commerce-onboarding.spec.ts
@@ -298,7 +298,9 @@ test.describe("Commerce onboarding route isolation", () => {
       [connectionId],
     );
     expect(concrete.rows[0]).toMatchObject({
-      connection_url: "https://reports.decocms.com/api/v2/mcp",
+      // The host is environment-specific (COMMERCE_DISCOVERY_INTERNAL_API_URL);
+      // assert only the invariant path suffix.
+      connection_url: expect.stringMatching(/\/api\/v2\/mcp$/),
       connection_type: "HTTP",
       title: "Store Report",
     });

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -337,13 +337,14 @@ export const getCommerceDiscoveryAgentId = commerceDiscoveryPrefix.get;
 export function getWellKnownCommerceDiscoveryConnection(
   orgId: string,
   authorizationToken: string,
+  connectionUrl = COMMERCE_DISCOVERY_MCP_URL,
 ): ConnectionCreateData {
   return {
     id: WellKnownOrgMCPId.COMMERCE_DISCOVERY(orgId),
     title: "Store Report",
     description: "Your store's report and diagnostics",
     connection_type: "HTTP",
-    connection_url: COMMERCE_DISCOVERY_MCP_URL,
+    connection_url: connectionUrl,
     icon: COMMERCE_DISCOVERY_ICON,
     app_name: "commerce-discovery",
     app_id: null,


### PR DESCRIPTION
## What is this contribution about?

The Commerce Discovery MCP connection URL was hardcoded to the prod worker (`COMMERCE_DISCOVERY_MCP_URL` constant). In staging, `COMMERCE_DISCOVERY_INTERNAL_API_URL` points to `https://reports-stg.decocms.com`, but the CD connection still proxied through the prod worker — causing two symptoms:

1. **401 on `get_my_diagnostic`** — the report token is minted against `reports-stg`, then validated by the prod worker, which rejects it as `Unauthorized`.
2. **`github_audit_not_attached`** — the GitHub binding is registered in the prod worker (via the CD connection's `onChange` config event), but the diagnostic run executes in the stg worker where the binding was never registered → `connection_resolved: false`.

**Fix:** derive the MCP URL from the same origin as `COMMERCE_DISCOVERY_INTERNAL_API_URL`:
- `resolveCommerceDiscoveryMcpUrl()` added to `auth-client.ts` — reuses `resolveBaseUrl` which already respects the env override.
- `getWellKnownCommerceDiscoveryConnection` gains an optional `connectionUrl` param (defaults to the hardcoded constant, so prod is unaffected).
- `COMMERCE_DISCOVERY_SETUP` now also writes `connection_url` in the **update** path, so every re-claim (already triggered on each site setup) self-migrates existing stg connections from the stale prod URL to the correct env-specific URL. No manual migration needed.

## Screenshots/Demonstration

N/A — backend-only change.

## How to Test

1. In staging (`studio-stg.decocms.com`), open `/commerce-onboarding?org=<org>&siteUrl=<site>`.
2. Click "Ver relatório completo" (triggers `COMMERCE_DISCOVERY_SETUP` → `COMMERCE_DISCOVERY_RUN`).
3. Verify the report view loads without the `{"error":"Unauthorized"}` error.
4. Check studio-stg pod logs: the CD connection's `connection_url` should now be `https://reports-stg.decocms.com/api/v2/mcp`.
5. In prod: flow is unchanged — `COMMERCE_DISCOVERY_INTERNAL_API_URL` is not set, so `resolveCommerceDiscoveryMcpUrl` falls back to the hardcoded prod constant.

## Migration Notes

No DB migration required. Existing stg connections with the wrong `connection_url` are automatically corrected the next time `COMMERCE_DISCOVERY_SETUP` runs for that org (which happens on every "Ver relatório completo" click).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derive the Commerce Discovery MCP connection URL from `COMMERCE_DISCOVERY_INTERNAL_API_URL` so staging points to the correct instance. Fixes `401 Unauthorized` on `get_my_diagnostic` and missing GitHub binding in staging; prod behavior is unchanged.

- **Bug Fixes**
  - Added `resolveCommerceDiscoveryMcpUrl()` (uses `resolveBaseUrl`) to build the MCP URL from the internal API base.
  - `getWellKnownCommerceDiscoveryConnection` accepts an optional `connectionUrl`; `COMMERCE_DISCOVERY_SETUP` passes it and also updates `connection_url` on existing connections.
  - Tests updated: mock includes `resolveCommerceDiscoveryMcpUrl`; e2e asserts `/api/v2/mcp` suffix instead of a hardcoded host.

- **Migration**
  - No manual steps. Staging connections self-correct on the next `COMMERCE_DISCOVERY_SETUP` run.

<sup>Written for commit 9f1b6e2c7ea839050562a850d1ff45c4422c986c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

