### PR TITLE
fix(sandbox): flush pending UTF-8 decoder bytes on task stream close

### DIFF
--- a/packages/sandbox/daemon/process/task-manager.test.ts
+++ b/packages/sandbox/daemon/process/task-manager.test.ts
@@ -56,6 +56,19 @@ describe("TaskManager pipe-mode output decoding", () => {
     await tm.finished(t.id);
     expect(tm.output(t.id)?.stdout).toBe("✓ ok\n");
   });
+
+  it("flushes a dangling multi-byte sequence still buffered when the stream closes", async () => {
+    const tm = makeManager();
+    const t = await tm.spawn({
+      // Writes only the first 2 of 3 bytes of ✓ (0xE2 0x9C 0x93), then exits
+      // with no further output — the decoder never sees a completing byte.
+      command: "printf '\\xe2\\x9c'",
+      cwd: "/tmp",
+      mode: "pipe",
+    });
+    await tm.finished(t.id);
+    expect(tm.output(t.id)?.stdout.length).toBeGreaterThan(0);
+  });
 });
 
 describe("TaskManager kill status", () => {

--- a/packages/sandbox/daemon/process/task-manager.ts
+++ b/packages/sandbox/daemon/process/task-manager.ts
@@ -558,6 +558,21 @@ export class TaskManager {
       if (task.timer) clearTimeout(task.timer);
       // Reap survivors of any backgrounded children.
       killGroup("SIGKILL");
+      // A trailing multi-byte UTF-8 sequence can still be buffered inside
+      // the decoder when the stream ends (no more bytes ever arrive to
+      // complete it) — flush it now so it isn't silently dropped.
+      const stdoutTail = stdoutDecoder.end();
+      if (stdoutTail) {
+        task.stdout.append(stdoutTail);
+        task.tee.write(stdoutTail);
+        this.fanOut(task, { stream: "stdout", data: stdoutTail });
+      }
+      const stderrTail = stderrDecoder.end();
+      if (stderrTail) {
+        task.stderr.append(stderrTail);
+        task.tee.write(stderrTail);
+        this.fanOut(task, { stream: "stderr", data: stderrTail });
+      }
       // A signal-terminated child (e.g. our own SIGTERM/SIGKILL via
       // kill()/killByLogName()) reports `code: null` here — mapping that
       // to `1` collapsed every explicit kill into status "exited" instead


### PR DESCRIPTION
## Summary
A bug found while reading `TaskManager` (recently-churned file, several other decoder/kill-escalation fixes landed here already — #4640, #4538, #4522).

Pipe-mode tasks decode `child.stdout`/`child.stderr` through a `node:string_decoder` `StringDecoder` so a multi-byte UTF-8 character split across two `data` chunks isn't mangled (this itself was fixed in #4640). But the decoder is only ever fed via `.write()` — nothing ever calls `.end()`. `StringDecoder` intentionally buffers a trailing incomplete multi-byte sequence internally until more bytes arrive to complete it; `.end()` is the only way to flush what's left when no more bytes are coming.

**Failure scenario:** a task's stdout/stderr stream closes (process exits) while an incomplete multi-byte sequence is still sitting in the decoder's internal buffer (e.g. a truncated/binary write, or last bytes happening to land on a multi-byte boundary at EOF). Those trailing bytes are silently dropped forever — never appended to the ring buffer, never written to the on-disk tee log, never fanned out over SSE. No error, no truncation flag — the output is just quietly incomplete.

**Fix:** flush both decoders with `.end()` in the `child.on("close", ...)` handler (after both streams are guaranteed done) and route any leftover decoded text through the same append/tee/fanOut path as a normal chunk.

**Regression test:** `packages/sandbox/daemon/process/task-manager.test.ts` — spawns `printf '\xe2\x9c'` (2 of 3 bytes of `✓`, no completing byte ever sent) and asserts the captured stdout is non-empty. Confirmed it fails on current `main` (empty string) and passes with the fix.

## Test plan
- [x] `bun test packages/sandbox/daemon/process/task-manager.test.ts` — 16 pass (was 15 pass / 1 fail before the fix, confirmed by temporarily reverting the fix)
- [x] `bun x tsc --noEmit` in `packages/sandbox` — clean
- [x] `bun run fmt` — clean
- Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing trailing UTF‑8 bytes in pipe‑mode task output by flushing the decoder when the child exits. Ensures stdout/stderr include any buffered bytes in the ring buffer, tee log, and SSE fan‑out.

- **Bug Fixes**
  - Call `.end()` on `StringDecoder`s in `child.on("close")` and process any returned text.
  - Route flushed text through the same append/tee/fan‑out path as normal chunks.
  - Add a regression test that spawns `printf '\xe2\x9c'` to ensure buffered bytes are captured.

<sup>Written for commit 024837fc81ae4d432f71150f7a8c718b4a07fd24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

