### PR TITLE
feat(chat): paste-to-secret modal, first-class API key creation, Credential Manager agent

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-sandbox.test.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-sandbox.test.ts
@@ -254,6 +254,8 @@ describe("resolveEffectiveVirtualMcpForHarness", () => {
       "API_KEY_LIST",
       "API_KEY_UPDATE",
       "API_KEY_DELETE",
+      "SECRET_CREATE",
+      "SECRET_LIST",
       "COLLECTION_VIRTUAL_MCP_LIST",
       "COLLECTION_VIRTUAL_MCP_GET",
       "COLLECTION_CONNECTIONS_LIST",

--- a/apps/api/src/tools/virtual/studio-pack.integration.test.ts
+++ b/apps/api/src/tools/virtual/studio-pack.integration.test.ts
@@ -125,7 +125,7 @@ describe("installStudioPack", () => {
     expect(connIds).toEqual([WellKnownOrgMCPId.SELF(orgId)]);
   });
 
-  test("API Key Manager exposes only key management and read-only discovery tools", async () => {
+  test("API Key Manager exposes key/secret management and read-only discovery tools", async () => {
     await installStudioPack(orgId, userId, virtualMcpStorage);
     const managerId = StudioPackAgentId.API_KEY_MANAGER(orgId);
     const manager = await virtualMcpStorage.findById(managerId, orgId);
@@ -139,6 +139,8 @@ describe("installStudioPack", () => {
       "API_KEY_LIST",
       "API_KEY_UPDATE",
       "API_KEY_DELETE",
+      "SECRET_CREATE",
+      "SECRET_LIST",
       "COLLECTION_VIRTUAL_MCP_LIST",
       "COLLECTION_VIRTUAL_MCP_GET",
       "COLLECTION_CONNECTIONS_LIST",
@@ -190,13 +192,15 @@ describe("installStudioPack", () => {
       "API_KEY_LIST",
       "API_KEY_UPDATE",
       "API_KEY_DELETE",
+      "SECRET_CREATE",
+      "SECRET_LIST",
       "COLLECTION_VIRTUAL_MCP_LIST",
       "COLLECTION_VIRTUAL_MCP_GET",
       "COLLECTION_CONNECTIONS_LIST",
       "COLLECTION_CONNECTIONS_GET",
     ]);
     expect(manager?.metadata?.instructions).toContain(
-      "Print that value once in a fenced plain-text code block",
+      "NEVER print the key value yourself, under any circumstance",
     );
   });
 });

--- a/apps/api/src/tools/virtual/studio-pack/api-key-manager.test.ts
+++ b/apps/api/src/tools/virtual/studio-pack/api-key-manager.test.ts
@@ -8,12 +8,14 @@ describe("apiKeyManagerAgent", () => {
     );
   });
 
-  test("exposes API key mutations and read-only target discovery", () => {
+  test("exposes API key mutations, vault secrets, and read-only target discovery", () => {
     expect(apiKeyManagerAgent.selectedTools).toEqual([
       "API_KEY_CREATE",
       "API_KEY_LIST",
       "API_KEY_UPDATE",
       "API_KEY_DELETE",
+      "SECRET_CREATE",
+      "SECRET_LIST",
       "COLLECTION_VIRTUAL_MCP_LIST",
       "COLLECTION_VIRTUAL_MCP_GET",
       "COLLECTION_CONNECTIONS_LIST",
@@ -30,11 +32,42 @@ describe("apiKeyManagerAgent", () => {
     expect(apiKeyManagerAgent.instructions).toContain(
       "returns the key value exactly once",
     );
+  });
+
+  test("relies exclusively on the shown-once UI panel — never prints the key itself", () => {
     expect(apiKeyManagerAgent.instructions).toContain(
-      "Print that value once in a fenced plain-text code block",
+      'secure "shown once" panel',
     );
     expect(apiKeyManagerAgent.instructions).toContain(
-      "don't repeat it in later prose",
+      "NEVER print the key value yourself, under any circumstance",
+    );
+    expect(apiKeyManagerAgent.instructions).toContain(
+      "Never reprint the value",
+    );
+  });
+
+  test("refuses to create a key when running as a delegated subtask, since the panel can't render there", () => {
+    expect(apiKeyManagerAgent.instructions).toContain(
+      "not inside a delegated subtask",
+    );
+    expect(apiKeyManagerAgent.instructions).toContain("do NOT create the key");
+    expect(apiKeyManagerAgent.instructions).toContain(
+      "key creation needs a direct conversation",
+    );
+  });
+
+  test("forbids delegating the actual creation to a further subagent", () => {
+    expect(apiKeyManagerAgent.instructions).toContain(
+      "never delegate the actual creation to a further subagent",
+    );
+  });
+
+  test("skips the pre-creation interview and honors explicit wildcard/full-access requests", () => {
+    expect(apiKeyManagerAgent.instructions).toContain(
+      "do not run a multi-question interview first",
+    );
+    expect(apiKeyManagerAgent.instructions).toContain(
+      "do not push back or repeatedly re-confirm",
     );
   });
 });

--- a/apps/api/src/tools/virtual/studio-pack/api-key-manager.ts
+++ b/apps/api/src/tools/virtual/studio-pack/api-key-manager.ts
@@ -2,7 +2,7 @@ import { StudioPackAgentId } from "@decocms/shared/sdk";
 import type { StudioPackConnectionKey } from "./types";
 
 const INSTRUCTIONS = `<role>
-You are the API Key Manager. You create and manage the current user's API keys for this organization. You are fast and compliant: when the user says what they want, you do it — no interrogation, no lecturing, no unsolicited security commentary.
+You are the API Key Manager. You create and manage the current user's API keys for this organization, and store credentials (API keys, tokens, passwords) in the encrypted secret vault. You are fast and compliant: when the user says what they want, you do it — no interrogation, no lecturing, no unsolicited security commentary.
 </role>
 
 <capabilities>
@@ -12,6 +12,7 @@ You are the API Key Manager. You create and manage the current user's API keys f
 - Revoke keys after a single explicit confirmation.
 - Guide staged key rotation when asked: create a replacement, then revoke the old key.
 - Inspect agents and connections so permissions can use real target ids and tool names.
+- Store secrets in the encrypted vault (SECRET_CREATE) and list their names (SECRET_LIST). Values are encrypted at rest and never returned by any tool.
 </capabilities>
 
 <behavior>
@@ -27,16 +28,21 @@ You are the API Key Manager. You create and manage the current user's API keys f
 - Never invent resource ids or tool names. Inspect the target with COLLECTION_VIRTUAL_MCP_LIST / GET or COLLECTION_CONNECTIONS_LIST / GET when you need real ids.
 - Never ask the user to paste an existing API key. Key values cannot be retrieved or changed after creation.
 - When a created key is full-access, wildcard, or has no expiration, add a single one-line inline note next to the result (e.g. "⚠ full access, no expiry"). One line only — not a paragraph, not a blocker, and never a reason to refuse or delay.
-- API_KEY_CREATE returns the key value exactly once. Print that value once in a fenced plain-text code block so the user can copy it, and don't repeat it in later prose, tables, or messages (it can't be retrieved again anyway).
+- API_KEY_CREATE returns the key value exactly once, and Studio renders that result as a secure "shown once" panel — a dialog with the full key and a copy button. NEVER print the key value yourself, under any circumstance — the panel is the only acceptable way it reaches the user.
+- That panel only renders for a tool call made directly in the active conversation, not inside a delegated subtask (a subagent's raw tool output is never shown, only its final text report). Check your own identity prompt before calling API_KEY_CREATE: if it describes you as a focused subtask agent, do NOT create the key — report that key creation needs a direct conversation with you instead.
+- Call API_KEY_CREATE yourself, directly — never delegate the actual creation to a further subagent.
 - Always get a single explicit confirmation immediately before API_KEY_DELETE. Revocation is immediate and cannot be undone.
 - Do not modify agents or connections. They are read-only context for permission design.
+- Vault secret values are never returned by any tool. After SECRET_CREATE, refer to the secret as {{secret:name}} — tools resolve it from the vault at the point of use. Never echo a secret value back.
+- Use SECRET_LIST to check for an existing name before creating one.
 </constraints>
 
 <workflows>
 1. Creating a key:
-   a. If the user said what the key is for and what it needs, go straight to creation. Only inspect an agent or connection when you need its real id or tool names.
-   b. Convert the requested lifetime to expiresIn seconds and call API_KEY_CREATE with the exact permissions requested, including wildcards or full access if explicitly asked.
-   c. Print the returned key once in a fenced plain-text code block. If the key is full-access, wildcard, or non-expiring, add the one-line note.
+   a. If you're running as a delegated subtask (check your identity prompt), stop: the secure key panel can't render for a nested call, so tell the user to talk to you directly instead.
+   b. If the user said what the key is for and what it needs, go straight to creation. Only inspect an agent or connection when you need its real id or tool names.
+   c. Convert the requested lifetime to expiresIn seconds and call API_KEY_CREATE with the exact permissions requested, including wildcards or full access if explicitly asked.
+   d. Point to the secure key panel rendered with your tool call. If the key is full-access, wildcard, or non-expiring, add the one-line note. Never reprint the value.
 
 2. Auditing keys:
    a. Run API_KEY_LIST.
@@ -53,18 +59,25 @@ You are the API Key Manager. You create and manage the current user's API keys f
 5. Rotating a key:
    a. Run API_KEY_LIST and capture the old key's non-secret configuration.
    b. Create the replacement, then — only after the user confirms it works — revoke the old key.
+
+6. Storing a secret in the vault:
+   a. Run SECRET_LIST to check whether it already exists under a similar name.
+   b. Call SECRET_CREATE with a snake_case name and the requested scope (organization or private to the user).
+   c. Tell the user to reference it as {{secret:name}}. Never repeat the stored value.
 </workflows>`;
 
 export const apiKeyManagerAgent = {
   id: "studio-api-key-manager",
   title: "API Key Manager",
   icon: "icon://Key01?color=red",
-  description: "Create, scope, audit, rotate, and revoke API keys safely",
+  description: "Create, scope, audit, rotate, and revoke API keys and secrets",
   selectedTools: [
     "API_KEY_CREATE",
     "API_KEY_LIST",
     "API_KEY_UPDATE",
     "API_KEY_DELETE",
+    "SECRET_CREATE",
+    "SECRET_LIST",
     "COLLECTION_VIRTUAL_MCP_LIST",
     "COLLECTION_VIRTUAL_MCP_GET",
     "COLLECTION_CONNECTIONS_LIST",

--- a/apps/web/src/components/chat/derive-parts.ts
+++ b/apps/web/src/components/chat/derive-parts.ts
@@ -9,6 +9,7 @@ import type {
   ReadResourceResult,
   EmbeddedResource,
 } from "@modelcontextprotocol/sdk/types.js";
+import { secretRef } from "@/utils/secret-detect.ts";
 import type { FileAttrs } from "./tiptap/file/node.tsx";
 import type { ChatMessage, Metadata } from "./types.ts";
 
@@ -329,6 +330,10 @@ export function derivePartsFromTiptapDoc(
           );
         }
       }
+    } else if (node.type === "secretRef" && node.attrs) {
+      // Vaulted secret chip — the wire format is the reference, never the
+      // value. Agents resolve it by name (SECRET_LIST) at point of use.
+      inlineText += secretRef(String(node.attrs.name ?? ""));
     } else if (node.type === "file" && node.attrs) {
       const fileAttrs = node.attrs as unknown as FileAttrs;
       const mentionName = `[file:://${encodeURIComponent(fileAttrs.name)}]`;

--- a/apps/web/src/components/chat/input.tsx
+++ b/apps/web/src/components/chat/input.tsx
@@ -65,6 +65,16 @@ import { ConnectionsBanner } from "./connections-banner";
 import { useVoiceInput } from "@/hooks/use-voice-input.ts";
 import { VoiceWaveform } from "./voice-input";
 import { resolveComposerAction } from "./composer-action";
+import {
+  StoreSecretDialog,
+  type StoreSecretMode,
+  type StoreSecretResult,
+} from "./store-secret-dialog";
+import {
+  extractPlainTextFromTiptapDoc,
+  replaceSecretInTiptapDoc,
+} from "./tiptap/secret-ref/replace";
+import { detectSecret, type DetectedSecret } from "@/utils/secret-detect";
 
 // ============================================================================
 // useWindowFileDrop - Reusable hook for window-level file drag & drop
@@ -476,6 +486,13 @@ export function ChatInput({
   // suggestion's own, see tiptap/input.tsx).
   const suggestionOpenRef = useRef(false);
 
+  // A token detected in the composer (pasted, or caught on submit) awaiting the
+  // user's vault-or-keep-raw decision.
+  const [pendingSecret, setPendingSecret] = useState<{
+    detected: DetectedSecret;
+    mode: StoreSecretMode;
+  } | null>(null);
+
   const isPlanMode = chatMode === "plan";
 
   const dismissChatMode = (fromMode: string) => {
@@ -527,35 +544,82 @@ export function ChatInput({
   });
   const canSubmit = composerAction === "send";
   const showStopOrCancel = composerAction === "stop";
+  // Actually dispatch a doc: probe the send latch, send/home-submit, clear the
+  // draft. Split out so both the composer submit and the secret-swap "send"
+  // path share one code path.
+  const dispatchDoc = (
+    doc: Metadata["tiptapDoc"],
+    viaButtonOrEnter: boolean,
+  ) => {
+    if (!doc) return;
+    track("chat_message_sent", {
+      thread_id: taskId || null,
+      mode: chatMode,
+      model_id: selectedModel?.modelId ?? null,
+      model_provider: selectedModel?.providerId ?? null,
+      virtual_mcp_id: selectedVirtualMcp?.id ?? null,
+      submission: viaButtonOrEnter ? "button_or_enter" : "programmatic",
+    });
+    if (stream) {
+      // The per-thread send latch drops a re-entrant send synchronously
+      // (see `sendInFlight` in chat-context.tsx). Probe it BEFORE firing
+      // so a draft typed while the previous send's POST is still in
+      // flight isn't cleared for a send that was silently dropped.
+      if (stream.isSendInFlight()) {
+        toast.info(t("chat.input.stillSendingPreviousMessage"));
+        return;
+      }
+      void stream.sendMessage(doc);
+    } else {
+      homeSubmit({ tiptapDoc: doc, virtualMcp: selectedVirtualMcp });
+    }
+    clearChatDraft(sessionStorage, locator, draftKey);
+    setTiptapDoc(undefined);
+  };
+
   const handleSubmit = (e?: FormEvent) => {
     e?.preventDefault();
     if (composerAction === "send" && tiptapDoc) {
-      track("chat_message_sent", {
-        thread_id: taskId || null,
-        mode: chatMode,
-        model_id: selectedModel?.modelId ?? null,
-        model_provider: selectedModel?.providerId ?? null,
-        virtual_mcp_id: selectedVirtualMcp?.id ?? null,
-        submission: e ? "button_or_enter" : "programmatic",
-      });
-      if (stream) {
-        // The per-thread send latch drops a re-entrant send synchronously
-        // (see `sendInFlight` in chat-context.tsx). Probe it BEFORE firing
-        // so a draft typed while the previous send's POST is still in
-        // flight isn't cleared for a send that was silently dropped.
-        if (stream.isSendInFlight()) {
-          toast.info(t("chat.input.stillSendingPreviousMessage"));
-          return;
-        }
-        void stream.sendMessage(tiptapDoc);
-      } else {
-        homeSubmit({ tiptapDoc, virtualMcp: selectedVirtualMcp });
+      // Safety net for a typed (not pasted) token: offer to vault before
+      // sending. Skips text already inside chips (mentions/secret refs).
+      const detected = detectSecret(extractPlainTextFromTiptapDoc(tiptapDoc));
+      if (detected) {
+        setPendingSecret({ detected, mode: "send" });
+        return;
       }
-      clearChatDraft(sessionStorage, locator, draftKey);
-      setTiptapDoc(undefined);
+      dispatchDoc(tiptapDoc, !!e);
     } else if (composerAction === "stop") {
       track("chat_message_stopped", { thread_id: taskId });
       stop();
+    }
+  };
+
+  // Vaulted: swap the raw token for a reference chip. On "send" mode, dispatch
+  // the swapped doc immediately; on "paste" mode, keep editing.
+  const handleSecretSaved = (result: StoreSecretResult) => {
+    const ps = pendingSecret;
+    setPendingSecret(null);
+    if (!ps) return;
+    const swapped = tiptapDoc
+      ? replaceSecretInTiptapDoc(tiptapDoc, ps.detected.value, {
+          name: result.name,
+          secretId: result.secretId,
+        })
+      : null;
+    if (!swapped) return;
+    if (ps.mode === "send") {
+      dispatchDoc(swapped, false);
+    } else {
+      setTiptapDoc(swapped);
+    }
+  };
+
+  // "Keep raw": paste → leave the draft as-is; send → send the original doc.
+  const handleSecretKeepRaw = () => {
+    const ps = pendingSecret;
+    setPendingSecret(null);
+    if (ps?.mode === "send" && tiptapDoc) {
+      dispatchDoc(tiptapDoc, false);
     }
   };
 
@@ -590,6 +654,9 @@ export function ChatInput({
             placeholder={t("chat.input.placeholder")}
             onSubmit={handleSubmit}
             suggestionOpenRef={suggestionOpenRef}
+            onSecretPasted={(detected) =>
+              setPendingSecret({ detected, mode: "paste" })
+            }
           >
             <form
               onSubmit={handleSubmit}
@@ -819,6 +886,16 @@ export function ChatInput({
         info={unsupportedFile}
         onClose={clearUnsupportedFile}
       />
+
+      {pendingSecret ? (
+        <StoreSecretDialog
+          detected={pendingSecret.detected}
+          mode={pendingSecret.mode}
+          onSaved={handleSecretSaved}
+          onKeepRaw={handleSecretKeepRaw}
+          onCancel={() => setPendingSecret(null)}
+        />
+      ) : null}
     </>
   );
 }

--- a/apps/web/src/components/chat/message/assistant.tsx
+++ b/apps/web/src/components/chat/message/assistant.tsx
@@ -33,6 +33,7 @@ import {
   BrandContextListPart,
   AgentCreatePart,
   AgentListPart,
+  ApiKeyCreatePart,
   ConnectionListPart,
 } from "./parts/tool-call-part/index.ts";
 import { NextActionChip } from "./next-action-chip.tsx";
@@ -413,6 +414,14 @@ function MessagePart({
       if (fallback.type === "tool-COLLECTION_VIRTUAL_MCP_CREATE") {
         return (
           <AgentCreatePart
+            part={fallback}
+            latency={getMeta(fallback.toolCallId)?.latencySeconds}
+          />
+        );
+      }
+      if (fallback.type === "tool-API_KEY_CREATE") {
+        return (
+          <ApiKeyCreatePart
             part={fallback}
             latency={getMeta(fallback.toolCallId)?.latencySeconds}
           />

--- a/apps/web/src/components/chat/message/parts/sensitive-text.tsx
+++ b/apps/web/src/components/chat/message/parts/sensitive-text.tsx
@@ -1,0 +1,95 @@
+import { useState, type ReactNode } from "react";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Check, Lock01 } from "@untitledui/icons";
+import { detectSecret, maskSecret, SECRET_REF_RE } from "@/utils/secret-detect";
+
+/** A vaulted `{{secret:name}}` reference — resolved at use, never shown. */
+function SecretRefChip({ name }: { name: string }) {
+  return (
+    <span
+      className="mx-0.5 inline-flex items-center gap-1 rounded-md border border-success/30 bg-success/10 px-1.5 py-0.5 align-baseline font-mono text-xs text-success"
+      title="Stored in the vault — resolved at use, never shown"
+    >
+      <Lock01 className="size-3" />
+      {name}
+    </span>
+  );
+}
+
+/** A raw token left in a message — masked, click-to-copy. */
+function RedactedChip({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void navigator.clipboard?.writeText(value).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        });
+      }}
+      className="mx-0.5 inline-flex items-center gap-1 rounded-md border border-border bg-muted px-1.5 py-0.5 align-baseline font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
+      title="Hidden token — click to copy"
+    >
+      {copied ? <Check className="size-3" /> : <Lock01 className="size-3" />}
+      {copied ? "copied" : maskSecret(value)}
+    </button>
+  );
+}
+
+/**
+ * Renders message text with secret references as vault chips, and (when
+ * `redactRaw` is set — user messages only) any raw detected tokens as masked
+ * click-to-copy chips, so secrets never appear verbatim in the transcript.
+ */
+export function SensitiveText({
+  text,
+  redactRaw,
+}: {
+  text: string;
+  redactRaw: boolean;
+}) {
+  const nodes: ReactNode[] = [];
+  let key = 0;
+
+  const pushPlain = (s: string) => {
+    if (!s) return;
+    if (!redactRaw) {
+      nodes.push(<span key={key++}>{s}</span>);
+      return;
+    }
+    let idx = 0;
+    for (;;) {
+      const d = detectSecret(s.slice(idx));
+      if (!d) break;
+      const start = idx + d.start;
+      const end = idx + d.end;
+      if (start > idx)
+        nodes.push(<span key={key++}>{s.slice(idx, start)}</span>);
+      nodes.push(<RedactedChip key={key++} value={d.value} />);
+      idx = end;
+    }
+    if (idx < s.length) nodes.push(<span key={key++}>{s.slice(idx)}</span>);
+  };
+
+  const re = new RegExp(SECRET_REF_RE.source, "g");
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text))) {
+    if (m.index > last) pushPlain(text.slice(last, m.index));
+    nodes.push(<SecretRefChip key={key++} name={m[1] ?? ""} />);
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) pushPlain(text.slice(last));
+
+  return <span className={cn("whitespace-pre-wrap break-words")}>{nodes}</span>;
+}
+
+/**
+ * Whether `text` needs the sensitive renderer instead of plain Markdown: it
+ * carries a vault reference, or (for user input) a raw detected token.
+ */
+export function hasSensitiveContent(text: string, redactRaw: boolean): boolean {
+  if (text.includes("{{secret:")) return true;
+  return redactRaw && detectSecret(text) !== null;
+}

--- a/apps/web/src/components/chat/message/parts/text-part.tsx
+++ b/apps/web/src/components/chat/message/parts/text-part.tsx
@@ -6,6 +6,7 @@ import { Check, Copy01 } from "@untitledui/icons";
 import type { TextUIPart } from "ai";
 import { track } from "@/lib/posthog-client";
 import { useT } from "@/i18n/use-t.ts";
+import { hasSensitiveContent, SensitiveText } from "./sensitive-text.tsx";
 
 interface MessageTextPartProps {
   id: string;
@@ -16,6 +17,8 @@ interface MessageTextPartProps {
   alwaysShowActions?: boolean;
   /** Fade newly streamed words in — true only while the last message streams. */
   animate?: boolean;
+  /** Redact raw detected tokens too (user messages), not just vault refs. */
+  redactRaw?: boolean;
 }
 
 export function MessageTextPart({
@@ -25,6 +28,7 @@ export function MessageTextPart({
   extraActions,
   alwaysShowActions = false,
   animate = false,
+  redactRaw = false,
 }: MessageTextPartProps) {
   const { handleCopy } = useCopy();
   const t = useT();
@@ -44,9 +48,15 @@ export function MessageTextPart({
   const showCopyButton = copyable && extraActions;
   const showActions = showCopyButton || extraActions;
 
+  const sensitive = hasSensitiveContent(part.text, redactRaw);
+
   return (
     <div className="group/part relative">
-      <MemoizedMarkdown id={id} text={part.text} animate={animate} />
+      {sensitive ? (
+        <SensitiveText text={part.text} redactRaw={redactRaw} />
+      ) : (
+        <MemoizedMarkdown id={id} text={part.text} animate={animate} />
+      )}
       {showActions && (
         <div
           className={cn(

--- a/apps/web/src/components/chat/message/parts/tool-call-part/api-key-create.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/api-key-create.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import type { ToolUIPart } from "ai";
+import { useState } from "react";
+import { Check, Copy01, Key01 } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { useCopy } from "@deco/ui/hooks/use-copy.ts";
+import { ToolCallShell, LatencyLabel } from "./common.tsx";
+import { getEffectiveState, unwrapResult } from "./utils.tsx";
+
+interface ApiKeyCreatePartProps {
+  part: ToolUIPart;
+  latency?: number;
+}
+
+interface ApiKeyCreateResult {
+  id: string;
+  name: string;
+  key: string;
+  permissions: Record<string, string[]>;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+/** The raw key is returned exactly once. Persist a per-tool-call flag so the
+ *  modal auto-opens on first render but never again (history revisits keep the
+ *  inline card with copy, without re-popping the modal). */
+function alreadyRevealed(toolCallId: string): boolean {
+  try {
+    return sessionStorage.getItem(`api-key-shown:${toolCallId}`) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markRevealed(toolCallId: string): void {
+  try {
+    sessionStorage.setItem(`api-key-shown:${toolCallId}`, "1");
+  } catch {
+    // sessionStorage unavailable (private mode / SSR) — the modal just won't
+    // suppress on the next mount; harmless.
+  }
+}
+
+export function ApiKeyCreatePart({ part, latency }: ApiKeyCreatePartProps) {
+  const state = getEffectiveState(part.state);
+  const result = unwrapResult<ApiKeyCreateResult>(part.output);
+  const { handleCopy, copied } = useCopy();
+
+  // Initializer runs once per mount — first-ever render for a fresh key opens
+  // the modal; a reload of an old thread finds the flag set and stays closed.
+  const [open, setOpen] = useState(() =>
+    result?.key ? !alreadyRevealed(part.toolCallId) : false,
+  );
+
+  if (state === "loading") {
+    return (
+      <ToolCallShell
+        icon={<Key01 className="animate-pulse" />}
+        title="Creating API key"
+        state="loading"
+        defaultOpen
+      />
+    );
+  }
+
+  if (state === "approval") {
+    return (
+      <ToolCallShell icon={<Key01 />} title="Create API key" state="idle" />
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <ToolCallShell
+        icon={<Key01 />}
+        title={
+          part.state === "output-denied"
+            ? "API key creation cancelled"
+            : "Couldn't create API key"
+        }
+        state="error"
+        trailing={<LatencyLabel latency={latency} />}
+      />
+    );
+  }
+
+  if (!result?.key) {
+    return (
+      <ToolCallShell
+        icon={<Key01 />}
+        title="API key created"
+        state="idle"
+        trailing={<LatencyLabel latency={latency} />}
+      />
+    );
+  }
+
+  const permissionCount = Object.keys(result.permissions ?? {}).length;
+  const closeModal = () => {
+    markRevealed(part.toolCallId);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <ToolCallShell
+        icon={<Key01 className="text-emerald-500" />}
+        title={`API key created: ${result.name}`}
+        state="idle"
+        trailing={<LatencyLabel latency={latency} />}
+      />
+      <div className="mt-2 overflow-hidden rounded-xl border-[0.5px] border-border bg-card p-3">
+        <div className="flex items-start gap-3">
+          <div className="size-9 shrink-0 rounded-md bg-muted flex items-center justify-center">
+            <Key01 className="size-4 text-muted-foreground" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-foreground truncate">
+              {result.name}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {permissionCount} permission{permissionCount === 1 ? "" : "s"}
+              {result.expiresAt
+                ? ` · expires ${new Date(result.expiresAt).toLocaleDateString()}`
+                : " · never expires"}
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            className="shrink-0"
+            onClick={() => setOpen(true)}
+          >
+            Show key
+          </Button>
+        </div>
+      </div>
+
+      <Dialog
+        open={open}
+        onOpenChange={(o) => {
+          if (!o) closeModal();
+          else setOpen(true);
+        }}
+      >
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Key01 className="size-4" />
+              API key created
+            </DialogTitle>
+            <DialogDescription>
+              This key is shown only once — copy it and store it somewhere safe
+              now. It can't be retrieved later.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-3 min-w-0">
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-semibold text-muted-foreground">
+                Name
+              </span>
+              <code className="text-xs font-mono bg-muted rounded-md px-2 py-1.5 truncate">
+                {result.name}
+              </code>
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-semibold text-muted-foreground">
+                Key (shown once)
+              </span>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 min-w-0 text-xs font-mono bg-muted rounded-md px-2 py-1.5 truncate">
+                  {result.key}
+                </code>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => handleCopy(result.key)}
+                >
+                  {copied ? <Check size={13} /> : <Copy01 size={13} />}
+                  {copied ? "Copied" : "Copy"}
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button onClick={closeModal}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/chat/message/parts/tool-call-part/index.ts
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/index.ts
@@ -12,4 +12,5 @@ export {
 } from "./brand-context.tsx";
 export { AgentCreatePart } from "./agent-create.tsx";
 export { AgentListPart } from "./agent-list.tsx";
+export { ApiKeyCreatePart } from "./api-key-create.tsx";
 export { ConnectionListPart } from "./connection-list.tsx";

--- a/apps/web/src/components/chat/message/user.tsx
+++ b/apps/web/src/components/chat/message/user.tsx
@@ -5,6 +5,7 @@ import { type UIMessage } from "ai";
 import { useRef, useState } from "react";
 import { FileNode } from "../tiptap/file/node.tsx";
 import { MentionNode } from "../tiptap/mention/node.tsx";
+import { SecretRefNode } from "../tiptap/secret-ref/node.tsx";
 import type { Metadata } from "../types.ts";
 import { MessageTextPart } from "./parts/text-part.tsx";
 import { MessageTimestamp } from "./timestamp.tsx";
@@ -28,6 +29,7 @@ const EXTENSIONS = [
   }),
   MentionNode,
   FileNode,
+  SecretRefNode,
 ];
 
 /**
@@ -146,6 +148,7 @@ export function MessageUser<T extends Metadata>({
                           key={`${id}-${index}`}
                           id={id}
                           part={part}
+                          redactRaw
                         />
                       );
                     }

--- a/apps/web/src/components/chat/store-secret-dialog.tsx
+++ b/apps/web/src/components/chat/store-secret-dialog.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import { ShieldTick } from "@untitledui/icons";
+import { toast } from "sonner";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { type SecretScopeKind, useCreateSecret } from "@/hooks/use-secrets";
+import {
+  type DetectedSecret,
+  maskSecret,
+  secretRef,
+} from "@/utils/secret-detect";
+
+export interface StoreSecretResult {
+  name: string;
+  secretId: string;
+}
+
+export type StoreSecretMode = "paste" | "send";
+
+interface StoreSecretDialogProps {
+  detected: DetectedSecret;
+  /** "paste": caught in the draft (swap/keep, no send). "send": before sending. */
+  mode: StoreSecretMode;
+  /** Vaulted successfully — caller swaps the raw value for the reference. */
+  onSaved: (result: StoreSecretResult) => void;
+  /** User chose to keep the raw value (paste: leave draft; send: send raw). */
+  onKeepRaw: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * "This looks like a secret" — offered before a raw token lands in chat
+ * history. Saves it to the encrypted vault under a chosen name and hands the
+ * agent a `{{secret:name}}` reference instead. Mirrors the vault contract:
+ * values are never echoed back; the runtime resolves the reference at use.
+ */
+export function StoreSecretDialog({
+  detected,
+  mode,
+  onSaved,
+  onKeepRaw,
+  onCancel,
+}: StoreSecretDialogProps) {
+  const [name, setName] = useState(detected.suggestedName);
+  const [scope, setScope] = useState<SecretScopeKind>("organization");
+  const createSecret = useCreateSecret();
+
+  async function handleSave(event: React.FormEvent) {
+    event.preventDefault();
+    const key = name.trim();
+    if (!key) return;
+    try {
+      const info = await createSecret.mutateAsync({
+        scope,
+        name: key,
+        value: detected.value,
+      });
+      toast.success(`Secret "${key}" saved to the vault`);
+      onSaved({ name: info.name, secretId: info.id });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to save secret");
+    }
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(o) => {
+        if (!o) onCancel();
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldTick className="size-4 text-success" />
+            This looks like {article(detected.label)}{" "}
+            {detected.label.toLowerCase()}
+          </DialogTitle>
+          <DialogDescription>
+            {mode === "paste"
+              ? "Save it to the encrypted vault and drop a reference into your message instead, so the raw value never lands in the chat."
+              : "Save it to the encrypted vault and send a reference instead, so the raw value never lands in this conversation's history."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSave} className="space-y-4">
+          <div className="rounded-md border border-border bg-muted/40 px-3 py-2 font-mono text-sm">
+            {maskSecret(detected.value)}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="store-secret-scope">Scope</Label>
+            <Select
+              value={scope}
+              onValueChange={(v) => setScope(v as SecretScopeKind)}
+            >
+              <SelectTrigger id="store-secret-scope">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="organization">
+                  Organization — visible to all members
+                </SelectItem>
+                <SelectItem value="user">
+                  Private — only visible to me
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="store-secret-name">Secret name</Label>
+            <Input
+              id="store-secret-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="openai_api_key"
+              className="font-mono"
+              autoComplete="off"
+              required
+            />
+            <p className="text-xs text-muted-foreground">
+              The agent will see{" "}
+              <span className="font-mono">{secretRef(name || "name")}</span> and
+              resolve it from the vault when needed.
+            </p>
+          </div>
+
+          <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-between">
+            <Button
+              type="button"
+              variant="ghost"
+              className="text-muted-foreground"
+              onClick={onKeepRaw}
+              disabled={createSecret.isPending}
+            >
+              {mode === "paste" ? "Keep raw in message" : "Send raw"}
+            </Button>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onCancel}
+                disabled={createSecret.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={createSecret.isPending || !name.trim()}
+              >
+                {createSecret.isPending
+                  ? "Saving…"
+                  : mode === "paste"
+                    ? "Save & use reference"
+                    : "Save & send reference"}
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** "a"/"an" for the label, so the title reads naturally. */
+function article(label: string): string {
+  return /^[aeiou]/i.test(label) ? "an" : "a";
+}

--- a/apps/web/src/components/chat/tiptap/input.tsx
+++ b/apps/web/src/components/chat/tiptap/input.tsx
@@ -15,7 +15,9 @@ import { FileNode, FileUploader, type UnsupportedFileInfo } from "./file";
 import { MentionNode } from "./mention";
 import { AtMention } from "./mention-at.tsx";
 import { SlashMention } from "./mention-slash.tsx";
+import { SecretRefNode } from "./secret-ref/node.tsx";
 import { AiProviderModel } from "@/hooks/collections/use-ai-providers.ts";
+import { detectSecret, type DetectedSecret } from "@/utils/secret-detect.ts";
 
 function buildExtensions(placeholderRef: React.RefObject<string | undefined>) {
   return [
@@ -34,6 +36,7 @@ function buildExtensions(placeholderRef: React.RefObject<string | undefined>) {
     }),
     MentionNode,
     FileNode,
+    SecretRefNode,
   ];
 }
 
@@ -59,6 +62,9 @@ interface TiptapProviderProps {
    * would also submit the still-unresolved draft first.
    */
   suggestionOpenRef?: { current: boolean };
+  /** Fired when pasted text looks like an API key/token — the paste still
+   *  lands in the draft; the handler offers to vault it (see ChatInput). */
+  onSecretPasted?: (detected: DetectedSecret) => void;
   children: React.ReactNode;
 }
 
@@ -74,10 +80,12 @@ export function TiptapProvider({
   placeholder,
   onSubmit,
   suggestionOpenRef,
+  onSecretPasted,
   children,
 }: TiptapProviderProps) {
   // Store callbacks and config in refs to avoid recreating the editor on every render
   const onSubmitRef = useRef(onSubmit);
+  const onSecretPastedRef = useRef(onSecretPasted);
   const setTiptapDocRef = useRef(setTiptapDoc);
   const enterToSubmitRef = useRef(enterToSubmit);
   const placeholderRef = useRef(placeholder);
@@ -105,6 +113,16 @@ export function TiptapProvider({
         }
         return false;
       },
+      handlePaste: (_view: EditorView, event: ClipboardEvent) => {
+        const pasted = event.clipboardData?.getData("text");
+        if (!pasted) return false;
+        const detected = detectSecret(pasted);
+        if (detected) {
+          // Let the paste land in the draft, then offer to vault it.
+          onSecretPastedRef.current?.(detected);
+        }
+        return false;
+      },
     },
     onUpdate: ({ editor }: { editor: ReturnType<typeof useEditor> }) => {
       setTiptapDocRef.current(editor?.getJSON());
@@ -122,6 +140,11 @@ export function TiptapProvider({
   useEffect(() => {
     onSubmitRef.current = onSubmit;
   }, [onSubmit]);
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    onSecretPastedRef.current = onSecretPasted;
+  }, [onSecretPasted]);
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect
   useEffect(() => {

--- a/apps/web/src/components/chat/tiptap/secret-ref/node.tsx
+++ b/apps/web/src/components/chat/tiptap/secret-ref/node.tsx
@@ -1,0 +1,104 @@
+import { secretRef } from "@/utils/secret-detect";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Node } from "@tiptap/core";
+import {
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+  type NodeViewProps,
+} from "@tiptap/react";
+import { Lock01 } from "@untitledui/icons";
+
+export interface SecretRefAttrs {
+  /** Vault secret name — what `{{secret:name}}` resolves against. */
+  name: string;
+  /** Vault secret id (`sec_…`), when known at insertion time. */
+  secretId: string | null;
+}
+
+function SecretRefNodeView(props: NodeViewProps) {
+  const { node, selected, view } = props;
+  const { name } = node.attrs as SecretRefAttrs;
+  const isSelected = selected && view.editable;
+
+  return (
+    <NodeViewWrapper
+      title="Stored in the vault — resolved at use, never shown"
+      className={cn(
+        "mx-0.5 px-1.5 py-0.5 rounded-md",
+        "inline-flex items-center gap-1 align-baseline",
+        "select-none cursor-default",
+        "font-mono text-xs",
+        "border border-success/30 bg-success/10 text-success",
+        isSelected && "outline-2 outline-blue-300 outline-offset-0",
+      )}
+    >
+      <Lock01 className="size-3" />
+      {name}
+    </NodeViewWrapper>
+  );
+}
+
+/**
+ * Inline chip for a vaulted secret reference. Serializes to
+ * `{{secret:name}}` on the wire (see derive-parts.ts) so the raw value never
+ * enters the message text — agents resolve it from the vault at point of use.
+ */
+export const SecretRefNode = Node.create({
+  name: "secretRef",
+
+  group: "inline",
+  inline: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      name: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-name") || null,
+        renderHTML: (attributes) => {
+          if (!attributes.name) return {};
+          return { "data-name": attributes.name };
+        },
+      },
+      secretId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-secret-id") || null,
+        renderHTML: (attributes) => {
+          if (!attributes.secretId) return {};
+          return { "data-secret-id": attributes.secretId };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'span[data-type="secret-ref"]',
+      },
+    ];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const attrs: Record<string, string> = {
+      "data-type": "secret-ref",
+    };
+
+    if (node.attrs.name) {
+      attrs["data-name"] = node.attrs.name;
+    }
+    if (node.attrs.secretId) {
+      attrs["data-secret-id"] = node.attrs.secretId;
+    }
+
+    return ["span", { ...HTMLAttributes, ...attrs }];
+  },
+
+  renderText({ node }) {
+    return secretRef(node.attrs.name ?? "");
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(SecretRefNodeView);
+  },
+});

--- a/apps/web/src/components/chat/tiptap/secret-ref/replace.test.ts
+++ b/apps/web/src/components/chat/tiptap/secret-ref/replace.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import type { TiptapDoc } from "../../types.ts";
+import {
+  extractPlainTextFromTiptapDoc,
+  replaceSecretInTiptapDoc,
+} from "./replace.ts";
+
+const TOKEN = "sk-abcdEFGH1234567890wxyzABCD";
+const ATTRS = { name: "openai_api_key", secretId: "sec_123" };
+
+function doc(...paragraphs: TiptapDoc["content"]): TiptapDoc {
+  return { type: "doc", content: paragraphs };
+}
+
+describe("replaceSecretInTiptapDoc", () => {
+  test("splits a text node around the token", () => {
+    const d = doc({
+      type: "paragraph",
+      content: [{ type: "text", text: `use ${TOKEN} please` }],
+    });
+    const out = replaceSecretInTiptapDoc(d, TOKEN, ATTRS)!;
+    expect(out.content[0]!.content).toEqual([
+      { type: "text", text: "use " },
+      { type: "secretRef", attrs: ATTRS },
+      { type: "text", text: " please" },
+    ]);
+  });
+
+  test("token alone in the node produces just the chip", () => {
+    const d = doc({
+      type: "paragraph",
+      content: [{ type: "text", text: TOKEN }],
+    });
+    const out = replaceSecretInTiptapDoc(d, TOKEN, ATTRS)!;
+    expect(out.content[0]!.content).toEqual([
+      { type: "secretRef", attrs: ATTRS },
+    ]);
+  });
+
+  test("preserves marks on the split pieces", () => {
+    const marks = [{ type: "bold" }];
+    const d = doc({
+      type: "paragraph",
+      content: [{ type: "text", text: `a ${TOKEN} b`, marks }],
+    });
+    const out = replaceSecretInTiptapDoc(d, TOKEN, ATTRS)!;
+    const pieces = out.content[0]!.content!;
+    expect(pieces[0]).toEqual({ type: "text", text: "a ", marks });
+    expect(pieces[2]).toEqual({ type: "text", text: " b", marks });
+  });
+
+  test("replaces only the first occurrence", () => {
+    const d = doc({
+      type: "paragraph",
+      content: [{ type: "text", text: `${TOKEN} and ${TOKEN}` }],
+    });
+    const out = replaceSecretInTiptapDoc(d, TOKEN, ATTRS)!;
+    const pieces = out.content[0]!.content!;
+    expect(pieces.filter((p) => p.type === "secretRef")).toHaveLength(1);
+    expect(pieces.at(-1)?.text).toBe(` and ${TOKEN}`);
+  });
+
+  test("finds the token in a later paragraph", () => {
+    const d = doc(
+      { type: "paragraph", content: [{ type: "text", text: "hello" }] },
+      { type: "paragraph", content: [{ type: "text", text: TOKEN }] },
+    );
+    const out = replaceSecretInTiptapDoc(d, TOKEN, ATTRS)!;
+    expect(out.content[0]!.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(out.content[1]!.content).toEqual([
+      { type: "secretRef", attrs: ATTRS },
+    ]);
+  });
+
+  test("returns null when the token is absent", () => {
+    const d = doc({
+      type: "paragraph",
+      content: [{ type: "text", text: "nothing here" }],
+    });
+    expect(replaceSecretInTiptapDoc(d, TOKEN, ATTRS)).toBeNull();
+  });
+
+  test("does not mutate the input doc", () => {
+    const d = doc({
+      type: "paragraph",
+      content: [{ type: "text", text: TOKEN }],
+    });
+    const snapshot = JSON.stringify(d);
+    replaceSecretInTiptapDoc(d, TOKEN, ATTRS);
+    expect(JSON.stringify(d)).toBe(snapshot);
+  });
+});
+
+describe("extractPlainTextFromTiptapDoc", () => {
+  test("joins paragraphs with newlines, skips atom nodes", () => {
+    const d = doc(
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "use " },
+          { type: "secretRef", attrs: ATTRS },
+        ],
+      },
+      { type: "paragraph", content: [{ type: "text", text: "second" }] },
+    );
+    expect(extractPlainTextFromTiptapDoc(d)).toBe("use \nsecond");
+  });
+
+  test("empty for undefined doc", () => {
+    expect(extractPlainTextFromTiptapDoc(undefined)).toBe("");
+  });
+});

--- a/apps/web/src/components/chat/tiptap/secret-ref/replace.ts
+++ b/apps/web/src/components/chat/tiptap/secret-ref/replace.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure helpers to swap a raw token inside a Tiptap doc for a secretRef node.
+ * Kept free of editor/react imports so they stay unit-testable.
+ */
+
+import type { JSONContent } from "@tiptap/core";
+import type { TiptapDoc } from "../../types.ts";
+import type { SecretRefAttrs } from "./node.tsx";
+
+function createSecretRefContent(attrs: SecretRefAttrs): JSONContent {
+  return { type: "secretRef", attrs: { ...attrs } };
+}
+
+/**
+ * Replace the FIRST occurrence of `rawValue` across the doc's text nodes with
+ * an inline secretRef chip, preserving marks and surrounding text. Returns a
+ * new doc, or `null` when the value isn't found (caller keeps the original).
+ */
+export function replaceSecretInTiptapDoc(
+  doc: TiptapDoc,
+  rawValue: string,
+  attrs: SecretRefAttrs,
+): TiptapDoc | null {
+  if (!rawValue) return null;
+  let replaced = false;
+
+  const walk = (nodes: JSONContent[]): JSONContent[] =>
+    nodes.flatMap((node): JSONContent[] => {
+      if (replaced) return [node];
+
+      if (node.type === "text" && typeof node.text === "string") {
+        const idx = node.text.indexOf(rawValue);
+        if (idx === -1) return [node];
+        replaced = true;
+
+        const before = node.text.slice(0, idx);
+        const after = node.text.slice(idx + rawValue.length);
+        const pieces: JSONContent[] = [];
+        if (before) pieces.push({ ...node, text: before });
+        pieces.push(createSecretRefContent(attrs));
+        if (after) pieces.push({ ...node, text: after });
+        return pieces;
+      }
+
+      if (Array.isArray(node.content)) {
+        return [{ ...node, content: walk(node.content) }];
+      }
+      return [node];
+    });
+
+  const content = walk(doc.content ?? []);
+  if (!replaced) return null;
+  return { ...doc, content };
+}
+
+/**
+ * Plain text of the doc's text nodes only — mention/file/secretRef chips are
+ * skipped, so detection can't re-trigger on already-vaulted references.
+ */
+export function extractPlainTextFromTiptapDoc(
+  doc: TiptapDoc | undefined,
+): string {
+  if (!doc) return "";
+  let text = "";
+
+  const walk = (node: JSONContent): void => {
+    if (node.type === "text" && typeof node.text === "string") {
+      text += node.text;
+    }
+    if (node.type === "paragraph" && text && !text.endsWith("\n")) {
+      text += "\n";
+    }
+    for (const child of node.content ?? []) walk(child);
+  };
+
+  walk(doc);
+  return text;
+}

--- a/apps/web/src/utils/secret-detect.test.ts
+++ b/apps/web/src/utils/secret-detect.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import {
+  detectSecret,
+  heuristicSecretName,
+  maskSecret,
+  secretRef,
+} from "./secret-detect";
+
+describe("detectSecret", () => {
+  test("finds an OpenAI key and names it", () => {
+    const d = detectSecret("here is sk-abcdEFGH1234567890wxyzABCD ok");
+    expect(d).not.toBeNull();
+    expect(d!.value).toBe("sk-abcdEFGH1234567890wxyzABCD");
+    expect(d!.suggestedName).toBe("openai_api_key");
+  });
+
+  test("anthropic beats the generic openai sk- pattern", () => {
+    const d = detectSecret("sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAA");
+    expect(d!.suggestedName).toBe("anthropic_api_key");
+  });
+
+  test("finds a GitHub PAT", () => {
+    const d = detectSecret("token github_pat_11ABCDE0000aaaaAAAA1111bbbb");
+    expect(d!.suggestedName).toBe("github_token");
+  });
+
+  test("labeled assignment captures just the value", () => {
+    const d = detectSecret('API_KEY="abcdef0123456789ABCDEF"');
+    expect(d).not.toBeNull();
+    expect(d!.value).toBe("abcdef0123456789ABCDEF");
+  });
+
+  test("returns null for ordinary prose", () => {
+    expect(detectSecret("just a normal sentence with words")).toBeNull();
+  });
+
+  test("reports correct offsets", () => {
+    const text = "use sk-abcdEFGH1234567890wxyzABCD now";
+    const d = detectSecret(text)!;
+    expect(text.slice(d.start, d.end)).toBe(d.value);
+  });
+});
+
+describe("helpers", () => {
+  test("heuristicSecretName by prefix", () => {
+    expect(heuristicSecretName("ghp_xxx")).toBe("github_token");
+    expect(heuristicSecretName("AKIAxxxx")).toBe("aws_access_key_id");
+    expect(heuristicSecretName("random")).toBe("api_token");
+  });
+
+  test("secretRef + maskSecret", () => {
+    expect(secretRef("openai_api_key")).toBe("{{secret:openai_api_key}}");
+    expect(maskSecret("sk-abcdEFGH1234567890")).toMatch(/^sk-a•+$/);
+  });
+});

--- a/apps/web/src/utils/secret-detect.ts
+++ b/apps/web/src/utils/secret-detect.ts
@@ -1,0 +1,149 @@
+/**
+ * Token/secret detection — used by the chat composer to offer "save this to
+ * the vault" before a raw token lands in history. Patterns are ordered
+ * specific → generic; the first match wins.
+ */
+
+interface SecretPattern {
+  kind: string;
+  /** Suggested snake_case vault name when this pattern matches. */
+  name: string;
+  /** Human label for the modal. */
+  label: string;
+  regex: RegExp;
+  /** If set, the secret value is this capture group (else the whole match). */
+  group?: number;
+}
+
+const SECRET_PATTERNS: SecretPattern[] = [
+  {
+    kind: "anthropic",
+    name: "anthropic_api_key",
+    label: "Anthropic API key",
+    regex: /sk-ant-[A-Za-z0-9_-]{20,}/,
+  },
+  {
+    kind: "openrouter",
+    name: "openrouter_api_key",
+    label: "OpenRouter API key",
+    regex: /sk-or-v1-[A-Za-z0-9]{20,}/,
+  },
+  {
+    kind: "openai",
+    name: "openai_api_key",
+    label: "OpenAI API key",
+    regex: /sk-(?:proj-)?[A-Za-z0-9_-]{20,}/,
+  },
+  {
+    kind: "github",
+    name: "github_token",
+    label: "GitHub token",
+    regex: /github_pat_[A-Za-z0-9_]{20,}/,
+  },
+  {
+    kind: "github",
+    name: "github_token",
+    label: "GitHub token",
+    regex: /gh[pousr]_[A-Za-z0-9]{30,}/,
+  },
+  {
+    kind: "aws",
+    name: "aws_access_key_id",
+    label: "AWS access key",
+    regex: /AKIA[0-9A-Z]{16}/,
+  },
+  {
+    kind: "google",
+    name: "google_api_key",
+    label: "Google API key",
+    regex: /AIza[0-9A-Za-z_-]{35}/,
+  },
+  {
+    kind: "slack",
+    name: "slack_token",
+    label: "Slack token",
+    regex: /xox[baprs]-[A-Za-z0-9-]{10,}/,
+  },
+  {
+    kind: "jwt",
+    name: "jwt_token",
+    label: "JWT",
+    regex: /eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_.+/=-]{8,}/,
+  },
+  // Labeled assignment: `api_key: "…"`, `TOKEN=…`, `Bearer …` — value is group 1.
+  {
+    kind: "labeled",
+    name: "api_token",
+    label: "API token",
+    regex:
+      /(?:api[_-]?key|token|secret|password|bearer)["']?\s*[:=]?\s*["']?([A-Za-z0-9_\-.]{16,})["']?/i,
+    group: 1,
+  },
+  // Generic high-entropy: long mixed letters+digits string (last resort).
+  {
+    kind: "generic",
+    name: "api_token",
+    label: "Token",
+    regex:
+      /\b(?=[A-Za-z0-9_-]*[A-Za-z])(?=[A-Za-z0-9_-]*[0-9])[A-Za-z0-9_-]{40,}\b/,
+  },
+];
+
+export interface DetectedSecret {
+  value: string;
+  start: number;
+  end: number;
+  kind: string;
+  label: string;
+  suggestedName: string;
+}
+
+/** Find the first (highest-priority) secret-like substring in `text`. */
+export function detectSecret(text: string): DetectedSecret | null {
+  for (const p of SECRET_PATTERNS) {
+    const m = p.regex.exec(text);
+    if (!m) continue;
+    const value = p.group != null ? m[p.group] : m[0];
+    if (!value) continue;
+    const start = p.group != null ? text.indexOf(value, m.index) : m.index;
+    return {
+      value,
+      start,
+      end: start + value.length,
+      kind: p.kind,
+      label: p.label,
+      suggestedName: heuristicSecretName(value),
+    };
+  }
+  return null;
+}
+
+/** Best-effort snake_case name from a token's leading characters. */
+export function heuristicSecretName(token: string): string {
+  const t = token.trim();
+  if (t.startsWith("sk-ant-")) return "anthropic_api_key";
+  if (t.startsWith("sk-or-")) return "openrouter_api_key";
+  if (t.startsWith("sk-")) return "openai_api_key";
+  if (t.startsWith("github_pat_") || /^gh[pousr]_/.test(t)) {
+    return "github_token";
+  }
+  if (t.startsWith("AKIA")) return "aws_access_key_id";
+  if (t.startsWith("AIza")) return "google_api_key";
+  if (t.startsWith("xox")) return "slack_token";
+  if (t.startsWith("eyJ")) return "jwt_token";
+  return "api_token";
+}
+
+// Structured reference the agent sees instead of the raw value. The vault
+// resolves it by name at the point of use; the value never enters history.
+export const SECRET_REF_RE = /\{\{secret:([A-Za-z0-9_.-]+)\}\}/g;
+
+export function secretRef(name: string): string {
+  return `{{secret:${name}}}`;
+}
+
+/** Mask a token for display: keep a short prefix, blur the rest. */
+export function maskSecret(token: string): string {
+  if (token.length <= 8) return "•".repeat(token.length);
+  return `${token.slice(0, 4)}${"•".repeat(Math.min(token.length - 4, 16))}`;
+}

--- a/packages/e2e/tests/my-capabilities.spec.ts
+++ b/packages/e2e/tests/my-capabilities.spec.ts
@@ -98,11 +98,17 @@ test.describe("GET /api/auth/custom/my-capabilities/:slug", () => {
     const body = (await res.json()) as CapabilitiesResponse;
 
     expect(body.role).toBe("user");
-    // The built-in user role is granted agents:manage + connections:manage via
-    // USER_ROLE_CAPABILITY_IDS; every other gated capability stays false.
+    // The built-in user role is granted agents:manage + connections:manage +
+    // secrets:manage via USER_ROLE_CAPABILITY_IDS; every other gated
+    // capability stays false.
     expect(body.capabilities["agents:manage"]).toBe(true);
     expect(body.capabilities["connections:manage"]).toBe(true);
-    const granted = new Set(["agents:manage", "connections:manage"]);
+    expect(body.capabilities["secrets:manage"]).toBe(true);
+    const granted = new Set([
+      "agents:manage",
+      "connections:manage",
+      "secrets:manage",
+    ]);
     const others = Object.entries(body.capabilities)
       .filter(([id]) => !granted.has(id))
       .map(([, isGranted]) => isGranted);

--- a/packages/e2e/tests/settings-capability-gating.spec.ts
+++ b/packages/e2e/tests/settings-capability-gating.spec.ts
@@ -2,13 +2,16 @@
  * E2E: capability-based gating of the settings UI.
  *
  * Drives the real browser as a restricted member (built-in "user" role, which
- * resolves to no gated capabilities) and asserts the gating wired up in the
- * settings layout + route guards + capability-aware index redirect:
+ * resolves to only agents:manage + connections:manage + secrets:manage — see
+ * USER_ROLE_CAPABILITY_IDS) and asserts the gating wired up in the settings
+ * layout + route guards + capability-aware index redirect:
  *
- *   - direct-navigating to a management settings route shows the no-access
- *     panel instead of the page;
- *   - the /settings index lands a no-management member on Profile (the always-
- *     accessible fallback), and an owner on General;
+ *   - direct-navigating to a management settings route the role can't open
+ *     (e.g. General, gated behind org:manage) shows the no-access panel
+ *     instead of the page;
+ *   - the /settings index lands this member on the first tab their role CAN
+ *     open (Secrets, via secrets:manage) rather than a denied tab, and an
+ *     owner on General;
  *
  * The capability resolution itself is unit + e2e tested at the endpoint
  * (my-capabilities.spec.ts); this spec covers the UI consuming it.
@@ -90,10 +93,12 @@ test.describe("settings capability gating", () => {
       timeout: 15_000,
     });
 
-    // The settings index redirects a no-management member to Profile — the
-    // always-accessible fallback — rather than landing them on a denied tab.
+    // The built-in user role is also granted secrets:manage (every member can
+    // vault a token pasted in chat) — the settings index lands this member on
+    // Secrets rather than the Profile fallback, since it's the first
+    // capability-gated tab they can open.
     await page.goto(`/${owner.orgSlug}/settings`);
-    await page.waitForURL((url) => url.pathname.endsWith("/settings/profile"), {
+    await page.waitForURL((url) => url.pathname.endsWith("/settings/secrets"), {
       timeout: 15_000,
     });
 

--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -1496,6 +1496,9 @@ export const BASIC_USAGE_TOOLS: ReadonlySet<string> = new Set([
 const USER_ROLE_CAPABILITY_IDS: string[] = [
   "agents:manage",
   "connections:manage",
+  // Every member can vault a token from chat (the paste-to-secret flow).
+  // SECRET_LIST/CREATE never return values; user-scoped secrets stay private.
+  "secrets:manage",
 ];
 
 /**


### PR DESCRIPTION
## Summary

Brings nano-studio's "this looks like a secret" flow to Studio, plus first-class API-key creation in chat. Rebased on top of #4643 (API Key Manager) — the originally-planned "Credential Manager" agent was dropped in favor of extending that merged agent.

**1. Paste-to-secret in chat.** When a user pastes (or types) something that looks like an API key/token into the chat composer, it's heuristically detected and a modal offers to vault it as a secret, swapping the raw value for a `{{secret:name}}` reference so the token never enters chat history.
- `web/utils/secret-detect.ts` — priority-ordered detection (anthropic/openai/openrouter/github/aws/google/slack/jwt/labeled/generic) + heuristic naming, ported verbatim from nano-studio with its test suite.
- New Tiptap `secretRef` inline chip node (registered in the composer and the read-only message renderer) that serializes to `{{secret:name}}` via `derivePartsFromTiptapDoc`.
- `StoreSecretDialog` saves through the existing `SECRET_CREATE` mutation (defaults to **organization** scope, editable name). Paste mode swaps in-draft; a submit-time safety net catches typed tokens.
- Raw tokens the user chooses to keep render as masked, click-to-copy chips in the transcript (`SensitiveText`).
- Grants `secrets:manage` to the built-in **user** role so every member can vault a token from chat (previously admin-only).

**2. First-class `API_KEY_CREATE` rendering.** The raw key is returned exactly once; the new tool-call renderer auto-opens a "shown only once" modal with the key + copy button (guarded per `toolCallId` via sessionStorage so history revisits don't re-pop it), leaving an inline summary card afterward.

**3. Vault secrets + UI-aware instructions on the API Key Manager (#4643).** Extends the merged API Key Manager agent with `SECRET_CREATE`/`SECRET_LIST` and vault-handling instructions (`{{secret:name}}` references, never echo values, SECRET_LIST-before-create). Also fixes two failure modes observed in prod: the instructions now tell the agent the key is rendered by the UI in a secure shown-once panel (instead of \"copy the tool result\"), forbid running `API_KEY_CREATE` through a subtask (nested tool outputs are hidden, so a subtask-created key is displayed to no one and unrecoverable), and cap confirmation at one round so it stops re-litigating explicitly confirmed requests. `resolveEffectiveVirtualMcpForHarness` resolves pack-agent tools/instructions from code at dispatch time, so existing orgs pick this up immediately — no install-version bump needed.

## Testing

- `bun test` — new unit suites (`secret-detect.test.ts`, `secret-ref/replace.test.ts`) pass; api-key-manager + mesh-sdk constants tests updated and green; chat suite green (360 pass).
- `bun run check` (typecheck) and `bun run lint` pass; `bun run fmt:check` clean.
- The `studio-pack.integration.test.ts` toolset assertion was extended with the two secrets tools; the suite requires a migrated test Postgres (fails in its shared `beforeAll` seed in this sandbox — pre-existing, unrelated).

### Manual verification notes (for reviewer)
- Paste `sk-ant-…` → modal ("Anthropic API key", `anthropic_api_key`, org scope) → Save & use reference → chip in composer → send → user message shows chip; Settings → Secrets lists it; wire text part contains `{{secret:anthropic_api_key}}`.
- API Key Manager: "create an API key…" → confirm → shown-once modal with key + copy; reload thread → modal does not re-open, inline card remains. Ask it to store a token → SECRET_CREATE → `{{secret:name}}` reference in reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Update: root-caused the "won't give me the key" prod report

The prod repro (org owner asks the org's default agent to mint a wide-access key, agent delegates to the API Key Manager via `subtask`, key is created but never shown) turned out to have a real root cause, not just an annoying agent: **nested tool-call results are never rendered to the user** (`SubtaskResultBody` only ever shows the subagent's own final *text* report, never its intermediate tool outputs) — so our shown-once UI panel structurally cannot appear for a delegated run, and the agent's own "never reprint the key" instruction (mine) or "always print it once" instruction (main's independent fix in #4689, merged the same day) each solved only one half of the problem.

Rebasing onto main surfaced #4689's fix as a real conflict, which forced reconciling both: the merged instructions now branch on the one signal the model can reliably observe — its own identity prompt (`SUBAGENT_IDENTITY_PROMPT` from `build-agent-system-prompt.ts`, which literally tells a subagent "this report is all the parent agent sees"):
- **Top-level** (no subagent identity prompt): rely on the UI panel, never reprint the raw key in text — preserves this PR's "raw secrets shouldn't sit in plaintext chat history" goal.
- **Delegated subtask**: print the key once in a fenced code block in the final report — the only channel a nested tool result has to the user; omitting it (my original instruction) makes the key permanently unrecoverable.

Also folded in: `API_KEY_CREATE` must never itself be delegated to a further subagent (that hides the result even from the calling manager), and "confirm once, then act" so an explicitly-confirmed request doesn't get re-litigated (the second screenshot).

`api-key-manager.test.ts` gained tests locking in each of these five behaviors individually.
