### PR TITLE
fix(sections-editor): disable header Publish button when diff contains code

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/use-publish-gate.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-publish-gate.ts
@@ -1,0 +1,94 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  canPublishDirectly,
+  combinePublishDiffs,
+  fetchGitDiff,
+  fetchGitStatus,
+  hasGitLocalWork,
+  isSandboxUnreachable,
+  type GitDiffResult,
+  type PublishGate,
+} from "../../thread/github/sandbox-git-api.ts";
+
+function publishGateQueryKey(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+  base: string,
+  signature: string,
+) {
+  return [
+    "publish-gate",
+    orgSlug,
+    virtualMcpId,
+    branch,
+    base,
+    signature,
+  ] as const;
+}
+
+/**
+ * Fetch the full direct-publish diff (committed base…head unioned with the
+ * uncommitted working tree, mirroring the publish dialog's `loadPublishDiff`)
+ * and evaluate whether it may be published directly. Lets the header's side
+ * "Publish" button gate itself — disabled with a tooltip when the diff contains
+ * code — instead of opening a dialog whose Publish button is already dead.
+ *
+ * `signature` (a fingerprint of the branch's git state from the daemon SSE)
+ * feeds the query key so a commit/push/dirty-flip refetches immediately; the
+ * poll interval backstops working-tree edits that keep the dirty flag set.
+ */
+export function usePublishGate(args: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  base: string;
+  headSha?: string | null;
+  signature: string;
+  enabled?: boolean;
+}): { gate: PublishGate; ready: boolean } {
+  const {
+    orgSlug,
+    virtualMcpId,
+    branch,
+    base,
+    headSha,
+    signature,
+    enabled = true,
+  } = args;
+
+  const query = useQuery<GitDiffResult>({
+    queryKey: publishGateQueryKey(
+      orgSlug,
+      virtualMcpId,
+      branch,
+      base,
+      signature,
+    ),
+    queryFn: async () => {
+      const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
+      const baseDiff =
+        (status.aheadOfBase ?? 0) > 0
+          ? await fetchGitDiff(orgSlug, virtualMcpId, branch, {
+              base,
+              ...(headSha ? { headSha } : {}),
+            })
+          : null;
+      const workingDiff = hasGitLocalWork(status)
+        ? await fetchGitDiff(orgSlug, virtualMcpId, branch)
+        : null;
+      return combinePublishDiffs(baseDiff, workingDiff);
+    },
+    enabled: enabled && !!branch,
+    refetchInterval: 10_000,
+    staleTime: 5_000,
+    retry: (count, error) => !isSandboxUnreachable(error) && count < 2,
+  });
+
+  // While the diff is still loading (or the sandbox is unreachable) don't gate
+  // the button — let the click fall through to the dialog, which does its own
+  // loading + gating. Only enforce the gate once we actually have the diff.
+  if (!query.data)
+    return { gate: { allowed: true, reason: null }, ready: false };
+  return { gate: canPublishDirectly(query.data), ready: true };
+}

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -32,8 +32,10 @@ import * as tpl from "./message-templates.ts";
 import { saveChangesDebug } from "./save-changes-debug.ts";
 import { resolveSandboxBranchFromMap } from "./resolve-sandbox-branch.ts";
 import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events.ts";
+import { usePublishGate } from "@/web/components/sandbox/hooks/use-publish-gate.ts";
 import { useChecks, usePrByBranch } from "./use-pr-data.ts";
 import { usePrReviews } from "./use-pr-reviews.ts";
+import type { PublishGate } from "./sandbox-git-api.ts";
 
 interface Props {
   virtualMcpId: string;
@@ -137,6 +139,33 @@ export function HeaderActions({ virtualMcpId }: Props) {
   // daemon's own poll fallback. It also applies the boot-dirty baseline filter
   // that a raw /git/status poll would miss.
   const effectiveBranchMeta = branchMeta;
+
+  // Gate the side "Publish" button up-front: fetch the direct-publish diff and
+  // disable the button (with a tooltip) when it contains code, instead of
+  // opening a dialog whose Publish button is already dead. Only fetch when
+  // there's local work not yet merged (i.e. a side Publish button could show).
+  const publishGateBase =
+    effectiveBranchMeta.kind === "ready" ? effectiveBranchMeta.base : "main";
+  const publishGateEnabled =
+    effectiveBranchMeta.kind === "ready" &&
+    Boolean(sandboxRouteBranch) &&
+    (effectiveBranchMeta.workingTreeDirty ||
+      effectiveBranchMeta.unpushed > 0 ||
+      effectiveBranchMeta.aheadOfBase > 0);
+  const publishGateSignature =
+    effectiveBranchMeta.kind === "ready"
+      ? `${effectiveBranchMeta.headSha}:${effectiveBranchMeta.workingTreeDirty}:${effectiveBranchMeta.unpushed}:${effectiveBranchMeta.aheadOfBase}`
+      : "unknown";
+  const { gate: publishGate } = usePublishGate({
+    orgSlug: org.slug,
+    virtualMcpId,
+    branch: sandboxRouteBranch ?? "",
+    base: publishGateBase,
+    headSha:
+      effectiveBranchMeta.kind === "ready" ? effectiveBranchMeta.headSha : null,
+    signature: publishGateSignature,
+    enabled: publishGateEnabled,
+  });
 
   // Detached: repo linked via a GitHub connection that's no longer aggregated.
   // Render a reconnect pill instead of nothing so the user has a recovery path
@@ -319,6 +348,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
         onActivate={onActivate}
         showPublishSide={showPublishSide}
         onPublishSide={onPublishSide}
+        publishGate={publishGate}
         prNumber={pr?.number}
         prBase={pr?.base}
         onSquashMerge={handleSquashMerge}
@@ -372,6 +402,7 @@ function HeaderButtonRenderer(props: {
   onActivate: (action: HeaderButton["action"]) => void;
   showPublishSide: boolean;
   onPublishSide: () => void;
+  publishGate: PublishGate;
   prNumber?: number;
   prBase?: string;
   onSquashMerge: (pullNumber: number) => void | Promise<void>;
@@ -427,11 +458,15 @@ function HeaderButtonRenderer(props: {
         </Button>
       </WithTooltip>
       {props.showPublishSide ? (
-        <WithTooltip label="Publish directly, skipping review">
+        <WithTooltip
+          label={
+            props.publishGate.reason ?? "Publish directly, skipping review"
+          }
+        >
           <Button
             size="sm"
             variant="success"
-            disabled={props.githubActionPending}
+            disabled={props.githubActionPending || !props.publishGate.allowed}
             onClick={props.onPublishSide}
           >
             Publish


### PR DESCRIPTION
## Summary

The header's green **Publish** button always opened the publish dialog, but the code-gate (`isDecoOnlyDiff`) was only enforced on the Publish button *inside* the modal. For code changes this meant clicking **Publish** opened a dialog whose Publish button was already disabled — a dead-end.

This moves the gate up to the header button so it's disabled **with a tooltip** (`Code changes can't be published directly — use Submit for review`) instead of opening a useless modal.

## How

- **New hook** `apps/mesh/src/web/components/sandbox/hooks/use-publish-gate.ts` — fetches the same direct-publish diff the modal uses (`combinePublishDiffs` of committed base…head + working tree), runs `canPublishDirectly`, and returns the `PublishGate`. It:
  - Only fetches when there's local unmerged work (dirty / unpushed / ahead of base), so it's idle in up-to-date/published states.
  - Keys the query on a signature of the daemon's SSE git state (`headSha`/dirty/unpushed/aheadOfBase) so a commit/push refetches immediately, with a 10s poll backstop for working-tree edits.
  - Defaults to **allowed while loading** — a click before the diff resolves still falls through to the dialog's own loading + gating.
- **`header-actions.tsx`** — calls the hook (before early returns, stable hook order), threads the gate into `HeaderButtonRenderer`, and applies it to the side Publish button (`disabled` + tooltip reason).

The modal's internal gate is kept as defense-in-depth.

## Testing

- `tsc --noEmit` (apps/mesh) — passes
- `oxlint` on changed files — 0 warnings/errors
- `biome format` — clean

Tradeoff: the gate now does a lightweight diff fetch in the header, but only when there's unmerged local work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the header Publish button when the diff includes code and show a tooltip instead of opening a modal with a disabled button. This removes the dead-end and guides users to submit for review.

- **Bug Fixes**
  - Moved the direct-publish gate to the header button; shows tooltip: "Code changes can't be published directly — use Submit for review".
  - Added `usePublishGate` to compute the direct-publish diff and return a `PublishGate` using `@tanstack/react-query` (keyed by git state; 10s refetch).
  - Only fetches when there’s local unmerged work; idle otherwise.
  - Defaults to allowed while loading; modal gate remains as a backup.

<sup>Written for commit 713505ef768c5e90774b585447ad6469f8212591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

