### PR TITLE
fix(commerce-onboarding): always run SETUP before RUN in openReport

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -854,16 +854,15 @@ function CommerceSetupContent({
     const normalized = normalizeReportsSiteUrl(currentSiteUrl);
     if (normalized.ok) {
       try {
+        // Always run setup before triggering the run. Setup is idempotent
+        // (/upgrade per (org, site)) and ensures the CD connection's
+        // connection_url and token are always in sync with the current
+        // environment (prod vs. stg) before the report view opens.
+        await setupMutation.mutateAsync(normalized.value);
         let runResult = await runMutation.mutateAsync(normalized.value);
-        // triggered:false means the site isn't claimed for this org on the
-        // Commerce Discovery side (not_upgraded — see triggerCommerceDiscoveryRun).
-        // This can diverge from the studio connection's metadata.siteUrl (which
-        // gates setupReady): the connection looks claimed here, so setup is
-        // skipped on load, the report token is never refreshed, and every run
-        // 409s — a dead end where "reload" changes nothing. Reconcile by
-        // re-running setup (idempotent /upgrade re-claims the site AND persists a
-        // fresh connection token, which also fixes the CD proxy 401s), then retry
-        // the run once before giving up.
+        // triggered:false means the site still isn't claimed after the setup
+        // above (e.g. /upgrade failed silently, or a race). Keep the fallback
+        // reclaim path so a second attempt can recover.
         if (!runResult.triggered) {
           track("commerce_onboarding_run_reclaim", {
             domain: siteUrlToHost(currentSiteUrl) ?? undefined,


### PR DESCRIPTION
## What is this contribution about?

SETUP was only called as a fallback when RUN returned \`not_upgraded\`. A returning session (site already upgraded from a previous visit) skipped SETUP entirely — meaning \`COMMERCE_DISCOVERY_SETUP\` (which now updates the connection's \`connection_url\` to match \`COMMERCE_DISCOVERY_INTERNAL_API_URL\`) never ran, and the CD proxy kept pointing at the prod worker even in staging.

**Fix:** always call SETUP before RUN in \`openReport\`. SETUP is idempotent (\`/upgrade\` per org+site), so this adds one extra fast call per "Ver relatório completo" click but guarantees the connection's \`connection_url\` and token are always synced with the current environment before the report view opens.

The \`not_upgraded\` fallback path (double SETUP + retry RUN) is preserved for edge cases where the first SETUP fails to claim the site (race conditions, cross-org conflicts, etc.).

## Screenshots/Demonstration

N/A — backend flow change.

## How to Test

1. In staging, open \`/commerce-onboarding?org=<org>&siteUrl=<site>\`.
2. Click "Ver relatório completo" (first time — triggers SETUP + RUN + navigate).
3. Go back, click "Ver relatório completo" again (returning session).
4. Verify the report view loads without the \`{"error":"Unauthorized"}\` error — confirming SETUP ran and updated \`connection_url\` even on the second click.

## Migration Notes

N/A — no DB changes.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always run SETUP before RUN when opening the Commerce Onboarding report to keep the connection pointing to the correct environment and prevent unauthorized errors for returning sessions. This ensures the `connection_url` and token are always up to date.

- **Bug Fixes**
  - Call SETUP (idempotent `/upgrade`) before RUN on every report open.
  - Keep the fallback: if RUN isn’t triggered, run SETUP again and retry RUN once.

<sup>Written for commit ff94ac270ae0f8c9d356cf59ca443f5f6c23157c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

