### PR TITLE
fix(web): paginate GitHub PR file list beyond first 100 files

### DIFF
--- a/apps/mesh/src/web/components/thread/github/github-pr-diff.test.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-diff.test.ts
@@ -108,4 +108,49 @@ describe("github-pr-diff", () => {
     );
     expect(fromCall?.arguments.path).toBe("old.ts");
   });
+
+  it("fetchGithubPrDiff paginates past the first 100 changed files", async () => {
+    const totalFiles = 150;
+    const client = {
+      callTool: async (req: {
+        name: string;
+        arguments: Record<string, unknown>;
+      }) => {
+        if (req.name === "pull_request_read") {
+          const page = Number(req.arguments.page ?? 1);
+          const perPage = Number(req.arguments.perPage ?? 100);
+          const start = (page - 1) * perPage;
+          const pageFiles = Array.from(
+            { length: Math.max(0, Math.min(perPage, totalFiles - start)) },
+            (_, i) => ({
+              filename: `file-${start + i}.ts`,
+              status: "modified",
+              additions: 1,
+              deletions: 1,
+              changes: 2,
+            }),
+          );
+          return { structuredContent: pageFiles };
+        }
+        return {
+          content: [
+            {
+              type: "resource",
+              resource: { text: JSON.stringify("content") },
+            },
+          ],
+        };
+      },
+    };
+
+    const result = await fetchGithubPrDiff(client, {
+      owner: "acme",
+      repo: "widgets",
+      pullNumber: 1,
+      base: "main",
+      headSha: "headsha",
+    });
+
+    expect(Object.keys(result.diffs)).toHaveLength(totalFiles);
+  });
 });

--- a/apps/mesh/src/web/components/thread/github/github-pr-diff.ts
+++ b/apps/mesh/src/web/components/thread/github/github-pr-diff.ts
@@ -10,6 +10,11 @@ type GithubMcpClient = {
 };
 
 const FILE_FETCH_CONCURRENCY = 10;
+const FILES_PER_PAGE = 100;
+// GitHub's PR files endpoint itself stops paginating past 3000 files
+// (returns whatever it has and no further pages) — this bounds our loop
+// to the same ceiling so a huge PR can't spin forever.
+const MAX_FILE_PAGES = 30;
 
 export function decodeGithubFileContent(result: unknown): string | null {
   const typed = result as {
@@ -103,6 +108,30 @@ async function mapWithConcurrency<T>(
  * Fallback when the sandbox shallow clone can't resolve merge-base: load full
  * file blobs from GitHub at the PR head and merge-base (when known).
  */
+async function fetchAllPrFiles(
+  client: GithubMcpClient,
+  args: { owner: string; repo: string; pullNumber: number },
+): Promise<PrFile[]> {
+  const files: PrFile[] = [];
+  for (let page = 1; page <= MAX_FILE_PAGES; page++) {
+    const filesResult = await client.callTool({
+      name: "pull_request_read",
+      arguments: {
+        method: "get_files",
+        owner: args.owner,
+        repo: args.repo,
+        pullNumber: args.pullNumber,
+        page,
+        perPage: FILES_PER_PAGE,
+      },
+    });
+    const pageFiles = parsePrFiles(filesResult);
+    files.push(...pageFiles);
+    if (pageFiles.length < FILES_PER_PAGE) break;
+  }
+  return files;
+}
+
 export async function fetchGithubPrDiff(
   client: GithubMcpClient,
   args: {
@@ -114,18 +143,8 @@ export async function fetchGithubPrDiff(
     mergeBaseSha?: string;
   },
 ): Promise<GitDiffResult> {
-  const filesResult = await client.callTool({
-    name: "pull_request_read",
-    arguments: {
-      method: "get_files",
-      owner: args.owner,
-      repo: args.repo,
-      pullNumber: args.pullNumber,
-      perPage: 100,
-    },
-  });
-
-  const files = parsePrFiles(filesResult).filter((f) => f.filename.length > 0);
+  const allFiles = await fetchAllPrFiles(client, args);
+  const files = allFiles.filter((f) => f.filename.length > 0);
   const diffs: GitDiffResult["diffs"] = {};
   const fromRef = args.mergeBaseSha
     ? { sha: args.mergeBaseSha }


### PR DESCRIPTION
## Summary
- `fetchGithubPrDiff` (the GitHub-API fallback path used when the sandbox's shallow clone can't resolve a merge-base) called `pull_request_read(get_files)` with `perPage: 100` and never fetched additional pages.
- Failure scenario: a PR touching more than 100 files silently rendered a diff view with only the first 100 files — no error, no truncation notice, the rest just vanished from the UI.
- Fix loops the same tool call across pages (`page`, `perPage`) until a short page signals the end, capped at 30 pages (3000 files) to mirror GitHub's own API ceiling on that endpoint.

## Test plan
- Added a regression test in `github-pr-diff.test.ts` that mocks a 150-file PR and asserts all 150 show up in `result.diffs` — this test fails against the old single-page code (`Expected length: 150, Received length: 100`) and passes with the fix.
- `bun test apps/mesh/src/web/components/thread/github/github-pr-diff.test.ts` — 7 pass.
- `bun run fmt` clean; targeted `tsc --noEmit` in `apps/mesh` shows no new errors (pre-existing unrelated `@tiptap/extension-text-align` errors are untouched by this change).
- Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub PR diff to include all changed files by paginating the files list. Previously only the first 100 files showed; now it fetches all pages up to 3000 for accurate diffs.

- **Bug Fixes**
  - Paginate the fallback path by looping `pull_request_read(get_files)` across pages until a short page or 30 pages (GitHub’s limit).
  - Added `fetchAllPrFiles` with `FILES_PER_PAGE=100` and `MAX_FILE_PAGES=30`; filters out empty filenames.
  - Added a regression test that mocks 150 files and verifies all are included.

<sup>Written for commit 40818e53519517151cc4d0ee71834cb7b029d9a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

