### PR TITLE
fix(sandbox): seed LogTee.written before the rotation cap check

### DIFF
--- a/packages/sandbox/daemon/process/log-tee.test.ts
+++ b/packages/sandbox/daemon/process/log-tee.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LogTee } from "./log-tee";
+
+function tmpPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "log-tee-test-"));
+  return join(dir, "app-name");
+}
+
+describe("LogTee", () => {
+  it("rotates on the very first write when reopening a path already near the cap", () => {
+    // Regression: named-script tees reopen the same path across runs. A
+    // fresh LogTee instance starts with `written = 0` until it stats the
+    // file — the overflow check must not fire against that stale zero.
+    const path = tmpPath();
+    writeFileSync(path, "x".repeat(95));
+    const tee = new LogTee(path, 100);
+    tee.write("y".repeat(20));
+    tee.close();
+
+    expect(tee.isTruncated()).toBe(true);
+    expect(statSync(path).size).toBeLessThanOrEqual(100);
+    expect(readFileSync(path, "utf-8")).toContain("y".repeat(20));
+  });
+
+  it("does not rotate when reopening a path that still has headroom", () => {
+    const path = tmpPath();
+    writeFileSync(path, "x".repeat(50));
+    const tee = new LogTee(path, 100);
+    tee.write("y".repeat(20));
+    tee.close();
+
+    expect(tee.isTruncated()).toBe(false);
+    expect(readFileSync(path, "utf-8")).toBe(
+      `${"x".repeat(50)}${"y".repeat(20)}`,
+    );
+  });
+});

--- a/packages/sandbox/daemon/process/log-tee.ts
+++ b/packages/sandbox/daemon/process/log-tee.ts
@@ -34,10 +34,15 @@ export class LogTee {
   write(data: string): void {
     if (data.length === 0) return;
     const buf = Buffer.from(data, "utf-8");
+    // Open first so `written` is seeded from the file's actual on-disk size
+    // (named-script tees reopen an existing path across runs) — checking the
+    // cap against a stale `written` of 0 would let this first write blow
+    // past maxBytes without rotating.
+    if (!this.openIfNeeded()) return;
     if (this.written + buf.length > this.maxBytes) {
       this.rotate();
+      if (this.fd === null) return;
     }
-    if (!this.openIfNeeded()) return;
     try {
       writeSync(this.fd as number, buf);
       this.written += buf.length;


### PR DESCRIPTION
## Source
Bug found reading `packages/sandbox/daemon/process/log-tee.ts` (recently-churned area — same directory as the port-sniffer/task-manager fixes landed this week).

## The bug
`LogTee.write()` checked `this.written + buf.length > this.maxBytes` to decide whether to rotate **before** `openIfNeeded()` had a chance to run — but `openIfNeeded()` is exactly what seeds `written` from the file's real on-disk size (see its comment: "Seed from existing file size so the cap applies across runs that append to the same path"). A brand new `LogTee` instance starts with `written = 0`, so the very first `write()` call compared the incoming chunk against that stale zero instead of the real size.

Named-script tees (`logName` set) intentionally reopen the same path across task reruns without clearing it. So: task A fills `app/dev` close to `maxBytes`; task A finishes; task B reruns the same script, constructing a fresh `LogTee` against the same path. Task B's first `write()` silently blows past `maxBytes` (no rotation, `isTruncated()` stays `false`), hiding the overrun from `TaskSummary.truncated` — the same failure shape the existing `ring-buffer.test.ts` comment (`#4522`) describes for a different component.

Reproduced directly: seeded a file with 95 bytes against a 100-byte cap, then `write()`d 20 more bytes on a fresh `LogTee` — file grew to 115 bytes with `isTruncated() === false`. After the fix, it correctly rotates and reports truncated.

## Fix
Move `openIfNeeded()` ahead of the overflow check so `written` reflects the real on-disk size before the cap is evaluated. Added `log-tee.test.ts` with a regression test for the reopen-near-cap case (fails on the old code) and a sibling test confirming the no-rotation path still works when there's headroom.

## Verify
```
bun test packages/sandbox/daemon/process/log-tee.test.ts
```

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` in `packages/sandbox` (clean)
- `bun test packages/sandbox/daemon/process/log-tee.test.ts` (2 pass)

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes log rotation in `LogTee` by seeding `written` from the existing file before checking `maxBytes`, preventing silent overruns on the first write when reopening a log.

- **Bug Fixes**
  - Call `openIfNeeded()` before the cap check so `written` reflects on-disk size; rotate and set `isTruncated()` correctly on first write.
  - Add `log-tee.test.ts` with a reopen-near-cap regression test and a headroom test.

<sup>Written for commit 33b451e9bfce733b48d844e080dcd38eb0916e62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

