### PR TITLE
fix(commerce-discovery): remove stale workers.dev reference and update env docs

### DIFF
--- a/apps/mesh/src/tools/reports/setup.test.ts
+++ b/apps/mesh/src/tools/reports/setup.test.ts
@@ -17,7 +17,7 @@ const fetchAuthMock = mock(
 mock.module("./auth-client", () => ({
   fetchCommerceDiscoveryAuth: fetchAuthMock,
   resolveCommerceDiscoveryMcpUrl: () =>
-    "https://commerce-skills.deco-cx.workers.dev/api/v2/mcp",
+    "https://reports-stg.decocms.com/api/v2/mcp",
 }));
 
 const { COMMERCE_DISCOVERY_SETUP } = await import("./setup");

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -38,11 +38,11 @@ export const WellKnownOrgMCPId = {
 // Public origin for the Commerce Discovery (reports) service. Deliberately the
 // stable custom domain, NOT the Cloudflare `workers.dev` URL, so the service can
 // move off Workers later by just repointing DNS — no code change or data
-// migration. Feeds two things: the write/claim path default (auth-client.ts uses
-// its .origin, overridable per-deploy via COMMERCE_DISCOVERY_INTERNAL_API_URL)
-// and the read-path "Store Report" connection URL (getWellKnownCommerceDiscovery
-// Connection below), which is not env-configurable — so keeping this a domain we
-// control is what keeps the whole integration portable.
+// migration. This is only the prod default: both the write/claim path
+// (auth-client.ts's .origin) and the read-path "Store Report" connection URL
+// (getWellKnownCommerceDiscoveryConnection below, via its connectionUrl param)
+// are overridable per-deploy through COMMERCE_DISCOVERY_INTERNAL_API_URL, so
+// staging derives both from reports-stg.decocms.com instead.
 export const COMMERCE_DISCOVERY_MCP_URL =
   "https://reports.decocms.com/api/v2/mcp";
 export const COMMERCE_DISCOVERY_REPORT_TOOL_NAME = "get_my_diagnostic";


### PR DESCRIPTION
## What is this contribution about?

Removed outdated workers.dev reference from test mock and clarified documentation in constants.ts. The test was mocking `resolveCommerceDiscoveryMcpUrl()` with the old `commerce-skills.deco-cx.workers.dev` URL, which doesn't match the current production/staging domains. Updated to `reports-stg.decocms.com` to reflect actual env-specific behavior.

Fixed stale comment that claimed the Commerce Discovery connection URL was "not env-configurable" — it actually is, via `COMMERCE_DISCOVERY_INTERNAL_API_URL`. This env var already controls both the internal write path (/upgrade, /bindings, /run) and the read path (MCP connection URL), so staging correctly uses `reports-stg.decocms.com` and prod uses `reports.decocms.com`. This fix was already shipped in PR #4644; this commit just clarifies the documentation.

## How to Test

- Verify `bun test apps/mesh/src/tools/reports/setup.test.ts` still passes (5 tests).
- Confirm the constant comment now accurately describes env-overridable behavior.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the stale workers.dev URL in the Commerce Discovery test mock with the current staging domain and corrected docs to reflect env-driven configuration.
Both the write/claim path and the MCP connection URL are overridable via `COMMERCE_DISCOVERY_INTERNAL_API_URL` (staging: reports-stg.decocms.com; prod: reports.decocms.com).

<sup>Written for commit ef13405786afa1f0c3384a4da9027afbc4a61202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

