### PR TITLE
feat(home): connected data tiles + tasks on the org home

### DIFF
--- a/apps/mesh/src/web/components/home/home-grid.tsx
+++ b/apps/mesh/src/web/components/home/home-grid.tsx
@@ -50,10 +50,11 @@ interface HomeGridProps {
   isEditMode: boolean;
 }
 
-// Default tile footprint before the user resizes it.
-const TILE_DEFAULT_SIZE = { w: 2, h: 4 } as const;
+// Default tile footprint before the user resizes it. w:3 keeps agent tiles at
+// half width on the 6-column grid (see tile-board/constants).
+const TILE_DEFAULT_SIZE = { w: 3, h: 4 } as const;
 const TILE_MIN_SIZE = { w: 1, h: 2 } as const;
-const PROMPT_DEFAULT_SIZE = { w: 1, h: 1 } as const;
+const PROMPT_DEFAULT_SIZE = { w: 2, h: 1 } as const;
 
 /** Stable, deterministic id so the persisted layout matches the same item
  *  on the next render. */

--- a/apps/mesh/src/web/components/home/home-tasks.tsx
+++ b/apps/mesh/src/web/components/home/home-tasks.tsx
@@ -1,0 +1,275 @@
+/**
+ * Home tasks panel — the fixed top of the Overview (not a tile).
+ *
+ * An agent summary line (the "resume", with the Super Agent icon) derived from
+ * the live task board, then the tasks that need attention as the same rows the
+ * kanban shows, with status tabs. Always present above the customizable card
+ * board (the metric tiles).
+ */
+import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { formatTimeAgo } from "@/web/lib/format-time";
+import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { ArrowUpRight, Calendar, Flag01, Plus } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import { useMembers } from "@/web/hooks/use-members";
+import {
+  useTaskBoardItemActions,
+  useTaskBoardItems,
+} from "@/web/hooks/use-task-board-items";
+import {
+  PRIORITY_CONFIG,
+  STATUS_CONFIG,
+  type TaskBoardItem,
+  type TaskBoardItemStatus,
+} from "@/web/layouts/task-board/config";
+import { TaskBoardItemDialog } from "@/web/layouts/task-board/task-dialog";
+
+/** Same asset as the Super Agent icon in getWellKnownDecopilotVirtualMCP. */
+const DECOPILOT_ICON_URL =
+  "https://assets.decocache.com/decocms/fd07a578-6b1c-40f1-bc05-88a3b981695d/f7fc4ffa81aec04e37ae670c3cd4936643a7b269.png";
+
+function DecoAvatar({ className }: { className?: string }) {
+  return (
+    <img
+      src={DECOPILOT_ICON_URL}
+      alt="Deco"
+      className={cn("size-4 shrink-0 rounded-full object-cover", className)}
+    />
+  );
+}
+
+interface OrgMember {
+  userId: string;
+  user?: { name?: string; email?: string; image?: string | null };
+}
+
+type TaskTab =
+  | "all"
+  | Extract<TaskBoardItemStatus, "in_progress" | "in_review" | "done">;
+
+const TASK_TABS: { id: TaskTab; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "in_progress", label: "In progress" },
+  { id: "in_review", label: "In review" },
+  { id: "done", label: "Done" },
+];
+
+/** Rows shown before the trailing "See all tasks" link. */
+const MAX_VISIBLE_TASKS = 4;
+
+function TaskRow({
+  task,
+  assignee,
+  onOpen,
+}: {
+  task: TaskBoardItem;
+  assignee?: OrgMember;
+  onOpen: () => void;
+}) {
+  const statusConfig = STATUS_CONFIG[task.status];
+  const StatusIcon = statusConfig.icon;
+  const priority = PRIORITY_CONFIG[task.priority];
+  const assigneeName =
+    assignee?.user?.name ?? assignee?.user?.email?.split("@")[0] ?? null;
+  const when = formatTimeAgo(new Date(task.updatedAt));
+  const due = task.dueDate
+    ? {
+        label: new Intl.DateTimeFormat(undefined, {
+          month: "short",
+          day: "numeric",
+        }).format(new Date(task.dueDate)),
+        overdue: new Date(task.dueDate).getTime() < Date.now(),
+      }
+    : null;
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex w-full items-center gap-3 rounded-2xl bg-card px-4 py-3.5 text-left card-shadow transition-colors hover:bg-accent/60"
+    >
+      <StatusIcon
+        className={cn("size-4 shrink-0", statusConfig.iconClassName)}
+      />
+      <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+        {task.title}
+      </span>
+      <div className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
+        {/* Tags the board card shows (assignee, priority, when), dropped
+            progressively as the panel narrows so the title keeps room. */}
+        <span className="hidden @2xl:inline-flex">
+          <Avatar
+            shape="circle"
+            size="2xs"
+            url={assignee?.user?.image ?? undefined}
+            fallback={(assigneeName ?? "?").slice(0, 2).toUpperCase()}
+          />
+        </span>
+        <Flag01 className={cn("size-3.5 shrink-0", priority.flagClassName)} />
+        {due && (
+          <span
+            className={cn(
+              "hidden items-center gap-1 @xl:inline-flex",
+              due.overdue ? "text-red-600" : "",
+            )}
+          >
+            <Calendar className="size-3" />
+            {due.label}
+          </span>
+        )}
+        <span className="hidden @xl:inline">{when}</span>
+      </div>
+    </button>
+  );
+}
+
+function buildSummary(tasks: TaskBoardItem[]): string {
+  const active = tasks.filter((t) => t.status !== "done");
+  if (active.length === 0) {
+    return "You're all caught up. Nothing needs your attention right now.";
+  }
+  const inProgress = active.filter((t) => t.status === "in_progress").length;
+  const inReview = active.filter((t) => t.status === "in_review").length;
+  const highPriority = active.filter(
+    (t) => t.priority === "urgent" || t.priority === "high",
+  ).length;
+  const overdue = active.filter(
+    (t) => t.dueDate && new Date(t.dueDate).getTime() < Date.now(),
+  ).length;
+
+  const breakdown: string[] = [];
+  if (inProgress > 0) breakdown.push(`${inProgress} in progress`);
+  if (inReview > 0)
+    breakdown.push(`${inReview} need${inReview === 1 ? "s" : ""} review`);
+
+  let lead = `You have ${active.length} active task${active.length === 1 ? "" : "s"}`;
+  if (breakdown.length > 0) lead += ` — ${breakdown.join(", ")}`;
+  lead += ".";
+
+  const notes: string[] = [];
+  if (highPriority > 0)
+    notes.push(
+      `${highPriority} ${highPriority === 1 ? "is" : "are"} high priority.`,
+    );
+  if (overdue > 0)
+    notes.push(`${overdue} task${overdue === 1 ? " is" : "s are"} overdue.`);
+
+  return notes.length > 0 ? `${lead} ${notes.join(" ")}` : lead;
+}
+
+export function HomeTasks() {
+  const navigate = useNavigate();
+  const { items, error } = useTaskBoardItems();
+  const actions = useTaskBoardItemActions();
+  const { data: membersData } = useMembers();
+  const members = (membersData?.data?.members ?? []) as OrgMember[];
+  const memberByUserId = new Map(members.map((m) => [m.userId, m] as const));
+  const [tab, setTab] = useState<TaskTab>("all");
+  const [createOpen, setCreateOpen] = useState(false);
+
+  // Task board can be off for an org (list errors) — treat as no tasks.
+  const tasks = error ? [] : items;
+  const sorted = [...tasks].sort((a, b) =>
+    (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""),
+  );
+  const summary = buildSummary(tasks);
+  const filtered =
+    tab === "all" ? sorted : sorted.filter((t) => t.status === tab);
+
+  // Open the task board in the main panel next to chat (same as the Tasks
+  // toolbar toggle).
+  const openBoard = () =>
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({ ...prev, main: "board" }),
+    });
+
+  return (
+    <div className="flex flex-col gap-10">
+      <div className="flex items-start gap-4 animate-in fade-in slide-in-from-top-1 duration-300">
+        <DecoAvatar className="mt-0.5 size-6" />
+        <p className="max-w-3xl text-lg font-medium leading-snug text-foreground">
+          {summary}
+        </p>
+      </div>
+
+      <section className="flex flex-col gap-4">
+        <div className="flex items-center gap-3">
+          <h2 className="text-base font-medium text-foreground">Tasks</h2>
+          <div className="flex items-center gap-1">
+            {TASK_TABS.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setTab(t.id)}
+                className={cn(
+                  "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                  tab === t.id
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 rounded-2xl bg-card px-4 py-10 text-center card-shadow">
+            <p className="text-sm text-muted-foreground">
+              {tab === "all"
+                ? "No tasks yet. Create one to get started."
+                : `Nothing ${tab === "in_progress" ? "in progress" : tab === "in_review" ? "in review" : "done"} right now.`}
+            </p>
+            {tab === "all" && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setCreateOpen(true)}
+                className="gap-2"
+              >
+                <Plus className="size-4" />
+                Create new task
+              </Button>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {filtered.slice(0, MAX_VISIBLE_TASKS).map((task) => (
+              <TaskRow
+                key={task.id}
+                task={task}
+                assignee={
+                  task.assigneeId
+                    ? memberByUserId.get(task.assigneeId)
+                    : undefined
+                }
+                onOpen={openBoard}
+              />
+            ))}
+            <button
+              type="button"
+              onClick={openBoard}
+              className="flex w-full items-center justify-center gap-1.5 rounded-2xl bg-card px-4 py-3 text-sm font-medium text-muted-foreground card-shadow transition-colors hover:bg-accent/60 hover:text-foreground"
+            >
+              See all tasks
+              <ArrowUpRight className="size-3.5" />
+            </button>
+          </div>
+        )}
+      </section>
+
+      <TaskBoardItemDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        isSaving={actions.create.isPending}
+        onSubmit={(input) => {
+          actions.create.mutate(input);
+          setCreateOpen(false);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/home/native-tiles.tsx
+++ b/apps/mesh/src/web/components/home/native-tiles.tsx
@@ -5,19 +5,38 @@
  * on/off state rides the board layout (see home-grid + the add-tile drawer's
  * "Built-in tiles" section).
  *
- * The default board is the four product tiles below: Tasks (real task-board
- * data) plus Coding / Analytics / Sales (visual mocks whose hover CTA invites
- * the user to connect the backing integration). Recent conversations is still
- * available but `defaultHidden` — re-add it from Customize.
+ * The default board is the home-redesign metric cards, each as its own tile:
+ * Pageviews / Sessions / Orders / Revenue (striped area charts) and Coding (a
+ * GitHub contributions calendar). Each tile shows the card design with a sample
+ * preview and a hover "Connect" that runs the real connect flow for its backing
+ * integration (Google Analytics / VTEX·Shopify / GitHub); once connected it
+ * shows real data (GitHub PRs) or an honest placeholder. Tasks is NOT a tile —
+ * it's the fixed section above the board (see home-tasks + overview-tab).
+ * Recent conversations is available but `defaultHidden` — re-add from Customize.
+ *
+ * The board wraps every tile in `bg-card card-shadow rounded-2xl`, so each tile
+ * body is just the card interior (label + content), matching the redesign.
  */
-import { Suspense, useState } from "react";
+import { Suspense, useId, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { formatDistanceToNow } from "date-fns";
+import { formatTimeAgo } from "@/web/lib/format-time";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@deco/ui/components/chart.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
+  ArrowUpRight,
   BarChart10,
   CheckCircle,
   GitBranch01,
@@ -25,22 +44,27 @@ import {
   MessageChatCircle,
   ShoppingCart01,
 } from "@untitledui/icons";
+import { Area, AreaChart, XAxis } from "recharts";
 import { useConnections, useProjectContext } from "@decocms/mesh-sdk";
 import { getOrgGithubConnections } from "@/shared/github-repo-scope";
+import { useConnectApp } from "@/web/hooks/use-connect-app";
 import { useGithubRecentPrs } from "@/web/hooks/use-github-recent-prs";
+import {
+  useGithubContributions,
+  CONTRIB_WEEKS,
+  type ContribGrid,
+} from "@/web/hooks/use-github-contributions";
 import { useStudioTools } from "@/web/lib/studio-tools";
 import { useMembers } from "@/web/hooks/use-members";
-import { useTaskBoardItems } from "@/web/hooks/use-task-board-items";
-import { STATUS_CONFIG } from "@/web/layouts/task-board/config";
 import { GitHubIcon } from "@/web/components/icons/github-icon";
 import { AddConnectionDialog } from "@/web/views/virtual-mcp/add-connection-dialog";
-import { useConnectApp } from "@/web/hooks/use-connect-app";
 import { KEYS } from "@/web/lib/query-keys";
 
-const TASKS_TILE_ID = "tasks";
+const PAGEVIEWS_TILE_ID = "pageviews";
+const SESSIONS_TILE_ID = "sessions";
+const ORDERS_TILE_ID = "orders";
 const CODING_TILE_ID = "coding";
-const ANALYTICS_TILE_ID = "analytics";
-const SALES_TILE_ID = "sales";
+const REVENUE_TILE_ID = "revenue";
 const RECENT_CONVERSATIONS_TILE_ID = "recent-conversations";
 
 export interface NativeTileDef {
@@ -53,38 +77,46 @@ export interface NativeTileDef {
   defaultHidden?: boolean;
 }
 
-/** Native tiles offered on the home board, in display order. The first four
- *  form the default board (2×2 in the 4-col grid). */
+/** Native tiles offered on the home board, in display order. All but Recent
+ *  conversations form the default board on the 6-column grid: three cards
+ *  across (Pageviews + Sessions + Orders, w:2 each), then Revenue + Coding
+ *  below at half width (w:3 each). */
 export const NATIVE_TILES: NativeTileDef[] = [
   {
-    id: TASKS_TILE_ID,
-    title: "Tasks",
-    defaultSize: { w: 2, h: 4 },
+    id: PAGEVIEWS_TILE_ID,
+    title: "Pageviews",
+    defaultSize: { w: 2, h: 3 },
+    minSize: { w: 1, h: 2 },
+  },
+  {
+    id: SESSIONS_TILE_ID,
+    title: "Sessions",
+    defaultSize: { w: 2, h: 3 },
+    minSize: { w: 1, h: 2 },
+  },
+  {
+    id: ORDERS_TILE_ID,
+    title: "Orders",
+    defaultSize: { w: 2, h: 3 },
+    minSize: { w: 1, h: 2 },
+  },
+  {
+    id: REVENUE_TILE_ID,
+    title: "Revenue",
+    defaultSize: { w: 3, h: 3 },
     minSize: { w: 2, h: 2 },
   },
   {
     id: CODING_TILE_ID,
     title: "Coding",
-    defaultSize: { w: 2, h: 4 },
-    minSize: { w: 2, h: 2 },
-  },
-  {
-    id: ANALYTICS_TILE_ID,
-    title: "Analytics",
-    defaultSize: { w: 2, h: 4 },
-    minSize: { w: 2, h: 2 },
-  },
-  {
-    id: SALES_TILE_ID,
-    title: "Sales",
-    defaultSize: { w: 2, h: 4 },
+    defaultSize: { w: 3, h: 3 },
     minSize: { w: 2, h: 2 },
   },
   {
     id: RECENT_CONVERSATIONS_TILE_ID,
     title: "Recent conversations",
-    // Full width (grid is 4 cols) × 4 rows.
-    defaultSize: { w: 4, h: 4 },
+    // Full width (grid is 6 cols) × 4 rows.
+    defaultSize: { w: 6, h: 4 },
     minSize: { w: 2, h: 2 },
     defaultHidden: true,
   },
@@ -93,6 +125,386 @@ export const NATIVE_TILES: NativeTileDef[] = [
 /** The board candidate id for a native tile. */
 export function nativeCandidateId(nativeId: string): string {
   return `native:${nativeId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Metric chart — recharts area chart with a vertical-line fill pattern.
+// ---------------------------------------------------------------------------
+
+interface MetricPoint {
+  label: string;
+  value: number;
+}
+
+function MetricChart({
+  points,
+  metricLabel,
+}: {
+  points: MetricPoint[];
+  metricLabel: string;
+}) {
+  const patternId = useId().replace(/:/g, "");
+  const color = "var(--success)";
+  return (
+    <ChartContainer
+      config={{ value: { label: metricLabel, color } }}
+      className="h-full w-full"
+    >
+      <AreaChart
+        data={points}
+        margin={{ top: 6, right: 0, bottom: 0, left: 0 }}
+      >
+        <defs>
+          <pattern
+            id={patternId}
+            width={6}
+            height={8}
+            patternUnits="userSpaceOnUse"
+          >
+            <line
+              x1={0}
+              y1={0}
+              x2={0}
+              y2={8}
+              stroke={color}
+              strokeOpacity={0.22}
+              strokeWidth={4}
+            />
+          </pattern>
+        </defs>
+        <XAxis dataKey="label" hide />
+        <ChartTooltip
+          cursor={{ stroke: "var(--border)" }}
+          content={<ChartTooltipContent indicator="line" />}
+        />
+        <Area
+          type="monotone"
+          dataKey="value"
+          stroke={color}
+          strokeWidth={2}
+          fill={`url(#${patternId})`}
+          fillOpacity={1}
+          animationDuration={350}
+          dot={false}
+          activeDot={{
+            r: 4,
+            fill: color,
+            stroke: "var(--background)",
+            strokeWidth: 2,
+          }}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}
+
+interface MetricConfig {
+  value: string;
+  delta: string;
+  series: number[];
+}
+
+const METRIC_CONFIG: Record<string, MetricConfig> = {
+  pageviews: {
+    value: "12.2k",
+    delta: "+1.9%",
+    series: [
+      9800, 10100, 9950, 10600, 10400, 11000, 11200, 11500, 11900, 12200,
+    ],
+  },
+  sessions: {
+    value: "3.2k",
+    delta: "+25.6%",
+    series: [2100, 2250, 2200, 2500, 2600, 2750, 2900, 3000, 3100, 3200],
+  },
+  orders: {
+    value: "142",
+    delta: "+8.4%",
+    series: [96, 102, 99, 110, 108, 118, 124, 131, 137, 142],
+  },
+  revenue: {
+    value: "$8,240",
+    delta: "+12.0%",
+    series: [6100, 6400, 6250, 6800, 6700, 7100, 7400, 7700, 8000, 8240],
+  },
+};
+
+function toPoints(data: number[]): MetricPoint[] {
+  return data.map((value, i) => {
+    const daysAgo = data.length - 1 - i;
+    const label =
+      daysAgo === 0 ? "Today" : daysAgo === 1 ? "Yesterday" : `${daysAgo}d ago`;
+    return { label, value };
+  });
+}
+
+function MetricValue({ value, delta }: { value: string; delta: string }) {
+  return (
+    <div className="mt-3 flex items-center gap-2.5">
+      <span className="text-2xl font-medium tabular-nums text-foreground">
+        {value}
+      </span>
+      <span className="inline-flex items-center gap-1 text-sm font-medium tabular-nums text-success">
+        <ArrowUpRight className="size-4" />
+        {delta}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Contributions grid — a GitHub-style commit heatmap (the "collab calendar").
+// ---------------------------------------------------------------------------
+
+/** Fake deterministic data shown before GitHub is connected. */
+function mockCommitsAt(week: number, day: number): number {
+  const h = (week * 31 + day * 17 + 7) % 100;
+  if (h < 38) return 0;
+  if (h < 60) return 1 + (h % 2);
+  if (h < 80) return 3 + (h % 3);
+  if (h < 93) return 6 + (h % 3);
+  return 9 + (h % 4);
+}
+
+function contribLevelClass(count: number): string {
+  if (count === 0) return "bg-muted-foreground/15";
+  if (count <= 2) return "bg-success/25";
+  if (count <= 5) return "bg-success/45";
+  if (count <= 8) return "bg-success/70";
+  return "bg-success";
+}
+
+function ContributionsGrid({ grid }: { grid?: ContribGrid }) {
+  return (
+    <TooltipProvider delayDuration={0}>
+      <div
+        className="grid w-full gap-1"
+        style={{ gridTemplateColumns: `repeat(${CONTRIB_WEEKS}, 1fr)` }}
+      >
+        {Array.from({ length: CONTRIB_WEEKS }, (_, week) => (
+          <div key={week} className="flex flex-col gap-1">
+            {Array.from({ length: 5 }, (_, day) => {
+              const count = grid
+                ? (grid[week]?.[day] ?? 0)
+                : mockCommitsAt(week, day);
+              return (
+                <Tooltip key={day}>
+                  <TooltipTrigger asChild>
+                    <div
+                      className={cn(
+                        "aspect-square rounded-[2px]",
+                        contribLevelClass(count),
+                      )}
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {count === 0
+                      ? "No commits"
+                      : `${count} commit${count === 1 ? "" : "s"}`}
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </TooltipProvider>
+  );
+}
+
+/** Soft always-visible overlay with a connect button over the preview chart. */
+function ConnectOverlay({
+  label,
+  icon,
+  onConnect,
+  pending,
+}: {
+  label: string;
+  icon: React.ReactNode;
+  onConnect: () => void;
+  pending?: boolean;
+}) {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-background/30 backdrop-blur-[2px]">
+      <Button
+        size="sm"
+        onClick={onConnect}
+        disabled={pending}
+        className="gap-2 shadow-sm"
+      >
+        {pending ? <Loading01 className="size-4 animate-spin" /> : icon}
+        {label}
+      </Button>
+    </div>
+  );
+}
+
+/** Connected but the source's reporting isn't wired yet. Honest placeholder,
+ *  never a fabricated number. */
+function ConnectedSoon({ label }: { label: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
+      <CheckCircle className="size-6 text-success/60" />
+      <p className="text-xs text-muted-foreground">
+        {label} connected. Live data coming soon.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Analytics metric tiles (Google Analytics) — Pageviews / Sessions
+// ---------------------------------------------------------------------------
+
+function AnalyticsMetricTile({
+  metricKey,
+}: {
+  metricKey: keyof typeof METRIC_CONFIG;
+}) {
+  const connected = useConnections({ slug: "google-analytics" }).length > 0;
+  const { connect, isConnecting } = useConnectApp("deco/google-analytics");
+  const cfg = METRIC_CONFIG[metricKey];
+  if (connected || !cfg) return <ConnectedSoon label="Analytics" />;
+  return (
+    <div className="relative flex h-full flex-col">
+      <div className="min-h-0 flex-1">
+        <MetricChart points={toPoints(cfg.series)} metricLabel={metricKey} />
+      </div>
+      <MetricValue value={cfg.value} delta={cfg.delta} />
+      <ConnectOverlay
+        label="Connect Google Analytics"
+        icon={<BarChart10 className="size-4" />}
+        onConnect={connect}
+        pending={isConnecting}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Commerce metric tiles (VTEX or Shopify) — Orders / Revenue
+// ---------------------------------------------------------------------------
+
+function CommerceMetricTile({
+  metricKey,
+}: {
+  metricKey: keyof typeof METRIC_CONFIG;
+}) {
+  const connected =
+    useConnections({ slug: "vtex" }).length > 0 ||
+    useConnections({ slug: "shopify" }).length > 0;
+  const [open, setOpen] = useState(false);
+  const cfg = METRIC_CONFIG[metricKey];
+  if (connected || !cfg) return <ConnectedSoon label="Commerce" />;
+  return (
+    <>
+      <div className="relative flex h-full flex-col">
+        <div className="min-h-0 flex-1">
+          <MetricChart points={toPoints(cfg.series)} metricLabel={metricKey} />
+        </div>
+        <MetricValue value={cfg.value} delta={cfg.delta} />
+        <ConnectOverlay
+          label="Connect commerce platform"
+          icon={<ShoppingCart01 className="size-4" />}
+          onConnect={() => setOpen(true)}
+        />
+      </div>
+      <AddConnectionDialog
+        mode="browse"
+        open={open}
+        onOpenChange={setOpen}
+        defaultTab="all"
+        initialSearch="shopify vtex"
+      />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Coding tile (GitHub) — contributions calendar + headline; real PRs once
+// connected.
+// ---------------------------------------------------------------------------
+
+function CodingTileBody() {
+  const connection = getOrgGithubConnections(
+    useConnections({ slug: "mcp-github" }),
+  )[0];
+  return connection ? (
+    <CodingConnected connectionId={connection.id} />
+  ) : (
+    <CodingDisconnected />
+  );
+}
+
+function CodingDisconnected() {
+  const { connect, isConnecting } = useConnectApp("deco/mcp-github");
+  return (
+    <div className="relative flex h-full flex-col">
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ContributionsGrid />
+      </div>
+      <ConnectOverlay
+        label="Connect GitHub"
+        icon={<GitHubIcon className="size-4" />}
+        onConnect={connect}
+        pending={isConnecting}
+      />
+    </div>
+  );
+}
+
+function CodingConnected({ connectionId }: { connectionId: string }) {
+  const { data, isLoading } = useGithubRecentPrs(connectionId);
+  const { data: grid } = useGithubContributions(connectionId);
+  return (
+    <div className="flex h-full flex-col gap-3 overflow-hidden">
+      <ContributionsGrid grid={grid} />
+      {isLoading ? (
+        <div className="flex flex-col gap-1.5">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div
+              key={`pr-skeleton-${i}`}
+              className="h-5 w-full animate-pulse rounded-md bg-muted/40"
+            />
+          ))}
+        </div>
+      ) : !data || data.prs.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          {data?.repo ? `${data.repo} · ` : ""}No recent pull requests.
+        </p>
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto">
+          {data.repo && (
+            <div className="truncate text-xs text-muted-foreground">
+              {data.repo}
+            </div>
+          )}
+          {data.prs.map((pr) => (
+            <a
+              key={pr.number}
+              href={pr.htmlUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-2 rounded-md px-1.5 py-1.5 text-sm transition-colors hover:bg-accent/60"
+            >
+              <GitBranch01 className="size-4 shrink-0 text-muted-foreground" />
+              <span className="truncate text-foreground">{pr.title}</span>
+              <span
+                className={cn(
+                  "ml-auto shrink-0 rounded-full px-1.5 py-0.5 text-xs font-medium",
+                  pr.merged
+                    ? "bg-success/10 text-success"
+                    : "bg-muted text-muted-foreground",
+                )}
+              >
+                #{pr.number}
+              </span>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -142,7 +554,7 @@ function RecentConversationsList() {
 
   if (threads.length === 0) {
     return (
-      <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
         <MessageChatCircle className="size-6 text-muted-foreground/50" />
         <p className="text-xs text-muted-foreground">
           No conversations yet. Start one and it'll show up here for your team.
@@ -152,16 +564,14 @@ function RecentConversationsList() {
   }
 
   return (
-    <div className="flex flex-col gap-0.5 overflow-y-auto p-1.5">
+    <div className="flex h-full flex-col gap-0.5 overflow-y-auto">
       {threads.map((thread) => {
         const member = memberByUserId.get(thread.created_by);
         const authorName =
           member?.user?.name ?? member?.user?.email?.split("@")[0] ?? "Someone";
         const status = thread.status ? STATUS_LABEL[thread.status] : undefined;
         const when = thread.updated_at
-          ? formatDistanceToNow(new Date(thread.updated_at), {
-              addSuffix: true,
-            })
+          ? formatTimeAgo(new Date(thread.updated_at))
           : null;
         return (
           <button
@@ -206,441 +616,49 @@ function RecentConversationsList() {
 }
 
 // ---------------------------------------------------------------------------
-// Tasks (real task-board data)
-// ---------------------------------------------------------------------------
-
-function TasksTileBody() {
-  const { org } = useProjectContext();
-  const navigate = useNavigate();
-  const { items, isLoading, error } = useTaskBoardItems();
-
-  const openBoard = () =>
-    navigate({ to: "/$org/board", params: { org: org.slug } });
-
-  if (isLoading) {
-    return (
-      <div className="flex flex-col gap-2 p-3">
-        {Array.from({ length: 4 }, (_, i) => (
-          <div
-            key={`task-skeleton-${i}`}
-            className="h-6 w-full animate-pulse rounded-md bg-muted/40"
-          />
-        ))}
-      </div>
-    );
-  }
-
-  // An error usually means the task board is off for this org; either way,
-  // show the empty affordance rather than a scary error.
-  if (error || items.length === 0) {
-    return (
-      <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
-        <CheckCircle className="size-6 text-muted-foreground/50" />
-        <p className="text-xs text-muted-foreground">No tasks yet.</p>
-        <Button size="sm" variant="ghost" onClick={openBoard} className="h-7">
-          Open task board
-        </Button>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col gap-0.5 overflow-y-auto p-1.5">
-      {items.slice(0, 8).map((item) => {
-        const cfg = STATUS_CONFIG[item.status];
-        const Icon = cfg.icon;
-        return (
-          <button
-            key={item.id}
-            type="button"
-            onClick={openBoard}
-            className="flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left transition-colors hover:bg-accent/60"
-          >
-            <Icon className={cn("size-4 shrink-0", cfg.iconClassName)} />
-            <span className="truncate text-sm text-foreground">
-              {item.title}
-            </span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Product tiles — Coding / Analytics / Sales.
-//
-// Disconnected: sample data behind a hover "Connect" overlay (GitHub / Google
-// Analytics connect directly; Sales opens the catalog for VTEX or Shopify).
-// Connected: Coding shows real recent PRs; Analytics / Sales show a "live data
-// coming soon" placeholder until their reporting tools are wired.
-// ---------------------------------------------------------------------------
-
-function TileSkeleton() {
-  return (
-    <div className="flex flex-col gap-2 p-3">
-      {Array.from({ length: 4 }, (_, i) => (
-        <div
-          key={`tile-skeleton-${i}`}
-          className="h-6 w-full animate-pulse rounded-md bg-muted/40"
-        />
-      ))}
-    </div>
-  );
-}
-
-function ComingSoonPanel({ label }: { label: string }) {
-  return (
-    <div className="flex h-full flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
-      <CheckCircle className="size-6 text-success/60" />
-      <p className="text-xs text-muted-foreground">
-        {label} connected. Live data coming soon.
-      </p>
-    </div>
-  );
-}
-
-function MockConnectOverlay({
-  label,
-  icon,
-  onConnect,
-  pending,
-}: {
-  label: string;
-  icon: React.ReactNode;
-  onConnect: () => void;
-  pending?: boolean;
-}) {
-  return (
-    <div className="absolute inset-0 flex items-center justify-center bg-background/70 opacity-0 backdrop-blur-sm transition-opacity duration-150 group-hover/mock:opacity-100">
-      <Button
-        size="sm"
-        variant="secondary"
-        className="gap-2 shadow-sm"
-        onClick={onConnect}
-        disabled={pending}
-      >
-        {pending ? <Loading01 className="size-4 animate-spin" /> : icon}
-        {label}
-      </Button>
-    </div>
-  );
-}
-
-/** Presentational mock-tile shell: sample content + hover connect overlay. */
-function MockTile({
-  children,
-  connectLabel,
-  connectIcon,
-  onConnect,
-  pending,
-}: {
-  children: React.ReactNode;
-  connectLabel: string;
-  connectIcon: React.ReactNode;
-  onConnect: () => void;
-  pending?: boolean;
-}) {
-  return (
-    <div className="group/mock relative flex h-full flex-col overflow-hidden">
-      <div className="flex flex-1 flex-col p-3">{children}</div>
-      <MockConnectOverlay
-        label={connectLabel}
-        icon={connectIcon}
-        onConnect={onConnect}
-        pending={pending}
-      />
-    </div>
-  );
-}
-
-/** A tiny deterministic contributions grid (7 rows × 14 weeks). Static
- *  classes so Tailwind keeps the opacity variants. */
-const CONTRIB_LEVEL_CLASS = [
-  "bg-foreground/10",
-  "bg-foreground/25",
-  "bg-foreground/45",
-  "bg-foreground/70",
-];
-function ContributionsGrid() {
-  return (
-    <div className="flex gap-1">
-      {Array.from({ length: 14 }, (_, col) => (
-        <div key={`col-${col}`} className="flex flex-col gap-1">
-          {Array.from({ length: 7 }, (_, row) => {
-            // Deterministic pseudo-pattern — stable render, no randomness.
-            const cls = CONTRIB_LEVEL_CLASS[(col * 7 + row) % 4];
-            return (
-              <div
-                key={`cell-${col}-${row}`}
-                className={cn("size-2 rounded-[2px]", cls)}
-              />
-            );
-          })}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-const MOCK_PRS = [
-  { id: 128, title: "Fix checkout flow", state: "merged" },
-  { id: 127, title: "Add product search", state: "open" },
-  { id: 126, title: "Bump deps", state: "merged" },
-];
-
-function CodingTileBody() {
-  return (
-    <Suspense fallback={<TileSkeleton />}>
-      <CodingTileInner />
-    </Suspense>
-  );
-}
-
-function CodingTileInner() {
-  const connection = getOrgGithubConnections(
-    useConnections({ slug: "mcp-github" }),
-  )[0];
-  return connection ? (
-    <CodingConnected connectionId={connection.id} />
-  ) : (
-    <CodingMock />
-  );
-}
-
-function CodingMock() {
-  const { connect, isConnecting } = useConnectApp("deco/mcp-github");
-  return (
-    <MockTile
-      connectLabel="Connect GitHub"
-      connectIcon={<GitHubIcon className="size-4" />}
-      onConnect={connect}
-      pending={isConnecting}
-    >
-      <ContributionsGrid />
-      <div className="mt-3 flex flex-col gap-1.5">
-        {MOCK_PRS.map((pr) => (
-          <div key={pr.id} className="flex items-center gap-2 text-xs">
-            <GitBranch01 className="size-3.5 shrink-0 text-muted-foreground" />
-            <span className="truncate text-foreground">{pr.title}</span>
-            <span
-              className={cn(
-                "ml-auto shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
-                pr.state === "merged"
-                  ? "bg-success/10 text-success"
-                  : "bg-muted text-muted-foreground",
-              )}
-            >
-              #{pr.id}
-            </span>
-          </div>
-        ))}
-      </div>
-    </MockTile>
-  );
-}
-
-function CodingConnected({ connectionId }: { connectionId: string }) {
-  const { data, isLoading } = useGithubRecentPrs(connectionId);
-  if (isLoading) return <TileSkeleton />;
-  if (!data || data.prs.length === 0) return <ComingSoonPanel label="Coding" />;
-  return (
-    <div className="flex h-full flex-col overflow-y-auto p-3">
-      {data.repo && (
-        <div className="mb-2 truncate text-xs text-muted-foreground">
-          {data.repo}
-        </div>
-      )}
-      <div className="flex flex-col gap-0.5">
-        {data.prs.map((pr) => (
-          <a
-            key={pr.number}
-            href={pr.htmlUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="flex items-center gap-2 rounded-md px-1.5 py-1 text-xs transition-colors hover:bg-accent/60"
-          >
-            <GitBranch01 className="size-3.5 shrink-0 text-muted-foreground" />
-            <span className="truncate text-foreground">{pr.title}</span>
-            <span
-              className={cn(
-                "ml-auto shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
-                pr.merged
-                  ? "bg-success/10 text-success"
-                  : "bg-muted text-muted-foreground",
-              )}
-            >
-              #{pr.number}
-            </span>
-          </a>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-const MOCK_SPARKLINE = [8, 12, 10, 16, 14, 20, 18, 26, 24, 30];
-function Sparkline() {
-  const max = Math.max(...MOCK_SPARKLINE);
-  const pts = MOCK_SPARKLINE.map((v, i) => {
-    const x = (i / (MOCK_SPARKLINE.length - 1)) * 100;
-    const y = 32 - (v / max) * 30;
-    return `${x},${y}`;
-  }).join(" ");
-  return (
-    <svg
-      viewBox="0 0 100 32"
-      preserveAspectRatio="none"
-      className="h-10 w-full text-foreground/70"
-      aria-hidden
-    >
-      <polyline
-        points={pts}
-        fill="none"
-        stroke="currentColor"
-        strokeWidth={1.5}
-        vectorEffect="non-scaling-stroke"
-      />
-    </svg>
-  );
-}
-
-function StatNumber({ value, label }: { value: string; label: string }) {
-  return (
-    <div className="flex flex-col">
-      <span className="text-lg font-semibold text-foreground">{value}</span>
-      <span className="text-xs text-muted-foreground">{label}</span>
-    </div>
-  );
-}
-
-function AnalyticsTileBody() {
-  return (
-    <Suspense fallback={<TileSkeleton />}>
-      <AnalyticsTileInner />
-    </Suspense>
-  );
-}
-
-function AnalyticsTileInner() {
-  const connected = useConnections({ slug: "google-analytics" }).length > 0;
-  return connected ? <ComingSoonPanel label="Analytics" /> : <AnalyticsMock />;
-}
-
-function AnalyticsMock() {
-  const { connect, isConnecting } = useConnectApp("deco/google-analytics");
-  return (
-    <MockTile
-      connectLabel="Connect Google Analytics"
-      connectIcon={<BarChart10 className="size-4" />}
-      onConnect={connect}
-      pending={isConnecting}
-    >
-      <div className="flex gap-6">
-        <StatNumber value="12.4k" label="Pageviews" />
-        <StatNumber value="3.2k" label="Sessions" />
-      </div>
-      <div className="mt-auto pt-3">
-        <Sparkline />
-      </div>
-    </MockTile>
-  );
-}
-
-const MOCK_BARS = [40, 65, 50, 80, 70, 95, 60];
-function BarChartMock() {
-  const max = Math.max(...MOCK_BARS);
-  return (
-    <div className="flex h-12 items-end gap-1.5">
-      {MOCK_BARS.map((v, i) => (
-        <div
-          key={`bar-${i}`}
-          className="flex-1 rounded-t-sm bg-foreground/60"
-          style={{ height: `${(v / max) * 100}%` }}
-        />
-      ))}
-    </div>
-  );
-}
-
-function SalesTileBody() {
-  return (
-    <Suspense fallback={<TileSkeleton />}>
-      <SalesTileInner />
-    </Suspense>
-  );
-}
-
-function SalesTileInner() {
-  // Sales is backed by either provider — connected if either is present.
-  const vtex = useConnections({ slug: "vtex" });
-  const shopify = useConnections({ slug: "shopify" });
-  const connected = vtex.length > 0 || shopify.length > 0;
-  return connected ? <ComingSoonPanel label="Sales" /> : <SalesMock />;
-}
-
-function SalesMock() {
-  // VTEX or Shopify — the user picks, so open the catalog rather than
-  // connecting a single app directly.
-  const [open, setOpen] = useState(false);
-  return (
-    <>
-      <MockTile
-        connectLabel="Connect VTEX or Shopify"
-        connectIcon={<ShoppingCart01 className="size-4" />}
-        onConnect={() => setOpen(true)}
-      >
-        <div className="flex gap-6">
-          <StatNumber value="$8,240" label="Revenue" />
-          <StatNumber value="142" label="Orders" />
-        </div>
-        <div className="mt-auto pt-3">
-          <BarChartMock />
-        </div>
-      </MockTile>
-      <AddConnectionDialog
-        mode="browse"
-        open={open}
-        onOpenChange={setOpen}
-        defaultTab="all"
-        initialSearch="shopify vtex"
-      />
-    </>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Registry renderer
 // ---------------------------------------------------------------------------
 
+function NativeTileBody({ nativeId }: { nativeId: string }) {
+  switch (nativeId) {
+    case PAGEVIEWS_TILE_ID:
+      return <AnalyticsMetricTile metricKey="pageviews" />;
+    case SESSIONS_TILE_ID:
+      return <AnalyticsMetricTile metricKey="sessions" />;
+    case ORDERS_TILE_ID:
+      return <CommerceMetricTile metricKey="orders" />;
+    case REVENUE_TILE_ID:
+      return <CommerceMetricTile metricKey="revenue" />;
+    case CODING_TILE_ID:
+      return <CodingTileBody />;
+    case RECENT_CONVERSATIONS_TILE_ID:
+      return (
+        <Suspense
+          fallback={<div className="h-full animate-pulse bg-muted/30" />}
+        >
+          <RecentConversationsList />
+        </Suspense>
+      );
+    default:
+      return null;
+  }
+}
+
 /**
- * Renders a native tile's body by id. Unknown ids render nothing (the tile
- * still occupies its cell, but degrades gracefully). Chrome (drag handle,
- * remove menu) is supplied by the board in edit mode, same as any tile.
+ * Renders a native tile by id. The board supplies the card frame
+ * (`bg-card card-shadow rounded-2xl`) and edit-mode chrome, so this is just the
+ * card interior — a label + body, matching the home-redesign card design.
+ * Unknown ids render nothing (the tile still occupies its cell).
  */
 export function NativeTile({ nativeId }: { nativeId: string }) {
   const def = NATIVE_TILES.find((t) => t.id === nativeId);
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-xl border border-border bg-background">
-      <div className="shrink-0 border-b border-border/60 px-3 py-2 text-xs font-medium text-muted-foreground">
+    <div className="flex h-full flex-col overflow-hidden p-4">
+      <span className="shrink-0 text-xs font-medium text-muted-foreground">
         {def?.title ?? "Tile"}
-      </div>
-      <div className="min-h-0 flex-1 overflow-hidden">
-        {nativeId === RECENT_CONVERSATIONS_TILE_ID ? (
-          <Suspense
-            fallback={<div className="h-full animate-pulse bg-muted/30" />}
-          >
-            <RecentConversationsList />
-          </Suspense>
-        ) : nativeId === TASKS_TILE_ID ? (
-          <TasksTileBody />
-        ) : nativeId === CODING_TILE_ID ? (
-          <CodingTileBody />
-        ) : nativeId === ANALYTICS_TILE_ID ? (
-          <AnalyticsTileBody />
-        ) : nativeId === SALES_TILE_ID ? (
-          <SalesTileBody />
-        ) : null}
+      </span>
+      <div className="relative mt-2 min-h-0 flex-1">
+        <NativeTileBody nativeId={nativeId} />
       </div>
     </div>
   );

--- a/apps/mesh/src/web/components/home/tile-board/constants.ts
+++ b/apps/mesh/src/web/components/home/tile-board/constants.ts
@@ -1,12 +1,14 @@
-/** 4-column home-board grid; tiles snap to a discrete preset list. */
+/** 6-column home-board grid; tiles snap to a discrete preset list. Six columns
+ *  so the default metric board reads as three cards across (w:2 each) with the
+ *  wider tiles below at half width (w:3). */
 
 import type { TileSize } from "./types";
 
-export const GRID_COLS = 4;
+export const GRID_COLS = 6;
 export const ROW_HEIGHT_PX = 100;
 export const GRID_GAP_PX = 12;
 
 /** Tallest a tile may grow in the resize menu. */
 export const MAX_TILE_ROWS = 5;
 
-export const DEFAULT_SIZE: TileSize = { w: 2, h: 2 };
+export const DEFAULT_SIZE: TileSize = { w: 3, h: 2 };

--- a/apps/mesh/src/web/hooks/use-github-contributions.ts
+++ b/apps/mesh/src/web/hooks/use-github-contributions.ts
@@ -1,0 +1,113 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
+import { fetchGithubInstallations } from "@/web/lib/github-installations";
+import { KEYS } from "@/web/lib/query-keys";
+
+export const CONTRIB_WEEKS = 26;
+const CONTRIB_DAYS = 7;
+
+export type ContribGrid = number[][];
+
+interface RepoSummary {
+  full_name: string;
+  updated_at: string;
+}
+
+interface GitHubCommit {
+  commit?: {
+    committer?: { date?: string };
+    author?: { date?: string };
+  };
+}
+
+export function useGithubContributions(connectionId: string) {
+  const { org } = useProjectContext();
+  const self = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const github = useMCPClient({
+    connectionId,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+
+  return useQuery({
+    queryKey: KEYS.homeGithubContributions(org.id, connectionId),
+    queryFn: async (): Promise<ContribGrid> => {
+      const { installations } = await fetchGithubInstallations(
+        (req) => self.callTool(req),
+        connectionId,
+      );
+      const inst = installations[0];
+      if (!inst) return emptyGrid();
+
+      const qualifier = inst.type === "User" ? "user" : "org";
+      const reposRes = await github.callTool({
+        name: "search_repositories",
+        arguments: {
+          query: `${qualifier}:${inst.login}`,
+          page: 1,
+          perPage: 30,
+        },
+      });
+      const reposText = (reposRes as { content?: Array<{ text?: string }> })
+        .content?.[0]?.text;
+      const repos: RepoSummary[] = reposText
+        ? ((JSON.parse(reposText).items ?? []) as RepoSummary[])
+        : [];
+      const top = [...repos].sort((a, b) =>
+        (b.updated_at ?? "").localeCompare(a.updated_at ?? ""),
+      )[0];
+      if (!top?.full_name) return emptyGrid();
+
+      const [owner, repo] = top.full_name.split("/");
+      const since = new Date(Date.now() - CONTRIB_WEEKS * 7 * 86400000);
+
+      const commitsRes = await github.callTool({
+        name: "list_commits",
+        arguments: {
+          owner,
+          repo,
+          since: since.toISOString(),
+          perPage: 100,
+        },
+      });
+      const commitsText = (commitsRes as { content?: Array<{ text?: string }> })
+        .content?.[0]?.text;
+      const commits: GitHubCommit[] = commitsText
+        ? (JSON.parse(commitsText) as GitHubCommit[])
+        : [];
+
+      const grid = emptyGrid();
+      const now = Date.now();
+
+      for (const c of commits) {
+        const raw = c.commit?.committer?.date ?? c.commit?.author?.date ?? "";
+        const date = new Date(raw);
+        if (isNaN(date.getTime())) continue;
+        const daysAgo = Math.floor((now - date.getTime()) / 86400000);
+        if (daysAgo < 0 || daysAgo >= CONTRIB_WEEKS * 7) continue;
+        const weekIdx = CONTRIB_WEEKS - 1 - Math.floor(daysAgo / 7);
+        const dayIdx = date.getDay();
+        const week = grid[weekIdx];
+        if (week) week[dayIdx] = (week[dayIdx] ?? 0) + 1;
+      }
+
+      return grid;
+    },
+    staleTime: 300_000,
+    retry: false,
+  });
+}
+
+function emptyGrid(): ContribGrid {
+  return Array.from({ length: CONTRIB_WEEKS }, () =>
+    Array.from({ length: CONTRIB_DAYS }, () => 0),
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/overview-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/overview-tab.tsx
@@ -14,13 +14,14 @@
 import { useState } from "react";
 import { Check, LayoutAlt04, Plus, X } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
-import { useProjectContext } from "@decocms/mesh-sdk";
 import {
   HomeEditProvider,
   useHomeEdit,
 } from "@/web/components/home/home-edit-context";
 import { HomeGrid } from "@/web/components/home/home-grid";
 import { AddTileDrawer } from "@/web/components/home/add-tile-drawer";
+import { HomeTasks } from "@/web/components/home/home-tasks";
+import { useReportsOnly } from "@/web/hooks/use-organization-settings";
 
 function CustomizeToolbar({
   isEditMode,
@@ -88,27 +89,34 @@ function CustomizeToolbar({
 }
 
 function OverviewBoard() {
-  const { org } = useProjectContext();
   const { isEditMode, enter, save, cancel, hasChanges } = useHomeEdit();
   const [addTileOpen, setAddTileOpen] = useState(false);
+  const reportsOnly = useReportsOnly();
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-8">
-        <div className="flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-semibold text-foreground">{org.name}</h1>
-          <div className="shrink-0">
-            <CustomizeToolbar
-              isEditMode={isEditMode}
-              hasChanges={hasChanges}
-              onEnter={enter}
-              onSave={save}
-              onCancel={cancel}
-              onAddTile={() => setAddTileOpen(true)}
-            />
-          </div>
+      <div className="@container mx-auto flex max-w-5xl flex-col gap-10 px-6 py-8">
+        {/* Fixed top: the agent "resume" (summary + Super Agent icon) and the
+            tasks that need attention. Not tiles. */}
+        <HomeTasks />
+        {/* The metric cards live on the customizable tile board below. */}
+        <div className="flex flex-col gap-4">
+          {/* Commerce (reports-only) home is curated: no Customize, so the
+              default board (metric cards) stays fixed. */}
+          {!reportsOnly && (
+            <div className="flex justify-end">
+              <CustomizeToolbar
+                isEditMode={isEditMode}
+                hasChanges={hasChanges}
+                onEnter={enter}
+                onSave={save}
+                onCancel={cancel}
+                onAddTile={() => setAddTileOpen(true)}
+              />
+            </div>
+          )}
+          <HomeGrid isEditMode={isEditMode} />
         </div>
-        <HomeGrid isEditMode={isEditMode} />
       </div>
       <AddTileDrawer open={addTileOpen} onOpenChange={setAddTileOpen} />
     </div>

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -15,6 +15,11 @@ export const KEYS = {
   // a deployed version newer than the client's own build.
   appVersionCheck: () => ["appVersionCheck"] as const,
 
+  // Auth-related queries
+  session: () => ["session"] as const,
+
+  messages: (locator: string) => ["messages", locator] as const,
+
   // Organizations list
   organizations: () => ["organizations"] as const,
 
@@ -38,6 +43,9 @@ export const KEYS = {
 
   homeGithubRecentPrs: (orgId: string, connectionId: string) =>
     ["home-github-recent-prs", orgId, connectionId] as const,
+
+  homeGithubContributions: (orgId: string, connectionId: string) =>
+    ["home-github-contributions", orgId, connectionId] as const,
 
   // Public report deck for a scanned domain (/report/:domain, no auth).
   publicReport: (domain: string, key?: string) =>
@@ -124,6 +132,10 @@ export const KEYS = {
   isMCPAuthenticated: (url: string, token: string | null) =>
     ["is-mcp-authenticated", url, token] as const,
 
+  // MCP tools (scoped by URL and optional token)
+  mcpTools: (url: string, token?: string | null) =>
+    ["mcp", "tools", url, token] as const,
+
   // Prefix for all mesh-sdk mcp-client queries (mcpClient, mcpToolsList,
   // mcpResourcesList, mcpPromptsList, mcpReadResource, mcpGetPrompt,
   // mcpToolCall — all start with ["mcp", "client", ...]). Use with
@@ -141,6 +153,9 @@ export const KEYS = {
   // Org access status (for /:org gate — pending invite / auto-join / no access)
   orgAccessStatus: (slug: string) => ["org-access-status", slug] as const,
 
+  // Models list (scoped by organization)
+  modelsList: (orgId: string) => ["models-list", orgId] as const,
+
   // Home next-actions — agent prompts under Chat.Input.
   homeNextActions: (orgSlug: string) => ["home-next-actions", orgSlug] as const,
 
@@ -151,10 +166,22 @@ export const KEYS = {
   agentPrompts: (orgId: string, agentId: string) =>
     ["agent-prompts", orgId, agentId] as const,
 
+  // Allowed models for current user (scoped by organization)
+  allowedModels: (locator: ProjectLocator) =>
+    [locator, "allowed-models"] as const,
+
+  // Collections (scoped by connection)
+  connectionCollections: (connectionId: string) =>
+    [connectionId, "collections", "discovery"] as const,
+
   // Tool call results (generic caching for MCP tool calls)
   // scope is required - scopes the cache (connectionId for connection-scoped, locator for org/project-scoped)
   toolCall: (scope: string, toolName: string, paramsKey: string) =>
     ["tool-call", scope, toolName, paramsKey] as const,
+
+  // Collection items (scoped by connection and collection name)
+  collectionItems: (connectionId: string, collectionName: string) =>
+    ["collection", connectionId, collectionName] as const,
 
   // Collection CRUD queries (scoped by orgId, scopeKey, client, and collection name)
   // orgId: organization ID
@@ -207,12 +234,20 @@ export const KEYS = {
     ] as const,
 
   // Monitoring queries
+  monitoringStats: () => ["monitoring", "stats"] as const,
   monitoringStatsToolCalls: (orgId: string, paramsKey: string) =>
     ["MONITORING_STATS", orgId, "tool-calls", paramsKey] as const,
   monitoringStatsLlm: (orgId: string, paramsKey: string) =>
     ["MONITORING_STATS", orgId, "llm", paramsKey] as const,
   monitoringThreadUsage: (locator: string, paramsKey: string) =>
     ["MONITORING_THREAD_USAGE", locator, paramsKey] as const,
+  monitoringLogs: (filters: {
+    connectionId?: string;
+    toolName?: string;
+    isError?: boolean;
+    limit?: number;
+    offset?: number;
+  }) => ["monitoring", "logs", filters] as const,
   monitoringLogsInfinite: (locator: string, paramsKey: string) =>
     ["monitoring", "logs-infinite", locator, paramsKey] as const,
   monitoringLogDetail: (logId: string) =>
@@ -233,11 +268,20 @@ export const KEYS = {
     ["threads", "overview", locator] as const,
   threadMessages: (locator: string, threadId: string) =>
     ["threads", "messages", locator, threadId] as const,
+  threadModelLogs: (locator: string, dateKey: string) =>
+    ["threads", "model-logs", locator, dateKey] as const,
+  threadSandbox: (orgKey: string, taskId: string | undefined) =>
+    ["thread-sandbox", "v2", orgKey, taskId] as const,
   threadOutputs: (threadId: string) => ["thread-outputs", threadId] as const,
   // Fetched text content of a previewed file (FilePreview), keyed by URL.
   fileText: (downloadUrl: string) => ["file-text", downloadUrl] as const,
   // First bytes of a CSV/TSV file for the card thumbnail (range request).
   csvThumb: (downloadUrl: string) => ["csv-thumb", downloadUrl] as const,
+
+  // Virtual MCP tools (for tool definition lookup in chat)
+  // null virtualMcpId means default virtual MCP
+  virtualMcpTools: (virtualMcpId: string | null, orgId: string) =>
+    ["virtual-mcp", orgId, virtualMcpId ?? "default", "tools"] as const,
 
   toolDefinitionLookup: (
     connectionId: string | null,
@@ -252,6 +296,10 @@ export const KEYS = {
       "lookup",
       rawToolName,
     ] as const,
+
+  // Virtual MCP agents (for agent mentions in chat)
+  virtualMcpAgents: (orgId: string) =>
+    ["virtual-mcp", orgId, "agents"] as const,
 
   // Virtual MCP prompts (for ice breakers in chat)
   // null virtualMcpId means default virtual MCP
@@ -271,8 +319,24 @@ export const KEYS = {
     query: string,
   ) => [...baseKey, isOpen, query] as const,
 
+  // Connection prompts (for Virtual MCP settings)
+  connectionPrompts: (connectionId: string) =>
+    ["connection", connectionId, "prompts"] as const,
+
+  // Connection resources (for Virtual MCP settings)
+  connectionResources: (connectionId: string) =>
+    ["connection", connectionId, "resources"] as const,
+
   // User data
   user: (userId: string) => ["user", userId] as const,
+
+  // Store README fetched from external URL
+  storeReadmeUrl: (readmeUrl: string | null | undefined) =>
+    ["store-readme-url", readmeUrl] as const,
+
+  // Remote MCP tools (for store server detail page)
+  remoteMcpTools: (remoteUrl: string | null) =>
+    ["remote-mcp-tools", remoteUrl] as const,
 
   // Tags (scoped by locator)
   tags: (locator: string) => [locator, "tags"] as const,
@@ -306,6 +370,21 @@ export const KEYS = {
 
   // Projects (scoped by organization)
   projects: (organizationId: string) => ["projects", organizationId] as const,
+  project: (organizationId: string, slug: string) =>
+    ["project", organizationId, slug] as const,
+  // Virtual MCP entity (scoped by org + id)
+  virtualMcp: (orgId: string, virtualMcpId: string) =>
+    ["virtual-mcp", orgId, virtualMcpId] as const,
+
+  // Project plugin configs
+  projectPluginConfigs: (projectId: string) =>
+    ["project-plugin-configs", projectId] as const,
+  projectPluginConfig: (projectId: string, pluginId: string) =>
+    ["project-plugin-config", projectId, pluginId] as const,
+
+  // Project connections (dependencies)
+  projectConnections: (projectId: string) =>
+    ["project-connections", projectId] as const,
 
   // Project connection details (with tools, for sidebar)
   projectConnectionDetails: (projectId: string, connectionIds: string[]) =>
@@ -413,6 +492,9 @@ export const KEYS = {
   defaultBrand: (organizationId: string) =>
     ["brand-context", organizationId, "default"] as const,
 
+  // Deco profile (scoped by user email)
+  decoProfile: (email: string | undefined) => ["deco-profile", email] as const,
+
   // Deco sites (scoped by user email)
   decoSites: (email: string | undefined) => ["deco-sites", email] as const,
   decoApps: () => ["deco-apps"] as const,
@@ -427,6 +509,10 @@ export const KEYS = {
     ["sandbox-invoke", sandboxKey, loaderKey] as const,
   sandboxRepoDir: (orgSlug: string, virtualMcpId: string, branch: string) =>
     ["sandbox-repo-dir", orgSlug, virtualMcpId, branch] as const,
+
+  // Link daemon status (user-scoped; the cluster derives the userSub
+  // from the bearer session, so we don't include it in the key).
+  linkStatus: () => ["link-status"] as const,
 
   // Current link info (org-scoped; includes capabilities, machineId, cliVersion).
   currentLink: (orgId: string) => ["current-link", orgId] as const,
@@ -447,6 +533,8 @@ export const KEYS = {
       installationLogin,
       query,
     ] as const,
+  vmEnv: (orgSlug: string, virtualMcpId: string, branch: string) =>
+    ["vm-env", orgSlug, virtualMcpId, branch] as const,
 } as const;
 
 export function invalidateVirtualMcpQueries(


### PR DESCRIPTION
## Summary
Home overview redesign. Split out of the home-redesign branch for easier review. Independent of the shell PR (file-disjoint), can merge on its own.

- Adds **HomeTasks** to the overview: the agent "resume" summary + the tasks that need attention (not tiles), pinned above the board.
- Moves the metric cards onto the customizable tile board and widens the board to a **6-column grid** so metric cards read three-across, wider tiles at half width.
- Adds the **GitHub contributions** hook feeding the connected native tiles (+ query key).

## Testing
- `bun run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the org Home: added a fixed Tasks section (agent summary + tasks needing attention) and moved metrics to a 6‑column customizable tile board with connected Analytics, Commerce, and GitHub tiles (with a contributions calendar and recent PRs).

- **New Features**
  - Added HomeTasks panel with summary, status tabs, quick create, and “See all” opening the board.
  - Metric tiles: Pageviews, Sessions, Orders, Revenue with preview area charts and a “Connect” flow (Google Analytics, VTEX/Shopify); show a connected placeholder until live reporting is wired.
  - Coding tile shows a GitHub contributions grid and recent PRs when connected; introduced `useGithubContributions` and a `homeGithubContributions` query key.

- **Refactors**
  - Expanded the board to a 6‑column grid; updated defaults so metrics fit three‑across (w:2) and wider tiles sit at half width (w:3); tile defaults now `w:3 x h:4`, prompt tiles `w:2 x h:1`.
  - Native tiles render as card interiors with the board providing `bg-card` styling; “Recent conversations” remains available but hidden by default.
  - Updated the Overview to place `HomeTasks` above the board and hide Customize in reports‑only mode.

<sup>Written for commit 2caf57b9591076f97d9cee177320beb75e0ecf70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

