### PR TITLE
fix(sandbox): mint real MCP endpoint for hosted tool-scripting sync

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -116,7 +116,8 @@ import type { StreamBuffer } from "./stream-buffer";
 import type { ChatMessage, ModelsConfig as ClientModelsConfig } from "./types";
 import type { CancelBroadcast } from "./cancel-broadcast";
 import { resolveCliSessionRef } from "./cli-session-messages";
-import { getInternalUrl, getPublicUrl } from "@/core/server-constants";
+import { getPublicUrl } from "@/core/server-constants";
+import { mintMcpEndpoint } from "@/mcp-clients/virtual-mcp/mint-endpoint";
 import { mintOrgFsConfigJson } from "@/file-storage/mount/provisioning";
 import { meter, traced } from "@/observability";
 import { safeMemoryUsage } from "@/observability/profiling/safe-memory";
@@ -327,64 +328,6 @@ async function resolveSecretModelSource(
     apiKey,
     modelId,
   });
-}
-
-/**
- * Mint a 1h-TTL API key + return the MCP endpoint URL/headers a CLI
- * harness will use to talk to mesh's virtual-MCP gateway over HTTP. Only
- * called for harnesses that actually open an HTTP MCP connection
- * (claude-code, codex); decopilot's in-process passthrough doesn't need
- * this.
- *
- * `sandboxProviderKind` decides which base URL to mint:
- *   - `"agent-sandbox"` — `getInternalUrl()` (loopback; the harness runs
- *     in hosted execution alongside the API).
- *   - `"user-desktop"` — `getPublicUrl()` (the harness runs on the user's
- *     laptop and dials mesh back over the public network).
- */
-const MCP_KEY_TTL_SECONDS = 3600;
-
-async function mintMcpEndpoint(
-  ctx: StudioContext,
-  agentId: string,
-  organization: { id: string; slug?: string; name?: string },
-  apiKeyName: string,
-  sandboxProviderKind: DispatchTarget["sandboxProviderKind"],
-): Promise<{
-  url: string;
-  headers: Record<string, string>;
-  expiresAt: number;
-}> {
-  const apiKey = await ctx.boundAuth.apiKey.create({
-    name: apiKeyName,
-    // The per-run key is the agent's own callback credential — it proxies to
-    // `/mcp/virtual-mcp/<agentId>` (a `vir_*` resource) and acts on behalf of
-    // the user for the duration of the run, so it needs full access. With no
-    // implicit default (auth/index.ts), the scope must be explicit; wildcard
-    // matches the prior behavior (full access via the admin bypass).
-    permissions: { "*": ["*"] },
-    expiresIn: MCP_KEY_TTL_SECONDS,
-    metadata: {
-      organization: {
-        id: organization.id,
-        slug: organization.slug,
-        name: organization.name,
-      },
-    },
-  });
-  const baseUrl =
-    sandboxProviderKind === "user-desktop" ? getPublicUrl() : getInternalUrl();
-  return {
-    url: `${baseUrl}/mcp/virtual-mcp/${agentId}`,
-    headers: {
-      Authorization: `Bearer ${apiKey.key}`,
-      "x-org-id": organization.id,
-    },
-    // Wire-shape: HarnessStreamInputWire requires expiresAt for the
-    // remote-cli path so the daemon can pre-empt expiry with a refresh
-    // (v2 — currently only used for logging / forward-compat).
-    expiresAt: Date.now() + MCP_KEY_TTL_SECONDS * 1000,
-  };
 }
 
 // ============================================================================

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/cluster-sandbox-fs.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/cluster-sandbox-fs.ts
@@ -16,27 +16,42 @@
 import {
   createSandboxFsHooks,
   type SandboxProvider,
+  type SandboxProviderKind,
 } from "@decocms/sandbox/provider";
 import type { StudioContext } from "@/core/studio-context";
+import { mintMcpEndpoint } from "@/mcp-clients/virtual-mcp/mint-endpoint";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import { ensureSandbox } from "@/tools/sandbox/start";
 import { removeSandboxMapEntry } from "@/tools/sandbox/sandbox-map";
 import type { SandboxFsHooks } from "@decocms/harness/decopilot/built-in-tools/vm-tools/sandbox-fs-hooks-types";
 
 /**
- * Fire-and-forget: have the daemon materialize the run's tool catalog +
- * endpoint file under `<repo>/.deco/tools/` so agents can script tool calls
- * (see the tool-scripting skill). Hosted harnesses drive the daemon via
- * fs/exec routes without a /dispatch envelope, so the daemon's own
- * onDispatchMcp hook never fires on this path — this call is its cloud-side
- * counterpart. Failures only warn: the run must never depend on it.
+ * Fire-and-forget: mint the run's virtual-MCP endpoint and have the daemon
+ * materialize the tool catalog + endpoint file under `<repo>/.deco/tools/` so
+ * agents can script tool calls (see the tool-scripting skill). Hosted
+ * harnesses drive the daemon via fs/exec routes without a /dispatch envelope,
+ * so the daemon's own onDispatchMcp hook never fires on this path — this call
+ * is its cloud-side counterpart. Minted here (not passed in) because
+ * decopilot's stream input carries the in-process sentinel `mcp.url === ""`,
+ * and minting lazily keys the endpoint's TTL to the actual provisioning.
+ * Failures only warn: the run must never depend on it.
  */
 async function syncToolsCatalog(
+  ctx: StudioContext,
   runner: SandboxProvider,
   handle: string,
-  mcp: { url: string; headers: Record<string, string>; expiresAt?: number },
+  vm: { virtualMcpId: string; providerKind: SandboxProviderKind },
 ): Promise<void> {
   try {
+    const organization = ctx.organization;
+    if (!organization) return;
+    const mcp = await mintMcpEndpoint(
+      ctx,
+      vm.virtualMcpId,
+      organization,
+      "tool-scripting",
+      vm.providerKind,
+    );
     const res = await runner.proxyDaemonRequest(
       handle,
       "/_sandbox/tools/sync",
@@ -75,9 +90,9 @@ export async function buildClusterSandboxFs(
     virtualMcpId: string;
     branch: string;
     userId: string;
-    /** When present, tools/sync fires after each (re)provisioning — see
+    /** When true, tools/sync fires after each (re)provisioning — see
      *  `syncToolsCatalog`. */
-    mcp?: { url: string; headers: Record<string, string>; expiresAt?: number };
+    syncTools?: boolean;
   },
 ): Promise<SandboxFsHooks> {
   // `dispatch-run` already populated `ctx.sandboxPreference` from the resolved
@@ -113,10 +128,14 @@ export async function buildClusterSandboxFs(
       // auto-restarted sandbox — whose new workspace lost the catalog —
       // gets re-synced too. Provisioning stays lazy: this only fires when
       // a VM tool actually ensures the sandbox.
-      if (vm.mcp) {
-        const mcp = vm.mcp;
+      if (vm.syncTools) {
         void cached
-          .then((handle) => syncToolsCatalog(runner, handle, mcp))
+          .then((handle) =>
+            syncToolsCatalog(ctx, runner, handle, {
+              virtualMcpId: vm.virtualMcpId,
+              providerKind,
+            }),
+          )
           .catch(() => {});
       }
     }

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -85,14 +85,13 @@ export type VmContext = {
    */
   threadId: string;
   /**
-   * The run's pre-authenticated Virtual MCP endpoint. When present, the
-   * sandbox fs layer fires POST /_sandbox/tools/sync after provisioning so
-   * the daemon materializes the tool catalog + endpoint file under
-   * `<repo>/.deco/tools/` — hosted harnesses never send a /dispatch
-   * envelope, so this is the cloud-path counterpart of the daemon's
-   * onDispatchMcp hook.
+   * When true, the sandbox fs layer mints a virtual-MCP endpoint and fires
+   * POST /_sandbox/tools/sync after provisioning so the daemon materializes
+   * the tool catalog + endpoint file under `<repo>/.deco/tools/` — hosted
+   * harnesses never send a /dispatch envelope, so this is the cloud-path
+   * counterpart of the daemon's onDispatchMcp hook.
    */
-  mcp?: { url: string; headers: Record<string, string>; expiresAt?: number };
+  syncTools?: boolean;
 };
 
 export interface BuiltinToolParams {
@@ -241,7 +240,7 @@ async function buildAllTools(
       virtualMcpId: vmContext.virtualMcpId,
       branch: vmContext.branch,
       userId: vmContext.userId,
-      mcp: vmContext.mcp,
+      syncTools: vmContext.syncTools,
     });
     vmTools = createVmTools({
       fs,

--- a/apps/mesh/src/harnesses/decopilot/tools.ts
+++ b/apps/mesh/src/harnesses/decopilot/tools.ts
@@ -307,10 +307,12 @@ export async function assembleDecopilotTools(
           // model-outputs/<threadId>/. Cannot be derived from the
           // sandbox row since one ephemeral sandbox serves many threads.
           threadId: extras.threadId,
-          // Lets the fs layer materialize the tool catalog + endpoint file
-          // into the sandbox once it's provisioned (hosted runs never send
-          // a /dispatch envelope, so the daemon can't do it itself).
-          mcp: input.mcp,
+          // Lets the fs layer mint an endpoint and materialize the tool
+          // catalog into the sandbox once it's provisioned (hosted runs
+          // never send a /dispatch envelope, so the daemon can't do it
+          // itself; `input.mcp` is decopilot's in-process sentinel with an
+          // empty url — never forward it).
+          syncTools: true,
         }
       : null;
 

--- a/apps/mesh/src/mcp-clients/virtual-mcp/mint-endpoint.ts
+++ b/apps/mesh/src/mcp-clients/virtual-mcp/mint-endpoint.ts
@@ -1,0 +1,62 @@
+/**
+ * Mint a 1h-TTL API key + return the MCP endpoint URL/headers a sandbox-side
+ * consumer uses to talk to mesh's virtual-MCP gateway over HTTP. Two callers:
+ * dispatch-run (CLI harnesses opening a real HTTP MCP connection) and the
+ * cluster sandbox-fs layer (materializing the tool-scripting endpoint file
+ * into a provisioned sandbox).
+ *
+ * `sandboxProviderKind` decides which base URL to mint:
+ *   - `"agent-sandbox"` — `getInternalUrl()` (loopback; the consumer runs
+ *     in hosted execution alongside the API).
+ *   - `"user-desktop"` — `getPublicUrl()` (the consumer runs on the user's
+ *     laptop and dials mesh back over the public network).
+ */
+
+import type { SandboxProviderKind } from "@decocms/sandbox/provider";
+import { getInternalUrl, getPublicUrl } from "@/core/server-constants";
+import type { StudioContext } from "@/core/studio-context";
+
+const MCP_KEY_TTL_SECONDS = 3600;
+
+export async function mintMcpEndpoint(
+  ctx: StudioContext,
+  agentId: string,
+  organization: { id: string; slug?: string; name?: string },
+  apiKeyName: string,
+  sandboxProviderKind: SandboxProviderKind,
+): Promise<{
+  url: string;
+  headers: Record<string, string>;
+  expiresAt: number;
+}> {
+  const apiKey = await ctx.boundAuth.apiKey.create({
+    name: apiKeyName,
+    // The per-run key is the agent's own callback credential — it proxies to
+    // `/mcp/virtual-mcp/<agentId>` (a `vir_*` resource) and acts on behalf of
+    // the user for the duration of the run, so it needs full access. With no
+    // implicit default (auth/index.ts), the scope must be explicit; wildcard
+    // matches the prior behavior (full access via the admin bypass).
+    permissions: { "*": ["*"] },
+    expiresIn: MCP_KEY_TTL_SECONDS,
+    metadata: {
+      organization: {
+        id: organization.id,
+        slug: organization.slug,
+        name: organization.name,
+      },
+    },
+  });
+  const baseUrl =
+    sandboxProviderKind === "user-desktop" ? getPublicUrl() : getInternalUrl();
+  return {
+    url: `${baseUrl}/mcp/virtual-mcp/${agentId}`,
+    headers: {
+      Authorization: `Bearer ${apiKey.key}`,
+      "x-org-id": organization.id,
+    },
+    // Wire-shape: HarnessStreamInputWire requires expiresAt for the
+    // remote-cli path so the daemon can pre-empt expiry with a refresh
+    // (v2 — currently only used for logging / forward-compat).
+    expiresAt: Date.now() + MCP_KEY_TTL_SECONDS * 1000,
+  };
+}

--- a/packages/sandbox/daemon/daemon.tools.e2e.test.ts
+++ b/packages/sandbox/daemon/daemon.tools.e2e.test.ts
@@ -170,6 +170,14 @@ describe("POST /_sandbox/tools/sync", () => {
     expect(res.status).toBe(400);
   });
 
+  test("rejects an empty url with 400, writes no endpoint file", async () => {
+    // Regression: the decopilot in-process sentinel (`url: ""`) used to be
+    // forwarded here and materialized a broken .endpoint.json.
+    const res = await sync({ url: "", headers: {} });
+    expect(res.status).toBe(400);
+    expect(existsSync(catalogPath(".endpoint.json"))).toBe(false);
+  });
+
   test("surfaces an unreachable endpoint as 502, endpoint file still written", async () => {
     const res = await sync({
       url: "http://127.0.0.1:1/mcp/virtual-mcp/test",

--- a/packages/sandbox/daemon/routes/tools.ts
+++ b/packages/sandbox/daemon/routes/tools.ts
@@ -31,12 +31,14 @@ export function makeToolsSyncHandler(deps: ToolsDeps) {
     const mcp = body as Partial<McpEndpoint>;
     if (
       typeof mcp?.url !== "string" ||
+      !URL.canParse(mcp.url) ||
       typeof mcp.headers !== "object" ||
       mcp.headers === null
     ) {
       return jsonResponse(
         {
-          error: "body must be { url: string, headers: Record<string,string> }",
+          error:
+            "body must be { url: string (valid URL), headers: Record<string,string> }",
         },
         400,
       );


### PR DESCRIPTION
## What is this contribution about?
The hosted tool-scripting sync from #4638 forwarded decopilot's in-process mcp sentinel (`{url: "", headers: {}}`) into the sandbox, so the daemon materialized a broken `.deco/tools/.endpoint.json` with no catalog — `typegen tools` failed with "Invalid URL" and agents fell back to one-at-a-time context tool calls until blowing the context window (prod thread: 488 VTEX orders → 1.3M tokens → run failed). The sandbox fs layer now mints the run's virtual-MCP endpoint lazily at provisioning time via a shared `mintMcpEndpoint` (extracted from dispatch-run; provider kind picks public vs internal base URL), `VmContext` carries a `syncTools` flag instead of the endpoint, and the daemon's `/_sandbox/tools/sync` now 400s on unparseable URLs instead of writing a broken endpoint file.

## How to Test
1. `bun run --cwd=packages/sandbox build:daemon && bun test packages/sandbox/daemon/daemon.tools.e2e.test.ts` — includes a new regression test (empty url → 400, no endpoint file written).
2. On a hosted decopilot run that touches the sandbox, check `<repo>/.deco/tools/`: `.endpoint.json` has a real `url`/`Authorization`/`expiresAt` and the per-tool JSON schemas are materialized; `typegen tools` lists them.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hosted tool-scripting sync by minting a real virtual-MCP endpoint at sandbox provisioning time and validating URLs on the daemon. Prevents broken `.deco/tools/.endpoint.json`, ensures the tool catalog is generated, and avoids fallback context calls that blew token limits.

- **Bug Fixes**
  - Sandbox FS now mints the endpoint via `mintMcpEndpoint` (chooses internal vs public base by provider) and triggers `/_sandbox/tools/sync` after provisioning.
  - Daemon `/_sandbox/tools/sync` returns 400 for invalid URLs and skips writing the endpoint file; added e2e regression test (empty url → 400, no file).

- **Refactors**
  - Extracted `mintMcpEndpoint` to a shared module.
  - `VmContext` now uses a `syncTools` flag instead of forwarding an endpoint; decopilot’s in‑process sentinel is no longer passed through.

<sup>Written for commit e0746e146482f41fa3c2e9250b8f17f7fef5e597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

