### PR TITLE
fix(sections-editor): drill straight from section to array item in breadcrumb

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -281,6 +281,7 @@ export function ArrayField({
   label,
   breadcrumbPath = [],
   onBreadcrumbChange,
+  hasSiblingDrillDownFields,
   meta,
   decofile,
   onSaveReferencedBlock,
@@ -293,6 +294,12 @@ export function ArrayField({
   const items = Array.isArray(value) ? value : [];
   const itemSchema = schema.items;
   const arrayFieldKey = arrayFieldKeyFromPath(path);
+  // Options that let buildArrayDrillDownBreadcrumb decide whether this array's
+  // own label must stay in the trail to keep the item uniquely addressable.
+  const drillDownOpts = {
+    arrayKey: arrayFieldKey,
+    hasSiblingDrillDownFields,
+  };
   const usesSectionPicker = isSectionArrayField(schema, arrayFieldKey);
   // Only plain object arrays (banners, links, …) get the hide toggle. Section
   // pickers have their own hide flow, and primitive arrays can't be wrapped.
@@ -356,7 +363,12 @@ export function ArrayField({
     const labelText = itemLabel(items[index], index);
     setOpenIndex(index);
     onBreadcrumbChange?.(
-      buildArrayDrillDownBreadcrumb(breadcrumbPath, label, labelText),
+      buildArrayDrillDownBreadcrumb(
+        breadcrumbPath,
+        label,
+        labelText,
+        drillDownOpts,
+      ),
     );
   };
 
@@ -367,7 +379,12 @@ export function ArrayField({
     setOpenIndex(nextIndex);
     const labelText = getArrayItemLabel(item, nextIndex, itemSchema);
     onBreadcrumbChange?.(
-      buildArrayDrillDownBreadcrumb(breadcrumbPath, label, labelText),
+      buildArrayDrillDownBreadcrumb(
+        breadcrumbPath,
+        label,
+        labelText,
+        drillDownOpts,
+      ),
     );
   };
 
@@ -399,7 +416,12 @@ export function ArrayField({
     setOpenIndex(nextIndex);
     const labelText = getArrayItemLabel(defaultVal, nextIndex, itemSchema);
     onBreadcrumbChange?.(
-      buildArrayDrillDownBreadcrumb(breadcrumbPath, label, labelText),
+      buildArrayDrillDownBreadcrumb(
+        breadcrumbPath,
+        label,
+        labelText,
+        drillDownOpts,
+      ),
     );
   };
 
@@ -535,6 +557,7 @@ export function ArrayField({
         breadcrumbPath,
         label,
         itemName,
+        drillDownOpts,
       );
       const itemIndex = findBreadcrumbLabelIndex(trail, itemName);
       if (itemIndex >= 0) {

--- a/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/field-props.ts
@@ -17,6 +17,14 @@ export interface FieldProps {
   label: string;
   breadcrumbPath?: string[];
   onBreadcrumbChange?: (path: string[]) => void;
+  /**
+   * True when this field shares its object scope with another array/drill-down
+   * field. Array fields use it to decide whether their own label must stay in
+   * the breadcrumb: a bare `[itemLabel]` trail can't say WHICH sibling array an
+   * item belongs to (two label-less arrays both fall back to "Item N"), so when
+   * siblings exist the array label is kept as a disambiguator.
+   */
+  hasSiblingDrillDownFields?: boolean;
   meta?: LiveMeta;
   decofile?: Record<string, unknown>;
   containerResolveType?: string;

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -272,10 +272,22 @@ describe("isArrayDrillDownField", () => {
 });
 
 describe("buildArrayDrillDownBreadcrumb", () => {
-  test("includes array label before item label", () => {
+  test("omits the array label — drills straight from section to item", () => {
+    // The array is an implementation detail (its list is shown inline in the
+    // parent); the breadcrumb jumps straight to the item so there's no
+    // redundant "list only" crumb to click back through.
     expect(
       buildArrayDrillDownBreadcrumb([], "Flag Desconto", "Partiu ferias"),
-    ).toEqual(["Flag Desconto", "Partiu ferias"]);
+    ).toEqual(["Partiu ferias"]);
+  });
+
+  test("keeps the array label ONLY to disambiguate an item labelled like the array", () => {
+    // Item label == array label (e.g. label driven by `alt`): keep the array
+    // crumb so breadcrumbPathForActiveField can tell the two levels apart.
+    expect(buildArrayDrillDownBreadcrumb([], "Banner", "Banner")).toEqual([
+      "Banner",
+      "Banner",
+    ]);
   });
 
   test("does not duplicate crumbs already in trail", () => {
@@ -286,6 +298,14 @@ describe("buildArrayDrillDownBreadcrumb", () => {
         "Partiu ferias",
       ),
     ).toEqual(["Flag Desconto", "Partiu ferias"]);
+  });
+
+  test("nested drill-down stays free of array labels (no doubled crumb)", () => {
+    // Opening an item inside an already-open item appends only the new item
+    // label — the intermediate array levels never enter the trail.
+    expect(
+      buildArrayDrillDownBreadcrumb(["Leve 3 pague 2"], "Images", "Detroit"),
+    ).toEqual(["Leve 3 pague 2", "Detroit"]);
   });
 });
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -281,13 +281,43 @@ describe("buildArrayDrillDownBreadcrumb", () => {
     ).toEqual(["Partiu ferias"]);
   });
 
-  test("keeps the array label ONLY to disambiguate an item labelled like the array", () => {
+  test("keeps the array label to disambiguate an item labelled like the array", () => {
     // Item label == array label (e.g. label driven by `alt`): keep the array
     // crumb so breadcrumbPathForActiveField can tell the two levels apart.
     expect(buildArrayDrillDownBreadcrumb([], "Banner", "Banner")).toEqual([
       "Banner",
       "Banner",
     ]);
+  });
+
+  test("keeps the array label to disambiguate an item labelled like the array KEY", () => {
+    // Item label == array's property key: breadcrumbPathForActiveField strips a
+    // head crumb matching the key too, so the array crumb must be kept.
+    expect(
+      buildArrayDrillDownBreadcrumb([], "Products", "items", {
+        arrayKey: "items",
+      }),
+    ).toEqual(["Products", "items"]);
+  });
+
+  test("keeps the array label when a sibling array/drill-down field exists", () => {
+    // A bare [itemLabel] trail can't say WHICH sibling array the item belongs to
+    // (two label-less arrays both fall back to "Item N"), so keep the array
+    // label as a disambiguator when siblings are present.
+    expect(
+      buildArrayDrillDownBreadcrumb([], "Logos", "Item 1", {
+        hasSiblingDrillDownFields: true,
+      }),
+    ).toEqual(["Logos", "Item 1"]);
+  });
+
+  test("omits the array label when it is the sole drill-down field in scope", () => {
+    expect(
+      buildArrayDrillDownBreadcrumb([], "Images", "Item 1", {
+        arrayKey: "images",
+        hasSiblingDrillDownFields: false,
+      }),
+    ).toEqual(["Item 1"]);
   });
 
   test("does not duplicate crumbs already in trail", () => {
@@ -306,6 +336,57 @@ describe("buildArrayDrillDownBreadcrumb", () => {
     expect(
       buildArrayDrillDownBreadcrumb(["Leve 3 pague 2"], "Images", "Detroit"),
     ).toEqual(["Leve 3 pague 2", "Detroit"]);
+  });
+});
+
+describe("sibling array disambiguation (regression)", () => {
+  // Two sibling arrays of label-less objects: getArrayItemLabel falls back to
+  // "Item N" for both, so a bare ["Item 1"] trail is ambiguous. The array label
+  // must be kept, and the correct array must resolve — otherwise clicking one
+  // array's item opens the other (the wrong-array bug).
+  const itemSchema = {
+    type: "object",
+    properties: { src: { type: "string", title: "Src" } },
+  } as SchemaProperty;
+  const properties = {
+    images: { title: "Images", type: "array", items: itemSchema },
+    logos: { title: "Logos", type: "array", items: itemSchema },
+  } as Record<string, SchemaProperty>;
+  const objValue = { images: [{ src: "a" }], logos: [{ src: "b" }] };
+
+  test("keeps array label and resolves to the clicked array, not the first sibling", () => {
+    const trail = buildArrayDrillDownBreadcrumb([], "Logos", "Item 1", {
+      arrayKey: "logos",
+      hasSiblingDrillDownFields: true,
+    });
+    expect(trail).toEqual(["Logos", "Item 1"]);
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(properties),
+        properties,
+        objValue,
+        trail,
+      ),
+    ).toBe("logos");
+  });
+
+  test("sole array resolves from a bare [itemLabel] trail", () => {
+    const soleProps = {
+      cards: { title: "Cards", type: "array", items: { type: "object" } },
+    } as Record<string, SchemaProperty>;
+    const trail = buildArrayDrillDownBreadcrumb([], "Cards", "Men's", {
+      arrayKey: "cards",
+      hasSiblingDrillDownFields: false,
+    });
+    expect(trail).toEqual(["Men's"]);
+    expect(
+      resolveActiveFieldKey(
+        ["cards"],
+        soleProps,
+        { cards: [{ title: "Men's" }] },
+        trail,
+      ),
+    ).toBe("cards");
   });
 });
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
@@ -26,7 +26,23 @@ function labelsMatchLoose(a: string, b: string): boolean {
   );
 }
 
-/** Breadcrumb trail when opening an array item (includes the array field label). */
+/**
+ * Breadcrumb trail when opening an array item.
+ *
+ * The array field itself is an implementation detail: its list is already shown
+ * inline in the parent form, so drilling into an item jumps straight from the
+ * section to the item. We deliberately do NOT add the array's own label as a
+ * crumb — it would show a redundant "list only" step the user has to click back
+ * through (and, once nested, could even appear twice). Resolution
+ * ({@link resolveActiveFieldKey}, {@link resolveArrayItemSelection}) already
+ * matches an item by its label without the array crumb present.
+ *
+ * The ONE exception is disambiguation: when the item's display label equals the
+ * array label (e.g. an item whose label comes from `alt` that happens to match
+ * the array title), we keep the array crumb so {@link breadcrumbPathForActiveField}
+ * can still tell the array level from the item level — otherwise it would strip
+ * the sole crumb and lose the selection (the array-label == item-label bug).
+ */
 export function buildArrayDrillDownBreadcrumb(
   breadcrumbPath: string[],
   arrayLabel: string,
@@ -42,8 +58,12 @@ export function buildArrayDrillDownBreadcrumb(
     return breadcrumbPath;
   }
   const trail = [...breadcrumbPath];
-  const hasArrayLabel = trail.some((crumb) => labelsMatch(crumb, arrayLabel));
-  if (!hasArrayLabel) trail.push(arrayLabel);
+  if (
+    labelsMatch(itemLabel, arrayLabel) &&
+    !trail.some((crumb) => labelsMatch(crumb, arrayLabel))
+  ) {
+    trail.push(arrayLabel);
+  }
   trail.push(itemLabel);
   return trail;
 }

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
@@ -43,7 +43,7 @@ function labelsMatchLoose(a: string, b: string): boolean {
  *   key — {@link breadcrumbPathForActiveField} strips a head crumb that matches
  *   either, which would drop the sole crumb and lose the selection.
  */
-export function arrayCrumbNeededForDisambiguation(
+function arrayCrumbNeededForDisambiguation(
   arrayLabel: string,
   itemLabel: string,
   opts?: { arrayKey?: string; hasSiblingDrillDownFields?: boolean },

--- a/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/mesh/src/web/components/sections-editor/schema-form-breadcrumb.ts
@@ -27,6 +27,35 @@ function labelsMatchLoose(a: string, b: string): boolean {
 }
 
 /**
+ * Whether the array's own label must stay in the breadcrumb trail so the item
+ * remains uniquely addressable.
+ *
+ * A trail of just `[itemLabel]` can't say WHICH array an item came from. That's
+ * fine for the common case — the array is an implementation detail whose list is
+ * already shown inline in the parent — but it breaks when the crumb is
+ * ambiguous, so the array label is kept as a disambiguator when EITHER:
+ *
+ * - a sibling array/drill-down field exists in the same scope
+ *   ({@link resolveActiveFieldKey} would otherwise pick the first sibling whose
+ *   item shares the crumb — e.g. two label-less arrays both fall back to
+ *   "Item N"); or
+ * - the item's own label collides with the array's display label or property
+ *   key — {@link breadcrumbPathForActiveField} strips a head crumb that matches
+ *   either, which would drop the sole crumb and lose the selection.
+ */
+export function arrayCrumbNeededForDisambiguation(
+  arrayLabel: string,
+  itemLabel: string,
+  opts?: { arrayKey?: string; hasSiblingDrillDownFields?: boolean },
+): boolean {
+  return (
+    (opts?.hasSiblingDrillDownFields ?? false) ||
+    labelsMatch(itemLabel, arrayLabel) ||
+    (opts?.arrayKey != null && labelsMatch(itemLabel, opts.arrayKey))
+  );
+}
+
+/**
  * Breadcrumb trail when opening an array item.
  *
  * The array field itself is an implementation detail: its list is already shown
@@ -37,16 +66,15 @@ function labelsMatchLoose(a: string, b: string): boolean {
  * ({@link resolveActiveFieldKey}, {@link resolveArrayItemSelection}) already
  * matches an item by its label without the array crumb present.
  *
- * The ONE exception is disambiguation: when the item's display label equals the
- * array label (e.g. an item whose label comes from `alt` that happens to match
- * the array title), we keep the array crumb so {@link breadcrumbPathForActiveField}
- * can still tell the array level from the item level — otherwise it would strip
- * the sole crumb and lose the selection (the array-label == item-label bug).
+ * The exception is when the crumb would be ambiguous — see
+ * {@link arrayCrumbNeededForDisambiguation}: then the array label is kept so the
+ * right array (and item) still resolves.
  */
 export function buildArrayDrillDownBreadcrumb(
   breadcrumbPath: string[],
   arrayLabel: string,
   itemLabel: string,
+  opts?: { arrayKey?: string; hasSiblingDrillDownFields?: boolean },
 ): string[] {
   const normalizedItem = normalizeBreadcrumbLabel(itemLabel);
   if (
@@ -59,7 +87,7 @@ export function buildArrayDrillDownBreadcrumb(
   }
   const trail = [...breadcrumbPath];
   if (
-    labelsMatch(itemLabel, arrayLabel) &&
+    arrayCrumbNeededForDisambiguation(arrayLabel, itemLabel, opts) &&
     !trail.some((crumb) => labelsMatch(crumb, arrayLabel))
   ) {
     trail.push(arrayLabel);

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -28,6 +28,7 @@ import {
   breadcrumbPathForActiveField,
   consumedBreadcrumbPrefix,
   fieldDisplayLabel,
+  isArrayDrillDownField,
   resolveActiveFieldKey,
 } from "./schema-form-breadcrumb";
 import { inferBlockRefArrayItemSchema } from "./block-ref-array-inference";
@@ -476,6 +477,15 @@ export function SchemaForm({
       ? objValue.__resolveType
       : undefined;
 
+  // When more than one array/drill-down field lives in this scope, an item's
+  // bare `[itemLabel]` breadcrumb is ambiguous (two label-less arrays both fall
+  // back to "Item N"), so array fields keep their own label as a disambiguator.
+  const hasSiblingDrillDownFields =
+    keys.filter((key) => {
+      const s = properties[key];
+      return s != null && isArrayDrillDownField(s, objValue[key]);
+    }).length > 1;
+
   const activeKey =
     breadcrumbPath.length > 0
       ? resolveActiveFieldKey(keys, properties, objValue, breadcrumbPath)
@@ -520,6 +530,7 @@ export function SchemaForm({
           label,
           breadcrumbPath: fieldBreadcrumbPath,
           onBreadcrumbChange: fieldOnBreadcrumbChange,
+          hasSiblingDrillDownFields,
           meta,
           decofile,
           onSaveReferencedBlock,


### PR DESCRIPTION
## Problem

Opening an array item (e.g. a Carousel banner) inserted the **array field's own label** as a breadcrumb crumb (`Images`). That crumb is pure noise:

- The array's list is already shown **inline** in the parent section form, so the crumb just opened a redundant "list only" view.
- Going **back** from an item stopped at that list view instead of returning to the section.
- On the global-section render path the same label could even appear **twice** — `Home > Carousel > Images > Images > <item>`.

Screenshots (before): section form → clicking an item bounced through a standalone `Images` list; the breadcrumb showed a doubled `Images`.

## Fix

Drill **straight from the section to the item** — `buildArrayDrillDownBreadcrumb` no longer adds the array label to the trail. The resolution helpers (`resolveActiveFieldKey`, `resolveArrayItemSelection`) already match an item by its label **without** the array crumb present (covered by existing tests), so forward-nav and back-nav keep working with a clean trail:

`Home > Carousel > Leve 3 pague 2` — and Back goes item → section directly, no intermediate list.

The array crumb is kept in **one** case only: when the item's display label equals the array label (e.g. label driven by `alt`), so `breadcrumbPathForActiveField` can still tell the array level from the item level — otherwise it would strip the sole crumb and lose the selection (the documented array-label == item-label focus-loss bug).

## Tests

- Inverted the test that asserted the old "array label before item label" behavior.
- Added cases: disambiguation (`Banner`/`Banner` keeps the crumb) and nested drill-down (no doubled crumb).
- Full `sections-editor/` suite: **422 pass, 0 fail**.

## Not covered

- Verified via traced repro of the real click flow + unit tests (pure navigation logic). Not exercised visually in a running Studio instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Breadcrumb now drills straight from a section to an array item. This removes the redundant array crumb, fixes back navigation, prevents doubled labels, and keeps the array crumb only when needed to disambiguate (fixes the wrong-array selection with sibling arrays).

- **Bug Fixes**
  - Updated `buildArrayDrillDownBreadcrumb` to omit the array crumb by default; it now keeps it when a sibling array/drill-down exists, or when the item label matches the array label or its property key. Introduced `arrayCrumbNeededForDisambiguation`, threaded `hasSiblingDrillDownFields` through `SchemaForm` → `ArrayField`, and made the helper internal (non-exported).
  - Expanded tests: inverted the old expectation; added cases for sibling arrays, array-key collisions, equal labels, sole-array disambiguation, and nested drill-down (no doubled crumb).

<sup>Written for commit 1f4577a84d3a9d7e60b75df6e1f981c982c2b242. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

