### PR TITLE
fix(web): remove client repo from GitHub config placeholder

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
@@ -271,7 +271,7 @@ export function GitHubConfigForm({
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           disabled={isPending}
-          placeholder="Buscar repositório (ex: deco-sites/fila-store)"
+          placeholder="Buscar repositório"
           aria-label="Buscar repositório"
           className="h-8 pl-8"
         />


### PR DESCRIPTION
## What is this contribution about?

Removes `deco-sites/fila-store` as an example in the GitHub repository search placeholder in the commerce onboarding GitHub config form. This is a client repo that should not be used as copy in the product.

## Screenshots/Demonstration

The placeholder text in the repository search input changes from `Buscar repositório (ex: deco-sites/fila-store)` to simply `Buscar repositório`.

## How to Test

1. Go through the commerce onboarding flow and reach the GitHub configuration step.
2. Verify the repository search input no longer shows `deco-sites/fila-store` as example text.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `deco-sites/fila-store` example from the GitHub repository search placeholder in the commerce onboarding form to avoid referencing a client repo. The input now uses the generic placeholder "Buscar repositório".

<sup>Written for commit b04ec0d854534f489885cb7eb0801b10417f459f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

