### PR TITLE
feat(reports): require login before viewing reports

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -93,7 +93,7 @@ import { createProxyRoutes } from "./routes/proxy";
 import { createTriggerCallbackRoutes } from "./routes/trigger-callback";
 import publicConfigRoutes from "./routes/public-config";
 import { createReportPagesRoutes } from "./routes/report-pages";
-import publicReportsRoutes from "./routes/public-reports";
+import reportsRoutes from "./routes/reports";
 import filesRoutes from "./routes/files";
 import { createThreadOutputsRoutes } from "./routes/thread-outputs";
 import { createSelfRoutes } from "./routes/self";
@@ -1263,12 +1263,12 @@ export async function createApp(options: CreateAppOptions = {}) {
   // ============================================================================
   app.route("/api/config", publicConfigRoutes);
 
-  // Public commerce reports (no auth required) — anonymous proxy to the
-  // reports engine for the /report/:domain page.
-  app.route("/api/_reports", publicReportsRoutes);
+  // Report shell stays public so authentication can happen inline, while all
+  // report data and scan operations behind this proxy require a user session.
+  app.route("/api/_reports", reportsRoutes);
 
-  // Public report page + dynamic metadata. API-only/test apps safely return
-  // 404 for the HTML shell when no built client directory is supplied.
+  // Auth-gated report page + domain-derived metadata. API-only/test apps safely
+  // return 404 for the HTML shell when no built client directory is supplied.
   app.route("/report", createReportPagesRoutes(options.clientDir));
 
   // ============================================================================

--- a/apps/mesh/src/api/routes/report-pages.tsx
+++ b/apps/mesh/src/api/routes/report-pages.tsx
@@ -1,9 +1,10 @@
 /**
- * Server-rendered head for the public report page (`/report/:domain`).
+ * Server-rendered shell for the auth-gated report page (`/report/:domain`).
  *
  * Link unfurlers do not run the SPA, so production serves the built index.html
- * with domain-specific title, description, canonical URL, and favicon. The SPA
- * then boots normally from the same document.
+ * with domain-derived title, description, canonical URL, and favicon. Report
+ * data is deliberately absent from this anonymous shell; the authenticated SPA
+ * fetches it after the session gate.
  *
  * Intentionally no dynamic `og:image`: the original Satori + Resvg renderer
  * performed CPU-heavy synchronous work inside Studio's Bun process, blocking
@@ -15,7 +16,6 @@
 
 import { Hono } from "hono";
 import { join } from "node:path";
-import type { TemplateDeck } from "@/reports/deck-types";
 import {
   brandFromDomain,
   faviconForDomain,
@@ -23,7 +23,6 @@ import {
   reportShareCopy,
 } from "@/shared/report-seo";
 import { getSettings } from "@/settings";
-import { fetchPublicReport } from "./public-reports";
 
 /** Escape a string for safe interpolation into an HTML attribute/text node. */
 function esc(value: string): string {
@@ -34,39 +33,18 @@ function esc(value: string): string {
     .replaceAll('"', "&quot;");
 }
 
-async function buildReportHead(rawDomain: string): Promise<string> {
+function buildReportHead(rawDomain: string): string {
   const domain = normalizeDomain(rawDomain);
-
-  // Best-effort deck read — a failure degrades to domain-derived copy.
-  let deck: TemplateDeck | null = null;
-  try {
-    const state = await fetchPublicReport(rawDomain);
-    deck = state.deck;
-  } catch {
-    deck = null;
-  }
-
-  const brand = deck?.meta.brand?.trim() || brandFromDomain(domain);
-  const favicon = deck?.meta.faviconUrl || faviconForDomain(domain, 128);
+  const brand = brandFromDomain(domain);
+  const favicon = faviconForDomain(domain, 128);
   const origin = (
     getSettings().baseUrl ?? "https://studio.decocms.com"
   ).replace(/\/+$/, "");
   const canonical = `${origin}/report/${encodeURIComponent(domain)}`;
 
-  const cover = deck?.slides.find((slide) => {
-    return slide.template?.template === "cover";
-  });
-  const coverBody = cover?.template as
-    | { score?: { value?: number } }
-    | undefined;
-  const score =
-    typeof coverBody?.score?.value === "number" ? coverBody.score.value : null;
-
   const { title, description } = reportShareCopy({
     brand,
     domain,
-    score,
-    verdict: cover?.headline ?? null,
   });
 
   return [
@@ -110,7 +88,7 @@ export function createReportPagesRoutes(clientDir: string | undefined): Hono {
 
     const html = await indexFile.text();
     try {
-      const head = await buildReportHead(raw);
+      const head = buildReportHead(raw);
       return c.html(rewriteHead(html, head), 200, {
         "Cache-Control": "public, max-age=0, s-maxage=300",
       });

--- a/apps/mesh/src/api/routes/reports.ts
+++ b/apps/mesh/src/api/routes/reports.ts
@@ -1,14 +1,14 @@
 /**
- * Public Reports Routes — `/api/_reports/*`
+ * Authenticated Report Routes — `/api/_reports/*`
  *
- * Anonymous (no-auth) proxy between the report page (`/report/:domain`) and
- * the reports engine (reports.decocms.com, `/api/v2`). The engine's master API
- * key stays server-side; base URL + key resolve exactly like the Commerce
- * Discovery tools (`tools/reports/auth-client.ts`). Ported from the decocms
- * landing's TanStack server fns (`src/server/diagnostics.ts` + `suggest.ts`).
+ * Session-gated proxy between the report page (`/report/:domain`) and the
+ * reports engine (reports.decocms.com, `/api/v2`). The engine's master API key
+ * stays server-side; the caller's session email is the only delivery
+ * address accepted when a scan starts.
  */
 
 import { Hono } from "hono";
+import { auth } from "@/auth";
 import { resolveApiKey, resolveBaseUrl } from "@/tools/reports/auth-client";
 import {
   type DomainSuggestion,
@@ -25,11 +25,9 @@ function engineFetch(path: string, init?: RequestInit): Promise<Response> {
 }
 
 /**
- * Anonymous read of an already-scanned domain's deck. Exported for the
- * head-rewrite + OG-image handlers, which reuse the exact same fetch +
- * normalize path.
+ * Read an already-scanned domain's deck after the route's session gate.
  */
-export async function fetchPublicReport(
+async function fetchReport(
   domain: string,
   // Reviewer preview: the approval password unlocks a pre-publish read —
   // forwarded as ?pw=, the engine bypasses ONLY its publish gate and returns
@@ -56,7 +54,31 @@ export async function fetchPublicReport(
 
 const TERMINAL = new Set(["complete", "errored", "terminated", "unknown"]);
 
-const app = new Hono();
+type ReportsEnv = {
+  Variables: {
+    reportUser: { email: string };
+  };
+};
+
+const app = new Hono<ReportsEnv>();
+
+app.use("*", async (c, next) => {
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
+  if (!session?.user?.id) {
+    return c.json({ error: "Authentication required" }, 401, {
+      "Cache-Control": "private, no-store",
+      Vary: "Cookie",
+    });
+  }
+
+  c.set("reportUser", {
+    email: session.user.email,
+  });
+  await next();
+  c.header("Cache-Control", "private, no-store");
+  c.header("Vary", "Cookie");
+  return undefined;
+});
 
 /** GET /api/_reports/site/:domain — the deck for an already-scanned domain. */
 app.get("/site/:domain", async (c) => {
@@ -64,7 +86,7 @@ app.get("/site/:domain", async (c) => {
   if (!domain) return c.json({ error: "domain is required" }, 400);
   const key = c.req.query("key")?.trim() || undefined;
   try {
-    const state = await fetchPublicReport(domain, key);
+    const state = await fetchReport(domain, key);
     // Never cached: the deck carries short-lived signed screenshot URLs.
     c.header("Cache-Control", "private, no-store");
     return c.json(state);
@@ -75,12 +97,12 @@ app.get("/site/:domain", async (c) => {
 
 /** POST /api/_reports/run — trigger a scan (master-key, server-only). The
  *  engine is idempotent + single-flight, so spamming this for a domain never
- *  starts parallel runs. An optional `email` rides the same body — the engine
- *  attaches it to the paused workflow to notify the requester. The optional
- *  `distinctId` is the visitor's PostHog id, so the engine's server-side
- *  funnel events attribute to the same person. */
+ *  starts parallel runs. The engine receives the authenticated session email
+ *  to notify the requester; it never accepts a caller-supplied address. The
+ *  optional `distinctId` is the visitor's PostHog id, so the engine's
+ *  server-side funnel events attribute to the same person. */
 app.post("/run", async (c) => {
-  let body: { domain?: unknown; email?: unknown; distinctId?: unknown };
+  let body: { domain?: unknown; distinctId?: unknown };
   try {
     body = await c.req.json();
   } catch {
@@ -88,10 +110,7 @@ app.post("/run", async (c) => {
   }
   const domain = typeof body.domain === "string" ? body.domain.trim() : "";
   if (!domain) return c.json({ error: "domain is required" }, 400);
-  const email =
-    typeof body.email === "string" && body.email.trim()
-      ? body.email.trim()
-      : undefined;
+  const email = c.get("reportUser").email;
   const distinctId =
     typeof body.distinctId === "string" &&
     body.distinctId.trim() &&
@@ -148,9 +167,8 @@ app.get("/status", async (c) => {
 });
 
 /** GET /api/_reports/link-token/:id — resolve an email link's `d` token to the
- *  {domain, run_id} it was minted for. The engine mints an unguessable id per
- *  send — the id itself is the only credential, so this is a plain anonymous
- *  read. Null on a 404 (never minted). */
+ *  {domain, run_id} it was minted for. Session auth is still required even
+ *  though the engine token itself is unguessable. Null on a 404. */
 app.get("/link-token/:id", async (c) => {
   const id = c.req.param("id");
   try {

--- a/apps/mesh/src/api/utils/paths.test.ts
+++ b/apps/mesh/src/api/utils/paths.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { isServerPath, shouldSkipStudioContext, SYSTEM_PATHS } from "./paths";
 
-describe("public report paths", () => {
+describe("report page paths", () => {
   test("routes report pages through Hono for dynamic metadata", () => {
     expect(isServerPath("/report/nike.com")).toBe(true);
   });

--- a/apps/mesh/src/web/components/auth-entry.tsx
+++ b/apps/mesh/src/web/components/auth-entry.tsx
@@ -19,6 +19,12 @@ export interface AuthEntryProps {
   brand?: ReactNode;
   /** Optional localized copy for the auth form. */
   copy?: Partial<UnifiedAuthFormCopy>;
+  /** Compact layout for embedded auth surfaces. */
+  variant?: "default" | "compact";
+  /** Limit social buttons without changing the global login page. */
+  allowedSocialProviders?: string[];
+  /** Hide password auth in OTP-first embedded surfaces. */
+  allowPassword?: boolean;
 }
 
 class RetriableAutoLoginResponse {
@@ -138,6 +144,9 @@ export function AuthEntry({
   subtitle,
   brand,
   copy,
+  variant,
+  allowedSocialProviders,
+  allowPassword,
 }: AuthEntryProps) {
   const {
     sso,
@@ -173,6 +182,9 @@ export function AuthEntry({
         subtitle={subtitle}
         brand={brand}
         copy={copy}
+        variant={variant}
+        allowedSocialProviders={allowedSocialProviders}
+        allowPassword={allowPassword}
       />
     );
   }

--- a/apps/mesh/src/web/components/auth-entry.tsx
+++ b/apps/mesh/src/web/components/auth-entry.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useState } from "react";
+import { useEffect, useEffectEvent, useState } from "react";
 import type { ReactNode } from "react";
 import { retry, RetryError } from "@decocms/std";
 import { SplashScreen } from "@/web/components/splash-screen";
 import { UnifiedAuthForm } from "@/web/components/unified-auth-form";
-import type { UnifiedAuthFormCopy } from "@/web/components/unified-auth-form";
+import type {
+  AuthFlowEvent,
+  UnifiedAuthFormCopy,
+} from "@/web/components/unified-auth-form";
 import { authClient } from "@/web/lib/auth-client";
 import { useAuthConfig } from "@/web/providers/auth-config-provider";
 
@@ -25,6 +28,8 @@ export interface AuthEntryProps {
   allowedSocialProviders?: string[];
   /** Hide password auth in OTP-first embedded surfaces. */
   allowPassword?: boolean;
+  /** Optional lifecycle sink for embedded surfaces with their own funnel. */
+  onAuthEvent?: (event: AuthFlowEvent) => void;
 }
 
 class RetriableAutoLoginResponse {
@@ -41,14 +46,28 @@ function safeRelativeRedirect(redirectTo: string): string {
  * Auto-login for local mode.
  * Calls the local-session endpoint and reloads to pick up the session cookie.
  */
-function AutoLogin({ redirectTo }: { redirectTo: string }) {
+function AutoLogin({
+  redirectTo,
+  onAuthEvent,
+}: {
+  redirectTo: string;
+  onAuthEvent?: (event: AuthFlowEvent) => void;
+}) {
   const [error, setError] = useState<string | null>(null);
+  const emitAuthEvent = useEffectEvent((event: AuthFlowEvent) => {
+    try {
+      onAuthEvent?.(event);
+    } catch {
+      // An analytics sink must never interrupt authentication.
+    }
+  });
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect
   useEffect(() => {
     let cancelled = false;
 
     (async () => {
+      emitAuthEvent({ type: "started", method: "local" });
       try {
         let res: Response;
         try {
@@ -86,10 +105,17 @@ function AutoLogin({ redirectTo }: { redirectTo: string }) {
           throw new Error(data?.error || "Auto-login failed");
         }
         if (!cancelled) {
+          emitAuthEvent({ type: "succeeded", method: "local" });
           window.location.href = safeRelativeRedirect(redirectTo);
         }
       } catch (err) {
         if (!cancelled) {
+          emitAuthEvent({
+            type: "failed",
+            method: "local",
+            stage: "authenticate",
+            error: err instanceof Error ? err.message : String(err),
+          });
           setError(err instanceof Error ? err.message : "Auto-login failed");
         }
       }
@@ -119,17 +145,45 @@ function AutoLogin({ redirectTo }: { redirectTo: string }) {
 function RunSSO({
   callbackURL,
   providerId,
+  onAuthEvent,
 }: {
   providerId: string;
   callbackURL: string;
+  onAuthEvent?: (event: AuthFlowEvent) => void;
 }) {
+  const emitAuthEvent = useEffectEvent((event: AuthFlowEvent) => {
+    try {
+      onAuthEvent?.(event);
+    } catch {
+      // An analytics sink must never interrupt authentication.
+    }
+  });
+
   // oxlint-disable-next-line ban-use-effect/ban-use-effect
   useEffect(() => {
     (async () => {
-      await authClient.signIn.sso({
-        providerId,
-        callbackURL,
+      emitAuthEvent({
+        type: "started",
+        method: "sso",
+        provider: providerId,
       });
+      try {
+        const result = await authClient.signIn.sso({
+          providerId,
+          callbackURL,
+        });
+        if (result.error) {
+          throw new Error(result.error.message || "SSO redirect failed");
+        }
+      } catch (error) {
+        emitAuthEvent({
+          type: "failed",
+          method: "sso",
+          provider: providerId,
+          stage: "redirect",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     })();
   }, [providerId, callbackURL]);
 
@@ -147,6 +201,7 @@ export function AuthEntry({
   variant,
   allowedSocialProviders,
   allowPassword,
+  onAuthEvent,
 }: AuthEntryProps) {
   const {
     sso,
@@ -159,12 +214,18 @@ export function AuthEntry({
   const redirectAfterLogin = redirectUrl || callbackUrl;
 
   if (localMode && allowAutoLogin) {
-    return <AutoLogin redirectTo={redirectAfterLogin} />;
+    return (
+      <AutoLogin redirectTo={redirectAfterLogin} onAuthEvent={onAuthEvent} />
+    );
   }
 
   if (sso.enabled) {
     return (
-      <RunSSO callbackURL={redirectAfterLogin} providerId={sso.providerId} />
+      <RunSSO
+        callbackURL={redirectAfterLogin}
+        providerId={sso.providerId}
+        onAuthEvent={onAuthEvent}
+      />
     );
   }
 
@@ -185,6 +246,7 @@ export function AuthEntry({
         variant={variant}
         allowedSocialProviders={allowedSocialProviders}
         allowPassword={allowPassword}
+        onAuthEvent={onAuthEvent}
       />
     );
   }

--- a/apps/mesh/src/web/components/unified-auth-form.tsx
+++ b/apps/mesh/src/web/components/unified-auth-form.tsx
@@ -37,6 +37,12 @@ interface UnifiedAuthFormProps {
   brand?: React.ReactNode;
   /** Optional localized copy for this auth surface. */
   copy?: Partial<UnifiedAuthFormCopy>;
+  /** Compact layout for embedded auth surfaces. The login page stays default. */
+  variant?: "default" | "compact";
+  /** Limit social buttons without changing the deployment-wide auth config. */
+  allowedSocialProviders?: string[];
+  /** Hide password auth when an embedded surface should use OTP only. */
+  allowPassword?: boolean;
 }
 
 type FormView = "signIn" | "signUp" | "forgotPassword" | "emailOtp";
@@ -147,9 +153,23 @@ export function UnifiedAuthForm({
   subtitle,
   brand,
   copy: copyOverrides,
+  variant = "default",
+  allowedSocialProviders,
+  allowPassword = true,
 }: UnifiedAuthFormProps) {
   const { emailAndPassword, resetPassword, emailOtp, socialProviders } =
     useAuthConfig();
+  const compact = variant === "compact";
+  const visibleSocialProviders = allowedSocialProviders
+    ? socialProviders.providers.filter((provider) =>
+        allowedSocialProviders.includes(provider.name),
+      )
+    : socialProviders.providers;
+  const hasSocialProviders =
+    socialProviders.enabled && visibleSocialProviders.length > 0;
+  const emailAndPasswordEnabled =
+    emailAndPassword.enabled &&
+    (allowPassword || (!emailOtp.enabled && !hasSocialProviders));
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
@@ -427,7 +447,7 @@ export function UnifiedAuthForm({
         : subtitle;
 
   return (
-    <div className="w-full grid gap-10">
+    <div className={cn("grid w-full", compact ? "gap-5" : "gap-10")}>
       {/* Brand */}
       {brand ?? (
         <div>
@@ -446,9 +466,21 @@ export function UnifiedAuthForm({
 
       {/* Header */}
       <div className="space-y-2">
-        <h1 className="text-2xl font-medium leading-8">{headerTitle}</h1>
+        <h1
+          className={cn(
+            "font-medium",
+            compact ? "text-xl leading-7" : "text-2xl leading-8",
+          )}
+        >
+          {headerTitle}
+        </h1>
         {headerSubtitle && (
-          <p className="text-base text-muted-foreground leading-6">
+          <p
+            className={cn(
+              "text-muted-foreground",
+              compact ? "text-sm leading-5" : "text-base leading-6",
+            )}
+          >
             {headerSubtitle}
           </p>
         )}
@@ -469,51 +501,61 @@ export function UnifiedAuthForm({
       )}
 
       {/* Social Provider Buttons */}
-      {!isForgotPassword &&
-        !(isEmailOtp && otpSent) &&
-        socialProviders.enabled && (
-          <div className="grid gap-2">
-            {socialProviders.providers.map((provider) => (
-              <button
-                key={provider.name}
-                type="button"
-                disabled={isLoading}
-                onClick={() => {
-                  authClient.signIn.social({
-                    provider: provider.name,
-                    callbackURL: redirectUrl ?? callbackUrl,
-                  });
-                }}
-                className="flex h-12 w-full items-center justify-center gap-3 rounded-xl bg-background dark:bg-input/30 px-3 text-sm font-medium text-foreground card-shadow transition-colors hover:bg-accent hover:text-accent-foreground dark:hover:bg-input/50 disabled:opacity-50 disabled:pointer-events-none"
-              >
-                {provider.icon && (
-                  <img
-                    src={provider.icon}
-                    alt=""
-                    className={cn(
-                      "h-5 w-5",
-                      provider.name === "github" && "dark:invert",
-                    )}
-                    aria-hidden="true"
-                  />
-                )}
-                {copy.continueWith(
-                  provider.name.charAt(0).toUpperCase() +
-                    provider.name.slice(1),
-                )}
-              </button>
-            ))}
-          </div>
-        )}
+      {!isForgotPassword && !(isEmailOtp && otpSent) && hasSocialProviders && (
+        <div className="grid gap-2">
+          {visibleSocialProviders.map((provider) => (
+            <button
+              key={provider.name}
+              type="button"
+              disabled={isLoading}
+              onClick={() => {
+                authClient.signIn.social({
+                  provider: provider.name,
+                  callbackURL: redirectUrl ?? callbackUrl,
+                });
+              }}
+              className={cn(
+                "flex w-full items-center justify-center gap-3 bg-background px-3 text-sm font-medium text-foreground card-shadow transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 dark:bg-input/30 dark:hover:bg-input/50",
+                compact ? "h-11 rounded-lg" : "h-12 rounded-xl",
+              )}
+            >
+              {provider.icon && (
+                <img
+                  src={provider.icon}
+                  alt=""
+                  className={cn(
+                    "h-5 w-5",
+                    provider.name === "github" && "dark:invert",
+                  )}
+                  aria-hidden="true"
+                />
+              )}
+              {copy.continueWith(
+                provider.name.charAt(0).toUpperCase() + provider.name.slice(1),
+              )}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Divider between social and email-based auth */}
       {!isForgotPassword &&
         !(isEmailOtp && otpSent) &&
-        socialProviders.enabled &&
-        (emailAndPassword.enabled || emailOtp.enabled) && (
-          <div className="flex items-center gap-2.5 -my-4">
+        hasSocialProviders &&
+        (emailAndPasswordEnabled || emailOtp.enabled) && (
+          <div
+            className={cn(
+              "flex items-center gap-2.5",
+              compact ? "my-0" : "-my-4",
+            )}
+          >
             <div className="h-px flex-1 bg-border" />
-            <span className="text-base text-muted-foreground">
+            <span
+              className={cn(
+                "text-muted-foreground",
+                compact ? "text-sm" : "text-base",
+              )}
+            >
               {copy.divider}
             </span>
             <div className="h-px flex-1 bg-border" />
@@ -524,9 +566,20 @@ export function UnifiedAuthForm({
       {isEmailOtp && emailOtp.enabled && (
         <>
           {!otpSent ? (
-            <form onSubmit={handleSendOtp} className="grid gap-2">
+            <form
+              onSubmit={handleSendOtp}
+              className={cn(
+                "grid gap-2",
+                compact && "sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start",
+              )}
+            >
               <div className="grid gap-2">
-                <label className="text-sm font-medium text-foreground">
+                <label
+                  className={cn(
+                    "text-sm font-medium text-foreground",
+                    compact && "sr-only",
+                  )}
+                >
                   {copy.emailLabel}
                 </label>
                 <Input
@@ -548,15 +601,29 @@ export function UnifiedAuthForm({
               <button
                 type="submit"
                 disabled={isLoading || !canSubmit}
-                className="flex h-12 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80 disabled:opacity-50 disabled:pointer-events-none"
+                className={cn(
+                  "flex items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80 disabled:pointer-events-none disabled:opacity-50",
+                  compact ? "h-11 sm:w-auto" : "h-12 w-full",
+                )}
               >
                 {isLoading ? copy.sending : copy.sendCode}
               </button>
             </form>
           ) : (
-            <form onSubmit={handleVerifyOtp} className="grid gap-2">
+            <form
+              onSubmit={handleVerifyOtp}
+              className={cn(
+                "grid gap-2",
+                compact && "sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start",
+              )}
+            >
               <div className="grid gap-2">
-                <label className="text-sm font-medium text-foreground">
+                <label
+                  className={cn(
+                    "text-sm font-medium text-foreground",
+                    compact && "sr-only",
+                  )}
+                >
                   {copy.verificationCodeLabel}
                 </label>
                 <Input
@@ -576,7 +643,10 @@ export function UnifiedAuthForm({
               <button
                 type="submit"
                 disabled={isLoading || !canSubmit}
-                className="flex h-12 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80 disabled:opacity-50 disabled:pointer-events-none"
+                className={cn(
+                  "flex items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80 disabled:pointer-events-none disabled:opacity-50",
+                  compact ? "h-11 sm:w-auto" : "h-12 w-full",
+                )}
               >
                 {isLoading ? copy.verifying : copy.verify}
               </button>
@@ -590,7 +660,10 @@ export function UnifiedAuthForm({
                   verifyOtpMutation.reset();
                 }}
                 disabled={isLoading}
-                className="mt-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                className={cn(
+                  "mt-1 text-sm text-muted-foreground transition-colors hover:text-foreground",
+                  compact && "sm:col-span-2",
+                )}
               >
                 {copy.useDifferentEmail}
               </button>
@@ -600,7 +673,7 @@ export function UnifiedAuthForm({
       )}
 
       {/* Forgot Password Form */}
-      {isForgotPassword && emailAndPassword.enabled && !resetEmailSent && (
+      {isForgotPassword && emailAndPasswordEnabled && !resetEmailSent && (
         <form onSubmit={handleForgotPassword} className="grid gap-4">
           <div>
             <label className="block text-sm font-medium text-foreground mb-2">
@@ -634,7 +707,7 @@ export function UnifiedAuthForm({
       )}
 
       {/* Email & Password Form */}
-      {!isForgotPassword && !isEmailOtp && emailAndPassword.enabled && (
+      {!isForgotPassword && !isEmailOtp && emailAndPasswordEnabled && (
         <form onSubmit={handleEmailPassword} className="grid gap-5">
           {isSignUp && (
             <div>
@@ -735,7 +808,7 @@ export function UnifiedAuthForm({
           >
             {copy.backToSignIn}
           </button>
-        ) : isEmailOtp && emailAndPassword.enabled ? (
+        ) : isEmailOtp && emailAndPasswordEnabled ? (
           <button
             type="button"
             onClick={() => switchView("signIn")}
@@ -744,7 +817,7 @@ export function UnifiedAuthForm({
           >
             {copy.signInWithPassword}
           </button>
-        ) : !isEmailOtp && emailAndPassword.enabled ? (
+        ) : !isEmailOtp && emailAndPasswordEnabled ? (
           <>
             {isSignUp ? copy.alreadyHaveAccount : copy.dontHaveAccount}
             <button

--- a/apps/mesh/src/web/components/unified-auth-form.tsx
+++ b/apps/mesh/src/web/components/unified-auth-form.tsx
@@ -7,6 +7,35 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 
+export type AuthFlowMethod =
+  | "email_otp"
+  | "email_password"
+  | "social"
+  | "sso"
+  | "local";
+
+export type AuthFlowEvent =
+  | {
+      type: "started" | "succeeded";
+      method: AuthFlowMethod;
+      provider?: string;
+      mode?: "sign_in" | "sign_up";
+    }
+  | { type: "otp_sent" | "otp_submitted"; method: "email_otp" }
+  | {
+      type: "failed";
+      method: AuthFlowMethod;
+      stage:
+        | "validation"
+        | "authenticate"
+        | "send_otp"
+        | "verify_otp"
+        | "redirect";
+      error: string;
+      provider?: string;
+      mode?: "sign_in" | "sign_up";
+    };
+
 interface UnifiedAuthFormProps {
   /**
    * URL to redirect to after successful authentication.
@@ -43,6 +72,8 @@ interface UnifiedAuthFormProps {
   allowedSocialProviders?: string[];
   /** Hide password auth when an embedded surface should use OTP only. */
   allowPassword?: boolean;
+  /** Optional lifecycle sink for embedded surfaces with their own funnel. */
+  onAuthEvent?: (event: AuthFlowEvent) => void;
 }
 
 type FormView = "signIn" | "signUp" | "forgotPassword" | "emailOtp";
@@ -156,9 +187,17 @@ export function UnifiedAuthForm({
   variant = "default",
   allowedSocialProviders,
   allowPassword = true,
+  onAuthEvent,
 }: UnifiedAuthFormProps) {
   const { emailAndPassword, resetPassword, emailOtp, socialProviders } =
     useAuthConfig();
+  const emitAuthEvent = (event: AuthFlowEvent) => {
+    try {
+      onAuthEvent?.(event);
+    } catch {
+      // An analytics sink must never interrupt authentication.
+    }
+  };
   const compact = variant === "compact";
   const visibleSocialProviders = allowedSocialProviders
     ? socialProviders.providers.filter((provider) =>
@@ -222,11 +261,30 @@ export function UnifiedAuthForm({
         throw err instanceof Error ? err : new Error(copy.authenticationFailed);
       }
     },
+    onMutate: () => {
+      emitAuthEvent({
+        type: "started",
+        method: "email_password",
+        mode: isSignUp ? "sign_up" : "sign_in",
+      });
+    },
     onSuccess: () => {
+      emitAuthEvent({
+        type: "succeeded",
+        method: "email_password",
+        mode: isSignUp ? "sign_up" : "sign_in",
+      });
       globalThis.localStorage?.setItem("hasLoggedIn", "true");
       window.location.href = redirectUrl ?? callbackUrl;
     },
     onError: (error) => {
+      emitAuthEvent({
+        type: "failed",
+        method: "email_password",
+        mode: isSignUp ? "sign_up" : "sign_in",
+        stage: "authenticate",
+        error: error instanceof Error ? error.message : String(error),
+      });
       track(isSignUp ? "user_signup_failed" : "user_signin_failed", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -266,11 +324,21 @@ export function UnifiedAuthForm({
       }
       return result;
     },
+    onMutate: () => {
+      emitAuthEvent({ type: "started", method: "email_otp" });
+    },
     onSuccess: () => {
+      emitAuthEvent({ type: "otp_sent", method: "email_otp" });
       track("email_otp_sent");
       setOtpSent(true);
     },
     onError: (error) => {
+      emitAuthEvent({
+        type: "failed",
+        method: "email_otp",
+        stage: "send_otp",
+        error: error instanceof Error ? error.message : String(error),
+      });
       track("email_otp_send_failed", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -288,11 +356,21 @@ export function UnifiedAuthForm({
       }
       return result;
     },
+    onMutate: () => {
+      emitAuthEvent({ type: "otp_submitted", method: "email_otp" });
+    },
     onSuccess: () => {
+      emitAuthEvent({ type: "succeeded", method: "email_otp" });
       globalThis.localStorage?.setItem("hasLoggedIn", "true");
       window.location.href = redirectUrl ?? callbackUrl;
     },
     onError: (error) => {
+      emitAuthEvent({
+        type: "failed",
+        method: "email_otp",
+        stage: "verify_otp",
+        error: error instanceof Error ? error.message : String(error),
+      });
       track("email_otp_verify_failed", {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -315,6 +393,13 @@ export function UnifiedAuthForm({
 
     if (!validateEmail(email)) {
       setEmailError(copy.invalidEmail);
+      emitAuthEvent({
+        type: "failed",
+        method: "email_password",
+        mode: isSignUp ? "sign_up" : "sign_in",
+        stage: "validation",
+        error: "invalid_email",
+      });
       return;
     }
 
@@ -337,6 +422,12 @@ export function UnifiedAuthForm({
 
     if (!validateEmail(email)) {
       setEmailError(copy.invalidEmail);
+      emitAuthEvent({
+        type: "failed",
+        method: "email_otp",
+        stage: "validation",
+        error: "invalid_email",
+      });
       return;
     }
 
@@ -432,6 +523,29 @@ export function UnifiedAuthForm({
 
   const displayError = error || forgotPasswordError || otpError;
 
+  const handleSocialSignIn = async (provider: string) => {
+    emitAuthEvent({ type: "started", method: "social", provider });
+    try {
+      const result = await authClient.signIn.social({
+        provider,
+        callbackURL: redirectUrl ?? callbackUrl,
+      });
+      if (result.error) {
+        throw new Error(result.error.message || copy.authenticationFailed);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      emitAuthEvent({
+        type: "failed",
+        method: "social",
+        provider,
+        stage: "redirect",
+        error: message,
+      });
+      track("social_signin_failed", { provider, error: message });
+    }
+  };
+
   const headerTitle = isForgotPassword
     ? copy.resetPasswordTitle
     : isEmailOtp && otpSent
@@ -508,12 +622,7 @@ export function UnifiedAuthForm({
               key={provider.name}
               type="button"
               disabled={isLoading}
-              onClick={() => {
-                authClient.signIn.social({
-                  provider: provider.name,
-                  callbackURL: redirectUrl ?? callbackUrl,
-                });
-              }}
+              onClick={() => void handleSocialSignIn(provider.name)}
               className={cn(
                 "flex w-full items-center justify-center gap-3 bg-background px-3 text-sm font-medium text-foreground card-shadow transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 dark:bg-input/30 dark:hover:bg-input/50",
                 compact ? "h-11 rounded-lg" : "h-12 rounded-xl",

--- a/apps/mesh/src/web/components/unified-auth-form.tsx
+++ b/apps/mesh/src/web/components/unified-auth-form.tsx
@@ -199,11 +199,26 @@ export function UnifiedAuthForm({
     }
   };
   const compact = variant === "compact";
-  const visibleSocialProviders = allowedSocialProviders
+  const restrictedSocialProviders = allowedSocialProviders
     ? socialProviders.providers.filter((provider) =>
         allowedSocialProviders.includes(provider.name),
       )
     : socialProviders.providers;
+  const hasRestrictedSocialProviders =
+    socialProviders.enabled && restrictedSocialProviders.length > 0;
+  const passwordAvailableWithoutSocialFallback =
+    emailAndPassword.enabled &&
+    (allowPassword || (!emailOtp.enabled && !hasRestrictedSocialProviders));
+  // An embedded allowlist must not dead-end a deployment whose only enabled
+  // method is another social provider (for example a GitHub-only self-host).
+  const visibleSocialProviders =
+    socialProviders.enabled &&
+    socialProviders.providers.length > 0 &&
+    !hasRestrictedSocialProviders &&
+    !emailOtp.enabled &&
+    !passwordAvailableWithoutSocialFallback
+      ? socialProviders.providers
+      : restrictedSocialProviders;
   const hasSocialProviders =
     socialProviders.enabled && visibleSocialProviders.length > 0;
   const emailAndPasswordEnabled =

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -230,9 +230,9 @@ const commerceOnboardingRoute = createRoute({
   ),
 });
 
-// Public commerce report (Signal Deck) for a scanned domain — no auth. The
-// static /report segment wins over the /$org catch-all by specificity.
-const publicReportRoute = createRoute({
+// Auth-gated commerce report for a scanned domain. The route itself stays
+// outside the org shell so login can happen inline over its locked preview.
+const reportRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/report/$domain",
   component: lazyRouteComponent(() => import("./routes/reports.tsx")),
@@ -645,7 +645,7 @@ const routeTree = rootRoute.addChildren([
   adminLayoutWithChildren,
   onboardingRoute,
   commerceOnboardingRoute,
-  publicReportRoute,
+  reportRoute,
   loginRoute,
   cliAuthSuccessRoute,
   resetPasswordRoute,

--- a/apps/mesh/src/web/lib/posthog-client.test.ts
+++ b/apps/mesh/src/web/lib/posthog-client.test.ts
@@ -50,6 +50,7 @@ mock.module("posthog-js", () => ({
 const {
   initPostHog,
   identifyUser,
+  sanitizeAnalyticsUrl,
   setOrganizationGroup,
   resetUser,
   __resetForTest,
@@ -70,6 +71,91 @@ function stubLocalStorage(seed: Record<string, string> = {}) {
   (globalThis.window as { localStorage?: unknown }).localStorage = stub;
   return store;
 }
+
+describe("posthog-client report URL privacy", () => {
+  beforeEach(() => {
+    initCalls.length = 0;
+    __resetForTest();
+  });
+
+  test("removes report credentials while preserving attribution", () => {
+    expect(
+      sanitizeAnalyticsUrl(
+        "https://studio.decocms.com/report/acme.com?key=preview&d=email-token&share_id=share-1&utm_source=email#overview",
+      ),
+    ).toBe(
+      "https://studio.decocms.com/report/acme.com?share_id=share-1&utm_source=email#overview",
+    );
+    expect(
+      sanitizeAnalyticsUrl(
+        "/api/_reports/site/acme.com?key=preview&share_id=share-1",
+      ),
+    ).toBe("/api/_reports/site/acme.com?share_id=share-1");
+  });
+
+  test("redacts email link tokens embedded in API paths", () => {
+    expect(
+      sanitizeAnalyticsUrl(
+        "/api/_reports/link-token/private-token?email_run_id=run-42",
+      ),
+    ).toBe("/api/_reports/link-token/redacted?email_run_id=run-42");
+  });
+
+  test("leaves ordinary URLs and non-URL values unchanged", () => {
+    expect(sanitizeAnalyticsUrl("https://studio.decocms.com/acme/tasks")).toBe(
+      "https://studio.decocms.com/acme/tasks",
+    );
+    expect(sanitizeAnalyticsUrl("not a URL")).toBe("not a URL");
+  });
+
+  test("applies the sanitizer to events and session replay URLs", () => {
+    initPostHog("phc_test", "https://us.i.posthog.com");
+    const config = initCalls[0]?.[1] as {
+      before_send: (event: {
+        properties: Record<string, unknown>;
+        $set_once?: Record<string, unknown>;
+      }) => {
+        properties: Record<string, unknown>;
+        $set_once?: Record<string, unknown>;
+      };
+      session_recording: {
+        maskCapturedNetworkRequestFn: (request: { name: string }) => {
+          name: string;
+        };
+      };
+    };
+
+    const event = config.before_send({
+      properties: {
+        $current_url:
+          "https://studio.decocms.com/report/acme.com?key=preview&utm_source=share",
+      },
+      $set_once: {
+        $initial_current_url:
+          "https://studio.decocms.com/report/acme.com?d=email-token&utm_source=email",
+      },
+    });
+    expect(event.properties.$current_url).toBe(
+      "https://studio.decocms.com/report/acme.com?utm_source=share",
+    );
+    expect(event.$set_once?.$initial_current_url).toBe(
+      "https://studio.decocms.com/report/acme.com?utm_source=email",
+    );
+
+    expect(
+      config.session_recording.maskCapturedNetworkRequestFn({
+        name: "/api/_reports/site/acme.com?key=preview",
+      }),
+    ).toEqual({
+      name: "/api/_reports/site/acme.com",
+    });
+    expect(
+      config.session_recording.maskCapturedNetworkRequestFn({
+        name: "/api/_reports/link-token/email-token",
+      }),
+    ).toEqual({ name: "/api/_reports/link-token/redacted" });
+  });
+});
 
 describe("posthog-client.setOrganizationGroup", () => {
   beforeEach(() => {

--- a/apps/mesh/src/web/lib/posthog-client.ts
+++ b/apps/mesh/src/web/lib/posthog-client.ts
@@ -10,6 +10,7 @@
  */
 
 import posthog from "posthog-js";
+import type { BeforeSendFn, Properties } from "posthog-js";
 
 import { wasCacheRestored, wasOrgCacheRestored } from "@/web/lib/query-persist";
 
@@ -18,10 +19,67 @@ let lastOrgGroupKey: string | null = null;
 let bootstrapTimingSent = false;
 
 const LP_DISTINCT_ID_STASH = "mesh:lp-distinct-id";
+const REPORT_LINK_TOKEN_PATH = "/api/_reports/link-token/";
 // How long a stashed LP id stays mergeable. Long enough for "clicked the CTA
 // this morning, signed up tonight"; short enough that a shared machine can't
 // attach someone's week-old LP browsing to an unrelated login.
 const LP_STASH_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Remove report credentials from URLs before they leave the browser in
+ * analytics events, performance entries, or session replay metadata. */
+export function sanitizeAnalyticsUrl(value: string): string {
+  const base = "https://analytics.invalid";
+  const isAbsolute = /^[a-z][a-z\d+.-]*:\/\//i.test(value);
+  const isProtocolRelative = value.startsWith("//");
+
+  try {
+    const url = new URL(value, base);
+    let changed = false;
+
+    for (const parameter of ["key", "d"]) {
+      if (url.searchParams.has(parameter)) {
+        url.searchParams.delete(parameter);
+        changed = true;
+      }
+    }
+
+    if (
+      url.pathname.startsWith(REPORT_LINK_TOKEN_PATH) &&
+      url.pathname !== REPORT_LINK_TOKEN_PATH
+    ) {
+      url.pathname = `${REPORT_LINK_TOKEN_PATH}redacted`;
+      changed = true;
+    }
+
+    if (!changed) return value;
+    if (isAbsolute) return url.toString();
+    if (isProtocolRelative) {
+      return `//${url.host}${url.pathname}${url.search}${url.hash}`;
+    }
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return value;
+  }
+}
+
+function sanitizeAnalyticsProperties(properties: Properties): Properties {
+  return Object.fromEntries(
+    Object.entries(properties).map(([key, value]) => [
+      key,
+      typeof value === "string" ? sanitizeAnalyticsUrl(value) : value,
+    ]),
+  );
+}
+
+const sanitizeAnalyticsEvent: BeforeSendFn = (event) => {
+  if (!event) return null;
+  event.properties = sanitizeAnalyticsProperties(event.properties);
+  if (event.$set) event.$set = sanitizeAnalyticsProperties(event.$set);
+  if (event.$set_once) {
+    event.$set_once = sanitizeAnalyticsProperties(event.$set_once);
+  }
+  return event;
+};
 
 /** The stashed LP distinct_id, or undefined when absent/expired/corrupt. */
 function readLpStash(): string | undefined {
@@ -125,6 +183,7 @@ export function initPostHog(key: string, host: string) {
     capture_pageview: "history_change",
     capture_pageleave: true,
     autocapture: true,
+    before_send: sanitizeAnalyticsEvent,
     // Real-user Core Web Vitals (LCP, FCP, CLS, INP) as $web_vitals events.
     // On a cold refresh LCP ≈ when the app shell paints, so this is the
     // headline "how slow is the load" signal, sliceable by org/route/device.
@@ -144,6 +203,12 @@ export function initPostHog(key: string, host: string) {
     session_recording: {
       maskAllInputs: true,
       blockClass: "ph-no-capture",
+      maskCapturedNetworkRequestFn: (request) => ({
+        ...request,
+        ...(typeof request.name === "string"
+          ? { name: sanitizeAnalyticsUrl(request.name) }
+          : {}),
+      }),
     },
     person_profiles: "identified_only",
   });

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -47,9 +47,9 @@ export const KEYS = {
   homeGithubContributions: (orgId: string, connectionId: string) =>
     ["home-github-contributions", orgId, connectionId] as const,
 
-  // Public report deck for a scanned domain (/report/:domain, no auth).
-  publicReport: (domain: string, key?: string) =>
-    ["public-report", domain, key ?? ""] as const,
+  // Authenticated report deck for a scanned domain (/report/:domain).
+  report: (domain: string, key?: string) =>
+    ["report", domain, key ?? ""] as const,
 
   commerceDiscoveryConnection: (orgId: string, connectionId: string) =>
     ["commerce-discovery", "connection", orgId, connectionId] as const,

--- a/apps/mesh/src/web/routes/reports.tsx
+++ b/apps/mesh/src/web/routes/reports.tsx
@@ -8,10 +8,16 @@ import {
 } from "@/shared/report-seo";
 import { KEYS } from "@/web/lib/query-keys";
 import { authClient } from "@/web/lib/auth-client";
+import { isPostHogInitialized } from "@/web/lib/posthog-client";
 import { getReport } from "./reports/api";
 import { ReportAuthGate, ReportBackdrop } from "./reports/auth-gate";
 import ScanGate from "./reports/scan-gate";
-import { setReportReviewerMode } from "./reports/track";
+import {
+  captureReport,
+  consumeReportAuthAttempt,
+  reportAuthAttemptProperties,
+  setReportReviewerMode,
+} from "./reports/track";
 import "./reports/reports.css";
 
 const route = getRouteApi("/report/$domain");
@@ -94,6 +100,28 @@ export default function ReportPage() {
     return () => setReportReviewerMode(false);
   };
 
+  const authCompletionRef = (element: HTMLDivElement | null) => {
+    if (
+      !element ||
+      !authenticated ||
+      element.dataset.authCompletionTracked === "true" ||
+      !isPostHogInitialized()
+    )
+      return;
+    const attempt = consumeReportAuthAttempt(domain);
+    if (!attempt) return;
+    element.dataset.authCompletionTracked = "true";
+    captureReport("report_auth_succeeded", {
+      domain,
+      surface: "deck_v2",
+      ...reportAuthAttemptProperties(attempt),
+      method: attempt.method ?? "unknown",
+      time_to_auth_ms: Math.max(0, Date.now() - attempt.gate_shown_at),
+      ...(attempt.provider ? { provider: attempt.provider } : {}),
+      ...(attempt.auth_mode ? { auth_mode: attempt.auth_mode } : {}),
+    });
+  };
+
   const content = session.isPending ? (
     <ReportAuthGate domain={domain} loading />
   ) : !session.data?.user ? (
@@ -122,6 +150,7 @@ export default function ReportPage() {
           initial.data?.deck?.meta.faviconUrl,
         )(el);
         const cleanupReviewer = reviewerCleanupRef(el);
+        authCompletionRef(el);
         return () => {
           cleanupChrome?.();
           cleanupReviewer?.();

--- a/apps/mesh/src/web/routes/reports.tsx
+++ b/apps/mesh/src/web/routes/reports.tsx
@@ -9,7 +9,7 @@ import {
 import { KEYS } from "@/web/lib/query-keys";
 import { authClient } from "@/web/lib/auth-client";
 import { isPostHogInitialized } from "@/web/lib/posthog-client";
-import { getReport } from "./reports/api";
+import { getReport, isReportsUnauthorized } from "./reports/api";
 import { ReportAuthGate, ReportBackdrop } from "./reports/auth-gate";
 import ScanGate from "./reports/scan-gate";
 import {
@@ -70,6 +70,62 @@ function domainChromeRef(
   };
 }
 
+function UnauthorizedReportGate({
+  domain,
+  refreshSession,
+}: {
+  domain: string;
+  refreshSession: () => void;
+}) {
+  const refreshSessionRef = (element: HTMLDivElement | null) => {
+    if (!element || element.dataset.sessionRefreshStarted === "true") return;
+    element.dataset.sessionRefreshStarted = "true";
+    refreshSession();
+  };
+
+  return (
+    <div ref={refreshSessionRef}>
+      <ReportAuthGate domain={domain} />
+    </div>
+  );
+}
+
+function ReportLoadError({
+  domain,
+  retry,
+}: {
+  domain: string;
+  retry: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 overflow-y-auto">
+      <ReportBackdrop domain={domain} />
+      <div className="pointer-events-none absolute inset-0 bg-white/35" />
+      <div className="relative z-10 flex min-h-full items-center justify-center px-4 py-10">
+        <section
+          role="alert"
+          aria-label="Não foi possível carregar o relatório"
+          className="w-full max-w-[440px] rounded-3xl bg-background px-7 py-8 text-foreground shadow-2xl"
+        >
+          <h1 className="text-xl font-medium leading-7">
+            Não foi possível carregar este relatório.
+          </h1>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Verifique sua conexão e tente novamente.
+          </p>
+          <button
+            type="button"
+            onClick={retry}
+            className="mt-6 inline-flex h-11 items-center justify-center rounded-lg bg-primary px-5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/80"
+          >
+            Tentar novamente
+          </button>
+        </section>
+      </div>
+    </div>
+  );
+}
+
 export default function ReportPage() {
   const { domain: rawDomain } = route.useParams();
   const { key } = route.useSearch();
@@ -87,8 +143,11 @@ export default function ReportPage() {
     queryFn: () => getReport(domain, key),
     enabled: authenticated,
     staleTime: Infinity,
-    retry: 1,
+    retry: (failureCount, error) =>
+      !isReportsUnauthorized(error) && failureCount < 1,
   });
+  const reportUnauthorized =
+    initial.isError && isReportsUnauthorized(initial.error);
 
   const brand =
     initial.data?.deck?.meta.brand?.trim() || brandFromDomain(domain);
@@ -104,6 +163,7 @@ export default function ReportPage() {
     if (
       !element ||
       !authenticated ||
+      reportUnauthorized ||
       element.dataset.authCompletionTracked === "true" ||
       !isPostHogInitialized()
     )
@@ -126,6 +186,11 @@ export default function ReportPage() {
     <ReportAuthGate domain={domain} loading />
   ) : !session.data?.user ? (
     <ReportAuthGate domain={domain} />
+  ) : reportUnauthorized ? (
+    <UnauthorizedReportGate
+      domain={domain}
+      refreshSession={() => void session.refetch()}
+    />
   ) : initial.isPending ? (
     // Bare stage while the authenticated read resolves — ScanGate takes over
     // with the full scanning UI (or the deck renders when ready).
@@ -133,6 +198,8 @@ export default function ReportPage() {
       <ReportBackdrop domain={domain} />
       <div className="pointer-events-none absolute inset-0 bg-white/35" />
     </div>
+  ) : initial.isError ? (
+    <ReportLoadError domain={domain} retry={() => void initial.refetch()} />
   ) : (
     <ScanGate
       domain={domain}

--- a/apps/mesh/src/web/routes/reports.tsx
+++ b/apps/mesh/src/web/routes/reports.tsx
@@ -7,7 +7,9 @@ import {
   reportShareCopy,
 } from "@/shared/report-seo";
 import { KEYS } from "@/web/lib/query-keys";
-import { getPublicReport } from "./reports/api";
+import { authClient } from "@/web/lib/auth-client";
+import { getReport } from "./reports/api";
+import { ReportAuthGate } from "./reports/auth-gate";
 import ScanGate from "./reports/scan-gate";
 import { setReportReviewerMode } from "./reports/track";
 import { DECK } from "./reports/templates/tokens";
@@ -67,6 +69,8 @@ export default function ReportPage() {
   const { domain: rawDomain } = route.useParams();
   const { key } = route.useSearch();
   const domain = normalizeDomain(rawDomain);
+  const session = authClient.useSession();
+  const authenticated = Boolean(session.data?.user);
 
   // Reviewer sessions (?key=) flag every event with report_preview — set at
   // render (module state, so it lands before any child capture) and cleared
@@ -74,8 +78,9 @@ export default function ReportPage() {
   setReportReviewerMode(Boolean(key));
 
   const initial = useQuery({
-    queryKey: KEYS.publicReport(domain, key),
-    queryFn: () => getPublicReport(domain, key),
+    queryKey: KEYS.report(domain, key),
+    queryFn: () => getReport(domain, key),
+    enabled: authenticated,
     staleTime: Infinity,
     retry: 1,
   });
@@ -86,20 +91,29 @@ export default function ReportPage() {
 
   const reviewerCleanupRef = (el: HTMLDivElement | null) => {
     if (!el) return;
+    setReportReviewerMode(Boolean(key));
     return () => setReportReviewerMode(false);
   };
 
-  if (initial.isPending) {
-    // Bare stage while the first read resolves — ScanGate takes over with the
-    // full scanning UI (or the deck renders straight away when ready).
-    return (
-      <div
-        className="fixed inset-0"
-        style={{ background: DECK.forest }}
-        aria-busy="true"
-      />
-    );
-  }
+  const content = session.isPending ? (
+    <ReportAuthGate domain={domain} loading />
+  ) : !session.data?.user ? (
+    <ReportAuthGate domain={domain} />
+  ) : initial.isPending ? (
+    // Bare stage while the authenticated read resolves — ScanGate takes over
+    // with the full scanning UI (or the deck renders when ready).
+    <div
+      className="fixed inset-0"
+      style={{ background: DECK.forest }}
+      aria-busy="true"
+    />
+  ) : (
+    <ScanGate
+      domain={domain}
+      initial={initial.data}
+      sessionEmail={session.data.user.email}
+    />
+  );
 
   return (
     <div
@@ -116,7 +130,7 @@ export default function ReportPage() {
         };
       }}
     >
-      <ScanGate domain={domain} initial={initial.data} />
+      {content}
     </div>
   );
 }

--- a/apps/mesh/src/web/routes/reports.tsx
+++ b/apps/mesh/src/web/routes/reports.tsx
@@ -9,10 +9,9 @@ import {
 import { KEYS } from "@/web/lib/query-keys";
 import { authClient } from "@/web/lib/auth-client";
 import { getReport } from "./reports/api";
-import { ReportAuthGate } from "./reports/auth-gate";
+import { ReportAuthGate, ReportBackdrop } from "./reports/auth-gate";
 import ScanGate from "./reports/scan-gate";
 import { setReportReviewerMode } from "./reports/track";
-import { DECK } from "./reports/templates/tokens";
 import "./reports/reports.css";
 
 const route = getRouteApi("/report/$domain");
@@ -102,11 +101,10 @@ export default function ReportPage() {
   ) : initial.isPending ? (
     // Bare stage while the authenticated read resolves — ScanGate takes over
     // with the full scanning UI (or the deck renders when ready).
-    <div
-      className="fixed inset-0"
-      style={{ background: DECK.forest }}
-      aria-busy="true"
-    />
+    <div className="fixed inset-0 overflow-hidden" aria-busy="true">
+      <ReportBackdrop domain={domain} />
+      <div className="pointer-events-none absolute inset-0 bg-white/35" />
+    </div>
   ) : (
     <ScanGate
       domain={domain}

--- a/apps/mesh/src/web/routes/reports/api.ts
+++ b/apps/mesh/src/web/routes/reports/api.ts
@@ -8,8 +8,19 @@ import type {
   ScanTrigger,
 } from "@/reports/to-deck";
 
+class ReportsApiError extends Error {
+  constructor(readonly status: number) {
+    super(`reports API HTTP ${status}`);
+    this.name = "ReportsApiError";
+  }
+}
+
+export function isReportsUnauthorized(error: unknown): boolean {
+  return error instanceof ReportsApiError && error.status === 401;
+}
+
 async function json<T>(res: Response): Promise<T> {
-  if (!res.ok) throw new Error(`reports API HTTP ${res.status}`);
+  if (!res.ok) throw new ReportsApiError(res.status);
   return (await res.json()) as T;
 }
 

--- a/apps/mesh/src/web/routes/reports/api.ts
+++ b/apps/mesh/src/web/routes/reports/api.ts
@@ -1,4 +1,4 @@
-// Thin client for the public reports proxy (`/api/_reports/*`, no auth).
+// Thin client for the authenticated reports proxy (`/api/_reports/*`).
 // Mirrors the server types in `@/reports/to-deck`.
 
 import type {
@@ -13,11 +13,8 @@ async function json<T>(res: Response): Promise<T> {
   return (await res.json()) as T;
 }
 
-/** Anonymous read — the deck for an already-scanned domain (instant). */
-export function getPublicReport(
-  domain: string,
-  key?: string,
-): Promise<ReportState> {
+/** Read the deck for an already-scanned domain (instant). */
+export function getReport(domain: string, key?: string): Promise<ReportState> {
   const qs = key ? `?key=${encodeURIComponent(key)}` : "";
   return fetch(`/api/_reports/site/${encodeURIComponent(domain)}${qs}`).then(
     (r) => json<ReportState>(r),
@@ -27,7 +24,6 @@ export function getPublicReport(
 /** Trigger a scan. Idempotent + single-flight on the engine side. */
 export function runReportScan(input: {
   domain: string;
-  email?: string;
   distinctId?: string;
 }): Promise<ScanTrigger> {
   return fetch("/api/_reports/run", {

--- a/apps/mesh/src/web/routes/reports/auth-gate.tsx
+++ b/apps/mesh/src/web/routes/reports/auth-gate.tsx
@@ -1,8 +1,18 @@
 import { AuthEntry } from "@/web/components/auth-entry";
-import type { UnifiedAuthFormCopy } from "@/web/components/unified-auth-form";
+import type {
+  AuthFlowEvent,
+  UnifiedAuthFormCopy,
+} from "@/web/components/unified-auth-form";
 import { brandFromDomain, faviconForDomain } from "@/shared/report-seo";
+import { isPostHogInitialized } from "@/web/lib/posthog-client";
 import { ReportSocialProof } from "./report-social-proof";
-import { captureReport } from "./track";
+import {
+  beginReportAuthAttempt,
+  captureReport,
+  reportAuthAttemptProperties,
+  reportAuthErrorType,
+  updateReportAuthAttempt,
+} from "./track";
 import { DECK } from "./templates/tokens";
 
 const REPORT_AUTH_COPY = {
@@ -244,12 +254,51 @@ export function ReportAuthGate({
   domain: string;
   loading?: boolean;
 }) {
+  const handleAuthEvent = (event: AuthFlowEvent) => {
+    const provider = "provider" in event ? event.provider : undefined;
+    const authMode = "mode" in event ? event.mode : undefined;
+    const method =
+      event.method === "social" ? (provider ?? "social") : event.method;
+    const details = {
+      method,
+      provider,
+      auth_mode: authMode,
+    };
+    const attempt = updateReportAuthAttempt(domain, details);
+
+    const properties = {
+      domain,
+      surface: "deck_v2",
+      ...reportAuthAttemptProperties(attempt),
+      ...details,
+    };
+
+    if (event.type === "started") {
+      captureReport("report_auth_started", properties);
+    } else if (event.type === "otp_sent") {
+      captureReport("report_auth_otp_sent", properties);
+    } else if (event.type === "otp_submitted") {
+      captureReport("report_auth_otp_submitted", properties);
+    } else if (event.type === "failed") {
+      captureReport("report_auth_failed", {
+        ...properties,
+        failure_stage: event.stage,
+        error_type: reportAuthErrorType(event.error),
+      });
+    }
+    // `succeeded` updates the durable attempt above. The identified success
+    // event is emitted after the auth redirect, when the report route unlocks.
+  };
+
   const trackGateRef = (element: HTMLDivElement | null) => {
-    if (!element || loading || element.dataset.tracked === "true") return;
+    if (!element || loading) return;
+    const attempt = beginReportAuthAttempt(domain);
+    if (element.dataset.tracked === "true" || !isPostHogInitialized()) return;
     element.dataset.tracked = "true";
     captureReport("report_auth_gate_shown", {
       domain,
       surface: "deck_v2",
+      ...reportAuthAttemptProperties(attempt),
     });
   };
 
@@ -286,6 +335,7 @@ export function ReportAuthGate({
               variant="compact"
               allowedSocialProviders={["google"]}
               allowPassword={false}
+              onAuthEvent={handleAuthEvent}
               brand={
                 <div className="flex items-center justify-between gap-4">
                   <div

--- a/apps/mesh/src/web/routes/reports/auth-gate.tsx
+++ b/apps/mesh/src/web/routes/reports/auth-gate.tsx
@@ -1,6 +1,7 @@
 import { AuthEntry } from "@/web/components/auth-entry";
 import type { UnifiedAuthFormCopy } from "@/web/components/unified-auth-form";
 import { brandFromDomain, faviconForDomain } from "@/shared/report-seo";
+import { ReportSocialProof } from "./report-social-proof";
 import { captureReport } from "./track";
 import { DECK } from "./templates/tokens";
 
@@ -33,7 +34,7 @@ function callbackUrl(domain: string): string {
   return `${path}${window.location.search}${window.location.hash}`;
 }
 
-function ReportBackdrop({ domain }: { domain: string }) {
+export function ReportBackdrop({ domain }: { domain: string }) {
   const brand = brandFromDomain(domain);
 
   return (
@@ -263,7 +264,7 @@ export function ReportAuthGate({
       }}
     >
       <ReportBackdrop domain={domain} />
-      <div className="absolute inset-0 bg-white/35" />
+      <div className="pointer-events-none absolute inset-0 bg-white/35" />
 
       <div className="relative z-10 flex min-h-full items-center justify-center px-3 py-5 sm:px-6 sm:py-10">
         {loading ? (
@@ -318,6 +319,7 @@ export function ReportAuthGate({
             >
               Acesso gratuito. Leva menos de um minuto.
             </p>
+            <ReportSocialProof compact />
           </section>
         )}
       </div>

--- a/apps/mesh/src/web/routes/reports/auth-gate.tsx
+++ b/apps/mesh/src/web/routes/reports/auth-gate.tsx
@@ -1,0 +1,326 @@
+import { AuthEntry } from "@/web/components/auth-entry";
+import type { UnifiedAuthFormCopy } from "@/web/components/unified-auth-form";
+import { brandFromDomain, faviconForDomain } from "@/shared/report-seo";
+import { captureReport } from "./track";
+import { DECK } from "./templates/tokens";
+
+const REPORT_AUTH_COPY = {
+  otpSendFailed: "Não foi possível enviar o código",
+  invalidCode: "Código inválido",
+  invalidEmail: "Digite um email válido",
+  networkError: "Erro de conexão. Tente novamente.",
+  tooManyAttempts: "Muitas tentativas. Aguarde um momento e tente novamente.",
+  invalidOrExpiredCode: "Código inválido ou expirado. Tente novamente.",
+  genericError: "Algo deu errado. Tente novamente.",
+  verificationCodeTitle: "Digite o código",
+  codeSentTo: (email: string) => `Enviamos um código para ${email}`,
+  continueWith: (provider: string) => `Continuar com ${provider}`,
+  divider: "ou",
+  emailLabel: "Email",
+  emailPlaceholder: "seu@email.com",
+  sending: "Enviando...",
+  sendCode: "Continuar",
+  verificationCodeLabel: "Código de verificação",
+  enterCodePlaceholder: "Digite o código",
+  verifying: "Verificando...",
+  verify: "Entrar",
+  useDifferentEmail: "Usar outro email",
+} satisfies Partial<UnifiedAuthFormCopy>;
+
+function callbackUrl(domain: string): string {
+  const path = `/report/${encodeURIComponent(domain)}`;
+  if (typeof window === "undefined") return path;
+  return `${path}${window.location.search}${window.location.hash}`;
+}
+
+function ReportBackdrop({ domain }: { domain: string }) {
+  const brand = brandFromDomain(domain);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-[-18px] select-none overflow-hidden"
+      style={{
+        background: DECK.bg,
+        color: DECK.ink,
+        filter: "blur(9px)",
+        fontFamily: "Switzer, 'Inter var', Helvetica, Arial, sans-serif",
+        transform: "scale(1.025)",
+      }}
+    >
+      <div className="flex h-full min-h-[640px] flex-col px-6 py-5 sm:px-10 sm:py-8 lg:px-16">
+        <header
+          className="flex items-center justify-between border-b pb-5"
+          style={{ borderColor: DECK.border }}
+        >
+          <div className="flex items-center gap-3">
+            <img
+              src={faviconForDomain(domain)}
+              alt=""
+              className="h-8 w-8 rounded-lg object-contain"
+            />
+            <div>
+              <p className="text-sm font-medium">{brand}</p>
+              <p className="text-xs" style={{ color: DECK.faint }}>
+                {domain}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              className="h-2 w-16 rounded-full"
+              style={{ background: DECK.border }}
+            />
+            <span
+              className="h-9 w-24 rounded-full"
+              style={{ background: DECK.ink }}
+            />
+          </div>
+        </header>
+
+        <main className="grid min-h-0 flex-1 items-center gap-8 py-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(420px,1.1fr)] lg:gap-14">
+          <div className="space-y-7">
+            <div className="space-y-4">
+              <p
+                className="text-xs font-medium uppercase tracking-[0.08em]"
+                style={{ color: DECK.soft }}
+              >
+                Relatório de comércio digital
+              </p>
+              <h1 className="max-w-[13ch] text-4xl font-normal leading-[1.04] tracking-[-0.035em] sm:text-6xl">
+                Uma visão completa da sua loja.
+              </h1>
+              <p
+                className="max-w-[38rem] text-base leading-7"
+                style={{ color: DECK.muted }}
+              >
+                Oportunidades, comparativos e próximos passos reunidos em um
+                único relatório.
+              </p>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              {["Experiência", "Descoberta", "Conversão", "Operação"].map(
+                (label, index) => (
+                  <div
+                    key={label}
+                    className="rounded-2xl border p-4"
+                    style={{ borderColor: DECK.border, background: "#fff" }}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm" style={{ color: DECK.muted }}>
+                        {label}
+                      </span>
+                      <span className="text-2xl font-light">
+                        {72 + index * 5}
+                      </span>
+                    </div>
+                    <div
+                      className="mt-4 h-1.5 overflow-hidden rounded-full"
+                      style={{ background: DECK.border }}
+                    >
+                      <div
+                        className="h-full rounded-full"
+                        style={{
+                          background: DECK.soft,
+                          width: `${54 + index * 9}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                ),
+              )}
+            </div>
+          </div>
+
+          <div
+            className="relative hidden h-[min(68vh,660px)] min-h-[430px] overflow-hidden rounded-[2rem] border p-8 lg:block"
+            style={{
+              borderColor: DECK.border,
+              background:
+                "radial-gradient(circle at 18% 18%, rgba(208,236,26,.45), transparent 35%), radial-gradient(circle at 82% 30%, rgba(152,221,255,.7), transparent 34%), radial-gradient(circle at 60% 86%, rgba(255,183,214,.65), transparent 42%), #f7f5ef",
+            }}
+          >
+            <div
+              className="absolute inset-x-8 top-8 rounded-2xl border bg-white p-3 shadow-xl"
+              style={{ borderColor: DECK.border }}
+            >
+              <div
+                className="mb-3 flex items-center gap-2 border-b pb-3"
+                style={{ borderColor: DECK.border }}
+              >
+                <span className="h-2.5 w-2.5 rounded-full bg-[#ff6b67]" />
+                <span className="h-2.5 w-2.5 rounded-full bg-[#f5c451]" />
+                <span className="h-2.5 w-2.5 rounded-full bg-[#65c466]" />
+                <span
+                  className="ml-3 h-6 flex-1 rounded-full"
+                  style={{ background: DECK.bg }}
+                />
+              </div>
+              <div className="grid h-[330px] grid-cols-[0.72fr_1.28fr] gap-3">
+                <div
+                  className="space-y-3 rounded-xl p-4"
+                  style={{ background: DECK.forest }}
+                >
+                  <div className="h-3 w-16 rounded-full bg-white/30" />
+                  <div className="h-8 w-full rounded-lg bg-white/80" />
+                  <div className="h-3 w-4/5 rounded-full bg-white/30" />
+                  <div className="mt-8 h-24 rounded-xl bg-white/10" />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  {[0, 1, 2, 3].map((item) => (
+                    <div
+                      key={item}
+                      className="rounded-xl border bg-white p-3"
+                      style={{ borderColor: DECK.border }}
+                    >
+                      <div
+                        className="h-24 rounded-lg"
+                        style={{ background: DECK.bg }}
+                      />
+                      <div
+                        className="mt-3 h-3 w-4/5 rounded-full"
+                        style={{ background: DECK.border }}
+                      />
+                      <div
+                        className="mt-2 h-3 w-1/2 rounded-full"
+                        style={{ background: DECK.border }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <div className="absolute bottom-8 left-8 right-8 flex items-center justify-between rounded-2xl bg-white/85 px-5 py-4 shadow-lg">
+              <div className="space-y-2">
+                <div
+                  className="h-3 w-28 rounded-full"
+                  style={{ background: DECK.border }}
+                />
+                <div
+                  className="h-5 w-44 rounded-full"
+                  style={{ background: DECK.ink }}
+                />
+              </div>
+              <div
+                className="h-12 w-12 rounded-full"
+                style={{ background: DECK.soft }}
+              />
+            </div>
+          </div>
+        </main>
+
+        <footer
+          className="flex items-center justify-between border-t pt-5"
+          style={{ borderColor: DECK.border }}
+        >
+          <span
+            className="h-2 w-24 rounded-full"
+            style={{ background: DECK.border }}
+          />
+          <div className="flex gap-2">
+            {[0, 1, 2, 3].map((item) => (
+              <span
+                key={item}
+                className="h-2 rounded-full"
+                style={{
+                  background: item === 0 ? DECK.ink : DECK.border,
+                  width: item === 0 ? 28 : 8,
+                }}
+              />
+            ))}
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+export function ReportAuthGate({
+  domain,
+  loading = false,
+}: {
+  domain: string;
+  loading?: boolean;
+}) {
+  const trackGateRef = (element: HTMLDivElement | null) => {
+    if (!element || loading || element.dataset.tracked === "true") return;
+    element.dataset.tracked = "true";
+    captureReport("report_auth_gate_shown", {
+      domain,
+      surface: "deck_v2",
+    });
+  };
+
+  return (
+    <div
+      ref={trackGateRef}
+      className="fixed inset-0 overflow-y-auto"
+      style={{
+        color: DECK.ink,
+        fontFamily: "Switzer, 'Inter var', Helvetica, Arial, sans-serif",
+        WebkitFontSmoothing: "antialiased",
+      }}
+    >
+      <ReportBackdrop domain={domain} />
+      <div className="absolute inset-0 bg-white/35" />
+
+      <div className="relative z-10 flex min-h-full items-center justify-center px-3 py-5 sm:px-6 sm:py-10">
+        {loading ? (
+          <div
+            className="h-[330px] w-full max-w-[440px] animate-pulse rounded-3xl bg-white/90"
+            aria-label="Carregando sessão"
+          />
+        ) : (
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-label="Acesse seu relatório"
+            className="w-full max-w-[440px] rounded-2xl bg-white px-5 py-5 shadow-2xl sm:rounded-3xl sm:px-7 sm:py-7"
+          >
+            <AuthEntry
+              callbackUrl={callbackUrl(domain)}
+              title="Acesse seu relatório"
+              subtitle="Entre ou crie sua conta para ver a análise completa."
+              variant="compact"
+              allowedSocialProviders={["google"]}
+              allowPassword={false}
+              brand={
+                <div className="flex items-center justify-between gap-4">
+                  <div
+                    className="inline-flex min-w-0 items-center gap-2 rounded-full border px-3 py-1.5"
+                    style={{ borderColor: DECK.border, background: DECK.bg }}
+                  >
+                    <img
+                      src={faviconForDomain(domain)}
+                      alt=""
+                      className="h-4 w-4 shrink-0 rounded object-contain"
+                    />
+                    <span
+                      className="truncate text-[13px]"
+                      style={{ color: DECK.muted }}
+                    >
+                      {domain}
+                    </span>
+                  </div>
+                  <img
+                    src="/logos/deco logo.svg"
+                    alt="Deco"
+                    className="h-7 w-7 shrink-0"
+                  />
+                </div>
+              }
+              copy={REPORT_AUTH_COPY}
+            />
+            <p
+              className="mt-5 text-center text-xs leading-5"
+              style={{ color: DECK.faint }}
+            >
+              Acesso gratuito. Leva menos de um minuto.
+            </p>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/reports/orchestrate-scan.ts
+++ b/apps/mesh/src/web/routes/reports/orchestrate-scan.ts
@@ -1,5 +1,5 @@
 // The scan lifecycle as a pure async function (no React): trigger the scan,
-// then poll the public read (and the durable run's status when we have an id)
+// then poll the authenticated read (and the durable run's status when we have an id)
 // until the deck is ready or the run terminates. Ported from ScanGate's effect
 // in the decocms landing — here it's started from a mount callback ref and
 // cancelled via AbortSignal.
@@ -7,7 +7,7 @@
 import { sleep } from "@decocms/std";
 import type { TemplateDeck } from "@/reports/deck-types";
 import type { SlideDrop } from "@/reports/to-deck";
-import { getPublicReport, getScanStatus, runReportScan } from "./api";
+import { getReport, getScanStatus, runReportScan } from "./api";
 import { captureReport } from "./track";
 
 const POLL_MS = 4000;
@@ -32,9 +32,9 @@ export function reportDrops(domain: string, drops?: SlideDrop[]): void {
     });
 }
 
-// localStorage mark: this browser already has a scan in flight for the domain
-// (so a reload lands straight on the pending screen, keeping the typed email).
-type PendingMark = { emailed: boolean };
+// localStorage mark: this browser already has a scan in flight for the domain,
+// so a reload lands straight on the pending screen.
+type PendingMark = { startedAt?: number };
 const PKEY = (d: string) => `report:pending:${d}`;
 export const readPending = (d: string): PendingMark | null => {
   try {
@@ -43,9 +43,9 @@ export const readPending = (d: string): PendingMark | null => {
     return null;
   }
 };
-export const writePending = (d: string, v: PendingMark) => {
+const writePending = (d: string) => {
   try {
-    localStorage.setItem(PKEY(d), JSON.stringify(v));
+    localStorage.setItem(PKEY(d), JSON.stringify({ startedAt: Date.now() }));
   } catch {
     /* ignore */
   }
@@ -85,11 +85,11 @@ export async function orchestrateScan(
         domain,
         surface: "deck_v2",
       });
-      writePending(domain, readPending(domain) ?? { emailed: false });
+      writePending(domain);
     }
 
     for (let i = 0; i < MAX_POLLS && !signal.aborted; i++) {
-      const next = await getPublicReport(domain);
+      const next = await getReport(domain);
       if (signal.aborted) return;
       if (next.status === "ready" && next.deck) {
         clearPending(domain);
@@ -102,7 +102,7 @@ export async function orchestrateScan(
         if (signal.aborted) return;
         if (st.done) {
           await sleep(POLL_MS, { signal });
-          const fin = await getPublicReport(domain);
+          const fin = await getReport(domain);
           if (signal.aborted) return;
           if (fin.status === "ready" && fin.deck) {
             clearPending(domain);

--- a/apps/mesh/src/web/routes/reports/orchestrate-scan.ts
+++ b/apps/mesh/src/web/routes/reports/orchestrate-scan.ts
@@ -7,13 +7,24 @@
 import { sleep } from "@decocms/std";
 import type { TemplateDeck } from "@/reports/deck-types";
 import type { SlideDrop } from "@/reports/to-deck";
-import { getReport, getScanStatus, runReportScan } from "./api";
+import {
+  getReport,
+  getScanStatus,
+  isReportsUnauthorized,
+  runReportScan,
+} from "./api";
 import { captureReport } from "./track";
 
 const POLL_MS = 4000;
 const MAX_POLLS = 180;
 
-export type ScanPhase = "scanning" | "pending" | "blocked" | "empty" | "error";
+export type ScanPhase =
+  | "scanning"
+  | "pending"
+  | "blocked"
+  | "empty"
+  | "unauthorized"
+  | "error";
 
 export interface ScanEvents {
   onPhase: (phase: ScanPhase) => void;
@@ -136,16 +147,17 @@ export async function orchestrateScan(
       });
       events.onPhase("empty");
     }
-  } catch {
+  } catch (error) {
     if (!signal.aborted) {
       clearPending(domain);
+      const unauthorized = isReportsUnauthorized(error);
       captureReport("report_scan_failed", {
         domain,
-        phase: "error",
-        reason: "exception",
+        phase: unauthorized ? "unauthorized" : "error",
+        reason: unauthorized ? "unauthorized" : "exception",
         surface: "deck_v2",
       });
-      events.onPhase("error");
+      events.onPhase(unauthorized ? "unauthorized" : "error");
     }
   }
 }

--- a/apps/mesh/src/web/routes/reports/report-social-proof.tsx
+++ b/apps/mesh/src/web/routes/reports/report-social-proof.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { DECK } from "./templates/tokens";
+
+// Intrinsic pixel dimensions keep SVGs with preserveAspectRatio="none" from
+// stretching when they are rendered inside the carousel cells.
+const CAROUSEL_LOGOS = [
+  { src: "/logos/summit/fila.svg", alt: "Fila", w: 100, h: 34 },
+  { src: "/logos/summit/osklen.svg", alt: "Osklen", w: 152, h: 21 },
+  { src: "/logos/summit/farm-rio.svg", alt: "Farm Rio", w: 159, h: 23 },
+  { src: "/logos/summit/electrolux.svg", alt: "Electrolux", w: 154, h: 35 },
+  { src: "/logos/summit/monte-carlo.svg", alt: "Monte Carlo", w: 116, h: 61 },
+  {
+    src: "/logos/summit/leroy-merlin.svg",
+    alt: "Leroy Merlin",
+    w: 109,
+    h: 62,
+  },
+  { src: "/logos/summit/technos.svg", alt: "Technos", w: 141, h: 29 },
+  { src: "/logos/summit/bagaggio.svg", alt: "Bagaggio", w: 149, h: 22 },
+  { src: "/logos/summit/le-biscuit.svg", alt: "Le Biscuit", w: 141, h: 24 },
+  { src: "/logos/summit/miess.svg", alt: "Miess", w: 113, h: 43 },
+  {
+    src: "/logos/summit/casa-e-video.svg",
+    alt: "Casa & Video",
+    w: 145,
+    h: 18,
+  },
+  { src: "/logos/summit/hering-fill.svg", alt: "Hering", w: 140, h: 30 },
+] as const;
+
+const CAROUSEL_COLS = 4;
+const CYCLE_MS = 2400;
+
+type LogoEntry = (typeof CAROUSEL_LOGOS)[number];
+
+function splitLogos(n: number): LogoEntry[][] {
+  const cols: LogoEntry[][] = Array.from({ length: n }, () => []);
+  CAROUSEL_LOGOS.forEach((logo, index) => cols[index % n]?.push(logo));
+  return cols;
+}
+
+function LogoCol({
+  logos,
+  delayMs,
+  last,
+  bottomRow,
+}: {
+  logos: LogoEntry[];
+  delayMs: number;
+  last?: boolean;
+  bottomRow?: boolean;
+}) {
+  const [index, setIndex] = useState(0);
+
+  const cycleRef = (element: HTMLDivElement | null) => {
+    if (!element) return;
+    let interval: ReturnType<typeof setInterval> | undefined;
+    const timeout = setTimeout(() => {
+      interval = setInterval(
+        () => setIndex((current) => (current + 1) % logos.length),
+        CYCLE_MS,
+      );
+    }, delayMs);
+    return () => {
+      clearTimeout(timeout);
+      if (interval) clearInterval(interval);
+    };
+  };
+
+  const logo = logos[index % logos.length] ?? logos[0];
+  if (!logo) return null;
+
+  const maxWidth = 78;
+  const maxHeight = 22;
+  const scale = Math.min(maxWidth / logo.w, maxHeight / logo.h);
+  const renderWidth = Math.round(logo.w * scale);
+  const renderHeight = Math.round(logo.h * scale);
+
+  return (
+    <div
+      ref={cycleRef}
+      className="flex flex-1 items-center justify-center overflow-hidden py-3"
+      style={{
+        borderRight: last ? undefined : `1px solid ${DECK.border}`,
+        borderTop: bottomRow ? `1px solid ${DECK.border}` : undefined,
+      }}
+    >
+      <img
+        key={index}
+        src={logo.src}
+        alt={logo.alt}
+        width={renderWidth}
+        height={renderHeight}
+        className="logo-carousel-enter block"
+      />
+    </div>
+  );
+}
+
+function LogoCarousel() {
+  const cols = splitLogos(CAROUSEL_COLS);
+
+  return (
+    <>
+      <div
+        className="grid grid-cols-2 overflow-hidden rounded-xl sm:hidden"
+        style={{ border: `1px solid ${DECK.border}` }}
+      >
+        {cols.map((logos, index) => (
+          <LogoCol
+            key={logos[0]?.src}
+            logos={logos}
+            delayMs={index * 380}
+            last={index % 2 === 1}
+            bottomRow={index >= 2}
+          />
+        ))}
+      </div>
+      <div
+        className="hidden overflow-hidden rounded-xl sm:flex"
+        style={{ border: `1px solid ${DECK.border}` }}
+      >
+        {cols.map((logos, index) => (
+          <LogoCol
+            key={logos[0]?.src}
+            logos={logos}
+            delayMs={index * 380}
+            last={index === cols.length - 1}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+export function ReportSocialProof({ compact = false }: { compact?: boolean }) {
+  return (
+    <div
+      className={cn(compact ? "mt-5 pt-5" : "mt-8 pt-6")}
+      style={{ borderTop: `1px solid ${DECK.border}` }}
+    >
+      <p
+        className="mb-4 text-center text-[11px] uppercase tracking-[0.04em]"
+        style={{ color: DECK.faint }}
+      >
+        Já receberam
+      </p>
+      <LogoCarousel />
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/reports/reports.css
+++ b/apps/mesh/src/web/routes/reports/reports.css
@@ -69,15 +69,6 @@
   }
 }
 
-/* ── ScanGate email input ───────────────────────────────────────────────── */
-.scan-gate-input::placeholder {
-  color: #78726e;
-}
-.scan-gate-input:focus {
-  border-color: rgba(40, 37, 36, 0.35) !important;
-  outline: none;
-}
-
 /* ── ScanGate logo carousel ─────────────────────────────────────────────── */
 @keyframes logoCycleEnter {
   from {

--- a/apps/mesh/src/web/routes/reports/scan-gate.tsx
+++ b/apps/mesh/src/web/routes/reports/scan-gate.tsx
@@ -4,16 +4,13 @@ import type { TemplateDeck } from "@/reports/deck-types";
 import { faviconForDomain } from "@/shared/report-seo";
 import type { ReportState } from "@/reports/to-deck";
 import { isPostHogInitialized } from "@/web/lib/posthog-client";
-import { runReportScan } from "./api";
 import {
   orchestrateScan,
   readPending,
   reportDrops,
   type ScanPhase,
-  writePending,
 } from "./orchestrate-scan";
 import SignalDeck from "./signal-deck";
-import { captureReport } from "./track";
 import { DECK } from "./templates/tokens";
 
 const LIME = "#D0EC1A";
@@ -54,9 +51,11 @@ function splitLogos(n: number) {
 export default function ScanGate({
   domain,
   initial,
+  sessionEmail,
 }: {
   domain: string;
   initial?: ReportState;
+  sessionEmail: string;
 }) {
   const [deck, setDeck] = useState<TemplateDeck | null>(
     initial?.status === "ready" ? initial.deck : null,
@@ -83,7 +82,7 @@ export default function ScanGate({
 
   return (
     <div ref={scanRef}>
-      <ScanScreen domain={domain} phase={phase} />
+      <ScanScreen domain={domain} phase={phase} email={sessionEmail} />
     </div>
   );
 }
@@ -107,7 +106,15 @@ function stagesFor(phase: ScanPhase): StageState[] {
 
 // ── page shell ────────────────────────────────────────────────────────────────
 
-function ScanScreen({ domain, phase }: { domain: string; phase: ScanPhase }) {
+function ScanScreen({
+  domain,
+  phase,
+  email,
+}: {
+  domain: string;
+  phase: ScanPhase;
+  email: string;
+}) {
   const isActive = phase === "scanning" || phase === "pending";
   const stages = stagesFor(phase);
 
@@ -182,10 +189,11 @@ function ScanScreen({ domain, phase }: { domain: string; phase: ScanPhase }) {
               className="mt-2 sm:mt-3 text-[13px] sm:text-[14px] leading-[1.6]"
               style={{ color: DECK.muted }}
             >
-              Deixe seu email abaixo e avisamos quando estiver pronto.
+              Você pode acompanhar por aqui. Também avisaremos quando estiver
+              pronto.
             </p>
 
-            {/* Email capture */}
+            {/* Authenticated delivery address */}
             <div
               className="mt-4 sm:mt-5 rounded-xl sm:rounded-2xl px-4 sm:px-5 py-4 sm:py-5"
               style={{ background: "#F2F1EF" }}
@@ -194,9 +202,9 @@ function ScanScreen({ domain, phase }: { domain: string; phase: ScanPhase }) {
                 className="mb-2.5 sm:mb-3 text-[15px] sm:text-[16px]"
                 style={{ color: DECK.ink }}
               >
-                Receba uma notificação quando ficar pronto:
+                Enviaremos uma notificação para:
               </p>
-              <EmailCapture domain={domain} />
+              <NotificationEmail email={email} />
             </div>
 
             {/* Tracker */}
@@ -390,95 +398,46 @@ function StepDot({ state }: { state: StageState }) {
   );
 }
 
-// ── email capture ─────────────────────────────────────────────────────────────
+// ── authenticated delivery address ──────────────────────────────────────────
 
-function EmailCapture({ domain }: { domain: string }) {
-  const [email, setEmail] = useState("");
-  const [sent, setSent] = useState(() => readPending(domain)?.emailed ?? false);
-
-  function submit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!email.trim() || sent) return;
-    setSent(true);
-    writePending(domain, { emailed: true });
-    captureReport("report_pending_email", { domain, surface: "deck_v2" });
-    if (isPostHogInitialized()) {
-      posthog.setPersonProperties({
-        email: email.trim(),
-        last_scanned_domain: domain,
-      });
-    }
-    runReportScan({
-      domain,
-      email: email.trim(),
-      distinctId: distinctId(),
-    }).catch(() => {});
-  }
-
-  if (sent) {
-    return (
-      <div
-        className="flex items-center gap-3 rounded-xl px-4 py-3"
-        style={{ background: DECK.limeTint }}
-      >
-        <div
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
-          style={{ background: DECK.soft }}
-        >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            aria-hidden="true"
-          >
-            <path
-              d="M2 6l2.5 2.5L10 3.5"
-              stroke="#fff"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </div>
-        <div>
-          <p className="text-[13px] font-medium" style={{ color: FOREST }}>
-            Email registrado
-          </p>
-          <p className="text-[12px]" style={{ color: DECK.soft }}>
-            Avisamos assim que ficar pronto.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
+function NotificationEmail({ email }: { email: string }) {
   return (
-    <form onSubmit={submit} className="flex items-center gap-3">
-      <input
-        id="notify-email"
-        type="email"
-        required
-        // eslint-disable-next-line jsx-a11y/no-autofocus
-        autoFocus
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="seu@email.com"
-        className="scan-gate-input min-w-0 flex-1 h-12 px-6 rounded-full text-[15px] outline-none transition-colors"
-        style={{
-          background: "#fff",
-          border: `1px solid ${DECK.inputBorder}`,
-          color: DECK.ink,
-        }}
-      />
-      <button
-        type="submit"
-        className="shrink-0 cursor-pointer h-12 px-6 rounded-full text-[15px] font-medium transition-transform active:scale-[0.97]"
-        style={{ background: DECK.primary, color: DECK.primaryFg }}
+    <div
+      className="flex min-w-0 items-center gap-3 rounded-xl px-4 py-3"
+      style={{ background: DECK.limeTint }}
+    >
+      <div
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
+        style={{ background: DECK.soft }}
       >
-        Avisar
-      </button>
-    </form>
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M2 6l2.5 2.5L10 3.5"
+            stroke="#fff"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+      <div className="min-w-0">
+        <p
+          className="truncate text-[13px] font-medium"
+          style={{ color: FOREST }}
+        >
+          {email}
+        </p>
+        <p className="text-[12px]" style={{ color: DECK.soft }}>
+          Avisamos assim que ficar pronto.
+        </p>
+      </div>
+    </div>
   );
 }
 

--- a/apps/mesh/src/web/routes/reports/scan-gate.tsx
+++ b/apps/mesh/src/web/routes/reports/scan-gate.tsx
@@ -10,7 +10,7 @@ import {
   reportDrops,
   type ScanPhase,
 } from "./orchestrate-scan";
-import { ReportBackdrop } from "./auth-gate";
+import { ReportAuthGate, ReportBackdrop } from "./auth-gate";
 import { ReportSocialProof } from "./report-social-proof";
 import SignalDeck from "./signal-deck";
 import { DECK } from "./templates/tokens";
@@ -52,6 +52,9 @@ export default function ScanGate({
   };
 
   if (deck) return <SignalDeck deck={deck} />;
+  if (phase === "unauthorized") {
+    return <ReportAuthGate domain={domain} />;
+  }
 
   return (
     <div ref={scanRef}>

--- a/apps/mesh/src/web/routes/reports/scan-gate.tsx
+++ b/apps/mesh/src/web/routes/reports/scan-gate.tsx
@@ -10,6 +10,8 @@ import {
   reportDrops,
   type ScanPhase,
 } from "./orchestrate-scan";
+import { ReportBackdrop } from "./auth-gate";
+import { ReportSocialProof } from "./report-social-proof";
 import SignalDeck from "./signal-deck";
 import { DECK } from "./templates/tokens";
 
@@ -18,35 +20,6 @@ const FOREST = "#07401A";
 
 const distinctId = () =>
   isPostHogInitialized() ? posthog.get_distinct_id() : undefined;
-
-// Full logo set — intrinsic pixel dimensions prevent SVG blowup
-const CAROUSEL_LOGOS = [
-  { src: "/logos/summit/fila.svg", alt: "Fila", w: 100, h: 34 },
-  { src: "/logos/summit/osklen.svg", alt: "Osklen", w: 152, h: 21 },
-  { src: "/logos/summit/farm-rio.svg", alt: "Farm Rio", w: 159, h: 23 },
-  { src: "/logos/summit/electrolux.svg", alt: "Electrolux", w: 154, h: 35 },
-  { src: "/logos/summit/monte-carlo.svg", alt: "Monte Carlo", w: 116, h: 61 },
-  { src: "/logos/summit/leroy-merlin.svg", alt: "Leroy Merlin", w: 109, h: 62 },
-  { src: "/logos/summit/technos.svg", alt: "Technos", w: 141, h: 29 },
-  { src: "/logos/summit/bagaggio.svg", alt: "Bagaggio", w: 149, h: 22 },
-  { src: "/logos/summit/le-biscuit.svg", alt: "Le Biscuit", w: 141, h: 24 },
-  { src: "/logos/summit/miess.svg", alt: "Miess", w: 113, h: 43 },
-  { src: "/logos/summit/casa-e-video.svg", alt: "Casa & Video", w: 145, h: 18 },
-  { src: "/logos/summit/hering-fill.svg", alt: "Hering", w: 140, h: 30 },
-] as const;
-
-const CAROUSEL_COLS = 4;
-const CYCLE_MS = 2400;
-
-// Split logos into N columns (round-robin, deterministic)
-function splitLogos(n: number) {
-  const cols: (typeof CAROUSEL_LOGOS)[number][][] = Array.from(
-    { length: n },
-    () => [],
-  );
-  CAROUSEL_LOGOS.forEach((logo, i) => cols[i % n]?.push(logo));
-  return cols;
-}
 
 export default function ScanGate({
   domain,
@@ -131,12 +104,14 @@ function ScanScreen({
     <div
       className="fixed inset-0 overflow-y-auto"
       style={{
-        background: FOREST,
         color: DECK.ink,
         fontFamily: "Switzer, 'Inter var', Helvetica, Arial, sans-serif",
         WebkitFontSmoothing: "antialiased",
       }}
     >
+      <ReportBackdrop domain={domain} />
+      <div className="pointer-events-none absolute inset-0 bg-white/35" />
+
       {/* Lime progress strip */}
       <div
         className="fixed inset-x-0 top-0 z-10 h-[2px] overflow-hidden"
@@ -150,7 +125,7 @@ function ScanScreen({
         )}
       </div>
 
-      <div className="flex min-h-full flex-col items-center justify-center px-3 py-4 sm:px-5 sm:py-16">
+      <div className="relative z-10 flex min-h-full flex-col items-center justify-center px-3 py-4 sm:px-5 sm:py-16">
         {isActive && (
           <div
             className="w-full max-w-[460px] rounded-2xl sm:rounded-3xl px-5 pt-5 pb-6 sm:px-8 sm:pt-8 sm:pb-9"
@@ -278,19 +253,7 @@ function ScanScreen({
               })}
             </div>
 
-            {/* Social proof */}
-            <div
-              className="mt-8 pt-6"
-              style={{ borderTop: `1px solid ${DECK.border}` }}
-            >
-              <p
-                className="mb-4 text-[11px] uppercase tracking-[0.04em] text-center"
-                style={{ color: DECK.faint }}
-              >
-                Já receberam
-              </p>
-              <LogoCarousel />
-            </div>
+            <ReportSocialProof />
           </div>
         )}
 
@@ -438,108 +401,5 @@ function NotificationEmail({ email }: { email: string }) {
         </p>
       </div>
     </div>
-  );
-}
-
-// ── logo carousel ─────────────────────────────────────────────────────────────
-
-type LogoEntry = (typeof CAROUSEL_LOGOS)[number];
-
-function LogoCol({
-  logos,
-  delayMs,
-  last,
-  bottomRow,
-}: {
-  logos: LogoEntry[];
-  delayMs: number;
-  last?: boolean;
-  bottomRow?: boolean;
-}) {
-  const [idx, setIdx] = useState(0);
-
-  // Staggered cycle timer, alive while the column is mounted.
-  const cycleRef = (el: HTMLDivElement | null) => {
-    if (!el) return;
-    let interval: ReturnType<typeof setInterval>;
-    const timeout = setTimeout(() => {
-      interval = setInterval(
-        () => setIdx((i) => (i + 1) % logos.length),
-        CYCLE_MS,
-      );
-    }, delayMs);
-    return () => {
-      clearTimeout(timeout);
-      clearInterval(interval);
-    };
-  };
-
-  const logo = logos[idx % logos.length] ?? logos[0];
-  if (!logo) return null;
-
-  // These SVGs have preserveAspectRatio="none" width="100%" height="100%",
-  // so they stretch to fill whatever pixel box you give them. The only fix
-  // is computing the exact proportional pixel dimensions from the viewBox.
-  const MAX_W = 78;
-  const MAX_H = 22;
-  const scale = Math.min(MAX_W / logo.w, MAX_H / logo.h);
-  const renderW = Math.round(logo.w * scale);
-  const renderH = Math.round(logo.h * scale);
-
-  return (
-    <div
-      ref={cycleRef}
-      className="flex flex-1 items-center justify-center overflow-hidden py-3"
-      style={{
-        borderRight: last ? undefined : `1px solid ${DECK.border}`,
-        borderTop: bottomRow ? `1px solid ${DECK.border}` : undefined,
-      }}
-    >
-      <img
-        key={idx}
-        src={logo.src}
-        alt={logo.alt}
-        width={renderW}
-        height={renderH}
-        className="logo-carousel-enter block"
-      />
-    </div>
-  );
-}
-
-function LogoCarousel() {
-  const cols = splitLogos(CAROUSEL_COLS);
-  return (
-    <>
-      {/* 2×2 on mobile */}
-      <div
-        className="grid grid-cols-2 overflow-hidden rounded-xl sm:hidden"
-        style={{ border: `1px solid ${DECK.border}` }}
-      >
-        {cols.map((logos, i) => (
-          <LogoCol
-            key={i}
-            logos={logos}
-            delayMs={i * 380}
-            last={false}
-            bottomRow={i >= 2}
-          />
-        ))}
-      </div>
-      {/* 4 columns on sm+ */}
-      <div
-        className="hidden sm:flex overflow-hidden rounded-xl"
-        style={{ border: `1px solid ${DECK.border}` }}
-      >
-        {cols.map((logos, i) => (
-          <LogoCol
-            key={i}
-            logos={logos}
-            delayMs={i * 380}
-            last={i === cols.length - 1}
-          />
-        ))}
-      </div>
-    </>
   );
 }

--- a/apps/mesh/src/web/routes/reports/track.test.ts
+++ b/apps/mesh/src/web/routes/reports/track.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { reportAttributionFromSearch, reportAuthErrorType } from "./track";
+
+describe("reportAttributionFromSearch", () => {
+  test("keeps share attribution and campaign fields", () => {
+    expect(
+      reportAttributionFromSearch(
+        "?share_id=store%3Aslide%3Aabc&utm_source=share&utm_medium=deck&utm_campaign=report",
+      ),
+    ).toEqual({
+      entrypoint: "share",
+      share_id: "store:slide:abc",
+      utm_source: "share",
+      utm_medium: "deck",
+      utm_campaign: "report",
+    });
+  });
+
+  test("recognizes email links without exposing their private token", () => {
+    expect(
+      reportAttributionFromSearch(
+        "?d=private-token&email_run_id=run-42&utm_source=email",
+      ),
+    ).toEqual({
+      entrypoint: "email",
+      email_run_id: "run-42",
+      utm_source: "email",
+    });
+  });
+
+  test("distinguishes campaigns from direct visits", () => {
+    expect(reportAttributionFromSearch("?utm_source=partner")).toEqual({
+      entrypoint: "campaign",
+      utm_source: "partner",
+    });
+    expect(reportAttributionFromSearch("")).toEqual({
+      entrypoint: "direct",
+    });
+  });
+});
+
+describe("reportAuthErrorType", () => {
+  test.each([
+    ["invalid_email", "invalid_email"],
+    ["HTTP 429", "rate_limited"],
+    ["Invalid OTP", "invalid_or_expired_code"],
+    ["Código inválido", "invalid_or_expired_code"],
+    ["Unauthorized", "invalid_credentials"],
+    ["Account already exists", "account_exists"],
+    ["Failed to fetch", "network"],
+    ["Popup closed", "cancelled"],
+    ["Unexpected response", "unknown"],
+  ])("maps %s to a bounded category", (message, category) => {
+    expect(reportAuthErrorType(message)).toBe(category);
+  });
+});

--- a/apps/mesh/src/web/routes/reports/track.ts
+++ b/apps/mesh/src/web/routes/reports/track.ts
@@ -51,7 +51,7 @@ export function reportAttributionFromSearch(search: string): ReportAttribution {
   };
 }
 
-export function currentReportAttribution(): ReportAttribution {
+function currentReportAttribution(): ReportAttribution {
   return reportAttributionFromSearch(
     typeof window === "undefined" ? "" : window.location.search,
   );

--- a/apps/mesh/src/web/routes/reports/track.ts
+++ b/apps/mesh/src/web/routes/reports/track.ts
@@ -4,6 +4,175 @@ import { isPostHogInitialized } from "@/web/lib/posthog-client";
 
 let reviewerMode = false;
 
+const AUTH_ATTEMPT_PREFIX = "report:auth-attempt:";
+const AUTH_ATTEMPT_TTL_MS = 60 * 60 * 1000;
+
+export interface ReportAttribution {
+  entrypoint: "direct" | "share" | "email" | "campaign";
+  share_id?: string;
+  email_run_id?: string;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+}
+
+export interface ReportAuthAttempt extends ReportAttribution {
+  attempt_id: string;
+  domain: string;
+  gate_shown_at: number;
+  method?: string;
+  provider?: string;
+  auth_mode?: "sign_in" | "sign_up";
+}
+
+export function reportAttributionFromSearch(search: string): ReportAttribution {
+  const params = new URLSearchParams(search);
+  const shareId = params.get("share_id") || undefined;
+  const emailRunId = params.get("email_run_id") || undefined;
+  const utmSource = params.get("utm_source") || undefined;
+  const utmMedium = params.get("utm_medium") || undefined;
+  const utmCampaign = params.get("utm_campaign") || undefined;
+  const entrypoint =
+    shareId || utmSource === "share"
+      ? "share"
+      : emailRunId || params.has("d") || utmSource === "email"
+        ? "email"
+        : utmSource
+          ? "campaign"
+          : "direct";
+
+  return {
+    entrypoint,
+    ...(shareId ? { share_id: shareId } : {}),
+    ...(emailRunId ? { email_run_id: emailRunId } : {}),
+    ...(utmSource ? { utm_source: utmSource } : {}),
+    ...(utmMedium ? { utm_medium: utmMedium } : {}),
+    ...(utmCampaign ? { utm_campaign: utmCampaign } : {}),
+  };
+}
+
+export function currentReportAttribution(): ReportAttribution {
+  return reportAttributionFromSearch(
+    typeof window === "undefined" ? "" : window.location.search,
+  );
+}
+
+function attemptKey(domain: string): string {
+  return `${AUTH_ATTEMPT_PREFIX}${domain}`;
+}
+
+function newAttemptId(): string {
+  try {
+    return globalThis.crypto.randomUUID();
+  } catch {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  }
+}
+
+function readReportAuthAttempt(domain: string): ReportAuthAttempt | null {
+  try {
+    const raw = window.sessionStorage.getItem(attemptKey(domain));
+    if (!raw) return null;
+    const attempt = JSON.parse(raw) as Partial<ReportAuthAttempt>;
+    if (
+      attempt.domain !== domain ||
+      typeof attempt.attempt_id !== "string" ||
+      typeof attempt.gate_shown_at !== "number" ||
+      Date.now() - attempt.gate_shown_at > AUTH_ATTEMPT_TTL_MS
+    ) {
+      window.sessionStorage.removeItem(attemptKey(domain));
+      return null;
+    }
+    return attempt as ReportAuthAttempt;
+  } catch {
+    return null;
+  }
+}
+
+function writeReportAuthAttempt(attempt: ReportAuthAttempt): void {
+  try {
+    window.sessionStorage.setItem(
+      attemptKey(attempt.domain),
+      JSON.stringify(attempt),
+    );
+  } catch {
+    // Analytics state must never interfere with authentication.
+  }
+}
+
+/** Preserve one gated visit across OTP reloads and OAuth round-trips. */
+export function beginReportAuthAttempt(domain: string): ReportAuthAttempt {
+  const existing = readReportAuthAttempt(domain);
+  if (existing) return existing;
+  const attempt: ReportAuthAttempt = {
+    attempt_id: newAttemptId(),
+    domain,
+    gate_shown_at: Date.now(),
+    ...currentReportAttribution(),
+  };
+  writeReportAuthAttempt(attempt);
+  return attempt;
+}
+
+export function updateReportAuthAttempt(
+  domain: string,
+  details: Pick<ReportAuthAttempt, "method" | "provider" | "auth_mode">,
+): ReportAuthAttempt {
+  const attempt = { ...beginReportAuthAttempt(domain), ...details };
+  writeReportAuthAttempt(attempt);
+  return attempt;
+}
+
+export function reportAuthAttemptProperties(attempt: ReportAuthAttempt) {
+  return {
+    auth_attempt_id: attempt.attempt_id,
+    entrypoint: attempt.entrypoint,
+    ...(attempt.share_id ? { share_id: attempt.share_id } : {}),
+    ...(attempt.email_run_id ? { email_run_id: attempt.email_run_id } : {}),
+    ...(attempt.utm_source ? { utm_source: attempt.utm_source } : {}),
+    ...(attempt.utm_medium ? { utm_medium: attempt.utm_medium } : {}),
+    ...(attempt.utm_campaign ? { utm_campaign: attempt.utm_campaign } : {}),
+  };
+}
+
+export function consumeReportAuthAttempt(
+  domain: string,
+): ReportAuthAttempt | null {
+  const attempt = readReportAuthAttempt(domain);
+  if (!attempt) return null;
+  try {
+    window.sessionStorage.removeItem(attemptKey(domain));
+  } catch {
+    // The event can still be sent; at worst a later render de-dupes on its DOM.
+  }
+  return attempt;
+}
+
+export function reportAuthErrorType(error: string): string {
+  const message = error.toLowerCase();
+  if (message === "invalid_email") return "invalid_email";
+  if (message.includes("429") || message.includes("rate limit"))
+    return "rate_limited";
+  if (
+    message.includes("otp") ||
+    message.includes("verification code") ||
+    message.includes("invalid code") ||
+    message.includes("expired code") ||
+    message.includes("código") ||
+    message.includes("codigo")
+  )
+    return "invalid_or_expired_code";
+  if (message.includes("401") || message.includes("unauthorized"))
+    return "invalid_credentials";
+  if (message.includes("409") || message.includes("already exists"))
+    return "account_exists";
+  if (message.includes("network") || message.includes("fetch"))
+    return "network";
+  if (message.includes("cancel") || message.includes("closed"))
+    return "cancelled";
+  return "unknown";
+}
+
 /** Set at /report route render time (module state, so it lands before any
  *  child component captures — effects would run too late) and cleared on
  *  unmount. Reviewer sessions (?key=) flag every report event with
@@ -12,7 +181,7 @@ export function setReportReviewerMode(on: boolean): void {
   reviewerMode = on;
 }
 
-/** posthog.capture for report-funnel events — merges the reviewer flag.
+/** posthog.capture for report-funnel events — merges attribution + reviewer flag.
  *  Direct posthog (not the `track` wrapper) because CTA clicks need
  *  `{transport: "sendBeacon"}`; the init-deferral guard is kept. */
 export function captureReport(
@@ -21,9 +190,17 @@ export function captureReport(
   options?: CaptureOptions,
 ): void {
   if (!isPostHogInitialized()) return;
-  posthog.capture(
-    event,
-    { ...props, ...(reviewerMode ? { report_preview: "reviewer" } : {}) },
-    options,
-  );
+  try {
+    posthog.capture(
+      event,
+      {
+        ...currentReportAttribution(),
+        ...props,
+        ...(reviewerMode ? { report_preview: "reviewer" } : {}),
+      },
+      options,
+    );
+  } catch {
+    // Analytics must never affect report access or navigation.
+  }
 }

--- a/packages/e2e/fixtures/commerce-upgrade-mock.ts
+++ b/packages/e2e/fixtures/commerce-upgrade-mock.ts
@@ -15,6 +15,8 @@
  *   POST /upgrade { org_id, name } -> { url, org_id, scope, token, run }
  *   POST /run     { org_id }       -> { url, scope, run }   (triggered on
  *                                      "See full report"; the flow awaits it)
+ * It also captures the public report scan contract used by report-auth specs:
+ *   POST /api/v2/diagnostics/run { url, email, distinct_id }
  */
 
 import { createServer } from "node:http";
@@ -22,6 +24,9 @@ import { createServer } from "node:http";
 const port = Number(process.env.COMMERCE_MOCK_PORT ?? "4100");
 const UPGRADE_RE = /^\/api\/v2\/internal\/diagnostics\/([^/]+)\/upgrade$/;
 const RUN_RE = /^\/api\/v2\/internal\/diagnostics\/([^/]+)\/run$/;
+const PUBLIC_REPORT_RUN_PATH = "/api/v2/diagnostics/run";
+const CAPTURED_REPORT_RUN_PATH = "/__e2e/report-run";
+const capturedReportRuns = new Map<string, Record<string, unknown>>();
 
 const server = createServer((req, res) => {
   const url = new URL(req.url ?? "/", "http://localhost");
@@ -29,6 +34,43 @@ const server = createServer((req, res) => {
   if (req.method === "GET" && url.pathname === "/health") {
     res.writeHead(200, { "content-type": "application/json" });
     res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === CAPTURED_REPORT_RUN_PATH) {
+    const domain = url.searchParams.get("domain") ?? "";
+    const captured = capturedReportRuns.get(domain);
+    res.writeHead(captured ? 200 : 404, {
+      "content-type": "application/json",
+    });
+    res.end(JSON.stringify(captured ?? { error: "not found" }));
+    return;
+  }
+
+  if (req.method === "POST" && url.pathname === PUBLIC_REPORT_RUN_PATH) {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      let body: Record<string, unknown>;
+      try {
+        body = JSON.parse(raw || "{}") as Record<string, unknown>;
+      } catch {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "invalid JSON" }));
+        return;
+      }
+      const domain = typeof body.url === "string" ? body.url : "";
+      if (!domain) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "url is required" }));
+        return;
+      }
+      capturedReportRuns.set(domain, body);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ status: "fresh" }));
+    });
     return;
   }
 

--- a/packages/e2e/tests/report-auth-gate.spec.ts
+++ b/packages/e2e/tests/report-auth-gate.spec.ts
@@ -1,0 +1,38 @@
+import { signUpViaApi } from "../fixtures/auth-api";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+test("report data and scan operations reject anonymous callers", async ({
+  playwright,
+}) => {
+  const anonymous = await newApiContext(playwright);
+  const responses = await Promise.all([
+    anonymous.get("/api/_reports/site/example.com"),
+    anonymous.post("/api/_reports/run", {
+      data: { domain: "example.com", email: "other@example.com" },
+    }),
+    anonymous.get("/api/_reports/status?id=run-id"),
+    anonymous.get("/api/_reports/link-token/token-id"),
+    anonymous.get("/api/_reports/suggest?q=e"),
+  ]);
+
+  for (const response of responses) {
+    expect(response.status()).toBe(401);
+    expect(response.headers()["cache-control"]).toContain("no-store");
+  }
+
+  await anonymous.dispose();
+});
+
+test("a Studio session unlocks the report API", async ({ playwright }) => {
+  const authenticated = await newApiContext(playwright);
+  await signUpViaApi(authenticated);
+
+  // A one-character query returns locally before the reports engine is called,
+  // so this pins session acceptance without depending on an external service.
+  const response = await authenticated.get("/api/_reports/suggest?q=e");
+  expect(response.status()).toBe(200);
+  expect(await response.json()).toEqual({ suggestions: [] });
+  expect(response.headers()["cache-control"]).toContain("no-store");
+
+  await authenticated.dispose();
+});

--- a/packages/e2e/tests/report-auth-gate.spec.ts
+++ b/packages/e2e/tests/report-auth-gate.spec.ts
@@ -55,3 +55,85 @@ test("a Studio session unlocks the report API", async ({ playwright }) => {
 
   await authenticated.dispose();
 });
+
+test("an expired report session returns to the inline login", async ({
+  page,
+}) => {
+  await signUpViaApi(page.context().request);
+  await page.route("**/api/_reports/site/**", (route) =>
+    route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Authentication required" }),
+    }),
+  );
+
+  await page.goto("/report/session-expired.example");
+
+  await expect(
+    page.getByRole("dialog", { name: "Acesse seu relatório" }),
+  ).toBeVisible();
+});
+
+test("a failed initial read never triggers a scan", async ({ page }) => {
+  await signUpViaApi(page.context().request);
+  let scanRequests = 0;
+  await page.route("**/api/_reports/site/**", (route) =>
+    route.fulfill({
+      status: 502,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "report read failed" }),
+    }),
+  );
+  await page.route("**/api/_reports/run", (route) => {
+    scanRequests += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ state: "fresh" }),
+    });
+  });
+
+  await page.goto("/report/read-error.example");
+
+  await expect(
+    page.getByRole("alert", {
+      name: "Não foi possível carregar o relatório",
+    }),
+  ).toBeVisible();
+  expect(scanRequests).toBe(0);
+});
+
+test("an authenticated scan uses the session email", async ({ playwright }) => {
+  const authenticated = await newApiContext(playwright);
+  const user = await signUpViaApi(authenticated);
+  const domain = `session-email-${crypto.randomUUID()}.example`;
+
+  const response = await authenticated.post("/api/_reports/run", {
+    data: {
+      domain,
+      email: "attacker-controlled@example.com",
+    },
+  });
+  expect(response.status()).toBe(200);
+
+  const commerceMock = await playwright.request.newContext({
+    baseURL: `http://localhost:${process.env.COMMERCE_MOCK_PORT ?? "4100"}`,
+  });
+  const capturedResponse = await commerceMock.get(
+    `/__e2e/report-run?domain=${encodeURIComponent(domain)}`,
+  );
+  expect(capturedResponse.status()).toBe(200);
+  const captured = (await capturedResponse.json()) as {
+    url?: string;
+    email?: string;
+  };
+  expect(captured).toMatchObject({
+    url: domain,
+    email: user.email,
+  });
+  expect(captured.email).not.toBe("attacker-controlled@example.com");
+
+  await commerceMock.dispose();
+  await authenticated.dispose();
+});

--- a/packages/e2e/tests/report-auth-gate.spec.ts
+++ b/packages/e2e/tests/report-auth-gate.spec.ts
@@ -1,10 +1,12 @@
 import { signUpViaApi } from "../fixtures/auth-api";
 import { expect, newApiContext, test } from "../fixtures/test";
 
-test("anonymous report page shows login over a blurred preview", async ({
+test("anonymous shared report shows login over a blurred preview", async ({
   page,
 }) => {
-  await page.goto("/report/example.com");
+  await page.goto(
+    "/report/example.com?share_id=example%3Aslide%3Atest&utm_source=share#overview",
+  );
 
   const dialog = page.getByRole("dialog", { name: "Acesse seu relatório" });
   await expect(dialog).toBeVisible();
@@ -14,6 +16,8 @@ test("anonymous report page shows login over a blurred preview", async ({
     .locator('div[aria-hidden="true"]')
     .filter({ hasText: "Uma visão completa da sua loja." });
   await expect(preview).toHaveCSS("filter", "blur(9px)");
+  await expect(page).toHaveURL(/share_id=example%3Aslide%3Atest/);
+  await expect(page).toHaveURL(/#overview$/);
 });
 
 test("report data and scan operations reject anonymous callers", async ({

--- a/packages/e2e/tests/report-auth-gate.spec.ts
+++ b/packages/e2e/tests/report-auth-gate.spec.ts
@@ -1,6 +1,21 @@
 import { signUpViaApi } from "../fixtures/auth-api";
 import { expect, newApiContext, test } from "../fixtures/test";
 
+test("anonymous report page shows login over a blurred preview", async ({
+  page,
+}) => {
+  await page.goto("/report/example.com");
+
+  const dialog = page.getByRole("dialog", { name: "Acesse seu relatório" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Já receberam")).toBeVisible();
+
+  const preview = page
+    .locator('div[aria-hidden="true"]')
+    .filter({ hasText: "Uma visão completa da sua loja." });
+  await expect(preview).toHaveCSS("filter", "blur(9px)");
+});
+
 test("report data and scan operations reject anonymous callers", async ({
   playwright,
 }) => {


### PR DESCRIPTION
## What is this contribution about?
Require a Studio session before report data or scan endpoints are accessible, and replace the anonymous email capture with compact inline email OTP/Google authentication over a safe blurred report preview. Scan notifications now use the authenticated account email, while the existing deck and in-progress scan experience remain unchanged after login.

## Screenshots/Demonstration
Validated locally in desktop, mobile, and OTP states; screenshots are available in the Conductor workspace artifacts.

## How to Test
1. Open `/report/example.com` while signed out and confirm the compact auth dialog appears over the blurred preview.
2. Complete email OTP or Google login and confirm the same URL loads the report or starts its scan.
3. Request `/api/_reports/site/example.com` without a session and confirm it returns `401` with `Cache-Control: private, no-store`.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (not needed)
- [ ] No breaking changes — anonymous report access is intentionally removed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a Studio login to view report data or start scans. Adds a compact inline auth gate over a blurred preview and tracks the auth funnel with share/email attribution; notifications use the session email.

- **New Features**
  - Gate all `/api/_reports/*` endpoints behind a user session; anonymous calls return 401 with `Cache-Control: private, no-store` and `Vary: Cookie`.
  - Inline auth dialog on `/report/:domain` (compact `UnifiedAuthForm` with OTP + Google) over a safe blurred preview; stays blurred while scanning.
  - Track the authentication funnel with PostHog: durable attempt IDs across redirects, share/email/UTM attribution, and start/OTP/failed/success events; keeps the attribution helper internal.
  - Report page shell stays public for SEO; the SPA fetches report data only after login. Head metadata derives from the domain only.
  - Scan notifications use the authenticated account email; removed the anonymous email capture UI.
  - Added social proof to the auth gate. Includes compact layout controls to limit providers and hide password auth.
  - Added e2e tests for the inline gate and for rejecting/accepting API calls based on session.

- **Migration**
  - Clients must authenticate before accessing report data or running scans.
  - Stop sending `email` to `runReportScan`; the server forwards the session email.
  - Update client APIs/keys: `getPublicReport` → `getReport`, `KEYS.publicReport` → `KEYS.report`.
  - Handle 401 responses from `/api/_reports/*` by prompting login (the report page provides an inline gate).

<sup>Written for commit 157ff981a38edf41b3dd8b23e9183040facf3b9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

