### PR TITLE
fix(chat): auto-switch desktop pick to cloud when link is offline

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -46,8 +46,10 @@ import type { HarnessId } from "@/harnesses";
 import {
   AGENT_OPTION_PINS,
   agentOptionFor,
+  resolveOfflineAgentOption,
   type AgentOption,
 } from "./pills/agent-options";
+import { useCurrentLink } from "@/web/hooks/use-current-link";
 import { resolveSubmitSettings } from "./resolve-submit-settings";
 import {
   isDeepResearchModel,
@@ -606,12 +608,17 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
         )
       : null;
 
-  // Preserve the user's selected runtime exactly. Presence/capability probes are
-  // advisory only; dispatch should surface the real backend error if the choice
-  // cannot run. (Cloud chat via the org router works even where the cloud
-  // *sandbox* is unavailable, so we must not rewrite the harness here — the
-  // preview's cloud-vs-local fallback is handled at the sandbox layer.)
-  const selectedAgentOption = pendingAgentOption;
+  // Capability probes are advisory — we don't rewrite the harness for a missing
+  // CLI (cloud chat via the org router works even where the cloud *sandbox*
+  // doesn't). The one exception is a desktop pick whose link is *confirmed*
+  // offline: it can't run anywhere and nothing prompted the user to reconnect,
+  // so we auto-switch it to cloud. Derived (not persisted), so the desktop pick
+  // returns on its own once the link reconnects.
+  const link = useCurrentLink();
+  const selectedAgentOption = resolveOfflineAgentOption(
+    pendingAgentOption,
+    link.ready && !link.online,
+  );
 
   // When the thread is locked, the agent option is dictated by the persisted
   // (harness, sandbox) pair — period. Otherwise, fall through to the user's

--- a/apps/mesh/src/web/components/chat/pills/agent-options.test.ts
+++ b/apps/mesh/src/web/components/chat/pills/agent-options.test.ts
@@ -8,6 +8,7 @@ import {
   agentOptionFor,
   agentOptionIsAvailable,
   preferredLocalAgentOption,
+  resolveOfflineAgentOption,
 } from "./agent-options";
 
 const ALL_AVAILABLE: AgentOptionAvailability = {
@@ -135,5 +136,32 @@ describe("preferredLocalAgentOption", () => {
         codex: false,
       }),
     ).toBeNull();
+  });
+});
+
+describe("resolveOfflineAgentOption", () => {
+  test("auto-switches a desktop pick to cloud when the link is offline", () => {
+    expect(resolveOfflineAgentOption("claude-code-desktop", true)).toBe(
+      "decopilot",
+    );
+    expect(resolveOfflineAgentOption("codex-desktop", true)).toBe("decopilot");
+  });
+
+  test("keeps the desktop pick while the link is online (or unresolved)", () => {
+    // The old behavior: a desktop pick is preserved exactly. It must only be
+    // overridden on a *confirmed* offline probe, never the unresolved default.
+    expect(resolveOfflineAgentOption("claude-code-desktop", false)).toBe(
+      "claude-code-desktop",
+    );
+    expect(resolveOfflineAgentOption("codex-desktop", false)).toBe(
+      "codex-desktop",
+    );
+  });
+
+  test("leaves cloud and null picks untouched regardless of link state", () => {
+    expect(resolveOfflineAgentOption("decopilot", true)).toBe("decopilot");
+    expect(resolveOfflineAgentOption("decopilot", false)).toBe("decopilot");
+    expect(resolveOfflineAgentOption(null, true)).toBeNull();
+    expect(resolveOfflineAgentOption(null, false)).toBeNull();
   });
 });

--- a/apps/mesh/src/web/components/chat/pills/agent-options.ts
+++ b/apps/mesh/src/web/components/chat/pills/agent-options.ts
@@ -84,6 +84,29 @@ export function preferredLocalAgentOption(
   return null;
 }
 
+/**
+ * Auto-switch a desktop pick to cloud when its link is confirmed offline. A
+ * `user-desktop` option can't run anywhere while the link is down and nothing
+ * prompts the user to reconnect, so it strands them on an impossible "This
+ * device" state. Non-desktop picks (and a live/unknown link) pass through
+ * unchanged. `desktopOffline` MUST come from a resolved probe (`link.ready`),
+ * never the initial unresolved state — otherwise a genuinely-linked user is
+ * briefly demoted on load.
+ */
+export function resolveOfflineAgentOption(
+  option: AgentOption | null,
+  desktopOffline: boolean,
+): AgentOption | null {
+  if (
+    desktopOffline &&
+    option &&
+    AGENT_OPTION_PINS[option].sandbox === "user-desktop"
+  ) {
+    return "decopilot";
+  }
+  return option;
+}
+
 /** Whether `option` can run given the current `availability`. */
 export function agentOptionIsAvailable(
   option: AgentOption,


### PR DESCRIPTION
## Summary

Fixes the impossible "This device" state reported by Guilherme: the runtime shows **This device** (and dispatch stays bound to it) while the desktop link is **offline** — not linked, yet "running on this device", with the *This device* row itself disabled. Nothing told the user they'd been left on a dead runtime.

Per the call ("auto switch pra cloud"): when the link probe **confirms** the desktop is offline, a persisted desktop pick auto-switches to the cloud sandbox.

## Root cause

`ChatPrefsProvider` deliberately preserved the persisted `pendingAgentOption` verbatim and let dispatch surface the backend `user_desktop_link_offline` 409. So a past "This device" pick (localStorage, pinned to a `user-desktop` harness) kept driving both the `RuntimeSwitcher` display and the dispatch body even with no live link.

## Fix

- New pure helper `resolveOfflineAgentOption(option, desktopOffline)` in `agent-options.ts` — a `user-desktop` pick with a confirmed-offline link resolves to `decopilot` (cloud); everything else passes through.
- Wired into `chat-context.tsx` at the **single source** (`effectiveAgentOption`), so the switcher display and the submit body can't disagree.
- **Derived, not persisted** — the desktop pick returns on its own once the link reconnects.
- Gated on `link.ready && !link.online` so the initial probe can't briefly demote a genuinely-linked user.

Locked threads are unaffected (their runtime is fixed at first message; `DesktopOfflineBanner` still warns there).

## Testing

- Unit test `resolveOfflineAgentOption` (offline→switch, online/unresolved→preserve, cloud/null untouched) — `agent-options.test.ts`, 18 pass.
- `tsc --noEmit` clean, `bun run lint` 0 errors, `bun run fmt` clean.

Not driven live against a real linked→offline desktop; the logic is pure and unit-covered, the wiring is a typechecked substitution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-switches a saved “This device” runtime to cloud when the desktop link is confirmed offline, fixing the impossible state where chat showed “This device” while the link was down. Ensures the switcher display and dispatch stay in sync.

- **Bug Fixes**
  - Added `resolveOfflineAgentOption(option, desktopOffline)` to map `user-desktop` picks to `decopilot` when `link.ready && !link.online`.
  - Applied at the single source (`effectiveAgentOption`) in `chat-context.tsx`; derived only (not persisted) so the desktop pick returns after reconnection.
  - Non-desktop picks and locked threads are unchanged. Unit tests added for the helper.

<sup>Written for commit d2c14ade9c7756675dd113253cf96076594f4f81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

