### PR TITLE
fix(decopilot): don't expose propose_plan outside plan mode

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/build-built-in-tools.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/build-built-in-tools.test.ts
@@ -1,0 +1,27 @@
+/**
+ * buildBuiltInTools — plan-mode gating for propose_plan.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildBuiltInTools } from "./index";
+
+const baseOpts = {
+  ctx: {} as never,
+  writer: {} as never,
+  toolOutputMap: new Map<string, string>(),
+  // provider: null skips subtask construction, so no ctx/writer plumbing is
+  // exercised — this stays a pure unit test.
+  subtaskParams: { provider: null } as never,
+};
+
+describe("buildBuiltInTools", () => {
+  test("omits propose_plan outside plan mode", () => {
+    const tools = buildBuiltInTools({ ...baseOpts, planMode: false });
+    expect(tools.propose_plan).toBeUndefined();
+  });
+
+  test("includes propose_plan in plan mode", () => {
+    const tools = buildBuiltInTools({ ...baseOpts, planMode: true });
+    expect(tools.propose_plan).toBeDefined();
+  });
+});

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -546,19 +546,18 @@ export interface BuildBuiltInToolsOptions {
 export function buildBuiltInTools(
   opts: BuildBuiltInToolsOptions,
 ): Record<string, unknown> {
-  const {
-    ctx,
-    writer,
-    toolOutputMap,
-    subtaskParams,
-    planMode: _planMode,
-  } = opts;
+  const { ctx, writer, toolOutputMap, subtaskParams, planMode } = opts;
   const tools: Record<string, unknown> = {
     user_ask: userAskTool,
     todo_write: todoWriteTool,
-    propose_plan: proposePlanTool,
     read_tool_output: createReadToolOutputTool({ toolOutputMap }),
   };
+  // Mirrors getBuiltInTools' plan-mode gate: propose_plan's UX ("approve →
+  // new thread seeded with this plan") only makes sense in Plan Mode —
+  // outside it the model must not be able to trigger that flow.
+  if (planMode) {
+    tools.propose_plan = proposePlanTool;
+  }
   // subtask requires a provider — skip when provider is null.
   if (subtaskParams.provider) {
     tools.subtask = createSubtaskTool(writer, subtaskParams, ctx);


### PR DESCRIPTION
## Source
Bug found reading recently-changed code around `apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts` (top of this run's churn list).

## The bug
`buildBuiltInTools` (the light built-in tool assembler used by `assembleAgentTools` for the cluster engine's `kind: "agent"` parent-turn path) accepted a `planMode` option but never read it — it was destructured into a discarded `_planMode` — so `propose_plan` was unconditionally included in its output.

That parent-turn path (`run-agent-loop.ts` → `assembleAgentTools`) always merges its light built-in set with `extraTools` supplied from `assembleDecopilotTools`'s heavy path, which *does* correctly omit `propose_plan` outside plan mode (by destructuring the key away). But `{ ...assembledTools, ...extraTools }` can only overwrite keys — it can't delete a key already present in `assembledTools` when `extraTools` simply lacks it. So the light path's `propose_plan` survived the merge and reached the model on every regular (non-plan-mode) chat turn.

**Failure scenario:** in ordinary chat (not Plan Mode), the model is still handed a callable `propose_plan` tool. Its description promises "after approval, a new thread will be created with this plan as the starting context" — calling it outside Plan Mode surfaces that approve/reject UI and can spawn a new thread the user never asked for, mid regular conversation.

## Fix
`buildBuiltInTools` now gates `propose_plan` on `planMode`, matching the existing gate in `getBuiltInTools` (the heavy path already does this correctly via a post-hoc delete).

## Regression test
`apps/mesh/src/harnesses/decopilot/built-in-tools/build-built-in-tools.test.ts` — asserts `propose_plan` is absent when `planMode: false` and present when `planMode: true`. Fails on the pre-fix code (confirmed locally by reverting the fix and re-running), passes after.

```
bun test apps/mesh/src/harnesses/decopilot/built-in-tools/build-built-in-tools.test.ts
```

## Locally verified
- `bun run fmt` — clean, no changes.
- `bun x tsc --noEmit` in `apps/mesh` — no new errors (two pre-existing, unrelated missing-dependency errors in `sections-editor`/`echart-area` files untouched by this change).
- The regression test above, passing.

Full CI will run the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate `propose_plan` to Plan Mode in Decopilot so it’s not exposed during normal chat. This prevents the approve/reject UI and unexpected thread creation outside Plan Mode.

- **Bug Fixes**
  - Read `planMode` in `buildBuiltInTools` and only include `propose_plan` when true, aligning with the heavy path behavior.
  - Added `build-built-in-tools.test.ts` to assert `propose_plan` is omitted when `planMode: false` and included when `planMode: true`.

<sup>Written for commit 541edb9039a89eeee20bfa427b2cd627e23bdc4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

