### PR TITLE
fix(shutdown): skip NLB drain sleep for worker pods

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -17,6 +17,7 @@ import {
 } from "./dispatch-queue/queue-names";
 import { buildDbosConfig } from "./dbos/config";
 import { getSettings } from "./settings";
+import { resolveShutdownDrainMs } from "./settings/resolve-config";
 import { initObservability } from "./observability";
 import { startProfiling } from "./observability/profiling";
 
@@ -426,8 +427,10 @@ async function gracefulShutdown(signal: string) {
     //    connections to a dead socket -> CF 520 during rollout. Stay under the
     //    force-exit timer (derived from terminationGracePeriodSeconds above) so
     //    it never trips before drain completes.
-    const drainMs = Number(
-      process.env.SHUTDOWN_DRAIN_MS ?? Math.floor(forceExitMs * 0.6),
+    const drainMs = resolveShutdownDrainMs(
+      settings.dispatchRole,
+      forceExitMs,
+      process.env.SHUTDOWN_DRAIN_MS,
     );
     await sleep(drainMs);
 

--- a/apps/mesh/src/settings/resolve-config.test.ts
+++ b/apps/mesh/src/settings/resolve-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { resolveConfig } from "./resolve-config";
+import { resolveConfig, resolveShutdownDrainMs } from "./resolve-config";
 import type { CliFlags } from "./types";
 
 const flags: CliFlags = {
@@ -96,5 +96,23 @@ describe("resolveConfig deployment admin emails", () => {
       "alice@example.com",
       "bob@example.com",
     ]);
+  });
+});
+
+describe("resolveShutdownDrainMs", () => {
+  const forceExitMs = 115_000;
+
+  it("worker skips the NLB drain (not a frontdoor target)", () => {
+    expect(resolveShutdownDrainMs("worker", forceExitMs, undefined)).toBe(0);
+  });
+
+  it("api and all drain ~60% of the force-exit budget", () => {
+    expect(resolveShutdownDrainMs("api", forceExitMs, undefined)).toBe(69_000);
+    expect(resolveShutdownDrainMs("all", forceExitMs, undefined)).toBe(69_000);
+  });
+
+  it("SHUTDOWN_DRAIN_MS overrides every role", () => {
+    expect(resolveShutdownDrainMs("worker", forceExitMs, "5000")).toBe(5_000);
+    expect(resolveShutdownDrainMs("api", forceExitMs, "0")).toBe(0);
   });
 });

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -19,6 +19,21 @@ function resolveDispatchRole(raw: string | undefined): DispatchRole {
     : "all";
 }
 
+// The shutdown drain only exists to outlast NLB ip-target deregistration of the
+// frontdoor HTTP listener. "worker" pods aren't frontdoor targets (no
+// `decocms.com/frontdoor` label), so draining just steals the grace budget
+// DBOS.shutdown() needs to drain in-flight runs — skip it. `SHUTDOWN_DRAIN_MS`
+// overrides either way.
+export function resolveShutdownDrainMs(
+  role: DispatchRole,
+  forceExitMs: number,
+  envOverride: string | undefined,
+): number {
+  return Number(
+    envOverride ?? (role === "worker" ? 0 : Math.floor(forceExitMs * 0.6)),
+  );
+}
+
 function toBool(value: string | undefined): boolean {
   return value === "true" || value === "1";
 }


### PR DESCRIPTION
## What

`gracefulShutdown` sleeps ~69s (`0.6 * force-exit budget`) on SIGTERM to wait out AWS NLB ip-target deregistration before closing the listener and running `DBOS.shutdown()`. That drain is correct for pods behind the frontdoor NLB — but **worker pods aren't NLB targets**.

The `deco-studio-nlb` Service selects `decocms.com/frontdoor: "true"`. API pods carry that label; worker pods (`MESH_DISPATCH_ROLE=worker`) do not — they're ClusterIP-only and dequeue the heavy DBOS run queues (decopilot streams, automations). So for the worker the 69s sleep waits for a deregistration that never applies, leaving only ~46s of the 120s grace for `DBOS.shutdown()` to drain in-flight runs.

## Why it matters (observed in prod)

In `deco-studio` (us-west-2), the **worker** logs `[shutdown] Timed out after 115000ms, forcing exit` ~once per hour (**21× in 24h**). At force-exit:
- in-flight runs are killed mid-flight (recovered later by DBOS/conductor, but disruptive), and
- the thread-gate handoff — which runs *after* `DBOS.shutdown()` — **never executes** (0 log hits in 24h), because the drain sleep + blocked `DBOS.shutdown()` consume the whole window first.

API pods are essentially unaffected (1 force-exit in 24h); their churn is normal Karpenter consolidation, not this.

## Change

Make the drain role-aware: `worker` → `0`, `api`/`all` → unchanged (`0.6 * forceExitMs`). `SHUTDOWN_DRAIN_MS` still overrides for any role. Extracted as a pure `resolveShutdownDrainMs()` helper with unit tests.

This gives the worker the full grace budget for `DBOS.shutdown()` and lets the handoff run when draining completes in time. It does **not** claim to eliminate every worker force-exit — a genuinely long in-flight run can still exceed the budget — but it stops throwing 69s away first.

## Testing

- `bun test apps/mesh/src/settings/resolve-config.test.ts` — 3 new cases (worker=0, api/all=69000, env override).
- `bun run fmt`, typecheck clean for touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the NLB drain sleep for worker pods during graceful shutdown to give them the full grace period for `DBOS.shutdown()` and reduce forced exits. API pods keep the drain; `SHUTDOWN_DRAIN_MS` still overrides.

- **Bug Fixes**
  - Workers are not NLB targets (`decocms.com/frontdoor` label absent). `worker` now uses `0ms` drain; `api`/`all` keep `~60%` of `forceExitMs`.
  - Added `resolveShutdownDrainMs()` and updated `gracefulShutdown` to use it, with unit tests for role-based and env override behavior.

<sup>Written for commit d22becbe4ae0e5b920c321f904a5729f5b38af76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

