### PR TITLE
feat(blog-editor): author type field, dateModified stamping, author picker fix

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.test.ts
@@ -4,10 +4,13 @@ import {
   blockComponentName,
   buildBlogBlock,
   discoverBlogBlockTypes,
+  emptyBlogPayload,
   listPostsWithMeta,
+  relationPickerState,
   removeCategoryFromPost,
   renameCategoryOnPost,
   replaceCategoryOnPost,
+  stampPostModified,
 } from "./blog-data";
 import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
 
@@ -273,6 +276,143 @@ describe("listPostsWithMeta", () => {
     expect(listPostsWithMeta(decofile).map((p) => p.key)).toEqual([
       "collections/blog/posts/a",
     ]);
+  });
+});
+
+describe("relationPickerState", () => {
+  const records = [
+    {
+      key: "collections/blog/authors/a",
+      payload: {
+        name: "Ada",
+        type: "Person",
+        email: "ada@x.com",
+        jobTitle: "Engineer",
+        company: "Acme",
+        avatar: "ada.png",
+      },
+    },
+    {
+      key: "collections/blog/authors/b",
+      payload: { name: "No Mail", email: "" },
+    },
+  ];
+  const args = {
+    records,
+    valueField: "email",
+    toRef: (payload: Record<string, unknown>) => ({ ...payload }),
+  };
+
+  test("options are keyed by record key and labeled by name", () => {
+    const { options } = relationPickerState({ ...args, selected: [] });
+    expect(options).toEqual([
+      { value: "collections/blog/authors/a", label: "Ada" },
+      { value: "collections/blog/authors/b", label: "No Mail" },
+    ]);
+  });
+
+  test("resolves a selected ref by its identity field", () => {
+    const { selectedValues } = relationPickerState({
+      ...args,
+      selected: [{ name: "Stale Name", email: "ada@x.com" }],
+    });
+    expect(selectedValues).toEqual(["collections/blog/authors/a"]);
+  });
+
+  test("falls back to the name when the identity field is empty", () => {
+    const { selectedValues } = relationPickerState({
+      ...args,
+      selected: [{ name: "No Mail", email: "" }],
+    });
+    expect(selectedValues).toEqual(["collections/blog/authors/b"]);
+  });
+
+  test("tolerates plain-string refs (categories store bare slugs)", () => {
+    const { selectedValues } = relationPickerState({
+      records: [
+        {
+          key: "collections/blog/categories/c",
+          payload: { name: "News", slug: "news" },
+        },
+      ],
+      valueField: "slug",
+      toRef: (payload: Record<string, unknown>) => ({
+        name: payload.name,
+        slug: payload.slug,
+      }),
+      selected: ["news"],
+    });
+    expect(selectedValues).toEqual(["collections/blog/categories/c"]);
+  });
+
+  test("maps picked keys back through toRef — full record for authors", () => {
+    const { refsForValues } = relationPickerState({ ...args, selected: [] });
+    expect(
+      refsForValues([
+        "collections/blog/authors/a",
+        "collections/blog/authors/b",
+      ]),
+    ).toEqual([
+      {
+        name: "Ada",
+        type: "Person",
+        email: "ada@x.com",
+        jobTitle: "Engineer",
+        company: "Acme",
+        avatar: "ada.png",
+      },
+      { name: "No Mail", email: "" },
+    ]);
+  });
+
+  test("keeps unresolvable refs visible and round-trips them unchanged", () => {
+    const ghost = { name: "Deleted Author", email: "ghost@x.com" };
+    const { options, selectedValues, refsForValues } = relationPickerState({
+      ...args,
+      selected: [ghost],
+    });
+    expect(selectedValues).toEqual(["unresolved:0"]);
+    expect(options).toContainEqual({
+      value: "unresolved:0",
+      label: "Deleted Author",
+    });
+    const refs = refsForValues(["unresolved:0", "collections/blog/authors/a"]);
+    expect(refs[0]).toEqual(ghost);
+    expect(refs[1]).toEqual(records[0]!.payload);
+  });
+
+  test("dedupes refs that resolve to the same record", () => {
+    const { selectedValues } = relationPickerState({
+      ...args,
+      selected: [
+        { name: "Ada", email: "ada@x.com" },
+        { name: "Ada Again", email: "ada@x.com" },
+      ],
+    });
+    expect(selectedValues).toEqual(["collections/blog/authors/a"]);
+  });
+});
+
+describe("stampPostModified", () => {
+  test("sets dateModified to an ISO date-time, preserving other fields", () => {
+    const next = stampPostModified({ title: "P", slug: "p" });
+    expect(next.title).toBe("P");
+    expect(next.slug).toBe("p");
+    expect(typeof next.dateModified).toBe("string");
+    const stamp = String(next.dateModified);
+    expect(new Date(stamp).toISOString()).toBe(stamp);
+  });
+
+  test("does not mutate the input payload", () => {
+    const payload = { title: "P" };
+    stampPostModified(payload);
+    expect(payload).toEqual({ title: "P" });
+  });
+});
+
+describe("emptyBlogPayload", () => {
+  test("new authors default to type Person", () => {
+    expect(emptyBlogPayload("authors").type).toBe("Person");
   });
 });
 

--- a/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blog-data.ts
@@ -193,6 +193,91 @@ export function blogBlockFilePath(key: string): string {
   return `.deco/blocks/${encodeURIComponent(key)}.json`;
 }
 
+// ------------------ Post relations (authors/categories picker) ------------------
+
+export interface RelationPickerState {
+  /** One option per record, plus one per unresolvable selected ref. */
+  options: Array<{ value: string; label: string }>;
+  /** The current selection expressed as option values. */
+  selectedValues: string[];
+  /** Map the picker's next values back to the denormalized refs to store. */
+  refsForValues: (values: string[]) => unknown[];
+}
+
+/**
+ * State for the multi-select that links a post to Author/Category records.
+ *
+ * Options are keyed by the record's decofile key — the only identity that is
+ * guaranteed present and unique. The denormalized refs stored on the post
+ * (`{ name, email }` / `{ name, slug }`, or plain strings) resolve back to a
+ * record by the identity field when present, falling back to the name —
+ * authors created in the UI start with an empty email, and without the
+ * fallback their selection would never display. Refs that resolve to no
+ * record at all (record deleted, identity renamed) become synthetic options,
+ * so they stay visible and unselectable instead of being silently dropped by
+ * the next change.
+ */
+export function relationPickerState({
+  records,
+  selected,
+  valueField,
+  toRef,
+}: {
+  records: Array<{ key: string; payload: Record<string, unknown> }>;
+  selected: unknown;
+  /** Identity field of the denormalized ref (authors: email, categories: slug). */
+  valueField: string;
+  /** Build the denormalized ref stored on the post for a picked record. */
+  toRef: (payload: Record<string, unknown>) => Record<string, unknown>;
+}): RelationPickerState {
+  const refs = Array.isArray(selected) ? selected : [];
+  const refValue = (ref: unknown): string =>
+    typeof ref === "string" ? ref : str(asRecord(ref)?.[valueField]);
+  const refName = (ref: unknown): string =>
+    typeof ref === "string" ? ref : str(asRecord(ref)?.name);
+
+  const recordFor = (ref: unknown) => {
+    const value = refValue(ref);
+    const byValue = value
+      ? records.find(({ payload }) => str(payload[valueField]) === value)
+      : undefined;
+    if (byValue) return byValue;
+    const name = refName(ref);
+    return name
+      ? records.find(({ payload }) => str(payload.name) === name)
+      : undefined;
+  };
+
+  const options = records.map(({ key, payload }) => ({
+    value: key,
+    label: str(payload.name) || str(payload[valueField]) || key,
+  }));
+
+  const unresolved = new Map<string, unknown>();
+  const selectedValues: string[] = [];
+  refs.forEach((ref, index) => {
+    const match = recordFor(ref);
+    if (match) {
+      if (!selectedValues.includes(match.key)) selectedValues.push(match.key);
+      return;
+    }
+    const value = `unresolved:${index}`;
+    unresolved.set(value, ref);
+    selectedValues.push(value);
+    options.push({ value, label: refName(ref) || refValue(ref) || "Unknown" });
+  });
+
+  const refsForValues = (values: string[]): unknown[] =>
+    values
+      .map((value) => {
+        const record = records.find((r) => r.key === value);
+        return record ? toRef(record.payload) : unresolved.get(value);
+      })
+      .filter((ref) => ref !== undefined);
+
+  return { options, selectedValues, refsForValues };
+}
+
 // ------------------ Post metadata + category mutation ------------------
 
 /** A single category reference, denormalized on a post payload. */
@@ -352,6 +437,18 @@ export function removeCategoryFromPost(
   };
 }
 
+/**
+ * Stamp a post payload as modified now (full ISO date-time). Apply on every
+ * write that changes an existing post — editor autosave, category cascades,
+ * bulk updates — but NOT on create/duplicate, where `dateModified` would just
+ * echo the creation date. Pure: returns a new payload.
+ */
+export function stampPostModified(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...payload, dateModified: new Date().toISOString() };
+}
+
 function randomHex(length: number): string {
   const bytes = new Uint8Array(Math.ceil(length / 2));
   crypto.getRandomValues(bytes);
@@ -387,6 +484,7 @@ export function emptyBlogPayload(kind: BlogKind): Record<string, unknown> {
     case "authors":
       return {
         name: "New author",
+        type: "Person",
         email: "",
         jobTitle: "",
         company: "",

--- a/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
@@ -27,6 +27,7 @@ import {
   listBlogPayloads,
   listPostsWithMeta,
   renameCategoryOnPost,
+  stampPostModified,
 } from "./blog-data";
 import { buildBlogCategoryPreviewUrl } from "./blog-preview-url";
 import { useSaveBlogBlock } from "./use-blog-mutations";
@@ -139,7 +140,7 @@ export function CategoryEditor({
         if (next === payload) continue;
         await save.mutateAsync({
           blockKey: key,
-          data: buildBlogBlock(key, "posts", next),
+          data: buildBlogBlock(key, "posts", stampPostModified(next)),
         });
         changed += 1;
       }

--- a/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
@@ -13,7 +13,13 @@ import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { ImageField } from "@/web/components/sections-editor/fields/image-field";
 import { StringField } from "@/web/components/sections-editor/fields/string-field";
 import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
-import { buildBlogBlock, getBlogPayload, listBlogPayloads } from "./blog-data";
+import {
+  buildBlogBlock,
+  getBlogPayload,
+  listBlogPayloads,
+  relationPickerState,
+  stampPostModified,
+} from "./blog-data";
 import { buildBlogPostPreviewUrl } from "./blog-preview-url";
 import { useSaveBlogBlock } from "./use-blog-mutations";
 import { useAutosave } from "./use-autosave";
@@ -66,7 +72,10 @@ export function PostEditor({
   const initial = getBlogPayload(block, "posts");
 
   const [post, setPost] = useAutosave(initial, (next) => {
-    save.mutate({ blockKey, data: buildBlogBlock(blockKey, "posts", next) });
+    save.mutate({
+      blockKey,
+      data: buildBlogBlock(blockKey, "posts", stampPostModified(next)),
+    });
   });
 
   const setField = (key: string, value: unknown) =>
@@ -204,21 +213,28 @@ function PostSettings({
         path="post-image"
         label="Cover image"
       />
+      {/* Authors denormalize their FULL record onto the post — the blog app
+          renders the author box (type, job title, company, avatar) from it. */}
       <RelationSelect
         label="Authors"
         decofile={decofile}
         kind="authors"
         valueField="email"
-        extraFields={["email"]}
+        toRef={(author) => ({ ...author })}
         selected={post.authors}
         onChange={(v) => onChange("authors", v)}
       />
+      {/* Categories denormalize only `{ name, slug }` — copying the category's
+          own body (description, sections) onto every post would bloat them. */}
       <RelationSelect
         label="Categories"
         decofile={decofile}
         kind="categories"
         valueField="slug"
-        extraFields={["slug"]}
+        toRef={(category) => ({
+          name: str(category.name),
+          slug: str(category.slug),
+        })}
         selected={post.categories}
         onChange={(v) => onChange("categories", v)}
       />
@@ -278,14 +294,14 @@ function ExtraPropsField({
 
 /**
  * Multi-select that links a post to existing Author/Category records.
- * Stores the denormalized subset deco expects (e.g. `{ name, email }`).
+ * Stores the denormalized ref `toRef` builds from the picked record.
  */
 function RelationSelect({
   label,
   decofile,
   kind,
   valueField,
-  extraFields,
+  toRef,
   selected,
   onChange,
 }: {
@@ -293,39 +309,16 @@ function RelationSelect({
   decofile: Record<string, unknown>;
   kind: "authors" | "categories";
   valueField: string;
-  extraFields: string[];
+  toRef: (payload: Record<string, unknown>) => Record<string, unknown>;
   selected: unknown;
-  onChange: (value: Array<Record<string, unknown>>) => void;
+  onChange: (value: unknown[]) => void;
 }) {
-  const records = listBlogPayloads(decofile, kind);
-  const valueOf = (payload: Record<string, unknown>, key: string) =>
-    str(payload[valueField]) || key;
-
-  const options = records.map(({ key, payload }) => ({
-    value: valueOf(payload, key),
-    label: str(payload.name) || valueOf(payload, key),
-  }));
-
-  const selectedArr = Array.isArray(selected)
-    ? (selected as Array<Record<string, unknown>>)
-    : [];
-  const defaultValue = selectedArr
-    .map((s) => str(s[valueField]))
-    .filter(Boolean);
-
-  const handleChange = (values: string[]) => {
-    onChange(
-      values.map((value) => {
-        const match = records.find(
-          ({ key, payload }) => valueOf(payload, key) === value,
-        );
-        if (!match) return { name: value, [valueField]: value };
-        const out: Record<string, unknown> = { name: str(match.payload.name) };
-        for (const f of extraFields) out[f] = match.payload[f] ?? value;
-        return out;
-      }),
-    );
-  };
+  const { options, selectedValues, refsForValues } = relationPickerState({
+    records: listBlogPayloads(decofile, kind),
+    selected,
+    valueField,
+    toRef,
+  });
 
   return (
     <div className="space-y-2">
@@ -338,8 +331,8 @@ function RelationSelect({
       ) : (
         <MultiSelect
           options={options}
-          defaultValue={defaultValue}
-          onValueChange={handleChange}
+          defaultValue={selectedValues}
+          onValueChange={(values) => onChange(refsForValues(values))}
           placeholder={`Select ${label.toLowerCase()}`}
           maxCount={4}
         />

--- a/apps/mesh/src/web/components/sandbox/content/blog/record-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/record-editor.tsx
@@ -1,5 +1,12 @@
 import { Input } from "@deco/ui/components/input.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { ImageField } from "@/web/components/sections-editor/fields/image-field";
 import { buildBlogBlock, getBlogPayload, type BlogKind } from "./blog-data";
@@ -13,13 +20,24 @@ type RecordKind = Extract<BlogKind, "authors">;
 interface FieldDef {
   key: string;
   label: string;
-  widget: "text" | "textarea" | "image";
+  widget: "text" | "textarea" | "image" | "select";
   placeholder?: string;
+  /** Choices for the "select" widget; the first one is the display default. */
+  options?: Array<{ value: string; label: string }>;
 }
 
 const FIELDS: Record<RecordKind, FieldDef[]> = {
   authors: [
     { key: "name", label: "Name", widget: "text" },
+    {
+      key: "type",
+      label: "Type",
+      widget: "select",
+      options: [
+        { value: "Person", label: "Person" },
+        { value: "Organization", label: "Organization" },
+      ],
+    },
     {
       key: "email",
       label: "Email",
@@ -83,6 +101,25 @@ export function RecordEditor({
                   path={field.key}
                   label={field.label}
                 />
+              ) : field.widget === "select" ? (
+                <>
+                  <Label htmlFor={field.key}>{field.label}</Label>
+                  <Select
+                    value={str(payload[field.key]) || field.options?.[0]?.value}
+                    onValueChange={(v) => setField(field.key, v)}
+                  >
+                    <SelectTrigger id={field.key} className="h-10 w-full">
+                      <SelectValue placeholder={field.label} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(field.options ?? []).map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </>
               ) : (
                 <>
                   <Label htmlFor={field.key}>{field.label}</Label>

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -135,6 +135,7 @@ import {
   removeCategoryFromPost,
   replaceCategoryOnPost,
   scanBlogEntries,
+  stampPostModified,
 } from "./blog/blog-data";
 import {
   useDeleteBlogBlock,
@@ -946,7 +947,7 @@ function ContentBrowserReady({
       if (next === payload) continue;
       await saveBlogBlock.mutateAsync({
         blockKey: key,
-        data: buildBlogBlock(key, "posts", next),
+        data: buildBlogBlock(key, "posts", stampPostModified(next)),
       });
       changed += 1;
     }
@@ -1019,7 +1020,7 @@ function ContentBrowserReady({
               if (next === payload) continue;
               await saveBlogBlock.mutateAsync({
                 blockKey: postKey,
-                data: buildBlogBlock(postKey, "posts", next),
+                data: buildBlogBlock(postKey, "posts", stampPostModified(next)),
               });
             }
           }


### PR DESCRIPTION
## Summary

Three changes to the blog content editor (`apps/mesh/src/web/components/sandbox/content/blog/`):

### 1. Fix the post author picker
The multi-select's options fell back to the block key when an author had no email, but the stored selection was mapped back **by email only** — since authors created in the UI start with `email: ""`, their selection never displayed, and refs that matched no record were silently dropped on the next change.

The picker logic is now a pure, tested helper (`relationPickerState` in `blog-data.ts`):
- Options are keyed by the record's **decofile key** (the only identity guaranteed present and unique).
- Stored refs resolve back by the identity field (email/slug) with a **name fallback**, and tolerate plain-string refs.
- Unresolvable refs (record deleted, identity renamed) become synthetic options so they stay visible and unselectable instead of being lost.

### 2. Denormalize the full author record onto the post
Selecting an author now copies the **entire** author payload (`type`, `jobTitle`, `company`, `avatar`, and any future props) via a per-kind `toRef` callback — not just `{ name, email }`. Categories intentionally keep `{ name, slug }` only, since copying their `description`/`sections` onto every post would bloat the blocks.

### 3. Author `type` + `dateModified`
- The author editor gains a **Type** select (`Person` | `Organization`) via a new generic select widget in `RecordEditor`; new authors default to `Person`.
- `dateModified` (full ISO date-time) is stamped on every write that changes an existing post: editor autosave, category slug-rename cascade, bulk category updates, and the category delete cascade. Create/duplicate are intentionally **not** stamped (it would just echo the creation date).

## Testing

- `bun test apps/mesh/src/web/components/sandbox/content/blog/` — 79 pass (new coverage for `relationPickerState`, including the no-email author case that reproduced the picker bug, plus `stampPostModified` and the `Person` default).
- `tsc --noEmit` clean on `apps/mesh`; `bun run lint` reports no warnings on touched files; `bun run fmt` applied.

Known limitation (pre-existing): editing an author record does not cascade the refreshed copy into posts that already reference it — the copy refreshes when the post's author selection is next touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the post author picker, adds an Author Type field, and stamps `dateModified` on post updates. Also copies the full author record onto posts for accurate rendering.

- **New Features**
  - Added Author Type select (Person | Organization) to the author editor; new authors default to Person.
  - Selecting authors now denormalizes the full author object onto the post; categories remain `{ name, slug }` only.
  - Stamps `dateModified` (ISO) on updates to existing posts (autosave, category rename/delete cascades, bulk updates); not applied on create/duplicate.

- **Bug Fixes**
  - Author multi-select is now robust: options keyed by the record’s decofile key, refs resolve by identity with a name fallback, plain-string refs are supported, and unresolved refs remain visible as synthetic options.

<sup>Written for commit fe43ef023d1130319e0ffe5d0b4d7bebdb4e682f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

