### PR TITLE
refactor(sandbox): remove unused LogTee.bytesWritten()

### DIFF
--- a/packages/sandbox/daemon/process/log-tee.ts
+++ b/packages/sandbox/daemon/process/log-tee.ts
@@ -93,10 +93,6 @@ export class LogTee {
     return this.rotatedOnce;
   }
 
-  bytesWritten(): number {
-    return this.written;
-  }
-
   close(): void {
     if (this.fd === null) return;
     try {


### PR DESCRIPTION
## Source
Source 4 (net code reduction) — dead code found while reading recently-churned sandbox daemon files.

## Why
`LogTee.bytesWritten()` (packages/sandbox/daemon/process/log-tee.ts) has zero callers anywhere in the repo — verified with `grep -rn "\.bytesWritten(" --include="*.ts" packages apps`, which only matches an unrelated `bytesWritten` field on a different type in `daemon/routes/fs.ts` / `sandbox-fs-hooks.test.ts`. `LogTee`'s own test file (`log-tee.test.ts`) doesn't reference it either. It's a leftover accessor from earlier log-rotation work (`written` is otherwise only read internally).

Net line delta: -4 / +0. Behavior-preserving — the method body was a pure getter over `this.written` with no side effects, so removing it changes nothing observable.

## Command to confirm
```
bun test packages/sandbox/daemon/process/log-tee.test.ts
```

## Checks run locally
- `bun run fmt`
- `tsc --noEmit` in `packages/sandbox`
- `bun test packages/sandbox/daemon/process/log-tee.test.ts` (2 pass)

Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `LogTee.bytesWritten()` from `packages/sandbox/daemon/process/log-tee.ts` to clean up dead code. No behavior change; the getter only returned an internal counter and had no side effects.

<sup>Written for commit 85cef8898d6a758b500555b125bab8ec15a26444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

