### PR TITLE
fix(web): CMS without dev server, subdir package path, and reliable preview refresh

### DIFF
--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
@@ -136,7 +136,6 @@ export function BlocksPanel({
             workspace.state.editSeoPageKey === activePageBlockKey
           }
           onExitSeo={workspace.consumeEditSeo}
-          onSaved={workspace.notifySaved}
           onVariantPreviewOverride={workspace.setVariantOverride}
         />
       </Suspense>

--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
@@ -40,15 +40,17 @@ export function BlocksPanel({
   const workspace = useBlocksPreviewWorkspace();
   const devServerReady = sandboxEvents.lifecycle.phase === "running";
   const previewUrl = lifecycle.previewUrl;
-  const fetchParams =
-    currentBranch && devServerReady
-      ? {
-          orgSlug: org.slug,
-          virtualMcpId,
-          branch: currentBranch,
-          previewUrl,
-        }
-      : null;
+  // Not gated on the dev server: when it's down (crashed/paused) we read the
+  // committed `.deco/*.gen.json` snapshot so the Blocks form editor still opens
+  // (block edits persist to the FS). The live routes take over once it's up.
+  const fetchParams = currentBranch
+    ? {
+        orgSlug: org.slug,
+        virtualMcpId,
+        branch: currentBranch,
+        previewUrl,
+      }
+    : null;
   const decofile = useDecofile(fetchParams, { fetchEnabled: devServerReady });
   const meta = useLiveMeta(fetchParams, { fetchEnabled: devServerReady });
   const state = resolveBlocksTabState({

--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-context.tsx
@@ -11,7 +11,6 @@ interface BlocksPreviewWorkspaceContextValue {
   selectTarget: (target: BlocksTarget) => void;
   editSeo: (target: Extract<BlocksTarget, { kind: "page" }>) => void;
   consumeEditSeo: () => void;
-  notifySaved: () => void;
   setVariantOverride: (params: string[] | null) => void;
 }
 
@@ -35,7 +34,6 @@ export function BlocksPreviewWorkspaceProvider({
         selectTarget: (target) => dispatch({ type: "select", target }),
         editSeo: (target) => dispatch({ type: "edit-seo", target }),
         consumeEditSeo: () => dispatch({ type: "consume-edit-seo" }),
-        notifySaved: () => dispatch({ type: "saved" }),
         setVariantOverride: (params) =>
           dispatch({ type: "variant-override", params }),
       }}

--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-state.test.ts
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-state.test.ts
@@ -5,7 +5,7 @@ import {
 } from "./blocks-preview-workspace-state";
 
 describe("blocksPreviewWorkspaceReducer", () => {
-  test("selects a page without requesting a preview refresh", () => {
+  test("selects a page", () => {
     const next = blocksPreviewWorkspaceReducer(
       INITIAL_BLOCKS_PREVIEW_WORKSPACE,
       {
@@ -19,16 +19,6 @@ describe("blocksPreviewWorkspaceReducer", () => {
       key: "pages-home",
       path: "/",
     });
-    expect(next.previewRevision).toBe(0);
-  });
-
-  test("save requests exactly one preview refresh", () => {
-    const next = blocksPreviewWorkspaceReducer(
-      INITIAL_BLOCKS_PREVIEW_WORKSPACE,
-      { type: "saved" },
-    );
-
-    expect(next.previewRevision).toBe(1);
   });
 
   test("edit SEO records both target and intent", () => {
@@ -58,7 +48,6 @@ describe("blocksPreviewWorkspaceReducer", () => {
     ).toEqual({
       target: { kind: "page", key: "pages-home", path: "/" },
       editSeoPageKey: null,
-      previewRevision: 0,
       variantOverride: null,
     });
   });

--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-state.ts
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-preview-workspace-state.ts
@@ -5,7 +5,6 @@ export type BlocksTarget =
 export interface BlocksPreviewWorkspaceState {
   target: BlocksTarget | null;
   editSeoPageKey: string | null;
-  previewRevision: number;
   /**
    * `x-deco-matchers-override` params published by the Blocks panel so the
    * (independent) Preview iframe renders the variant currently selected in the
@@ -21,13 +20,11 @@ export type BlocksPreviewWorkspaceAction =
       target: Extract<BlocksTarget, { kind: "page" }>;
     }
   | { type: "consume-edit-seo" }
-  | { type: "saved" }
   | { type: "variant-override"; params: string[] | null };
 
 export const INITIAL_BLOCKS_PREVIEW_WORKSPACE: BlocksPreviewWorkspaceState = {
   target: null,
   editSeoPageKey: null,
-  previewRevision: 0,
   variantOverride: null,
 };
 
@@ -48,8 +45,6 @@ export function blocksPreviewWorkspaceReducer(
       };
     case "consume-edit-seo":
       return { ...state, editSeoPageKey: null };
-    case "saved":
-      return { ...state, previewRevision: state.previewRevision + 1 };
     case "variant-override":
       return { ...state, variantOverride: action.params };
   }

--- a/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/category-editor.tsx
@@ -30,6 +30,7 @@ import {
   stampPostModified,
 } from "./blog-data";
 import { buildBlogCategoryPreviewUrl } from "./blog-preview-url";
+import { usePackagePath } from "@/web/components/sections-editor/use-package-path";
 import { useSaveBlogBlock } from "./use-blog-mutations";
 import { useAutosave } from "./use-autosave";
 import { SaveStatus } from "./save-status";
@@ -78,7 +79,12 @@ export function CategoryEditor({
   onOpenPost: (key: string) => void;
   previewBaseUrl?: string | null;
 }) {
-  const save = useSaveBlogBlock({ orgSlug, virtualMcpId, branch });
+  const save = useSaveBlogBlock({
+    orgSlug,
+    virtualMcpId,
+    branch,
+    packagePath: usePackagePath(virtualMcpId),
+  });
   const initial = getBlogPayload(block, "categories");
 
   const [category, setCategory, syncCategory] = useAutosave(initial, (next) => {

--- a/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/post-editor.tsx
@@ -21,6 +21,7 @@ import {
   stampPostModified,
 } from "./blog-data";
 import { buildBlogPostPreviewUrl } from "./blog-preview-url";
+import { usePackagePath } from "@/web/components/sections-editor/use-package-path";
 import { useSaveBlogBlock } from "./use-blog-mutations";
 import { useAutosave } from "./use-autosave";
 import { SaveStatus } from "./save-status";
@@ -68,7 +69,12 @@ export function PostEditor({
   meta: LiveMeta;
   previewBaseUrl?: string | null;
 }) {
-  const save = useSaveBlogBlock({ orgSlug, virtualMcpId, branch });
+  const save = useSaveBlogBlock({
+    orgSlug,
+    virtualMcpId,
+    branch,
+    packagePath: usePackagePath(virtualMcpId),
+  });
   const initial = getBlogPayload(block, "posts");
 
   const [post, setPost] = useAutosave(initial, (next) => {

--- a/apps/mesh/src/web/components/sandbox/content/blog/record-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/record-editor.tsx
@@ -11,6 +11,7 @@ import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { ImageField } from "@/web/components/sections-editor/fields/image-field";
 import { buildBlogBlock, getBlogPayload, type BlogKind } from "./blog-data";
 import { str } from "./blocks/primitives";
+import { usePackagePath } from "@/web/components/sections-editor/use-package-path";
 import { useSaveBlogBlock } from "./use-blog-mutations";
 import { useAutosave } from "./use-autosave";
 import { SaveStatus } from "./save-status";
@@ -69,7 +70,12 @@ export function RecordEditor({
   blockKey: string;
   block: Record<string, unknown> | undefined;
 }) {
-  const save = useSaveBlogBlock({ orgSlug, virtualMcpId, branch });
+  const save = useSaveBlogBlock({
+    orgSlug,
+    virtualMcpId,
+    branch,
+    packagePath: usePackagePath(virtualMcpId),
+  });
   const initial = getBlogPayload(block, kind);
 
   const [payload, setPayload] = useAutosave(initial, (next) => {

--- a/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
@@ -6,7 +6,6 @@
  * the rest of the Content tab reads blog blocks like any other entry.
  */
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useVirtualMCP } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
 import { decoRepoPath } from "@/web/components/sections-editor/deco-repo-path";
 import { blogBlockFilePath } from "./blog-data";
@@ -15,6 +14,12 @@ interface BlogMutationParams {
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
+  /**
+   * Project package path (`metadata.runtime.path`) to prefix onto the daemon
+   * write path — the daemon resolves against the repo root. Resolve via
+   * `usePackagePath` at the call site (keeps this hook free of ProjectContext).
+   */
+  packagePath?: string | null;
 }
 
 function decofileQueryKey({
@@ -63,10 +68,6 @@ async function postToSandbox(
 
 export function useSaveBlogBlock(params: BlogMutationParams) {
   const queryClient = useQueryClient();
-  // Prefix with the project's package path when it isn't at the repo root — the
-  // daemon resolves file writes against the repo root.
-  const packagePath =
-    useVirtualMCP(params.virtualMcpId)?.metadata?.runtime?.path ?? null;
 
   return useMutation({
     mutationFn: ({ blockKey, data }: { blockKey: string; data: unknown }) =>
@@ -74,7 +75,7 @@ export function useSaveBlogBlock(params: BlogMutationParams) {
         params,
         "write",
         {
-          path: decoRepoPath(packagePath, blogBlockFilePath(blockKey)),
+          path: decoRepoPath(params.packagePath, blogBlockFilePath(blockKey)),
           content: JSON.stringify(data, null, 2),
         },
         "Write failed",
@@ -103,15 +104,13 @@ export function useSaveBlogBlock(params: BlogMutationParams) {
 
 export function useDeleteBlogBlock(params: BlogMutationParams) {
   const queryClient = useQueryClient();
-  const packagePath =
-    useVirtualMCP(params.virtualMcpId)?.metadata?.runtime?.path ?? null;
 
   return useMutation({
     mutationFn: ({ blockKey }: { blockKey: string }) =>
       postToSandbox(
         params,
         "unlink",
-        { path: decoRepoPath(packagePath, blogBlockFilePath(blockKey)) },
+        { path: decoRepoPath(params.packagePath, blogBlockFilePath(blockKey)) },
         "Delete failed",
       ) as Promise<{ ok: true; existed: boolean }>,
     onMutate: async ({ blockKey }) => {

--- a/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
@@ -6,7 +6,9 @@
  * the rest of the Content tab reads blog blocks like any other entry.
  */
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useVirtualMCP } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
+import { decoRepoPath } from "@/web/components/sections-editor/deco-repo-path";
 import { blogBlockFilePath } from "./blog-data";
 
 interface BlogMutationParams {
@@ -61,6 +63,10 @@ async function postToSandbox(
 
 export function useSaveBlogBlock(params: BlogMutationParams) {
   const queryClient = useQueryClient();
+  // Prefix with the project's package path when it isn't at the repo root — the
+  // daemon resolves file writes against the repo root.
+  const packagePath =
+    useVirtualMCP(params.virtualMcpId)?.metadata?.runtime?.path ?? null;
 
   return useMutation({
     mutationFn: ({ blockKey, data }: { blockKey: string; data: unknown }) =>
@@ -68,7 +74,7 @@ export function useSaveBlogBlock(params: BlogMutationParams) {
         params,
         "write",
         {
-          path: blogBlockFilePath(blockKey),
+          path: decoRepoPath(packagePath, blogBlockFilePath(blockKey)),
           content: JSON.stringify(data, null, 2),
         },
         "Write failed",
@@ -97,13 +103,15 @@ export function useSaveBlogBlock(params: BlogMutationParams) {
 
 export function useDeleteBlogBlock(params: BlogMutationParams) {
   const queryClient = useQueryClient();
+  const packagePath =
+    useVirtualMCP(params.virtualMcpId)?.metadata?.runtime?.path ?? null;
 
   return useMutation({
     mutationFn: ({ blockKey }: { blockKey: string }) =>
       postToSandbox(
         params,
         "unlink",
-        { path: blogBlockFilePath(blockKey) },
+        { path: decoRepoPath(packagePath, blogBlockFilePath(blockKey)) },
         "Delete failed",
       ) as Promise<{ ok: true; existed: boolean }>,
     onMutate: async ({ blockKey }) => {

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -330,6 +330,7 @@ export function ContentBrowser({ mode = "content" }: ContentBrowserProps) {
       branch={branch}
       previewUrl={previewUrl}
       mode={mode}
+      devServerReady={vmEvents.lifecycle.phase === "running"}
     />
   );
 }
@@ -358,17 +359,21 @@ function ContentBrowserReady({
   branch,
   previewUrl,
   mode,
+  devServerReady,
 }: {
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
   previewUrl: string | null;
   mode: "content" | "blocks";
+  devServerReady: boolean;
 }) {
   const workspace = useBlocksPreviewWorkspace();
   const fetchParams = { orgSlug, virtualMcpId, branch, previewUrl };
-  const { data: decofile, isLoading: decofileLoading } =
-    useDecofile(fetchParams);
+  const { data: decofile, isLoading: decofileLoading } = useDecofile(
+    fetchParams,
+    { fetchEnabled: devServerReady },
+  );
 
   const [activeCollection, setActiveCollection] =
     useState<CollectionId>("pages");
@@ -466,6 +471,7 @@ function ContentBrowserReady({
     isLoading: metaLoading,
     isFetching: metaFetching,
   } = useLiveMeta(fetchParams, {
+    fetchEnabled: devServerReady,
     refetchInterval: (query) => {
       const currentMeta = query.state.data;
 

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -1362,9 +1362,6 @@ function ContentBrowserReady({
                     setOpenPageSeoKey(null);
                     if (mode === "blocks") workspace.consumeEditSeo();
                   }}
-                  onSaved={
-                    mode === "blocks" ? workspace.notifySaved : undefined
-                  }
                 />
               )
             ) : (

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -43,6 +43,7 @@ import { authClient } from "@/web/lib/auth-client";
 import { useChatTask } from "@/web/components/chat/context";
 import { useDecofile } from "@/web/components/sections-editor/use-decofile";
 import { useLiveMeta } from "@/web/components/sections-editor/use-live-meta";
+import { usePackagePath } from "@/web/components/sections-editor/use-package-path";
 import { hasEditableAppEditorSchema } from "./app-editor-schema";
 import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
 import { useSaveBlock } from "@/web/components/sections-editor/use-save-block";
@@ -370,6 +371,7 @@ function ContentBrowserReady({
 }) {
   const workspace = useBlocksPreviewWorkspace();
   const fetchParams = { orgSlug, virtualMcpId, branch, previewUrl };
+  const packagePath = usePackagePath(virtualMcpId);
   const { data: decofile, isLoading: decofileLoading } = useDecofile(
     fetchParams,
     { fetchEnabled: devServerReady },
@@ -525,8 +527,8 @@ function ContentBrowserReady({
 
   const saveBlock = useSaveBlock(fetchParams);
   const deleteBlock = useDeleteBlock(fetchParams);
-  const saveBlogBlock = useSaveBlogBlock(fetchParams);
-  const deleteBlogBlock = useDeleteBlogBlock(fetchParams);
+  const saveBlogBlock = useSaveBlogBlock({ ...fetchParams, packagePath });
+  const deleteBlogBlock = useDeleteBlogBlock({ ...fetchParams, packagePath });
 
   // Dialog state
   const [pageDialog, setPageDialog] = useState<PageDialogState>(null);

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -413,6 +413,15 @@ export function SandboxEventsProvider({
             const isDecoFile =
               filePath.startsWith(".deco/") || filePath.includes("/.deco/");
             if (isDecoFile) {
+              // Only act while the dev server is running. When it's down
+              // (crashed/paused — the state the committed-snapshot fallback
+              // supports editing in), `blocks.gen.json` is a stale build
+              // artifact the dev server can't regenerate, so invalidating +
+              // refetching it would overwrite the optimistic cache update from
+              // useSaveBlock/useDeleteBlock and the edit would visibly revert.
+              // Leave the optimistic cache as the source of truth; the
+              // lifecycle→running transition re-invalidates onto the live routes.
+              if (prevLifecyclePhase !== "running") return;
               // Turn on the preview's loading overlay immediately — before the
               // debounce below — so the pending refresh feels instant instead of
               // only appearing once the reload finally fires.

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -77,6 +77,12 @@ export interface SandboxEventsValue {
   subscribeChunks: (handler: ChunkHandler) => () => void;
   /** "reload" SSE fires on config edits framework HMR doesn't watch. */
   subscribeReload: (handler: ReloadHandler) => () => void;
+  /**
+   * Fires the instant a `.deco/*` change is detected — before the debounced
+   * reload — so the preview can show its loading overlay immediately instead of
+   * waiting out the rebuild debounce.
+   */
+  subscribeReloadStart: (handler: ReloadHandler) => () => void;
 }
 
 const DEFAULT_VALUE: SandboxEventsValue = {
@@ -91,6 +97,7 @@ const DEFAULT_VALUE: SandboxEventsValue = {
   hasData: () => false,
   subscribeChunks: () => () => {},
   subscribeReload: () => () => {},
+  subscribeReloadStart: () => () => {},
 };
 
 export const SandboxEventsContext =
@@ -211,6 +218,7 @@ export function SandboxEventsProvider({
   const buffers = useRef(new Map<string, ChunkBuffer>());
   const chunkHandlers = useRef(new Set<ChunkHandler>());
   const reloadHandlers = useRef(new Set<ReloadHandler>());
+  const reloadStartHandlers = useRef(new Set<ReloadHandler>());
   const prevPortRef = useRef<number | null>(null);
   const directDaemonEventsUrl = buildDirectDaemonEventsUrl(previewUrl);
 
@@ -398,7 +406,23 @@ export function SandboxEventsProvider({
             const { path: filePath } =
               payload as DaemonEventPayload<"file-changed">;
             const cacheKey = `${org.slug}/${virtualMcpId}/${branch}`;
-            if (filePath.startsWith(".deco/")) {
+            // A `.deco/*` change is a config edit the framework's HMR won't pick
+            // up. `/.deco/` (not just a leading `.deco/`) also matches projects
+            // whose package path isn't the repo root (`<pkg>/.deco/...`), since
+            // the daemon reports paths relative to the repo root.
+            const isDecoFile =
+              filePath.startsWith(".deco/") || filePath.includes("/.deco/");
+            if (isDecoFile) {
+              // Turn on the preview's loading overlay immediately — before the
+              // debounce below — so the pending refresh feels instant instead of
+              // only appearing once the reload finally fires.
+              for (const fn of reloadStartHandlers.current) {
+                try {
+                  fn();
+                } catch {
+                  // swallow
+                }
+              }
               // Debounce decofile invalidation for the same reason as liveMeta
               // below: writing a `.deco/` block emits `file-changed`, but the
               // dev server needs a moment to rebuild before `/.decofile`
@@ -413,7 +437,20 @@ export function SandboxEventsProvider({
                 void queryClient.invalidateQueries({
                   queryKey: KEYS.decofile(cacheKey),
                 });
-              }, 1_000);
+                // Reload the preview iframe once the rebuild has landed — HMR
+                // won't reflect a decofile edit, so this is the only thing that
+                // refreshes the rendered page after a Blocks save (or an
+                // external/agent `.deco/` write). Debounced with the
+                // invalidation above so it fires after the dev server rebuilds,
+                // not against the stale pre-rebuild page.
+                for (const fn of reloadHandlers.current) {
+                  try {
+                    fn();
+                  } catch {
+                    // swallow
+                  }
+                }
+              }, 500);
             } else {
               // Debounce liveMeta invalidation so the dev server has time to
               // rebuild before we hit /live/_meta. Rapid successive
@@ -585,6 +622,12 @@ export function SandboxEventsProvider({
       reloadHandlers.current.add(handler);
       return () => {
         reloadHandlers.current.delete(handler);
+      };
+    },
+    subscribeReloadStart: (handler: ReloadHandler) => {
+      reloadStartHandlers.current.add(handler);
+      return () => {
+        reloadStartHandlers.current.delete(handler);
       };
     },
   };

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -247,6 +247,10 @@ export function SandboxEventsProvider({
     let decofileDebounceTimer: ReturnType<typeof setTimeout> | null = null;
     let studioEs: EventSource | null = null;
     let directEs: EventSource | null = null;
+    // Tracks the dev-server lifecycle so we can invalidate the CMS queries once
+    // it comes up (switching them from the committed `.deco/*.gen.json` snapshot
+    // to the live `/.decofile` + `/live/_meta` routes).
+    let prevLifecyclePhase: string | null = null;
 
     const handleClaimPhase = (e: MessageEvent) => {
       try {
@@ -314,6 +318,27 @@ export function SandboxEventsProvider({
           case "lifecycle": {
             const lp = payload as DaemonEventPayload<"lifecycle">;
             setLifecycle(lp.state);
+            // Dev server just came up: swap the CMS queries off the committed
+            // `.deco/*.gen.json` snapshot and onto the live routes. This is the
+            // trigger they rely on (they're enabled as soon as the daemon is up,
+            // so the `enabled` flip no longer does it) — see use-decofile /
+            // use-live-meta.
+            if (
+              lp.state.phase === "running" &&
+              prevLifecyclePhase !== "running"
+            ) {
+              const cacheKey = `${org.slug}/${virtualMcpId}/${branch}`;
+              void queryClient.invalidateQueries({
+                queryKey: KEYS.decofile(cacheKey),
+              });
+              void queryClient.invalidateQueries({
+                predicate: (query) =>
+                  query.queryKey[0] === "live-meta" &&
+                  typeof query.queryKey[1] === "string" &&
+                  query.queryKey[1].startsWith(`${cacheKey}/`),
+              });
+            }
+            prevLifecyclePhase = lp.state.phase;
             // Detect dev server port change (running phase carries port);
             // reload iframe so it picks up the new backend.
             const newPort = lp.state.phase === "running" ? lp.state.port : null;

--- a/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-events.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-events.ts
@@ -51,3 +51,23 @@ export function useSandboxReloadHandler(handler: ReloadHandler | null) {
     return unsubscribe;
   }, [subscribeReload]);
 }
+
+/**
+ * Fires the instant a `.deco/*` change is detected (before the debounced
+ * reload), so the caller can show a loading indicator immediately.
+ */
+export function useSandboxReloadStartHandler(handler: ReloadHandler | null) {
+  const { subscribeReloadStart } = useSandboxEvents();
+  const handlerRef = useRef(handler);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
+  handlerRef.current = handler;
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect — subscription lifecycle bound to the component mount; uses ref for stable identity
+  useEffect(() => {
+    const fn: ReloadHandler = () => {
+      handlerRef.current?.();
+    };
+    const unsubscribe = subscribeReloadStart(fn);
+    return unsubscribe;
+  }, [subscribeReloadStart]);
+}

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
@@ -11,6 +11,7 @@ import {
   joinTreePath,
   mergeGlobLists,
   pathExistsInFileList,
+  stripLineNumbers,
   toDaemonPath,
   toTreePath,
   validateExplorerEntryName,
@@ -137,5 +138,33 @@ describe("file-explorer utils", () => {
       directories: ["src"],
       truncated: true,
     });
+  });
+});
+
+describe("stripLineNumbers", () => {
+  it("strips the <n>\\t prefix from a single line", () => {
+    expect(stripLineNumbers("1\thello")).toBe("hello");
+  });
+
+  it("strips the prefix from every line", () => {
+    expect(stripLineNumbers('1\t{\n2\t  "a": 1\n3\t}')).toBe('{\n  "a": 1\n}');
+  });
+
+  it("preserves a line containing a carriage return verbatim", () => {
+    // A `(.*)` capture would stop at \r and truncate the rest; `replace` keeps it.
+    expect(stripLineNumbers("1\tvalue\rmore")).toBe("value\rmore");
+  });
+
+  it("preserves U+2028 / U+2029 line separators (the regression this fixes)", () => {
+    // These aren't `\n`, so `.split("\n")` keeps them within one line; the old
+    // `(.*)` capture stopped at them and truncated the tail. `replace` keeps it.
+    expect(stripLineNumbers("1\ta b")).toBe("a b");
+    expect(stripLineNumbers("1\tx y")).toBe("x y");
+  });
+
+  it("leaves a line without a numeric-tab prefix untouched", () => {
+    expect(stripLineNumbers("no prefix here")).toBe("no prefix here");
+    // Only a leading <digits>\t is stripped, not an interior tab.
+    expect(stripLineNumbers("1\tkey\tvalue")).toBe("key\tvalue");
   });
 });

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -325,13 +325,16 @@ export function flattenTree(
 /**
  * Strip the line-number prefix from the daemon's read endpoint.
  * The daemon returns content in `"1\tcontent\n2\tcontent"` format.
+ *
+ * Uses `replace` rather than a `(.*)` capture: `.` does not match `\r`,
+ * \u2028, or \u2029, so a capture group would truncate any line containing
+ * one of those (e.g. a JSON string value with an embedded line separator),
+ * silently corrupting large files. `replace` drops only the `<n>\t` prefix
+ * and keeps the rest of the line verbatim.
  */
 export function stripLineNumbers(content: string): string {
   return content
     .split("\n")
-    .map((line) => {
-      const match = line.match(/^\d+\t(.*)/);
-      return match ? match[1] : line;
-    })
+    .map((line) => line.replace(/^\d+\t/, ""))
     .join("\n");
 }

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -75,6 +75,7 @@ import { VisualEditorPrompt } from "./visual-editor-prompt";
 import {
   useSandboxEvents,
   useSandboxReloadHandler,
+  useSandboxReloadStartHandler,
 } from "../hooks/use-sandbox-events";
 import { SandboxStateCard } from "./state-card";
 import {
@@ -423,14 +424,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   /** Path we navigated to programmatically; ignore stale iframe onLoad events. */
   const intendedPathRef = useRef<string | null>(null);
 
-  // "reload" fires on config edits framework HMR won't catch (.ts/.tsx use HMR).
-  useSandboxReloadHandler(() => {
-    const iframe = previewIframeRef.current;
-    const src = iframeSrcRef.current;
-    if (!iframe || !src) return;
-    iframe.src = src;
-  });
-
   // Only the user-pause state routes to the suspended overlay (resume
   // affordance). The daemon's `error` state means the dev script crashed
   // — that's a failure, but the daemon's HTTP proxy serves an auto-reloading
@@ -700,10 +693,17 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     iframe.src = iframeSrc;
   };
 
-  // Reload the preview after a Blocks save without moving keyboard focus.
+  // Reload the preview without moving keyboard focus. Used both for the daemon
+  // "reload" event (config edits HMR won't catch) and, via the debounced
+  // `.deco/` file-changed signal, after a Blocks save once the dev server has
+  // rebuilt (see sandbox-events-context).
   const reloadPreviewPreservingScroll = () => {
     const iframe = previewIframeRef.current;
     if (!iframe) return;
+    // Show the same loading overlay as page navigation while the reloaded page
+    // fetches; the iframe's onLoad clears it (with beginNavigation's safety net
+    // as a fallback if onLoad never fires).
+    beginNavigation();
     const focused = document.activeElement as HTMLElement | null;
     const prevTabIndex = iframe.tabIndex;
     iframe.tabIndex = -1;
@@ -725,15 +725,17 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     setTimeout(restore, 3000);
   };
 
-  const [handledPreviewRevision, setHandledPreviewRevision] = useState(
-    workspace.state.previewRevision,
-  );
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- synchronizes persisted Blocks saves with the mounted preview iframe
-  useEffect(() => {
-    if (handledPreviewRevision === workspace.state.previewRevision) return;
-    setHandledPreviewRevision(workspace.state.previewRevision);
+  // Fires on the daemon "reload" event and on debounced `.deco/` file changes
+  // (Blocks saves, external/agent decofile writes) — the only refresh path for
+  // decofile edits, which the framework's HMR doesn't cover.
+  useSandboxReloadHandler(() => {
     reloadPreviewPreservingScroll();
-  }, [handledPreviewRevision, workspace.state.previewRevision]);
+  });
+  // Show the loading overlay the instant a `.deco/` change is detected, ahead of
+  // the debounced reload above, so the pending refresh feels immediate.
+  useSandboxReloadStartHandler(() => {
+    beginNavigation();
+  });
 
   const handleHardReload = () => {
     if (!previewIframeRef.current || !iframeSrc) return;

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -314,9 +314,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // agent-sandbox, whose daemon reports a container-internal path ("/app/repo").
   const repoDir = isDesktopSandbox ? rawRepoDir : null;
 
-  // Decofile pages for the URL bar dropdown — fetch only after dev server is up.
+  // Decofile pages/global sections for the URL bar dropdown. Not gated on the
+  // dev server: when it's down we read the committed `.deco/*.gen.json` snapshot
+  // so the dropdown still lists pages; the live routes take over once it's up.
+  // (The inline CMS overlay still needs the dev server — it edits the page
+  // rendered inside the iframe, which the dev server serves.)
   const decofileParams =
-    virtualMcpId && branch && devServerReady
+    virtualMcpId && branch
       ? { orgSlug: org.slug, virtualMcpId, branch, previewUrl }
       : null;
   const { data: decofile } = useDecofile(decofileParams, {

--- a/apps/mesh/src/web/components/sections-editor/deco-repo-path.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/deco-repo-path.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { decoRepoPath } from "./deco-repo-path";
+
+describe("decoRepoPath", () => {
+  test("returns the bare path at the repo root", () => {
+    expect(decoRepoPath(null, ".deco/blocks.gen.json")).toBe(
+      ".deco/blocks.gen.json",
+    );
+    expect(decoRepoPath(undefined, ".deco/meta.gen.json")).toBe(
+      ".deco/meta.gen.json",
+    );
+    expect(decoRepoPath("", ".deco/blocks.gen.json")).toBe(
+      ".deco/blocks.gen.json",
+    );
+    expect(decoRepoPath("   ", ".deco/blocks.gen.json")).toBe(
+      ".deco/blocks.gen.json",
+    );
+  });
+
+  test("prefixes the package path when the project is in a subdirectory", () => {
+    expect(
+      decoRepoPath(
+        "eitri-shopping-monte-carlo-shared",
+        ".deco/blocks.gen.json",
+      ),
+    ).toBe("eitri-shopping-monte-carlo-shared/.deco/blocks.gen.json");
+  });
+
+  test("normalizes leading and trailing slashes on the package path", () => {
+    expect(decoRepoPath("/pkg/", ".deco/meta.gen.json")).toBe(
+      "pkg/.deco/meta.gen.json",
+    );
+    expect(decoRepoPath("pkg", ".deco/meta.gen.json")).toBe(
+      "pkg/.deco/meta.gen.json",
+    );
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/deco-repo-path.ts
+++ b/apps/mesh/src/web/components/sections-editor/deco-repo-path.ts
@@ -1,0 +1,18 @@
+/**
+ * Join a virtual MCP's package path (`metadata.runtime.path`, e.g.
+ * "eitri-shopping-monte-carlo-shared") with a repo-relative `.deco/*` path.
+ *
+ * The sandbox daemon resolves file reads against the repo root, but when the
+ * project doesn't live at the repo root the dev server runs with the package
+ * path as its cwd — so the committed `.deco/*.gen.json` artifacts sit under it
+ * (`<packagePath>/.deco/blocks.gen.json`). The live `/.decofile` + `/live/_meta`
+ * routes already resolve relative to that cwd; only the committed-snapshot reads
+ * need the prefix. An empty/absent package path means the repo root.
+ */
+export function decoRepoPath(
+  packagePath: string | null | undefined,
+  relative: string,
+): string {
+  const base = (packagePath ?? "").trim().replace(/^[/\\]+|[/\\]+$/g, "");
+  return base ? `${base}/${relative}` : relative;
+}

--- a/apps/mesh/src/web/components/sections-editor/read-committed-file.ts
+++ b/apps/mesh/src/web/components/sections-editor/read-committed-file.ts
@@ -1,0 +1,48 @@
+import { stripLineNumbers } from "@/web/components/sandbox/preview/file-explorer/utils";
+
+interface RepoFileParams {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+}
+
+/**
+ * Read a JSON file committed to the repo working tree via the sandbox daemon's
+ * file-read proxy. Unlike `/.decofile` and `/live/_meta` (served by the dev
+ * server), this works as soon as the daemon is up — before the dev script boots
+ * or even when it has crashed — so the CMS can be read (and, since block writes
+ * go straight to the FS, edited) without a working preview.
+ *
+ * Returns `null` when the file is absent (daemon 400) or unparseable; throws on
+ * transient daemon-unreachable errors so the caller's query retries.
+ */
+export async function readCommittedJson<T>(
+  params: RepoFileParams,
+  path: string,
+): Promise<T | null> {
+  const url = `/api/${params.orgSlug}/sandbox/${encodeURIComponent(
+    params.virtualMcpId,
+  )}/${encodeURIComponent(params.branch)}/read`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ path, full: true }),
+  });
+  // 400 = file not found: the repo simply doesn't commit this artifact, so
+  // there is no committed source to fall back to. Don't retry.
+  if (res.status === 400) return null;
+  if (!res.ok) {
+    const err = new Error(`Failed to read ${path}: ${res.status}`);
+    (err as { status?: number }).status = res.status;
+    throw err;
+  }
+  // The daemon returns line-number-prefixed content ("1\t...\n2\t..."), even
+  // with `full: true`, so strip it before parsing.
+  const data = (await res.json()) as { content?: string };
+  if (typeof data.content !== "string") return null;
+  try {
+    return JSON.parse(stripLineNumbers(data.content)) as T;
+  } catch {
+    return null;
+  }
+}

--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
+import { useVirtualMCP } from "@decocms/mesh-sdk";
 import { exponentialBackoffWithJitter } from "@decocms/std";
 import { KEYS } from "@/web/lib/query-keys";
+import { decoRepoPath } from "./deco-repo-path";
 import { buildDecofileFetchUrl } from "./preview-fetch-url";
 import { readCommittedJson } from "./read-committed-file";
 
@@ -24,13 +26,19 @@ export function useDecofile(
   // so optimistic block writes (which persist to the FS) operate on a full base
   // and the CMS stays editable even if the preview never comes up.
   const fetchEnabled = options?.fetchEnabled ?? true;
+  // Committed snapshot lives under the project's package path
+  // (`metadata.runtime.path`) when the project isn't at the repo root — the
+  // daemon reads resolve against the repo root, so prefix it. The live
+  // `/.decofile` route already resolves relative to the dev-server cwd.
+  const packagePath =
+    useVirtualMCP(params?.virtualMcpId)?.metadata?.runtime?.path ?? null;
   return useQuery({
     queryKey: KEYS.decofile(key),
     queryFn: async () => {
       const readCommitted = () =>
         readCommittedJson<Record<string, unknown>>(
           params!,
-          ".deco/blocks.gen.json",
+          decoRepoPath(packagePath, ".deco/blocks.gen.json"),
         );
       if (fetchEnabled) {
         const res = await fetch(buildDecofileFetchUrl(params!), {

--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { exponentialBackoffWithJitter } from "@decocms/std";
 import { KEYS } from "@/web/lib/query-keys";
 import { buildDecofileFetchUrl } from "./preview-fetch-url";
+import { readCommittedJson } from "./read-committed-file";
 
 interface UseDecofileParams {
   orgSlug: string;
@@ -17,25 +18,48 @@ export function useDecofile(
   const key = params
     ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}`
     : "";
+  // `fetchEnabled` means the dev server is up, so the live `/.decofile` route is
+  // worth hitting. When it's down we read the committed `.deco/blocks.gen.json`
+  // straight from the working tree — a single source of truth for KEYS.decofile,
+  // so optimistic block writes (which persist to the FS) operate on a full base
+  // and the CMS stays editable even if the preview never comes up.
   const fetchEnabled = options?.fetchEnabled ?? true;
   return useQuery({
     queryKey: KEYS.decofile(key),
     queryFn: async () => {
-      const res = await fetch(buildDecofileFetchUrl(params!), {
-        cache: "no-store",
-      });
-      if (!res.ok) {
-        const err = new Error(`Failed to fetch decofile: ${res.status}`);
-        (err as { status?: number }).status = res.status;
+      const readCommitted = () =>
+        readCommittedJson<Record<string, unknown>>(
+          params!,
+          ".deco/blocks.gen.json",
+        );
+      if (fetchEnabled) {
+        const res = await fetch(buildDecofileFetchUrl(params!), {
+          cache: "no-store",
+        }).catch(() => null);
+        if (res?.ok) return (await res.json()) as Record<string, unknown>;
+        // Dev server reported ready but the route failed (e.g. dev script
+        // crashed): fall back to the committed snapshot so editing still works.
+        const committed = await readCommitted();
+        if (committed) return committed;
+        const err = new Error(
+          `Failed to fetch decofile: ${res?.status ?? "network error"}`,
+        );
+        (err as { status?: number }).status = res?.status ?? 502;
         throw err;
       }
-      return (await res.json()) as Record<string, unknown>;
+      const committed = await readCommitted();
+      if (committed) return committed;
+      const err = new Error(
+        "decofile unavailable (preview down, no committed snapshot)",
+      );
+      (err as { status?: number }).status = 502;
+      throw err;
     },
-    enabled: !!params && fetchEnabled,
+    enabled: !!params,
     staleTime: 30_000,
-    // 502 = preview unreachable (sandbox starting or down). The SSE lifecycle
-    // re-enables this query when the preview is back, so retrying just hammers
-    // a known-down endpoint and spams 5xx logs.
+    // 502 = preview unreachable / nothing available yet. The sandbox lifecycle
+    // re-invalidates this query when the dev server comes up (see
+    // sandbox-events-context), so retrying just hammers a known-down endpoint.
     retry: (failureCount, error) =>
       (error as { status?: number }).status !== 502 && failureCount < 2,
     retryDelay: (attempt) =>

--- a/apps/mesh/src/web/components/sections-editor/use-delete-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-delete-block.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useVirtualMCP } from "@decocms/mesh-sdk";
 import { KEYS } from "@/web/lib/query-keys";
 import { decoBlockFilePath } from "./deco-block-key";
+import { decoRepoPath } from "./deco-repo-path";
 
 interface UseDeleteBlockParams {
   orgSlug: string;
@@ -20,10 +22,14 @@ export function useDeleteBlock({
   branch,
 }: UseDeleteBlockParams) {
   const queryClient = useQueryClient();
+  // Under the project's package path (`metadata.runtime.path`) when the project
+  // isn't at the repo root — the daemon resolves against the repo root.
+  const packagePath =
+    useVirtualMCP(virtualMcpId)?.metadata?.runtime?.path ?? null;
 
   return useMutation({
     mutationFn: async ({ blockKey }: { blockKey: string }) => {
-      const path = decoBlockFilePath(blockKey);
+      const path = decoRepoPath(packagePath, decoBlockFilePath(blockKey));
       const res = await fetch(
         `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/unlink`,
         {

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
@@ -1,6 +1,7 @@
 import { type Query, useQuery } from "@tanstack/react-query";
 import { exponentialBackoffWithJitter } from "@decocms/std";
 import { KEYS } from "@/web/lib/query-keys";
+import { readCommittedJson } from "./read-committed-file";
 import type { LiveMeta } from "./resolve-schema";
 
 interface UseLiveMetaParams {
@@ -32,22 +33,38 @@ export function useLiveMeta(
         )
       : KEYS.liveMeta(""),
     queryFn: async () => {
-      const url = new URL("/live/_meta", previewUrl!).href;
-      const res = await fetch(url, { cache: "no-store" });
-      if (!res.ok) {
-        const err = new Error(`Failed to fetch live meta: ${res.status}`);
-        (err as { status?: number }).status = res.status;
+      const readCommitted = () =>
+        readCommittedJson<LiveMeta>(params!, ".deco/meta.gen.json");
+      // Prefer the live `/live/_meta` when the dev server is up; otherwise (or on
+      // failure) read the committed `.deco/meta.gen.json` snapshot so the CMS
+      // schema is available even without a working preview.
+      if (fetchEnabled && previewUrl) {
+        const url = new URL("/live/_meta", previewUrl).href;
+        const res = await fetch(url, { cache: "no-store" }).catch(() => null);
+        if (res?.ok) return (await res.json()) as LiveMeta;
+        const committed = await readCommitted();
+        if (committed) return committed;
+        const err = new Error(
+          `Failed to fetch live meta: ${res?.status ?? "network error"}`,
+        );
+        (err as { status?: number }).status = res?.status ?? 502;
         throw err;
       }
-      return (await res.json()) as LiveMeta;
+      const committed = await readCommitted();
+      if (committed) return committed;
+      const err = new Error(
+        "live meta unavailable (preview down, no committed snapshot)",
+      );
+      (err as { status?: number }).status = 502;
+      throw err;
     },
-    enabled: !!params && !!previewUrl && fetchEnabled,
+    enabled: !!params,
     refetchInterval: options?.refetchInterval,
     refetchIntervalInBackground: false,
     staleTime: 300_000,
-    // 502 = preview unreachable (sandbox starting or down). The SSE lifecycle
-    // re-enables this query when the preview is back, so retrying just hammers
-    // a known-down endpoint and spams 5xx logs.
+    // 502 = preview unreachable / nothing available yet. The sandbox lifecycle
+    // re-invalidates this query when the dev server comes up (see
+    // sandbox-events-context), so retrying just hammers a known-down endpoint.
     retry: (failureCount, error) =>
       (error as { status?: number }).status !== 502 && failureCount < 3,
     retryDelay: (attempt) =>

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
@@ -1,6 +1,8 @@
 import { type Query, useQuery } from "@tanstack/react-query";
+import { useVirtualMCP } from "@decocms/mesh-sdk";
 import { exponentialBackoffWithJitter } from "@decocms/std";
 import { KEYS } from "@/web/lib/query-keys";
+import { decoRepoPath } from "./deco-repo-path";
 import { readCommittedJson } from "./read-committed-file";
 import type { LiveMeta } from "./resolve-schema";
 
@@ -23,6 +25,11 @@ export function useLiveMeta(
 ) {
   const fetchEnabled = options?.fetchEnabled ?? true;
   const previewUrl = params?.previewUrl;
+  // Committed snapshot lives under the project's package path
+  // (`metadata.runtime.path`) when the project isn't at the repo root; the live
+  // `/live/_meta` route already resolves relative to the dev-server cwd.
+  const packagePath =
+    useVirtualMCP(params?.virtualMcpId)?.metadata?.runtime?.path ?? null;
   return useQuery({
     queryKey: params
       ? KEYS.liveMeta(
@@ -34,7 +41,10 @@ export function useLiveMeta(
       : KEYS.liveMeta(""),
     queryFn: async () => {
       const readCommitted = () =>
-        readCommittedJson<LiveMeta>(params!, ".deco/meta.gen.json");
+        readCommittedJson<LiveMeta>(
+          params!,
+          decoRepoPath(packagePath, ".deco/meta.gen.json"),
+        );
       // Prefer the live `/live/_meta` when the dev server is up; otherwise (or on
       // failure) read the committed `.deco/meta.gen.json` snapshot so the CMS
       // schema is available even without a working preview.

--- a/apps/mesh/src/web/components/sections-editor/use-package-path.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-package-path.ts
@@ -1,0 +1,17 @@
+import { useVirtualMCP } from "@decocms/mesh-sdk";
+
+/**
+ * The project's package path (`metadata.runtime.path`, e.g.
+ * "eitri-shopping-monte-carlo-shared"), or null when the project lives at the
+ * repo root. Pair with {@link decoRepoPath} to address `.deco/*` files through
+ * the sandbox daemon, which resolves paths against the repo root.
+ *
+ * Suspense-backed and requires ProjectContext (via `useVirtualMCP`), so resolve
+ * it in a component/hook that has both and thread the plain string into leaf
+ * data hooks/mutations — keeping those free of that coupling.
+ */
+export function usePackagePath(
+  virtualMcpId: string | undefined,
+): string | null {
+  return useVirtualMCP(virtualMcpId)?.metadata?.runtime?.path ?? null;
+}

--- a/apps/mesh/src/web/components/sections-editor/use-save-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-save-block.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useVirtualMCP } from "@decocms/mesh-sdk";
 import { toast } from "sonner";
 import { decoBlockFilePath } from "./deco-block-key";
+import { decoRepoPath } from "./deco-repo-path";
 import { KEYS } from "@/web/lib/query-keys";
 
 /** Debounce window for form-driven block autosaves (ms). */
@@ -19,6 +21,12 @@ export function useSaveBlock({
   branch,
 }: UseSaveBlockParams) {
   const queryClient = useQueryClient();
+  // Block writes target `.deco/blocks/<key>.json` under the project's package
+  // path (`metadata.runtime.path`) — the daemon resolves against the repo root,
+  // so a subdir project needs the prefix or the dev server (watching its own
+  // `.deco/`) never regenerates and the committed read won't see the write.
+  const packagePath =
+    useVirtualMCP(virtualMcpId)?.metadata?.runtime?.path ?? null;
 
   return useMutation({
     mutationFn: async ({
@@ -28,7 +36,7 @@ export function useSaveBlock({
       blockKey: string;
       data: unknown;
     }) => {
-      const path = decoBlockFilePath(blockKey);
+      const path = decoRepoPath(packagePath, decoBlockFilePath(blockKey));
       const content = JSON.stringify(data, null, 2);
       const res = await fetch(
         `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/write`,

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -122,6 +122,36 @@ describe("isDecoOnlyDiff", () => {
     expect(isDecoOnlyDiff(diff)).toBe(false);
   });
 
+  test("true for a subdir package path (`<pkg>/.deco/...` + generated assets)", () => {
+    const diff: GitDiffResult = {
+      diffs: {
+        "eitri-shopping-monte-carlo-shared/.deco/blocks/foo.json": {
+          from: "{}",
+          to: "{}",
+        },
+        "eitri-shopping-monte-carlo-shared/.deco/blocks.gen.json": {
+          from: "{}",
+          to: '{"foo":{}}',
+        },
+        "eitri-shopping-monte-carlo-shared/static/tailwind.css": {
+          from: "a",
+          to: "b",
+        },
+      },
+    };
+    expect(isDecoOnlyDiff(diff)).toBe(true);
+  });
+
+  test("false when subdir code changes alongside `<pkg>/.deco`", () => {
+    const diff: GitDiffResult = {
+      diffs: {
+        "pkg/.deco/blocks/foo.json": { from: "{}", to: "{}" },
+        "pkg/routes/index.tsx": { from: "a", to: "b" },
+      },
+    };
+    expect(isDecoOnlyDiff(diff)).toBe(false);
+  });
+
   test("true when diff includes auto-generated blocks.gen.json", () => {
     const diff: GitDiffResult = {
       diffs: {

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -216,6 +216,20 @@ function isTailwindCssPath(path: string): boolean {
   );
 }
 
+/**
+ * CMS artifacts live under a `.deco/` directory. The `/.deco/` (and `/.deco`)
+ * forms also match projects whose package path isn't the repo root
+ * (`<pkg>/.deco/...`), matching how block writes are addressed elsewhere.
+ */
+function isDecoPath(path: string): boolean {
+  return (
+    path === ".deco" ||
+    path.endsWith("/.deco") ||
+    path.startsWith(".deco/") ||
+    path.includes("/.deco/")
+  );
+}
+
 /** Publish (squash-merge) is only allowed for CMS JSON under `.deco/` (plus generated assets). */
 export function isDecoOnlyDiff(
   diff: GitDiffResult | null | undefined,
@@ -224,11 +238,7 @@ export function isDecoOnlyDiff(
   const paths = Object.keys(diff.diffs);
   if (paths.length === 0) return false;
   return paths.every(
-    (p) =>
-      p === ".deco" ||
-      p.startsWith(".deco/") ||
-      isBlocksGenJsonPath(p) ||
-      isTailwindCssPath(p),
+    (p) => isDecoPath(p) || isBlocksGenJsonPath(p) || isTailwindCssPath(p),
   );
 }
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
@@ -43,16 +43,36 @@ describe("resolveBlocksTabState", () => {
     expect(resolveBlocksTabState(input())).toEqual({ kind: "empty" });
   });
 
-  test.each([
-    "clone-failed",
-    "install-failed",
-    "start-failed",
-    "crashed",
-  ] as const)("renders a sandbox error for %s", (lifecyclePhase) => {
-    expect(resolveBlocksTabState(input({ lifecyclePhase }))).toEqual({
-      kind: "error",
-      source: "sandbox",
-    });
+  test.each(["clone-failed", "install-failed", "start-failed"] as const)(
+    "renders a sandbox error for %s",
+    (lifecyclePhase) => {
+      expect(resolveBlocksTabState(input({ lifecyclePhase }))).toEqual({
+        kind: "error",
+        source: "sandbox",
+      });
+    },
+  );
+
+  test("renders editable content from the committed snapshot when crashed", () => {
+    // Dev server paused/crashed but the committed `.deco/*.gen.json` is still
+    // readable, so the Blocks editor stays available for FS-backed edits.
+    expect(
+      resolveBlocksTabState(
+        input({ lifecyclePhase: "crashed", hasEditableContent: true }),
+      ),
+    ).toEqual({ kind: "content" });
+  });
+
+  test("loads while crashed and the committed snapshot is still pending", () => {
+    expect(
+      resolveBlocksTabState(
+        input({
+          lifecyclePhase: "crashed",
+          decofile: { status: "pending", hasData: false },
+          meta: { status: "pending", hasData: false },
+        }),
+      ),
+    ).toEqual({ kind: "loading" });
   });
 
   test("renders a data error when an initial request fails", () => {

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
@@ -30,10 +30,21 @@ const TERMINAL_LIFECYCLE_PHASES = new Set<LifecycleState["phase"]>([
 export function resolveBlocksTabState(
   input: BlocksTabStateInput,
 ): BlocksTabState {
-  if (TERMINAL_LIFECYCLE_PHASES.has(input.lifecyclePhase)) {
+  // `crashed` = the dev server was running and stopped responding (paused or
+  // died). The committed `.deco/*.gen.json` is still readable from the daemon,
+  // so treat it like `running` here and let the data drive the state: the user
+  // can still edit blocks (writes persist to the FS), only the live preview is
+  // broken until the dev server is back. Genuine setup failures stay terminal.
+  const devUpOrRecoverable =
+    input.lifecyclePhase === "running" || input.lifecyclePhase === "crashed";
+
+  if (
+    TERMINAL_LIFECYCLE_PHASES.has(input.lifecyclePhase) &&
+    input.lifecyclePhase !== "crashed"
+  ) {
     return { kind: "error", source: "sandbox" };
   }
-  if (input.lifecyclePhase !== "running") return { kind: "loading" };
+  if (!devUpOrRecoverable) return { kind: "loading" };
 
   const initialDataFailed =
     (input.decofile.status === "error" && !input.decofile.hasData) ||

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -261,8 +261,10 @@ export function useMainPanelTabs(ctx: {
           previewUrl,
         }
       : null;
-  // Subscribe to the same query keys as Preview; only fetch after the dev
-  // server is running, but still re-render when Preview warms the cache.
+  // Subscribe to the same query keys as Preview. The committed `.deco/*.gen.json`
+  // snapshots are read as soon as the daemon is up (before the dev server), so
+  // the Content tab can show without waiting; the live route fetch stays gated
+  // behind `devServerReady` and takes over once the preview warms up.
   const { data: decofile } = useDecofile(decofileFetchParams, {
     fetchEnabled: devServerReady,
   });


### PR DESCRIPTION
## Summary

Makes the Blocks/Content CMS usable when the sandbox dev server is down, extends it to projects whose code lives in a subdirectory, and fixes the preview so it reliably auto-refreshes after an edit.

### 1. CMS works without the dev server
Read the committed `.deco/*.gen.json` snapshots straight from the working tree (via the daemon file proxy) as a fallback for the live `/.decofile` + `/live/_meta` routes. The Blocks editor opens, the preview URL-bar page dropdown populates, and edits (which persist to the FS) still work even when the dev server is crashed/paused. The live routes take over once it comes back up (lifecycle re-invalidates the queries). `crashed` is treated as recoverable instead of terminal.

### 2. Subdir package path support
The daemon resolves file ops against the **repo root**, but a project may live under a package path (`metadata.runtime.path`, e.g. `eitri-shopping-monte-carlo-shared`). New `decoRepoPath()` helper prefixes that package path onto every `.deco/*` daemon path — committed reads (`blocks.gen.json` / `meta.gen.json`) **and** block writes/deletes (generic + blog) — so `<pkg>/.deco/...` resolves correctly. The live routes already resolve relative to the dev-server cwd, so only the daemon-relative paths needed the prefix. The `file-changed` SSE handler now matches `/.deco/` too, so subdir projects aren't misrouted.

### 3. Reliable preview auto-refresh after an edit
Previously the iframe reloaded immediately on save — racing the dev server rebuild and often showing stale content, with no second reload. Now a `.deco/*` `file-changed` (Blocks save, external/agent write, decofile regen) reloads the iframe via the debounced rebuild-wait (500ms) using the existing scroll/focus-preserving reload. The dead `notifySaved`/`previewRevision` plumbing was removed. A new `reloadStart` signal shows the loading overlay **instantly** on change (before the debounce); the iframe's `onLoad` clears it.

## Testing
- `bun run fmt`, `bun run --cwd=apps/mesh check` (tsc), `bun run lint` (0 errors) all pass
- Unit tests green, incl. new `deco-repo-path.test.ts` and updated reducer/tab-state tests
- Manually verified on a root-project site: form edits and preview auto-refresh (with instant loading overlay)

## Follow-up (not in this PR)
- File-explorer `.deco/blocks/` filters still assume repo root (JSON viewer only) — minor, subdir projects would mis-filter that list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the CMS and preview navigation work without the dev server, add subdirectory package support, and make preview refresh on `.deco/*` edits reliable. Blocks/Content and the preview URL bar read committed snapshots when the server is down and switch to live data when it’s running.

- New Features
  - CMS fallback to committed `.deco/blocks.gen.json` and `.deco/meta.gen.json` via the daemon; live `/.decofile` and `/live/_meta` take over once running (queries revalidated on the lifecycle transition).
  - Treat `crashed` as recoverable so Blocks/Content stay editable from committed data; the preview URL-bar page/global dropdowns also load from the snapshot.
  - Subdirectory support: new `decoRepoPath` prefixes `metadata.runtime.path` on all daemon `.deco/*` reads/writes (Blocks + blog), and `file-changed` now matches `/.deco/` for subdir projects.
  - Reliable preview refresh: when running, debounce `.deco/*` change reloads by 500ms to wait for rebuilds; `subscribeReloadStart` shows the loading overlay immediately; reload preserves scroll/focus.

- Bug Fixes
  - Skip `.deco/*` invalidation and iframe reloads unless the dev server is `running` to avoid clobbering optimistic saves and overlay flashes on a dead preview.
  - Fixed `stripLineNumbers` to remove only the `<n>\t` prefix, preserving lines with `\r`, U+2028, or U+2029.
  - `isDecoOnlyDiff` now recognizes `<pkg>/.deco/...` so pure CMS edits in subdirectory projects can be published directly.

<sup>Written for commit 0526053db7eafdc5c0c61ccdd528e46e9b86c841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

