### PR TITLE
feat(home): show recent PRs from top 3 repos in Coding tile

### DIFF
--- a/apps/mesh/src/web/components/home/native-tiles.tsx
+++ b/apps/mesh/src/web/components/home/native-tiles.tsx
@@ -468,38 +468,40 @@ function CodingConnected({ connectionId }: { connectionId: string }) {
             />
           ))}
         </div>
-      ) : !data || data.prs.length === 0 ? (
+      ) : !data || data.repos.length === 0 ? (
         <p className="text-xs text-muted-foreground">
-          {data?.repo ? `${data.repo} · ` : ""}No recent pull requests.
+          No recent pull requests.
         </p>
       ) : (
-        <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto">
-          {data.repo && (
-            <div className="truncate text-xs text-muted-foreground">
-              {data.repo}
+        <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
+          {data.repos.map((group) => (
+            <div key={group.repo} className="flex flex-col gap-0.5">
+              <div className="truncate text-xs text-muted-foreground">
+                {group.repo}
+              </div>
+              {group.prs.map((pr) => (
+                <a
+                  key={`${group.repo}#${pr.number}`}
+                  href={pr.htmlUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-2 rounded-md px-1.5 py-1.5 text-sm transition-colors hover:bg-accent/60"
+                >
+                  <GitBranch01 className="size-4 shrink-0 text-muted-foreground" />
+                  <span className="truncate text-foreground">{pr.title}</span>
+                  <span
+                    className={cn(
+                      "ml-auto shrink-0 rounded-full px-1.5 py-0.5 text-xs font-medium",
+                      pr.merged
+                        ? "bg-success/10 text-success"
+                        : "bg-muted text-muted-foreground",
+                    )}
+                  >
+                    #{pr.number}
+                  </span>
+                </a>
+              ))}
             </div>
-          )}
-          {data.prs.map((pr) => (
-            <a
-              key={pr.number}
-              href={pr.htmlUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-center gap-2 rounded-md px-1.5 py-1.5 text-sm transition-colors hover:bg-accent/60"
-            >
-              <GitBranch01 className="size-4 shrink-0 text-muted-foreground" />
-              <span className="truncate text-foreground">{pr.title}</span>
-              <span
-                className={cn(
-                  "ml-auto shrink-0 rounded-full px-1.5 py-0.5 text-xs font-medium",
-                  pr.merged
-                    ? "bg-success/10 text-success"
-                    : "bg-muted text-muted-foreground",
-                )}
-              >
-                #{pr.number}
-              </span>
-            </a>
           ))}
         </div>
       )}

--- a/apps/mesh/src/web/hooks/use-github-recent-prs.ts
+++ b/apps/mesh/src/web/hooks/use-github-recent-prs.ts
@@ -2,8 +2,9 @@
  * Fetches a few recent pull requests for the org's GitHub connection, for the
  * home Coding tile. Chains the proven-wired github-mcp-server tools: resolve the
  * installation (GITHUB_LIST_USER_ORGS) → list its repos (search_repositories) →
- * pull requests of the most-recently-updated repo (list_pull_requests). There is
- * no org-wide "all my PRs" tool wired, so we scope to the busiest repo.
+ * pull requests of the most-recently-updated repos (list_pull_requests). There
+ * is no org-wide "all my PRs" tool wired, so we fan out over the top few busiest
+ * repos and group the results per repo.
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -24,10 +25,19 @@ export interface RecentPr {
   htmlUrl: string;
 }
 
+export interface RepoPrs {
+  repo: string;
+  prs: RecentPr[];
+}
+
 interface RepoSummary {
   full_name: string;
   updated_at: string;
 }
+
+// ponytail: fan out one list_pull_requests per repo; no org-wide "my PRs" tool exists.
+const MAX_REPOS = 3;
+const PRS_PER_REPO = 5;
 
 export function useGithubRecentPrs(connectionId: string) {
   const { org } = useProjectContext();
@@ -44,13 +54,13 @@ export function useGithubRecentPrs(connectionId: string) {
 
   return useQuery({
     queryKey: KEYS.homeGithubRecentPrs(org.id, connectionId),
-    queryFn: async (): Promise<{ prs: RecentPr[]; repo: string | null }> => {
+    queryFn: async (): Promise<{ repos: RepoPrs[] }> => {
       const { installations } = await fetchGithubInstallations(
         (req) => self.callTool(req),
         connectionId,
       );
       const inst = installations[0];
-      if (!inst) return { prs: [], repo: null };
+      if (!inst) return { repos: [] };
 
       const qualifier = inst.type === "User" ? "user" : "org";
       const reposRes = await github.callTool({
@@ -66,27 +76,34 @@ export function useGithubRecentPrs(connectionId: string) {
       const repos: RepoSummary[] = reposText
         ? ((JSON.parse(reposText).items ?? []) as RepoSummary[])
         : [];
-      const top = [...repos].sort((a, b) =>
-        (b.updated_at ?? "").localeCompare(a.updated_at ?? ""),
-      )[0];
-      if (!top?.full_name) return { prs: [], repo: null };
+      const top = [...repos]
+        .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
+        .filter((r) => r.full_name)
+        .slice(0, MAX_REPOS);
+      if (top.length === 0) return { repos: [] };
 
-      const [owner, repo] = top.full_name.split("/");
-      const prsRes = await github.callTool({
-        name: "list_pull_requests",
-        arguments: { owner, repo, state: "all", perPage: 5 },
-      });
-      const prs = extractPullRequestList(prsRes)
-        .map((p) => ({
-          number: (p.number as number) ?? 0,
-          title: (p.title as string) ?? "",
-          merged: (p.merged_at as string | null) != null,
-          state: p.state === "closed" ? ("closed" as const) : ("open" as const),
-          htmlUrl: (p.html_url as string) ?? "",
-        }))
-        .filter((p) => p.number > 0);
+      const grouped = await Promise.all(
+        top.map(async (r): Promise<RepoPrs> => {
+          const [owner, repo] = r.full_name.split("/");
+          const prsRes = await github.callTool({
+            name: "list_pull_requests",
+            arguments: { owner, repo, state: "all", perPage: PRS_PER_REPO },
+          });
+          const prs = extractPullRequestList(prsRes)
+            .map((p) => ({
+              number: (p.number as number) ?? 0,
+              title: (p.title as string) ?? "",
+              merged: (p.merged_at as string | null) != null,
+              state:
+                p.state === "closed" ? ("closed" as const) : ("open" as const),
+              htmlUrl: (p.html_url as string) ?? "",
+            }))
+            .filter((p) => p.number > 0);
+          return { repo: r.full_name, prs };
+        }),
+      );
 
-      return { prs, repo: top.full_name };
+      return { repos: grouped.filter((g) => g.prs.length > 0) };
     },
     staleTime: 60_000,
     retry: false,


### PR DESCRIPTION
## Summary
The home **Coding** tile only ever showed pull requests from a single repo — the two `[0]` picks in `use-github-recent-prs.ts` (first installation + single busiest repo) collapsed the view to one repo.

This fans out `list_pull_requests` over the **top 3 most-recently-updated repos** of the installation and groups the results per repo in the tile. No new MCP tools needed — same `search_repositories` + `list_pull_requests` chain, just not truncated to one repo.

## Changes
- `use-github-recent-prs.ts`: take the top `MAX_REPOS` (3) repos instead of `[0]`, `Promise.all` a `list_pull_requests` per repo, return `{ repos: { repo, prs }[] }` (was `{ prs, repo }`). Drops repos with no PRs.
- `native-tiles.tsx` (`CodingConnected`): render a section per repo (repo label + its PR rows) instead of one flat list under a single repo label.

## Notes / scope
- Kept it to the single-installation path (`installations[0]`) — a full org/account switcher was the heavier alternative the task offered "or"; this is the minimal fix that satisfies "at least 3 repos". A switcher can build on `github-repo-picker.tsx`'s `InstallationPicker`/`RepoList` later if wanted.
- No org-wide "all my PRs" GitHub tool is wired (per the hook's own comment), so multi-repo inherently means one `list_pull_requests` call per repo.

## Testing
- `bun run --cwd apps/mesh check` passes for both changed files.
- `bun run fmt` applied.
