### PR TITLE
feat(web): persist per-thread tab layout across thread switches

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -58,6 +58,7 @@ import { AgentAvatar } from "@/web/components/agent-icon";
 import { MyThreadsSection } from "./my-threads-section";
 import type { SidebarFilters } from "./next-page-offset";
 import { findArchiveFallback } from "./archive-fallback";
+import { forgetThreadLayout } from "@/web/lib/thread-layout-memory";
 
 type TypeFilter = "all" | "manual" | "automation";
 type GroupBy = "flat" | "status";
@@ -244,6 +245,9 @@ export function TaskGroupsList({
     }
     const wasActive = task.id === activeTaskId;
     hide(task.id);
+    // Drop the archived thread's remembered layout so it can't resurface if a
+    // new thread ever reuses the id within this session.
+    forgetThreadLayout(task.id);
     if (!wasActive) return;
     // Follow the sidebar's current filtered order across agents, while keeping
     // teammate threads opt-in even when Team scope renders them.

--- a/apps/mesh/src/web/layouts/resolve-task-switch-search.test.ts
+++ b/apps/mesh/src/web/layouts/resolve-task-switch-search.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import { resolveTaskSwitchSearch } from "./resolve-task-switch-search";
+import type { ThreadLayout } from "@/web/lib/thread-layout-memory";
+
+const DECOPILOT = "decopilot-agent";
+const AUTOSEND = "1";
+
+function resolve(
+  over: Partial<Parameters<typeof resolveTaskSwitchSearch>[0]> = {},
+) {
+  return resolveTaskSwitchSearch({
+    prev: {},
+    decopilotId: DECOPILOT,
+    savedLayout: null,
+    autosendValue: AUTOSEND,
+    ...over,
+  });
+}
+
+describe("resolveTaskSwitchSearch — no memory (legacy behavior)", () => {
+  test("defaults to chat side panel open, no main", () => {
+    expect(resolve()).toEqual({ sidepanel: "chat" });
+  });
+
+  test("carries a system tab forward within the same agent", () => {
+    expect(
+      resolve({
+        prev: { virtualmcpid: "repo-1", main: "git" },
+        virtualMcpId: "repo-1",
+      }),
+    ).toEqual({ virtualmcpid: "repo-1", main: "git", sidepanel: "chat" });
+  });
+
+  test("drops per-thread tabs when carrying forward", () => {
+    expect(
+      resolve({
+        prev: { virtualmcpid: "repo-1", main: "file:abc" },
+        virtualMcpId: "repo-1",
+      }),
+    ).toEqual({ virtualmcpid: "repo-1", sidepanel: "chat" });
+  });
+
+  test("agent switch drops the previous view", () => {
+    expect(
+      resolve({
+        prev: { virtualmcpid: "repo-1", main: "git" },
+        virtualMcpId: "repo-2",
+      }),
+    ).toEqual({ virtualmcpid: "repo-2", sidepanel: "chat" });
+  });
+
+  test("param-less Super Agent → repo agent counts as a switch", () => {
+    // prev has no virtualmcpid (Super Agent); target repo-1 differs → no carry.
+    expect(
+      resolve({ prev: { main: "overview" }, virtualMcpId: "repo-1" }),
+    ).toEqual({
+      virtualmcpid: "repo-1",
+      sidepanel: "chat",
+    });
+  });
+
+  test("opts.main is an explicit intent that wins", () => {
+    expect(
+      resolve({ prev: { virtualmcpid: "repo-1" }, opts: { main: "preview" } }),
+    ).toEqual({ virtualmcpid: "repo-1", main: "preview", sidepanel: "chat" });
+  });
+
+  test("opts.autosend appends the sentinel", () => {
+    expect(resolve({ opts: { autosend: true } })).toEqual({
+      sidepanel: "chat",
+      autosend: AUTOSEND,
+    });
+  });
+});
+
+describe("resolveTaskSwitchSearch — restoring per-thread memory", () => {
+  test("restores the target thread's saved main tab", () => {
+    const savedLayout: ThreadLayout = { main: "preview", sidepanel: "chat" };
+    expect(resolve({ prev: { virtualmcpid: "repo-1" }, savedLayout })).toEqual({
+      virtualmcpid: "repo-1",
+      main: "preview",
+      sidepanel: "chat",
+    });
+  });
+
+  test("restores a per-thread tab the thread owned (keyed by task id)", () => {
+    const savedLayout: ThreadLayout = { main: "file:abc" };
+    expect(resolve({ savedLayout })).toEqual({
+      main: "file:abc",
+      sidepanel: "chat",
+    });
+  });
+
+  test("restores a closed side panel", () => {
+    const savedLayout: ThreadLayout = { main: "git", sidepanel: 0 };
+    expect(resolve({ savedLayout })).toEqual({ main: "git", sidepanel: 0 });
+  });
+
+  test("saved layout overrides carry-forward of the source tab", () => {
+    // Source thread has git open; target remembers preview → preview wins.
+    const savedLayout: ThreadLayout = { main: "preview" };
+    expect(
+      resolve({
+        prev: { virtualmcpid: "repo-1", main: "git" },
+        virtualMcpId: "repo-1",
+        savedLayout,
+      }),
+    ).toEqual({ virtualmcpid: "repo-1", main: "preview", sidepanel: "chat" });
+  });
+
+  test("empty saved layout restores the default (no carry-forward)", () => {
+    // Target was last on its default view → returning keeps the default even if
+    // the source thread had a system tab open.
+    expect(
+      resolve({
+        prev: { virtualmcpid: "repo-1", main: "git" },
+        virtualMcpId: "repo-1",
+        savedLayout: {},
+      }),
+    ).toEqual({ virtualmcpid: "repo-1", sidepanel: "chat" });
+  });
+
+  test("opts.main still beats saved layout", () => {
+    const savedLayout: ThreadLayout = { main: "preview", sidepanel: 0 };
+    expect(resolve({ opts: { main: "settings" }, savedLayout })).toEqual({
+      main: "settings",
+      sidepanel: "chat",
+    });
+  });
+});

--- a/apps/mesh/src/web/layouts/resolve-task-switch-search.ts
+++ b/apps/mesh/src/web/layouts/resolve-task-switch-search.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure computation of the `?main`/`?sidepanel`/`?virtualmcpid` search params
+ * produced when switching to another thread. Extracted from `usePanelActions`
+ * (shell-layout) so the precedence rules are unit-testable without a router.
+ *
+ * Precedence for the main tab:
+ *   1. `opts.main` — an explicit caller intent (e.g. home tile → pinned view).
+ *   2. `savedLayout` — the target thread's own remembered layout (per-thread
+ *      memory). Restores that thread's tabs, including per-thread views it owned.
+ *   3. carry-forward — within the same agent, keep a system-level tab
+ *      (git/preview/settings/…) but drop per-thread tabs from the source thread.
+ *      Skipped on an agent switch so the new agent's own default resolves.
+ *
+ * The side panel defaults to chat-open unless the restored layout closed it.
+ */
+
+import { isPerThreadTab } from "@/web/layouts/main-panel-tabs/tab-id";
+import type { ThreadLayout } from "@/web/lib/thread-layout-memory";
+
+export interface ResolveTaskSwitchInput {
+  /** The current (source) thread's search params. */
+  prev: { virtualmcpid?: unknown; main?: unknown };
+  /** Target agent id, when the caller pins one. */
+  virtualMcpId?: string;
+  /** Well-known Decopilot agent id — the default when no `virtualmcpid`. */
+  decopilotId: string;
+  /** The target thread's remembered layout, or null if none. */
+  savedLayout: ThreadLayout | null;
+  opts?: { autosend?: boolean; main?: string };
+  /** `?autosend` sentinel value, injected to avoid an import cycle. */
+  autosendValue: string;
+}
+
+export function resolveTaskSwitchSearch(
+  input: ResolveTaskSwitchInput,
+): Record<string, unknown> {
+  const { prev, virtualMcpId, decopilotId, savedLayout, opts, autosendValue } =
+    input;
+
+  const next: Record<string, unknown> = {};
+  if (virtualMcpId) next.virtualmcpid = virtualMcpId;
+  else if (prev.virtualmcpid) next.virtualmcpid = prev.virtualmcpid;
+
+  // The Super Agent (Decopilot) is the default when the URL carries no
+  // `virtualmcpid`, so treat an absent id as Decopilot on BOTH sides —
+  // otherwise switching FROM the param-less Super Agent TO a repo agent isn't
+  // detected as a switch and wrongly carries the previous view forward.
+  const prevVmcp =
+    typeof prev.virtualmcpid === "string" ? prev.virtualmcpid : decopilotId;
+  const targetVmcp = virtualMcpId ?? prevVmcp;
+  const isAgentSwitch = targetVmcp !== prevVmcp;
+
+  let sidepanel: "chat" | 0 = "chat";
+
+  if (opts?.main) {
+    // Explicit intent wins outright — ignore saved/carried layout.
+    next.main = opts.main;
+  } else if (savedLayout) {
+    // Restore the target thread's own layout. A remembered per-thread tab is
+    // valid here because it belongs to *this* thread; if it has since become
+    // stale, MainPanelContent falls back to Settings rather than crashing.
+    if (savedLayout.main !== undefined) next.main = savedLayout.main;
+    if (savedLayout.sidepanel !== undefined) sidepanel = savedLayout.sidepanel;
+  } else if (!isAgentSwitch) {
+    const prevMain = prev.main;
+    if (prevMain && typeof prevMain === "string" && !isPerThreadTab(prevMain)) {
+      next.main = prevMain;
+    }
+  }
+
+  next.sidepanel = sidepanel;
+  if (opts?.autosend) next.autosend = autosendValue;
+  return next;
+}

--- a/apps/mesh/src/web/layouts/shell-layout.tsx
+++ b/apps/mesh/src/web/layouts/shell-layout.tsx
@@ -30,7 +30,11 @@ import {
 import { KEYS } from "../lib/query-keys";
 import { readCachedTaskBranch } from "../lib/read-cached-task-branch";
 import { useOptionalThreadManager } from "@/web/components/chat/store/hooks";
-import { isPerThreadTab } from "@/web/layouts/main-panel-tabs/tab-id";
+import { resolveTaskSwitchSearch } from "@/web/layouts/resolve-task-switch-search";
+import {
+  readThreadLayout,
+  saveThreadLayout,
+} from "@/web/lib/thread-layout-memory";
 import { useOrganizationSettingsNonBlocking } from "../hooks/use-organization-settings";
 import { homeNextActionsQueryOptions } from "../hooks/use-home-next-actions";
 import { useOrgSsoStatus } from "../hooks/use-org-sso";
@@ -90,7 +94,11 @@ export function usePanelActions() {
     org?: string;
     taskId?: string;
   };
-  const search = useSearch({ strict: false }) as { virtualmcpid?: string };
+  const search = useSearch({ strict: false }) as {
+    virtualmcpid?: string;
+    main?: string | 0;
+    sidepanel?: "chat" | 0;
+  };
   const orgSlug = params.org ?? "";
   const currentTaskId = params.taskId ?? "";
 
@@ -118,52 +126,35 @@ export function usePanelActions() {
     id: string,
     virtualMcpId?: string,
     opts?: { autosend?: boolean; main?: string },
-  ) =>
-    navWith(
+  ) => {
+    const isSameThread = !!currentTaskId && currentTaskId === id;
+    // Remember the layout of the thread we're leaving so returning to it
+    // restores the same tabs/side-panel instead of the agent default.
+    if (currentTaskId && !isSameThread) {
+      saveThreadLayout(currentTaskId, {
+        main: search.main,
+        sidepanel: search.sidepanel,
+      });
+    }
+    // Restore the target thread's own remembered layout (null when unseen this
+    // session, or when re-selecting the current thread — then keep its URL).
+    const savedLayout = isSameThread ? null : readThreadLayout(id);
+    const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
+
+    return navWith(
       id,
-      (prev) => {
-        const next: Record<string, unknown> = { sidepanel: "chat" };
-        if (virtualMcpId) next.virtualmcpid = virtualMcpId;
-        else if (prev.virtualmcpid) next.virtualmcpid = prev.virtualmcpid;
-        // An agent switch (target vMCP differs from the current) must NOT carry
-        // the previous agent's view — those tabs are agent-specific. Carrying
-        // "overview" onto a repo agent, or "preview" onto the Super Agent
-        // ("No source to preview"), is exactly the stuck-view bug. Leaving
-        // `main` unset lets the new agent's own defaultMainView resolve.
-        // The Super Agent is the default agent when the URL carries no
-        // `virtualmcpid`, so treat an absent id as the Super Agent on BOTH
-        // sides. Otherwise switching FROM the param-less Super Agent TO a repo
-        // agent isn't detected as a switch and wrongly carries "overview" onto
-        // an agent that has no Overview tab.
-        const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
-        const prevVmcp =
-          typeof prev.virtualmcpid === "string"
-            ? prev.virtualmcpid
-            : decopilotId;
-        const targetVmcp = virtualMcpId ?? prevVmcp;
-        const isAgentSwitch = targetVmcp !== prevVmcp;
-        // Explicit main tab takes priority (e.g. home tile → pinned view).
-        if (opts?.main) {
-          next.main = opts.main;
-        } else if (!isAgentSwitch) {
-          // Preserve system-level panel tabs (git, preview, settings, …) across
-          // thread switches WITHIN the same agent, but drop per-thread tabs
-          // (expanded tool views, web-page previews, automation details) that
-          // are specific to the previous task.
-          const prevMain = prev.main;
-          if (
-            prevMain &&
-            typeof prevMain === "string" &&
-            !isPerThreadTab(prevMain)
-          ) {
-            next.main = prevMain;
-          }
-        }
-        if (opts?.autosend) next.autosend = AUTOSEND_QUERY_VALUE;
-        return next;
-      },
+      (prev) =>
+        resolveTaskSwitchSearch({
+          prev: prev as { virtualmcpid?: unknown; main?: unknown },
+          virtualMcpId,
+          decopilotId,
+          savedLayout,
+          opts,
+          autosendValue: AUTOSEND_QUERY_VALUE,
+        }),
       false,
     );
+  };
 
   // Create a new task carrying the current task's branch (if any) so the
   // new thread lands on the same warm sandbox. Server picks from sandboxMap when

--- a/apps/mesh/src/web/lib/thread-layout-memory.test.ts
+++ b/apps/mesh/src/web/lib/thread-layout-memory.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import {
+  sanitizeThreadLayout,
+  upsertThreadLayoutEntries,
+} from "./thread-layout-memory";
+
+describe("sanitizeThreadLayout", () => {
+  test("keeps well-shaped values", () => {
+    expect(sanitizeThreadLayout({ main: "git", sidepanel: "chat" })).toEqual({
+      main: "git",
+      sidepanel: "chat",
+    });
+    expect(sanitizeThreadLayout({ main: 0, sidepanel: 0 })).toEqual({
+      main: 0,
+      sidepanel: 0,
+    });
+  });
+
+  test("drops absent fields (meaning: use the default)", () => {
+    expect(sanitizeThreadLayout({})).toEqual({});
+    expect(sanitizeThreadLayout({ main: "git" })).toEqual({ main: "git" });
+  });
+
+  test("drops tampered/unexpected values", () => {
+    const dirty = {
+      main: 5,
+      sidepanel: "tasks",
+      extra: "x",
+    } as unknown as Parameters<typeof sanitizeThreadLayout>[0];
+    expect(sanitizeThreadLayout(dirty)).toEqual({});
+  });
+});
+
+describe("upsertThreadLayoutEntries", () => {
+  test("appends a new entry as most-recent (last)", () => {
+    const out = upsertThreadLayoutEntries([], "a", { main: "git" });
+    expect(out).toEqual([["a", { main: "git" }]]);
+  });
+
+  test("moves an existing entry to most-recent and replaces its layout", () => {
+    const out = upsertThreadLayoutEntries(
+      [
+        ["a", { main: "git" }],
+        ["b", { main: "preview" }],
+      ],
+      "a",
+      { main: "settings" },
+    );
+    expect(out).toEqual([
+      ["b", { main: "preview" }],
+      ["a", { main: "settings" }],
+    ]);
+  });
+
+  test("sanitizes on write", () => {
+    const dirty = { main: "git", junk: 1 } as unknown as Parameters<
+      typeof upsertThreadLayoutEntries
+    >[2];
+    expect(upsertThreadLayoutEntries([], "a", dirty)).toEqual([
+      ["a", { main: "git" }],
+    ]);
+  });
+
+  test("evicts the oldest entries past the cap", () => {
+    const out = upsertThreadLayoutEntries(
+      [
+        ["a", {}],
+        ["b", {}],
+      ],
+      "c",
+      {},
+      2,
+    );
+    // "a" (oldest) evicted; "c" is newest.
+    expect(out.map(([id]) => id)).toEqual(["b", "c"]);
+  });
+});

--- a/apps/mesh/src/web/lib/thread-layout-memory.ts
+++ b/apps/mesh/src/web/lib/thread-layout-memory.ts
@@ -1,0 +1,107 @@
+/**
+ * Per-thread layout memory.
+ *
+ * The workspace tab layout (`?main=<tabId>` + `?sidepanel=`) lives in the URL,
+ * so switching threads drops it and the target thread opens on its agent
+ * default. This module remembers each thread's last layout, keyed by task id,
+ * so returning to a thread restores the tabs/side-panel the user left it with.
+ *
+ * Storage is **sessionStorage**: layout is a within-session working state, not a
+ * durable preference. Per-tab isolation is intentional — the same thread open in
+ * two tabs keeps independent layouts, and nothing accumulates across sessions.
+ *
+ * All access is best-effort: sessionStorage can throw (privacy mode, quota, SSR)
+ * and stored JSON can be tampered with, so every read is sanitized and every
+ * write is wrapped. A read failure means "no memory", never a crash.
+ */
+
+const STORAGE_KEY = "studio:thread-layout:v1";
+
+/** LRU cap. Bounds growth within a session; oldest threads evict first. */
+const MAX_THREADS = 50;
+
+export interface ThreadLayout {
+  /** `?main` value: a tab id, or `0` for the closed main panel. */
+  main?: string | 0;
+  /** `?sidepanel` value: `"chat"` open, or `0` closed. */
+  sidepanel?: "chat" | 0;
+}
+
+/** Most-recent entry last, so `.shift()` evicts the least-recently-saved. */
+type StoredEntry = [taskId: string, layout: ThreadLayout];
+
+/**
+ * Keep only well-shaped values. Guards against tampered storage and against
+ * accidentally persisting unrelated search params. Absent/invalid fields are
+ * dropped (meaning "use the default"), which is distinct from an absent entry.
+ */
+export function sanitizeThreadLayout(layout: ThreadLayout): ThreadLayout {
+  const clean: ThreadLayout = {};
+  if (layout.main === 0 || typeof layout.main === "string") {
+    clean.main = layout.main;
+  }
+  if (layout.sidepanel === 0 || layout.sidepanel === "chat") {
+    clean.sidepanel = layout.sidepanel;
+  }
+  return clean;
+}
+
+/**
+ * LRU upsert: move `taskId` to the most-recent slot with `layout`, evicting the
+ * oldest entries past the cap. Pure — takes and returns the entry list.
+ */
+export function upsertThreadLayoutEntries(
+  entries: StoredEntry[],
+  taskId: string,
+  layout: ThreadLayout,
+  cap: number = MAX_THREADS,
+): StoredEntry[] {
+  const next = entries.filter(([id]) => id !== taskId);
+  next.push([taskId, sanitizeThreadLayout(layout)]);
+  while (next.length > cap) next.shift();
+  return next;
+}
+
+function readStore(): StoredEntry[] {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is StoredEntry =>
+        Array.isArray(e) && e.length === 2 && typeof e[0] === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeStore(entries: StoredEntry[]): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // sessionStorage unavailable or over quota — layout memory is best-effort.
+  }
+}
+
+/** Remember `taskId`'s current layout. No-op for a falsy id or empty session. */
+export function saveThreadLayout(taskId: string, layout: ThreadLayout): void {
+  if (!taskId) return;
+  writeStore(upsertThreadLayoutEntries(readStore(), taskId, layout));
+}
+
+/** The remembered layout for `taskId`, or null when nothing is stored. */
+export function readThreadLayout(taskId: string): ThreadLayout | null {
+  if (!taskId) return null;
+  const entry = readStore().find(([id]) => id === taskId);
+  return entry ? sanitizeThreadLayout(entry[1]) : null;
+}
+
+/** Drop a thread's memory — called when the thread is archived/deleted. */
+export function forgetThreadLayout(taskId: string): void {
+  if (!taskId) return;
+  const entries = readStore();
+  const next = entries.filter(([id]) => id !== taskId);
+  if (next.length !== entries.length) writeStore(next);
+}


### PR DESCRIPTION
## What is this contribution about?

Switching between chat threads reset the workspace tab layout to the agent
default. The layout (`?main=<tabId>` + `?sidepanel=`) lives entirely in the
URL, so navigating to another thread dropped it, and returning never restored
what you left the thread with.

This adds **per-thread layout memory**: the URL stays the source of truth for
the *current* thread, and `sessionStorage` remembers each thread's last layout
(keyed by task id). On switch we **save the leaving thread's layout** and
**restore the target thread's own**.

### Approach
- **Save-on-leave / restore-on-enter** happens inside the existing
  `usePanelActions.setTaskId` navigation handler — event-driven, so **no
  `useEffect`** (respects `plugins/ban-use-effect.ts`).
- **sessionStorage, not localStorage** — layout is a within-session working
  state, not a durable preference; per-tab isolation keeps the same thread open
  in two tabs independent, and nothing accumulates across sessions.
- Precedence for the restored view: **explicit `opts.main`** (e.g. home tile →
  pinned view) › **restored per-thread layout** › **same-agent carry-forward**
  (system tabs only; unchanged legacy behavior).

### Files
- `apps/mesh/src/web/lib/thread-layout-memory.ts` — guarded (try/catch),
  sanitized-on-read (tamper-proof), LRU-bounded (50 threads) sessionStorage
  store. Pure helpers extracted for testing.
- `apps/mesh/src/web/layouts/resolve-task-switch-search.ts` — pure resolver for
  the next `?main`/`?sidepanel`/`?virtualmcpid`.
- `usePanelActions.setTaskId` (shell-layout) — save/restore + delegates param
  building to the resolver.
- `task-groups-list.tsx` `handleArchive` — `forgetThreadLayout` on archive
  (lifecycle cleanup).

### Robustness
- A since-deleted per-thread tab (open file/deck) falls back to Settings via the
  existing `ErrorBoundary` in `main-panel-tabs/index.tsx` — no crash.
- Restoring defaults the side panel to chat-open unless the saved layout
  explicitly closed it — matches the prior always-`sidepanel=chat` behavior.

## How to Test
1. Open thread A, open some tabs / toggle the side panel.
2. Switch to thread B → opens on its own remembered/default layout.
3. Switch back to A → A's exact tabs + side-panel are restored.

## Testing notes
- 20 new unit tests (pure precedence + LRU/sanitize logic); all pass.
- `bunx tsc --noEmit` clean, `bun run lint` 0 errors, `bun run fmt` clean.
- Not driven live in the running app (no dev-server run in this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves each thread’s tab layout when switching chats by saving `?main` and `?sidepanel` in `sessionStorage` (LRU 50) and restoring them on return. Threads now reopen exactly where you left them instead of resetting to the agent default.

- **New Features**
  - Save on leave and restore on enter in `usePanelActions.setTaskId` (no `useEffect`).
  - Precedence: `opts.main` > saved per-thread layout > carry forward only system tabs within the same agent; never carry across agent switches.
  - Side panel defaults to chat unless the saved layout closed it; `forgetThreadLayout` runs on archive.
  - Guarded, sanitized `sessionStorage` store with an LRU cap.

- **Refactors**
  - Extracted `resolveTaskSwitchSearch` to compute `?main`, `?sidepanel`, and `?virtualmcpid` (and handle `?autosend`).
  - Added unit tests for precedence, sanitization, and LRU behavior.

<sup>Written for commit d70af98409d5d0ef50a3b18a727a9c9aa3a255d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

