### PR TITLE
fix(web): hide dev terminal drawer on Tasks/Library overlays

### DIFF
--- a/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-with-drawer.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-with-drawer.tsx
@@ -4,11 +4,17 @@
  * `hasClonableSource` so non-cloneable agents (e.g. decopilot) don't see it.
  */
 
+import { useSearch } from "@tanstack/react-router";
 import { useChatTask } from "@/web/components/chat/chat-context";
 import { useInsetContext } from "@/web/layouts/agent-shell-layout";
 import { agentHasClonableSource } from "@/web/lib/agent-capabilities";
 import { MainPanelContent } from "@/web/layouts/main-panel-tabs";
 import { PreviewDrawerHost } from "./preview-drawer-host";
+
+// Agent-independent overlays (Tasks `board`, Library `files`) take over the
+// whole panel and aren't sandbox-backed views — the dev terminal drawer must
+// not stay glued below them when switching over from Preview/Code.
+const OVERLAY_TABS = new Set(["board", "files"]);
 
 export function MainPanelWithDrawer({
   virtualMcpId,
@@ -19,18 +25,21 @@ export function MainPanelWithDrawer({
 }) {
   const inset = useInsetContext();
   const { activeTask } = useChatTask();
+  const { main } = useSearch({ strict: false }) as { main?: string | 0 };
   // Thread-scoped repo (bound by `load_repo`) also gets the drawer + dev
   // terminal, not just agents with their own repo.
   const hasClonableSource =
     agentHasClonableSource(inset?.entity?.metadata) ||
     agentHasClonableSource(activeTask?.metadata);
+  const showDrawer =
+    hasClonableSource && !(typeof main === "string" && OVERLAY_TABS.has(main));
 
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="flex-1 min-h-0 overflow-hidden">
         <MainPanelContent taskId={taskId} virtualMcpId={virtualMcpId} />
       </div>
-      {hasClonableSource && <PreviewDrawerHost />}
+      {showDrawer && <PreviewDrawerHost />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Switching to the **Tasks** (`?main=board`) or **Library** (`?main=files`) overlay left the sandbox dev terminal drawer glued to the bottom of the panel — it rendered as if Tasks were a Preview view, with the `[orchestrator] dev script exited` output still showing underneath.

`MainPanelWithDrawer` mounted `PreviewDrawerHost` for **every** main-panel view, gated only on `hasClonableSource` — never on which tab is active. The Tasks/Library overlays are agent-independent, full-panel views that aren't sandbox-backed, so the terminal has no business appearing below them.

Fix: skip the drawer when the active `?main` view is one of the agent-independent overlays (`board`, `files`). The drawer's persisted per-agent open preference is untouched, so returning to Preview/Code restores it as before.

## Testing

- `biome format` clean; change reuses the existing `useSearch({ strict: false })` cast pattern already used in `use-main-panel-tabs.ts` / `use-main-overlay-toggle.ts`.

## Affected areas

- `apps/mesh/src/web/layouts/main-panel-tabs/main-panel-with-drawer.tsx`