### PR TITLE
fix(shell): reserve WCO traffic-light inset on desktop sidebar header

### DIFF
--- a/apps/mesh/index.css
+++ b/apps/mesh/index.css
@@ -54,6 +54,15 @@
        (3rem) for the WCO case only. */
     height: env(titlebar-area-height, 3rem);
   }
+  /* On desktop the sidebar — not the toolbar — owns the top-left corner where
+     the OS window controls (macOS traffic lights) overlay sits, so its header
+     reserves the same left inset. Left-only: the sidebar isn't full width, so
+     the 100vw right inset .app-titlebar uses doesn't apply. max() keeps the
+     header's default px-2 gutter when there's no OS inset. */
+  .sidebar-titlebar {
+    padding-left: max(env(titlebar-area-x, 0), 0.5rem);
+    height: env(titlebar-area-height, 3rem);
+  }
   .wco-drag {
     -webkit-app-region: drag;
     app-region: drag;

--- a/apps/mesh/src/web/components/sidebar/navigation.tsx
+++ b/apps/mesh/src/web/components/sidebar/navigation.tsx
@@ -104,7 +104,7 @@ function NavigationSidebarInner({
   return (
     <Sidebar variant={variant}>
       {header && (
-        <SidebarHeader className="shrink-0 h-12 flex flex-row items-center px-2 py-0 group-data-[collapsible=icon]/sidebar:hidden">
+        <SidebarHeader className="sidebar-titlebar wco-drag shrink-0 h-12 flex flex-row items-center px-2 py-0 group-data-[collapsible=icon]/sidebar:hidden">
           {header}
         </SidebarHeader>
       )}


### PR DESCRIPTION
## Summary

On the installed desktop PWA (Window Controls Overlay), the org + agent switchers rendered **under** the macOS traffic-light window controls.

`#4658` moved the toolbar header into the right column so the sidebar now owns the top-left corner of the window. That corner is exactly where the macOS traffic lights overlay sits — but the sidebar header (`SidebarOwnHeader`: org + agent switchers) never carried the `env(titlebar-area-x)` inset that `.app-titlebar` (the old full-width toolbar header) had. So the inset that used to protect that zone was dropped when the header moved.

## Fix

- Add a left-only WCO inset class `.sidebar-titlebar` in `apps/mesh/index.css` (inside the existing `@media (display-mode: window-controls-overlay)` block) + reuse `.wco-drag` on the sidebar header.
- Left-only on purpose: the sidebar isn't full width, so `.app-titlebar`'s `100vw` right inset doesn't apply here. `max(env(titlebar-area-x, 0), 0.5rem)` preserves the header's default `px-2` gutter when there's no OS inset.

## Blast radius / no new regressions

- Only affects the one desktop sidebar header (`StudioSidebar` → `SidebarOwnHeader`), the single surface that sits at the window top-left.
- Inert outside WCO — no rules apply in a normal browser tab, so web is unchanged.
- Windows unaffected: controls are on the right, `titlebar-area-x` ≈ 0 → falls back to `0.5rem`.
- Drag region is safe: all three crumb buttons already carry `wco-no-drag`; popovers render in portals.
- Collapsed icon rail: header is hidden, so unchanged (the collapsed-rail overlap is a pre-existing `#4658` condition, tracked as follow-up).

## Testing

Can't drive the macOS PWA shell from CI; verified the mechanism by code. To check visually: open the installed desktop PWA, expanded sidebar → org + agent switchers now clear the traffic lights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Window Controls Overlay overlap on macOS by reserving the traffic-light inset on the desktop sidebar header. Org and agent switchers no longer sit under the OS window buttons in the installed PWA.

- **Bug Fixes**
  - Added `.sidebar-titlebar` with left-only WCO inset and applied `.wco-drag` to the `SidebarHeader`.
  - Scoped to desktop WCO only; normal tabs and Windows are unchanged.

<sup>Written for commit 4b35426e33029241787d6c0f91145d91251b0d28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

