### PR TITLE
ci(sandbox): build studio-sandbox multi-arch (amd64 + arm64)

### DIFF
--- a/.github/workflows/release-studio-sandbox.yaml
+++ b/.github/workflows/release-studio-sandbox.yaml
@@ -103,7 +103,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          # Multi-arch to match every sibling image (mesh, orgfs-sidecar,
+          # sandbox-netinit, s3-sync). Without arm64 the sandbox can't run
+          # natively on Apple Silicon / arm64 nodes. buildx emulates arm64 via
+          # the runner's preinstalled binfmt, same as orgfs-sidecar.
+          platforms: linux/amd64,linux/arm64
 
       - name: Install cosign
         if: steps.tag-check.outputs.exists != 'true'


### PR DESCRIPTION
## What

Adds `linux/arm64` to the `studio-sandbox` image build (it was `linux/amd64` only).

## Why

Every sibling image (`mesh`, `orgfs-sidecar`, `sandbox-netinit`, `s3-sync`) is already multi-arch — `studio-sandbox` was the lone exception. On arm64 nodes (Apple Silicon, arm64 cloud) a SandboxClaim pod fails to pull it:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

The operator (`agent-sandbox-controller`) and `orgfs-sidecar` already run on arm64, so this is the only thing blocking sandboxes there.

## How

One line: `platforms: linux/amd64,linux/arm64`. buildx emulates arm64 via the runner's preinstalled binfmt (same as `orgfs-sidecar`, which builds both with only `setup-buildx`) — no QEMU step needed.

## Impact / risk

- Isolated, additive: only changes how the image is built. amd64 consumers are unaffected.
- Takes effect on the next `studio-sandbox` publish (push under `packages/sandbox/**` or a manual `workflow_dispatch` of *Release Studio Sandbox Image*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build `studio-sandbox` as a multi-arch image (`linux/amd64`, `linux/arm64`) in the release workflow. This fixes pull failures on arm64 nodes (Apple Silicon, arm64 cloud) and aligns with sibling images.

- **Migration**
  - Takes effect on the next `studio-sandbox` publish or a manual run of "Release Studio Sandbox Image".

<sup>Written for commit 7b3363c85641fed3d1310096b39d46e4ee94a66c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

