### PR TITLE
test(reports): pin HTML-escaping of the untrusted domain route param

### DIFF
--- a/apps/mesh/src/api/routes/report-pages.test.ts
+++ b/apps/mesh/src/api/routes/report-pages.test.ts
@@ -1,0 +1,43 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { createReportPagesRoutes } from "./report-pages";
+
+const INDEX_HTML = `<!doctype html>
+<html>
+  <head>
+    <title>decocms</title>
+    <meta name="description" content="default" />
+  </head>
+  <body></body>
+</html>`;
+
+const dirs: string[] = [];
+
+function clientDirWithIndex(): string {
+  const dir = mkdtempSync(join(tmpdir(), "report-pages-"));
+  writeFileSync(join(dir, "index.html"), INDEX_HTML);
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (dirs.length)
+    rmSync(dirs.pop() as string, { recursive: true, force: true });
+});
+
+describe("report pages HTML escaping", () => {
+  test("escapes an HTML-injecting domain route param", async () => {
+    const app = createReportPagesRoutes(clientDirWithIndex());
+    // No `/`, `?`, or `#` — normalizeDomain() would otherwise truncate the
+    // payload at the first one, masking whether esc() actually escapes it.
+    const malicious = 'evil.com"><svg onload=alert(1)>';
+
+    const res = await app.request(`/${encodeURIComponent(malicious)}`);
+    const html = await res.text();
+
+    expect(html).not.toContain('"><svg onload=alert(1)>');
+    expect(html).toContain("&quot;&gt;&lt;svg onload=alert(1)&gt;");
+  });
+});


### PR DESCRIPTION
## Source
Improvement found while reading recently-changed files: `apps/mesh/src/api/routes/report-pages.tsx` (added in #4664) has no test file at all.

## Why
`createReportPagesRoutes` takes the raw `:domain` route param straight from the URL — untrusted input from any anonymous requester (this route exists specifically to serve link-unfurler bots) — and interpolates it into a server-rendered HTML document via a local `esc()` helper. That's a reflected-XSS-shaped trust boundary with zero test coverage, in a codebase that has repeatedly needed dedicated XSS fixes (#4114 SVG stored XSS, #4115 markdown stored XSS). A future tweak to `esc()`/`rewriteHead()` (e.g. "simplify the replace chain") could silently reopen that hole and nothing would catch it before it reached a live report page.

## What the test does
Spins up `createReportPagesRoutes` against a temp `index.html`, requests `/:domain` with an HTML/attribute-breaking payload (`evil.com"><svg onload=alert(1)>`), and asserts the rendered response has the payload safely entity-escaped rather than reflected raw.

## Commands to verify
```
bun test apps/mesh/src/api/routes/report-pages.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (pre-existing unrelated errors only, from missing `echarts`/`@tiptap/extension-text-align` deps in this sandbox — not touched by this change)
- `bun test apps/mesh/src/api/routes/report-pages.test.ts` — passes

Full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test to ensure the untrusted `:domain` route param in report pages is HTML-escaped. This verifies a malicious payload is entity-escaped in the rendered HTML, preventing reflected XSS regressions in `createReportPagesRoutes`.

<sup>Written for commit c34f52d7ef379c05120046ef5078ee4af2092a20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

