### PR TITLE
chore: add script to clear sandboxes on local kind cluster

### DIFF
--- a/scripts/clear-sandboxes-kind.sh
+++ b/scripts/clear-sandboxes-kind.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Delete all sandbox claims, then all sandboxes, on the local kind cluster.
+# ponytail: hardcoded to kind-studio-sandbox-dev so it can never hit a prod context.
+set -euo pipefail
+
+CTX=kind-studio-sandbox-dev
+NS=agent-sandbox-system
+
+kubectl --context="$CTX" -n "$NS" delete sandboxclaims --all --ignore-not-found
+kubectl --context="$CTX" -n "$NS" delete sandboxes --all --ignore-not-found
+
+echo "done. remaining (warmpool may have recreated fresh members):"
+kubectl --context="$CTX" -n "$NS" get sandboxclaims,sandboxes 2>&1


### PR DESCRIPTION
## Summary
Small standalone dev script, split out of #4680 since it's unrelated to the task-board work.

Deletes all sandbox claims and sandboxes on the local `kind-studio-sandbox-dev` cluster (hardcoded to that context so it can never hit a prod cluster).

## Testing
n/a — dev-only utility script

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dev-only script to quickly reset the local kind sandbox environment by deleting all sandbox claims and sandboxes. It targets the `kind-studio-sandbox-dev` context and the `agent-sandbox-system` namespace to avoid touching prod.

<sup>Written for commit 561396d8b75f9ab4c0d1d5b16a0fe2689744883d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

