### PR TITLE
fix(task-board): close Super Agent state-machine gaps from #4680 review

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/cluster-mcp-tool-hooks.ts
+++ b/apps/mesh/src/api/routes/decopilot/cluster-mcp-tool-hooks.ts
@@ -35,9 +35,14 @@ export interface ClusterMcpToolHooks {
  * Build the cluster `resolveArgs` + `onToolCalled` hooks from a
  * StudioContext. The closures are byte-equivalent to the originals that
  * lived in `helpers.ts`'s `toolsFromMCP` wrapper.
+ *
+ * `threadId` is passed through to the PR-open task-board reaction so it can
+ * resolve a linked task via `task_board_item_threads` when the run carries no
+ * `runMetadata.taskBoardItemId` (a re-prompted, repo-backed task's PR).
  */
 export function buildClusterMcpToolHooks(
   ctx: StudioContext,
+  threadId?: string,
 ): ClusterMcpToolHooks {
   return {
     resolveArgs: (input) => resolveArgsStorageRefs(input, ctx),
@@ -45,7 +50,7 @@ export function buildClusterMcpToolHooks(
       // A Super Agent task run just opened a PR via the GitHub MCP tool —
       // move its card to In Review. Fire-and-forget (no-ops off a task run).
       if (!event.isError && isPrCreateMcpTool(event.toolName)) {
-        void advanceTaskBoardForRun(ctx, "in_review");
+        void advanceTaskBoardForRun(ctx, "in_review", threadId);
       }
       const orgId = ctx.organization?.id;
       const userId = ctx.auth?.user?.id;

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,7 +1,7 @@
 {
   "auth/install-studio-pack-workflow.ts": "a0bc8a8c62a62c7978c11676d67397f7116b3903579091e9b85ef7ef67b04ce5",
   "automations/dbos-workflow.ts": "18471f9fda4e16afda73f11a894f48eb8e7f2eb4539eed195c5563a63082a82c",
-  "dispatch-queue/hosted-harness-workflow.ts": "334a365a065f740c5111f051a78052e7462ee93adcd630fbe7bd8f13d18c0c02",
+  "dispatch-queue/hosted-harness-workflow.ts": "1ee53df2391d0b73f10630be7f7d947db16653d5b8740b799e64a98cb2f49c86",
   "dispatch-queue/thread-gate-workflow.ts": "674cd393ad3b06806e967389dfe7e87bd0de6ba933fd54df1e5cd24a08b99e43",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",
   "harnesses/decopilot/background-tool-workflow.ts": "a47d58f9dc4850c45cc3fbea65666e9beea6a3d61081934b984fd8b34c4798e3",

--- a/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/mesh/src/dispatch-queue/hosted-harness-workflow.ts
@@ -210,12 +210,22 @@ export async function runHostedHarness(
 
   // A Super Agent task run is starting to execute — move its card to In Progress.
   // Fire-and-forget: the transition is best-effort and must not delay the loop.
-  void advanceTaskBoardForRun(studioCtx, "in_progress");
+  void advanceTaskBoardForRun(studioCtx, "in_progress", input.threadId);
 
   // If the user re-engaged a task that had moved to In Review, pull it back to
   // In Progress. Link-based (`task_board_item_threads`), so it fires for a
   // re-prompt that carries no run metadata — unlike the forward advance above.
-  void reopenTasksOnThreadRun(studioCtx, input.threadId);
+  //
+  // Skipped when `runMetadata.taskBoardItemId` is set: that means this
+  // execution IS the Super Agent's own task run (dispatched by
+  // `enqueueSuperAgentForTask`, or DBOS recovering/retrying it after a pod
+  // death) — never a human re-prompt, which never carries that key. Firing
+  // unconditionally here would regress an already-reviewed card (PR opened,
+  // pod died, DBOS re-runs the workflow) back to In Progress every time the
+  // run resumes, with no second PR coming to re-advance it.
+  if (!request.runMetadata?.taskBoardItemId) {
+    void reopenTasksOnThreadRun(studioCtx, input.threadId);
+  }
 
   // No wall-clock cap: a hosted run lives as long as it makes progress. The
   // RunRegistry idle reaper aborts + fails a run that goes RUN_IDLE_TIMEOUT_MS

--- a/apps/mesh/src/harnesses/decopilot/harness-deps.ts
+++ b/apps/mesh/src/harnesses/decopilot/harness-deps.ts
@@ -125,7 +125,10 @@ export function buildClusterEnvironmentTools(args: {
       const runContext = requireDecopilotRunContext(streamInput);
       const toolOutputMap = new Map<string, string>();
       const pendingImages: PendingImage[] = [];
-      const { resolveArgs, onToolCalled } = buildClusterMcpToolHooks(ctx);
+      const { resolveArgs, onToolCalled } = buildClusterMcpToolHooks(
+        ctx,
+        streamInput.threadId,
+      );
 
       const assembled = await assembleDecopilotTools(streamInput, ctx, {
         writer: sideChannel.writer,

--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
@@ -182,7 +182,10 @@ export async function runAgentLoop(
   // ── Tools ─────────────────────────────────────────────────────────
   // Cluster MCP tool-call hooks: storage-ref resolution + posthog
   // analytics, built from ctx. The portable assembler forwards them as-is.
-  const { resolveArgs, onToolCalled } = buildClusterMcpToolHooks(opts.ctx);
+  const { resolveArgs, onToolCalled } = buildClusterMcpToolHooks(
+    opts.ctx,
+    opts.currentThreadId,
+  );
   const { tools: assembledTools } = await assembleAgentTools({
     kind: opts.kind,
     ctx: opts.ctx,
@@ -207,30 +210,33 @@ export async function runAgentLoop(
     ? (undefined as never)
     : createLanguageModel(opts.provider, opts.models.thinking);
 
-  // For a Super Agent task run, watch each step's bash calls for `gh pr create`
-  // and move the card to In Review. Only wrap when this run is task-linked, so
-  // normal runs pay nothing. (The GitHub MCP tool path is caught separately via
+  // Watch each step's bash calls for `gh pr create` (or a REST fallback) and
+  // move a linked task card to In Review. The scan itself is a cheap per-step
+  // array walk, so it's unconditional — a normal run never has a `bash` call
+  // matching the PR regexes, and `advanceTaskBoardForRun` only touches the DB
+  // when one does. (The GitHub MCP tool path is caught separately via
   // `onToolCalled`, whose raw tool name is reliable; here the model-facing tool
   // name can be mangled, so we key off the built-in `bash` tool + its command.)
-  const taskLinked = !!opts.ctx.metadata?.runMetadata?.taskBoardItemId;
-  const onStepFinish: StreamTextOnStepFinishCallback<ToolSet> | undefined =
-    taskLinked
-      ? (step) => {
-          for (const call of step.toolCalls ?? []) {
-            const command = (call.input as { command?: string } | undefined)
-              ?.command;
-            if (
-              call.toolName === "bash" &&
-              command &&
-              isPrCreateBashCommand(command)
-            ) {
-              void advanceTaskBoardForRun(opts.ctx, "in_review");
-              break;
-            }
-          }
-          return opts.onStepFinish?.(step);
-        }
-      : opts.onStepFinish;
+  // `currentThreadId` lets the resolution fall back to the thread link when the
+  // run carries no `runMetadata.taskBoardItemId` (a re-prompted task's 2nd PR).
+  const onStepFinish: StreamTextOnStepFinishCallback<ToolSet> = (step) => {
+    for (const call of step.toolCalls ?? []) {
+      const command = (call.input as { command?: string } | undefined)?.command;
+      if (
+        call.toolName === "bash" &&
+        command &&
+        isPrCreateBashCommand(command)
+      ) {
+        void advanceTaskBoardForRun(
+          opts.ctx,
+          "in_review",
+          opts.currentThreadId,
+        );
+        break;
+      }
+    }
+    return opts.onStepFinish?.(step);
+  };
 
   const handle = runNativeAgentLoopCore({
     model,

--- a/apps/mesh/src/storage/task-board.ts
+++ b/apps/mesh/src/storage/task-board.ts
@@ -180,11 +180,18 @@ export class TaskBoardStorage {
   }
 
   async delete(id: string, organizationId: string): Promise<void> {
-    await this.db
-      .deleteFrom("task_board_items")
-      .where("id", "=", id)
-      .where("organization_id", "=", organizationId)
-      .execute();
+    await this.db.transaction().execute(async (trx) => {
+      await trx
+        .deleteFrom("task_board_item_threads")
+        .where("task_board_item_id", "=", id)
+        .where("organization_id", "=", organizationId)
+        .execute();
+      await trx
+        .deleteFrom("task_board_items")
+        .where("id", "=", id)
+        .where("organization_id", "=", organizationId)
+        .execute();
+    });
   }
 
   /**
@@ -209,8 +216,12 @@ export class TaskBoardStorage {
       .execute();
   }
 
-  /** Task ids linked to a run thread (reverse of the many-to-many link). */
-  private async linkedTaskIds(
+  /**
+   * Task ids linked to a run thread (reverse of the many-to-many link). Public
+   * so a run-metadata-less caller (a PR opened on a re-prompted thread) can
+   * resolve its task the same way the thread-finish/reopen hooks do.
+   */
+  async linkedTaskIds(
     threadId: string,
     organizationId: string,
   ): Promise<string[]> {

--- a/apps/mesh/src/tools/task-board/run-reactions.ts
+++ b/apps/mesh/src/tools/task-board/run-reactions.ts
@@ -13,8 +13,9 @@
  * The last two are LINK-based (`task_board_item_threads`), not runMetadata-based,
  * so they hold for a re-prompted thread that carries no run metadata.
  *
- * The link is `ctx.metadata.runMetadata.taskBoardItemId` (set at enqueue), which
- * flows onto the run's StudioContext — so these hooks need no thread↔task column.
+ * The PR-open path resolves the item from `ctx.metadata.runMetadata.taskBoardItemId`
+ * (set at enqueue) first, falling back to the same thread link when that's absent —
+ * so a repo-backed task's SECOND PR, opened after a re-prompt, still lands In Review.
  * Each transition also pushes the updated item over SSE for a real-time board.
  */
 
@@ -46,33 +47,45 @@ export function emitTaskBoardUpdated(orgId: string, item: TaskBoardItem): void {
 }
 
 /**
- * Advance the run's linked task board item forward to `status` and broadcast it.
- * No-op when the run isn't tied to a task, when the item is gone, or when the
- * target status wouldn't move the card forward. Best-effort: a failure here
- * never disturbs the agent run.
+ * Advance the run's linked task board item(s) forward to `status` and
+ * broadcast each move. Resolves the linked item(s) from `runMetadata` first
+ * (set at enqueue for the task's own run), falling back to the
+ * `task_board_item_threads` link by `threadId` — the fallback is what makes
+ * this fire for a re-prompted, repo-backed task's second PR, which carries no
+ * run metadata. No-op when neither resolves, when an item is gone, or when
+ * the target status wouldn't move its card forward. Best-effort: a failure
+ * here never disturbs the agent run.
  */
 export async function advanceTaskBoardForRun(
   ctx: StudioContext,
   status: TaskBoardItemStatus,
+  threadId?: string,
 ): Promise<void> {
-  const itemId = ctx.metadata?.runMetadata?.taskBoardItemId;
   const orgId = ctx.organization?.id;
-  if (!itemId || !orgId) return;
+  if (!orgId) return;
   try {
-    const current = await ctx.storage.taskBoard.getById(itemId, orgId);
-    // ponytail: read-then-write rank guard. A single run's transitions are
-    // sequential, so the race window is negligible; it buys idempotency (a
-    // repeated PR tool call, or in_progress re-fired on a DBOS retry, won't
-    // regress a card that's already further along). Upgrade to a conditional
-    // UPDATE ... WHERE status-rank < new-rank only if concurrency ever bites.
-    if (!current || RANK[status] <= RANK[current.status]) return;
-    const item = await ctx.storage.taskBoard.update(
-      itemId,
-      orgId,
-      { status },
-      ctx.auth?.user?.id ?? current.updatedBy,
-    );
-    emitTaskBoardUpdated(orgId, item);
+    const metadataItemId = ctx.metadata?.runMetadata?.taskBoardItemId;
+    const itemIds = metadataItemId
+      ? [metadataItemId]
+      : threadId
+        ? await ctx.storage.taskBoard.linkedTaskIds(threadId, orgId)
+        : [];
+    for (const itemId of itemIds) {
+      const current = await ctx.storage.taskBoard.getById(itemId, orgId);
+      // ponytail: read-then-write rank guard. A single run's transitions are
+      // sequential, so the race window is negligible; it buys idempotency (a
+      // repeated PR tool call, or in_progress re-fired on a DBOS retry, won't
+      // regress a card that's already further along). Upgrade to a conditional
+      // UPDATE ... WHERE status-rank < new-rank only if concurrency ever bites.
+      if (!current || RANK[status] <= RANK[current.status]) continue;
+      const item = await ctx.storage.taskBoard.update(
+        itemId,
+        orgId,
+        { status },
+        ctx.auth?.user?.id ?? current.updatedBy,
+      );
+      emitTaskBoardUpdated(orgId, item);
+    }
   } catch (err) {
     console.error("[task-board] run transition failed", err);
   }


### PR DESCRIPTION
## Summary

Follow-up to #4680 (already merged) fixing three gaps found in review of the run-driven status transitions:

- **PR-open reaction missed a re-prompted repo-backed task's 2nd PR.** `advanceTaskBoardForRun` only resolved its target item via `ctx.metadata.runMetadata.taskBoardItemId`. A re-prompt (user re-engages a task pulled back to In Progress) starts a run with no `runMetadata` — so if that run opens a second PR, the card never advances to In Review; it's stuck In Progress. Fixed by falling back to the same `task_board_item_threads` link-based resolution the thread-finish/reopen hooks already use, threaded through from `currentThreadId`/`streamInput.threadId`/`input.threadId` at each call site.

- **DBOS recovery regressed an already-reviewed card.** `reopenLinkedTasksOnThreadRun` fired unconditionally at the top of every `runHostedHarness` execution — including a DBOS recovery re-run of the *same* run after a pod death. Sequence: agent opens a PR → card advances to In Review → pod dies mid-run → DBOS re-runs the workflow → reopen yanks the card back to In Progress → resumed agent doesn't open a second PR → card stuck. Fixed by skipping the reopen when `runMetadata.taskBoardItemId` is set, since that key is only ever present on the task's own dispatched run, never a genuine human re-prompt (POST /messages doesn't set it).

- **Task delete orphaned link rows.** `TaskBoardStorage.delete` didn't clean up `task_board_item_threads`, and the migration has no FK/cascade. Now both deletes run in one transaction.

## Testing
- Existing unit suite (`task-board.test.ts`, `run-reactions.test.ts`, `validate-assignee.test.ts`, `load-repo.test.ts`) still green — 24 pass.
- `bun run check` and `bun run lint` clean.
- No new unit tests: the changed logic is composition over `ctx.storage`/DB (not pure), matching this feature's existing test-tier split — only the pure decision function (`shouldAdvanceToReview`) gets unit coverage; the wiring is thin and untested end-to-end, same as the original PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task board state machine gaps for Super Agent runs so PRs reliably move cards to In Review and recovery runs don’t regress reviewed tasks. Also cleans up thread links on delete.

- **Bug Fixes**
  - Advance to In Review for PRs opened on re-prompted threads by falling back to `task_board_item_threads` via `threadId` in `advanceTaskBoardForRun`.
  - Skip `reopenLinkedTasksOnThreadRun` when `runMetadata.taskBoardItemId` is set to avoid regressing an already-reviewed card during DBOS recovery/resume.
  - Remove `task_board_item_threads` links in the same transaction when deleting a task to prevent orphaned rows.
  - Pass `threadId` through `buildClusterMcpToolHooks`, the bash PR scan, and `advanceTaskBoardForRun` (for both `in_progress` and `in_review`) to support runs without `runMetadata`.

<sup>Written for commit 3563a959e6e78617902391756a86789cff54f975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

