### PR TITLE
feat(home): commerce diagnostic report banner on overview

### DIFF
--- a/apps/mesh/src/web/components/home/commerce-report-banner-status.test.ts
+++ b/apps/mesh/src/web/components/home/commerce-report-banner-status.test.ts
@@ -40,4 +40,13 @@ describe("deriveCommerceReportBannerStatus", () => {
     expect(deriveCommerceReportBannerStatus({ scanned_at: null })).toBe("none");
     expect(deriveCommerceReportBannerStatus({})).toBe("none");
   });
+
+  test("run_in_progress: false with a completed scan is ready", () => {
+    expect(
+      deriveCommerceReportBannerStatus({
+        run_in_progress: false,
+        scanned_at: "2026-07-01T00:00:00.000Z",
+      }),
+    ).toBe("ready");
+  });
 });

--- a/apps/mesh/src/web/components/home/commerce-report-banner-status.test.ts
+++ b/apps/mesh/src/web/components/home/commerce-report-banner-status.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { deriveCommerceReportBannerStatus } from "./commerce-report-banner-status";
+
+describe("deriveCommerceReportBannerStatus", () => {
+  test("no diagnostic hides the banner", () => {
+    expect(deriveCommerceReportBannerStatus(null)).toBe("none");
+    expect(deriveCommerceReportBannerStatus(undefined)).toBe("none");
+  });
+
+  test("a live run is generating, even when a prior deck exists", () => {
+    expect(
+      deriveCommerceReportBannerStatus({
+        run_in_progress: true,
+        scanned_at: "2026-07-01T00:00:00.000Z",
+      }),
+    ).toBe("generating");
+    expect(
+      deriveCommerceReportBannerStatus({
+        run_in_progress: true,
+        scanned_at: null,
+      }),
+    ).toBe("generating");
+  });
+
+  test("a completed run with no live run is ready", () => {
+    expect(
+      deriveCommerceReportBannerStatus({
+        scanned_at: "2026-07-01T00:00:00.000Z",
+      }),
+    ).toBe("ready");
+    expect(
+      deriveCommerceReportBannerStatus({
+        run_in_progress: undefined,
+        scanned_at: "2026-07-01T00:00:00.000Z",
+      }),
+    ).toBe("ready");
+  });
+
+  test("claimed but never run (or a stale run the server no longer reports) hides the banner", () => {
+    expect(deriveCommerceReportBannerStatus({ scanned_at: null })).toBe("none");
+    expect(deriveCommerceReportBannerStatus({})).toBe("none");
+  });
+});

--- a/apps/mesh/src/web/components/home/commerce-report-banner-status.ts
+++ b/apps/mesh/src/web/components/home/commerce-report-banner-status.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure derivation of the home report banner state from `get_my_diagnostic`
+ * (Commerce Discovery's owner view). Kept UI-free so the truth table is
+ * unit-testable.
+ *
+ * The tool is the single source of truth for run state:
+ * - `run_in_progress` is computed server-side (run_started_at > last_run_at,
+ *   with a staleness cap) and means "the client must stay in the generating
+ *   state" (see commerce-skills api/diagnostic/public-view.ts).
+ * - `scanned_at` (= last_run_at) non-null means a completed deck exists.
+ *
+ * Anything else (no diagnostic, a claimed-but-never-run store, a stale/failed
+ * run) derives to "none" so the banner never promises a report it can't show.
+ */
+
+export interface CommerceDiagnosticRunState {
+  scanned_at?: string | null;
+  run_in_progress?: boolean;
+}
+
+export type CommerceReportBannerStatus = "generating" | "ready" | "none";
+
+export function deriveCommerceReportBannerStatus(
+  diagnostic: CommerceDiagnosticRunState | null | undefined,
+): CommerceReportBannerStatus {
+  if (!diagnostic) return "none";
+  if (diagnostic.run_in_progress) return "generating";
+  if (diagnostic.scanned_at) return "ready";
+  return "none";
+}

--- a/apps/mesh/src/web/components/home/commerce-report-banner.tsx
+++ b/apps/mesh/src/web/components/home/commerce-report-banner.tsx
@@ -190,9 +190,6 @@ function BannerShell({
       <MiniReportPage generating={generating} />
       <div className="relative flex h-36 items-center gap-6 pr-6 pl-6 sm:pl-52">
         <div className="hidden min-w-0 flex-1 flex-col gap-1 sm:flex">
-          <span className="text-xs font-medium text-muted-foreground">
-            Diagnóstico de commerce
-          </span>
           <span className="text-lg font-medium leading-6 text-foreground">
             {generating
               ? "Gerando seu diagnóstico"
@@ -200,15 +197,12 @@ function BannerShell({
           </span>
           <span className="truncate text-sm text-muted-foreground">
             {generating
-              ? `Analisando ${store}. Isso leva alguns minutos, acompanhe em tempo real.`
+              ? `Analisando ${store}. Isso leva alguns minutos.`
               : `Veja a análise completa de ${store}.`}
           </span>
         </div>
         {/* mobile: the page is hidden, keep the copy compact */}
         <div className="flex min-w-0 flex-1 flex-col gap-1 sm:hidden">
-          <span className="text-xs font-medium text-muted-foreground">
-            Diagnóstico de commerce
-          </span>
           <span className="text-base font-medium leading-6 text-foreground">
             {generating
               ? "Gerando seu diagnóstico"

--- a/apps/mesh/src/web/components/home/commerce-report-banner.tsx
+++ b/apps/mesh/src/web/components/home/commerce-report-banner.tsx
@@ -30,6 +30,7 @@ import { ErrorBoundary } from "@/web/components/error-boundary";
 import { formatPinnedViewTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 import { track } from "@/web/lib/posthog-client";
 import { KEYS } from "@/web/lib/query-keys";
+import { unwrapToolResult } from "@/web/routes/commerce-onboarding/companions-core";
 import {
   type CommerceDiagnosticRunState,
   type CommerceReportBannerStatus,
@@ -39,30 +40,14 @@ import {
 /** Poll cadence while a run is live; a run takes minutes, not seconds. */
 const GENERATING_POLL_MS = 20_000;
 
-interface ToolCallResult {
-  structuredContent?: unknown;
-  isError?: boolean;
-  content?: Array<{ text?: string }>;
-}
-
 interface ConnectionItem {
   metadata?: Record<string, unknown> | null;
-}
-
-function unwrapToolResult<T>(result: unknown): T {
-  const toolResult = result as ToolCallResult;
-  if (toolResult.isError) {
-    throw new Error(
-      toolResult.content?.find((item) => item.text)?.text ?? "Tool call failed",
-    );
-  }
-  return (toolResult.structuredContent ?? result) as T;
 }
 
 function hostFromSiteUrl(siteUrl: unknown): string | null {
   if (typeof siteUrl !== "string" || !siteUrl) return null;
   try {
-    return new URL(siteUrl).hostname;
+    return new URL(siteUrl).hostname || null;
   } catch {
     return null;
   }
@@ -245,7 +230,8 @@ function CommerceReportBannerInner() {
     retry: false,
     staleTime: 60_000,
     queryFn: async () => {
-      const result = await selfClient!.callTool({
+      if (!selfClient) throw new Error("selfClient not ready");
+      const result = await selfClient.callTool({
         name: "COLLECTION_CONNECTIONS_GET",
         arguments: { id: connectionId },
       });
@@ -266,15 +252,17 @@ function CommerceReportBannerInner() {
   });
 
   const diagnosticQuery = useQuery({
-    queryKey: KEYS.commerceDiscoveryDiagnostic(org.id),
+    queryKey: KEYS.commerceDiscoveryDiagnostic(org.id, connectionId),
     enabled: !!cdClient,
     retry: 1,
     refetchInterval: (query) =>
+      query.state.status !== "error" &&
       deriveCommerceReportBannerStatus(query.state.data) === "generating"
         ? GENERATING_POLL_MS
         : false,
     queryFn: async () => {
-      const result = await cdClient!.callTool({
+      if (!cdClient) throw new Error("cdClient not ready");
+      const result = await cdClient.callTool({
         name: COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
         arguments: {},
       });

--- a/apps/mesh/src/web/components/home/commerce-report-banner.tsx
+++ b/apps/mesh/src/web/components/home/commerce-report-banner.tsx
@@ -76,7 +76,9 @@ function MiniReportPage({ generating }: { generating: boolean }) {
     <div
       aria-hidden
       className={cn(
-        "pointer-events-none absolute -bottom-14 left-6 h-48 w-36 -rotate-6 rounded-xl border border-border bg-background shadow-lg",
+        // Decorative — hidden below sm so it never crowds the copy on narrow
+        // screens; the text reclaims the full width there.
+        "pointer-events-none absolute -bottom-14 left-6 hidden h-48 w-36 -rotate-6 rounded-xl border border-border bg-background shadow-lg sm:block",
         "transition-transform duration-500 ease-out group-hover:-translate-y-2 group-hover:-rotate-3",
       )}
     >
@@ -188,9 +190,10 @@ function BannerShell({
         )}
       />
       <MiniReportPage generating={generating} />
-      <div className="relative flex h-36 items-center gap-6 pr-6 pl-6 sm:pl-52">
-        <div className="hidden min-w-0 flex-1 flex-col gap-1 sm:flex">
-          <span className="text-lg font-medium leading-6 text-foreground">
+      {/* pl steps up to clear the decorative page once it appears at sm. */}
+      <div className="relative flex min-h-28 items-center gap-4 px-5 py-5 sm:h-36 sm:gap-6 sm:pr-6 sm:pl-52">
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <span className="text-base font-medium leading-6 text-foreground sm:text-lg">
             {generating
               ? "Gerando seu diagnóstico"
               : "Seu relatório está pronto"}
@@ -199,14 +202,6 @@ function BannerShell({
             {generating
               ? `Analisando ${store}. Isso leva alguns minutos.`
               : `Veja a análise completa de ${store}.`}
-          </span>
-        </div>
-        {/* mobile: the page is hidden, keep the copy compact */}
-        <div className="flex min-w-0 flex-1 flex-col gap-1 sm:hidden">
-          <span className="text-base font-medium leading-6 text-foreground">
-            {generating
-              ? "Gerando seu diagnóstico"
-              : "Seu relatório está pronto"}
           </span>
         </div>
         <div

--- a/apps/mesh/src/web/components/home/commerce-report-banner.tsx
+++ b/apps/mesh/src/web/components/home/commerce-report-banner.tsx
@@ -1,0 +1,334 @@
+/**
+ * Home report banner — surfaces the Commerce Discovery diagnostic on the
+ * Overview for orgs that onboarded a store, and opens the report app.
+ *
+ * A miniature report page bleeds out of the banner's clipped bottom edge,
+ * slightly tilted, and straightens on hover. While the run is live the page
+ * shimmers and the copy says so; once the deck exists the page shows a score
+ * ring and the arrow invites the click. State comes live from
+ * `get_my_diagnostic` (see commerce-report-banner-status.ts), polled gently
+ * only while generating.
+ *
+ * Orgs without the Commerce Discovery connection never get past the first
+ * (cheap, self-tool) gate: the banner renders nothing and no client to the
+ * external MCP is ever created. Every failure path also renders nothing —
+ * home must never break because of this banner.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { ArrowRight } from "@untitledui/icons";
+import {
+  COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+  getCommerceDiscoveryAgentId,
+  mcpClientQueryOptions,
+  SELF_MCP_ALIAS_ID,
+  useProjectContext,
+  WellKnownOrgMCPId,
+} from "@decocms/mesh-sdk";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { ErrorBoundary } from "@/web/components/error-boundary";
+import { formatPinnedViewTabId } from "@/web/layouts/main-panel-tabs/tab-id";
+import { track } from "@/web/lib/posthog-client";
+import { KEYS } from "@/web/lib/query-keys";
+import {
+  type CommerceDiagnosticRunState,
+  type CommerceReportBannerStatus,
+  deriveCommerceReportBannerStatus,
+} from "./commerce-report-banner-status";
+
+/** Poll cadence while a run is live; a run takes minutes, not seconds. */
+const GENERATING_POLL_MS = 20_000;
+
+interface ToolCallResult {
+  structuredContent?: unknown;
+  isError?: boolean;
+  content?: Array<{ text?: string }>;
+}
+
+interface ConnectionItem {
+  metadata?: Record<string, unknown> | null;
+}
+
+function unwrapToolResult<T>(result: unknown): T {
+  const toolResult = result as ToolCallResult;
+  if (toolResult.isError) {
+    throw new Error(
+      toolResult.content?.find((item) => item.text)?.text ?? "Tool call failed",
+    );
+  }
+  return (toolResult.structuredContent ?? result) as T;
+}
+
+function hostFromSiteUrl(siteUrl: unknown): string | null {
+  if (typeof siteUrl !== "string" || !siteUrl) return null;
+  try {
+    return new URL(siteUrl).hostname;
+  } catch {
+    return null;
+  }
+}
+
+/** The tilted miniature report page bleeding out of the banner's bottom
+ *  edge. Pure decoration (aria-hidden); `generating` swaps the score ring
+ *  and chart for shimmering placeholders. */
+function MiniReportPage({ generating }: { generating: boolean }) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute -bottom-14 left-6 h-48 w-36 -rotate-6 rounded-xl border border-border bg-background shadow-lg",
+        "transition-transform duration-500 ease-out group-hover:-translate-y-2 group-hover:-rotate-3",
+      )}
+    >
+      <div className="flex h-full flex-col gap-3 p-4">
+        {/* page header: score ring + title lines */}
+        <div className="flex items-center gap-2.5">
+          <svg viewBox="0 0 32 32" className="size-9 shrink-0 -rotate-90">
+            <circle
+              cx="16"
+              cy="16"
+              r="12"
+              fill="none"
+              strokeWidth="4"
+              className="stroke-muted"
+            />
+            <circle
+              cx="16"
+              cy="16"
+              r="12"
+              fill="none"
+              strokeWidth="4"
+              strokeLinecap="round"
+              strokeDasharray="75.4"
+              strokeDashoffset={generating ? "75.4" : "22"}
+              className={cn(
+                "transition-[stroke-dashoffset] duration-1000 ease-out",
+                generating ? "stroke-muted" : "stroke-success",
+              )}
+            />
+          </svg>
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <div
+              className={cn(
+                "h-1.5 w-full rounded-full bg-muted",
+                generating && "animate-pulse",
+              )}
+            />
+            <div
+              className={cn(
+                "h-1.5 w-2/3 rounded-full bg-muted",
+                generating && "animate-pulse",
+              )}
+            />
+          </div>
+        </div>
+        {/* mini bar chart */}
+        <div className="flex h-10 items-end gap-1.5">
+          {[7, 10, 5, 9, 6, 8].map((h, i) => (
+            <div
+              key={`bar-${i}`}
+              style={{ height: `${h * 4}px` }}
+              className={cn(
+                "flex-1 rounded-sm",
+                generating
+                  ? "animate-pulse bg-muted"
+                  : i % 2 === 0
+                    ? "bg-success/70"
+                    : "bg-success/30",
+              )}
+            />
+          ))}
+        </div>
+        {/* body lines running past the clipped edge */}
+        <div className="flex flex-col gap-1.5">
+          {["w-full", "w-5/6", "w-full", "w-2/3", "w-full"].map((w, i) => (
+            <div
+              key={`line-${i}`}
+              className={cn(
+                "h-1.5 rounded-full bg-muted",
+                w,
+                generating && "animate-pulse",
+              )}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BannerShell({
+  status,
+  host,
+  onOpen,
+}: {
+  status: Exclude<CommerceReportBannerStatus, "none">;
+  host: string | null;
+  onOpen: () => void;
+}) {
+  const generating = status === "generating";
+  const store = host ?? "sua loja";
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className={cn(
+        "group relative block w-full cursor-pointer overflow-hidden rounded-3xl border border-border bg-card card-shadow text-left",
+        "transition-colors duration-300 hover:bg-accent/30",
+        "animate-in fade-in slide-in-from-bottom-2 duration-500",
+      )}
+    >
+      {/* atmosphere: a soft glow rising from behind the page */}
+      <div
+        aria-hidden
+        className={cn(
+          "absolute -bottom-24 -left-10 size-64 rounded-full blur-3xl transition-colors duration-700",
+          generating ? "bg-warning/15" : "bg-success/15",
+        )}
+      />
+      <MiniReportPage generating={generating} />
+      <div className="relative flex h-36 items-center gap-6 pr-6 pl-6 sm:pl-52">
+        <div className="hidden min-w-0 flex-1 flex-col gap-1 sm:flex">
+          <span className="text-xs font-medium text-muted-foreground">
+            Diagnóstico de commerce
+          </span>
+          <span className="text-lg font-medium leading-6 text-foreground">
+            {generating
+              ? "Gerando seu diagnóstico"
+              : "Seu relatório está pronto"}
+          </span>
+          <span className="truncate text-sm text-muted-foreground">
+            {generating
+              ? `Analisando ${store}. Isso leva alguns minutos, acompanhe em tempo real.`
+              : `Veja a análise completa de ${store}.`}
+          </span>
+        </div>
+        {/* mobile: the page is hidden, keep the copy compact */}
+        <div className="flex min-w-0 flex-1 flex-col gap-1 sm:hidden">
+          <span className="text-xs font-medium text-muted-foreground">
+            Diagnóstico de commerce
+          </span>
+          <span className="text-base font-medium leading-6 text-foreground">
+            {generating
+              ? "Gerando seu diagnóstico"
+              : "Seu relatório está pronto"}
+          </span>
+        </div>
+        <div
+          className={cn(
+            "flex size-11 shrink-0 items-center justify-center rounded-full border border-border bg-background",
+            "transition-transform duration-300 group-hover:translate-x-1",
+          )}
+        >
+          {generating ? (
+            <span className="relative flex size-2.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-warning opacity-60" />
+              <span className="relative inline-flex size-2.5 rounded-full bg-warning" />
+            </span>
+          ) : (
+            <ArrowRight size={18} className="text-foreground" aria-hidden />
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function CommerceReportBannerInner() {
+  const { org } = useProjectContext();
+  const navigate = useNavigate();
+  const connectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
+
+  const { data: selfClient } = useQuery(
+    mcpClientQueryOptions({
+      connectionId: SELF_MCP_ALIAS_ID,
+      orgId: org.id,
+      orgSlug: org.slug,
+    }),
+  );
+
+  // Gate 1 (cheap, in-house): does this org have the CD connection at all?
+  // Same key + shape as the onboarding query, so the caches cooperate.
+  const connectionQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryConnection(org.id, connectionId),
+    enabled: !!selfClient,
+    retry: false,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const result = await selfClient!.callTool({
+        name: "COLLECTION_CONNECTIONS_GET",
+        arguments: { id: connectionId },
+      });
+      return unwrapToolResult<{ item: ConnectionItem | null }>(result);
+    },
+  });
+  const connectionItem = connectionQuery.data?.item ?? null;
+
+  // Gate 2 (external): only orgs that passed gate 1 ever open a client to the
+  // Commerce Discovery MCP and read the diagnostic.
+  const { data: cdClient } = useQuery({
+    ...mcpClientQueryOptions({
+      connectionId,
+      orgId: org.id,
+      orgSlug: org.slug,
+    }),
+    enabled: !!connectionItem,
+  });
+
+  const diagnosticQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryDiagnostic(org.id),
+    enabled: !!cdClient,
+    retry: 1,
+    refetchInterval: (query) =>
+      deriveCommerceReportBannerStatus(query.state.data) === "generating"
+        ? GENERATING_POLL_MS
+        : false,
+    queryFn: async () => {
+      const result = await cdClient!.callTool({
+        name: COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+        arguments: {},
+      });
+      const parsed = unwrapToolResult<{
+        diagnostic?: CommerceDiagnosticRunState | null;
+      }>(result);
+      return parsed.diagnostic ?? null;
+    },
+  });
+
+  const status = diagnosticQuery.isSuccess
+    ? deriveCommerceReportBannerStatus(diagnosticQuery.data)
+    : "none";
+  if (status === "none") return null;
+
+  const host = hostFromSiteUrl(connectionItem?.metadata?.siteUrl);
+
+  const openReport = () => {
+    track("home_report_banner_clicked", {
+      organization_id: org.id,
+      status,
+      domain: host ?? undefined,
+    });
+    navigate({
+      to: "/$org/$taskId",
+      params: { org: org.slug, taskId: crypto.randomUUID() },
+      search: {
+        virtualmcpid: getCommerceDiscoveryAgentId(org.id),
+        main: formatPinnedViewTabId(
+          connectionId,
+          COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+        ),
+      },
+    });
+  };
+
+  return <BannerShell status={status} host={host} onOpen={openReport} />;
+}
+
+export function CommerceReportBanner() {
+  return (
+    <ErrorBoundary fallback={null}>
+      <CommerceReportBannerInner />
+    </ErrorBoundary>
+  );
+}

--- a/apps/mesh/src/web/components/home/home-tasks.tsx
+++ b/apps/mesh/src/web/components/home/home-tasks.tsx
@@ -6,7 +6,7 @@
  * kanban shows, with status tabs. Always present above the customizable card
  * board (the metric tiles).
  */
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { formatTimeAgo } from "@/web/lib/format-time";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
@@ -158,7 +158,7 @@ function buildSummary(tasks: TaskBoardItem[]): string {
   return notes.length > 0 ? `${lead} ${notes.join(" ")}` : lead;
 }
 
-export function HomeTasks() {
+export function HomeTasks({ afterSummary }: { afterSummary?: ReactNode }) {
   const navigate = useNavigate();
   const { items, error } = useTaskBoardItems();
   const actions = useTaskBoardItemActions();
@@ -193,6 +193,8 @@ export function HomeTasks() {
           {summary}
         </p>
       </div>
+
+      {afterSummary}
 
       <section className="flex flex-col gap-4">
         <div className="flex items-center gap-3">

--- a/apps/mesh/src/web/layouts/main-panel-tabs/overview-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/overview-tab.tsx
@@ -18,6 +18,7 @@ import {
   HomeEditProvider,
   useHomeEdit,
 } from "@/web/components/home/home-edit-context";
+import { CommerceReportBanner } from "@/web/components/home/commerce-report-banner";
 import { HomeGrid } from "@/web/components/home/home-grid";
 import { AddTileDrawer } from "@/web/components/home/add-tile-drawer";
 import { HomeTasks } from "@/web/components/home/home-tasks";
@@ -99,6 +100,9 @@ function OverviewBoard() {
         {/* Fixed top: the agent "resume" (summary + Super Agent icon) and the
             tasks that need attention. Not tiles. */}
         <HomeTasks />
+        {/* Commerce diagnostic banner — self-hides for orgs without the
+            Commerce Discovery connection. */}
+        <CommerceReportBanner />
         {/* The metric cards live on the customizable tile board below. */}
         <div className="flex flex-col gap-4">
           {/* Commerce (reports-only) home is curated: no Customize, so the

--- a/apps/mesh/src/web/layouts/main-panel-tabs/overview-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/overview-tab.tsx
@@ -98,11 +98,10 @@ function OverviewBoard() {
     <div className="h-full overflow-y-auto">
       <div className="@container mx-auto flex max-w-5xl flex-col gap-10 px-6 py-8">
         {/* Fixed top: the agent "resume" (summary + Super Agent icon) and the
-            tasks that need attention. Not tiles. */}
-        <HomeTasks />
-        {/* Commerce diagnostic banner — self-hides for orgs without the
-            Commerce Discovery connection. */}
-        <CommerceReportBanner />
+            tasks that need attention. Not tiles. The commerce diagnostic
+            banner slots between the resume and the task list; it self-hides
+            for orgs without the Commerce Discovery connection. */}
+        <HomeTasks afterSummary={<CommerceReportBanner />} />
         {/* The metric cards live on the customizable tile board below. */}
         <div className="flex flex-col gap-4">
           {/* Commerce (reports-only) home is curated: no Customize, so the

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -53,6 +53,10 @@ export const KEYS = {
 
   commerceDiscoveryConnection: (orgId: string, connectionId: string) =>
     ["commerce-discovery", "connection", orgId, connectionId] as const,
+  // Owner diagnostic (get_my_diagnostic) polled by the home report banner —
+  // keyed per org; the store itself is pinned by the connection's token.
+  commerceDiscoveryDiagnostic: (orgId: string) =>
+    ["commerce-discovery", "diagnostic", orgId] as const,
   commerceDiscoveryVirtualMcp: (orgId: string, virtualMcpId: string) =>
     ["commerce-discovery", "virtual-mcp", orgId, virtualMcpId] as const,
 

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -54,9 +54,9 @@ export const KEYS = {
   commerceDiscoveryConnection: (orgId: string, connectionId: string) =>
     ["commerce-discovery", "connection", orgId, connectionId] as const,
   // Owner diagnostic (get_my_diagnostic) polled by the home report banner —
-  // keyed per org; the store itself is pinned by the connection's token.
-  commerceDiscoveryDiagnostic: (orgId: string) =>
-    ["commerce-discovery", "diagnostic", orgId] as const,
+  // keyed per org + connection so a credential rotation forces a fresh fetch.
+  commerceDiscoveryDiagnostic: (orgId: string, connectionId: string) =>
+    ["commerce-discovery", "diagnostic", orgId, connectionId] as const,
   commerceDiscoveryVirtualMcp: (orgId: string, virtualMcpId: string) =>
     ["commerce-discovery", "virtual-mcp", orgId, virtualMcpId] as const,
 

--- a/packages/e2e/tests/commerce-report-banner.spec.ts
+++ b/packages/e2e/tests/commerce-report-banner.spec.ts
@@ -119,9 +119,19 @@ test.describe("commerce report banner", () => {
     authedPage,
   }) => {
     const { page, orgSlug } = authedPage;
+    // Register before navigating so we don't miss the response if the gate
+    // resolves before we can await below (the app has persistent SSE
+    // connections so waitForLoadState("networkidle") never settles).
+    const connectionGateDone = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/mcp/self") &&
+        (resp.request().postData()?.includes("COLLECTION_CONNECTIONS_GET") ??
+          false),
+      { timeout: HOME_TIMEOUT_MS },
+    );
     await waitForHome(page, orgSlug);
-    // Wait for the connection gate query to settle before asserting absence.
-    await page.waitForLoadState("networkidle", { timeout: HOME_TIMEOUT_MS });
+    // Gate 1 resolved with { item: null } — banner correctly stays hidden.
+    await connectionGateDone;
     await expect(
       page.getByRole("button", { name: new RegExp(READY_TITLE) }),
     ).toHaveCount(0);
@@ -205,9 +215,15 @@ test.describe("commerce report banner", () => {
       orgId,
       "http://127.0.0.1:9/dead",
     );
+    // Register before navigating — the failing CD probe fires after the
+    // connection gate resolves and might complete before we await below.
+    const diagnosticFailed = page.waitForResponse(
+      (resp) => resp.url().includes(cdConnectionId(orgId)) && !resp.ok(),
+      { timeout: HOME_TIMEOUT_MS },
+    );
     await waitForHome(page, orgSlug);
-    // Wait for the connection gate + the failing client attempt to settle.
-    await page.waitForLoadState("networkidle", { timeout: HOME_TIMEOUT_MS });
+    // diagnosticQuery entered error state — banner stays hidden.
+    await diagnosticFailed;
     await expect(
       page.getByRole("button", { name: new RegExp(READY_TITLE) }),
     ).toHaveCount(0);

--- a/packages/e2e/tests/commerce-report-banner.spec.ts
+++ b/packages/e2e/tests/commerce-report-banner.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * E2E: the Commerce Discovery report banner on the org home (Overview).
+ *
+ * The banner reads run state live from the CD connection's own MCP
+ * (`get_my_diagnostic`), so these specs stand up a controlled test MCP
+ * server (fixtures/test-mcp-server.ts) and register it under the org's
+ * well-known Commerce Discovery connection id. Wire-contract strings
+ * (tool name, connection id shape, banner copy) are inlined on purpose —
+ * this suite owns its contract (see ban-e2e-app-imports).
+ *
+ * Covered:
+ *   1. Org without the CD connection → no banner, home intact.
+ *   2. Completed diagnostic → "ready" banner; click navigates to the
+ *      report app (new task URL with virtualmcpid + pinned main tab).
+ *   3. Live run → "generating" banner.
+ *   4. CD connection whose MCP is unreachable → no banner, home intact.
+ */
+
+import type { APIRequestContext, Page } from "@playwright/test";
+import { sleep } from "@decocms/std";
+import { z } from "zod";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import {
+  startTestMcpServer,
+  type TestMcpServer,
+} from "../fixtures/test-mcp-server";
+import { expect, test } from "../fixtures/test";
+
+/** Wire contract: the org's well-known CD connection id (mesh-sdk
+ *  WellKnownOrgMCPId.COMMERCE_DISCOVERY) and the report tool name. */
+const cdConnectionId = (orgId: string) => `${orgId}_commerce-discovery`;
+const REPORT_TOOL = "get_my_diagnostic";
+
+const BANNER_EYEBROW = "Diagnóstico de commerce";
+const READY_TITLE = "Seu relatório está pronto";
+const GENERATING_TITLE = "Gerando seu diagnóstico";
+
+const SITE_URL = "https://minha-loja.example";
+
+/** Cold-Vite first paint can take tens of seconds on a fresh sandbox. */
+const HOME_TIMEOUT_MS = 60_000;
+
+/** Resolve the org id for a slug via Better Auth's organization list —
+ *  the same endpoint signUpViaApi uses to resolve the slug. */
+async function findOrgId(
+  request: APIRequestContext,
+  orgSlug: string,
+): Promise<string> {
+  const res = await request.get("/api/auth/organization/list");
+  if (!res.ok()) {
+    throw new Error(`organization/list → HTTP ${res.status()}`);
+  }
+  const body = (await res.json()) as
+    | Array<{ id: string; slug: string }>
+    | { data?: Array<{ id: string; slug: string }> };
+  const orgs = Array.isArray(body) ? body : (body.data ?? []);
+  const org = orgs.find((o) => o.slug === orgSlug);
+  if (!org) throw new Error(`org ${orgSlug} not found in organization/list`);
+  return org.id;
+}
+
+/** Diagnostic rows as `get_my_diagnostic` returns them (owner view). */
+interface DiagnosticFixture {
+  url: string;
+  scope: string;
+  scanned_at: string | null;
+  run_in_progress?: boolean;
+}
+
+function startDiagnosticMcp(
+  diagnostic: DiagnosticFixture,
+): Promise<TestMcpServer> {
+  return startTestMcpServer({
+    tools: [
+      {
+        name: REPORT_TOOL,
+        description: "Return the diagnostic for the store.",
+        outputSchema: {
+          diagnostic: z
+            .object({
+              url: z.string(),
+              scope: z.string(),
+              scanned_at: z.string().nullable(),
+              run_in_progress: z.boolean().optional(),
+            })
+            .nullable(),
+        },
+        handler: () => ({ diagnostic }),
+      },
+    ],
+  });
+}
+
+/** Register `url` as the org's well-known CD connection. */
+async function createCdConnection(
+  request: APIRequestContext,
+  orgSlug: string,
+  orgId: string,
+  url: string,
+): Promise<void> {
+  await callSelfMcpTool(request, orgSlug, "COLLECTION_CONNECTIONS_CREATE", {
+    data: {
+      id: cdConnectionId(orgId),
+      title: "Commerce Discovery (e2e)",
+      connection_type: "HTTP",
+      connection_url: url,
+      metadata: { siteUrl: SITE_URL },
+    },
+  });
+}
+
+async function waitForHome(page: Page, orgSlug: string): Promise<void> {
+  await page.goto(`/${orgSlug}`);
+  await page
+    .getByRole("button", { name: "Customize" })
+    .waitFor({ state: "visible", timeout: HOME_TIMEOUT_MS });
+}
+
+test.describe("commerce report banner", () => {
+  test("org without the CD connection shows no banner and home stays intact", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    await waitForHome(page, orgSlug);
+    // The banner mounts with the Overview and resolves its (local, fast)
+    // connection gate right after paint; give it a beat, then assert absence.
+    await sleep(4000);
+    await expect(page.getByText(BANNER_EYEBROW)).toHaveCount(0);
+    // Home is still functional.
+    await expect(page.getByRole("button", { name: "Customize" })).toBeVisible();
+  });
+
+  test("completed diagnostic shows the ready banner and opens the report app", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+    const orgId = await findOrgId(request, orgSlug);
+
+    const mcp = await startDiagnosticMcp({
+      url: SITE_URL,
+      scope: "private",
+      scanned_at: "2026-07-10T12:00:00.000Z",
+    });
+    try {
+      await createCdConnection(request, orgSlug, orgId, mcp.url);
+      await waitForHome(page, orgSlug);
+
+      const banner = page.getByRole("button", {
+        name: new RegExp(READY_TITLE),
+      });
+      await expect(banner).toBeVisible({ timeout: HOME_TIMEOUT_MS });
+      // The subtitle names the store from the connection metadata.
+      await expect(banner).toContainText("minha-loja.example");
+
+      await banner.click();
+      // New task URL carrying the CD agent + the pinned report view.
+      await expect(page).toHaveURL(/virtualmcpid=commerce-discovery/, {
+        timeout: 15_000,
+      });
+      await expect(page).toHaveURL(new RegExp(REPORT_TOOL));
+      await expect(page).toHaveURL(new RegExp(`/${orgSlug}/[0-9a-f-]{36}`));
+    } finally {
+      await mcp.stop();
+    }
+  });
+
+  test("live run shows the generating banner", async ({ authedPage }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+    const orgId = await findOrgId(request, orgSlug);
+
+    const mcp = await startDiagnosticMcp({
+      url: SITE_URL,
+      scope: "private",
+      scanned_at: null,
+      run_in_progress: true,
+    });
+    try {
+      await createCdConnection(request, orgSlug, orgId, mcp.url);
+      await waitForHome(page, orgSlug);
+
+      await expect(
+        page.getByRole("button", { name: new RegExp(GENERATING_TITLE) }),
+      ).toBeVisible({ timeout: HOME_TIMEOUT_MS });
+    } finally {
+      await mcp.stop();
+    }
+  });
+
+  test("unreachable CD MCP hides the banner without breaking home", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+    const orgId = await findOrgId(request, orgSlug);
+
+    // Nothing listens here — the connection exists but its MCP is dead.
+    await createCdConnection(
+      request,
+      orgSlug,
+      orgId,
+      "http://127.0.0.1:9/dead",
+    );
+    await waitForHome(page, orgSlug);
+    // Long enough for the connection gate + the failing client attempt.
+    await sleep(8000);
+    await expect(page.getByText(BANNER_EYEBROW)).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Customize" })).toBeVisible();
+  });
+});

--- a/packages/e2e/tests/commerce-report-banner.spec.ts
+++ b/packages/e2e/tests/commerce-report-banner.spec.ts
@@ -17,7 +17,6 @@
  */
 
 import type { APIRequestContext, Page } from "@playwright/test";
-import { sleep } from "@decocms/std";
 import { z } from "zod";
 import { callSelfMcpTool } from "../fixtures/mcp-tools";
 import {
@@ -31,7 +30,6 @@ import { expect, test } from "../fixtures/test";
 const cdConnectionId = (orgId: string) => `${orgId}_commerce-discovery`;
 const REPORT_TOOL = "get_my_diagnostic";
 
-const BANNER_EYEBROW = "Diagnóstico de commerce";
 const READY_TITLE = "Seu relatório está pronto";
 const GENERATING_TITLE = "Gerando seu diagnóstico";
 
@@ -122,10 +120,14 @@ test.describe("commerce report banner", () => {
   }) => {
     const { page, orgSlug } = authedPage;
     await waitForHome(page, orgSlug);
-    // The banner mounts with the Overview and resolves its (local, fast)
-    // connection gate right after paint; give it a beat, then assert absence.
-    await sleep(4000);
-    await expect(page.getByText(BANNER_EYEBROW)).toHaveCount(0);
+    // Wait for the connection gate query to settle before asserting absence.
+    await page.waitForLoadState("networkidle", { timeout: HOME_TIMEOUT_MS });
+    await expect(
+      page.getByRole("button", { name: new RegExp(READY_TITLE) }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: new RegExp(GENERATING_TITLE) }),
+    ).toHaveCount(0);
     // Home is still functional.
     await expect(page.getByRole("button", { name: "Customize" })).toBeVisible();
   });
@@ -154,12 +156,13 @@ test.describe("commerce report banner", () => {
       await expect(banner).toContainText("minha-loja.example");
 
       await banner.click();
-      // New task URL carrying the CD agent + the pinned report view.
-      await expect(page).toHaveURL(/virtualmcpid=commerce-discovery/, {
-        timeout: 15_000,
-      });
-      await expect(page).toHaveURL(new RegExp(REPORT_TOOL));
-      await expect(page).toHaveURL(new RegExp(`/${orgSlug}/[0-9a-f-]{36}`));
+      // New task URL: /$org/<uuid>?virtualmcpid=commerce-discovery_<orgId>&main=...<tool>
+      await expect(page).toHaveURL(
+        new RegExp(
+          `/${orgSlug}/[0-9a-f-]{36}.*virtualmcpid=commerce-discovery_[^&]+.*${REPORT_TOOL}`,
+        ),
+        { timeout: 15_000 },
+      );
     } finally {
       await mcp.stop();
     }
@@ -203,9 +206,14 @@ test.describe("commerce report banner", () => {
       "http://127.0.0.1:9/dead",
     );
     await waitForHome(page, orgSlug);
-    // Long enough for the connection gate + the failing client attempt.
-    await sleep(8000);
-    await expect(page.getByText(BANNER_EYEBROW)).toHaveCount(0);
+    // Wait for the connection gate + the failing client attempt to settle.
+    await page.waitForLoadState("networkidle", { timeout: HOME_TIMEOUT_MS });
+    await expect(
+      page.getByRole("button", { name: new RegExp(READY_TITLE) }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: new RegExp(GENERATING_TITLE) }),
+    ).toHaveCount(0);
     await expect(page.getByRole("button", { name: "Customize" })).toBeVisible();
   });
 });

--- a/packages/e2e/tests/commerce-report-banner.spec.ts
+++ b/packages/e2e/tests/commerce-report-banner.spec.ts
@@ -121,12 +121,11 @@ test.describe("commerce report banner", () => {
     const { page, orgSlug } = authedPage;
     // Register before navigating so we don't miss the response if the gate
     // resolves before we can await below (the app has persistent SSE
-    // connections so waitForLoadState("networkidle") never settles).
+    // connections so waitForLoadState("networkidle") never settles). The self
+    // client calls builtin tools over REST (POST /api/:org/tools/:name), so
+    // the tool name is in the URL path, not the /mcp/self body.
     const connectionGateDone = page.waitForResponse(
-      (resp) =>
-        resp.url().includes("/mcp/self") &&
-        (resp.request().postData()?.includes("COLLECTION_CONNECTIONS_GET") ??
-          false),
+      (resp) => resp.url().includes("/tools/COLLECTION_CONNECTIONS_GET"),
       { timeout: HOME_TIMEOUT_MS },
     );
     await waitForHome(page, orgSlug);


### PR DESCRIPTION
## Summary

Adds a report banner to the org home (Overview tab) for orgs that onboarded a commerce store. A tilted miniature report page bleeds out of the banner's clipped edge (per design direction), with a soft glow and hover motion:

- **Generating**: muted shimmering page, warm glow, pulsing dot — "Gerando seu diagnóstico".
- **Ready**: score ring + green mini chart, success glow, arrow CTA — "Seu relatório está pronto".
- Clicking opens the report app exactly like onboarding's "Ver relatório completo" (new task, `virtualmcpid` + pinned `main` tab).

## How state is derived

No new backend state: the banner reads run state **live** from the CD connection's own `get_my_diagnostic` tool (the same source of truth the report app uses):

- `run_in_progress` (computed server-side in commerce-skills) → generating, polled every 20s.
- `scanned_at` non-null → ready (polling stops).
- Anything else (no diagnostic, claimed-but-never-ran, stale run) → banner hidden.

Derivation is a pure function (`commerce-report-banner-status.ts`) with co-located unit tests.

## Safety for orgs without the report MCP

- Gate 1 is a cheap in-house self-tool call (`COLLECTION_CONNECTIONS_GET` on the well-known CD connection id); orgs without it never open a client to the external MCP and render nothing.
- All queries are non-suspending with `retry` bounded; every failure path renders nothing; the whole banner is wrapped in an `ErrorBoundary` with a null fallback.

## Testing

- Unit: `commerce-report-banner-status.test.ts` (4 tests, truth table of the derivation).
- E2E (`packages/e2e/tests/commerce-report-banner.spec.ts`, black-box, all passing locally):
  1. Org without the CD connection → no banner, home intact.
  2. Completed diagnostic (mock CD MCP via `startTestMcpServer`) → ready banner with store host, click navigates to the report app URL.
  3. Live run → generating banner.
  4. CD connection pointing at an unreachable MCP → no banner, home intact.
- `bun run check`, `bun run lint` (0 errors), `bun run fmt`, knip clean. Web unit-test failures seen in full local runs are pre-existing cross-file pollution (same files pass in isolation with and without this diff; nothing in the unit tier imports the touched files).

## Screenshots

Captured from the real app against a mock CD MCP (also saved in the workspace under `.context/banner-shots/`).

| Ready | Generating |
|---|---|
| tilted mini report page with score ring + green chart, arrow CTA | shimmering muted page, warm glow, pulsing dot |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a commerce diagnostic banner to the org Overview for stores with a Commerce Discovery connection. It shows live status (Generating/Ready) and opens the full report in a new task with `virtualmcpid` and pinned `main`, placed below the agent resume.

- **New Features**
  - Status via `deriveCommerceReportBannerStatus`; polls every 20s only while generating.
  - Safe gating with `COLLECTION_CONNECTIONS_GET`; failures hide the banner; wrapped in an error boundary.
  - UI: trimmed copy; uses `metadata.siteUrl` to show the store host when valid; click opens the report app.

- **Bug Fixes**
  - Fixed narrow-screen overlap: hide the decorative mini page below `sm`; single responsive text block.
  - Hardened queries: added `connectionId` to the diagnostic query key, guarded `selfClient`/`cdClient` readiness, stopped polling on error, and reused `unwrapToolResult`.
  - Reliability: host parsing ignores empty/invalid `siteUrl`; added a `run_in_progress: false` unit case; e2e now uses targeted `waitForResponse` and matches the REST self-tool path `/tools/COLLECTION_CONNECTIONS_GET` to avoid SSE-related flakiness.

<sup>Written for commit 384cbfe94add8b1f285cf2f3d73f5e7c6fc6b784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

