### PR TITLE
test(task-board): cover run-advance target resolution (#4682 follow-up)

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.ts
@@ -213,8 +213,10 @@ export async function runAgentLoop(
   // Watch each step's bash calls for `gh pr create` (or a REST fallback) and
   // move a linked task card to In Review. The scan itself is a cheap per-step
   // array walk, so it's unconditional — a normal run never has a `bash` call
-  // matching the PR regexes, and `advanceTaskBoardForRun` only touches the DB
-  // when one does. (The GitHub MCP tool path is caught separately via
+  // matching the PR regexes, and `advanceTaskBoardForRun` hits the DB only when
+  // one does: a link SELECT to resolve the target, then a write only if that
+  // run is actually task-linked (a non-task match reads nothing to update).
+  // (The GitHub MCP tool path is caught separately via
   // `onToolCalled`, whose raw tool name is reliable; here the model-facing tool
   // name can be mangled, so we key off the built-in `bash` tool + its command.)
   // `currentThreadId` lets the resolution fall back to the thread link when the

--- a/apps/mesh/src/tools/task-board/run-reactions.test.ts
+++ b/apps/mesh/src/tools/task-board/run-reactions.test.ts
@@ -1,5 +1,34 @@
 import { describe, expect, it } from "bun:test";
-import { isPrCreateBashCommand, isPrCreateMcpTool } from "./run-reactions";
+import {
+  isPrCreateBashCommand,
+  isPrCreateMcpTool,
+  resolveAdvanceTargets,
+} from "./run-reactions";
+
+describe("resolveAdvanceTargets", () => {
+  it("uses the metadata item alone when present (the task's own run)", () => {
+    expect(resolveAdvanceTargets("item-1", [])).toEqual(["item-1"]);
+  });
+
+  it("never unions metadata with the thread link", () => {
+    // The task's own run: metadata wins, link rows are ignored even if present.
+    expect(resolveAdvanceTargets("item-1", ["item-2", "item-3"])).toEqual([
+      "item-1",
+    ]);
+  });
+
+  it("falls back to the thread link when there is no metadata", () => {
+    // A re-prompted, repo-backed task's 2nd PR carries no run metadata.
+    expect(resolveAdvanceTargets(undefined, ["item-2", "item-3"])).toEqual([
+      "item-2",
+      "item-3",
+    ]);
+  });
+
+  it("targets nothing when neither resolves (a normal run)", () => {
+    expect(resolveAdvanceTargets(undefined, [])).toEqual([]);
+  });
+});
 
 describe("isPrCreateMcpTool", () => {
   it("matches the GitHub MCP PR-create tools", () => {

--- a/apps/mesh/src/tools/task-board/run-reactions.ts
+++ b/apps/mesh/src/tools/task-board/run-reactions.ts
@@ -47,6 +47,21 @@ export function emitTaskBoardUpdated(orgId: string, item: TaskBoardItem): void {
 }
 
 /**
+ * Which task item(s) a run-driven advance targets: the enqueue-set
+ * `runMetadata.taskBoardItemId` when present (the task's own dispatched run),
+ * else the thread's `task_board_item_threads` link rows. Metadata wins over
+ * the link — it never unions the two, so the task's own run advances exactly
+ * its item, and only a metadata-less re-prompt falls back to the link. Pure so
+ * the fallback decision is unit-tested without a StudioContext.
+ */
+export function resolveAdvanceTargets(
+  metadataItemId: string | undefined,
+  linkedIds: string[],
+): string[] {
+  return metadataItemId ? [metadataItemId] : linkedIds;
+}
+
+/**
  * Advance the run's linked task board item(s) forward to `status` and
  * broadcast each move. Resolves the linked item(s) from `runMetadata` first
  * (set at enqueue for the task's own run), falling back to the
@@ -65,12 +80,13 @@ export async function advanceTaskBoardForRun(
   if (!orgId) return;
   try {
     const metadataItemId = ctx.metadata?.runMetadata?.taskBoardItemId;
-    const itemIds = metadataItemId
-      ? [metadataItemId]
-      : threadId
+    // Query the thread link only on the fallback path (no metadata + a
+    // threadId) — the task's own run never reads it.
+    const linkedIds =
+      !metadataItemId && threadId
         ? await ctx.storage.taskBoard.linkedTaskIds(threadId, orgId)
         : [];
-    for (const itemId of itemIds) {
+    for (const itemId of resolveAdvanceTargets(metadataItemId, linkedIds)) {
       const current = await ctx.storage.taskBoard.getById(itemId, orgId);
       // ponytail: read-then-write rank guard. A single run's transitions are
       // sequential, so the race window is negligible; it buys idempotency (a


### PR DESCRIPTION
Stacked on #4682 — addresses the two review notes from that PR.

## Changes
- **Unit-cover the fallback resolution.** The metadata-first / thread-link fallback in `advanceTaskBoardForRun` was the heart of #4682's fix but untested (it touches `ctx.storage`, so the whole function is e2e-tier). Extracted the *decision* into a pure `resolveAdvanceTargets(metadataItemId, linkedIds)` — metadata wins, never unions with the link — and unit-tested it, mirroring the existing `shouldAdvanceToReview` split. The DB-query avoidance (only read the link on the metadata-less path) is preserved at the call site.
- **Comment accuracy.** The `run-agent-loop` note claimed the scan "only touches the DB when one does [match]"; the fallback now issues a link SELECT even for a non-task run that matches the PR regex (reads nothing to update). Reworded to distinguish the resolution *read* from the task-linked *write*.

## Not done here
A true e2e for the DBOS pod-death recovery / reopen-skip path (dispatch a task → open a PR → simulate a recovery re-run → assert the card stays In Review) needs the sandbox + real GitHub + recovery machinery the suite doesn't have today, and no task-board e2e exists yet. Flagging as follow-up rather than half-building it.

## Testing
- `bun test apps/mesh/src/tools/task-board/` — green (10 pass).
- `bun run --cwd apps/mesh check` clean; workflow-source guard unaffected (no snapshot-tracked file touched).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unit tests for run-advance target resolution by extracting a pure `resolveAdvanceTargets(metadataItemId, linkedIds)` used by `advanceTaskBoardForRun`. Metadata wins (no union), we only query thread links on the fallback path, and the agent loop comment now distinguishes the link SELECT (read) from the task-linked write.

<sup>Written for commit 5f7157341139d82bc0da18f1772bef3ffa154a22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

