### PR TITLE
chore(sandbox): republish studio-sandbox multi-arch (amd64 + arm64)

### DIFF
--- a/packages/sandbox/image/Dockerfile
+++ b/packages/sandbox/image/Dockerfile
@@ -1,4 +1,7 @@
 # Build: docker build -t studio-sandbox:local -f packages/sandbox/image/Dockerfile packages/sandbox
+# Published multi-arch (linux/amd64 + linux/arm64) by
+# .github/workflows/release-studio-sandbox.yaml so sandboxes run natively on
+# arm64 nodes (Apple Silicon, arm64 cloud) as well as amd64.
 FROM oven/bun:1.3.14-debian
 
 ARG NODE_MAJOR=26


### PR DESCRIPTION
## What

Bumps `packages/sandbox` (via the release-tagging automation on merge) to cut a
new `studio-sandbox` release. Adds a doc comment in the image Dockerfile; **no
runtime change**.

## Why

#4678 made the `studio-sandbox` build multi-arch, but nothing republished — the
existing tags (`latest`, `1.12.0`, `1.15.18`) are all still **amd64-only**. On
arm64 nodes (Apple Silicon, arm64 cloud) a SandboxClaim pod fails:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

This release triggers a rebuild with the fixed workflow, publishing a tag with
both `linux/amd64` and `linux/arm64`.

## Impact

- Backward-compatible: the new manifest still includes amd64, so amd64 consumers
  are unchanged.
- On merge, `release-tagging` bumps the version and `release-studio-sandbox`
  publishes it multi-arch; the `bump-deco-apps-cd` job then bumps the sandbox
  tag in deco-apps-cd (stg + prod) — a tag move for NEW SandboxClaims only,
  running pods untouched, functionally identical on amd64.

## Follow-up

The public `sandbox-env` chart still pins `image.tag: 1.12.0`; a separate PR
will bump its default to the new multi-arch version for self-hosters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Republish `studio-sandbox` with a multi-arch Docker manifest (linux/amd64 + linux/arm64) so Sandbox pods run on arm64 without pull errors. No runtime changes; adds a Dockerfile comment and relies on release automation to publish the multi-arch tag.

<sup>Written for commit 745688d6d3539accf2cd814fc8b726fe49747883. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

