### PR TITLE
fix(commerce-onboarding): stop repo/site picker from reverting the user's selection

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -142,6 +142,12 @@ export function GitHubConfigForm({
 
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, 300);
+  // Applies the persisted repo to the form ONCE, the first time the prefill
+  // query resolves. selectedQuery only refetches after a successful save, so
+  // without this guard every render caused by the user picking a different
+  // repo would see the (still-stale) persisted value and immediately revert
+  // their selection back to it before they could hit Save.
+  const prefilledRef = useRef(false);
 
   // Prefill: the repo currently persisted on the CD connection.
   const selectedQuery = useQuery({
@@ -223,14 +229,17 @@ export function GitHubConfigForm({
     onIsPendingChange?.(isPending);
   }, [isPending, onIsPendingChange]);
 
+  const selectedRepo = selectedQuery.data ?? "";
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- prefill the form once from the persisted repo (an async query result), not on every render
+  useEffect(() => {
+    if (!selectedQuery.isSuccess || prefilledRef.current) return;
+    prefilledRef.current = true;
+    if (selectedQuery.data) form.setValue("githubRepo", selectedQuery.data);
+  }, [selectedQuery.isSuccess, selectedQuery.data, form]);
+
   const handleSubmit = form.handleSubmit(async (data) => {
     saveMutation.mutate(data.githubRepo);
   });
-
-  const selectedRepo = selectedQuery.data ?? "";
-  if (selectedRepo && form.getValues("githubRepo") !== selectedRepo) {
-    form.setValue("githubRepo", selectedRepo);
-  }
 
   const results = reposQuery.data?.repos ?? [];
   const failedAccounts = reposQuery.data?.failed ?? 0;

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -63,10 +63,39 @@ export function GoogleSearchConsoleConfigForm({
     onDone,
   });
 
+  // Applies the persisted/auto-matched site to the form ONCE. Without this
+  // guard, every render caused by the user picking a different site would
+  // see `card.configurationState` (only refreshed after a successful save)
+  // still holding the old value and immediately revert the selection to it.
+  const prefilledRef = useRef(false);
+  const savedSiteUrl = card.configurationState?.siteUrl as string | undefined;
+
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- notify parent of save pending state
   useEffect(() => {
     onIsPendingChange?.(isPending);
   }, [isPending, onIsPendingChange]);
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- prefill the form once from the persisted/auto-matched site (async query result), not on every render
+  useEffect(() => {
+    if (prefilledRef.current || !sitesQuery.isSuccess) return;
+    prefilledRef.current = true;
+    if (savedSiteUrl) {
+      if (form.getValues("siteUrl") !== savedSiteUrl) {
+        form.setValue("siteUrl", savedSiteUrl);
+      }
+      return;
+    }
+    if (!form.getValues("siteUrl")) {
+      const matchedSite = matchGscSite(contextSiteUrl, sitesQuery.data ?? []);
+      if (matchedSite) form.setValue("siteUrl", matchedSite);
+    }
+  }, [
+    sitesQuery.isSuccess,
+    sitesQuery.data,
+    savedSiteUrl,
+    contextSiteUrl,
+    form,
+  ]);
 
   const handleSubmit = form.handleSubmit(async (data) => {
     save(data);
@@ -101,16 +130,6 @@ export function GoogleSearchConsoleConfigForm({
         </p>
       </div>
     );
-  }
-
-  const savedSiteUrl = card.configurationState?.siteUrl as string | undefined;
-  if (savedSiteUrl && form.getValues("siteUrl") !== savedSiteUrl) {
-    form.setValue("siteUrl", savedSiteUrl);
-  } else if (!savedSiteUrl && !form.getValues("siteUrl")) {
-    const matchedSite = matchGscSite(contextSiteUrl, sites);
-    if (matchedSite) {
-      form.setValue("siteUrl", matchedSite);
-    }
   }
 
   return (


### PR DESCRIPTION
## What is this contribution about?

Fixes the commerce onboarding GitHub repo picker (and the Google Search Console site picker, which had the identical bug) reverting the user's selection back to the previously persisted value on every click, before they could ever hit Save.

**Root cause:** both `GitHubConfigForm` and `GoogleSearchConsoleConfigForm` synced the persisted value (`selectedQuery.data` / `card.configurationState.siteUrl`) into the form on **every render**, not just on initial prefill:

```ts
const selectedRepo = selectedQuery.data ?? "";
if (selectedRepo && form.getValues("githubRepo") !== selectedRepo) {
  form.setValue("githubRepo", selectedRepo);
}
```

`selectedQuery` only refetches after a successful save. So the sequence was:
1. Form loads, prefilled with the org's persisted repo (e.g. `deco-sites/vicbeaute`).
2. User clicks a different repo in the picker (e.g. `deco-sites/fila-store`) → `field.onChange` fires → form state updates → re-render.
3. On that re-render, `selectedQuery.data` is *still* `vicbeaute` (unchanged) → the block above sees a mismatch and immediately calls `form.setValue("githubRepo", "vicbeaute")`, silently reverting the click.

The other companion forms (GA4, VTEX, SA-binding) don't have this bug because their persisted value is available synchronously via `card.configurationState` at `useForm({ defaultValues })` time — only GitHub and GSC pull it from an async query/prop that resolves after mount, which is why they needed (and got) this now-buggy manual sync.

**Fix:** guard the sync with a ref so it only ever applies once, the first time the persisted value resolves. Moved into a `useEffect` (with the same `oxlint-disable` precedent already used in these files for `onIsPendingChange`) because oxlint's `ban-ref-current-assignment` rule explicitly forbids touching `.current` during render — which is exactly the anti-pattern that caused this bug in the first place.

## Screenshots/Demonstration
N/A (logic fix in an existing dialog; no visual change)

## How to Test
1. Open an org's Commerce Discovery onboarding where a GitHub repo is already connected (`github_repo` set on the CD connection's `configuration_state`).
2. Open the GitHub config dialog and pick a **different** repo from the list.
3. Before this fix: the picker instantly snaps back to the previously persisted repo. After this fix: the selection sticks, and clicking Save persists the new repo.
4. Repeat with the Google Search Console config dialog and a different verified site — same before/after behavior.

## Migration Notes
N/A

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working (`bun run fmt`, oxlint clean on both files, `tsc --noEmit` clean on both files)
- [ ] Documentation is updated (if needed) — N/A
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Commerce Onboarding GitHub repo and Google Search Console site pickers reverting to the previously saved value. Persisted values are now applied once after load, so user selections stick until save.

- **Bug Fixes**
  - Root cause: forms re-synced the saved value on every render, overwriting new picks while the async data was still stale.
  - Fix: guard with a ref and move the sync to a one-time `useEffect`, complying with oxlint’s `ban-ref-current-assignment`.

<sup>Written for commit c10e2408566ecd6e127e27f10ef85589dea6b026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

