### PR TITLE
feat(task-board): redesign kanban, add filters and lane quick-add

### DIFF
--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -1491,7 +1491,12 @@ export type TaskBoardItemStatus =
   | "in_review"
   | "done";
 
-export type TaskBoardItemPriority = "low" | "medium" | "high" | "urgent";
+export type TaskBoardItemPriority =
+  | "none"
+  | "low"
+  | "medium"
+  | "high"
+  | "urgent";
 
 export interface TaskBoardItemTable {
   id: string;

--- a/apps/mesh/src/tools/task-board/schema.ts
+++ b/apps/mesh/src/tools/task-board/schema.ts
@@ -11,6 +11,7 @@ export const TaskBoardItemStatusSchema = z.enum([
 ]);
 
 export const TaskBoardItemPrioritySchema = z.enum([
+  "none",
   "low",
   "medium",
   "high",

--- a/apps/mesh/src/web/layouts/task-board/config.tsx
+++ b/apps/mesh/src/web/layouts/task-board/config.tsx
@@ -75,6 +75,7 @@ export const STATUS_CONFIG: Record<
 };
 
 export const PRIORITIES: TaskBoardItemPriority[] = [
+  "none",
   "low",
   "medium",
   "high",
@@ -89,6 +90,11 @@ export const PRIORITY_CONFIG: Record<
     dotClassName: string;
   }
 > = {
+  none: {
+    label: "No priority",
+    flagClassName: "text-muted-foreground",
+    dotClassName: "border border-muted-foreground/50",
+  },
   low: {
     label: "Low",
     flagClassName: "text-muted-foreground",

--- a/apps/mesh/src/web/layouts/task-board/config.tsx
+++ b/apps/mesh/src/web/layouts/task-board/config.tsx
@@ -48,7 +48,7 @@ export const STATUS_CONFIG: Record<
   { label: string; icon: typeof Circle; iconClassName: string }
 > = {
   triage: {
-    label: "Triage",
+    label: "Backlog",
     icon: AlertCircle,
     iconClassName: "text-muted-foreground",
   },
@@ -83,26 +83,30 @@ export const PRIORITIES: TaskBoardItemPriority[] = [
 
 export const PRIORITY_CONFIG: Record<
   TaskBoardItemPriority,
-  { label: string; badgeClassName: string; flagClassName: string }
+  {
+    label: string;
+    flagClassName: string;
+    dotClassName: string;
+  }
 > = {
   low: {
     label: "Low",
-    badgeClassName: "bg-muted text-muted-foreground",
     flagClassName: "text-muted-foreground",
+    dotClassName: "bg-muted-foreground/40",
   },
   medium: {
     label: "Medium",
-    badgeClassName: "bg-blue-500/10 text-blue-600",
     flagClassName: "text-blue-500",
+    dotClassName: "bg-blue-500",
   },
   high: {
     label: "High",
-    badgeClassName: "bg-orange-500/10 text-orange-600",
     flagClassName: "text-orange-500",
+    dotClassName: "bg-orange-500",
   },
   urgent: {
     label: "Urgent",
-    badgeClassName: "bg-red-500/10 text-red-600",
     flagClassName: "text-red-500",
+    dotClassName: "bg-red-500",
   },
 };

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -527,11 +527,17 @@ function TaskCard({
         </p>
       )}
 
-      <div className="flex flex-wrap items-center gap-1.5 pl-6">
-        {isTaskBlocked(item) && <BlockedBadge />}
-        <PriorityPill priority={item.priority} />
-        {item.dueDate && <DueDatePill iso={item.dueDate} />}
-      </div>
+      {(isTaskBlocked(item) ||
+        item.priority !== "none" ||
+        Boolean(item.dueDate)) && (
+        <div className="flex flex-wrap items-center gap-1.5 pl-6">
+          {isTaskBlocked(item) && <BlockedBadge />}
+          {item.priority !== "none" && (
+            <PriorityPill priority={item.priority} />
+          )}
+          {item.dueDate && <DueDatePill iso={item.dueDate} />}
+        </div>
+      )}
     </button>
   );
 }
@@ -560,9 +566,11 @@ function ListRow({
         {item.title}
       </span>
       {isTaskBlocked(item) && <BlockedBadge />}
-      <span className="hidden sm:inline-flex">
-        <PriorityPill priority={item.priority} />
-      </span>
+      {item.priority !== "none" && (
+        <span className="hidden sm:inline-flex">
+          <PriorityPill priority={item.priority} />
+        </span>
+      )}
       {item.dueDate && (
         <span className="hidden sm:inline-flex">
           <DueDatePill iso={item.dueDate} />

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -40,6 +40,7 @@ import { TaskBoardItemDialog } from "./task-dialog";
 import {
   EMPTY_FILTERS,
   TaskFiltersBar,
+  TaskFiltersDrawer,
   taskMatchesFilters,
   type TaskFilters,
 } from "./task-filters";
@@ -224,18 +225,29 @@ export function TaskBoardPage() {
       <div className="flex flex-col gap-4 px-4 pt-6 sm:px-8 sm:pt-8">
         <h1 className="text-xl font-medium text-foreground">Tasks</h1>
 
-        {/* Toolbar — filters on the left, view toggle + New task aligned to
-            their right. Controls take their own full-width row on mobile. */}
+        {/* Toolbar — filters on the left (inline bar on desktop, a single
+            drawer button on mobile), view toggle + New task on the right. */}
         <div className="flex flex-wrap items-center gap-2">
           {items.length > 0 && (
-            <TaskFiltersBar
-              filters={filters}
-              members={members}
-              onChange={setFilters}
-            />
+            <>
+              <div className="sm:hidden">
+                <TaskFiltersDrawer
+                  filters={filters}
+                  members={members}
+                  onChange={setFilters}
+                />
+              </div>
+              <div className="hidden sm:block">
+                <TaskFiltersBar
+                  filters={filters}
+                  members={members}
+                  onChange={setFilters}
+                />
+              </div>
+            </>
           )}
 
-          <div className="flex w-full items-center justify-between gap-2 sm:ml-auto sm:w-auto sm:justify-end">
+          <div className="ml-auto flex items-center gap-2">
             <div className="inline-flex rounded-lg bg-muted p-0.5">
               <LayoutToggle
                 active={layout === "list"}

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -9,7 +9,6 @@ import { getInitials } from "@/web/lib/get-initials";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
-import { Badge } from "@deco/ui/components/badge.tsx";
 import {
   Calendar,
   Columns03,
@@ -33,10 +32,17 @@ import {
   STATUSES,
   SUPER_AGENT_ASSIGNEE_ID,
   type TaskBoardItem,
+  type TaskBoardItemPriority,
   type TaskBoardItemStatus,
   type Member,
 } from "./config";
 import { TaskBoardItemDialog } from "./task-dialog";
+import {
+  EMPTY_FILTERS,
+  TaskFiltersBar,
+  taskMatchesFilters,
+  type TaskFilters,
+} from "./task-filters";
 import { useFlipLanes } from "./use-flip-lanes";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 
@@ -65,15 +71,32 @@ function formatDueDate(iso: string): { label: string; overdue: boolean } {
   return { label: DATE_FMT.format(d), overdue };
 }
 
+/**
+ * Shared meta chip: outlined (border, no fill), lightly rounded (not a full
+ * pill), with room for a larger leading icon.
+ */
+const PILL =
+  "inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2 py-1 text-xs font-medium text-muted-foreground";
+
 /** Card flag for a task whose agent is paused waiting on human input. */
 function BlockedBadge() {
   return (
     <span
-      className="inline-flex items-center gap-1 rounded-md bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-600"
+      className={cn(PILL, "border-amber-500/30 text-amber-600")}
       title="The agent is waiting for your input"
     >
-      <HelpCircle size={10} />
+      <HelpCircle size={14} />
       Needs input
+    </span>
+  );
+}
+
+function PriorityPill({ priority }: { priority: TaskBoardItemPriority }) {
+  const config = PRIORITY_CONFIG[priority];
+  return (
+    <span className={PILL}>
+      <span className={cn("size-2 rounded-full", config.dotClassName)} />
+      {config.label}
     </span>
   );
 }
@@ -82,14 +105,9 @@ function DueDatePill({ iso }: { iso: string }) {
   const { label, overdue } = formatDueDate(iso);
   return (
     <span
-      className={cn(
-        "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px]",
-        overdue
-          ? "bg-red-500/10 text-red-600"
-          : "bg-muted text-muted-foreground",
-      )}
+      className={cn(PILL, overdue && "border-destructive/30 text-destructive")}
     >
-      <Calendar size={10} />
+      <Calendar size={14} />
       {label}
     </span>
   );
@@ -154,12 +172,29 @@ export function TaskBoardPage() {
   const memberByUserId = new Map(members.map((m) => [m.userId, m]));
 
   const [layout, setLayout] = useState<Layout>("board");
+  const [filters, setFilters] = useState<TaskFilters>(EMPTY_FILTERS);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<TaskBoardItem | null>(null);
+  // Status a newly-created task should start in (set by a lane's "+"); null for
+  // the generic "New task" button.
+  const [createStatus, setCreateStatus] = useState<TaskBoardItemStatus | null>(
+    null,
+  );
   const { setTaskId } = usePanelActions();
+
+  const visibleItems = items.filter((item) =>
+    taskMatchesFilters(item, filters),
+  );
 
   const openCreate = () => {
     setEditingItem(null);
+    setCreateStatus(null);
+    setDialogOpen(true);
+  };
+
+  const openCreateInLane = (status: TaskBoardItemStatus) => {
+    setEditingItem(null);
+    setCreateStatus(status);
     setDialogOpen(true);
   };
 
@@ -181,51 +216,77 @@ export function TaskBoardPage() {
   }
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div
-        className={cn(
-          "mx-auto flex w-full flex-col gap-6 px-10 pt-10 pb-16",
-          layout === "board" ? "max-w-[1400px]" : "max-w-[900px]",
-        )}
-      >
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Header — shares the board/list left edge so the two views line up. */}
+      <div className="flex flex-col gap-4 px-4 pt-6 sm:px-8 sm:pt-8">
         <h1 className="text-xl font-medium text-foreground">Tasks</h1>
 
+        {/* Toolbar — filters on the left, view toggle + New task aligned to
+            their right. Controls take their own full-width row on mobile. */}
         <div className="flex flex-wrap items-center gap-2">
-          <Button size="sm" onClick={openCreate}>
-            <Plus size={16} />
-            New task
-          </Button>
+          {items.length > 0 && (
+            <TaskFiltersBar
+              filters={filters}
+              members={members}
+              onChange={setFilters}
+            />
+          )}
 
-          <div className="ml-auto inline-flex rounded-lg bg-muted p-0.5">
-            <LayoutToggle
-              active={layout === "list"}
-              onClick={() => setLayout("list")}
-              icon={List}
-              label="List"
-            />
-            <LayoutToggle
-              active={layout === "board"}
-              onClick={() => setLayout("board")}
-              icon={Columns03}
-              label="Board"
-            />
+          <div className="flex w-full items-center justify-between gap-2 sm:ml-auto sm:w-auto sm:justify-end">
+            <div className="inline-flex rounded-lg bg-muted p-0.5">
+              <LayoutToggle
+                active={layout === "list"}
+                onClick={() => setLayout("list")}
+                icon={List}
+                label="List"
+              />
+              <LayoutToggle
+                active={layout === "board"}
+                onClick={() => setLayout("board")}
+                icon={Columns03}
+                label="Board"
+              />
+            </div>
+
+            <Button size="sm" onClick={openCreate}>
+              <Plus size={16} />
+              New task
+            </Button>
           </div>
         </div>
+      </div>
 
-        {items.length === 0 ? (
-          <div className="rounded-xl border border-border bg-card px-4 py-12 text-center text-sm text-muted-foreground">
+      {items.length === 0 ? (
+        <div className="px-4 pt-6 sm:px-8">
+          <div className="rounded-xl bg-card px-4 py-12 text-center text-sm text-muted-foreground card-shadow">
             No tasks yet. Start one with New task.
           </div>
-        ) : layout === "board" ? (
-          <Lanes
-            items={items}
-            memberByUserId={memberByUserId}
-            onOpen={openTask}
-            onMove={(id, status) => actions.update.mutate({ id, status })}
-          />
-        ) : (
-          <div className="flex flex-col gap-2">
-            {items.map((item) => (
+        </div>
+      ) : visibleItems.length === 0 ? (
+        <div className="px-4 pt-6 sm:px-8">
+          <div className="flex flex-col items-center gap-3 rounded-xl bg-card px-4 py-12 text-center text-sm text-muted-foreground card-shadow">
+            No tasks match these filters.
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setFilters(EMPTY_FILTERS)}
+            >
+              Clear filters
+            </Button>
+          </div>
+        </div>
+      ) : layout === "board" ? (
+        <Lanes
+          items={visibleItems}
+          memberByUserId={memberByUserId}
+          onOpen={openTask}
+          onCreate={openCreateInLane}
+          onMove={(id, status) => actions.update.mutate({ id, status })}
+        />
+      ) : (
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 pt-6 pb-16 sm:px-8">
+          <div className="mx-auto flex max-w-[820px] flex-col gap-2">
+            {visibleItems.map((item) => (
               <ListRow
                 key={item.id}
                 item={item}
@@ -243,14 +304,19 @@ export function TaskBoardPage() {
               />
             ))}
           </div>
-        )}
-      </div>
+        </div>
+      )}
 
       <TaskBoardItemDialog
-        key={dialogOpen ? (editingItem?.id ?? "new") : "closed"}
+        key={
+          dialogOpen
+            ? (editingItem?.id ?? `new-${createStatus ?? "default"}`)
+            : "closed"
+        }
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}
         item={editingItem ?? undefined}
+        defaultStatus={createStatus ?? undefined}
         isSaving={actions.create.isPending || actions.update.isPending}
         onSubmit={(input) => {
           if (editingItem) {
@@ -314,11 +380,13 @@ function Lanes({
   items,
   memberByUserId,
   onOpen,
+  onCreate,
   onMove,
 }: {
   items: TaskBoardItem[];
   memberByUserId: Map<string, Member>;
   onOpen: (item: TaskBoardItem) => void;
+  onCreate: (status: TaskBoardItemStatus) => void;
   onMove: (id: string, status: TaskBoardItemStatus) => void;
 }) {
   const [overLane, setOverLane] = useState<TaskBoardItemStatus | null>(null);
@@ -329,9 +397,12 @@ function Lanes({
   useFlipLanes(boardRef, signature);
 
   return (
+    // A kanban isn't fit-width: lanes keep a comfortable fixed width and the
+    // board scrolls horizontally when they don't all fit (incl. mobile). The
+    // px matches the header so lane 1 lines up with the "Tasks" title.
     <div
       ref={boardRef}
-      className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5"
+      className="flex min-h-0 flex-1 gap-3 overflow-x-auto overflow-y-auto px-4 pt-6 pb-16 sm:px-8"
     >
       {STATUSES.map((status) => {
         const laneItems = items.filter((t) => t.status === status);
@@ -356,21 +427,32 @@ function Lanes({
               setOverLane(null);
             }}
             className={cn(
-              "flex flex-col rounded-xl p-1 transition-colors",
+              "flex w-[300px] shrink-0 flex-col rounded-xl p-1 transition-colors",
               overLane === status && "bg-muted/50",
             )}
           >
-            <div className="flex items-center gap-2 p-2">
+            <div className="flex items-center gap-2 px-2 py-1.5">
               <LaneIcon
-                size={14}
+                size={15}
                 className={cn("shrink-0", config.iconClassName)}
               />
-              <span className="text-xs text-foreground">{config.label}</span>
-              <span className="text-[11px] text-muted-foreground">
+              <span className="text-sm font-medium text-foreground">
+                {config.label}
+              </span>
+              <span className="rounded-md bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
                 {laneItems.length}
               </span>
+              <button
+                type="button"
+                aria-label={`New task in ${config.label}`}
+                title={`New task in ${config.label}`}
+                onClick={() => onCreate(status)}
+                className="ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <Plus size={15} />
+              </button>
             </div>
-            <div className="flex min-h-12 flex-col gap-2">
+            <div className="flex min-h-12 flex-col gap-2 pt-1">
               {laneItems.map((item) => (
                 <TaskCard
                   key={item.id}
@@ -407,8 +489,8 @@ function TaskCard({
   assignedBy?: Member;
   onOpen: () => void;
 }) {
-  const priorityConfig = PRIORITY_CONFIG[item.priority];
-  const due = item.dueDate ? formatDueDate(item.dueDate) : null;
+  const statusConfig = STATUS_CONFIG[item.status];
+  const StatusIcon = statusConfig.icon;
   const lastMessage = primaryThread(item)?.lastMessage;
 
   return (
@@ -421,11 +503,15 @@ function TaskCard({
         e.dataTransfer.effectAllowed = "move";
       }}
       onClick={onOpen}
-      className="flex cursor-grab flex-col gap-1.5 rounded-[10px] border border-border bg-card px-3 py-2.5 text-left transition-colors will-change-transform hover:border-ring/40 active:cursor-grabbing"
+      className="group flex cursor-grab flex-col gap-2 rounded-xl bg-card px-3 py-2.5 text-left card-shadow transition-colors will-change-transform hover:bg-accent/60 active:cursor-grabbing"
       title={item.title}
     >
-      <div className="flex items-start justify-between gap-2">
-        <span className="min-w-0 flex-1 truncate text-[12px] font-medium leading-snug text-foreground">
+      <div className="flex items-start gap-2">
+        <StatusIcon
+          size={16}
+          className={cn("mt-px shrink-0", statusConfig.iconClassName)}
+        />
+        <span className="min-w-0 flex-1 text-sm font-medium leading-snug text-foreground line-clamp-2">
           {item.title}
         </span>
         <AssigneeDisplay
@@ -436,36 +522,15 @@ function TaskCard({
       </div>
 
       {lastMessage && (
-        <p className="line-clamp-2 text-[11px] leading-snug text-muted-foreground">
+        <p className="line-clamp-2 pl-6 text-xs leading-snug text-muted-foreground">
           {lastMessage}
         </p>
       )}
 
-      {isTaskBlocked(item) && (
-        <div className="flex">
-          <BlockedBadge />
-        </div>
-      )}
-
-      <div className="flex items-center justify-between gap-2">
-        <span
-          className={cn(
-            "inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-medium",
-            priorityConfig.badgeClassName,
-          )}
-        >
-          {priorityConfig.label}
-        </span>
-        {due && (
-          <span
-            className={cn(
-              "text-[11px] text-muted-foreground",
-              due.overdue && "text-red-600",
-            )}
-          >
-            {due.label}
-          </span>
-        )}
+      <div className="flex flex-wrap items-center gap-1.5 pl-6">
+        {isTaskBlocked(item) && <BlockedBadge />}
+        <PriorityPill priority={item.priority} />
+        {item.dueDate && <DueDatePill iso={item.dueDate} />}
       </div>
     </button>
   );
@@ -488,28 +553,27 @@ function ListRow({
     <button
       type="button"
       onClick={onOpen}
-      className="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 text-left transition-colors hover:border-ring/40"
+      className="flex items-center gap-3 rounded-xl bg-card px-4 py-3 text-left card-shadow transition-colors hover:bg-accent/60"
     >
-      <StatusIcon size={15} className={cn("shrink-0", config.iconClassName)} />
+      <StatusIcon size={16} className={cn("shrink-0", config.iconClassName)} />
       <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
         {item.title}
       </span>
       {isTaskBlocked(item) && <BlockedBadge />}
-      <Badge
-        className={cn(
-          "shrink-0 text-[10px]",
-          PRIORITY_CONFIG[item.priority].badgeClassName,
-        )}
-      >
-        {PRIORITY_CONFIG[item.priority].label}
-      </Badge>
-      {item.dueDate && <DueDatePill iso={item.dueDate} />}
+      <span className="hidden sm:inline-flex">
+        <PriorityPill priority={item.priority} />
+      </span>
+      {item.dueDate && (
+        <span className="hidden sm:inline-flex">
+          <DueDatePill iso={item.dueDate} />
+        </span>
+      )}
       <AssigneeDisplay
         item={item}
         assignee={assignee}
         assignedBy={assignedBy}
       />
-      <span className="shrink-0 text-[11px] text-muted-foreground/70">
+      <span className="hidden shrink-0 text-[11px] text-muted-foreground/70 sm:inline">
         {formatTimeAgo(new Date(item.createdAt))}
       </span>
     </button>

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -216,7 +216,10 @@ export function TaskBoardPage() {
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    // Cap the whole page (header + board/list) and center it so content
+    // doesn't stretch edge-to-edge on wide monitors; the panel background
+    // still spans full width. Board lanes scroll horizontally within this cap.
+    <div className="mx-auto flex min-h-0 w-full max-w-[1680px] flex-1 flex-col">
       {/* Header — shares the board/list left edge so the two views line up. */}
       <div className="flex flex-col gap-4 px-4 pt-6 sm:px-8 sm:pt-8">
         <h1 className="text-xl font-medium text-foreground">Tasks</h1>
@@ -401,84 +404,78 @@ function Lanes({
     // board scrolls horizontally when they don't all fit (incl. mobile).
     <div
       ref={boardRef}
-      className="min-h-0 flex-1 overflow-x-auto overflow-y-auto px-4 pt-6 pb-16 sm:px-8"
+      className="flex min-h-0 flex-1 gap-3 overflow-x-auto overflow-y-auto px-4 pt-6 pb-16 sm:px-8"
     >
-      {/* w-max + mx-auto centers the lane row on wide monitors instead of
-          leaving it edge-to-edge, while staying fully scrollable when it
-          overflows (auto margins collapse to 0, so the first lane stays
-          reachable — unlike justify-center). */}
-      <div className="mx-auto flex w-max gap-3">
-        {STATUSES.map((status) => {
-          const laneItems = items.filter((t) => t.status === status);
-          const config = STATUS_CONFIG[status];
-          const LaneIcon = config.icon;
-          return (
-            <div
-              key={status}
-              onDragOver={(e) => {
-                e.preventDefault();
-                setOverLane(status);
-              }}
-              onDragLeave={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                  setOverLane(null);
-                }
-              }}
-              onDrop={(e) => {
-                e.preventDefault();
-                const id = e.dataTransfer.getData("text/plain");
-                if (id) onMove(id, status);
+      {STATUSES.map((status) => {
+        const laneItems = items.filter((t) => t.status === status);
+        const config = STATUS_CONFIG[status];
+        const LaneIcon = config.icon;
+        return (
+          <div
+            key={status}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setOverLane(status);
+            }}
+            onDragLeave={(e) => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
                 setOverLane(null);
-              }}
-              className={cn(
-                "flex w-[300px] shrink-0 flex-col rounded-xl p-1 transition-colors",
-                overLane === status && "bg-muted/50",
-              )}
-            >
-              <div className="flex items-center gap-2 px-2 py-1.5">
-                <LaneIcon
-                  size={15}
-                  className={cn("shrink-0", config.iconClassName)}
-                />
-                <span className="text-sm font-medium text-foreground">
-                  {config.label}
-                </span>
-                <span className="rounded-md bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
-                  {laneItems.length}
-                </span>
-                <button
-                  type="button"
-                  aria-label={`New task in ${config.label}`}
-                  title={`New task in ${config.label}`}
-                  onClick={() => onCreate(status)}
-                  className="ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                >
-                  <Plus size={15} />
-                </button>
-              </div>
-              <div className="flex min-h-12 flex-col gap-2 pt-1">
-                {laneItems.map((item) => (
-                  <TaskCard
-                    key={item.id}
-                    item={item}
-                    assignee={
-                      item.assigneeId
-                        ? memberByUserId.get(item.assigneeId)
-                        : undefined
-                    }
-                    assignedBy={
-                      item.assignedBy
-                        ? memberByUserId.get(item.assignedBy)
-                        : undefined
-                    }
-                    onOpen={() => onOpen(item)}
-                  />
-                ))}
-              </div>
+              }
+            }}
+            onDrop={(e) => {
+              e.preventDefault();
+              const id = e.dataTransfer.getData("text/plain");
+              if (id) onMove(id, status);
+              setOverLane(null);
+            }}
+            className={cn(
+              "flex w-[300px] shrink-0 flex-col rounded-xl p-1 transition-colors",
+              overLane === status && "bg-muted/50",
+            )}
+          >
+            <div className="flex items-center gap-2 px-2 py-1.5">
+              <LaneIcon
+                size={15}
+                className={cn("shrink-0", config.iconClassName)}
+              />
+              <span className="text-sm font-medium text-foreground">
+                {config.label}
+              </span>
+              <span className="rounded-md bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
+                {laneItems.length}
+              </span>
+              <button
+                type="button"
+                aria-label={`New task in ${config.label}`}
+                title={`New task in ${config.label}`}
+                onClick={() => onCreate(status)}
+                className="ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <Plus size={15} />
+              </button>
             </div>
-          );
-        })}
-      </div>
+            <div className="flex min-h-12 flex-col gap-2 pt-1">
+              {laneItems.map((item) => (
+                <TaskCard
+                  key={item.id}
+                  item={item}
+                  assignee={
+                    item.assigneeId
+                      ? memberByUserId.get(item.assigneeId)
+                      : undefined
+                  }
+                  assignedBy={
+                    item.assignedBy
+                      ? memberByUserId.get(item.assignedBy)
+                      : undefined
+                  }
+                  onOpen={() => onOpen(item)}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -398,82 +398,87 @@ function Lanes({
 
   return (
     // A kanban isn't fit-width: lanes keep a comfortable fixed width and the
-    // board scrolls horizontally when they don't all fit (incl. mobile). The
-    // px matches the header so lane 1 lines up with the "Tasks" title.
+    // board scrolls horizontally when they don't all fit (incl. mobile).
     <div
       ref={boardRef}
-      className="flex min-h-0 flex-1 gap-3 overflow-x-auto overflow-y-auto px-4 pt-6 pb-16 sm:px-8"
+      className="min-h-0 flex-1 overflow-x-auto overflow-y-auto px-4 pt-6 pb-16 sm:px-8"
     >
-      {STATUSES.map((status) => {
-        const laneItems = items.filter((t) => t.status === status);
-        const config = STATUS_CONFIG[status];
-        const LaneIcon = config.icon;
-        return (
-          <div
-            key={status}
-            onDragOver={(e) => {
-              e.preventDefault();
-              setOverLane(status);
-            }}
-            onDragLeave={(e) => {
-              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      {/* w-max + mx-auto centers the lane row on wide monitors instead of
+          leaving it edge-to-edge, while staying fully scrollable when it
+          overflows (auto margins collapse to 0, so the first lane stays
+          reachable — unlike justify-center). */}
+      <div className="mx-auto flex w-max gap-3">
+        {STATUSES.map((status) => {
+          const laneItems = items.filter((t) => t.status === status);
+          const config = STATUS_CONFIG[status];
+          const LaneIcon = config.icon;
+          return (
+            <div
+              key={status}
+              onDragOver={(e) => {
+                e.preventDefault();
+                setOverLane(status);
+              }}
+              onDragLeave={(e) => {
+                if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                  setOverLane(null);
+                }
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                const id = e.dataTransfer.getData("text/plain");
+                if (id) onMove(id, status);
                 setOverLane(null);
-              }
-            }}
-            onDrop={(e) => {
-              e.preventDefault();
-              const id = e.dataTransfer.getData("text/plain");
-              if (id) onMove(id, status);
-              setOverLane(null);
-            }}
-            className={cn(
-              "flex w-[300px] shrink-0 flex-col rounded-xl p-1 transition-colors",
-              overLane === status && "bg-muted/50",
-            )}
-          >
-            <div className="flex items-center gap-2 px-2 py-1.5">
-              <LaneIcon
-                size={15}
-                className={cn("shrink-0", config.iconClassName)}
-              />
-              <span className="text-sm font-medium text-foreground">
-                {config.label}
-              </span>
-              <span className="rounded-md bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
-                {laneItems.length}
-              </span>
-              <button
-                type="button"
-                aria-label={`New task in ${config.label}`}
-                title={`New task in ${config.label}`}
-                onClick={() => onCreate(status)}
-                className="ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                <Plus size={15} />
-              </button>
-            </div>
-            <div className="flex min-h-12 flex-col gap-2 pt-1">
-              {laneItems.map((item) => (
-                <TaskCard
-                  key={item.id}
-                  item={item}
-                  assignee={
-                    item.assigneeId
-                      ? memberByUserId.get(item.assigneeId)
-                      : undefined
-                  }
-                  assignedBy={
-                    item.assignedBy
-                      ? memberByUserId.get(item.assignedBy)
-                      : undefined
-                  }
-                  onOpen={() => onOpen(item)}
+              }}
+              className={cn(
+                "flex w-[300px] shrink-0 flex-col rounded-xl p-1 transition-colors",
+                overLane === status && "bg-muted/50",
+              )}
+            >
+              <div className="flex items-center gap-2 px-2 py-1.5">
+                <LaneIcon
+                  size={15}
+                  className={cn("shrink-0", config.iconClassName)}
                 />
-              ))}
+                <span className="text-sm font-medium text-foreground">
+                  {config.label}
+                </span>
+                <span className="rounded-md bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
+                  {laneItems.length}
+                </span>
+                <button
+                  type="button"
+                  aria-label={`New task in ${config.label}`}
+                  title={`New task in ${config.label}`}
+                  onClick={() => onCreate(status)}
+                  className="ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  <Plus size={15} />
+                </button>
+              </div>
+              <div className="flex min-h-12 flex-col gap-2 pt-1">
+                {laneItems.map((item) => (
+                  <TaskCard
+                    key={item.id}
+                    item={item}
+                    assignee={
+                      item.assigneeId
+                        ? memberByUserId.get(item.assigneeId)
+                        : undefined
+                    }
+                    assignedBy={
+                      item.assignedBy
+                        ? memberByUserId.get(item.assignedBy)
+                        : undefined
+                    }
+                    onOpen={() => onOpen(item)}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -443,7 +443,9 @@ export function TaskBoardItemDialog({
                     the human who handed it off. */}
                 {isSuperAgent && assignedBy && (
                   <div className="relative flex items-center pl-5">
-                    <span className="absolute left-3 top-0 h-1/2 w-2.5 rounded-bl-md border-b border-l border-border" />
+                    {/* Elbow drops from the center of the assigner's avatar
+                        (px-3 padding + half of the w-4 "2xs" avatar = 20px). */}
+                    <span className="absolute left-5 top-0 h-1/2 w-2.5 rounded-bl-md border-b border-l border-border" />
                     <span
                       className={cn(PROPERTY_BUTTON, "pointer-events-none")}
                     >

--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -442,10 +442,12 @@ export function TaskBoardItemDialog({
                 {/* Delegation: the Super Agent doing the work, nested under
                     the human who handed it off. */}
                 {isSuperAgent && assignedBy && (
-                  <div className="relative flex items-center pl-5">
+                  <div className="relative mt-1.5 flex items-center pl-5">
                     {/* Elbow drops from the center of the assigner's avatar
-                        (px-3 padding + half of the w-4 "2xs" avatar = 20px). */}
-                    <span className="absolute left-5 top-0 h-1/2 w-2.5 rounded-bl-md border-b border-l border-border" />
+                        (px-3 padding + half of the w-4 "2xs" avatar = 20px).
+                        Starts 6px above the row to bridge the mt-1.5 gap and
+                        still land at this row's vertical center. */}
+                    <span className="absolute -top-1.5 left-5 h-[calc(50%+0.375rem)] w-2.5 rounded-bl-md border-b border-l border-border" />
                     <span
                       className={cn(PROPERTY_BUTTON, "pointer-events-none")}
                     >

--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -32,11 +32,13 @@ import {
   Calendar,
   CheckCircle,
   ChevronRight,
+  DotsHorizontal,
   HelpCircle,
   Loading02,
   Plus,
   Trash03,
   User01,
+  UserPlus01,
   X,
 } from "@untitledui/icons";
 import { SuperAgentIcon } from "@/web/components/super-agent-icon";
@@ -294,13 +296,22 @@ export function TaskBoardItemDialog({
                       priority === "none" && "text-muted-foreground",
                     )}
                   >
-                    <span
-                      className={cn(
-                        "size-2 rounded-full",
-                        PRIORITY_CONFIG[priority].dotClassName,
-                      )}
-                    />
-                    {PRIORITY_CONFIG[priority].label}
+                    {priority === "none" ? (
+                      <>
+                        <DotsHorizontal size={16} />
+                        Set priority
+                      </>
+                    ) : (
+                      <>
+                        <span
+                          className={cn(
+                            "size-2 rounded-full",
+                            PRIORITY_CONFIG[priority].dotClassName,
+                          )}
+                        />
+                        {PRIORITY_CONFIG[priority].label}
+                      </>
+                    )}
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" className="w-40">
@@ -359,8 +370,11 @@ export function TaskBoardItemDialog({
                         </>
                       ) : (
                         <>
-                          <User01 size={16} className="text-muted-foreground" />
-                          Assignee
+                          <UserPlus01
+                            size={16}
+                            className="text-muted-foreground"
+                          />
+                          Assign
                         </>
                       )}
                     </button>

--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -81,9 +81,12 @@ const DUE_DATE_FMT = new Intl.DateTimeFormat(undefined, {
   day: "numeric",
 });
 
-/** Sidebar property row — ghost button that opens an editor popover/menu. */
+/**
+ * Property control that opens an editor popover/menu. Outlined chip on mobile
+ * (wrapping row); a borderless ghost row in the desktop sidebar.
+ */
 const PROPERTY_BUTTON =
-  "inline-flex h-9 items-center gap-2 rounded-lg px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted";
+  "inline-flex h-9 items-center gap-2 rounded-lg border border-border px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted sm:border-transparent";
 
 const THREAD_STATUS: Record<
   NonNullable<TaskBoardItemThread["status"]>,
@@ -117,6 +120,7 @@ export function TaskBoardItemDialog({
   open,
   onClose,
   item,
+  defaultStatus,
   onSubmit,
   onDelete,
   onOpenThread,
@@ -126,6 +130,9 @@ export function TaskBoardItemDialog({
   onClose: () => void;
   /** Present in edit mode, prefills the form. */
   item?: TaskBoardItem;
+  /** In create mode, the status to start the new task in (e.g. the lane the
+   * "+" was clicked from). Falls back to "triage". */
+  defaultStatus?: TaskBoardItemStatus;
   onSubmit: (input: {
     title: string;
     description: string | null;
@@ -144,7 +151,7 @@ export function TaskBoardItemDialog({
   const [title, setTitle] = useState(item?.title ?? "");
   const [description, setDescription] = useState(item?.description ?? "");
   const [status, setStatus] = useState<TaskBoardItemStatus>(
-    item?.status ?? "triage",
+    item?.status ?? defaultStatus ?? "triage",
   );
   const [priority, setPriority] = useState<TaskBoardItemPriority>(
     item?.priority ?? "medium",
@@ -161,7 +168,7 @@ export function TaskBoardItemDialog({
   const reset = () => {
     setTitle(item?.title ?? "");
     setDescription(item?.description ?? "");
-    setStatus(item?.status ?? "triage");
+    setStatus(item?.status ?? defaultStatus ?? "triage");
     setPriority(item?.priority ?? "medium");
     setAssigneeId(item?.assigneeId ?? null);
     setDueDate(parseIsoDate(item?.dueDate));
@@ -196,7 +203,7 @@ export function TaskBoardItemDialog({
   return (
     <Dialog open={open} onOpenChange={(next) => !next && close()}>
       <DialogContent
-        className="flex h-[85vh] max-h-[640px] flex-col gap-0 overflow-hidden rounded-2xl p-0 sm:max-w-[850px]"
+        className="flex max-h-[90vh] flex-col gap-0 overflow-hidden rounded-2xl p-0 sm:h-[85vh] sm:max-h-[640px] sm:max-w-[850px]"
         closeButtonClassName="hidden"
       >
         <DialogTitle className="sr-only">
@@ -212,9 +219,10 @@ export function TaskBoardItemDialog({
           <X size={16} />
         </button>
 
-        <div className="flex min-h-0 flex-1">
-          {/* Editor pane */}
-          <div className="flex min-w-0 flex-1 flex-col gap-6 overflow-y-auto p-8">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto sm:flex-row sm:overflow-hidden">
+          {/* Editor pane — content-height on mobile so it doesn't leave a big
+              gap above the properties; fills the column on desktop. */}
+          <div className="flex min-w-0 flex-col gap-6 p-6 sm:flex-1 sm:overflow-y-auto sm:p-8">
             <input
               value={title}
               onChange={(e) => setTitle(e.target.value)}
@@ -227,7 +235,7 @@ export function TaskBoardItemDialog({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Describe a task for an agent..."
-              className="min-h-[120px] w-full flex-1 resize-none border-0 bg-transparent text-[15px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/50"
+              className="min-h-[96px] w-full flex-1 resize-none border-0 bg-transparent text-[15px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/50 sm:min-h-[120px]"
             />
 
             {thread && (
@@ -239,13 +247,14 @@ export function TaskBoardItemDialog({
             )}
           </div>
 
-          {/* Properties pane */}
-          <div className="flex w-[220px] shrink-0 flex-col gap-4 border-l border-border px-6 py-10">
-            <span className="px-3 text-sm text-muted-foreground">
+          {/* Properties pane — wrapping chips under the editor on mobile, a
+              stacked sidebar on desktop. */}
+          <div className="flex w-full shrink-0 flex-col gap-4 border-t border-border p-6 sm:w-[220px] sm:border-t-0 sm:border-l sm:px-6 sm:py-10">
+            <span className="hidden px-3 text-sm text-muted-foreground sm:block">
               Properties
             </span>
 
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap gap-2 sm:flex-col">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <button type="button" className={PROPERTY_BUTTON}>
@@ -282,7 +291,7 @@ export function TaskBoardItemDialog({
                     <span
                       className={cn(
                         "size-2 rounded-full",
-                        PRIORITY_CONFIG[priority].badgeClassName,
+                        PRIORITY_CONFIG[priority].dotClassName,
                       )}
                     />
                     {PRIORITY_CONFIG[priority].label}
@@ -294,7 +303,7 @@ export function TaskBoardItemDialog({
                       <span
                         className={cn(
                           "size-2 rounded-full",
-                          PRIORITY_CONFIG[p].badgeClassName,
+                          PRIORITY_CONFIG[p].dotClassName,
                         )}
                       />
                       {PRIORITY_CONFIG[p].label}

--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -341,14 +341,37 @@ export function TaskBoardItemDialog({
                     >
                       {isSuperAgent && assignedBy ? (
                         <>
-                          <Avatar
-                            url={assignedBy.user?.image ?? undefined}
-                            fallback={getInitials(assignedBy.user?.name)}
-                            shape="circle"
-                            size="2xs"
-                          />
-                          <span className="truncate">
-                            {assignedBy.user?.name ?? "Super Agent"}
+                          {/* Desktop: the assigner; the Super Agent doing the
+                              work is the nested elbow row below. */}
+                          <span className="hidden items-center gap-2 sm:flex">
+                            <Avatar
+                              url={assignedBy.user?.image ?? undefined}
+                              fallback={getInitials(assignedBy.user?.name)}
+                              shape="circle"
+                              size="2xs"
+                            />
+                            <span className="truncate">
+                              {assignedBy.user?.name ?? "Super Agent"}
+                            </span>
+                          </span>
+                          {/* Mobile: no room for the elbow tree — fold the
+                              delegation into one chip, the assigner eclipsed by
+                              the Super Agent. */}
+                          <span className="flex items-center gap-2 sm:hidden">
+                            <span className="inline-flex items-center">
+                              <Avatar
+                                url={assignedBy.user?.image ?? undefined}
+                                fallback={getInitials(assignedBy.user?.name)}
+                                shape="circle"
+                                size="2xs"
+                                className="-mr-1.5 ring-2 ring-background"
+                              />
+                              <SuperAgentIcon
+                                size={16}
+                                className="ring-2 ring-background"
+                              />
+                            </span>
+                            Super Agent
                           </span>
                         </>
                       ) : isSuperAgent ? (
@@ -440,9 +463,10 @@ export function TaskBoardItemDialog({
                 </Popover>
 
                 {/* Delegation: the Super Agent doing the work, nested under
-                    the human who handed it off. */}
+                    the human who handed it off. Desktop only — on mobile the
+                    assignee chip folds this in (see above). */}
                 {isSuperAgent && assignedBy && (
-                  <div className="relative mt-1.5 flex items-center pl-5">
+                  <div className="relative mt-1.5 hidden items-center pl-5 sm:flex">
                     {/* Elbow drops from the center of the assigner's avatar
                         (px-3 padding + half of the w-4 "2xs" avatar = 20px).
                         Starts 6px above the row to bridge the mt-1.5 gap and

--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -287,7 +287,13 @@ export function TaskBoardItemDialog({
 
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <button type="button" className={PROPERTY_BUTTON}>
+                  <button
+                    type="button"
+                    className={cn(
+                      PROPERTY_BUTTON,
+                      priority === "none" && "text-muted-foreground",
+                    )}
+                  >
                     <span
                       className={cn(
                         "size-2 rounded-full",
@@ -315,7 +321,13 @@ export function TaskBoardItemDialog({
               <div className="flex flex-col">
                 <Popover open={assigneeOpen} onOpenChange={setAssigneeOpen}>
                   <PopoverTrigger asChild>
-                    <button type="button" className={PROPERTY_BUTTON}>
+                    <button
+                      type="button"
+                      className={cn(
+                        PROPERTY_BUTTON,
+                        !assigneeId && "text-muted-foreground",
+                      )}
+                    >
                       {isSuperAgent && assignedBy ? (
                         <>
                           <Avatar
@@ -430,7 +442,13 @@ export function TaskBoardItemDialog({
 
               <Popover open={dueOpen} onOpenChange={setDueOpen}>
                 <PopoverTrigger asChild>
-                  <button type="button" className={PROPERTY_BUTTON}>
+                  <button
+                    type="button"
+                    className={cn(
+                      PROPERTY_BUTTON,
+                      !dueDate && "text-muted-foreground",
+                    )}
+                  >
                     <Calendar size={16} className="text-muted-foreground" />
                     {dueDate ? DUE_DATE_FMT.format(dueDate) : "Due date"}
                     {dueDate && (

--- a/apps/mesh/src/web/layouts/task-board/task-filters.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-filters.tsx
@@ -7,6 +7,15 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@deco/ui/components/drawer.tsx";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -67,6 +76,14 @@ function hasActiveFilters(f: TaskFilters): boolean {
   return f.assignee !== null || f.priority !== null || f.due !== null;
 }
 
+function activeFilterCount(f: TaskFilters): number {
+  return (
+    (f.assignee !== null ? 1 : 0) +
+    (f.priority !== null ? 1 : 0) +
+    (f.due !== null ? 1 : 0)
+  );
+}
+
 const DAY_MS = 86_400_000;
 
 function isSameDay(a: number, b: number): boolean {
@@ -113,10 +130,14 @@ const DUE_OPTIONS: { value: DueFilter; label: string }[] = [
   { value: "none", label: "No due date" },
 ];
 
-/** Shared trigger styling — a compact chip that fills in when a value is set. */
-function chipClass(active: boolean): string {
+/**
+ * Shared trigger styling — a compact chip that fills in when a value is set.
+ * `block` makes it a full-width row for the mobile filter drawer.
+ */
+function chipClass(active: boolean, block = false): string {
   return cn(
     "inline-flex h-8 items-center gap-1.5 rounded-lg border px-2.5 text-xs font-medium outline-none transition-colors",
+    block && "h-10 w-full justify-start px-3 text-sm",
     active
       ? "border-transparent bg-accent text-foreground"
       : "border-border text-muted-foreground hover:bg-muted/60 hover:text-foreground",
@@ -127,10 +148,12 @@ function AssigneeFilter({
   value,
   members,
   onChange,
+  block,
 }: {
   value: string | null;
   members: Member[];
   onChange: (next: string | null) => void;
+  block?: boolean;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -159,7 +182,8 @@ function AssigneeFilter({
     setOpen(false);
   };
 
-  const triggerClass = chipClass(value !== null);
+  const triggerClass = chipClass(value !== null, block);
+  const chevronClass = cn("shrink-0 opacity-60", block && "ml-auto");
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -167,7 +191,7 @@ function AssigneeFilter({
         <button type="button" className={triggerClass}>
           {glyph}
           <span className="max-w-[10rem] truncate">{label}</span>
-          <ChevronDown size={12} className="shrink-0 opacity-60" />
+          <ChevronDown size={12} className={chevronClass} />
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-56 p-0">
@@ -224,11 +248,14 @@ function AssigneeFilter({
 function PriorityFilter({
   value,
   onChange,
+  block,
 }: {
   value: TaskBoardItemPriority | null;
   onChange: (next: TaskBoardItemPriority | null) => void;
+  block?: boolean;
 }) {
-  const triggerClass = chipClass(value !== null);
+  const triggerClass = chipClass(value !== null, block);
+  const chevronClass = cn("shrink-0 opacity-60", block && "ml-auto");
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -244,7 +271,7 @@ function PriorityFilter({
             <Flag01 size={14} className="shrink-0" />
           )}
           {value ? PRIORITY_CONFIG[value].label : "Priority"}
-          <ChevronDown size={12} className="shrink-0 opacity-60" />
+          <ChevronDown size={12} className={chevronClass} />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-40">
@@ -274,19 +301,22 @@ function PriorityFilter({
 function DueDateFilter({
   value,
   onChange,
+  block,
 }: {
   value: DueFilter | null;
   onChange: (next: DueFilter | null) => void;
+  block?: boolean;
 }) {
   const label = DUE_OPTIONS.find((o) => o.value === value)?.label;
-  const triggerClass = chipClass(value !== null);
+  const triggerClass = chipClass(value !== null, block);
+  const chevronClass = cn("shrink-0 opacity-60", block && "ml-auto");
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button type="button" className={triggerClass}>
           <Calendar size={14} className="shrink-0" />
           {label ?? "Due date"}
-          <ChevronDown size={12} className="shrink-0 opacity-60" />
+          <ChevronDown size={12} className={chevronClass} />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-44">
@@ -318,6 +348,41 @@ function DueDateFilter({
   );
 }
 
+/** The three filter controls, shared by the inline bar and the mobile drawer. */
+function FilterControls({
+  filters,
+  members,
+  onChange,
+  block,
+}: {
+  filters: TaskFilters;
+  members: Member[];
+  onChange: (next: TaskFilters) => void;
+  block?: boolean;
+}) {
+  return (
+    <>
+      <AssigneeFilter
+        block={block}
+        value={filters.assignee}
+        members={members}
+        onChange={(assignee) => onChange({ ...filters, assignee })}
+      />
+      <PriorityFilter
+        block={block}
+        value={filters.priority}
+        onChange={(priority) => onChange({ ...filters, priority })}
+      />
+      <DueDateFilter
+        block={block}
+        value={filters.due}
+        onChange={(due) => onChange({ ...filters, due })}
+      />
+    </>
+  );
+}
+
+/** Inline filter bar for desktop widths. */
 export function TaskFiltersBar({
   filters,
   members,
@@ -333,19 +398,7 @@ export function TaskFiltersBar({
         size={16}
         className="mr-0.5 shrink-0 text-muted-foreground"
       />
-      <AssigneeFilter
-        value={filters.assignee}
-        members={members}
-        onChange={(assignee) => onChange({ ...filters, assignee })}
-      />
-      <PriorityFilter
-        value={filters.priority}
-        onChange={(priority) => onChange({ ...filters, priority })}
-      />
-      <DueDateFilter
-        value={filters.due}
-        onChange={(due) => onChange({ ...filters, due })}
-      />
+      <FilterControls filters={filters} members={members} onChange={onChange} />
       {hasActiveFilters(filters) && (
         <button
           type="button"
@@ -356,5 +409,66 @@ export function TaskFiltersBar({
         </button>
       )}
     </div>
+  );
+}
+
+/**
+ * Mobile filters: a single button (with an active-count badge) that opens a
+ * bottom drawer holding the controls full-width — instead of the inline bar
+ * wrapping across several rows on a narrow header.
+ */
+export function TaskFiltersDrawer({
+  filters,
+  members,
+  onChange,
+}: {
+  filters: TaskFilters;
+  members: Member[];
+  onChange: (next: TaskFilters) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const count = activeFilterCount(filters);
+  const triggerClass = chipClass(count > 0);
+  return (
+    <Drawer open={open} onOpenChange={setOpen} direction="bottom">
+      <DrawerTrigger asChild>
+        <button type="button" className={triggerClass}>
+          <FilterLines size={14} className="shrink-0" />
+          Filters
+          {count > 0 && (
+            <span className="ml-0.5 flex size-4 items-center justify-center rounded-full bg-foreground text-[10px] font-semibold text-background">
+              {count}
+            </span>
+          )}
+        </button>
+      </DrawerTrigger>
+      <DrawerContent className="p-0">
+        <DrawerTitle className="px-4 pt-4 text-base font-medium text-foreground">
+          Filters
+        </DrawerTitle>
+        <div className="flex flex-col gap-2 p-4">
+          <FilterControls
+            block
+            filters={filters}
+            members={members}
+            onChange={onChange}
+          />
+        </div>
+        <DrawerFooter className="flex-row gap-2">
+          {count > 0 && (
+            <Button
+              variant="outline"
+              className="flex-1"
+              onClick={() => onChange(EMPTY_FILTERS)}
+            >
+              Clear all
+            </Button>
+          )}
+          <DrawerClose asChild>
+            <Button className="flex-1">Done</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
   );
 }

--- a/apps/mesh/src/web/layouts/task-board/task-filters.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-filters.tsx
@@ -46,7 +46,7 @@ import {
 } from "./config";
 
 /** Sentinel assignee filter matching tasks with no assignee. */
-export const UNASSIGNED_FILTER = "__unassigned__";
+const UNASSIGNED_FILTER = "__unassigned__";
 
 export type DueFilter = "overdue" | "today" | "week" | "none";
 
@@ -63,7 +63,7 @@ export const EMPTY_FILTERS: TaskFilters = {
   due: null,
 };
 
-export function hasActiveFilters(f: TaskFilters): boolean {
+function hasActiveFilters(f: TaskFilters): boolean {
   return f.assignee !== null || f.priority !== null || f.due !== null;
 }
 

--- a/apps/mesh/src/web/layouts/task-board/task-filters.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-filters.tsx
@@ -1,0 +1,360 @@
+/**
+ * Task board filters — assignee, priority and due date. Filtering is pure
+ * (`taskMatchesFilters`) so both the board and list views share it, and the
+ * bar is presentational: it owns no state beyond the open/closed popovers.
+ */
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Avatar } from "@deco/ui/components/avatar.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deco/ui/components/popover.tsx";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@deco/ui/components/command.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  Calendar,
+  ChevronDown,
+  Flag01,
+  FilterLines,
+  User01,
+} from "@untitledui/icons";
+import { SuperAgentIcon } from "@/web/components/super-agent-icon";
+import { getInitials } from "@/web/lib/get-initials";
+import {
+  PRIORITIES,
+  PRIORITY_CONFIG,
+  SUPER_AGENT_ASSIGNEE_ID,
+  type Member,
+  type TaskBoardItem,
+  type TaskBoardItemPriority,
+} from "./config";
+
+/** Sentinel assignee filter matching tasks with no assignee. */
+export const UNASSIGNED_FILTER = "__unassigned__";
+
+export type DueFilter = "overdue" | "today" | "week" | "none";
+
+export type TaskFilters = {
+  /** userId | SUPER_AGENT_ASSIGNEE_ID | UNASSIGNED_FILTER | null (anyone) */
+  assignee: string | null;
+  priority: TaskBoardItemPriority | null;
+  due: DueFilter | null;
+};
+
+export const EMPTY_FILTERS: TaskFilters = {
+  assignee: null,
+  priority: null,
+  due: null,
+};
+
+export function hasActiveFilters(f: TaskFilters): boolean {
+  return f.assignee !== null || f.priority !== null || f.due !== null;
+}
+
+const DAY_MS = 86_400_000;
+
+function isSameDay(a: number, b: number): boolean {
+  const da = new Date(a);
+  const db = new Date(b);
+  return (
+    da.getFullYear() === db.getFullYear() &&
+    da.getMonth() === db.getMonth() &&
+    da.getDate() === db.getDate()
+  );
+}
+
+export function taskMatchesFilters(
+  item: TaskBoardItem,
+  f: TaskFilters,
+): boolean {
+  if (f.assignee !== null) {
+    if (f.assignee === UNASSIGNED_FILTER) {
+      if (item.assigneeId !== null) return false;
+    } else if (item.assigneeId !== f.assignee) {
+      return false;
+    }
+  }
+  if (f.priority !== null && item.priority !== f.priority) return false;
+  if (f.due !== null) {
+    if (f.due === "none") {
+      if (item.dueDate) return false;
+    } else {
+      if (!item.dueDate) return false;
+      const t = new Date(item.dueDate).getTime();
+      const now = Date.now();
+      if (f.due === "overdue" && t >= now) return false;
+      if (f.due === "today" && !isSameDay(t, now)) return false;
+      if (f.due === "week" && t > now + 7 * DAY_MS) return false;
+    }
+  }
+  return true;
+}
+
+const DUE_OPTIONS: { value: DueFilter; label: string }[] = [
+  { value: "overdue", label: "Overdue" },
+  { value: "today", label: "Due today" },
+  { value: "week", label: "Due this week" },
+  { value: "none", label: "No due date" },
+];
+
+/** Shared trigger styling — a compact chip that fills in when a value is set. */
+function chipClass(active: boolean): string {
+  return cn(
+    "inline-flex h-8 items-center gap-1.5 rounded-lg border px-2.5 text-xs font-medium outline-none transition-colors",
+    active
+      ? "border-transparent bg-accent text-foreground"
+      : "border-border text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+  );
+}
+
+function AssigneeFilter({
+  value,
+  members,
+  onChange,
+}: {
+  value: string | null;
+  members: Member[];
+  onChange: (next: string | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  let glyph: ReactNode = <User01 size={14} className="shrink-0" />;
+  let label = "Assignee";
+  if (value === UNASSIGNED_FILTER) {
+    label = "Unassigned";
+  } else if (value === SUPER_AGENT_ASSIGNEE_ID) {
+    glyph = <SuperAgentIcon size={14} />;
+    label = "Super Agent";
+  } else if (value) {
+    const member = members.find((m) => m.userId === value);
+    glyph = (
+      <Avatar
+        url={member?.user?.image ?? undefined}
+        fallback={getInitials(member?.user?.name)}
+        shape="circle"
+        size="2xs"
+      />
+    );
+    label = member?.user?.name ?? "Member";
+  }
+
+  const select = (next: string | null) => {
+    onChange(next);
+    setOpen(false);
+  };
+
+  const triggerClass = chipClass(value !== null);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button type="button" className={triggerClass}>
+          {glyph}
+          <span className="max-w-[10rem] truncate">{label}</span>
+          <ChevronDown size={12} className="shrink-0 opacity-60" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-56 p-0">
+        <Command>
+          <CommandInput placeholder="Filter by assignee…" className="h-9" />
+          <CommandList>
+            <CommandEmpty>No members found.</CommandEmpty>
+            <CommandGroup>
+              <CommandItem value="Anyone" onSelect={() => select(null)}>
+                Anyone
+              </CommandItem>
+              <CommandItem
+                value="Unassigned"
+                onSelect={() => select(UNASSIGNED_FILTER)}
+                className="gap-2"
+              >
+                <User01 size={16} className="text-muted-foreground" />
+                Unassigned
+              </CommandItem>
+              <CommandItem
+                value="Super Agent"
+                onSelect={() => select(SUPER_AGENT_ASSIGNEE_ID)}
+                className="gap-2"
+              >
+                <SuperAgentIcon size={16} />
+                Super Agent
+              </CommandItem>
+            </CommandGroup>
+            <CommandGroup heading="Members">
+              {members.map((m) => (
+                <CommandItem
+                  key={m.userId}
+                  value={m.user?.name ?? m.userId}
+                  onSelect={() => select(m.userId)}
+                  className="gap-2"
+                >
+                  <Avatar
+                    url={m.user?.image ?? undefined}
+                    fallback={getInitials(m.user?.name)}
+                    shape="circle"
+                    size="2xs"
+                  />
+                  <span className="truncate">{m.user?.name ?? m.userId}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function PriorityFilter({
+  value,
+  onChange,
+}: {
+  value: TaskBoardItemPriority | null;
+  onChange: (next: TaskBoardItemPriority | null) => void;
+}) {
+  const triggerClass = chipClass(value !== null);
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button" className={triggerClass}>
+          {value ? (
+            <span
+              className={cn(
+                "size-2 shrink-0 rounded-full",
+                PRIORITY_CONFIG[value].dotClassName,
+              )}
+            />
+          ) : (
+            <Flag01 size={14} className="shrink-0" />
+          )}
+          {value ? PRIORITY_CONFIG[value].label : "Priority"}
+          <ChevronDown size={12} className="shrink-0 opacity-60" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-40">
+        <DropdownMenuItem onSelect={() => onChange(null)}>
+          Any priority
+        </DropdownMenuItem>
+        {PRIORITIES.map((p) => (
+          <DropdownMenuItem
+            key={p}
+            onSelect={() => onChange(p)}
+            className="gap-2"
+          >
+            <span
+              className={cn(
+                "size-2 rounded-full",
+                PRIORITY_CONFIG[p].dotClassName,
+              )}
+            />
+            {PRIORITY_CONFIG[p].label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function DueDateFilter({
+  value,
+  onChange,
+}: {
+  value: DueFilter | null;
+  onChange: (next: DueFilter | null) => void;
+}) {
+  const label = DUE_OPTIONS.find((o) => o.value === value)?.label;
+  const triggerClass = chipClass(value !== null);
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button" className={triggerClass}>
+          <Calendar size={14} className="shrink-0" />
+          {label ?? "Due date"}
+          <ChevronDown size={12} className="shrink-0 opacity-60" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-44">
+        <DropdownMenuItem onSelect={() => onChange(null)} className="gap-2">
+          <Calendar size={16} className="text-muted-foreground" />
+          Any time
+        </DropdownMenuItem>
+        {DUE_OPTIONS.map((o) => {
+          const danger = o.value === "overdue";
+          return (
+            <DropdownMenuItem
+              key={o.value}
+              onSelect={() => onChange(o.value)}
+              className={cn("gap-2", danger && "text-destructive")}
+            >
+              <Calendar
+                size={16}
+                className={cn(
+                  "shrink-0",
+                  danger ? "text-destructive" : "text-muted-foreground",
+                )}
+              />
+              {o.label}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function TaskFiltersBar({
+  filters,
+  members,
+  onChange,
+}: {
+  filters: TaskFilters;
+  members: Member[];
+  onChange: (next: TaskFilters) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <FilterLines
+        size={16}
+        className="mr-0.5 shrink-0 text-muted-foreground"
+      />
+      <AssigneeFilter
+        value={filters.assignee}
+        members={members}
+        onChange={(assignee) => onChange({ ...filters, assignee })}
+      />
+      <PriorityFilter
+        value={filters.priority}
+        onChange={(priority) => onChange({ ...filters, priority })}
+      />
+      <DueDateFilter
+        value={filters.due}
+        onChange={(due) => onChange({ ...filters, due })}
+      />
+      {hasActiveFilters(filters) && (
+        <button
+          type="button"
+          onClick={() => onChange(EMPTY_FILTERS)}
+          className="ml-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Clear
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What is this contribution about?
Reworks the task board UI end to end: cards now use the card shadow with a status icon beside a larger title and unified outlined meta chips, lanes scroll horizontally instead of squishing into a fit-width grid, the list view is centered, and both share one aligned header/toolbar. Adds an assignee / priority / due-date filter bar, a per-lane "+" that opens the create dialog pre-set to that lane's status, and a mobile-friendly task dialog (content-height sheet with wrapping property chips). Also renames the "triage" status label to "Backlog" (label only, the `triage` key is unchanged, so no data migration).

## Screenshots/Demonstration
UI-only change to `/$org/board`; see the board and the task dialog on both desktop and mobile widths.

## How to Test
1. Open the Tasks board for an org with the task board enabled.
2. Toggle List/Board, use the Assignee/Priority/Due filters, and click a lane's "+" to create a task already in that status.
3. Expected: cards/filters/header render cleanly, lanes scroll horizontally, and the task dialog is usable at mobile widths.

## Migration Notes
None. The status label change is display-only; the `triage` status key is unchanged.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Tasks board for clarity and speed: centered layout with horizontally scrollable lanes, updated cards with status icons and outlined meta chips, a shared filter bar with a mobile drawer, lane quick‑add, and a mobile‑friendly task dialog. Adds a “No priority” option and relabels “Triage” to “Backlog” in the UI only.

- **New Features**
  - Horizontal‑scroll kanban lanes with a shared header; lane “+” opens create prefilled with that status.
  - Card redesign: status icon, larger title, and outlined meta chips (hide priority when “No priority”; due date chip).
  - Filter bar for assignee (includes “Unassigned”), priority (includes “No priority”), and due date; works in board and list, with Clear and a no‑match empty state. On mobile, a single Filters button opens a drawer with an active count.
  - Mobile‑friendly task dialog with wrapping property chips, dashed “Set priority” / “Assign” when unset, and support for a defaultStatus when creating.

- **Bug Fixes**
  - Capped and centered the whole Tasks page on wide screens; lanes still scroll horizontally.
  - Made internal filter helpers module‑private to satisfy static analysis; no behavior change.
  - Aligned the delegation connector in the task dialog: drops from the assigner avatar center, adds spacing below the assigner, and extends the elbow to bridge the gap.
  - On mobile, folded Super Agent delegation into a single chip; desktop keeps the elbow tree.

<sup>Written for commit 23aef1eb324d4f7878f0221cb8cd7483aed75524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

