### PR TITLE
fix(studio-pack): wire API key manager tools

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -40,10 +40,7 @@ import {
   shouldOffload,
   type MessagesRef,
 } from "@decocms/harness/offload-messages";
-import {
-  findStudioPackAgentByMcpId,
-  resolveStudioPackRuntime,
-} from "@/tools/virtual/studio-pack";
+import { resolveEffectiveStudioPackVirtualMcp } from "@/tools/virtual/studio-pack";
 import { computeClaimHandle } from "@/sandbox/claim-handle";
 import { composeSandboxRef } from "@decocms/sandbox/provider";
 import { normalizeCoAuthorIdentity } from "@decocms/sandbox/shared";
@@ -782,28 +779,12 @@ export async function resolveEffectiveVirtualMcpForHarness({
   organizationId: string;
   ctx: StudioContext;
 }): Promise<VirtualMCPEntity> {
-  const studioPackAgent = findStudioPackAgentByMcpId(agentId);
-  if (!studioPackAgent) return virtualMcp;
-
-  const resolved = await resolveStudioPackRuntime(studioPackAgent, {
-    orgId: organizationId,
+  return resolveEffectiveStudioPackVirtualMcp({
+    virtualMcp,
+    agentId,
+    organizationId,
     ctx,
   });
-  const selectedTools = resolved.selectedTools
-    ? [...resolved.selectedTools]
-    : null;
-
-  return {
-    ...virtualMcp,
-    metadata: {
-      ...((virtualMcp.metadata as Record<string, unknown>) ?? {}),
-      instructions: resolved.instructions,
-    },
-    connections: virtualMcp.connections.map((connection) => ({
-      ...connection,
-      selected_tools: selectedTools,
-    })),
-  };
 }
 
 /**

--- a/apps/mesh/src/api/routes/decopilot/dispatch-sandbox.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-sandbox.test.ts
@@ -218,4 +218,46 @@ describe("resolveEffectiveVirtualMcpForHarness", () => {
       },
     ]);
   });
+
+  it("restores API key tools when an installed manager has stale selections", async () => {
+    const virtualMcp = {
+      id: "studio-api-key-manager_org-1",
+      title: "API Key Manager",
+      description: "Manage API keys",
+      icon: null,
+      created_at: "2026-07-17T00:00:00.000Z",
+      updated_at: "2026-07-17T00:00:00.000Z",
+      created_by: "user-1",
+      organization_id: "org-1",
+      status: "active" as const,
+      pinned: false,
+      metadata: { instructions: "persisted instructions" },
+      connections: [
+        {
+          connection_id: "org-1_self",
+          selected_tools: [],
+          selected_resources: null,
+          selected_prompts: null,
+        },
+      ],
+    };
+
+    const resolved = await resolveEffectiveVirtualMcpForHarness({
+      virtualMcp,
+      agentId: virtualMcp.id,
+      organizationId: "org-1",
+      ctx: {} as never,
+    });
+
+    expect(resolved.connections[0]?.selected_tools).toEqual([
+      "API_KEY_CREATE",
+      "API_KEY_LIST",
+      "API_KEY_UPDATE",
+      "API_KEY_DELETE",
+      "COLLECTION_VIRTUAL_MCP_LIST",
+      "COLLECTION_VIRTUAL_MCP_GET",
+      "COLLECTION_CONNECTIONS_LIST",
+      "COLLECTION_CONNECTIONS_GET",
+    ]);
+  });
 });

--- a/apps/mesh/src/auth/install-studio-pack-workflow.ts
+++ b/apps/mesh/src/auth/install-studio-pack-workflow.ts
@@ -86,8 +86,9 @@ const installStudioPackWorkflow = DBOS.registerWorkflow(
  * newly added agents in existing orgs.
  * v2: added Usage Manager.
  * v3: added API Key Manager.
+ * v4: overrides configuration for already-installed Studio Pack agents.
  */
-const INSTALL_VERSION = "v3";
+const INSTALL_VERSION = "v4";
 
 /**
  * Fire-and-forget enqueue from the Better Auth org.afterCreate callback.

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,5 +1,5 @@
 {
-  "auth/install-studio-pack-workflow.ts": "a0bc8a8c62a62c7978c11676d67397f7116b3903579091e9b85ef7ef67b04ce5",
+  "auth/install-studio-pack-workflow.ts": "1cf06645663602989054ec171a7b06fe4c16d5c40e4348bcc86c725e3769c5a0",
   "automations/dbos-workflow.ts": "18471f9fda4e16afda73f11a894f48eb8e7f2eb4539eed195c5563a63082a82c",
   "dispatch-queue/hosted-harness-workflow.ts": "1ee53df2391d0b73f10630be7f7d947db16653d5b8740b799e64a98cb2f49c86",
   "dispatch-queue/thread-gate-workflow.ts": "674cd393ad3b06806e967389dfe7e87bd0de6ba933fd54df1e5cd24a08b99e43",

--- a/apps/mesh/src/harnesses/decopilot/resolve-subagent.ts
+++ b/apps/mesh/src/harnesses/decopilot/resolve-subagent.ts
@@ -14,6 +14,7 @@ import {
   createVirtualClientFrom,
 } from "@/mcp-clients/virtual-mcp";
 import type { PassthroughClient } from "@/mcp-clients/virtual-mcp/passthrough-client";
+import { resolveEffectiveStudioPackVirtualMcp } from "@/tools/virtual/studio-pack";
 
 export interface ResolvedSubagent {
   mcpClient: PassthroughClient;
@@ -48,8 +49,13 @@ export async function resolveSubagent(
       throw new Error("Agent is not active");
     }
 
-    const mcpClient = await createVirtualClientFrom(
+    const effectiveVirtualMcp = await resolveEffectiveStudioPackVirtualMcp({
       virtualMcp,
+      organizationId,
+      ctx,
+    });
+    const mcpClient = await createVirtualClientFrom(
+      effectiveVirtualMcp,
       ctx,
       "passthrough",
       superUser,
@@ -60,9 +66,9 @@ export async function resolveSubagent(
       mcpClient,
       targetKind: "virtual-mcp",
       targetRef: {
-        id: virtualMcp.id,
+        id: effectiveVirtualMcp.id,
         instructions: mcpClient.getInstructions(),
-        repo: virtualMcp.metadata?.githubRepo ?? undefined,
+        repo: effectiveVirtualMcp.metadata?.githubRepo ?? undefined,
       },
     };
   }

--- a/apps/mesh/src/tools/virtual/studio-pack.integration.test.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack.integration.test.ts
@@ -145,4 +145,40 @@ describe("installStudioPack", () => {
       "COLLECTION_CONNECTIONS_GET",
     ]);
   });
+
+  test("overwrites stale tool selections on an existing API Key Manager", async () => {
+    await installStudioPack(orgId, userId, virtualMcpStorage);
+    const managerId = StudioPackAgentId.API_KEY_MANAGER(orgId);
+
+    await virtualMcpStorage.update(managerId, userId, {
+      metadata: {
+        instructions: "Never reproduce the key value in your response.",
+      },
+      connections: [
+        {
+          connection_id: WellKnownOrgMCPId.SELF(orgId),
+          selected_tools: ["COLLECTION_CONNECTIONS_LIST"],
+          selected_resources: null,
+          selected_prompts: null,
+        },
+      ],
+    });
+
+    await installStudioPack(orgId, userId, virtualMcpStorage);
+    const manager = await virtualMcpStorage.findById(managerId, orgId);
+
+    expect(manager?.connections[0]?.selected_tools).toEqual([
+      "API_KEY_CREATE",
+      "API_KEY_LIST",
+      "API_KEY_UPDATE",
+      "API_KEY_DELETE",
+      "COLLECTION_VIRTUAL_MCP_LIST",
+      "COLLECTION_VIRTUAL_MCP_GET",
+      "COLLECTION_CONNECTIONS_LIST",
+      "COLLECTION_CONNECTIONS_GET",
+    ]);
+    expect(manager?.metadata?.instructions).toContain(
+      "print that value exactly once in a fenced plain-text code block",
+    );
+  });
 });

--- a/apps/mesh/src/tools/virtual/studio-pack/api-key-manager.test.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/api-key-manager.test.ts
@@ -29,7 +29,10 @@ describe("apiKeyManagerAgent", () => {
       "returns the key value exactly once",
     );
     expect(apiKeyManagerAgent.instructions).toContain(
-      "Do not repeat that value",
+      "print that value exactly once in a fenced plain-text code block",
+    );
+    expect(apiKeyManagerAgent.instructions).not.toContain(
+      "Never reproduce the key value",
     );
   });
 });

--- a/apps/mesh/src/tools/virtual/studio-pack/api-key-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/api-key-manager.ts
@@ -22,7 +22,7 @@ You are the API Key Manager. You create and manage the current user's API keys f
 - Never invent resource ids or tool names. Inspect the target with COLLECTION_VIRTUAL_MCP_LIST / GET or COLLECTION_CONNECTIONS_LIST / GET first.
 - When inspecting agents or connections, use only their ids and public tool metadata for permission design. Never expose or reuse connection authentication or configuration secrets.
 - Never ask the user to paste an existing API key. Key values cannot be retrieved or changed after creation.
-- API_KEY_CREATE returns the key value exactly once. Do not repeat that value in prose, logs, tables, or later messages; tell the user to copy the tool result directly into an approved secret manager.
+- API_KEY_CREATE returns the key value exactly once. In the response immediately after creation, print that value exactly once in a fenced plain-text code block so the user can copy it. Keep the key out of all other prose, tables, and later messages, and tell the user to store it now in an approved secret manager.
 - Treat permission expansion and metadata replacement as sensitive changes. Show the complete proposed permission set and get confirmation before API_KEY_UPDATE because permissions and metadata replace their previous values.
 - Always get explicit confirmation immediately before API_KEY_DELETE. Revocation is immediate and cannot be undone.
 - Do not modify agents or connections. They are read-only context for permission design.
@@ -35,7 +35,7 @@ You are the API Key Manager. You create and manage the current user's API keys f
    c. Inspect the named agent or connection and its tools. For Studio management operations use the self resource; for an agent or connection use that exact id as the resource.
    d. Present the proposed name, expiration, purpose, and complete permission map. Call out every wildcard. Wait for explicit confirmation.
    e. Convert the confirmed lifetime to expiresIn seconds and call API_KEY_CREATE.
-   f. Tell the user the key is shown only in the tool result and must be copied now into an approved secret manager. Never reproduce the key value in your response.
+   f. Print the returned key exactly once in a fenced plain-text code block, with no other content inside the block. Tell the user to copy and store it now because it cannot be retrieved later.
 
 2. Auditing keys:
    a. Run API_KEY_LIST.

--- a/apps/mesh/src/tools/virtual/studio-pack/index.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/index.ts
@@ -1,5 +1,7 @@
 import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
 import type { VirtualMCPStorage } from "@/storage/virtual";
+import type { StudioContext } from "@/core/studio-context";
+import type { VirtualMCPEntity } from "../schema";
 import { agentManagerAgent } from "./agent-manager";
 import { apiKeyManagerAgent } from "./api-key-manager";
 import { automationManagerAgent } from "./automation-manager";
@@ -46,7 +48,7 @@ export function findStudioPackAgentByMcpId(
   );
 }
 
-export async function resolveStudioPackRuntime(
+async function resolveStudioPackRuntime(
   agent: StudioPackAgent,
   rt: RuntimeResolveContext,
 ): Promise<ResolvedRuntime> {
@@ -56,6 +58,46 @@ export async function resolveStudioPackRuntime(
   return {
     instructions: agent.instructions,
     selectedTools: agent.selectedTools,
+  };
+}
+
+/**
+ * Apply the code-owned runtime configuration for a Studio Pack agent.
+ * Persisted rows can lag behind the current definition until the startup
+ * override runs, so every execution path resolves through this helper.
+ */
+export async function resolveEffectiveStudioPackVirtualMcp({
+  virtualMcp,
+  agentId = virtualMcp.id,
+  organizationId,
+  ctx,
+}: {
+  virtualMcp: VirtualMCPEntity;
+  agentId?: string;
+  organizationId: string;
+  ctx: StudioContext;
+}): Promise<VirtualMCPEntity> {
+  const studioPackAgent = findStudioPackAgentByMcpId(agentId);
+  if (!studioPackAgent) return virtualMcp;
+
+  const resolved = await resolveStudioPackRuntime(studioPackAgent, {
+    orgId: organizationId,
+    ctx,
+  });
+  const selectedTools = resolved.selectedTools
+    ? [...resolved.selectedTools]
+    : null;
+
+  return {
+    ...virtualMcp,
+    metadata: {
+      ...((virtualMcp.metadata as Record<string, unknown>) ?? {}),
+      instructions: resolved.instructions,
+    },
+    connections: virtualMcp.connections.map((connection) => ({
+      ...connection,
+      selected_tools: selectedTools,
+    })),
   };
 }
 
@@ -90,14 +132,35 @@ export async function installStudioPack(
     STUDIO_PACK_AGENTS.map(async (agent) => {
       const agentId = agent.getId(orgId);
 
-      // Idempotent: skip if this agent already exists in the org. This also
-      // lets startup backfills install newly added managers without replacing
-      // existing ones.
+      // Startup backfills install missing managers. Existing Studio Pack
+      // agents are system-managed, so overwrite their connection and tool
+      // selections with the current code-owned definition.
       const existing = await virtualMcpStorage.findById(agentId, orgId);
-      if (existing) return;
-
       const connectionKeys = agent.selectedConnections ?? ["self"];
       const connectionIds = connectionKeys.map((k) => connectionForKey[k]);
+
+      if (existing) {
+        await virtualMcpStorage.update(agentId, createdBy, {
+          metadata: {
+            ...((existing.metadata as Record<string, unknown>) ?? {}),
+            instructions: agent.instructions,
+          },
+          connections: connectionIds.map((connection_id) => {
+            const current = existing.connections.find(
+              (connection) => connection.connection_id === connection_id,
+            );
+            return {
+              connection_id,
+              selected_tools: agent.selectedTools
+                ? [...agent.selectedTools]
+                : null,
+              selected_resources: current?.selected_resources ?? null,
+              selected_prompts: current?.selected_prompts ?? null,
+            };
+          }),
+        });
+        return;
+      }
 
       await virtualMcpStorage.create(
         orgId,


### PR DESCRIPTION
## Summary

- override persisted Studio Pack configuration during the v4 startup backfill so existing API Key Managers receive the current tools and instructions
- resolve code-owned Studio Pack runtime configuration for both direct chats and delegated subagents
- print newly created API keys exactly once in a copyable plain-text block
- add regressions for stale API Key Manager tools and instructions

## Testing

- `bun test apps/mesh/src/tools/virtual/studio-pack/api-key-manager.test.ts apps/mesh/src/api/routes/decopilot/dispatch-sandbox.test.ts`
- `bun run --cwd=apps/mesh check`
- `bun run lint` (0 errors)
- `bun run knip`
- targeted Biome formatting and `git diff --check`

Not run locally: `apps/mesh/src/tools/virtual/studio-pack.integration.test.ts` requires PostgreSQL; the regression is included for the storage-integration CI job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale Studio Pack configuration so the API Key Manager always uses the current tools and instructions, and updates key creation responses to show the key exactly once. Applies the code-owned config at runtime and during the v4 startup backfill for consistent behavior.

- **Bug Fixes**
  - Resolve Studio Pack runtime at call time using `resolveEffectiveStudioPackVirtualMcp` for direct chats and delegated subagents to avoid stale tools/instructions.
  - v4 install backfill overwrites existing Studio Pack agents’ tools, connection selections, and instructions with the code-owned set (keeps connection resources/prompts); bumps install version to `v4`.
  - API Key Manager now prints a newly created key exactly once in a fenced plain-text code block; adds tests to lock in the behavior and restore tools when persisted selections are stale.

<sup>Written for commit ac37f69cc767f2b927e84899917610e156710eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

