### PR TITLE
fix(task-board): move task to In Review when a subtask opens the PR

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -283,6 +283,9 @@ async function buildAllTools(
           // Pass the caller's own agent id so the model can clone itself by
           // omitting agent_id (heavy discovery → fresh, isolated context).
           self: { id: agentId },
+          // The current thread id (taskId) — lets a subagent-opened PR advance
+          // the linked task board card via the thread link (In Review).
+          currentThreadId: taskId,
           needsApproval:
             toolNeedsApproval(toolApprovalLevel, false, approvalOpts) !== false,
           // Roll the child run's usage into the parent's accumulator (Task 17).

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -79,6 +79,15 @@ export interface SubtaskParams {
     id: string;
   };
   /**
+   * The parent run's current thread id. Forwarded to the subagent's
+   * `runAgentLoop` so its PR-open task-board reactions (GitHub MCP tool /
+   * `gh pr create`) can resolve a linked task via the `task_board_item_threads`
+   * link when the run carries no `runMetadata.taskBoardItemId` — the case for a
+   * re-prompted or repo-backed task whose PR is opened inside a subtask. Without
+   * it the subagent's fallback path is dead and the card never reaches In Review.
+   */
+  currentThreadId?: string;
+  /**
    * Usage roll-up sink (Task 17). When present, the subtask tool calls this
    * with each completed child run's token totals so the PARENT run's usage
    * accumulator can fold them into its final `message-metadata.usage` (the
@@ -177,6 +186,7 @@ export function createSubtaskTool(
     vmTools,
     codingWorkspace,
     parentBuiltInParams,
+    currentThreadId,
   } = params;
 
   return tool({
@@ -305,6 +315,10 @@ export function createSubtaskTool(
           provider,
           models,
           messages: [{ role: "user", content: prompt }],
+          // Inherit the parent's thread id so a PR the subagent opens still
+          // moves the linked task board card to In Review via the thread link
+          // (see SubtaskParams.currentThreadId).
+          currentThreadId,
           systemAgentInstructions: targetRef.instructions,
           abortSignal: abortSignal ?? new AbortController().signal,
           stepLimit: SUBAGENT_STEP_LIMIT,


### PR DESCRIPTION
## Problem

The kanban state machine (`apps/mesh/src/tools/task-board/run-reactions.ts`) moves a task card to **In Review** when the agent opens a PR — detected two ways: a GitHub MCP `create_pull_request` tool call, or a `gh pr create` / REST-POST bash command.

`advanceTaskBoardForRun` resolves *which* card to advance in two ways:
1. `ctx.metadata.runMetadata.taskBoardItemId` (set at enqueue for a task's own dispatched run), else
2. the `task_board_item_threads` link, keyed by **thread id** — the fallback for a re-prompted or repo-backed task's PR that carries no run metadata.

The subtask tool ran the subagent via `runAgentLoop` **without passing `currentThreadId`**. Both PR-open detectors fire inside the subagent, but they call `advanceTaskBoardForRun(ctx, "in_review", undefined)` — with no thread id, the link fallback is unreachable (`linkedIds` is always `[]`). So when the agent delegates PR creation to a subtask, a link-only task never reaches In Review.

## Fix

Thread the parent run's thread id (`taskId`) through `SubtaskParams.currentThreadId` into the subagent's `runAgentLoop`, so the subagent's PR-open reactions can resolve the linked card via the thread link — matching the main run's behavior.

Two-line wiring change across two files; no behavior change for tasks that already resolve via `runMetadata`.

## Testing

- `bun run check` (apps/mesh) — passes
- `bun test` subtask + run-reactions suites — 37 pass
- `bun run fmt`

Full end-to-end verification (subtask opens a PR on a link-only task → card moves) belongs in the e2e tier (real DB + run); the pure resolution logic (`resolveAdvanceTargets`) is already unit-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure tasks move to In Review when a subtask opens a PR. We pass the parent thread id to the subagent so PR-open reactions can resolve the linked card.

- **Bug Fixes**
  - Forward `currentThreadId` through `SubtaskParams` into the subagent’s `runAgentLoop`, allowing `advanceTaskBoardForRun` to resolve the task via `task_board_item_threads` when no `runMetadata.taskBoardItemId` exists.
  - Supports both PR-open detectors (GitHub MCP `create_pull_request` and `gh pr create`/REST).

<sup>Written for commit 428c5eca7a117a3a9854bdf60e174d39bf4ae888. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

