### PR TITLE
test(task-board): lock PR-open thread-link resolution in runAgentLoop

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/run-agent-loop.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/run-agent-loop.test.ts
@@ -188,6 +188,104 @@ describe("runAgentLoop user/userContext threading", () => {
   });
 });
 
+describe("runAgentLoop PR-open → task board thread-link resolution", () => {
+  // The subtask fix threads the parent's thread id into the subagent's
+  // runAgentLoop so a PR opened INSIDE a subtask still advances the linked
+  // card. These tests lock the mechanism that fix restores: the bash PR
+  // detector resolves the linked task via `currentThreadId` when the run
+  // carries no `runMetadata.taskBoardItemId` (the link fallback). Given no
+  // thread id, the fallback is unreachable — the exact failure a subtask that
+  // omits `currentThreadId` produces.
+
+  const fakeResult = {
+    text: Promise.resolve(""),
+    finishReason: Promise.resolve("stop"),
+    usage: Promise.resolve({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+    toUIMessageStream: () => ({ async *[Symbol.asyncIterator]() {} }),
+    response: Promise.resolve({ messages: [] }),
+  } as never;
+
+  const mockMcpClient = {
+    listTools: async () => ({ tools: [] }),
+    getInstructions: () => "",
+  } as never;
+
+  // ctx whose taskBoard.linkedTaskIds records the (threadId, orgId) it's asked
+  // to resolve. No `metadata.runMetadata` → forces the thread-link path.
+  function makePrCtx(linkedCalls: Array<{ threadId: string; orgId: string }>) {
+    return {
+      organization: { id: "org_test" },
+      auth: { user: { id: "u1" } },
+      metadata: {},
+      storage: {
+        virtualMcps: { list: async () => [] },
+        taskBoard: {
+          linkedTaskIds: async (threadId: string, orgId: string) => {
+            linkedCalls.push({ threadId, orgId });
+            return [];
+          },
+          getById: async () => null,
+        },
+      },
+    } as never;
+  }
+
+  async function runWithBashStep(
+    currentThreadId: string | undefined,
+    command: string,
+    linkedCalls: Array<{ threadId: string; orgId: string }>,
+  ) {
+    let onStepFinish:
+      | ((step: { toolCalls?: unknown[] }) => unknown)
+      | undefined;
+    const fakeStreamText = (cfg: { onStepFinish?: typeof onStepFinish }) => {
+      onStepFinish = cfg.onStepFinish;
+      return fakeResult;
+    };
+
+    await runAgentLoop({
+      kind: "subagent",
+      ctx: makePrCtx(linkedCalls),
+      organization: mockOrg,
+      virtualMcp: { id: "vir_test" },
+      mcpClient: mockMcpClient,
+      provider: mockProvider,
+      models: mockModels,
+      messages: [{ role: "user", content: "open a pr" }],
+      currentThreadId,
+      abortSignal: new AbortController().signal,
+      writer: mockWriter,
+      subtaskParams: mockSubtaskParams,
+      __streamText: fakeStreamText as never,
+    } as never);
+
+    // linkedTaskIds is invoked synchronously (before the first await inside
+    // advanceTaskBoardForRun), so the record is present as soon as the step
+    // callback returns — no timer needed.
+    await onStepFinish?.({
+      toolCalls: [{ toolName: "bash", input: { command } }],
+    });
+  }
+
+  test("resolves the linked task via currentThreadId on a `gh pr create` step", async () => {
+    const linkedCalls: Array<{ threadId: string; orgId: string }> = [];
+    await runWithBashStep("thr_abc", "gh pr create --fill", linkedCalls);
+    expect(linkedCalls).toEqual([{ threadId: "thr_abc", orgId: "org_test" }]);
+  });
+
+  test("does NOT query the thread link when currentThreadId is absent (the subtask-omission failure mode)", async () => {
+    const linkedCalls: Array<{ threadId: string; orgId: string }> = [];
+    await runWithBashStep(undefined, "gh pr create --fill", linkedCalls);
+    expect(linkedCalls).toEqual([]);
+  });
+
+  test("ignores a non-PR bash command", async () => {
+    const linkedCalls: Array<{ threadId: string; orgId: string }> = [];
+    await runWithBashStep("thr_abc", "git status", linkedCalls);
+    expect(linkedCalls).toEqual([]);
+  });
+});
+
 describe("runAgentLoop assembledSystemMessages (single surviving assembler)", () => {
   test("exposes exactly buildAgentSystemPrompt's output — the prompt feeding the model is the same one the _request.systemSections debug metadata is derived from", async () => {
     const fakeResult = {


### PR DESCRIPTION
Follow-up to #4690.

## What

Adds unit coverage for the bash PR-open detector's task-board reaction in `runAgentLoop`, using the `__streamText` shim already established in this test file:

- a `gh pr create` step resolves the linked task via `currentThreadId`
- **no `currentThreadId` → the thread link is never queried** — the exact failure mode a subtask that omits `currentThreadId` produces (the bug #4690 fixes)
- a non-PR bash command is ignored

## Why this tier, and the honest limitation

The value I can lock at the unit level is the **mechanism**: the PR-open detector resolving a linked card through the `task_board_item_threads` fallback, keyed on the thread id. The inverse test reproduces the "no thread id" regression directly.

A true end-to-end test (real model emits a subtask call → subagent opens a PR → card moves to In Review) is **not achievable in the black-box e2e suite**: the task-board reactions only fire on the hosted decopilot agent loop, which calls a real LLM via `createLanguageModel`. The e2e suite has no deterministic model injection on that path — its dispatch tests all use the user-desktop relay that bypasses the agent loop entirely. Building that would require net-new app-side mock-model scaffolding, out of scope here.

The one-line subtask→`runAgentLoop` `currentThreadId` forwarding in #4690 is itself compile-time typed.

## Testing

`bun test run-agent-loop.test.ts` — 8 pass (5 existing + 3 new); `bun run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for the PR-open detector in `runAgentLoop` to lock the task-board thread-link fallback via `currentThreadId`. Verifies `gh pr create` resolves the linked task, missing `currentThreadId` skips the link query, and non-PR bash commands are ignored.

<sup>Written for commit e6be38e16aaa7e2416fc939357865218cd2602d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

