### PR TITLE
fix(task-board): exclude already-overdue tasks from the 'due this week' filter

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/task-filters.test.ts
+++ b/apps/mesh/src/web/layouts/task-board/task-filters.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { taskMatchesFilters, EMPTY_FILTERS } from "./task-filters";
+import type { TaskBoardItem } from "./config";
+
+function item(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
+  return {
+    id: "item-1",
+    organizationId: "org-1",
+    title: "Task",
+    description: null,
+    status: "todo",
+    priority: "none",
+    assigneeId: null,
+    assignedBy: null,
+    dueDate: null,
+    threads: [],
+    createdBy: "user-1",
+    createdAt: new Date().toISOString(),
+    updatedBy: "user-1",
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as TaskBoardItem;
+}
+
+describe("taskMatchesFilters — due date", () => {
+  test("'week' excludes a task that is already overdue", () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    expect(
+      taskMatchesFilters(item({ dueDate: yesterday }), {
+        ...EMPTY_FILTERS,
+        due: "week",
+      }),
+    ).toBe(false);
+  });
+
+  test("'week' includes a task due within the next 7 days", () => {
+    const in3Days = new Date(
+      Date.now() + 3 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    expect(
+      taskMatchesFilters(item({ dueDate: in3Days }), {
+        ...EMPTY_FILTERS,
+        due: "week",
+      }),
+    ).toBe(true);
+  });
+
+  test("'week' excludes a task due more than 7 days out", () => {
+    const in10Days = new Date(
+      Date.now() + 10 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    expect(
+      taskMatchesFilters(item({ dueDate: in10Days }), {
+        ...EMPTY_FILTERS,
+        due: "week",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/mesh/src/web/layouts/task-board/task-filters.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-filters.tsx
@@ -117,7 +117,7 @@ export function taskMatchesFilters(
       const now = Date.now();
       if (f.due === "overdue" && t >= now) return false;
       if (f.due === "today" && !isSameDay(t, now)) return false;
-      if (f.due === "week" && t > now + 7 * DAY_MS) return false;
+      if (f.due === "week" && (t < now || t > now + 7 * DAY_MS)) return false;
     }
   }
   return true;


### PR DESCRIPTION
## Summary

Follows #4688 (task-board kanban redesign, filters, lane quick-add), which shipped the "Due this week" filter without handling the overdue variant.

`taskMatchesFilters` in `task-filters.tsx` only checked the upper bound for the `week` due-date filter (`t > now + 7 * DAY_MS`), never the lower bound. A task already overdue (due date in the past) also satisfies that condition and incorrectly shows up when a user picks the "Due this week" filter — alongside genuinely upcoming tasks.

## Failure scenario

Task due yesterday, user opens the task board and filters by "Due this week" → the overdue task appears in the filtered list even though it isn't due *this week*, it's already late.

## Fix

`week` now also excludes dates in the past: `t < now || t > now + 7 * DAY_MS`.

## Regression test

`apps/mesh/src/web/layouts/task-board/task-filters.test.ts` — asserts an overdue task is excluded from the `week` filter, a task 3 days out is included, and a task 10 days out is excluded. Confirmed the first assertion fails against the pre-fix code and passes after the fix.

## Reviewer command

```
bun test apps/mesh/src/web/layouts/task-board/task-filters.test.ts
```

## Checks run locally

- `bun run fmt`
- `cd apps/mesh && bunx tsc --noEmit`
- `bun test apps/mesh/src/web/layouts/task-board/task-filters.test.ts`

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task-board “Due this week” filter so overdue tasks no longer appear; it now matches only due dates from now through 7 days out. Adds a unit test that verifies overdue is excluded, 3-days-out is included, and 10-days-out is excluded.

<sup>Written for commit 313c23da93af06115f4dd5f36388e441f40fec4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

