### PR TITLE
fix(task-board): scroll the board from the full panel width

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -217,12 +217,13 @@ export function TaskBoardPage() {
   }
 
   return (
-    // Cap the whole page (header + board/list) and center it so content
-    // doesn't stretch edge-to-edge on wide monitors; the panel background
-    // still spans full width. Board lanes scroll horizontally within this cap.
-    <div className="mx-auto flex min-h-0 w-full max-w-[1680px] flex-1 flex-col">
-      {/* Header — shares the board/list left edge so the two views line up. */}
-      <div className="flex flex-col gap-4 px-4 pt-6 sm:px-8 sm:pt-8">
+    // Full-width so each region's scroll container spans the whole panel — the
+    // max-width lives on the *content* inside (header + lanes), so the mouse can
+    // sit in the empty margins on wide monitors and still scroll the board.
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Header — capped + centered to the same width as the board content so
+          they line up; content-capped, not scroll-capped. */}
+      <div className="mx-auto flex w-full max-w-[1680px] flex-col gap-4 px-4 pt-6 sm:px-8 sm:pt-8">
         <h1 className="text-xl font-medium text-foreground">Tasks</h1>
 
         {/* Toolbar — filters on the left (inline bar on desktop, a single
@@ -272,13 +273,13 @@ export function TaskBoardPage() {
       </div>
 
       {items.length === 0 ? (
-        <div className="px-4 pt-6 sm:px-8">
+        <div className="mx-auto w-full max-w-[1680px] px-4 pt-6 sm:px-8">
           <div className="rounded-xl bg-card px-4 py-12 text-center text-sm text-muted-foreground card-shadow">
             No tasks yet. Start one with New task.
           </div>
         </div>
       ) : visibleItems.length === 0 ? (
-        <div className="px-4 pt-6 sm:px-8">
+        <div className="mx-auto w-full max-w-[1680px] px-4 pt-6 sm:px-8">
           <div className="flex flex-col items-center gap-3 rounded-xl bg-card px-4 py-12 text-center text-sm text-muted-foreground card-shadow">
             No tasks match these filters.
             <Button
@@ -412,82 +413,86 @@ function Lanes({
   useFlipLanes(boardRef, signature);
 
   return (
-    // A kanban isn't fit-width: lanes keep a comfortable fixed width and the
-    // board scrolls horizontally when they don't all fit (incl. mobile).
+    // Scroll container spans the full panel width so the wheel works even when
+    // the pointer is in the empty margins on wide monitors. The lane row inside
+    // is capped + centered to the same width as the header (so they align), and
+    // overflows this row to scroll when it doesn't fit.
     <div
       ref={boardRef}
-      className="flex min-h-0 flex-1 gap-3 overflow-x-auto overflow-y-auto px-4 pt-6 pb-16 sm:px-8"
+      className="min-h-0 flex-1 overflow-x-auto overflow-y-auto px-4 pt-6 pb-16 sm:px-8"
     >
-      {STATUSES.map((status) => {
-        const laneItems = items.filter((t) => t.status === status);
-        const config = STATUS_CONFIG[status];
-        const LaneIcon = config.icon;
-        return (
-          <div
-            key={status}
-            onDragOver={(e) => {
-              e.preventDefault();
-              setOverLane(status);
-            }}
-            onDragLeave={(e) => {
-              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      <div className="mx-auto flex w-full max-w-[1680px] gap-3">
+        {STATUSES.map((status) => {
+          const laneItems = items.filter((t) => t.status === status);
+          const config = STATUS_CONFIG[status];
+          const LaneIcon = config.icon;
+          return (
+            <div
+              key={status}
+              onDragOver={(e) => {
+                e.preventDefault();
+                setOverLane(status);
+              }}
+              onDragLeave={(e) => {
+                if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                  setOverLane(null);
+                }
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                const id = e.dataTransfer.getData("text/plain");
+                if (id) onMove(id, status);
                 setOverLane(null);
-              }
-            }}
-            onDrop={(e) => {
-              e.preventDefault();
-              const id = e.dataTransfer.getData("text/plain");
-              if (id) onMove(id, status);
-              setOverLane(null);
-            }}
-            className={cn(
-              "flex w-[300px] shrink-0 flex-col rounded-xl p-1 transition-colors",
-              overLane === status && "bg-muted/50",
-            )}
-          >
-            <div className="flex items-center gap-2 px-2 py-1.5">
-              <LaneIcon
-                size={15}
-                className={cn("shrink-0", config.iconClassName)}
-              />
-              <span className="text-sm font-medium text-foreground">
-                {config.label}
-              </span>
-              <span className="rounded-md bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
-                {laneItems.length}
-              </span>
-              <button
-                type="button"
-                aria-label={`New task in ${config.label}`}
-                title={`New task in ${config.label}`}
-                onClick={() => onCreate(status)}
-                className="ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                <Plus size={15} />
-              </button>
-            </div>
-            <div className="flex min-h-12 flex-col gap-2 pt-1">
-              {laneItems.map((item) => (
-                <TaskCard
-                  key={item.id}
-                  item={item}
-                  assignee={
-                    item.assigneeId
-                      ? memberByUserId.get(item.assigneeId)
-                      : undefined
-                  }
-                  assignedBy={
-                    item.assignedBy
-                      ? memberByUserId.get(item.assignedBy)
-                      : undefined
-                  }
-                  onOpen={() => onOpen(item)}
+              }}
+              className={cn(
+                "flex w-[300px] shrink-0 flex-col rounded-xl p-1 transition-colors",
+                overLane === status && "bg-muted/50",
+              )}
+            >
+              <div className="flex items-center gap-2 px-2 py-1.5">
+                <LaneIcon
+                  size={15}
+                  className={cn("shrink-0", config.iconClassName)}
                 />
-              ))}
+                <span className="text-sm font-medium text-foreground">
+                  {config.label}
+                </span>
+                <span className="rounded-md bg-muted px-1.5 text-[11px] font-medium text-muted-foreground">
+                  {laneItems.length}
+                </span>
+                <button
+                  type="button"
+                  aria-label={`New task in ${config.label}`}
+                  title={`New task in ${config.label}`}
+                  onClick={() => onCreate(status)}
+                  className="ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  <Plus size={15} />
+                </button>
+              </div>
+              <div className="flex min-h-12 flex-col gap-2 pt-1">
+                {laneItems.map((item) => (
+                  <TaskCard
+                    key={item.id}
+                    item={item}
+                    assignee={
+                      item.assigneeId
+                        ? memberByUserId.get(item.assigneeId)
+                        : undefined
+                    }
+                    assignedBy={
+                      item.assignedBy
+                        ? memberByUserId.get(item.assignedBy)
+                        : undefined
+                    }
+                    onOpen={() => onOpen(item)}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -419,9 +419,11 @@ function Lanes({
     // overflows this row to scroll when it doesn't fit.
     <div
       ref={boardRef}
-      className="min-h-0 flex-1 overflow-x-auto overflow-y-auto px-4 pt-6 pb-16 sm:px-8"
+      className="min-h-0 flex-1 overflow-x-auto overflow-y-auto"
     >
-      <div className="mx-auto flex w-full max-w-[1680px] gap-3">
+      {/* Padding lives on the capped row (not the scroll container) so its left
+          edge matches the header's max-w + px exactly. */}
+      <div className="mx-auto flex w-full max-w-[1680px] gap-3 px-4 pt-6 pb-16 sm:px-8">
         {STATUSES.map((status) => {
           const laneItems = items.filter((t) => t.status === status);
           const config = STATUS_CONFIG[status];

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -451,7 +451,9 @@ function Lanes({
                 overLane === status && "bg-muted/50",
               )}
             >
-              <div className="flex items-center gap-2 px-2 py-1.5">
+              {/* Sticky so the column header stays visible while the cards
+                  scroll vertically under it. */}
+              <div className="sticky top-0 z-10 flex items-center gap-2 bg-background px-2 py-1.5">
                 <LaneIcon
                   size={15}
                   className={cn("shrink-0", config.iconClassName)}


### PR DESCRIPTION
## What is this contribution about?
The board's 1680px max-width was applied to the whole page column, so the scroll container itself was capped — on wide monitors the empty margins outside 1680px weren't part of the scroll area, so the wheel only worked with the pointer over the (narrower) content. This moves the cap onto the *content* (the header and the lane row) while letting each region's scroll container span the full panel width, so you can scroll with the mouse anywhere, including the margins. The lanes stay capped + centered and aligned with the header, and still overflow-scroll horizontally when they don't fit.

## How to Test
1. Open the Tasks board on a wide monitor.
2. Put the pointer in the empty space to the right of the lanes and scroll — the board should scroll (vertically, and horizontally when lanes overflow).
3. Confirm the header and the first lane still line up, and content stays centered/capped.

## Migration Notes
None — CSS/layout only.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Tasks board scrollable from the full panel width by moving the 1680px max-width to the content. Column headers are now sticky, so labels, counts, and quick-add stay visible while cards scroll.

- **Bug Fixes**
  - Aligned lanes with the header by moving padding from the scroll container to the capped lane row, fixing the ~32px left offset on wide screens.

<sup>Written for commit 9e56b86bdeca0e0495cdbf124172d78890593890. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

