### PR TITLE
fix(task-board): cascade-delete task_board_item_threads links when a thread is deleted

### DIFF
--- a/apps/mesh/migrations/131-task-board-thread-link-cascade.ts
+++ b/apps/mesh/migrations/131-task-board-thread-link-cascade.ts
@@ -1,0 +1,28 @@
+import type { Kysely } from "kysely";
+
+/**
+ * `task_board_item_threads.thread_id` had no FK back to `threads` (migration
+ * 130), so deleting a thread left an orphaned link row forever — the row is
+ * filtered out by the board's inner join but never cleaned up. Add the same
+ * ON DELETE CASCADE convention used by every other threads-referencing table
+ * (021, 098, 102).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_item_threads")
+    .addForeignKeyConstraint(
+      "task_board_item_threads_thread_id_fkey",
+      ["thread_id"],
+      "threads",
+      ["id"],
+      (cb) => cb.onDelete("cascade"),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_item_threads")
+    .dropConstraint("task_board_item_threads_thread_id_fkey")
+    .execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -129,6 +129,7 @@ import * as migration127taskboardduedate from "./127-task-board-due-date.ts";
 import * as migration128reportsonly from "./128-reports-only.ts";
 import * as migration129taskboardassignedby from "./129-task-board-assigned-by.ts";
 import * as migration130taskboardthreadid from "./130-task-board-thread-id.ts";
+import * as migration131taskboardthreadlinkcascade from "./131-task-board-thread-link-cascade.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -283,6 +284,7 @@ const migrations: Record<string, Migration> = {
   "128-reports-only": migration128reportsonly,
   "129-task-board-assigned-by": migration129taskboardassignedby,
   "130-task-board-thread-id": migration130taskboardthreadid,
+  "131-task-board-thread-link-cascade": migration131taskboardthreadlinkcascade,
 };
 
 export default migrations;


### PR DESCRIPTION
## Source

Reduction/hardening: closes a lifecycle gap in the task-board/thread linking
introduced by #4680 (Super Agent delegation).

## Why

`task_board_item_threads` (migration 130) links task cards to run threads
many-to-many. The `task_board_item_id` side is cleaned up on delete
(`TaskBoardStorage.delete` runs both deletes in one transaction), but
`thread_id` has no FK at all. Every other table that references `threads.id`
(021-threads, 098-thread-message-parts, 102-observational-agent) uses
`ON DELETE CASCADE` — this table is the one exception, so deleting a thread
via `COLLECTION_THREADS_DELETE` leaves its link row behind forever. It's
invisible today (the board's query inner-joins `threads`, so orphaned rows
are silently filtered out), but it's an unbounded leak in a table that grows
with every Super-Agent-delegated task.

## Change

New migration `131` adds `ON DELETE CASCADE` on `task_board_item_threads.thread_id`
referencing `threads.id`, matching the existing convention. No application code
changes — purely closing the DB-level lifecycle gap.

## Verify

- `bun test apps/mesh/migrations/index.test.ts` — the migration-registration guardrail (added after a real incident where a migration file existed but was never wired into `index.ts`).
- `cd apps/mesh && bunx tsc --noEmit` — clean.
- Reviewer: run `bun run --cwd=apps/mesh migrate` locally and confirm the new FK exists (`\d task_board_item_threads` in psql).

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an `ON DELETE CASCADE` foreign key on `task_board_item_threads.thread_id` to `threads.id` so link rows are removed when a thread is deleted. Prevents orphaned records and unbounded growth in the task-board link table.

<sup>Written for commit 5648718f9b33fff6f2bebf419f25e40812afb23c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

