### PR TITLE
fix(mcp-utils): tolerate a failing connection during gateway aggregation

### DIFF
--- a/packages/mcp-utils/src/aggregate/gateway-client.test.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.test.ts
@@ -162,6 +162,68 @@ describe("GatewayClient", () => {
     });
   });
 
+  describe("resilience to failing connections", () => {
+    it("skips a connection whose listTools throws, keeps the rest", async () => {
+      const healthy = createMockClient([{ name: "ok_tool" }]);
+      const broken = createMockClient([{ name: "dead_tool" }]);
+      // Simulate a 401 / circuit-breaker-open upstream.
+      broken.listTools = mock(async () => {
+        throw new Error("circuit breaker is open — downstream unreachable");
+      });
+
+      const gw = new GatewayClient({
+        healthy: { client: healthy },
+        broken: { client: broken },
+      });
+      const result = await gw.listTools();
+
+      expect(result.tools.map((t) => t.name)).toEqual(["healthy_ok_tool"]);
+    });
+
+    it("skips a connection whose lazy factory throws on resolve", async () => {
+      const healthy = createMockClient([{ name: "ok_tool" }]);
+
+      const gw = new GatewayClient({
+        healthy: { client: healthy },
+        broken: {
+          client: () => {
+            throw new Error("Unauthorized: Authentication required");
+          },
+        },
+      });
+      const result = await gw.listTools();
+
+      expect(result.tools.map((t) => t.name)).toEqual(["healthy_ok_tool"]);
+    });
+
+    it("degrades resources and prompts the same way", async () => {
+      const healthy = createMockClient(
+        [],
+        [{ uri: "res://ok", name: "ok" }],
+        [{ name: "ok_prompt" }],
+      );
+      const broken = createMockClient();
+      broken.listResources = mock(async () => {
+        throw new Error("boom");
+      });
+      broken.listPrompts = mock(async () => {
+        throw new Error("boom");
+      });
+
+      const gw = new GatewayClient({
+        healthy: { client: healthy },
+        broken: { client: broken },
+      });
+
+      expect((await gw.listResources()).resources.map((r) => r.uri)).toEqual([
+        "res://ok",
+      ]);
+      expect((await gw.listPrompts()).prompts.map((p) => p.name)).toEqual([
+        "healthy_ok_prompt",
+      ]);
+    });
+  });
+
   describe("prompt namespacing", () => {
     it("prefixes prompt names with slugified client key", async () => {
       const client = createMockClient([], [], [{ name: "greet" }]);

--- a/packages/mcp-utils/src/aggregate/gateway-client.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.ts
@@ -296,6 +296,31 @@ export class GatewayClient extends Client {
   // Auto-pagination helpers
   // ---------------------------------------------------------------------------
 
+  /**
+   * Resolve one upstream client and list its items, tolerating failure. A
+   * single unreachable/unauthenticated connection (401, circuit-breaker-open,
+   * transport error) must NOT abort the whole aggregation — that would take
+   * down the entire agent run over one broken connection. Log and contribute
+   * nothing instead; the caller degrades to the connections that did resolve.
+   */
+  private async listFromClient<T>(
+    clientKey: string,
+    fetchAll: (client: IClient) => Promise<T[]>,
+    kind: string,
+  ): Promise<T[]> {
+    try {
+      const client = await this.resolveClient(clientKey);
+      return await fetchAll(client);
+    } catch (err) {
+      console.warn(
+        `GatewayClient: skipping ${kind} from client "${clientKey}" — ${
+          (err as Error)?.message ?? err
+        }`,
+      );
+      return [];
+    }
+  }
+
   private async fetchAllTools(client: IClient): Promise<Tool[]> {
     const tools: Tool[] = [];
     let cursor: string | undefined;
@@ -364,8 +389,11 @@ export class GatewayClient extends Client {
     const tools: Tool[] = [];
 
     for (const [clientKey, entry] of Object.entries(this.clients)) {
-      const client = await this.resolveClient(clientKey);
-      const clientTools = await this.fetchAllTools(client);
+      const clientTools = await this.listFromClient(
+        clientKey,
+        (c) => this.fetchAllTools(c),
+        "tools",
+      );
 
       const selected = entry.tools;
       const selectedSet = selected ? new Set(selected) : null;
@@ -403,8 +431,11 @@ export class GatewayClient extends Client {
     const routeMap = new Map<string, string>();
 
     for (const [clientKey, entry] of Object.entries(this.clients)) {
-      const client = await this.resolveClient(clientKey);
-      const clientResources = await this.fetchAllResources(client);
+      const clientResources = await this.listFromClient(
+        clientKey,
+        (c) => this.fetchAllResources(c),
+        "resources",
+      );
 
       const selected = entry.resources;
       const selectedSet = selected ? new Set(selected) : null;
@@ -455,8 +486,11 @@ export class GatewayClient extends Client {
     const resourceTemplates: ResourceTemplate[] = [];
 
     for (const [clientKey, _entry] of Object.entries(this.clients)) {
-      const client = await this.resolveClient(clientKey);
-      const clientTemplates = await this.fetchAllResourceTemplates(client);
+      const clientTemplates = await this.listFromClient(
+        clientKey,
+        (c) => this.fetchAllResourceTemplates(c),
+        "resource templates",
+      );
 
       for (const template of clientTemplates) {
         if (seen.has(template.uriTemplate)) {
@@ -494,8 +528,11 @@ export class GatewayClient extends Client {
     const prompts: Prompt[] = [];
 
     for (const [clientKey, entry] of Object.entries(this.clients)) {
-      const client = await this.resolveClient(clientKey);
-      const clientPrompts = await this.fetchAllPrompts(client);
+      const clientPrompts = await this.listFromClient(
+        clientKey,
+        (c) => this.fetchAllPrompts(c),
+        "prompts",
+      );
 
       const selected = entry.prompts;
       const selectedSet = selected ? new Set(selected) : null;


### PR DESCRIPTION
## Summary

A single unreachable/unauthenticated downstream connection made the virtual-MCP gateway abort **tool assembly for the whole run**, surfacing a raw transport error to users:

> Streamable HTTP error: Error POSTing to endpoint: `{"jsonrpc":"2.0","error":{"code":-32000,"message":"Unauthorized: Authentication required"},"id":null}`

Reported on staging (`deco-studio-stg`). One broken connection in a workspace killed the entire chat.

## Root cause

`GatewayClient.aggregateTools()` — and its `aggregateResources` / `aggregateResourceTemplates` / `aggregatePrompts` siblings — looped connections with a bare `await resolveClient()` + `await fetchAll*()` and **no per-connection guard**. When one connection 401s, trips the circuit breaker, or is otherwise unreachable, the whole aggregation throws. That propagates up through `toolsFromMCP`'s `client.listTools()` during tool assembly, aborts the agent run, and renders as the top-level "Error occurred" card with the raw string.

## Fix

Add a `listFromClient()` helper that wraps each connection's resolve+list in try/catch. On failure it `console.warn`s (which connection + why) and contributes zero items, so the run degrades to the connections that resolved instead of dying. Applied to all four aggregation methods.

`PassthroughClient` (the virtual-MCP client) inherits `GatewayClient.listTools`/`aggregateTools` unchanged, and its `listPrompts` override delegates via `super.listPrompts()`, so all live paths are covered.

## Testing

- 3 new unit tests in `gateway-client.test.ts`: listTools throws, lazy factory throws on resolve, resources + prompts degrade the same way. 41/41 pass.
- `tsc --noEmit` clean, `bun run lint` 0 errors, `bun run fmt` applied.

## Not in scope

The runtime tool-call path (a `callTool` that 401s mid-run) still shows the raw error inside its own tool card — model-visible and non-fatal. Can be prettified in a follow-up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the MCP gateway resilient to a failing downstream connection during aggregation so one 401/unreachable client no longer aborts tool/resource/prompt discovery or the chat run.

- **Bug Fixes**
  - Added a per-connection guard `listFromClient` that wraps resolve+list in try/catch, logs a warning, and returns an empty list on failure.
  - Applied across `aggregateTools`, `aggregateResources`, `aggregateResourceTemplates`, and `aggregatePrompts`; `PassthroughClient` benefits via inheritance.
  - Added unit tests for thrown listings, failing lazy factories, and degradation for resources and prompts.

<sup>Written for commit 46ab4875be02533a761023c39da27220c5cc8e03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

