### PR TITLE
fix(harness): map downstream MCP connection errors to friendly chat text

### DIFF
--- a/packages/harness/src/stream-error.test.ts
+++ b/packages/harness/src/stream-error.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   classifyStreamError,
   isCreditError,
+  mcpConnectionErrorMessage,
   sanitizeStreamError,
 } from "./stream-error";
 
@@ -37,6 +38,40 @@ describe("sanitizeStreamError", () => {
 
   it("falls back to JSON for opaque objects without a message", () => {
     expect(sanitizeStreamError({ foo: "bar" })).toContain("foo");
+  });
+});
+
+describe("mcpConnectionErrorMessage", () => {
+  const AUTH_RAW =
+    'Streamable HTTP error: Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32000,"message":"Unauthorized: Authentication required"},"id":null}';
+
+  it("maps a downstream 401 to a re-auth message", () => {
+    expect(mcpConnectionErrorMessage(AUTH_RAW)).toMatch(/re-authenticated/i);
+  });
+
+  it("maps an open circuit breaker to a temporarily-unreachable message", () => {
+    const raw =
+      "Connection conn_l6eqXMhVzGPAYKHCdLRP0 circuit breaker is open — downstream server unreachable. Retry in 7s.";
+    expect(mcpConnectionErrorMessage(raw)).toMatch(/temporarily unreachable/i);
+  });
+
+  it("maps a non-auth MCP transport failure to a generic reach message", () => {
+    const raw =
+      "Streamable HTTP error: Error POSTing to endpoint: 502 Bad Gateway";
+    expect(mcpConnectionErrorMessage(raw)).toMatch(/couldn't reach/i);
+  });
+
+  it("does NOT map a model-provider auth failure (no MCP markers)", () => {
+    expect(
+      mcpConnectionErrorMessage("Incorrect API key provided. 401 Unauthorized"),
+    ).toBeNull();
+  });
+
+  it("sanitizeStreamError returns the friendly text, never the raw -32000 blob", () => {
+    const out = sanitizeStreamError(new Error(AUTH_RAW));
+    expect(out).not.toContain("-32000");
+    expect(out).not.toContain("jsonrpc");
+    expect(out).toMatch(/re-authenticated/i);
   });
 });
 

--- a/packages/harness/src/stream-error.ts
+++ b/packages/harness/src/stream-error.ts
@@ -128,6 +128,34 @@ export function isCreditError(error: unknown): boolean {
 }
 
 /**
+ * Downstream MCP connection failures reach the chat as raw transport strings:
+ * the SDK's `"Streamable HTTP error: Error POSTing to endpoint: {...-32000...
+ * Unauthorized...}"` or our circuit-breaker's `"... circuit breaker is open —
+ * downstream server unreachable"`. Neither is meaningful to a user, and the
+ * model parrots them back verbatim. Map the known shapes to a short, actionable
+ * sentence; return null for anything else so provider/model errors (including
+ * genuine model-provider 401s) fall through unchanged.
+ */
+export function mcpConnectionErrorMessage(message: string): string | null {
+  const lower = message.toLowerCase();
+  if (lower.includes("circuit breaker is open")) {
+    return "A connected app is temporarily unreachable — it'll keep retrying. Try again in a moment.";
+  }
+  // Gate the auth/reach mapping on the MCP transport markers so a model-provider
+  // auth failure (a bad API key) is never mislabeled as a connection problem.
+  const isMcpTransport =
+    lower.includes("error posting to endpoint") ||
+    lower.includes("streamable http error");
+  if (!isMcpTransport) return null;
+  if (
+    /unauthorized|authentication required|forbidden|\b401\b|\b403\b/.test(lower)
+  ) {
+    return "A connected app needs to be re-authenticated before it can be used. Reconnect it, then try again.";
+  }
+  return "Couldn't reach a connected app. Try again in a moment.";
+}
+
+/**
  * Returns a sanitized, user-facing error message.
  * Provider-specific URLs and branding are stripped so they are never
  * surfaced to the client.
@@ -135,6 +163,8 @@ export function isCreditError(error: unknown): boolean {
 // TODO @pedrofrxncx: remove this code in favor of a better solution
 export function sanitizeStreamError(error: unknown): string {
   const { message } = extractErrorParts(error);
+  const connectionMsg = mcpConnectionErrorMessage(message);
+  if (connectionMsg) return connectionMsg;
   if (isCreditError(error)) {
     // Prefix with [CREDITS] so the frontend can detect credit errors
     // without fragile string matching on provider-specific messages.


### PR DESCRIPTION
## Summary

Follow-up to #4695. That PR stopped one broken connection from aborting the whole run during **tool assembly**. This one handles the *runtime* path: a `callTool` to a downstream connection that 401s or trips the circuit breaker mid-run.

Before, the raw transport string surfaced in the tool card's expanded detail **and** was fed back to the model verbatim:

> Streamable HTTP error: Error POSTing to endpoint: `{"jsonrpc":"2.0","error":{"code":-32000,"message":"Unauthorized: Authentication required"},"id":null}`

## Change

Add `mcpConnectionErrorMessage()` and call it first in `sanitizeStreamError()` — the single choke point feeding `errorText` for both the tool-error part and the top-level stream error (`run-stream.ts` → `toUIMessageStream({ onError })`). Known downstream shapes map to a short, actionable sentence:

- circuit-breaker-open → "A connected app is temporarily unreachable — it'll keep retrying. Try again in a moment."
- MCP transport + 401/403/unauthorized → "A connected app needs to be re-authenticated before it can be used. Reconnect it, then try again."
- other MCP transport failure → "Couldn't reach a connected app. Try again in a moment."

The auth/reach mapping is **gated on the MCP transport markers** (`error posting to endpoint` / `streamable http error`) so a genuine model-provider auth failure (a bad API key) is never mislabeled as a connection problem.

## Testing

- 5 new unit tests in `stream-error.test.ts`, including a negative case asserting a provider 401 (`"Incorrect API key provided. 401 Unauthorized"`) is **not** mapped, and that `sanitizeStreamError` never returns the raw `-32000`/`jsonrpc` blob. 15/15 pass.
- `tsc --noEmit` clean, `bun run fmt` applied.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map downstream MCP connection errors to short, user-friendly messages during runtime tool calls, so users and the model no longer see raw transport strings.

- **Bug Fixes**
  - Added `mcpConnectionErrorMessage()` and call it first in `sanitizeStreamError()` to classify MCP transport errors.
  - Return clear messages for: circuit breaker open, 401/403/unauthorized, and generic reachability. Mappings are gated on MCP transport markers to avoid mislabeling provider auth failures.
  - Added 5 unit tests to cover positive and negative cases and ensure no raw `-32000`/`jsonrpc` blobs leak to the UI.

<sup>Written for commit 43a39edfb37c399b23a1c2a693b24b406ae2129e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

