### PR TITLE
refactor(chat): use the warning design token in CollapsibleHighlight

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
@@ -81,19 +81,19 @@ const VARIANT_OVERLAY: Record<HighlightVariant, string> = {
   error:
     "isolate after:content-[''] after:absolute after:inset-0 after:rounded-xl after:bg-destructive/5 after:pointer-events-none after:-z-10",
   warning:
-    "isolate after:content-[''] after:absolute after:inset-0 after:rounded-xl after:bg-amber-500/5 after:pointer-events-none after:-z-10",
+    "isolate after:content-[''] after:absolute after:inset-0 after:rounded-xl after:bg-warning/5 after:pointer-events-none after:-z-10",
 };
 
 const VARIANT_BORDER: Record<HighlightVariant, string> = {
   default: "border-border",
   error: "border-destructive/30",
-  warning: "border-amber-500/30",
+  warning: "border-warning/30",
 };
 
 const VARIANT_ICON_COLOR: Record<HighlightVariant, string> = {
   default: "text-muted-foreground",
   error: "text-destructive",
-  warning: "text-amber-600 dark:text-amber-500",
+  warning: "text-warning",
 };
 
 export function CollapsibleHighlight({


### PR DESCRIPTION
## Summary
CREATIVE-mode design-token debt cleanup (C-DEBT). `CollapsibleHighlight`'s `warning` variant hard-coded `amber-500`/`amber-600` Tailwind classes instead of the existing `--warning` design-system token, even though its sibling `error` variant in the same file already uses the equivalent `--destructive` token for the identical purpose (overlay tint, border, icon color).

The `warning` semantic token (`text-warning` / `bg-warning` / `border-warning`) is already used the same way elsewhere in the chat UI — `context-panel.tsx`, `usage-stats.tsx`, `select-model/shared.tsx`, and the subtask/common tool-call parts — so the mapping is unambiguous, not a judgment call about shade.

## Mapping
- `after:bg-amber-500/5` → `after:bg-warning/5`
- `border-amber-500/30` → `border-warning/30`
- `text-amber-600 dark:text-amber-500` → `text-warning` (the token already resolves per-theme via the CSS variable, so the manual `dark:` override is redundant)

## Test plan
- Behavior-preserving token swap only, no logic changes — `--warning` resolves to the same amber-ish oklch value in both light and dark themes (see `packages/ui/src/styles/global.css`), so the rendered colors are unchanged.
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — clean
- Reviewer check: `rg 'variant="warning"' apps/mesh/src/web/components/chat` to see the two current callers (`desktop-offline-banner.tsx`, `highlight/index.tsx`) and confirm the warning banner still renders amber.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor the `warning` variant in `CollapsibleHighlight` to use the design-system `--warning` token for overlay, border, and icon color. Matches the `error` variant and other chat components; no visual change.

- **Refactors**
  - Replaced `amber-500/600` classes with `bg-warning/5`, `border-warning/30`, and `text-warning`.
  - Removed `dark:` override since the `--warning` token is theme-aware.

<sup>Written for commit ddd32bcee802ef0087e06e5bcf7623b1ece49bab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

