### PR TITLE
fix(task-board): prefetch chat chunk so opening task activity doesn't flash

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -40,6 +40,9 @@ import { TaskBoardItemDialog } from "./task-dialog";
 import { useFlipLanes } from "./use-flip-lanes";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 
+// Warm the chat chunk so opening a task's activity doesn't cold-load it (flash).
+void import("../agent-shell-layout/index.tsx").catch(() => {});
+
 type Layout = "board" | "list";
 
 export default function TaskBoard() {


### PR DESCRIPTION
## Summary

Opening a task's **activity** in the Task dialog and clicking a linked thread reads as a **full page refresh** ("refreshão"). It isn't a real reload — the click already navigates client-side (TanStack `navigate()`, no `<a href>`/`window.location`).

The flash is a **cold lazy-chunk load**:
- The board (`/$org/board`) is its own lazy chunk.
- The chat lives under `agentShellLayout`, a **separately-lazy** pathless layout with `pendingComponent: ShellRouteLoading`.
- The board and chat don't share a mounted layout, so the first time you cross from board → task, `agent-shell-layout` cold-loads, the whole main region unmounts to show `ShellRouteLoading`, then the chat mounts — visually indistinguishable from a reload, worst on a cold chunk fetch.

## Fix

Warm the `agent-shell-layout` chunk in the background when the board module evaluates, so the navigation finds it already resolved. Bundler dedups the dynamic import to the same chunk `lazyRouteComponent` requests, so it's fetched once.

```ts
void import("../agent-shell-layout/index.tsx").catch(() => {});
```

3-line diff, one file.

## Testing

- `tsc` passes for the changed file; the relative specifier resolves to the existing `agent-shell-layout/index.tsx`.
- Manual repro/verify not run end-to-end (needs an org with `task_board_enabled` + a task with a linked thread); the change is a low-risk background prefetch that can only make the first board→chat navigation faster.

## Known limitation / follow-up

This targets the reported board → chat path. Other first-time entries into chat (e.g. onboarding) can still cold-load the chunk. A broader fix would restructure the route tree so the board lives under `agentShellLayout` (shared mounted layout, no teardown), but that's a larger change — filing as follow-up rather than bundling here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefetch the `agent-shell-layout` chunk when the Task Board loads to remove the cold-load flash when opening a task’s activity or clicking a linked thread. This avoids showing `ShellRouteLoading` and prevents the perceived full-page refresh on the first board→chat navigation.

<sup>Written for commit b6e6564e0b25826a0a12f3e21c176815a5b4ea55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

