### PR TITLE
refactor(web): use the warning design token for the expired task status

### DIFF
--- a/apps/mesh/src/web/lib/task-status.ts
+++ b/apps/mesh/src/web/lib/task-status.ts
@@ -50,8 +50,8 @@ export const STATUS_CONFIG: Record<StatusKey, StatusConfig> = {
     label: "Timed out",
     verb: "Stopped responding",
     icon: Hourglass03,
-    iconClassName: "text-amber-500",
-    labelColor: "text-amber-600 dark:text-amber-400",
+    iconClassName: "text-warning",
+    labelColor: "text-warning",
   },
   in_progress: {
     label: "Running",


### PR DESCRIPTION
## Source

Follows #4697, which migrated `CollapsibleHighlight`'s `warning` variant from raw `amber-500`/`amber-600` classes to the semantic `warning` token.

## Why

`apps/mesh/src/web/lib/task-status.ts`'s `expired` status ("Timed out" / "Stopped responding") uses the identical `text-amber-500` / `text-amber-600 dark:text-amber-400` pair for the same cautionary-but-non-fatal intent that `CollapsibleHighlight`'s `warning` variant had — it just wasn't touched by that pass. This file is shared across the sidebar task groups, tasks panel, automation runs, and thread monitoring views, so it's a single, low-risk spot to close the gap.

## Change

`iconClassName`/`labelColor` for `expired` now use `text-warning` (matching the exact migration `#4697` did — token has its own dark-mode value already, so the `dark:` variant is dropped, same as that PR).

`--warning` resolves to `oklch(0.62 0.17 70)` (amber hue) — this aligns the shade to the design-system token, it isn't guaranteed pixel-identical to the old `amber-500`/`amber-600` values.

## Verify

- `cd apps/mesh && bun x tsc --noEmit` — clean.
- `bun run fmt` — no changes.
- Reviewer: view any "Timed out" task (sidebar task groups, tasks panel, automation runs, or thread monitoring) in both light and dark mode.

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the expired task status to the `warning` design token for consistent styling and built-in dark mode. This aligns the "Timed out" UI with the design system across all task views.

- **Refactors**
  - Replaced `text-amber-500` and `text-amber-600 dark:text-amber-400` with `text-warning` for `iconClassName` and `labelColor` (follows #4697; token handles dark mode).
  - Applies to the "Timed out" / "Stopped responding" status in sidebar task groups, tasks panel, automation runs, and thread monitoring.

<sup>Written for commit 9257cb03a2849b01179e60c1bfafbee25a1175e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

