### PR TITLE
feat(sections-editor): image/video quality + muted selector

### DIFF
--- a/apps/mesh/ct/tests/file-field.ct.tsx
+++ b/apps/mesh/ct/tests/file-field.ct.tsx
@@ -192,6 +192,22 @@ test("video: with a value a <video> element and the filename render", async ({
   await expect(component.getByText("clip.mp4", { exact: true })).toBeVisible();
 });
 
+test("video: clicking the preview opens the file picker", async ({ mount }) => {
+  const component = await mount(
+    <FieldHarness
+      schema={VIDEO_SCHEMA}
+      label="Clip"
+      path="clip"
+      initialValue="https://x.test/clip.mp4"
+    />,
+  );
+
+  await expect(component.getByTestId("file-picker-stub")).toHaveCount(0);
+  await component.getByRole("button", { name: "Replace video" }).click();
+
+  await expect(component.getByTestId("file-picker-stub")).toBeVisible();
+});
+
 test("video: quality picked via the ⋮ menu writes ?quality= to the value", async ({
   mount,
   page,

--- a/apps/mesh/ct/tests/file-field.ct.tsx
+++ b/apps/mesh/ct/tests/file-field.ct.tsx
@@ -62,7 +62,7 @@ test("file: with a value the filename and uppercase ext chip are shown", async (
   await expect(component.getByText("pdf", { exact: true })).toBeVisible();
 });
 
-test("file: with a value Replace and Remove file controls appear", async ({
+test("file: with a value the clickable row + Remove file controls appear", async ({
   mount,
 }) => {
   const component = await mount(
@@ -74,12 +74,29 @@ test("file: with a value Replace and Remove file controls appear", async ({
     />,
   );
 
+  // Replacing is done by clicking the row now — no separate Replace button.
   await expect(
-    component.getByRole("button", { name: "Replace" }),
+    component.getByRole("button", { name: "Replace file" }),
   ).toBeVisible();
   await expect(
     component.getByRole("button", { name: "Remove file" }),
   ).toBeVisible();
+});
+
+test("file: clicking the file row opens the file picker", async ({ mount }) => {
+  const component = await mount(
+    <FieldHarness
+      schema={FILE_SCHEMA}
+      label="Doc"
+      path="doc"
+      initialValue="https://x.test/report.pdf"
+    />,
+  );
+
+  await expect(component.getByTestId("file-picker-stub")).toHaveCount(0);
+  await component.getByRole("button", { name: "Replace file" }).click();
+
+  await expect(component.getByTestId("file-picker-stub")).toBeVisible();
 });
 
 test("file: clicking Remove file clears the value to an empty string", async ({
@@ -109,9 +126,9 @@ test("file: empty state has no Replace/Remove controls and shows Browse", async 
   await expect(
     component.getByRole("button", { name: "Browse", exact: true }),
   ).toBeVisible();
-  await expect(component.getByRole("button", { name: "Replace" })).toHaveCount(
-    0,
-  );
+  await expect(
+    component.getByRole("button", { name: "Replace", exact: true }),
+  ).toHaveCount(0);
   await expect(
     component.getByRole("button", { name: "Remove file" }),
   ).toHaveCount(0);
@@ -173,4 +190,65 @@ test("video: with a value a <video> element and the filename render", async ({
 
   await expect(component.locator("video")).toBeVisible();
   await expect(component.getByText("clip.mp4", { exact: true })).toBeVisible();
+});
+
+test("video: quality picked via the ⋮ menu writes ?quality= to the value", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={VIDEO_SCHEMA}
+      label="Clip"
+      path="clip"
+      initialValue="https://x.test/clip.mp4"
+    />,
+  );
+
+  await component.getByRole("button", { name: "Media options" }).click();
+  // Popover content is portaled to <body>, outside the mounted root.
+  await page.getByRole("radio", { name: "medium" }).click();
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual("https://x.test/clip.mp4?quality=medium");
+});
+
+test("video: toggling Muted off writes muted=false to the value", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={VIDEO_SCHEMA}
+      label="Clip"
+      path="clip"
+      initialValue="https://x.test/clip.mp4"
+    />,
+  );
+
+  await component.getByRole("button", { name: "Media options" }).click();
+  // Muted (the CDN default) starts on; turning it off records muted=false.
+  await page.getByRole("switch", { name: "Muted" }).click();
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual("https://x.test/clip.mp4?muted=false");
+});
+
+test("file: plain (non-video) files expose no ⋮ media-options menu", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={FILE_SCHEMA}
+      label="Doc"
+      path="doc"
+      initialValue="https://x.test/report.pdf"
+    />,
+  );
+
+  await expect(
+    component.getByRole("button", { name: "Media options" }),
+  ).toHaveCount(0);
 });

--- a/apps/mesh/ct/tests/image-field.ct.tsx
+++ b/apps/mesh/ct/tests/image-field.ct.tsx
@@ -37,9 +37,9 @@ test("empty state: drop-zone prompt, empty url input, Browse button", async ({
   await expect(
     component.getByRole("button", { name: "Browse", exact: true }),
   ).toBeVisible();
-  await expect(component.getByRole("button", { name: "Replace" })).toHaveCount(
-    0,
-  );
+  await expect(
+    component.getByRole("button", { name: "Replace image" }),
+  ).toHaveCount(0);
   await expect(
     component.getByRole("button", { name: "Remove image" }),
   ).toHaveCount(0);
@@ -249,4 +249,42 @@ test("quality: picking a level via the ⋮ menu writes ?quality= to the value", 
   await expect
     .poll(() => readFormValue(component))
     .toEqual("https://x.test/a.png?quality=high");
+});
+
+test("quality: toggling the active level off clears ?quality= from the value", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={IMAGE_SCHEMA}
+      label="Hero"
+      initialValue="https://x.test/a.png?quality=high"
+    />,
+  );
+
+  await component.getByRole("button", { name: "Media options" }).click();
+  // Radix single-select emits "" on toggle-off → the param is removed.
+  await page.getByRole("radio", { name: "high" }).click();
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual("https://x.test/a.png");
+});
+
+test("image ⋮ menu has no Muted switch (muted is video-only)", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={IMAGE_SCHEMA}
+      label="Hero"
+      initialValue="https://x.test/a.png"
+    />,
+  );
+
+  await component.getByRole("button", { name: "Media options" }).click();
+  await expect(page.getByRole("radio", { name: "high" })).toBeVisible();
+  await expect(page.getByRole("switch", { name: "Muted" })).toHaveCount(0);
 });

--- a/apps/mesh/ct/tests/image-field.ct.tsx
+++ b/apps/mesh/ct/tests/image-field.ct.tsx
@@ -78,7 +78,7 @@ test("paste URL: shows filename and extension chip", async ({ mount }) => {
   await expect(component.getByText("png", { exact: true })).toBeVisible();
 });
 
-test("paste URL: Browse becomes Replace and Remove image appears", async ({
+test("paste URL: Browse disappears; clickable preview + Remove image appear", async ({
   mount,
 }) => {
   const component = await mount(
@@ -87,8 +87,9 @@ test("paste URL: Browse becomes Replace and Remove image appears", async ({
 
   await component.getByLabel("Hero").fill("https://x.test/a.png");
 
+  // Replacing is done by clicking the preview now — no separate Replace button.
   await expect(
-    component.getByRole("button", { name: "Replace" }),
+    component.getByRole("button", { name: "Replace image" }),
   ).toBeVisible();
   await expect(
     component.getByRole("button", { name: "Browse", exact: true }),
@@ -98,7 +99,7 @@ test("paste URL: Browse becomes Replace and Remove image appears", async ({
   ).toBeVisible();
 });
 
-test("populated: renders Replace + Remove image from initialValue", async ({
+test("populated: renders clickable preview + Remove image from initialValue", async ({
   mount,
 }) => {
   const component = await mount(
@@ -113,7 +114,7 @@ test("populated: renders Replace + Remove image from initialValue", async ({
     "https://x.test/a.png",
   );
   await expect(
-    component.getByRole("button", { name: "Replace" }),
+    component.getByRole("button", { name: "Replace image" }),
   ).toBeVisible();
   await expect(
     component.getByRole("button", { name: "Remove image" }),
@@ -207,4 +208,45 @@ test("browse + pick: picker closes after selecting a file", async ({
   await component.getByTestId("file-picker-pick").click();
 
   await expect(component.getByTestId("file-picker-stub")).toHaveCount(0);
+});
+
+test("preview: clicking the image opens the picker in image mode", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={IMAGE_SCHEMA}
+      label="Hero"
+      initialValue="https://x.test/a.png"
+    />,
+  );
+
+  await expect(component.getByTestId("file-picker-stub")).toHaveCount(0);
+
+  await component.getByRole("button", { name: "Replace image" }).click();
+
+  const stub = component.getByTestId("file-picker-stub");
+  await expect(stub).toBeVisible();
+  await expect(stub).toHaveAttribute("data-mode", "image");
+});
+
+test("quality: picking a level via the ⋮ menu writes ?quality= to the value", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <FieldHarness
+      schema={IMAGE_SCHEMA}
+      label="Hero"
+      initialValue="https://x.test/a.png"
+    />,
+  );
+
+  await component.getByRole("button", { name: "Media options" }).click();
+  // The popover content is portaled to <body>, outside the mounted root.
+  await page.getByRole("radio", { name: "high" }).click();
+
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual("https://x.test/a.png?quality=high");
 });

--- a/apps/mesh/src/web/components/sections-editor/fields/click-to-replace-overlay.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/click-to-replace-overlay.tsx
@@ -1,0 +1,17 @@
+import { Upload01 } from "@untitledui/icons";
+
+/**
+ * Hover/focus hint shown over a clickable media preview to signal that clicking
+ * it replaces the file. Expects an ancestor with the `group` class (the preview
+ * wrapper); reveals on hover and on keyboard focus-within for parity.
+ */
+export function ClickToReplaceOverlay() {
+  return (
+    <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+      <span className="flex items-center gap-1.5 rounded-md bg-background px-3 py-1.5 text-xs font-medium shadow">
+        <Upload01 size={14} />
+        Click to replace
+      </span>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
@@ -12,6 +12,7 @@ import {
 import { matchSiteSlugConfig } from "@/web/components/file-picker/match-site-slug-config";
 import { useFileConfigsQuery } from "@/web/hooks/use-file-configs";
 import { useFilePickerUpload } from "@/web/hooks/use-file-picker";
+import { ClickToReplaceOverlay } from "./click-to-replace-overlay";
 import { extractUrl } from "./extract-url";
 import type { FieldProps } from "./field-props";
 import { MediaTransformControls } from "./media-transform-controls";
@@ -163,12 +164,7 @@ export function FileField({
                   preload="metadata"
                   className="h-full w-full object-contain"
                 />
-                <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
-                  <span className="flex items-center gap-1.5 rounded-md bg-background px-3 py-1.5 text-xs font-medium shadow">
-                    <Upload01 size={14} />
-                    Click to replace
-                  </span>
-                </div>
+                <ClickToReplaceOverlay />
               </button>
               <div className="flex items-center gap-2 border-t border-border/60 bg-background/50 px-3 py-2">
                 <Film01 size={14} className="shrink-0 text-muted-foreground" />
@@ -249,7 +245,6 @@ export function FileField({
           <MediaTransformControls
             value={strValue}
             onChange={onChange}
-            path={path}
             showMuted
           />
         )}

--- a/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
@@ -14,6 +14,7 @@ import { useFileConfigsQuery } from "@/web/hooks/use-file-configs";
 import { useFilePickerUpload } from "@/web/hooks/use-file-picker";
 import { extractUrl } from "./extract-url";
 import type { FieldProps } from "./field-props";
+import { MediaTransformControls } from "./media-transform-controls";
 
 function ExtBadge({ ext }: { ext: string }) {
   if (!ext) return null;
@@ -150,14 +151,25 @@ export function FileField({
         {strValue ? (
           isVideo ? (
             <>
-              <div className="relative h-40 w-full overflow-hidden bg-black">
+              <button
+                type="button"
+                onClick={() => setPickerOpen(true)}
+                aria-label="Replace video"
+                className="relative block h-40 w-full cursor-pointer overflow-hidden bg-black"
+              >
                 <video
                   key={strValue}
                   src={strValue}
                   preload="metadata"
                   className="h-full w-full object-contain"
                 />
-              </div>
+                <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+                  <span className="flex items-center gap-1.5 rounded-md bg-background px-3 py-1.5 text-xs font-medium shadow">
+                    <Upload01 size={14} />
+                    Click to replace
+                  </span>
+                </div>
+              </button>
               <div className="flex items-center gap-2 border-t border-border/60 bg-background/50 px-3 py-2">
                 <Film01 size={14} className="shrink-0 text-muted-foreground" />
                 <p className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
@@ -167,7 +179,12 @@ export function FileField({
               </div>
             </>
           ) : (
-            <div className="flex items-center gap-3 px-3 py-2.5">
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              aria-label="Replace file"
+              className="flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left hover:bg-muted/60"
+            >
               <div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-background">
                 <File02 size={18} className="text-muted-foreground" />
               </div>
@@ -178,7 +195,7 @@ export function FileField({
                 </p>
               </div>
               <ExtBadge ext={ext} />
-            </div>
+            </button>
           )
         ) : (
           <button
@@ -216,16 +233,26 @@ export function FileField({
           placeholder="https://..."
           className="h-9 min-w-0 flex-1"
         />
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => setPickerOpen(true)}
-          className="h-9 shrink-0"
-        >
-          <Upload01 size={14} />
-          {strValue ? "Replace" : "Browse"}
-        </Button>
+        {!strValue && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setPickerOpen(true)}
+            className="h-9 shrink-0"
+          >
+            <Upload01 size={14} />
+            Browse
+          </Button>
+        )}
+        {isVideo && strValue && (
+          <MediaTransformControls
+            value={strValue}
+            onChange={onChange}
+            path={path}
+            showMuted
+          />
+        )}
         {strValue && (
           <Button
             type="button"

--- a/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
@@ -12,6 +12,7 @@ import {
 import { matchSiteSlugConfig } from "@/web/components/file-picker/match-site-slug-config";
 import { useFileConfigsQuery } from "@/web/hooks/use-file-configs";
 import { useFilePickerUpload } from "@/web/hooks/use-file-picker";
+import { ClickToReplaceOverlay } from "./click-to-replace-overlay";
 import { extractUrl } from "./extract-url";
 import type { FieldProps } from "./field-props";
 import { MediaTransformControls } from "./media-transform-controls";
@@ -207,12 +208,7 @@ export function ImageField({
               {!imageLoaded && !imageErrored && (
                 <div className="absolute inset-0 animate-pulse bg-muted/60" />
               )}
-              <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
-                <span className="flex items-center gap-1.5 rounded-md bg-background px-3 py-1.5 text-xs font-medium shadow">
-                  <Upload01 size={14} />
-                  Click to replace
-                </span>
-              </div>
+              <ClickToReplaceOverlay />
             </button>
             <div className="flex items-center gap-2 border-t border-border/60 bg-background/50 px-3 py-2">
               <span className="min-w-0 flex-1 truncate text-xs font-medium">
@@ -275,11 +271,7 @@ export function ImageField({
         )}
         {strValue && (
           <>
-            <MediaTransformControls
-              value={strValue}
-              onChange={setValue}
-              path={path}
-            />
+            <MediaTransformControls value={strValue} onChange={setValue} />
             <Button
               type="button"
               variant="ghost"

--- a/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
@@ -14,6 +14,7 @@ import { useFileConfigsQuery } from "@/web/hooks/use-file-configs";
 import { useFilePickerUpload } from "@/web/hooks/use-file-picker";
 import { extractUrl } from "./extract-url";
 import type { FieldProps } from "./field-props";
+import { MediaTransformControls } from "./media-transform-controls";
 
 function basename(url: string): string {
   try {
@@ -175,7 +176,12 @@ export function ImageField({
       >
         {strValue ? (
           <>
-            <div className="relative h-40 w-full bg-[image:linear-gradient(45deg,rgba(0,0,0,0.04)_25%,transparent_25%,transparent_75%,rgba(0,0,0,0.04)_75%),linear-gradient(45deg,rgba(0,0,0,0.04)_25%,transparent_25%,transparent_75%,rgba(0,0,0,0.04)_75%)] bg-[position:0_0,8px_8px] [background-size:16px_16px]">
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              aria-label="Replace image"
+              className="relative block h-40 w-full cursor-pointer bg-[image:linear-gradient(45deg,rgba(0,0,0,0.04)_25%,transparent_25%,transparent_75%,rgba(0,0,0,0.04)_75%),linear-gradient(45deg,rgba(0,0,0,0.04)_25%,transparent_25%,transparent_75%,rgba(0,0,0,0.04)_75%)] bg-[position:0_0,8px_8px] [background-size:16px_16px]"
+            >
               {!imageErrored && (
                 <img
                   // Remount whenever the URL changes so onLoad/onError
@@ -201,7 +207,13 @@ export function ImageField({
               {!imageLoaded && !imageErrored && (
                 <div className="absolute inset-0 animate-pulse bg-muted/60" />
               )}
-            </div>
+              <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+                <span className="flex items-center gap-1.5 rounded-md bg-background px-3 py-1.5 text-xs font-medium shadow">
+                  <Upload01 size={14} />
+                  Click to replace
+                </span>
+              </div>
+            </button>
             <div className="flex items-center gap-2 border-t border-border/60 bg-background/50 px-3 py-2">
               <span className="min-w-0 flex-1 truncate text-xs font-medium">
                 {fileName}
@@ -249,27 +261,36 @@ export function ImageField({
           placeholder="https://..."
           className="h-9 min-w-0 flex-1"
         />
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => setPickerOpen(true)}
-          className="h-9 shrink-0"
-        >
-          <Upload01 size={14} />
-          {strValue ? "Replace" : "Browse"}
-        </Button>
-        {strValue && (
+        {!strValue && (
           <Button
             type="button"
-            variant="ghost"
+            variant="outline"
             size="sm"
-            onClick={() => setValue("")}
+            onClick={() => setPickerOpen(true)}
             className="h-9 shrink-0"
-            aria-label="Remove image"
           >
-            <Trash01 size={14} />
+            <Upload01 size={14} />
+            Browse
           </Button>
+        )}
+        {strValue && (
+          <>
+            <MediaTransformControls
+              value={strValue}
+              onChange={setValue}
+              path={path}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setValue("")}
+              className="h-9 shrink-0"
+              aria-label="Remove image"
+            >
+              <Trash01 size={14} />
+            </Button>
+          </>
         )}
       </div>
 

--- a/apps/mesh/src/web/components/sections-editor/fields/media-transform-controls.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/media-transform-controls.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { DotsVertical } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
@@ -29,15 +30,13 @@ import {
 export function MediaTransformControls({
   value,
   onChange,
-  path,
   showMuted = false,
 }: {
   value: string;
   onChange: (next: string) => void;
-  /** Field path — used to give the muted switch a stable, unique id. */
-  path: string;
   showMuted?: boolean;
 }) {
+  const mutedId = useId();
   const quality = getQualityFromUrl(value);
   const muted = getMutedFromUrl(value);
 
@@ -84,13 +83,13 @@ export function MediaTransformControls({
           {showMuted && (
             <div className="flex items-center justify-between gap-3">
               <Label
-                htmlFor={`${path}-muted`}
+                htmlFor={mutedId}
                 className="text-xs text-muted-foreground"
               >
                 Muted
               </Label>
               <Switch
-                id={`${path}-muted`}
+                id={mutedId}
                 checked={muted}
                 onCheckedChange={(v) => onChange(setMutedOnUrl(value, v))}
               />

--- a/apps/mesh/src/web/components/sections-editor/fields/media-transform-controls.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/media-transform-controls.tsx
@@ -1,0 +1,103 @@
+import { DotsVertical } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deco/ui/components/popover.tsx";
+import { Switch } from "@deco/ui/components/switch.tsx";
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@deco/ui/components/toggle-group.tsx";
+import {
+  getMutedFromUrl,
+  getQualityFromUrl,
+  isQuality,
+  QUALITY_OPTIONS,
+  setMutedOnUrl,
+  setQualityOnUrl,
+} from "./media-url-params";
+
+/**
+ * CDN transform controls tucked behind a "⋮" popover next to the media actions:
+ * a `quality` segmented control (images + video) and, for video, a `muted`
+ * switch. Reads/writes the params directly on the URL string via
+ * {@link media-url-params}, so the value the form persists stays a plain URL.
+ */
+export function MediaTransformControls({
+  value,
+  onChange,
+  path,
+  showMuted = false,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  /** Field path — used to give the muted switch a stable, unique id. */
+  path: string;
+  showMuted?: boolean;
+}) {
+  const quality = getQualityFromUrl(value);
+  const muted = getMutedFromUrl(value);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-9 shrink-0"
+          aria-label="Media options"
+        >
+          <DotsVertical size={14} />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-auto min-w-52 p-3">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-xs text-muted-foreground">Quality</Label>
+            <ToggleGroup
+              type="single"
+              variant="outline"
+              size="sm"
+              value={quality ?? ""}
+              // Radix single-select yields "" when the active item is toggled
+              // off — map that back to "no quality param".
+              onValueChange={(q) =>
+                onChange(setQualityOnUrl(value, isQuality(q) ? q : undefined))
+              }
+            >
+              {QUALITY_OPTIONS.map((opt) => (
+                <ToggleGroupItem
+                  key={opt}
+                  value={opt}
+                  className="h-8 px-3 text-xs capitalize"
+                >
+                  {opt}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+          </div>
+
+          {showMuted && (
+            <div className="flex items-center justify-between gap-3">
+              <Label
+                htmlFor={`${path}-muted`}
+                className="text-xs text-muted-foreground"
+              >
+                Muted
+              </Label>
+              <Switch
+                id={`${path}-muted`}
+                checked={muted}
+                onCheckedChange={(v) => onChange(setMutedOnUrl(value, v))}
+              />
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/fields/media-url-params.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/media-url-params.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getMutedFromUrl,
+  getQualityFromUrl,
+  isQuality,
+  setMutedOnUrl,
+  setQualityOnUrl,
+} from "./media-url-params";
+
+describe("quality", () => {
+  it("reads a valid quality param from an absolute URL", () => {
+    expect(getQualityFromUrl("https://cdn.deco.cx/x.png?quality=high")).toBe(
+      "high",
+    );
+  });
+
+  it("ignores an invalid quality value", () => {
+    expect(
+      getQualityFromUrl("https://cdn.deco.cx/x.png?quality=ultra"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when absent or url empty", () => {
+    expect(getQualityFromUrl("https://cdn.deco.cx/x.png")).toBeUndefined();
+    expect(getQualityFromUrl(undefined)).toBeUndefined();
+  });
+
+  it("reads from a non-URL string via the raw fallback", () => {
+    expect(getQualityFromUrl("/local/x.png?quality=low")).toBe("low");
+  });
+
+  it("does not match a quality param that only shares a prefix", () => {
+    expect(getQualityFromUrl("/x.png?quality=lowering")).toBeUndefined();
+  });
+
+  it("sets, replaces, and clears the param on an absolute URL", () => {
+    const base = "https://cdn.deco.cx/x.png";
+    const withQ = setQualityOnUrl(base, "medium");
+    expect(getQualityFromUrl(withQ)).toBe("medium");
+    expect(getQualityFromUrl(setQualityOnUrl(withQ, "original"))).toBe(
+      "original",
+    );
+    expect(setQualityOnUrl(withQ, undefined)).toBe(`${base}`);
+  });
+
+  it("sets and clears the param on a non-URL string, preserving other params", () => {
+    const set = setQualityOnUrl("/x.png?w=10", "high");
+    expect(set).toContain("w=10");
+    expect(getQualityFromUrl(set)).toBe("high");
+    expect(getQualityFromUrl(setQualityOnUrl(set, undefined))).toBeUndefined();
+  });
+
+  it("isQuality narrows all and only valid values", () => {
+    expect(isQuality("low")).toBe(true);
+    expect(isQuality("original")).toBe(true);
+    expect(isQuality("nope")).toBe(false);
+    expect(isQuality(null)).toBe(false);
+  });
+});
+
+describe("muted", () => {
+  it("defaults to muted when no param is present", () => {
+    expect(getMutedFromUrl("https://cdn.deco.cx/v.mp4")).toBe(true);
+    expect(getMutedFromUrl(undefined)).toBe(true);
+  });
+
+  it("reads muted=false as unmuted", () => {
+    expect(getMutedFromUrl("https://cdn.deco.cx/v.mp4?muted=false")).toBe(
+      false,
+    );
+    expect(getMutedFromUrl("/v.mp4?muted=false")).toBe(false);
+  });
+
+  it("writes muted=false only when unmuted and clears it when muted", () => {
+    const base = "https://cdn.deco.cx/v.mp4";
+    const unmuted = setMutedOnUrl(base, false);
+    expect(getMutedFromUrl(unmuted)).toBe(false);
+    // Muting is the default → param removed, back to the clean URL.
+    expect(setMutedOnUrl(unmuted, true)).toBe(base);
+  });
+
+  it("handles the non-URL fallback and leaves sibling params intact", () => {
+    const unmuted = setMutedOnUrl("/v.mp4?quality=high", false);
+    expect(unmuted).toContain("quality=high");
+    expect(getMutedFromUrl(unmuted)).toBe(false);
+    expect(getMutedFromUrl(setMutedOnUrl(unmuted, true))).toBe(true);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/fields/media-url-params.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/media-url-params.test.ts
@@ -55,6 +55,53 @@ describe("quality", () => {
     expect(isQuality("original")).toBe(true);
     expect(isQuality("nope")).toBe(false);
     expect(isQuality(null)).toBe(false);
+    // "" is the sentinel Radix ToggleGroup emits when the active item is
+    // toggled off — it must NOT narrow to a quality.
+    expect(isQuality("")).toBe(false);
+  });
+
+  it("reads an empty string as no quality", () => {
+    expect(getQualityFromUrl("")).toBeUndefined();
+  });
+
+  it("replaces an existing quality on a non-URL string (mid and end)", () => {
+    // The param is not last → exercises the middle-of-query path.
+    expect(setQualityOnUrl("/x.png?quality=low&w=10", "high")).toBe(
+      "/x.png?w=10&quality=high",
+    );
+    // Reading back through the raw fallback still finds it.
+    expect(getQualityFromUrl("/x.png?w=1&quality=high&h=2")).toBe("high");
+  });
+
+  it("clears a mid-string quality without leaving a dangling separator", () => {
+    expect(setQualityOnUrl("/x.png?quality=low&w=10", undefined)).toBe(
+      "/x.png?w=10",
+    );
+    expect(setQualityOnUrl("/x.png?quality=low", undefined)).toBe("/x.png");
+  });
+
+  it("preserves a #fragment when writing on a non-URL string", () => {
+    expect(setQualityOnUrl("/x.png#frag", "high")).toBe(
+      "/x.png?quality=high#frag",
+    );
+    expect(setQualityOnUrl("/x.png?quality=high#frag", undefined)).toBe(
+      "/x.png#frag",
+    );
+    expect(setQualityOnUrl("/x.png?w=1#frag", "low")).toBe(
+      "/x.png?w=1&quality=low#frag",
+    );
+  });
+
+  it("does not re-encode untouched params on an absolute URL", () => {
+    expect(
+      setQualityOnUrl("https://cdn.deco.cx/x.png?caption=a b", "high"),
+    ).toBe("https://cdn.deco.cx/x.png?caption=a b&quality=high");
+  });
+
+  it("clears every occurrence of a repeated quality param", () => {
+    expect(setQualityOnUrl("/x.png?quality=low&quality=high", undefined)).toBe(
+      "/x.png",
+    );
   });
 });
 
@@ -84,5 +131,16 @@ describe("muted", () => {
     expect(unmuted).toContain("quality=high");
     expect(getMutedFromUrl(unmuted)).toBe(false);
     expect(getMutedFromUrl(setMutedOnUrl(unmuted, true))).toBe(true);
+  });
+
+  it("clears a mid-string muted param and keeps the fragment", () => {
+    expect(setMutedOnUrl("/v.mp4?muted=false&quality=high", true)).toBe(
+      "/v.mp4?quality=high",
+    );
+    expect(setMutedOnUrl("/v.mp4?muted=false#frag", true)).toBe("/v.mp4#frag");
+  });
+
+  it("reads an empty string as muted (the default)", () => {
+    expect(getMutedFromUrl("")).toBe(true);
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/fields/media-url-params.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/media-url-params.ts
@@ -2,8 +2,12 @@
  * Helpers for reading/writing deco-CDN transform params on a media URL's query
  * string — `quality` (images + video) and `muted` (video). Kept URL-string
  * based (not object state) so the value the form persists is always the plain
- * URL other tools already understand. Every writer round-trips through URL when
- * possible and falls back to raw string editing for non-absolute values.
+ * URL other tools already understand.
+ *
+ * Writes edit the raw string rather than round-tripping through `URL`: that
+ * preserves a `#fragment`, keeps every untouched param byte-for-byte (no
+ * re-encoding of e.g. `caption=a b` or a signed-URL param), and clears *all*
+ * occurrences of a repeated param without leaving a dangling `?`/`&`.
  */
 
 export type Quality = "low" | "medium" | "high" | "original";
@@ -14,19 +18,63 @@ export function isQuality(v: string | null): v is Quality {
   return v === "low" || v === "medium" || v === "high" || v === "original";
 }
 
+/** Read the first value of `key` from a URL's query string, if present. */
+function getParam(url: string, key: string): string | null {
+  try {
+    return new URL(url).searchParams.get(key);
+  } catch {
+    // Not an absolute URL — scan the raw query string ourselves.
+    const query = rawQuery(url);
+    for (const pair of query) {
+      const eq = pair.indexOf("=");
+      const k = eq >= 0 ? pair.slice(0, eq) : pair;
+      if (k === key) return eq >= 0 ? pair.slice(eq + 1) : "";
+    }
+    return null;
+  }
+}
+
+/**
+ * Write (or clear, when `value` is undefined) `key` on a URL, editing the raw
+ * string so the fragment and every other param are preserved exactly.
+ */
+function setParam(url: string, key: string, value: string | undefined): string {
+  const hashIdx = url.indexOf("#");
+  const hash = hashIdx >= 0 ? url.slice(hashIdx) : "";
+  const base = hashIdx >= 0 ? url.slice(0, hashIdx) : url;
+  const qIdx = base.indexOf("?");
+  const path = qIdx >= 0 ? base.slice(0, qIdx) : base;
+
+  const kept = (qIdx >= 0 ? base.slice(qIdx + 1).split("&") : [])
+    .filter(Boolean)
+    .filter((pair) => {
+      const eq = pair.indexOf("=");
+      return (eq >= 0 ? pair.slice(0, eq) : pair) !== key;
+    });
+  if (value !== undefined) kept.push(`${key}=${value}`);
+
+  return `${path}${kept.length ? `?${kept.join("&")}` : ""}${hash}`;
+}
+
+/** Split the raw (non-absolute-URL) query string into `key=value` pairs. */
+function rawQuery(url: string): string[] {
+  const hashIdx = url.indexOf("#");
+  const base = hashIdx >= 0 ? url.slice(0, hashIdx) : url;
+  const qIdx = base.indexOf("?");
+  if (qIdx < 0) return [];
+  return base
+    .slice(qIdx + 1)
+    .split("&")
+    .filter(Boolean);
+}
+
 /** Read the `quality` query param off a media URL, if present and valid. */
 export function getQualityFromUrl(
   url: string | undefined,
 ): Quality | undefined {
   if (!url) return undefined;
-  try {
-    const q = new URL(url).searchParams.get("quality");
-    return isQuality(q) ? q : undefined;
-  } catch {
-    // Not an absolute URL — fall back to a raw query-string match.
-    const match = url.match(/[?&]quality=(low|medium|high|original)\b/);
-    return match && isQuality(match[1]!) ? (match[1] as Quality) : undefined;
-  }
+  const q = getParam(url, "quality");
+  return isQuality(q) ? q : undefined;
 }
 
 /** Write (or clear, when `undefined`) the `quality` query param on a URL. */
@@ -34,20 +82,7 @@ export function setQualityOnUrl(
   url: string,
   quality: Quality | undefined,
 ): string {
-  try {
-    const u = new URL(url);
-    if (quality) u.searchParams.set("quality", quality);
-    else u.searchParams.delete("quality");
-    return u.toString();
-  } catch {
-    // Non-URL string: strip any existing quality param, then re-append.
-    const cleaned = url
-      .replace(/([?&])quality=[^&]*(&|$)/, "$1")
-      .replace(/[?&]$/, "");
-    if (!quality) return cleaned;
-    const sep = cleaned.includes("?") ? "&" : "?";
-    return `${cleaned}${sep}quality=${quality}`;
-  }
+  return setParam(url, "quality", quality);
 }
 
 /**
@@ -57,26 +92,10 @@ export function setQualityOnUrl(
  */
 export function getMutedFromUrl(url: string | undefined): boolean {
   if (!url) return true;
-  try {
-    return new URL(url).searchParams.get("muted") !== "false";
-  } catch {
-    return !/[?&]muted=false\b/.test(url);
-  }
+  return getParam(url, "muted") !== "false";
 }
 
 /** Write `muted=false` when unmuted; clear the param when muted (default). */
 export function setMutedOnUrl(url: string, muted: boolean): string {
-  try {
-    const u = new URL(url);
-    if (muted) u.searchParams.delete("muted");
-    else u.searchParams.set("muted", "false");
-    return u.toString();
-  } catch {
-    const cleaned = url
-      .replace(/([?&])muted=[^&]*(&|$)/, "$1")
-      .replace(/[?&]$/, "");
-    if (muted) return cleaned;
-    const sep = cleaned.includes("?") ? "&" : "?";
-    return `${cleaned}${sep}muted=false`;
-  }
+  return setParam(url, "muted", muted ? undefined : "false");
 }

--- a/apps/mesh/src/web/components/sections-editor/fields/media-url-params.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/media-url-params.ts
@@ -1,0 +1,82 @@
+/**
+ * Helpers for reading/writing deco-CDN transform params on a media URL's query
+ * string — `quality` (images + video) and `muted` (video). Kept URL-string
+ * based (not object state) so the value the form persists is always the plain
+ * URL other tools already understand. Every writer round-trips through URL when
+ * possible and falls back to raw string editing for non-absolute values.
+ */
+
+export type Quality = "low" | "medium" | "high" | "original";
+
+export const QUALITY_OPTIONS: Quality[] = ["low", "medium", "high", "original"];
+
+export function isQuality(v: string | null): v is Quality {
+  return v === "low" || v === "medium" || v === "high" || v === "original";
+}
+
+/** Read the `quality` query param off a media URL, if present and valid. */
+export function getQualityFromUrl(
+  url: string | undefined,
+): Quality | undefined {
+  if (!url) return undefined;
+  try {
+    const q = new URL(url).searchParams.get("quality");
+    return isQuality(q) ? q : undefined;
+  } catch {
+    // Not an absolute URL — fall back to a raw query-string match.
+    const match = url.match(/[?&]quality=(low|medium|high|original)\b/);
+    return match && isQuality(match[1]!) ? (match[1] as Quality) : undefined;
+  }
+}
+
+/** Write (or clear, when `undefined`) the `quality` query param on a URL. */
+export function setQualityOnUrl(
+  url: string,
+  quality: Quality | undefined,
+): string {
+  try {
+    const u = new URL(url);
+    if (quality) u.searchParams.set("quality", quality);
+    else u.searchParams.delete("quality");
+    return u.toString();
+  } catch {
+    // Non-URL string: strip any existing quality param, then re-append.
+    const cleaned = url
+      .replace(/([?&])quality=[^&]*(&|$)/, "$1")
+      .replace(/[?&]$/, "");
+    if (!quality) return cleaned;
+    const sep = cleaned.includes("?") ? "&" : "?";
+    return `${cleaned}${sep}quality=${quality}`;
+  }
+}
+
+/**
+ * Whether the URL is muted. Muted is the CDN default, so only `muted=false`
+ * means "play with sound" — no param (or any other value) reads as muted. We
+ * therefore only ever write `muted=false` explicitly and delete otherwise.
+ */
+export function getMutedFromUrl(url: string | undefined): boolean {
+  if (!url) return true;
+  try {
+    return new URL(url).searchParams.get("muted") !== "false";
+  } catch {
+    return !/[?&]muted=false\b/.test(url);
+  }
+}
+
+/** Write `muted=false` when unmuted; clear the param when muted (default). */
+export function setMutedOnUrl(url: string, muted: boolean): string {
+  try {
+    const u = new URL(url);
+    if (muted) u.searchParams.delete("muted");
+    else u.searchParams.set("muted", "false");
+    return u.toString();
+  } catch {
+    const cleaned = url
+      .replace(/([?&])muted=[^&]*(&|$)/, "$1")
+      .replace(/[?&]$/, "");
+    if (muted) return cleaned;
+    const sep = cleaned.includes("?") ? "&" : "?";
+    return `${cleaned}${sep}muted=false`;
+  }
+}


### PR DESCRIPTION
## Summary

Ports the CDN transform controls from admin's `MediaUploadWidget` into the sections-editor media fields.

- **New `media-url-params.ts`** — pure helpers that read/write `quality` (images + video) and `muted` (video) as query params directly on the URL string, so the value the form persists stays a plain URL. Falls back to raw string editing for non-absolute URLs.
- **New `MediaTransformControls`** — tucks a `quality` segmented control (and, for video, a `muted` switch) behind a **⋮** popover in the action row.
  - `ImageField` → quality only (image-only).
  - `FileField` → quality + muted, for video only; plain files show no menu.
- **Click-to-replace** — clicking the media preview now opens the file picker (with a hover "Click to replace" overlay). The standalone **Replace** button was removed; **Browse** remains for the empty state.

## Testing

- `media-url-params.test.ts` — 12 unit tests (pure logic): non-URL fallback, set/replace/clear, prefix-mismatch guard, muted default + round-trip.
- `image-field.ct.tsx` / `file-field.ct.tsx` — component tests updated for the new flow; added coverage for click-to-replace, quality via the ⋮ menu, muted toggle, and that plain files expose no ⋮ menu. **27 passing.**
- `bun run fmt`, `bun run --cwd=apps/mesh check`, and `bun run lint` all clean.

## Notes

Quality applies to video as well as images, matching admin's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds media transform controls to the sections editor so editors can set image/video quality and toggle video mute directly on the media URL. Also switches previews to click-to-replace and removes the separate Replace button; URL param handling is hardened to avoid data loss.

- New Features
  - `media-url-params` helpers to read/write `quality` (images + video) and `muted` (video) as URL query params, with non-absolute URL fallback.
  - `MediaTransformControls` popover (⋮) in the action row: quality for images and video; muted switch for video only; non-video files show no menu.
  - Click the image/video/file row to open the picker; the preview is the Replace action, and “Browse” only shows in the empty state.

- Bug Fixes
  - Rewrote non-URL param writers to preserve `#fragment` and untouched params byte-for-byte, handle mid-query edits, and clear duplicate keys without re-encoding.
  - Extracted a shared `ClickToReplaceOverlay` with keyboard focus support; used `useId` for the muted switch.
  - Tests expanded for fragment/duplicate handling, quality toggle-off, image menu without Muted, and video click-to-replace.

<sup>Written for commit 7a57897cc32330524780d10af50e998b3f23a456. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

