### PR TITLE
fix(chat): tolerate orphaned tool output in stream reconstruction

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/use-subtask-stream.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/use-subtask-stream.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { readUIMessageStream, type UIMessage, type UIMessageChunk } from "ai";
+import { guardToolInvariant } from "../../../store/tool-invariant-guard";
 
 /** Parse an SSE byte stream into the `UIMessageChunk`s the AI SDK reader folds. */
 function sseToChunkStream(
@@ -74,8 +75,11 @@ export function useSubtaskStream(args: {
           },
         );
         if (!resp.ok || !resp.body) return;
+        // Same tool-invocation guard as the main thread reader: a reconstructed
+        // subtask stream can deliver a tool's output without its input part,
+        // which would otherwise throw and silently truncate the subtask view.
         for await (const msg of readUIMessageStream({
-          stream: sseToChunkStream(resp.body),
+          stream: guardToolInvariant(sseToChunkStream(resp.body), undefined),
         })) {
           if (abort.signal.aborted) return;
           setMessages([msg]);

--- a/apps/mesh/src/web/components/chat/store/thread-connection-replay.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection-replay.test.ts
@@ -29,6 +29,7 @@
 import { describe, expect, test } from "bun:test";
 import { readUIMessageStream } from "ai";
 import type { UIMessage, UIMessageChunk } from "ai";
+import { guardToolInvariant } from "./tool-invariant-guard";
 
 const TOOL_CALL_ID = "tc_replay_test";
 const MESSAGE_ID = "msg_replay_test";
@@ -189,6 +190,46 @@ describe("UI message stream replay (web_search)", () => {
       "No tool invocation found",
     );
     expect(String(combined?.message ?? "")).toContain(TOOL_CALL_ID);
+  });
+
+  test("guarded: orphan tool-output (no seed, no input) folds cleanly instead of throwing", async () => {
+    // Same post-purge / ghost-run shape as the test above — a
+    // tool-output-available with no preceding tool-input and no DB seed — but
+    // routed through `guardToolInvariant`, which synthesizes the missing input
+    // so the chat survives an abnormally-terminated run.
+    const postPurgeChunks: UIMessageChunk[] = [
+      {
+        type: "tool-output-available",
+        toolCallId: TOOL_CALL_ID,
+        output: { success: true, content: REPORT, query: QUERY },
+      },
+      { type: "finish-step" },
+      { type: "finish" },
+    ];
+
+    const errors: unknown[] = [];
+    const iter = readUIMessageStream({
+      stream: guardToolInvariant(streamOf(postPurgeChunks), undefined),
+      onError: (e) => errors.push(e),
+    });
+
+    const { messages, error } = await drain(iter);
+    expect(error).toBeNull();
+    expect(errors).toEqual([]);
+
+    const final = messages.at(-1);
+    expect(final).toBeDefined();
+    // A synthesized tool-unknown part carries the recovered output.
+    const toolPart = final!.parts.find(
+      (p) =>
+        typeof p === "object" &&
+        p !== null &&
+        "type" in p &&
+        (p as { type: string }).type === "tool-unknown",
+    ) as { state: string; output?: { content?: string } } | undefined;
+    expect(toolPart).toBeDefined();
+    expect(toolPart!.state).toBe("output-available");
+    expect(toolPart!.output?.content).toBe(REPORT);
   });
 
   test("reattach mid-research with stub seed: web_search completes and follow-up steps fold cleanly", async () => {

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -49,6 +49,7 @@ import type { ToolApprovalLevel } from "@/web/hooks/use-preferences";
 import type { SimpleModeTier } from "@/tools/organization/schema";
 import { Store } from "./store-primitive";
 import { extractToolErrorMessage } from "./mcp-utils";
+import { guardToolInvariant } from "./tool-invariant-guard";
 import type { ChatMode } from "../types";
 import { toast } from "sonner";
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
@@ -1102,7 +1103,11 @@ export class ThreadConnection {
     this.freshRunSubstream = false;
     const iter = readUIMessageStream({
       message: seed,
-      stream: sub,
+      // Guard the tool-invocation invariant: after abnormal termination
+      // (ghost-run force-fail, subject purge, retention gap) a tool's output
+      // can arrive without its input part, which otherwise throws
+      // "No tool invocation found for tool call ID …" and bricks the chat.
+      stream: guardToolInvariant(sub, seed),
       onError: (e) => {
         const err = e instanceof Error ? e : new Error(String(e));
         this.failTo(err);

--- a/apps/mesh/src/web/components/chat/store/tool-invariant-guard.test.ts
+++ b/apps/mesh/src/web/components/chat/store/tool-invariant-guard.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import type { UIMessage, UIMessageChunk } from "ai";
+import {
+  createToolInvariantGuard,
+  toolCallIdsInMessage,
+} from "./tool-invariant-guard";
+
+const flat = (
+  guard: (c: UIMessageChunk) => UIMessageChunk[],
+  chunks: UIMessageChunk[],
+): UIMessageChunk[] => chunks.flatMap((c) => guard(c));
+
+describe("toolCallIdsInMessage", () => {
+  it("collects toolCallIds from tool parts, ignores others", () => {
+    const msg = {
+      id: "m1",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "hi" },
+        {
+          type: "tool-web_search",
+          toolCallId: "tc_1",
+          state: "input-available",
+        },
+        { type: "tool-foo", toolCallId: "tc_2", state: "output-available" },
+      ],
+    } as unknown as UIMessage;
+    expect(toolCallIdsInMessage(msg)).toEqual(["tc_1", "tc_2"]);
+  });
+
+  it("returns [] for undefined or partless messages", () => {
+    expect(toolCallIdsInMessage(undefined)).toEqual([]);
+    expect(
+      toolCallIdsInMessage({ id: "x", role: "user" } as UIMessage),
+    ).toEqual([]);
+  });
+});
+
+describe("createToolInvariantGuard", () => {
+  it("passes an input→output pair through untouched", () => {
+    const guard = createToolInvariantGuard();
+    const out = flat(guard, [
+      {
+        type: "tool-input-available",
+        toolCallId: "tc",
+        toolName: "x",
+        input: {},
+      },
+      { type: "tool-output-available", toolCallId: "tc", output: { ok: true } },
+    ] as UIMessageChunk[]);
+    expect(out.map((c) => c.type)).toEqual([
+      "tool-input-available",
+      "tool-output-available",
+    ]);
+  });
+
+  it("synthesizes a tool-input-available before an orphan output", () => {
+    const guard = createToolInvariantGuard();
+    const out = flat(guard, [
+      { type: "tool-output-available", toolCallId: "tc", output: { ok: true } },
+    ] as UIMessageChunk[]);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({
+      type: "tool-input-available",
+      toolCallId: "tc",
+      toolName: "unknown",
+    });
+    expect(out[1]).toMatchObject({ type: "tool-output-available" });
+  });
+
+  it("does NOT synthesize when the id was seeded from the message", () => {
+    const guard = createToolInvariantGuard(["tc"]);
+    const out = flat(guard, [
+      { type: "tool-output-available", toolCallId: "tc", output: {} },
+    ] as UIMessageChunk[]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.type).toBe("tool-output-available");
+  });
+
+  it("synthesizes only once per tool call id", () => {
+    const guard = createToolInvariantGuard();
+    const out = flat(guard, [
+      { type: "tool-output-error", toolCallId: "tc", errorText: "boom" },
+      { type: "tool-output-available", toolCallId: "tc", output: {} },
+    ] as UIMessageChunk[]);
+    // One synthetic input, then both original chunks.
+    expect(out.map((c) => c.type)).toEqual([
+      "tool-input-available",
+      "tool-output-error",
+      "tool-output-available",
+    ]);
+  });
+
+  it("leaves non-tool chunks alone", () => {
+    const guard = createToolInvariantGuard();
+    const out = flat(guard, [
+      { type: "start", messageId: "m" },
+      { type: "text-delta", id: "t", delta: "hi" },
+      { type: "finish" },
+    ] as UIMessageChunk[]);
+    expect(out.map((c) => c.type)).toEqual(["start", "text-delta", "finish"]);
+  });
+});

--- a/apps/mesh/src/web/components/chat/store/tool-invariant-guard.ts
+++ b/apps/mesh/src/web/components/chat/store/tool-invariant-guard.ts
@@ -1,0 +1,104 @@
+/**
+ * Tool-invocation invariant guard.
+ *
+ * The AI SDK's `readUIMessageStream` throws
+ * `No tool invocation found for tool call ID "X"` when a `tool-output-available`
+ * / `tool-output-error` / `tool-input-delta` chunk references a tool call whose
+ * `tool-input-*` part is neither in the seed message nor earlier in the stream.
+ *
+ * That invariant breaks whenever a run is reconstructed after abnormal
+ * termination — the owning pod is SIGTERM'd mid-step (ghost run force-fail),
+ * the JetStream subject is purged mid-window, or a retention gap drops the
+ * input seq — so a tool's output survives but its input does not. The whole
+ * chat then bricks on reload.
+ *
+ * The guard sits between the chunk source and the reader: it tracks which tool
+ * call ids already have an invocation (seeded from the message's existing
+ * parts, then updated as `tool-input-*` chunks flow through) and synthesizes a
+ * minimal `tool-input-available` before any orphaned reference. The tool then
+ * renders as a completed call with an unknown name instead of aborting the run.
+ */
+
+import type { UIMessage, UIMessageChunk } from "ai";
+
+/** Chunk types that create a tool invocation the reader can look up later. */
+const CREATES_INVOCATION = new Set([
+  "tool-input-start",
+  "tool-input-available",
+]);
+
+/** Chunk types that require a pre-existing invocation and throw without one. */
+const REQUIRES_INVOCATION = new Set([
+  "tool-input-delta",
+  "tool-output-available",
+  "tool-output-error",
+]);
+
+/** Placeholder name for a tool whose input part was lost. */
+const UNKNOWN_TOOL_NAME = "unknown";
+
+/** Collect every `toolCallId` already present on a seed message's parts. */
+export function toolCallIdsInMessage(msg: UIMessage | undefined): string[] {
+  const ids: string[] = [];
+  for (const part of msg?.parts ?? []) {
+    const id = (part as { toolCallId?: unknown }).toolCallId;
+    if (typeof id === "string") ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * Build a stateful guard. Call it once per chunk in stream order; it returns
+ * the chunk(s) to forward — either the input unchanged, or a synthetic
+ * `tool-input-available` followed by the orphaned chunk.
+ */
+export function createToolInvariantGuard(
+  seedToolCallIds: Iterable<string> = [],
+): (chunk: UIMessageChunk) => UIMessageChunk[] {
+  const known = new Set(seedToolCallIds);
+
+  return (chunk) => {
+    const { type } = chunk;
+    const toolCallId = (chunk as { toolCallId?: unknown }).toolCallId;
+
+    if (typeof toolCallId !== "string") return [chunk];
+
+    if (CREATES_INVOCATION.has(type)) {
+      known.add(toolCallId);
+      return [chunk];
+    }
+
+    if (REQUIRES_INVOCATION.has(type) && !known.has(toolCallId)) {
+      known.add(toolCallId);
+      const synthetic = {
+        type: "tool-input-available",
+        toolCallId,
+        toolName:
+          (chunk as { toolName?: unknown }).toolName ?? UNKNOWN_TOOL_NAME,
+        input: {},
+      } as UIMessageChunk;
+      return [synthetic, chunk];
+    }
+
+    return [chunk];
+  };
+}
+
+/**
+ * Wrap a chunk stream so the tool-invocation invariant always holds before the
+ * chunks reach `readUIMessageStream`. `seed` is the message the reader folds
+ * into (its existing tool parts count as already-known invocations).
+ */
+export function guardToolInvariant(
+  stream: ReadableStream<UIMessageChunk>,
+  seed: UIMessage | undefined,
+): ReadableStream<UIMessageChunk> {
+  const guard = createToolInvariantGuard(toolCallIdsInMessage(seed));
+  return stream.pipeThrough(
+    new TransformStream<UIMessageChunk, UIMessageChunk>({
+      transform(chunk, controller) {
+        for (const out of guard(chunk)) controller.enqueue(out);
+      },
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

Reported on staging: a chat bricks with `No tool invocation found for tool call ID "toolu_…"`. The error is thrown in the browser by the AI SDK's `readUIMessageStream` when a `tool-output-available` / `tool-output-error` / `tool-input-delta` chunk references a tool call whose `tool-input-*` part is neither in the seed message nor earlier in the stream.

That invariant breaks whenever a run is **reconstructed after abnormal termination** — the tool's output survives but its input does not:

- a **user-desktop (link) run** whose desktop/dev-server drops mid-tool-call (the reported case: `LINK_CURRENT_GET`, `503 Dev server not running`, `502 "Is the computer able to access the url?"`, then a `Ghost run detected, force-failing`),
- a cluster-hosted **ghost-run force-fail** (pod terminated mid-step),
- a JetStream **subject purge** in the reconnect window, or a **retention gap**.

The existing repro (`thread-connection-replay.test.ts` → *"refresh AT completion … throws"*) documents this exact failure.

## Fix

Add `tool-invariant-guard.ts`: a small, transport-agnostic guard placed between the chunk stream and `readUIMessageStream` in `foldSubStream`. It tracks which tool call ids already have an invocation (seeded from the folded message's existing tool parts, then updated as `tool-input-*` chunks pass through) and, before any orphaned output/delta, injects a synthetic `tool-input-available` (placeholder name `unknown`, empty input). The tool then renders as a completed call with an unknown name instead of aborting the whole run.

It's a pass-through for healthy streams (an id seen via a real `tool-input-*` or present in the seed is never synthesized), so it only changes behavior on the degraded path.

Because the throw is in the browser and both cluster-hosted and desktop-link runs fold through the same client reader, this one guard covers every trigger.

## Testing

- Inverted the documented failure: the same orphan post-purge chunks that `readUIMessageStream` rejects now fold cleanly through the guard (tool part present, `output-available`, output preserved).
- 6 pure-unit tests for the guard (pass-through pair, synthesize-before-orphan, no-synthesize-when-seeded, synthesize-once-per-id, non-tool chunks untouched, `toolCallIdsInMessage`).
- 13/13 pass; `tsc --noEmit` clean; lint 0 errors; `bun run fmt` applied.

## Out of scope

The underlying triggers (staging pods cycling on a 115s drain-timeout force-exit; desktop links dropping) are separate infra issues. This PR makes the chat *survive* them rather than fixing why runs get orphaned.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent chat and the subtask panel from crashing or truncating when reconstructing runs that lost tool-input chunks. We synthesize a minimal tool-input before orphaned tool output so the UI keeps working instead of throwing “No tool invocation found for tool call ID …”.

- **Bug Fixes**
  - Added a transport-agnostic guard (`tool-invariant-guard.ts`) that tracks seen tool call IDs and injects a synthetic `tool-input-available` before any orphaned `tool-output-*` or `tool-input-delta`.
  - Wrapped the main thread reader (`ThreadConnection`) and the subtask live tail (`use-subtask-stream`) in `guardToolInvariant` so both the chat and subtasks are protected.
  - Pass-through for healthy streams; only activates on reconstructed/abnormally terminated runs (ghost-run force-fail, desktop link drop, JetStream purge, retention gap).
  - Added focused unit tests and a replay test confirming the guard preserves tool output and avoids reader exceptions.

<sup>Written for commit bdcbfc94058414b69b03d4771b919a2abc2503c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

