### PR TITLE
feat(content): add Redirects collection to the Content tab

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   Code01,
   Copy01,
+  CornerUpRight,
   Database01,
   DotsHorizontal,
   Edit01,
@@ -119,6 +120,14 @@ import {
 import { PageFormDialog, type PageFormMode } from "./page-form-dialog";
 import { SectionRenameDialog } from "./section-rename-dialog";
 import {
+  buildRedirectBlock,
+  extractRedirects,
+  generateRedirectBlockKey,
+  REDIRECT_STATUS,
+  type RedirectEntry,
+  type RedirectType,
+} from "./redirect-data";
+import {
   type BlogEntry,
   type BlogKind,
   type CategoryRef,
@@ -187,6 +196,10 @@ const VariantCalendar = lazy(() =>
   })),
 );
 
+const RedirectEditor = lazy(() =>
+  import("./redirect-editor").then((m) => ({ default: m.RedirectEditor })),
+);
+
 const VARIANT_GREEN = "oklch(0.65 0.15 160)";
 
 type CollectionId =
@@ -198,6 +211,7 @@ type CollectionId =
   | "calendar"
   | "loaders"
   | "actions"
+  | "redirects"
   | BlogKind;
 
 type CollectionCounts = Record<
@@ -206,6 +220,7 @@ type CollectionCounts = Record<
   | "apps"
   | "loaders"
   | "actions"
+  | "redirects"
   | "posts"
   | "authors"
   | "categories",
@@ -221,6 +236,7 @@ type Selection =
       title: string;
     }
   | { collection: "apps"; key: string }
+  | { collection: "redirects"; key: string }
   | { collection: BlogKind; key: string }
   | null;
 
@@ -288,6 +304,7 @@ type PageDialogState = {
 type DeleteTarget =
   | { kind: "page"; key: string; label: string }
   | { kind: "section"; key: string; label: string }
+  | { kind: "redirect"; key: string; label: string }
   | { kind: "blog"; blogKind: BlogKind; key: string; label: string }
   | { kind: "blog-bulk"; keys: string[]; count: number }
   | null;
@@ -587,6 +604,9 @@ function ContentBrowserReady({
   const pages = extractPages(decofile).sort((a, b) =>
     a.name.localeCompare(b.name),
   );
+  const redirects = extractRedirects(decofile).sort((a, b) =>
+    a.from.localeCompare(b.from),
+  );
   const globalSections = extractGlobalSections(decofile, meta);
   // Only the Sections tab needs the raw catalog. Use the cheap lister (labels
   // only, no per-section schema resolution) — resolving every section's schema
@@ -632,7 +652,8 @@ function ContentBrowserReady({
     !hasEditableDecoContent(decofile, meta) &&
     !showBlog &&
     loadersCount === 0 &&
-    actionsCount === 0
+    actionsCount === 0 &&
+    redirects.length === 0
   ) {
     return (
       <EmptyMessage
@@ -649,6 +670,7 @@ function ContentBrowserReady({
     apps: appCatalog.length,
     loaders: loadersCount,
     actions: actionsCount,
+    redirects: redirects.length,
     posts: allBlogEntries.posts.length,
     authors: allBlogEntries.authors.length,
     categories: allBlogEntries.categories.length,
@@ -855,6 +877,28 @@ function ContentBrowserReady({
       setRenameSectionKey(null);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Rename failed");
+    }
+  };
+
+  // ------------------ Redirect CRUD ------------------
+  // Redirects are standalone `website/loaders/redirect.ts` blocks; the site's
+  // routes auto-discover them, so create/delete is a plain block write.
+  const handleCreateRedirect = async () => {
+    const key = generateRedirectBlockKey(decofile, "");
+    const data = buildRedirectBlock({
+      from: "",
+      to: "",
+      type: "temporary",
+      discardQueryParameters: false,
+    });
+    try {
+      await saveBlock.mutateAsync({ blockKey: key, data });
+      toast.success("Created redirect");
+      setSelection({ collection: "redirects", key });
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Could not create redirect",
+      );
     }
   };
 
@@ -1081,6 +1125,7 @@ function ContentBrowserReady({
             blocksMode={mode === "blocks"}
             activeCollection={activeCollection}
             pages={pages}
+            redirects={redirects}
             sections={globalSections}
             availableSections={availableSections}
             appCatalog={appCatalog}
@@ -1124,6 +1169,8 @@ function ContentBrowserReady({
             onCreate={() => {
               if (activeCollection === "pages") {
                 openCreatePage();
+              } else if (activeCollection === "redirects") {
+                void handleCreateRedirect();
               } else if (isBlogKind(activeCollection)) {
                 void handleCreateBlog(activeCollection);
               }
@@ -1155,6 +1202,13 @@ function ContentBrowserReady({
             onRenameSection={(s) => setRenameSectionKey(s.key)}
             onDeleteSection={(s) =>
               setDeleteTarget({ kind: "section", key: s.key, label: s.name })
+            }
+            onDeleteRedirect={(entry) =>
+              setDeleteTarget({
+                kind: "redirect",
+                key: entry.key,
+                label: entry.from || entry.key,
+              })
             }
             onDuplicateBlog={handleDuplicateBlog}
             onDeleteBlog={(e) =>
@@ -1322,6 +1376,15 @@ function ContentBrowserReady({
                   blockKey={selection.key}
                   block={decofile[selection.key] as Record<string, unknown>}
                 />
+              ) : selection.collection === "redirects" ? (
+                <RedirectEditor
+                  key={`redirect:${selection.key}`}
+                  orgSlug={orgSlug}
+                  virtualMcpId={virtualMcpId}
+                  branch={branch}
+                  blockKey={selection.key}
+                  block={decofile[selection.key] as Record<string, unknown>}
+                />
               ) : (
                 <SectionsEditor
                   key={
@@ -1365,7 +1428,9 @@ function ContentBrowserReady({
                       ? "a page"
                       : activeCollection === "apps"
                         ? "an app"
-                        : "a section"
+                        : activeCollection === "redirects"
+                          ? "a redirect"
+                          : "a section"
                 } to edit`}
                 description={
                   activeCollection === "apps"
@@ -1631,6 +1696,14 @@ function CollectionsSidebar({
           onSelect={onSelect}
         />
         <CollectionRow
+          id="redirects"
+          icon={CornerUpRight}
+          label="Redirects"
+          count={counts.redirects}
+          active={active === "redirects"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
           id="loaders"
           icon={Database01}
           label="Loaders"
@@ -1750,6 +1823,7 @@ function ItemList({
   blocksMode,
   activeCollection,
   pages,
+  redirects,
   sections,
   availableSections,
   appCatalog,
@@ -1784,12 +1858,14 @@ function ItemList({
   onDuplicateSection,
   onRenameSection,
   onDeleteSection,
+  onDeleteRedirect,
   onDuplicateBlog,
   onDeleteBlog,
 }: {
   blocksMode: boolean;
   activeCollection: CollectionId;
   pages: PageEntry[];
+  redirects: RedirectEntry[];
   sections: GlobalSectionEntry[];
   availableSections: AvailableSectionEntry[];
   appCatalog: AppCatalogEntry[];
@@ -1827,6 +1903,7 @@ function ItemList({
   onDuplicateSection: (section: GlobalSectionEntry) => void;
   onRenameSection: (section: GlobalSectionEntry) => void;
   onDeleteSection: (section: GlobalSectionEntry) => void;
+  onDeleteRedirect: (entry: RedirectEntry) => void;
   onDuplicateBlog: (entry: BlogEntry) => void;
   onDeleteBlog: (entry: BlogEntry) => void;
 }) {
@@ -1836,6 +1913,10 @@ function ItemList({
       !q ||
       p.name.toLowerCase().includes(q) ||
       p.path.toLowerCase().includes(q),
+  );
+  const filteredRedirects = redirects.filter(
+    (r) =>
+      !q || r.from.toLowerCase().includes(q) || r.to.toLowerCase().includes(q),
   );
   const filteredSections = sections.filter(
     (s) =>
@@ -1952,7 +2033,9 @@ function ItemList({
   const placeholder = `Search ${activeCollection}…`;
   const createTooltip = isBlogKind(activeCollection)
     ? `Create new ${BLOG_SINGULAR[activeCollection]}`
-    : "Create new page";
+    : activeCollection === "redirects"
+      ? "Create new redirect"
+      : "Create new page";
   // Sections are created by saving an available section, not via the "+".
   const showCreateButton =
     activeCollection !== "apps" && activeCollection !== "sections";
@@ -2220,6 +2303,34 @@ function ItemList({
                   />
                 );
               })
+            )
+          ) : activeCollection === "redirects" ? (
+            filteredRedirects.length === 0 ? (
+              <ListEmpty
+                hasItems={redirects.length > 0}
+                emptyLabel="No redirects yet."
+                emptyHint='Click "+" to create your first redirect.'
+              />
+            ) : (
+              filteredRedirects.map((entry) => (
+                <ItemRow
+                  key={entry.key}
+                  icon={CornerUpRight}
+                  title={entry.from || "(no source)"}
+                  subtitle={`→ ${entry.to || "(no target)"}`}
+                  active={
+                    selection?.collection === "redirects" &&
+                    selection.key === entry.key
+                  }
+                  trailing={<RedirectTypeBadge type={entry.type} />}
+                  onClick={() =>
+                    onSelect({ collection: "redirects", key: entry.key })
+                  }
+                  menu={
+                    <ItemActions onDelete={() => onDeleteRedirect(entry)} />
+                  }
+                />
+              ))
             )
           ) : isPostsCollection ? (
             sortedPosts.length === 0 ? (
@@ -2761,7 +2872,7 @@ function ItemActions({
   onViewJson,
   onDelete,
 }: {
-  onDuplicate: () => void;
+  onDuplicate?: () => void;
   onRename?: () => void;
   onAddVariant?: () => void;
   onEditSeo?: () => void;
@@ -2787,10 +2898,12 @@ function ItemActions({
             Rename
           </DropdownMenuItem>
         )}
-        <DropdownMenuItem onClick={onDuplicate}>
-          <Copy01 size={14} />
-          Duplicate
-        </DropdownMenuItem>
+        {onDuplicate && (
+          <DropdownMenuItem onClick={onDuplicate}>
+            <Copy01 size={14} />
+            Duplicate
+          </DropdownMenuItem>
+        )}
         {onAddVariant && (
           <>
             <DropdownMenuSeparator />
@@ -2831,6 +2944,22 @@ function ItemActions({
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+/** Compact status-code badge for a redirect row (301 permanent / 307 temporary). */
+function RedirectTypeBadge({ type }: { type: RedirectType }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-muted-foreground">
+          {REDIRECT_STATUS[type]}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="left">
+        {type === "permanent" ? "Permanent" : "Temporary"}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -883,10 +883,13 @@ function ContentBrowserReady({
   // Redirects are standalone `website/loaders/redirect.ts` blocks; the site's
   // routes auto-discover them, so create/delete is a plain block write.
   const handleCreateRedirect = async () => {
-    const key = generateRedirectBlockKey(decofile, "");
+    // Seed non-empty placeholder paths so the new block is a valid redirect
+    // (never an empty from/to that would emit a broken route once published).
+    const from = "/redirect-from";
+    const key = generateRedirectBlockKey(decofile, from);
     const data = buildRedirectBlock({
-      from: "",
-      to: "",
+      from,
+      to: "/redirect-to",
       type: "temporary",
       discardQueryParameters: false,
     });

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -652,8 +652,7 @@ function ContentBrowserReady({
     !hasEditableDecoContent(decofile, meta) &&
     !showBlog &&
     loadersCount === 0 &&
-    actionsCount === 0 &&
-    redirects.length === 0
+    actionsCount === 0
   ) {
     return (
       <EmptyMessage

--- a/apps/mesh/src/web/components/sandbox/content/redirect-data.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/redirect-data.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import {
+  REDIRECT_RESOLVE_TYPE,
+  buildRedirectBlock,
+  extractRedirects,
+  generateRedirectBlockKey,
+  getRedirectPayload,
+} from "./redirect-data";
+
+const redirectBlock = (
+  redirect: Record<string, unknown>,
+): Record<string, unknown> => ({
+  redirect,
+  __resolveType: REDIRECT_RESOLVE_TYPE,
+});
+
+describe("extractRedirects", () => {
+  test("picks only redirect blocks and narrows fields", () => {
+    const decofile = {
+      "redirects-a-1": redirectBlock({
+        from: "/old",
+        to: "/new",
+        type: "permanent",
+        discardQueryParameters: true,
+      }),
+      "redirects-b-2": redirectBlock({ from: "/tmp", to: "/dest" }),
+      "pages-home-x": { path: "/", __resolveType: "website/pages/Page.tsx" },
+      site: { __resolveType: "site/apps/site.ts" },
+    };
+    const redirects = extractRedirects(decofile).sort((a, b) =>
+      a.key.localeCompare(b.key),
+    );
+    expect(redirects).toEqual([
+      {
+        key: "redirects-a-1",
+        from: "/old",
+        to: "/new",
+        type: "permanent",
+        discardQueryParameters: true,
+      },
+      {
+        key: "redirects-b-2",
+        from: "/tmp",
+        to: "/dest",
+        type: "temporary",
+        discardQueryParameters: false,
+      },
+    ]);
+  });
+
+  test("defaults an unknown type to temporary and tolerates a malformed redirect", () => {
+    const decofile = {
+      "redirects-weird": redirectBlock({ from: "/x", to: "/y", type: "301" }),
+      "redirects-broken": {
+        redirect: "nope",
+        __resolveType: REDIRECT_RESOLVE_TYPE,
+      },
+    };
+    const byKey = Object.fromEntries(
+      extractRedirects(decofile).map((r) => [r.key, r]),
+    );
+    expect(byKey["redirects-weird"]?.type).toBe("temporary");
+    expect(byKey["redirects-broken"]).toEqual({
+      key: "redirects-broken",
+      from: "",
+      to: "",
+      type: "temporary",
+      discardQueryParameters: false,
+    });
+  });
+
+  test("ignores arrays and null values without throwing", () => {
+    const decofile = {
+      arr: [1, 2, 3],
+      nope: null,
+      "redirects-ok": redirectBlock({ from: "/a", to: "/b" }),
+    } as unknown as Record<string, unknown>;
+    expect(extractRedirects(decofile).map((r) => r.key)).toEqual([
+      "redirects-ok",
+    ]);
+  });
+});
+
+describe("buildRedirectBlock / getRedirectPayload round-trip", () => {
+  test("omits discardQueryParameters when false", () => {
+    const block = buildRedirectBlock({
+      from: "/a",
+      to: "/b",
+      type: "temporary",
+      discardQueryParameters: false,
+    });
+    expect(block).toEqual({
+      redirect: { from: "/a", to: "/b", type: "temporary" },
+      __resolveType: REDIRECT_RESOLVE_TYPE,
+    });
+    expect(getRedirectPayload(block)).toEqual({
+      from: "/a",
+      to: "/b",
+      type: "temporary",
+      discardQueryParameters: false,
+    });
+  });
+
+  test("keeps discardQueryParameters when true", () => {
+    const block = buildRedirectBlock({
+      from: "/a",
+      to: "/b",
+      type: "permanent",
+      discardQueryParameters: true,
+    });
+    expect(
+      (block.redirect as Record<string, unknown>).discardQueryParameters,
+    ).toBe(true);
+    expect(getRedirectPayload(block).discardQueryParameters).toBe(true);
+  });
+});
+
+describe("generateRedirectBlockKey", () => {
+  test("derives a slug from the `from` path and never collides", () => {
+    const key = generateRedirectBlockKey({}, "/Bazar-Farm/Short?map=c");
+    expect(key.startsWith("redirects-Bazar-Farm-Short-")).toBe(true);
+  });
+
+  test("falls back to a stable slug for a rootish path", () => {
+    expect(
+      generateRedirectBlockKey({}, "/").startsWith("redirects-redirect-"),
+    ).toBe(true);
+    expect(
+      generateRedirectBlockKey({}, "").startsWith("redirects-redirect-"),
+    ).toBe(true);
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/content/redirect-data.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/redirect-data.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import {
   REDIRECT_RESOLVE_TYPE,
+  REDIRECT_STATUS,
   buildRedirectBlock,
   extractRedirects,
   generateRedirectBlockKey,
   getRedirectPayload,
 } from "./redirect-data";
+
+test("REDIRECT_STATUS locks the HTTP status contract", () => {
+  expect(REDIRECT_STATUS).toEqual({ temporary: 307, permanent: 301 });
+});
 
 const redirectBlock = (
   redirect: Record<string, unknown>,
@@ -116,17 +121,38 @@ describe("buildRedirectBlock / getRedirectPayload round-trip", () => {
 });
 
 describe("generateRedirectBlockKey", () => {
-  test("derives a slug from the `from` path and never collides", () => {
+  test("derives a slug from the `from` path, stripping the query string", () => {
     const key = generateRedirectBlockKey({}, "/Bazar-Farm/Short?map=c");
     expect(key.startsWith("redirects-Bazar-Farm-Short-")).toBe(true);
   });
 
-  test("falls back to a stable slug for a rootish path", () => {
-    expect(
-      generateRedirectBlockKey({}, "/").startsWith("redirects-redirect-"),
-    ).toBe(true);
-    expect(
-      generateRedirectBlockKey({}, "").startsWith("redirects-redirect-"),
-    ).toBe(true);
+  test("caps the slug at 32 chars for a long `from`", () => {
+    const long = `/${"a".repeat(100)}`;
+    const key = generateRedirectBlockKey({}, long);
+    // key = `redirects-<slug>-<uuid>`; the slug segment is capped at 32.
+    const slug = key.slice(
+      "redirects-".length,
+      -"-00000000-0000-0000-0000-000000000000".length,
+    );
+    expect(slug).toBe("a".repeat(32));
+  });
+
+  test("falls back to a stable slug for empty / rootish / all-special `from`", () => {
+    for (const from of ["/", "", "   ", "/@#$%"]) {
+      expect(
+        generateRedirectBlockKey({}, from).startsWith("redirects-redirect-"),
+      ).toBe(true);
+    }
+  });
+
+  test("returns a distinct key for the same `from` (uniqueness guard)", () => {
+    // Exercises the collision-retry loop: seed the decofile with a key, then
+    // confirm two fresh generations for the same `from` never collide.
+    const decofile: Record<string, unknown> = {};
+    const first = generateRedirectBlockKey(decofile, "/x");
+    decofile[first] = { __resolveType: REDIRECT_RESOLVE_TYPE };
+    const second = generateRedirectBlockKey(decofile, "/x");
+    expect(second).not.toBe(first);
+    expect(Object.hasOwn(decofile, second)).toBe(false);
   });
 });

--- a/apps/mesh/src/web/components/sandbox/content/redirect-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/redirect-data.ts
@@ -13,6 +13,16 @@
 
 export const REDIRECT_RESOLVE_TYPE = "website/loaders/redirect.ts";
 
+/**
+ * Both redirect loader resolveTypes (the per-redirect block and the plural
+ * aggregator). Redirects have a dedicated collection, so these are excluded
+ * from the generic Loaders catalog to avoid double-listing the same blocks.
+ */
+export const REDIRECT_LOADER_RESOLVE_TYPES: ReadonlySet<string> = new Set([
+  REDIRECT_RESOLVE_TYPE,
+  "website/loaders/redirects.ts",
+]);
+
 export type RedirectType = "temporary" | "permanent";
 
 /** HTTP status the deco redirect handler emits for each type. */

--- a/apps/mesh/src/web/components/sandbox/content/redirect-data.ts
+++ b/apps/mesh/src/web/components/sandbox/content/redirect-data.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure helpers for the Content tab "Redirects" collection.
+ *
+ * A deco site stores each URL redirect as a standalone top-level decofile
+ * block of `__resolveType` `website/loaders/redirect.ts`, shaped as:
+ *
+ *   { "redirect": { from, to, type, discardQueryParameters }, "__resolveType": "…redirect.ts" }
+ *
+ * The site's routes include an inline `website/loaders/redirects.ts` (plural)
+ * that auto-discovers ALL such blocks via `resolveTypeSelector`, so CRUD here
+ * is just create/update/delete of these blocks — no routes/site wiring needed.
+ */
+
+export const REDIRECT_RESOLVE_TYPE = "website/loaders/redirect.ts";
+
+export type RedirectType = "temporary" | "permanent";
+
+/** HTTP status the deco redirect handler emits for each type. */
+export const REDIRECT_STATUS: Record<RedirectType, number> = {
+  temporary: 307,
+  permanent: 301,
+};
+
+export interface RedirectEntry {
+  key: string;
+  from: string;
+  to: string;
+  type: RedirectType;
+  discardQueryParameters: boolean;
+}
+
+export interface RedirectPayload {
+  from: string;
+  to: string;
+  type: RedirectType;
+  discardQueryParameters: boolean;
+}
+
+const asStr = (v: unknown): string => (typeof v === "string" ? v : "");
+const asType = (v: unknown): RedirectType =>
+  v === "permanent" ? "permanent" : "temporary";
+
+/** The `redirect` sub-object of a redirect block, defensively narrowed. */
+function readRedirect(
+  block: Record<string, unknown> | undefined,
+): RedirectPayload {
+  const raw =
+    block &&
+    typeof block.redirect === "object" &&
+    block.redirect !== null &&
+    !Array.isArray(block.redirect)
+      ? (block.redirect as Record<string, unknown>)
+      : {};
+  return {
+    from: asStr(raw.from),
+    to: asStr(raw.to),
+    type: asType(raw.type),
+    discardQueryParameters: raw.discardQueryParameters === true,
+  };
+}
+
+/** Every redirect block in the decofile, most-specific fields narrowed. */
+export function extractRedirects(
+  decofile: Record<string, unknown>,
+): RedirectEntry[] {
+  const out: RedirectEntry[] = [];
+  for (const [key, val] of Object.entries(decofile)) {
+    if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+    const obj = val as Record<string, unknown>;
+    if (obj.__resolveType !== REDIRECT_RESOLVE_TYPE) continue;
+    const { from, to, type, discardQueryParameters } = readRedirect(obj);
+    out.push({ key, from, to, type, discardQueryParameters });
+  }
+  return out;
+}
+
+/** Editable payload for a single redirect block (empty defaults when missing). */
+export function getRedirectPayload(
+  block: Record<string, unknown> | undefined,
+): RedirectPayload {
+  return readRedirect(block);
+}
+
+/** Build the decofile block for a redirect. Omits falsy optional fields. */
+export function buildRedirectBlock(
+  payload: RedirectPayload,
+): Record<string, unknown> {
+  const redirect: Record<string, unknown> = {
+    from: payload.from,
+    to: payload.to,
+    type: payload.type,
+  };
+  if (payload.discardQueryParameters) redirect.discardQueryParameters = true;
+  return { redirect, __resolveType: REDIRECT_RESOLVE_TYPE };
+}
+
+/** A URL-safe slug derived from the redirect's `from` path (for the block key). */
+function slugifyFrom(from: string): string {
+  const path = (from.split(/[?#]/)[0] ?? "").replace(/^\/+/, "");
+  const slug = path
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+  return slug || "redirect";
+}
+
+const MAX_UNIQUE_KEY_ATTEMPTS = 1000;
+
+/** Fresh `redirects-<slug>-<uuid>` key not colliding with an existing block. */
+export function generateRedirectBlockKey(
+  decofile: Record<string, unknown>,
+  from: string,
+): string {
+  const slug = slugifyFrom(from);
+  for (let i = 0; i < MAX_UNIQUE_KEY_ATTEMPTS; i++) {
+    const key = `redirects-${slug}-${crypto.randomUUID()}`;
+    if (!Object.hasOwn(decofile, key)) return key;
+  }
+  throw new Error("Could not generate a unique redirect block key");
+}

--- a/apps/mesh/src/web/components/sandbox/content/redirect-editor.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/redirect-editor.tsx
@@ -1,0 +1,128 @@
+import { Checkbox } from "@deco/ui/components/checkbox.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { useSaveBlock } from "@/web/components/sections-editor/use-save-block";
+import { useAutosave } from "./blog/use-autosave";
+import { SaveStatus } from "./blog/save-status";
+import {
+  buildRedirectBlock,
+  getRedirectPayload,
+  REDIRECT_STATUS,
+  type RedirectPayload,
+  type RedirectType,
+} from "./redirect-data";
+
+const TYPE_OPTIONS: Array<{ value: RedirectType; label: string }> = [
+  { value: "temporary", label: `Temporary (${REDIRECT_STATUS.temporary})` },
+  { value: "permanent", label: `Permanent (${REDIRECT_STATUS.permanent})` },
+];
+
+/**
+ * Right-pane editor for a single redirect block. Autosaves each field change
+ * (write-through the shared decofile cache via `useSaveBlock`), mirroring the
+ * blog record editor. Create/delete happen upstream in the Content browser.
+ */
+export function RedirectEditor({
+  orgSlug,
+  virtualMcpId,
+  branch,
+  blockKey,
+  block,
+}: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  blockKey: string;
+  block: Record<string, unknown> | undefined;
+}) {
+  const save = useSaveBlock({ orgSlug, virtualMcpId, branch });
+  const initial = getRedirectPayload(block);
+
+  const [payload, setPayload] = useAutosave(initial, (next) => {
+    save.mutate({ blockKey, data: buildRedirectBlock(next) });
+  });
+
+  const setField = (patch: Partial<RedirectPayload>) =>
+    setPayload({ ...payload, ...patch });
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-12 shrink-0 items-center justify-between border-b px-6">
+        <span className="text-sm font-medium">Redirect</span>
+        <SaveStatus isPending={save.isPending} isError={save.isError} />
+      </div>
+      <div className="min-w-0 flex-1 overflow-y-auto px-6 py-6">
+        <div className="mx-auto max-w-xl space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="redirect-from">From</Label>
+            <Input
+              id="redirect-from"
+              value={payload.from}
+              placeholder="/old-path"
+              onChange={(e) => setField({ from: e.target.value })}
+              className="h-10"
+            />
+            <p className="text-xs text-muted-foreground">
+              The source path to match. Supports URLPattern syntax (e.g.{" "}
+              <code>/product/:slug</code>).
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="redirect-to">To</Label>
+            <Input
+              id="redirect-to"
+              value={payload.to}
+              placeholder="/new-path"
+              onChange={(e) => setField({ to: e.target.value })}
+              className="h-10"
+            />
+            <p className="text-xs text-muted-foreground">
+              The destination — a relative path or an absolute URL.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="redirect-type">Type</Label>
+            <Select
+              value={payload.type}
+              onValueChange={(v) => setField({ type: v as RedirectType })}
+            >
+              <SelectTrigger id="redirect-type" className="h-10 w-full">
+                <SelectValue placeholder="Type" />
+              </SelectTrigger>
+              <SelectContent>
+                {TYPE_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Use <strong>Temporary</strong> when the redirect may change;{" "}
+              <strong>Permanent</strong> lets browsers cache it.
+            </p>
+          </div>
+
+          <label className="flex cursor-pointer items-center gap-2.5">
+            <Checkbox
+              checked={payload.discardQueryParameters}
+              onCheckedChange={(checked) =>
+                setField({ discardQueryParameters: checked === true })
+              }
+            />
+            <span className="text-sm">Discard query parameters</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/runnable-catalog.test.ts
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-catalog.test.ts
@@ -185,4 +185,35 @@ describe("runnable-catalog", () => {
       },
     ]);
   });
+
+  it("excludes redirect loaders — they have a dedicated Redirects collection", () => {
+    // `website/loaders/redirect.ts` is a real manifest loader, so without the
+    // guard it would double-list under Loaders alongside the Redirects tab.
+    const redirectMeta: LiveMeta = {
+      manifest: {
+        blocks: {
+          loaders: {
+            "site/loaders/products.ts": { $ref: "#/definitions/Products" },
+            "website/loaders/redirect.ts": { $ref: "#/definitions/Redirect" },
+            "website/loaders/redirects.ts": { $ref: "#/definitions/Redirects" },
+          },
+        },
+      },
+      schema: {},
+    };
+    const decofile: Record<string, unknown> = {
+      "redirects-old-abc": {
+        __resolveType: "website/loaders/redirect.ts",
+        redirect: { from: "/old", to: "/new", type: "permanent" },
+      },
+      MyProducts: { __resolveType: "site/loaders/products.ts" },
+    };
+
+    expect(
+      listAvailableRunnables(redirectMeta, "loaders").map((l) => l.resolveType),
+    ).toEqual(["site/loaders/products.ts"]);
+    expect(
+      listSavedRunnables(redirectMeta, decofile, "loaders").map((e) => e.key),
+    ).toEqual(["MyProducts"]);
+  });
 });

--- a/apps/mesh/src/web/components/sandbox/content/runnable-catalog.ts
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-catalog.ts
@@ -4,6 +4,7 @@ import {
   type LiveMeta,
 } from "@/web/components/sections-editor/resolve-schema";
 import { labelFromResolveType } from "@/web/components/sections-editor/section-types";
+import { REDIRECT_LOADER_RESOLVE_TYPES } from "./redirect-data";
 
 /** The two block kinds surfaced by the Loaders / Actions content tabs. */
 export type RunnableKind = "loaders" | "actions";
@@ -114,6 +115,7 @@ export function listAvailableRunnables(
 
   for (const resolveType of allKeys) {
     if (resolveType.toLowerCase().includes("preview")) continue;
+    if (REDIRECT_LOADER_RESOLVE_TYPES.has(resolveType)) continue;
     if (HIDDEN_RUNNABLE_GROUPS.has(runnableGroupKey(resolveType))) continue;
     if (hasSuffixedAlias(resolveType, allKeys)) continue;
     const metadata = resolveBlockSchemaMetadata(resolveType, meta);
@@ -202,6 +204,7 @@ export function listSavedRunnables(
     const obj = val as Record<string, unknown>;
     const rt = obj.__resolveType;
     if (typeof rt !== "string") continue;
+    if (REDIRECT_LOADER_RESOLVE_TYPES.has(rt)) continue;
     if (HIDDEN_RUNNABLE_GROUPS.has(runnableGroupKey(rt))) continue;
     if (!isManifestRunnableResolveType(meta, rt, kind)) continue;
 

--- a/apps/mesh/src/web/components/sections-editor/page-list.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-list.test.ts
@@ -230,6 +230,17 @@ describe("page-list", () => {
     expect(hasEditableDecoContent(decofile, meta)).toBe(true);
   });
 
+  it("hasEditableDecoContent is true when only redirects exist", () => {
+    const decofile = {
+      "redirects-old-abc": {
+        __resolveType: "website/loaders/redirect.ts",
+        redirect: { from: "/old", to: "/new", type: "permanent" },
+      },
+    };
+    // No meta needed — redirects are detected without the manifest.
+    expect(hasEditableDecoContent(decofile, null)).toBe(true);
+  });
+
   it("hasEditableDecoContent is false without pages or sections", () => {
     expect(hasEditableDecoContent({}, null)).toBe(false);
     expect(

--- a/apps/mesh/src/web/components/sections-editor/page-list.tsx
+++ b/apps/mesh/src/web/components/sections-editor/page-list.tsx
@@ -6,6 +6,7 @@ import {
 } from "./resolve-schema";
 import { normalizePagePath } from "./page-path-utils";
 import { listSavedSectionBlocks } from "./section-catalog";
+import { extractRedirects } from "@/web/components/sandbox/content/redirect-data";
 
 export interface PageEntry {
   key: string;
@@ -92,6 +93,7 @@ export function hasEditableDecoContent(
 ): boolean {
   if (!decofile) return false;
   if (extractPages(decofile).length > 0) return true;
+  if (extractRedirects(decofile).length > 0) return true;
   if (!meta) return false;
   if (extractGlobalSections(decofile, meta).length > 0) return true;
   if (findSiteAppEntry(decofile, meta)) return true;


### PR DESCRIPTION
## Summary

Adds a **Redirects** collection to the Content tab (in the sidebar between **Apps** and **Loaders**), mirroring the old deco admin's Redirects page — "identifies the blocks of type redirect".

A deco site stores each URL redirect as a standalone top-level decofile block of `__resolveType` `website/loaders/redirect.ts`:

```jsonc
{ "redirect": { "from": "/old", "to": "/new", "type": "permanent", "discardQueryParameters": true },
  "__resolveType": "website/loaders/redirect.ts" }
```

The site's routes include an inline `website/loaders/redirects.ts` (plural) that **auto-discovers all** such blocks via `resolveTypeSelector`, so CRUD is a plain block create/update/delete via the existing `useSaveBlock`/`useDeleteBlock` — no routes/site wiring needed. Verified against a real decofile (farmrio.com.br: 700 redirect blocks, 0 explicit refs).

Scope: simple CRUD (From / To / Type 301·307). Bulk CSV import is intentionally out of scope.

## Changes
- **`redirect-data.ts`** (new) — pure helpers: `extractRedirects`, `getRedirectPayload`, `buildRedirectBlock`, `generateRedirectBlockKey` (`redirects-<slug>-<uuid>`), `REDIRECT_STATUS` (temporary→307, permanent→301). Defensive against malformed blocks.
- **`redirect-data.test.ts`** (new) — 7 unit tests (extraction, type defaults, build/read round-trip, key generation).
- **`redirect-editor.tsx`** (new) — right-pane form (From / To / Type / discard query params), autosaves via `useSaveBlock` + `useAutosave`, mirroring the author record editor.
- **`content-browser.tsx`** — `CollectionId`/`CollectionCounts`/`Selection`/`DeleteTarget` extended; "Redirects" sidebar row (icon `CornerUpRight`, with count); list branch (from → to + 301/307 badge); right pane; `handleCreateRedirect`; delete reuses the generic block-delete flow; `ItemActions.onDuplicate` made optional.

## Testing
- `bun test` on `redirect-data.test.ts` — 7 pass
- `bun run --cwd=apps/mesh check` (tsc) — clean
- `bun run lint` — 0 errors; `knip` — clean; `bun run fmt` — applied

Manual verification (needs a running sandbox with a deco site): open a project's Content tab → **Redirects** → create/edit/delete; confirm it persists as a `website/loaders/redirect.ts` block and that the redirect applies after publishing.

## Known limitations (v1)
- **Redirect-only sites**: the Content tab's visibility gate (`hasEditableDecoContent`) doesn't count redirects, so a site with *only* redirects wouldn't show the tab. Left out to avoid inverting the `sections-editor → content` dependency; easy to extend.
- No bulk CSV import and no duplicate action (out of agreed scope). A newly-created redirect starts blank (from/to empty) until edited — inert on the live site until filled (an empty `pathTemplate` matches no request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Redirects collection to the Content tab so users can create, edit, and delete URL redirects stored as `website/loaders/redirect.ts` blocks. Also seeds placeholder paths on creation, prevents double-listing under Loaders, and ensures redirect-only sites still see the Content tab.

- **New Features**
  - New Redirects sidebar row with counts, search, and create/delete; list shows source → target with a 301/307 badge.
  - Right-pane editor for From, To, Type (temporary/permanent), and Discard query parameters; autosaves via `useSaveBlock`.
  - Helpers: `extractRedirects`, `getRedirectPayload`, `buildRedirectBlock`, `generateRedirectBlockKey`; 301/307 mapping; Duplicate action optional; unit tests included.

- **Bug Fixes**
  - Exclude `website/loaders/redirect.ts` and `website/loaders/redirects.ts` from the Loaders catalog to avoid double-listing.
  - Count redirects in `hasEditableDecoContent`, so redirect-only sites show the Content tab.
  - Seed `from="/redirect-from"` and `to="/redirect-to"` when creating a redirect to ensure a valid block.

<sup>Written for commit 390483342400d653d53c9b7f441f64bb102cf816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

