### PR TITLE
feat(task-board): add copy button for task description

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -26,12 +26,15 @@ import {
 import { Calendar as DayPickerCalendar } from "@deco/ui/components/calendar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { useCopy } from "@deco/ui/hooks/use-copy.ts";
 import {
   AlertCircle,
   AlertSquare,
   Calendar,
+  Check,
   CheckCircle,
   ChevronRight,
+  Copy01,
   DotsHorizontal,
   GitMerge,
   GitPullRequest,
@@ -154,6 +157,7 @@ export function TaskBoardItemDialog({
 }) {
   const { data } = useMembers();
   const members = (data?.data?.members ?? []) as Member[];
+  const { handleCopy, copied } = useCopy();
 
   const [title, setTitle] = useState(item?.title ?? "");
   const [description, setDescription] = useState(item?.description ?? "");
@@ -238,12 +242,26 @@ export function TaskBoardItemDialog({
               className="w-full border-0 bg-transparent text-xl font-medium text-foreground outline-none placeholder:text-foreground/30"
             />
 
-            <textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Describe a task for an agent..."
-              className="min-h-[96px] w-full flex-1 resize-none border-0 bg-transparent text-[15px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/50 sm:min-h-[120px]"
-            />
+            <div className="group relative flex flex-1 flex-col">
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Describe a task for an agent..."
+                className="min-h-[96px] w-full flex-1 resize-none border-0 bg-transparent text-[15px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/50 sm:min-h-[120px]"
+              />
+              {description && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Copy description"
+                  className="absolute right-0 top-0 size-7 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+                  onClick={() => handleCopy(description)}
+                >
+                  {copied ? <Check size={14} /> : <Copy01 size={14} />}
+                </Button>
+              )}
+            </div>
 
             {thread && (
               <ActivityCard


### PR DESCRIPTION
## Summary
- Adds a small icon button (Copy01/Check swap) to copy the task description in the Tasks kanban task modal, shown on hover.
- Reuses the shared `useCopy()` hook (`@deco/ui/hooks/use-copy.ts`) and the same `Button variant="ghost" size="icon"` styling already used elsewhere in this dialog, for UI consistency.

## Test plan
- [x] `bun run fmt` / lint / typecheck pass on the changed file
- [ ] Manually verify: open a task with a description, hover the textarea, click copy, paste to confirm clipboard content, icon flips to check for 2s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a hover-revealed copy button to the task description in the Task Board modal that copies the text to the clipboard and briefly swaps from `Copy01` to `Check` on success. Uses the shared `useCopy` hook (`@deco/ui/hooks/use-copy.ts`) and the existing `Button` `variant="ghost"` `size="icon"` styling; the button appears only when a description is present.

<sup>Written for commit 82bacda36262c414128a1855a3a3154d1993a9e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

