### PR TITLE
fix(decopilot): restore thread status when a run resumes

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.integration.test.ts
@@ -184,9 +184,21 @@ describe("reactAll (real Postgres)", () => {
   });
 
   describe("RUN_RESUMED", () => {
-    it("sets run_started_at WITHOUT touching status; emits 1 event", async () => {
+    it("restores in_progress and clears the force-fail columns, keeping run_config; emits 1 event", async () => {
       const { deps, sseEvents } = makeReactor();
-      const thread = await createThread(); // status "completed"
+      // A run force-failed as ghost/reaped: terminal status, a recorded
+      // failure, a stale progress timestamp — but run_config still on the row
+      // (resume must keep it). `create()` doesn't persist these columns, so
+      // drive the row into that state with an explicit update.
+      const thread = await createThread();
+      await storage.update(thread.id, ORG, {
+        status: "failed",
+        failure_reason:
+          "Run stalled — no progress within the idle timeout window",
+        failure_kind: "stall",
+        last_progress_at: "2020-01-01T00:00:00.000Z",
+        run_config: { resume: true },
+      });
 
       await react(
         {
@@ -202,9 +214,22 @@ describe("reactAll (real Postgres)", () => {
 
       const row = await storage.get(thread.id, ORG);
       expect(row?.run_started_at).toBeTruthy();
-      // Proof the status column was never written: it stays "completed".
-      expect(row?.status).toBe("completed");
+      // The recovered run is executing again — the row must reflect it.
+      expect(row?.status).toBe("in_progress");
+      // Resume keeps the prior run's config (only START writes a fresh one).
+      expect(row?.run_config).toEqual({ resume: true });
       expect(sseEvents).toHaveLength(1);
+
+      // `threadFromDbRow` doesn't surface these columns, so read them raw to
+      // prove the write landed (and wasn't dropped by the update() whitelist).
+      const raw = await database.db
+        .selectFrom("threads")
+        .select(["failure_reason", "failure_kind", "last_progress_at"])
+        .where("id", "=", thread.id)
+        .executeTakeFirst();
+      expect(raw?.failure_reason).toBeNull();
+      expect(raw?.failure_kind).toBeNull();
+      expect(raw?.last_progress_at).toBeNull();
     });
   });
 

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.test.ts
@@ -185,6 +185,58 @@ describe("run reactor", () => {
     expect(updates[0]!.failure_kind).toBeNull();
   });
 
+  test("RUN_RESUMED restores in_progress and clears the stale force-fail columns", async () => {
+    // Regression: a run force-failed as ghost/reaped and then recovered used to
+    // keep status:"failed" in the DB — RUN_RESUMED only stamped run_started_at,
+    // so the thread only self-corrected at the next FINISH. It must flip the row
+    // back to in_progress on resume.
+    const updates: Record<string, unknown>[] = [];
+    const deps: RunReactorDeps = {
+      storage: {
+        update: async (
+          _id: string,
+          _orgId: string,
+          data: Record<string, unknown>,
+        ) => {
+          updates.push(data);
+          return null;
+        },
+        get: async () => ({
+          id: "run_1",
+          organization_id: "org_1",
+          created_by: "user_1",
+          status: "in_progress",
+        }),
+      } as unknown as ThreadStoragePort,
+      sseHub: { emit: () => {} },
+    };
+
+    await reactAll(
+      [
+        {
+          event: {
+            type: "RUN_RESUMED",
+            taskId: "run_1",
+            orgId: "org_1",
+            userId: "user_1",
+            abortController: new AbortController(),
+            podId: "pod_1",
+          },
+          state: undefined,
+        },
+      ],
+      deps,
+    );
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.status).toBe("in_progress");
+    expect(updates[0]!.failure_reason).toBeNull();
+    expect(updates[0]!.failure_kind).toBeNull();
+    expect(updates[0]!.last_progress_at).toBeNull();
+    // Resume must NOT overwrite the prior run's config.
+    expect(updates[0]!).not.toHaveProperty("run_config");
+  });
+
   test("RUN_STARTED emits the in_progress thread-status event with data.message_id", async () => {
     const emitted: { type: string; data: Record<string, unknown> }[] = [];
     const deps: RunReactorDeps = {

--- a/apps/mesh/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/mesh/src/api/routes/decopilot/run-reactor.ts
@@ -113,8 +113,19 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
     }
 
     case "RUN_RESUMED": {
+      // A resumed run (DBOS recovery / reaper hand-back) is executing again —
+      // flip the thread out of any terminal state a prior force-fail (ghost /
+      // reaped) left it in and clear the stale failure, so the UI reflects the
+      // running state immediately instead of only at the next FINISH. Mirrors
+      // RUN_STARTED, minus run_config (resume keeps the prior run's config).
+      // last_progress_at is reset so the stall reaper gives the resumed run a
+      // fresh idle window rather than re-reaping it on a stale timestamp.
       await storage.update(event.taskId, event.orgId, {
+        status: "in_progress",
         run_started_at: new Date().toISOString(),
+        last_progress_at: null,
+        failure_reason: null,
+        failure_kind: null,
       });
       const resumedThread = await storage.get(event.taskId, event.orgId);
       sseHub.emit(


### PR DESCRIPTION
## Summary

Follow-on from the staging investigation: a decopilot run got stuck `pending`, the DBOS conductor / reaper **did** recover it, but the thread status stayed stale and only corrected at the end of the run.

## Root cause

`RUN_STARTED` (`run-reactor.ts:88`) flips the thread to `status: "in_progress"` and clears `failure_reason` / `failure_kind`. `RUN_RESUMED` (`run-reactor.ts:116`) only stamped `run_started_at`.

So a run that was force-failed as **ghost** or **reaped** (`status: "failed"`) and then recovered kept `status: "failed"` in the DB. The `in_progress` SSE the reactor emits on resume is transient — a fresh page load reads the stale row — and the status only self-corrected at the terminal `FINISH` write. Reported symptom: *"ele só muda o status depois do finish / ele não volta o status da thread uma vez que o reaper volta."*

## Fix

Make `RUN_RESUMED` mirror `RUN_STARTED`'s status restore:

- `status: "in_progress"` — flip the row out of the terminal force-fail state.
- `failure_reason: null`, `failure_kind: null` — clear the stale ghost/reaped failure.
- `last_progress_at: null` — reset the stall reaper's idle window so the resumed run isn't immediately re-reaped on a stale timestamp.

`run_config` is deliberately **not** written — resume keeps the prior run's config (only `START` carries a fresh one).

## Testing

- New unit test asserting `RUN_RESUMED` writes `status: "in_progress"`, nulls `failure_reason`/`failure_kind`/`last_progress_at`, and does **not** touch `run_config`. Mirrors the existing *"RUN_STARTED clears stale failure"* test.
- 6/6 `run-reactor.test.ts` pass; `tsc --noEmit` clean; lint 0 errors; `bun run fmt` applied.

## Context (out of scope)

The recovery itself is jammed for a different class of workflow on staging — the conductor loops forever on `Cannot find workflow function … 'projectCheckpointWorkflow'` (orphaned workflows from a drained app version whose function the current code no longer registers). That's a separate infra/version-skew issue, not addressed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore thread status on run resume so resumed decopilot runs no longer appear “failed” until finish. `RUN_RESUMED` now mirrors `RUN_STARTED` to reflect the running state immediately and avoid instant re-reap.

- **Bug Fixes**
  - On `RUN_RESUMED`, set `status: 'in_progress'`, clear `failure_reason`/`failure_kind`, and reset `last_progress_at`.
  - Keep `run_config` unchanged on resume.
  - Updated unit and real Postgres integration tests to assert status restore, failure clears, and `run_config` preservation.

<sup>Written for commit a2d9908278fbb3fbad75b04e725d9637acf7f105. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

