### PR TITLE
feat(mcp-apps): let app-view messages drive in-panel navigation

### DIFF
--- a/apps/mesh/src/web/routes/project-app-view.tsx
+++ b/apps/mesh/src/web/routes/project-app-view.tsx
@@ -24,6 +24,15 @@ import { usePanelActions } from "@/web/layouts/shell-layout";
 
 const EMPTY_TOOL_INPUT: Record<string, unknown> = {};
 
+// An app can request in-panel navigation (instead of sending content to chat)
+// by emitting a lone `studio://navigate?main=<tab>` resource-link message —
+// e.g. the commerce diagnostic report's "task board" button. Restricted to the
+// agent-independent overlay tabs (mirrors OVERLAY_TABS in
+// main-panel-tabs/main-panel-with-drawer.tsx) so a message can't drive
+// arbitrary navigation.
+const NAVIGATE_SCHEME = "studio://navigate";
+const APP_NAVIGABLE_TABS = new Set(["board", "files"]);
+
 function AppRenderer({
   client,
   resourceURI,
@@ -76,6 +85,23 @@ function AppRenderer({
   };
 
   const handleAppMessage = (params: McpUiMessageRequest["params"]) => {
+    // Intercept a navigate request and drive the router instead of inserting
+    // it into chat; any other message falls through to the normal path.
+    const [block] = params.content;
+    if (
+      params.content.length === 1 &&
+      block?.type === "resource_link" &&
+      block.uri.startsWith(NAVIGATE_SCHEME)
+    ) {
+      let main: string | null = null;
+      try {
+        main = new URL(block.uri).searchParams.get("main");
+      } catch {
+        // malformed navigate URI — ignore
+      }
+      if (main && APP_NAVIGABLE_TABS.has(main)) openTab(main);
+      return;
+    }
     const doc = contentBlocksToTiptapDoc(params.content);
     if (doc.content.length > 0) {
       openSidePanel("chat");


### PR DESCRIPTION
## What

Teaches the MCP app-view host to treat a **navigation message** from an embedded app as an in-panel route change, instead of only ever inserting message content into chat.

An app emits a lone `studio://navigate?main=<tab>` **resource-link** message; `handleAppMessage` intercepts it and calls `openTab(main)` (drives `?main=<tab>`), restricted to the agent-independent overlay tabs (`board`, `files`). Anything else falls through to the existing insert-into-chat behavior unchanged.

## Why

Embedded apps had no way to move the user elsewhere in Studio — MCP-UI exposes no host-navigation primitive, and `openLink` only does `window.open(_blank)`. This unlocks the companion change in commerce-skills: decocms/reports#242 — the diagnostic report's new "Acompanhar no quadro de tarefas" button opens the task board in the panel next to chat.

## Notes

- Single file: `apps/mesh/src/web/routes/project-app-view.tsx`.
- The tab allowlist mirrors `OVERLAY_TABS` in `main-panel-tabs/main-panel-with-drawer.tsx` so a message can't drive arbitrary navigation.
- No behavior change for any existing message (only a lone `studio://navigate` resource link is intercepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)