### PR TITLE
fix(commerce-onboarding): mirror GitHub repo onto Report Agent metadata

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
@@ -4,7 +4,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  type ConnectionEntity,
   getCommerceDiscoveryAgentId,
+  type GithubRepo,
   WellKnownOrgMCPId,
 } from "@decocms/mesh-sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -21,7 +23,11 @@ import { DialogFooter } from "@deco/ui/components/dialog.tsx";
 import { SearchSm } from "@untitledui/icons";
 import { KEYS, invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
 import { useDebouncedValue } from "@/web/hooks/use-debounced-value.ts";
-import { fetchGithubInstallations } from "@/web/lib/github-installations";
+import {
+  fetchGithubInstallations,
+  findGithubInstallation,
+} from "@/web/lib/github-installations";
+import { provisionRepoScopedGithubConnection } from "@/web/lib/provision-repo-scoped-github-connection";
 import { unwrapToolResult } from "../companions-core.ts";
 import { SelectableList } from "./selectable-list.tsx";
 import { LoadingIndicator } from "../loading-indicator.tsx";
@@ -214,22 +220,90 @@ export function GitHubConfigForm({
         },
       });
 
-      // Also mirror onto the Report Agent virtual MCP's `metadata.githubRepo`
-      // — the field `agentHasClonableSource` reads to decide whether the
-      // Preview/Code tabs show up next to the report view. Without this, a
-      // reports-only org's GitHub connection lived only on the connection's
-      // `configuration_state` and Preview never appeared.
+      // Mirror onto the Report Agent virtual MCP's `metadata.githubRepo` —
+      // `agentHasClonableSource` reads it to show the Preview/Code tabs and
+      // SANDBOX_START reads it to clone. A bare `{ owner, name, url }` clones
+      // anonymously (fails on a private store repo), so provision a repo-scoped
+      // GitHub connection (same path the repo picker uses) and store its
+      // `connectionId` so the clone is authenticated.
       const [owner, name] = githubRepo.split("/");
+      if (!owner || !name) {
+        throw new Error(
+          `Repositório inválido: "${githubRepo}". Use o formato owner/nome.`,
+        );
+      }
+      const agentId = getCommerceDiscoveryAgentId(org.id);
+
+      const existingRepo = unwrapToolResult<{
+        item: { metadata?: { githubRepo?: GithubRepo | null } | null } | null;
+      }>(
+        await selfClient.callTool({
+          name: "COLLECTION_VIRTUAL_MCP_GET",
+          arguments: { id: agentId },
+        }),
+      ).item?.metadata?.githubRepo;
+
+      // Reuse the existing repo-scoped connection when the same repo is
+      // re-saved so a no-op save doesn't orphan a fresh connection each time.
+      const reuse =
+        existingRepo?.connectionId &&
+        existingRepo.owner === owner &&
+        existingRepo.name === name
+          ? existingRepo
+          : null;
+
+      let repoConnectionId = reuse?.connectionId;
+      let installationId = reuse?.installationId;
+
+      if (!repoConnectionId) {
+        const { installations } = await fetchGithubInstallations(
+          (req) => selfClient.callTool(req),
+          connectionId,
+        );
+        const installation = findGithubInstallation(installations, owner);
+        if (!installation) {
+          throw new Error(
+            `Nenhuma instalação do GitHub encontrada para "${owner}".`,
+          );
+        }
+        installationId = installation.installationId;
+        const sourceConnection = unwrapToolResult<{
+          item: ConnectionEntity | null;
+        }>(
+          await selfClient.callTool({
+            name: "COLLECTION_CONNECTIONS_GET",
+            arguments: { id: connectionId },
+          }),
+        ).item;
+        if (!sourceConnection) {
+          throw new Error("Conexão do GitHub não encontrada.");
+        }
+        const { childConnectionId } = await provisionRepoScopedGithubConnection(
+          {
+            orgSlug: org.slug,
+            sourceConnection,
+            installationId,
+            owner,
+            repo: name,
+            githubCallTool: (req) => companionClient.callTool(req),
+            selfCallTool: (req) => selfClient.callTool(req),
+          },
+        );
+        repoConnectionId = childConnectionId;
+      }
+
       await selfClient.callTool({
         name: "COLLECTION_VIRTUAL_MCP_UPDATE",
         arguments: {
-          id: getCommerceDiscoveryAgentId(org.id),
+          id: agentId,
           data: {
             metadata: {
               githubRepo: {
                 owner,
                 name,
                 url: `https://github.com/${githubRepo}`,
+                installationId,
+                connectionId: repoConnectionId,
               },
             },
           },

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
@@ -245,15 +245,19 @@ export function GitHubConfigForm({
 
       // Reuse the existing repo-scoped connection when the same repo is
       // re-saved so a no-op save doesn't orphan a fresh connection each time.
+      // GitHub owner/name are case-insensitive, so compare lowercased.
       const reuse =
         existingRepo?.connectionId &&
-        existingRepo.owner === owner &&
-        existingRepo.name === name
+        existingRepo.owner.toLowerCase() === owner.toLowerCase() &&
+        existingRepo.name.toLowerCase() === name.toLowerCase()
           ? existingRepo
           : null;
 
       let repoConnectionId = reuse?.connectionId;
       let installationId = reuse?.installationId;
+      // The connection we mint below, if any — deleted on a later failure so a
+      // partial save leaves nothing behind (the picker flow does the same).
+      let provisionedConnectionId: string | undefined;
 
       if (!repoConnectionId) {
         const { installations } = await fetchGithubInstallations(
@@ -290,25 +294,41 @@ export function GitHubConfigForm({
           },
         );
         repoConnectionId = childConnectionId;
+        provisionedConnectionId = childConnectionId;
       }
 
-      await selfClient.callTool({
-        name: "COLLECTION_VIRTUAL_MCP_UPDATE",
-        arguments: {
-          id: agentId,
-          data: {
-            metadata: {
-              githubRepo: {
-                owner,
-                name,
-                url: `https://github.com/${githubRepo}`,
-                installationId,
-                connectionId: repoConnectionId,
+      try {
+        await selfClient.callTool({
+          name: "COLLECTION_VIRTUAL_MCP_UPDATE",
+          arguments: {
+            id: agentId,
+            data: {
+              metadata: {
+                githubRepo: {
+                  owner,
+                  name,
+                  url: `https://github.com/${githubRepo}`,
+                  installationId,
+                  connectionId: repoConnectionId,
+                },
               },
             },
           },
-        },
-      });
+        });
+      } catch (err) {
+        // The connectionId lives only on the metadata we just failed to write,
+        // so the reuse guard can never recover it — delete it now, else every
+        // retry mints another orphan.
+        if (provisionedConnectionId) {
+          await selfClient
+            .callTool({
+              name: "COLLECTION_CONNECTIONS_DELETE",
+              arguments: { id: provisionedConnectionId, force: true },
+            })
+            .catch(() => {});
+        }
+        throw err;
+      }
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
@@ -3,7 +3,10 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { WellKnownOrgMCPId } from "@decocms/mesh-sdk";
+import {
+  getCommerceDiscoveryAgentId,
+  WellKnownOrgMCPId,
+} from "@decocms/mesh-sdk";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   Form,
@@ -16,7 +19,7 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { DialogFooter } from "@deco/ui/components/dialog.tsx";
 import { SearchSm } from "@untitledui/icons";
-import { KEYS } from "@/web/lib/query-keys";
+import { KEYS, invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
 import { useDebouncedValue } from "@/web/hooks/use-debounced-value.ts";
 import { fetchGithubInstallations } from "@/web/lib/github-installations";
 import { unwrapToolResult } from "../companions-core.ts";
@@ -210,6 +213,28 @@ export function GitHubConfigForm({
           data: { configuration_state: merged },
         },
       });
+
+      // Also mirror onto the Report Agent virtual MCP's `metadata.githubRepo`
+      // — the field `agentHasClonableSource` reads to decide whether the
+      // Preview/Code tabs show up next to the report view. Without this, a
+      // reports-only org's GitHub connection lived only on the connection's
+      // `configuration_state` and Preview never appeared.
+      const [owner, name] = githubRepo.split("/");
+      await selfClient.callTool({
+        name: "COLLECTION_VIRTUAL_MCP_UPDATE",
+        arguments: {
+          id: getCommerceDiscoveryAgentId(org.id),
+          data: {
+            metadata: {
+              githubRepo: {
+                owner,
+                name,
+                url: `https://github.com/${githubRepo}`,
+              },
+            },
+          },
+        },
+      });
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
@@ -218,6 +243,7 @@ export function GitHubConfigForm({
       await queryClient.invalidateQueries({
         queryKey: KEYS.commerceDiscoveryCompanionConnectionsPrefix(org.id),
       });
+      invalidateVirtualMcpQueries(queryClient, org.id);
       onDone();
     },
   });

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
@@ -234,14 +234,19 @@ export function GitHubConfigForm({
       }
       const agentId = getCommerceDiscoveryAgentId(org.id);
 
-      const existingRepo = unwrapToolResult<{
-        item: { metadata?: { githubRepo?: GithubRepo | null } | null } | null;
+      const agentItem = unwrapToolResult<{
+        item: {
+          metadata?: { githubRepo?: GithubRepo | null } | null;
+          connections?: Array<{ connection_id: string }> | null;
+        } | null;
       }>(
         await selfClient.callTool({
           name: "COLLECTION_VIRTUAL_MCP_GET",
           arguments: { id: agentId },
         }),
-      ).item?.metadata?.githubRepo;
+      ).item;
+      const existingRepo = agentItem?.metadata?.githubRepo;
+      const existingConnections = agentItem?.connections ?? [];
 
       // Reuse the existing repo-scoped connection when the same repo is
       // re-saved so a no-op save doesn't orphan a fresh connection each time.
@@ -297,12 +302,39 @@ export function GitHubConfigForm({
         provisionedConnectionId = childConnectionId;
       }
 
+      // A previous save may have linked a different repo with its own
+      // repo-scoped connection. The metadata write below overwrites it, and
+      // COLLECTION_VIRTUAL_MCP_UPDATE does no cascade — so once it's no longer
+      // referenced, delete it (after the write succeeds) or it leaks a
+      // connection + its vault token on every repo switch.
+      const staleConnectionId =
+        existingRepo?.connectionId &&
+        existingRepo.connectionId !== repoConnectionId
+          ? existingRepo.connectionId
+          : undefined;
+
+      // Aggregate the repo-scoped connection onto the agent — `git publish`
+      // (parseGithubRepoFromMetadata) only trusts `githubRepo.connectionId` when
+      // it's one of the agent's connections. `selected_tools: []` keeps it as a
+      // credential-only link without surfacing GitHub tools on the report agent.
+      // Drop the stale one from the list so the de-aggregation lands before its
+      // delete below (child_connection_id is ON DELETE RESTRICT, migration 026).
+      const mergedConnections = [
+        ...existingConnections.filter(
+          (c) =>
+            c.connection_id !== repoConnectionId &&
+            c.connection_id !== staleConnectionId,
+        ),
+        { connection_id: repoConnectionId, selected_tools: [] },
+      ];
+
       try {
         await selfClient.callTool({
           name: "COLLECTION_VIRTUAL_MCP_UPDATE",
           arguments: {
             id: agentId,
             data: {
+              connections: mergedConnections,
               metadata: {
                 githubRepo: {
                   owner,
@@ -315,6 +347,14 @@ export function GitHubConfigForm({
             },
           },
         });
+        if (staleConnectionId) {
+          await selfClient
+            .callTool({
+              name: "COLLECTION_CONNECTIONS_DELETE",
+              arguments: { id: staleConnectionId, force: true },
+            })
+            .catch(() => {});
+        }
       } catch (err) {
         // The connectionId lives only on the metadata we just failed to write,
         // so the reuse guard can never recover it — delete it now, else every


### PR DESCRIPTION
## Summary
- Reports-only orgs saved their connected GitHub repo only onto the Commerce Discovery connection's `configuration_state.github_repo` (a plain `owner/name` string). `agentHasClonableSource`/`hasClonableSource` — which gate the Preview/Code tabs in the main-panel tab bar — never look at that field, so Preview never showed up next to the report view once GitHub was connected.
- On save, also mirror the repo onto the Report Agent virtual MCP's `metadata.githubRepo` (`{ owner, name, url }`) via `COLLECTION_VIRTUAL_MCP_UPDATE`, and invalidate the virtual MCP query cache so the tab bar picks it up immediately.

## Testing notes
- `bun run --cwd=apps/mesh check` and `bun run fmt:check` pass.
- Not covered by an automated test — this is glue wiring (one MCP tool call mirroring a field), not branching logic; verifying end-to-end would require the full commerce-onboarding e2e flow with a real GitHub App installation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Preview/Code tabs for reports-only orgs by mirroring the selected GitHub repo onto the Report Agent metadata and using an authenticated, repo-scoped GitHub connection for private repos. Also cleans up stale repo connections and aggregates the scoped connection on the agent so publish trusts it.

- **Bug Fixes**
  - Mirror repo to `metadata.githubRepo` via `COLLECTION_VIRTUAL_MCP_UPDATE` (`{ owner, name, url, installationId, connectionId }`) and aggregate the repo-scoped connection onto the agent (`selected_tools: []`), dropping any stale link, so Preview/Code, sandbox clone, and publish work.
  - Provision a repo-scoped GitHub connection; reuse on same-repo re-saves (case-insensitive), validate `owner/name`, and roll back a newly created connection if the metadata write fails to avoid orphans.
  - Invalidate virtual MCP queries to refresh the tab bar.
  - Add `getCommerceDiscoveryAgentId` from `@decocms/mesh-sdk`.

<sup>Written for commit ef48ce28be43985a78865f002874caa0b93280ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

