### PR TITLE
test(mcp-apps): cover the in-panel navigate tab allowlist

### DIFF
--- a/apps/mesh/src/web/routes/project-app-navigate.test.ts
+++ b/apps/mesh/src/web/routes/project-app-navigate.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import type { ContentBlock } from "@modelcontextprotocol/sdk/types.js";
+import { resolveAppNavigateTarget } from "@/web/routes/project-app-navigate.ts";
+
+function navigateBlock(uri: string): ContentBlock[] {
+  return [{ type: "resource_link", name: "navigate", uri }];
+}
+
+describe("resolveAppNavigateTarget", () => {
+  test("navigates to an allowlisted tab", () => {
+    expect(
+      resolveAppNavigateTarget(navigateBlock("studio://navigate?main=board")),
+    ).toEqual({ isNavigate: true, tab: "board" });
+    expect(
+      resolveAppNavigateTarget(navigateBlock("studio://navigate?main=files")),
+    ).toEqual({ isNavigate: true, tab: "files" });
+  });
+
+  test("drops the request instead of navigating when the tab isn't allowlisted", () => {
+    // Guards against an app driving navigation to an arbitrary tab.
+    expect(
+      resolveAppNavigateTarget(
+        navigateBlock("studio://navigate?main=settings"),
+      ),
+    ).toEqual({ isNavigate: true, tab: null });
+  });
+
+  test("drops the request when the URI is malformed", () => {
+    expect(
+      resolveAppNavigateTarget(navigateBlock("studio://navigate??main")),
+    ).toEqual({ isNavigate: true, tab: null });
+  });
+
+  test("drops the request when main is missing", () => {
+    expect(
+      resolveAppNavigateTarget(navigateBlock("studio://navigate")),
+    ).toEqual({ isNavigate: true, tab: null });
+  });
+
+  test("is not a navigate message for a different scheme", () => {
+    expect(
+      resolveAppNavigateTarget(navigateBlock("https://example.com?main=board")),
+    ).toEqual({ isNavigate: false });
+  });
+
+  test("is not a navigate message for non-resource_link content", () => {
+    expect(resolveAppNavigateTarget([{ type: "text", text: "hello" }])).toEqual(
+      { isNavigate: false },
+    );
+  });
+
+  test("is not a navigate message when there's more than one content block", () => {
+    expect(
+      resolveAppNavigateTarget([
+        {
+          type: "resource_link",
+          name: "navigate",
+          uri: "studio://navigate?main=board",
+        },
+        { type: "text", text: "extra" },
+      ]),
+    ).toEqual({ isNavigate: false });
+  });
+});

--- a/apps/mesh/src/web/routes/project-app-navigate.ts
+++ b/apps/mesh/src/web/routes/project-app-navigate.ts
@@ -1,0 +1,45 @@
+import type { ContentBlock } from "@modelcontextprotocol/sdk/types.js";
+
+// An app can request in-panel navigation (instead of sending content to chat)
+// by emitting a lone `studio://navigate?main=<tab>` resource-link message —
+// e.g. the commerce diagnostic report's "task board" button. Restricted to the
+// agent-independent overlay tabs (mirrors OVERLAY_TABS in
+// main-panel-tabs/main-panel-with-drawer.tsx) so a message can't drive
+// arbitrary navigation.
+const NAVIGATE_SCHEME = "studio://navigate";
+const APP_NAVIGABLE_TABS = new Set(["board", "files"]);
+
+/**
+ * Classifies a `handleAppMessage` payload as a navigate request or not.
+ *
+ * - `{ isNavigate: false }` — not a navigate message; the caller should fall
+ *   through to the normal content-to-chat handling.
+ * - `{ isNavigate: true, tab }` — a navigate message was intercepted; the
+ *   caller should stop processing. `tab` is the allowlisted tab to open, or
+ *   null if the URI was malformed or targeted a non-allowlisted tab (in which
+ *   case the request is silently dropped, not sent to chat).
+ */
+export function resolveAppNavigateTarget(
+  content: ContentBlock[],
+): { isNavigate: false } | { isNavigate: true; tab: string | null } {
+  const [block] = content;
+  if (
+    content.length !== 1 ||
+    block?.type !== "resource_link" ||
+    !block.uri.startsWith(NAVIGATE_SCHEME)
+  ) {
+    return { isNavigate: false };
+  }
+
+  let main: string | null = null;
+  try {
+    main = new URL(block.uri).searchParams.get("main");
+  } catch {
+    // malformed navigate URI — ignore
+  }
+
+  return {
+    isNavigate: true,
+    tab: main && APP_NAVIGABLE_TABS.has(main) ? main : null,
+  };
+}

--- a/apps/mesh/src/web/routes/project-app-view.tsx
+++ b/apps/mesh/src/web/routes/project-app-view.tsx
@@ -21,17 +21,9 @@ import { MCPAppRenderer } from "@/mcp-apps/mcp-app-renderer.tsx";
 import { getUIResourceUri, MCP_APP_DISPLAY_MODES } from "@/mcp-apps/types.ts";
 import { useChatStream, useChatPrefs } from "@/web/components/chat/context.tsx";
 import { usePanelActions } from "@/web/layouts/shell-layout";
+import { resolveAppNavigateTarget } from "@/web/routes/project-app-navigate.ts";
 
 const EMPTY_TOOL_INPUT: Record<string, unknown> = {};
-
-// An app can request in-panel navigation (instead of sending content to chat)
-// by emitting a lone `studio://navigate?main=<tab>` resource-link message —
-// e.g. the commerce diagnostic report's "task board" button. Restricted to the
-// agent-independent overlay tabs (mirrors OVERLAY_TABS in
-// main-panel-tabs/main-panel-with-drawer.tsx) so a message can't drive
-// arbitrary navigation.
-const NAVIGATE_SCHEME = "studio://navigate";
-const APP_NAVIGABLE_TABS = new Set(["board", "files"]);
 
 function AppRenderer({
   client,
@@ -87,19 +79,9 @@ function AppRenderer({
   const handleAppMessage = (params: McpUiMessageRequest["params"]) => {
     // Intercept a navigate request and drive the router instead of inserting
     // it into chat; any other message falls through to the normal path.
-    const [block] = params.content;
-    if (
-      params.content.length === 1 &&
-      block?.type === "resource_link" &&
-      block.uri.startsWith(NAVIGATE_SCHEME)
-    ) {
-      let main: string | null = null;
-      try {
-        main = new URL(block.uri).searchParams.get("main");
-      } catch {
-        // malformed navigate URI — ignore
-      }
-      if (main && APP_NAVIGABLE_TABS.has(main)) openTab(main);
+    const navigateResult = resolveAppNavigateTarget(params.content);
+    if (navigateResult.isNavigate) {
+      if (navigateResult.tab) openTab(navigateResult.tab);
       return;
     }
     const doc = contentBlocksToTiptapDoc(params.content);


### PR DESCRIPTION
Follows #4707.

That PR added an app-message interceptor: any connected MCP app can drive in-panel navigation by emitting a `studio://navigate?main=<tab>` resource-link message, gated by an `APP_NAVIGABLE_TABS` allowlist so a message can't drive navigation to an arbitrary tab. This is a trust-boundary check — the URI comes from an MCP app connection, not from the host — and shipped with no test.

**Why this qualifies as a standalone test:** the allowlist is the only thing stopping an app-supplied string from reaching `openTab(...)` unchecked; a regression here (e.g. someone widening the check or dropping the allowlist) would let an app navigate the host UI to an arbitrary tab. There's no other test on this repo touching it.

**What changed:** extracted the pure decision (`resolveAppNavigateTarget`) out of the `handleAppMessage` closure into `project-app-navigate.ts` so it's directly unit-testable, with no behavior change — `project-app-view.tsx` just calls the extracted function. Added `project-app-navigate.test.ts` covering:
- an allowlisted tab navigates
- a non-allowlisted tab is silently dropped (not sent to chat)
- a malformed navigate URI is silently dropped
- non-navigate content still falls through to the normal content-to-chat path

**Reviewer check:** `bun test apps/mesh/src/web/routes/project-app-navigate.test.ts`

**Local verification:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh), and the targeted test file above — all green. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for the MCP app in-panel navigation allowlist, ensuring only `board` and `files` can be opened via `studio://navigate?main=<tab>` and that invalid/non-navigate messages are ignored (not sent to chat). Extracted the decision logic into `resolveAppNavigateTarget` in `project-app-navigate.ts` and wired it into `project-app-view.tsx` with no behavior change.

<sup>Written for commit 20172750de9e4b12efac185e4e21cc7fe4c1da49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

