### PR TITLE
feat(commerce): reports_only hides Library and defaults to task board

### DIFF
--- a/apps/mesh/src/web/hooks/use-organization-settings.ts
+++ b/apps/mesh/src/web/hooks/use-organization-settings.ts
@@ -239,10 +239,13 @@ export function useReportsOnly(): boolean {
 }
 
 export function useTaskBoardEnabled(): boolean {
+  const reportsOnly = useReportsOnly();
   const { data } = useOrganizationSettings(
     (s) => s.task_board_enabled ?? false,
   );
-  return data ?? false;
+  // Commerce (reports-only) orgs always have the task board enabled — no need
+  // to toggle it on in settings.
+  return reportsOnly || (data ?? false);
 }
 
 export function useUpdateTaskBoardEnabled() {

--- a/apps/mesh/src/web/layouts/agent-shell-layout/library-toggle.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/library-toggle.tsx
@@ -1,6 +1,7 @@
 import { Folder } from "@untitledui/icons";
 import { HeaderTabButton } from "@/web/layouts/main-panel-tabs/header-tab-button";
 import { track } from "@/web/lib/posthog-client";
+import { useReportsOnly } from "@/web/hooks/use-organization-settings";
 import { useMainOverlayToggle } from "./use-main-overlay-toggle";
 
 /**
@@ -14,11 +15,12 @@ import { useMainOverlayToggle } from "./use-main-overlay-toggle";
  * tab (see useMainOverlayToggle) rather than closing the panel outright.
  */
 export function LibraryToggle() {
+  const reportsOnly = useReportsOnly();
   const { active, enabled, toggle } = useMainOverlayToggle("files");
 
   // Needs a task route to toggle the main panel against; render nothing on
-  // routes without one.
-  if (!enabled) return null;
+  // routes without one. Commerce (reports-only) orgs hide the Library button.
+  if (!enabled || reportsOnly) return null;
 
   return (
     <HeaderTabButton

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -267,9 +267,14 @@ export function useMainPanelTabs(ctx: {
   });
   const showContentTab = hasEditableDecoContent(decofile, meta);
 
+  // Commerce (reports-only) orgs default to the task board when no ?main param
+  // is set — the board is their primary surface.
+  const effectiveMainParam =
+    reportsOnly && search.main === undefined ? "board" : search.main;
+
   const { activeTab: rawActiveTab, mainOpen: rawMainOpen } =
     resolveActiveTabAndOpen({
-      mainParam: search.main,
+      mainParam: effectiveMainParam,
       metadata:
         effectiveDefaultMainView || entityLayout
           ? {

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -267,14 +267,9 @@ export function useMainPanelTabs(ctx: {
   });
   const showContentTab = hasEditableDecoContent(decofile, meta);
 
-  // Commerce (reports-only) orgs default to the task board when no ?main param
-  // is set — the board is their primary surface.
-  const effectiveMainParam =
-    reportsOnly && search.main === undefined ? "board" : search.main;
-
   const { activeTab: rawActiveTab, mainOpen: rawMainOpen } =
     resolveActiveTabAndOpen({
-      mainParam: effectiveMainParam,
+      mainParam: search.main,
       metadata:
         effectiveDefaultMainView || entityLayout
           ? {


### PR DESCRIPTION
## What is this contribution about?

Two behavior changes gated on the \`reports_only\` org flag for commerce orgs:
1. The Library toggle button is hidden — commerce orgs don't use the org file library.
2. The task board toggle (\`useTaskBoardEnabled\`) returns \`true\` automatically, so the Tasks button appears in the toolbar without the user needing to enable it in settings.

## Screenshots/Demonstration

Manual testing required — enable \`reports_only\` on a local org and verify the Library button is absent and the Tasks toggle is visible without touching settings.

## How to Test

1. Enable \`reports_only\` on a local org (via \`ORGANIZATION_UPDATE\` settings tool or direct DB update).
2. Navigate to any task route (\`/$org/$taskId\`).
3. Confirm the Library button is not shown in the left toolbar.
4. Confirm the Tasks toggle button is visible in the toolbar (even if \`task_board_enabled\` is \`false\` in org settings).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes