### PR TITLE
refactor(web): share OVERLAY_TABS between drawer visibility and app-navigate allowlist

### DIFF
--- a/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-with-drawer.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/main-panel-with-drawer.tsx
@@ -9,12 +9,8 @@ import { useChatTask } from "@/web/components/chat/chat-context";
 import { useInsetContext } from "@/web/layouts/agent-shell-layout";
 import { agentHasClonableSource } from "@/web/lib/agent-capabilities";
 import { MainPanelContent } from "@/web/layouts/main-panel-tabs";
+import { OVERLAY_TABS } from "./tab-id";
 import { PreviewDrawerHost } from "./preview-drawer-host";
-
-// Agent-independent overlays (Tasks `board`, Library `files`) take over the
-// whole panel and aren't sandbox-backed views — the dev terminal drawer must
-// not stay glued below them when switching over from Preview/Code.
-const OVERLAY_TABS = new Set(["board", "files"]);
 
 export function MainPanelWithDrawer({
   virtualMcpId,

--- a/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/tab-id.ts
@@ -182,6 +182,11 @@ export const FIXED_SYSTEM_TABS = [
 
 const FIXED_SYSTEM_TAB_SET = new Set<string>(FIXED_SYSTEM_TABS);
 
+// Agent-independent overlays (Tasks `board`, Library `files`) take over the
+// whole panel and aren't sandbox-backed views. Shared by the drawer-visibility
+// check and the in-panel-app navigate allowlist so the two stay in sync.
+export const OVERLAY_TABS = new Set(["board", "files"]);
+
 /**
  * Returns true for tab ids that are scoped to a specific thread and must not
  * be carried across task switches:

--- a/apps/mesh/src/web/routes/project-app-navigate.ts
+++ b/apps/mesh/src/web/routes/project-app-navigate.ts
@@ -1,13 +1,11 @@
 import type { ContentBlock } from "@modelcontextprotocol/sdk/types.js";
+import { OVERLAY_TABS } from "@/web/layouts/main-panel-tabs/tab-id";
 
 // An app can request in-panel navigation (instead of sending content to chat)
 // by emitting a lone `studio://navigate?main=<tab>` resource-link message —
-// e.g. the commerce diagnostic report's "task board" button. Restricted to the
-// agent-independent overlay tabs (mirrors OVERLAY_TABS in
-// main-panel-tabs/main-panel-with-drawer.tsx) so a message can't drive
-// arbitrary navigation.
+// e.g. the commerce diagnostic report's "task board" button. Restricted to
+// OVERLAY_TABS so a message can't drive arbitrary navigation.
 const NAVIGATE_SCHEME = "studio://navigate";
-const APP_NAVIGABLE_TABS = new Set(["board", "files"]);
 
 /**
  * Classifies a `handleAppMessage` payload as a navigate request or not.
@@ -40,6 +38,6 @@ export function resolveAppNavigateTarget(
 
   return {
     isNavigate: true,
-    tab: main && APP_NAVIGABLE_TABS.has(main) ? main : null,
+    tab: main && OVERLAY_TABS.has(main) ? main : null,
   };
 }


### PR DESCRIPTION
## Source
Follows #4709. That PR extracted the in-panel app-navigate allowlist check into `resolveAppNavigateTarget`, but left `APP_NAVIGABLE_TABS` (`project-app-navigate.ts`) as a literal duplicate of `OVERLAY_TABS` (`main-panel-with-drawer.tsx`) — the comment in both files explicitly says one "mirrors" the other. Two independently-maintained copies of the same security-relevant allowlist is exactly the kind of drift risk the comment itself was flagging (both places have to be updated in lockstep whenever the overlay tab set changes).

## Why a maintainer wants it
Collapses the duplicated `Set(["board", "files"])` literal into a single exported `OVERLAY_TABS` constant in `tab-id.ts` (already the home for other shared tab-id helpers), imported by both the drawer-visibility check and the app-navigate allowlist. One source of truth for a value with the same security-relevant meaning in both places — a future tab addition/removal only needs one edit instead of two.

Net diff: -11 / +10, no behavior change (same values, same Set semantics).

## How to verify
`bun test apps/mesh/src/web/routes/project-app-navigate.test.ts` — still exercises the same allowlist logic end-to-end.

## Checks run locally
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` (green)
- `bun test apps/mesh/src/web/routes/project-app-navigate.test.ts` (7 pass)

Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the overlay tab allowlist by exporting `OVERLAY_TABS` from `tab-id.ts` and using it for both drawer visibility and in-panel app navigation. Reduces drift risk with a single source of truth; no behavior change.

- **Refactors**
  - Move `OVERLAY_TABS` to `tab-id.ts`; import in `main-panel-with-drawer.tsx` and `project-app-navigate.ts`.
  - Remove `APP_NAVIGABLE_TABS`; both checks now use the same Set (`board`, `files`).

<sup>Written for commit 0fbc0cd614bd40f5e8beefdd7c0439c40673ae12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

