### PR TITLE
refactor(web): extract shared fetch helper in use-org-sso

### DIFF
--- a/apps/mesh/src/web/hooks/use-org-sso.ts
+++ b/apps/mesh/src/web/hooks/use-org-sso.ts
@@ -14,17 +14,32 @@ interface SsoConfigResponse {
   config?: OrgSsoConfigPublic;
 }
 
+/** Fetch + parse JSON, throwing `errorMessage` (or the body's own `error`) on failure. */
+async function ssoFetch<T>(
+  url: string,
+  init: RequestInit | undefined,
+  errorMessage: string,
+): Promise<T> {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    throw new Error(body?.error || errorMessage);
+  }
+  return response.json();
+}
+
 export function useOrgSsoStatus(
   orgId: string | undefined,
   orgSlug: string | undefined,
 ) {
   return useQuery({
     queryKey: KEYS.orgSsoStatus(orgId ?? ""),
-    queryFn: async (): Promise<SsoStatusResponse> => {
-      const response = await fetch(`/api/${orgSlug}/sso/status`);
-      if (!response.ok) throw new Error("Failed to check SSO status");
-      return response.json();
-    },
+    queryFn: () =>
+      ssoFetch<SsoStatusResponse>(
+        `/api/${orgSlug}/sso/status`,
+        undefined,
+        "Failed to check SSO status",
+      ),
     enabled: !!orgId && !!orgSlug,
   });
 }
@@ -35,11 +50,12 @@ export function useOrgSsoConfig(
 ) {
   return useQuery({
     queryKey: KEYS.orgSsoConfig(orgId ?? ""),
-    queryFn: async (): Promise<SsoConfigResponse> => {
-      const response = await fetch(`/api/${orgSlug}/sso/config`);
-      if (!response.ok) throw new Error("Failed to fetch SSO config");
-      return response.json();
-    },
+    queryFn: () =>
+      ssoFetch<SsoConfigResponse>(
+        `/api/${orgSlug}/sso/config`,
+        undefined,
+        "Failed to fetch SSO config",
+      ),
     enabled: !!orgId && !!orgSlug,
   });
 }
@@ -48,7 +64,7 @@ export function useSaveOrgSsoConfig(orgId: string, orgSlug: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (data: {
+    mutationFn: (data: {
       issuer: string;
       clientId: string;
       clientSecret: string;
@@ -56,18 +72,16 @@ export function useSaveOrgSsoConfig(orgId: string, orgSlug: string) {
       scopes?: string[];
       domain: string;
       enforced?: boolean;
-    }) => {
-      const response = await fetch(`/api/${orgSlug}/sso/config`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
-      });
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.error || "Failed to save SSO config");
-      }
-      return response.json();
-    },
+    }) =>
+      ssoFetch(
+        `/api/${orgSlug}/sso/config`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(data),
+        },
+        "Failed to save SSO config",
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: KEYS.orgSsoConfig(orgId) });
       queryClient.invalidateQueries({ queryKey: KEYS.orgSsoStatus(orgId) });
@@ -79,13 +93,12 @@ export function useDeleteOrgSsoConfig(orgId: string, orgSlug: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async () => {
-      const response = await fetch(`/api/${orgSlug}/sso/config`, {
-        method: "DELETE",
-      });
-      if (!response.ok) throw new Error("Failed to delete SSO config");
-      return response.json();
-    },
+    mutationFn: () =>
+      ssoFetch(
+        `/api/${orgSlug}/sso/config`,
+        { method: "DELETE" },
+        "Failed to delete SSO config",
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: KEYS.orgSsoConfig(orgId) });
       queryClient.invalidateQueries({ queryKey: KEYS.orgSsoStatus(orgId) });
@@ -97,15 +110,16 @@ export function useToggleSsoEnforcement(orgId: string, orgSlug: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (enforced: boolean) => {
-      const response = await fetch(`/api/${orgSlug}/sso/config/enforce`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enforced }),
-      });
-      if (!response.ok) throw new Error("Failed to toggle SSO enforcement");
-      return response.json();
-    },
+    mutationFn: (enforced: boolean) =>
+      ssoFetch(
+        `/api/${orgSlug}/sso/config/enforce`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enforced }),
+        },
+        "Failed to toggle SSO enforcement",
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: KEYS.orgSsoConfig(orgId) });
       queryClient.invalidateQueries({ queryKey: KEYS.orgSsoStatus(orgId) });


### PR DESCRIPTION
## Source
C1 reduction — the CLAUDE.md hardening checklist calls out `apps/mesh/src/web` for hand-rolled `await fetch(...)` + `if (!res.ok) throw ...` shapes with no shared client; `use-org-sso.ts` has five copies of the exact same pattern in one file.

## Why
All five hooks (`useOrgSsoStatus`, `useOrgSsoConfig`, `useSaveOrgSsoConfig`, `useDeleteOrgSsoConfig`, `useToggleSsoEnforcement`) repeated the same fetch → check `.ok` → throw shape, with the save mutation additionally parsing the response body for a more specific error message. Collapsing them into one `ssoFetch` helper removes the duplication and gives every hook the better (body-aware) error message for free.

## Change
Net diff: +53/-39 (one net-new helper, five call sites simplified). Behavior-preserving: success path (return `response.json()`) is unchanged for all five; failure path now uniformly tries `response.json().error` before falling back to the same default message each hook already had — a strict improvement, never a regression (a non-JSON error body just falls through to `.catch(() => null)` and the original default message, same as before).

## How to verify
`cd apps/mesh && bunx tsc --noEmit` — no errors introduced.

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (clean)

No existing test covers this file (frontend fetch wiring — no unit test per the repo's testing tiers); full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared `ssoFetch` helper in `use-org-sso.ts` to remove duplicated fetch/error handling across all org SSO hooks. Success behavior is unchanged; errors now surface the API’s `error` field when available.

- **Refactors**
  - Added `ssoFetch<T>(url, init, errorMessage)` for fetch + JSON parse with uniform error handling.
  - Simplified `useOrgSsoStatus`, `useOrgSsoConfig`, `useSaveOrgSsoConfig`, `useDeleteOrgSsoConfig`, and `useToggleSsoEnforcement`.
  - Non-JSON error bodies fall back to previous default messages.

<sup>Written for commit acf8d5a2f0a83d926119eec93a957e4f1e11c0c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

