### PR TITLE
refactor(commerce-onboarding): extract report-agent repo plan into pure, tested helpers

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/github-config-form.tsx
@@ -28,6 +28,11 @@ import {
   findGithubInstallation,
 } from "@/web/lib/github-installations";
 import { provisionRepoScopedGithubConnection } from "@/web/lib/provision-repo-scoped-github-connection";
+import {
+  parseRepoFullName,
+  planAgentConnections,
+  planRepoReuse,
+} from "./report-agent-repo-plan";
 import { unwrapToolResult } from "../companions-core.ts";
 import { SelectableList } from "./selectable-list.tsx";
 import { LoadingIndicator } from "../loading-indicator.tsx";
@@ -226,12 +231,13 @@ export function GitHubConfigForm({
       // anonymously (fails on a private store repo), so provision a repo-scoped
       // GitHub connection (same path the repo picker uses) and store its
       // `connectionId` so the clone is authenticated.
-      const [owner, name] = githubRepo.split("/");
-      if (!owner || !name) {
+      const parsed = parseRepoFullName(githubRepo);
+      if (!parsed) {
         throw new Error(
           `Repositório inválido: "${githubRepo}". Use o formato owner/nome.`,
         );
       }
+      const { owner, name } = parsed;
       const agentId = getCommerceDiscoveryAgentId(org.id);
 
       const agentItem = unwrapToolResult<{
@@ -250,13 +256,7 @@ export function GitHubConfigForm({
 
       // Reuse the existing repo-scoped connection when the same repo is
       // re-saved so a no-op save doesn't orphan a fresh connection each time.
-      // GitHub owner/name are case-insensitive, so compare lowercased.
-      const reuse =
-        existingRepo?.connectionId &&
-        existingRepo.owner.toLowerCase() === owner.toLowerCase() &&
-        existingRepo.name.toLowerCase() === name.toLowerCase()
-          ? existingRepo
-          : null;
+      const reuse = planRepoReuse({ existingRepo, owner, name });
 
       let repoConnectionId = reuse?.connectionId;
       let installationId = reuse?.installationId;
@@ -302,31 +302,18 @@ export function GitHubConfigForm({
         provisionedConnectionId = childConnectionId;
       }
 
-      // A previous save may have linked a different repo with its own
-      // repo-scoped connection. The metadata write below overwrites it, and
-      // COLLECTION_VIRTUAL_MCP_UPDATE does no cascade — so once it's no longer
-      // referenced, delete it (after the write succeeds) or it leaks a
-      // connection + its vault token on every repo switch.
-      const staleConnectionId =
-        existingRepo?.connectionId &&
-        existingRepo.connectionId !== repoConnectionId
-          ? existingRepo.connectionId
-          : undefined;
-
       // Aggregate the repo-scoped connection onto the agent — `git publish`
       // (parseGithubRepoFromMetadata) only trusts `githubRepo.connectionId` when
-      // it's one of the agent's connections. `selected_tools: []` keeps it as a
-      // credential-only link without surfacing GitHub tools on the report agent.
-      // Drop the stale one from the list so the de-aggregation lands before its
-      // delete below (child_connection_id is ON DELETE RESTRICT, migration 026).
-      const mergedConnections = [
-        ...existingConnections.filter(
-          (c) =>
-            c.connection_id !== repoConnectionId &&
-            c.connection_id !== staleConnectionId,
-        ),
-        { connection_id: repoConnectionId, selected_tools: [] },
-      ];
+      // it's one of the agent's connections. A previous save may have linked a
+      // different repo whose connection now leaks (metadata overwrite does no
+      // cascade); planAgentConnections drops it from the list so the
+      // de-aggregation lands before its delete below (child_connection_id is
+      // ON DELETE RESTRICT, migration 026).
+      const { staleConnectionId, mergedConnections } = planAgentConnections({
+        existingRepo,
+        existingConnections,
+        repoConnectionId,
+      });
 
       try {
         await selfClient.callTool({

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/report-agent-repo-plan.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/report-agent-repo-plan.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test";
+import type { GithubRepo } from "@decocms/mesh-sdk";
+import {
+  parseRepoFullName,
+  planAgentConnections,
+  planRepoReuse,
+} from "./report-agent-repo-plan";
+
+const repo = (over: Partial<GithubRepo>): GithubRepo => ({
+  url: "https://github.com/acme/store",
+  owner: "acme",
+  name: "store",
+  ...over,
+});
+
+describe("parseRepoFullName", () => {
+  it("splits owner/name", () => {
+    expect(parseRepoFullName("acme/store")).toEqual({
+      owner: "acme",
+      name: "store",
+    });
+  });
+
+  it("rejects a missing name", () => {
+    expect(parseRepoFullName("acme")).toBeNull();
+    expect(parseRepoFullName("acme/")).toBeNull();
+  });
+
+  it("rejects a missing owner", () => {
+    expect(parseRepoFullName("/store")).toBeNull();
+    expect(parseRepoFullName("")).toBeNull();
+  });
+});
+
+describe("planRepoReuse", () => {
+  it("reuses when the same repo has a connectionId", () => {
+    expect(
+      planRepoReuse({
+        existingRepo: repo({ connectionId: "conn_1", installationId: 42 }),
+        owner: "acme",
+        name: "store",
+      }),
+    ).toEqual({ connectionId: "conn_1", installationId: 42 });
+  });
+
+  it("matches repo case-insensitively (GitHub owner/name are)", () => {
+    expect(
+      planRepoReuse({
+        existingRepo: repo({
+          owner: "Acme",
+          name: "Store",
+          connectionId: "conn_1",
+        }),
+        owner: "acme",
+        name: "store",
+      }),
+    ).toMatchObject({ connectionId: "conn_1" });
+  });
+
+  it("does not reuse a different repo", () => {
+    expect(
+      planRepoReuse({
+        existingRepo: repo({ name: "other", connectionId: "conn_1" }),
+        owner: "acme",
+        name: "store",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not reuse when no connectionId was stored (public-clone mode)", () => {
+    expect(
+      planRepoReuse({
+        existingRepo: repo({ connectionId: undefined }),
+        owner: "acme",
+        name: "store",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not reuse when there is no existing repo", () => {
+    expect(
+      planRepoReuse({ existingRepo: null, owner: "acme", name: "store" }),
+    ).toBeNull();
+  });
+});
+
+describe("planAgentConnections", () => {
+  it("appends the repo connection as a credential-only link", () => {
+    const { staleConnectionId, mergedConnections } = planAgentConnections({
+      existingRepo: null,
+      existingConnections: [],
+      repoConnectionId: "conn_new",
+    });
+    expect(staleConnectionId).toBeUndefined();
+    expect(mergedConnections).toEqual([
+      { connection_id: "conn_new", selected_tools: [] },
+    ]);
+  });
+
+  it("flags the previous repo's connection as stale on a repo switch", () => {
+    const { staleConnectionId, mergedConnections } = planAgentConnections({
+      existingRepo: repo({ connectionId: "conn_old" }),
+      existingConnections: [{ connection_id: "conn_old", selected_tools: [] }],
+      repoConnectionId: "conn_new",
+    });
+    expect(staleConnectionId).toBe("conn_old");
+    // stale is de-aggregated (dropped) before the caller deletes it
+    expect(mergedConnections).toEqual([
+      { connection_id: "conn_new", selected_tools: [] },
+    ]);
+  });
+
+  it("has no stale connection when the same connection is reused", () => {
+    const { staleConnectionId, mergedConnections } = planAgentConnections({
+      existingRepo: repo({ connectionId: "conn_1" }),
+      existingConnections: [{ connection_id: "conn_1", selected_tools: [] }],
+      repoConnectionId: "conn_1",
+    });
+    expect(staleConnectionId).toBeUndefined();
+    // no duplicate: the existing repo connection is filtered then re-added once
+    expect(mergedConnections).toEqual([
+      { connection_id: "conn_1", selected_tools: [] },
+    ]);
+  });
+
+  it("preserves unrelated connections and their selected_tools", () => {
+    const other = {
+      connection_id: "conn_other",
+      selected_tools: ["TOOL_A"],
+      selected_resources: null,
+    };
+    const { mergedConnections } = planAgentConnections({
+      existingRepo: repo({ connectionId: "conn_old" }),
+      existingConnections: [
+        other,
+        { connection_id: "conn_old", selected_tools: [] },
+      ],
+      repoConnectionId: "conn_new",
+    });
+    expect(mergedConnections).toEqual([
+      other,
+      { connection_id: "conn_new", selected_tools: [] },
+    ]);
+  });
+});

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/report-agent-repo-plan.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-forms/report-agent-repo-plan.ts
@@ -1,0 +1,85 @@
+import type { GithubRepo } from "@decocms/mesh-sdk";
+
+/**
+ * Pure decision logic for mirroring a GitHub repo onto the Report Agent's
+ * `metadata.githubRepo` + connection aggregations. The I/O (MCP calls,
+ * provisioning, rollback) lives in the mutation; this module owns the branches
+ * that decide *what* to write, so they can be unit-tested without a live agent.
+ */
+
+/** Split `owner/name` into its parts. `null` when the shape is invalid. */
+export function parseRepoFullName(
+  githubRepo: string,
+): { owner: string; name: string } | null {
+  const [owner, name] = githubRepo.split("/");
+  if (!owner || !name) {
+    return null;
+  }
+  return { owner, name };
+}
+
+/**
+ * Decide whether the repo-scoped connection already on the agent can be reused.
+ * Reuse only when a connectionId is present AND the same repo is being re-saved
+ * — GitHub owner/name are case-insensitive, so compare lowercased. Returns the
+ * reusable connection's id + installationId, or `null` to provision a fresh one.
+ */
+export function planRepoReuse(params: {
+  existingRepo?: GithubRepo | null;
+  owner: string;
+  name: string;
+}): { connectionId: string; installationId?: number } | null {
+  const { existingRepo, owner, name } = params;
+  if (
+    existingRepo?.connectionId &&
+    existingRepo.owner.toLowerCase() === owner.toLowerCase() &&
+    existingRepo.name.toLowerCase() === name.toLowerCase()
+  ) {
+    return {
+      connectionId: existingRepo.connectionId,
+      installationId: existingRepo.installationId,
+    };
+  }
+  return null;
+}
+
+/**
+ * Compute the agent's new connection list and any connection that became stale.
+ *
+ * - `staleConnectionId`: a connection from a previously-linked repo that the
+ *   metadata write is about to orphan (delete it AFTER the write, since
+ *   `child_connection_id` is ON DELETE RESTRICT — migration 026).
+ * - `mergedConnections`: existing connections minus the repo/stale ones, plus
+ *   the repo-scoped connection as a credential-only link (`selected_tools: []`
+ *   keeps GitHub tools off the report agent). Existing entries are preserved
+ *   as-is so their `selected_tools`/`selected_resources`/`selected_prompts`
+ *   survive the round-trip.
+ */
+export function planAgentConnections<
+  T extends { connection_id: string },
+>(params: {
+  existingRepo?: GithubRepo | null;
+  existingConnections: T[];
+  repoConnectionId: string;
+}): {
+  staleConnectionId?: string;
+  mergedConnections: Array<T | { connection_id: string; selected_tools: [] }>;
+} {
+  const { existingRepo, existingConnections, repoConnectionId } = params;
+
+  const staleConnectionId =
+    existingRepo?.connectionId && existingRepo.connectionId !== repoConnectionId
+      ? existingRepo.connectionId
+      : undefined;
+
+  const mergedConnections = [
+    ...existingConnections.filter(
+      (c) =>
+        c.connection_id !== repoConnectionId &&
+        c.connection_id !== staleConnectionId,
+    ),
+    { connection_id: repoConnectionId, selected_tools: [] as [] },
+  ];
+
+  return { staleConnectionId, mergedConnections };
+}


### PR DESCRIPTION
## Summary
Follow-up to #4708. That PR's GitHub companion-form mutation decided **reuse-vs-provision**, **stale-connection selection**, and **connection merging** inline with its MCP I/O, and shipped those branches untested (the PR body called it "glue wiring, not branching logic" — it's four branches with data-integrity stakes).

This extracts the pure decisions into three helpers and unit-tests them. No behavior change; the I/O sequencing and rollback stay in the mutation (those genuinely need e2e).

- `parseRepoFullName` — `owner/name` split + validation.
- `planRepoReuse` — case-insensitive same-repo reuse of an existing repo-scoped connection.
- `planAgentConnections` — stale-connection selection + the merged aggregation list (drops the stale one so de-aggregation lands before its `ON DELETE RESTRICT` delete; preserves unrelated connections' `selected_tools`).

## Testing notes
- New `report-agent-repo-plan.test.ts` — 12 cases: parse edges, reuse match/case-insensitivity/miss/no-connectionId/no-repo, and merge for new/switch/reuse/preserve-others.
- `bun test report-agent-repo-plan.test.ts` → 12 pass.
- `bun run --cwd=apps/mesh check` and `bun run lint` (0 errors) pass; `bun run fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the repo-planning logic for the commerce onboarding GitHub form into pure helpers and added unit tests. No behavior change; improves testability while keeping I/O sequencing and rollback in the mutation.

- **Refactors**
  - Introduced `parseRepoFullName`, `planRepoReuse`, and `planAgentConnections` to handle reuse-vs-provision, stale-connection selection, and connection merging.
  - Updated the form to use these helpers; preserves unrelated connections and matches owner/name case-insensitively.
  - Ensures stale repo connections are de-aggregated before deletion to satisfy `ON DELETE RESTRICT`.
  - Added 12 unit tests covering parse, reuse (including case-insensitive matches), repo switch, and preservation of other connections.

<sup>Written for commit 6a6abea477bc09079d01d72d7af4bc41c2705478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

