### PR TITLE
fix(sidebar): scope thread pagination so "Show more" loads matching chats

### DIFF
--- a/apps/mesh/src/web/components/chat/store/hooks.tsx
+++ b/apps/mesh/src/web/components/chat/store/hooks.tsx
@@ -100,6 +100,7 @@ export function useThreadActions() {
     setStatus: m.setStatus.bind(m),
     setBranch: m.setBranch.bind(m),
     setAgent: m.setAgent.bind(m),
+    setScope: m.setScope.bind(m),
     setActive: m.setActive.bind(m),
     closeActive: m.closeActive.bind(m),
   };

--- a/apps/mesh/src/web/components/chat/store/thread-manager-store.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-manager-store.test.ts
@@ -702,6 +702,68 @@ describe("ThreadManagerStore pagination via COLLECTION_THREADS_LIST", () => {
     expect(store.threads.get().map((t) => t.id)).toEqual(["t-after-reconnect"]);
     store.dispose();
   });
+
+  it("scopes the list to created_by: 'me' by default", async () => {
+    const sse = makeFakePool();
+    const wheres: unknown[] = [];
+    const callTool = mock(
+      async (args: { name: string; arguments: { where: unknown } }) => {
+        if (args.name !== "COLLECTION_THREADS_LIST") return {};
+        wheres.push(args.arguments.where);
+        return { structuredContent: { items: [], hasMore: false } };
+      },
+    );
+    const store = new ThreadManagerStore("acme", "loc-1", {
+      client: { callTool } as unknown as MCPClient,
+      sse,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(wheres[0]).toEqual({ hidden: false, created_by: "me" });
+    store.dispose();
+  });
+
+  it("setScope reloads page 1 with the new where and resets offset", async () => {
+    const sse = makeFakePool();
+    const wheres: Record<string, unknown>[] = [];
+    let call = 0;
+    const callTool = mock(
+      async (args: {
+        name: string;
+        arguments: { where: Record<string, unknown>; offset: number };
+      }) => {
+        if (args.name !== "COLLECTION_THREADS_LIST") return {};
+        call++;
+        wheres.push(args.arguments.where);
+        return {
+          structuredContent: {
+            items: [
+              { id: `scope-${call}`, updated_at: "2026-05-19T00:00:00Z" },
+            ],
+            hasMore: false,
+          },
+        };
+      },
+    );
+    const store = new ThreadManagerStore("acme", "loc-1", {
+      client: { callTool } as unknown as MCPClient,
+      sse,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(wheres[0]).toEqual({ hidden: false, created_by: "me" });
+
+    // Widen to Team scope (org-wide).
+    store.setScope({});
+    await new Promise((r) => setTimeout(r, 10));
+    expect(wheres[1]).toEqual({ hidden: false });
+    expect(store.threads.get().map((t) => t.id)).toEqual(["scope-2"]);
+
+    // Unchanged scope is a no-op (no extra fetch).
+    const before = call;
+    store.setScope({});
+    await new Promise((r) => setTimeout(r, 10));
+    expect(call).toBe(before);
+    store.dispose();
+  });
 });
 
 describe("ThreadManagerStore event buffer during boot", () => {

--- a/apps/mesh/src/web/components/chat/store/thread-manager-store.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-manager-store.ts
@@ -90,10 +90,12 @@ export class ThreadManagerStore {
    * server-side) so the sidebar's default "Mine" scope paginates only the
    * user's threads. Without it, "Show more" pages the org-wide feed while the
    * sidebar filters to the user client-side — so a page of teammates' rows is
-   * fetched, discarded, and nothing new appears. `setScope` swaps it (e.g. `{}`
-   * for Team scope, adding `has_trigger` for the type filter). Other readers
-   * (org-home, breadcrumb) re-filter to the user themselves, so widening the
-   * scope for Team view is harmless to them.
+   * fetched, discarded, and nothing new appears. `setScope` swaps it (`{}` for
+   * Team scope). Only the owner scope is pushed here, never the type filter:
+   * other readers (org-home, breadcrumb) read this shared store via
+   * `findReusableNewChat`, so narrowing by `has_trigger` would hide the user's
+   * manual "New chat" and make them mint a duplicate. Widening to Team scope is
+   * harmless because those readers re-filter to the user themselves.
    */
   private scopeWhere: Record<string, unknown> = { created_by: "me" };
   private scopeKey = JSON.stringify({ created_by: "me" });

--- a/apps/mesh/src/web/components/chat/store/thread-manager-store.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-manager-store.ts
@@ -85,6 +85,24 @@ export class ThreadManagerStore {
   private nextOffset = 0;
   private readonly pageSize = 10;
   /**
+   * Server-side filter fragment merged into `where` for both the initial page
+   * and `fetchNextPage`. Defaults to the current user ("me" is resolved
+   * server-side) so the sidebar's default "Mine" scope paginates only the
+   * user's threads. Without it, "Show more" pages the org-wide feed while the
+   * sidebar filters to the user client-side — so a page of teammates' rows is
+   * fetched, discarded, and nothing new appears. `setScope` swaps it (e.g. `{}`
+   * for Team scope, adding `has_trigger` for the type filter). Other readers
+   * (org-home, breadcrumb) re-filter to the user themselves, so widening the
+   * scope for Team view is harmless to them.
+   */
+  private scopeWhere: Record<string, unknown> = { created_by: "me" };
+  private scopeKey = JSON.stringify({ created_by: "me" });
+  /**
+   * Bumped on every (re)load so a scope switch mid-flight discards the stale
+   * response instead of clobbering the newer scope's list.
+   */
+  private loadGeneration = 0;
+  /**
    * Event buffer: `[]` means "boot, buffering"; `null` means "ready, dispatching live".
    * thread.* events arriving before loadInitialPage resolves are queued here
    * and replayed (tombstone-checked) after the first page lands.
@@ -289,6 +307,7 @@ export class ThreadManagerStore {
   }
 
   private async loadInitialPage(): Promise<void> {
+    const gen = ++this.loadGeneration;
     if (!this.client) {
       // No MCP client — drain the buffer immediately so SSE events are
       // dispatched live (store stays in "loading" status until a client
@@ -303,9 +322,10 @@ export class ThreadManagerStore {
           limit: this.pageSize,
           offset: 0,
           orderBy: [{ field: ["updated_at"], direction: "desc" }],
-          where: { hidden: false },
+          where: { hidden: false, ...this.scopeWhere },
         },
       });
+      if (gen !== this.loadGeneration) return;
       if ((result as { isError?: boolean }).isError) {
         throw new Error(
           extractToolErrorMessage(result, "COLLECTION_THREADS_LIST failed"),
@@ -320,11 +340,30 @@ export class ThreadManagerStore {
       this.threadsStatus.set({ kind: "ready" });
       this.drainEventBuffer();
     } catch (err) {
+      if (gen !== this.loadGeneration) return;
       this.threadsStatus.set({
         kind: "error",
         error: err instanceof Error ? err : new Error(String(err)),
       });
     }
+  }
+
+  /**
+   * Repoint the paginated feed at a new server-side scope (the `where`
+   * fragment merged into every list call). No-op if unchanged. Resets
+   * pagination and reloads the first page.
+   *
+   * Safe to call during render: the synchronous body only mutates plain
+   * fields and kicks the async reload, which performs no store writes before
+   * its first `await`.
+   */
+  setScope(where: Record<string, unknown>): void {
+    const key = JSON.stringify(where);
+    if (key === this.scopeKey) return;
+    this.scopeKey = key;
+    this.scopeWhere = where;
+    this.nextOffset = 0;
+    void this.loadInitialPage();
   }
 
   private drainEventBuffer(): void {
@@ -341,6 +380,7 @@ export class ThreadManagerStore {
     if (!this.hasMore.get()) return;
     if (this.isFetchingMore.get()) return;
     this.isFetchingMore.set(true);
+    const gen = this.loadGeneration;
     try {
       const result = await this.client.callTool({
         name: "COLLECTION_THREADS_LIST",
@@ -348,9 +388,12 @@ export class ThreadManagerStore {
           limit: this.pageSize,
           offset: this.nextOffset,
           orderBy: [{ field: ["updated_at"], direction: "desc" }],
-          where: { hidden: false },
+          where: { hidden: false, ...this.scopeWhere },
         },
       });
+      // A scope switch reset pagination mid-flight — this page is for the old
+      // scope, so drop it rather than appending it to the new list.
+      if (gen !== this.loadGeneration) return;
       if ((result as { isError?: boolean }).isError) {
         throw new Error(
           extractToolErrorMessage(result, "COLLECTION_THREADS_LIST failed"),

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -205,15 +205,19 @@ export function TaskGroupsList({
     currentUserId: currentUserId ?? null,
   };
 
-  // Keep the shared thread feed scoped, server-side, to what the flat list
-  // currently shows (scope + type), so "Show more" pages matching rows instead
-  // of the org-wide feed and then dropping them client-side. Idempotent — a
-  // no-op unless scope/type actually changed. The client-side filters below
-  // stay as defense against live SSE rows arriving outside the current scope.
+  // Keep the shared thread feed scoped, server-side, to the current owner scope
+  // (Mine/Team), so "Show more" pages matching rows instead of the org-wide feed
+  // and then dropping them client-side. Idempotent — a no-op unless the scope
+  // actually changed. The client-side filters below stay as defense against live
+  // SSE rows arriving outside the current scope.
+  //
+  // Only `created_by` is pushed server-side, NOT the type filter: this store is
+  // shared, and org-home / breadcrumb read it via `findReusableNewChat` to reuse
+  // the user's empty manual "New chat". Narrowing by `has_trigger` would hide
+  // that manual thread whenever the Automation filter is active, so those
+  // readers would mint a duplicate. Type stays a client-side filter.
   const scopeWhere: Record<string, unknown> = {};
   if (!showAll) scopeWhere.created_by = "me";
-  if (typeFilter === "automation") scopeWhere.has_trigger = true;
-  else if (typeFilter === "manual") scopeWhere.has_trigger = false;
   setScope(scopeWhere);
 
   // Until the session resolves, `currentUserId` is undefined — render nothing

--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -164,7 +164,7 @@ export function TaskGroupsList({
     fetchNextPage,
   } = useThreads();
   const visibleThreads = allThreads.filter((thread) => !thread.hidden);
-  const { hide } = useThreadActions();
+  const { hide, setScope } = useThreadActions();
 
   const navigate = useNavigate();
   const { setTaskId, createNewTask } = usePanelActions();
@@ -198,17 +198,23 @@ export function TaskGroupsList({
   const [searchEverOpened, setSearchEverOpened] = useState(false);
 
   // `filters` drives the per-status / per-group server pagination (status mode),
-  // where `member: "mine"` scopes the query to the current user. The flat list,
-  // by contrast, paginates the shared org-wide thread store and filters to the
-  // active scope (My/All) client-side — so in "My" mode a "Show more" can page
-  // in teammate-only rows that get filtered out.
-  // ponytail: proper per-scope flat pagination needs a store fetch that accepts
-  // a created_by filter; deferred as a follow-up.
+  // where `member: "mine"` scopes the query to the current user.
   const filters: SidebarFilters = {
     type: typeFilter,
     member: "mine",
     currentUserId: currentUserId ?? null,
   };
+
+  // Keep the shared thread feed scoped, server-side, to what the flat list
+  // currently shows (scope + type), so "Show more" pages matching rows instead
+  // of the org-wide feed and then dropping them client-side. Idempotent — a
+  // no-op unless scope/type actually changed. The client-side filters below
+  // stay as defense against live SSE rows arriving outside the current scope.
+  const scopeWhere: Record<string, unknown> = {};
+  if (!showAll) scopeWhere.created_by = "me";
+  if (typeFilter === "automation") scopeWhere.has_trigger = true;
+  else if (typeFilter === "manual") scopeWhere.has_trigger = false;
+  setScope(scopeWhere);
 
   // Until the session resolves, `currentUserId` is undefined — render nothing
   // rather than leaking every member's threads into the "My threads" list.


### PR DESCRIPTION
## Summary

The sidebar "Show more" button did nothing: clicking it fired `COLLECTION_THREADS_LIST` (offset advanced correctly, e.g. `offset:50`), the server returned 10 items with `hasMore: true`, but no new rows appeared.

**Root cause.** The flat list paginates the *shared org-wide* thread store with only `where: { hidden: false }` (no `created_by`), then filters to the current user (and type) **client-side**. When the org feed is dominated by another user's automation threads — e.g. 7340 "Automation: Grafana alerts" rows — every "Show more" pages in 10 non-matching rows that get discarded by the client filter, while `hasMore` stays `true` forever. The store *was* updating; the fetched page just never survived the filter. This was a known, documented gap (a `ponytail:` TODO in `task-groups-list.tsx`).

## Fix

Scope the store's list calls **server-side** to what the sidebar actually shows (the list tool already supports `where.created_by` with a `"me"` sentinel + `where.has_trigger`):

- Store defaults to `{ created_by: "me" }` — the sidebar's default "Mine" scope now pages only the user's threads.
- `setScope(where)` swaps the filter (`{}` for Team scope; adds `has_trigger` for the type filter), resets pagination, and reloads page 1. No-op when unchanged.
- A `loadGeneration` guard drops a stale in-flight page if the scope switches mid-fetch.
- `task-groups-list.tsx` reconciles the store scope with the current scope/type filters each render (idempotent; `setScope`'s synchronous body only mutates plain fields and kicks the async reload — no store writes before its first `await`, so it's render-safe without `useEffect`).

Other store readers (org-home, breadcrumb) only use `threads` to feed `findReusableNewChat`, which already filters to `session.user.id`, so widening the scope for Team view is harmless to them. The client-side scope/type filters stay as defense against live SSE rows arriving outside the current scope.

## Testing

- `bun test` on the store + sidebar suites (added 2 tests: default `created_by: "me"` scope, and `setScope` reload/reset/no-op).
- `bun run check` (typecheck) and `bun run lint` clean; `bun run fmt` applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar "Show more" so it loads chats that match the current Mine/Team scope. Server pagination is now scoped by owner (`created_by`), and the type filter stays client-side to avoid hiding the manual "New chat" reused elsewhere.

- **Bug Fixes**
  - Server pagination defaults to `where: { created_by: "me" }`; Team scope uses `{}`. The type filter is no longer pushed into the shared store.
  - Added `setScope(where)` to the thread store (resets pagination and reloads) and exposed via `useThreadActions`; `TaskGroupsList` keeps the store scope in sync.
  - Added a generation guard to drop stale in-flight pages when the scope changes.
  - Tests added for default owner scoping and `setScope` reload/no-op behavior.

<sup>Written for commit 4b24328d53b1762e59fbc9b273029749b6d4562d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

