### PR TITLE
fix(organization): stop duplicate member rows for invited domain users

### DIFF
--- a/apps/mesh/migrations/133-dedupe-duplicate-members.ts
+++ b/apps/mesh/migrations/133-dedupe-duplicate-members.ts
@@ -1,0 +1,45 @@
+import { sql, type Kysely } from "kysely";
+
+/**
+ * Removes duplicate organization membership rows.
+ *
+ * A user could end up with two `member` rows in the same org: domain auto-join
+ * at signup created one, then accepting the pending invitation created another
+ * (Better Auth's acceptInvitation calls createMember unconditionally, without
+ * an existing-member check). The signup-side fix now skips the auto-join when a
+ * pending invitation governs membership; this migration cleans up rows already
+ * created before that fix.
+ *
+ * Per (organizationId, userId) we keep a single row, preferring: a privileged
+ * role (owner > admin) so we never demote someone, then the row carrying the
+ * most tags (member_tags cascades on delete, so a discarded row must not be the
+ * one holding a user's tags), then the earliest createdAt, then the smallest id
+ * for a deterministic tiebreak. Everything else in the group is deleted.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DELETE FROM member
+    WHERE id IN (
+      SELECT id FROM (
+        SELECT
+          m.id,
+          row_number() OVER (
+            PARTITION BY m."organizationId", m."userId"
+            ORDER BY
+              (m.role = 'owner') DESC,
+              (m.role = 'admin') DESC,
+              (SELECT count(*) FROM member_tags mt WHERE mt.member_id = m.id) DESC,
+              m."createdAt" ASC,
+              m.id ASC
+          ) AS rn
+        FROM member m
+      ) ranked
+      WHERE ranked.rn > 1
+    )
+  `.execute(db);
+}
+
+export async function down(_db: Kysely<unknown>): Promise<void> {
+  // No rollback — the deleted rows were accidental duplicates and the surviving
+  // row already represents the membership.
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -131,6 +131,7 @@ import * as migration129taskboardassignedby from "./129-task-board-assigned-by.t
 import * as migration130taskboardthreadid from "./130-task-board-thread-id.ts";
 import * as migration131taskboardthreadlinkcascade from "./131-task-board-thread-link-cascade.ts";
 import * as migration132taskboarditemprs from "./132-task-board-item-prs.ts";
+import * as migration133dedupeduplicatemembers from "./133-dedupe-duplicate-members.ts";
 
 /**
  * Core migrations for the Mesh application.
@@ -287,6 +288,7 @@ const migrations: Record<string, Migration> = {
   "130-task-board-thread-id": migration130taskboardthreadid,
   "131-task-board-thread-link-cascade": migration131taskboardthreadlinkcascade,
   "132-task-board-item-prs": migration132taskboarditemprs,
+  "133-dedupe-duplicate-members": migration133dedupeduplicatemembers,
 };
 
 export default migrations;

--- a/apps/mesh/src/auth/ensure-user-organization.ts
+++ b/apps/mesh/src/auth/ensure-user-organization.ts
@@ -89,7 +89,10 @@ export type EnsureOrganizationResult =
     }
   | {
       status: "skipped";
-      reason: "auto-create-disabled" | "no-safe-domain-action";
+      reason:
+        | "auto-create-disabled"
+        | "no-safe-domain-action"
+        | "pending-invitation";
       domain: string | null;
     };
 
@@ -162,6 +165,13 @@ async function ensureUserOrganizationInTransaction(options: {
 
     if (candidates.length === 1 && candidates[0]?.joinMode === "auto") {
       const organization = candidates[0]!;
+      // An explicit invitation to this org already governs membership. Skip the
+      // domain auto-join so accepting the invitation is the single membership
+      // path — otherwise the user gets a member row here AND a second one when
+      // acceptInvitation unconditionally creates a member, showing up twice.
+      if (await hasPendingInvitationToOrg(db, user.email, organization.id)) {
+        return { status: "skipped", reason: "pending-invitation", domain };
+      }
       await addMemberIdempotent(authApi, user.id, organization.id);
 
       return { status: "joined", organization, domain, createdVia };
@@ -192,6 +202,9 @@ async function ensureUserOrganizationInTransaction(options: {
       lockedCandidates[0]?.joinMode === "auto"
     ) {
       const organization = lockedCandidates[0]!;
+      if (await hasPendingInvitationToOrg(db, user.email, organization.id)) {
+        return { status: "skipped", reason: "pending-invitation", domain };
+      }
       await addMemberIdempotent(authApi, user.id, organization.id);
 
       return { status: "joined", organization, domain, createdVia };
@@ -388,6 +401,25 @@ async function getOrganizationsForDomainRecords(
     const { metadata: _metadata, ...activeOrganization } = organization;
     return [{ ...activeOrganization, joinMode: record.joinMode }];
   });
+}
+
+async function hasPendingInvitationToOrg(
+  db: DatabaseExecutor,
+  email: string,
+  organizationId: string,
+): Promise<boolean> {
+  // The invitation table is managed by Better Auth and isn't in the Kysely
+  // Database type, so query it with raw SQL (camelCase columns need quoting).
+  const result = await sql<{ exists: boolean }>`
+    select exists(
+      select 1 from invitation
+      where lower(email) = lower(${email})
+        and "organizationId" = ${organizationId}
+        and status = 'pending'
+        and "expiresAt" > now()
+    ) as exists
+  `.execute(db);
+  return result.rows[0]?.exists ?? false;
 }
 
 async function addMemberIdempotent(

--- a/packages/e2e/tests/invite-no-duplicate-member.spec.ts
+++ b/packages/e2e/tests/invite-no-duplicate-member.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Domain auto-join must not duplicate an invited member.
+ *
+ * Repro of the reported bug: an owner invites teammates on the org's corporate
+ * domain; each invitee signs up, gets domain-auto-joined at signup (member row
+ * #1), then accepts the invitation, which unconditionally creates member row #2
+ * — so they appear twice in the members list.
+ *
+ * The fix skips the domain auto-join when a pending invitation already governs
+ * membership, so accepting the invitation is the single membership path. This
+ * spec exercises `ensureUserOrganization` through its real HTTP surface
+ * (POST /api/auth/custom/ensure-organization) with a pending invitation present
+ * vs. removed, proving the invitation is what suppresses the auto-join.
+ *
+ * Like auto-domain-join-multi-org.spec.ts, the domain claim needs
+ * emailVerified=true (an OTP flow we can't drive headlessly), so we seed the
+ * org + verified domain directly and flip the signed-up user to verified.
+ */
+
+import { type Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUp } from "../fixtures/auth";
+import { expect, test } from "../fixtures/test";
+
+const TEST_DOMAIN = `invite-e2e-${Date.now()}.test`;
+const ORG_SLUG = `e2e-invite-org-${Date.now()}`;
+const ORG_ID = `e2e_invite_org_${Date.now()}`;
+
+test.describe("Invite: domain auto-join does not duplicate the member", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+    const now = new Date().toISOString();
+
+    await db.query(
+      `INSERT INTO "organization" (id, name, slug, "createdAt")
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (id) DO NOTHING`,
+      [ORG_ID, "Invite E2E Org", ORG_SLUG, now],
+    );
+
+    await db.query(
+      `INSERT INTO organization_domains
+         (id, organization_id, domain, join_mode, verification_status,
+          verification_method, verified_at, created_at, updated_at)
+       VALUES
+         (gen_random_uuid()::text, $1, $2, 'auto', 'verified', 'email', $3, $3, $3)
+       ON CONFLICT (organization_id, domain) DO UPDATE
+         SET join_mode = EXCLUDED.join_mode,
+             verification_status = EXCLUDED.verification_status,
+             updated_at = EXCLUDED.updated_at`,
+      [ORG_ID, TEST_DOMAIN, now],
+    );
+  });
+
+  test.afterAll(async () => {
+    if (!db) return;
+    await db.query(`DELETE FROM invitation WHERE "organizationId" = $1`, [
+      ORG_ID,
+    ]);
+    await db.query(`DELETE FROM organization_domains WHERE domain = $1`, [
+      TEST_DOMAIN,
+    ]);
+    await db.query(`DELETE FROM "member" WHERE "organizationId" = $1`, [
+      ORG_ID,
+    ]);
+    await db.query(`DELETE FROM "organization" WHERE id = $1`, [ORG_ID]);
+    await db.end();
+  });
+
+  test("skips auto-join while an invitation is pending, joins once it is gone", async ({
+    page,
+  }) => {
+    const suffix = Date.now() + Math.floor(Math.random() * 100000);
+    const email = `invitee-${suffix}@${TEST_DOMAIN}`;
+    await signUp(page, { email });
+
+    const userRow = await db.query<{ id: string }>(
+      `SELECT id FROM "user" WHERE email = $1`,
+      [email],
+    );
+    const userId = userRow.rows[0]?.id;
+    if (!userId) throw new Error(`Test user ${email} not found after signup`);
+
+    // /ensure-organization only domain-joins verified corporate users, and the
+    // user must not already belong to an org (signup auto-creates one).
+    await db.query(`UPDATE "user" SET "emailVerified" = true WHERE id = $1`, [
+      userId,
+    ]);
+    await db.query(`DELETE FROM "member" WHERE "userId" = $1`, [userId]);
+
+    // A pending invitation to the same org, addressed to this user.
+    const expiresAt = new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString();
+    const now = new Date().toISOString();
+    await db.query(
+      `INSERT INTO invitation
+         (id, "organizationId", email, role, status, "expiresAt", "inviterId", "createdAt")
+       VALUES (gen_random_uuid()::text, $1, $2, 'user', 'pending', $3, $4, $5)`,
+      [ORG_ID, email, expiresAt, userId, now],
+    );
+
+    // With the invitation pending, the auto-join must be skipped.
+    const skipped = await page.request.post(
+      "/api/auth/custom/ensure-organization",
+    );
+    const skippedBody = await skipped.json();
+    expect(skippedBody.status).toBe("skipped");
+    expect(skippedBody.reason).toBe("pending-invitation");
+
+    const afterSkip = await db.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM "member"
+       WHERE "userId" = $1 AND "organizationId" = $2`,
+      [userId, ORG_ID],
+    );
+    expect(afterSkip.rows[0]!.count).toBe("0");
+
+    // Remove the invitation (as accepting it would) and re-run: now the domain
+    // auto-join proceeds, producing exactly one membership — never two.
+    await db.query(`DELETE FROM invitation WHERE "organizationId" = $1`, [
+      ORG_ID,
+    ]);
+
+    const joined = await page.request.post(
+      "/api/auth/custom/ensure-organization",
+    );
+    const joinedBody = await joined.json();
+    expect(joinedBody.success).toBe(true);
+
+    const afterJoin = await db.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM "member"
+       WHERE "userId" = $1 AND "organizationId" = $2`,
+      [userId, ORG_ID],
+    );
+    expect(afterJoin.rows[0]!.count).toBe("1");
+  });
+});


### PR DESCRIPTION
## Problem

A customer invited teammates on their corporate domain (`@licitei.com.br`) and each invitee showed up **twice** in the members list — two real member rows (name, avatar, role, joined date), not a member-plus-pending-invitation.

## Root cause

Two membership-creating paths collide for a user whose email matches an org's **auto-join domain**:

1. **Signup** → `ensureUserOrganization` domain-auto-joins the verified corporate user → **member row #1**.
2. **Accepting the pending invitation** → Better Auth's `acceptInvitation` calls `createMember` **unconditionally** (no existing-member check) → **member row #2**.

`addMember` (domain join, join-request approve) is guarded via `isAlreadyMemberError`; `acceptInvitation` is the one unguarded path, and it lives in the `@decocms/better-auth` fork.

## Fix

- **`ensure-user-organization.ts`** — skip the domain auto-join when a **pending, non-expired invitation** to that org already exists for the user's email. The invitation becomes the single membership path, so accept creates the one and only member row. New `skipped` reason `pending-invitation`.
- **Migration `133-dedupe-duplicate-members`** — removes duplicate `member` rows already created before the fix. Per `(organizationId, userId)` it keeps one row, preferring privileged role (owner > admin) → most tags (`member_tags` cascades on delete) → earliest `createdAt` → smallest id.

## Testing

- `packages/e2e/tests/invite-no-duplicate-member.spec.ts` — seeds an org + verified auto domain + a pending invitation, then hits `POST /api/auth/custom/ensure-organization`: asserts it **skips** (`reason: pending-invitation`, 0 members) while the invite is pending, and **joins exactly once** after the invite is removed.
- `bun run --cwd=apps/mesh check`, `bun run lint` (0 errors), `bun run fmt`, migrations index test — all pass.

Note: the fix is forward-looking prevention; the migration handles existing bad data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate org member rows for invited users on auto-join domains by skipping domain auto-join when a valid pending invitation exists. Adds a migration to clean up existing duplicates.

- **Bug Fixes**
  - `ensureUserOrganization` now skips auto-join when a pending, unexpired invitation exists for the same org/email; returns reason `pending-invitation`.
  - Adds an e2e test to verify skip while pending and single join after the invitation is removed.
  - Notes: `acceptInvitation` in `@decocms/better-auth` still creates a member unconditionally; this change avoids hitting that path twice.

- **Migration**
  - Adds `133-dedupe-duplicate-members` to delete duplicate `member` rows, keeping one per `(organizationId, userId)` by preferring role (owner > admin) → most tags → earliest `createdAt` → smallest id.

<sup>Written for commit a552d82246bc9132cb76eb1a2c356cfb6b5f6138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

