### PR TITLE
fix(boot): retry DBOS post-launch setup on transient DB connect timeout

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -6,7 +6,7 @@
  * Or: bun run src/index.ts
  */
 
-import { sleep } from "@decocms/std";
+import { retry, sleep } from "@decocms/std";
 // Side-effect-free queue names — safe to import before DBOS.setConfig (unlike
 // the workflow modules, which register workflows at import time).
 import {
@@ -183,8 +183,16 @@ await DBOS.launch({
 console.log(`[dbos] application version: ${DBOS.applicationVersion}`);
 // Post-launch DBOS setup (queue registration, schedule reconciliation).
 // Must run after launch because registerQueue / listSchedules require an
-// initialized executor.
-await app.initDbos();
+// initialized executor. Retry: registerQueue + reconcile are idempotent, so a
+// transient boot-time DB connect timeout (shared RDS under connection pressure)
+// retries instead of exiting the process — otherwise one blip crash-loops every
+// pod at once.
+await retry(() => app.initDbos(), {
+  maxAttempts: 5,
+  minTimeout: 1000,
+  maxTimeout: 10_000,
+  jitter: 0.5,
+});
 
 // When running via CLI, the calling script handles its own banner/config output
 if (!settings.isCli) {


### PR DESCRIPTION
## Summary

Prod pod `deco-studio-...` restarted once at boot (exit code 1, reason `Error` — **not** OOMKilled, **not** a liveness SIGKILL). Root cause traced via VictoriaLogs:

```
18:05:40  Dynamic scheduler: error listing schedules: timeout exceeded when trying to connect
18:05:40  error: timeout exceeded when trying to connect  (pg-pool/index.js:45)
18:05:40  error: "deco" exited with code 1
```

A transient Postgres **connection-establishment** timeout (`connectionTimeoutMillis: 30000`) during `app.initDbos()` (queue registration + schedule reconciliation via `DBOS.listSchedules`) was thrown **unhandled** at the top level (`index.ts` `await app.initDbos()`), aborting the whole process. It self-recovered on the next restart (~1 min), but under shared-RDS connection pressure a single blip crash-loops **every** pod at boot simultaneously — turning a blip into an outage.

This is unrelated to the known event-loop-stall killers; stalls in the affected pod maxed at 1.5s.

## Fix

`registerQueue` and `reconcileAutomationSchedules` are idempotent, so wrap `initDbos()` in `@decocms/std` `retry` (5 attempts, 1s→10s backoff, jitter) to ride out a transient connect timeout instead of exiting.

## Testing

- `bun run fmt` clean.
- Behavior preserving on the happy path (first attempt succeeds → identical to before); retry only engages on a thrown boot-time DB error.

## Follow-up (not in this PR)

Root DB blip is infra (shared RDS connection pressure at boot). If retries start exhausting, consider staggering the pool ramp or raising the boot connect timeout — retry covers the transient case for now.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a retry to DBOS post-launch setup to handle transient Postgres connect timeouts at boot. This prevents the process from exiting and avoids pod crash-loops.

- **Bug Fixes**
  - Wrap `app.initDbos()` with `@decocms/std` `retry` (5 attempts, 1s–10s backoff, 0.5 jitter).
  - Safe because queue registration and schedule reconciliation are idempotent.

<sup>Written for commit 9d1bbd530fe6b9a9c39262b614861cf53a1b5d50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

