### PR TITLE
fix(boot): log each DBOS post-launch retry attempt

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -187,12 +187,27 @@ console.log(`[dbos] application version: ${DBOS.applicationVersion}`);
 // transient boot-time DB connect timeout (shared RDS under connection pressure)
 // retries instead of exiting the process — otherwise one blip crash-loops every
 // pod at once.
-await retry(() => app.initDbos(), {
-  maxAttempts: 5,
-  minTimeout: 1000,
-  maxTimeout: 10_000,
-  jitter: 0.5,
-});
+let initDbosAttempt = 0;
+await retry(
+  async () => {
+    initDbosAttempt++;
+    try {
+      return await app.initDbos();
+    } catch (error) {
+      console.warn(
+        `[dbos] initDbos attempt ${initDbosAttempt}/5 failed, retrying`,
+        error,
+      );
+      throw error;
+    }
+  },
+  {
+    maxAttempts: 5,
+    minTimeout: 1000,
+    maxTimeout: 10_000,
+    jitter: 0.5,
+  },
+);
 
 // When running via CLI, the calling script handles its own banner/config output
 if (!settings.isCli) {


### PR DESCRIPTION
## Summary

Follows #4717, which wrapped `app.initDbos()` in `@decocms/std` `retry()` (5 attempts, 1s-10s backoff) so a transient boot-time Postgres connect timeout retries instead of crash-looping every pod. `retry()` has no `onRetry` hook, so as shipped, a flapping boot-time DB connection produces **zero log output** between the first failure and either eventual success or the final thrown `RetryError` — up to ~40s of silence. That's the exact gap the original incident (#4717's description) needed VictoriaLogs boot logs to diagnose in the first place.

## Fix

Log a `console.warn` on each failed attempt (with the attempt number and the underlying error) before the wrapped function rethrows for `retry()` to catch. Behavior is otherwise unchanged: happy path (first attempt succeeds) logs nothing new, and final exhaustion still throws `RetryError` as before.

## Verify

`cd apps/mesh && bunx tsc --noEmit`

## Testing

- `bun run fmt` clean.
- `bunx tsc --noEmit` in `apps/mesh` clean.
- No test added: this is a single log statement in a boot-only retry wrapper, not new branching logic — full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log a warning for each DBOS init retry during boot to eliminate the ~40s silent gap and make progress visible in pod logs. Retry behavior stays the same.

- **Bug Fixes**
  - On each failed attempt, emit a console.warn with attempt number (e.g., 2/5) and the underlying error while `@decocms/std` `retry()` handles backoff.
  - No change to success path; still throws final RetryError if all attempts fail.

<sup>Written for commit c12e770c31d56b2fe480861b62583ff87c8ab991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

