### PR TITLE
refactor(chat): replace raw palette with success/warning tokens in credits eyebrow

### DIFF
--- a/apps/mesh/src/web/components/chat/credits-eyebrow.tsx
+++ b/apps/mesh/src/web/components/chat/credits-eyebrow.tsx
@@ -22,13 +22,12 @@ export function CreditsEyebrow({ balanceDollars }: CreditsEyebrowProps) {
     <div
       className={cn(
         "inline-flex items-center gap-1.5 px-3 py-1 rounded-full",
-        "bg-emerald-50 dark:bg-emerald-950/30",
-        "border border-emerald-200/60 dark:border-emerald-800/40",
+        "bg-success/10 border border-success/20",
         "animate-in fade-in-0 slide-in-from-bottom-2 duration-300",
       )}
     >
-      <Coins04 size={13} className="text-emerald-600 dark:text-emerald-400" />
-      <span className="text-xs font-medium text-emerald-700 dark:text-emerald-300 tabular-nums">
+      <Coins04 size={13} className="text-success" />
+      <span className="text-xs font-medium text-success tabular-nums">
         ${formatted} in credits to get started
       </span>
     </div>
@@ -50,15 +49,14 @@ export function NoCreditsEyebrow() {
       }
       className={cn(
         "inline-flex items-center gap-1.5 px-3 py-1 rounded-full cursor-pointer",
-        "bg-amber-50 dark:bg-amber-950/30",
-        "border border-amber-200/60 dark:border-amber-800/40",
-        "hover:bg-amber-100/60 dark:hover:bg-amber-900/30",
+        "bg-warning/10 border border-warning/20",
+        "hover:bg-warning/15",
         "transition-colors duration-150",
         "animate-in fade-in-0 slide-in-from-bottom-2 duration-300",
       )}
     >
-      <AlertCircle size={13} className="text-amber-600 dark:text-amber-400" />
-      <span className="text-xs font-medium text-amber-700 dark:text-amber-300">
+      <AlertCircle size={13} className="text-warning" />
+      <span className="text-xs font-medium text-warning">
         No credits remaining &middot; Add more
       </span>
     </button>


### PR DESCRIPTION
## Source
C-DEBT: design-token drift in `apps/mesh/src/web/components/chat/credits-eyebrow.tsx` (flagged as a highest-debt frontend file, palette=9).

## Why
`CreditsEyebrow`/`NoCreditsEyebrow` hand-roll `emerald-*`/`amber-*` palette classes plus manual `dark:` variants for what are plainly success/warning status pills — the exact pattern the design system already has tokens for.

## Mapping (unambiguous — same shape already used elsewhere in the codebase)
- `bg-emerald-50 dark:bg-emerald-950/30` + `border-emerald-200/60 dark:border-emerald-800/40` → `bg-success/10 border-success/20`
- `text-emerald-600/700 dark:text-emerald-400/300` → `text-success`
- `bg-amber-50 dark:bg-amber-950/30` + `border-amber-200/60 dark:border-amber-800/40` → `bg-warning/10 border-warning/20`
- `hover:bg-amber-100/60 dark:hover:bg-amber-900/30` → `hover:bg-warning/15`
- `text-amber-600/700 dark:text-amber-400/300` → `text-warning`

Precedent: `native-tiles.tsx` already uses `bg-success/10 text-success` for an identical pill badge, and `commerce-report-banner.tsx` uses `bg-warning/15` / `bg-success/15` for the same success-vs-warning intent pairing. This aligns the shade to the design-system tokens — it is not guaranteed pixel-identical to the old raw emerald/amber values, but the mapping is semantically exact (success = has credits, warning = no credits) and both light/dark variants are handled by the token automatically, removing the need for manual `dark:` overrides.

## Verification
- `bun run fmt`
- `cd apps/mesh && bunx tsc --noEmit` — clean
- No test exists for this presentational component (none needed); a reviewer can confirm visually by rendering `CreditsEyebrow`/`NoCreditsEyebrow` in light and dark mode.

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded emerald/amber Tailwind classes in `CreditsEyebrow` and `NoCreditsEyebrow` with semantic success/warning tokens to match the design system and auto-handle dark mode. Behavior is unchanged; styling is simpler and more consistent.

<sup>Written for commit cf07f5bacb5d6cfd42e4e30755366d5c63b9c129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

