### PR TITLE
fix(storage): make replaceMessageParts insert idempotent (ON CONFLICT DO UPDATE)

### DIFF
--- a/apps/mesh/src/storage/thread-message-parts.integration.test.ts
+++ b/apps/mesh/src/storage/thread-message-parts.integration.test.ts
@@ -7,14 +7,26 @@ import {
   resetTestPgDatabase,
 } from "../database/test-db-pg";
 import type { StudioDatabase } from "../database";
+import { sleep } from "@decocms/std";
 import { SqlThreadStorage } from "./threads";
-import { SqlThreadMessagePartStorage } from "./thread-message-parts";
+import {
+  SqlThreadMessagePartStorage,
+  serializePayload,
+} from "./thread-message-parts";
 import type { ThreadMessagePart } from "./fold-parts";
 import { foldedToUIMessage } from "@/api/routes/decopilot/projector-seed";
 import { createRunPersistence } from "@/api/routes/decopilot/run-persistence";
 import { projectChunks } from "@/api/routes/decopilot/project-chunks";
 
 const ORG = "org_1";
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 describe("SqlThreadMessagePartStorage", () => {
   let database: StudioDatabase;
@@ -158,6 +170,72 @@ describe("SqlThreadMessagePartStorage", () => {
       database.db,
     );
     expect(Number(rows[0]!.n)).toBe(3);
+  });
+
+  it("R9b: replaceMessageParts survives a concurrent committed row on the same id (no dup-key throw)", async () => {
+    // Regression for the prod "No response was generated": replaceMessageParts'
+    // DELETE-then-INSERT is not atomic against a concurrent writer (the
+    // projector's appendParts, or a redelivered consumeRunProjection step) that
+    // commits a colliding (id) between the DELETE and the INSERT. A bare INSERT
+    // then violated thread_message_parts_pkey, the projection step threw, and
+    // the assistant message was left empty. The fix makes the INSERT
+    // upsert-on-conflict.
+    //
+    // Reproduced deterministically: a concurrent txn inserts the colliding id
+    // and holds OPEN (uncommitted) so replaceMessageParts' INSERT blocks on the
+    // unique index; committing it then forces the exact conflict. (The natural
+    // DELETE→INSERT window is too tight to hit by scheduling alone.)
+    const M = "m_race";
+    const run = "r_race";
+    const mkr = (seq: number, extra: Partial<ThreadMessagePart> = {}) =>
+      mk({
+        id: `${run}:${M}:${seq}`,
+        seq,
+        run_id: run,
+        message_id: M,
+        ...extra,
+      });
+
+    const inserted = deferred();
+    const release = deferred();
+    const other = database.db.transaction().execute(async (trx) => {
+      await trx
+        .insertInto("thread_message_parts")
+        .values({
+          id: `${run}:${M}:0`,
+          seq: 0,
+          org_id: ORG,
+          thread_id: threadId,
+          run_id: run,
+          message_id: M,
+          role: "assistant",
+          kind: "text",
+          payload: serializePayload({ type: "text", text: "concurrent" }),
+          payload_ref: null,
+          metadata: null,
+          created_at: new Date(1700000000000).toISOString(),
+        })
+        .execute();
+      inserted.resolve();
+      await release.promise; // hold the txn open (uncommitted)
+    });
+
+    await inserted.promise;
+    // DELETE sees no committed rows; the INSERT then blocks on the held id.
+    const replacePromise = parts.replaceMessageParts(threadId, M, [
+      mkr(0, { payload: { type: "text", text: "answer" } }),
+      mkr(1, { kind: "finish", payload: {} }),
+    ]);
+    await sleep(300); // let replace reach and block on its INSERT
+    release.resolve(); // commit the concurrent row → replace's INSERT conflicts
+    await other;
+    await replacePromise; // pre-fix: rejects with dup-key; post-fix: upserts
+
+    // The message ends complete with replace's authoritative snapshot.
+    const { messages } = await parts.loadWindow(threadId, { limit: 500 });
+    const msg = messages.find((m) => m.id === M)!;
+    expect(msg.status).toBe("complete");
+    expect(msg.parts).toMatchObject([{ type: "text", text: "answer" }]);
   });
 
   it("deleteMessageParts hard-deletes one message's rows (incl. finish anchor) and leaves the other message intact", async () => {

--- a/apps/mesh/src/storage/thread-message-parts.ts
+++ b/apps/mesh/src/storage/thread-message-parts.ts
@@ -176,6 +176,25 @@ export class SqlThreadMessagePartStorage {
         await trx
           .insertInto("thread_message_parts")
           .values(rowsToInsert)
+          // Concurrency / DBOS-retry safety: this DELETE-then-INSERT is not
+          // atomic against a concurrent writer (the projector's `appendParts`,
+          // or a redelivered `consumeRunProjection` step) that commits a
+          // colliding `id` between our DELETE and INSERT. A bare INSERT then
+          // fails the whole batch on `thread_message_parts_pkey`, the
+          // projection step throws, and the assistant message is left empty
+          // ("No response was generated"). This method owns the authoritative
+          // snapshot, so overwrite the row on conflict rather than aborting.
+          .onConflict((oc) =>
+            oc.column("id").doUpdateSet((eb) => ({
+              seq: eb.ref("excluded.seq"),
+              role: eb.ref("excluded.role"),
+              kind: eb.ref("excluded.kind"),
+              payload: eb.ref("excluded.payload"),
+              payload_ref: eb.ref("excluded.payload_ref"),
+              metadata: eb.ref("excluded.metadata"),
+              created_at: eb.ref("excluded.created_at"),
+            })),
+          )
           .execute();
       }
     });


### PR DESCRIPTION
## Summary

Reported on staging: a run rendered **"No response was generated"** (empty assistant message). The projector's persistence was throwing a duplicate-key violation:

```
error: duplicate key value violates unique constraint "thread_message_parts_pkey"
detail: Key (id)=(96991f73…:msg_XJD_ojN2wf4FJrGcb75yT:0) already exists.
sql: insert into "thread_message_parts" (...) values (...), (...), …   ← no ON CONFLICT
```

## Root cause

`PartEmitter` has two persistence paths: `appendParts` (already idempotent — `ON CONFLICT (id) DO NOTHING`) and `replaceMessageParts` (used by `replaceFinal` / `emitRequestMessage`), which does **DELETE-then-INSERT** in a transaction with a **bare INSERT**.

That DELETE→INSERT is not atomic against a concurrent writer — the projector's own `appendParts`, or a redelivered `consumeRunProjection` step (rampant on staging: the logs are a storm of `upstream prematurely closed` SSE drops + DBOS retries) — committing a colliding `id` between the DELETE and the INSERT. The bare multi-row INSERT then violates `thread_message_parts_pkey`, **the whole batch fails**, the projection step throws, no content parts land, and the assistant message renders empty.

## Fix

`replaceMessageParts` owns the authoritative message snapshot, so make its INSERT **upsert on conflict** (`ON CONFLICT (id) DO UPDATE` from `excluded`) instead of aborting the batch. Mirrors the idempotency `appendParts` already has — the "make side-effecting steps idempotent" rule.

## Testing

Added a **real-Postgres** regression test that reproduces the race *deterministically*: a concurrent transaction inserts the colliding `id` and holds open (uncommitted) so `replaceMessageParts`' INSERT blocks on the unique index; committing it forces the exact conflict. (A naturally-scheduled concurrent insert can't reliably hit the tiny DELETE→INSERT window — a looped-concurrency version passed even against the buggy code.)

Verified locally against Postgres 16:
- **With** the fix: passes (message ends complete with the authoritative snapshot).
- **Without** the fix (temporarily reverted): fails with `code: 23505` (`thread_message_parts_pkey`) — the exact production error.

Full `thread-message-parts.integration.test.ts` suite 10/10, `tsc --noEmit` clean, lint 0 errors, `bun run fmt` applied.

## Context (out of scope)

The DBOS step redelivery / SSE churn that makes the race fire so often is the same staging pod-instability seen in the sibling PRs; this change makes persistence *survive* it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `replaceMessageParts` idempotent by upserting on insert to prevent duplicate-key errors that caused empty assistant messages. Adds a deterministic Postgres test that reproduces the race and verifies the fix.

- **Bug Fixes**
  - `replaceMessageParts` now uses `INSERT ... ON CONFLICT (id) DO UPDATE` instead of bare INSERT after DELETE.
  - Survives concurrent writers (e.g., `appendParts` or retried projection steps) that insert the same `id`.
  - Prevents `thread_message_parts_pkey` violations that led to “No response was generated.”
  - Adds a real-Postgres regression test that forces the conflict; fails before the fix, passes after.

<sup>Written for commit 1f25068253d1009a24f1829cec3116b3b21bd783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

