### PR TITLE
fix(boot): don't log "retrying" on the final DBOS init retry attempt

### DIFF
--- a/apps/mesh/src/index.ts
+++ b/apps/mesh/src/index.ts
@@ -187,6 +187,7 @@ console.log(`[dbos] application version: ${DBOS.applicationVersion}`);
 // transient boot-time DB connect timeout (shared RDS under connection pressure)
 // retries instead of exiting the process — otherwise one blip crash-loops every
 // pod at once.
+const initDbosMaxAttempts = 5;
 let initDbosAttempt = 0;
 await retry(
   async () => {
@@ -194,15 +195,17 @@ await retry(
     try {
       return await app.initDbos();
     } catch (error) {
+      const outcome =
+        initDbosAttempt >= initDbosMaxAttempts ? "giving up" : "retrying";
       console.warn(
-        `[dbos] initDbos attempt ${initDbosAttempt}/5 failed, retrying`,
+        `[dbos] initDbos attempt ${initDbosAttempt}/${initDbosMaxAttempts} failed, ${outcome}`,
         error,
       );
       throw error;
     }
   },
   {
-    maxAttempts: 5,
+    maxAttempts: initDbosMaxAttempts,
     minTimeout: 1000,
     maxTimeout: 10_000,
     jitter: 0.5,


### PR DESCRIPTION
Follows #4718.

That PR added a per-attempt `console.warn` around the DBOS post-launch retry loop so a boot-time RDS blip is visible in pod logs. The message always says `failed, retrying`, including on the last attempt — but `retry()` (packages/std/src/retry.ts) throws `RetryError` once `attempt + 1 >= maxAttempts` instead of retrying again. So the final log line before the process actually exits misleadingly claims it's about to try again — exactly the moment an on-call engineer reading logs during a real incident needs an accurate signal. This also removes the duplicated `5` literal (log message vs. `maxAttempts: 5`) that caused the mismatch risk in the first place.

Fix: track `initDbosMaxAttempts` once, and log `giving up` instead of `retrying` when the current attempt is the last one.

**To confirm:** read `apps/mesh/src/index.ts` around the `initDbos` retry block — the warning text now only says "retrying" while `initDbosAttempt < initDbosMaxAttempts`.

**Checks run locally:** `bun run fmt`, `cd apps/mesh && bun x tsc --noEmit` (both clean). No test added — this is a top-level boot script with no unit-testable surface (Bun.serve, DBOS.launch side effects); full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misleading boot logs during DBOS init retries: on the final attempt, log now says "giving up" instead of "retrying," matching `retry()` behavior when it throws and the process exits. Also dedupes the attempt count by introducing `initDbosMaxAttempts` and using it in the log and `maxAttempts`.

<sup>Written for commit 47c59b0bf5dd52ee87fc01cf9e9d63f4c93ebda9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

