### PR TITLE
refactor(task-board): use warning design token for in-review status icon

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/config.tsx
+++ b/apps/mesh/src/web/layouts/task-board/config.tsx
@@ -67,7 +67,7 @@ export const STATUS_CONFIG: Record<
   in_review: {
     label: "In Review",
     icon: Eye,
-    iconClassName: "text-amber-500",
+    iconClassName: "text-warning",
   },
   done: {
     label: "Done",


### PR DESCRIPTION
## Source
Design-token debt sweep (`apps/mesh/src/web/layouts/task-board/config.tsx` is on the injected HIGHEST-DEBT list, palette=9).

## Why
The repo already established `text-amber-500` → `text-warning` as the mapping for this exact class in two prior PRs touching adjacent status-indicator code: #4700 (`task-status.ts`, "Timed out" status) and #4719 ("credits eyebrow", emerald/amber → success/warning). The task-board's "In Review" status icon still used the raw `text-amber-500` class this convention was meant to replace.

## Change
`iconClassName: "text-amber-500"` → `"text-warning"` for the `in_review` status entry in `STATUS_CONFIG`. This aligns the icon's shade to the design-system `warning` token (not a guaranteed pixel-identical match to the old amber-500 value, but the same semantic color already used for equivalent "needs attention" states elsewhere in the codebase).

## Verify
`grep -n "text-warning" apps/mesh/src/web/layouts/task-board/config.tsx` shows the updated class; `bun x tsc --noEmit` in `apps/mesh` is clean.

## Checks run locally
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` (clean)

CI runs the full test/lint suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the design token `text-warning` for the task board “In Review” status icon, replacing the raw `text-amber-500`.
This aligns the icon with the existing warning color convention used in adjacent status indicators.

<sup>Written for commit 5539c658fd9b1bf3113afe56987a48d63816f24a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

