### PR TITLE
refactor(task-board): use design tokens for done status and priority colors

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/config.tsx
+++ b/apps/mesh/src/web/layouts/task-board/config.tsx
@@ -72,7 +72,7 @@ export const STATUS_CONFIG: Record<
   done: {
     label: "Done",
     icon: CheckCircle,
-    iconClassName: "text-green-600",
+    iconClassName: "text-success",
   },
 };
 
@@ -109,12 +109,12 @@ export const PRIORITY_CONFIG: Record<
   },
   high: {
     label: "High",
-    flagClassName: "text-orange-500",
-    dotClassName: "bg-orange-500",
+    flagClassName: "text-warning",
+    dotClassName: "bg-warning",
   },
   urgent: {
     label: "Urgent",
-    flagClassName: "text-red-500",
-    dotClassName: "bg-red-500",
+    flagClassName: "text-destructive",
+    dotClassName: "bg-destructive",
   },
 };


### PR DESCRIPTION
## Summary

Follows #4722, which swapped the `in_review` status icon from `text-amber-500` to the `text-warning` design token. This PR closes the sibling gap in the same file/object: the `done` status icon and the `high`/`urgent` priority styles were still on raw Tailwind palette classes with a direct semantic-token equivalent already established elsewhere in the codebase (e.g. `apps/mesh/src/web/components/home/native-tiles.tsx:517` uses `text-success` for a "Completed" state).

- `done` status icon: `text-green-600` → `text-success`
- `high` priority flag/dot: `text-orange-500`/`bg-orange-500` → `text-warning`/`bg-warning`
- `urgent` priority flag/dot: `text-red-500`/`bg-red-500` → `text-destructive`/`bg-destructive`

`in_progress`'s icon and `medium` priority's color are intentionally left on `blue-500` — the design system currently has no blue/info token to map them to, so swapping them would either be a no-op or silently change the rendered color (e.g. to the neutral `primary` token). That's a separate, bigger decision (adding a new token) than this cleanup.

Payoff: keeps the task-board status/priority palette in sync with the design system so a future theme/token change (e.g. adjusting `--success` or `--destructive`) doesn't miss cards that still hardcode the old palette value. This lint (`ensure-tailwind-design-system-tokens`) is currently disabled in oxlint config (see the plugin's own comment), so nothing in CI catches this drift.

## Test plan
- `bun run fmt` — clean
- `cd apps/mesh && bun x tsc --noEmit` — clean
- Purely a className swap to already-defined, theme-aware tokens; no behavior change. Reviewer can confirm visually on the task board (`bun run --cwd=apps/mesh dev:client`) by checking a "Done" card and "High"/"Urgent" priority flags in both light and dark mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched task-board status and priority colors to design tokens for consistency and theme awareness.

- **Refactors**
  - `done` icon: `text-green-600` → `text-success`
  - `high` flag/dot: `text-orange-500`/`bg-orange-500` → `text-warning`/`bg-warning`
  - `urgent` flag/dot: `text-red-500`/`bg-red-500` → `text-destructive`/`bg-destructive`

<sup>Written for commit 511542d0429065e6a83203a6e9968ccfbbdfc8d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

