### PR TITLE
refactor(task-status): use destructive design token for failed status

### DIFF
--- a/apps/mesh/src/web/lib/task-status.ts
+++ b/apps/mesh/src/web/lib/task-status.ts
@@ -43,8 +43,8 @@ export const STATUS_CONFIG: Record<StatusKey, StatusConfig> = {
     label: "Failed",
     verb: "Something went wrong",
     icon: XCircle,
-    iconClassName: "text-red-500",
-    labelColor: "text-red-600 dark:text-red-400",
+    iconClassName: "text-destructive",
+    labelColor: "text-destructive",
   },
   expired: {
     label: "Timed out",


### PR DESCRIPTION
## Summary
- `getStatusConfig`/`STATUS_CONFIG` in `task-status.ts` is the shared status lookup used by thread monitoring, automation runs, the task board sidebar/dialog, and the home tasks list.
- The `failed` entry hand-rolled `text-red-500` / `text-red-600 dark:text-red-400` instead of the existing `text-destructive` semantic token, while the sibling `expired` entry in the same object already uses `text-warning`/`text-warning`, and `task-board/index.tsx` already uses `text-destructive` for its own error/overdue state in the same domain — so the mapping is unambiguous, not a judgment call.
- `--destructive` (packages/ui/src/styles/global.css) already defines distinct light/dark OKLCH values, so this aligns the shade to the design-system destructive token rather than claiming a pixel-identical match to the old red.

## Test plan
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — passes
- No existing test covers this static lookup table (pure color/label constants); full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the `failed` status in `task-status.ts` to use the `text-destructive` token for both icon and label, replacing hard-coded `text-red-*` classes. This aligns with the design system, matches existing usage, and fixes light/dark theming consistency.

<sup>Written for commit 1c86c8fc76b956912aaf23f33eb556b7a8be1cd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

