### PR TITLE
fix(commerce-onboarding): always show Preview/Code for reports-only orgs

### DIFF
--- a/apps/mesh/src/web/layouts/main-panel-tabs/mobile-main-panel-tab-select.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/mobile-main-panel-tab-select.tsx
@@ -6,8 +6,16 @@ import {
   SelectItem,
   SelectTrigger,
 } from "@deco/ui/components/select.tsx";
-import { useTaskBoardEnabled } from "@/web/hooks/use-organization-settings";
+import {
+  getCommerceDiscoveryAgentId,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
+import {
+  useReportsOnly,
+  useTaskBoardEnabled,
+} from "@/web/hooks/use-organization-settings";
 import { useMainPanelTabs } from "./use-main-panel-tabs";
+import { shouldDeepLinkSourceTab } from "./source-system-tabs";
 import type { TabIcon } from "./resolve-tab-icon";
 import { TabIconGlyph } from "./tab-icon-glyph";
 import { track } from "@/web/lib/posthog-client";
@@ -59,6 +67,9 @@ export function MobileMainPanelTabSelect({
     taskId,
   });
   const taskBoardEnabled = useTaskBoardEnabled();
+  const { org } = useProjectContext();
+  const reportsOnly = useReportsOnly();
+  const onReportAgent = virtualMcpId === getCommerceDiscoveryAgentId(org.id);
 
   // Tasks / Library are toggled via `?main=board|files`; they need a task route
   // to act on (same gate as the desktop toggles).
@@ -96,6 +107,20 @@ export function MobileMainPanelTabSelect({
       tab_id: value,
       source: "mobile_select",
     });
+    // Reports-only: the storefront Preview/Code live on the Report Agent, so
+    // from any other shell deep-link into it instead of opening a source-less
+    // panel on the current agent (mirrors setActiveTab in useMainPanelTabs).
+    if (shouldDeepLinkSourceTab({ reportsOnly, onReportAgent, tabId: value })) {
+      navigate({
+        to: "/$org/$taskId",
+        params: { org: org.slug, taskId: crypto.randomUUID() },
+        search: {
+          virtualmcpid: getCommerceDiscoveryAgentId(org.id),
+          main: value,
+        },
+      });
+      return;
+    }
     navigate({
       to: ".",
       search: (prev: Record<string, unknown>) =>

--- a/apps/mesh/src/web/layouts/main-panel-tabs/source-system-tabs.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/source-system-tabs.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { getSourceSystemTabs } from "./source-system-tabs";
+import {
+  getSourceSystemTabs,
+  shouldDeepLinkSourceTab,
+} from "./source-system-tabs";
 
 describe("getSourceSystemTabs", () => {
   test("returns Preview and Code for clonable source", () => {
@@ -11,5 +14,51 @@ describe("getSourceSystemTabs", () => {
 
   test("returns no source tabs without clonable source", () => {
     expect(getSourceSystemTabs(false)).toEqual([]);
+  });
+});
+
+describe("shouldDeepLinkSourceTab", () => {
+  test("deep-links Preview/Code from off the Report Agent on reports-only", () => {
+    for (const tabId of ["preview", "code"]) {
+      expect(
+        shouldDeepLinkSourceTab({
+          reportsOnly: true,
+          onReportAgent: false,
+          tabId,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test("does not deep-link when already on the Report Agent", () => {
+    expect(
+      shouldDeepLinkSourceTab({
+        reportsOnly: true,
+        onReportAgent: true,
+        tabId: "preview",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not deep-link for non-reports-only orgs", () => {
+    expect(
+      shouldDeepLinkSourceTab({
+        reportsOnly: false,
+        onReportAgent: false,
+        tabId: "preview",
+      }),
+    ).toBe(false);
+  });
+
+  test("only deep-links the source tabs, not other tabs", () => {
+    for (const tabId of ["settings", "automations", "overview", "content"]) {
+      expect(
+        shouldDeepLinkSourceTab({
+          reportsOnly: true,
+          onReportAgent: false,
+          tabId,
+        }),
+      ).toBe(false);
+    }
   });
 });

--- a/apps/mesh/src/web/layouts/main-panel-tabs/source-system-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/source-system-tabs.ts
@@ -13,3 +13,21 @@ export function getSourceSystemTabs(
 ): SourceSystemTab[] {
   return hasClonableSource ? [...SOURCE_SYSTEM_TABS] : [];
 }
+
+/**
+ * Reports-only orgs surface Preview/Code on every shell, but the storefront
+ * they point at lives on the Report Agent. From any other shell the click must
+ * deep-link into the Report Agent rather than toggle the current (source-less)
+ * agent's panel. On the Report Agent itself it's a normal in-place toggle.
+ */
+export function shouldDeepLinkSourceTab(opts: {
+  reportsOnly: boolean;
+  onReportAgent: boolean;
+  tabId: string;
+}): boolean {
+  return (
+    opts.reportsOnly &&
+    !opts.onReportAgent &&
+    (opts.tabId === "preview" || opts.tabId === "code")
+  );
+}

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -15,6 +15,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Globe01, Monitor01 } from "@untitledui/icons";
 import { createElement, useSyncExternalStore } from "react";
 import {
+  getCommerceDiscoveryAgentId,
   getDevConnectionId,
   useConnections,
   useMCPClientOptional,
@@ -57,7 +58,10 @@ import {
   type AutomationTabParsed,
 } from "./tab-id";
 import { resolveTabIcon, type TabIcon, type TabKind } from "./resolve-tab-icon";
-import { getSourceSystemTabs } from "./source-system-tabs";
+import {
+  getSourceSystemTabs,
+  shouldDeepLinkSourceTab,
+} from "./source-system-tabs";
 import { useCapability } from "@/web/hooks/use-capability";
 import { useReportsOnly } from "@/web/hooks/use-organization-settings";
 
@@ -316,7 +320,14 @@ export function useMainPanelTabs(ctx: {
   if (effectiveDefaultMainView?.type === "overview") {
     leadingSystemTabs.push({ id: "overview", title: "Overview" });
   }
-  leadingSystemTabs.push(...getSourceSystemTabs(hasClonableSource));
+  // Reports-only orgs get a persistent Preview/Code entry point to their
+  // storefront regardless of which agent/screen they're on — visibility is
+  // keyed to the settled org flag, not to whether the current agent happens to
+  // have a mirrored `githubRepo`. Clicking from off the Report Agent deep-links
+  // into it (see setActiveTab).
+  leadingSystemTabs.push(
+    ...getSourceSystemTabs(hasClonableSource || reportsOnly),
+  );
 
   const systemTabs: Array<{ id: string; title: string }> = [];
   if (hasClonableSource && showContentTab) {
@@ -489,7 +500,23 @@ export function useMainPanelTabs(ctx: {
     })),
   ];
 
+  const onReportAgent =
+    ctx.virtualMcpId === getCommerceDiscoveryAgentId(org.id);
+
   const setActiveTab = (id: string) => {
+    // On a reports-only org sitting on any shell other than the Report Agent
+    // (e.g. the Super Agent home), the storefront preview lives on the Report
+    // Agent — so deep-link into it with the panel open instead of trying to
+    // preview the current agent, which has no source. On the Report Agent
+    // itself this falls through to the normal tab-toggle below.
+    if (shouldDeepLinkSourceTab({ reportsOnly, onReportAgent, tabId: id })) {
+      navigate({
+        to: "/$org/$taskId",
+        params: { org: org.slug, taskId: crypto.randomUUID() },
+        search: { virtualmcpid: getCommerceDiscoveryAgentId(org.id), main: id },
+      });
+      return;
+    }
     const target = resolveTabClickTarget({
       clickedId: id,
       activeTab,


### PR DESCRIPTION
## Problem

For reports-only orgs, the Preview/Code tabs should let the merchant reach their storefront from **any** screen. Before this, the tabs were gated on the *current* agent carrying a mirrored `metadata.githubRepo` (added in #4708), so:

- Preview only appeared when you were already sitting **on the Report Agent**.
- Visibility depended on a write-then-invalidate (`COLLECTION_VIRTUAL_MCP_UPDATE` + cache invalidation) having succeeded — flaky and screen-specific.
- Reports-only orgs land on the **Super Agent home**, which has no clonable source → no Preview there.

## Approach

Decouple the two things the old approach conflated:

1. **Tab visibility** → keyed to the settled `reports_only` org flag (deterministic, cached), not the mirrored metadata. So Preview/Code are always present on any shell for reports-only orgs.
2. **Preview content** → always the *Report Agent's* own sandbox. When a reports-only user clicks Preview/Code from any shell **other than** the Report Agent, it **deep-links** into the Report Agent (`?virtualmcpid=commerce-discovery_<org>&main=preview`), reusing the single existing sandbox lifecycle rather than standing up a second concurrent one. On the Report Agent it stays a normal in-place toggle.

The deep-link decision is a shared pure predicate `shouldDeepLinkSourceTab({ reportsOnly, onReportAgent, tabId })`, used by both the desktop tab bar (`useMainPanelTabs.setActiveTab`) and the mobile view select (`MobileMainPanelTabSelect`), so the two entry points can't drift.

`hasClonableSource` itself is left untouched — Content tab / decofile fetching behaviour is unchanged. #4708's metadata mirror stays (it feeds the actual sandbox clone on the Report Agent).

## Files
- `main-panel-tabs/source-system-tabs.ts` — `shouldDeepLinkSourceTab` predicate.
- `main-panel-tabs/use-main-panel-tabs.ts` — show source tabs on `hasClonableSource || reportsOnly`; deep-link on click.
- `main-panel-tabs/mobile-main-panel-tab-select.tsx` — same deep-link on the mobile path.
- `main-panel-tabs/source-system-tabs.test.ts` — unit tests for the predicate.

## Testing

- `bun run --cwd=apps/mesh check`, `bun run fmt:check`, `bun run lint` (0 errors), and the new unit tests pass.
- Verified locally against a `reports_only` org: on the Super Agent home the **Preview** and **Code** entries now appear, and selecting Preview navigates to `?virtualmcpid=commerce-discovery_<org>&main=preview`. (In a real reports-only org the Report Agent is created together with the flag by `COMMERCE_DISCOVERY_SETUP`, so the deep-link target always exists.)

## Note / follow-up
`reports_only` and the `commerce-discovery` Report Agent are created atomically in `COMMERCE_DISCOVERY_SETUP`, so the deep-link target is guaranteed to exist in production. If we ever want to harden against a degenerate state (flag on, Report Agent missing), we could additionally gate visibility on the Report Agent resolving — deliberately left out here since it would hide the always-on Preview the feature is about.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show Preview and Code for reports-only orgs on every screen, and deep-link to the Report Agent when clicked from other shells to reliably open the storefront. This removes flaky metadata gating and reuses a single sandbox.

- **Bug Fixes**
  - Show Preview/Code when `reports_only` is true, not based on mirrored `metadata.githubRepo`.
  - Deep-link to the Report Agent when clicking Preview/Code off the Report Agent; toggle in place when on it.
  - Use a shared `shouldDeepLinkSourceTab` predicate for desktop and mobile; added unit tests.
  - Keep `hasClonableSource` logic unchanged so Content/decofile behavior stays the same.

<sup>Written for commit 7f96a8b458c5c82a91e99c8764b33d7024ec1f32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

