### PR TITLE
feat(task-board): Auto-fix button for reports_only orgs

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -13,6 +13,7 @@ import {
   Calendar,
   Columns03,
   HelpCircle,
+  Lightning01,
   List,
   Loading01,
   Plus,
@@ -46,6 +47,7 @@ import {
 } from "./task-filters";
 import { useFlipLanes } from "./use-flip-lanes";
 import { usePanelActions } from "@/web/layouts/shell-layout";
+import { useReportsOnly } from "@/web/hooks/use-organization-settings";
 
 // Warm the chat chunk so opening a task's activity doesn't cold-load it (flash).
 void import("../agent-shell-layout/index.tsx").catch(() => {});
@@ -171,6 +173,7 @@ function AssigneeDisplay({
 export function TaskBoardPage() {
   const { items, isLoading } = useTaskBoardItems();
   const actions = useTaskBoardItemActions();
+  const reportsOnly = useReportsOnly();
   const { data: membersData } = useMembers();
   const members = (membersData?.data?.members ?? []) as Member[];
   const memberByUserId = new Map(members.map((m) => [m.userId, m]));
@@ -301,6 +304,15 @@ export function TaskBoardPage() {
           onOpen={openTask}
           onCreate={openCreateInLane}
           onMove={(id, status) => actions.update.mutate({ id, status })}
+          onAutoFix={
+            reportsOnly
+              ? (item) =>
+                  actions.update.mutate({
+                    id: item.id,
+                    assigneeId: SUPER_AGENT_ASSIGNEE_ID,
+                  })
+              : undefined
+          }
         />
       ) : (
         <div className="min-h-0 flex-1 overflow-y-auto px-4 pt-6 pb-16 sm:px-8">
@@ -401,12 +413,14 @@ function Lanes({
   onOpen,
   onCreate,
   onMove,
+  onAutoFix,
 }: {
   items: TaskBoardItem[];
   memberByUserId: Map<string, Member>;
   onOpen: (item: TaskBoardItem) => void;
   onCreate: (status: TaskBoardItemStatus) => void;
   onMove: (id: string, status: TaskBoardItemStatus) => void;
+  onAutoFix?: (item: TaskBoardItem) => void;
 }) {
   const [overLane, setOverLane] = useState<TaskBoardItemStatus | null>(null);
   const boardRef = useRef<HTMLDivElement>(null);
@@ -493,6 +507,7 @@ function Lanes({
                         : undefined
                     }
                     onOpen={() => onOpen(item)}
+                    onAutoFix={onAutoFix ? () => onAutoFix(item) : undefined}
                   />
                 ))}
               </div>
@@ -509,15 +524,22 @@ function TaskCard({
   assignee,
   assignedBy,
   onOpen,
+  onAutoFix,
 }: {
   item: TaskBoardItem;
   assignee?: Member;
   assignedBy?: Member;
   onOpen: () => void;
+  onAutoFix?: () => void;
 }) {
   const statusConfig = STATUS_CONFIG[item.status];
   const StatusIcon = statusConfig.icon;
   const lastMessage = primaryThread(item)?.lastMessage;
+
+  const showAutoFix =
+    onAutoFix &&
+    (item.status === "triage" || item.status === "todo") &&
+    item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID;
 
   return (
     <button
@@ -563,6 +585,20 @@ function TaskCard({
           )}
           {item.dueDate && <DueDatePill iso={item.dueDate} />}
         </div>
+      )}
+
+      {showAutoFix && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAutoFix();
+          }}
+          className="flex items-center gap-1.5 self-end rounded-md border border-border bg-background px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+        >
+          <Lightning01 size={12} />
+          Auto-fix
+        </button>
       )}
     </button>
   );


### PR DESCRIPTION
## What is this contribution about?

Adds an "Auto-fix" button on task cards in the Triage and To-do columns of the task board. The button is only visible when the org has the `reports_only` flag enabled. Clicking it instantly assigns the task to the Super Agent without opening the task dialog.

## Screenshots/Demonstration

Button appears at the bottom-right of eligible cards (Triage/To-do, not yet assigned to Super Agent) in reports_only orgs only.

## How to Test

1. Enable `reports_only = true` and `task_board_enabled = true` in `organization_settings` for your local org
2. Open the task board (`/$org/board`)
3. Create a task in the Triage or To-do column
4. Confirm the "Auto-fix" button appears at the bottom-right of the card
5. Click it — the task should be assigned to the Super Agent immediately
6. Confirm the button disappears after assignment and the Super Agent avatar appears on the card

## Migration Notes

No migrations required. The button is gated client-side on the existing `reports_only` org setting.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Auto-fix button to task cards for `reports_only` orgs, enabling one-click assignment to the Super Agent from Triage and To-do. This speeds triage by skipping the task dialog.

- **New Features**
  - Show “Auto-fix” on Triage/To-do cards only when `useReportsOnly` is true and not already assigned to `SUPER_AGENT_ASSIGNEE_ID`.
  - Clicking assigns via `actions.update.mutate` and hides the button; Super Agent avatar appears.
  - Button placed at the bottom-right of eligible cards with a lightning icon.

<sup>Written for commit 3ca373fd12f69fd2c0578e2464feeb765226ed9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

