### PR TITLE
fix(task-board): allow task title to wrap across multiple lines

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -234,12 +234,20 @@ export function TaskBoardItemDialog({
           {/* Editor pane — content-height on mobile so it doesn't leave a big
               gap above the properties; fills the column on desktop. */}
           <div className="flex min-w-0 flex-col gap-6 p-6 sm:flex-1 sm:overflow-y-auto sm:p-8">
-            <input
+            <textarea
               value={title}
-              onChange={(e) => setTitle(e.target.value)}
+              onChange={(e) => {
+                setTitle(e.target.value);
+                e.target.style.height = "auto";
+                e.target.style.height = `${e.target.scrollHeight}px`;
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.preventDefault();
+              }}
               placeholder="Task title..."
               autoFocus
-              className="w-full border-0 bg-transparent text-xl font-medium text-foreground outline-none placeholder:text-foreground/30"
+              rows={1}
+              className="w-full resize-none overflow-hidden border-0 bg-transparent text-xl font-medium leading-snug text-foreground outline-none placeholder:text-foreground/30"
             />
 
             <div className="group relative flex flex-1 flex-col">


### PR DESCRIPTION
## What is this contribution about?

The task title field in the task modal was a single-line `<input>`, causing long titles to truncate rather than wrap. This replaces it with an auto-resizing `<textarea>` that starts as one line and grows as text wraps, while suppressing Enter to prevent newlines in titles.

## Screenshots/Demonstration

> Before: long titles were clipped to a single line.
> After: the title field expands vertically to show the full text.

## How to Test

1. Open the task board and click any task (or create a new one).
2. Type a long title that exceeds the modal width.
3. Expected: the title field wraps and grows — no truncation.

## Migration Notes

No migrations required.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes truncation of long task titles in the task modal by replacing the single-line input with an auto‑resizing textarea that wraps and expands to show the full text. Enter is suppressed so titles stay single‑paragraph.

<sup>Written for commit fb55c73cfc23b060bf36dbfe71844691b068cb43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

