### PR TITLE
refactor(task-status): use warning design token for requires_action status

### DIFF
--- a/apps/mesh/src/web/lib/task-status.ts
+++ b/apps/mesh/src/web/lib/task-status.ts
@@ -36,8 +36,8 @@ export const STATUS_CONFIG: Record<StatusKey, StatusConfig> = {
     label: "Needs review",
     verb: "Waiting for your review",
     icon: AlertCircle,
-    iconClassName: "text-orange-500",
-    labelColor: "text-orange-600 dark:text-orange-400",
+    iconClassName: "text-warning",
+    labelColor: "text-warning",
   },
   failed: {
     label: "Failed",


### PR DESCRIPTION
Follows #4724 / #4723, which tokenized the \`failed\`, \`done\`, and priority colors in the task board's status configs.

The \`requires_action\` state in \`task-status.ts\` was left on raw \`text-orange-500\` / \`text-orange-600 dark:text-orange-400\`, while its sibling \`expired\` state in the same file already uses the semantic \`text-warning\` token for the identical cautionary intent (previously fixed in #4700). This closes that remaining gap so the whole file is consistent.

## Change
\`requires_action\`'s \`iconClassName\`/\`labelColor\` now use \`text-warning\` instead of the raw orange palette classes (also drops the separate light/dark hardcoded pair, since the token already resolves per-theme).

## Verify
- \`bun run fmt\` — clean
- \`cd apps/mesh && bunx tsc --noEmit\` — clean
- Pure class-name swap with no logic change; visually confirm the "Needs review" status pill/icon in the sidebar task groups or tasks panel still renders in the expected warning color in both light and dark mode.

CI runs the full test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded orange classes in the `requires_action` task status with the `text-warning` design token. This aligns warning styling with `expired` and keeps colors consistent across light and dark themes, with no logic changes.

<sup>Written for commit a422da7848d300c93d6a535b06e2526388edd5a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

