### PR TITLE
feat(task-board): real-time create & delete on the kanban board

### DIFF
--- a/apps/mesh/src/api/routes/task-board-import.ts
+++ b/apps/mesh/src/api/routes/task-board-import.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { StudioContext } from "@/core/studio-context";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@/shared/task-board";
 import { reactToSuperAgentDelegation } from "@/tools/task-board/enqueue-super-agent";
+import { emitTaskBoardUpdated } from "@/tools/task-board/run-reactions";
 import { TaskBoardItemPrioritySchema } from "@/tools/task-board/schema";
 import { bearerToken, isVaultServiceToken } from "./credential-vault";
 
@@ -150,6 +151,8 @@ export const createTaskBoardImportRoutes = () => {
         by: "system",
       });
       created++;
+      // Broadcast each imported card so open boards fill in live.
+      emitTaskBoardUpdated(organizationId, row);
       if (toSuperAgent) {
         delegated++;
         await reactToSuperAgentDelegation(ctx, row);

--- a/apps/mesh/src/shared/task-board.ts
+++ b/apps/mesh/src/shared/task-board.ts
@@ -13,3 +13,10 @@ export const SUPER_AGENT_ASSIGNEE_ID = "super-agent";
  * react-query cache from it, so the board is real-time with no polling.
  */
 export const TASK_BOARD_ITEM_UPDATED_EVENT = "task-board.item.updated";
+
+/**
+ * Org-scoped SSE event pushed on `sseHub` whenever a task board item is deleted.
+ * Its `data` is `{ id }`; the web board drops that item from its react-query
+ * cache, so a delete on one client clears the card on every open board.
+ */
+export const TASK_BOARD_ITEM_DELETED_EVENT = "task-board.item.deleted";

--- a/apps/mesh/src/tools/task-board/create.ts
+++ b/apps/mesh/src/tools/task-board/create.ts
@@ -10,6 +10,7 @@ import {
 import { assertValidAssignee } from "./validate-assignee";
 import { requireTaskBoardEnabled } from "./require-enabled";
 import { reactToSuperAgentDelegation } from "./enqueue-super-agent";
+import { emitTaskBoardUpdated } from "./run-reactions";
 
 export const TASK_BOARD_ITEM_CREATE = defineTool({
   name: "TASK_BOARD_ITEM_CREATE",
@@ -62,6 +63,8 @@ export const TASK_BOARD_ITEM_CREATE = defineTool({
       by: getUserId(ctx)!,
     });
 
+    // Broadcast the new card so every open board adds it live, no polling.
+    emitTaskBoardUpdated(organizationId, item);
     await reactToSuperAgentDelegation(ctx, item);
 
     return { item };

--- a/apps/mesh/src/tools/task-board/delete.ts
+++ b/apps/mesh/src/tools/task-board/delete.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth } from "@/core/studio-context";
 import { requireTaskBoardEnabled } from "./require-enabled";
+import { emitTaskBoardDeleted } from "./run-reactions";
 
 export const TASK_BOARD_ITEM_DELETE = defineTool({
   name: "TASK_BOARD_ITEM_DELETE",
@@ -29,6 +30,8 @@ export const TASK_BOARD_ITEM_DELETE = defineTool({
     await requireTaskBoardEnabled(ctx, organizationId);
 
     await ctx.storage.taskBoard.delete(input.id, organizationId);
+    // Broadcast the removal so every open board drops the card live.
+    emitTaskBoardDeleted(organizationId, input.id);
     return { success: true };
   },
 });

--- a/apps/mesh/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/mesh/src/tools/task-board/enqueue-super-agent.ts
@@ -5,13 +5,13 @@ import { enqueueThreadRun } from "@/dispatch-queue";
 import { PartEmitter } from "@/api/routes/decopilot/part-emitter";
 import { getDecopilotId } from "@decocms/mesh-sdk";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@/shared/task-board";
-import { emitTaskBoardUpdated } from "./run-reactions";
 
 /**
  * The shared post-write reaction for a task delegated to the Super Agent:
- * broadcast the updated item over SSE and enqueue the run. No-op for any
- * other assignee, so callers that already know the write delegated (create)
- * and callers that gate on the transition (update) share one body. Enqueue is
+ * enqueue the run. No-op for any other assignee, so callers that already know
+ * the write delegated (create) and callers that gate on the transition
+ * (update) share one body. The SSE broadcast is emitted by each write site
+ * itself (every create/update broadcasts, not just delegations). Enqueue is
  * best-effort — the task is already persisted, so a dispatch failure (e.g. no
  * model configured) must never fail the write that delegated it.
  */
@@ -20,7 +20,6 @@ export async function reactToSuperAgentDelegation(
   item: TaskBoardItem,
 ): Promise<void> {
   if (item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID) return;
-  emitTaskBoardUpdated(item.organizationId, item);
   await enqueueSuperAgentForTask(ctx, item).catch((err) => {
     console.error("[task-board] Super Agent enqueue failed", err);
   });

--- a/apps/mesh/src/tools/task-board/run-reactions.ts
+++ b/apps/mesh/src/tools/task-board/run-reactions.ts
@@ -22,7 +22,10 @@
 import type { StudioContext } from "@/core/studio-context";
 import { extractPrFromValue } from "./pr-extract";
 import { sseHub } from "@/event-bus/sse-hub";
-import { TASK_BOARD_ITEM_UPDATED_EVENT } from "@/shared/task-board";
+import {
+  TASK_BOARD_ITEM_DELETED_EVENT,
+  TASK_BOARD_ITEM_UPDATED_EVENT,
+} from "@/shared/task-board";
 import type { TaskBoardStorage } from "@/storage/task-board";
 import type { TaskBoardItem, TaskBoardItemStatus } from "@/storage/types";
 
@@ -43,6 +46,18 @@ export function emitTaskBoardUpdated(orgId: string, item: TaskBoardItem): void {
     source: "task-board",
     subject: item.id,
     data: item,
+    time: new Date().toISOString(),
+  });
+}
+
+/** Push a task board item deletion to every SSE listener on its org. */
+export function emitTaskBoardDeleted(orgId: string, itemId: string): void {
+  sseHub.emit(orgId, {
+    id: crypto.randomUUID(),
+    type: TASK_BOARD_ITEM_DELETED_EVENT,
+    source: "task-board",
+    subject: itemId,
+    data: { id: itemId },
     time: new Date().toISOString(),
   });
 }

--- a/apps/mesh/src/tools/task-board/update.ts
+++ b/apps/mesh/src/tools/task-board/update.ts
@@ -10,6 +10,7 @@ import {
 import { assertValidAssignee } from "./validate-assignee";
 import { requireTaskBoardEnabled } from "./require-enabled";
 import { reactToSuperAgentDelegation } from "./enqueue-super-agent";
+import { emitTaskBoardUpdated } from "./run-reactions";
 
 export const TASK_BOARD_ITEM_UPDATE = defineTool({
   name: "TASK_BOARD_ITEM_UPDATE",
@@ -82,9 +83,11 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
       getUserId(ctx)!,
     );
 
-    // Only the transition INTO Super Agent reacts — a later edit of an
-    // already-delegated task must not re-enqueue.
+    // Broadcast the delegation flip (assignee + forced To Do) so every open
+    // board reflects it live. Plain edits already round-trip through the
+    // mutation's optimistic patch + invalidate on the acting client.
     if (becameSuperAgent) {
+      emitTaskBoardUpdated(organizationId, item);
       await reactToSuperAgentDelegation(ctx, item);
     }
 

--- a/apps/mesh/src/web/hooks/use-task-board-events.ts
+++ b/apps/mesh/src/web/hooks/use-task-board-events.ts
@@ -2,15 +2,17 @@
  * useTaskBoardEvents — real-time task board transitions over SSE.
  *
  * Subscribes to the shared `/api/:org/watch` connection, filtered to
- * `task-board.item.updated`, and hands each updated item to `onUpdate`. The
- * Super Agent lifecycle (enqueued→todo, executing→in_progress, PR→in_review)
- * pushes these, so the board moves cards live with no polling.
+ * `task-board.item.updated` / `.deleted`, and hands each updated item to
+ * `onUpdate` and each removed id to `onDelete`. Creates, Super Agent
+ * transitions (enqueued→todo, executing→in_progress, PR→in_review) and deletes
+ * push these, so the board adds/moves/removes cards live with no polling.
  *
  * Mirrors `useDecopilotEvents`: useSyncExternalStore for React 19 lifecycle,
  * callbacks read from a ref so the connection stays stable across re-renders.
  */
 
 import type { TaskBoardItem } from "@/storage/types";
+import { TASK_BOARD_ITEM_DELETED_EVENT } from "@/shared/task-board";
 import { useRef, useSyncExternalStore } from "react";
 import { taskBoardWatchView } from "./watch-sse-pool";
 
@@ -20,14 +22,19 @@ export interface UseTaskBoardEventsOptions {
   orgSlug: string;
   enabled?: boolean;
   onUpdate: (item: TaskBoardItem) => void;
+  onDelete?: (id: string) => void;
 }
 
 export function useTaskBoardEvents(options: UseTaskBoardEventsOptions): void {
-  const { orgSlug, enabled = true, onUpdate } = options;
+  const { orgSlug, enabled = true, onUpdate, onDelete } = options;
 
   const onUpdateRef = useRef(onUpdate);
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- callback kept fresh without re-subscribing
   onUpdateRef.current = onUpdate;
+
+  const onDeleteRef = useRef(onDelete);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- callback kept fresh without re-subscribing
+  onDeleteRef.current = onDelete;
 
   const subscribeRef = useRef<
     ((onStoreChange: () => void) => () => void) | null
@@ -57,13 +64,21 @@ export function useTaskBoardEvents(options: UseTaskBoardEventsOptions): void {
       if (!enabled || !orgSlug) return () => {};
 
       const handler = (e: MessageEvent) => {
-        let event: { data?: TaskBoardItem };
+        let event: { data?: TaskBoardItem | { id: string } };
         try {
-          event = JSON.parse(e.data) as { data?: TaskBoardItem };
+          event = JSON.parse(e.data) as {
+            data?: TaskBoardItem | { id: string };
+          };
         } catch {
           return;
         }
-        if (event.data) onUpdateRef.current(event.data);
+        if (event.data) {
+          if (e.type === TASK_BOARD_ITEM_DELETED_EVENT) {
+            onDeleteRef.current?.((event.data as { id: string }).id);
+          } else {
+            onUpdateRef.current(event.data as TaskBoardItem);
+          }
+        }
         onStoreChange();
       };
 

--- a/apps/mesh/src/web/hooks/use-task-board-items.ts
+++ b/apps/mesh/src/web/hooks/use-task-board-items.ts
@@ -32,6 +32,12 @@ export function useTaskBoardItems() {
           : [patched, ...next];
       });
     },
+    // Live deletes: drop the removed card so it clears on every open board.
+    onDelete: (id) => {
+      queryClient.setQueryData<TaskBoardItem[]>(queryKey, (prev) =>
+        prev?.filter((t) => t.id !== id),
+      );
+    },
   });
 
   // Live run status of linked threads (in_progress / requires_action / …).

--- a/apps/mesh/src/web/hooks/watch-sse-pool.ts
+++ b/apps/mesh/src/web/hooks/watch-sse-pool.ts
@@ -5,7 +5,10 @@
  */
 
 import { ALL_DECOPILOT_EVENT_TYPES } from "@decocms/mesh-sdk";
-import { TASK_BOARD_ITEM_UPDATED_EVENT } from "@/shared/task-board";
+import {
+  TASK_BOARD_ITEM_DELETED_EVENT,
+  TASK_BOARD_ITEM_UPDATED_EVENT,
+} from "@/shared/task-board";
 import {
   createSSESubscription,
   filterEventTypes,
@@ -16,6 +19,7 @@ import {
 const WATCH_TYPES = [
   ...ALL_DECOPILOT_EVENT_TYPES,
   TASK_BOARD_ITEM_UPDATED_EVENT,
+  TASK_BOARD_ITEM_DELETED_EVENT,
 ];
 
 /** `?types=` patterns sent to the server. */
@@ -38,7 +42,8 @@ export const decopilotWatchView: SSESubscription = filterEventTypes(watchSSE, [
   ...ALL_DECOPILOT_EVENT_TYPES,
 ]);
 
-/** Task board item transitions (`task-board.item.updated`). */
+/** Task board item lifecycle (`task-board.item.updated` / `.deleted`). */
 export const taskBoardWatchView: SSESubscription = filterEventTypes(watchSSE, [
   TASK_BOARD_ITEM_UPDATED_EVENT,
+  TASK_BOARD_ITEM_DELETED_EVENT,
 ]);


### PR DESCRIPTION
## Summary

The kanban task board already moved cards live for Super Agent status transitions, but **creates and deletes were not broadcast** — they relied on the acting client invalidating its own query cache, so any *other* open board (a teammate's, or a second tab) didn't see new or removed cards until it refetched.

This wires create/delete into the same `/api/:org/watch` SSE channel the status transitions already use.

## Changes

**Backend**
- Emit `TASK_BOARD_ITEM_UPDATED_EVENT` on **every** create — the `TASK_BOARD_ITEM_CREATE` tool and the bulk import route — and on the update→Super-Agent delegation flip. The emit was moved out of `reactToSuperAgentDelegation` so each write site broadcasts explicitly (that helper is now enqueue-only). The existing frontend `onUpdate` handler already upserts, so a broadcast create makes the card appear live.
- New `TASK_BOARD_ITEM_DELETED_EVENT` (`data: { id }`), emitted from `TASK_BOARD_ITEM_DELETE`.

**Frontend**
- `watch-sse-pool` streams and filters the new deleted event alongside the updated one.
- `useTaskBoardEvents` gains an `onDelete(id)` callback, dispatched by SSE event type.
- `useTaskBoardItems` drops the removed item from the react-query cache on delete.

## Notes / scope
- Plain field edits (title/priority/drag-to-move by a user) still round-trip through the mutation's optimistic patch + invalidate on the acting client, unchanged — this PR is scoped to create/delete real-time, matching the request.
- Delete broadcast carries only `{ id }`; the frontend filters by id.

## Testing
- `bun test apps/mesh/src/tools/task-board/` — 35 pass
- `bun run check` (tsc) — clean
- `bun run fmt` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real-time create and delete on the Kanban board via the org SSE channel. New and removed cards now appear/disappear live across tabs, no polling.

- **New Features**
  - Backend: emit `TASK_BOARD_ITEM_UPDATED_EVENT` on every create (tool + bulk import) and on the update→Super Agent delegation; add `TASK_BOARD_ITEM_DELETED_EVENT` with `{ id }`; move SSE emit out of `reactToSuperAgentDelegation` so each write broadcasts directly.
  - SSE: `/api/:org/watch` now streams both update and delete events for task board items.
  - Frontend: `watch-sse-pool` filters the new types; `useTaskBoardEvents` adds `onDelete`; `useTaskBoardItems` upserts on update and removes on delete.

<sup>Written for commit 905b10406890d6f4ca48ff50b789e3166386cb74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

