### PR TITLE
refactor(registry): use destructive/success design tokens in broken-MCP list

### DIFF
--- a/apps/mesh/src/web/views/registry/broken-mcp-list.tsx
+++ b/apps/mesh/src/web/views/registry/broken-mcp-list.tsx
@@ -33,7 +33,7 @@ function BrokenMCPCard({ result }: { result: MonitorResult }) {
         className="w-full text-left p-3 flex items-start gap-3 hover:bg-muted/30 transition-colors"
         onClick={() => setExpanded(!expanded)}
       >
-        <span className="text-red-500 text-sm mt-0.5">✗</span>
+        <span className="text-destructive text-sm mt-0.5">✗</span>
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex items-center gap-2">
             <h4 className="text-sm font-medium truncate">
@@ -53,7 +53,7 @@ function BrokenMCPCard({ result }: { result: MonitorResult }) {
             <span>tools listed: {result.tools_listed ? "✓" : "✗"}</span>
             <span>{result.duration_ms}ms</span>
             {failedTools.length > 0 && (
-              <span className="text-red-600">
+              <span className="text-destructive">
                 {failedTools.length} tool{failedTools.length > 1 ? "s" : ""}{" "}
                 failed
               </span>
@@ -67,7 +67,7 @@ function BrokenMCPCard({ result }: { result: MonitorResult }) {
 
           {/* Error message preview */}
           {result.error_message && (
-            <p className="text-xs text-red-600 line-clamp-2">
+            <p className="text-xs text-destructive line-clamp-2">
               {result.error_message}
             </p>
           )}
@@ -82,10 +82,10 @@ function BrokenMCPCard({ result }: { result: MonitorResult }) {
           {/* Full error message */}
           {result.error_message && (
             <div className="space-y-0.5">
-              <p className="text-[10px] font-semibold text-red-600">
+              <p className="text-[10px] font-semibold text-destructive">
                 Full Error
               </p>
-              <pre className="text-[11px] bg-red-500/5 border border-red-500/10 rounded px-2.5 py-1.5 whitespace-pre-wrap break-all text-red-700">
+              <pre className="text-[11px] bg-destructive/5 border border-destructive/10 rounded px-2.5 py-1.5 whitespace-pre-wrap break-all text-destructive">
                 {result.error_message}
               </pre>
             </div>
@@ -98,7 +98,7 @@ function BrokenMCPCard({ result }: { result: MonitorResult }) {
               <p
                 className={cn(
                   "text-xs font-medium",
-                  result.connection_ok ? "text-emerald-600" : "text-red-600",
+                  result.connection_ok ? "text-success" : "text-destructive",
                 )}
               >
                 {result.connection_ok ? "OK" : "Failed"}
@@ -109,7 +109,7 @@ function BrokenMCPCard({ result }: { result: MonitorResult }) {
               <p
                 className={cn(
                   "text-xs font-medium",
-                  result.tools_listed ? "text-emerald-600" : "text-red-600",
+                  result.tools_listed ? "text-success" : "text-destructive",
                 )}
               >
                 {result.tools_listed ? "Yes" : "No"}
@@ -124,16 +124,16 @@ function BrokenMCPCard({ result }: { result: MonitorResult }) {
           {/* Failed tool details */}
           {failedTools.length > 0 && (
             <div className="space-y-1">
-              <p className="text-[10px] font-semibold text-red-600">
+              <p className="text-[10px] font-semibold text-destructive">
                 Failed Tools ({failedTools.length})
               </p>
               {failedTools.map((tool) => (
                 <div
                   key={`${result.id}-${tool.toolName}`}
-                  className="rounded border border-red-500/10 bg-red-500/5 px-2.5 py-1.5 space-y-1"
+                  className="rounded border border-destructive/10 bg-destructive/5 px-2.5 py-1.5 space-y-1"
                 >
                   <div className="flex items-center gap-2">
-                    <span className="text-xs font-mono font-medium text-red-700">
+                    <span className="text-xs font-mono font-medium text-destructive">
                       {tool.toolName}
                     </span>
                     <span className="text-[10px] text-muted-foreground">
@@ -141,7 +141,7 @@ function BrokenMCPCard({ result }: { result: MonitorResult }) {
                     </span>
                   </div>
                   {tool.error && (
-                    <pre className="text-[11px] whitespace-pre-wrap break-all text-red-600">
+                    <pre className="text-[11px] whitespace-pre-wrap break-all text-destructive">
                       {tool.error}
                     </pre>
                   )}


### PR DESCRIPTION
## Summary
`BrokenMCPList`/`BrokenMCPCard` hand-rolled failure/success colors with raw `red-*`/`emerald-*` Tailwind classes instead of the repo's semantic design tokens.

- All `red-*` usages represent a failure/error state — the same file already uses `variant="destructive"` Badges for that exact meaning, so `text-destructive` (and `bg-destructive/5`, `border-destructive/10`) is an unambiguous swap.
- All `emerald-600` usages represent a healthy/OK state — `registry-item-card.tsx` in the same view group already uses `text-success` for that exact meaning.

This aligns the shade to the design-system tokens; it isn't necessarily pixel-identical to the old palette values, but the semantic meaning (destructive/success) is preserved exactly.

## Why
Un-CI-enforced design-token drift accumulates in the frontend; this is a small, low-risk cleanup with an unambiguous mapping (no judgment call on shade/brand).

## Test plan
- [x] `bun run fmt`
- [x] `cd apps/mesh && bun x tsc --noEmit` — clean
- Pure CSS class rename, no logic/behavior change — verify by loading a registry monitor run with a broken MCP and confirming the failed/healthy states still render in the destructive/success colors.

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced raw Tailwind red/emerald colors in the Broken MCP list with semantic design tokens. Uses destructive for error states and success for OK states to align with the design system; no behavior change.

<sup>Written for commit 49d79c77a48ab4a16486499a7cbce6a5b4f6f817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

