### PR TITLE
fix(task-board): auto-size title textarea on open, not just on edit

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -235,6 +235,11 @@ export function TaskBoardItemDialog({
               gap above the properties; fills the column on desktop. */}
           <div className="flex min-w-0 flex-col gap-6 p-6 sm:flex-1 sm:overflow-y-auto sm:p-8">
             <textarea
+              ref={(el) => {
+                if (!el) return;
+                el.style.height = "auto";
+                el.style.height = `${el.scrollHeight}px`;
+              }}
               value={title}
               onChange={(e) => {
                 setTitle(e.target.value);


### PR DESCRIPTION
Follows #4727, which turned the task title into an auto-growing textarea so long titles wrap instead of getting clipped. The auto-grow only ran from the `onChange` handler, so it never fired for the title the dialog opens with — a task whose *existing* title is long enough to wrap still renders clipped to a single line (`rows={1}` + `overflow-hidden`) until the user edits it. That's the exact case the fix was meant to cover.

Fix: a callback ref sizes the textarea from its `scrollHeight` on mount. The dialog is keyed by the task id (`apps/mesh/src/web/layouts/task-board/index.tsx`), so it fully remounts per task and the ref fires for every open, not just the first.

To confirm: open a task with a long, multi-line-worthy title on `main` — it stays clipped to one line until you type. On this branch it's expanded to full height immediately on open.

Checks run locally: `bun run fmt` (clean) and `cd apps/mesh && bun x tsc --noEmit` (clean, unmodified). No unit-testable logic here (pure DOM sizing behavior) — full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-sizes the task title textarea when the dialog opens so long titles expand immediately instead of clipping to one line. This removes the need to type before the field grows.

- **Bug Fixes**
  - Set height on mount via a callback ref: reset to "auto", then set to `scrollHeight`.
  - Runs on every open since the dialog is keyed by task id.

<sup>Written for commit a729ba36f8db21daa70b0ad3ccec60a245f75b23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

