### PR TITLE
refactor(registry): use destructive/success/warning design tokens in monitor dashboard

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
@@ -110,10 +110,10 @@ function ResultLogEntry({
           className={cn(
             "shrink-0",
             r.status === "passed"
-              ? "text-emerald-600"
+              ? "text-success"
               : r.status === "needs_auth"
-                ? "text-amber-600"
-                : "text-red-600",
+                ? "text-warning"
+                : "text-destructive",
           )}
         >
           {r.status === "passed" ? "✓" : r.status === "needs_auth" ? "🔑" : "✗"}
@@ -129,25 +129,25 @@ function ResultLogEntry({
           className={cn(
             "text-[9px] capitalize shrink-0",
             r.status === "passed"
-              ? "text-emerald-600 border-emerald-500/20"
+              ? "text-success border-success/20"
               : r.status === "needs_auth"
-                ? "text-amber-600 border-amber-500/20"
-                : "text-red-600 border-red-500/20",
+                ? "text-warning border-warning/20"
+                : "text-destructive border-destructive/20",
           )}
         >
           {r.status.replace("_", " ")}
         </Badge>
         {r.connection_ok ? (
-          <span className="text-[10px] text-emerald-600 shrink-0">conn✓</span>
+          <span className="text-[10px] text-success shrink-0">conn✓</span>
         ) : (
-          <span className="text-[10px] text-red-600 shrink-0">conn✗</span>
+          <span className="text-[10px] text-destructive shrink-0">conn✗</span>
         )}
         {r.tools_listed && (
           <span className="text-[10px] text-muted-foreground shrink-0">
             {hasToolTests ? (
               <>
-                <span className="text-emerald-600">{passedTools}✓</span>{" "}
-                <span className={cn(failedTools > 0 ? "text-red-600" : "")}>
+                <span className="text-success">{passedTools}✓</span>{" "}
+                <span className={cn(failedTools > 0 ? "text-destructive" : "")}>
                   {failedTools}✗
                 </span>
               </>
@@ -170,8 +170,10 @@ function ResultLogEntry({
         <div className="border-t border-border px-3 py-2 space-y-2 bg-muted/10">
           {r.error_message && (
             <div className="space-y-0.5">
-              <p className="text-[10px] font-semibold text-red-600">Error</p>
-              <pre className="text-[11px] bg-red-500/5 border border-red-500/10 rounded px-2 py-1.5 whitespace-pre-wrap break-all text-red-700 max-h-20 overflow-auto">
+              <p className="text-[10px] font-semibold text-destructive">
+                Error
+              </p>
+              <pre className="text-[11px] bg-destructive/5 border border-destructive/10 rounded px-2 py-1.5 whitespace-pre-wrap break-all text-destructive max-h-20 overflow-auto">
                 {r.error_message}
               </pre>
             </div>
@@ -182,7 +184,7 @@ function ResultLogEntry({
               Connection:{" "}
               <span
                 className={cn(
-                  r.connection_ok ? "text-emerald-600" : "text-red-600",
+                  r.connection_ok ? "text-success" : "text-destructive",
                 )}
               >
                 {r.connection_ok ? "OK" : "Failed"}
@@ -192,7 +194,7 @@ function ResultLogEntry({
               Tools listed:{" "}
               <span
                 className={cn(
-                  r.tools_listed ? "text-emerald-600" : "text-red-600",
+                  r.tools_listed ? "text-success" : "text-destructive",
                 )}
               >
                 {r.tools_listed ? "Yes" : "No"}
@@ -266,7 +268,7 @@ function ToolMiniRow({ tool }: { tool: MonitorToolResult }) {
         <span
           className={cn(
             "font-bold",
-            tool.success ? "text-emerald-600" : "text-red-600",
+            tool.success ? "text-success" : "text-destructive",
           )}
         >
           {tool.success ? "✓" : "✗"}
@@ -276,7 +278,10 @@ function ToolMiniRow({ tool }: { tool: MonitorToolResult }) {
           {tool.durationMs}ms
         </span>
         {tool.error && (
-          <span className="text-red-500 truncate max-w-28" title={tool.error}>
+          <span
+            className="text-destructive truncate max-w-28"
+            title={tool.error}
+          >
             {tool.error}
           </span>
         )}
@@ -285,7 +290,7 @@ function ToolMiniRow({ tool }: { tool: MonitorToolResult }) {
       {showDetails && (
         <div className="border-t border-border px-2 py-1.5 space-y-1 bg-muted/10 text-[11px]">
           {tool.error && (
-            <pre className="bg-red-500/5 border border-red-500/10 rounded px-2 py-1 whitespace-pre-wrap break-all text-red-700 max-h-20 overflow-auto">
+            <pre className="bg-destructive/5 border border-destructive/10 rounded px-2 py-1 whitespace-pre-wrap break-all text-destructive max-h-20 overflow-auto">
               {tool.error}
             </pre>
           )}
@@ -529,14 +534,14 @@ export function MonitorDashboard({
 
               <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
                 <Card className="p-2.5 space-y-0.5">
-                  <p className="text-[10px] text-emerald-600">Passed</p>
-                  <p className="text-lg font-bold text-emerald-600">
+                  <p className="text-[10px] text-success">Passed</p>
+                  <p className="text-lg font-bold text-success">
                     {run.passed_items}
                   </p>
                 </Card>
                 <Card className="p-2.5 space-y-0.5">
-                  <p className="text-[10px] text-red-600">Failed</p>
-                  <p className="text-lg font-bold text-red-600">
+                  <p className="text-[10px] text-destructive">Failed</p>
+                  <p className="text-lg font-bold text-destructive">
                     {run.failed_items}
                   </p>
                 </Card>


### PR DESCRIPTION
## Source
Follows #4730 and #4728, which migrated the same raw-Tailwind status-color pattern to design tokens in the sibling `broken-mcp-list.tsx` and `task-status.ts`. `monitor-dashboard.tsx` (same `registry/` monitoring feature, same `MonitorResult` shape) still had 19 unmigrated instances of the identical pass/fail/needs-auth pattern.

## Why
Raw `red-*`/`emerald-*`/`amber-*` classes drift from the design system and don't adapt with future theme/token changes; `#4730` already established this exact mapping for the sibling component.

## Mapping (unambiguous — same file already encodes the same status semantics elsewhere)
- `text-emerald-600` / `bg-emerald-500` (pass/OK) → `text-success` / `bg-success` — the CSS `--success` token resolves to the same green hue (oklch hue 149).
- `text-red-600` / `text-red-500` / `text-red-700` / `bg-red-500` (fail/error) → `text-destructive` / `bg-destructive` — `--destructive` resolves to the same red hue (oklch hue 27).
- `text-amber-600` (needs_auth) → `text-warning` — `--warning` resolves to the same amber hue (oklch hue 70).

Left two instances unchanged (documented in the diff-adjacent code, not touched): the `bg-blue-500/10` "running" badge (no `info` token exists in this design system, so there's no unambiguous target) and the `bg-orange-500` progress-bar segment (a different, less clear-cut semantic than the plain fail/pass split used for the stat cards). This aligns the shade to the design-system tokens — it is not guaranteed to be pixel-identical to the old raw palette values, though the token hues were chosen to match.

## Verify
`cd apps/mesh && bunx tsc --noEmit` — clean. `bun run fmt` — no changes needed. No behavior/logic change (ternary conditions untouched, only class strings), so no new test is needed; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the registry monitor dashboard to use design tokens for status styling, replacing raw Tailwind reds/greens/ambers. This keeps colors consistent with the design system and future themes, with no behavior changes.

- **Refactors**
  - Replaced status classes: `emerald` → `success`, `red` → `destructive`, `amber` → `warning` (including text, bg, border, and error panels).
  - Left `bg-blue-500/10` (running badge) and `bg-orange-500` (progress segment) unchanged due to no clear token equivalents.

<sup>Written for commit 08716b86dc30ddf7a05a5d5f118f8eac4222db90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

