### PR TITLE
refactor(members): use warning design token for pending invite badge

### DIFF
--- a/apps/mesh/src/web/routes/orgs/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/members.tsx
@@ -920,7 +920,7 @@ function OrgMembersContent() {
                                 <div className="flex items-center gap-2">
                                   <Badge
                                     variant="outline"
-                                    className="w-fit text-amber-600 border-amber-400"
+                                    className="w-fit text-warning border-warning/40"
                                   >
                                     Pending
                                   </Badge>


### PR DESCRIPTION
## Source
C-DEBT: design-token drift found while auditing `apps/mesh/src/web/routes/orgs/members.tsx` (flagged as a highest-debt frontend file).

## Why
The "Pending" invitation `Badge` hand-picked `text-amber-600 border-amber-400` instead of the semantic `warning` token that the codebase already uses for this exact meaning (e.g. `task-board/config.tsx`, `task-status.ts`, and the in-flight `monitor-dashboard.tsx` migration in #4732, which converts the identical `amber-600`/`border-amber-*` → `text-warning`/`border-warning` shape). The mapping is unambiguous: "Pending" is a warning/attention state, and `--warning` resolves to an amber-hued oklch value (`oklch(0.62 0.17 70)`), so this aligns the shade to the design-system `warning` token rather than being a pixel-identical no-op.

Note: the file's other raw-palette hits (`ROLE_COLORS`, `BUILTIN_ROLE_COLORS`) are a deliberate rainbow color picker for member role dots, not status semantics, so they were left alone.

## Change
`-1 / +1` — swaps `text-amber-600 border-amber-400` for `text-warning border-warning/40` on one `Badge`. Behavior-preserving (no logic change, just the class string).

## How to verify
Open the org members page, view a pending invitation card — the "Pending" badge should render with the app's warning color instead of a hardcoded amber.

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (clean)
Full CI (lint, test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the semantic `warning` design token for the “Pending” invitation Badge on the org members page by replacing `text-amber-600 border-amber-400` with `text-warning border-warning/40`. Aligns the badge with the design system and keeps behavior the same.

<sup>Written for commit 49a832ba40544efebc7c92b35e062b9b1645a814. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

