### PR TITLE
refactor(registry): use warning/success tokens for QA run progress bar

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
@@ -525,7 +525,7 @@ export function MonitorDashboard({
                 <div
                   className={cn(
                     "h-full transition-all duration-500",
-                    run.failed_items > 0 ? "bg-orange-500" : "bg-emerald-500",
+                    run.failed_items > 0 ? "bg-warning" : "bg-success",
                     isRunning ? "animate-pulse" : "",
                   )}
                   style={{ width: `${pct(run)}%` }}


### PR DESCRIPTION
Follows #4732, which swapped raw Tailwind palette classes for design-system tokens (`text-success`/`text-warning`/`text-destructive`) across `monitor-dashboard.tsx` but missed the one instance driving the QA run progress bar fill color (`bg-orange-500` / `bg-emerald-500`).

This closes the gap so the whole file is consistent with the design-system tokens already established (`--success`, `--warning`) and used elsewhere in the same component.

Reviewer check: `rg -n "text-(emerald|red|amber)-[0-9]+|bg-(emerald|red|amber|orange)-[0-9]+" apps/mesh/src/web/views/registry/monitor-dashboard.tsx` now returns no matches.

Locally ran: `bun run fmt`, `bun x tsc --noEmit` (in `apps/mesh`) — both clean. No behavior change, pure class-name swap, so no test needed; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace raw Tailwind colors in the QA run progress bar with design-system tokens to keep `monitor-dashboard.tsx` consistent. Swaps `bg-orange-500`/`bg-emerald-500` for `bg-warning`/`bg-success`; no behavior change.

<sup>Written for commit c8541b974cc9e232c6bc6a5ccc5bc85c4c148c44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

