### PR TITLE
refactor(registry): use destructive/success/warning tokens in monitor run detail

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-run-detail.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-run-detail.tsx
@@ -17,15 +17,14 @@ import type {
 function statusColor(status: MonitorResultStatus) {
   switch (status) {
     case "passed":
-      return "bg-emerald-500/10 text-emerald-600 border-emerald-500/20";
+      return "bg-success/10 text-success border-success/20";
     case "failed":
-      return "bg-red-500/10 text-red-600 border-red-500/20";
     case "error":
-      return "bg-orange-500/10 text-orange-600 border-orange-500/20";
+      return "bg-destructive/10 text-destructive border-destructive/20";
     case "needs_auth":
-      return "bg-amber-500/10 text-amber-600 border-amber-500/20";
+      return "bg-warning/10 text-warning border-warning/20";
     case "skipped":
-      return "bg-zinc-500/10 text-zinc-500 border-zinc-500/20";
+      return "bg-muted text-muted-foreground border-border";
     default:
       return "";
   }
@@ -60,7 +59,7 @@ function ToolResultRow({ tool }: { tool: MonitorToolResult }) {
         <span
           className={cn(
             "text-xs font-bold",
-            tool.success ? "text-emerald-600" : "text-red-600",
+            tool.success ? "text-success" : "text-destructive",
           )}
         >
           {tool.success ? "✓" : "✗"}
@@ -79,8 +78,10 @@ function ToolResultRow({ tool }: { tool: MonitorToolResult }) {
         <div className="border-t border-border px-3 py-2 space-y-1.5 bg-muted/20">
           {tool.error && (
             <div className="space-y-0.5">
-              <p className="text-[10px] font-semibold text-red-600">Error</p>
-              <pre className="text-[11px] bg-red-500/5 border border-red-500/10 rounded px-2 py-1.5 whitespace-pre-wrap break-all text-red-700">
+              <p className="text-[10px] font-semibold text-destructive">
+                Error
+              </p>
+              <pre className="text-[11px] bg-destructive/5 border border-destructive/10 rounded px-2 py-1.5 whitespace-pre-wrap break-all text-destructive">
                 {tool.error}
               </pre>
             </div>
@@ -189,7 +190,7 @@ function ResultCard({ result }: { result: MonitorResult }) {
               <p
                 className={cn(
                   "text-xs font-medium",
-                  result.connection_ok ? "text-emerald-600" : "text-red-600",
+                  result.connection_ok ? "text-success" : "text-destructive",
                 )}
               >
                 {result.connection_ok ? "Connected" : "Failed"}
@@ -200,7 +201,7 @@ function ResultCard({ result }: { result: MonitorResult }) {
               <p
                 className={cn(
                   "text-xs font-medium",
-                  result.tools_listed ? "text-emerald-600" : "text-red-600",
+                  result.tools_listed ? "text-success" : "text-destructive",
                 )}
               >
                 {result.tools_listed
@@ -223,10 +224,10 @@ function ResultCard({ result }: { result: MonitorResult }) {
           {/* Error message */}
           {result.error_message && (
             <div className="space-y-1">
-              <p className="text-[10px] font-semibold text-red-600">
+              <p className="text-[10px] font-semibold text-destructive">
                 Error Message
               </p>
-              <pre className="text-xs bg-red-500/5 border border-red-500/10 rounded px-3 py-2 whitespace-pre-wrap break-all text-red-700">
+              <pre className="text-xs bg-destructive/5 border border-destructive/10 rounded px-3 py-2 whitespace-pre-wrap break-all text-destructive">
                 {result.error_message}
               </pre>
             </div>
@@ -390,14 +391,14 @@ export function MonitorRunDetail({ runId }: { runId?: string }) {
             <p className="text-lg font-bold">{run.tested_items}</p>
           </Card>
           <Card className="p-2.5 space-y-0.5">
-            <p className="text-[10px] text-emerald-600">Passed</p>
-            <p className="text-lg font-bold text-emerald-600">
-              {run.passed_items}
-            </p>
+            <p className="text-[10px] text-success">Passed</p>
+            <p className="text-lg font-bold text-success">{run.passed_items}</p>
           </Card>
           <Card className="p-2.5 space-y-0.5">
-            <p className="text-[10px] text-red-600">Failed</p>
-            <p className="text-lg font-bold text-red-600">{run.failed_items}</p>
+            <p className="text-[10px] text-destructive">Failed</p>
+            <p className="text-lg font-bold text-destructive">
+              {run.failed_items}
+            </p>
           </Card>
           <Card className="p-2.5 space-y-0.5">
             <p className="text-[10px] text-muted-foreground">Skipped</p>


### PR DESCRIPTION
## Summary
Follows #4732 / #4733 — those PRs migrated `monitor-dashboard.tsx` from raw Tailwind palette classes to the semantic `success`/`destructive`/`warning` design tokens for MCP monitor run status; this file (`monitor-run-detail.tsx`, the drill-down detail view for the same monitor run data) was still using `emerald-600`/`red-600`/`orange-600`/`amber-600`/`zinc-500`.

## Mapping (unambiguous — same status names, same domain, already established in `monitor-dashboard.tsx`)
- `passed` → `success` (dashboard already uses this exact mapping)
- `needs_auth` → `warning` (dashboard already uses this exact mapping)
- `failed` / `error` → `destructive` (dashboard's own status-color logic treats every non-passed/non-needs_auth status as destructive — collapsing `error`'s distinct orange into `destructive` alongside `failed`'s red)
- `skipped` → `muted` (no existing token used elsewhere in this file for "neutral/inactive"; `bg-muted`/`text-muted-foreground` is the closest semantic equivalent already used throughout this file for de-emphasized text)
- Tool success/failure, connection/tools-listed indicators, and error blocks → `success`/`destructive` per the same convention

## Honest visual note
This is not purely cosmetic in one spot: previously `error` (orange) and `needs_auth` (amber) rendered as visually distinct near-neighbor colors; `error` now renders identically to `failed` (both `destructive`/red) instead of orange. This matches the precedent already shipped in `monitor-dashboard.tsx`, where `error` and `failed` are already collapsed into the same "else" branch. Everywhere else, this aligns the shade to the design-system token rather than being pixel-identical to the old palette value.

## Test plan
- [x] `bun run fmt`
- [x] `cd apps/mesh && bunx tsc --noEmit` — clean
- [ ] Full CI validates lint/tests

To confirm: open the MCP monitor run detail view and check status badges/colors render correctly for passed/failed/error/needs_auth/skipped runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the monitor run detail view to semantic status tokens for badges, tool indicators, and error messages, aligning visuals with the dashboard and design system.

- **Refactors**
  - Replaces palette classes with `success`, `destructive`, `warning`, and `muted` tokens in `monitor-run-detail.tsx`.
  - Status mapping: `passed`→`success`, `needs_auth`→`warning`, `failed`/`error`→`destructive`, `skipped`→`muted`.
  - Applies tokens to tool success/failure marks, connection/tools-listed indicators, and error blocks.

<sup>Written for commit d8372ca2541a2350c419b190aa450ccacb69e698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

