### PR TITLE
refactor(roles): dedupe role-color helper into shared lib

### DIFF
--- a/apps/mesh/src/web/lib/role-color.ts
+++ b/apps/mesh/src/web/lib/role-color.ts
@@ -1,0 +1,42 @@
+const ROLE_COLORS = [
+  "bg-red-500",
+  "bg-orange-500",
+  "bg-amber-500",
+  "bg-yellow-500",
+  "bg-lime-500",
+  "bg-green-500",
+  "bg-emerald-500",
+  "bg-teal-500",
+  "bg-cyan-500",
+  "bg-sky-500",
+  "bg-blue-500",
+  "bg-indigo-500",
+  "bg-violet-500",
+  "bg-purple-500",
+  "bg-fuchsia-500",
+  "bg-pink-500",
+  "bg-rose-500",
+] as const;
+
+const BUILTIN_ROLE_COLORS: Record<string, string> = {
+  owner: "bg-red-500",
+  admin: "bg-blue-500",
+  user: "bg-green-500",
+};
+
+export function getRoleColor(roleName: string): string {
+  if (!roleName) return "bg-neutral-400";
+  let hash = 0;
+  for (let i = 0; i < roleName.length; i++) {
+    const char = roleName.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+  }
+  const index = Math.abs(hash) % ROLE_COLORS.length;
+  return ROLE_COLORS[index] ?? ROLE_COLORS[0];
+}
+
+export function getRoleDotColor(role: string, isBuiltin: boolean): string {
+  if (isBuiltin) return BUILTIN_ROLE_COLORS[role] ?? "bg-neutral-400";
+  return getRoleColor(role);
+}

--- a/apps/mesh/src/web/routes/orgs/settings/roles.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/roles.tsx
@@ -6,6 +6,7 @@ import {
 import { useOrgAuthClient } from "@/web/hooks/use-org-auth-client";
 import { KEYS } from "@/web/lib/query-keys";
 import { track } from "@/web/lib/posthog-client";
+import { getRoleDotColor } from "@/web/lib/role-color";
 import { Badge } from "@deco/ui/components/badge.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
@@ -58,49 +59,6 @@ const BUILTIN_ROLES = [
   { role: "admin", label: "Admin", color: "bg-blue-500" },
   { role: "user", label: "User", color: "bg-green-500" },
 ] as const;
-
-const ROLE_COLORS = [
-  "bg-red-500",
-  "bg-orange-500",
-  "bg-amber-500",
-  "bg-yellow-500",
-  "bg-lime-500",
-  "bg-green-500",
-  "bg-emerald-500",
-  "bg-teal-500",
-  "bg-cyan-500",
-  "bg-sky-500",
-  "bg-blue-500",
-  "bg-indigo-500",
-  "bg-violet-500",
-  "bg-purple-500",
-  "bg-fuchsia-500",
-  "bg-pink-500",
-  "bg-rose-500",
-] as const;
-
-function getRoleColor(roleName: string): string {
-  if (!roleName) return "bg-neutral-400";
-  let hash = 0;
-  for (let i = 0; i < roleName.length; i++) {
-    const char = roleName.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash;
-  }
-  const index = Math.abs(hash) % ROLE_COLORS.length;
-  return ROLE_COLORS[index] ?? ROLE_COLORS[0];
-}
-
-const BUILTIN_ROLE_COLORS: Record<string, string> = {
-  owner: "bg-red-500",
-  admin: "bg-blue-500",
-  user: "bg-green-500",
-};
-
-function getRoleDotColor(role: string, isBuiltin: boolean): string {
-  if (isBuiltin) return BUILTIN_ROLE_COLORS[role] ?? "bg-neutral-400";
-  return getRoleColor(role);
-}
 
 // ============================================================================
 // Roles Table (main page content)

--- a/apps/mesh/src/web/views/settings/org-role-detail.tsx
+++ b/apps/mesh/src/web/views/settings/org-role-detail.tsx
@@ -12,6 +12,7 @@ import { useOrgAuthClient } from "@/web/hooks/use-org-auth-client";
 import { getInitials } from "@/web/lib/get-initials";
 import { KEYS } from "@/web/lib/query-keys";
 import { track } from "@/web/lib/posthog-client";
+import { getRoleColor, getRoleDotColor } from "@/web/lib/role-color";
 import {
   useConnections,
   useProjectContext,
@@ -76,53 +77,6 @@ export type RoleEditorTarget =
   | { kind: "builtin"; role: "owner" | "admin" | "user" }
   | { kind: "custom"; role: OrganizationRole }
   | { kind: "new" };
-
-// ============================================================================
-// Role color helpers
-// ============================================================================
-
-const ROLE_COLORS = [
-  "bg-red-500",
-  "bg-orange-500",
-  "bg-amber-500",
-  "bg-yellow-500",
-  "bg-lime-500",
-  "bg-green-500",
-  "bg-emerald-500",
-  "bg-teal-500",
-  "bg-cyan-500",
-  "bg-sky-500",
-  "bg-blue-500",
-  "bg-indigo-500",
-  "bg-violet-500",
-  "bg-purple-500",
-  "bg-fuchsia-500",
-  "bg-pink-500",
-  "bg-rose-500",
-] as const;
-
-const BUILTIN_ROLE_COLORS: Record<string, string> = {
-  owner: "bg-red-500",
-  admin: "bg-blue-500",
-  user: "bg-green-500",
-};
-
-function getRoleColor(roleName: string): string {
-  if (!roleName) return "bg-neutral-400";
-  let hash = 0;
-  for (let i = 0; i < roleName.length; i++) {
-    const char = roleName.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash;
-  }
-  const index = Math.abs(hash) % ROLE_COLORS.length;
-  return ROLE_COLORS[index] ?? ROLE_COLORS[0];
-}
-
-function getRoleDotColor(roleSlug: string, isBuiltin: boolean): string {
-  if (isBuiltin) return BUILTIN_ROLE_COLORS[roleSlug] ?? "bg-neutral-400";
-  return getRoleColor(roleSlug);
-}
 
 // ============================================================================
 // Zod Schema


### PR DESCRIPTION
## Source
Code-reduction hunt across the highest-debt frontend files (see repo maintenance notes) — `apps/mesh/src/web/routes/orgs/settings/roles.tsx` and `apps/mesh/src/web/views/settings/org-role-detail.tsx` carried a byte-identical `ROLE_COLORS` array, `BUILTIN_ROLE_COLORS` map, and `getRoleColor`/`getRoleDotColor` hash-based color picker (confirmed with a `diff` of the two blocks — only whitespace/param-name differences).

## Payoff
One less place to keep two copies of the same 17-color palette and hash logic in sync; future edits (e.g. adding a role color) now touch one file instead of two.

## Change
Moved the duplicated block into `apps/mesh/src/web/lib/role-color.ts` and imported `getRoleColor`/`getRoleDotColor` from both call sites. Net: **-90 / +44** (including the +37-line new shared file). Confirmed `rg -n "getRoleColor|getRoleDotColor"` shows no other callers, and the logic itself is copy-pasted verbatim (not rewritten), so behavior is unchanged.

Note: `apps/mesh/src/web/routes/orgs/members.tsx` has a *different* index-based (not hash-based) color-assignment algorithm for the same visual purpose — left untouched since unifying it would change which color a given role renders as there.

## Verify
```
cd apps/mesh && bunx tsc --noEmit
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (clean)
Full CI (lint, tests) will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated role color helpers into a shared module to reduce maintenance and keep behavior consistent across role views. No visual or logic changes.

- **Refactors**
  - Moved `ROLE_COLORS`, `BUILTIN_ROLE_COLORS`, `getRoleColor`, and `getRoleDotColor` to `apps/mesh/src/web/lib/role-color.ts`.
  - Updated `apps/mesh/src/web/routes/orgs/settings/roles.tsx` and `apps/mesh/src/web/views/settings/org-role-detail.tsx` to import from the shared module.
  - Left `apps/mesh/src/web/routes/orgs/members.tsx` as-is due to its different color assignment logic.

<sup>Written for commit a695fadce094f82b876f698003da5e74d80fe618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

