### PR TITLE
refactor(registry): use design-system tokens in monitorStatusBadgeClass

### DIFF
--- a/apps/mesh/src/web/lib/registry/monitor-utils.ts
+++ b/apps/mesh/src/web/lib/registry/monitor-utils.ts
@@ -3,15 +3,15 @@ import type { MonitorToolResult } from "./types";
 export function monitorStatusBadgeClass(status: string): string {
   switch (status) {
     case "running":
-      return "bg-blue-500/10 text-blue-600 border-blue-500/20";
+      return "bg-primary/10 text-primary border-primary/20";
     case "completed":
-      return "bg-emerald-500/10 text-emerald-600 border-emerald-500/20";
+      return "bg-success/10 text-success border-success/20";
     case "failed":
-      return "bg-red-500/10 text-red-600 border-red-500/20";
+      return "bg-destructive/10 text-destructive border-destructive/20";
     case "cancelled":
-      return "bg-zinc-500/10 text-zinc-500 border-zinc-500/20";
+      return "bg-muted text-muted-foreground border-border";
     case "pending":
-      return "bg-amber-500/10 text-amber-600 border-amber-500/20";
+      return "bg-warning/10 text-warning border-warning/20";
     default:
       return "";
   }


### PR DESCRIPTION
## Summary

Follows #4735 and #4734. Those two PRs migrated the inline status-color switches in `monitor-run-detail.tsx` and the QA run progress bar from raw Tailwind palette classes to `success`/`warning`/`destructive` design-system tokens. The shared `monitorStatusBadgeClass` helper in `apps/mesh/src/web/lib/registry/monitor-utils.ts` — used by `monitor-run-history.tsx` and `monitor-dashboard.tsx` — has the exact same status set (`running`/`completed`/`failed`/`cancelled`/`pending`) but was left on raw palette (`bg-blue-500`, `bg-emerald-500`, `bg-red-500`, `bg-zinc-500`, `bg-amber-500`). This closes that gap so all monitor status-badge rendering in the registry views is consistent and theme-aware.

Net: -5 / +5 lines, no behavior change (same switch shape, same call sites). Color mapping mirrors what the two sibling PRs already established: `completed`→success, `failed`→destructive, `pending`→warning, `cancelled`→muted/border (same treatment `monitor-run-detail.tsx`'s `skipped` case got), `running`→primary (the token already used elsewhere in this codebase for active/selected state, e.g. `registry-item-dialog.tsx`, `monitor-connections-panel.tsx`).

## Test plan
- [x] `bun run fmt`
- [x] `cd apps/mesh && bun x tsc --noEmit` — clean
- Reviewer: visually confirm `monitor-run-history.tsx` and `monitor-dashboard.tsx` badges still render with the same semantic colors (light/dark) — full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `monitorStatusBadgeClass` to design-system tokens for status badges. Keeps behavior the same and aligns `monitor-run-history.tsx` and `monitor-dashboard.tsx` with existing token use.

Mappings: running→primary, completed→success, failed→destructive, pending→warning, cancelled→muted/border.

<sup>Written for commit c4e5d807d98e59e927bd5376a1719b840d7535b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

