### PR TITLE
refactor(registry): use success/warning tokens in monitor connections auth badge

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -40,11 +40,11 @@ type SourceFilter = "all" | "store" | "request";
 function authBadgeStyle(status: MonitorConnectionAuthStatus) {
   switch (status) {
     case "authenticated":
-      return "bg-emerald-500/10 text-emerald-600 border-emerald-500/20";
+      return "bg-success/10 text-success border-success/20";
     case "needs_auth":
-      return "bg-amber-500/10 text-amber-600 border-amber-500/20";
+      return "bg-warning/10 text-warning border-warning/20";
     default:
-      return "bg-zinc-500/10 text-zinc-500 border-zinc-500/20";
+      return "bg-muted text-muted-foreground border-border";
   }
 }
 


### PR DESCRIPTION
## Summary
- `authBadgeStyle()` in `monitor-connections-panel.tsx` hand-rolled `bg-emerald-500/10 text-emerald-600 border-emerald-500/20` / amber / zinc classes for the `authenticated` / `needs_auth` / default connection-auth states.
- The sibling files in the same registry-monitor area (`monitor-utils.ts` #4737, `monitor-run-detail.tsx` #4735, QA progress bar #4734) were just migrated from this exact emerald/amber/zinc palette to the `success`/`warning`/`muted` design-system tokens for the identical success/warning/neutral status meaning — this file had the same case shape and was simply missed.
- Aligns the shade to the design-system `success`/`warning`/`muted` tokens (not a guaranteed pixel-identical match to the old emerald/amber/zinc values).

## Why
Keeps this file consistent with the token convention the team just established next door, and removes raw-palette drift the design-token lint doesn't catch.

## Test plan
- [x] `bun run fmt`
- [x] `bunx tsc --noEmit` in `apps/mesh` (clean)
- Reviewer: visually confirm the connection auth badges in the registry monitor connections panel still read as green/amber/neutral.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hard-coded emerald/amber/zinc classes in the monitor connections auth badge with design tokens (`success`, `warning`, `muted`) for consistent styling across the registry monitor. No behavior change.

- **Refactors**
  - Updated `authBadgeStyle()` mappings: `authenticated` → `bg-success/10 text-success border-success/20`, `needs_auth` → `bg-warning/10 text-warning border-warning/20`, default → `bg-muted text-muted-foreground border-border`.

<sup>Written for commit 2dff6e9cd75fbcb8f436767406f02440d2468dc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

