### PR TITLE
fix(sandbox): refuse daemon push to protected branches

### DIFF
--- a/packages/sandbox/daemon/git/protect-branch.ts
+++ b/packages/sandbox/daemon/git/protect-branch.ts
@@ -16,6 +16,16 @@ done
 exit 0
 `;
 
+// Branches a sandbox must never push to directly. Not every repo names its
+// default branch main/master (trunk, develop, etc.) — protect the repo's actual
+// default too, or a sandbox push would sail straight through on those repos.
+// Single source of truth for both the pre-push hook and the in-code guard in
+// publish() (the hook alone is not enough: the publish path pushes with
+// --no-verify, which skips pre-push hooks entirely).
+export function protectedBranches(repoDir: string): Set<string> {
+  return new Set(["main", "master", resolveRemoteDefaultBranch(repoDir)]);
+}
+
 // Sync fs here would block the daemon's single event loop long enough to
 // miss a health probe (CONTRIBUTING.md rule #4) — use the async variants.
 export async function installProtectedBranchHook(
@@ -26,17 +36,9 @@ export async function installProtectedBranchHook(
   await writeFile(join(hooksDir, "pre-push"), HOOK, { encoding: "utf-8" });
   await chmod(join(hooksDir, "pre-push"), 0o755);
 
-  // Not every repo names its default branch main/master (trunk, develop,
-  // etc.) — protect the repo's actual default too, or a sandbox push would
-  // sail straight through on those repos.
-  const branches = new Set([
-    "main",
-    "master",
-    resolveRemoteDefaultBranch(repoDir),
-  ]);
   await writeFile(
     join(hooksDir, "protected-branches"),
-    `${[...branches].join("\n")}\n`,
+    `${[...protectedBranches(repoDir)].join("\n")}\n`,
     { encoding: "utf-8" },
   );
 }

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -29,6 +29,12 @@ function initRepo(): { appRoot: string; repoDir: string } {
   return { appRoot, repoDir };
 }
 
+// publish() refuses to push from a protected branch (main/master/default), so
+// tests that exercise the commit/push path must move onto a feature branch first.
+function onFeatureBranch(repoDir: string): void {
+  gitSync(["checkout", "-b", "feature/x"], { cwd: repoDir, asUser: false });
+}
+
 describe("git routes", () => {
   it("status reports modified files", async () => {
     const { appRoot, repoDir } = initRepo();
@@ -305,6 +311,7 @@ describe("git routes", () => {
 
   it("publish appends operator co-author trailer", async () => {
     const { appRoot, repoDir } = initRepo();
+    onFeatureBranch(repoDir);
     writeFileSync(join(repoDir, "README.md"), "updated\n");
     const handler = makeGitPublishHandler({
       appRoot,
@@ -330,6 +337,7 @@ describe("git routes", () => {
 
   it("publish commits staged changes", async () => {
     const { appRoot, repoDir } = initRepo();
+    onFeatureBranch(repoDir);
     writeFileSync(join(repoDir, "README.md"), "updated\n");
     const handler = makeGitPublishHandler({ appRoot, repoDir });
     const res = await handler(
@@ -361,8 +369,23 @@ describe("git routes", () => {
     });
   });
 
+  it("publish() refuses to push to a protected branch (main)", () => {
+    const { appRoot, repoDir } = initRepo(); // initRepo checks out main
+    writeFileSync(join(repoDir, "README.md"), "changed\n");
+    expect(() => publish({ appRoot, repoDir }, "shutdown sync")).toThrow(
+      /protected branch "main"/,
+    );
+    // Nothing was committed on main — the guard fires before add/commit.
+    const log = gitSync(["log", "-1", "--pretty=%s"], {
+      cwd: repoDir,
+      asUser: false,
+    });
+    expect(log.trim()).toBe("init");
+  });
+
   it("publish() rejects a tokenless github origin with a clear error", () => {
     const { appRoot, repoDir } = initRepo();
+    onFeatureBranch(repoDir);
     gitSync(["remote", "add", "origin", "https://github.com/owner/repo.git"], {
       cwd: repoDir,
       asUser: false,
@@ -375,6 +398,7 @@ describe("git routes", () => {
 
   it("publish skips failing pre-commit hooks", async () => {
     const { appRoot, repoDir } = initRepo();
+    onFeatureBranch(repoDir);
     const hooksDir = join(repoDir, ".git", "hooks");
     mkdirSync(hooksDir, { recursive: true });
     const hookPath = join(hooksDir, "pre-commit");
@@ -403,6 +427,7 @@ describe("git routes", () => {
 
   it("publish stages only paths with working tree changes", async () => {
     const { appRoot, repoDir } = initRepo();
+    onFeatureBranch(repoDir);
     writeFileSync(join(repoDir, "tracked.txt"), "original\n");
     gitSync(["add", "tracked.txt"], { cwd: repoDir, asUser: false });
     gitSync(["commit", "-m", "add tracked"], { cwd: repoDir, asUser: false });

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { appendCoAuthorTrailer } from "../../git-co-author";
 import { computeBranchDivergence } from "../git/branch-divergence";
 import { parsePorcelainFiles } from "../git/porcelain";
+import { protectedBranches } from "../git/protect-branch";
 import { rebaseOntoBase } from "../git/rebase-onto-base";
 import {
   cloneUrlHasCredentials,
@@ -498,6 +499,15 @@ export function publish(deps: GitDeps, message: string): { pushed: boolean } {
   const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (!branch || branch === "HEAD") {
     throw new Error("Cannot publish from a detached HEAD");
+  }
+  // The pre-push hook (protect-branch.ts) also guards this, but the push below
+  // runs with --no-verify and skips it — so the block MUST live in code too.
+  // Refuse before committing so we never leave a stray commit on a protected
+  // branch either. Changes reach the default branch via PR, never a direct push.
+  if (protectedBranches(repoDir).has(branch)) {
+    throw new Error(
+      `Refusing to push to protected branch "${branch}" from a sandbox. Work on a feature branch; changes reach the default branch via PR.`,
+    );
   }
 
   const status = computeWorkingTreeStatus(repoDir);


### PR DESCRIPTION
## Problem

The sandbox daemon was pushing commits **directly to `main`** — the `chore(daemon): sync all local changes to remote on shutdown` commits piling up on the default branch.

## Root cause

There *is* a protection mechanism: `protect-branch.ts` installs a `pre-push` git hook that blocks pushes to `main`/`master`/the repo default. But the publish path — used by both the HTTP `Publish` route and the shutdown auto-sync — pushes with `git push --no-verify`:

```
// pushBranch(), routes/git.ts
"push", "--no-verify", "-u", "origin", branch,
```

`--no-verify` **skips pre-push hooks**, so the daemon's own branch-protection hook never ran on the publish path. The `--no-verify` was added to skip a repo's *own* lefthook/husky pre-push scripts (which can hang the shutdown sync past the pod's grace period) — but it silently disabled our protection too. Whenever the sandbox's current branch was `main`, publish pushed straight to it.

## Fix

Enforce the protected-branch rule **in code** (can't be bypassed by `--no-verify`), with a single source of truth shared with the hook:

- `protect-branch.ts`: extract `protectedBranches(repoDir)` (main / master / resolved default); the hook writer now uses it too.
- `publish()`: throw before staging/committing if the current branch is protected. Changes reach the default branch via PR, never a direct push. This covers both the HTTP publish route and the shutdown auto-sync (which shares `publish()`).

The pre-push hook stays as defense-in-depth for the manual-terminal-push path.

## Tests

- New: `publish() refuses to push to a protected branch (main)` — asserts the throw *and* that nothing was committed on `main`.
- Existing publish tests moved onto a feature branch (they exercise the commit/push path, which is now forbidden on `main`).

`bun test packages/sandbox/daemon/routes/git.test.ts packages/sandbox/daemon/git/protect-branch.test.ts` → 24 pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sandbox daemon from pushing directly to protected branches (`main`, `master`, or the repo’s default) by enforcing the rule in code. This prevents auto-sync commits from landing on the default branch; changes now flow via PR.

- **Bug Fixes**
  - `publish()` now blocks publish from protected branches before staging or committing (covers HTTP publish and shutdown auto-sync).
  - Added `protectedBranches(repoDir)` and shared it between the pre-push hook and the runtime check.
  - Tests updated: added refusal test; existing publish-path tests now run on a feature branch.

<sup>Written for commit 7f115ac2746334fb3b1da96585c35e23d4bd0fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

