### PR TITLE
refactor(registry): use design-system tokens in monitor status badges

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-configuration.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-configuration.tsx
@@ -78,12 +78,12 @@ export function MonitorConfiguration() {
         </div>
         <div className="flex items-center gap-2">
           {isDirty && (
-            <Badge className="bg-amber-500/10 text-amber-600 border-amber-500/20 text-[10px]">
+            <Badge className="bg-warning/10 text-warning border-warning/20 text-[10px]">
               Unsaved changes
             </Badge>
           )}
           {justSaved && (
-            <Badge className="bg-emerald-500/10 text-emerald-600 border-emerald-500/20 text-[10px]">
+            <Badge className="bg-success/10 text-success border-success/20 text-[10px]">
               ✓ Saved
             </Badge>
           )}

--- a/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
@@ -574,7 +574,7 @@ export function MonitorDashboard({
             </div>
             <div className="flex items-center gap-2">
               {isRunning && (
-                <Badge className="bg-blue-500/10 text-blue-600 border-blue-500/20 animate-pulse">
+                <Badge className="bg-primary/10 text-primary border-primary/20 animate-pulse">
                   run in progress
                 </Badge>
               )}


### PR DESCRIPTION
Follows #4737, which migrated `monitorStatusBadgeClass` from raw Tailwind palette classes to design-system tokens. Two sibling components in the same registry monitor feature still had the identical raw-palette pattern (`bg-amber-500/10 text-amber-600 border-amber-500/20`, `bg-emerald-500/10 ...`, `bg-blue-500/10 ...`) that #4737 didn't touch.

- `monitor-configuration.tsx`: "Unsaved changes" (amber) → `warning`, "✓ Saved" (emerald) → `success`
- `monitor-dashboard.tsx`: "run in progress" (blue) → `primary`

Net effect is purely visual-token consistency (same colors resolve through the design system, correct in both light/dark themes); no behavior change.

To confirm: view the QA Configuration panel and the QA run log in the registry monitor UI, badges render identically.

Verified locally: `bun run fmt`, `bunx tsc --noEmit` in `apps/mesh` (clean). Full CI covers lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced raw Tailwind palette classes with design-system tokens for monitor status badges in the registry UI. Ensures consistent colors across themes; no behavior changes.

- **Refactors**
  - monitor-configuration: “Unsaved changes” → warning; “✓ Saved” → success.
  - monitor-dashboard: “run in progress” → primary.

<sup>Written for commit 7a6fcfa7428bc54433a1ad436524700450732dbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

