### PR TITLE
refactor(registry): use design-system tokens in CSV import dialog

### DIFF
--- a/apps/mesh/src/web/views/registry/csv-import-dialog.tsx
+++ b/apps/mesh/src/web/views/registry/csv-import-dialog.tsx
@@ -334,11 +334,11 @@ export function CsvImportDialog({
 
           {/* Warnings */}
           {warnings.length > 0 && (
-            <div className="rounded-lg border border-yellow-200 bg-yellow-50 dark:border-yellow-900 dark:bg-yellow-950/30 p-3 grid gap-1">
+            <div className="rounded-lg border border-warning/20 bg-warning/10 p-3 grid gap-1">
               {warnings.map((w, i) => (
                 <p
                   key={`${w.line}-${i}`}
-                  className="text-xs text-yellow-700 dark:text-yellow-400 flex items-start gap-1.5"
+                  className="text-xs text-warning flex items-start gap-1.5"
                 >
                   <AlertCircle size={12} className="shrink-0 mt-0.5" />
                   <span>
@@ -361,7 +361,7 @@ export function CsvImportDialog({
                 <span className="text-sm font-medium">Preview</span>
                 <Badge variant="secondary">{items.length} items</Badge>
                 {parseResult?.skipped ? (
-                  <Badge variant="outline" className="text-yellow-600">
+                  <Badge variant="outline" className="text-warning">
                     {parseResult.skipped} skipped
                   </Badge>
                 ) : null}
@@ -398,7 +398,7 @@ export function CsvImportDialog({
                             {item.is_public ? (
                               <Badge
                                 variant="secondary"
-                                className="text-[10px] bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400"
+                                className="text-[10px] bg-success/10 text-success"
                               >
                                 Yes
                               </Badge>
@@ -426,7 +426,7 @@ export function CsvImportDialog({
           {importResult && (
             <div className="rounded-lg border p-3 grid gap-1.5">
               <div className="flex items-center gap-2 text-sm font-medium">
-                <CheckCircle size={16} className="text-emerald-600" />
+                <CheckCircle size={16} className="text-success" />
                 Imported {importResult.created} item(s) successfully
               </div>
               {importResult.errors.length > 0 && (


### PR DESCRIPTION
## Summary
- Replaces raw Tailwind palette classes with the existing semantic `warning`/`success` design tokens in the registry CSV import dialog.
- Follows the same token migration recently done in sibling registry files (#4737, #4738, #4740) and matches the established `bg-warning/10 text-warning border-warning/20` / `bg-success/10 text-success` pattern already used in `monitor-utils.ts` and `monitor-run-detail.tsx`.

## Details
- The unparsed-row warnings banner and "skipped" badge (`yellow-*`) → `warning` token — this is literally a warning alert, and the same `text-warning`/`bg-warning/10` shade is already used elsewhere in `apps/mesh/src/web/views/registry/` for warning state.
- The "is public: Yes" badge and "Imported successfully" checkmark (`emerald-*`) → `success` token — same established pattern as `bg-success/10 text-success` in `monitor-utils.ts`/`monitor-run-detail.tsx`.
- Pure class-name swap, no logic changes. This aligns the shade to the design-system token (not necessarily pixel-identical to the old raw yellow/emerald), consistent with how the sibling PRs described their token migration.

## Test plan
- `bun run fmt` — clean
- `cd apps/mesh && bun x tsc --noEmit` — clean
- Reviewer: open the "Import from CSV" dialog in the registry view with some invalid/skipped rows and a successful import to visually confirm the warning/success colors still read correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized status colors in the registry CSV import dialog by replacing raw Tailwind `yellow`/`emerald` classes with design-system `warning` and `success` tokens. No logic changes; styling now matches the rest of the registry.

- **Refactors**
  - Warnings banner and "skipped" badge now use `text-warning`, `bg-warning/10`, `border-warning/20`.
  - "Is public: Yes" badge and import success icon now use `text-success`, `bg-success/10`.

<sup>Written for commit b3d03577d9d697d6cccf27fb1f0e0dacc71ea6be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

