### PR TITLE
fix(sandbox): give thread sandboxes a real git branch so work syncs off main

### DIFF
--- a/apps/mesh/src/tools/sandbox/start.test.ts
+++ b/apps/mesh/src/tools/sandbox/start.test.ts
@@ -240,6 +240,12 @@ function makeCtx(overrides: {
       connections: {
         findById: mock(async (_id: string) => ({ metadata: null })),
       },
+      // A `thread:` branch resolves the thread's bound repo; return no thread so
+      // provisioning falls back to the VM's own githubRepo.
+      threads: {
+        get: mock(async (_id: string) => null),
+        update: mock(async () => {}),
+      },
     } as never,
     timings: {
       measure: async <T>(_name: string, cb: () => Promise<T>) => await cb(),
@@ -340,6 +346,32 @@ describe("SANDBOX_START", () => {
       packageManager: "npm",
       devPort: 3000,
     });
+  });
+
+  it("sends a real git branch for a synthetic thread branch, keeping the ref synthetic", async () => {
+    const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
+    const ctx = makeCtx({ virtualMcp });
+    const synthetic = "thread:t1/conn_a";
+
+    await SANDBOX_START.handler(
+      { virtualMcpId: VMCP_ID, branch: synthetic },
+      ctx,
+    );
+
+    const [id, opts] = mockEnsure.mock.calls[0]! as [SandboxId, EnsureOptions];
+    // Git config gets a REAL, non-default ref — so shutdown-sync persists to git
+    // on its own branch, never `main`.
+    expect(opts.repo?.branch).toBe("sandbox/thread-t1-conn_a");
+    // Isolation stays synthetic: projectRef + handle key are unchanged, so
+    // sandbox identity/reuse is stable across reboots.
+    expect(opts.branch).toBe(synthetic);
+    expect(id.projectRef).toBe(
+      composeSandboxRef({
+        orgId: ORG_ID,
+        virtualMcpId: VMCP_ID,
+        branch: synthetic,
+      }),
+    );
   });
 
   it("persists sandboxMap entry with handle + previewUrl + sandboxProviderKind", async () => {

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -46,6 +46,7 @@ import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import {
   getThreadGithubRepo,
   setThreadSandboxMapEntry,
+  syntheticBranchToGitRef,
   threadIdFromBranch,
 } from "./thread-repo";
 import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
@@ -402,6 +403,13 @@ async function provisionSandbox(
       }
     }
 
+    // The git branch the daemon actually checks out and pushes. A synthetic
+    // isolation key (thread:*) maps to a real, deterministic ref so work is
+    // persisted to git on its own branch — never the repo default. The isolation
+    // key itself (projectRef, handle, sandboxMap) stays synthetic below.
+    const gitBranch = branch.startsWith("thread:")
+      ? syntheticBranchToGitRef(branch)
+      : branch;
     repoOpts = {
       cloneUrl,
       // Persisted so the runner can re-mint on recovery; absent for anonymous.
@@ -410,7 +418,7 @@ async function provisionSandbox(
         : {}),
       userName: gitUserName,
       userEmail: gitUserEmail,
-      branch,
+      branch: gitBranch,
       displayName: `${githubRepo.owner}/${githubRepo.name}`,
     };
   }

--- a/apps/mesh/src/tools/sandbox/thread-repo.test.ts
+++ b/apps/mesh/src/tools/sandbox/thread-repo.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test";
-import { threadBranch, threadIdFromBranch } from "./thread-repo";
+import {
+  syntheticBranchToGitRef,
+  threadBranch,
+  threadIdFromBranch,
+} from "./thread-repo";
 
 test("threadBranch round-trips through threadIdFromBranch", () => {
   const id = "f3ef4465-b187-4e8d-b71a-a36cf4035046";
@@ -19,4 +23,29 @@ test("threadIdFromBranch ignores non-thread branches", () => {
   expect(threadIdFromBranch("ephemeral")).toBeNull();
   expect(threadIdFromBranch("main")).toBeNull();
   expect(threadIdFromBranch(null)).toBeNull();
+});
+
+test("syntheticBranchToGitRef maps a synthetic key to a real, valid, non-default ref", () => {
+  expect(syntheticBranchToGitRef("thread:t1")).toBe("sandbox/thread-t1");
+  expect(syntheticBranchToGitRef("thread:t1/conn_a")).toBe(
+    "sandbox/thread-t1-conn_a",
+  );
+  // Never the repo default — that is the whole point (no push to main).
+  for (const ref of ["thread:t1", "thread:t1/conn_a"]) {
+    const out = syntheticBranchToGitRef(ref);
+    expect(out).not.toBe("main");
+    expect(out).not.toBe("master");
+    // Valid git ref charset: no colon (the synthetic separator) survives.
+    expect(out.includes(":")).toBe(false);
+    expect(/^[A-Za-z0-9._/-]+$/.test(out)).toBe(true);
+  }
+});
+
+test("syntheticBranchToGitRef is deterministic and per-thread distinct (restore + isolation)", () => {
+  expect(syntheticBranchToGitRef(threadBranch("t1"))).toBe(
+    syntheticBranchToGitRef(threadBranch("t1")),
+  );
+  expect(syntheticBranchToGitRef(threadBranch("t1", "conn_a"))).not.toBe(
+    syntheticBranchToGitRef(threadBranch("t2", "conn_a")),
+  );
 });

--- a/apps/mesh/src/tools/sandbox/thread-repo.ts
+++ b/apps/mesh/src/tools/sandbox/thread-repo.ts
@@ -40,6 +40,25 @@ export function threadBranch(
 }
 
 /**
+ * Real, deterministic git ref for a synthetic sandbox branch. The synthetic key
+ * (`thread:<id>[/<connectionId>]`) is a sandbox isolation key, NOT a git ref —
+ * the daemon deliberately never checks it out, so the working tree stays on the
+ * repo default (main). That is how the shutdown sync used to push straight to
+ * `main`. Mapping it to a real branch instead makes the daemon's normal path
+ * take over: it forks this branch from the default on first boot, pushes it on
+ * shutdown, and restores it on reboot (clone.ts ls-remote probe) — so a
+ * per-thread sandbox's work lives in git on its own branch, never on `main`.
+ *
+ * Deterministic (same synthetic key → same ref) so a reboot restores the same
+ * branch. Only `thread:*` keys reach git: `ephemeral` sandboxes have no repo.
+ *   thread:abc/conn_1 → sandbox/thread-abc-conn_1
+ */
+export function syntheticBranchToGitRef(branch: string): string {
+  const body = branch.replace(/^thread:/, "").replace(/\//g, "-");
+  return `sandbox/thread-${body}`;
+}
+
+/**
  * Extract the thread id from a synthetic sandbox branch
  * (`thread:<id>` or `thread:<id>/<connectionId>`), or null for non-thread
  * branches. Lets provisioning recover the thread repo from the branch alone,


### PR DESCRIPTION
## Problem

Per-thread / decopilot sandboxes were persisting their work **directly to `main`**. This is the root cause behind the daemon commits piling up on the default branch (companion to #4739, which blocks the push at the daemon layer).

## Root cause

A sandbox's `branch` did **triple duty**: sandbox isolation key (`composeSandboxRef` → projectRef), routing handle (`composeBranchHandle`), *and* the git branch sent to the daemon (`git.repository.branch`).

For thread/decopilot sandboxes that value is a **synthetic key** — `thread:<id>` / `thread:<id>/<conn>` (`harnesses/decopilot/tools.ts`). The daemon deliberately **never checks out a synthetic branch** (`isSyntheticBranch`, guarded in `clone.ts` / `orchestrator.ts`), so the working tree stayed on the freshly-cloned **default branch (`main`)**. On shutdown the sync pushed `HEAD` — i.e. `main`. Main was silently doing double duty as the per-sandbox persistence branch.

Skipping the sync would instead **lose the work** (sandboxes are stateless — state lives in git). The fix has to give each sandbox its **own durable branch**.

## Fix (Studio-side only)

Decouple the two roles in `provisionSandbox` (`tools/sandbox/start.ts`):

- **Isolation key stays synthetic** — `projectRef`, the routing handle, and `sandboxMap` keys are unchanged, so sandbox identity/reuse is stable across reboots.
- **Git branch becomes a real, deterministic ref** — `syntheticBranchToGitRef()` maps `thread:<id>/<conn>` → `sandbox/thread-<id>-<conn>` and that goes into `repo.branch` (→ `git.repository.branch`).

No daemon changes needed — its normal (non-synthetic) path already does the right thing:
- **First boot:** `ls-remote` probe finds the branch absent → clone default, fork the branch locally (`clone.ts`).
- **Shutdown:** pushes `HEAD` = the real branch (a non-default branch, which #4739 permits).
- **Reboot:** probe finds the branch on origin → checks it out → **work restored**.

`ephemeral` sandboxes have no repo (`isEphemeralAgent = !effectiveRepo`), so they never reach git — nothing changes for them.

## Tests

- `thread-repo.test.ts`: `syntheticBranchToGitRef` — valid non-default ref, deterministic (restore), per-thread distinct (isolation).
- `start.test.ts`: a synthetic `thread:*` branch produces a real `repo.branch` (`sandbox/thread-…`) while `projectRef` + the handle key stay synthetic.

`bun test apps/mesh/src/tools/sandbox/thread-repo.test.ts apps/mesh/src/tools/sandbox/start.test.ts` → 24 pass.

## Follow-up (deferred)

Branch pruning — deleting `sandbox/thread-<id>` when its thread is deleted — is out of scope here; tracked as a follow-up so thousands of threads don't leave orphaned branches.

## Relationship to #4739

- **#4739** — daemon refuses to push to a protected branch (the backstop).
- **This PR** — makes sure the sandbox is on a real non-default branch in the first place, so the sync succeeds and work is preserved.

Both are needed: #4739 stops the damage; this restores correct persistence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Thread sandboxes now use a real, deterministic git branch so their work syncs off `main` and restores on reboot. This prevents daemon pushes from landing on `main` and complements #4739.

- **Bug Fixes**
  - Map synthetic thread keys (`thread:<id>[/<conn>]`) to real branches via `syntheticBranchToGitRef` → `sandbox/thread-<id>-<conn>`.
  - Keep isolation keys synthetic for routing/identity; only `repo.branch` changes in `provisionSandbox`.
  - Daemon follows the normal path: fork on first boot, push on shutdown, checkout on reboot.
  - Added tests for mapping validity, determinism, and start flow behavior.

<sup>Written for commit 2cb8ada94a6f7ccb033d3e9c31238569acde1be2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

