### PR TITLE
fix(sandbox): refuse rebase force-push to protected branches

### DIFF
--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -103,4 +103,25 @@ describe("rebaseOntoBase", () => {
       cleanup();
     }
   });
+
+  it("refuses to rebase and force-push a protected branch (main)", () => {
+    const { repoDir, cleanup } = setupConflictingRepo();
+    try {
+      execSync(`git -C ${repoDir} checkout main`, { stdio: "ignore" });
+      const mainBefore = execSync(`git -C ${repoDir} rev-parse origin/main`)
+        .toString()
+        .trim();
+
+      expect(() => rebaseOntoBase(repoDir, "main", { asUser: false })).toThrow(
+        /protected branch "main"/,
+      );
+
+      const mainAfter = execSync(`git -C ${repoDir} rev-parse origin/main`)
+        .toString()
+        .trim();
+      expect(mainAfter).toBe(mainBefore);
+    } finally {
+      cleanup();
+    }
+  });
 });

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { appendCoAuthorTrailer } from "../../git-co-author";
 import { gitSync as rawGitSync } from "./git-sync";
 import { parsePorcelainEntry } from "./porcelain";
+import { protectedBranches } from "./protect-branch";
 import { assertValidRemoteBranchName } from "./ref-name";
 import type { OperatorIdentity } from "../types";
 
@@ -326,6 +327,14 @@ function rebaseOntoBaseInner(
   const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (!branch || branch === "HEAD") {
     throw new Error("Cannot rebase from a detached HEAD");
+  }
+  // Same guard as publish() (protect-branch.ts): this ends in a force-push,
+  // which is even more destructive than a normal push, so a sandbox sitting
+  // on main/master/default must never reach it.
+  if (protectedBranches(repoDir).has(branch)) {
+    throw new Error(
+      `Refusing to rebase and force-push protected branch "${branch}" from a sandbox. Work on a feature branch; changes reach the default branch via PR.`,
+    );
   }
 
   runGit(repoDir, ["fetch", "-p", "origin", base, branch]);


### PR DESCRIPTION
## Summary
- Follows #4739, which added a guard so `publish()` refuses to push to a protected branch (main/master/repo default) from a sandbox.
- That PR missed a sibling push path: `rebaseOntoBase()` also derives the current branch from HEAD and unconditionally force-pushes it (`forcePushRebasedBranch`) — reachable directly via the daemon's `/git/rebase` route. If a sandbox's HEAD is on a protected branch, this force-pushes over it, which is more destructive than the plain push #4739 blocked.
- Fix: reuse the same `protectedBranches()` check from `protect-branch.ts` in `rebaseOntoBaseInner`, thrown before any fetch/rebase/push happens.

## Test plan
- Added `rebase-onto-base.test.ts`: checks out `main` in the test repo, asserts `rebaseOntoBase` throws `Refusing to rebase and force-push protected branch "main"...` and that `origin/main` is untouched (inverts what would otherwise silently force-push).
- `cd packages/sandbox && bun x tsc --noEmit` — clean.
- `bun test packages/sandbox/daemon/git/rebase-onto-base.test.ts` — 2 pass.
- `bun test packages/sandbox/daemon/routes/git.test.ts` — 21 pass (unaffected sibling suite, sanity-checked).
- Reviewer repro: `bun test packages/sandbox/daemon/git/rebase-onto-base.test.ts`. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent force-pushing to protected branches when rebasing from a sandbox. Blocks the daemon `/git/rebase` path from overwriting `main`, `master`, or the repo default.

- **Bug Fixes**
  - Added `protectedBranches()` guard in `rebaseOntoBaseInner` to refuse rebases when HEAD is on a protected branch, before any fetch/rebase/push.
  - Added `rebase-onto-base.test.ts` to verify the error and ensure `origin/main` remains unchanged.

<sup>Written for commit 897ec7d4f2c49ad120bf393c967e99aa241e8780. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

