### PR TITLE
refactor(agents): use design-system tokens in share modal status indicators

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx
@@ -70,7 +70,7 @@ function CopyUrlButton({ url, agentId }: ShareButtonProps) {
       className="h-auto py-3 px-4 flex flex-col items-center gap-2"
     >
       {copied ? (
-        <Check size={20} className="text-green-600" />
+        <Check size={20} className="text-success" />
       ) : (
         <Copy01 size={20} />
       )}
@@ -164,7 +164,7 @@ function InstallClaudeButton({ url, serverName, agentId }: ShareWithNameProps) {
       className="h-auto py-3 px-4 flex flex-col items-center gap-2"
     >
       {copied ? (
-        <Check size={20} className="text-green-600" />
+        <Check size={20} className="text-success" />
       ) : (
         <img
           src="/logos/Claude Code.svg"
@@ -261,7 +261,7 @@ function TypegenSectionInner({ virtualMcp }: { virtualMcp: VirtualMCPEntity }) {
       </div>
 
       {apiKey && (
-        <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+        <p className="rounded-md border border-warning/20 bg-warning/10 px-3 py-2 text-xs text-warning">
           Store this key securely — it won't be shown again.
         </p>
       )}
@@ -282,7 +282,7 @@ function TypegenSectionInner({ virtualMcp }: { virtualMcp: VirtualMCPEntity }) {
             onClick={handleCopy}
           >
             {copied ? (
-              <Check size={12} className="text-green-600" />
+              <Check size={12} className="text-success" />
             ) : (
               <Copy01 size={12} />
             )}
@@ -338,7 +338,7 @@ function EnvVarsBlock({
           onClick={handleCopy}
         >
           {copied ? (
-            <Check size={12} className="text-green-600" />
+            <Check size={12} className="text-success" />
           ) : (
             <Copy01 size={12} />
           )}
@@ -463,7 +463,7 @@ function ChatBridgeSectionInner({
       </div>
 
       {apiKey && (
-        <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+        <p className="rounded-md border border-warning/20 bg-warning/10 px-3 py-2 text-xs text-warning">
           Store this key securely — it won't be shown again.
         </p>
       )}
@@ -484,7 +484,7 @@ function ChatBridgeSectionInner({
             onClick={handleCopy}
           >
             {copied ? (
-              <Check size={12} className="text-green-600" />
+              <Check size={12} className="text-success" />
             ) : (
               <Copy01 size={12} />
             )}


### PR DESCRIPTION
## Summary
`virtual-mcp-share-modal.tsx` hand-rolled raw Tailwind palette classes (`text-green-600`, `border-amber-200 bg-amber-50 text-amber-700`) for copy-success checkmarks and the "store this key securely" warning banners, instead of the design-system `success`/`warning` tokens already used for the identical meaning elsewhere in this codebase (e.g. `credits-eyebrow.tsx`'s `bg-warning/10 border-warning/20 text-warning` banner, and the recent monitor-dashboard/monitor-configuration token migrations).

- `text-green-600` (copy-success `Check` icon, 5 occurrences) → `text-success`
- `border-amber-200 bg-amber-50 text-amber-700` (2 warning banners) → `border-warning/20 bg-warning/10 text-warning`

This aligns the shade to the design-system tokens (not a pixel-identical match to the old raw palette values) and is unambiguous because the same visual meaning (success checkmark / warning banner) already uses these exact tokens elsewhere in the codebase.

## Test plan
- `bun run fmt` — clean, no changes
- `bun x tsc --noEmit` in `apps/mesh` — passes (pure className change, no type impact)
- Pure CSS class rename, no behavior change; full CI runs the rest

Reviewer check: `git diff main -- apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx`
