### PR TITLE
fix(sandbox): exclude org-fs mount from git so shutdown sync never commits it

### DIFF
--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -361,6 +361,36 @@ describe("git routes", () => {
     });
   });
 
+  it("publish() does not commit org-fs mount content excluded via .git/info/exclude", () => {
+    const { appRoot, repoDir } = initRepo();
+    // Simulate the org-fs mount landing inside the working tree (org/…), as it
+    // did on the deco-sites farm repo. gitSetup registers `/org` at boot.
+    mkdirSync(join(repoDir, ".git", "info"), { recursive: true });
+    writeFileSync(join(repoDir, ".git", "info", "exclude"), "/org\n");
+    mkdirSync(join(repoDir, "org", "home", "pages"), { recursive: true });
+    writeFileSync(
+      join(repoDir, "org", "home", "pages", "ver27-performance.html"),
+      "<html></html>\n",
+    );
+    // A real tracked change so the commit isn't empty.
+    writeFileSync(join(repoDir, "README.md"), "changed\n");
+
+    // No remote configured → the push throws, but the commit lands first.
+    try {
+      publish({ appRoot, repoDir }, "shutdown sync");
+    } catch {
+      // expected: push fails without a remote
+    }
+
+    const files = gitSync(["show", "--name-only", "--pretty=", "HEAD"], {
+      cwd: repoDir,
+      asUser: false,
+    });
+    expect(files).toContain("README.md");
+    expect(files).not.toContain("ver27-performance.html");
+    expect(files).not.toContain("org/");
+  });
+
   it("publish() rejects a tokenless github origin with a clear error", () => {
     const { appRoot, repoDir } = initRepo();
     gitSync(["remote", "add", "origin", "https://github.com/owner/repo.git"], {

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -14,6 +14,7 @@ import {
 import type { Broadcaster } from "../events/broadcast";
 import type { DaemonStatus } from "../events/types";
 import type { BranchStatusMonitor } from "../git/branch-status";
+import { ensureGitExclude } from "../git-exclude";
 import { gitSync } from "../git/git-sync";
 import { spawnCheckoutBranch } from "../git/checkout-branch";
 import { syncOriginRemote } from "../git/sync-origin-remote";
@@ -636,6 +637,14 @@ export class SetupOrchestrator {
           `\r\n[orchestrator] warning: could not install protected-branch hook: ${(e as Error).message}\r\n`,
         );
       }
+      // Exclude the org-fs mount at boot, before any sync can run. The mount /
+      // its `repoDir/org` symlink is daemon-managed, never repo source —
+      // ensureRepoOrgLink also excludes it, but only lazily at dispatch once
+      // mounts are up, so a shutdown sync that races that leaves org-fs files
+      // (org/…) staged onto the user's branch. info/exclude is local-only and
+      // never affects already-tracked files, so a repo that genuinely tracks
+      // org/ is unharmed.
+      await ensureGitExclude(config.repoDir, "/org");
     }
     const branch = config.git?.repository?.branch;
     if (branch && !isSyntheticBranch(branch)) {


### PR DESCRIPTION
## Problem

The daemon's shutdown sync committed **org-fs content into a customer's repo** — `org/home/pages/ver27-performance.html` landed on `deco-sites/farmrio`'s `main`. No prod impact, but org files leaking onto a user branch is wrong.

## What actually happened (verified)

The committed `org` entry is a real directory (`git ls-tree main` → `040000 tree org`), containing real files matching the org-fs **"home" volume** layout (`org/home/...`). It is **not** a symlink (a symlink would commit as `120000`). So real org content was sitting **inside** the repo working tree at `repoDir/org`, and `publish()`'s `git add` swept it in.

## Root cause

Org-fs volumes mount at `<appRoot>/org` (a sibling of `repoDir` = `<appRoot>/repo`) and are surfaced to the harness cwd via a `repoDir/org -> ../org` symlink from `ensureRepoOrgLink` (`org-fs/repo-link.ts`), which *also* registers `/org` in `.git/info/exclude`.

But that exclusion is written **lazily, at dispatch time, only once mounts are up** — and `ensureRepoOrgLink` **early-returns without excluding** when `repoDir/org` already exists as a non-symlink real directory (repo-link.ts:24-27). The deco framework/CMS writes file-based content into the working tree (cf. the `.deco/blocks/*.json` note in `routes/git.ts`), so `repoDir/org` can be a real dir with real files while `/org` was never excluded. A shutdown sync then commits it.

> NB: the exact chain that left real files under `repoDir/org` on the farm pod is inferred from the committed tree + code, not confirmed on a live pod. The fix below holds regardless of that chain.

## Fix

Register `/org` in `.git/info/exclude` at **boot git-setup** (`orchestrator.gitSetup`, right after the protected-branch hook), before any sync can run — independent of dispatch timing, mount state, or whether `repoDir/org` is a symlink or a real dir.

`.git/info/exclude` is local-only (never leaks into the repo, unlike `.gitignore`) and git ignore patterns **never affect already-tracked files** — so a repo that legitimately tracks `org/` is unaffected; only untracked mount/framework content is kept out of the commit.

## Test

`git.test.ts`: `publish()` does not commit a real `org/home/pages/ver27-performance.html` in the working tree when `/org` is in `.git/info/exclude` — asserts the commit contains the real change but not the org file.

`bun test packages/sandbox/daemon/routes/git.test.ts` -> 21 pass.

## Relationship to the other sandbox-sync PRs

- #4739 — daemon refuses to push to a protected branch.
- #4742 — thread sandboxes get a real (non-default) git branch so their work syncs off `main`.
- **This PR** — org-fs content never enters the commit.

Independent fixes for distinct facets of the same "shutdown sync committed the wrong thing" report.
