### PR TITLE
[chore]: rename root package to @decocms/studio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@decocms/mesh-monorepo",
+  "name": "@decocms/studio",
   "devDependencies": {
     "@biomejs/biome": "2.2.5",
     "@types/bun": "^1.3.1",


### PR DESCRIPTION
## Summary
- Rename the root workspace package from `@decocms/mesh-monorepo` to `@decocms/studio`, matching the repo's rename from `mesh` to `studio` on GitHub.

## Test plan
- [x] No other files reference the old package name (`grep -rl "mesh-monorepo"`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename the root workspace package to `@decocms/studio` to match the repository rename and keep package metadata consistent. No other references to `@decocms/mesh-monorepo` remain.

<sup>Written for commit 027eaca9aee83b581d4e4e7eef99cba5fb47401a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

