### PR TITLE
refactor(task-board): use design-system tokens in task dialog status colors

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -102,10 +102,10 @@ const THREAD_STATUS: Record<
   NonNullable<TaskBoardItemThread["status"]>,
   { label: string; className: string; icon: typeof AlertSquare; spin?: boolean }
 > = {
-  failed: { label: "Error", className: "text-red-600", icon: AlertSquare },
+  failed: { label: "Error", className: "text-destructive", icon: AlertSquare },
   requires_action: {
     label: "Needs input",
-    className: "text-amber-600",
+    className: "text-warning",
     icon: HelpCircle,
   },
   in_progress: {
@@ -116,7 +116,7 @@ const THREAD_STATUS: Record<
   },
   completed: {
     label: "Completed",
-    className: "text-green-600",
+    className: "text-success",
     icon: CheckCircle,
   },
   expired: {
@@ -676,7 +676,11 @@ function prStateStyle(pr: TaskBoardItemPr): {
   if (pr.merged)
     return { label: "Merged", className: "text-purple-600", icon: GitMerge };
   if (pr.state === "closed")
-    return { label: "Closed", className: "text-red-600", icon: GitPullRequest };
+    return {
+      label: "Closed",
+      className: "text-destructive",
+      icon: GitPullRequest,
+    };
   if (pr.draft)
     return {
       label: "Draft",
@@ -684,7 +688,7 @@ function prStateStyle(pr: TaskBoardItemPr): {
       icon: GitPullRequest,
     };
   // "open" or unknown live state — still a link the user can follow.
-  return { label: "Open", className: "text-green-600", icon: GitPullRequest };
+  return { label: "Open", className: "text-success", icon: GitPullRequest };
 }
 
 /** One PR row — state badge, title (falls back to repo#number), external link,


### PR DESCRIPTION
## Summary
Follows #4724 / #4728 (which migrated `task-status.ts`'s `failed`/`requires_action` raw palette classes to `text-destructive`/`text-warning`) by applying the same, already-established mapping to `task-dialog.tsx`'s two other status-badge palettes (`THREAD_STATUS` and `prStateStyle`), which encode the identical semantic statuses (failed/requires_action/completed, and PR closed/open) but were left on raw Tailwind colors.

- `THREAD_STATUS.failed`: `text-red-600` → `text-destructive`
- `THREAD_STATUS.requires_action`: `text-amber-600` → `text-warning`
- `THREAD_STATUS.completed`: `text-green-600` → `text-success`
- `prStateStyle` closed: `text-red-600` → `text-destructive`
- `prStateStyle` open: `text-green-600` → `text-success`

Left untouched (no unambiguous design-system token exists for these): `in_progress` (blue — same as the still-raw-blue `in_progress` in `task-status.ts`) and `merged` (purple).

This aligns the shade to the design-system tokens (not necessarily an identical pixel match to the old palette values) and keeps status coloring consistent between the task-status pill and this dialog's activity/PR cards.

## Test plan
- [x] `bun run fmt`
- [x] `bun x tsc --noEmit` in `apps/mesh` (clean)
- No behavior change — only Tailwind class names changed, same conditional logic.

Reviewer check: open a task with a failed/needs-input/completed run, or a linked PR, and confirm the status colors still render sensibly (destructive/warning/success). Full CI runs lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced raw Tailwind colors in task dialog status badges with design-system tokens to keep status colors consistent with the task status pill. No behavior change, only class name updates.

- **Refactors**
  - `THREAD_STATUS`: `failed` `text-red-600` → `text-destructive`; `requires_action` `text-amber-600` → `text-warning`; `completed` `text-green-600` → `text-success`.
  - `prStateStyle`: `closed` `text-red-600` → `text-destructive`; `open` `text-green-600` → `text-success`.
  - Left as-is: `in_progress` (blue) and `merged` (purple) until tokens exist.

<sup>Written for commit 8483d8ca9c915ece9655df7a78bb39f4b73193ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

