### PR TITLE
test(multi-pod): rollout-churn scenario reproducing 'No response was generated'

### DIFF
--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -44,6 +44,22 @@ services:
       retries: 5
       start_period: 5s
 
+  # External S3 (object store). Runs as its OWN container so it survives a
+  # mesh pod SIGKILL+restart — the rollout-churn scenario needs pods to reboot
+  # cleanly, and mesh's DECOCMS_LOCAL_MODE otherwise spawns an embedded MinIO
+  # *child* that dies with the container and races/crashes on reprovision. With
+  # S3_ENDPOINT + bucket + creds set below, ensureServices takes the external
+  # path (skipMinio) and never manages an embedded instance. Also faithful to
+  # prod, which uses external S3. No healthcheck: the minio server image ships
+  # no curl/wget/shell to probe with, and mesh's provisionMinioBucket already
+  # retries the startup ECONNREFUSED race.
+  minio:
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    command: server /data
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+
   # Migrations run once before any mesh pod starts. Pods themselves skip the
   # migration step (we override the entrypoint with a direct start command) to
   # avoid races on parallel boot.
@@ -90,6 +106,11 @@ services:
       DECOCMS_LOCAL_MODE: "true"
       ENCRYPTION_KEY: test-encryption-key-32chars-long!
       DATA_DIR: /app/data
+      # External S3 → ensureServices skips embedded MinIO (survives restarts).
+      S3_ENDPOINT: http://minio:9000
+      S3_BUCKET: studio-dev
+      S3_ACCESS_KEY_ID: minioadmin
+      S3_SECRET_ACCESS_KEY: minioadmin
       # Pin the sandbox provider so POST /decopilot/messages doesn't default
       # to "user-desktop" — there's no link daemon in this cluster, and
       # resolveDispatchTarget would 409 with link_offline. "agent-sandbox"
@@ -109,6 +130,8 @@ services:
         condition: service_healthy
       nats:
         condition: service_healthy
+      minio:
+        condition: service_started
       migrate:
         condition: service_completed_successfully
     healthcheck:
@@ -137,6 +160,8 @@ services:
         condition: service_healthy
       nats:
         condition: service_healthy
+      minio:
+        condition: service_started
       migrate:
         condition: service_completed_successfully
       mesh-1:
@@ -154,6 +179,8 @@ services:
         condition: service_healthy
       nats:
         condition: service_healthy
+      minio:
+        condition: service_started
       migrate:
         condition: service_completed_successfully
       mesh-2:

--- a/tests/multi-pod/lib/db.ts
+++ b/tests/multi-pod/lib/db.ts
@@ -114,3 +114,23 @@ export async function countThreadMessageParts(
   );
   return Number(rows[0]?.n ?? "0");
 }
+
+/**
+ * Count assistant parts that would actually RENDER in the chat — i.e. every
+ * kind except the `finish` anchor (text/reasoning/tool_call/tool_result/
+ * file/error). Zero of these on a terminal thread is exactly the
+ * "No response was generated" condition: a message with a finish anchor
+ * (or nothing) but no visible content. This is the invariant the
+ * rollout-churn scenario asserts.
+ */
+export async function countRenderableAssistantParts(
+  threadId: string,
+): Promise<number> {
+  const rows = await dbQuery<{ n: string }>(
+    `SELECT COUNT(*) AS n FROM thread_message_parts
+     WHERE thread_id = '${sqlLit(threadId)}'
+       AND role = 'assistant'
+       AND kind <> 'finish'`,
+  );
+  return Number(rows[0]?.n ?? "0");
+}

--- a/tests/multi-pod/scenarios/rollout-churn.test.ts
+++ b/tests/multi-pod/scenarios/rollout-churn.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Rollout churn — a thread must survive redeploys of the cluster mid-run.
+ *
+ * Reproduces, locally, the staging failure behind the recurring "No response
+ * was generated": pods there force-exit roughly every ~15 min (the 115s
+ * graceful-drain timeout → SIGKILL), interrupting whatever run they own. A
+ * user iterating quickly keeps landing on an interrupted run whose answer is
+ * lost — either a blank bubble or a cryptic terminal error.
+ *
+ * Shared setup drives one long run, then rolls the WHOLE cluster like a
+ * rolling deploy: SIGKILL each pod in turn (matching staging's forced exit)
+ * and bring it back healthy. `run_owner_pod` isn't populated in this
+ * architecture, so recycling every pod guarantees the (unknown) owner is
+ * hard-killed mid-flight.
+ *
+ * Two invariants, at two strengths:
+ *
+ *   1. LIVE GATE (must stay green): a rollout never leaves the thread blank
+ *      or stuck — it reaches a terminal state (not wedged in_progress) AND its
+ *      assistant message has ≥1 renderable part (not the empty "No response
+ *      was generated"). This guards the two worst user-facing outcomes.
+ *
+ *   2. FULL RECOVERY (skipped — currently reproduces the bug): the run should
+ *      actually SURVIVE and complete. Today it does not: DBOS recovery resumes
+ *      the workflow, but the JetStream subject is gapped/purged across the
+ *      kill+resume, so the projector fails with
+ *      `stream truncated ... missing seq 1` and marks the run `failed` with a
+ *      cryptic `Error: missing seq 1` part. Un-skip once resume stops purging
+ *      the subject and recovery replays the full chunk log (see the recovery
+ *      gaps documented in pod-death-dbos-replay.test.ts).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { postJson } from "../lib/client";
+import { countRenderableAssistantParts, getThreadStatus } from "../lib/db";
+import { waitReady } from "../lib/cluster";
+import { registerTestHooks } from "../lib/hooks";
+import { kill, start } from "../lib/pod";
+import { ALL_PODS, PODS } from "../lib/pods";
+import { pollUntil } from "../lib/poll-until";
+import {
+  bootstrapSession,
+  createTestAgent,
+  createTestThread,
+  wireMockProvider,
+} from "../lib/setup";
+
+registerTestHooks();
+
+/** ~3 min of in-flight streaming — stays running across a full rolling deploy. */
+const MOCK_HINT = "slow:180x1000";
+const TERMINAL = new Set(["completed", "failed", "requires_action"]);
+
+/**
+ * Start a long run, wait until it's dispatched, then SIGKILL+restart every pod
+ * (one rolling deploy) and wait for the thread to reach a terminal state.
+ * Returns the terminal status and the renderable-assistant-part count.
+ */
+async function runThroughRollingDeploy(): Promise<{
+  status: string | null;
+  renderable: number;
+}> {
+  const session = await bootstrapSession(PODS.MESH_1);
+  await wireMockProvider(PODS.MESH_1, session);
+  const { virtualMcpId } = await createTestAgent(PODS.MESH_1, session);
+  const { threadId } = await createTestThread(
+    PODS.MESH_1,
+    session,
+    virtualMcpId,
+  );
+
+  const postRes = await postJson(
+    PODS.MESH_1,
+    `/api/${session.orgSlug}/decopilot/threads/${threadId}/messages`,
+    {
+      messages: [
+        {
+          id: crypto.randomUUID(),
+          role: "user",
+          parts: [{ type: "text", text: MOCK_HINT }],
+        },
+      ],
+      agent: { id: virtualMcpId },
+      tier: "smart",
+    },
+    { auth: { apiKey: session.apiKey } },
+  );
+  expect(postRes.status).toBe(202);
+
+  // Proof the run was dispatched before we churn (run_owner_pod stays null in
+  // this architecture, so gate on the thread status).
+  await pollUntil(
+    async () => (await getThreadStatus(threadId)) === "in_progress",
+    { timeoutMs: 30_000, intervalMs: 500, label: "run-dispatched" },
+  );
+
+  // Rolling deploy: SIGKILL each pod in turn and bring it back, healthy
+  // between pods. The run's (unknown) owner is hard-killed mid-flight.
+  for (const pod of ALL_PODS) {
+    console.log(`  → recycling ${pod.service} (SIGKILL + restart)`);
+    await kill(pod.service);
+    await start(pod.service);
+    await waitReady();
+  }
+
+  // A hang here (timeout) is itself a caught bug: the run wedged in_progress.
+  await pollUntil(
+    async () => {
+      const status = await getThreadStatus(threadId);
+      return status !== null && TERMINAL.has(status);
+    },
+    { timeoutMs: 240_000, intervalMs: 1000, label: "run-terminal" },
+  );
+
+  const status = await getThreadStatus(threadId);
+  const renderable = await countRenderableAssistantParts(threadId);
+  console.log(
+    `  → terminal status=${status}, renderable assistant parts=${renderable}`,
+  );
+  return { status, renderable };
+}
+
+describe("rollout churn", () => {
+  test("a rolling deploy never leaves the thread blank or stuck", async () => {
+    const { renderable } = await runThroughRollingDeploy();
+    // The invariant behind "No response was generated": a terminal turn must
+    // never be empty. (`runThroughRollingDeploy` already fails the test if
+    // the run wedges in_progress — the terminal poll times out.)
+    expect(renderable).toBeGreaterThan(0);
+  }, 600_000);
+
+  // Un-skip once rollout recovery is complete (see file header). Currently the
+  // run is marked `failed` with `missing seq 1` instead of completing.
+  test.skip("a run survives a rolling deploy and completes", async () => {
+    const { status } = await runThroughRollingDeploy();
+    expect(status).toBe("completed");
+  }, 600_000);
+});


### PR DESCRIPTION
## Summary

A local chaos harness that reproduces the staging failure behind the recurring **"No response was generated"**: pods there force-exit roughly every ~15 min (the 115s graceful-drain timeout → SIGKILL), interrupting whatever run they own.

New scenario `tests/multi-pod/scenarios/rollout-churn.test.ts` on the existing 3-pod cluster:
1. Starts a long run (mock streams ~3 min).
2. Performs a **full rolling deploy** — SIGKILL each pod in turn and bring it back healthy (staging's forced exit; `run_owner_pod` isn't populated in this architecture, so recycling every pod guarantees the owner is hit mid-flight).
3. Asserts the invariants.

## Supporting changes

- **`docker-compose.yml`**: added an external **MinIO** container + `S3_*` env. Without it pods can't reboot at all — `DECOCMS_LOCAL_MODE` spawns an embedded MinIO *child* that dies with the SIGKILL'd container and crash-loops on re-provision (`provisionMinioBucket` → `ECONNREFUSED`). External S3 (matching prod) makes restarts clean — verified a pod reboots healthy in ~2s.
- **`lib/db.ts`**: `countRenderableAssistantParts()` — DB-level detector for the empty terminal turn behind "No response was generated" (a message whose only part is the `finish` anchor).

## Invariants (1 pass, 1 skip)

- **Live gate (green):** *a rolling deploy never leaves the thread blank or stuck* — reaches terminal (not wedged `in_progress`) **and** has ≥1 renderable assistant part.
- **Skipped repro (currently red):** *a run survives a rolling deploy and completes* (`status === "completed"`). Today it does **not**: DBOS recovery resumes the workflow, but the JetStream subject is gapped/purged across kill+resume, so the projector fails with `stream truncated … missing seq 1` and marks the run `failed`. Un-skip when rollout recovery is fixed. (Matches the `.skip` precedent in `pod-death-dbos-replay.test.ts`.)

## What it caught

Running it locally reproduced a real staging-class failure: the run **did not survive** the rolling deploy — recovery fired (`Recovering N workflows`) but the projector died on `missing seq 1 (next delivered is 9)` and the run ended `failed` with a cryptic error part instead of completing.

Run: `docker compose -f tests/multi-pod/docker-compose.yml up -d --build` then `bun test tests/multi-pod/scenarios/rollout-churn.test.ts` (or `tests/multi-pod/run.sh`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi‑pod rollout churn test that reproduces the “No response was generated” issue by killing and restarting each pod during a long run, ensuring the thread isn’t left blank or stuck. Also adds an external `minio` to the test cluster and a DB helper to detect empty assistant turns.

- New Features
  - `tests/multi-pod/scenarios/rollout-churn.test.ts`: drives a ~3‑min run, SIGKILL+restarts each pod (rolling deploy), then asserts terminal state with ≥1 renderable assistant part; includes a skipped completion check pending rollout recovery (JetStream gap).
  - `tests/multi-pod/docker-compose.yml`: adds external `minio` with `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY` so pods reboot cleanly during churn (matches prod).
  - `tests/multi-pod/lib/db.ts`: adds `countRenderableAssistantParts(threadId)` to flag the empty terminal assistant turn behind “No response was generated.”

<sup>Written for commit 14978801a0f90eb9d9aab7e527936755b12a6404. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

