### PR TITLE
fix(decopilot): don't purge the chunk log on resume (breaks recovery)

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -1151,8 +1151,15 @@ async function prepareRun(
       }
     }
 
-    // Purge stale buffered chunks from any previous run on this thread
-    streamBuffer?.purge(mem.thread.id);
+    // Purge stale buffered chunks from any PREVIOUS run on this thread — but
+    // NOT on resume. A resumed run (DBOS recovery after its owner pod died) IS
+    // "the previous run": purging here beheads the very chunk log its projector
+    // must replay, so replay hits a StreamGapError ("missing seq 1") and the
+    // recovered run is marked `failed` instead of completing. Recovery depends
+    // on the seq 1..N log surviving the pod that owned it.
+    if (!input.isResume) {
+      streamBuffer?.purge(mem.thread.id);
+    }
 
     let systemMessages: ChatMessage[] = [];
     let materializedRequestMessage: ChatMessage | undefined;


### PR DESCRIPTION
## Summary

A primary cause of the recurring **"No response was generated"** on staging: a run that gets interrupted by a pod rollout is **recovered but then dies** instead of completing.

`prepareRun` purged the thread's JetStream subject **unconditionally**, including on resume (`dispatch-run.ts:1155`). But a resumed run — DBOS recovery after the owner pod died mid-flight — *is* "the previous run". Purging there beheads the very `seq 1..N` chunk log its projector must replay, so the projector hits a `StreamGapError` (`missing seq 1`) and marks the recovered run `failed` with a cryptic error part.

Staging pods force-exit roughly every ~15 min (115s graceful-drain timeout → SIGKILL), so runs get interrupted constantly and this fires often.

## Fix

Skip the purge when `input.isResume` is true. A fresh run (`START`) still purges any prior turn's remnants; only resume preserves the in-flight log recovery needs.

```ts
if (!input.isResume) {
  streamBuffer?.purge(mem.thread.id);
}
```

## Verification (local, end-to-end)

Using the multi-pod **rollout-churn harness** (#4748) — a run driven through a full rolling deploy (SIGKILL + restart every pod mid-flight):

- **Before:** `terminal status=failed`, `failure_reason: stream truncated … missing seq 1 (next delivered is 9)`.
- **After:** `terminal status=completed`, renderable assistant part present — the run recovers and finishes.

Both harness assertions pass (`2 pass, 0 fail`), including the previously-`.skip`ped *"survives a rolling deploy and completes"* case. Once this + #4748 land, that test can be un-skipped as the permanent gate. `tsc --noEmit` clean.

## Scope

This fixes the **rollout-recovery** cause. "No response was generated" has other causes (genuinely empty model output, desktop-link drops, `RUN_FAILED` paths that persist no part) — a separate catch-all (never render a bare empty terminal turn) is the follow-up to close the class.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops purging the thread chunk log on resume so recovered runs can replay and complete. This reduces “No response was generated” during pod rollouts on staging.

- **Bug Fixes**
  - Skip purge when `input.isResume` is true; fresh runs still purge prior remnants.
  - Prevents `StreamGapError` (“missing seq 1”) on recovery; verified with the rollout churn harness that runs now complete.

<sup>Written for commit 590f01c265be63c381ad401510595e170c031bce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

