### PR TITLE
refactor(task-board): finish design-token migration in task dialog status colors

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -110,7 +110,7 @@ const THREAD_STATUS: Record<
   },
   in_progress: {
     label: "Running",
-    className: "text-blue-600",
+    className: "text-primary",
     icon: Loading02,
     spin: true,
   },
@@ -674,7 +674,7 @@ function prStateStyle(pr: TaskBoardItemPr): {
   icon: typeof GitPullRequest;
 } {
   if (pr.merged)
-    return { label: "Merged", className: "text-purple-600", icon: GitMerge };
+    return { label: "Merged", className: "text-special", icon: GitMerge };
   if (pr.state === "closed")
     return {
       label: "Closed",


### PR DESCRIPTION
## Summary
Follows #4747, which migrated most `task-dialog.tsx` status colors (failed, requires_action, completed, expired, closed, open) to design-system tokens but missed two spots in the same file that still used raw Tailwind palette classes:

- `THREAD_STATUS.in_progress` — `text-blue-600` → `text-primary` (matches the "in progress/running" → primary-blue convention already established in #4740's monitor-dashboard badge)
- `prStateStyle` "Merged" case — `text-purple-600` → `text-special` (the shared `--special` token, oklch hue 290, is the design system's purple equivalent — defined in `packages/ui/src/styles/global.css` but previously unused anywhere in the app)

## Why
The `ensure-tailwind-design-system-tokens` oxlint rule that would normally catch raw-palette classes is currently disabled (see the plugin's own comment), so these two survived the sibling migration in #4747 unnoticed. Same file, same category of fix, worth closing out in one pass rather than leaving inconsistent styling next to the tokens that were just introduced.

## Testing notes
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — clean
- Purely cosmetic class-name swap (colors are equivalent hues), no behavior change; grepped the file afterward to confirm no raw-palette color classes remain (`purple-`, `red-`, `green-`, `amber-`, `yellow-`, `emerald-`, `blue-`, followed by a numeric shade)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes the design-token migration in the task dialog’s status colors for consistency with the design system. Replaces `text-blue-600` → `text-primary` for Running and `text-purple-600` → `text-special` for Merged; no behavior change.

<sup>Written for commit a0fb78618bccbf0c5b56cb0e6b40a95891e3567a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

