### PR TITLE
refactor(tool-details): use design-system tokens in MCP status dot

### DIFF
--- a/apps/mesh/src/web/components/details/tool.tsx
+++ b/apps/mesh/src/web/components/details/tool.tsx
@@ -729,14 +729,14 @@ function ToolDetailsAuthenticated({
             {/* MCP Status */}
             <div className="flex items-center gap-2 px-2.5 py-1 bg-muted/50 rounded-md h-fit shrink-0">
               {toolsQuery.isSuccess ? (
-                <div className="h-1.5 w-1.5 rounded-full bg-green-500 animate-pulse shrink-0" />
+                <div className="h-1.5 w-1.5 rounded-full bg-success animate-pulse shrink-0" />
               ) : toolsQuery.isLoading ? (
                 <Loading01
                   size={10}
                   className="animate-spin text-yellow-500 shrink-0"
                 />
               ) : (
-                <div className="h-1.5 w-1.5 rounded-full bg-red-500 shrink-0" />
+                <div className="h-1.5 w-1.5 rounded-full bg-destructive shrink-0" />
               )}
               <span className="font-mono text-xs capitalize text-muted-foreground leading-none">
                 {toolsQuery.isSuccess


### PR DESCRIPTION
## Summary
- The tool-details page header's MCP connection-status dot used raw Tailwind palette classes (`bg-green-500` for ready, `bg-red-500` for error) instead of the semantic `bg-success`/`bg-destructive` tokens.
- Same class → token mapping already applied to the equivalent status indicators in task-board and the registry monitor views (#4747, #4740, #4738), and matches the existing `bg-success`/`bg-destructive` rounded-full "pulse" dot pattern used for connection status elsewhere (e.g. `linked-desktop-indicator.tsx`, `shell-breadcrumb.tsx`).
- Left the loading-state `text-yellow-500` spinner untouched — "connecting" isn't a warning, and there's no unambiguous existing token for that in-progress meaning.
- This aligns the shade to the design-system `success`/`destructive` tokens, not a byte-identical color swap.

## Test plan
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — clean (pure class-name change, no type impact)
- Reviewer: view the tool details page (`/orgs/:org/tools/:id`) for a connection and confirm the status dot color is unchanged in light/dark themes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the MCP status dot in the tool-details header to design-system tokens `bg-success`/`bg-destructive` instead of Tailwind palette classes. Matches other views and maintains theme consistency; loading spinner is unchanged.

<sup>Written for commit a062e964239598f39787f9fe8b4c42abf714c82e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

