### PR TITLE
refactor(task-board): use design-system tokens for in-progress/blocked status colors

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/config.tsx
+++ b/apps/mesh/src/web/layouts/task-board/config.tsx
@@ -62,7 +62,7 @@ export const STATUS_CONFIG: Record<
   in_progress: {
     label: "In Progress",
     icon: Loading02,
-    iconClassName: "text-blue-500",
+    iconClassName: "text-primary",
   },
   in_review: {
     label: "In Review",

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -88,7 +88,7 @@ const PILL =
 function BlockedBadge() {
   return (
     <span
-      className={cn(PILL, "border-amber-500/30 text-amber-600")}
+      className={cn(PILL, "border-warning/30 text-warning")}
       title="The agent is waiting for your input"
     >
       <HelpCircle size={14} />

--- a/apps/mesh/src/web/lib/task-status.ts
+++ b/apps/mesh/src/web/lib/task-status.ts
@@ -57,8 +57,8 @@ export const STATUS_CONFIG: Record<StatusKey, StatusConfig> = {
     label: "Running",
     verb: "Agent is working",
     icon: Loading01,
-    iconClassName: "text-blue-500",
-    labelColor: "text-blue-600 dark:text-blue-400",
+    iconClassName: "text-primary",
+    labelColor: "text-primary",
   },
   completed: {
     label: "Done",


### PR DESCRIPTION
## Summary
Follows #4750, which finished migrating `task-dialog.tsx`'s status colors (`in_progress` -> `text-primary`, "Merged" -> `text-special`) to design-system tokens. That PR only touched `task-dialog.tsx`; the same raw-palette colors for the *same semantic states* were still present in three sibling files in this directory:

- `apps/mesh/src/web/lib/task-status.ts` — `STATUS_CONFIG.in_progress` (`text-blue-500` / `text-blue-600 dark:text-blue-400` -> `text-primary`)
- `apps/mesh/src/web/layouts/task-board/config.tsx` — `STATUS_CONFIG.in_progress` (`text-blue-500` -> `text-primary`)
- `apps/mesh/src/web/layouts/task-board/index.tsx` — `BlockedBadge`, rendered for the same `requires_action` state that `task-status.ts` and `task-dialog.tsx` already tokenize as `text-warning` (`border-amber-500/30 text-amber-600` -> `border-warning/30 text-warning`)

## Why
Same category of fix as #4750 (raw Tailwind palette not caught by the currently-disabled `ensure-tailwind-design-system-tokens` rule), just in files that PR didn't cover. Worth closing out so the "in progress" and "blocked" states are visually consistent across the task board instead of some spots using tokens and others using raw hex-equivalent classes.

Left `PRIORITY_CONFIG.medium`'s `text-blue-500`/`bg-blue-500` in `config.tsx` alone — that's priority-level coloring, a different semantic than status/state, and out of scope for this fix.

## Testing notes
- Purely cosmetic class-name swap (equivalent hues), no behavior change.
- `bun run fmt` — clean
- `cd apps/mesh && bun x tsc --noEmit` — clean
- Grepped all three files afterward to confirm no raw-palette status-color classes remain: `grep -n "blue-\|amber-\|purple-\|red-\|green-\|emerald-\|yellow-" src/web/lib/task-status.ts src/web/layouts/task-board/config.tsx src/web/layouts/task-board/index.tsx`

A reviewer can confirm by loading the task board with a running task and a blocked (needs-input) task and comparing the colors against the task dialog for the same states.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced raw Tailwind colors with design-system tokens for “In Progress” and “Blocked” so task board colors match the task dialog. Cosmetic-only; no behavior changes.

- **Refactors**
  - `apps/mesh/src/web/lib/task-status.ts`: `in_progress` icon and label → `text-primary`
  - `apps/mesh/src/web/layouts/task-board/config.tsx`: `STATUS_CONFIG.in_progress.iconClassName` → `text-primary`
  - `apps/mesh/src/web/layouts/task-board/index.tsx`: `BlockedBadge` → `border-warning/30 text-warning`

<sup>Written for commit e60bdc8e216481475d29f5484faa5e1c50c0b147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

