### PR TITLE
refactor(registry): use design-system tokens for connection auth badge

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -326,11 +326,11 @@ function ConnectionRow({
                   authFlavor === "server_error"
                     ? "border-destructive/40 text-destructive"
                     : authFlavor === "oauth_connected"
-                      ? "border-emerald-500/30 text-emerald-600"
+                      ? "border-success/30 text-success"
                       : authFlavor === "oauth_available"
                         ? "border-sky-500/30 text-sky-600"
                         : authFlavor === "token_required"
-                          ? "border-amber-500/30 text-amber-600"
+                          ? "border-warning/30 text-warning"
                           : "text-muted-foreground",
                 )}
               >


### PR DESCRIPTION
## Source
C-DEBT: design-token drift in `apps/mesh/src/web/views/registry/monitor-connections-panel.tsx` (flagged in the highest-debt-frontend list).

## Why
`authBadgeStyle()` in this same file (lines 40-49) already maps the `authenticated`/`needs_auth` states to `bg-success/text-success/border-success` and `bg-warning/text-warning/border-warning`. A second badge just below it renders the exact same two states (`oauth_connected`, `token_required`) but used raw `emerald-500`/`amber-600` palette classes instead — this closes that inconsistency by aligning both badges to the same tokens. The mapping is unambiguous because it's copying an existing same-file, same-meaning precedent, not a guess about shade.

Left `oauth_available` on `sky-500/sky-600` untouched — there's no semantic "info" token in the design system, so migrating it would be a guess.

## Net change
+2/-2, one file, class-string only — no type or behavior change.

## Verify
`git diff apps/mesh/src/web/views/registry/monitor-connections-panel.tsx` — compare `authBadgeStyle()` (line 43/45) with the updated ternary (line ~329/333) to confirm identical token usage for identical states.

## Checks run locally
- `bun run fmt` — clean.
- No `bunx tsc --noEmit` run: change is a Tailwind class string only, no type surface touched. Full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the Monitor Connections auth badge to design-system tokens for consistency with `authBadgeStyle()`.

`oauth_connected` now uses `border-success text-success`, `token_required` uses `border-warning text-warning`; `oauth_available` stays on `sky` palette; no behavior changes.

<sup>Written for commit fbd6baebad11d777082bfc79aa1abac75013aad0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

