### PR TITLE
refactor(registry): use design-system tokens for QA run pass/fail colors

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-run-history.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-run-history.tsx
@@ -81,11 +81,11 @@ export function MonitorRunHistory({
                   <span className="text-muted-foreground">
                     {run.tested_items}/{run.total_items} tested
                   </span>
-                  <span className="text-emerald-600 font-medium">
+                  <span className="text-success font-medium">
                     {run.passed_items} passed
                   </span>
                   {run.failed_items > 0 && (
-                    <span className="text-red-600 font-medium">
+                    <span className="text-destructive font-medium">
                       {run.failed_items} failed
                     </span>
                   )}
@@ -114,7 +114,7 @@ export function MonitorRunHistory({
                     {run.config_snapshot.onFailure !== "none" && (
                       <Badge
                         variant="outline"
-                        className="text-[9px] text-red-600"
+                        className="text-[9px] text-destructive"
                       >
                         on fail:{" "}
                         {run.config_snapshot.onFailure.replace(/_/g, " ")}


### PR DESCRIPTION
## Summary
- `monitor-run-history.tsx` already imports `monitorStatusBadgeClass`, which uses `text-success`/`text-destructive` semantic tokens for the run-status badge in this exact component.
- The nearby pass/fail item counts in the same card used raw `text-emerald-600` / `text-red-600` for the identical pass/fail meaning — unmigrated leftovers from the same debt category.
- Swapped both (plus the "on fail" badge, also red-600/destructive) to the semantic tokens already used one line above in the same file.

## Payoff
Keeps one component internally consistent — the status badge and the pass/fail counts next to it now resolve to the same semantic color instead of drifting to raw Tailwind palette values that won't track future theme/token changes.

## Verification
- `bun run fmt` — clean, only the 3 touched lines changed.
- `bunx tsc --noEmit` in `apps/mesh` — no errors.
- Pure className swap, no logic touched; full CI covers the rest.

## Reviewer check
`git diff main -- apps/mesh/src/web/views/registry/monitor-run-history.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swapped raw Tailwind colors to design-system tokens for run pass/fail counts and the "on fail" badge in `monitor-run-history.tsx`.
Uses `text-success` and `text-destructive` to match the status badge and keep colors consistent with the theme.

<sup>Written for commit 34aa4e0c9992c393aca3c8e18126af184574dccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

