### PR TITLE
refactor(registry): use semantic tokens in monitor run history

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-run-history.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-run-history.tsx
@@ -81,11 +81,11 @@ export function MonitorRunHistory({
                   <span className="text-muted-foreground">
                     {run.tested_items}/{run.total_items} tested
                   </span>
-                  <span className="text-emerald-600 font-medium">
+                  <span className="text-success font-medium">
                     {run.passed_items} passed
                   </span>
                   {run.failed_items > 0 && (
-                    <span className="text-red-600 font-medium">
+                    <span className="text-destructive font-medium">
                       {run.failed_items} failed
                     </span>
                   )}
@@ -114,7 +114,7 @@ export function MonitorRunHistory({
                     {run.config_snapshot.onFailure !== "none" && (
                       <Badge
                         variant="outline"
-                        className="text-[9px] text-red-600"
+                        className="text-[9px] text-destructive"
                       >
                         on fail:{" "}
                         {run.config_snapshot.onFailure.replace(/_/g, " ")}


### PR DESCRIPTION
## Source
Un-CI-enforced design-token drift in `apps/mesh/src/web/views/registry/monitor-run-history.tsx` (flagged as a high-debt frontend file).

## Why
This component already imports `monitorStatusBadgeClass` from `monitor-utils.ts`, which maps the "completed"/"failed" run states to `text-success`/`text-destructive`. Three spans in the same component render the identical passed/failed semantics but used raw Tailwind palette classes (`text-emerald-600`, `text-red-600`) instead. This aligns the shade to the design-system tokens the file already relies on for the same meaning elsewhere — not a claim of pixel-identical color, just closing the drift.

## Mapping
- `text-emerald-600` → `text-success` (passed-items count — same "completed" meaning as `monitorStatusBadgeClass`'s `text-success`)
- `text-red-600` → `text-destructive` (failed-items count and the "on fail" config badge — same "failed" meaning as `monitorStatusBadgeClass`'s `text-destructive`)

## Verify
```
bun run fmt
cd apps/mesh && bun x tsc --noEmit
```
Both pass clean locally (no type or format changes needed beyond the class swap). Full CI runs lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch monitor run history to semantic tokens for passed/failed states to align styling with the design system and `monitorStatusBadgeClass`. Replaced `text-emerald-600`/`text-red-600` with `text-success`/`text-destructive` for the passed/failed counts and the on-fail badge.

<sup>Written for commit 2a33e13e6323a897af3a6016d05966937cb554ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

