### PR TITLE
refactor(tool-details): use text-warning token for MCP loading status dot

### DIFF
--- a/apps/mesh/src/web/components/details/tool.tsx
+++ b/apps/mesh/src/web/components/details/tool.tsx
@@ -733,7 +733,7 @@ function ToolDetailsAuthenticated({
               ) : toolsQuery.isLoading ? (
                 <Loading01
                   size={10}
-                  className="animate-spin text-yellow-500 shrink-0"
+                  className="animate-spin text-warning shrink-0"
                 />
               ) : (
                 <div className="h-1.5 w-1.5 rounded-full bg-destructive shrink-0" />


### PR DESCRIPTION
Follows #4751, which converted the same 3-branch MCP status indicator's success (`bg-green-500` → `bg-success`) and error (`bg-red-500` → `bg-destructive`) states to design-system tokens but left the loading-state `text-yellow-500` as raw Tailwind palette — the exact variant that first pass skipped in the same component.

`text-warning` is the token already used for this identical pending/loading meaning throughout the registry monitor views (`monitor-dashboard.tsx`, `monitor-connections-panel.tsx`, `monitor-configuration.tsx`, `task-status.ts`), so this brings the third branch in line with its two siblings.

Net diff: -1 / +1, one class name, no behavior change.

Reviewer check: `apps/mesh/src/web/components/details/tool.tsx` — the loading dot next to a tool's MCP status renders the same yellow as before, just via the semantic token.

Verified locally: `bun run fmt` (no changes) and `tsc --noEmit` in `apps/mesh` (clean). No test needed — pure class-name swap, matching the precedent set by #4751/#4752/#4753/#4754/#4755 which shipped without tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the MCP loading status dot in tool details to the `text-warning` design token instead of `text-yellow-500`. Keeps the loading color consistent with other registry monitor views; no behavior change.

<sup>Written for commit d608606109473ac3bd7cdee8ee1b5a89c7aee6c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

