### PR TITLE
refactor(thread): use design-system tokens for git-diff status dot colors

### DIFF
--- a/apps/mesh/src/web/components/thread/github/git-diff-list.tsx
+++ b/apps/mesh/src/web/components/thread/github/git-diff-list.tsx
@@ -61,10 +61,10 @@ export function GitDiffList({
         const directory = lastSlash >= 0 ? raw.slice(0, lastSlash) : null;
         const language = getLanguageFromPath(filepath);
         const dotColor = isNew
-          ? "bg-green-500"
+          ? "bg-success"
           : isDeleted
-            ? "bg-red-500"
-            : "bg-amber-500";
+            ? "bg-destructive"
+            : "bg-warning";
 
         return (
           <div key={filepath}>


### PR DESCRIPTION
## Source
Continues the token-migration series from #4751–#4755 (raw palette → semantic tokens), applied here to `GitDiffList`'s per-file status dot.

## Why
`bg-green-500` / `bg-red-500` / `bg-amber-500` encoded add/delete/modify intent with raw palette colors, while the same file already uses `bg-destructive`/`text-destructive` for the delete/discard action a few lines below — same "destructive" intent, two different color sources. Mapping is unambiguous: `--destructive` is hue 27° (red), `--success` is hue 149° (green), `--warning` is hue 70° (amber) in `packages/ui/src/styles/global.css`, matching add/delete/modify 1:1.

- `isNew` (added file) → `bg-green-500` → `bg-success`
- `isDeleted` (removed file) → `bg-red-500` → `bg-destructive`
- modified file → `bg-amber-500` → `bg-warning`

This aligns the shade to the design-system tokens rather than the exact old palette value; no other logic changed.

## Verification
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — clean
- Net diff: 3 lines changed, no behavior change (pure className swap)

Reviewer check: open a chat thread with sandbox git changes and confirm the file-status dots in the diff list still color-code added/deleted/modified files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace raw Tailwind palette classes with design-system tokens for the per-file status dot in `GitDiffList`. Maps add/delete/modify to `bg-success`, `bg-destructive`, and `bg-warning` with no logic or behavior changes.

<sup>Written for commit ad6940f38b3224cbd3d8722eac3c3cdcb85e4e2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

