### PR TITLE
refactor(chat): use design-system success token for approved-plan badge

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/propose-plan.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/propose-plan.tsx
@@ -27,7 +27,7 @@ export function ProposePlanPart({ part }: ProposePlanPartProps) {
           Implementation Plan
         </span>
         {isApproved && (
-          <span className="flex items-center gap-1 text-xs text-green-600 bg-green-500/10 px-1.5 py-0.5 rounded-md">
+          <span className="flex items-center gap-1 text-xs text-success bg-success/10 px-1.5 py-0.5 rounded-md">
             <Check size={12} />
             Approved
           </span>


### PR DESCRIPTION
## Summary
- C-DEBT: design-token drift in `ProposePlanPart` — the "Approved" badge used raw `text-green-600 bg-green-500/10` instead of the design system's semantic success token.
- Mapping: `text-green-600` → `text-success`, `bg-green-500/10` → `bg-success/10`. Unambiguous because the same "Check icon + approved/success badge" pattern already uses `text-success` elsewhere (e.g. `virtual-mcp-share-modal.tsx`, `csv-import-dialog.tsx`, `registry-item-card.tsx`), and this component pairs the badge with a `Check` icon for exactly that meaning.
- This aligns the shade to the design-system `success` token — not necessarily pixel-identical to the old `green-600`/`green-500` values, but the same semantic intent already used consistently elsewhere in the codebase.
- Left the decorative `text-purple-500` / `border-purple-500/30` (plan icon color, not a status) untouched — no unambiguous semantic mapping for those.

## Test plan
- [x] `bun run fmt`
- [x] `cd apps/mesh && bun x tsc --noEmit` — clean
- No behavior change; pure class-name swap. Full CI (lint/tests) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Approved badge in `ProposePlanPart` to use design-system success tokens for consistent semantic styling. Replaces `text-green-600 bg-green-500/10` with `text-success bg-success/10`; no behavior change.

<sup>Written for commit 760acce766f50454fd52f96183684308c64df094. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

