### PR TITLE
refactor(roles): remove dead color field from BUILTIN_ROLES

### DIFF
--- a/apps/mesh/src/web/routes/orgs/settings/roles.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/roles.tsx
@@ -50,14 +50,10 @@ import {
 } from "@/web/views/settings/org-role-detail.tsx";
 import { RequirePrivileged } from "@/web/components/require-privileged";
 
-// ============================================================================
-// Role color helpers
-// ============================================================================
-
 const BUILTIN_ROLES = [
-  { role: "owner", label: "Owner", color: "bg-red-500" },
-  { role: "admin", label: "Admin", color: "bg-blue-500" },
-  { role: "user", label: "User", color: "bg-green-500" },
+  { role: "owner", label: "Owner" },
+  { role: "admin", label: "Admin" },
+  { role: "user", label: "User" },
 ] as const;
 
 // ============================================================================


### PR DESCRIPTION
## Source
Dead-code cleanup found while auditing `apps/mesh/src/web/routes/orgs/settings/roles.tsx` for un-CI-enforced debt.

## Why
Each entry in the local `BUILTIN_ROLES` array carried a `color` field (`bg-red-500` / `bg-blue-500` / `bg-green-500`), but it was never read anywhere in the file or the rest of the codebase (`rg` for `.role.color` / `role.color` across `apps/mesh`, `apps/docs`, and `packages` returns zero hits). The role dot actually rendered in the table comes from `getRoleDotColor(row.role.role, ...)`, which resolves built-in role colors from its own `BUILTIN_ROLE_COLORS` map in `apps/mesh/src/web/lib/role-color.ts` — so the field in this file was pure dead weight duplicating that map.

## Change
-7 / +3 lines. Removed the unused `color` property from the three `BUILTIN_ROLES` entries. Purely a type/data shrink — the rendered UI is unaffected since that field was never consumed.

## Verify
```
rg -n "\.role\.color|role\.color\b" apps/mesh/src apps/docs packages   # zero hits, confirms it was dead
cd apps/mesh && bunx tsc --noEmit
```

## Checks run locally
`bun run fmt` and `bunx tsc --noEmit` (apps/mesh workspace) both pass. Full CI will run lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `color` field from `BUILTIN_ROLES` to eliminate dead data and duplication. UI is unchanged; role dot colors continue to come from `getRoleDotColor()` and `BUILTIN_ROLE_COLORS`.

<sup>Written for commit 3e59a89333e72f0fd7e56200b3100c3b875224f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

