### PR TITLE
refactor(account-popover): use design-system warning token for impersonation indicator

### DIFF
--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -100,7 +100,7 @@ function MenuItemButton({
 
 function ImpersonatingPill() {
   return (
-    <span className="shrink-0 inline-flex items-center rounded-full bg-amber-100 dark:bg-amber-500/20 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-400">
+    <span className="shrink-0 inline-flex items-center rounded-full bg-warning/10 px-2 py-0.5 text-[10px] font-medium text-warning">
       Impersonating
     </span>
   );
@@ -462,7 +462,7 @@ export function AccountPopover() {
             label: "Admin Dashboard",
             icon: <ShieldTick size={16} />,
             onClick: () => navigate({ to: "/_admin" }),
-            className: "text-amber-700 dark:text-amber-400",
+            className: "text-warning",
           } satisfies MenuItem,
         ]
       : []),
@@ -498,7 +498,7 @@ export function AccountPopover() {
           }
           window.location.href = "/";
         },
-        className: "text-amber-700 dark:text-amber-400",
+        className: "text-warning",
       }
     : null;
 
@@ -535,7 +535,7 @@ export function AccountPopover() {
             onClick={() => setOpen(true)}
             className={cn(
               "flex items-center gap-3 w-full px-3 py-2.5 rounded-lg transition-colors text-sm text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground",
-              isImpersonating && "border-2 border-dashed border-amber-500",
+              isImpersonating && "border-2 border-dashed border-warning",
             )}
           >
             <Avatar
@@ -559,7 +559,7 @@ export function AccountPopover() {
               tooltip={user?.name ?? "Account"}
               className={cn(
                 "rounded-md",
-                isImpersonating && "border-2 border-dashed border-amber-500",
+                isImpersonating && "border-2 border-dashed border-warning",
               )}
             >
               <Avatar


### PR DESCRIPTION
## Summary
- C-DEBT: replaces 5 raw `amber-*` Tailwind classes in `account-popover.tsx` with the design-system `warning` token, for the admin-impersonation pill/menu-item/border indicator (impersonating badge, admin-dashboard link, stop-impersonation item, and the two dashed-border avatar wrappers).
- The `warning` token (`packages/ui/src/styles/global.css`) resolves to an amber/orange hue and is already the established pattern for this exact "admin/warning" meaning elsewhere in the chat UI (e.g. `credits-eyebrow.tsx` uses `bg-warning/10` + `text-warning` for its pill). All 5 hits in this file are the same "impersonation is dangerous" concept, so the mapping is unambiguous — not a judgment call about shade.
- Aligns the shade to the design-system `warning` token; this is not guaranteed to be pixel-identical to the old amber-700/amber-400/amber-500 values, just the closest semantic equivalent already used for this meaning elsewhere.

## Test plan
- `bun run fmt` — clean, no changes needed beyond the edit
- `cd apps/mesh && bunx tsc --noEmit` — passes
- Visual verification not possible in this environment; a reviewer can confirm by loading the account popover while impersonating a user and comparing the badge/border color against `credits-eyebrow.tsx`'s warning pill

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced raw amber Tailwind colors with the design-system `warning` token for all impersonation indicators in the account popover. This standardizes the UI and keeps admin/warning styling consistent across themes.

- **Refactors**
  - Swapped five `amber-*` classes for `text-warning`, `bg-warning/10`, and `border-warning` in `account-popover.tsx`.
  - Applies to the impersonating pill, Admin Dashboard link, Stop Impersonation item, and two dashed avatar borders.

<sup>Written for commit b93890743625fdbfca220e211f301da7b3ca9bc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

