### PR TITLE
refactor(registry): use design-system tokens for discover-tools status blocks

### DIFF
--- a/apps/mesh/src/web/views/registry/registry-item-dialog.tsx
+++ b/apps/mesh/src/web/views/registry/registry-item-dialog.tsx
@@ -910,8 +910,8 @@ export function RegistryItemDialog({
           </div>
 
           {discoverStatus === "success" && tools.length > 0 && (
-            <div className="rounded-lg border border-green-500/20 bg-green-50 dark:bg-green-950/20 px-3 py-2 space-y-1.5">
-              <div className="flex items-center gap-2 text-xs text-green-600 dark:text-green-400">
+            <div className="rounded-lg border border-success/20 bg-success/10 px-3 py-2 space-y-1.5">
+              <div className="flex items-center gap-2 text-xs text-success">
                 <CheckCircle size={14} className="shrink-0" />
                 <span className="font-medium">
                   {tools.length} tool{tools.length !== 1 ? "s" : ""} discovered
@@ -941,7 +941,7 @@ export function RegistryItemDialog({
           )}
 
           {discoverStatus === "auth_required" && discoverError && (
-            <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/20 border border-amber-500/20 rounded-lg px-3 py-2">
+            <div className="flex items-center gap-2 text-xs text-warning bg-warning/10 border border-warning/20 rounded-lg px-3 py-2">
               <AlertCircle size={14} className="shrink-0" />
               <span>
                 This server requires authentication. The connection is valid but


### PR DESCRIPTION
## Summary
- The "discover tools" flow in the add-MCP-server dialog has three status blocks (success, auth-required, error), but only the error block used the design-system `text-destructive`/`bg-destructive/10` tokens — the success and auth-required (warning) blocks still used raw Tailwind palette classes (`green-500`/`green-50`/`green-950`, `amber-600`/`amber-50`/`amber-950`).
- Sibling registry views (`monitor-connections-panel.tsx`) already use `bg-success/10 text-success border-success/20` and `bg-warning/10 text-warning border-warning/20` for the identical status-badge shape, so the mapping here is unambiguous: success → `success` token, auth-required warning → `warning` token.
- This aligns the shade to the design-system `success`/`warning` tokens (not necessarily pixel-identical to the old green-500/amber-600 values) and keeps the pattern consistent with the neighboring `destructive` block in the same file.

## Test plan
- [x] `bun run fmt`
- No logic/type changes — pure Tailwind class swap, no test needed.

Command to confirm: `git diff apps/mesh/src/web/views/registry/registry-item-dialog.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use design-system tokens for the "discover tools" status blocks in the add-MCP-server dialog, replacing raw Tailwind colors. Success → `success` token and auth-required → `warning` token, matching `monitor-connections-panel` and the existing `destructive` block; no logic changes.

<sup>Written for commit aa7e032f87c7a77d1f69460608d6f2d0c3bf3aeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

