### PR TITLE
refactor(members): dedup role-color logic into shared role-color.ts

### DIFF
--- a/apps/mesh/src/web/routes/orgs/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/members.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/web/hooks/use-invitations";
 import { useOrganizationRoles } from "@/web/hooks/use-organization-roles";
 import { useOrgAuthClient } from "@/web/hooks/use-org-auth-client";
+import { getRoleColor, getRoleDotColor } from "@/web/lib/role-color";
 import { KEYS } from "@/web/lib/query-keys";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import {
@@ -71,53 +72,21 @@ import { Suspense, useState } from "react";
 import { toast } from "sonner";
 import { TagMultiSelect } from "@/web/components/tag-multi-select";
 
-const ROLE_COLORS = [
-  "bg-neutral-400",
-  "bg-red-500",
-  "bg-orange-500",
-  "bg-amber-500",
-  "bg-yellow-500",
-  "bg-lime-500",
-  "bg-green-500",
-  "bg-emerald-500",
-  "bg-teal-500",
-  "bg-cyan-500",
-  "bg-sky-500",
-  "bg-blue-500",
-  "bg-indigo-500",
-  "bg-violet-500",
-  "bg-purple-500",
-  "bg-fuchsia-500",
-  "bg-pink-500",
-  "bg-rose-500",
-  "bg-slate-500",
-] as const;
+const BUILTIN_ROLES = ["owner", "admin", "user"];
 
-const BUILTIN_ROLE_COLORS: Record<string, string> = {
-  owner: "bg-red-500",
-  admin: "bg-blue-500",
-  user: "bg-green-500",
-};
-
-// Create a Map for O(1) role color lookups
+// Create a Map for O(1) role color lookups, reusing the shared role-color palette.
 function createRoleColorMap(
   customRoles: Array<{ role: string }>,
 ): Map<string, string> {
   const colorMap = new Map<string, string>();
 
-  // Add built-in role colors
-  for (const [role, color] of Object.entries(BUILTIN_ROLE_COLORS)) {
-    colorMap.set(role, color);
+  for (const role of BUILTIN_ROLES) {
+    colorMap.set(role, getRoleDotColor(role, true));
   }
 
-  // Add custom role colors
-  for (let i = 0; i < customRoles.length; i++) {
-    const role = customRoles[i];
+  for (const role of customRoles) {
     if (role && !colorMap.has(role.role)) {
-      colorMap.set(
-        role.role,
-        ROLE_COLORS[i % ROLE_COLORS.length] ?? "bg-neutral-400",
-      );
+      colorMap.set(role.role, getRoleColor(role.role));
     }
   }
 


### PR DESCRIPTION
## Summary

`members.tsx` hand-rolled its own `ROLE_COLORS` array, `BUILTIN_ROLE_COLORS` map, and a
position-based (`i % ROLE_COLORS.length`) color assignment for custom roles — duplicating
the hash-based `getRoleColor`/`getRoleDotColor` helpers in `@/web/lib/role-color`, already
used by `org-role-detail.tsx` and `orgs/settings/roles.tsx`.

Beyond the duplication, the two implementations disagreed: this file assigned a custom
role's swatch color by its *position* in the fetched roles list, while the other two views
derive it from a *hash of the role name*. That meant the same custom role could render with
a different color on the Members page than on the Roles/Role-detail pages. Switching to the
shared helpers removes the duplicate palette and fixes that inconsistency.

Net: **-38 / +7** lines. Built-in role colors (owner/admin/user) are unchanged (both maps
used identical `bg-red-500` / `bg-blue-500` / `bg-green-500` values); only custom-role
colors now match the rest of the app.

## Test plan

- `bun run fmt` — clean
- `bunx tsc --noEmit` in `apps/mesh` — clean
- No existing test file covers `members.tsx`; verified via `rg` that `ROLE_COLORS` /
  `BUILTIN_ROLE_COLORS` / `createRoleColorMap`'s old body have no other references before
  removing them.
- A reviewer can confirm by opening an org's Members page and Roles page side by side and
  checking a custom role's dot color matches on both.

Full CI (lint, full typecheck, test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates role color logic in the Members page by reusing `getRoleColor` and `getRoleDotColor` from `@/web/lib/role-color`. Custom role colors are now deterministic and match Roles/Role Detail pages; built-in role colors remain the same.

- **Refactors**
  - Removed local `ROLE_COLORS`/`BUILTIN_ROLE_COLORS` and switched to shared helpers.
  - Kept O(1) map lookups; built-ins resolved via `getRoleDotColor(role, true)`.

- **Bug Fixes**
  - Custom roles now use hash-based colors instead of list-position colors.

<sup>Written for commit 2a7263b2fb237b20e0f9e459b4450f0298aa9325. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

