### PR TITLE
refactor(chat): use design-system warning token for no-credits icon

### DIFF
--- a/apps/mesh/src/web/components/chat/credits-empty-state.tsx
+++ b/apps/mesh/src/web/components/chat/credits-empty-state.tsx
@@ -117,13 +117,10 @@ export function CreditsEmptyState() {
       >
         {/* Header */}
         <div className="relative px-6 pt-7 pb-5">
-          <div className="absolute inset-x-0 top-0 h-24 bg-gradient-to-b from-amber-500/8 to-transparent pointer-events-none rounded-t-lg" />
+          <div className="absolute inset-x-0 top-0 h-24 bg-gradient-to-b from-warning/8 to-transparent pointer-events-none rounded-t-lg" />
           <DialogHeader className="relative gap-3">
-            <div className="flex items-center justify-center size-11 rounded-full bg-amber-100 dark:bg-amber-900/40 border border-amber-200/60 dark:border-amber-800/40 mx-auto">
-              <Coins04
-                size={20}
-                className="text-amber-600 dark:text-amber-400"
-              />
+            <div className="flex items-center justify-center size-11 rounded-full bg-warning/10 border border-warning/20 mx-auto">
+              <Coins04 size={20} className="text-warning" />
             </div>
             <div className="text-center">
               <DialogTitle className="text-lg font-semibold">


### PR DESCRIPTION
## Summary
Follows #4760 (account-popover) and #4758 (propose-plan), which migrated the same raw amber-shade → `warning` token pattern in sibling files this session. `CreditsEmptyState`'s "no credits" icon was still hand-rolling `amber-100/900/40` + `amber-200/60/800/40` + `amber-600/400` light/dark pairs for the exact same warning-icon idiom those PRs already tokenized elsewhere.

Mapping (unambiguous — same light/dark pair the design system already collapses to `warning` in #4760):
- `bg-gradient-to-b from-amber-500/8 to-transparent` → `from-warning/8 to-transparent`
- `bg-amber-100 dark:bg-amber-900/40 border border-amber-200/60 dark:border-amber-800/40` → `bg-warning/10 border border-warning/20`
- `text-amber-600 dark:text-amber-400` → `text-warning`

This aligns the icon's shade to the design-system `warning` token (not a pixel-identical color, since the token collapses several light/dark amber shades into one CSS variable) — no other change.

## Test plan
- `bun run fmt` — clean
- `bunx tsc --noEmit` in `apps/mesh` — clean
- Reviewer: open the "no credits" modal (new org with a Deco AI Gateway key and zero credits) and confirm the icon still renders as an amber/warning-toned circle in both light and dark mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the "no credits" icon in chat `CreditsEmptyState` to the design system `warning` token instead of hard-coded amber shades. Improves theme consistency with no visual or behavioral changes.

- **Refactors**
  - Replaced gradient, background/border, and icon color classes with `from-warning/8`, `bg-warning/10`, `border-warning/20`, and `text-warning`.

<sup>Written for commit 688565ac765d182cf8183c3bda048851f4ea9043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

