### PR TITLE
refactor(registry): use design-system success token for discover-success block

### DIFF
--- a/apps/mesh/src/web/views/registry/tools-editor.tsx
+++ b/apps/mesh/src/web/views/registry/tools-editor.tsx
@@ -122,7 +122,7 @@ export function ToolsEditor({
 
       {/* Status feedback */}
       {discoverStatus === "success" && (
-        <div className="flex items-center gap-2 text-xs text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-950/30 rounded-lg px-3 py-2">
+        <div className="flex items-center gap-2 text-xs text-success bg-success/10 rounded-lg px-3 py-2">
           <CheckCircle size={14} className="shrink-0" />
           <span>
             Discovered {tools.length} tool{tools.length !== 1 ? "s" : ""}{" "}


### PR DESCRIPTION
## Source
C-DEBT frontend-token-drift pass over `apps/mesh/src/web/views/registry/tools-editor.tsx` (one of the HIGHEST-DEBT frontend files, palette=2).

## Why
The discover-success feedback block hardcoded `text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-950/30` instead of the semantic `success` token. The mapping is unambiguous: the error feedback block a few lines below (`discoverStatus === "error"`) already uses `text-destructive bg-destructive/10` for the identical shape (icon + message, colored text + colored bg/10, `rounded-lg px-3 py-2`) — the success block should mirror that pattern with `text-success bg-success/10`, and `--success`/`--color-success` are established tokens already used the same way elsewhere (e.g. `native-tiles.tsx`, `credits-eyebrow.tsx`).

This aligns the shade to the design-system `success` token rather than claiming pixel-identical output — dark mode in particular now resolves through the token's own dark-theme value instead of the hardcoded `green-950/30`.

## How to verify
- `git diff apps/mesh/src/web/views/registry/tools-editor.tsx`
- Discover tools on a registry connection form and confirm the "Discovered N tools successfully" banner still reads as a success state.

## Checks run locally
- `bun run fmt` — clean, no changes needed
- `bunx tsc --noEmit` in `apps/mesh` — passes
- No test covers this pure JSX class change; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the discover-success banner in `apps/mesh/src/web/views/registry/tools-editor.tsx` to use the design-system `success` tokens (`text-success bg-success/10`) instead of hardcoded green classes. This makes success styling consistent across themes and matches the existing error-state pattern.

<sup>Written for commit 1e522e40379885265486b55e68f0474ad886bfc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

