### PR TITLE
refactor(sandbox): use design-system warning token for running-sandbox notice

### DIFF
--- a/apps/mesh/src/web/components/sandbox/runtime-card/env-vars-field.tsx
+++ b/apps/mesh/src/web/components/sandbox/runtime-card/env-vars-field.tsx
@@ -195,8 +195,8 @@ function RunningSandboxNotice<T extends FieldValues>({
   };
 
   return (
-    <div className="flex items-center justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs dark:border-amber-900/40 dark:bg-amber-950/30">
-      <div className="flex min-w-0 items-center gap-2 text-amber-900 dark:text-amber-200">
+    <div className="flex items-center justify-between gap-3 rounded-md border border-warning/20 bg-warning/10 px-3 py-2 text-xs">
+      <div className="flex min-w-0 items-center gap-2 text-warning">
         <AlertTriangle className="size-3.5 shrink-0" />
         <span className="truncate">
           Your sandbox is running. Restart the dev script to apply the new env.


### PR DESCRIPTION
## Summary
The "sandbox is running, restart to apply env" banner in `env-vars-field.tsx` hand-rolled raw amber Tailwind classes (`border-amber-200 bg-amber-50 text-amber-900` + separate dark-mode overrides) for what is a warning-intent banner. The codebase already has an established `border-warning/20 bg-warning/10 text-warning` idiom for this exact bordered-banner shape (see `virtual-mcp-share-modal.tsx`, `csv-import-dialog.tsx`), which also collapses the manual dark-mode variants since the `--warning` CSS var already resolves per-theme.

- Exact mapping: `border-amber-200 bg-amber-50 ... dark:border-amber-900/40 dark:bg-amber-950/30` → `border-warning/20 bg-warning/10`; `text-amber-900 dark:text-amber-200` → `text-warning`.
- This aligns the shade to the design-system `warning` token — it is not a pixel-identical amber, but matches the same semantic intent (and exact box construction) already used elsewhere for warning banners.

## Test plan
- [x] `bun run fmt`
- [x] `cd apps/mesh && bun x tsc --noEmit` — clean
- No behavior change (pure class swap), so no test needed beyond typecheck. Full CI runs the rest.

Reviewer check: `bun run --cwd=apps/mesh dev:client`, open a sandbox with a running dev process, edit an env var — the notice banner should render with the same warning styling as the CSV-import/share-modal warning banners elsewhere in the app.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the running-sandbox notice in `env-vars-field.tsx` to the design-system warning token for consistent banner styling. Replaced hard-coded amber classes with `border-warning/20 bg-warning/10 text-warning` and removed dark-mode overrides; no behavior change.

<sup>Written for commit 4f9b664978407aad663c4f3eeeb7c2705b671cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

