### PR TITLE
refactor(connection-detail): drop redundant any-casts on tool outputSchema/annotations

### DIFF
--- a/apps/mesh/src/web/components/details/connection/index.tsx
+++ b/apps/mesh/src/web/components/details/connection/index.tsx
@@ -686,9 +686,7 @@ function ConnectionInspectorViewContent() {
         name: t.name,
         description: t.description,
         inputSchema: t.inputSchema as Record<string, unknown> | undefined,
-        outputSchema: (t as any).outputSchema as
-          | Record<string, unknown>
-          | undefined,
+        outputSchema: t.outputSchema as Record<string, unknown> | undefined,
         annotations: t.annotations,
         _meta: t._meta as Record<string, unknown> | undefined,
       }))
@@ -696,10 +694,8 @@ function ConnectionInspectorViewContent() {
         name: t.name,
         description: t.description,
         inputSchema: t.inputSchema as Record<string, unknown> | undefined,
-        outputSchema: (t as any).outputSchema as
-          | Record<string, unknown>
-          | undefined,
-        annotations: (t as any).annotations,
+        outputSchema: t.outputSchema as Record<string, unknown> | undefined,
+        annotations: t.annotations,
         _meta: t._meta as Record<string, unknown> | undefined,
       }));
 


### PR DESCRIPTION
## Source
C-DEBT: `no-explicit-any` cleanup in `apps/mesh/src/web/components/details/connection/index.tsx`, one of the highest-any-count frontend files.

## Why
`(t as any).outputSchema` / `(t as any).annotations` cast around fields that are already properly typed. Both `Tool` (from `@modelcontextprotocol/sdk`'s `ToolSchema`, used for `toolsData.tools`) and `ToolDefinition` (from `@decocms/mesh-sdk`, `ToolSchema.extend(...)`, used for `connection?.tools`) declare `outputSchema` and `annotations` as first-class optional fields — the `any` cast was masking real types with no compile-time safety, not covering a genuine gap. This is a behavior-preserving pure type fix: same runtime values, same downstream `Record<string, unknown> | undefined` cast for `outputSchema`, just without silently laundering through `any`.

## Confirming
`cd apps/mesh && bun x tsc --noEmit` — stays green with the casts removed, proving the fields resolve correctly without `any`.

## Verified locally
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` (clean)

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant `any` casts for `outputSchema` and `annotations` in the connection detail view to rely on proper types from `@modelcontextprotocol/sdk` and `@decocms/mesh-sdk`. No runtime changes; improves type safety and readability.

<sup>Written for commit e1f94ff496e1905831485678923475b7ec1eba7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

