### PR TITLE
refactor(settings): use design-system destructive token for join-request badge dot

### DIFF
--- a/apps/mesh/src/web/layouts/settings-layout.tsx
+++ b/apps/mesh/src/web/layouts/settings-layout.tsx
@@ -278,7 +278,7 @@ export function SettingsSidebar() {
                         <span className="relative shrink-0">
                           {item.icon}
                           {item.badge ? (
-                            <span className="absolute -right-1 -top-1 size-2 rounded-full bg-red-500 pointer-events-none" />
+                            <span className="absolute -right-1 -top-1 size-2 rounded-full bg-destructive pointer-events-none" />
                           ) : null}
                         </span>
                         <span className="truncate">{item.label}</span>
@@ -369,7 +369,7 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
                 <span className="relative shrink-0">
                   {item.icon}
                   {item.badge ? (
-                    <span className="absolute -right-1 -top-1 size-2 rounded-full bg-red-500 pointer-events-none" />
+                    <span className="absolute -right-1 -top-1 size-2 rounded-full bg-destructive pointer-events-none" />
                   ) : null}
                 </span>
                 <span className="truncate">{item.label}</span>


### PR DESCRIPTION
## Source
C-DEBT (design-token drift) in the always-available frontend-debt hunt — `settings-layout.tsx` was in the HIGHEST-DEBT FRONTEND FILES list with 2 raw-palette hits.

## What / why
The pending-join-request notification dot (desktop + mobile settings sidebar) used a raw `bg-red-500` instead of the design system's semantic `bg-destructive` token. The exact same "small colored status dot" pattern already uses `bg-destructive` for the "urgent" priority indicator in `apps/mesh/src/web/layouts/task-board/config.tsx:118`, so the mapping here is unambiguous — it's the same shape (a `size-2 rounded-full` attention dot) carrying the same "needs your attention now" meaning (a pending join request the org owner must act on).

Note: `--destructive` resolves via oklch to a slightly different shade than `red-500` — this aligns the shade to the design-system token, it isn't pixel-identical to the old color.

## Verification
- `bun run fmt` — clean, no changes needed beyond the edit itself.
- Change is a className string literal only — no type surface touched, so no typecheck/test run was needed.
- A reviewer can confirm by loading `/[org]/settings` with a pending join request and comparing the badge dot color against other `bg-destructive` usages (e.g. the urgent task-board dot).

Full CI (lint/typecheck/tests) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the join-request badge dot in the settings sidebar (desktop and mobile) from `bg-red-500` to the design-system `bg-destructive` token for consistency with status dot patterns. The shade changes slightly to match the token’s color.

<sup>Written for commit 2dc51ea35e139f4aa224021cfdfa15de321de506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

