### PR TITLE
refactor(chat): use design-system success token for active-connection status

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/connection-list.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/connection-list.tsx
@@ -21,7 +21,7 @@ interface ConnectionListPartProps {
 }
 
 const STATUS_DOT: Record<ConnectionEntity["status"], string> = {
-  active: "bg-emerald-500",
+  active: "bg-success",
   inactive: "bg-muted-foreground",
   error: "bg-destructive",
 };
@@ -125,7 +125,7 @@ export function ConnectionListPart({ part, latency }: ConnectionListPartProps) {
   return (
     <>
       <ToolCallShell
-        icon={<Link01 className="text-emerald-500" />}
+        icon={<Link01 className="text-success" />}
         title={
           items.length === 1 ? "1 connection" : `${items.length} connections`
         }


### PR DESCRIPTION
## Source
C-DEBT: design-token drift in a highest-debt frontend file (`connection-list.tsx` was flagged for raw-palette hits).

## Why
`ConnectionListPart` already uses the semantic `bg-destructive` token for the `error` connection status, but the `active` status and its matching header icon hard-coded `emerald-500`/`text-emerald-500` instead of the equivalent semantic `success` token. This is an unambiguous mapping: "active" is the textbook `success` intent, the file already follows the destructive/error convention for the sibling status, and the design system's `--success` token (`packages/ui/src/styles/global.css`) resolves to the same green hue family as `emerald-500`.

## Change
- `bg-emerald-500` -> `bg-success` for the active status dot
- `text-emerald-500` -> `text-success` for the connections-loaded icon

Net: -2 / +2, no behavior change — same green hue family, now sourced from the design-system token instead of a raw Tailwind palette class.

## Verify
- `bun run fmt` (clean)
- `cd apps/mesh && bun x tsc --noEmit` (clean)

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` in `apps/mesh`
Full CI runs the rest (lint, test suite).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the design-system `success` token for the active connection status and icon in `connection-list.tsx`. Aligns with semantic tokens and removes raw palette usage; no visual change.

- **Refactors**
  - Replace `bg-emerald-500` with `bg-success` for the active status dot.
  - Replace `text-emerald-500` with `text-success` for the header icon.

<sup>Written for commit ed1c1da27b8e6c721daefa175c16d0ae04c38cf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

