### PR TITLE
refactor(registry): use design-system success token for discover button

### DIFF
--- a/apps/mesh/src/web/views/registry/tools-editor.tsx
+++ b/apps/mesh/src/web/views/registry/tools-editor.tsx
@@ -101,7 +101,7 @@ export function ToolsEditor({
               type="button"
               variant="outline"
               size="sm"
-              className="h-7 text-xs gap-1.5 border-green-500/30 text-green-600 dark:text-green-400 shadow-[0_0_8px_rgba(34,197,94,0.3)] hover:shadow-[0_0_14px_rgba(34,197,94,0.5)] hover:border-green-500/50 transition-all"
+              className="h-7 text-xs gap-1.5 border-success/30 text-success shadow-[0_0_8px_color-mix(in_oklch,var(--success)_30%,transparent)] hover:shadow-[0_0_14px_color-mix(in_oklch,var(--success)_50%,transparent)] hover:border-success/50 transition-all"
               onClick={handleDiscover}
               disabled={discoverStatus === "loading"}
             >


### PR DESCRIPTION
Follows #4764, which tokenized the discover-success feedback block in the same file (`tools-editor.tsx`) but missed the "Auto-discover"/"Refresh" button right above it, which still used raw `green-500`/`green-600` palette classes plus hardcoded `rgba(34,197,94,...)` glow shadows.

Swaps `border-green-500/30 text-green-600 dark:text-green-400` for `border-success/30 text-success`, and replaces the raw-rgba glow shadows with `color-mix(in oklch, var(--success) ..., transparent)` so the glow tracks the token instead of a hardcoded color (matching the existing `shadow-[0_0_0_1px_hsl(var(--sidebar-border))]` precedent for referencing CSS vars in arbitrary shadow values).

No behavior change — same visual color in both themes (`--success` is a green-ish oklch value), just token-driven instead of hardcoded.

To confirm: open a registry item with a remote MCP URL configured and view the "Auto-discover"/"Refresh" button in the tools editor — same green outline glow as before.

Ran locally: `bun run fmt` and `bunx tsc --noEmit` in `apps/mesh` (both clean). No test needed — this is a pure className swap with no logic change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Tools Editor “Auto-discover/Refresh” button to the design-system `success` token, replacing hardcoded greens for consistent theming. Uses `border-success/30 text-success` and `color-mix(... var(--success) ...)` shadows; no behavior or visual change.

<sup>Written for commit 71710fe1ddc1047914eec33ae82607114bf6c1bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

