### PR TITLE
refactor(settings): use design-system warning token for dangerous-capability icon

### DIFF
--- a/apps/mesh/src/web/views/settings/org-role-detail.tsx
+++ b/apps/mesh/src/web/views/settings/org-role-detail.tsx
@@ -219,7 +219,7 @@ function OrgPermissionsTab({
                           {cap.dangerous && (
                             <AlertTriangle
                               size={12}
-                              className="text-amber-500 shrink-0"
+                              className="text-warning shrink-0"
                             />
                           )}
                         </span>


### PR DESCRIPTION
## Summary
- `org-role-detail.tsx` was one of the injected HIGHEST-DEBT FRONTEND FILES (raw-palette hit) — a hardcoded `text-amber-500` on the `AlertTriangle` icon that flags a role capability as "dangerous".
- The codebase already has an unambiguous precedent for this exact shape (warning-triangle icon → `text-warning` token) in `apps/mesh/src/web/components/sandbox/runtime-card/env-vars-field.tsx:199-200`, so this mapping is a direct copy of an existing convention, not a judgment call.
- Aligns the icon's shade to the design-system `warning` token (not necessarily pixel-identical to the old amber-500, but the same semantic intent already used elsewhere for warning triangles).

## Test plan
- `bun run fmt` — clean
- `cd apps/mesh && bun x tsc --noEmit` — passes
- Reviewer: `git diff main -- apps/mesh/src/web/views/settings/org-role-detail.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use design-system `text-warning` for the dangerous capability icon in org role settings. Replaces hardcoded `text-amber-500` to match existing warning-triangle convention and reduce design debt.

<sup>Written for commit 3154ef5a0b586c7d789a4d448fa120d6ac950a54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

