### PR TITLE
refactor(auth): use design-system success token for reset-password confirmation

### DIFF
--- a/apps/mesh/src/web/routes/reset-password.tsx
+++ b/apps/mesh/src/web/routes/reset-password.tsx
@@ -104,7 +104,7 @@ export default function ResetPasswordRoute() {
           {/* Success state */}
           {success && (
             <>
-              <div className="rounded-xl bg-emerald-500/10 p-3 text-sm text-emerald-600 dark:text-emerald-400 text-center">
+              <div className="rounded-xl bg-success/10 p-3 text-sm text-success text-center">
                 Your password has been reset. You can now sign in with your new
                 password.
               </div>


### PR DESCRIPTION
## Summary
- C-DEBT (design-token drift) — the reset-password success banner used raw `emerald-500/600` classes while the adjacent error banner in the same file already uses the semantic `bg-destructive/10 text-destructive` tokens.
- Maps to `bg-success/10 text-success`, the exact pattern already used for success states elsewhere (`credits-eyebrow.tsx`, `propose-plan.tsx`, `native-tiles.tsx`). The `--success` CSS var resolves to the same green hue family (oklch hue ~149) as `emerald`, so this aligns the shade to the design-system `success` token rather than being a pixel-identical change.
- Payoff: keeps the file consistent with its own destructive-token usage and removes one more hardcoded palette color from the un-CI-enforced design-token drift.

## Test plan
- `bun run fmt` — clean
- `bunx tsc --noEmit` in `apps/mesh` — clean
- No behavior change (pure class swap); reviewer can confirm by visiting `/reset-password` with a valid token and completing the reset flow.

Full CI (lint/tests) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the reset-password success banner to use design-system `bg-success/10` and `text-success` tokens instead of hardcoded `emerald` classes. This aligns with existing token usage in the file and reduces design-token drift with no behavior change.

<sup>Written for commit 48383dc685bef1628a1568086d25bfe394e77017. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

