### PR TITLE
refactor(credits): use design-system warning token for low-balance state

### DIFF
--- a/apps/mesh/src/web/views/settings/ai-providers/deco-credits-hero.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/deco-credits-hero.tsx
@@ -151,7 +151,7 @@ function QuickTopUp() {
 
 function creditColorClass(dollars: number): string {
   if (dollars <= 0) return "text-destructive";
-  if (dollars <= 1) return "text-amber-500 dark:text-amber-400";
+  if (dollars <= 1) return "text-warning";
   return "text-foreground";
 }
 


### PR DESCRIPTION
## Summary
Objective un-CI-enforced design-token drift in `deco-credits-hero.tsx` (C-DEBT).

`creditColorClass()` already maps the zero-balance tier to the semantic `text-destructive` token; the adjacent low-balance tier (`<= $1`) used a raw `text-amber-500 dark:text-amber-400` instead of the matching semantic `text-warning` token — the same file already establishes the severity-tier -> semantic-token convention, so this mapping is unambiguous (destructive -> warning -> foreground as the amount goes from critical to low to fine), and `--warning` in `global.css` resolves to an amber hue (`oklch(.62 .17 70)`), so this aligns the shade to the design-system warning token rather than exactly reproducing the old amber value pixel-for-pixel.

## Testing
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (clean)
- No behavior change — pure class-name swap; a reviewer can confirm by viewing Settings → AI Providers with an org balance between $0 and $1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the low-balance state color in the credits hero to the design-system `text-warning` token. This aligns with existing semantic tokens (`text-destructive` for zero) and removes raw amber class usage.

- **Refactors**
  - Replaced `text-amber-500 dark:text-amber-400` with `text-warning` in `creditColorClass()`; no behavior change.

<sup>Written for commit 248b59454395749cde8af4f18bc2512e30feb049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

