### PR TITLE
refactor(admin): use design-system success token for verified-email badge

### DIFF
--- a/apps/mesh/src/web/routes/admin/users.tsx
+++ b/apps/mesh/src/web/routes/admin/users.tsx
@@ -91,7 +91,7 @@ export default function AdminUsersPage() {
       header: "Email",
       render: (user) =>
         user.emailVerified ? (
-          <Badge variant="outline" className="text-green-600 border-green-400">
+          <Badge variant="outline" className="text-success border-success/20">
             Verified
           </Badge>
         ) : (


### PR DESCRIPTION
## Summary
- `admin/users.tsx` hard-coded `text-green-600 border-green-400` on the "Verified" email badge instead of the design-system `success` token already used for identical positive-state outline badges elsewhere in the app (`monitor-dashboard.tsx`, `monitor-connections-panel.tsx`, `monitor-configuration.tsx`, `registry-item-dialog.tsx` all use the `text-success border-success/20` shape for a passed/positive `Badge variant="outline"`).
- Mapping is unambiguous: same component (`Badge variant="outline"`), same semantic meaning (a positive/confirmed state), same existing shade convention (`text-success` + `border-success/20`) used repeatedly in this codebase for exactly this kind of badge.
- This aligns the shade to the design-system `success` token — it is not a pixel-identical green, but it is the same semantic color already standardized on for this UI pattern.

## Test plan
- [x] `bun run fmt`
- [x] `cd apps/mesh && bunx tsc --noEmit` (clean)
- No behavior change — purely a class swap on a single badge; reviewer can confirm by viewing the admin Users page email column.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the admin Users page "Verified" email badge with the design system by replacing hard-coded greens with the `success` token (`text-success border-success/20`). Matches the outline badge style used elsewhere; no behavior change.

<sup>Written for commit 86840697210e233d6be986e8780bf27efd8d8937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

