### PR TITLE
refactor(automations): use design-system success token for active-status dot

### DIFF
--- a/apps/mesh/src/web/views/automations/automation-list-row.tsx
+++ b/apps/mesh/src/web/views/automations/automation-list-row.tsx
@@ -66,7 +66,7 @@ export function AutomationListRow({
           className={cn(
             "inline-block size-2 rounded-full shrink-0",
             automation.active && automation.trigger_count > 0
-              ? "bg-emerald-500"
+              ? "bg-success"
               : "bg-muted-foreground/40",
           )}
           aria-label={


### PR DESCRIPTION
## Summary
Design-token drift cleanup (C-DEBT), same pattern as #4768/#4769/#4770/#4771/#4772/#4773.

- `automation-list-row.tsx` hardcoded `bg-emerald-500` for the "Active" status dot, while the same component already uses design-system tokens for its other two states (`bg-muted-foreground/40` for paused/no-triggers, `bg-destructive` for the delete action). The `aria-label` literally says `"Active"`, so the semantic mapping to `--success` is unambiguous — no shade/brand judgment call needed.
- Net change: `bg-emerald-500` → `bg-success` (1 line).

This aligns the shade to the design-system `success` token rather than claiming a pixel-identical visual match — the two colors are close but not guaranteed equal.

## Test plan
- [x] `bun run fmt` — clean, no diff produced
- No type change and no existing test covers this literal, so nothing to run beyond formatting; a reviewer can confirm by loading an org with an active automation (trigger_count > 0) and checking the status dot still renders as a green dot.

Follow CI for full lint/typecheck/test validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the "Active" status dot in the automation list to the design-system success token for visual consistency. Replaces the hardcoded emerald color; no functional changes.

- **Refactors**
  - `automation-list-row.tsx`: `bg-emerald-500` → `bg-success`.

<sup>Written for commit 888425e64b290316a9fa8991f768575f5383bf6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

