### PR TITLE
refactor(monitoring): use design-system success token for live-streaming dot

### DIFF
--- a/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
@@ -727,7 +727,7 @@ function MonitoringDashboardContent({
                     onClick={onStreamingToggle}
                   >
                     {isStreaming && (
-                      <span className="size-2 rounded-full bg-emerald-500 animate-pulse" />
+                      <span className="size-2 rounded-full bg-success animate-pulse" />
                     )}
                     <span>Live</span>
                     {isStreaming && (


### PR DESCRIPTION
## Source
Un-CI-enforced design-token drift (C-DEBT) in the highest-debt frontend files list — `apps/mesh/src/web/routes/orgs/monitoring/index.tsx` had one raw-Tailwind-palette hit.

## Why
The "Live" toggle button renders a pulsing dot with `bg-emerald-500` to indicate active streaming. The design system already uses `bg-success` for this exact "active/live pulsing indicator" meaning elsewhere in the same codebase — e.g. `no-ai-provider-empty-state.tsx` (`bg-success ring-2 ring-background animate-pulse`) and `monitor-dashboard.tsx` (status dot `bg-success`/`bg-warning`). The mapping is unambiguous: same meaning, same visual role, already-established token.

## Change
`bg-emerald-500` → `bg-success` on the live-streaming indicator dot. This aligns the shade to the design-system `success` token (not necessarily pixel-identical to emerald-500, but the correct semantic color for this state).

## Verify
1. `bun run fmt` — clean, no other changes.
2. Visually: go to Org → Monitoring → toggle "Live" streaming on, the pulsing dot next to the button label should render in the `success` token color.

No type changes, so no targeted `tsc` run was needed for this one-line class change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the pulsing “Live” indicator dot color in Monitoring with the design-system `bg-success` token. This removes the hardcoded `bg-emerald-500` and keeps status colors consistent across the app with no behavior changes.

<sup>Written for commit 53afcf0b8ae0dda9a2057d3d3c24131286161089. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

