### PR TITLE
refactor(registry): use design-system success token for discover-tools button

### DIFF
--- a/apps/mesh/src/web/views/registry/registry-item-dialog.tsx
+++ b/apps/mesh/src/web/views/registry/registry-item-dialog.tsx
@@ -80,7 +80,7 @@ const STEP_LABELS = ["Essentials", "Details", "Advanced"] as const;
 type WizardStep = 1 | 2 | 3;
 
 const AI_BUTTON_CLASS =
-  "h-7 text-xs border-green-500/30 text-green-600 dark:text-green-400 shadow-[0_0_8px_rgba(34,197,94,0.3)] hover:shadow-[0_0_14px_rgba(34,197,94,0.5)] hover:border-green-500/50 transition-all";
+  "h-7 text-xs border-success/30 text-success shadow-[0_0_8px_color-mix(in_oklch,var(--success)_30%,transparent)] hover:shadow-[0_0_14px_color-mix(in_oklch,var(--success)_50%,transparent)] hover:border-success/50 transition-all";
 
 function parseRemoteInput(value: string): string {
   return value.replace(/^https?:\/\//i, "").trim();


### PR DESCRIPTION
## Summary
- `registry-item-dialog.tsx`'s "Discover tools from URL" button used raw `green-500/600` Tailwind classes (border, text, and a hardcoded `rgba(34,197,94,...)` glow shadow) instead of the design-system `success` token.
- The exact same button class string exists in `tools-editor.tsx`, which PR #4769 (open) migrates to `border-success`/`text-success` with a `color-mix(in oklch, var(--success) ...)` shadow. This PR applies the identical, already-established mapping to this sibling file so both "discover tools" buttons stay consistent with the design system.

## Why
Keeps the two structurally-identical buttons (same component, same copy, same styling) in sync, and removes a hand-rolled `rgba()` shadow color that will silently drift from the `--success` token if the theme changes (light/dark or a future brand tweak).

## Verification
- `bun run fmt` — clean, no other files touched.
- `bun x tsc --noEmit` in `apps/mesh` — clean (pure class-string change, no type impact).
- Visual check: `border-success`/`text-success` resolve to the same `--success` CSS variable already used elsewhere in this codebase (e.g. `native-tiles.tsx`), and the shadow now tracks that variable via `color-mix` instead of a hardcoded RGB value — same visual intent (green accent + glow), now token-driven.

Full CI (lint, full test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the “Discover tools from URL” button in `registry-item-dialog.tsx` to the design-system `success` token, replacing hardcoded Tailwind green classes and rgba shadow. This matches the same button in `tools-editor.tsx` and keeps the color in sync with theme changes.

<sup>Written for commit e26bcace95e664d95d3632802f2b3f6d056ff337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

