### PR TITLE
refactor(library): extract shared fetchText helper in cards.tsx

### DIFF
--- a/apps/mesh/src/web/layouts/library/cards.tsx
+++ b/apps/mesh/src/web/layouts/library/cards.tsx
@@ -85,6 +85,13 @@ function extOf(filename: string): string {
   return filename.split(".").pop()?.toLowerCase() ?? "";
 }
 
+/** Shared fetch-as-text helper for the card thumbnail/preview queries below. */
+async function fetchText(url: string, init?: RequestInit): Promise<string> {
+  const res = await fetch(url, { credentials: "include", ...init });
+  if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+  return res.text();
+}
+
 /** Shared "Share" menu item — opens the share dialog for a file/folder. */
 function ShareMenuItem({ onShare }: { onShare: () => void }) {
   return (
@@ -389,11 +396,7 @@ export function SkillCard({
 }) {
   const { data } = useQuery({
     queryKey: KEYS.fileText(skillMdUrl),
-    queryFn: async () => {
-      const res = await fetch(skillMdUrl, { credentials: "include" });
-      if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
-      return res.text();
-    },
+    queryFn: () => fetchText(skillMdUrl),
     staleTime: 60_000,
     retry: false,
   });
@@ -475,11 +478,7 @@ export function BrandCard({
 }) {
   const { data } = useQuery({
     queryKey: KEYS.fileText(tokensUrl),
-    queryFn: async () => {
-      const res = await fetch(tokensUrl, { credentials: "include" });
-      if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
-      return res.text();
-    },
+    queryFn: () => fetchText(tokensUrl),
     staleTime: 60_000,
     retry: false,
   });
@@ -573,11 +572,7 @@ function LazyThumb({ children }: { children: ReactNode }) {
 function TextThumb({ url }: { url: string }) {
   const { data } = useQuery({
     queryKey: KEYS.fileText(url),
-    queryFn: async () => {
-      const res = await fetch(url, { credentials: "include" });
-      if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
-      return res.text();
-    },
+    queryFn: () => fetchText(url),
     staleTime: 60_000,
     retry: false,
   });
@@ -592,14 +587,7 @@ function TextThumb({ url }: { url: string }) {
 function CsvThumb({ url, ext }: { url: string; ext: string }) {
   const { data } = useQuery({
     queryKey: KEYS.csvThumb(url),
-    queryFn: async () => {
-      const res = await fetch(url, {
-        credentials: "include",
-        headers: { Range: "bytes=0-8191" },
-      });
-      if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
-      return res.text();
-    },
+    queryFn: () => fetchText(url, { headers: { Range: "bytes=0-8191" } }),
     staleTime: 60_000,
     retry: false,
   });


### PR DESCRIPTION
## Summary
- `layouts/library/cards.tsx` had 4 copies of the same `await fetch(...)` -> `if (!res.ok) throw new Error(...)` -> `res.text()` shape (SkillCard, BrandCard, TextThumb, CsvThumb query fns). Extracted a local `fetchText(url, init?)` helper and had all four call it.
- Net: -12 lines, same behavior — each call site passes the same URL and (for CsvThumb) the same `Range` header; `fetchText` always sends `credentials: "include"` as all four did before.

## Why
Straight duplication cleanup in a file with no other consumers — collapsing it makes any future change to the fetch/error shape a one-line edit instead of four.

## Verification
- `bun run fmt` — clean
- `cd apps/mesh && bun x tsc --noEmit` — clean
- No behavior change: same request URL/headers/credentials per call site, same error thrown on non-ok response, same `.text()` return. Reviewer can confirm with `git diff main -- apps/mesh/src/web/layouts/library/cards.tsx`.

Full CI suite (lint, tests) will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared `fetchText(url, init?)` helper in `apps/mesh/src/web/layouts/library/cards.tsx` and updated SkillCard, BrandCard, TextThumb, and CsvThumb to use it. Removes duplicated fetch/error/parse logic with no behavior change.

- **Refactors**
  - Consolidated four identical fetch blocks into `fetchText`; uses `credentials: "include"`, throws on non-ok, returns `.text()`.
  - `CsvThumb` passes `Range: bytes=0-8191`; others unchanged.
  - Net: -12 lines.

<sup>Written for commit f83f97af3777aed23f9228160736fb06c9f44c9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

