### PR TITLE
refactor(virtual-mcp): narrow error-code any-cast in dependency dialog fallback

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/dependency-selection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/dependency-selection-dialog.tsx
@@ -55,7 +55,7 @@ function createMethodNotFoundFallback(notSupportedMessage: string) {
     // Check for "Method not found" error (code -32601)
     const isMethodNotFound =
       error?.message?.includes("Method not found") ||
-      (error as any)?.code === -32601;
+      (error as { code?: number } | null)?.code === -32601;
 
     if (isMethodNotFound) {
       return (


### PR DESCRIPTION
## Summary
- `warn`-level `no-explicit-any` debt (not CI-enforced) in `createMethodNotFoundFallback`'s "Method not found" (JSON-RPC -32601) check: `(error as any)?.code` widened the whole cast to `any` instead of just narrowing the extra `code` field.
- Replaced with `(error as { code?: number } | null)?.code`, which types the actual shape being read (an optional numeric `code` on an otherwise `Error | null`) instead of suppressing the checker entirely.

## Why
A stray `as any` here silently swallows any future typo/rename of `code` — narrowing it means a mistake becomes a compile error instead of a silent `undefined !== -32601` runtime miss.

## Verification
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit -p .` — clean
- Behavior is unchanged: same runtime check, same fallback UI; confirmed no other `any` usage remains in the file (`grep -n "as any" dependency-selection-dialog.tsx` empty).

Reviewer check: `cd apps/mesh && bun x tsc --noEmit -p .` (full CI runs lint/tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed the JSON-RPC error code check in the dependency selection dialog by replacing `(error as any)?.code` with a typed `(error as { code?: number } | null)?.code`. Behavior is unchanged; this removes an `any` escape hatch and enforces compile-time safety for the `-32601` "Method not found" fallback.

<sup>Written for commit 0a298ebcff258c33ea996a6b3d8d827baad3702d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

