### PR TITLE
refactor(auth): use design-system success token for reset-email confirmation

### DIFF
--- a/apps/mesh/src/web/components/unified-auth-form.tsx
+++ b/apps/mesh/src/web/components/unified-auth-form.tsx
@@ -624,7 +624,7 @@ export function UnifiedAuthForm({
 
       {/* Success message for forgot password */}
       {resetEmailSent && (
-        <div className="rounded-xl bg-emerald-500/10 p-3 text-sm text-emerald-600 dark:text-emerald-400 text-center">
+        <div className="rounded-xl bg-success/10 p-3 text-sm text-success text-center">
           {copy.resetEmailSent}
         </div>
       )}


### PR DESCRIPTION
## Source
C-DEBT: design-token drift in `apps/mesh/src/web/components/unified-auth-form.tsx` (in the injected HIGHEST-DEBT FRONTEND FILES list).

## Why
This component already renders the parallel error state with the semantic `bg-destructive/10 text-destructive` classes right above (line 620). The success/confirmation block a few lines below used raw `emerald-500/10` / `emerald-600`/`emerald-400` instead of the matching semantic pair — an unambiguous mapping since it's the same component, same structural role (rounded box, `p-3 text-sm ... text-center`), just the success counterpart to the existing destructive one. The `success`/`bg-success` tokens are already used this way elsewhere in the codebase (e.g. `credits-eyebrow.tsx`, `native-tiles.tsx`, `propose-plan.tsx`).

Mapping: `bg-emerald-500/10 text-emerald-600 dark:text-emerald-400` → `bg-success/10 text-success` (the `success` token already has light/dark variants defined in `packages/ui/src/styles/global.css`, so no separate `dark:` override is needed).

This aligns the shade to the design-system `success` token — it is not necessarily pixel-identical to the old emerald value, just the correct semantic token for this state.

## Test plan
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — passes
- No existing test covers this component; change is a pure class-name swap with no logic touched.

Reviewer check: `git diff` — 1 line changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use design-system `success` token for the reset-email confirmation, replacing hard-coded emerald classes in `apps/mesh/src/web/components/unified-auth-form.tsx`.
Aligns success styling with the error state's semantic tokens for consistency and theme support.

<sup>Written for commit 4d2f827eddbe66fb4338b4f9cd24e872370fc2dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

