### PR TITLE
refactor(library): use design-system success token for copy-link checkmark

### DIFF
--- a/apps/mesh/src/web/layouts/library/file-share-button.tsx
+++ b/apps/mesh/src/web/layouts/library/file-share-button.tsx
@@ -148,7 +148,7 @@ function ShareControls({
         aria-label="Copy link"
       >
         {copied ? (
-          <Check size={12} className="text-green-600" />
+          <Check size={12} className="text-success" />
         ) : (
           <Copy01 size={12} />
         )}


### PR DESCRIPTION
## Source
C-DEBT (design-token drift) in `apps/mesh/src/web/layouts/library/file-share-button.tsx`, one of the injected HIGHEST-DEBT FRONTEND FILES.

## Why
`text-green-600` is a raw palette class hardcoding the "copied" checkmark color instead of the design system's semantic `text-success` token. The exact same copy→checkmark pattern already uses `text-success` elsewhere in this codebase (e.g. `apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx`, same `Check size={12}` shape), so the mapping here is unambiguous, not a judgment call.

## Change
`text-green-600` → `text-success` on the copy-confirmation checkmark icon in `ShareControls`. This aligns the shade to the design-system success token — it is not necessarily pixel-identical to the old green-600 value.

## Verification
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — passes
- Net diff: 1 file, +1/-1, single class name swap, no logic touched

Reviewer check: `grep -n "text-success" apps/mesh/src/web/views/virtual-mcp/virtual-mcp-share-modal.tsx` to see the precedent for this exact copy-checkmark pattern.

Full CI (lint, full typecheck, tests) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swapped `text-green-600` for the design token `text-success` on the copy-link checkmark in `apps/mesh/src/web/layouts/library/file-share-button.tsx`. Aligns the share button with the design system and keeps success color consistent with other views; no logic changes.

<sup>Written for commit e0b5460f8e311ceb38d558fa37fd8cb2caf4bffd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

