### PR TITLE
refactor(registry): extract shared summarizeToolResults helper for monitor QA views

### DIFF
--- a/apps/mesh/src/web/lib/registry/monitor-utils.ts
+++ b/apps/mesh/src/web/lib/registry/monitor-utils.ts
@@ -30,7 +30,7 @@ export function formatMonitorDuration(
   return `${Math.floor(ms / 60000)}m ${Math.round((ms % 60000) / 1000)}s`;
 }
 
-export function collapseLatestToolResults(
+function collapseLatestToolResults(
   toolResults: MonitorToolResult[],
 ): MonitorToolResult[] {
   const byToolName = new Map<string, MonitorToolResult>();

--- a/apps/mesh/src/web/lib/registry/monitor-utils.ts
+++ b/apps/mesh/src/web/lib/registry/monitor-utils.ts
@@ -42,3 +42,34 @@ export function collapseLatestToolResults(
   }
   return Array.from(byToolName.values());
 }
+
+export interface ToolResultSummary {
+  latestToolResults: MonitorToolResult[];
+  realToolTests: MonitorToolResult[];
+  isHealthCheck: boolean;
+  passedTools: number;
+  failedTools: number;
+  hasToolTests: boolean;
+}
+
+export function summarizeToolResults(
+  toolResults: MonitorToolResult[],
+): ToolResultSummary {
+  const latestToolResults = collapseLatestToolResults(toolResults);
+  const isHealthCheck = latestToolResults.every(
+    (t) => t.outputPreview === "health_check: not called",
+  );
+  const realToolTests = latestToolResults.filter(
+    (t) => t.outputPreview !== "health_check: not called",
+  );
+  const passedTools = realToolTests.filter((t) => t.success).length;
+  const failedTools = realToolTests.filter((t) => !t.success).length;
+  return {
+    latestToolResults,
+    realToolTests,
+    isHealthCheck,
+    passedTools,
+    failedTools,
+    hasToolTests: realToolTests.length > 0,
+  };
+}

--- a/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-dashboard.tsx
@@ -28,9 +28,9 @@ import type {
 } from "@/web/lib/registry/types";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
-  collapseLatestToolResults,
   formatMonitorDuration,
   monitorStatusBadgeClass,
+  summarizeToolResults,
 } from "@/web/lib/registry/monitor-utils";
 import { Play, StopSquare } from "@untitledui/icons";
 
@@ -59,16 +59,14 @@ function ResultLogEntry({
   icon?: string | null;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const latestToolResults = collapseLatestToolResults(r.tool_results);
-  const isHealthCheck = latestToolResults.every(
-    (t) => t.outputPreview === "health_check: not called",
-  );
-  const realToolTests = latestToolResults.filter(
-    (t) => t.outputPreview !== "health_check: not called",
-  );
-  const passedTools = realToolTests.filter((t) => t.success).length;
-  const failedTools = realToolTests.filter((t) => !t.success).length;
-  const hasToolTests = realToolTests.length > 0;
+  const {
+    latestToolResults,
+    realToolTests,
+    isHealthCheck,
+    passedTools,
+    failedTools,
+    hasToolTests,
+  } = summarizeToolResults(r.tool_results);
   const testedToolsCount = realToolTests.length;
   const inferredDiscoveredToolsCount = inferDiscoveredToolsCountFromSummary(
     r.agent_summary,

--- a/apps/mesh/src/web/views/registry/monitor-run-detail.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-run-detail.tsx
@@ -7,7 +7,7 @@ import {
   useMonitorResults,
   useMonitorRun,
 } from "@/web/hooks/registry/use-monitor";
-import { collapseLatestToolResults } from "@/web/lib/registry/monitor-utils";
+import { summarizeToolResults } from "@/web/lib/registry/monitor-utils";
 import type {
   MonitorResult,
   MonitorResultStatus,
@@ -122,16 +122,14 @@ function ToolResultRow({ tool }: { tool: MonitorToolResult }) {
 function ResultCard({ result }: { result: MonitorResult }) {
   const [expanded, setExpanded] = useState(result.status !== "passed");
 
-  const latestToolResults = collapseLatestToolResults(result.tool_results);
-  const isHealthCheck = latestToolResults.every(
-    (t) => t.outputPreview === "health_check: not called",
-  );
-  const realToolTests = latestToolResults.filter(
-    (t) => t.outputPreview !== "health_check: not called",
-  );
-  const passedTools = realToolTests.filter((t) => t.success).length;
-  const failedTools = realToolTests.filter((t) => !t.success).length;
-  const hasTestedTools = realToolTests.length > 0;
+  const {
+    latestToolResults,
+    realToolTests,
+    isHealthCheck,
+    passedTools,
+    failedTools,
+    hasToolTests: hasTestedTools,
+  } = summarizeToolResults(result.tool_results);
 
   return (
     <div className="rounded-lg border border-border overflow-hidden">


### PR DESCRIPTION
## Source
Net code reduction found while hunting recently-changed files (`monitor-dashboard.tsx`, `monitor-run-detail.tsx`, `monitor-run-history.tsx` all churned recently as part of the registry QA-monitor feature).

## Why
`ResultLogEntry` (monitor-dashboard.tsx) and `ResultCard` (monitor-run-detail.tsx) each hand-rolled the identical derivation from `collapseLatestToolResults`: `isHealthCheck`, `realToolTests`, `passedTools`, `failedTools`. Same 6 lines, copy-pasted verbatim in two files. Collapsed into one `summarizeToolResults()` export in `monitor-utils.ts`, the existing shared home for this module's derived-state helpers.

## Behavior
Pure move, no logic changed — same filter/every/length expressions, just called once instead of twice. Confirmed `collapseLatestToolResults` has no other remaining direct importers (now only used internally by the new helper).

Net diff: +49/-22 across 3 files (one new shared function, two call sites simplified).

## Verify
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` — clean
- No test exists yet for `monitor-utils.ts`; this is a behavior-preserving refactor (same expressions moved, not new logic), so the typecheck + zero-remaining-callers check is the verification. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared `summarizeToolResults` helper in `monitor-utils.ts` and updated the monitor dashboard and run detail views to use it. This removes duplicate logic, keeps behavior unchanged, and makes `collapseLatestToolResults` internal.

- **Refactors**
  - Added `summarizeToolResults(...)` returning `latestToolResults`, `realToolTests`, `isHealthCheck`, pass/fail counts, and `hasToolTests` via `ToolResultSummary`.
  - Replaced duplicated logic in `monitor-dashboard.tsx` and `monitor-run-detail.tsx`; `collapseLatestToolResults` is now internal to `monitor-utils`.

<sup>Written for commit 4011ce1cac78e4a9e0c50352f1f66ded27fdeb80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

