### PR TITLE
refactor(chat): use design-system success token for agent tool-call icons

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/agent-create.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/agent-create.tsx
@@ -122,7 +122,7 @@ export function AgentCreatePart({ part, latency }: AgentCreatePartProps) {
   return (
     <>
       <ToolCallShell
-        icon={<UserCircle className="text-emerald-500" />}
+        icon={<UserCircle className="text-success" />}
         title={`Agent created: ${agent.title}`}
         state="idle"
         trailing={<LatencyLabel latency={latency} />}

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/agent-list.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/agent-list.tsx
@@ -121,7 +121,7 @@ export function AgentListPart({ part, latency }: AgentListPartProps) {
   return (
     <>
       <ToolCallShell
-        icon={<UserCircle className="text-emerald-500" />}
+        icon={<UserCircle className="text-success" />}
         title={items.length === 1 ? "1 agent" : `${items.length} agents`}
         state="idle"
         trailing={<LatencyLabel latency={latency} />}


### PR DESCRIPTION
## Source
C-DEBT: design-token drift in `apps/mesh/src/web` — no CI-enforced check for raw Tailwind palette classes vs. design-system tokens.

## Why
`agent-create.tsx` and `agent-list.tsx` used raw `text-emerald-500` for the completed-tool-call icon, while sibling files in the same `tool-call-part/` directory (`connection-list.tsx`, `propose-plan.tsx`) already use the `text-success` token for the identical idle/success-state icon. This is an unambiguous mapping: same component family, same semantic meaning (successful tool completion), token already established as the local convention.

Aligns the shade to the design-system `success` token — not necessarily pixel-identical to the old emerald-500 value, but the correct semantic color for this state.

## Changes
- `agent-create.tsx`: `text-emerald-500` → `text-success` on the created-agent icon
- `agent-list.tsx`: `text-emerald-500` → `text-success` on the agent-list icon

Net: 2 lines changed, no behavior change (pure class-name swap).

## Verification
- `bun run fmt` — clean
- `bunx tsc --noEmit` in `apps/mesh` — clean
- No test changes needed (pure CSS class swap, no logic touched)

A reviewer can confirm by opening a chat where an agent is created or an agent-list tool result renders, and checking the icon renders in the `success` token color instead of raw emerald.

Full CI (lint, unit tests) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the design-system `text-success` token for agent tool-call icons in chat, replacing `text-emerald-500` in `agent-create.tsx` and `agent-list.tsx`. Aligns with sibling components and design tokens; no behavior change (only a possible slight color shift).

<sup>Written for commit aec6371c33ef1fa473f88b4992221b89778f5e42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

