### PR TITLE
refactor(chat): give prompt-argument zod schema a real type

### DIFF
--- a/apps/mesh/src/web/components/chat/dialog-prompt-arguments.tsx
+++ b/apps/mesh/src/web/components/chat/dialog-prompt-arguments.tsx
@@ -23,7 +23,7 @@ import { Spinner } from "@deco/ui/components/spinner.tsx";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Prompt } from "@modelcontextprotocol/sdk/types.js";
 import { useId } from "react";
-import { useForm, type Resolver } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 export type PromptArgumentValues = Record<string, string>;
@@ -36,10 +36,10 @@ interface PromptArgsDialogProps {
   defaultValues?: PromptArgumentValues;
 }
 
-function buildArgumentSchema(prompt: Prompt) {
-  const shape: Record<string, z.ZodTypeAny> = {};
+function buildArgumentSchema(prompt: Prompt | null) {
+  const shape: Record<string, z.ZodString> = {};
 
-  for (const arg of prompt.arguments ?? []) {
+  for (const arg of prompt?.arguments ?? []) {
     shape[arg.name] = arg.required ? z.string().min(1, "Required") : z.string();
   }
 
@@ -64,10 +64,9 @@ export function PromptArgsDialog({
   defaultValues,
 }: PromptArgsDialogProps) {
   const id = useId();
-  const schema = prompt ? buildArgumentSchema(prompt) : z.object({});
-  const resolver = zodResolver(schema as any);
+  const schema = buildArgumentSchema(prompt);
   const form = useForm<PromptArgumentValues>({
-    resolver: resolver as unknown as Resolver<PromptArgumentValues>,
+    resolver: zodResolver(schema),
     defaultValues: prompt ? buildDefaultValues(prompt, defaultValues) : {},
     mode: "onChange",
   });


### PR DESCRIPTION
## Summary
`buildArgumentSchema` in `dialog-prompt-arguments.tsx` typed its shape as `Record<string, z.ZodTypeAny>`, which erases the inferred value type to `any`. That forced two casts to bridge `zodResolver` to `useForm<PromptArgumentValues>`: `zodResolver(schema as any)` then `resolver as unknown as Resolver<PromptArgumentValues>`.

Since every field in the shape is built from `z.string()` (optionally `.min(1, ...)`), which is a `z.ZodString`, typing the shape as `Record<string, z.ZodString>` makes `z.infer<typeof schema>` resolve to `Record<string, string>` — exactly `PromptArgumentValues`. `zodResolver(schema)` now matches `useForm`'s generic directly, so both casts are removed.

## Why
This is un-CI-enforced `any`/`as`-cast debt (`no-explicit-any` is a `warn`-only lint rule) in a real form component. The fix is a legitimate compile-time-safety win: a future shape change that breaks the `Record<string, string>` assumption is now a type error instead of silently passing through `any`.

## Verified
- Behavior-preserving: `buildArgumentSchema` produces the exact same runtime schema; only compile-time types changed. `z.object({})` fallback for `prompt === null` is now handled inside `buildArgumentSchema` itself (accepts `Prompt | null`) rather than at the call site — same resulting empty-shape schema.
- `cd apps/mesh && bun x tsc --noEmit` — passes clean, no errors.
- `bun run fmt` — no changes needed.

## To confirm
```
cd apps/mesh && bun x tsc --noEmit
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed the prompt-argument `zod` schema as `Record<string, z.ZodString>` to remove `any` casts and make `zodResolver(schema)` match `useForm<PromptArgumentValues>` directly. Behavior is unchanged; type safety is better.

- **Refactors**
  - Updated `buildArgumentSchema` to accept `Prompt | null`, build from `Record<string, z.ZodString>`, and handle the empty schema internally.
  - Removed `Resolver` import and both casts; use `zodResolver(schema)` directly from `@hookform/resolvers/zod` with `react-hook-form`.
  - Preserved runtime behavior; compile-time types now enforce the `Record<string, string>` assumption.

<sup>Written for commit 117b082b551801eee7f3dd6e8077acb1f17dbdf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

