### PR TITLE
refactor(sidebar): use design-system warning token for low-credit chip

### DIFF
--- a/apps/mesh/src/web/components/sidebar/top-actions.tsx
+++ b/apps/mesh/src/web/components/sidebar/top-actions.tsx
@@ -32,7 +32,7 @@ class SilentErrorBoundary extends Component<
 
 function creditColor(balanceDollars: number): string {
   if (balanceDollars <= 1) return "text-destructive";
-  if (balanceDollars <= 5) return "text-amber-500 dark:text-amber-400";
+  if (balanceDollars <= 5) return "text-warning";
   return "text-foreground/70";
 }
 


### PR DESCRIPTION
## Summary
- The sidebar credit chip (`SidebarTopActions` in `top-actions.tsx`) hardcoded `text-amber-500 dark:text-amber-400` for the "low balance" state instead of the design-system `warning` token.
- `apps/mesh/src/web/views/settings/ai-providers/deco-credits-hero.tsx` already has the identical `creditColorClass`/low-credit-balance pattern (`if (dollars <= 1) return "text-warning"`, alongside `text-destructive` for critical), so the mapping here is unambiguous — same semantic (low credit balance warning), same component family.

## Why
Un-CI-enforced design-token drift: this file wasn't using the shared token even though the sibling credits component already established the convention, so a future palette/theme change would miss this spot.

## Change
`text-amber-500 dark:text-amber-400` → `text-warning` in `creditColor()` (apps/mesh/src/web/components/sidebar/top-actions.tsx). This aligns the shade to the design-system `warning` token (not necessarily a pixel-identical amber, but the correct semantic token per the existing convention).

## Test plan
- `bun run fmt` — clean
- `cd apps/mesh && bun x tsc --noEmit` — clean
- Visual: the sidebar credit chip color for balances between $1–$5 will render via the `warning` token instead of raw amber; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the sidebar credit chip low-balance color from hardcoded amber classes to the design-system warning token. This aligns the chip with the existing credits UI and keeps colors consistent across themes and future palette changes.

<sup>Written for commit db964c0ecd87e707102ea5c138618a804e1b719c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

