### PR TITLE
refactor(thread): use design-system success token for publish status dot

### DIFF
--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -497,7 +497,7 @@ function PublishDialogBody({
               {openPrFromCommits ? "Submit for review" : publishLabel}
             </p>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-green-500" />
+              <span className="inline-block h-2.5 w-2.5 shrink-0 rounded-full bg-success" />
               {diffCount} {diffCount === 1 ? "change" : "changes"}{" "}
               {openPrFromCommits ? "in this PR" : "to publish"}
             </div>


### PR DESCRIPTION
## Source
C-DEBT: raw-Tailwind palette drift in a high-debt frontend file (`apps/mesh/src/web/components/thread/github/publish-dialog.tsx`).

## Why
This exact "status dot" pattern (`h-2.5 w-2.5 shrink-0 rounded-full`) already exists in the sibling file `git-diff-list.tsx` (same `thread/github` feature directory), where it uses the semantic `bg-success`/`bg-destructive`/`bg-warning` tokens to color new/deleted/modified diff rows. `publish-dialog.tsx`'s dot represents the same "changes ready to publish" positive status but was still using the raw `bg-green-500` class. This aligns the shade to the design-system `success` token (not necessarily pixel-identical to the old green-500) and removes one more raw-palette holdout.

## Net change
-1 / +1 (single class swap, no behavior change — the dot is purely decorative, no logic touched).

## How to verify
Open a thread with local Git changes and view the Publish dialog; the dot next to the change count should render in the app's success color.

## Checks run locally
- `bun run fmt`
- `cd apps/mesh && bunx tsc --noEmit` (clean)
Full CI (lint, tests) will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the publish dialog status dot from Tailwind `bg-green-500` to the design-system `bg-success` to match `git-diff-list.tsx` and keep success colors consistent. Visual-only token swap; no logic changes.

<sup>Written for commit a8eb2c455d4e32e4de4564cb4c6c435a56e45c0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

