### PR TITLE
refactor(chat): use design-system warning token for unsupported-file icon

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
@@ -252,7 +252,7 @@ export function UnsupportedFileDialog({
             }}
           />
           <DialogHeader className="relative gap-4">
-            <div className="flex items-center justify-center size-9 rounded-lg bg-amber-500/15 text-amber-600 dark:text-amber-400">
+            <div className="flex items-center justify-center size-9 rounded-lg bg-warning/15 text-warning">
               <AlertTriangle size={18} />
             </div>
             <div>


### PR DESCRIPTION
## Summary
- C-DEBT (design-token drift): the unsupported-file dialog's AlertTriangle badge used raw `bg-amber-500/15 text-amber-600 dark:text-amber-400` instead of the repo's `warning` semantic token.
- The icon is explicitly a warning affordance (comment: "subtle amber warning gradient", `AlertTriangle` icon), and the same semantic (warning icon in a tinted rounded badge) already exists via `bg-warning/10 border border-warning/20` + `text-warning` in `credits-empty-state.tsx` and `credits-eyebrow.tsx` — so the mapping is unambiguous, not a shade judgment call.
- `--warning` resolves to `oklch(0.62 0.17 70)` (amber/orange hue), so this aligns the shade to the design-system `warning` token rather than being pixel-identical to the old amber-600/amber-400 values, and it also collapses the separate light/dark-mode classes into the token's built-in light/dark handling.

## Test plan
- [x] `bun run fmt`
- [x] `bunx tsc --noEmit` in `apps/mesh` (clean)
- Reviewer: `git diff main -- apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded amber classes with the design-system `warning` token for the unsupported-file dialog icon. This removes token drift, unifies warning styling, and handles light/dark mode via tokens.

- **Refactors**
  - In `apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx`, changed `bg-amber-500/15 text-amber-600 dark:text-amber-400` to `bg-warning/15 text-warning`.
  - Matches existing warning badge usage in other components; no behavior changes.

<sup>Written for commit 131801fe220d5cef89940bfe35bd78d64d949231. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

