### PR TITLE
fix(automations): order trigger message before the reply in automation chats

### DIFF
--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -47,6 +47,8 @@ import {
   tryResolveTier,
 } from "@/core/resolve-tier";
 import { isPermanentRunError } from "@/core/dispatch-errors";
+import { PartEmitter } from "@/api/routes/decopilot/part-emitter";
+import type { AnyMessage } from "@/api/routes/decopilot/part-row-builder";
 import type { AutomationsStorage } from "@/storage/automations";
 import type { Automation } from "@/storage/types";
 import type { SimpleModeTier } from "@/tools/organization/schema";
@@ -373,6 +375,31 @@ async function buildDispatchRequestStep(
         { id: crypto.randomUUID(), role: "user", parts: extraParts },
       ] as typeof request.messages;
     }
+  }
+
+  // Persist the trigger/user turn BEFORE dispatch so it lands with an early
+  // created_at. The projector anchors the assistant reply at
+  // max(existing created_at)+1; without a pre-persisted user turn it can run
+  // before the hosted child's own user-message emit, read no user parts, and
+  // stamp the reply at Date.now() — inverting their order in the UI (reply
+  // first, then the trigger message trailed by "No response was generated").
+  // Idempotent: the child's emit reuses this message id and ON CONFLICT keeps
+  // these rows. Mirrors the task-board path (enqueue-super-agent.ts).
+  const userTurn = request.messages.find((m) => m.role !== "system");
+  if (userTurn) {
+    await new PartEmitter({
+      storage: studioCtx.storage.threads.messageParts(),
+      orgId: automation.organization_id,
+      threadId: taskId,
+      runId: taskId,
+    })
+      .emitRequestMessage(userTurn as AnyMessage)
+      .catch((err) =>
+        console.error(
+          "[fireAutomationWorkflow] request-message pre-persist failed",
+          err,
+        ),
+      );
   }
 
   // Strip the (non-serializable, locally-built) abort signal — the

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,6 +1,6 @@
 {
   "auth/install-studio-pack-workflow.ts": "1cf06645663602989054ec171a7b06fe4c16d5c40e4348bcc86c725e3769c5a0",
-  "automations/dbos-workflow.ts": "18471f9fda4e16afda73f11a894f48eb8e7f2eb4539eed195c5563a63082a82c",
+  "automations/dbos-workflow.ts": "48975df08d346ef9d542438430dd22ff327f00f146361926597e0f717ca80fe1",
   "dispatch-queue/hosted-harness-workflow.ts": "1ee53df2391d0b73f10630be7f7d947db16653d5b8740b799e64a98cb2f49c86",
   "dispatch-queue/thread-gate-workflow.ts": "674cd393ad3b06806e967389dfe7e87bd0de6ba933fd54df1e5cd24a08b99e43",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",


### PR DESCRIPTION
## Problem

Event- and webhook-triggered **automation** chat threads render their messages out of order: the assistant reply appears **first**, followed by the `Triggered by event …` user message, trailed by a `No response was generated` placeholder.

![bug](https://user-images.githubusercontent.com/placeholder)

## Root cause

Message order is driven by `created_at = base + seq` (see `part-emitter.ts`). The projector anchors the assistant reply at `base = max(existing created_at for the run) + 1`.

The automation dispatch path uses the legacy `messages` request variant and **never pre-persists the user turn** — it relies on the hosted child's own `emitUserMessage` during `prepareRun`. That emit races the projector: when the projector's consume step reads the run's max `created_at` before the user parts land, it finds none and stamps the reply at `Date.now()`. The user turn then persists with a *later* `created_at`, inverting the two. `useMessagePairs` renders the lone assistant, then the trigger message with no assistant → `No response was generated`.

The task-board Super Agent path already fixed the identical race by persisting the request message before dispatch (`enqueue-super-agent.ts`); the automation/webhook path was left unguarded.

## Fix

Pre-persist the trigger/user turn via `emitRequestMessage` inside `buildDispatchRequestStep`, before the run is dispatched. This lands the user parts with an early `created_at`, so the projector's `max(...) + 1` anchors the reply strictly after them.

Idempotent: the hosted child's later emit reuses the same message id and `ON CONFLICT` keeps these rows. Automation threads are single-turn (fresh thread per fire), so run-wide-max anchoring is sufficient — no `requestMessageId` threading needed.

The persist runs inside the existing `buildDispatchRequest` DBOS step (side effect only; recorded step I/O unchanged), so **no `DBOS_WORKFLOW_VERSION` bump** is required.

Covers both automation event triggers and webhook triggers (both flow through `fireAutomationWorkflow`).

## Testing

- `bun run check` (all workspaces) ✅
- `bun run lint` — 0 errors ✅
- Related unit suites (`part-emitter`, `part-row-builder`, `fold-parts`, `consume-run-projection`) ✅

No automation-fire e2e added: firing a real automation depends on a model provider tier absent in the test org (a documented e2e footgun), and the sibling task-board fix shipped structurally covered for the same reason.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes message ordering in automation chats by pre-persisting the trigger/user message before dispatch so the assistant reply comes after it. Removes the “reply first” bug and the “No response was generated” placeholder.

- Bug Fixes
  - Pre-persist trigger/user turn via `emitRequestMessage` before dispatch; earlier `created_at` ensures the reply sorts after it.
  - Idempotent: hosted child reuses the message id; `ON CONFLICT` avoids duplicates; mirrors the task-board path.
  - Applies to event- and webhook-triggered automations; re-baselined `workflow-source-guard.snapshot.json`; recovery-compatible and no `DBOS_WORKFLOW_VERSION` bump.

<sup>Written for commit 8c100c97cc15a34aa331de8c5d890acb61c8b0db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

