### PR TITLE
refactor(web): stop importing server-only core constant into the web bundle

### DIFF
--- a/apps/mesh/src/web/utils/constants.ts
+++ b/apps/mesh/src/web/utils/constants.ts
@@ -1,2 +1,3 @@
-// Re-export from core for backwards compatibility
-export { MCP_MESH_KEY as MCP_MESH_DECOCMS_KEY } from "@/core/constants";
+// Mirrors MCP_MESH_KEY from @/core/constants — duplicated (not imported) since
+// @/core is server-only and the web bundle must not pull in server code.
+export const MCP_MESH_DECOCMS_KEY = "mcp.mesh";


### PR DESCRIPTION
## Summary
- `apps/mesh/src/web/utils/constants.ts` re-exported `MCP_MESH_KEY` from the server-only `@/core/constants` module, a value import across the web/server boundary that `oxlint`'s `ban-web-server-imports` rule flags (warn-level, not CI-blocking, so it had accumulated silently).
- Replaced the re-export with a locally-declared constant carrying the same string value (`"mcp.mesh"`), so the web bundle no longer depends on server-only code for this constant.

Why a maintainer wants this: the web/server boundary exists specifically to keep server deps/secrets out of the browser bundle (see repo CLAUDE.md); this was one of 31 pre-existing warn-level violations of that rule found by `bun run lint`, none enforced by CI.

## Verification
- `bun run lint` — the `ban-web-server-imports` warning for this file is gone (confirmed no other files changed).
- `cd apps/mesh && bun x tsc --noEmit` — passes with no errors.
- `bun run fmt` — no changes needed.
- Behavior is unchanged: same string value (`"mcp.mesh"`), same single consumer (`apps/mesh/src/web/utils/extract-connection-data.ts`).

A reviewer can confirm with:
```
bun run lint 2>&1 | grep "web/utils/constants.ts"
```
(should return nothing)

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the re-export of `MCP_MESH_KEY` from `@/core/constants` with a local `MCP_MESH_DECOCMS_KEY = "mcp.mesh"` in `apps/mesh/src/web/utils/constants.ts`. This keeps server-only code out of the web bundle and clears the `oxlint` `ban-web-server-imports` warning with no behavior change.

<sup>Written for commit 46e630de40b0ef5a525c03b3c0c95aa1f803074c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

