### PR TITLE
refactor(chat): use design-system success token for subtask done icon

### DIFF
--- a/apps/mesh/src/web/components/chat/context-panel.tsx
+++ b/apps/mesh/src/web/components/chat/context-panel.tsx
@@ -223,7 +223,7 @@ function SubtaskRow({ part }: { part: SubtaskToolPart }) {
         ) : isApproval ? (
           <AlertCircle size={12} className="text-warning" />
         ) : (
-          <CheckCircle size={12} className="text-emerald-500" />
+          <CheckCircle size={12} className="text-success" />
         )}
       </span>
     </div>


### PR DESCRIPTION
## Source
Design-system-token debt hunt (C-DEBT) in `apps/mesh/src/web/components/chat/context-panel.tsx` (highest-debt frontend file list).

## Why
`SubtaskRow`'s status icon switch already uses semantic tokens for its other two states — `text-destructive` for the error branch and `text-warning` for the approval branch — but the success/"done" `CheckCircle` branch was still on the raw `text-emerald-500` palette class. `text-success` is the established token for exactly this case elsewhere in the codebase (e.g. `home/native-tiles.tsx`'s `CheckCircle className="size-6 text-success/60"`), so this closes the one inconsistent branch in the same component.

## Change
`text-emerald-500` → `text-success` on the `CheckCircle` icon (apps/mesh/src/web/components/chat/context-panel.tsx:226). This aligns the shade to the design-system `success` token (`oklch(0.6 0.17 149)` light / `oklch(0.45 0.15 149)` dark) — not necessarily pixel-identical to emerald-500, but the same semantic green already used for "done" states elsewhere.

## How to verify
`grep -n "text-success\|text-emerald" apps/mesh/src/web/components/chat/context-panel.tsx` shows only the token now.

## Checks run locally
- `bun run fmt`
- `bun x tsc --noEmit` in `apps/mesh` (clean)
Full CI validates lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the “done” CheckCircle icon in SubtaskRow from text-emerald-500 to text-success to use the design-system token. This makes status colors consistent with other states and across themes.

<sup>Written for commit 6363905c05ef9f089dc1f1aed2685332d4ba0bec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

