### PR TITLE
fix(automations): derive trigger-message ids from taskId instead of random

### DIFF
--- a/apps/mesh/src/automations/build-stream-request.test.ts
+++ b/apps/mesh/src/automations/build-stream-request.test.ts
@@ -43,7 +43,7 @@ function makeResolvedModel(
 }
 
 describe("buildStreamRequest", () => {
-  it("generates fresh message ids (not the stored ones)", () => {
+  it("generates fresh message ids derived from taskId (not the stored ones)", () => {
     const result = buildStreamRequest(
       makeAutomation(),
       "trig_1",
@@ -55,9 +55,27 @@ describe("buildStreamRequest", () => {
     expect(msg.role).toBe("user");
     expect(msg.parts).toEqual([{ type: "text", text: "hello" }]);
     expect(msg.id).not.toBe("m1");
-    expect(msg.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    expect(msg.id).toBe("thrd_1:0");
+  });
+
+  it("generates the SAME message ids across repeated calls for the same taskId", () => {
+    // buildDispatchRequestStep (the DBOS step wrapping this call) pre-persists
+    // this message via PartEmitter before the step's own output is recorded.
+    // A crash mid-step forces a full re-invocation with the same taskId — the
+    // id must stay stable or the replay orphans a duplicate message row.
+    const first = buildStreamRequest(
+      makeAutomation(),
+      "trig_1",
+      "thrd_1",
+      makeResolvedModel(),
     );
+    const second = buildStreamRequest(
+      makeAutomation(),
+      "trig_1",
+      "thrd_1",
+      makeResolvedModel(),
+    );
+    expect(second.messages[0]!.id).toBe(first.messages[0]!.id);
   });
 
   it("places the resolved model in the request body", () => {

--- a/apps/mesh/src/automations/build-stream-request.ts
+++ b/apps/mesh/src/automations/build-stream-request.ts
@@ -62,14 +62,19 @@ export function buildStreamRequest(
   runMetadata?: Record<string, string>,
 ): DispatchRunInput {
   const rawMessages = JSON.parse(automation.messages);
-  // Generate fresh ids for each run so concurrent automation runs don't
-  // collide on the same message id (a shared id would let the message be
-  // attributed to the first thread only, making it invisible in subsequent
-  // threads).
-  const messages = rawMessages.map((m: { id?: string; role: string }) => ({
-    ...m,
-    id: crypto.randomUUID(),
-  }));
+  // Derive ids from taskId rather than crypto.randomUUID(): fresh ids per run
+  // still avoid concurrent-run collisions (a shared id would attribute the
+  // message to the first thread only), but they must also be STABLE if this
+  // function re-runs — buildDispatchRequestStep is a DBOS step that pre-persists
+  // this message via PartEmitter before its own output is durably recorded, so
+  // a crash mid-step forces a full re-invocation. A random id there would emit
+  // a second, orphaned message row instead of the intended idempotent replace.
+  const messages = rawMessages.map(
+    (m: { id?: string; role: string }, i: number) => ({
+      ...m,
+      id: `${taskId}:${i}`,
+    }),
+  );
 
   const request: DispatchRunInput = {
     messages,


### PR DESCRIPTION
Follows #4787, which added a pre-persist of the automation trigger/user message via `PartEmitter` inside `buildDispatchRequestStep` — a DBOS step — so the message lands with an early `created_at` and orders before the assistant reply.

**The gap:** `buildDispatchRequestStep`'s output (the request, including the message id) is only durable once DBOS records the step as complete. `buildStreamRequest` mints the message id with `crypto.randomUUID()` on every call, so if the process crashes after the `PartEmitter` write but before the step is recorded, DBOS re-invokes the step from scratch on workflow recovery — generating a *new* random id and persisting a second, orphaned trigger-message row instead of idempotently replacing the first one (the `#4787` comment's "the child's emit reuses this message id" assumption doesn't hold across a step replay). Net effect: a stray duplicate user-turn bubble can appear in an automation-triggered thread after a crash/resume.

**Fix:** derive the message id from `taskId` (`${taskId}:${i}`) instead of `crypto.randomUUID()`. `taskId` is itself already durable from an earlier, already-recorded step, so it's stable across any step replay, while staying unique per automation run (satisfying the original "no cross-run id collision" comment).

**Regression test:** `build-stream-request.test.ts` — inverted the old test asserting a fresh UUID per call (that behavior was the bug) into one asserting the derived, taskId-scoped id, plus a new test asserting two calls with the same `taskId` produce the *same* message id.

Reviewer: `bun test apps/mesh/src/automations/build-stream-request.test.ts`

Ran locally: `bun run fmt`, `tsc --noEmit` (apps/mesh), and the targeted test file above (19/19 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make trigger/user message IDs deterministic by deriving them from `taskId` instead of random UUIDs. This keeps IDs stable across DBOS step replays and prevents duplicate/orphaned user messages after crash/retry.

**Bug Fixes**
- In `buildStreamRequest`, message IDs are now `${taskId}:${i}` to stay stable across re-invocations while remaining unique per run.
- Tests updated to assert derived IDs and that repeated calls with the same `taskId` return the same ID.

<sup>Written for commit f9e2001f98134bc66e08d1c1b9a9509cf17ac5a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

