### PR TITLE
refactor(sandbox): dedupe blog mutation fetch+error-check into one helper

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
@@ -30,33 +30,41 @@ function writeUrl(
   return `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/${op}`;
 }
 
+async function postToSandbox(
+  params: BlogMutationParams,
+  op: "write" | "unlink",
+  body: unknown,
+  fallbackError: string,
+) {
+  const res = await fetch(writeUrl(params, op), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({}));
+    throw new Error(
+      (errBody as { error?: string }).error ??
+        `${fallbackError} (${res.status})`,
+    );
+  }
+  return res.json();
+}
+
 export function useSaveBlogBlock(params: BlogMutationParams) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({
-      blockKey,
-      data,
-    }: {
-      blockKey: string;
-      data: unknown;
-    }) => {
-      const res = await fetch(writeUrl(params, "write"), {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
+    mutationFn: ({ blockKey, data }: { blockKey: string; data: unknown }) =>
+      postToSandbox(
+        params,
+        "write",
+        {
           path: blogBlockFilePath(blockKey),
           content: JSON.stringify(data, null, 2),
-        }),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `Write failed (${res.status})`,
-        );
-      }
-      return res.json();
-    },
+        },
+        "Write failed",
+      ),
     onMutate: async ({ blockKey, data }) => {
       const queryKey = decofileQueryKey(params);
       await queryClient.cancelQueries({ queryKey });
@@ -83,20 +91,13 @@ export function useDeleteBlogBlock(params: BlogMutationParams) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ blockKey }: { blockKey: string }) => {
-      const res = await fetch(writeUrl(params, "unlink"), {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ path: blogBlockFilePath(blockKey) }),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `Delete failed (${res.status})`,
-        );
-      }
-      return res.json() as Promise<{ ok: true; existed: boolean }>;
-    },
+    mutationFn: ({ blockKey }: { blockKey: string }) =>
+      postToSandbox(
+        params,
+        "unlink",
+        { path: blogBlockFilePath(blockKey) },
+        "Delete failed",
+      ) as Promise<{ ok: true; existed: boolean }>,
     onMutate: async ({ blockKey }) => {
       const queryKey = decofileQueryKey(params);
       await queryClient.cancelQueries({ queryKey });


### PR DESCRIPTION
## Source
C1 reduction found while scanning `apps/mesh/src/web` for the repeated hand-rolled `fetch` + `if (!res.ok) throw` shape the repo has already consolidated elsewhere.

## Why
`useSaveBlogBlock` and `useDeleteBlogBlock` in `use-blog-mutations.ts` each duplicated the exact same fetch/check-`res.ok`/parse-error-body/throw block, differing only in the URL op, request body, and fallback error string. Extracting `postToSandbox` removes the duplication and gives future ops (e.g. a rename) a single place to change.

## Change
Net: -35 / +36 lines in one file — mostly reformatting call sites to pass args into the new helper rather than repeating the fetch block. Behavior is unchanged: same URL, method, headers, error-parsing fallback, and return value for both mutations.

## Verify
- `cd apps/mesh && bun x tsc --noEmit` — clean.
- `bun run fmt` — clean.
- No test file exists for this hook; this is a pure logic relocation (verified by reading the diff — same fetch call, same error shape, same JSON return per call site).

## Local checks run
`bun run fmt`, `bunx tsc --noEmit` in `apps/mesh`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates blog mutation fetch and error handling by extracting a shared `postToSandbox` helper, used by `useSaveBlogBlock` and `useDeleteBlogBlock`. Behavior stays the same while centralizing future changes.

- **Refactors**
  - Added `postToSandbox` to handle fetch, `res.ok` checks, error parsing, and JSON return.
  - Updated `useSaveBlogBlock` and `useDeleteBlogBlock` to call the helper; same URLs, method, headers, error fallback, and return shape.

<sup>Written for commit 31f7a358314e6149c84a2d4e2a563b739b2189ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

