### PR TITLE
refactor(sandbox): use design-system success token for installed app badge

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -2288,7 +2288,7 @@ function ItemList({
                     active={isActive}
                     trailing={
                       entry.installed ? (
-                        <span className="shrink-0 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400">
+                        <span className="shrink-0 rounded-full bg-success/15 px-1.5 py-0.5 text-[10px] font-medium text-success">
                           Installed
                         </span>
                       ) : undefined


### PR DESCRIPTION
Follows #4789 — that PR replaced a raw `text-emerald-500` with the `text-success` design-system token for a chat subtask icon. It missed a sibling instance in the sandbox content browser's "Installed" app badge, which still used raw `bg-emerald-500/15` / `text-emerald-700 dark:text-emerald-400`.

This swaps it for the same `bg-success/*` / `text-success` token pair already used for equivalent badges elsewhere (e.g. `monitor-configuration.tsx`'s "Saved" badge), so it stays consistent across themes without needing a manual `dark:` variant (the `--success` CSS var already adapts).

Net change: -1/+1, pure class-name swap, no behavior change.

To confirm: view the app catalog list in the sandbox content browser and check installed apps' badge renders identically (green) in light and dark mode.

Checks run locally: `bun run fmt`, `bunx tsc --noEmit` in `apps/mesh` (both clean). Full CI covers lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swapped hardcoded emerald classes for design-system `bg-success/15` and `text-success` tokens on the "Installed" badge in the sandbox content browser. Keeps styling consistent across themes and aligned with other badges; no behavior change.

<sup>Written for commit bd07bf1f037529a97c65d2c5a34ec310f7b2e1f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

