### PR TITLE
refactor(web): drop unneeded any cast reading virtual MCP layout metadata

### DIFF
--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -383,7 +383,7 @@ function AgentInsetProvider() {
   // Fetch entity (Suspense-based — resolved before render)
   const entity = useVirtualMCP(virtualMcpId);
 
-  const layoutMetadata = (entity?.metadata as any)?.ui?.layout ?? null;
+  const layoutMetadata = entity?.metadata?.ui?.layout ?? null;
   const entityMetadata = layoutMetadata
     ? {
         defaultMainView: layoutMetadata.defaultMainView ?? null,


### PR DESCRIPTION
## Source
C-DEBT hunt: `agent-shell-layout/index.tsx` was flagged as the highest `no-explicit-any`-hit file in the frontend (1 hit, no CI enforcement on this `warn`-level rule).

## Why
`entity` is typed as `VirtualMCPEntity | null` (from `useVirtualMCP`), and `VirtualMCPEntitySchema.metadata.ui.layout` is already a properly-typed, nullable `VirtualMcpUILayoutSchema` (see `packages/mesh-sdk/src/types/virtual-mcp.ts`). The `as any` cast was unnecessary — optional chaining alone gives the same runtime behavior with full type safety, so a future rename/shape change of `metadata.ui.layout` becomes a compile error here instead of a silent runtime bug.

## Change
`(entity?.metadata as any)?.ui?.layout ?? null` → `entity?.metadata?.ui?.layout ?? null`. Purely a type-level change; behavior is identical (same optional-chaining semantics, same fallback to `null`).

## To verify
`cd apps/mesh && bunx tsc --noEmit` — passes clean with the cast removed.

## Local checks run
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (clean)

Full CI validates lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an unnecessary any cast when reading Virtual MCP layout metadata in the agent shell layout. Switched to typed optional chaining for better type safety with no behavior change.

<sup>Written for commit 7a9a0b577b6cee98bae93f5af9973c75c097196e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

