### PR TITLE
fix(automations): stabilize the context-event fallback message id

### DIFF
--- a/apps/mesh/src/automations/build-stream-request.test.ts
+++ b/apps/mesh/src/automations/build-stream-request.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { Automation } from "@/storage/types";
 import {
   buildStreamRequest,
+  contextMessageId,
   type ResolvedAutomationModel,
 } from "./build-stream-request";
 
@@ -249,5 +250,21 @@ describe("buildStreamRequest", () => {
       makeResolvedModel(),
     );
     expect(result.maxAgentSteps).toBe(50);
+  });
+});
+
+describe("contextMessageId", () => {
+  it("is stable across repeated calls for the same taskId", () => {
+    // buildDispatchRequestStep's fallback (no non-system message to prepend
+    // event parts onto) uses this id for the synthetic message it pre-persists
+    // via PartEmitter before its own step output is durably recorded — a
+    // crash mid-step forces a full re-invocation, so a random id here would
+    // orphan a duplicate message row the same way the fix in #4790 prevented
+    // for the taskId-derived `${taskId}:${i}` ids above.
+    expect(contextMessageId("thrd_1")).toBe(contextMessageId("thrd_1"));
+  });
+
+  it("never collides with a rawMessages index id", () => {
+    expect(contextMessageId("thrd_1")).not.toMatch(/^thrd_1:\d+$/);
   });
 });

--- a/apps/mesh/src/automations/build-stream-request.ts
+++ b/apps/mesh/src/automations/build-stream-request.ts
@@ -54,6 +54,18 @@ function parseToolAllowlist(raw: string | null): string[] | null {
   return null;
 }
 
+/**
+ * Deterministic id for the synthetic context-event message
+ * (`buildDispatchRequestStep`'s fallback when the automation's stored
+ * messages contain no non-system message to prepend event parts onto).
+ * Must stay stable across a step re-invocation for the same reason the
+ * message ids below are taskId-derived rather than random — see comment
+ * on `messages` below.
+ */
+export function contextMessageId(taskId: string): string {
+  return `${taskId}:context`;
+}
+
 export function buildStreamRequest(
   automation: Automation,
   triggerId: string | null,

--- a/apps/mesh/src/automations/dbos-workflow.ts
+++ b/apps/mesh/src/automations/dbos-workflow.ts
@@ -54,6 +54,7 @@ import type { Automation } from "@/storage/types";
 import type { SimpleModeTier } from "@/tools/organization/schema";
 import {
   buildStreamRequest,
+  contextMessageId,
   type ResolvedAutomationModel,
 } from "./build-stream-request";
 import { computeNextRunAt, type StudioContextFactory } from "./fire";
@@ -328,7 +329,7 @@ type BuildDispatchRequestOutcome =
 /**
  * Pre-flight for the dispatch: membership pre-check + `buildStreamRequest`.
  *
- * Runs as a step so the request payload — including `crypto.randomUUID()`
+ * Runs as a step so the request payload — including the taskId-derived
  * message ids — is recorded in the workflow journal and replay returns the
  * same payload. `runDispatchSteps` is invoked from the workflow body (not
  * here) because its inner steps can't be nested inside another step.
@@ -372,7 +373,7 @@ async function buildDispatchRequestStep(
     } else {
       request.messages = [
         ...request.messages,
-        { id: crypto.randomUUID(), role: "user", parts: extraParts },
+        { id: contextMessageId(taskId), role: "user", parts: extraParts },
       ] as typeof request.messages;
     }
   }

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,6 +1,6 @@
 {
   "auth/install-studio-pack-workflow.ts": "1cf06645663602989054ec171a7b06fe4c16d5c40e4348bcc86c725e3769c5a0",
-  "automations/dbos-workflow.ts": "48975df08d346ef9d542438430dd22ff327f00f146361926597e0f717ca80fe1",
+  "automations/dbos-workflow.ts": "088986a214dd803913438f51bdbaa14dfef25b151422e117605a7907dc2bd987",
   "dispatch-queue/hosted-harness-workflow.ts": "1ee53df2391d0b73f10630be7f7d947db16653d5b8740b799e64a98cb2f49c86",
   "dispatch-queue/thread-gate-workflow.ts": "674cd393ad3b06806e967389dfe7e87bd0de6ba933fd54df1e5cd24a08b99e43",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",


### PR DESCRIPTION
Follows #4790 — closes the one remaining spot with the same bug that PR fixed.

## Why
#4790 changed `buildStreamRequest` to derive message ids from `taskId` (`${taskId}:${i}`) instead of `crypto.randomUUID()`, because `buildDispatchRequestStep` is a DBOS step that pre-persists the user-turn message via `PartEmitter` *before* the step's own return value is durably recorded — a crash in that window forces DBOS to fully re-invoke the step, and a random id there emits a second, orphaned message row instead of an idempotent replace.

`buildDispatchRequestStep`'s own fallback branch (used when the automation's stored messages contain no non-system message to prepend event-context parts onto) builds a synthetic message the same way, but was left calling `crypto.randomUUID()` directly — the exact same instability #4790 just fixed, one branch away. It also gets pre-persisted by the same `PartEmitter` call a few lines below, so it's exposed to the identical crash-and-replay window.

## Fix
Extracted the id derivation into a small pure helper (`contextMessageId`, alongside the existing `${taskId}:${i}` logic in `build-stream-request.ts`) and used it for this fallback message instead of `crypto.randomUUID()`. Also fixed a stale doc comment on `buildDispatchRequestStep` that still described the (now-removed) `crypto.randomUUID()` behavior.

## Testing
- `bun test apps/mesh/src/automations/build-stream-request.test.ts` — new tests assert `contextMessageId` is stable across calls for the same `taskId` and never collides with a `${taskId}:${i}` rawMessages id.
- `cd apps/mesh && bun x tsc --noEmit` — passes.
- `bun run fmt` — clean.

Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the context-event fallback message id by deriving it from `taskId` to ensure idempotency and prevent duplicate, orphaned messages on DBOS step replays.

- **Bug Fixes**
  - Added `contextMessageId(taskId)` returning `${taskId}:context` and used it in `buildDispatchRequestStep` instead of `crypto.randomUUID()`.
  - Updated the step doc to reflect taskId-derived ids.
  - Added tests for stability and no collision with `${taskId}:\d+` ids.

<sup>Written for commit 022cf7d884a832f0276fb9443dd0a286bea3ee9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

