### PR TITLE
refactor(sandbox): route file-explorer read/save through the existing postSandbox helper

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -618,16 +618,10 @@ export function FileExplorer({
     });
 
     try {
-      const res = await fetch(
-        buildApiUrl(orgSlug, virtualMcpId, branch, "read"),
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ path: toDaemonPath(path), full: true }),
-        },
-      );
-      if (!res.ok) return;
-      const data = (await res.json()) as {
+      const data = (await postSandbox("read", {
+        path: toDaemonPath(path),
+        full: true,
+      })) as {
         kind?: string;
         content?: string;
       };
@@ -648,21 +642,7 @@ export function FileExplorer({
 
   async function saveFile(path: string, content: string) {
     try {
-      const res = await fetch(
-        buildApiUrl(orgSlug, virtualMcpId, branch, "write"),
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ path: toDaemonPath(path), content }),
-        },
-      );
-      if (!res.ok) {
-        saveChangesDebug("file save failed", {
-          path,
-          status: res.status,
-        });
-        return;
-      }
+      await postSandbox("write", { path: toDaemonPath(path), content });
       saveChangesDebug("file saved via sandbox /write", { path });
       void queryClient.invalidateQueries({
         queryKey: sandboxGitStatusQueryKey(orgSlug, virtualMcpId, branch),
@@ -684,8 +664,11 @@ export function FileExplorer({
         }
         return next;
       });
-    } catch {
-      // Save failed silently
+    } catch (err) {
+      saveChangesDebug("file save failed", {
+        path,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 


### PR DESCRIPTION
## Source
Bounded C1 duplication cleanup (not tied to an issue/PR). `FileExplorer` already defines a local `postSandbox(endpoint, body)` helper — used by write/mkdir/rename/unlink — that builds the sandbox request URL, sets headers, and throws on `!res.ok`. `loadFileContent` (the `read` endpoint) and `saveFile` (the `write` endpoint) duplicated that same fetch + status-check shape with raw `fetch()` calls instead of reusing it.

## Why
One less copy of the request-building/error-shape logic to keep in sync in a file that already established the pattern for its other four sandbox calls.

## Behavior preserved
- `loadFileContent`: previously `if (!res.ok) return` (buffer stays unloaded, silently). Now the helper throws on failure and the existing outer `catch { /* leave buffer empty */ }` swallows it — same net effect.
- `saveFile`: previously logged `saveChangesDebug("file save failed", { path, status })` on `!res.ok` and returned; success path was unchanged. Now the same debug event is logged from the (also pre-existing) outer catch with the thrown error's message instead of the raw status code — still a failure log with diagnostic content, still no user-visible behavior change.

Net diff: -27 / +10 lines, one file, no new deps.

## Reviewer check
`cd apps/mesh && bun x tsc --noEmit` — passes.

## Verified locally
- `bun run fmt` — no changes needed
- `cd apps/mesh && bun x tsc --noEmit` — clean
- No dedicated unit test exists for this component (only `utils.test.ts` covers pure helpers unrelated to this change); full CI suite covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates sandbox requests in `FileExplorer` by routing read/save through the existing `postSandbox` helper. This reduces code and keeps request and error handling consistent without changing behavior.

- **Refactors**
  - Replace raw `fetch` in `loadFileContent` and `saveFile` with `postSandbox("read"|"write")`.
  - Errors now bubble via the helper; existing catches handle silent read failures and log save failures with the error message.

<sup>Written for commit 9bce47cfa35dde4446d223e02ac00f0467c5b1cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

