### PR TITLE
fix(onboarding): don't silently fall through to org-creation on a failed domain lookup

### DIFF
--- a/apps/mesh/src/web/routes/onboarding.tsx
+++ b/apps/mesh/src/web/routes/onboarding.tsx
@@ -168,17 +168,24 @@ function OnboardingContent({
     ? domainLabel
     : (userName?.split(" ")[0] ?? "");
 
-  const { data: domainLookup, isLoading: domainLoading } =
-    useQuery<DomainLookupResult>({
-      queryKey: KEYS.domainLookup(emailDomain),
-      queryFn: async () => {
-        const res = await fetch("/api/auth/custom/domain-lookup", {
-          credentials: "include",
-        });
-        return res.json();
-      },
-      enabled: isCorporateEmail,
-    });
+  const {
+    data: domainLookup,
+    isLoading: domainLoading,
+    isError: domainLookupFailed,
+    refetch: refetchDomainLookup,
+  } = useQuery<DomainLookupResult>({
+    queryKey: KEYS.domainLookup(emailDomain),
+    queryFn: async () => {
+      const res = await fetch("/api/auth/custom/domain-lookup", {
+        credentials: "include",
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to look up domain (${res.status})`);
+      }
+      return res.json();
+    },
+    enabled: isCorporateEmail,
+  });
 
   // Track which orgs the user has already requested, per-slug, to prevent
   // duplicate access requests across the shared organization picker.
@@ -194,6 +201,29 @@ function OnboardingContent({
           <span className="text-sm text-muted-foreground">
             Checking {emailDomain}...
           </span>
+        </div>
+      </AuthSplitLayout>
+    );
+  }
+
+  // A failed lookup must not silently fall through to "no matching org" —
+  // that would route a corporate-domain user straight into creating a
+  // duplicate organization instead of joining the one they already have
+  // access to.
+  if (domainLookupFailed) {
+    return (
+      <AuthSplitLayout>
+        <div className="flex flex-col items-start gap-3 py-4">
+          <span className="text-sm text-muted-foreground">
+            Couldn't check {emailDomain} for an existing organization.
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refetchDomainLookup()}
+          >
+            Retry
+          </Button>
         </div>
       </AuthSplitLayout>
     );


### PR DESCRIPTION
## Source
Bug found reading `apps/mesh/src/web/routes/onboarding.tsx` — not tied to an issue or PR.

## Why a maintainer wants this
For a corporate-domain user, `GET /api/auth/custom/domain-lookup` returns `{ success: false, error: "Authentication required" }` (401) on a stale/expired session — a shape that doesn't match `DomainLookupResult`. The client's `queryFn` never checked `res.ok` before returning the body, so `domainLookup?.organizations` silently resolved to `[]` and the onboarding flow fell straight through to "create a new organization," even though the user already has access to a matching org. That's a real risk of duplicate-org creation on a transient auth hiccup, with no visible error.

## Fix
`queryFn` now throws on a non-2xx response, and the query's `isError` state renders a retry prompt (`AuthSplitLayout` + "Retry" button) instead of falling through to the org-creation form.

## Failure scenario + regression coverage
Scenario: session cookie is present but stale/expired when `OnboardingContent` mounts → 401 body doesn't match `DomainLookupResult` → user is silently routed to org creation instead of joining their real org.

This is a UI-only branch (no server logic changed), so the fix is a straightforward `res.ok` check; no server-side test needed — verified via typecheck (no test file exists for this route, and adding one would require mocking `authClient`/react-router context disproportionate to the fix).

## Reviewer verification
- `bunx tsc --noEmit` in `apps/mesh` (clean)
- Manually: hit `/onboarding` as a corporate-domain user, then expire the session cookie server-side before the domain-lookup fetch resolves — should show the retry prompt instead of the "create org" form.

## Checks run locally
- `bun run fmt`
- `cd apps/mesh && bunx tsc --noEmit` — clean

Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes onboarding domain lookup so a failed request no longer falls through to org creation. Shows a retry prompt on errors to prevent duplicate-org creation when a session is stale.

- **Bug Fixes**
  - Check `res.ok` in the domain-lookup query and throw on non-2xx responses.
  - Render an error state with a retry button instead of treating errors as “no matching orgs.”

<sup>Written for commit 4f948f4f50a8a29bdc996e7dfc9110026adf71dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

