### PR TITLE
refactor(web): route useOrgFsStat through the shared fsFetch helper

### DIFF
--- a/apps/mesh/src/web/hooks/use-org-fs.ts
+++ b/apps/mesh/src/web/hooks/use-org-fs.ts
@@ -71,18 +71,20 @@ function fsUrl(
   return `/api/${encodeURIComponent(orgSlug)}/fs/${encodeURIComponent(volume)}/${op}${qs ? `?${qs}` : ""}`;
 }
 
-async function fsFetch(url: string, init?: RequestInit): Promise<Response> {
+async function fsFetch(
+  url: string,
+  init?: RequestInit,
+  opts?: { allow404?: boolean },
+): Promise<Response> {
   const res = await fetch(url, init);
-  if (!res.ok) {
-    let detail = "";
-    try {
-      detail = ((await res.json()) as { error?: string }).error ?? "";
-    } catch {
-      // non-JSON body
-    }
-    throw new Error(detail || `HTTP ${res.status}`);
+  if (res.ok || (opts?.allow404 && res.status === 404)) return res;
+  let detail = "";
+  try {
+    detail = ((await res.json()) as { error?: string }).error ?? "";
+  } catch {
+    // non-JSON body
   }
-  return res;
+  throw new Error(detail || `HTTP ${res.status}`);
 }
 
 /** Children of `path` ("" = volume root), dirs first then by name. */
@@ -123,9 +125,12 @@ export function useOrgFsStat(
           query.state.data ? false : (opts.refetchIntervalWhenAbsent ?? false)
       : undefined,
     queryFn: async (): Promise<OrgFsEntry | null> => {
-      const res = await fetch(fsUrl(org.slug, volume ?? "", "stat", { path }));
+      const res = await fsFetch(
+        fsUrl(org.slug, volume ?? "", "stat", { path }),
+        undefined,
+        { allow404: true },
+      );
       if (res.status === 404) return null;
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       return ((await res.json()) as { entry: OrgFsEntry }).entry;
     },
   });


### PR DESCRIPTION
## Source
Reduction found while auditing `apps/mesh/src/web/hooks/use-org-fs.ts` (creative debt hunt) — every other query/mutation in the file goes through the local `fsFetch` helper (fetch + JSON-error-detail extraction + throw), except `useOrgFsStat`, which duplicated that check-and-throw shape inline with a raw `fetch` call.

## Why
One less hand-rolled fetch/error-handling copy in a file that already consolidated the pattern once; on a non-404 failure this call now also surfaces the JSON `error` field like every sibling query does, instead of a bare `HTTP ${status}`.

## What changed
- `fsFetch` gains an `allow404` option so a 404 response can be returned to the caller instead of being thrown.
- `useOrgFsStat` now calls `fsFetch(..., { allow404: true })` and checks `res.status === 404` for its null-on-absent case, same as before, just routed through the shared helper.

Net: -12 / +17 (helper grows by a few lines to support the 404 passthrough; the call site drops its own error-throwing branch). Behavior is unchanged for the two paths that mattered (404 → null, ok → parsed entry) and slightly improved for the other-error path (now surfaces `error` detail like the rest of the file).

## How to verify
`cd apps/mesh && bun x tsc --noEmit` (or open the Library page and hit a missing-file `stat` — it should still resolve to "not found" state, not throw).

## Checks run locally
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` — green
Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `useOrgFsStat` to use the shared `fsFetch` helper by adding an `allow404` option. This removes duplicated fetch/error logic and surfaces JSON error details on non-404 failures while keeping 404→null behavior.

- **Refactors**
  - Added `allow404` to `fsFetch` to return 404 responses instead of throwing.
  - Routed `useOrgFsStat` through `fsFetch(..., { allow404: true })` and kept 404 → null.
  - Non-404 errors now expose JSON `error` details like other FS calls.

<sup>Written for commit b2ed9c14918b6e8b165b34098e90c40405586bbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

