### PR TITLE
refactor(chat): dedupe raw-message timestamp formatting in context panel

### DIFF
--- a/apps/mesh/src/web/components/chat/context-panel.tsx
+++ b/apps/mesh/src/web/components/chat/context-panel.tsx
@@ -494,13 +494,7 @@ export function ChatContextPanel({
                       </div>
                       {createdAt && (
                         <span className="shrink-0 text-muted-foreground tabular-nums">
-                          {new Date(createdAt).toLocaleString("en-US", {
-                            month: "short",
-                            day: "numeric",
-                            year: "numeric",
-                            hour: "numeric",
-                            minute: "2-digit",
-                          })}
+                          {formatDate(createdAt)}
                         </span>
                       )}
                     </button>


### PR DESCRIPTION
## Summary
The raw-messages debug list in `ChatContextPanel` re-implemented the exact same `toLocaleString` options block (month/day/year/hour/minute) that the file already defines as its own `formatDate()` helper (used a few lines up for "Session Created" / "Last Activity"). Route the raw-message timestamp through the existing `formatDate()` instead of duplicating the formatting logic inline.

Net diff: -7 / +1.

## Why
Two copies of the same formatting logic in one file is exactly the kind of local duplication that should collapse into its existing single home — one less place to update if the display format ever changes, and `formatDate()`'s invalid-date guard (`"—"` fallback) now also covers this call site for free.

## Behavior
Unchanged for the existing path: both call sites use identical `toLocaleString("en-US", {...})` options, and the inline call was already guarded by `{createdAt && (...)}`, so `formatDate`'s additional `NaN`-date fallback never triggers for previously-valid inputs.

## How to verify
```
cd apps/mesh && bunx tsc --noEmit
```

## Checks run locally
- `bun run fmt` — clean, no changes needed
- `bunx tsc --noEmit` (apps/mesh workspace) — passes
- Full CI (lint, tests) will validate the rest

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates timestamp formatting in `ChatContextPanel` by routing raw-message timestamps through the existing `formatDate()` helper. Keeps the same display for valid dates and adds the helper’s invalid-date fallback.

<sup>Written for commit 4ae7e0b2e99c1ef2d00399a394560fd1a329d06a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

