### PR TITLE
refactor(roles): drop redundant OrganizationRole as-casts

### DIFF
--- a/apps/mesh/src/web/routes/orgs/settings/roles.tsx
+++ b/apps/mesh/src/web/routes/orgs/settings/roles.tsx
@@ -209,7 +209,7 @@ function RolesPageContent() {
             <span className="text-sm text-muted-foreground">Basic access</span>
           );
         }
-        const r = row.role as OrganizationRole;
+        const r = row.role;
         const parts: string[] = [];
         if (r.allowsAllStaticPermissions) {
           parts.push("Full org access");
@@ -265,7 +265,7 @@ function RolesPageContent() {
               <DropdownMenuItem
                 variant="destructive"
                 onClick={() => {
-                  const r = row.role as OrganizationRole;
+                  const r = row.role;
                   if (r.id) setRoleToDelete({ id: r.id, label: r.label });
                 }}
               >
@@ -284,7 +284,7 @@ function RolesPageContent() {
     if (row.kind === "builtin") {
       setActiveRole(`builtin-${row.role.role}`);
     } else {
-      const r = row.role as OrganizationRole;
+      const r = row.role;
       setActiveRole(r.id);
     }
   };


### PR DESCRIPTION
## Summary
Found while auditing recently-churned files in `apps/mesh/src/web` for un-CI-enforced type-safety debt (`as`-casts bypassing discriminated-union narrowing — see repo checklist item 9).

- `RoleRow` is a discriminated union on `kind` (`"builtin" | "custom"`).
- All three `row.role as OrganizationRole` casts sit right after a control-flow check (`row.kind === "builtin"` early-return, or an `if/else` on `kind`) that already narrows `row` to the custom-role member — the cast was doing nothing but suppressing the compiler's ability to catch a future mismatch.
- Removed the casts; TS narrows `row.role` correctly on its own.

## Why
An `as`-cast on a discriminated union defeats the point of the discriminant: if `RoleRow`'s shape ever changes, a real-narrowing version fails to compile at the mismatch, while the cast version would only fail at runtime (or silently misbehave) later. This is exactly the class of fix called out in the repo's coding-style guidance ("narrow with an `in` / discriminant check so a rename is a compile error, not a runtime regression").

## Verification
- `bun x tsc --noEmit` in `apps/mesh` — clean, confirming the discriminant already narrows `row.role` without the casts.
- `bun run fmt` — no changes.
- Behavior-preserving: pure type-level change, no runtime logic touched.

Reviewer check: `cd apps/mesh && bun x tsc --noEmit`

CI runs the full test/lint suite; only the targeted typecheck above was run locally per this bot's verification policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant `as OrganizationRole` casts in `apps/mesh/src/web/routes/orgs/settings/roles.tsx` by relying on existing `row.kind` discriminated-union checks to narrow `row.role`. Improves type safety with no behavior changes.

<sup>Written for commit 9e4b86acaa30036eb7b0d213fba00502fd987aa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

