### PR TITLE
refactor(virtual-mcp): dedupe form-update logic in dependency selection dialog

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/dependency-selection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/dependency-selection-dialog.tsx
@@ -619,6 +619,25 @@ function recordToConnections(formData: FormData): VirtualMCPConnection[] {
   }));
 }
 
+// Helper: Set a single field's selection for a connection, initializing the
+// entry (all fields null) if it doesn't exist yet.
+function withFieldValue(
+  formData: FormData,
+  connId: string,
+  field: "tools" | "resources" | "prompts",
+  value: SelectionValue,
+): FormData {
+  const existing = formData[connId] ?? {
+    tools: null,
+    resources: null,
+    prompts: null,
+  };
+  return {
+    ...formData,
+    [connId]: { ...existing, [field]: value },
+  };
+}
+
 // Dialog state reducer
 interface DialogState {
   activeTab: TabId;
@@ -675,18 +694,13 @@ export function DependencySelectionDialog({
       }
     }
 
-    const updatedFormData: FormData = { ...formData };
-    if (!updatedFormData[connId]) {
-      updatedFormData[connId] = { tools: null, resources: null, prompts: null };
-    } else {
-      updatedFormData[connId] = { ...updatedFormData[connId] };
-    }
-    updatedFormData[connId][field] = newSelection;
-
-    form.setValue("connections", recordToConnections(updatedFormData), {
-      shouldDirty: true,
-      shouldTouch: true,
-    });
+    form.setValue(
+      "connections",
+      recordToConnections(
+        withFieldValue(formData, connId, field, newSelection),
+      ),
+      { shouldDirty: true, shouldTouch: true },
+    );
   };
 
   const toggleAll = (
@@ -696,18 +710,13 @@ export function DependencySelectionDialog({
     const current = formData[connId]?.[field];
     const newSelection = current === null ? [] : null;
 
-    const updatedFormData: FormData = { ...formData };
-    if (!updatedFormData[connId]) {
-      updatedFormData[connId] = { tools: null, resources: null, prompts: null };
-    } else {
-      updatedFormData[connId] = { ...updatedFormData[connId] };
-    }
-    updatedFormData[connId][field] = newSelection;
-
-    form.setValue("connections", recordToConnections(updatedFormData), {
-      shouldDirty: true,
-      shouldTouch: true,
-    });
+    form.setValue(
+      "connections",
+      recordToConnections(
+        withFieldValue(formData, connId, field, newSelection),
+      ),
+      { shouldDirty: true, shouldTouch: true },
+    );
   };
 
   const toggleTool = (


### PR DESCRIPTION
## Summary
Bounded C1 duplication cleanup found while hunting recently-changed files — no issue/PR tracks this.

`toggleItem` and `toggleAll` in `dependency-selection-dialog.tsx` each rebuilt the connection's `FormData` entry with the identical "initialize with all-null defaults, or spread the existing entry" pattern before overwriting one field. Extracted that into a single `withFieldValue(formData, connId, field, value)` helper used by both call sites.

Net diff: -24 / +33 lines but removes one full duplicated block (was repeated twice, now defined once) — pure refactor, no behavior change: same object shape, same `form.setValue` call with the same options.

## Testing
- `bunx tsc --noEmit` in `apps/mesh` — passes
- `bun run fmt` — clean
- No existing test file covers this dialog's toggle logic; verified by inspection that `withFieldValue` produces byte-identical output to the two inlined blocks it replaces (same default object, same spread-then-override order).

Reviewer check: `bunx tsc --noEmit` in `apps/mesh`, full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the dependency selection dialog to dedupe form-update logic by extracting a single helper. Behavior is unchanged; this just cleans up code and reduces duplication.

- **Refactors**
  - Added withFieldValue(formData, connId, field, value) to initialize missing entries with nulls and update one field.
  - Replaced duplicate blocks in toggleItem and toggleAll with the helper, keeping the same form.setValue behavior and data shape.

<sup>Written for commit 60ea4a3aeddbbd203c5019f02b78d20d7e732593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

