### PR TITLE
refactor(auth): dedupe view-toggle link className in unified auth form

### DIFF
--- a/apps/mesh/src/web/components/unified-auth-form.tsx
+++ b/apps/mesh/src/web/components/unified-auth-form.tsx
@@ -78,6 +78,9 @@ interface UnifiedAuthFormProps {
 
 type FormView = "signIn" | "signUp" | "forgotPassword" | "emailOtp";
 
+const VIEW_TOGGLE_LINK_CLASS =
+  "font-medium text-[#8CAA25] hover:underline disabled:opacity-50";
+
 export interface UnifiedAuthFormCopy {
   signUpFailed: string;
   signInFailed: string;
@@ -928,7 +931,7 @@ export function UnifiedAuthForm({
             type="button"
             onClick={() => switchView("signIn")}
             disabled={isLoading}
-            className="font-medium text-[#8CAA25] hover:underline disabled:opacity-50"
+            className={VIEW_TOGGLE_LINK_CLASS}
           >
             {copy.backToSignIn}
           </button>
@@ -937,7 +940,7 @@ export function UnifiedAuthForm({
             type="button"
             onClick={() => switchView("signIn")}
             disabled={isLoading}
-            className="font-medium text-[#8CAA25] hover:underline disabled:opacity-50"
+            className={VIEW_TOGGLE_LINK_CLASS}
           >
             {copy.signInWithPassword}
           </button>
@@ -948,7 +951,7 @@ export function UnifiedAuthForm({
               type="button"
               onClick={() => switchView(isSignUp ? "signIn" : "signUp")}
               disabled={isLoading}
-              className="font-medium text-[#8CAA25] hover:underline disabled:opacity-50"
+              className={VIEW_TOGGLE_LINK_CLASS}
             >
               {isSignUp ? copy.signIn : copy.signUp}
             </button>
@@ -959,7 +962,7 @@ export function UnifiedAuthForm({
                   type="button"
                   onClick={() => switchView("emailOtp")}
                   disabled={isLoading}
-                  className="font-medium text-[#8CAA25] hover:underline disabled:opacity-50"
+                  className={VIEW_TOGGLE_LINK_CLASS}
                 >
                   {copy.signInWithEmailCode}
                 </button>


### PR DESCRIPTION
## Summary
- `UnifiedAuthForm` repeated the exact same 4-property className string (`"font-medium text-[#8CAA25] hover:underline disabled:opacity-50"`) verbatim across all 4 view-toggle links (back-to-sign-in, sign-in-with-password, sign-up/sign-in switch, sign-in-with-email-code).
- Extracted it into a single `VIEW_TOGGLE_LINK_CLASS` module constant so the 4 call sites can't silently drift from each other.

## Why
A future style tweak to these links (e.g. a hover-state change) currently requires editing 4 identical strings in lockstep; a single constant makes that a one-line change and removes the duplication risk.

## Verification
- Net diff: -4 duplicated strings / +1 constant (7 insertions, 4 deletions) — pure move, no behavior change (same class list, same render output).
- `bun run fmt` — clean.
- `bunx tsc --noEmit` in `apps/mesh` — clean.
- Reviewer check: `rg VIEW_TOGGLE_LINK_CLASS apps/mesh/src/web/components/unified-auth-form.tsx` shows the constant and its 4 usages.

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated the view-toggle link styling in `UnifiedAuthForm` by extracting a shared class constant for consistent styles and easier updates. No UI or behavior changes.

- **Refactors**
  - Extracted repeated link class string into `VIEW_TOGGLE_LINK_CLASS`.
  - Updated the four toggle buttons to use the constant.

<sup>Written for commit 6dcbec4e179711d286a90b9e574186750805ff90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

