### PR TITLE
refactor(content): extract EmptyMessage into its own file

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -153,6 +153,7 @@ import {
 import { PageJsonDialog } from "@/web/components/sections-editor/page-json-dialog";
 import { RunnableBlocksBrowser } from "./runnable-blocks-browser";
 import { countAvailableRunnables } from "./runnable-catalog";
+import { EmptyMessage } from "./empty-message";
 import { useBlocksPreviewWorkspace } from "@/web/components/sandbox/blocks/blocks-preview-workspace-context";
 import type { BlocksTarget } from "@/web/components/sandbox/blocks/blocks-preview-workspace-state";
 
@@ -3032,26 +3033,4 @@ function SandboxStateRenderer({
         />
       );
   }
-}
-
-export function EmptyMessage({
-  icon: Icon,
-  title,
-  description,
-}: {
-  icon?: React.ComponentType<{ size?: number; className?: string }>;
-  title: string;
-  description?: string;
-}) {
-  return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted-foreground">
-      {Icon && <Icon size={24} className="text-muted-foreground/60" />}
-      <div>{title}</div>
-      {description && (
-        <div className="text-xs text-muted-foreground/80 max-w-sm">
-          {description}
-        </div>
-      )}
-    </div>
-  );
 }

--- a/apps/mesh/src/web/components/sandbox/content/empty-message.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/empty-message.tsx
@@ -1,0 +1,21 @@
+export function EmptyMessage({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon?: React.ComponentType<{ size?: number; className?: string }>;
+  title: string;
+  description?: string;
+}) {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted-foreground">
+      {Icon && <Icon size={24} className="text-muted-foreground/60" />}
+      <div>{title}</div>
+      {description && (
+        <div className="text-xs text-muted-foreground/80 max-w-sm">
+          {description}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
@@ -19,7 +19,8 @@ import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
 import { GLOBAL_SECTION_ICON_COLOR } from "@/web/components/sections-editor/section-types";
 import { useSaveBlock } from "@/web/components/sections-editor/use-save-block";
 import { createReferencedBlockSaver } from "@/web/components/sections-editor/save-referenced-block";
-import { EmptyMessage, ItemRow } from "./content-browser";
+import { ItemRow } from "./content-browser";
+import { EmptyMessage } from "./empty-message";
 import {
   RunnableBlockEditor,
   type RunnableTarget,


### PR DESCRIPTION
## Summary
- `content-browser.tsx` (3057 lines, one of the largest frontend files) had a small, fully self-contained presentational component, `EmptyMessage`, sitting at the bottom of the file. It takes only props (icon/title/description) and shares no closures or local state with the rest of the file.
- `runnable-blocks-browser.tsx` was already importing `EmptyMessage` from `content-browser.tsx` — a component from a large "browser" file being re-exported as a de facto shared UI helper.
- Moved `EmptyMessage` verbatim into its own `empty-message.tsx` file in the same directory and updated both importers. No logic changes — pure relocation.

## Test plan
- [x] `bun run fmt`
- [x] `bun x tsc --noEmit` in `apps/mesh` — clean
- [x] `rg -n "EmptyMessage" apps/mesh/src/web` confirms both call sites (`content-browser.tsx`, `runnable-blocks-browser.tsx`) resolve to the new file and no stray references remain

Reviewer check: `rg -n "EmptyMessage" apps/mesh/src/web/components/sandbox/content`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the `EmptyMessage` presentational component from `content-browser.tsx` into `empty-message.tsx` to improve reuse and shrink a large file. Updated imports in `content-browser.tsx` and `runnable-blocks-browser.tsx`; no logic or UI changes.

<sup>Written for commit ec9d90142408e2b7a81af7f72e8d269c0dc2f171. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

