### PR TITLE
refactor(monitoring): extract ThreadsFiltersPopover into its own file

### DIFF
--- a/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/index.tsx
@@ -70,7 +70,8 @@ import { Avatar } from "@deco/ui/components/avatar.tsx";
 
 import { OverviewTabContent, OverviewTabSkeleton } from "./overview.tsx";
 import { AuditTabContent, MonitoringLogsTable } from "./audit.tsx";
-import { ThreadsTabContent, ThreadsFiltersPopover } from "./threads.tsx";
+import { ThreadsTabContent } from "./threads.tsx";
+import { ThreadsFiltersPopover } from "./threads-filters-popover.tsx";
 import { AutomationsTabContent } from "./automations.tsx";
 import { getOrgMembers } from "./utils.ts";
 import { track } from "@/web/lib/posthog-client";

--- a/apps/mesh/src/web/routes/orgs/monitoring/threads-filters-popover.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/threads-filters-popover.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Badge } from "@deco/ui/components/badge.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { MultiSelect } from "@deco/ui/components/multi-select.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deco/ui/components/popover.tsx";
+import { FilterLines } from "@untitledui/icons";
+
+interface ThreadsFiltersPopoverProps {
+  filterAgentIds: string[];
+  filterUserIds: string[];
+  filterStatus: string;
+  virtualMcpOptions: Array<{ value: string; label: string }>;
+  memberOptions: Array<{ value: string; label: string }>;
+  activeFiltersCount: number;
+  onUpdateFilters: (updates: {
+    filterAgentIds?: string[];
+    filterUserIds?: string[];
+    filterStatus?: string;
+  }) => void;
+}
+
+export function ThreadsFiltersPopover({
+  filterAgentIds,
+  filterUserIds,
+  filterStatus,
+  virtualMcpOptions,
+  memberOptions,
+  activeFiltersCount,
+  onUpdateFilters,
+}: ThreadsFiltersPopoverProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" className="relative">
+          <FilterLines size={16} />
+          <span className="hidden sm:inline">Filters</span>
+          {activeFiltersCount > 0 && (
+            <>
+              <Badge
+                variant="default"
+                className="sm:hidden absolute -top-1.5 -right-1.5 h-4 min-w-4 px-1 text-[10px] leading-none"
+              >
+                {activeFiltersCount}
+              </Badge>
+              <Badge
+                variant="default"
+                className="hidden sm:flex ml-1 h-5 w-5 rounded-full p-0 items-center justify-center text-xs"
+              >
+                {activeFiltersCount}
+              </Badge>
+            </>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-[280px]">
+        <div className="space-y-4">
+          <h4 className="font-medium text-sm">Filter Chats</h4>
+
+          <div className="space-y-3">
+            <div>
+              <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+                Agent
+              </label>
+              <MultiSelect
+                options={virtualMcpOptions}
+                defaultValue={filterAgentIds}
+                onValueChange={(values) =>
+                  onUpdateFilters({ filterAgentIds: values.slice(0, 1) })
+                }
+                placeholder="All agents"
+                variant="secondary"
+                className="w-full"
+                maxCount={1}
+              />
+            </div>
+
+            <div>
+              <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+                User
+              </label>
+              <MultiSelect
+                options={memberOptions}
+                defaultValue={filterUserIds}
+                onValueChange={(values) =>
+                  onUpdateFilters({ filterUserIds: values.slice(0, 1) })
+                }
+                placeholder="All users"
+                variant="secondary"
+                className="w-full"
+                maxCount={1}
+              />
+            </div>
+
+            <div>
+              <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+                Status
+              </label>
+              <Select
+                value={filterStatus}
+                onValueChange={(value) =>
+                  onUpdateFilters({ filterStatus: value })
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All statuses</SelectItem>
+                  <SelectItem value="completed">Completed</SelectItem>
+                  <SelectItem value="active">Active</SelectItem>
+                  <SelectItem value="failed">Failed</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {activeFiltersCount > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full"
+              onClick={() => {
+                onUpdateFilters({
+                  filterAgentIds: [],
+                  filterUserIds: [],
+                  filterStatus: "all",
+                });
+                setOpen(false);
+              }}
+            >
+              Clear all filters
+            </Button>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/threads.tsx
@@ -12,26 +12,12 @@ import {
 } from "@tanstack/react-query";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { Badge } from "@deco/ui/components/badge.tsx";
 import {
   Sheet,
   SheetContent,
   SheetHeader,
   SheetTitle,
 } from "@deco/ui/components/sheet.tsx";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@deco/ui/components/select.tsx";
-import { MultiSelect } from "@deco/ui/components/multi-select.tsx";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@deco/ui/components/popover.tsx";
 import {
   Table,
   TableBody,
@@ -41,12 +27,7 @@ import {
   TableRow,
 } from "@deco/ui/components/table.tsx";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
-import {
-  ChevronUp,
-  ChevronDown,
-  FilterLines,
-  Container,
-} from "@untitledui/icons";
+import { ChevronUp, ChevronDown, Container } from "@untitledui/icons";
 import { EmptyState } from "@/web/components/empty-state.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import {
@@ -580,142 +561,6 @@ export function ThreadSheetBody({
         />
       </Suspense>
     </ErrorBoundary>
-  );
-}
-
-// ── Threads filters popover ─────────────────────────────────────────────────
-
-interface ThreadsFiltersPopoverProps {
-  filterAgentIds: string[];
-  filterUserIds: string[];
-  filterStatus: string;
-  virtualMcpOptions: Array<{ value: string; label: string }>;
-  memberOptions: Array<{ value: string; label: string }>;
-  activeFiltersCount: number;
-  onUpdateFilters: (updates: {
-    filterAgentIds?: string[];
-    filterUserIds?: string[];
-    filterStatus?: string;
-  }) => void;
-}
-
-export function ThreadsFiltersPopover({
-  filterAgentIds,
-  filterUserIds,
-  filterStatus,
-  virtualMcpOptions,
-  memberOptions,
-  activeFiltersCount,
-  onUpdateFilters,
-}: ThreadsFiltersPopoverProps) {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button variant="outline" className="relative">
-          <FilterLines size={16} />
-          <span className="hidden sm:inline">Filters</span>
-          {activeFiltersCount > 0 && (
-            <>
-              <Badge
-                variant="default"
-                className="sm:hidden absolute -top-1.5 -right-1.5 h-4 min-w-4 px-1 text-[10px] leading-none"
-              >
-                {activeFiltersCount}
-              </Badge>
-              <Badge
-                variant="default"
-                className="hidden sm:flex ml-1 h-5 w-5 rounded-full p-0 items-center justify-center text-xs"
-              >
-                {activeFiltersCount}
-              </Badge>
-            </>
-          )}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="end" className="w-[280px]">
-        <div className="space-y-4">
-          <h4 className="font-medium text-sm">Filter Chats</h4>
-
-          <div className="space-y-3">
-            <div>
-              <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
-                Agent
-              </label>
-              <MultiSelect
-                options={virtualMcpOptions}
-                defaultValue={filterAgentIds}
-                onValueChange={(values) =>
-                  onUpdateFilters({ filterAgentIds: values.slice(0, 1) })
-                }
-                placeholder="All agents"
-                variant="secondary"
-                className="w-full"
-                maxCount={1}
-              />
-            </div>
-
-            <div>
-              <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
-                User
-              </label>
-              <MultiSelect
-                options={memberOptions}
-                defaultValue={filterUserIds}
-                onValueChange={(values) =>
-                  onUpdateFilters({ filterUserIds: values.slice(0, 1) })
-                }
-                placeholder="All users"
-                variant="secondary"
-                className="w-full"
-                maxCount={1}
-              />
-            </div>
-
-            <div>
-              <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
-                Status
-              </label>
-              <Select
-                value={filterStatus}
-                onValueChange={(value) =>
-                  onUpdateFilters({ filterStatus: value })
-                }
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All statuses</SelectItem>
-                  <SelectItem value="completed">Completed</SelectItem>
-                  <SelectItem value="active">Active</SelectItem>
-                  <SelectItem value="failed">Failed</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          {activeFiltersCount > 0 && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-full"
-              onClick={() => {
-                onUpdateFilters({
-                  filterAgentIds: [],
-                  filterUserIds: [],
-                  filterStatus: "all",
-                });
-                setOpen(false);
-              }}
-            >
-              Clear all filters
-            </Button>
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
   );
 }
 


### PR DESCRIPTION
## Summary
`threads.tsx` (1037 lines) is one of the monitoring view's largest frontend files (C5 God-component debt). `ThreadsFiltersPopover` is a self-contained unit — it only reads its own props plus a local `open` state, sharing no closures with the rest of the file — and is already imported independently by `monitoring/index.tsx`, so this is a byte-identical relocation, not a rewrite.

## What changed
- Moved `ThreadsFiltersPopoverProps` + `ThreadsFiltersPopover` verbatim into a new `threads-filters-popover.tsx`.
- Trimmed the now-unused imports (`Badge`, `MultiSelect`, `Popover*`, `Select*`, `FilterLines`) from `threads.tsx`.
- Updated `monitoring/index.tsx` to import the component from its new file.
- Net: -157 / +154 lines (component code moved, not duplicated).

## Testing notes
- `bun run fmt` — clean.
- `cd apps/mesh && bun x tsc --noEmit` — passes with no errors.
- No behavior change: same JSX, same props, same logic — just relocated. A reviewer can confirm with `git diff --stat` showing only the file split plus import updates.

Full CI (lint, test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted ThreadsFiltersPopover into its own file to reduce `threads.tsx` size and make the monitoring UI more modular. No behavior changes; only a file move and import updates.

- **Refactors**
  - Moved ThreadsFiltersPopover and its props to apps/mesh/src/web/routes/orgs/monitoring/threads-filters-popover.tsx.
  - Removed now-unused imports from apps/mesh/src/web/routes/orgs/monitoring/threads.tsx.
  - Updated apps/mesh/src/web/routes/orgs/monitoring/index.tsx to import the component from its new file.

<sup>Written for commit 31dde280424b7712fd4518e80b8eee26ebc3f2b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

