### PR TITLE
refactor(library): dedupe card actions-menu markup into EntryActionsMenu

### DIFF
--- a/apps/mesh/src/web/layouts/library/cards.tsx
+++ b/apps/mesh/src/web/layouts/library/cards.tsx
@@ -171,6 +171,52 @@ function FileActions({
   );
 }
 
+/** Shared "Actions" dropdown for a card: browse/share/delete, whichever
+ *  the caller passes. Renders nothing if none are given. */
+function EntryActionsMenu({
+  label,
+  onBrowse,
+  onShare,
+  onDelete,
+}: {
+  label: string;
+  onBrowse?: () => void;
+  onShare?: () => void;
+  onDelete?: () => void;
+}) {
+  if (!onBrowse && !onShare && !onDelete) return undefined;
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 shrink-0 opacity-0 transition-opacity group-hover/card:opacity-100 data-[state=open]:opacity-100"
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`Actions for ${label}`}
+        >
+          <DotsVertical size={14} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+        {onBrowse && (
+          <DropdownMenuItem onClick={onBrowse}>
+            <Folder size={14} />
+            Browse files
+          </DropdownMenuItem>
+        )}
+        {onShare && <ShareMenuItem onShare={onShare} />}
+        {onDelete && (
+          <DropdownMenuItem variant="destructive" onClick={onDelete}>
+            <Trash01 size={14} />
+            Delete
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 function CardShell({
   onOpen,
   children,
@@ -290,33 +336,11 @@ export function FolderCard({
         subtitle={subtitle}
         publicState={publicState}
         actions={
-          onShare || onDelete ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="size-6 shrink-0 opacity-0 transition-opacity group-hover/card:opacity-100 data-[state=open]:opacity-100"
-                  onClick={(e) => e.stopPropagation()}
-                  aria-label={`Actions for ${name}`}
-                >
-                  <DotsVertical size={14} />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                align="end"
-                onClick={(e) => e.stopPropagation()}
-              >
-                {onShare && <ShareMenuItem onShare={onShare} />}
-                {onDelete && (
-                  <DropdownMenuItem variant="destructive" onClick={onDelete}>
-                    <Trash01 size={14} />
-                    Delete
-                  </DropdownMenuItem>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : undefined
+          <EntryActionsMenu
+            label={name}
+            onShare={onShare}
+            onDelete={onDelete}
+          />
         }
       />
     </CardShell>
@@ -415,35 +439,12 @@ export function SkillCard({
         subtitle="Skill"
         publicState={publicState}
         actions={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-6 shrink-0 opacity-0 transition-opacity group-hover/card:opacity-100 data-[state=open]:opacity-100"
-                onClick={(e) => e.stopPropagation()}
-                aria-label={`Actions for ${dirName}`}
-              >
-                <DotsVertical size={14} />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <DropdownMenuItem onClick={onBrowse}>
-                <Folder size={14} />
-                Browse files
-              </DropdownMenuItem>
-              {onShare && <ShareMenuItem onShare={onShare} />}
-              {onDelete && (
-                <DropdownMenuItem variant="destructive" onClick={onDelete}>
-                  <Trash01 size={14} />
-                  Delete
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <EntryActionsMenu
+            label={dirName}
+            onBrowse={onBrowse}
+            onShare={onShare}
+            onDelete={onDelete}
+          />
         }
       />
       <p className="line-clamp-2 min-h-8 text-xs leading-4 text-muted-foreground">
@@ -500,34 +501,11 @@ export function BrandCard({
         meta={timeAgo(updatedAt)}
         subtitle="Brand"
         actions={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-6 shrink-0 opacity-0 transition-opacity group-hover/card:opacity-100 data-[state=open]:opacity-100"
-                onClick={(e) => e.stopPropagation()}
-                aria-label={`Actions for ${dirName}`}
-              >
-                <DotsVertical size={14} />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <DropdownMenuItem onClick={onBrowse}>
-                <Folder size={14} />
-                Browse files
-              </DropdownMenuItem>
-              {onDelete && (
-                <DropdownMenuItem variant="destructive" onClick={onDelete}>
-                  <Trash01 size={14} />
-                  Delete
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <EntryActionsMenu
+            label={dirName}
+            onBrowse={onBrowse}
+            onDelete={onDelete}
+          />
         }
       />
       <div className="flex min-h-5 items-center gap-1.5">


### PR DESCRIPTION
## Source

Duplication reduction (C1) found while auditing recently-touched frontend files — no linked issue.

## Why

`FolderCard`, `SkillCard`, and `BrandCard` in `apps/mesh/src/web/layouts/library/cards.tsx` each hand-rolled an identical dropdown-menu actions block (trigger button + conditional browse/share/delete items), differing only in which of the three optional items they passed. Collapsed into a single `EntryActionsMenu({ label, onBrowse?, onShare?, onDelete? })` used by all three.

## Change

- **-26 net lines** (`+62 / -84`, diff dominated by the deleted duplicate blocks).
- Behavior-preserving: `EntryActionsMenu` returns `undefined` when none of `onBrowse`/`onShare`/`onDelete` are passed (matches `FolderCard`'s prior `onShare || onDelete ? … : undefined` guard); `SkillCard`/`BrandCard` always pass `onBrowse`, so their trigger always renders as before. Markup, classNames, and item ordering (Browse → Share → Delete) are unchanged.
- Confirmed all three call sites (`FolderCard`, `SkillCard`, `BrandCard`) are wired up in `apps/mesh/src/web/layouts/library/index.tsx` and no other file imports from `cards.tsx`.

## To verify

`cd apps/mesh && bunx tsc --noEmit` — green. `bun run fmt` applied. No behavior test exists for this file (pure JSX composition); full CI covers lint/build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced duplicated actions dropdown in Library cards with a shared `EntryActionsMenu` component. UI and behavior are unchanged; code is simpler and easier to maintain.

- **Refactors**
  - Added `EntryActionsMenu({ label, onBrowse?, onShare?, onDelete? })` and used it in `FolderCard`, `SkillCard`, and `BrandCard`.
  - Preserves order (Browse → Share → Delete), classes, and conditional rendering; returns `undefined` when no actions exist.
  - Net -26 LOC in apps/mesh/src/web/layouts/library/cards.tsx.

<sup>Written for commit 6f8d00b7eb8b1b372a33807176fb741620d1e6eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

