### PR TITLE
fix(chat): insert multi-dropped/pasted files in order, not reversed

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/file/uploader.tsx
@@ -171,15 +171,17 @@ export function FileUploader({
 
           if (!coordinates) return false;
 
-          // Process all dropped files sequentially at the drop position
+          // Process dropped files one at a time, re-reading the selection after
+          // each insert so multiple files land in order instead of racing to
+          // insert at the same stale position.
           const fileArray = Array.from(files);
-          const currentPos = coordinates.pos;
-
-          for (const file of fileArray) {
-            // Call the ref to use the latest selectedModel
-            void processFileRef.current?.(file, currentPos);
-            // In practice, they'll be inserted at the same position which is fine
-          }
+          void (async () => {
+            let insertPos = coordinates.pos;
+            for (const file of fileArray) {
+              await processFileRef.current?.(file, insertPos);
+              insertPos = view.state.selection.to;
+            }
+          })();
 
           return true;
         },
@@ -195,11 +197,15 @@ export function FileUploader({
 
           event.preventDefault();
 
-          const { from } = view.state.selection;
-          for (const item of fileItems) {
-            const file = item.getAsFile();
-            if (file) void processFileRef.current?.(file, from);
-          }
+          void (async () => {
+            let insertPos = view.state.selection.from;
+            for (const item of fileItems) {
+              const file = item.getAsFile();
+              if (!file) continue;
+              await processFileRef.current?.(file, insertPos);
+              insertPos = view.state.selection.to;
+            }
+          })();
 
           return true;
         },


### PR DESCRIPTION
## Summary

`FileUploader`'s ProseMirror `handleDrop`/`handlePaste` handlers looped over each dropped/pasted file and fired `void processFileRef.current?.(file, currentPos)` without awaiting, all passing the *same* fixed document position.

`insertContentAt` resolves that position against the live document on each `editor.chain()...run()` call. Since the calls aren't awaited/sequential, and `processFile` itself does async work (`FileReader`), each insert lands via a fresh transaction against whatever the doc looks like at that moment — inserting again at the same original position pushes the previous file's content *forward*, so multiple files dropped or pasted together end up inserted in reverse order (or interleaved unpredictably depending on `FileReader` timing). The existing comment ("In practice, they'll be inserted at the same position which is fine") is the tell that this was a known-but-unverified shortcut.

## Fix

Process files sequentially (`await` each one) and re-read `view.state.selection.to` after every insert to get the live position for the next file, instead of reusing the stale position computed at drop/paste time.

## Testing

- Reasoning verified against `@tiptap/core`'s `insertContentAt` implementation (`node_modules/.bun/@tiptap+core@3.20.2.../dist/index.cjs`), which resolves `from`/`to` against the transaction's current doc on every call.
- `bun run fmt` and a targeted `apps/mesh` `tsc --noEmit` pass (both clean).
- No unit-test harness in the repo currently instantiates a live ProseMirror `Editor`/`view` (checked — no precedent), so this can't be covered by a `bun test` unit test without adding new test infrastructure; a reviewer can confirm by dragging or pasting 2+ files into the chat composer at once and checking they appear in drop/paste order.

## Reviewer check

Drag two or more files onto the chat input (or paste multiple files) in one gesture — they should now appear in the order dropped/pasted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-file drop/paste in the chat composer so files are inserted in the original order. Files are now processed one at a time, updating the insert position after each insert to prevent reversed or interleaved results.

- **Bug Fixes**
  - `handleDrop` and `handlePaste` now await each file before proceeding.
  - After each insert, the next insert position is read from `view.state.selection.to` instead of reusing the original position.

<sup>Written for commit 635670be47b0b16d1cd4bb477741b2660993799a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

