### PR TITLE
refactor(account): dedupe mobile/desktop markup in account popover

### DIFF
--- a/apps/mesh/src/web/components/account-popover.tsx
+++ b/apps/mesh/src/web/components/account-popover.tsx
@@ -106,6 +106,139 @@ function ImpersonatingPill() {
   );
 }
 
+function UserInfoHeader({
+  user,
+  userImage,
+  isImpersonating,
+  isMobile,
+}: {
+  user: { id?: string; name?: string; email?: string } | undefined;
+  userImage?: string;
+  isImpersonating: boolean;
+  isMobile: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 px-4",
+        isMobile ? "py-4 border-b border-border" : "py-3 mx-1 mt-1",
+      )}
+    >
+      <Avatar
+        url={userImage}
+        fallback={user?.name ?? "U"}
+        shape="circle"
+        size="sm"
+        className="shrink-0"
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-medium truncate">{user?.name ?? "User"}</p>
+          {isImpersonating && <ImpersonatingPill />}
+        </div>
+        <p className="text-xs text-muted-foreground truncate">{user?.email}</p>
+      </div>
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              tabIndex={-1}
+              onClick={() => {
+                if (!user?.id) return;
+                navigator.clipboard.writeText(user.id).then(() => {
+                  toast.success("User ID copied");
+                });
+              }}
+              className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Copy01 size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p className="text-xs">Copy user ID</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+}
+
+function ThemeSoundVersionBar({
+  themeOptions,
+  preferences,
+  setPreferences,
+  isMobile,
+}: {
+  themeOptions: { value: ThemeMode; icon: React.ReactNode; label: string }[];
+  preferences: ReturnType<typeof usePreferences>[0];
+  setPreferences: ReturnType<typeof usePreferences>[1];
+  isMobile: boolean;
+}) {
+  const buttonSize = isMobile ? "size-8" : "size-7";
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between border-t border-border/50",
+        isMobile ? "px-3 py-3" : "px-2 py-1.5",
+      )}
+    >
+      <div className="flex items-center gap-0.5">
+        {themeOptions.map(({ value, icon, label }) => (
+          <button
+            key={value}
+            type="button"
+            aria-label={label}
+            onClick={() =>
+              setPreferences((prev) => ({ ...prev, theme: value }))
+            }
+            className={cn(
+              buttonSize,
+              "rounded-md flex items-center justify-center transition-colors",
+              preferences.theme === value
+                ? "bg-sidebar-accent text-foreground"
+                : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
+            )}
+          >
+            {icon}
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          aria-label={
+            preferences.enableSounds ? "Disable sounds" : "Enable sounds"
+          }
+          onClick={() =>
+            setPreferences((prev) => ({
+              ...prev,
+              enableSounds: !prev.enableSounds,
+            }))
+          }
+          className={cn(
+            buttonSize,
+            "rounded-md flex items-center justify-center transition-colors",
+            preferences.enableSounds
+              ? "text-foreground hover:bg-sidebar-accent/50"
+              : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
+          )}
+        >
+          {preferences.enableSounds ? (
+            <VolumeMax size={14} />
+          ) : (
+            <VolumeX size={14} />
+          )}
+        </button>
+        <span className="text-xs text-muted-foreground/60">
+          v{__MESH_VERSION__}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 /** Shared content rendered inside popover (desktop) or drawer (mobile) */
 function AccountPopoverContent({
   user,
@@ -136,49 +269,12 @@ function AccountPopoverContent({
     // Mobile: single-column scrollable layout
     return (
       <div className="flex flex-col h-full overflow-hidden">
-        {/* User info */}
-        <div className="flex items-center gap-3 px-4 py-4 border-b border-border">
-          <Avatar
-            url={userImage}
-            fallback={user?.name ?? "U"}
-            shape="circle"
-            size="sm"
-            className="shrink-0"
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <p className="text-sm font-medium truncate">
-                {user?.name ?? "User"}
-              </p>
-              {isImpersonating && <ImpersonatingPill />}
-            </div>
-            <p className="text-xs text-muted-foreground truncate">
-              {user?.email}
-            </p>
-          </div>
-          <TooltipProvider delayDuration={300}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  tabIndex={-1}
-                  onClick={() => {
-                    if (!user?.id) return;
-                    navigator.clipboard.writeText(user.id).then(() => {
-                      toast.success("User ID copied");
-                    });
-                  }}
-                  className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <Copy01 size={14} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="right">
-                <p className="text-xs">Copy user ID</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
+        <UserInfoHeader
+          user={user}
+          userImage={userImage}
+          isImpersonating={isImpersonating}
+          isMobile
+        />
 
         {/* Scrollable content */}
         <div className="flex-1 min-h-0 overflow-y-auto">
@@ -194,58 +290,12 @@ function AccountPopoverContent({
           </nav>
         </div>
 
-        {/* Bottom bar: theme + sound + version */}
-        <div className="flex items-center justify-between px-3 py-3 border-t border-border/50">
-          <div className="flex items-center gap-0.5">
-            {themeOptions.map(({ value, icon, label }) => (
-              <button
-                key={value}
-                type="button"
-                aria-label={label}
-                onClick={() =>
-                  setPreferences((prev) => ({ ...prev, theme: value }))
-                }
-                className={cn(
-                  "size-8 rounded-md flex items-center justify-center transition-colors",
-                  preferences.theme === value
-                    ? "bg-sidebar-accent text-foreground"
-                    : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
-                )}
-              >
-                {icon}
-              </button>
-            ))}
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              aria-label={
-                preferences.enableSounds ? "Disable sounds" : "Enable sounds"
-              }
-              onClick={() =>
-                setPreferences((prev) => ({
-                  ...prev,
-                  enableSounds: !prev.enableSounds,
-                }))
-              }
-              className={cn(
-                "size-8 rounded-md flex items-center justify-center transition-colors",
-                preferences.enableSounds
-                  ? "text-foreground hover:bg-sidebar-accent/50"
-                  : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
-              )}
-            >
-              {preferences.enableSounds ? (
-                <VolumeMax size={14} />
-              ) : (
-                <VolumeX size={14} />
-              )}
-            </button>
-            <span className="text-xs text-muted-foreground/60">
-              v{__MESH_VERSION__}
-            </span>
-          </div>
-        </div>
+        <ThemeSoundVersionBar
+          themeOptions={themeOptions}
+          preferences={preferences}
+          setPreferences={setPreferences}
+          isMobile
+        />
       </div>
     );
   }
@@ -254,49 +304,12 @@ function AccountPopoverContent({
   return (
     <div className="flex w-full flex-col overflow-hidden">
       <div className="flex flex-col">
-        {/* User info */}
-        <div className="flex items-center gap-3 px-4 py-3 mx-1 mt-1">
-          <Avatar
-            url={userImage}
-            fallback={user?.name ?? "U"}
-            shape="circle"
-            size="sm"
-            className="shrink-0"
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <p className="text-sm font-medium truncate">
-                {user?.name ?? "User"}
-              </p>
-              {isImpersonating && <ImpersonatingPill />}
-            </div>
-            <p className="text-xs text-muted-foreground truncate">
-              {user?.email}
-            </p>
-          </div>
-          <TooltipProvider delayDuration={300}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  tabIndex={-1}
-                  onClick={() => {
-                    if (!user?.id) return;
-                    navigator.clipboard.writeText(user.id).then(() => {
-                      toast.success("User ID copied");
-                    });
-                  }}
-                  className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <Copy01 size={14} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="right">
-                <p className="text-xs">Copy user ID</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
+        <UserInfoHeader
+          user={user}
+          userImage={userImage}
+          isImpersonating={isImpersonating}
+          isMobile={false}
+        />
 
         {/* Navigation items */}
         <nav className="flex-1 flex flex-col px-2 pt-1 overflow-y-auto">
@@ -309,58 +322,12 @@ function AccountPopoverContent({
           <MenuItemButton item={signOutItem} onClose={close} />
         </nav>
 
-        {/* Bottom bar: theme toggles + sound + version */}
-        <div className="flex items-center justify-between px-2 py-1.5 border-t border-border/50">
-          <div className="flex items-center gap-0.5">
-            {themeOptions.map(({ value, icon, label }) => (
-              <button
-                key={value}
-                type="button"
-                aria-label={label}
-                onClick={() =>
-                  setPreferences((prev) => ({ ...prev, theme: value }))
-                }
-                className={cn(
-                  "size-7 rounded-md flex items-center justify-center transition-colors",
-                  preferences.theme === value
-                    ? "bg-sidebar-accent text-foreground"
-                    : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
-                )}
-              >
-                {icon}
-              </button>
-            ))}
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              aria-label={
-                preferences.enableSounds ? "Disable sounds" : "Enable sounds"
-              }
-              onClick={() =>
-                setPreferences((prev) => ({
-                  ...prev,
-                  enableSounds: !prev.enableSounds,
-                }))
-              }
-              className={cn(
-                "size-7 rounded-md flex items-center justify-center transition-colors",
-                preferences.enableSounds
-                  ? "text-foreground hover:bg-sidebar-accent/50"
-                  : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
-              )}
-            >
-              {preferences.enableSounds ? (
-                <VolumeMax size={14} />
-              ) : (
-                <VolumeX size={14} />
-              )}
-            </button>
-            <span className="text-xs text-muted-foreground/60">
-              v{__MESH_VERSION__}
-            </span>
-          </div>
-        </div>
+        <ThemeSoundVersionBar
+          themeOptions={themeOptions}
+          preferences={preferences}
+          setPreferences={setPreferences}
+          isMobile={false}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
`AccountPopoverContent` in `account-popover.tsx` had two near-identical JSX blocks — the user-info header (avatar/name/email/copy-id button) and the theme+sound+version bottom bar — duplicated across its mobile and desktop render branches, differing only in spacing and button-size classes.

Extracted both into local components, `UserInfoHeader` and `ThemeSoundVersionBar`, parameterized by an `isMobile` flag that drives the few className differences (padding, border, button size). Net: -33 lines, same markup/classes rendered per branch.

## Why
Same duplication-cleanup pattern already merged several times in this repo (e.g. #4802 "dedupe view-toggle link className", #4798 "dedupe date format", #4800 "dedupe form-update logic") — one less place to keep two copies in sync when this menu changes.

## Testing
- Confirmed behavior-preserving: diffed the extracted JSX against both original branches — same classNames (`size-8`/`size-7`, `py-4 border-b`/`py-3 mx-1 mt-1`, `px-3`/`px-2`) are still produced per the `isMobile` flag, and all props/handlers passed through unchanged.
- `bun run fmt`
- `cd apps/mesh && bunx tsc --noEmit` — clean, no errors introduced.
- Reviewer check: `bun x tsc --noEmit` in `apps/mesh`; full CI runs lint + tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the account popover by deduping mobile and desktop markup. Behavior is unchanged and the code is easier to maintain.

- **Refactors**
  - Extracted `UserInfoHeader` and `ThemeSoundVersionBar` local components.
  - `isMobile` prop mirrors previous spacing and button-size class differences.
  - Removed duplicated header and bottom bar JSX from both branches (net -33 lines).

<sup>Written for commit 51c2c8de22cc340145ebf5773532d2fa4dd44f4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

