### PR TITLE
refactor(connections): extract BulkDeleteDialog into its own file

### DIFF
--- a/apps/mesh/src/web/routes/orgs/bulk-delete-dialog.tsx
+++ b/apps/mesh/src/web/routes/orgs/bulk-delete-dialog.tsx
@@ -1,0 +1,47 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@deco/ui/components/alert-dialog.tsx";
+
+export function BulkDeleteDialog({
+  open,
+  onOpenChange,
+  count,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  count: number;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Delete {count} connection{count !== 1 ? "s" : ""}?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete the selected connection
+            {count !== 1 ? "s" : ""}. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Delete {count} connection{count !== 1 ? "s" : ""}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -21,6 +21,7 @@ import { useAuthConfig } from "@/web/providers/auth-config-provider";
 import { useMergedStoreDiscovery } from "@/web/hooks/use-merged-store-discovery";
 import { getGitHubAvatarUrl } from "@deco/ui/lib/github.ts";
 import { getConnectionSlug } from "@/shared/utils/connection-slug";
+import { BulkDeleteDialog } from "./bulk-delete-dialog.tsx";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -454,47 +455,6 @@ function AddToAgentDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Bulk delete confirmation dialog
-// ---------------------------------------------------------------------------
-
-function BulkDeleteDialog({
-  open,
-  onOpenChange,
-  count,
-  onConfirm,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  count: number;
-  onConfirm: () => void;
-}) {
-  return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
-            Delete {count} connection{count !== 1 ? "s" : ""}?
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            This will permanently delete the selected connection
-            {count !== 1 ? "s" : ""}. This action cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={onConfirm}
-            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          >
-            Delete {count} connection{count !== 1 ? "s" : ""}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
   );
 }
 


### PR DESCRIPTION
## Summary
`apps/mesh/src/web/routes/orgs/connections.tsx` is a 2000+ line God component (see the LARGEST FRONTEND FILES list). `BulkDeleteDialog` is a fully self-contained alert dialog — it only reads its own props (`open`, `onOpenChange`, `count`, `onConfirm`) and shares no closures/local state with the rest of the file — so it's a clean, bounded extraction (C5).

This is a byte-identical relocation: same JSX/behavior, moved to `bulk-delete-dialog.tsx`, plus one import in `connections.tsx`. No logic changed.

## Test plan
- `bunx tsc --noEmit` in `apps/mesh` passes (no type errors introduced)
- `bun run fmt` run, no changes needed
- Reviewer check: `git diff main -- apps/mesh/src/web/routes/orgs/connections.tsx apps/mesh/src/web/routes/orgs/bulk-delete-dialog.tsx` shows a pure move (dialog JSX unchanged, only import + call site updated)

Full CI (lint, unit tests) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the bulk delete confirmation dialog into its own `BulkDeleteDialog` component to shrink `apps/mesh/src/web/routes/orgs/connections.tsx` and improve readability. Behavior is unchanged; moved to `apps/mesh/src/web/routes/orgs/bulk-delete-dialog.tsx` and updated `connections.tsx` to import it.

<sup>Written for commit 8d7000e4afce5e8b8cffc99049c0f2db60776b97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

