### PR TITLE
fix(content): invalidate live-meta cache after deleting a blog block

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
@@ -23,6 +23,14 @@ function decofileQueryKey({
   return KEYS.decofile(`${orgSlug}/${virtualMcpId}/${branch}`);
 }
 
+function liveMetaQueryKey({
+  orgSlug,
+  virtualMcpId,
+  branch,
+}: BlogMutationParams) {
+  return KEYS.liveMeta(`${orgSlug}/${virtualMcpId}/${branch}`);
+}
+
 function writeUrl(
   { orgSlug, virtualMcpId, branch }: BlogMutationParams,
   op: "write" | "unlink",
@@ -117,6 +125,11 @@ export function useDeleteBlogBlock(params: BlogMutationParams) {
       if (context?.queryKey) {
         queryClient.setQueryData(context.queryKey, context.previous);
       }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: liveMetaQueryKey(params),
+      });
     },
   });
 }


### PR DESCRIPTION
## Summary

`useDeleteBlock` (`apps/mesh/src/web/components/sections-editor/use-delete-block.ts`), the generic decofile-block delete hook, invalidates the sandbox's `live-meta` manifest cache in `onSuccess` — deleting a block file removes its entry from `manifest.blocks` in the dev server's `/live/_meta` response, so the client-side manifest cache (`staleTime: 300_000`) needs a refetch or it serves a stale manifest for up to 5 minutes.

`useDeleteBlogBlock` (`apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts`) deletes the exact same kind of decofile block through the same `unlink` endpoint — its own doc comment says it "mirrors" the generic hooks — but never picked up this invalidation, so deleting a blog post/category leaves the manifest cache stale after a successful delete.

## Why a maintainer wants this

Consumers of the manifest (`useLiveMeta` in `content-browser.tsx`, schema resolution in `resolve-schema.ts`) can keep referencing a just-deleted blog block for up to 5 minutes, which is exactly the class of bug the sibling hook's invalidation was added to prevent.

## Fix

Add the same `onSuccess: () => queryClient.invalidateQueries({ queryKey: liveMetaQueryKey(params) })` to `useDeleteBlogBlock`, using the same cache-key convention (`KEYS.liveMeta`) already used by the generic hook and by `useLiveMeta`.

## How to confirm

Delete a blog post from the Content tab, then check React Query devtools (or network tab) — the `live-meta` query for that org/agent/branch should be marked stale/refetched immediately after the delete succeeds, matching what already happens when deleting a regular page/section block.

## Checks run locally

- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` (green)
- No existing test file covers `use-blog-mutations.ts`/`use-delete-block.ts`/`use-save-block.ts` (these mutation hooks aren't unit-tested elsewhere in the repo either — this change keeps behavior parity rather than introducing new test infra). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invalidate the sandbox `live-meta` manifest cache after deleting a blog block by adding `onSuccess` invalidation to `useDeleteBlogBlock`. This prevents stale manifest data for up to 5 minutes and matches the behavior of the generic `useDeleteBlock`.

<sup>Written for commit d7362456801d23fc8e2ffa45f8b94088bf5179ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

