### PR TITLE
refactor(home): extract AgentPromptList into its own file

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -33,7 +33,6 @@ import { getDevAgentIds } from "@/web/lib/agent-capabilities";
 import {
   getHomeTiles,
   isDecopilot,
-  useMCPClient,
   useProjectContext,
   useVirtualMCPActions,
   useVirtualMCPs,
@@ -44,7 +43,7 @@ import {
   useDefaultHomeAgents,
   useHomeAgentsWriter,
 } from "@/web/hooks/use-organization-settings";
-import { useHomeNextActions } from "@/web/hooks/use-home-next-actions";
+import { AgentPromptList } from "./agent-prompt-list";
 import { useHomeEdit } from "./home-edit-context";
 import { NATIVE_TILES, nativeCandidateId } from "./native-tiles";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -85,7 +84,7 @@ import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/
 
 /** How many agents the home view can actually display — adding past this is
  * blocked so the user never pins something that silently won't show. */
-const HOME_LIMIT = 8;
+export const HOME_LIMIT = 8;
 
 interface AddTileDrawerProps {
   open: boolean;
@@ -221,7 +220,7 @@ function useHomeBoard(validIds?: ReadonlySet<string>) {
   };
 }
 
-type HomeBoard = ReturnType<typeof useHomeBoard>;
+export type HomeBoard = ReturnType<typeof useHomeBoard>;
 
 function DrawerBody({ search }: { search: string }) {
   const agents = useVirtualMCPs({ pageSize: 1000 });
@@ -1207,7 +1206,7 @@ function AddToolRow({
   );
 }
 
-function ToggleButton({
+export function ToggleButton({
   isPinned,
   submitting,
   onClick,
@@ -1240,172 +1239,6 @@ function ToggleButton({
         <Plus size={14} />
       )}
     </button>
-  );
-}
-
-interface AgentPrompt {
-  name: string;
-  title?: string;
-  description?: string;
-}
-
-/**
- * Lists every prompt the agent's gateway exposes. Pin/unpin writes to
- * `metadata.ui.homePrompts` — when that field is null/absent the home
- * surfaces all prompts (default), when it's an array (even empty) the
- * BE honors that list verbatim.
- */
-function AgentPromptList({
-  agent,
-  home,
-  curated,
-}: {
-  agent: VirtualMCPEntity;
-  home: HomeBoard;
-  curated: string[] | null;
-}) {
-  const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: agent.id,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
-
-  const { data, isLoading, error } = useQuery({
-    queryKey: KEYS.agentPrompts(org.id, agent.id),
-    queryFn: async (): Promise<AgentPrompt[]> => {
-      const { prompts } = await client.listPrompts();
-      return prompts.map((p) => ({
-        name: p.name,
-        title: p.title,
-        description: p.description,
-      }));
-    },
-    staleTime: 30_000,
-    retry: false,
-  });
-
-  // Studio Pack agents and others whose gateway doesn't surface prompts
-  // via `prompts/list` still emit them through the home-next-actions
-  // endpoint (checklist items, etc). Merge that as a fallback source.
-  const homeNextActions = useHomeNextActions(org.slug);
-  const fromHome: AgentPrompt[] = homeNextActions.prompts
-    .filter((p) => p.agentId === agent.id && p.promptName)
-    .map((p) => ({
-      name: p.promptName,
-      title: p.title,
-      description: p.description,
-    }));
-
-  const merged: AgentPrompt[] = [...(data ?? [])];
-  for (const p of fromHome) {
-    if (!merged.some((m) => m.name === p.name)) merged.push(p);
-  }
-
-  if (isLoading && fromHome.length === 0) {
-    return (
-      <div className="flex flex-col gap-1">
-        <Skeleton className="h-7 w-full" />
-        <Skeleton className="h-7 w-2/3" />
-      </div>
-    );
-  }
-  if (error && fromHome.length === 0) {
-    console.error("[home-tiles] listPrompts failed for agent", agent.id, error);
-    return null;
-  }
-  if (merged.length === 0) {
-    return null;
-  }
-
-  // When `homePrompts` is null/absent, all prompts are surfaced — every
-  // row reads as pinned so the default "all on" state is conveyed by
-  // the buttons themselves.
-  const pinnedNames = new Set(curated ?? merged.map((p) => p.name));
-
-  return (
-    <div className="flex flex-col gap-0.5">
-      {merged.map((prompt) => (
-        <PromptRow
-          key={prompt.name}
-          agent={agent}
-          home={home}
-          prompt={prompt}
-          allPromptNames={merged.map((p) => p.name)}
-          isPinned={pinnedNames.has(prompt.name)}
-        />
-      ))}
-    </div>
-  );
-}
-
-function PromptRow({
-  agent,
-  home,
-  prompt,
-  allPromptNames,
-  isPinned,
-}: {
-  agent: VirtualMCPEntity;
-  home: HomeBoard;
-  prompt: AgentPrompt;
-  /** Every prompt the agent exposes — used when transitioning from
-   *  "all (uncurated)" to "curated" so we don't drop everything. */
-  allPromptNames: string[];
-  isPinned: boolean;
-}) {
-  const [submitting, setSubmitting] = useState(false);
-
-  const handleClick = async () => {
-    if (!isPinned && !home.isOnHome(agent.id) && home.atLimit) {
-      toast.error(`Home is full (${HOME_LIMIT}) — remove an agent first`);
-      return;
-    }
-    setSubmitting(true);
-    try {
-      // Compute next `homePrompts`. Three states:
-      //  - uncurated (null) + Remove → keep every prompt except this one
-      //  - curated array + Add → append name
-      //  - curated array + Remove → filter out name
-      const current = agent.metadata?.ui?.homePrompts;
-      let nextHomePrompts: string[];
-      if (!Array.isArray(current)) {
-        nextHomePrompts = isPinned
-          ? allPromptNames.filter((n) => n !== prompt.name)
-          : allPromptNames; // unreachable: pinned=true in uncurated mode
-      } else {
-        nextHomePrompts = isPinned
-          ? current.filter((n) => n !== prompt.name)
-          : [...current, prompt.name];
-      }
-      const nextMetadata = {
-        ...(agent.metadata ?? {}),
-        ui: {
-          ...(agent.metadata?.ui ?? {}),
-          homePrompts: nextHomePrompts,
-        },
-      };
-      await home.saveAgentMetadata(agent, nextMetadata);
-    } catch (err) {
-      console.error("[home-tiles] failed to toggle prompt", err);
-      toast.error("Couldn't update home — please try again.");
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return (
-    <div className="flex items-center gap-2.5 rounded-md px-2 py-1 hover:bg-accent/40">
-      <div className="min-w-0 flex-1 truncate text-sm text-foreground">
-        {prompt.title ?? toTitleCase(prompt.name)}
-      </div>
-      <ToggleButton
-        isPinned={isPinned}
-        submitting={submitting}
-        onClick={handleClick}
-        label={isPinned ? "Remove from home" : "Add to home"}
-      />
-    </div>
   );
 }
 

--- a/apps/mesh/src/web/components/home/agent-prompt-list.tsx
+++ b/apps/mesh/src/web/components/home/agent-prompt-list.tsx
@@ -1,0 +1,179 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+  useMCPClient,
+  useProjectContext,
+  type VirtualMCPEntity,
+} from "@decocms/mesh-sdk";
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import { toast } from "sonner";
+import { useHomeNextActions } from "@/web/hooks/use-home-next-actions";
+import { KEYS } from "@/web/lib/query-keys";
+import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
+import { HOME_LIMIT, ToggleButton, type HomeBoard } from "./add-tile-drawer";
+
+interface AgentPrompt {
+  name: string;
+  title?: string;
+  description?: string;
+}
+
+/**
+ * Lists every prompt the agent's gateway exposes. Pin/unpin writes to
+ * `metadata.ui.homePrompts` — when that field is null/absent the home
+ * surfaces all prompts (default), when it's an array (even empty) the
+ * BE honors that list verbatim.
+ */
+export function AgentPromptList({
+  agent,
+  home,
+  curated,
+}: {
+  agent: VirtualMCPEntity;
+  home: HomeBoard;
+  curated: string[] | null;
+}) {
+  const { org } = useProjectContext();
+  const client = useMCPClient({
+    connectionId: agent.id,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: KEYS.agentPrompts(org.id, agent.id),
+    queryFn: async (): Promise<AgentPrompt[]> => {
+      const { prompts } = await client.listPrompts();
+      return prompts.map((p) => ({
+        name: p.name,
+        title: p.title,
+        description: p.description,
+      }));
+    },
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  // Studio Pack agents and others whose gateway doesn't surface prompts
+  // via `prompts/list` still emit them through the home-next-actions
+  // endpoint (checklist items, etc). Merge that as a fallback source.
+  const homeNextActions = useHomeNextActions(org.slug);
+  const fromHome: AgentPrompt[] = homeNextActions.prompts
+    .filter((p) => p.agentId === agent.id && p.promptName)
+    .map((p) => ({
+      name: p.promptName,
+      title: p.title,
+      description: p.description,
+    }));
+
+  const merged: AgentPrompt[] = [...(data ?? [])];
+  for (const p of fromHome) {
+    if (!merged.some((m) => m.name === p.name)) merged.push(p);
+  }
+
+  if (isLoading && fromHome.length === 0) {
+    return (
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-7 w-full" />
+        <Skeleton className="h-7 w-2/3" />
+      </div>
+    );
+  }
+  if (error && fromHome.length === 0) {
+    console.error("[home-tiles] listPrompts failed for agent", agent.id, error);
+    return null;
+  }
+  if (merged.length === 0) {
+    return null;
+  }
+
+  // When `homePrompts` is null/absent, all prompts are surfaced — every
+  // row reads as pinned so the default "all on" state is conveyed by
+  // the buttons themselves.
+  const pinnedNames = new Set(curated ?? merged.map((p) => p.name));
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      {merged.map((prompt) => (
+        <PromptRow
+          key={prompt.name}
+          agent={agent}
+          home={home}
+          prompt={prompt}
+          allPromptNames={merged.map((p) => p.name)}
+          isPinned={pinnedNames.has(prompt.name)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function PromptRow({
+  agent,
+  home,
+  prompt,
+  allPromptNames,
+  isPinned,
+}: {
+  agent: VirtualMCPEntity;
+  home: HomeBoard;
+  prompt: AgentPrompt;
+  /** Every prompt the agent exposes — used when transitioning from
+   *  "all (uncurated)" to "curated" so we don't drop everything. */
+  allPromptNames: string[];
+  isPinned: boolean;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleClick = async () => {
+    if (!isPinned && !home.isOnHome(agent.id) && home.atLimit) {
+      toast.error(`Home is full (${HOME_LIMIT}) — remove an agent first`);
+      return;
+    }
+    setSubmitting(true);
+    try {
+      // Compute next `homePrompts`. Three states:
+      //  - uncurated (null) + Remove → keep every prompt except this one
+      //  - curated array + Add → append name
+      //  - curated array + Remove → filter out name
+      const current = agent.metadata?.ui?.homePrompts;
+      let nextHomePrompts: string[];
+      if (!Array.isArray(current)) {
+        nextHomePrompts = isPinned
+          ? allPromptNames.filter((n) => n !== prompt.name)
+          : allPromptNames; // unreachable: pinned=true in uncurated mode
+      } else {
+        nextHomePrompts = isPinned
+          ? current.filter((n) => n !== prompt.name)
+          : [...current, prompt.name];
+      }
+      const nextMetadata = {
+        ...(agent.metadata ?? {}),
+        ui: {
+          ...(agent.metadata?.ui ?? {}),
+          homePrompts: nextHomePrompts,
+        },
+      };
+      await home.saveAgentMetadata(agent, nextMetadata);
+    } catch (err) {
+      console.error("[home-tiles] failed to toggle prompt", err);
+      toast.error("Couldn't update home — please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2.5 rounded-md px-2 py-1 hover:bg-accent/40">
+      <div className="min-w-0 flex-1 truncate text-sm text-foreground">
+        {prompt.title ?? toTitleCase(prompt.name)}
+      </div>
+      <ToggleButton
+        isPinned={isPinned}
+        submitting={submitting}
+        onClick={handleClick}
+        label={isPinned ? "Remove from home" : "Add to home"}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Source
Bounded C5 extraction — `add-tile-drawer.tsx` is a 1429-line God-component (one of the largest frontend files in the repo).

## Why
`AgentPromptList` + its row renderer `PromptRow` only read their own props/hooks and share no closures or local state with the rest of the drawer, so they're a clean, self-contained unit to relocate (`interface AgentPrompt`, `AgentPromptList`, `PromptRow`, ~171 lines moved verbatim into `agent-prompt-list.tsx`). `HOME_LIMIT`, `ToggleButton`, and the `HomeBoard` type are now exported from `add-tile-drawer.tsx` so the new file can import them rather than duplicate them. No behavior change — same JSX, same logic, just relocated plus the new import wiring.

## Verify
- `cd apps/mesh && bunx tsc --noEmit` — clean
- `bun run fmt` — clean

## Local checks run
- `bunx tsc --noEmit` (apps/mesh workspace)
- `bun run fmt`
Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the agent prompt list into `agent-prompt-list.tsx` to split up the large `add-tile-drawer.tsx` and keep prompt pin/unpin logic self-contained. No behavior changes.

- **Refactors**
  - Moved `AgentPromptList` and `PromptRow` to `apps/mesh/src/web/components/home/agent-prompt-list.tsx`.
  - Exported `HOME_LIMIT`, `ToggleButton`, and `HomeBoard` from `add-tile-drawer.tsx` for reuse.
  - Updated `add-tile-drawer.tsx` to import `AgentPromptList`.

<sup>Written for commit 34805f979107acecf8e73c0fb8fe8943fe693b63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

