### PR TITLE
refactor(virtual-mcp): extract ConnectionItem card into its own file

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/connection-item.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/connection-item.tsx
@@ -1,0 +1,399 @@
+import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
+import { useMCPAuthStatus } from "@/web/hooks/use-mcp-auth-status";
+import { getConnectionSlug } from "@/shared/utils/connection-slug";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import {
+  type ConnectionEntity,
+  useConnection,
+  useConnectionActions,
+  useConnections,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
+import { Link } from "@tanstack/react-router";
+import {
+  Power01,
+  Settings02,
+  Settings04,
+  SlashCircle01,
+  XClose,
+} from "@untitledui/icons";
+import { Suspense } from "react";
+import { toast } from "sonner";
+
+const NEW_INSTANCE_VALUE = "__new_instance__";
+
+/**
+ * Connection Item - Card layout inspired by the reference design:
+ * Body: icon + name + description (clickable → connection detail page)
+ * Footer: instance selector + resources summary + edit (resource config) + remove
+ */
+export function ConnectionItem({
+  connection_id,
+  usedConnectionIds,
+  onOpenSettings,
+  onRemove,
+  onAuthenticate,
+  onSwitchInstance,
+  onNewInstance,
+}: {
+  connection_id: string;
+  usedConnectionIds: Set<string>;
+  onOpenSettings: () => void;
+  onRemove: () => void;
+  onAuthenticate: (connectionId: string) => void;
+  onSwitchInstance: (oldId: string, newId: string) => void;
+  onNewInstance?: () => void;
+}) {
+  const connection = useConnection(connection_id);
+  const { org } = useProjectContext();
+
+  if (!connection) return null;
+
+  const slug = getConnectionSlug(connection);
+
+  return (
+    <Suspense
+      fallback={<ConnectionItemAuthFallback connection_id={connection_id} />}
+    >
+      <ConnectionItemWithAuth
+        connection_id={connection_id}
+        connectionTitle={connection.title}
+        connectionDescription={connection.description}
+        connectionIcon={connection.icon}
+        connectionType={connection.connection_type}
+        connectionStatus={connection.status}
+        slug={slug}
+        orgSlug={org.slug}
+        appName={connection.app_name}
+        usedConnectionIds={usedConnectionIds}
+        onOpenSettings={onOpenSettings}
+        onRemove={onRemove}
+        onAuthenticate={onAuthenticate}
+        onSwitchInstance={onSwitchInstance}
+        onNewInstance={onNewInstance}
+      />
+    </Suspense>
+  );
+}
+
+function SiblingInstanceSelector({
+  appName,
+  connectionId,
+  usedConnectionIds,
+  onSwitchInstance,
+  onNewInstance,
+}: {
+  appName: string;
+  connectionId: string;
+  usedConnectionIds: Set<string>;
+  onSwitchInstance: (oldId: string, newId: string) => void;
+  onNewInstance?: () => void;
+}) {
+  const siblings = useConnections({
+    filters: [{ column: "app_name", value: appName }],
+  });
+
+  if (siblings.length <= 1) return null;
+
+  return (
+    <Select
+      value={connectionId}
+      onValueChange={(newId) => {
+        if (newId === NEW_INSTANCE_VALUE) {
+          onNewInstance?.();
+        } else {
+          onSwitchInstance(connectionId, newId);
+        }
+      }}
+    >
+      <SelectTrigger
+        size="sm"
+        className="w-auto text-xs gap-1 px-2 shadow-none"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {siblings.map((s) => (
+          <SelectItem
+            key={s.id}
+            value={s.id}
+            className="text-xs"
+            disabled={s.id !== connectionId && usedConnectionIds.has(s.id)}
+          >
+            {s.title}
+          </SelectItem>
+        ))}
+        {onNewInstance && (
+          <SelectItem
+            value={NEW_INSTANCE_VALUE}
+            className="text-xs text-muted-foreground"
+          >
+            + New instance
+          </SelectItem>
+        )}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function ConnectionItemWithAuth({
+  connection_id,
+  connectionTitle,
+  connectionDescription,
+  connectionIcon,
+  connectionType,
+  connectionStatus,
+  slug,
+  orgSlug,
+  appName,
+  usedConnectionIds,
+  onOpenSettings,
+  onRemove,
+  onAuthenticate,
+  onSwitchInstance,
+  onNewInstance,
+}: {
+  connection_id: string;
+  connectionTitle: string;
+  connectionDescription?: string | null;
+  connectionIcon?: string | null;
+  connectionType: string;
+  connectionStatus: ConnectionEntity["status"];
+  slug: string;
+  orgSlug: string;
+  appName?: string | null;
+  usedConnectionIds: Set<string>;
+  onOpenSettings: () => void;
+  onRemove: () => void;
+  onAuthenticate: (connectionId: string) => void;
+  onSwitchInstance: (oldId: string, newId: string) => void;
+  onNewInstance?: () => void;
+}) {
+  const authStatus = useMCPAuthStatus({ connectionId: connection_id });
+  const connectionActions = useConnectionActions();
+  const isVirtual = connectionType === "VIRTUAL";
+  const needsAuth =
+    !isVirtual && authStatus.supportsOAuth && !authStatus.isAuthenticated;
+  const isDisabled = connectionStatus !== "active";
+
+  const toggleStatus = async (status: "active" | "inactive") => {
+    try {
+      await connectionActions.update.mutateAsync({
+        id: connection_id,
+        data: { status },
+      });
+      toast.success(
+        status === "active" ? "Connection enabled" : "Connection disabled",
+      );
+    } catch {
+      toast.error("Failed to update connection");
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border overflow-hidden transition-colors",
+        needsAuth || isDisabled
+          ? "border-destructive/50 bg-destructive/5"
+          : "border-border bg-card",
+      )}
+    >
+      {/* Body — clickable, navigates to connection detail */}
+      <Link
+        to="/$org/settings/connections/$appSlug"
+        params={{
+          org: orgSlug,
+          appSlug: slug,
+        }}
+        className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-muted/50 transition-colors"
+      >
+        <IntegrationIcon
+          icon={connectionIcon}
+          name={connectionTitle}
+          size="sm"
+          className="shrink-0"
+        />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium truncate">{connectionTitle}</p>
+          {needsAuth ? (
+            <span className="text-xs text-destructive font-medium">
+              Needs authorization
+            </span>
+          ) : isDisabled ? (
+            <span className="text-xs text-destructive font-medium">
+              {connectionStatus === "error" ? "Disabled (error)" : "Disabled"}
+            </span>
+          ) : (
+            connectionDescription && (
+              <p className="text-xs text-muted-foreground truncate">
+                {connectionDescription}
+              </p>
+            )
+          )}
+        </div>
+        {needsAuth ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs shrink-0"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onAuthenticate(connection_id);
+            }}
+          >
+            Authorize
+          </Button>
+        ) : isDisabled ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs gap-1.5 shrink-0"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              toggleStatus("active");
+            }}
+          >
+            <Power01 size={13} />
+            Enable
+          </Button>
+        ) : (
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+              <span className="inline-flex items-center justify-center rounded-md h-7 w-7 hover:bg-accent text-muted-foreground shrink-0 transition-colors">
+                <Settings02 size={16} />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Connection settings</TooltipContent>
+          </Tooltip>
+        )}
+      </Link>
+
+      {/* Footer — instance selector + resources summary + edit + remove */}
+      <div className="flex items-center gap-3 px-4 py-2 border-t border-border bg-muted/25">
+        {/* Instance selector */}
+        {appName && (
+          <SiblingInstanceSelector
+            appName={appName}
+            connectionId={connection_id}
+            usedConnectionIds={usedConnectionIds}
+            onSwitchInstance={onSwitchInstance}
+            onNewInstance={onNewInstance}
+          />
+        )}
+
+        <div className="flex items-center gap-0.5 ml-auto">
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={onOpenSettings}
+                aria-label="Configure resources"
+              >
+                <Settings04 size={13} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Configure resources</TooltipContent>
+          </Tooltip>
+          {!isDisabled && (
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground"
+                  onClick={() => toggleStatus("inactive")}
+                  aria-label="Disable connection"
+                >
+                  <SlashCircle01 size={13} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Disable</TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                onClick={onRemove}
+                aria-label="Remove connection"
+              >
+                <XClose size={13} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Remove</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConnectionItemAuthFallback({
+  connection_id,
+}: {
+  connection_id: string;
+}) {
+  const connection = useConnection(connection_id);
+  if (!connection) return <ConnectionItemSkeleton />;
+
+  return (
+    <div className="rounded-xl border border-border overflow-hidden">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <IntegrationIcon
+          icon={connection.icon}
+          name={connection.title}
+          size="sm"
+          className="shrink-0"
+        />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium truncate">{connection.title}</p>
+          {connection.description && (
+            <p className="text-xs text-muted-foreground truncate">
+              {connection.description}
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center px-4 py-2 border-t border-border bg-muted/25">
+        <div className="h-5 w-20 rounded bg-muted animate-pulse" />
+      </div>
+    </div>
+  );
+}
+
+export function ConnectionItemSkeleton() {
+  return (
+    <div className="rounded-xl border border-border overflow-hidden">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <div className="size-8 rounded-md bg-muted animate-pulse shrink-0" />
+        <div className="flex-1 space-y-1.5">
+          <div className="h-4 w-32 rounded bg-muted animate-pulse" />
+          <div className="h-3 w-48 rounded bg-muted animate-pulse" />
+        </div>
+      </div>
+      <div className="flex items-center px-4 py-2 border-t border-border bg-muted/25">
+        <div className="h-5 w-20 rounded bg-muted animate-pulse" />
+      </div>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -9,7 +9,6 @@ import { ErrorBoundary } from "@/web/components/error-boundary";
 import { IntegrationIcon } from "@/web/components/integration-icon.tsx";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { User } from "@/web/components/user/user";
-import { useMCPAuthStatus } from "@/web/hooks/use-mcp-auth-status";
 
 import {
   authenticateMcp,
@@ -17,7 +16,6 @@ import {
 } from "@/web/lib/mcp-oauth";
 import { KEYS } from "@/web/lib/query-keys";
 import { useStudioTools } from "@/web/lib/studio-tools";
-import { getConnectionSlug } from "@/shared/utils/connection-slug";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -54,12 +52,9 @@ import {
 } from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
-  type ConnectionEntity,
   ENV_VAR_KEY_RE,
   StudioPackAgentId,
-  useConnection,
   useConnectionActions,
-  useConnections,
   useProjectContext,
   useVirtualMCP,
   useVirtualMCPActions,
@@ -67,19 +62,8 @@ import {
 } from "@decocms/mesh-sdk";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useNavigate } from "@tanstack/react-router";
-import {
-  Settings02,
-  Settings04,
-  Maximize01,
-  Play,
-  Plus,
-  Power01,
-  SlashCircle01,
-  Stars01,
-  Trash01,
-  XClose,
-} from "@untitledui/icons";
+import { useNavigate } from "@tanstack/react-router";
+import { Maximize01, Play, Plus, Stars01, Trash01 } from "@untitledui/icons";
 import { Suspense, useEffect, useReducer, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useDebouncedAutosave } from "@/web/hooks/use-debounced-autosave.ts";
@@ -92,6 +76,7 @@ import { FilesSection } from "./files-section";
 import { SubAgentsSection } from "./sub-agents-section";
 import { track } from "@/web/lib/posthog-client";
 import { DependencySelectionDialog } from "./dependency-selection-dialog";
+import { ConnectionItem, ConnectionItemSkeleton } from "./connection-item";
 import { ALL_ITEMS_SELECTED } from "./selection-utils";
 import {
   VirtualMcpFormSchema,
@@ -226,62 +211,6 @@ function stripIncompleteEnvEntries(
   };
 }
 
-/**
- * Connection Item - Card layout inspired by the reference design:
- * Body: icon + name + description (clickable → connection detail page)
- * Footer: instance selector + resources summary + edit (resource config) + remove
- */
-function ConnectionItem({
-  connection_id,
-  usedConnectionIds,
-  onOpenSettings,
-  onRemove,
-  onAuthenticate,
-  onSwitchInstance,
-  onNewInstance,
-}: {
-  connection_id: string;
-  usedConnectionIds: Set<string>;
-  onOpenSettings: () => void;
-  onRemove: () => void;
-  onAuthenticate: (connectionId: string) => void;
-  onSwitchInstance: (oldId: string, newId: string) => void;
-  onNewInstance?: () => void;
-}) {
-  const connection = useConnection(connection_id);
-  const { org } = useProjectContext();
-
-  if (!connection) return null;
-
-  const slug = getConnectionSlug(connection);
-
-  return (
-    <Suspense
-      fallback={<ConnectionItemAuthFallback connection_id={connection_id} />}
-    >
-      <ConnectionItemWithAuth
-        connection_id={connection_id}
-        connectionTitle={connection.title}
-        connectionDescription={connection.description}
-        connectionIcon={connection.icon}
-        connectionType={connection.connection_type}
-        connectionStatus={connection.status}
-        slug={slug}
-        orgSlug={org.slug}
-        appName={connection.app_name}
-        usedConnectionIds={usedConnectionIds}
-        onOpenSettings={onOpenSettings}
-        onRemove={onRemove}
-        onAuthenticate={onAuthenticate}
-        onSwitchInstance={onSwitchInstance}
-        onNewInstance={onNewInstance}
-      />
-    </Suspense>
-  );
-}
-
-const NEW_INSTANCE_VALUE = "__new_instance__";
-
 async function extractEmailFromTokenInfo(
   tokenInfo: {
     idToken: string | null;
@@ -341,315 +270,6 @@ function decodeJwtEmail(token: string): string | null {
     // Not a decodable JWT
   }
   return null;
-}
-
-function SiblingInstanceSelector({
-  appName,
-  connectionId,
-  usedConnectionIds,
-  onSwitchInstance,
-  onNewInstance,
-}: {
-  appName: string;
-  connectionId: string;
-  usedConnectionIds: Set<string>;
-  onSwitchInstance: (oldId: string, newId: string) => void;
-  onNewInstance?: () => void;
-}) {
-  const siblings = useConnections({
-    filters: [{ column: "app_name", value: appName }],
-  });
-
-  if (siblings.length <= 1) return null;
-
-  return (
-    <Select
-      value={connectionId}
-      onValueChange={(newId) => {
-        if (newId === NEW_INSTANCE_VALUE) {
-          onNewInstance?.();
-        } else {
-          onSwitchInstance(connectionId, newId);
-        }
-      }}
-    >
-      <SelectTrigger
-        size="sm"
-        className="w-auto text-xs gap-1 px-2 shadow-none"
-      >
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        {siblings.map((s) => (
-          <SelectItem
-            key={s.id}
-            value={s.id}
-            className="text-xs"
-            disabled={s.id !== connectionId && usedConnectionIds.has(s.id)}
-          >
-            {s.title}
-          </SelectItem>
-        ))}
-        {onNewInstance && (
-          <SelectItem
-            value={NEW_INSTANCE_VALUE}
-            className="text-xs text-muted-foreground"
-          >
-            + New instance
-          </SelectItem>
-        )}
-      </SelectContent>
-    </Select>
-  );
-}
-
-function ConnectionItemWithAuth({
-  connection_id,
-  connectionTitle,
-  connectionDescription,
-  connectionIcon,
-  connectionType,
-  connectionStatus,
-  slug,
-  orgSlug,
-  appName,
-  usedConnectionIds,
-  onOpenSettings,
-  onRemove,
-  onAuthenticate,
-  onSwitchInstance,
-  onNewInstance,
-}: {
-  connection_id: string;
-  connectionTitle: string;
-  connectionDescription?: string | null;
-  connectionIcon?: string | null;
-  connectionType: string;
-  connectionStatus: ConnectionEntity["status"];
-  slug: string;
-  orgSlug: string;
-  appName?: string | null;
-  usedConnectionIds: Set<string>;
-  onOpenSettings: () => void;
-  onRemove: () => void;
-  onAuthenticate: (connectionId: string) => void;
-  onSwitchInstance: (oldId: string, newId: string) => void;
-  onNewInstance?: () => void;
-}) {
-  const authStatus = useMCPAuthStatus({ connectionId: connection_id });
-  const connectionActions = useConnectionActions();
-  const isVirtual = connectionType === "VIRTUAL";
-  const needsAuth =
-    !isVirtual && authStatus.supportsOAuth && !authStatus.isAuthenticated;
-  const isDisabled = connectionStatus !== "active";
-
-  const toggleStatus = async (status: "active" | "inactive") => {
-    try {
-      await connectionActions.update.mutateAsync({
-        id: connection_id,
-        data: { status },
-      });
-      toast.success(
-        status === "active" ? "Connection enabled" : "Connection disabled",
-      );
-    } catch {
-      toast.error("Failed to update connection");
-    }
-  };
-
-  return (
-    <div
-      className={cn(
-        "rounded-xl border overflow-hidden transition-colors",
-        needsAuth || isDisabled
-          ? "border-destructive/50 bg-destructive/5"
-          : "border-border bg-card",
-      )}
-    >
-      {/* Body — clickable, navigates to connection detail */}
-      <Link
-        to="/$org/settings/connections/$appSlug"
-        params={{
-          org: orgSlug,
-          appSlug: slug,
-        }}
-        className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-muted/50 transition-colors"
-      >
-        <IntegrationIcon
-          icon={connectionIcon}
-          name={connectionTitle}
-          size="sm"
-          className="shrink-0"
-        />
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium truncate">{connectionTitle}</p>
-          {needsAuth ? (
-            <span className="text-xs text-destructive font-medium">
-              Needs authorization
-            </span>
-          ) : isDisabled ? (
-            <span className="text-xs text-destructive font-medium">
-              {connectionStatus === "error" ? "Disabled (error)" : "Disabled"}
-            </span>
-          ) : (
-            connectionDescription && (
-              <p className="text-xs text-muted-foreground truncate">
-                {connectionDescription}
-              </p>
-            )
-          )}
-        </div>
-        {needsAuth ? (
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 text-xs shrink-0"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              onAuthenticate(connection_id);
-            }}
-          >
-            Authorize
-          </Button>
-        ) : isDisabled ? (
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 text-xs gap-1.5 shrink-0"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              toggleStatus("active");
-            }}
-          >
-            <Power01 size={13} />
-            Enable
-          </Button>
-        ) : (
-          <Tooltip delayDuration={0}>
-            <TooltipTrigger asChild>
-              <span className="inline-flex items-center justify-center rounded-md h-7 w-7 hover:bg-accent text-muted-foreground shrink-0 transition-colors">
-                <Settings02 size={16} />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Connection settings</TooltipContent>
-          </Tooltip>
-        )}
-      </Link>
-
-      {/* Footer — instance selector + resources summary + edit + remove */}
-      <div className="flex items-center gap-3 px-4 py-2 border-t border-border bg-muted/25">
-        {/* Instance selector */}
-        {appName && (
-          <SiblingInstanceSelector
-            appName={appName}
-            connectionId={connection_id}
-            usedConnectionIds={usedConnectionIds}
-            onSwitchInstance={onSwitchInstance}
-            onNewInstance={onNewInstance}
-          />
-        )}
-
-        <div className="flex items-center gap-0.5 ml-auto">
-          <Tooltip delayDuration={0}>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={onOpenSettings}
-                aria-label="Configure resources"
-              >
-                <Settings04 size={13} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Configure resources</TooltipContent>
-          </Tooltip>
-          {!isDisabled && (
-            <Tooltip delayDuration={0}>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 text-muted-foreground"
-                  onClick={() => toggleStatus("inactive")}
-                  aria-label="Disable connection"
-                >
-                  <SlashCircle01 size={13} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Disable</TooltipContent>
-            </Tooltip>
-          )}
-          <Tooltip delayDuration={0}>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 text-muted-foreground hover:text-destructive"
-                onClick={onRemove}
-                aria-label="Remove connection"
-              >
-                <XClose size={13} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Remove</TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ConnectionItemAuthFallback({
-  connection_id,
-}: {
-  connection_id: string;
-}) {
-  const connection = useConnection(connection_id);
-  if (!connection) return <ConnectionItemSkeleton />;
-
-  return (
-    <div className="rounded-xl border border-border overflow-hidden">
-      <div className="flex items-center gap-3 px-4 py-3">
-        <IntegrationIcon
-          icon={connection.icon}
-          name={connection.title}
-          size="sm"
-          className="shrink-0"
-        />
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium truncate">{connection.title}</p>
-          {connection.description && (
-            <p className="text-xs text-muted-foreground truncate">
-              {connection.description}
-            </p>
-          )}
-        </div>
-      </div>
-      <div className="flex items-center px-4 py-2 border-t border-border bg-muted/25">
-        <div className="h-5 w-20 rounded bg-muted animate-pulse" />
-      </div>
-    </div>
-  );
-}
-
-function ConnectionItemSkeleton() {
-  return (
-    <div className="rounded-xl border border-border overflow-hidden">
-      <div className="flex items-center gap-3 px-4 py-3">
-        <div className="size-8 rounded-md bg-muted animate-pulse shrink-0" />
-        <div className="flex-1 space-y-1.5">
-          <div className="h-4 w-32 rounded bg-muted animate-pulse" />
-          <div className="h-3 w-48 rounded bg-muted animate-pulse" />
-        </div>
-      </div>
-      <div className="flex items-center px-4 py-2 border-t border-border bg-muted/25">
-        <div className="h-5 w-20 rounded bg-muted animate-pulse" />
-      </div>
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `views/virtual-mcp/index.tsx` (2085 lines, on the LARGEST-FILES watchlist) bundled the connection-card rendering — `ConnectionItem`, `SiblingInstanceSelector`, `ConnectionItemWithAuth`, `ConnectionItemAuthFallback`, `ConnectionItemSkeleton` — inline. This cluster only reads its own props/hooks (`useConnection`, `useConnections`, `useConnectionActions`, `useMCPAuthStatus`, `useProjectContext`) and shares no mutable closures with the rest of the file, so it's a clean, self-contained unit.
- Moved it byte-identical (same JSX/logic, just relocated) into `views/virtual-mcp/connection-item.tsx`, exporting `ConnectionItem` and `ConnectionItemSkeleton` (the two symbols `index.tsx` still calls). `index.tsx` drops from 2085 → 1690 lines.
- Net: `index.tsx` -383/+3, new file +399. Confirmed unchanged behavior — this is a pure relocation, no logic edited, imports adjusted only for symbols now local to the new file (`useConnection`, `getConnectionSlug`, `useConnections`, `useMCPAuthStatus`, `ConnectionEntity`, `Power01`/`Settings02`/`Settings04`/`SlashCircle01`/`XClose`, `Link`) vs. symbols still needed by both files (`Select*`, `useConnectionActions`, `IntegrationIcon`).

## Test plan
- `cd apps/mesh && bunx tsc --noEmit` — green, no type errors.
- No existing test file covers this component; verify manually by opening an agent's Connections tab in the running app and confirming connection cards, the sibling-instance selector, and the auth/skeleton fallbacks render as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the connection card UI from `views/virtual-mcp/index.tsx` into `views/virtual-mcp/connection-item.tsx` to reduce file size and improve readability. No behavior changes.

- **Refactors**
  - Moved `ConnectionItem`, `SiblingInstanceSelector`, `ConnectionItemWithAuth`, `ConnectionItemAuthFallback`, and `ConnectionItemSkeleton` to `views/virtual-mcp/connection-item.tsx`; `index.tsx` now imports `ConnectionItem` and `ConnectionItemSkeleton`.
  - Reduced `index.tsx` from 2085 → 1690 lines; new file adds 399 lines; only imports updated.
  - Type-check passes (`tsc --noEmit`), and manual UI verified unchanged.

<sup>Written for commit 06505682c6c5a76e96f67b49ab3e7bfc59d3daa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

