### PR TITLE
refactor(sections-editor): extract self-contained form panels into their own file

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/sections-editor-panels.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor-panels.tsx
@@ -1,0 +1,263 @@
+import { useState, type ReactNode } from "react";
+import { ChevronLeft, ChevronRight, Flag01 } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import { SchemaForm } from "./schema-form";
+import { type LiveMeta, type SchemaProperty } from "./resolve-schema";
+import type { SandboxConfig } from "./fields/field-props";
+import { SeoFormFields } from "./seo-form-fields";
+import { parsePageVariants, type PageVariant } from "./page-variants";
+import { formatMatcher } from "./format-matcher";
+
+/**
+ * Editor for a variant's matcher rule (e.g. Include/Exclude Locations).
+ * Owns its own breadcrumb state so users can drill into array items inside
+ * the rule without affecting the section editor's breadcrumb. Caller is
+ * expected to remount via `key` when the variant or rule resolveType changes.
+ */
+export function VariantRuleForm({
+  schema,
+  value,
+  onChange,
+  meta,
+  decofile,
+  onSaveReferencedBlock,
+  sandbox,
+}: {
+  schema: SchemaProperty;
+  value: Record<string, unknown>;
+  onChange: (v: unknown) => void;
+  meta?: LiveMeta;
+  decofile?: Record<string, unknown>;
+  onSaveReferencedBlock?: (
+    blockKey: string,
+    data: Record<string, unknown>,
+  ) => void;
+  sandbox?: SandboxConfig | null;
+}) {
+  const [breadcrumbPath, setBreadcrumbPath] = useState<string[]>([]);
+
+  return (
+    <div className="space-y-2">
+      {breadcrumbPath.length > 0 && (
+        <nav
+          aria-label="Variant rule breadcrumb"
+          className="flex min-w-0 items-center gap-1 overflow-hidden text-xs"
+        >
+          <button
+            type="button"
+            onClick={() => setBreadcrumbPath([])}
+            className="flex shrink-0 items-center gap-0.5 rounded-md px-1 py-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            title="Back to rule"
+          >
+            <ChevronLeft className="size-3.5" />
+          </button>
+          {breadcrumbPath.map((crumb, index) => {
+            const isLast = index === breadcrumbPath.length - 1;
+            return (
+              <span
+                key={`${crumb}-${index}`}
+                className="flex min-w-0 items-center gap-1 overflow-hidden"
+              >
+                {index > 0 && (
+                  <ChevronRight className="size-3 shrink-0 text-muted-foreground/60" />
+                )}
+                <button
+                  type="button"
+                  onClick={() =>
+                    setBreadcrumbPath(breadcrumbPath.slice(0, index + 1))
+                  }
+                  title={crumb}
+                  className={cn(
+                    "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
+                    isLast
+                      ? "font-medium text-foreground"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {crumb}
+                </button>
+              </span>
+            );
+          })}
+        </nav>
+      )}
+      <SchemaForm
+        schema={schema}
+        value={value}
+        onChange={onChange}
+        basePath=""
+        breadcrumbPath={breadcrumbPath}
+        onBreadcrumbChange={setBreadcrumbPath}
+        meta={meta}
+        decofile={decofile}
+        onSaveReferencedBlock={onSaveReferencedBlock}
+        sandbox={sandbox}
+      />
+    </div>
+  );
+}
+
+export function SchemaFormPanel({
+  activeSchema,
+  formValue,
+  formResetKey,
+  onFormChange,
+  onBreadcrumbChange,
+  breadcrumbPath = [],
+  emptyMessage,
+  beforeForm,
+  seoResolveType,
+  siteDefaultSeo,
+  meta,
+  decofile,
+  onSaveReferencedBlock,
+  sandbox,
+}: {
+  activeSchema: SchemaProperty | null | undefined;
+  formValue: unknown;
+  formResetKey: number;
+  onFormChange: (v: unknown) => void;
+  onBreadcrumbChange: (path: string[]) => void;
+  breadcrumbPath?: string[];
+  emptyMessage: string;
+  beforeForm?: ReactNode;
+  seoResolveType?: string;
+  siteDefaultSeo?: Record<string, unknown>;
+  meta?: LiveMeta;
+  decofile?: Record<string, unknown>;
+  onSaveReferencedBlock?: (
+    blockKey: string,
+    data: Record<string, unknown>,
+  ) => void;
+  sandbox?: SandboxConfig | null;
+}) {
+  const formBody =
+    activeSchema && formValue ? (
+      seoResolveType ? (
+        <SeoFormFields
+          schema={activeSchema}
+          resolveType={seoResolveType}
+          value={formValue as Record<string, unknown>}
+          formResetKey={formResetKey}
+          onChange={onFormChange}
+          onBreadcrumbChange={onBreadcrumbChange}
+          siteDefaultSeo={siteDefaultSeo}
+        />
+      ) : (
+        <SchemaForm
+          key={formResetKey}
+          schema={activeSchema}
+          value={formValue}
+          onChange={onFormChange}
+          basePath=""
+          breadcrumbPath={breadcrumbPath}
+          onBreadcrumbChange={onBreadcrumbChange}
+          meta={meta}
+          decofile={decofile}
+          onSaveReferencedBlock={onSaveReferencedBlock}
+          sandbox={sandbox}
+        />
+      )
+    ) : null;
+
+  return (
+    <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
+      <div className="mx-auto max-w-2xl">
+        {beforeForm}
+        {formBody ?? (
+          <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+            {emptyMessage}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const VARIANT_TAB_ACTIVE_CLASS =
+  "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.22)]";
+
+export function parsePageVariantsForEditor(
+  sections: unknown,
+  decofile: Record<string, unknown>,
+): PageVariant[] {
+  return parsePageVariants(sections, decofile, formatMatcher);
+}
+
+/**
+ * Editable page name + path inputs that hold local state to prevent
+ * focus loss when the parent re-renders after decofile invalidation.
+ */
+export function PageHeaderInputs({
+  pageKey,
+  initialName,
+  initialPath,
+  onFieldChange,
+}: {
+  pageKey: string;
+  initialName: string;
+  initialPath: string;
+  onFieldChange: (field: "name" | "path", value: string) => void;
+}) {
+  const [name, setName] = useState(initialName);
+  const [path, setPath] = useState(initialPath);
+  const [prevKey, setPrevKey] = useState(pageKey);
+
+  // Reset local state when navigating to a different page
+  if (prevKey !== pageKey) {
+    setPrevKey(pageKey);
+    setName(initialName);
+    setPath(initialPath);
+  }
+
+  return (
+    <div className="space-y-1">
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => {
+          setName(e.target.value);
+          onFieldChange("name", e.target.value);
+        }}
+        className="w-full bg-transparent text-sm font-semibold truncate outline-none border-none p-0 focus:ring-0 placeholder:text-muted-foreground"
+        placeholder="Page name"
+      />
+      <input
+        type="text"
+        value={path}
+        onChange={(e) => {
+          setPath(e.target.value);
+          onFieldChange("path", e.target.value);
+        }}
+        className="w-full bg-transparent text-xs text-muted-foreground truncate outline-none border-none p-0 focus:ring-0 placeholder:text-muted-foreground"
+        placeholder="/path"
+      />
+    </div>
+  );
+}
+
+export function AddVariantButton({ onClick }: { onClick: () => void }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Add variant"
+          className="size-7 shrink-0 text-[oklch(0.65_0.15_160)]"
+          onClick={onClick}
+        >
+          <Flag01 size={14} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Add variant</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, type ReactNode } from "react";
+import { useState, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { KEYS } from "@/web/lib/query-keys";
 import { useInsetContext } from "@/web/layouts/agent-shell-layout";
@@ -8,7 +8,6 @@ import {
   ChevronRight,
   ChevronUp,
   Code01,
-  Flag01,
   Globe01,
   Loading01,
   CreditCardSearch,
@@ -37,19 +36,12 @@ import { isLazyResolveType } from "./section-lazy";
 import { unwrapSection } from "./unwrap-section";
 import { arrayMove } from "@dnd-kit/sortable";
 import type { ParsedSection } from "./section-list";
-import { SchemaForm } from "./schema-form";
-import {
-  resolveSchema,
-  type LiveMeta,
-  type SchemaProperty,
-} from "./resolve-schema";
-import type { SandboxConfig } from "./fields/field-props";
+import { resolveSchema } from "./resolve-schema";
 import { findSiteSeoEntry, resolveSeoTarget } from "./seo-block";
 import { defaultPageSeoResolveType } from "./seo-schema";
 import { activeSeoResolveType, buildSeoSavePayload } from "./seo-save";
 import { isSeoEnabled, unwrapSeoConfig } from "./seo-lazy-render";
 import { PageSeoForm } from "./page-seo-form";
-import { SeoFormFields } from "./seo-form-fields";
 import {
   MatcherPicker,
   extractMatcherGlobals,
@@ -79,7 +71,6 @@ import {
   duplicatePageVariantEntry,
   getLastVariantIndex,
   isMultivariateArrayWrapper,
-  parsePageVariants,
   type PageVariant,
 } from "./page-variants";
 import {
@@ -112,254 +103,14 @@ import {
 import { PageJsonDialog } from "./page-json-dialog";
 import { createReferencedBlockSaver } from "./save-referenced-block";
 import { formatMatcher } from "./format-matcher";
-
-/**
- * Editor for a variant's matcher rule (e.g. Include/Exclude Locations).
- * Owns its own breadcrumb state so users can drill into array items inside
- * the rule without affecting the section editor's breadcrumb. Caller is
- * expected to remount via `key` when the variant or rule resolveType changes.
- */
-function VariantRuleForm({
-  schema,
-  value,
-  onChange,
-  meta,
-  decofile,
-  onSaveReferencedBlock,
-  sandbox,
-}: {
-  schema: SchemaProperty;
-  value: Record<string, unknown>;
-  onChange: (v: unknown) => void;
-  meta?: LiveMeta;
-  decofile?: Record<string, unknown>;
-  onSaveReferencedBlock?: (
-    blockKey: string,
-    data: Record<string, unknown>,
-  ) => void;
-  sandbox?: SandboxConfig | null;
-}) {
-  const [breadcrumbPath, setBreadcrumbPath] = useState<string[]>([]);
-
-  return (
-    <div className="space-y-2">
-      {breadcrumbPath.length > 0 && (
-        <nav
-          aria-label="Variant rule breadcrumb"
-          className="flex min-w-0 items-center gap-1 overflow-hidden text-xs"
-        >
-          <button
-            type="button"
-            onClick={() => setBreadcrumbPath([])}
-            className="flex shrink-0 items-center gap-0.5 rounded-md px-1 py-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-            title="Back to rule"
-          >
-            <ChevronLeft className="size-3.5" />
-          </button>
-          {breadcrumbPath.map((crumb, index) => {
-            const isLast = index === breadcrumbPath.length - 1;
-            return (
-              <span
-                key={`${crumb}-${index}`}
-                className="flex min-w-0 items-center gap-1 overflow-hidden"
-              >
-                {index > 0 && (
-                  <ChevronRight className="size-3 shrink-0 text-muted-foreground/60" />
-                )}
-                <button
-                  type="button"
-                  onClick={() =>
-                    setBreadcrumbPath(breadcrumbPath.slice(0, index + 1))
-                  }
-                  title={crumb}
-                  className={cn(
-                    "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
-                    isLast
-                      ? "font-medium text-foreground"
-                      : "text-muted-foreground",
-                  )}
-                >
-                  {crumb}
-                </button>
-              </span>
-            );
-          })}
-        </nav>
-      )}
-      <SchemaForm
-        schema={schema}
-        value={value}
-        onChange={onChange}
-        basePath=""
-        breadcrumbPath={breadcrumbPath}
-        onBreadcrumbChange={setBreadcrumbPath}
-        meta={meta}
-        decofile={decofile}
-        onSaveReferencedBlock={onSaveReferencedBlock}
-        sandbox={sandbox}
-      />
-    </div>
-  );
-}
-
-function SchemaFormPanel({
-  activeSchema,
-  formValue,
-  formResetKey,
-  onFormChange,
-  onBreadcrumbChange,
-  breadcrumbPath = [],
-  emptyMessage,
-  beforeForm,
-  seoResolveType,
-  siteDefaultSeo,
-  meta,
-  decofile,
-  onSaveReferencedBlock,
-  sandbox,
-}: {
-  activeSchema: SchemaProperty | null | undefined;
-  formValue: unknown;
-  formResetKey: number;
-  onFormChange: (v: unknown) => void;
-  onBreadcrumbChange: (path: string[]) => void;
-  breadcrumbPath?: string[];
-  emptyMessage: string;
-  beforeForm?: ReactNode;
-  seoResolveType?: string;
-  siteDefaultSeo?: Record<string, unknown>;
-  meta?: LiveMeta;
-  decofile?: Record<string, unknown>;
-  onSaveReferencedBlock?: (
-    blockKey: string,
-    data: Record<string, unknown>,
-  ) => void;
-  sandbox?: SandboxConfig | null;
-}) {
-  const formBody =
-    activeSchema && formValue ? (
-      seoResolveType ? (
-        <SeoFormFields
-          schema={activeSchema}
-          resolveType={seoResolveType}
-          value={formValue as Record<string, unknown>}
-          formResetKey={formResetKey}
-          onChange={onFormChange}
-          onBreadcrumbChange={onBreadcrumbChange}
-          siteDefaultSeo={siteDefaultSeo}
-        />
-      ) : (
-        <SchemaForm
-          key={formResetKey}
-          schema={activeSchema}
-          value={formValue}
-          onChange={onFormChange}
-          basePath=""
-          breadcrumbPath={breadcrumbPath}
-          onBreadcrumbChange={onBreadcrumbChange}
-          meta={meta}
-          decofile={decofile}
-          onSaveReferencedBlock={onSaveReferencedBlock}
-          sandbox={sandbox}
-        />
-      )
-    ) : null;
-
-  return (
-    <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
-      <div className="mx-auto max-w-2xl">
-        {beforeForm}
-        {formBody ?? (
-          <div className="px-3 py-6 text-center text-xs text-muted-foreground">
-            {emptyMessage}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-const VARIANT_TAB_ACTIVE_CLASS =
-  "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.22)]";
-
-function parsePageVariantsForEditor(
-  sections: unknown,
-  decofile: Record<string, unknown>,
-): PageVariant[] {
-  return parsePageVariants(sections, decofile, formatMatcher);
-}
-
-/**
- * Editable page name + path inputs that hold local state to prevent
- * focus loss when the parent re-renders after decofile invalidation.
- */
-function PageHeaderInputs({
-  pageKey,
-  initialName,
-  initialPath,
-  onFieldChange,
-}: {
-  pageKey: string;
-  initialName: string;
-  initialPath: string;
-  onFieldChange: (field: "name" | "path", value: string) => void;
-}) {
-  const [name, setName] = useState(initialName);
-  const [path, setPath] = useState(initialPath);
-  const [prevKey, setPrevKey] = useState(pageKey);
-
-  // Reset local state when navigating to a different page
-  if (prevKey !== pageKey) {
-    setPrevKey(pageKey);
-    setName(initialName);
-    setPath(initialPath);
-  }
-
-  return (
-    <div className="space-y-1">
-      <input
-        type="text"
-        value={name}
-        onChange={(e) => {
-          setName(e.target.value);
-          onFieldChange("name", e.target.value);
-        }}
-        className="w-full bg-transparent text-sm font-semibold truncate outline-none border-none p-0 focus:ring-0 placeholder:text-muted-foreground"
-        placeholder="Page name"
-      />
-      <input
-        type="text"
-        value={path}
-        onChange={(e) => {
-          setPath(e.target.value);
-          onFieldChange("path", e.target.value);
-        }}
-        className="w-full bg-transparent text-xs text-muted-foreground truncate outline-none border-none p-0 focus:ring-0 placeholder:text-muted-foreground"
-        placeholder="/path"
-      />
-    </div>
-  );
-}
-
-function AddVariantButton({ onClick }: { onClick: () => void }) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="Add variant"
-          className="size-7 shrink-0 text-[oklch(0.65_0.15_160)]"
-          onClick={onClick}
-        >
-          <Flag01 size={14} />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">Add variant</TooltipContent>
-    </Tooltip>
-  );
-}
+import {
+  AddVariantButton,
+  PageHeaderInputs,
+  parsePageVariantsForEditor,
+  SchemaFormPanel,
+  VARIANT_TAB_ACTIVE_CLASS,
+  VariantRuleForm,
+} from "./sections-editor-panels";
 
 /**
  * Side panel for editing deco.cx page sections.


### PR DESCRIPTION
## Summary
- `sections-editor.tsx` was the largest un-touched God-component in the repo (3034 lines, not yet covered by any open PR).
- `VariantRuleForm`, `SchemaFormPanel`, `PageHeaderInputs`, `AddVariantButton`, and `parsePageVariantsForEditor` only read their own props/args — no shared closures/local state with the rest of the file — so they're cleanly relocatable.
- Moved them byte-identical (same behavior, just relocated + a new import) into `sections-editor-panels.tsx`. `sections-editor.tsx` drops from 3034 -> 2785 lines.

## Why
Keeps the file more navigable for anyone touching the sections editor; no behavior change, no risk.

## How to verify
- `cd apps/mesh && bunx tsc --noEmit` — passes clean (verified locally).
- `bun run fmt` — no changes needed.
- Diff is a pure move: compare `sections-editor-panels.tsx` against the removed block in the previous `sections-editor.tsx` to confirm it's unchanged logic.

## Testing notes
Ran `bunx tsc --noEmit` in `apps/mesh` locally (green). No behavior change, so no new tests were added; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted self-contained panels from sections-editor.tsx into sections-editor-panels.tsx with no behavior changes, reducing the main file from 3034 to 2785 lines. This improves readability and makes the sections editor easier to maintain.

- **Refactors**
  - Moved VariantRuleForm, SchemaFormPanel, PageHeaderInputs, AddVariantButton, and parsePageVariantsForEditor into sections-editor-panels.tsx.
  - Updated sections-editor.tsx to import from the new module; logic remains byte-identical.

<sup>Written for commit 9a835b632ea48cb481e317dc0e435d11fda1367e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

