### PR TITLE
refactor(chat): extract model-resolution helpers from chat-context

### DIFF
--- a/apps/mesh/src/web/components/chat/chat-context.tsx
+++ b/apps/mesh/src/web/components/chat/chat-context.tsx
@@ -54,7 +54,6 @@ import { resolveSubmitSettings } from "./resolve-submit-settings";
 import {
   isDeepResearchModel,
   isQuickSearchModel,
-  pickSimpleModeDefaults,
   SELF_MCP_ALIAS_ID,
   useMCPClient,
   useProjectContext,
@@ -65,7 +64,6 @@ import { toast } from "sonner";
 import {
   useAiProviderKeys,
   useAiProviderModels,
-  type AiProviderKey,
   type AiProviderModel,
 } from "../../hooks/collections/use-ai-providers";
 import { useContext as useContextHook } from "../../hooks/use-context";
@@ -130,6 +128,13 @@ import { textFromParts } from "./queue-items";
 import { useMessageQueueActions } from "./use-message-queue";
 import { formatDeckTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 import { useSimpleMode } from "../../hooks/use-organization-settings";
+import {
+  findModel,
+  pickFallbackChatModel,
+  resolveActiveTier,
+  type ModelRef,
+  type SimpleTier,
+} from "./resolve-chat-model";
 
 // ============================================================================
 // Context Types
@@ -262,92 +267,6 @@ export interface ChatPrefsContextValue {
   pendingHarnessId: HarnessId | null;
   /** Derived from `pendingAgentOption`. Read-only. */
   pendingSandboxProviderKind: SandboxProviderKind | null;
-}
-
-// ============================================================================
-// Model resolution helpers (shared across chat / image / deep-research paths)
-// ============================================================================
-
-type ModelRef = { keyId: string; modelId: string };
-type SimpleTier = "fast" | "smart" | "thinking";
-
-/**
- * Resolve a stored ModelRef against the currently available keys and models.
- * Returns null when the ref's key no longer exists. Match is by `modelId`
- * only within `allModels` — the API-returned model objects don't carry
- * `keyId` (it's a client-side-only field), so we attach it ourselves.
- * When the model isn't in the provided list (list still loading, or list
- * scoped to a different credential), synthesize a minimal AiProviderModel
- * from the ref so callers always get a routable `{ keyId, modelId }`.
- */
-function findModel(
-  ref: ModelRef | null,
-  allKeys: AiProviderKey[],
-  allModels: AiProviderModel[],
-  title?: string,
-): AiProviderModel | null {
-  if (!ref) return null;
-  const key = allKeys.find((k) => k.id === ref.keyId);
-  if (!key) return null;
-  const hit = allModels.find((m) => m.modelId === ref.modelId);
-  if (hit) return { ...hit, keyId: ref.keyId };
-  return {
-    modelId: ref.modelId,
-    title: title ?? ref.modelId,
-    keyId: ref.keyId,
-    providerId: key.providerId,
-    description: null,
-    logo: null,
-    capabilities: [],
-    limits: null,
-    costs: null,
-  } as AiProviderModel;
-}
-
-/**
- * Pick the active chat tier from the user's stored choice, defaulting to
- * "smart". All three chat tiers are always selectable — the backend's
- * resolveTier() falls back to SDK provider defaults when the org's tier
- * slot is unset, so we don't need to gate on slot configuration here.
- */
-function resolveActiveTier(stored: SimpleTier | null): SimpleTier {
-  if (stored === "fast" || stored === "smart" || stored === "thinking") {
-    return stored;
-  }
-  return "smart";
-}
-
-/**
- * Mirror backend resolveTier() when no slot is explicitly assigned: pick a
- * tier-appropriate default from the effective key's catalog so the UI can
- * read capabilities (file upload, vision, etc.) instead of falling back to
- * a null model. Backend pickSimpleModeDefaults considers all keys; we only
- * have the effective key's catalog client-side, so multi-key orgs may see a
- * single-key-derived default. This matches the backend's pick when the
- * effective key is also the first match for the tier.
- */
-function pickFallbackChatModel(
-  tier: SimpleTier,
-  keys: AiProviderKey[],
-  effectiveKeyId: string | null,
-  models: AiProviderModel[],
-): AiProviderModel | null {
-  if (!effectiveKeyId || models.length === 0) return null;
-  const key = keys.find((k) => k.id === effectiveKeyId);
-  if (!key) return null;
-  const defaults = pickSimpleModeDefaults([key], {
-    [effectiveKeyId]: models,
-  });
-  const slot =
-    tier === "fast"
-      ? defaults.chat.fast
-      : tier === "thinking"
-        ? defaults.chat.thinking
-        : defaults.chat.smart;
-  if (!slot) return null;
-  const full = models.find((m) => m.modelId === slot.modelId);
-  if (!full) return null;
-  return { ...full, keyId: effectiveKeyId };
 }
 
 // ============================================================================

--- a/apps/mesh/src/web/components/chat/resolve-chat-model.ts
+++ b/apps/mesh/src/web/components/chat/resolve-chat-model.ts
@@ -1,0 +1,87 @@
+import { pickSimpleModeDefaults } from "@decocms/mesh-sdk";
+import type {
+  AiProviderKey,
+  AiProviderModel,
+} from "../../hooks/collections/use-ai-providers";
+
+export type ModelRef = { keyId: string; modelId: string };
+export type SimpleTier = "fast" | "smart" | "thinking";
+
+/**
+ * Resolve a stored ModelRef against the currently available keys and models.
+ * Returns null when the ref's key no longer exists. Match is by `modelId`
+ * only within `allModels` — the API-returned model objects don't carry
+ * `keyId` (it's a client-side-only field), so we attach it ourselves.
+ * When the model isn't in the provided list (list still loading, or list
+ * scoped to a different credential), synthesize a minimal AiProviderModel
+ * from the ref so callers always get a routable `{ keyId, modelId }`.
+ */
+export function findModel(
+  ref: ModelRef | null,
+  allKeys: AiProviderKey[],
+  allModels: AiProviderModel[],
+  title?: string,
+): AiProviderModel | null {
+  if (!ref) return null;
+  const key = allKeys.find((k) => k.id === ref.keyId);
+  if (!key) return null;
+  const hit = allModels.find((m) => m.modelId === ref.modelId);
+  if (hit) return { ...hit, keyId: ref.keyId };
+  return {
+    modelId: ref.modelId,
+    title: title ?? ref.modelId,
+    keyId: ref.keyId,
+    providerId: key.providerId,
+    description: null,
+    logo: null,
+    capabilities: [],
+    limits: null,
+    costs: null,
+  } as AiProviderModel;
+}
+
+/**
+ * Pick the active chat tier from the user's stored choice, defaulting to
+ * "smart". All three chat tiers are always selectable — the backend's
+ * resolveTier() falls back to SDK provider defaults when the org's tier
+ * slot is unset, so we don't need to gate on slot configuration here.
+ */
+export function resolveActiveTier(stored: SimpleTier | null): SimpleTier {
+  if (stored === "fast" || stored === "smart" || stored === "thinking") {
+    return stored;
+  }
+  return "smart";
+}
+
+/**
+ * Mirror backend resolveTier() when no slot is explicitly assigned: pick a
+ * tier-appropriate default from the effective key's catalog so the UI can
+ * read capabilities (file upload, vision, etc.) instead of falling back to
+ * a null model. Backend pickSimpleModeDefaults considers all keys; we only
+ * have the effective key's catalog client-side, so multi-key orgs may see a
+ * single-key-derived default. This matches the backend's pick when the
+ * effective key is also the first match for the tier.
+ */
+export function pickFallbackChatModel(
+  tier: SimpleTier,
+  keys: AiProviderKey[],
+  effectiveKeyId: string | null,
+  models: AiProviderModel[],
+): AiProviderModel | null {
+  if (!effectiveKeyId || models.length === 0) return null;
+  const key = keys.find((k) => k.id === effectiveKeyId);
+  if (!key) return null;
+  const defaults = pickSimpleModeDefaults([key], {
+    [effectiveKeyId]: models,
+  });
+  const slot =
+    tier === "fast"
+      ? defaults.chat.fast
+      : tier === "thinking"
+        ? defaults.chat.thinking
+        : defaults.chat.smart;
+  if (!slot) return null;
+  const full = models.find((m) => m.modelId === slot.modelId);
+  if (!full) return null;
+  return { ...full, keyId: effectiveKeyId };
+}


### PR DESCRIPTION
## Summary
- `chat-context.tsx` is 1552 lines, per the God-component debt list. It contained three pure, self-contained functions (`findModel`, `resolveActiveTier`, `pickFallbackChatModel`) plus their `ModelRef`/`SimpleTier` types, none of which close over any component state — they only read their own arguments.
- Moved them byte-identical into a new `resolve-chat-model.ts`, and import them back into `chat-context.tsx`. Net: -88/+7 in `chat-context.tsx`, +94 in the new file (pure relocation, no logic changes).
- Payoff: smaller, more navigable provider file; the extracted helpers are now independently importable/testable without pulling in the whole chat-context module.

## Verification
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — passes
- Confirmed via diff that this is a pure move: no behavior change, same function bodies, same call sites (just via import).

Reviewer check: `cd apps/mesh && bunx tsc --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted chat model-resolution helpers into `resolve-chat-model.ts` to shrink `chat-context.tsx` and make the helpers independently importable and testable. No behavior changes.

- **Refactors**
  - Moved `findModel`, `resolveActiveTier`, `pickFallbackChatModel` and their types to `resolve-chat-model.ts`.
  - Updated `chat-context.tsx` to import these helpers; pure relocation with identical function bodies.

<sup>Written for commit 9165fbda2b50ac23015e250f55d355dbb017de12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

