### PR TITLE
refactor(automations): extract EventTriggerForm into its own file

### DIFF
--- a/apps/mesh/src/web/components/automations/event-trigger-form.tsx
+++ b/apps/mesh/src/web/components/automations/event-trigger-form.tsx
@@ -1,0 +1,206 @@
+import {
+  useAutomationActions,
+  useTriggerList,
+  type TriggerDefinition,
+} from "@/web/hooks/use-automations";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { useConnections } from "@decocms/mesh-sdk";
+import { Loading01, XClose, Zap } from "@untitledui/icons";
+import { useState } from "react";
+import { toast } from "sonner";
+import { track } from "@/web/lib/posthog-client";
+
+export function EventTriggerForm({
+  automationId,
+  onDone,
+}: {
+  automationId: string;
+  onDone: () => void;
+}) {
+  const triggerConnections = useConnections({ binding: "TRIGGER" });
+  const [connectionId, setConnectionId] = useState<string | undefined>();
+  const [eventType, setEventType] = useState<string | undefined>();
+  const [params, setParams] = useState<Record<string, string>>({});
+  const { triggerAdd: addTrigger } = useAutomationActions();
+  const { data: triggerDefs, isLoading: isLoadingTriggers } =
+    useTriggerList(connectionId);
+
+  const selectedTrigger = triggerDefs?.find(
+    (t: TriggerDefinition) => t.type === eventType,
+  );
+
+  const handleSubmit = async () => {
+    if (!connectionId || !eventType) return;
+    try {
+      await addTrigger.mutateAsync({
+        automation_id: automationId,
+        type: "event",
+        event_type: eventType,
+        connection_id: connectionId,
+        params,
+      });
+      track("automation_trigger_added", {
+        automation_id: automationId,
+        trigger_type: "event",
+        connection_id: connectionId,
+        event_type: eventType,
+      });
+      toast.success("Event trigger added");
+      onDone();
+    } catch {
+      toast.error("Failed to add event trigger");
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 px-3 py-3 rounded-lg border border-border bg-background">
+      <div className="flex items-center gap-2">
+        <Zap size={14} className="text-muted-foreground shrink-0" />
+        <span className="text-sm font-medium">Event trigger</span>
+        <button
+          type="button"
+          className="ml-auto shrink-0 p-0.5 rounded text-muted-foreground hover:text-foreground"
+          onClick={onDone}
+        >
+          <XClose size={13} />
+        </button>
+      </div>
+
+      {/* Step 1: Connection */}
+      <Select
+        value={connectionId ?? ""}
+        onValueChange={(val) => {
+          setConnectionId(val);
+          setEventType(undefined);
+          setParams({});
+        }}
+      >
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Select connection..." />
+        </SelectTrigger>
+        <SelectContent>
+          {triggerConnections.length === 0 ? (
+            <div className="px-2 py-3 text-center text-xs text-muted-foreground">
+              No connections with trigger support
+            </div>
+          ) : (
+            triggerConnections.map((conn) => (
+              <SelectItem key={conn.id} value={conn.id}>
+                {conn.title}
+              </SelectItem>
+            ))
+          )}
+        </SelectContent>
+      </Select>
+
+      {/* Step 2: Event type */}
+      {connectionId && (
+        <Select
+          value={eventType ?? ""}
+          onValueChange={(val) => {
+            setEventType(val);
+            setParams({});
+          }}
+        >
+          <SelectTrigger className="w-full">
+            {isLoadingTriggers ? (
+              <span className="flex items-center gap-2 text-muted-foreground">
+                <Loading01 size={13} className="animate-spin" />
+                Loading events...
+              </span>
+            ) : (
+              <SelectValue placeholder="Select event type...">
+                {eventType ?? "Select event type..."}
+              </SelectValue>
+            )}
+          </SelectTrigger>
+          <SelectContent>
+            {triggerDefs?.map((t: TriggerDefinition) => (
+              <SelectItem key={t.type} value={t.type}>
+                <div className="flex flex-col">
+                  <span>{t.type}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {t.description}
+                  </span>
+                </div>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
+      {/* Step 3: Params */}
+      {selectedTrigger?.paramsSchema &&
+        Object.keys(selectedTrigger.paramsSchema).length > 0 && (
+          <div className="flex flex-col gap-2">
+            {Object.entries(selectedTrigger.paramsSchema).map(
+              ([key, schema]) => (
+                <div key={key} className="flex flex-col gap-1">
+                  <label className="text-xs text-muted-foreground">
+                    {key}
+                    {schema.description && (
+                      <span className="text-muted-foreground/60">
+                        {" "}
+                        — {schema.description}
+                      </span>
+                    )}
+                  </label>
+                  {schema.enum ? (
+                    <Select
+                      value={params[key] ?? ""}
+                      onValueChange={(val) =>
+                        setParams((p) => ({ ...p, [key]: val }))
+                      }
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder={`Select ${key}...`} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {schema.enum.map((val) => (
+                          <SelectItem key={val} value={val}>
+                            {val}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <input
+                      type="text"
+                      value={params[key] ?? ""}
+                      onChange={(e) =>
+                        setParams((p) => ({ ...p, [key]: e.target.value }))
+                      }
+                      placeholder={schema.description ?? key}
+                      className="text-sm border border-border rounded-md bg-background px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-ring"
+                    />
+                  )}
+                </div>
+              ),
+            )}
+          </div>
+        )}
+
+      {/* Submit */}
+      {connectionId && eventType && (
+        <Button
+          size="sm"
+          onClick={handleSubmit}
+          disabled={addTrigger.isPending}
+        >
+          {addTrigger.isPending ? (
+            <Loading01 size={13} className="animate-spin" />
+          ) : (
+            "Add trigger"
+          )}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/views/automations/automation-detail.tsx
+++ b/apps/mesh/src/web/views/automations/automation-detail.tsx
@@ -14,8 +14,6 @@ import { User } from "@/web/components/user/user.tsx";
 import {
   useAutomation,
   useAutomationActions,
-  useTriggerList,
-  type TriggerDefinition,
 } from "@/web/hooks/use-automations";
 import { useChatTask, useChatStream } from "@/web/components/chat/context";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -47,7 +45,6 @@ import {
   Stars01,
   Trash01,
   XClose,
-  Zap,
 } from "@untitledui/icons";
 import { Suspense, useEffect, useReducer, useState } from "react";
 import { useForm, Controller } from "react-hook-form";
@@ -121,206 +118,8 @@ import { isValidCron } from "@/web/lib/cron-utils.ts";
 import { AddStarterPopover } from "@/web/components/automations/add-starter-popover.tsx";
 import { TriggerCard } from "@/web/components/automations/trigger-card.tsx";
 import { WebhookSecretDialog } from "@/web/components/automations/webhook-secret-dialog.tsx";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@deco/ui/components/select.tsx";
+import { EventTriggerForm } from "@/web/components/automations/event-trigger-form.tsx";
 import { track } from "@/web/lib/posthog-client";
-
-// ============================================================================
-// Event Trigger Form
-// ============================================================================
-
-function EventTriggerForm({
-  automationId,
-  onDone,
-}: {
-  automationId: string;
-  onDone: () => void;
-}) {
-  const triggerConnections = useConnections({ binding: "TRIGGER" });
-  const [connectionId, setConnectionId] = useState<string | undefined>();
-  const [eventType, setEventType] = useState<string | undefined>();
-  const [params, setParams] = useState<Record<string, string>>({});
-  const { triggerAdd: addTrigger } = useAutomationActions();
-  const { data: triggerDefs, isLoading: isLoadingTriggers } =
-    useTriggerList(connectionId);
-
-  const selectedTrigger = triggerDefs?.find(
-    (t: TriggerDefinition) => t.type === eventType,
-  );
-
-  const handleSubmit = async () => {
-    if (!connectionId || !eventType) return;
-    try {
-      await addTrigger.mutateAsync({
-        automation_id: automationId,
-        type: "event",
-        event_type: eventType,
-        connection_id: connectionId,
-        params,
-      });
-      track("automation_trigger_added", {
-        automation_id: automationId,
-        trigger_type: "event",
-        connection_id: connectionId,
-        event_type: eventType,
-      });
-      toast.success("Event trigger added");
-      onDone();
-    } catch {
-      toast.error("Failed to add event trigger");
-    }
-  };
-
-  return (
-    <div className="flex flex-col gap-3 px-3 py-3 rounded-lg border border-border bg-background">
-      <div className="flex items-center gap-2">
-        <Zap size={14} className="text-muted-foreground shrink-0" />
-        <span className="text-sm font-medium">Event trigger</span>
-        <button
-          type="button"
-          className="ml-auto shrink-0 p-0.5 rounded text-muted-foreground hover:text-foreground"
-          onClick={onDone}
-        >
-          <XClose size={13} />
-        </button>
-      </div>
-
-      {/* Step 1: Connection */}
-      <Select
-        value={connectionId ?? ""}
-        onValueChange={(val) => {
-          setConnectionId(val);
-          setEventType(undefined);
-          setParams({});
-        }}
-      >
-        <SelectTrigger className="w-full">
-          <SelectValue placeholder="Select connection..." />
-        </SelectTrigger>
-        <SelectContent>
-          {triggerConnections.length === 0 ? (
-            <div className="px-2 py-3 text-center text-xs text-muted-foreground">
-              No connections with trigger support
-            </div>
-          ) : (
-            triggerConnections.map((conn) => (
-              <SelectItem key={conn.id} value={conn.id}>
-                {conn.title}
-              </SelectItem>
-            ))
-          )}
-        </SelectContent>
-      </Select>
-
-      {/* Step 2: Event type */}
-      {connectionId && (
-        <Select
-          value={eventType ?? ""}
-          onValueChange={(val) => {
-            setEventType(val);
-            setParams({});
-          }}
-        >
-          <SelectTrigger className="w-full">
-            {isLoadingTriggers ? (
-              <span className="flex items-center gap-2 text-muted-foreground">
-                <Loading01 size={13} className="animate-spin" />
-                Loading events...
-              </span>
-            ) : (
-              <SelectValue placeholder="Select event type...">
-                {eventType ?? "Select event type..."}
-              </SelectValue>
-            )}
-          </SelectTrigger>
-          <SelectContent>
-            {triggerDefs?.map((t: TriggerDefinition) => (
-              <SelectItem key={t.type} value={t.type}>
-                <div className="flex flex-col">
-                  <span>{t.type}</span>
-                  <span className="text-xs text-muted-foreground">
-                    {t.description}
-                  </span>
-                </div>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      )}
-
-      {/* Step 3: Params */}
-      {selectedTrigger?.paramsSchema &&
-        Object.keys(selectedTrigger.paramsSchema).length > 0 && (
-          <div className="flex flex-col gap-2">
-            {Object.entries(selectedTrigger.paramsSchema).map(
-              ([key, schema]) => (
-                <div key={key} className="flex flex-col gap-1">
-                  <label className="text-xs text-muted-foreground">
-                    {key}
-                    {schema.description && (
-                      <span className="text-muted-foreground/60">
-                        {" "}
-                        — {schema.description}
-                      </span>
-                    )}
-                  </label>
-                  {schema.enum ? (
-                    <Select
-                      value={params[key] ?? ""}
-                      onValueChange={(val) =>
-                        setParams((p) => ({ ...p, [key]: val }))
-                      }
-                    >
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder={`Select ${key}...`} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {schema.enum.map((val) => (
-                          <SelectItem key={val} value={val}>
-                            {val}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  ) : (
-                    <input
-                      type="text"
-                      value={params[key] ?? ""}
-                      onChange={(e) =>
-                        setParams((p) => ({ ...p, [key]: e.target.value }))
-                      }
-                      placeholder={schema.description ?? key}
-                      className="text-sm border border-border rounded-md bg-background px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-ring"
-                    />
-                  )}
-                </div>
-              ),
-            )}
-          </div>
-        )}
-
-      {/* Submit */}
-      {connectionId && eventType && (
-        <Button
-          size="sm"
-          onClick={handleSubmit}
-          disabled={addTrigger.isPending}
-        >
-          {addTrigger.isPending ? (
-            <Loading01 size={13} className="animate-spin" />
-          ) : (
-            "Add trigger"
-          )}
-        </Button>
-      )}
-    </div>
-  );
-}
 
 // ============================================================================
 // Settings Tab


### PR DESCRIPTION
## Summary
- `automation-detail.tsx` (912 lines) is one of the largest God-component files in the repo. `EventTriggerForm` is a genuinely self-contained sub-component — it only reads its own props (`automationId`, `onDone`) and shares no closures or local state with `SettingsTab` — so it's a clean, byte-identical relocation, not a rewrite.
- Moved it to `apps/mesh/src/web/components/automations/event-trigger-form.tsx`, matching the sibling automation components already split out (`add-starter-popover.tsx`, `trigger-card.tsx`, `webhook-secret-dialog.tsx`).
- Net effect: `automation-detail.tsx` drops from 912 → 711 lines; no behavior change (same JSX, same hooks, same logic — just relocated + one new import). Removed the now-unused `Zap`/`Select*` imports from `automation-detail.tsx` that only the extracted component needed.

## Test plan
- `bun run fmt` — clean
- `cd apps/mesh && bun x tsc --noEmit` — clean, no new errors
- Reviewer check: `git diff main -- apps/mesh/src/web/views/automations/automation-detail.tsx apps/mesh/src/web/components/automations/event-trigger-form.tsx` shows the moved code is unchanged aside from the import path
- Full CI (lint, unit tests) validates the rest

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted EventTriggerForm into its own component file to simplify `automation-detail.tsx` and align with other automation components. No behavior changes; this is a straight move.

- **Refactors**
  - Moved to `apps/mesh/src/web/components/automations/event-trigger-form.tsx` alongside existing automation components.
  - `automation-detail.tsx` now imports the component and removes unused `Zap`/`Select*` imports.
  - Reduced `automation-detail.tsx` from 912 to 711 lines; logic is byte-identical.

<sup>Written for commit 006f894f3bdd11e3e356181713b31f73e25dfd14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

