### PR TITLE
refactor(core): drop as-any casts on private-registry storage db handle

### DIFF
--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -56,6 +56,7 @@ import {
   MonitorResultStorage,
   MonitorConnectionStorage,
 } from "../storage/registry";
+import type { PrivateRegistryDatabase } from "../storage/registry/types";
 import { TagStorage } from "../storage/tags";
 import type { Database, Permission } from "../storage/types";
 import { UserStorage } from "../storage/user";
@@ -1306,12 +1307,24 @@ export async function createStudioContextFactory(
     orgSsoConfig: new OrgSsoConfigStorage(config.db, vault),
     orgSsoSessions: new OrgSsoSessionStorage(config.db),
     registry: {
-      items: new RegistryItemStorage(config.db as any),
-      publishRequests: new PublishRequestStorage(config.db as any),
-      publishApiKeys: new PublishApiKeyStorage(config.db as any),
-      monitorRuns: new MonitorRunStorage(config.db as any),
-      monitorResults: new MonitorResultStorage(config.db as any),
-      monitorConnections: new MonitorConnectionStorage(config.db as any),
+      items: new RegistryItemStorage(
+        config.db as unknown as Kysely<PrivateRegistryDatabase>,
+      ),
+      publishRequests: new PublishRequestStorage(
+        config.db as unknown as Kysely<PrivateRegistryDatabase>,
+      ),
+      publishApiKeys: new PublishApiKeyStorage(
+        config.db as unknown as Kysely<PrivateRegistryDatabase>,
+      ),
+      monitorRuns: new MonitorRunStorage(
+        config.db as unknown as Kysely<PrivateRegistryDatabase>,
+      ),
+      monitorResults: new MonitorResultStorage(
+        config.db as unknown as Kysely<PrivateRegistryDatabase>,
+      ),
+      monitorConnections: new MonitorConnectionStorage(
+        config.db as unknown as Kysely<PrivateRegistryDatabase>,
+      ),
     },
     brandContext: new BrandContextStorage(config.db),
     organizationDomains: new OrganizationDomainStorage(config.db),

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -15,6 +15,7 @@ import type { ColumnType } from "kysely";
 import type { OAuthConfig } from "../tools/connection/schema";
 import type { ChatMessage } from "../api/routes/decopilot/types";
 import { ThreadStatus, type ProviderId } from "@decocms/mesh-sdk";
+import type { PrivateRegistryDatabase } from "./registry/types";
 
 // ============================================================================
 // Type Utilities
@@ -1654,7 +1655,7 @@ export interface BrandContext {
  * NOTE: This uses *Table types with ColumnType for proper Kysely type mapping
  * NOTE: Organizations, teams, members, and roles are managed by Better Auth organization plugin
  */
-export interface Database {
+export interface Database extends PrivateRegistryDatabase {
   // Core tables (all within organization scope)
   users: UserTable; // System users
   user: BetterAuthUserTable; // Better Auth core table (singular)


### PR DESCRIPTION
## Source
Reduction found while hunting `as any` debt (C-DEBT): six `config.db as any` casts in `context-factory.ts` when constructing the private-registry storage classes.

## Why
`config.db` is `Kysely<Database>`, but `RegistryItemStorage`/`PublishRequestStorage`/etc. expect `Kysely<PrivateRegistryDatabase>`. `Database` never declared the `private_registry_*` tables even though they live in the same physical Postgres database (see migration `062-private-registry.ts`), so the previous code fell back to `as any`, which silently disables type-checking on all six constructor calls (wrong arg count/order would compile).

## Fix
- `Database` now `extends PrivateRegistryDatabase`, so the type accurately reflects the shared schema.
- Replaced each `as any` with `as unknown as Kysely<PrivateRegistryDatabase>`. A direct single assertion doesn't typecheck — Kysely's `transaction()` callback parameter makes `Kysely<T>` invariant in `T`, so widening a superset DB down to a subset view still needs the `unknown` bridge. This mirrors the existing cast already used for the same type in `public-publish-request.ts`.

Behavior-preserving: purely a type-level change (erased at runtime), same object passed through. No test relies on the removed `as any`.

## Verify
```
cd apps/mesh && bunx tsc --noEmit
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (green)
- No test file constructs these storage classes directly, so no targeted test to run; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unsafe as-any casts in private-registry storage construction by aligning DB types. This improves type safety without changing runtime behavior.

- **Refactors**
  - `Database` now extends `PrivateRegistryDatabase` to reflect the shared schema.
  - Replaced six `as any` casts with `as unknown as Kysely<PrivateRegistryDatabase>` to satisfy Kysely’s invariance.
  - Added import for `PrivateRegistryDatabase`; no runtime changes or test impact.

<sup>Written for commit 8f48d0bfb790167197af28c505fa4d403b38c5c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

