### PR TITLE
refactor(web): route store-discovery retry through @decocms/std

### DIFF
--- a/apps/mesh/src/web/hooks/use-merged-store-discovery.ts
+++ b/apps/mesh/src/web/hooks/use-merged-store-discovery.ts
@@ -12,6 +12,7 @@
 import { useInfiniteQuery, keepPreviousData } from "@tanstack/react-query";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { createMCPClient } from "@decocms/mesh-sdk";
+import { retry, RetryError } from "@decocms/std";
 import {
   inferRegistryListToolName,
   flattenPaginatedItems,
@@ -113,74 +114,82 @@ function useRegistryGroupQuery(
 
             const listToolName = inferRegistryListToolName(registry.id, orgId);
 
-            // Per-registry retry (2 attempts) since Promise.all would
-            // otherwise let one failure reject the entire group
-            let lastError: unknown;
-            for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
-              let client: Awaited<ReturnType<typeof createMCPClient>> | null =
-                null;
-              try {
-                client = await createMCPClient({
-                  connectionId: registry.id,
-                  orgId,
-                  orgSlug,
-                });
+            // Per-registry retry since Promise.all would otherwise let one
+            // failure reject the entire group.
+            try {
+              return await retry(
+                async (): Promise<RegistryPageResult> => {
+                  let client: Awaited<
+                    ReturnType<typeof createMCPClient>
+                  > | null = null;
+                  try {
+                    client = await createMCPClient({
+                      connectionId: registry.id,
+                      orgId,
+                      orgSlug,
+                    });
 
-                const params: Record<string, unknown> = { limit: PAGE_SIZE };
-                if (cursor) {
-                  params.cursor = cursor;
-                }
-                if (where) {
-                  params.where = where;
-                }
+                    const params: Record<string, unknown> = {
+                      limit: PAGE_SIZE,
+                    };
+                    if (cursor) {
+                      params.cursor = cursor;
+                    }
+                    if (where) {
+                      params.where = where;
+                    }
 
-                const result = (await client.callTool({
-                  name: listToolName,
-                  arguments: params,
-                })) as { structuredContent?: unknown };
+                    const result = (await client.callTool({
+                      name: listToolName,
+                      arguments: params,
+                    })) as { structuredContent?: unknown };
 
-                const payload = (result.structuredContent ?? result) as Record<
-                  string,
-                  unknown
-                >;
+                    const payload = (result.structuredContent ??
+                      result) as Record<string, unknown>;
 
-                const nextCursor =
-                  (payload as { nextCursor?: string; cursor?: string })
-                    .nextCursor ||
-                  (payload as { nextCursor?: string; cursor?: string })
-                    .cursor ||
-                  undefined;
+                    const nextCursor =
+                      (payload as { nextCursor?: string; cursor?: string })
+                        .nextCursor ||
+                      (payload as { nextCursor?: string; cursor?: string })
+                        .cursor ||
+                      undefined;
 
-                const items = flattenPaginatedItems<RegistryItem>(
-                  payload ? [payload] : [],
-                );
+                    const items = flattenPaginatedItems<RegistryItem>(
+                      payload ? [payload] : [],
+                    );
 
-                return {
-                  registryId: registry.id,
-                  registryTitle: registry.title,
-                  registryIcon: registry.icon,
-                  items,
-                  nextCursor,
-                };
-              } catch (err) {
-                lastError = err;
-              } finally {
-                await client?.close().catch(() => {});
-              }
+                    return {
+                      registryId: registry.id,
+                      registryTitle: registry.title,
+                      registryIcon: registry.icon,
+                      items,
+                      nextCursor,
+                    };
+                  } finally {
+                    await client?.close().catch(() => {});
+                  }
+                },
+                {
+                  maxAttempts: RETRY_ATTEMPTS,
+                  minTimeout: 0,
+                  maxTimeout: 1000,
+                  jitter: 0,
+                },
+              );
+            } catch (err) {
+              // All retries exhausted — log and return empty so other
+              // registries in the group are not affected
+              console.warn(
+                `[useMergedStoreDiscovery] Registry "${registry.title}" (${registry.id}) failed after ${RETRY_ATTEMPTS} attempts:`,
+                err instanceof RetryError ? err.cause : err,
+              );
+              return {
+                registryId: registry.id,
+                registryTitle: registry.title,
+                registryIcon: registry.icon,
+                items: [],
+              };
             }
-
-            // All retries exhausted — log and return empty so other registries
-            // in the group are not affected
-            console.warn(
-              `[useMergedStoreDiscovery] Registry "${registry.title}" (${registry.id}) failed after ${RETRY_ATTEMPTS} attempts:`,
-              lastError,
-            );
-            return {
-              registryId: registry.id,
-              registryTitle: registry.title,
-              registryIcon: registry.icon,
-              items: [],
-            };
           }),
         );
 


### PR DESCRIPTION
## Source
C1 reinvented-stdlib reduction found while hunting `apps/mesh/src/web` for hand-rolled retry loops (see `@decocms/std` guidance in CLAUDE.md — it was consolidated from ~9 ad-hoc backoff/retry copies).

## What
`useMergedStoreDiscovery`'s per-registry page fetch hand-rolled a `for (let attempt ...)` loop with a `lastError` variable to retry each registry's MCP call up to 3 times (so one flaky registry doesn't reject the whole `Promise.all` group). `@decocms/std`'s `retry()` already implements exactly this "call until success, else throw" pattern.

## Why a maintainer wants this
Removes a hand-rolled retry loop the repo has explicitly said not to reinvent, and gets a real (if tiny) improvement for free: attempts now have a backoff between them instead of hammering the MCP client back-to-back on failure.

## Behavior
Same attempt count (`RETRY_ATTEMPTS = 3`), same per-attempt `client.close()` cleanup via `finally`, same fallback on exhaustion (empty items + `console.warn`). The only behavior delta is a near-zero backoff between attempts (`minTimeout: 0, maxTimeout: 1000, jitter: 0`) where before there was none — negligible for a background registry-listing fetch, and arguably safer than back-to-back retries.

## To verify
```
cd apps/mesh && bun x tsc --noEmit
```

## Checks run locally
- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` — clean
- No existing test file covers this hook (`use-merged-store-discovery.ts` has no `.test.ts`), so full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routed per-registry retries in store discovery through `@decocms/std`’s `retry()` to replace a hand-rolled loop. Keeps 3 attempts and the same fallback, and adds a small backoff to avoid hammering the MCP client.

- **Refactors**
  - Switched `useMergedStoreDiscovery` per-page fetch to `retry()` from `@decocms/std`.
  - Preserves behavior: 3 attempts, per-attempt `client.close()` in `finally`, empty items + `console.warn` on exhaustion (uses `RetryError.cause`).
  - Adds minimal backoff (`minTimeout: 0`, `maxTimeout: 1000`, `jitter: 0`).

<sup>Written for commit 28044f7ef9a36335785983f4585262d07ca80ce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

