### PR TITLE
fix(web): fix live-meta cache invalidation key mismatch

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.test.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.test.tsx
@@ -1,0 +1,60 @@
+import { setupComponentTest } from "@/test/setup";
+setupComponentTest();
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { KEYS } from "@/web/lib/query-keys";
+import { useDeleteBlogBlock } from "./use-blog-mutations";
+
+const params = { orgSlug: "acme", virtualMcpId: "vmid-1", branch: "main" };
+const previewUrl = "https://preview.example.com";
+
+describe("useDeleteBlogBlock", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ ok: true, existed: true }), {
+          status: 200,
+        }),
+      )) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("invalidates the live-meta query cached under its previewUrl-suffixed key", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    // Mirrors how useLiveMeta actually keys its cache entry, including the
+    // previewUrl segment the delete mutation doesn't otherwise know about.
+    const liveMetaKey = KEYS.liveMeta(
+      params.orgSlug,
+      params.virtualMcpId,
+      params.branch,
+      previewUrl,
+    );
+    client.setQueryData(liveMetaKey, { ok: true });
+
+    function wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      );
+    }
+
+    const { result } = renderHook(() => useDeleteBlogBlock(params), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.mutate({ blockKey: "posts/hello-world" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.getQueryState(liveMetaKey)?.isInvalidated).toBe(true);
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
+++ b/apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.ts
@@ -28,7 +28,7 @@ function liveMetaQueryKey({
   virtualMcpId,
   branch,
 }: BlogMutationParams) {
-  return KEYS.liveMeta(`${orgSlug}/${virtualMcpId}/${branch}`);
+  return KEYS.liveMeta(orgSlug, virtualMcpId, branch);
 }
 
 function writeUrl(

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -253,7 +253,9 @@ export function FileExplorer({
         return rest;
       },
     );
-    void queryClient.invalidateQueries({ queryKey: KEYS.liveMeta(cacheKey) });
+    void queryClient.invalidateQueries({
+      queryKey: KEYS.liveMeta(orgSlug, virtualMcpId, branch),
+    });
   }
 
   function invalidateDecofileCachesForDeletedNode(node: TreeNode) {

--- a/apps/mesh/src/web/components/sections-editor/use-delete-block.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-delete-block.ts
@@ -62,8 +62,9 @@ export function useDeleteBlock({
       }
     },
     onSuccess: () => {
-      const cacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;
-      void queryClient.invalidateQueries({ queryKey: KEYS.liveMeta(cacheKey) });
+      void queryClient.invalidateQueries({
+        queryKey: KEYS.liveMeta(orgSlug, virtualMcpId, branch),
+      });
     },
   });
 }

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
@@ -20,13 +20,17 @@ export function useLiveMeta(
       | ((query: Query<LiveMeta>) => number | false | undefined);
   },
 ) {
-  const key = params
-    ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}/${params.previewUrl ?? ""}`
-    : "";
   const fetchEnabled = options?.fetchEnabled ?? true;
   const previewUrl = params?.previewUrl;
   return useQuery({
-    queryKey: KEYS.liveMeta(key),
+    queryKey: params
+      ? KEYS.liveMeta(
+          params.orgSlug,
+          params.virtualMcpId,
+          params.branch,
+          previewUrl ?? "",
+        )
+      : KEYS.liveMeta(""),
     queryFn: async () => {
       const url = new URL("/live/_meta", previewUrl!).href;
       const res = await fetch(url, { cache: "no-store" });

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -512,7 +512,9 @@ export const KEYS = {
 
   // Deco sections editor (sandbox preview)
   decofile: (previewUrl: string) => ["decofile", previewUrl] as const,
-  liveMeta: (previewUrl: string) => ["live-meta", previewUrl] as const,
+  // Variadic so an invalidation call can pass just the org/vmid/branch prefix
+  // and still partial-match the full org/vmid/branch/previewUrl query key.
+  liveMeta: (...parts: string[]) => ["live-meta", ...parts] as const,
   sandboxInvoke: (sandboxKey: string, loaderKey: string) =>
     ["sandbox-invoke", sandboxKey, loaderKey] as const,
   sandboxRepoDir: (orgSlug: string, virtualMcpId: string, branch: string) =>


### PR DESCRIPTION
Follows #4810 — hardening on the live-meta cache invalidation it added.

**The gap:** `useLiveMeta` caches under an `org/vmid/branch/previewUrl`-suffixed key (`apps/mesh/src/web/components/sections-editor/use-live-meta.ts:29`), but every invalidation call site — the blog block delete added in #4810, plus the pre-existing generic block delete and file-explorer delete — invalidated a plain `org/vmid/branch` key built by joining a template string. React Query's default partial-match invalidation compares query-key array elements positionally: `"a/b/c"` never matches `"a/b/c/previewUrl"` at the same array index, since they're different string primitives, not nested arrays it can partial-match into. So none of these invalidation calls actually reached the cached query — the live-meta cache stayed stale after every delete, silently defeating the fix #4810 shipped.

**Fix:** made `KEYS.liveMeta` variadic (`...parts: string[]`) so an `org/vmid/branch` invalidation call is a true array prefix of the full `org/vmid/branch/previewUrl` cache key, and updated all four call sites (the query hook + 3 invalidation sites) to pass segments instead of a pre-joined string.

**Regression test:** `use-blog-mutations.test.tsx` renders the real `useDeleteBlogBlock` hook against a `QueryClient` seeded with a live-meta entry keyed the way `useLiveMeta` actually keys it (including the previewUrl segment), then asserts the query is invalidated after the mutation succeeds. Confirmed it fails on the pre-fix code (`isInvalidated` is `false`) and passes after the fix.

**To verify:** `bun test apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.test.tsx`

**Checked locally:** `bun run fmt` (clean), `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes live-meta cache invalidation so deletes correctly invalidate the cached query and prevent stale UI. `KEYS.liveMeta` is now variadic and callers pass key segments, enabling React Query prefix matching.

- **Bug Fixes**
  - Made `KEYS.liveMeta(...parts)` variadic to support prefix invalidation of `org/vmid/branch/previewUrl` keys.
  - Updated `useLiveMeta` and invalidation sites (blog block delete, generic block delete, file explorer) to pass segments instead of joined strings.
  - Added regression test `apps/mesh/src/web/components/sandbox/content/blog/use-blog-mutations.test.tsx` to verify the live-meta query is invalidated.

<sup>Written for commit 931f7b10dea7a426d81d16343c56fa557fcd12ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

