### PR TITLE
fix(sandbox): fix live-meta invalidation on file-changed SSE events

### DIFF
--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.test.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildDirectDaemonEventsUrl,
   isDirectDaemonEventsGoneStatus,
+  isLiveMetaKeyForScope,
 } from "./sandbox-events-context";
 
 describe("buildDirectDaemonEventsUrl", () => {
@@ -32,5 +33,37 @@ describe("isDirectDaemonEventsGoneStatus", () => {
     expect(isDirectDaemonEventsGoneStatus(429)).toBe(false);
     expect(isDirectDaemonEventsGoneStatus(502)).toBe(false);
     expect(isDirectDaemonEventsGoneStatus(503)).toBe(false);
+  });
+});
+
+describe("isLiveMetaKeyForScope", () => {
+  test("matches a live-meta key regardless of its previewUrl suffix", () => {
+    expect(
+      isLiveMetaKeyForScope(
+        ["live-meta", "acme", "vmid-1", "main", "https://preview.example.com"],
+        "acme",
+        "vmid-1",
+        "main",
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match a different org, vmid, or branch", () => {
+    const scope = [
+      "live-meta",
+      "acme",
+      "vmid-1",
+      "main",
+      "https://x.example.com",
+    ];
+    expect(isLiveMetaKeyForScope(scope, "other-org", "vmid-1", "main")).toBe(
+      false,
+    );
+    expect(isLiveMetaKeyForScope(scope, "acme", "other-vmid", "main")).toBe(
+      false,
+    );
+    expect(isLiveMetaKeyForScope(scope, "acme", "vmid-1", "other-branch")).toBe(
+      false,
+    );
   });
 });

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.tsx
@@ -130,6 +130,21 @@ const DAEMON_EVENT_TYPES: readonly DaemonEventName[] = [
 // `log` is broadcast separately — same SSE stream, different shape.
 const LOG_EVENT = "log" as const;
 
+/** True when `queryKey` is a cached live-meta entry for this org/vmid/branch, regardless of its previewUrl suffix. */
+export function isLiveMetaKeyForScope(
+  queryKey: readonly unknown[],
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+): boolean {
+  return (
+    queryKey[0] === "live-meta" &&
+    queryKey[1] === orgSlug &&
+    queryKey[2] === virtualMcpId &&
+    queryKey[3] === branch
+  );
+}
+
 export function buildDirectDaemonEventsUrl(
   previewUrl: string | null | undefined,
 ): string | null {
@@ -382,14 +397,13 @@ export function SandboxEventsProvider({
               liveMetaDebounceTimer = setTimeout(() => {
                 liveMetaDebounceTimer = null;
                 void queryClient.invalidateQueries({
-                  predicate: (query) => {
-                    const key = query.queryKey;
-                    return (
-                      key[0] === "live-meta" &&
-                      typeof key[1] === "string" &&
-                      key[1].startsWith(`${cacheKey}/`)
-                    );
-                  },
+                  predicate: (query) =>
+                    isLiveMetaKeyForScope(
+                      query.queryKey,
+                      org.slug,
+                      virtualMcpId,
+                      branch,
+                    ),
                 });
               }, 1_000);
             }


### PR DESCRIPTION
## Source

Follows #4823. That PR made `KEYS.liveMeta` variadic (`["live-meta", org, vmid, branch, previewUrl]`) and fixed three invalidation call sites (blog block delete, generic block delete, file-explorer delete), but missed a fourth hand-rolled predicate in `sandbox-events-context.tsx`'s `file-changed` SSE handler.

## The gap

That predicate still did:
```ts
key[0] === "live-meta" && typeof key[1] === "string" && key[1].startsWith(`${cacheKey}/`)
```
where `cacheKey` is the joined string `"org/vmid/branch"`. Since `key[1]` is now just the org slug alone (not the joined string), this `startsWith` check can never be true — verified with a plain `bun -e` repro before touching the code. Net effect: every non-`.deco/` file change over SSE silently stops invalidating the live-meta cache, so the preview keeps serving stale `/live/_meta` data until a manual reload — the exact regression #4823 was written to fix, just at a fourth site.

## Fix

Extracted the match into `isLiveMetaKeyForScope` (this file already exports pure helpers like `buildDirectDaemonEventsUrl` for the same reason: SSE-handler logic isn't otherwise unit-testable) and compares key segments positionally instead of string-prefixing a joined key — matching how the three sibling call sites already invalidate by key-array prefix.

## Test

`sandbox-events-context.test.ts` adds `isLiveMetaKeyForScope` cases: matches regardless of `previewUrl` suffix, and rejects a mismatched org/vmid/branch. These fail against the old inline logic (confirmed via the `bun -e` repro above) and pass against the fix.

## Verification

- `bun run fmt`
- `cd apps/mesh && bun x tsc --noEmit` — clean
- `bun test apps/mesh/src/web/components/sandbox/hooks/sandbox-events-context.test.ts` — 7 pass, 0 fail

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale preview metadata by correctly invalidating the live-meta cache on file-changed SSE events. The preview now refreshes `/live/_meta` after edits without a manual reload.

- **Bug Fixes**
  - Replaced a broken string-prefix check with a positional match for variadic keys `["live-meta", org, vmid, branch, previewUrl]` using `isLiveMetaKeyForScope`.
  - Updated the `sandbox-events-context.tsx` predicate and added tests to cover correct matches and mismatches.

<sup>Written for commit 9014b39120208452914e328d55644f2db7e9d737. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

