### PR TITLE
refactor(web): replace any with a real ToolInputProperty type in add-tile-drawer

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -77,7 +77,10 @@ import { toast } from "sonner";
 import { getUIResourceUri } from "@/mcp-apps/types.ts";
 import { AgentAvatar } from "@/web/components/agent-icon";
 import { IntegrationIcon } from "@/web/components/integration-icon";
-import { ToolInputForm } from "@/web/components/tool-input-form";
+import {
+  ToolInputForm,
+  type ToolInputProperty,
+} from "@/web/components/tool-input-form";
 import { KEYS } from "@/web/lib/query-keys";
 import { useStudioTools } from "@/web/lib/studio-tools";
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
@@ -95,8 +98,10 @@ interface UITool {
   name: string;
   description?: string;
   resourceUri: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  inputSchema?: { properties?: Record<string, any>; required?: string[] };
+  inputSchema?: {
+    properties?: Record<string, ToolInputProperty>;
+    required?: string[];
+  };
 }
 
 interface ConnectionUITools {
@@ -827,8 +832,7 @@ function AgentToolList({
  * should toast). */
 function coerceFormValues(
   values: Record<string, unknown>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  properties: Record<string, any>,
+  properties: Record<string, ToolInputProperty>,
 ): Record<string, unknown> | null {
   const out: Record<string, unknown> = {};
   for (const [key, raw] of Object.entries(values)) {
@@ -857,8 +861,7 @@ function coerceFormValues(
  * JSON strings so they render in a Textarea. */
 function seedFormValues(
   toolInput: Record<string, unknown> | undefined,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  properties: Record<string, any> | undefined,
+  properties: Record<string, ToolInputProperty> | undefined,
 ): Record<string, unknown> {
   if (!toolInput || !properties) return {};
   const init: Record<string, unknown> = {};

--- a/apps/mesh/src/web/components/tool-input-form.tsx
+++ b/apps/mesh/src/web/components/tool-input-form.tsx
@@ -17,10 +17,15 @@ import {
 } from "@deco/ui/components/select.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 
+/** One entry of an MCP tool's `inputSchema.properties`. */
+export interface ToolInputProperty {
+  type: string;
+  description?: string;
+}
+
 interface ToolInputFormProps {
   /** `inputSchema.properties` from the MCP tool definition. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  properties: Record<string, any>;
+  properties: Record<string, ToolInputProperty>;
   /** Names of required fields (`inputSchema.required`). */
   required?: string[];
   /** Current field values. */


### PR DESCRIPTION
## Source
C-DEBT: `no-explicit-any` is a `warn`-level oxlint rule not enforced by CI, so these accumulate uncaught. `add-tile-drawer.tsx` had three separate `Record<string, any>` params (`UITool.inputSchema.properties`, `coerceFormValues`, `seedFormValues`), each carrying an `eslint-disable-next-line @typescript-eslint/no-explicit-any` comment, plus a fourth identical suppression in its direct consumer `tool-input-form.tsx`.

## Why
All four sites only ever read `.type` (string) and `.description` (optional string) off each property — the real shape was recoverable directly from usage, not guessed. Replacing `any` with a shared `ToolInputProperty { type: string; description?: string }` (exported from `tool-input-form.tsx`, imported where needed) closes the gap and lets a future shape mismatch be caught at compile time instead of silently passing through `any`.

## Change
Behavior-preserving type-only substitution — no logic changed. `-9 / +17` across the two files (net line count grows slightly because the type is now spelled out instead of suppressed, but four `any`/eslint-disable pairs are gone).

## Verify
- `cd apps/mesh && bun x tsc --noEmit` — clean, no new errors.
- `bun run fmt` — clean.
- No existing test file covers these two files; the type-only nature of the change plus a clean typecheck is the verification. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `any` with a real `ToolInputProperty` type for tool input schemas in `add-tile-drawer.tsx` and `tool-input-form.tsx` to improve type safety. No behavior changes; removes four `no-explicit-any` suppressions.

- **Refactors**
  - Added `ToolInputProperty { type: string; description?: string }` and exported from `tool-input-form.tsx`.
  - Updated `UITool.inputSchema.properties`, `coerceFormValues`, `seedFormValues`, and `ToolInputForm.properties` to `Record<string, ToolInputProperty>`.
  - Type-check passes cleanly.

<sup>Written for commit cef15e48f72298976ecb589a92cbfb2c7bec5400. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

