### PR TITLE
refactor(content): extract CollectionsSidebar into its own file

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/collections-sidebar.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/collections-sidebar.tsx
@@ -1,0 +1,182 @@
+import {
+  BookOpen01,
+  Calendar,
+  CornerUpRight,
+  Database01,
+  File02,
+  Globe02,
+  Grid01,
+  LayoutAlt01,
+  Settings01,
+  Tag01,
+  CreditCardSearch,
+  Users01,
+  Zap,
+} from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.js";
+import type { CollectionCounts, CollectionId } from "./content-browser";
+
+export function CollectionsSidebar({
+  active,
+  counts,
+  showBlog,
+  onSelect,
+}: {
+  active: CollectionId;
+  counts: CollectionCounts;
+  showBlog: boolean;
+  onSelect: (id: CollectionId) => void;
+}) {
+  return (
+    <div className="w-[208px] shrink-0 border-r flex flex-col">
+      <div className="px-3 h-12 flex items-center border-b shrink-0">
+        <span className="text-sm font-medium">Content</span>
+      </div>
+      <nav className="flex flex-col p-1.5 gap-0.5">
+        <CollectionRow
+          id="pages"
+          icon={LayoutAlt01}
+          label="Pages"
+          count={counts.pages}
+          active={active === "pages"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
+          id="sections"
+          icon={Globe02}
+          label="Sections"
+          count={counts.sections}
+          active={active === "sections"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
+          id="apps"
+          icon={Grid01}
+          label="Apps"
+          count={counts.apps}
+          active={active === "apps"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
+          id="redirects"
+          icon={CornerUpRight}
+          label="Redirects"
+          count={counts.redirects}
+          active={active === "redirects"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
+          id="loaders"
+          icon={Database01}
+          label="Loaders"
+          count={counts.loaders}
+          active={active === "loaders"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
+          id="actions"
+          icon={Zap}
+          label="Actions"
+          count={counts.actions}
+          active={active === "actions"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
+          id="site"
+          icon={Settings01}
+          label="Site"
+          active={active === "site"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
+          id="seo"
+          icon={CreditCardSearch}
+          label="SEO"
+          active={active === "seo"}
+          onSelect={onSelect}
+        />
+        <CollectionRow
+          id="calendar"
+          icon={Calendar}
+          label="Calendar"
+          active={active === "calendar"}
+          onSelect={onSelect}
+        />
+        {showBlog && (
+          <>
+            <div className="mt-3 flex items-center gap-1.5 px-2.5 pb-1 pt-1 text-xs font-medium text-muted-foreground/70">
+              <BookOpen01 size={13} className="shrink-0" />
+              Blog
+            </div>
+            <CollectionRow
+              id="posts"
+              icon={File02}
+              label="Posts"
+              count={counts.posts}
+              active={active === "posts"}
+              onSelect={onSelect}
+            />
+            <CollectionRow
+              id="authors"
+              icon={Users01}
+              label="Authors"
+              count={counts.authors}
+              active={active === "authors"}
+              onSelect={onSelect}
+            />
+            <CollectionRow
+              id="categories"
+              icon={Tag01}
+              label="Categories"
+              count={counts.categories}
+              active={active === "categories"}
+              onSelect={onSelect}
+            />
+          </>
+        )}
+      </nav>
+    </div>
+  );
+}
+
+function CollectionRow({
+  id,
+  icon: Icon,
+  label,
+  count,
+  active,
+  onSelect,
+}: {
+  id: CollectionId;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  label: string;
+  count?: number;
+  active: boolean;
+  onSelect: (id: CollectionId) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(id)}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors cursor-pointer",
+        active
+          ? "bg-accent text-accent-foreground"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+      )}
+    >
+      <Icon size={16} className="shrink-0" />
+      <span className="flex-1 truncate">{label}</span>
+      {count !== undefined && (
+        <span
+          className={cn(
+            "shrink-0 text-xs tabular-nums",
+            active ? "text-accent-foreground/70" : "text-muted-foreground/70",
+          )}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -2,12 +2,9 @@ import { Suspense, lazy, useState } from "react";
 import { type Query } from "@tanstack/react-query";
 import {
   AlertCircle,
-  BookOpen01,
-  Calendar,
   Code01,
   Copy01,
   CornerUpRight,
-  Database01,
   DotsHorizontal,
   Edit01,
   File02,
@@ -18,12 +15,10 @@ import {
   Loading01,
   Plus,
   SearchLg,
-  Settings01,
   Tag01,
   CreditCardSearch,
   Trash01,
   Users01,
-  Zap,
 } from "@untitledui/icons";
 import { toast } from "sonner";
 import {
@@ -89,6 +84,7 @@ import { suggestBlockId } from "@/web/components/sections-editor/page-sections";
 import { createReferencedBlockSaver } from "@/web/components/sections-editor/save-referenced-block";
 import { AvailableSectionEditor } from "./available-section-editor";
 import { SavedSectionEditor } from "./saved-section-editor";
+import { CollectionsSidebar } from "./collections-sidebar";
 import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events";
 import {
   sandboxUserStop,
@@ -197,7 +193,7 @@ const RedirectEditor = lazy(() =>
 
 const VARIANT_GREEN = "oklch(0.65 0.15 160)";
 
-type CollectionId =
+export type CollectionId =
   | "pages"
   | "sections"
   | "apps"
@@ -209,7 +205,7 @@ type CollectionId =
   | "redirects"
   | BlogKind;
 
-type CollectionCounts = Record<
+export type CollectionCounts = Record<
   | "pages"
   | "sections"
   | "apps"
@@ -1648,171 +1644,6 @@ function GroupHeader({
       <Icon size={13} className="shrink-0" />
       {label}
     </div>
-  );
-}
-
-function CollectionsSidebar({
-  active,
-  counts,
-  showBlog,
-  onSelect,
-}: {
-  active: CollectionId;
-  counts: CollectionCounts;
-  showBlog: boolean;
-  onSelect: (id: CollectionId) => void;
-}) {
-  return (
-    <div className="w-[208px] shrink-0 border-r flex flex-col">
-      <div className="px-3 h-12 flex items-center border-b shrink-0">
-        <span className="text-sm font-medium">Content</span>
-      </div>
-      <nav className="flex flex-col p-1.5 gap-0.5">
-        <CollectionRow
-          id="pages"
-          icon={LayoutAlt01}
-          label="Pages"
-          count={counts.pages}
-          active={active === "pages"}
-          onSelect={onSelect}
-        />
-        <CollectionRow
-          id="sections"
-          icon={Globe02}
-          label="Sections"
-          count={counts.sections}
-          active={active === "sections"}
-          onSelect={onSelect}
-        />
-        <CollectionRow
-          id="apps"
-          icon={Grid01}
-          label="Apps"
-          count={counts.apps}
-          active={active === "apps"}
-          onSelect={onSelect}
-        />
-        <CollectionRow
-          id="redirects"
-          icon={CornerUpRight}
-          label="Redirects"
-          count={counts.redirects}
-          active={active === "redirects"}
-          onSelect={onSelect}
-        />
-        <CollectionRow
-          id="loaders"
-          icon={Database01}
-          label="Loaders"
-          count={counts.loaders}
-          active={active === "loaders"}
-          onSelect={onSelect}
-        />
-        <CollectionRow
-          id="actions"
-          icon={Zap}
-          label="Actions"
-          count={counts.actions}
-          active={active === "actions"}
-          onSelect={onSelect}
-        />
-        <CollectionRow
-          id="site"
-          icon={Settings01}
-          label="Site"
-          active={active === "site"}
-          onSelect={onSelect}
-        />
-        <CollectionRow
-          id="seo"
-          icon={CreditCardSearch}
-          label="SEO"
-          active={active === "seo"}
-          onSelect={onSelect}
-        />
-        <CollectionRow
-          id="calendar"
-          icon={Calendar}
-          label="Calendar"
-          active={active === "calendar"}
-          onSelect={onSelect}
-        />
-        {showBlog && (
-          <>
-            <div className="mt-3 flex items-center gap-1.5 px-2.5 pb-1 pt-1 text-xs font-medium text-muted-foreground/70">
-              <BookOpen01 size={13} className="shrink-0" />
-              Blog
-            </div>
-            <CollectionRow
-              id="posts"
-              icon={File02}
-              label="Posts"
-              count={counts.posts}
-              active={active === "posts"}
-              onSelect={onSelect}
-            />
-            <CollectionRow
-              id="authors"
-              icon={Users01}
-              label="Authors"
-              count={counts.authors}
-              active={active === "authors"}
-              onSelect={onSelect}
-            />
-            <CollectionRow
-              id="categories"
-              icon={Tag01}
-              label="Categories"
-              count={counts.categories}
-              active={active === "categories"}
-              onSelect={onSelect}
-            />
-          </>
-        )}
-      </nav>
-    </div>
-  );
-}
-
-function CollectionRow({
-  id,
-  icon: Icon,
-  label,
-  count,
-  active,
-  onSelect,
-}: {
-  id: CollectionId;
-  icon: React.ComponentType<{ size?: number; className?: string }>;
-  label: string;
-  count?: number;
-  active: boolean;
-  onSelect: (id: CollectionId) => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => onSelect(id)}
-      className={cn(
-        "flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors cursor-pointer",
-        active
-          ? "bg-accent text-accent-foreground"
-          : "text-muted-foreground hover:bg-muted hover:text-foreground",
-      )}
-    >
-      <Icon size={16} className="shrink-0" />
-      <span className="flex-1 truncate">{label}</span>
-      {count !== undefined && (
-        <span
-          className={cn(
-            "shrink-0 text-xs tabular-nums",
-            active ? "text-accent-foreground/70" : "text-muted-foreground/70",
-          )}
-        >
-          {count}
-        </span>
-      )}
-    </button>
   );
 }
 


### PR DESCRIPTION
## Summary
- C5 God-component reduction: `content-browser.tsx` is 2700+ lines. `CollectionsSidebar` and its `CollectionRow` helper are pure-props components (no shared closures or local state with the rest of the file) — a self-contained sidebar-nav unit, so they move to `collections-sidebar.tsx` unchanged.
- `CollectionId`/`CollectionCounts` types are exported from `content-browser.tsx` (still used there for other state) and imported by the new file.
- Dropped now-unused icon imports (`Database01`, `Zap`, `Settings01`, `BookOpen01`, `Calendar`) from `content-browser.tsx` — they were only referenced inside the moved code (`Calendar` the icon vs. the unrelated `VariantCalendar` lazy import).

Net diff: content-browser.tsx -172/+3, new file +182. Byte-identical logic move, no behavior change.

## Test plan
- [x] `bun run fmt`
- [x] `cd apps/mesh && bun x tsc --noEmit` — green
- Full CI (lint, unit, e2e) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `CollectionsSidebar` into its own file to reduce the size of `content-browser.tsx` and keep the sidebar logic isolated. No behavior changes.

- **Refactors**
  - Moved `CollectionsSidebar` and `CollectionRow` from `content-browser.tsx` to `collections-sidebar.tsx` (code unchanged).
  - Exported `CollectionId` and `CollectionCounts` from `content-browser.tsx` and imported them in the new file.
  - Removed now-unused icon imports from `content-browser.tsx` that were only used in the moved code (from `@untitledui/icons`).

<sup>Written for commit ad1c9e3938e8555613ae0f69820ea5f371509039. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

