### PR TITLE
refactor(chat): extract thinking/generating indicator components from assistant.tsx

### DIFF
--- a/apps/mesh/src/web/components/chat/message/assistant.tsx
+++ b/apps/mesh/src/web/components/chat/message/assistant.tsx
@@ -1,19 +1,23 @@
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
-  Lightbulb01,
   MessageTextSquare01,
   RefreshCw01,
   Stars01,
-  Target04,
   Tool02,
 } from "@untitledui/icons";
 import type { ToolUIPart } from "ai";
-import { type ReactNode, Suspense, useEffect, useState } from "react";
+import { type ReactNode, Suspense, useState } from "react";
 import { ToolCallShell } from "./parts/tool-call-part/common.tsx";
 import type { ChatMessage } from "../types.ts";
 import { MessageStatsBar } from "../usage-stats.tsx";
 import { MessageTextPart } from "./parts/text-part.tsx";
 import { MessageTimestamp } from "./timestamp.tsx";
+import {
+  type ReasoningPart,
+  GeneratingFooter,
+  ThinkingState,
+  ThoughtSummary,
+} from "./thinking-indicator.tsx";
 import {
   GenericToolCallPart,
   GenerateImagePart,
@@ -38,235 +42,11 @@ import {
   type RenderItem,
   useFilterParts,
 } from "./use-filter-parts.ts";
-import { RUN_STATUS_COPY } from "../run-status.ts";
 import { addUsage, emptyUsageStats } from "@decocms/mesh-sdk";
 import { useOptionalChatStream, useOptionalChatTask } from "../context.tsx";
-import { LiveTimer } from "../../live-timer.tsx";
-import { GridLoader } from "../../grid-loader.tsx";
-import { formatDuration, toEpochMs } from "../../../lib/format-time.ts";
-import { useClockTick } from "../../../lib/use-clock-tick.ts";
-
-type ThinkingStage = "planning" | "thinking";
-
-interface ThinkingStageConfig {
-  icon: ReactNode;
-  label: string;
-  detail: string;
-}
-
-const THINKING_STAGES: Record<ThinkingStage, ThinkingStageConfig> = {
-  planning: {
-    icon: (
-      <Target04
-        className="text-muted-foreground shrink-0 animate-pulse"
-        size={14}
-      />
-    ),
-    label: "Planning next moves",
-    detail: "Deciding how to approach the request",
-  },
-  thinking: {
-    icon: (
-      <Stars01
-        className="text-muted-foreground shrink-0 animate-pulse"
-        size={14}
-      />
-    ),
-    label: "Thinking",
-    detail: "Working through the next response",
-  },
-};
-
-const PLANNING_DURATION = 1200;
-
-function ThoughtSummaryShell({
-  icon,
-  title,
-  summary,
-  detail,
-  state,
-  detailVariant = "prose",
-  latency,
-  trailing,
-}: {
-  icon: ReactNode;
-  title: ReactNode;
-  summary?: ReactNode;
-  detail?: string | null;
-  state: "loading" | "error" | "idle";
-  detailVariant?: "code" | "prose";
-  latency?: number;
-  trailing?: ReactNode;
-}) {
-  return (
-    <ToolCallShell
-      icon={icon}
-      title={title}
-      summary={summary}
-      detail={detail}
-      state={state}
-      detailVariant={detailVariant}
-      latency={latency}
-      trailing={trailing}
-    />
-  );
-}
-
-function RunStatusIndicator({ startedAt }: { startedAt: number | null }) {
-  const stage = useOptionalChatStream()?.runStatusStage ?? null;
-  const [fallbackStage, setFallbackStage] = useState<ThinkingStage>("planning");
-
-  // oxlint-disable-next-line ban-use-effect/ban-use-effect
-  useEffect(() => {
-    if (stage !== null) return;
-    const planningTimer = setTimeout(() => {
-      setFallbackStage("thinking");
-    }, PLANNING_DURATION);
-
-    return () => {
-      clearTimeout(planningTimer);
-    };
-  }, [stage]);
-
-  if (stage !== null) {
-    const copy = RUN_STATUS_COPY[stage];
-    return (
-      <ThoughtSummaryShell
-        icon={<Stars01 className="size-4" />}
-        title={`${copy.label}...`}
-        summary={copy.detail}
-        state="loading"
-        trailing={startedAt !== null && <LiveTimer since={startedAt} />}
-      />
-    );
-  }
-
-  const config = THINKING_STAGES[fallbackStage];
-
-  return (
-    <ThoughtSummaryShell
-      icon={config.icon}
-      title={`${config.label}...`}
-      summary={config.detail}
-      state="loading"
-      trailing={startedAt !== null && <LiveTimer since={startedAt} />}
-    />
-  );
-}
-
-function GeneratingFooter({ startedAt }: { startedAt: number }) {
-  return (
-    <div className="flex items-center gap-2.5 mt-1 pb-1 text-muted-foreground/40 select-none">
-      <GridLoader />
-      <LiveTimer since={startedAt} />
-    </div>
-  );
-}
-
-// After this long with no streamed content, the turn looks frozen even though
-// the model may just be slow to first token (common with proxied/liteLLM
-// providers). Surface the elapsed time + a cancel escape hatch rather than a
-// silent "Thinking…".
-const SLOW_AFTER_MS = 20_000;
-
-/**
- * Waiting state for a turn that has produced no parts yet. Pairs the
- * `RunStatusIndicator` with a live elapsed clock and, once the wait crosses
- * `SLOW_AFTER_MS`, a "taking longer than usual" hint + Cancel. `useClockTick`
- * (singleton interval via useSyncExternalStore — no useEffect) re-renders this
- * once per second so the threshold flips without a per-component timer.
- */
-function ThinkingState({ startedAt }: { startedAt: number | null }) {
-  useClockTick(1000);
-  const stream = useOptionalChatStream();
-  const elapsedMs = startedAt !== null ? Date.now() - startedAt : 0;
-  const isSlow = elapsedMs >= SLOW_AFTER_MS;
-
-  return (
-    <div className="flex flex-col gap-0.5">
-      <RunStatusIndicator startedAt={startedAt} />
-      {isSlow && stream?.stop && (
-        <div className="flex items-center gap-2 pb-1 text-[13px] text-muted-foreground/60">
-          <span>This is taking longer than usual.</span>
-          <button
-            type="button"
-            onClick={() => stream.stop()}
-            className="text-muted-foreground hover:text-foreground underline underline-offset-2"
-          >
-            Cancel
-          </button>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ThoughtSummary({
-  duration,
-  parts,
-  isStreaming,
-}: {
-  duration: number | null;
-  parts: ReasoningPart[];
-  isStreaming: boolean;
-}) {
-  const allPartsRedacted = parts.every((part) =>
-    part.text?.includes("REDACTED"),
-  );
-
-  const thoughtMessage = duration
-    ? duration / 1000 > 1
-      ? `Thought for ${formatDuration(duration / 1000)}`
-      : "Thought"
-    : "Thought";
-
-  // Join with newlines (not spaces) so we can extract individual lines
-  const rawText = parts
-    .map((p) => p.text ?? "")
-    .join("\n")
-    .trim();
-  const lines = rawText.split("\n").filter(Boolean);
-
-  // Streaming: show last line (latest thinking). Done: show first line (topic).
-  const summaryLine = isStreaming
-    ? (lines[lines.length - 1] ?? "")
-    : (lines[0] ?? "");
-
-  const summary =
-    !allPartsRedacted && summaryLine
-      ? summaryLine.length > 100
-        ? summaryLine.slice(0, 100) + "…"
-        : summaryLine
-      : undefined;
-
-  const fullText = parts.map((p) => p.text ?? "").join("\n\n");
-  const detail = !allPartsRedacted && fullText.trim() ? fullText : null;
-
-  const latency =
-    !isStreaming && duration != null ? duration / 1000 : undefined;
-
-  return (
-    <ThoughtSummaryShell
-      icon={
-        isStreaming ? (
-          <Stars01 className="size-4" />
-        ) : (
-          <Lightbulb01 className="size-4" />
-        )
-      }
-      title={isStreaming ? "Thinking..." : thoughtMessage}
-      summary={summary}
-      detail={detail}
-      state={isStreaming ? "loading" : "idle"}
-      detailVariant="prose"
-      latency={latency}
-    />
-  );
-}
+import { toEpochMs } from "../../../lib/format-time.ts";
 
 type MessagePart = ChatMessage["parts"][number];
-
-type ReasoningPart = Extract<MessagePart, { type: "reasoning" }>;
 
 /** Minimum number of tool-call items required before collapsing kicks in. */
 const COLLAPSE_THRESHOLD = 3;

--- a/apps/mesh/src/web/components/chat/message/thinking-indicator.tsx
+++ b/apps/mesh/src/web/components/chat/message/thinking-indicator.tsx
@@ -1,0 +1,234 @@
+import { Lightbulb01, Stars01, Target04 } from "@untitledui/icons";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { ToolCallShell } from "./parts/tool-call-part/common.tsx";
+import type { ChatMessage } from "../types.ts";
+import { RUN_STATUS_COPY } from "../run-status.ts";
+import { useOptionalChatStream } from "../context.tsx";
+import { LiveTimer } from "../../live-timer.tsx";
+import { GridLoader } from "../../grid-loader.tsx";
+import { formatDuration } from "../../../lib/format-time.ts";
+import { useClockTick } from "../../../lib/use-clock-tick.ts";
+
+export type ReasoningPart = Extract<
+  ChatMessage["parts"][number],
+  { type: "reasoning" }
+>;
+
+type ThinkingStage = "planning" | "thinking";
+
+interface ThinkingStageConfig {
+  icon: ReactNode;
+  label: string;
+  detail: string;
+}
+
+const THINKING_STAGES: Record<ThinkingStage, ThinkingStageConfig> = {
+  planning: {
+    icon: (
+      <Target04
+        className="text-muted-foreground shrink-0 animate-pulse"
+        size={14}
+      />
+    ),
+    label: "Planning next moves",
+    detail: "Deciding how to approach the request",
+  },
+  thinking: {
+    icon: (
+      <Stars01
+        className="text-muted-foreground shrink-0 animate-pulse"
+        size={14}
+      />
+    ),
+    label: "Thinking",
+    detail: "Working through the next response",
+  },
+};
+
+const PLANNING_DURATION = 1200;
+
+function ThoughtSummaryShell({
+  icon,
+  title,
+  summary,
+  detail,
+  state,
+  detailVariant = "prose",
+  latency,
+  trailing,
+}: {
+  icon: ReactNode;
+  title: ReactNode;
+  summary?: ReactNode;
+  detail?: string | null;
+  state: "loading" | "error" | "idle";
+  detailVariant?: "code" | "prose";
+  latency?: number;
+  trailing?: ReactNode;
+}) {
+  return (
+    <ToolCallShell
+      icon={icon}
+      title={title}
+      summary={summary}
+      detail={detail}
+      state={state}
+      detailVariant={detailVariant}
+      latency={latency}
+      trailing={trailing}
+    />
+  );
+}
+
+function RunStatusIndicator({ startedAt }: { startedAt: number | null }) {
+  const stage = useOptionalChatStream()?.runStatusStage ?? null;
+  const [fallbackStage, setFallbackStage] = useState<ThinkingStage>("planning");
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect
+  useEffect(() => {
+    if (stage !== null) return;
+    const planningTimer = setTimeout(() => {
+      setFallbackStage("thinking");
+    }, PLANNING_DURATION);
+
+    return () => {
+      clearTimeout(planningTimer);
+    };
+  }, [stage]);
+
+  if (stage !== null) {
+    const copy = RUN_STATUS_COPY[stage];
+    return (
+      <ThoughtSummaryShell
+        icon={<Stars01 className="size-4" />}
+        title={`${copy.label}...`}
+        summary={copy.detail}
+        state="loading"
+        trailing={startedAt !== null && <LiveTimer since={startedAt} />}
+      />
+    );
+  }
+
+  const config = THINKING_STAGES[fallbackStage];
+
+  return (
+    <ThoughtSummaryShell
+      icon={config.icon}
+      title={`${config.label}...`}
+      summary={config.detail}
+      state="loading"
+      trailing={startedAt !== null && <LiveTimer since={startedAt} />}
+    />
+  );
+}
+
+export function GeneratingFooter({ startedAt }: { startedAt: number }) {
+  return (
+    <div className="flex items-center gap-2.5 mt-1 pb-1 text-muted-foreground/40 select-none">
+      <GridLoader />
+      <LiveTimer since={startedAt} />
+    </div>
+  );
+}
+
+// After this long with no streamed content, the turn looks frozen even though
+// the model may just be slow to first token (common with proxied/liteLLM
+// providers). Surface the elapsed time + a cancel escape hatch rather than a
+// silent "Thinking…".
+const SLOW_AFTER_MS = 20_000;
+
+/**
+ * Waiting state for a turn that has produced no parts yet. Pairs the
+ * `RunStatusIndicator` with a live elapsed clock and, once the wait crosses
+ * `SLOW_AFTER_MS`, a "taking longer than usual" hint + Cancel. `useClockTick`
+ * (singleton interval via useSyncExternalStore — no useEffect) re-renders this
+ * once per second so the threshold flips without a per-component timer.
+ */
+export function ThinkingState({ startedAt }: { startedAt: number | null }) {
+  useClockTick(1000);
+  const stream = useOptionalChatStream();
+  const elapsedMs = startedAt !== null ? Date.now() - startedAt : 0;
+  const isSlow = elapsedMs >= SLOW_AFTER_MS;
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      <RunStatusIndicator startedAt={startedAt} />
+      {isSlow && stream?.stop && (
+        <div className="flex items-center gap-2 pb-1 text-[13px] text-muted-foreground/60">
+          <span>This is taking longer than usual.</span>
+          <button
+            type="button"
+            onClick={() => stream.stop()}
+            className="text-muted-foreground hover:text-foreground underline underline-offset-2"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ThoughtSummary({
+  duration,
+  parts,
+  isStreaming,
+}: {
+  duration: number | null;
+  parts: ReasoningPart[];
+  isStreaming: boolean;
+}) {
+  const allPartsRedacted = parts.every((part) =>
+    part.text?.includes("REDACTED"),
+  );
+
+  const thoughtMessage = duration
+    ? duration / 1000 > 1
+      ? `Thought for ${formatDuration(duration / 1000)}`
+      : "Thought"
+    : "Thought";
+
+  // Join with newlines (not spaces) so we can extract individual lines
+  const rawText = parts
+    .map((p) => p.text ?? "")
+    .join("\n")
+    .trim();
+  const lines = rawText.split("\n").filter(Boolean);
+
+  // Streaming: show last line (latest thinking). Done: show first line (topic).
+  const summaryLine = isStreaming
+    ? (lines[lines.length - 1] ?? "")
+    : (lines[0] ?? "");
+
+  const summary =
+    !allPartsRedacted && summaryLine
+      ? summaryLine.length > 100
+        ? summaryLine.slice(0, 100) + "…"
+        : summaryLine
+      : undefined;
+
+  const fullText = parts.map((p) => p.text ?? "").join("\n\n");
+  const detail = !allPartsRedacted && fullText.trim() ? fullText : null;
+
+  const latency =
+    !isStreaming && duration != null ? duration / 1000 : undefined;
+
+  return (
+    <ThoughtSummaryShell
+      icon={
+        isStreaming ? (
+          <Stars01 className="size-4" />
+        ) : (
+          <Lightbulb01 className="size-4" />
+        )
+      }
+      title={isStreaming ? "Thinking..." : thoughtMessage}
+      summary={summary}
+      detail={detail}
+      state={isStreaming ? "loading" : "idle"}
+      detailVariant="prose"
+      latency={latency}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- `assistant.tsx` is one of the largest God-components in the frontend (1471 lines). Extracts the self-contained "waiting for the model" indicator cluster — `ThinkingState`, `RunStatusIndicator`, `GeneratingFooter`, `ThoughtSummary`, `ThoughtSummaryShell`, and the `ReasoningPart` type — into its own file `thinking-indicator.tsx`.
- This cluster only reads its own props plus `useOptionalChatStream`/`useClockTick`; it shares no mutable state or closures with the rest of `assistant.tsx`, so the move is byte-identical logic relocation plus the new import — no behavior change.
- Net effect: `assistant.tsx` shrinks by 228 lines; the new file is a real, nameable unit (the turn-waiting/thinking indicator), not an arbitrary split.

## Test plan
- `bunx tsc --noEmit` in `apps/mesh` — clean.
- `bun test apps/mesh/src/web/components/chat/message/assistant.test.tsx` — 1 pass.
- Full CI (lint, full test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the chat thinking/generating indicator UI from assistant.tsx into thinking-indicator.tsx to reduce complexity and isolate the waiting-state UI. Behavior is unchanged; this is a pure move with updated imports.

- Refactors
  - Moved ThinkingState, RunStatusIndicator, GeneratingFooter, ThoughtSummary, ThoughtSummaryShell, and the ReasoningPart type into apps/mesh/src/web/components/chat/message/thinking-indicator.tsx.
  - assistant.tsx shrinks by 228 lines; the indicator is now a standalone unit that only uses its props plus useOptionalChatStream/useClockTick.

<sup>Written for commit 616f308ae0e2fd772d52b422179eb04cfd1a1120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

