### PR TITLE
test(sandbox): cover isSafeExplorerOpenPath path-traversal guard

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -57,6 +57,7 @@ import {
   getDirectoryContextPath,
   getLanguageFromPath,
   getParentTreePath,
+  isSafeExplorerOpenPath,
   joinTreePath,
   mergeGlobLists,
   pathExistsInFileList,
@@ -93,18 +94,6 @@ function buildApiUrl(
   endpoint: string,
 ) {
   return `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/${endpoint}`;
-}
-
-/** Reject path traversal and absolute paths outside the workspace root. */
-function isSafeExplorerOpenPath(path: string): boolean {
-  const normalized = toDaemonPath(path);
-  if (!normalized || normalized.includes("..") || normalized.includes("\\")) {
-    return false;
-  }
-  return (
-    normalized.startsWith(".deco/blocks/") ||
-    (!normalized.startsWith("/") && !normalized.includes("://"))
-  );
 }
 
 type FileIcon = React.ComponentType<{

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
@@ -7,6 +7,7 @@ import {
   getDirectoryContextPath,
   getParentTreePath,
   getPathDepth,
+  isSafeExplorerOpenPath,
   joinTreePath,
   mergeGlobLists,
   pathExistsInFileList,
@@ -102,6 +103,25 @@ describe("file-explorer utils", () => {
       directories: ["src", "src/components"],
       truncated: false,
     });
+  });
+
+  it("isSafeExplorerOpenPath rejects traversal, double-leading-slash, backslash, and remote paths", () => {
+    expect(isSafeExplorerOpenPath("../../etc/passwd")).toBe(false);
+    expect(isSafeExplorerOpenPath("src/../../etc/passwd")).toBe(false);
+    // Double leading slash survives the single-slash strip in toDaemonPath,
+    // so it's still absolute-looking and must be rejected.
+    expect(isSafeExplorerOpenPath("//etc/passwd")).toBe(false);
+    expect(isSafeExplorerOpenPath("..\\..\\windows\\win.ini")).toBe(false);
+    expect(isSafeExplorerOpenPath("https://evil.com/steal")).toBe(false);
+    expect(isSafeExplorerOpenPath("")).toBe(false);
+  });
+
+  it("isSafeExplorerOpenPath allows workspace-relative tree paths and .deco block refs", () => {
+    // Tree paths carry a single leading slash by convention (see toTreePath);
+    // toDaemonPath strips it back to a workspace-relative daemon path.
+    expect(isSafeExplorerOpenPath("src/index.ts")).toBe(true);
+    expect(isSafeExplorerOpenPath("/src/index.ts")).toBe(true);
+    expect(isSafeExplorerOpenPath(".deco/blocks/Header.json")).toBe(true);
   });
 
   it("mergeGlobLists preserves truncated across merges", () => {

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -25,6 +25,24 @@ export function toDaemonPath(treePath: string) {
   return treePath.startsWith("/") ? treePath.slice(1) : treePath;
 }
 
+/**
+ * Guards the deep-link `openPath` (sourced from the `?main=code:<path>` URL
+ * param) before it's used to read a file from the sandbox: rejects `..`
+ * traversal, backslashes, remote-looking URLs, and paths that stay absolute
+ * even after the single-leading-slash strip in `toDaemonPath`, so a crafted
+ * link can't make the daemon resolve outside the workspace root.
+ */
+export function isSafeExplorerOpenPath(path: string): boolean {
+  const normalized = toDaemonPath(path);
+  if (!normalized || normalized.includes("..") || normalized.includes("\\")) {
+    return false;
+  }
+  return (
+    normalized.startsWith(".deco/blocks/") ||
+    (!normalized.startsWith("/") && !normalized.includes("://"))
+  );
+}
+
 /** Path as shown in the explorer tree (leading slash). */
 export function toTreePath(daemonPath: string) {
   if (!daemonPath.trim()) return "/";


### PR DESCRIPTION
## Source
Found while hunting `apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx` (recently-changed, high-churn file) for review-ready work. No open PR or issue touches this function.

## Why
`isSafeExplorerOpenPath` is the only guard between a URL-controlled value (`?main=code:<encoded path>`, decoded in `parseCodeTabId` and passed as `openPath`) and a sandbox file read (`handleFileClick` → daemon read endpoint). It had zero test coverage — a regression here (e.g. loosening the `..` or backslash check) would only surface as a silent path-traversal hole, not a failing build. This clears the **trust-boundary** bar in the review checklist: a user-supplied path feeding a filesystem-read op.

## What changed
- Moved `isSafeExplorerOpenPath` from `file-explorer.tsx` into the existing `utils.ts` (already pure-logic, already unit-tested) — no behavior change, same implementation, just relocated + exported.
- Added tests in `utils.test.ts` covering: `..` traversal, double-leading-slash (still absolute after the single-slash strip in `toDaemonPath`), backslash paths, remote-looking URLs (all rejected), and legitimate workspace-relative / `.deco/blocks/` paths (allowed).
- Tightened the doc comment — the old one claimed to reject "absolute paths outside the workspace root", which isn't quite accurate: a single leading slash is normalized to a workspace-relative path by `toDaemonPath` (there's no real absolute-FS access in play), so `/foo` is legitimately allowed. The comment now describes the actual invariant.

## How to verify
```
bun test apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `apps/mesh` (clean)
- Targeted test file above (14/14 pass)

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the sandbox file-open guard by moving `isSafeExplorerOpenPath` to `utils.ts` and adding unit tests. Covers deep links from ?main=code:<path>; rejects traversal (`..`), double-leading slashes, backslashes, and remote URLs, and allows workspace-relative and `.deco/blocks/` paths.

<sup>Written for commit af87d864dfa0623b7fa045d37a6ba1ea43bc3bea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

