### PR TITLE
refactor(virtual-mcp): dedupe post-OAuth-success handling in AddConnectionDialog

### DIFF
--- a/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx
@@ -119,6 +119,23 @@ export function AddConnectionDialog({
     });
   };
 
+  // Shared post-OAuth-success bookkeeping for the three attach flows below:
+  // track the event, then refresh the MCP-auth check and connections list.
+  const invalidateAfterOAuthSuccess = async (
+    id: string,
+    flow: "clone" | "connect_new" | "custom_create",
+  ) => {
+    track("connection_oauth_succeeded", { connection_id: id, flow });
+    const mcpProxyUrl = new URL(
+      `/api/${org.slug}/mcp/${id}`,
+      window.location.origin,
+    );
+    await queryClient.invalidateQueries({
+      queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
+    });
+    invalidateConnections();
+  };
+
   // For connected apps: clone existing connection + add to agent
   const handleCloneAndAdd = async (base: ConnectionEntity) => {
     setConnectingItemId(base.app_name ?? base.id);
@@ -165,18 +182,7 @@ export function AddConnectionDialog({
       }
 
       if (auth.ran) {
-        track("connection_oauth_succeeded", {
-          connection_id: id,
-          flow: "clone",
-        });
-        const mcpProxyUrl = new URL(
-          `/api/${org.slug}/mcp/${id}`,
-          window.location.origin,
-        );
-        await queryClient.invalidateQueries({
-          queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
-        });
-        invalidateConnections();
+        await invalidateAfterOAuthSuccess(id, "clone");
       }
 
       trackAttach(id, base.app_name ?? null, "clone");
@@ -246,18 +252,7 @@ export function AddConnectionDialog({
       }
 
       if (auth.ran) {
-        track("connection_oauth_succeeded", {
-          connection_id: id,
-          flow: "connect_new",
-        });
-        const mcpProxyUrl = new URL(
-          `/api/${org.slug}/mcp/${id}`,
-          window.location.origin,
-        );
-        await queryClient.invalidateQueries({
-          queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
-        });
-        invalidateConnections();
+        await invalidateAfterOAuthSuccess(id, "connect_new");
         toast.success("Connected and authenticated");
       } else {
         toast.success("Connected");
@@ -349,18 +344,7 @@ export function AddConnectionDialog({
           }
 
           if (auth.ran) {
-            track("connection_oauth_succeeded", {
-              connection_id: id,
-              flow: "custom_create",
-            });
-            const mcpProxyUrl = new URL(
-              `/api/${org.slug}/mcp/${id}`,
-              window.location.origin,
-            );
-            await queryClient.invalidateQueries({
-              queryKey: KEYS.isMCPAuthenticated(mcpProxyUrl.href, null),
-            });
-            invalidateConnections();
+            await invalidateAfterOAuthSuccess(id, "custom_create");
           }
 
           // app_name unknown for custom-create; record null and let the


### PR DESCRIPTION
## Summary
`add-connection-dialog.tsx` had the identical post-OAuth-success block (track `connection_oauth_succeeded`, build the MCP proxy URL, invalidate the `isMCPAuthenticated` query, then `invalidateConnections()`) copy-pasted verbatim across all three attach flows: `handleCloneAndAdd`, `handleConnectAndAdd`, and the `CreateConnectionDialog.onCreated` callback — differing only in the `flow` tracking label. Extracted it into one `invalidateAfterOAuthSuccess(id, flow)` helper local to the file.

Net line delta: -19 / +3 net (20 insertions, 36 deletions in the diff). Behavior is unchanged — each call site passes the same `flow` string it used before, and the toast/early-return logic outside the extracted block (which does differ between flows) was left untouched.

## Why
Three near-identical blocks are collapsed into one; a future change to the success-path bookkeeping (e.g. adding another cache to invalidate) now only needs to happen once instead of three times in sync.

## Test plan
- [x] `bun run fmt`
- [x] `cd apps/mesh && bun x tsc --noEmit` — clean
- Full CI (lint, tests) runs the rest.

Reviewer check: `git diff main -- apps/mesh/src/web/views/virtual-mcp/add-connection-dialog.tsx` — confirm each of the 3 call sites still passes its original `flow` string and the surrounding failure/toast logic is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped the post-OAuth-success logic in AddConnectionDialog by moving it into a local `invalidateAfterOAuthSuccess(id, flow)` helper used by the clone, connect_new, and custom_create flows. Behavior is unchanged; we still track `connection_oauth_succeeded`, invalidate `isMCPAuthenticated` for the computed MCP proxy URL, and refresh connections in one place.

<sup>Written for commit 9b5dcd5d5dca5cabcff937e905cbd110c1c48d46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

