### PR TITLE
refactor(web): use text-destructive token in tool input form required marker

### DIFF
--- a/apps/mesh/src/web/components/tool-input-form.tsx
+++ b/apps/mesh/src/web/components/tool-input-form.tsx
@@ -50,7 +50,7 @@ export function ToolInputForm({
             <label className="text-xs font-medium leading-none flex items-center gap-1">
               {key}
               {requiredSet.has(key) && (
-                <span className="text-red-500 text-[10px]">*</span>
+                <span className="text-destructive text-[10px]">*</span>
               )}
             </label>
             <span className="text-[10px] text-muted-foreground font-mono">


### PR DESCRIPTION
Un-CI-enforced design-token drift (`ensure-tailwind-design-system-tokens` rule is currently disabled, so this doesn't get caught automatically).

`ToolInputForm`'s required-field asterisk used a raw `text-red-500` class instead of the design system's semantic `text-destructive` token. The exact same marker in the sibling `details/tool.tsx` (same "required field" meaning, same tool-input-rendering context) and 198 other call sites across `apps/mesh/src/web` already use `text-destructive` for this error/required-attention semantic, so the mapping is unambiguous.

This aligns the shade to the design-system `destructive` token (`oklch(0.58 0.22 27)` light / `oklch(0.62 0.22 27)` dark) rather than the raw Tailwind `red-500` value — close in hue but not pixel-identical, so it's a shade alignment, not a no-op.

How to confirm: `git diff` shows the single class-name swap in `apps/mesh/src/web/components/tool-input-form.tsx`; open the add-tile-drawer's inline tool-input expansion for any tool with a required property and confirm the `*` marker still renders in the theme's error red.

Locally verified: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean, no type changes). Full CI validates lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced text-red-500 with text-destructive for the required-field asterisk in ToolInputForm to align with the design system and match other tool inputs. This preserves intent and ensures consistent theming in light/dark modes.

<sup>Written for commit c71c4ffe2b8b089c947a29b0cd9c1211a13c54f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

