### PR TITLE
refactor(home): extract NativeTilesSection into its own file

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -44,8 +44,7 @@ import {
   useHomeAgentsWriter,
 } from "@/web/hooks/use-organization-settings";
 import { AgentPromptList } from "./agent-prompt-list";
-import { useHomeEdit } from "./home-edit-context";
-import { NATIVE_TILES, nativeCandidateId } from "./native-tiles";
+import { NativeTilesSection } from "./native-tiles-section";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
@@ -59,18 +58,13 @@ import {
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
-  BarChart10,
-  CheckCircle,
   ChevronDown,
   DotsGrid,
-  GitBranch01,
   Loading01,
-  MessageChatCircle,
   Minus,
   Plus,
   SearchSm,
   Settings01,
-  ShoppingCart01,
   X,
 } from "@untitledui/icons";
 import { toast } from "sonner";
@@ -262,85 +256,13 @@ function DrawerBody({ search }: { search: string }) {
   );
 }
 
-const NATIVE_TILE_ICON: Record<string, typeof MessageChatCircle> = {
-  tasks: CheckCircle,
-  coding: GitBranch01,
-  analytics: BarChart10,
-  sales: ShoppingCart01,
-  "recent-conversations": MessageChatCircle,
-};
-
-/**
- * Built-in (native) tiles — views like recent conversations that aren't
- * agents. Normal built-ins ride the board's `hidden` set; `defaultHidden`
- * ones (off the board by default) ride the `shown` set. Toggling here stages
- * into the same edit draft the rest of the board uses.
- */
-function NativeTilesSection() {
-  const { layout, commitLayout } = useHomeEdit();
-  const hidden = new Set(layout.hidden);
-  const shown = new Set(layout.shown ?? []);
-
-  return (
-    <div className="flex flex-col gap-1.5">
-      <SectionHeader title="Built-in tiles" />
-      {NATIVE_TILES.map((tile) => {
-        const candidateId = nativeCandidateId(tile.id);
-        const onHome = tile.defaultHidden
-          ? shown.has(candidateId) && !hidden.has(candidateId)
-          : !hidden.has(candidateId);
-        const Icon = NATIVE_TILE_ICON[tile.id] ?? MessageChatCircle;
-
-        const toggle = () => {
-          if (tile.defaultHidden) {
-            // Off-by-default tile: membership is the `shown` set. Adding also
-            // clears any lingering `hidden` entry; removing drops it from shown.
-            commitLayout({
-              ...layout,
-              hidden: layout.hidden.filter((id) => id !== candidateId),
-              shown: onHome
-                ? (layout.shown ?? []).filter((id) => id !== candidateId)
-                : [...(layout.shown ?? []), candidateId],
-            });
-            return;
-          }
-          commitLayout({
-            ...layout,
-            hidden: onHome
-              ? [...layout.hidden, candidateId]
-              : layout.hidden.filter((id) => id !== candidateId),
-          });
-        };
-
-        return (
-          <div
-            key={tile.id}
-            className="flex items-center gap-3 rounded-lg border border-border/60 px-3 py-2.5"
-          >
-            <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-              <Icon size={16} />
-            </span>
-            <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-              {tile.title}
-            </span>
-            <Button
-              type="button"
-              size="sm"
-              variant={onHome ? "outline" : "special"}
-              className="h-8 gap-1.5"
-              onClick={toggle}
-            >
-              {onHome ? <Minus size={14} /> : <Plus size={14} />}
-              {onHome ? "Remove" : "Add"}
-            </Button>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function SectionHeader({ title, hint }: { title: string; hint?: string }) {
+export function SectionHeader({
+  title,
+  hint,
+}: {
+  title: string;
+  hint?: string;
+}) {
   return (
     <div className="flex items-center justify-between px-1">
       <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">

--- a/apps/mesh/src/web/components/home/native-tiles-section.tsx
+++ b/apps/mesh/src/web/components/home/native-tiles-section.tsx
@@ -1,0 +1,91 @@
+import {
+  BarChart10,
+  CheckCircle,
+  GitBranch01,
+  MessageChatCircle,
+  Minus,
+  Plus,
+  ShoppingCart01,
+} from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import { SectionHeader } from "./add-tile-drawer";
+import { useHomeEdit } from "./home-edit-context";
+import { NATIVE_TILES, nativeCandidateId } from "./native-tiles";
+
+const NATIVE_TILE_ICON: Record<string, typeof MessageChatCircle> = {
+  tasks: CheckCircle,
+  coding: GitBranch01,
+  analytics: BarChart10,
+  sales: ShoppingCart01,
+  "recent-conversations": MessageChatCircle,
+};
+
+/**
+ * Built-in (native) tiles — views like recent conversations that aren't
+ * agents. Normal built-ins ride the board's `hidden` set; `defaultHidden`
+ * ones (off the board by default) ride the `shown` set. Toggling here stages
+ * into the same edit draft the rest of the board uses.
+ */
+export function NativeTilesSection() {
+  const { layout, commitLayout } = useHomeEdit();
+  const hidden = new Set(layout.hidden);
+  const shown = new Set(layout.shown ?? []);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <SectionHeader title="Built-in tiles" />
+      {NATIVE_TILES.map((tile) => {
+        const candidateId = nativeCandidateId(tile.id);
+        const onHome = tile.defaultHidden
+          ? shown.has(candidateId) && !hidden.has(candidateId)
+          : !hidden.has(candidateId);
+        const Icon = NATIVE_TILE_ICON[tile.id] ?? MessageChatCircle;
+
+        const toggle = () => {
+          if (tile.defaultHidden) {
+            // Off-by-default tile: membership is the `shown` set. Adding also
+            // clears any lingering `hidden` entry; removing drops it from shown.
+            commitLayout({
+              ...layout,
+              hidden: layout.hidden.filter((id) => id !== candidateId),
+              shown: onHome
+                ? (layout.shown ?? []).filter((id) => id !== candidateId)
+                : [...(layout.shown ?? []), candidateId],
+            });
+            return;
+          }
+          commitLayout({
+            ...layout,
+            hidden: onHome
+              ? [...layout.hidden, candidateId]
+              : layout.hidden.filter((id) => id !== candidateId),
+          });
+        };
+
+        return (
+          <div
+            key={tile.id}
+            className="flex items-center gap-3 rounded-lg border border-border/60 px-3 py-2.5"
+          >
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+              <Icon size={16} />
+            </span>
+            <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+              {tile.title}
+            </span>
+            <Button
+              type="button"
+              size="sm"
+              variant={onHome ? "outline" : "special"}
+              className="h-8 gap-1.5"
+              onClick={toggle}
+            >
+              {onHome ? <Minus size={14} /> : <Plus size={14} />}
+              {onHome ? "Remove" : "Add"}
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
Continues the extract-into-its-own-file cleanup already applied to other God-components in this codebase (#4836, #4825, #4817, #4801).

`add-tile-drawer.tsx` was 1265 lines. `NativeTilesSection` is a self-contained sub-component — it takes no props, reads its own `useHomeEdit()` hook, and only depends on the shared `SectionHeader` helper (now exported) plus `NATIVE_TILES`/`nativeCandidateId`. It shares no mutable closures or local state with the rest of the drawer, so it moves byte-identical into `native-tiles-section.tsx` with no behavior change.

Net diff: add-tile-drawer.tsx -86/+8 lines (now ~1187 lines), new file +91 lines. Five icon imports (`BarChart10`, `CheckCircle`, `GitBranch01`, `MessageChatCircle`, `ShoppingCart01`) that were only used by the extracted component were dropped from add-tile-drawer.tsx's import list.

To confirm: open the home board's "Manage home" drawer — the "Built-in tiles" section (toggle add/remove) should behave exactly as before.

Locally verified: `bun run fmt` and `cd apps/mesh && bunx tsc --noEmit` both pass clean. No test file covers this component (pure JSX relocation), so full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted NativeTilesSection from add-tile-drawer into its own file to simplify the drawer and improve readability. No UI or behavior changes to the “Built-in tiles” section.

- **Refactors**
  - Moved `NativeTilesSection` to `native-tiles-section.tsx` unchanged; it uses `useHomeEdit()`, `NATIVE_TILES`, and `nativeCandidateId`.
  - Exported `SectionHeader` from `add-tile-drawer` for reuse.
  - Removed unused icon imports from `@untitledui/icons` in `add-tile-drawer.tsx`.

<sup>Written for commit e5383de9998024f5c13b2793d53f9585ab304aba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

