### PR TITLE
refactor(web): use text-destructive token in tool detail required marker

### DIFF
--- a/apps/mesh/src/web/components/details/tool.tsx
+++ b/apps/mesh/src/web/components/details/tool.tsx
@@ -432,7 +432,7 @@ function ToolDetailsAuthenticated({
         {tool?.inputSchema?.required &&
           tool.inputSchema.required.length > 0 && (
             <span className="text-xs text-muted-foreground">
-              <span className="text-red-500">*</span> Required
+              <span className="text-destructive">*</span> Required
             </span>
           )}
       </div>
@@ -447,7 +447,7 @@ function ToolDetailsAuthenticated({
                   <label className="text-sm font-medium leading-none flex items-center gap-1.5">
                     {key}
                     {tool.inputSchema?.required?.includes(key) && (
-                      <span className="text-red-500 text-xs">*</span>
+                      <span className="text-destructive text-xs">*</span>
                     )}
                   </label>
                   <span className="text-xs text-muted-foreground font-mono">


### PR DESCRIPTION
Follows #4835, which fixed the identical raw-palette required-field marker in `tool-input-form.tsx` — the sibling `details/tool.tsx` component has the exact same `text-red-500` asterisk pattern in two spots (the section header "* Required" hint and the per-field required marker), left behind by that pass.

A maintainer wants this because it's the same design-token drift the previous PR just closed out one file over — leaving it means the Tool detail panel and the Tool input form render the "required" marker in two different reds.

Mapping is unambiguous: `details/tool.tsx` already uses `text-destructive` for its other error text (the schema-load `AlertDescription`, line 637), so swapping the two `text-red-500` required-marker spans to `text-destructive` aligns them to the same semantic token already established in this file. This aligns the shade to the design-system destructive token — not necessarily an identical pixel value to the old `red-500`.

No behavior change: purely a class-name swap, same DOM structure.

Reviewer check: `grep -n 'text-red-500' apps/mesh/src/web/components/details/tool.tsx` returns nothing; open the Tool detail panel for any tool with required params and confirm the `*` renders in the same red as other destructive/error text in that view.

Local checks run: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean, no type changes). No test touches this file — pure class-name swap. Full CI (lint, suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `text-destructive` for the required-field asterisk in Tool details (section hint and per-field markers) instead of `text-red-500` to match the design token and other error text in this view. Visual-only refactor; no behavior or DOM changes.

<sup>Written for commit 4e9f073ecc5a143526526eb670828bef73c1d6ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

