### PR TITLE
refactor(home): extract SectionHeader into its own file

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/web/hooks/use-organization-settings";
 import { AgentPromptList } from "./agent-prompt-list";
 import { NativeTilesSection } from "./native-tiles-section";
+import { SectionHeader } from "./section-header";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
@@ -253,23 +254,6 @@ function DrawerBody({ search }: { search: string }) {
       {!lower && <NativeTilesSection />}
       <AvailableSection home={home} agents={available} hasSearch={!!lower} />
     </>
-  );
-}
-
-export function SectionHeader({
-  title,
-  hint,
-}: {
-  title: string;
-  hint?: string;
-}) {
-  return (
-    <div className="flex items-center justify-between px-1">
-      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        {title}
-      </span>
-      {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
-    </div>
   );
 }
 

--- a/apps/mesh/src/web/components/home/native-tiles-section.tsx
+++ b/apps/mesh/src/web/components/home/native-tiles-section.tsx
@@ -8,9 +8,9 @@ import {
   ShoppingCart01,
 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
-import { SectionHeader } from "./add-tile-drawer";
 import { useHomeEdit } from "./home-edit-context";
 import { NATIVE_TILES, nativeCandidateId } from "./native-tiles";
+import { SectionHeader } from "./section-header";
 
 const NATIVE_TILE_ICON: Record<string, typeof MessageChatCircle> = {
   tasks: CheckCircle,

--- a/apps/mesh/src/web/components/home/section-header.tsx
+++ b/apps/mesh/src/web/components/home/section-header.tsx
@@ -1,0 +1,16 @@
+export function SectionHeader({
+  title,
+  hint,
+}: {
+  title: string;
+  hint?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between px-1">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {title}
+      </span>
+      {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
+    </div>
+  );
+}


### PR DESCRIPTION
Follows #4837.

That PR extracted `NativeTilesSection` into `native-tiles-section.tsx`, but left the shared `SectionHeader` component defined in `add-tile-drawer.tsx`. That created a two-file circular import: `native-tiles-section.tsx` imports `SectionHeader` from `add-tile-drawer.tsx`, while `add-tile-drawer.tsx` imports `NativeTilesSection` back from `native-tiles-section.tsx`. Moving `SectionHeader` into its own `section-header.tsx` module removes the cycle and lets both files depend on it independently.

Net change: -18 / +18 lines (pure move, no behavior change) — `add-tile-drawer.tsx` and `native-tiles-section.tsx` now both import `SectionHeader` from the new file instead of from each other.

To confirm: reviewer can diff-read `section-header.tsx` against the removed block in `add-tile-drawer.tsx` — identical component, just relocated.

Locally verified with `bun run fmt` and `bunx tsc --noEmit` (apps/mesh workspace) — both clean. No test changes needed since this is a pure move with no logic change; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the shared `SectionHeader` component into `section-header.tsx` to remove a circular import between `add-tile-drawer.tsx` and `native-tiles-section.tsx`. No behavior change; both files now import `SectionHeader` from the new module.

<sup>Written for commit 23a46cb6bf848a6db42dc24aece50e1ab575efb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

