### PR TITLE
refactor(content): use text-success design token instead of raw VARIANT_GREEN

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser-constants.ts
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser-constants.ts
@@ -1,1 +1,0 @@
-export const VARIANT_GREEN = "oklch(0.65 0.15 160)";

--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -131,7 +131,6 @@ import { countAvailableRunnables } from "./runnable-catalog";
 import { EmptyMessage } from "./empty-message";
 import { PostFilterBar, PostSelectionToolbar } from "./post-toolbar";
 import { ItemActions } from "./item-actions";
-import { VARIANT_GREEN } from "./content-browser-constants";
 import { useBlocksPreviewWorkspace } from "@/web/components/sandbox/blocks/blocks-preview-workspace-context";
 import type { BlocksTarget } from "@/web/components/sandbox/blocks/blocks-preview-workspace-state";
 
@@ -2280,11 +2279,7 @@ export function ItemRow({
       <span className="flex size-8 shrink-0 items-center justify-center">
         <Tooltip>
           <TooltipTrigger asChild>
-            <Icon
-              size={16}
-              className="shrink-0"
-              style={{ color: VARIANT_GREEN }}
-            />
+            <Icon size={16} className="shrink-0 text-success" />
           </TooltipTrigger>
           <TooltipContent side="right">{variantCount} variants</TooltipContent>
         </Tooltip>

--- a/apps/mesh/src/web/components/sandbox/content/item-actions.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/item-actions.tsx
@@ -14,7 +14,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
-import { VARIANT_GREEN } from "./content-browser-constants";
 
 export function ItemActions({
   onDuplicate,
@@ -61,10 +60,9 @@ export function ItemActions({
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={onAddVariant}
-              className="cursor-pointer"
-              style={{ color: VARIANT_GREEN }}
+              className="cursor-pointer text-success focus:text-success"
             >
-              <Flag01 size={14} style={{ color: VARIANT_GREEN }} />
+              <Flag01 size={14} />
               Add variant
             </DropdownMenuItem>
           </>


### PR DESCRIPTION
Follows #4825 (extract ItemActions into its own file), which relocated the pre-existing `VARIANT_GREEN = "oklch(0.65 0.15 160)"` constant without addressing it — the hardening-checklist item this closes is "raw palette instead of a design-system token".

The repo already has a `--success` token (`text-success` class) with light/dark variants in `packages/ui/src/styles/global.css`, used the same way (`text-success focus:text-success`) right next to this code for the Delete menu item's `text-destructive`. `VARIANT_GREEN` was a fixed color that never adapted between themes, unlike every other semantic color in this file.

Change: swapped the two `style={{ color: VARIANT_GREEN }}` usages (the "Add variant" dropdown item + its icon, and the variant-count row icon) for `text-success`, then deleted the now-dead `content-browser-constants.ts` (its only export had no remaining references — verified with `grep -rl VARIANT_GREEN apps/mesh/src`).

Net: -11 / +3 lines across 3 files, no behavior change beyond correct dark-mode theming.

A reviewer can confirm by opening the sandbox content browser's item context menu in both light and dark mode and checking "Add variant" renders in the same green as other success-toned UI (e.g. the credits-eyebrow icon).

Checks run locally: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean, no type errors). No test file covers this pure JSX/token swap, so nothing to target — full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded `VARIANT_GREEN` with the `text-success` design token to match the design system and correctly adapt in light/dark themes. Updated the "Add variant" menu item and variant-count icon; removed the unused constant file.

- **Refactors**
  - Use `text-success` and `focus:text-success` classes instead of inline color styles in `item-actions.tsx` and `content-browser.tsx`.
  - Deleted `apps/mesh/src/web/components/sandbox/content/content-browser-constants.ts`.

<sup>Written for commit 3bdf5181f3f71c2aa7c345b8376e90ca343c18b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

