### PR TITLE
refactor(home): extract tile form-value helpers into their own file

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -46,6 +46,11 @@ import {
 import { AgentPromptList } from "./agent-prompt-list";
 import { NativeTilesSection } from "./native-tiles-section";
 import { SectionHeader } from "./section-header";
+import {
+  coerceFormValues,
+  seedFormValues,
+  toolInputSummary,
+} from "./tile-form-values";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
@@ -731,77 +736,6 @@ function AgentToolList({
       </div>
     </div>
   );
-}
-
-/** Coerce form values for persistence: JSON-parse object/array fields,
- * convert number/integer strings. Returns null on parse error (caller
- * should toast). */
-function coerceFormValues(
-  values: Record<string, unknown>,
-  properties: Record<string, ToolInputProperty>,
-): Record<string, unknown> | null {
-  const out: Record<string, unknown> = {};
-  for (const [key, raw] of Object.entries(values)) {
-    const type = properties[key]?.type;
-    if ((type === "object" || type === "array") && typeof raw === "string") {
-      if (!raw.trim()) continue;
-      try {
-        out[key] = JSON.parse(raw);
-      } catch {
-        return null;
-      }
-    } else if (
-      (type === "number" || type === "integer") &&
-      typeof raw === "string"
-    ) {
-      if (!raw.trim()) continue;
-      out[key] = Number(raw);
-    } else if (raw !== "" && raw != null) {
-      out[key] = raw;
-    }
-  }
-  return out;
-}
-
-/** Stringify toolInput values for form display: object/array values become
- * JSON strings so they render in a Textarea. */
-function seedFormValues(
-  toolInput: Record<string, unknown> | undefined,
-  properties: Record<string, ToolInputProperty> | undefined,
-): Record<string, unknown> {
-  if (!toolInput || !properties) return {};
-  const init: Record<string, unknown> = {};
-  for (const [key, val] of Object.entries(toolInput)) {
-    const type = properties[key]?.type;
-    if (
-      (type === "object" || type === "array") &&
-      val != null &&
-      typeof val !== "string"
-    ) {
-      init[key] = JSON.stringify(val, null, 2);
-    } else {
-      init[key] = val;
-    }
-  }
-  return init;
-}
-
-/** Summarize toolInput for display in the pinned tile row. */
-function toolInputSummary(
-  toolInput: Record<string, unknown> | undefined,
-): string {
-  if (!toolInput) return "";
-  const entries = Object.entries(toolInput).filter(
-    ([, v]) => v != null && v !== "",
-  );
-  if (entries.length === 0) return "";
-  return entries
-    .slice(0, 3)
-    .map(([k, v]) => {
-      const s = typeof v === "object" ? JSON.stringify(v) : String(v);
-      return `${k}=${s.length > 20 ? `${s.slice(0, 20)}…` : s}`;
-    })
-    .join(", ");
 }
 
 /** Row for a pinned tile instance — shows a summary, gear to edit, minus to remove. */

--- a/apps/mesh/src/web/components/home/tile-form-values.test.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import {
+  coerceFormValues,
+  seedFormValues,
+  toolInputSummary,
+} from "./tile-form-values";
+
+describe("coerceFormValues", () => {
+  test("parses object/array JSON strings", () => {
+    expect(
+      coerceFormValues({ foo: '{"a":1}' }, { foo: { type: "object" } }),
+    ).toEqual({ foo: { a: 1 } });
+  });
+
+  test("returns null on invalid JSON", () => {
+    expect(
+      coerceFormValues({ foo: "{not json" }, { foo: { type: "object" } }),
+    ).toBeNull();
+  });
+
+  test("converts number/integer strings", () => {
+    expect(coerceFormValues({ n: "42" }, { n: { type: "integer" } })).toEqual({
+      n: 42,
+    });
+  });
+
+  test("drops empty values", () => {
+    expect(coerceFormValues({ s: "" }, { s: { type: "string" } })).toEqual({});
+  });
+});
+
+describe("seedFormValues", () => {
+  test("stringifies object/array values for display", () => {
+    expect(
+      seedFormValues({ foo: { a: 1 } }, { foo: { type: "object" } }),
+    ).toEqual({ foo: JSON.stringify({ a: 1 }, null, 2) });
+  });
+
+  test("passes through non-object values", () => {
+    expect(seedFormValues({ s: "hi" }, { s: { type: "string" } })).toEqual({
+      s: "hi",
+    });
+  });
+
+  test("returns empty object when toolInput or properties missing", () => {
+    expect(seedFormValues(undefined, {})).toEqual({});
+    expect(seedFormValues({ s: "hi" }, undefined)).toEqual({});
+  });
+});
+
+describe("toolInputSummary", () => {
+  test("returns empty string when no toolInput", () => {
+    expect(toolInputSummary(undefined)).toBe("");
+  });
+
+  test("filters empty entries and truncates long values", () => {
+    expect(
+      toolInputSummary({
+        a: "short",
+        b: "",
+        c: null,
+        d: "a".repeat(30),
+      }),
+    ).toBe(`a=short, d=${"a".repeat(20)}…`);
+  });
+
+  test("caps at 3 entries", () => {
+    expect(toolInputSummary({ a: 1, b: 2, c: 3, d: 4 })).toBe("a=1, b=2, c=3");
+  });
+});

--- a/apps/mesh/src/web/components/home/tile-form-values.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.ts
@@ -1,0 +1,72 @@
+import type { ToolInputProperty } from "@/web/components/tool-input-form";
+
+/** Coerce form values for persistence: JSON-parse object/array fields,
+ * convert number/integer strings. Returns null on parse error (caller
+ * should toast). */
+export function coerceFormValues(
+  values: Record<string, unknown>,
+  properties: Record<string, ToolInputProperty>,
+): Record<string, unknown> | null {
+  const out: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(values)) {
+    const type = properties[key]?.type;
+    if ((type === "object" || type === "array") && typeof raw === "string") {
+      if (!raw.trim()) continue;
+      try {
+        out[key] = JSON.parse(raw);
+      } catch {
+        return null;
+      }
+    } else if (
+      (type === "number" || type === "integer") &&
+      typeof raw === "string"
+    ) {
+      if (!raw.trim()) continue;
+      out[key] = Number(raw);
+    } else if (raw !== "" && raw != null) {
+      out[key] = raw;
+    }
+  }
+  return out;
+}
+
+/** Stringify toolInput values for form display: object/array values become
+ * JSON strings so they render in a Textarea. */
+export function seedFormValues(
+  toolInput: Record<string, unknown> | undefined,
+  properties: Record<string, ToolInputProperty> | undefined,
+): Record<string, unknown> {
+  if (!toolInput || !properties) return {};
+  const init: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(toolInput)) {
+    const type = properties[key]?.type;
+    if (
+      (type === "object" || type === "array") &&
+      val != null &&
+      typeof val !== "string"
+    ) {
+      init[key] = JSON.stringify(val, null, 2);
+    } else {
+      init[key] = val;
+    }
+  }
+  return init;
+}
+
+/** Summarize toolInput for display in the pinned tile row. */
+export function toolInputSummary(
+  toolInput: Record<string, unknown> | undefined,
+): string {
+  if (!toolInput) return "";
+  const entries = Object.entries(toolInput).filter(
+    ([, v]) => v != null && v !== "",
+  );
+  if (entries.length === 0) return "";
+  return entries
+    .slice(0, 3)
+    .map(([k, v]) => {
+      const s = typeof v === "object" ? JSON.stringify(v) : String(v);
+      return `${k}=${s.length > 20 ? `${s.slice(0, 20)}…` : s}`;
+    })
+    .join(", ");
+}


### PR DESCRIPTION
Follows the extract-into-own-file vein (#4817, #4825, #4801, #4781) — `add-tile-drawer.tsx` is a 1171-line God component and these three functions (`coerceFormValues`, `seedFormValues`, `toolInputSummary`) are pure helpers with zero closures over drawer state, only used within that one file.

Moved them byte-identical to a new `tile-form-values.ts`, with the drawer now importing them. A maintainer gets a smaller, more navigable drawer file and a testable module for logic that previously had no coverage at all.

Net: -71 / +76 in the drawer (function bodies removed, one import added), +72 new file, +67 new test file. Confirmed unchanged behavior — the functions were moved verbatim, no logic changes.

Added `tile-form-values.test.ts` covering all three functions' documented edge cases (JSON parse success/failure, number coercion, empty-value dropping, missing-input defaults, truncation, entry capping) since none existed before.

Reviewer check: `cd apps/mesh && bun test src/web/components/home/tile-form-values.test.ts`

Locally ran: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file (10/10 pass). Full CI covers lint and the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted tile form-value helpers into a dedicated module to shrink `add-tile-drawer.tsx` and make the logic testable. No behavior changes.

- **Refactors**
  - Moved `coerceFormValues`, `seedFormValues`, `toolInputSummary` to `tile-form-values.ts` and imported them in `add-tile-drawer.tsx`.
  - Added `tile-form-values.test.ts` covering JSON parse success/failure, number coercion, empty-value dropping, missing-input defaults, truncation, and entry capping.

<sup>Written for commit 84b8be5f84f554fc4bd2f5fce909ed9fa8759a64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

