### PR TITLE
fix(home): reject non-numeric input in number/integer tile fields

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -797,7 +797,7 @@ function PinnedTileRow({
           tool.inputSchema.properties,
         );
         if (!coerced) {
-          toast.error("Invalid JSON in one of the fields — please fix it.");
+          toast.error("Invalid value in one of the fields — please fix it.");
           setSubmitting(false);
           return;
         }
@@ -953,7 +953,7 @@ function AddToolRow({
           tool.inputSchema.properties,
         );
         if (!coerced) {
-          toast.error("Invalid JSON in one of the fields — please fix it.");
+          toast.error("Invalid value in one of the fields — please fix it.");
           setSubmitting(false);
           return;
         }

--- a/apps/mesh/src/web/components/home/tile-form-values.test.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.test.ts
@@ -24,6 +24,12 @@ describe("coerceFormValues", () => {
     });
   });
 
+  test("returns null on non-numeric string for number/integer field", () => {
+    expect(
+      coerceFormValues({ n: "abc" }, { n: { type: "integer" } }),
+    ).toBeNull();
+  });
+
   test("drops empty values", () => {
     expect(coerceFormValues({ s: "" }, { s: { type: "string" } })).toEqual({});
   });

--- a/apps/mesh/src/web/components/home/tile-form-values.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.ts
@@ -22,7 +22,9 @@ export function coerceFormValues(
       typeof raw === "string"
     ) {
       if (!raw.trim()) continue;
-      out[key] = Number(raw);
+      const parsed = Number(raw);
+      if (Number.isNaN(parsed)) return null;
+      out[key] = parsed;
     } else if (raw !== "" && raw != null) {
       out[key] = raw;
     }


### PR DESCRIPTION
Follows #4841 (extract tile form-value helpers into their own file) — reading the extracted `coerceFormValues` surfaced a validation gap that predates the extraction but is now easy to spot in isolation.

`coerceFormValues` JSON-parses object/array tool-input fields and rejects the whole form (returns `null`, caller shows an error toast) if `JSON.parse` fails — but the number/integer branch just does `Number(raw)` with no validation. Typing a non-numeric string (e.g. `"abc"`) into a number-typed tile field silently produces `NaN`, which then gets persisted into the tile's `toolInput` and sent to the tool call, instead of being rejected like the analogous JSON-parse-failure case.

Fix: `Number.isNaN(parsed)` now returns `null` through the same path the JSON-parse failure already uses, so the caller shows its existing invalid-input toast (reworded from "Invalid JSON" to "Invalid value" since it now covers both cases).

Regression test: `coerceFormValues({ n: "abc" }, { n: { type: "integer" } })` now asserts `null` instead of the previous `{ n: NaN }`.

Reviewer check: `bun test apps/mesh/src/web/components/home/tile-form-values.test.ts`

Locally ran: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and the targeted test file above — all pass. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject non-numeric input in number/integer tile fields so invalid entries don’t save as `NaN` and the form shows a clear error.

- **Bug Fixes**
  - `coerceFormValues` returns `null` when a number/integer field parses to `NaN`, blocking submission.
  - Error toast copy updated to “Invalid value in one of the fields — please fix it.”
  - Added a test to assert `coerceFormValues({ n: "abc" }, { n: { type: "integer" } })` returns `null`.

<sup>Written for commit 8d12167f63d063cfb2cc7f2b9c33384793ace545. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

