### PR TITLE
refactor(content): extract ListEmpty into its own file

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -57,6 +57,7 @@ import {
   type PageEntry,
 } from "@/web/components/sections-editor/page-list";
 import type { AppCatalogEntry } from "./app-catalog";
+import { ListEmpty } from "./list-empty";
 import { useDecoAppsCatalog } from "@/web/hooks/use-deco-apps-catalog";
 import { normalizePagePath } from "@/web/components/sections-editor/page-path-utils";
 import {
@@ -2385,29 +2386,6 @@ function RedirectTypeBadge({ type }: { type: RedirectType }) {
         {type === "permanent" ? "Permanent" : "Temporary"}
       </TooltipContent>
     </Tooltip>
-  );
-}
-
-function ListEmpty({
-  hasItems,
-  emptyLabel,
-  emptyHint,
-}: {
-  hasItems: boolean;
-  emptyLabel: string;
-  emptyHint: string;
-}) {
-  return (
-    <div className="px-3 py-6 text-center text-xs text-muted-foreground">
-      {hasItems ? (
-        "No results match your search."
-      ) : (
-        <>
-          <div>{emptyLabel}</div>
-          <div className="mt-1 text-muted-foreground/80">{emptyHint}</div>
-        </>
-      )}
-    </div>
   );
 }
 

--- a/apps/mesh/src/web/components/sandbox/content/list-empty.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/list-empty.tsx
@@ -1,0 +1,22 @@
+export function ListEmpty({
+  hasItems,
+  emptyLabel,
+  emptyHint,
+}: {
+  hasItems: boolean;
+  emptyLabel: string;
+  emptyHint: string;
+}) {
+  return (
+    <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+      {hasItems ? (
+        "No results match your search."
+      ) : (
+        <>
+          <div>{emptyLabel}</div>
+          <div className="mt-1 text-muted-foreground/80">{emptyHint}</div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
**Source:** C5 bounded extraction — `content-browser.tsx` is a 2458-line god-component (already the target of several prior extraction PRs: #4825, #4829, #4824, #4803).

**Why:** `ListEmpty` is a small, fully self-contained component (only reads its own props, no shared closures/local state with the rest of the file) used 7 times across the list-rendering sections. Pulling it into its own file, matching the existing pattern in this directory (`empty-message.tsx`, `item-actions.tsx`, `collections-sidebar.tsx`), shrinks the god-component without touching behavior.

**Change:** Byte-identical move — same JSX/logic, relocated to `list-empty.tsx`, plus the new import in `content-browser.tsx`. No behavior change.

**Verify:** `cd apps/mesh && bunx tsc --noEmit` (clean). `rg -n "ListEmpty" apps/mesh/src/web/components/sandbox/content/` confirms all 6 call sites now resolve to the new file's export.

**Locally ran:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace) — both clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the self-contained ListEmpty component from content-browser.tsx into list-empty.tsx to reduce the god-component’s size and match the directory’s pattern. Updated content-browser.tsx to import ListEmpty; no behavior or UI changes.

<sup>Written for commit 91bdfc60b0657c55abcd0f8469f215935cdef4b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

