### PR TITLE
fix(home): reject fractional input in integer tile fields

### DIFF
--- a/apps/mesh/src/web/components/home/tile-form-values.test.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.test.ts
@@ -30,6 +30,18 @@ describe("coerceFormValues", () => {
     ).toBeNull();
   });
 
+  test("returns null on fractional string for integer field", () => {
+    expect(
+      coerceFormValues({ n: "3.5" }, { n: { type: "integer" } }),
+    ).toBeNull();
+  });
+
+  test("accepts fractional string for number field", () => {
+    expect(coerceFormValues({ n: "3.5" }, { n: { type: "number" } })).toEqual({
+      n: 3.5,
+    });
+  });
+
   test("drops empty values", () => {
     expect(coerceFormValues({ s: "" }, { s: { type: "string" } })).toEqual({});
   });

--- a/apps/mesh/src/web/components/home/tile-form-values.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.ts
@@ -24,6 +24,7 @@ export function coerceFormValues(
       if (!raw.trim()) continue;
       const parsed = Number(raw);
       if (Number.isNaN(parsed)) return null;
+      if (type === "integer" && !Number.isInteger(parsed)) return null;
       out[key] = parsed;
     } else if (raw !== "" && raw != null) {
       out[key] = raw;


### PR DESCRIPTION
Follows #4842, which rejected non-numeric input (e.g. `"abc"`) in number/integer tile fields but only checked `Number.isNaN`. That check does not distinguish `number` from `integer`: a fractional string like `"3.5"` in an `integer`-typed field parses to `3.5` and passes straight through, violating the field's own declared type before it ever reaches the tool's schema.

Failure scenario: a tool with an `integer` input property, user types `3.5` into the tile form — `coerceFormValues` returned `{ field: 3.5 }` instead of rejecting it. Added `returns null on fractional string for integer field` (fails on old code, passes now) plus a control test confirming `number` fields still accept fractionals.

Fix: after the existing NaN check, also reject when `type === "integer"` and the parsed value isn't `Number.isInteger`.

Reviewer check: `bun test apps/mesh/src/web/components/home/tile-form-values.test.ts`

Locally ran: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and the targeted test file above (13 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject fractional input in integer tile fields. `coerceFormValues` now returns null when an `integer` field gets a fractional value (e.g., "3.5"), while `number` fields still accept decimals.

<sup>Written for commit a922ad93db397978fec1129369f20729cf757305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

