### PR TITLE
refactor(content): extract ItemRow into its own file

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -25,7 +25,6 @@ import {
   AlertDialogTitle,
 } from "@deco/ui/components/alert-dialog.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
-import { Checkbox } from "@deco/ui/components/checkbox.tsx";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import {
   Tooltip,
@@ -66,7 +65,6 @@ import {
   getPageVariantSectionsAt,
 } from "@/web/components/sections-editor/page-variants";
 import { listAvailableSections } from "@/web/components/sections-editor/section-catalog";
-import { GLOBAL_SECTION_ICON_COLOR } from "@/web/components/sections-editor/section-types";
 import { suggestBlockId } from "@/web/components/sections-editor/page-sections";
 import { createReferencedBlockSaver } from "@/web/components/sections-editor/save-referenced-block";
 import { AvailableSectionEditor } from "./available-section-editor";
@@ -132,6 +130,7 @@ import { countAvailableRunnables } from "./runnable-catalog";
 import { EmptyMessage } from "./empty-message";
 import { PostFilterBar, PostSelectionToolbar } from "./post-toolbar";
 import { ItemActions } from "./item-actions";
+import { ItemRow } from "./item-row";
 import { useBlocksPreviewWorkspace } from "@/web/components/sandbox/blocks/blocks-preview-workspace-context";
 import type { BlocksTarget } from "@/web/components/sandbox/blocks/blocks-preview-workspace-state";
 
@@ -2233,142 +2232,6 @@ function ItemList({
           )}
         </div>
       </ScrollArea>
-    </div>
-  );
-}
-
-export function ItemRow({
-  icon: Icon,
-  logoUrl,
-  title,
-  subtitle,
-  active,
-  accent,
-  variantCount,
-  trailing,
-  selectable,
-  selectionActive,
-  selected,
-  onToggleSelect,
-  onClick,
-  menu,
-}: {
-  icon: React.ComponentType<{
-    size?: number;
-    className?: string;
-    style?: React.CSSProperties;
-  }>;
-  logoUrl?: string;
-  title: string;
-  subtitle: string;
-  active: boolean;
-  /** "global" tints the row purple to mark a saved/global section. */
-  accent?: "global";
-  variantCount?: number;
-  trailing?: React.ReactNode;
-  selectable?: boolean;
-  /** In selection mode the checkbox is always shown (not just on hover). */
-  selectionActive?: boolean;
-  selected?: boolean;
-  onToggleSelect?: () => void;
-  onClick: () => void;
-  menu?: React.ReactNode;
-}) {
-  const isGlobal = accent === "global";
-  const rowIcon =
-    variantCount && variantCount > 1 ? (
-      <span className="flex size-8 shrink-0 items-center justify-center">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Icon size={16} className="shrink-0 text-success" />
-          </TooltipTrigger>
-          <TooltipContent side="right">{variantCount} variants</TooltipContent>
-        </Tooltip>
-      </span>
-    ) : logoUrl ? (
-      <img
-        src={logoUrl}
-        alt=""
-        className="size-8 shrink-0 rounded-lg object-cover bg-muted"
-      />
-    ) : (
-      <span
-        className={cn(
-          "flex size-8 shrink-0 items-center justify-center rounded-lg",
-          isGlobal ? "bg-global-section/15" : "bg-muted",
-        )}
-      >
-        <Icon
-          size={16}
-          className={cn(
-            "shrink-0",
-            !isGlobal &&
-              (active ? "text-accent-foreground" : "text-muted-foreground"),
-          )}
-          style={isGlobal ? { color: GLOBAL_SECTION_ICON_COLOR } : undefined}
-        />
-      </span>
-    );
-
-  return (
-    <div
-      className={cn(
-        "group relative flex min-w-0 items-center rounded-md transition-colors",
-        active
-          ? isGlobal
-            ? "bg-global-section/15 text-global-section-fg dark:text-global-section-fg-dark"
-            : "bg-accent text-accent-foreground"
-          : isGlobal
-            ? "hover:bg-global-section/10"
-            : "hover:bg-muted",
-      )}
-    >
-      {selectable && (
-        <span
-          className={cn(
-            "flex shrink-0 items-center pl-2.5 transition-opacity",
-            selected || selectionActive
-              ? "opacity-100"
-              : "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
-          )}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Checkbox
-            checked={selected}
-            onCheckedChange={() => onToggleSelect?.()}
-            aria-label={`Select ${title}`}
-          />
-        </span>
-      )}
-      <button
-        type="button"
-        onClick={onClick}
-        className="flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2.5 py-2 text-left cursor-pointer"
-      >
-        {rowIcon}
-        <span className="min-w-0 flex-1">
-          <span className="block truncate text-sm font-medium">{title}</span>
-          <span
-            className={cn(
-              "block truncate text-xs",
-              active ? "text-accent-foreground/70" : "text-muted-foreground",
-            )}
-          >
-            {subtitle}
-          </span>
-        </span>
-        {trailing}
-      </button>
-      {menu && (
-        <div
-          className={cn(
-            "pr-1 opacity-0 transition-opacity group-hover:opacity-100",
-            active && "opacity-100",
-          )}
-        >
-          {menu}
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sandbox/content/item-row.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/item-row.tsx
@@ -1,0 +1,144 @@
+import { Checkbox } from "@deco/ui/components/checkbox.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { cn } from "@deco/ui/lib/utils.js";
+import { GLOBAL_SECTION_ICON_COLOR } from "@/web/components/sections-editor/section-types";
+
+export function ItemRow({
+  icon: Icon,
+  logoUrl,
+  title,
+  subtitle,
+  active,
+  accent,
+  variantCount,
+  trailing,
+  selectable,
+  selectionActive,
+  selected,
+  onToggleSelect,
+  onClick,
+  menu,
+}: {
+  icon: React.ComponentType<{
+    size?: number;
+    className?: string;
+    style?: React.CSSProperties;
+  }>;
+  logoUrl?: string;
+  title: string;
+  subtitle: string;
+  active: boolean;
+  /** "global" tints the row purple to mark a saved/global section. */
+  accent?: "global";
+  variantCount?: number;
+  trailing?: React.ReactNode;
+  selectable?: boolean;
+  /** In selection mode the checkbox is always shown (not just on hover). */
+  selectionActive?: boolean;
+  selected?: boolean;
+  onToggleSelect?: () => void;
+  onClick: () => void;
+  menu?: React.ReactNode;
+}) {
+  const isGlobal = accent === "global";
+  const rowIcon =
+    variantCount && variantCount > 1 ? (
+      <span className="flex size-8 shrink-0 items-center justify-center">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Icon size={16} className="shrink-0 text-success" />
+          </TooltipTrigger>
+          <TooltipContent side="right">{variantCount} variants</TooltipContent>
+        </Tooltip>
+      </span>
+    ) : logoUrl ? (
+      <img
+        src={logoUrl}
+        alt=""
+        className="size-8 shrink-0 rounded-lg object-cover bg-muted"
+      />
+    ) : (
+      <span
+        className={cn(
+          "flex size-8 shrink-0 items-center justify-center rounded-lg",
+          isGlobal ? "bg-global-section/15" : "bg-muted",
+        )}
+      >
+        <Icon
+          size={16}
+          className={cn(
+            "shrink-0",
+            !isGlobal &&
+              (active ? "text-accent-foreground" : "text-muted-foreground"),
+          )}
+          style={isGlobal ? { color: GLOBAL_SECTION_ICON_COLOR } : undefined}
+        />
+      </span>
+    );
+
+  return (
+    <div
+      className={cn(
+        "group relative flex min-w-0 items-center rounded-md transition-colors",
+        active
+          ? isGlobal
+            ? "bg-global-section/15 text-global-section-fg dark:text-global-section-fg-dark"
+            : "bg-accent text-accent-foreground"
+          : isGlobal
+            ? "hover:bg-global-section/10"
+            : "hover:bg-muted",
+      )}
+    >
+      {selectable && (
+        <span
+          className={cn(
+            "flex shrink-0 items-center pl-2.5 transition-opacity",
+            selected || selectionActive
+              ? "opacity-100"
+              : "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+          )}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Checkbox
+            checked={selected}
+            onCheckedChange={() => onToggleSelect?.()}
+            aria-label={`Select ${title}`}
+          />
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2.5 py-2 text-left cursor-pointer"
+      >
+        {rowIcon}
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-medium">{title}</span>
+          <span
+            className={cn(
+              "block truncate text-xs",
+              active ? "text-accent-foreground/70" : "text-muted-foreground",
+            )}
+          >
+            {subtitle}
+          </span>
+        </span>
+        {trailing}
+      </button>
+      {menu && (
+        <div
+          className={cn(
+            "pr-1 opacity-0 transition-opacity group-hover:opacity-100",
+            active && "opacity-100",
+          )}
+        >
+          {menu}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/runnable-blocks-browser.tsx
@@ -19,7 +19,7 @@ import type { LiveMeta } from "@/web/components/sections-editor/resolve-schema";
 import { GLOBAL_SECTION_ICON_COLOR } from "@/web/components/sections-editor/section-types";
 import { useSaveBlock } from "@/web/components/sections-editor/use-save-block";
 import { createReferencedBlockSaver } from "@/web/components/sections-editor/save-referenced-block";
-import { ItemRow } from "./content-browser";
+import { ItemRow } from "./item-row";
 import { EmptyMessage } from "./empty-message";
 import {
   RunnableBlockEditor,


### PR DESCRIPTION
**Source:** C5 bounded extraction from a God-component. `content-browser.tsx` is 2400+ lines and this session's earlier extractions (#4843, #4825, #4829, #4834, #4836) already pulled several self-contained pieces out; `ItemRow` was the next clean one left.

**Why:** `ItemRow` is a pure list-item renderer — it only reads its own props, shares no closures/local state with the rest of the file — and it's already imported cross-file by `runnable-blocks-browser.tsx` (via `import { ItemRow } from "./content-browser"`), which is itself a sign it belongs in its own module rather than living inside the browser component file.

**Change:** Byte-identical relocation of the `ItemRow` component (and its now-unused `Checkbox`/`GLOBAL_SECTION_ICON_COLOR` imports) from `content-browser.tsx` into a new `item-row.tsx`, re-imported from both call sites. No logic changed.

**Verify:** `cd apps/mesh && bunx tsc --noEmit` — green. No behavior change, so no new test; `runnable-blocks-browser.tsx`'s existing usage continues to typecheck against the new import path.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace). Full CI covers lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the `ItemRow` component into `item-row.tsx` to reduce `content-browser.tsx` size and clarify reuse. No logic or UI changes; only import paths updated.

- **Refactors**
  - Moved `ItemRow` from content-browser.tsx to item-row.tsx.
  - Updated runnable-blocks-browser.tsx to import from item-row.
  - Removed now-unused `Checkbox` and `GLOBAL_SECTION_ICON_COLOR` imports from content-browser.tsx.

<sup>Written for commit ca337b72d0a33d8f766ed1c9ee29ba784979f9c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

