### PR TITLE
fix(home): block saving a home tile with a blank required field

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -795,6 +795,7 @@ function PinnedTileRow({
         const coerced = coerceFormValues(
           formValues,
           tool.inputSchema.properties,
+          tool.inputSchema.required,
         );
         if (!coerced) {
           toast.error("Invalid value in one of the fields — please fix it.");
@@ -951,6 +952,7 @@ function AddToolRow({
         const coerced = coerceFormValues(
           formValues,
           tool.inputSchema.properties,
+          tool.inputSchema.required,
         );
         if (!coerced) {
           toast.error("Invalid value in one of the fields — please fix it.");

--- a/apps/mesh/src/web/components/home/tile-form-values.test.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.test.ts
@@ -45,6 +45,18 @@ describe("coerceFormValues", () => {
   test("drops empty values", () => {
     expect(coerceFormValues({ s: "" }, { s: { type: "string" } })).toEqual({});
   });
+
+  test("returns null when a required field is left blank", () => {
+    expect(
+      coerceFormValues({ s: "" }, { s: { type: "string" } }, ["s"]),
+    ).toBeNull();
+  });
+
+  test("accepts a filled required field", () => {
+    expect(
+      coerceFormValues({ s: "hi" }, { s: { type: "string" } }, ["s"]),
+    ).toEqual({ s: "hi" });
+  });
 });
 
 describe("seedFormValues", () => {

--- a/apps/mesh/src/web/components/home/tile-form-values.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.ts
@@ -6,6 +6,7 @@ import type { ToolInputProperty } from "@/web/components/tool-input-form";
 export function coerceFormValues(
   values: Record<string, unknown>,
   properties: Record<string, ToolInputProperty>,
+  required?: string[],
 ): Record<string, unknown> | null {
   const out: Record<string, unknown> = {};
   for (const [key, raw] of Object.entries(values)) {
@@ -30,6 +31,7 @@ export function coerceFormValues(
       out[key] = raw;
     }
   }
+  if (required?.some((key) => !(key in out))) return null;
   return out;
 }
 


### PR DESCRIPTION
Follows #4844 (which rejected fractional input in integer tile fields). That PR hardened `coerceFormValues` for type coercion but the function still has no way to enforce `inputSchema.required` — `ToolInputForm` shows a `*` for required fields, but nothing stops `handleSave`/`saveTile` in `add-tile-drawer.tsx` from persisting a tile whose required field was left blank (the value is just silently dropped from `toolInput`). The tile save succeeds, but the tool call fails later at runtime with a confusing missing-argument error, and the user gets no feedback at save time.

Fix: `coerceFormValues` now takes an optional `required` list and returns `null` (the existing "invalid value" path) if any required field ended up missing from the output. Both call sites in `add-tile-drawer.tsx` now pass `tool.inputSchema.required` through, reusing the toast that's already there.

Failure scenario: a tool with a required `query: string` field, user leaves it blank and clicks Save — previously saved fine, now blocked with "Invalid value in one of the fields — please fix it."

Regression test added in `tile-form-values.test.ts`: `coerceFormValues({ s: "" }, { s: { type: "string" } }, ["s"])` now returns `null` (previously `{}`).

Reviewer check: `bun test apps/mesh/src/web/components/home/tile-form-values.test.ts`

Locally verified: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and the targeted test file above all pass. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block saving a Home tile when a required input is left blank to prevent later tool-call errors. Users now see the existing validation toast right away.

- **Bug Fixes**
  - `coerceFormValues` now accepts `required` and returns `null` if any required field is missing.
  - Both `add-tile-drawer.tsx` callers pass `tool.inputSchema.required`, triggering the existing invalid-value toast.
  - Added tests to cover blank vs filled required fields.

<sup>Written for commit ede9d531942f1e49680837f8b77dae128c38b12a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

