### PR TITLE
refactor(content): extract RedirectTypeBadge into its own file

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -97,10 +97,9 @@ import {
   buildRedirectBlock,
   extractRedirects,
   generateRedirectBlockKey,
-  REDIRECT_STATUS,
   type RedirectEntry,
-  type RedirectType,
 } from "./redirect-data";
+import { RedirectTypeBadge } from "./redirect-type-badge";
 import {
   type BlogEntry,
   type BlogKind,
@@ -2233,22 +2232,6 @@ function ItemList({
         </div>
       </ScrollArea>
     </div>
-  );
-}
-
-/** Compact status-code badge for a redirect row (301 permanent / 307 temporary). */
-function RedirectTypeBadge({ type }: { type: RedirectType }) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-muted-foreground">
-          {REDIRECT_STATUS[type]}
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="left">
-        {type === "permanent" ? "Permanent" : "Temporary"}
-      </TooltipContent>
-    </Tooltip>
   );
 }
 

--- a/apps/mesh/src/web/components/sandbox/content/redirect-type-badge.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/redirect-type-badge.tsx
@@ -1,0 +1,22 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { REDIRECT_STATUS, type RedirectType } from "./redirect-data";
+
+/** Compact status-code badge for a redirect row (301 permanent / 307 temporary). */
+export function RedirectTypeBadge({ type }: { type: RedirectType }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-muted-foreground">
+          {REDIRECT_STATUS[type]}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="left">
+        {type === "permanent" ? "Permanent" : "Temporary"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
Bounded extraction (C5) from `content-browser.tsx` (2299 lines, one of the largest frontend files) — `RedirectTypeBadge` was a self-contained component reading only its own props (`type: RedirectType`), used exactly once, with no shared mutable state with the rest of the file.

Why: shrinks the God-component by one nameable unit with a byte-identical logic move — same JSX/behavior, just relocated to `redirect-type-badge.tsx` plus the new import. Also drops the now-unused `REDIRECT_STATUS`/`RedirectType` imports from `content-browser.tsx` (still used inside the new file).

How to confirm: `cd apps/mesh && bunx tsc --noEmit` (green) and visually diff — the extracted component's JSX/logic is unchanged, only its file location moved.

Local checks run: `bun run fmt` (no changes needed) and `bunx tsc --noEmit` in `apps/mesh` (clean). No test file covers this component (pure presentational badge), so this is verified by typecheck only, matching the reduction/extraction bar in the review guide. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `RedirectTypeBadge` from `content-browser.tsx` into `redirect-type-badge.tsx` to shrink the file and keep the badge self-contained. Behavior is unchanged; updated the import and removed now-unused `REDIRECT_STATUS`/`RedirectType` imports from `content-browser.tsx`.

<sup>Written for commit 75bad5430fb22a0631832393f38329b6c8806490. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

