### PR TITLE
refactor(content): extract SectionsRightPane into its own file

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -65,10 +65,7 @@ import {
   getPageVariantSectionsAt,
 } from "@/web/components/sections-editor/page-variants";
 import { listAvailableSections } from "@/web/components/sections-editor/section-catalog";
-import { suggestBlockId } from "@/web/components/sections-editor/page-sections";
 import { createReferencedBlockSaver } from "@/web/components/sections-editor/save-referenced-block";
-import { AvailableSectionEditor } from "./available-section-editor";
-import { SavedSectionEditor } from "./saved-section-editor";
 import { CollectionsSidebar } from "./collections-sidebar";
 import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events";
 import {
@@ -127,6 +124,7 @@ import { PageJsonDialog } from "@/web/components/sections-editor/page-json-dialo
 import { RunnableBlocksBrowser } from "./runnable-blocks-browser";
 import { countAvailableRunnables } from "./runnable-catalog";
 import { EmptyMessage } from "./empty-message";
+import { SectionsRightPane } from "./sections-right-pane";
 import { PostFilterBar, PostSelectionToolbar } from "./post-toolbar";
 import { ItemActions } from "./item-actions";
 import { ItemRow } from "./item-row";
@@ -1526,89 +1524,6 @@ function ContentBrowserReady({
  * full section editor; an available (raw manifest) section opens a local
  * editor that persists only when named and saved.
  */
-function SectionsRightPane({
-  selection,
-  orgSlug,
-  virtualMcpId,
-  branch,
-  previewUrl,
-  meta,
-  decofile,
-  isCreating,
-  onCreateAvailable,
-  onSaveReferencedBlock,
-}: {
-  selection:
-    | { collection: "sections"; key: string }
-    | {
-        collection: "available-section";
-        resolveType: string;
-        title: string;
-      }
-    | null;
-  orgSlug: string;
-  virtualMcpId: string;
-  branch: string;
-  previewUrl: string | null;
-  meta: LiveMeta;
-  decofile: Record<string, unknown>;
-  isCreating: boolean;
-  onCreateAvailable: (
-    resolveType: string,
-    blockId: string,
-    data: Record<string, unknown>,
-  ) => Promise<void>;
-  onSaveReferencedBlock: (
-    blockKey: string,
-    data: Record<string, unknown>,
-  ) => void;
-}) {
-  if (!selection) {
-    return (
-      <EmptyMessage
-        title="Select a section to edit"
-        description="Pick a saved section to edit it, or an available one to customize and save as global."
-      />
-    );
-  }
-
-  if (selection.collection === "available-section") {
-    return (
-      <AvailableSectionEditor
-        key={`available:${selection.resolveType}`}
-        orgSlug={orgSlug}
-        virtualMcpId={virtualMcpId}
-        branch={branch}
-        previewUrl={previewUrl}
-        meta={meta}
-        decofile={decofile}
-        resolveType={selection.resolveType}
-        title={selection.title}
-        defaultBlockId={suggestBlockId(selection.title)}
-        isCreating={isCreating}
-        onCreate={(blockId, data) =>
-          onCreateAvailable(selection.resolveType, blockId, data)
-        }
-        onSaveReferencedBlock={onSaveReferencedBlock}
-      />
-    );
-  }
-
-  return (
-    <SavedSectionEditor
-      key={`saved:${selection.key}`}
-      orgSlug={orgSlug}
-      virtualMcpId={virtualMcpId}
-      branch={branch}
-      previewUrl={previewUrl}
-      meta={meta}
-      decofile={decofile}
-      blockKey={selection.key}
-      onSaveReferencedBlock={onSaveReferencedBlock}
-    />
-  );
-}
-
 function GroupHeader({
   icon: Icon,
   label,

--- a/apps/mesh/src/web/components/sandbox/content/sections-right-pane.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/sections-right-pane.tsx
@@ -1,0 +1,88 @@
+import { type LiveMeta } from "@/web/components/sections-editor/resolve-schema";
+import { suggestBlockId } from "@/web/components/sections-editor/page-sections";
+import { AvailableSectionEditor } from "./available-section-editor";
+import { SavedSectionEditor } from "./saved-section-editor";
+import { EmptyMessage } from "./empty-message";
+
+export function SectionsRightPane({
+  selection,
+  orgSlug,
+  virtualMcpId,
+  branch,
+  previewUrl,
+  meta,
+  decofile,
+  isCreating,
+  onCreateAvailable,
+  onSaveReferencedBlock,
+}: {
+  selection:
+    | { collection: "sections"; key: string }
+    | {
+        collection: "available-section";
+        resolveType: string;
+        title: string;
+      }
+    | null;
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  previewUrl: string | null;
+  meta: LiveMeta;
+  decofile: Record<string, unknown>;
+  isCreating: boolean;
+  onCreateAvailable: (
+    resolveType: string,
+    blockId: string,
+    data: Record<string, unknown>,
+  ) => Promise<void>;
+  onSaveReferencedBlock: (
+    blockKey: string,
+    data: Record<string, unknown>,
+  ) => void;
+}) {
+  if (!selection) {
+    return (
+      <EmptyMessage
+        title="Select a section to edit"
+        description="Pick a saved section to edit it, or an available one to customize and save as global."
+      />
+    );
+  }
+
+  if (selection.collection === "available-section") {
+    return (
+      <AvailableSectionEditor
+        key={`available:${selection.resolveType}`}
+        orgSlug={orgSlug}
+        virtualMcpId={virtualMcpId}
+        branch={branch}
+        previewUrl={previewUrl}
+        meta={meta}
+        decofile={decofile}
+        resolveType={selection.resolveType}
+        title={selection.title}
+        defaultBlockId={suggestBlockId(selection.title)}
+        isCreating={isCreating}
+        onCreate={(blockId, data) =>
+          onCreateAvailable(selection.resolveType, blockId, data)
+        }
+        onSaveReferencedBlock={onSaveReferencedBlock}
+      />
+    );
+  }
+
+  return (
+    <SavedSectionEditor
+      key={`saved:${selection.key}`}
+      orgSlug={orgSlug}
+      virtualMcpId={virtualMcpId}
+      branch={branch}
+      previewUrl={previewUrl}
+      meta={meta}
+      decofile={decofile}
+      blockKey={selection.key}
+      onSaveReferencedBlock={onSaveReferencedBlock}
+    />
+  );
+}


### PR DESCRIPTION
Continues the extraction pattern from #4847 and #4845 — `content-browser.tsx` (2282 lines) is a God-component; `SectionsRightPane` was a fully self-contained, prop-driven renderer with no closures over the surrounding component's state, called from exactly one place.

A maintainer benefits because this shrinks the largest file in the sections/content editor without touching any behavior, making the remaining file easier to navigate.

This is a byte-identical relocation: the function body is unchanged, only its imports (`EmptyMessage`, `AvailableSectionEditor`, `SavedSectionEditor`, `suggestBlockId`, `LiveMeta`) moved with it into the new file, and `content-browser.tsx` now imports `SectionsRightPane` from `./sections-right-pane`. Net diff: content-browser.tsx -86/+1 lines, one new 85-line file.

To confirm: `cd apps/mesh && bunx tsc --noEmit` (clean) — behavior is unchanged since no logic was altered, just moved.

Locally ran `bun run fmt` and `bunx tsc --noEmit` in apps/mesh (both clean); full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `SectionsRightPane` into `sections-right-pane.tsx` to shrink `content-browser.tsx` and make the sections editor easier to navigate. No behavior changes.

- **Refactors**
  - Moved `SectionsRightPane` and its dependencies (`EmptyMessage`, `AvailableSectionEditor`, `SavedSectionEditor`, `suggestBlockId`, `LiveMeta`) into `sections-right-pane.tsx`.
  - Updated `content-browser.tsx` to import `SectionsRightPane` and removed the inline component.

<sup>Written for commit 2731017d3fba7e7d38f2ea8a9d8e357519622139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

