### PR TITLE
refactor(home): dedupe tool-input coercion in add-tile drawer

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -738,6 +738,23 @@ function AgentToolList({
   );
 }
 
+/** Coerces the form values against the tool's schema, toasting and returning
+ * `undefined` on an invalid field. Shared by the pinned-tile save flow and the
+ * add-tile flow — both build the same `toolInput` from the same form. */
+function resolveToolInput(
+  formValues: Record<string, unknown>,
+  properties: Record<string, ToolInputProperty> | undefined,
+  required: string[] | undefined,
+): { toolInput?: Record<string, unknown> } | undefined {
+  if (!properties || Object.keys(properties).length === 0) return {};
+  const coerced = coerceFormValues(formValues, properties, required);
+  if (!coerced) {
+    toast.error("Invalid value in one of the fields — please fix it.");
+    return undefined;
+  }
+  return Object.keys(coerced).length > 0 ? { toolInput: coerced } : {};
+}
+
 /** Row for a pinned tile instance — shows a summary, gear to edit, minus to remove. */
 function PinnedTileRow({
   agent,
@@ -790,20 +807,16 @@ function PinnedTileRow({
   const handleSave = async () => {
     setSubmitting(true);
     try {
-      let toolInput: Record<string, unknown> | undefined;
-      if (hasProps && tool.inputSchema?.properties) {
-        const coerced = coerceFormValues(
-          formValues,
-          tool.inputSchema.properties,
-          tool.inputSchema.required,
-        );
-        if (!coerced) {
-          toast.error("Invalid value in one of the fields — please fix it.");
-          setSubmitting(false);
-          return;
-        }
-        if (Object.keys(coerced).length > 0) toolInput = coerced;
+      const resolved = resolveToolInput(
+        formValues,
+        tool.inputSchema?.properties,
+        tool.inputSchema?.required,
+      );
+      if (!resolved) {
+        setSubmitting(false);
+        return;
       }
+      const { toolInput } = resolved;
 
       const baseTiles = getHomeTiles(agent.metadata?.ui);
       const nextTiles = baseTiles.map((t) => {
@@ -947,20 +960,16 @@ function AddToolRow({
   const saveTile = async () => {
     setSubmitting(true);
     try {
-      let toolInput: Record<string, unknown> | undefined;
-      if (hasProps && tool.inputSchema?.properties) {
-        const coerced = coerceFormValues(
-          formValues,
-          tool.inputSchema.properties,
-          tool.inputSchema.required,
-        );
-        if (!coerced) {
-          toast.error("Invalid value in one of the fields — please fix it.");
-          setSubmitting(false);
-          return;
-        }
-        if (Object.keys(coerced).length > 0) toolInput = coerced;
+      const resolved = resolveToolInput(
+        formValues,
+        tool.inputSchema?.properties,
+        tool.inputSchema?.required,
+      );
+      if (!resolved) {
+        setSubmitting(false);
+        return;
       }
+      const { toolInput } = resolved;
 
       const baseTiles = getHomeTiles(agent.metadata?.ui);
       const nextTiles = [


### PR DESCRIPTION
Source: code-reduction (C1) — no linked issue.

`PinnedTileRow.handleSave` and `AddToolRow.saveTile` in `add-tile-drawer.tsx` had byte-for-byte identical logic for coercing the form values against the tool's input schema and toasting on an invalid field. Collapsed both into one `resolveToolInput` helper in the same file — one home for the logic instead of two copies that could silently drift apart on the next edit.

Behavior is unchanged: `resolveToolInput` returns the exact same `{ toolInput }` shape (or `undefined` on invalid input, after the same toast) that each call site built inline before. Net diff: +35/-26.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` (green). No test exists for this component (it's a UI form flow, not a trust boundary), so this is a pure logic relocation verified by typecheck plus manual read of both call sites confirming identical resulting behavior.

Locally ran: `bun run fmt` (no changes) and `bunx tsc --noEmit` in `apps/mesh` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated tool-input coercion in the add-tile drawer by introducing a shared `resolveToolInput` helper. Behavior is unchanged; this reduces duplication and drift risk.

- **Refactors**
  - Added `resolveToolInput` to coerce form values against the tool schema and toast on invalid fields.
  - Replaced inline logic in `PinnedTileRow.handleSave` and `AddToolRow.saveTile`.
  - Preserves the exact `{ toolInput }` return shape (or `undefined` on invalid). No UI or behavior changes.

<sup>Written for commit 4d93cf937752c4af6a2afafd14204e77615dc784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

