### PR TITLE
fix(home): reject whitespace-only value for required tile fields

### DIFF
--- a/apps/mesh/src/web/components/home/tile-form-values.test.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.test.ts
@@ -57,6 +57,18 @@ describe("coerceFormValues", () => {
       coerceFormValues({ s: "hi" }, { s: { type: "string" } }, ["s"]),
     ).toEqual({ s: "hi" });
   });
+
+  test("drops whitespace-only string values", () => {
+    expect(coerceFormValues({ s: "   " }, { s: { type: "string" } })).toEqual(
+      {},
+    );
+  });
+
+  test("returns null when a required field is only whitespace", () => {
+    expect(
+      coerceFormValues({ s: "   " }, { s: { type: "string" } }, ["s"]),
+    ).toBeNull();
+  });
 });
 
 describe("seedFormValues", () => {

--- a/apps/mesh/src/web/components/home/tile-form-values.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.ts
@@ -27,7 +27,10 @@ export function coerceFormValues(
       if (Number.isNaN(parsed)) return null;
       if (type === "integer" && !Number.isInteger(parsed)) return null;
       out[key] = parsed;
-    } else if (raw !== "" && raw != null) {
+    } else if (typeof raw === "string") {
+      if (!raw.trim()) continue;
+      out[key] = raw;
+    } else if (raw != null) {
       out[key] = raw;
     }
   }


### PR DESCRIPTION
Follows the recent tile-form-values hardening series (#4841, #4842, #4844, #4846).

#4846 blocked saving a home tile with a required field left completely blank (`""`), but `coerceFormValues` only applies a `raw.trim()` check to object/array and number/integer fields before adding them to the output. Plain string fields fall through to a bare `raw !== ""` check, so a required text field filled with only spaces (e.g. `"   "`) still lands in the coerced output and passes the `required` presence check (`key in out`), letting the tile save with an effectively-empty required field.

**Failure scenario:** user types only spaces into a required text field on the add-tile drawer form and saves — the tile is persisted with a whitespace value instead of being blocked like a truly blank field.

**Fix:** apply the same trim-based emptiness check already used for object/array/number/integer fields to plain string fields, so whitespace-only input is dropped (and triggers the required-field guard) consistently across all field types.

**Regression tests added** in `tile-form-values.test.ts`:
- `coerceFormValues` drops a whitespace-only string value for a non-required field.
- `coerceFormValues` returns `null` when a required field's value is only whitespace.

**To verify:** `bun test apps/mesh/src/web/components/home/tile-form-values.test.ts`

**Locally ran:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and the targeted test file above (all pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent saving a home tile when a required text field contains only whitespace by trimming string inputs during coercion. This aligns required checks across all field types.

- **Bug Fixes**
  - Apply trim-based emptiness check to plain string fields in `coerceFormValues`.
  - Whitespace-only strings are dropped; required fields now return null to block save.
  - Added regression tests in `tile-form-values.test.ts` for non-required and required cases.

<sup>Written for commit be1b842ce8f7639be0a7ec359961adb6f5696a2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

