### PR TITLE
refactor(connections): extract ConnectionCardHeaderActions into shared UI file

### DIFF
--- a/apps/mesh/src/web/routes/orgs/connection-selection-ui.tsx
+++ b/apps/mesh/src/web/routes/orgs/connection-selection-ui.tsx
@@ -17,12 +17,18 @@ import {
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { type VirtualMCPEntity } from "@decocms/mesh-sdk";
 import {
+  type ConnectionEntity,
+  type VirtualMCPEntity,
+} from "@decocms/mesh-sdk";
+import {
+  CheckSquare,
   Container,
   DotsVertical,
   Eye,
   Plus,
+  Power01,
+  SlashCircle01,
   Trash01,
   XClose,
 } from "@untitledui/icons";
@@ -145,6 +151,126 @@ export function ConnectionGroupCard({
         }
       />
     </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header actions dropdown for a single connected card (Open / Select /
+// Enable-Disable / Delete)
+// ---------------------------------------------------------------------------
+
+export function ConnectionCardHeaderActions({
+  connection,
+  isSelected,
+  selectionMode,
+  canManage,
+  canManageAgents,
+  onToggleSelect,
+  onOpen,
+  onToggleStatus,
+  onDelete,
+}: {
+  connection: ConnectionEntity;
+  isSelected: boolean;
+  selectionMode: boolean;
+  canManage: boolean;
+  canManageAgents: boolean;
+  onToggleSelect: () => void;
+  onOpen: () => void;
+  onToggleStatus: (status: "active" | "inactive") => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      {selectionMode ? (
+        <Checkbox
+          checked={isSelected}
+          onCheckedChange={onToggleSelect}
+          onClick={(e) => e.stopPropagation()}
+        />
+      ) : (
+        <span className="text-xs text-muted-foreground font-normal">
+          Connected
+        </span>
+      )}
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-150 ease-out",
+          selectionMode
+            ? "w-8 opacity-100"
+            : "w-0 opacity-0 group-hover:w-8 group-hover:opacity-100",
+        )}
+      >
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <DotsVertical size={20} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpen();
+              }}
+            >
+              <Eye size={16} />
+              Open
+            </DropdownMenuItem>
+            {(canManage || canManageAgents) && (
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleSelect();
+                }}
+              >
+                <CheckSquare size={16} />
+                Select
+              </DropdownMenuItem>
+            )}
+            {canManage &&
+              (connection.status === "active" ? (
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggleStatus("inactive");
+                  }}
+                >
+                  <SlashCircle01 size={16} />
+                  Disable
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggleStatus("active");
+                  }}
+                >
+                  <Power01 size={16} />
+                  Enable
+                </DropdownMenuItem>
+              ))}
+            {canManage && (
+              <DropdownMenuItem
+                variant="destructive"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+              >
+                <Trash01 size={16} />
+                Delete
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
   );
 }
 

--- a/apps/mesh/src/web/routes/orgs/connections.tsx
+++ b/apps/mesh/src/web/routes/orgs/connections.tsx
@@ -22,7 +22,6 @@ import { getConnectionSlug } from "@/shared/utils/connection-slug";
 import { BulkDeleteDialog } from "./bulk-delete-dialog.tsx";
 import { CatalogItemCard } from "./catalog-item-card.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
-import { Checkbox } from "@deco/ui/components/checkbox.tsx";
 import {
   Dialog,
   DialogContent,
@@ -41,12 +40,6 @@ import {
   DrawerTitle,
 } from "@deco/ui/components/drawer.tsx";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
 import {
   Form,
   FormControl,
@@ -78,17 +71,11 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import {
-  CheckSquare,
   Container,
-  DotsVertical,
-  Eye,
   Globe02,
   Loading01,
   Plus,
-  Power01,
-  SlashCircle01,
   Terminal,
-  Trash01,
   XClose,
 } from "@untitledui/icons";
 import { Suspense, useState } from "react";
@@ -127,6 +114,7 @@ import { groupConnections } from "@/shared/utils/group-connections";
 import {
   AddToAgentDialog,
   BulkActionBar,
+  ConnectionCardHeaderActions,
   ConnectionGroupCard,
 } from "./connection-selection-ui.tsx";
 
@@ -578,111 +566,29 @@ function ConnectionResults({
                     )}
                     headerActionsAlwaysVisible
                     headerActions={
-                      <div className="flex items-center gap-1">
-                        {selectionMode ? (
-                          <Checkbox
-                            checked={isSelected}
-                            onCheckedChange={() => toggleSelect(connection.id)}
-                            onClick={(e) => e.stopPropagation()}
-                          />
-                        ) : (
-                          <span className="text-xs text-muted-foreground font-normal">
-                            Connected
-                          </span>
-                        )}
-                        <div
-                          className={cn(
-                            "overflow-hidden transition-all duration-150 ease-out",
-                            selectionMode
-                              ? "w-8 opacity-100"
-                              : "w-0 opacity-0 group-hover:w-8 group-hover:opacity-100",
-                          )}
-                        >
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                className="h-8 w-8 p-0"
-                                onClick={(e) => e.stopPropagation()}
-                              >
-                                <DotsVertical size={20} />
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent
-                              align="end"
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              <DropdownMenuItem
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  navigate({
-                                    to: "/$org/settings/connections/$appSlug",
-                                    params: {
-                                      org: org.slug,
-                                      appSlug: getConnectionSlug(connection),
-                                    },
-                                  });
-                                }}
-                              >
-                                <Eye size={16} />
-                                Open
-                              </DropdownMenuItem>
-                              {(canManage || canManageAgents) && (
-                                <DropdownMenuItem
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    toggleSelect(connection.id);
-                                  }}
-                                >
-                                  <CheckSquare size={16} />
-                                  Select
-                                </DropdownMenuItem>
-                              )}
-                              {canManage &&
-                                (connection.status === "active" ? (
-                                  <DropdownMenuItem
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      handleToggleStatus(
-                                        connection.id,
-                                        "inactive",
-                                      );
-                                    }}
-                                  >
-                                    <SlashCircle01 size={16} />
-                                    Disable
-                                  </DropdownMenuItem>
-                                ) : (
-                                  <DropdownMenuItem
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      handleToggleStatus(
-                                        connection.id,
-                                        "active",
-                                      );
-                                    }}
-                                  >
-                                    <Power01 size={16} />
-                                    Enable
-                                  </DropdownMenuItem>
-                                ))}
-                              {canManage && (
-                                <DropdownMenuItem
-                                  variant="destructive"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    deleteConnection.requestDelete(connection);
-                                  }}
-                                >
-                                  <Trash01 size={16} />
-                                  Delete
-                                </DropdownMenuItem>
-                              )}
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </div>
-                      </div>
+                      <ConnectionCardHeaderActions
+                        connection={connection}
+                        isSelected={isSelected}
+                        selectionMode={selectionMode}
+                        canManage={canManage}
+                        canManageAgents={canManageAgents}
+                        onToggleSelect={() => toggleSelect(connection.id)}
+                        onOpen={() =>
+                          navigate({
+                            to: "/$org/settings/connections/$appSlug",
+                            params: {
+                              org: org.slug,
+                              appSlug: getConnectionSlug(connection),
+                            },
+                          })
+                        }
+                        onToggleStatus={(status) =>
+                          handleToggleStatus(connection.id, status)
+                        }
+                        onDelete={() =>
+                          deleteConnection.requestDelete(connection)
+                        }
+                      />
                     }
                   />
                 );


### PR DESCRIPTION
Source: reduction — `apps/mesh/src/web/routes/orgs/connections.tsx` is a 1568-line God-component (see LARGEST FRONTEND FILES); this pulls out one self-contained, provably-isolated unit.

The per-connection card's header-actions dropdown menu (Open / Select / Enable-Disable / Delete) only reads its own props (`connection`, `isSelected`, `selectionMode`, `canManage`, `canManageAgents`) and a handful of callbacks — no shared mutable state with the rest of `ConnectionResults`. It's moved verbatim into `connection-selection-ui.tsx`, which already houses the sibling components (`ConnectionGroupCard`, `BulkActionBar`, `AddToAgentDialog`) extracted from this same file in earlier PRs, so this keeps the same home pattern rather than creating a one-off file.

This is a byte-identical logic move: same JSX, same click handlers, same conditional rendering — only the closures (`toggleSelect(connection.id)`, `navigate(...)`, `handleToggleStatus(connection.id, status)`, `deleteConnection.requestDelete(connection)`) are now passed in as props (`onToggleSelect`, `onOpen`, `onToggleStatus`, `onDelete`) instead of being inlined. No behavior change.

How to confirm: open a connections list, hover/click the "⋮" menu on a connected card in both single and multi-select (bulk) mode, and confirm Open/Select/Enable/Disable/Delete all still work exactly as before.

Locally verified: `bunx tsc --noEmit` in `apps/mesh` (clean, no errors) and `bun run fmt`. No test file covers this pure JSX relocation — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the per-connection header actions dropdown into a shared component to shrink `connections.tsx` and keep related UI in one place. No behavior changes; actions work exactly as before.

- **Refactors**
  - Moved header actions into ConnectionCardHeaderActions in `connection-selection-ui.tsx` (Open/Select/Enable/Disable/Delete).
  - Replaced inline handlers with props: `onToggleSelect`, `onOpen`, `onToggleStatus`, `onDelete`.
  - Trimmed ~100 lines from `connections.tsx` and kept it aligned with existing shared components (ConnectionGroupCard, BulkActionBar, AddToAgentDialog).

<sup>Written for commit fea7f9b99eb164cbf851f38456d4307d1325d684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

