### PR TITLE
refactor(web): import connection types from mesh-sdk instead of server tree

### DIFF
--- a/apps/mesh/src/web/components/details/connection/connection-sidebar.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-sidebar.tsx
@@ -1,5 +1,3 @@
-import type { ConnectionEntity } from "@/tools/connection/schema";
-import { parseVirtualUrl } from "@/tools/connection/schema";
 import { EnvVarsEditor } from "@/web/components/env-vars-editor";
 import { useAuthConfig } from "@/web/providers/auth-config-provider";
 import { Badge } from "@deco/ui/components/badge.tsx";
@@ -25,6 +23,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@deco/ui/components/select.tsx";
+import { type ConnectionEntity, parseVirtualUrl } from "@decocms/mesh-sdk";
 import {
   CheckCircle,
   ChevronDown,


### PR DESCRIPTION
**Source:** frontend debt — a real `ban-web-server-imports` oxlint warning (warn-level, not CI-enforced, so it survives on main).

**Why:** `connection-sidebar.tsx` imported `ConnectionEntity`/`parseVirtualUrl` from `@/tools/connection/schema`, a server-only module. But that module (`apps/mesh/src/tools/connection/schema.ts`) is itself nothing but a re-export of these same symbols from `@decocms/mesh-sdk/types` (kept only to preserve legacy import paths). Importing the server tree from web code risks pulling server-only deps/secrets into the browser bundle if the server file ever grows real logic. The neighboring `tool-set-selector.tsx` already imports these exact symbols from `@decocms/mesh-sdk` directly — this change just aligns `connection-sidebar.tsx` with that existing, correct pattern.

**Change:** swap the two imports for a single `import { type ConnectionEntity, parseVirtualUrl } from "@decocms/mesh-sdk"`. Same runtime values, same types — a pure import-path fix, no logic touched. Net: -2/+1 lines.

**How I confirmed behavior is unchanged:** `@decocms/mesh-sdk`'s `parseVirtualUrl`/`ConnectionEntity` are the literal re-export source the old import path pointed to (traced `@/tools/connection/schema` -> `@decocms/mesh-sdk/types`), so this is a no-op at runtime.

**Command a reviewer runs to confirm:** `bunx oxlint apps/mesh/src/web/components/details/connection/connection-sidebar.tsx` (0 warnings, was 1 `ban-web-server-imports` before).

**Checks run locally:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), targeted `oxlint` on the touched file (0 warnings). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `connection-sidebar.tsx` to import `ConnectionEntity` and `parseVirtualUrl` from `@decocms/mesh-sdk` instead of the server-only `@/tools/connection/schema`, removing the `ban-web-server-imports` lint warning and avoiding potential server code in the web bundle. Aligns with `tool-set-selector.tsx`; no logic or runtime changes.

<sup>Written for commit b82abc926a49dab3f18f5b0461f4bf3a6f1a4301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

