### PR TITLE
refactor(file-explorer): dedupe file icon/color mapping into utils

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -3,12 +3,8 @@ import { useState, useRef } from "react";
 import Editor, { loader } from "@monaco-editor/react";
 import type { OnMount } from "@monaco-editor/react";
 import {
-  Brackets,
-  File02,
-  FileCode01,
   FilePlus01,
   FolderPlus,
-  Image01,
   Loading01,
   SearchSm,
   XClose,
@@ -46,6 +42,7 @@ import {
   flattenTree,
   getAncestorDirectories,
   getDirectoryContextPath,
+  getFileVisual,
   getLanguageFromPath,
   getParentTreePath,
   isSafeExplorerOpenPath,
@@ -85,43 +82,6 @@ function buildApiUrl(
   endpoint: string,
 ) {
   return `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/${endpoint}`;
-}
-
-type FileIcon = React.ComponentType<{
-  size?: number;
-  className?: string;
-  style?: React.CSSProperties;
-}>;
-
-/** Warm folder tone — reads well on both light and dark backgrounds. */
-const DEFAULT_FILE_COLOR = "#94a3b8";
-
-/**
- * Maps a filename to an icon + accent color by extension, so the tree reads at
- * a glance (blue for TS, amber for JSON, purple for images, …). Colors are
- * inline (not Tailwind scale tokens) and chosen to work in light and dark.
- */
-function getFileVisual(name: string): { Icon: FileIcon; color: string } {
-  const n = name.toLowerCase();
-  if (n.endsWith(".tsx") || n.endsWith(".ts"))
-    return { Icon: FileCode01, color: "#3b82f6" };
-  if (
-    n.endsWith(".jsx") ||
-    n.endsWith(".js") ||
-    n.endsWith(".mjs") ||
-    n.endsWith(".cjs")
-  )
-    return { Icon: FileCode01, color: "#d9a441" };
-  if (n.endsWith(".json")) return { Icon: Brackets, color: "#cb9b3f" };
-  if (n.endsWith(".css") || n.endsWith(".scss"))
-    return { Icon: FileCode01, color: "#06b6d4" };
-  if (n.endsWith(".html") || n.endsWith(".xml"))
-    return { Icon: FileCode01, color: "#f97316" };
-  if (/\.(png|jpe?g|gif|webp|avif|ico|svg)$/.test(n))
-    return { Icon: Image01, color: "#a855f7" };
-  if (n.endsWith(".md") || n.endsWith(".mdx"))
-    return { Icon: File02, color: "#64748b" };
-  return { Icon: File02, color: DEFAULT_FILE_COLOR };
 }
 
 export function FileExplorer({

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-tree-row.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-tree-row.tsx
@@ -13,12 +13,7 @@ import {
 } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.js";
 import type { TreeNode } from "./types";
-
-type FileIcon = React.ComponentType<{
-  size?: number;
-  className?: string;
-  style?: React.CSSProperties;
-}>;
+import type { FileIcon } from "./utils";
 
 const FOLDER_COLOR = "#d9a441";
 

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -1,3 +1,4 @@
+import { Brackets, File02, FileCode01, Image01 } from "@untitledui/icons";
 import type { FlatNode, TreeNode } from "./types";
 import { decoBlockKeyFromFileStem } from "@/web/components/sections-editor/deco-block-key";
 
@@ -168,6 +169,43 @@ export function getLanguageFromPath(filepath: string | null) {
   if (n.endsWith(".sh")) return "shell";
 
   return "plaintext";
+}
+
+export type FileIcon = React.ComponentType<{
+  size?: number;
+  className?: string;
+  style?: React.CSSProperties;
+}>;
+
+/** Warm folder tone — reads well on both light and dark backgrounds. */
+const DEFAULT_FILE_COLOR = "#94a3b8";
+
+/**
+ * Maps a filename to an icon + accent color by extension, so the tree reads at
+ * a glance (blue for TS, amber for JSON, purple for images, …). Colors are
+ * inline (not Tailwind scale tokens) and chosen to work in light and dark.
+ */
+export function getFileVisual(name: string): { Icon: FileIcon; color: string } {
+  const n = name.toLowerCase();
+  if (n.endsWith(".tsx") || n.endsWith(".ts"))
+    return { Icon: FileCode01, color: "#3b82f6" };
+  if (
+    n.endsWith(".jsx") ||
+    n.endsWith(".js") ||
+    n.endsWith(".mjs") ||
+    n.endsWith(".cjs")
+  )
+    return { Icon: FileCode01, color: "#d9a441" };
+  if (n.endsWith(".json")) return { Icon: Brackets, color: "#cb9b3f" };
+  if (n.endsWith(".css") || n.endsWith(".scss"))
+    return { Icon: FileCode01, color: "#06b6d4" };
+  if (n.endsWith(".html") || n.endsWith(".xml"))
+    return { Icon: FileCode01, color: "#f97316" };
+  if (/\.(png|jpe?g|gif|webp|avif|ico|svg)$/.test(n))
+    return { Icon: Image01, color: "#a855f7" };
+  if (n.endsWith(".md") || n.endsWith(".mdx"))
+    return { Icon: File02, color: "#64748b" };
+  return { Icon: File02, color: DEFAULT_FILE_COLOR };
 }
 
 export function getAncestorDirectories(filepath: string) {


### PR DESCRIPTION
Reduction/dedupe found while auditing the file-explorer (a recently-churned, largest-frontend-file candidate) — no open PR touches these three files.

`file-explorer.tsx` defined `getFileVisual()` plus a local `FileIcon` type and `DEFAULT_FILE_COLOR` const to map a filename to an icon + accent color. `file-tree-row.tsx` (the only consumer of the returned shape) redeclared the identical `FileIcon` type verbatim, purely to type its `fileVisual` prop — a real duplication with no shared home. `utils.ts` already has `getLanguageFromPath()`, doing the exact same extension-classification pattern, so the icon/color mapper belongs next to it.

Change: moved `getFileVisual`/`FileIcon`/`DEFAULT_FILE_COLOR` into `utils.ts` unchanged (byte-identical logic, just relocated + exported), `file-explorer.tsx` now imports `getFileVisual` from `./utils`, and `file-tree-row.tsx` imports the `FileIcon` type from `./utils` instead of redeclaring it. Net: -47 lines / +40 lines (net -7), one duplicate type definition eliminated. Pure move — no behavior change, verified by typecheck + the existing test file passing unchanged.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` (clean) and `bun test apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts` (14 pass, unchanged).

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in `apps/mesh`, and the single `utils.test.ts` file. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored file visual mapping by moving `getFileVisual`, `FileIcon`, and `DEFAULT_FILE_COLOR` into `utils.ts` next to `getLanguageFromPath`. No behavior change; just deduped logic.

- **Refactors**
  - Updated `file-explorer.tsx` and `file-tree-row.tsx` to import from `utils.ts`.
  - Removed a duplicate `FileIcon` type; net -7 LOC.

<sup>Written for commit 2b822a4813ed69b6be9e65551a524d0c05a1d590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

