### PR TITLE
refactor(content): extract SandboxStateRenderer into its own file

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -73,13 +73,9 @@ import {
   useSandboxStart,
   type SandboxStartArgs,
 } from "@/web/components/sandbox/hooks/use-sandbox-start";
-import { SandboxStateCard } from "@/web/components/sandbox/preview/state-card";
-import { derivePhaseProgress } from "@/web/components/sandbox/preview/derive-phase-progress";
-import {
-  computePreviewState,
-  type SandboxStartError,
-} from "@/web/components/sandbox/preview/preview-state";
+import { computePreviewState } from "@/web/components/sandbox/preview/preview-state";
 import { decodeSandboxStartError } from "@/shared/sandbox-start-errors";
+import { SandboxStateRenderer } from "./sandbox-state-renderer";
 import {
   buildDuplicatePage,
   buildEmptyPage,
@@ -2148,50 +2144,4 @@ function ItemList({
       </ScrollArea>
     </div>
   );
-}
-
-/**
- * Renders the SandboxStateCard variant that matches the current
- * sandbox state. Mirrors Preview's switch so Content shows the same
- * "Starting your sandbox" / "Sandbox is paused" cards. The daemon's
- * HTTP proxy serves every other "not live" case as auto-reloading
- * HTML through the iframe, so Content only needs these two overlays.
- */
-function SandboxStateRenderer({
-  state,
-  claimPhase,
-  lifecycle,
-  onStart,
-  connectionsHref,
-}: {
-  state:
-    | { kind: "starting" }
-    | { kind: "suspended" }
-    | { kind: "errored"; error: SandboxStartError };
-  claimPhase: ReturnType<typeof useSandboxEvents>["phase"];
-  lifecycle: ReturnType<typeof useSandboxEvents>["lifecycle"];
-  onStart: () => void;
-  connectionsHref?: string;
-}) {
-  switch (state.kind) {
-    case "starting":
-      return (
-        <SandboxStateCard
-          kind="starting"
-          progress={derivePhaseProgress({ claimPhase, lifecycle })}
-          claimPhase={claimPhase}
-        />
-      );
-    case "suspended":
-      return <SandboxStateCard kind="suspended" onResume={onStart} />;
-    case "errored":
-      return (
-        <SandboxStateCard
-          kind="errored"
-          error={state.error}
-          onRetry={onStart}
-          connectionsHref={connectionsHref}
-        />
-      );
-  }
 }

--- a/apps/mesh/src/web/components/sandbox/content/sandbox-state-renderer.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/sandbox-state-renderer.tsx
@@ -1,0 +1,50 @@
+import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events";
+import { SandboxStateCard } from "@/web/components/sandbox/preview/state-card";
+import { derivePhaseProgress } from "@/web/components/sandbox/preview/derive-phase-progress";
+import { type SandboxStartError } from "@/web/components/sandbox/preview/preview-state";
+
+/**
+ * Renders the SandboxStateCard variant that matches the current
+ * sandbox state. Mirrors Preview's switch so Content shows the same
+ * "Starting your sandbox" / "Sandbox is paused" cards. The daemon's
+ * HTTP proxy serves every other "not live" case as auto-reloading
+ * HTML through the iframe, so Content only needs these two overlays.
+ */
+export function SandboxStateRenderer({
+  state,
+  claimPhase,
+  lifecycle,
+  onStart,
+  connectionsHref,
+}: {
+  state:
+    | { kind: "starting" }
+    | { kind: "suspended" }
+    | { kind: "errored"; error: SandboxStartError };
+  claimPhase: ReturnType<typeof useSandboxEvents>["phase"];
+  lifecycle: ReturnType<typeof useSandboxEvents>["lifecycle"];
+  onStart: () => void;
+  connectionsHref?: string;
+}) {
+  switch (state.kind) {
+    case "starting":
+      return (
+        <SandboxStateCard
+          kind="starting"
+          progress={derivePhaseProgress({ claimPhase, lifecycle })}
+          claimPhase={claimPhase}
+        />
+      );
+    case "suspended":
+      return <SandboxStateCard kind="suspended" onResume={onStart} />;
+    case "errored":
+      return (
+        <SandboxStateCard
+          kind="errored"
+          error={state.error}
+          onRetry={onStart}
+          connectionsHref={connectionsHref}
+        />
+      );
+  }
+}


### PR DESCRIPTION
Continues the content-browser.tsx extraction series (#4848, #4847, #4845, #4843) — the file is still 2100+ lines and this is one more self-contained piece pulled out.

`SandboxStateRenderer` only reads its own props (`state`, `claimPhase`, `lifecycle`, `onStart`, `connectionsHref`) and renders the matching `SandboxStateCard` variant — it shares no closures or mutable state with the rest of `ContentBrowser`, so this is a byte-identical relocation plus the new import, not a rewrite.

Net diff: content-browser.tsx -52/+2 (removed the function, added an import), new file sandbox-state-renderer.tsx +50.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` — clean, confirms the moved component still type-checks against its now-explicit imports.

Locally ran: `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (clean, no changes needed). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `SandboxStateRenderer` into its own file to simplify `content-browser.tsx` and isolate sandbox state UI. Behavior is unchanged; this is a byte-identical move.

- **Refactors**
  - Added `apps/mesh/src/web/components/sandbox/content/sandbox-state-renderer.tsx` and moved the renderer logic and its imports.
  - Updated `content-browser.tsx` to import `SandboxStateRenderer` and removed the inline component.
  - Type checks pass; no runtime or UI changes.

<sup>Written for commit a876ffa0eb399dbe00ea1e4be5ddfb36e9deb5d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

