### PR TITLE
refactor(content): extract GroupHeader and section-grouping helper into its own file

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -128,6 +128,10 @@ import { SectionsRightPane } from "./sections-right-pane";
 import { PostFilterBar, PostSelectionToolbar } from "./post-toolbar";
 import { ItemActions } from "./item-actions";
 import { ItemRow } from "./item-row";
+import {
+  GroupHeader,
+  groupSavedSectionsByResolveType,
+} from "./section-group-header";
 import { useBlocksPreviewWorkspace } from "@/web/components/sandbox/blocks/blocks-preview-workspace-context";
 import type { BlocksTarget } from "@/web/components/sandbox/blocks/blocks-preview-workspace-state";
 
@@ -232,39 +236,6 @@ export interface AvailableSectionEntry {
   resolveType: string;
   title: string;
   description?: string;
-}
-
-interface SavedSectionGroup {
-  label: string;
-  sections: GlobalSectionEntry[];
-}
-
-/** Short label for a section's underlying component resolveType. */
-function sectionTypeLabel(resolveType: string): string {
-  return (
-    resolveType
-      .split("/")
-      .pop()
-      ?.replace(/\.tsx?$/, "") ||
-    resolveType ||
-    "Section"
-  );
-}
-
-/** Group saved sections by their underlying `resolveType`, sorted by label. */
-function groupSavedSectionsByResolveType(
-  sections: GlobalSectionEntry[],
-): SavedSectionGroup[] {
-  const byLabel = new Map<string, GlobalSectionEntry[]>();
-  for (const section of sections) {
-    const label = sectionTypeLabel(section.resolveType);
-    const bucket = byLabel.get(label);
-    if (bucket) bucket.push(section);
-    else byLabel.set(label, [section]);
-  }
-  return [...byLabel.entries()]
-    .map(([label, groupSections]) => ({ label, sections: groupSections }))
-    .sort((a, b) => a.label.localeCompare(b.label));
 }
 
 type PageDialogState = {
@@ -1515,33 +1486,6 @@ function ContentBrowserReady({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </div>
-  );
-}
-
-/**
- * Right pane for the Sections collection. A saved (global) section opens the
- * full section editor; an available (raw manifest) section opens a local
- * editor that persists only when named and saved.
- */
-function GroupHeader({
-  icon: Icon,
-  label,
-  className,
-}: {
-  icon: React.ComponentType<{ size?: number; className?: string }>;
-  label: string;
-  className?: string;
-}) {
-  return (
-    <div
-      className={cn(
-        "flex items-center gap-1.5 px-2.5 pb-1 pt-1 text-xs font-medium text-muted-foreground/70",
-        className,
-      )}
-    >
-      <Icon size={13} className="shrink-0" />
-      {label}
     </div>
   );
 }

--- a/apps/mesh/src/web/components/sandbox/content/section-group-header.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/section-group-header.tsx
@@ -1,0 +1,57 @@
+import { cn } from "@deco/ui/lib/utils.js";
+import type { GlobalSectionEntry } from "@/web/components/sections-editor/page-list";
+
+export interface SavedSectionGroup {
+  label: string;
+  sections: GlobalSectionEntry[];
+}
+
+/** Short label for a section's underlying component resolveType. */
+function sectionTypeLabel(resolveType: string): string {
+  return (
+    resolveType
+      .split("/")
+      .pop()
+      ?.replace(/\.tsx?$/, "") ||
+    resolveType ||
+    "Section"
+  );
+}
+
+/** Group saved sections by their underlying `resolveType`, sorted by label. */
+export function groupSavedSectionsByResolveType(
+  sections: GlobalSectionEntry[],
+): SavedSectionGroup[] {
+  const byLabel = new Map<string, GlobalSectionEntry[]>();
+  for (const section of sections) {
+    const label = sectionTypeLabel(section.resolveType);
+    const bucket = byLabel.get(label);
+    if (bucket) bucket.push(section);
+    else byLabel.set(label, [section]);
+  }
+  return [...byLabel.entries()]
+    .map(([label, groupSections]) => ({ label, sections: groupSections }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export function GroupHeader({
+  icon: Icon,
+  label,
+  className,
+}: {
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1.5 px-2.5 pb-1 pt-1 text-xs font-medium text-muted-foreground/70",
+        className,
+      )}
+    >
+      <Icon size={13} className="shrink-0" />
+      {label}
+    </div>
+  );
+}


### PR DESCRIPTION
**Source:** reduction/cleanup (C5) — `content-browser.tsx` is a 2198-line God component that's already had ~10 pieces extracted into their own files over recent PRs (#4803, #4824, #4825, #4829, #4840, #4843, #4845, #4847, #4848). `GroupHeader` (a tiny icon+label row used above the saved/available section groups) plus its `groupSavedSectionsByResolveType`/`sectionTypeLabel` grouping helpers were the next self-contained, props-only leftovers — no shared closures with the rest of the file.

**Why a maintainer wants it:** keeps chipping away at the file's size with the same low-risk, mechanical pattern the repo has already merged repeatedly; makes the section-grouping logic independently readable/testable outside the surrounding 2000+ lines.

**Change:** byte-identical move, not a rewrite — `GroupHeader`, `groupSavedSectionsByResolveType`, `sectionTypeLabel`, and the private `SavedSectionGroup` type moved verbatim into `apps/mesh/src/web/components/sandbox/content/section-group-header.tsx`; `content-browser.tsx` now imports `GroupHeader`/`groupSavedSectionsByResolveType` from there. Also dropped a stray, misattributed docblock ("Right pane for the Sections collection...") that was sitting directly above `GroupHeader` — leftover from an earlier extraction, describing neither this nor any remaining function. Net: -60/+61 in content-browser.tsx (one import block added), +57 in the new file.

**Verify:** `rg -n "GroupHeader|groupSavedSectionsByResolveType|sectionTypeLabel" apps/mesh/src/web` shows the only definitions/usages now live in `section-group-header.tsx` and its one caller in `content-browser.tsx` — no orphaned references.

**Local checks run:** `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (0 errors, both before and after). No behavior/logic changed, so no test file was added or needed — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `GroupHeader` and saved-section grouping helpers into `section-group-header.tsx` to shrink `content-browser.tsx` and make the grouping logic easier to read and test. No behavior change.

- **Refactors**
  - Moved `GroupHeader`, `groupSavedSectionsByResolveType`, `sectionTypeLabel`, and `SavedSectionGroup` into `apps/mesh/src/web/components/sandbox/content/section-group-header.tsx`.
  - Updated `content-browser.tsx` to import `GroupHeader` and `groupSavedSectionsByResolveType`.
  - Removed a stray, incorrect docblock above `GroupHeader`.

<sup>Written for commit c79f209bcd99150fae5ab9b0ea0c4530bbe1949b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

