### PR TITLE
refactor(home): dedupe home-tile metadata patch in add-tile drawer

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -738,6 +738,22 @@ function AgentToolList({
   );
 }
 
+/** Builds the agent metadata patch for a new set of home tiles. Shared by the
+ * pinned-tile remove/save flows and the add-tile flow. */
+function withHomeTiles(
+  agent: VirtualMCPEntity,
+  tiles: VirtualMcpHomeTile[],
+): VirtualMCPEntity["metadata"] {
+  return {
+    ...(agent.metadata ?? {}),
+    ui: {
+      ...(agent.metadata?.ui ?? {}),
+      homeTile: null,
+      homeTiles: tiles,
+    },
+  };
+}
+
 /** Coerces the form values against the tool's schema, toasting and returning
  * `undefined` on an invalid field. Shared by the pinned-tile save flow and the
  * add-tile flow — both build the same `toolInput` from the same form. */
@@ -786,15 +802,7 @@ function PinnedTileRow({
       const nextTiles = tile.tileId
         ? baseTiles.filter((t) => t.tileId !== tile.tileId)
         : baseTiles.filter((t) => t !== tile);
-      const nextMetadata = {
-        ...(agent.metadata ?? {}),
-        ui: {
-          ...(agent.metadata?.ui ?? {}),
-          homeTile: null,
-          homeTiles: nextTiles,
-        },
-      };
-      await home.saveAgentMetadata(agent, nextMetadata);
+      await home.saveAgentMetadata(agent, withHomeTiles(agent, nextTiles));
       setShowForm(false);
     } catch (err) {
       console.error("[home-tiles] failed to remove tile", err);
@@ -827,15 +835,7 @@ function PinnedTileRow({
           toolInput,
         };
       });
-      const nextMetadata = {
-        ...(agent.metadata ?? {}),
-        ui: {
-          ...(agent.metadata?.ui ?? {}),
-          homeTile: null,
-          homeTiles: nextTiles,
-        },
-      };
-      await home.saveAgentMetadata(agent, nextMetadata);
+      await home.saveAgentMetadata(agent, withHomeTiles(agent, nextTiles));
       setShowForm(false);
     } catch (err) {
       console.error("[home-tiles] failed to save tile", err);
@@ -982,15 +982,7 @@ function AddToolRow({
           ...(toolInput ? { toolInput } : {}),
         },
       ];
-      const nextMetadata = {
-        ...(agent.metadata ?? {}),
-        ui: {
-          ...(agent.metadata?.ui ?? {}),
-          homeTile: null,
-          homeTiles: nextTiles,
-        },
-      };
-      await home.saveAgentMetadata(agent, nextMetadata);
+      await home.saveAgentMetadata(agent, withHomeTiles(agent, nextTiles));
       setShowForm(false);
       setFormValues({});
     } catch (err) {


### PR DESCRIPTION
Source: C1 duplication reduction found while hunting recently-changed files (no open PR touches this file).

Why: `apps/mesh/src/web/components/home/add-tile-drawer.tsx` rebuilt the exact same `agent.metadata` patch (`ui: { ...ui, homeTile: null, homeTiles }`) inline in three separate handlers (pinned-tile remove, pinned-tile save, add-tile save). One `withHomeTiles(agent, tiles)` helper now backs all three, so a future change to the metadata shape only needs to happen once.

Net line delta: -27 / +19 (net -8, plus the new helper is shared so total call-site logic shrinks). Confirmed behavior-preserving: the helper is a byte-for-byte extraction of the object literal that was duplicated at each call site — same shape, same fields, same fallback (`agent.metadata ?? {}` / `agent.metadata?.ui ?? {}`), just parameterized by `tiles`.

How a reviewer confirms: read the diff — each of the three call sites now passes its already-computed `nextTiles` into `withHomeTiles(agent, nextTiles)` instead of building the object inline; the resulting metadata object is identical to before.

Checks run locally: `bun run fmt` (no changes needed) and `cd apps/mesh && bunx tsc --noEmit` (clean). No test file exists for this UI component (it's not unit-tested); full CI/e2e will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped the home-tile metadata patch in the add-tile drawer by introducing a shared `withHomeTiles(agent, tiles)` helper. This reduces repeated code and makes future metadata changes simpler, with no behavior change.

- **Refactors**
  - Added `withHomeTiles(agent, tiles)` to build the `agent.metadata.ui` patch with `homeTile: null` and `homeTiles`.
  - Updated pinned-tile remove/save and add-tile save flows to use the helper; same object shape and fallbacks preserved.

<sup>Written for commit 5876f98c7fb33839e4ed7bcd5f912707b8001407. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

