### PR TITLE
fix(home): reject Infinity/-Infinity strings in number tile fields

### DIFF
--- a/apps/mesh/src/web/components/home/tile-form-values.test.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.test.ts
@@ -42,6 +42,15 @@ describe("coerceFormValues", () => {
     });
   });
 
+  test("returns null on Infinity string for number field", () => {
+    expect(
+      coerceFormValues({ n: "Infinity" }, { n: { type: "number" } }),
+    ).toBeNull();
+    expect(
+      coerceFormValues({ n: "-Infinity" }, { n: { type: "number" } }),
+    ).toBeNull();
+  });
+
   test("drops empty values", () => {
     expect(coerceFormValues({ s: "" }, { s: { type: "string" } })).toEqual({});
   });

--- a/apps/mesh/src/web/components/home/tile-form-values.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.ts
@@ -24,7 +24,7 @@ export function coerceFormValues(
     ) {
       if (!raw.trim()) continue;
       const parsed = Number(raw);
-      if (Number.isNaN(parsed)) return null;
+      if (!Number.isFinite(parsed)) return null;
       if (type === "integer" && !Number.isInteger(parsed)) return null;
       out[key] = parsed;
     } else if (typeof raw === "string") {


### PR DESCRIPTION
Bug found while auditing `tile-form-values.ts` (recently churned by PR #4841-#4850, a series of fixes hardening this same file's numeric-field validation).

**Failure scenario:** `coerceFormValues` validates a "number"-type tile field with `Number.isNaN(parsed)` only. Typing the literal string `"Infinity"` (or `"-Infinity"`) into a number field passes validation and produces the JS value `Infinity`. That value is later persisted via `home.saveAgentMetadata`, which JSON-serializes the metadata — and `JSON.stringify({ n: Infinity })` silently collapses to `{"n":null}`. The user's input is silently dropped with no error shown, corrupting the saved tile config.

**Fix:** swap `Number.isNaN(parsed)` for `!Number.isFinite(parsed)`, so non-finite values are rejected the same way NaN already is (the "integer" type path was already safe, since `Number.isInteger(Infinity)` is `false`).

**Regression test:** added `returns null on Infinity string for number field` in `tile-form-values.test.ts` — fails on current code (returns `{ n: Infinity }`), passes after the fix (returns `null`).

**To verify:** `bun test apps/mesh/src/web/components/home/tile-form-values.test.ts`

**Checked locally:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and the targeted test file above all pass. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where "Infinity" and "-Infinity" were accepted in number tile fields and later saved as null, corrupting the tile config. Non-finite numbers are now rejected during form coercion.

- Bug Fixes
  - Use `!Number.isFinite(parsed)` in `coerceFormValues` for number fields; integer validation unchanged.
  - Added regression test: returns null on Infinity/-Infinity input for number fields.

<sup>Written for commit 42e12917c2a081ea1faa6b218596534c37ea3f24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

