### PR TITLE
refactor(home): dedupe home-tile mutation error handling in add-tile drawer

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -754,6 +754,17 @@ function withHomeTiles(
   };
 }
 
+/** Runs a home-tile mutation, logging and toasting on failure. Shared by the
+ * pinned-tile remove/save flows and the add-tile flow. */
+async function runHomeTileAction(action: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+  } catch (err) {
+    console.error(`[home-tiles] failed to ${action} tile`, err);
+    toast.error("Couldn't update home — please try again.");
+  }
+}
+
 /** Coerces the form values against the tool's schema, toasting and returning
  * `undefined` on an invalid field. Shared by the pinned-tile save flow and the
  * add-tile flow — both build the same `toolInput` from the same form. */
@@ -797,35 +808,28 @@ function PinnedTileRow({
 
   const handleRemove = async () => {
     setSubmitting(true);
-    try {
+    await runHomeTileAction("remove", async () => {
       const baseTiles = getHomeTiles(agent.metadata?.ui);
       const nextTiles = tile.tileId
         ? baseTiles.filter((t) => t.tileId !== tile.tileId)
         : baseTiles.filter((t) => t !== tile);
       await home.saveAgentMetadata(agent, withHomeTiles(agent, nextTiles));
       setShowForm(false);
-    } catch (err) {
-      console.error("[home-tiles] failed to remove tile", err);
-      toast.error("Couldn't update home — please try again.");
-    } finally {
-      setSubmitting(false);
-    }
+    });
+    setSubmitting(false);
   };
 
   const handleSave = async () => {
-    setSubmitting(true);
-    try {
-      const resolved = resolveToolInput(
-        formValues,
-        tool.inputSchema?.properties,
-        tool.inputSchema?.required,
-      );
-      if (!resolved) {
-        setSubmitting(false);
-        return;
-      }
-      const { toolInput } = resolved;
+    const resolved = resolveToolInput(
+      formValues,
+      tool.inputSchema?.properties,
+      tool.inputSchema?.required,
+    );
+    if (!resolved) return;
+    const { toolInput } = resolved;
 
+    setSubmitting(true);
+    await runHomeTileAction("save", async () => {
       const baseTiles = getHomeTiles(agent.metadata?.ui);
       const nextTiles = baseTiles.map((t) => {
         const isMatch = tile.tileId ? t.tileId === tile.tileId : t === tile;
@@ -837,12 +841,8 @@ function PinnedTileRow({
       });
       await home.saveAgentMetadata(agent, withHomeTiles(agent, nextTiles));
       setShowForm(false);
-    } catch (err) {
-      console.error("[home-tiles] failed to save tile", err);
-      toast.error("Couldn't update home — please try again.");
-    } finally {
-      setSubmitting(false);
-    }
+    });
+    setSubmitting(false);
   };
 
   const summary = toolInputSummary(tile.toolInput);
@@ -958,19 +958,16 @@ function AddToolRow({
   };
 
   const saveTile = async () => {
-    setSubmitting(true);
-    try {
-      const resolved = resolveToolInput(
-        formValues,
-        tool.inputSchema?.properties,
-        tool.inputSchema?.required,
-      );
-      if (!resolved) {
-        setSubmitting(false);
-        return;
-      }
-      const { toolInput } = resolved;
+    const resolved = resolveToolInput(
+      formValues,
+      tool.inputSchema?.properties,
+      tool.inputSchema?.required,
+    );
+    if (!resolved) return;
+    const { toolInput } = resolved;
 
+    setSubmitting(true);
+    await runHomeTileAction("add", async () => {
       const baseTiles = getHomeTiles(agent.metadata?.ui);
       const nextTiles = [
         ...baseTiles,
@@ -985,12 +982,8 @@ function AddToolRow({
       await home.saveAgentMetadata(agent, withHomeTiles(agent, nextTiles));
       setShowForm(false);
       setFormValues({});
-    } catch (err) {
-      console.error("[home-tiles] failed to add tile", err);
-      toast.error("Couldn't update home — please try again.");
-    } finally {
-      setSubmitting(false);
-    }
+    });
+    setSubmitting(false);
   };
 
   return (


### PR DESCRIPTION
Source: reduction (C1) — `PinnedTileRow`'s remove/save handlers and `AddToolRow`'s save handler each had an identical try/catch/finally block (same log-and-toast shape, only the action verb differed).

Why a maintainer wants it: same shape this file has already been deduped in twice this week (#4856, #4849) — one more copy of this pattern was left over, and each copy is a place a future edit to the error-handling behavior would need to be repeated three times.

Change: extracted a `runHomeTileAction(action, fn)` helper that runs `fn`, logging `[home-tiles] failed to ${action} tile` and toasting the same message on failure — used by all three handlers. Behavior-preserving: same try/catch/finally semantics, same log format, same toast copy. Net -7 lines (36 additions / 43 deletions in one file).

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` (green). No existing test covers this file's handlers (pure UI mutation flow, not a trust boundary), so no test changes.

Local checks run: `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates home‑tile mutation error handling by introducing a shared helper used in add/save/remove flows. Behavior and user messages are unchanged; code is simpler and smaller.

- Refactors
  - Added `runHomeTileAction(action, fn)` to log "[home-tiles] failed to ${action} tile" and toast on failure.
  - Replaced duplicate try/catch blocks in `PinnedTileRow` remove/save and `AddToolRow` save. Net −7 lines.

<sup>Written for commit 6093d4bf1d0b09b327bc7f3d202cde3bcff23db3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

