### PR TITLE
fix(home): validate numeric (non-string) Infinity/NaN toolInput values

### DIFF
--- a/apps/mesh/src/web/components/home/tile-form-values.test.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.test.ts
@@ -51,6 +51,15 @@ describe("coerceFormValues", () => {
     ).toBeNull();
   });
 
+  test("returns null on a raw (non-string) Infinity/NaN for number field", () => {
+    // seedFormValues passes numeric toolInput values through unstringified,
+    // so an untouched field can reach coerceFormValues as a real number.
+    expect(
+      coerceFormValues({ n: Infinity }, { n: { type: "number" } }),
+    ).toBeNull();
+    expect(coerceFormValues({ n: NaN }, { n: { type: "number" } })).toBeNull();
+  });
+
   test("drops empty values", () => {
     expect(coerceFormValues({ s: "" }, { s: { type: "string" } })).toEqual({});
   });

--- a/apps/mesh/src/web/components/home/tile-form-values.ts
+++ b/apps/mesh/src/web/components/home/tile-form-values.ts
@@ -20,10 +20,10 @@ export function coerceFormValues(
       }
     } else if (
       (type === "number" || type === "integer") &&
-      typeof raw === "string"
+      (typeof raw === "string" || typeof raw === "number")
     ) {
-      if (!raw.trim()) continue;
-      const parsed = Number(raw);
+      if (typeof raw === "string" && !raw.trim()) continue;
+      const parsed = typeof raw === "string" ? Number(raw) : raw;
       if (!Number.isFinite(parsed)) return null;
       if (type === "integer" && !Number.isInteger(parsed)) return null;
       out[key] = parsed;


### PR DESCRIPTION
Follows #4857 — that PR fixed `coerceFormValues` rejecting `"Infinity"`/`"-Infinity"` strings typed into a number tile field, but only checked the `typeof raw === "string"` branch.

**Gap:** `seedFormValues` (same file) does not stringify `number`/`integer` fields — only `object`/`array`. So when a pinned tile's persisted `toolInput` already contains a raw JS `Infinity`/`NaN` for a number field (e.g. a stale value from before #4857, or a hand-edited config) and the user re-saves the drawer without touching that specific field, `formValues[key]` is the actual number, not a string. It skips both the object/array and the number/string branches entirely and falls into the untyped passthrough (`else if (raw != null) out[key] = raw`), silently re-persisting the invalid value — the exact bug #4857 was meant to close, just reached via a different path.

**Fix:** the number/integer branch in `coerceFormValues` now also accepts `typeof raw === "number"` and runs the same `Number.isFinite`/integer checks against it.

**Regression test:** added `coerceFormValues({ n: Infinity/NaN }, { n: { type: "number" } })` returns `null` — fails on current `main`, passes after the fix.

Reviewer check: `bun test apps/mesh/src/web/components/home/tile-form-values.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in `apps/mesh`, and the single targeted test file above (19 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where numeric `Infinity`/`NaN` `toolInput` values could be re-saved when passed as numbers instead of strings. `coerceFormValues` now validates both string and number inputs for number/integer fields to block invalid values.

- **Bug Fixes**
  - Updated numeric branch to accept `number` and apply `Number.isFinite` and integer checks; still skips empty strings.
  - Added regression tests ensuring raw `Infinity`/`NaN` returns `null`.

<sup>Written for commit 08b8a84b4228a2f6ee5bec159209bf8fd871865b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

