### PR TITLE
refactor(connections): dedupe group-toggle-selection logic in ConnectionGroupCard

### DIFF
--- a/apps/mesh/src/web/routes/orgs/connection-selection-ui.tsx
+++ b/apps/mesh/src/web/routes/orgs/connection-selection-ui.tsx
@@ -55,6 +55,18 @@ export function ConnectionGroupCard({
   const allSelected = group.connections.every((c) => selectedIds.has(c.id));
   const someSelected = group.connections.some((c) => selectedIds.has(c.id));
 
+  // Selecting the group toggles every connection to match: all-off -> all-on,
+  // otherwise all-on -> all-off.
+  const toggleGroupSelection = () => {
+    for (const c of group.connections) {
+      if (allSelected) {
+        if (selectedIds.has(c.id)) onToggleSelect(c.id);
+      } else {
+        if (!selectedIds.has(c.id)) onToggleSelect(c.id);
+      }
+    }
+  };
+
   return (
     <>
       <ConnectionCard
@@ -63,19 +75,7 @@ export function ConnectionGroupCard({
           icon: group.icon,
           description: `${group.connections.length} instances`,
         }}
-        onClick={() =>
-          selectionMode
-            ? (() => {
-                for (const c of group.connections) {
-                  if (allSelected) {
-                    if (selectedIds.has(c.id)) onToggleSelect(c.id);
-                  } else {
-                    if (!selectedIds.has(c.id)) onToggleSelect(c.id);
-                  }
-                }
-              })()
-            : onOpen()
-        }
+        onClick={() => (selectionMode ? toggleGroupSelection() : onOpen())}
         className={cn(
           selectionMode && allSelected && "ring-2 ring-primary",
           selectionMode &&
@@ -92,15 +92,7 @@ export function ConnectionGroupCard({
                 checked={
                   allSelected ? true : someSelected ? "indeterminate" : false
                 }
-                onCheckedChange={() => {
-                  for (const c of group.connections) {
-                    if (allSelected) {
-                      if (selectedIds.has(c.id)) onToggleSelect(c.id);
-                    } else {
-                      if (!selectedIds.has(c.id)) onToggleSelect(c.id);
-                    }
-                  }
-                }}
+                onCheckedChange={toggleGroupSelection}
               />
             ) : (
               <div className="flex items-center gap-1">


### PR DESCRIPTION
**Source:** reduction (C1) — found while scanning recently-touched files in `apps/mesh/src/web/routes/orgs/` (this component was extracted in #4832/#4851).

**Why:** `ConnectionGroupCard`'s card `onClick` and its selection checkbox's `onCheckedChange` each carried an identical 8-line loop toggling every connection in the group to match the group's selection state. Collapsing it into one `toggleGroupSelection()` closure removes the duplication and the awkward IIFE in the `onClick` handler.

**Net line delta:** -8 (36 changed: +14/-22). Behavior-preserving — the extracted function is a byte-identical copy of the loop body, just called from both sites instead of pasted twice; no types or props changed.

**Reviewer check:** `cd apps/mesh && bunx tsc --noEmit` (clean), and visually diff the two call sites against the extracted `toggleGroupSelection` to confirm the logic is unchanged.

**Local verification:** `bun run fmt` (no changes) and `bunx tsc --noEmit` in `apps/mesh` (clean). No test file covers this UI-only interaction component; full CI runs the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `ConnectionGroupCard` to use a single `toggleGroupSelection()` for group selection. Both the card click and the checkbox now call it; behavior is unchanged and the code is smaller.

<sup>Written for commit 6875e736a9789c877e0719a367ed4f1e11ebd449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

