### PR TITLE
refactor(sandbox): dedupe exec-and-toast logic in preview drawer

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/drawer/drawer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/drawer/drawer.tsx
@@ -92,10 +92,7 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
     );
   };
 
-  const handleAddScript = async (name: string) => {
-    setScriptTabs((prev) => (prev.includes(name) ? prev : [...prev, name]));
-    setActive(name);
-    props.onOpenChange(true);
+  const runExec = async (name: string, failureMessage: string) => {
     try {
       const res = await execScript(name);
       // res === null means missing virtualMcpId/branch — programming error,
@@ -103,8 +100,15 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
       if (res === null) return;
       if (!res.ok) throw new Error(`Exec failed: ${res.statusText}`);
     } catch {
-      toast.error("Failed to run " + name);
+      toast.error(failureMessage);
     }
+  };
+
+  const handleAddScript = async (name: string) => {
+    setScriptTabs((prev) => (prev.includes(name) ? prev : [...prev, name]));
+    setActive(name);
+    props.onOpenChange(true);
+    await runExec(name, "Failed to run " + name);
   };
 
   // × on a script tab: kill the process AND drop the tab. Active tab
@@ -120,15 +124,10 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
   // daemon's task-manager replaces the existing task with the same logName.
   const handleRunActive = async () => {
     const wasRunning = vmEvents.activeProcesses.includes(active);
-    try {
-      const res = await execScript(active);
-      if (res === null) return;
-      if (!res.ok) throw new Error(`Exec failed: ${res.statusText}`);
-    } catch {
-      toast.error(
-        (wasRunning ? "Failed to restart " : "Failed to run ") + active,
-      );
-    }
+    await runExec(
+      active,
+      (wasRunning ? "Failed to restart " : "Failed to run ") + active,
+    );
   };
 
   // Per-script Stop on the active tab. Marks the script as killing so the


### PR DESCRIPTION
Source: C1 reduction found while sweeping for duplicated fetch/error-handling shapes (see CLAUDE.md's `apps/mesh/src/web` fetch-dedup note).

`handleAddScript` and `handleRunActive` in `drawer.tsx` each ran the identical sequence — call `execScript`, treat a `null` result as a silent no-op, throw on `!res.ok`, and toast on any failure — differing only in the toast message. Extracted the shared logic into a local `runExec(name, failureMessage)` helper; both call sites now delegate to it.

Net: -14 / +13 lines, same file. Behavior is unchanged — same fetch call, same null/ok checks, same error message per call site (verified by diff: the only change is where the try/catch lives).

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` (clean). No test file exists for this component (no RTL harness for it), so the `rg`-confirmed byte-identical logic move plus a green typecheck is the verification; full CI covers the rest.

Local checks run: `bun run fmt` (no changes needed) and `bunx tsc --noEmit` in `apps/mesh` (clean).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated exec-and-toast logic in the preview drawer by extracting a shared runExec(name, failureMessage) helper. Behavior is unchanged: same exec call, same null/ok checks, and the same toast messages for both add and run actions.

<sup>Written for commit 7fe4be889e49fd07cabb320d06e74f9461eeebc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

