### PR TITLE
refactor(automations): dedupe cron-trigger replace logic in TriggerCard

### DIFF
--- a/apps/mesh/src/web/components/automations/trigger-card.tsx
+++ b/apps/mesh/src/web/components/automations/trigger-card.tsx
@@ -84,6 +84,20 @@ export function TriggerCard({
     setConfirmDelete(false);
   };
 
+  // Cron triggers have no update endpoint: a new schedule is added, then the
+  // old trigger row is removed.
+  const replaceCronTrigger = async (cronExpression: string) => {
+    await addTrigger.mutateAsync({
+      automation_id: automationId,
+      type: "cron",
+      cron_expression: cronExpression,
+    });
+    await removeTrigger.mutateAsync({
+      trigger_id: trigger.id,
+      automation_id: automationId,
+    });
+  };
+
   const handleEditSave = async () => {
     const val = editValue.trim();
     if (!val || !isValidCron(val) || val === trigger.cron_expression) {
@@ -92,15 +106,7 @@ export function TriggerCard({
       return;
     }
     try {
-      await addTrigger.mutateAsync({
-        automation_id: automationId,
-        type: "cron",
-        cron_expression: val,
-      });
-      await removeTrigger.mutateAsync({
-        trigger_id: trigger.id,
-        automation_id: automationId,
-      });
+      await replaceCronTrigger(val);
       setIsEditing(false);
     } catch {
       toast.error("Failed to update starter");
@@ -132,15 +138,7 @@ export function TriggerCard({
     const newCron = buildCronFromInterval(clamped, interval.unit);
     if (newCron === trigger.cron_expression) return;
     try {
-      await addTrigger.mutateAsync({
-        automation_id: automationId,
-        type: "cron",
-        cron_expression: newCron,
-      });
-      await removeTrigger.mutateAsync({
-        trigger_id: trigger.id,
-        automation_id: automationId,
-      });
+      await replaceCronTrigger(newCron);
     } catch {
       toast.error("Failed to update starter");
       setCount(interval.count);


### PR DESCRIPTION
Source: reduction — no update endpoint exists for cron triggers, so `TriggerCard`'s `handleEditSave` (manual cron edit) and `handleCountSave` (interval-picker edit) each duplicated the identical add-then-remove-trigger sequence used to swap a schedule.

A maintainer wants this because it's the same duplication shape already collapsed in the two most recently merged PRs in this area (#4860 dedupe in ConnectionGroupCard, #4861 dedupe in PreviewDrawer) — one bug fix to the replace flow now only needs to happen in one place instead of two.

Behavior-preserving: `replaceCronTrigger(cronExpression)` is a byte-identical extraction of the two `mutateAsync` calls (same args, same order), each call site's own try/catch, toast message, and local-state rollback (`setEditValue`/`setCount`) are untouched. Net diff: +16/-18 lines, no logic added or removed.

To confirm: read `apps/mesh/src/web/components/automations/trigger-card.tsx` — `handleEditSave` and `handleCountSave` now both call the shared `replaceCronTrigger` helper instead of repeating the two mutations inline.

Locally verified: `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (no errors). No existing test file covers this component; full CI runs the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the cron schedule replace flow in `TriggerCard` by extracting a shared `replaceCronTrigger()` helper used by manual edits and the interval picker. Behavior is unchanged and future fixes now live in one place.

- **Refactors**
  - Added `replaceCronTrigger(cronExpression)` to add new cron trigger then remove the old one.
  - Updated `handleEditSave` and `handleCountSave` to call the helper; existing toasts and local state handling remain the same.

<sup>Written for commit 9136e4c489ef0488a40fbcaea66d282d20fe0e03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

