### PR TITLE
refactor(connections): dedupe header-actions dropdown toggle markup

### DIFF
--- a/apps/mesh/src/web/routes/orgs/connection-selection-ui.tsx
+++ b/apps/mesh/src/web/routes/orgs/connection-selection-ui.tsx
@@ -32,8 +32,48 @@ import {
   Trash01,
   XClose,
 } from "@untitledui/icons";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { type ConnectionGroup } from "@/shared/utils/group-connections";
+
+// ---------------------------------------------------------------------------
+// Shared dropdown-menu toggle: hidden until selection mode or row hover,
+// used by both the grouped and single-connection card header actions.
+// ---------------------------------------------------------------------------
+
+function HeaderActionsMenu({
+  selectionMode,
+  children,
+}: {
+  selectionMode: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "overflow-hidden transition-all duration-150 ease-out",
+        selectionMode
+          ? "w-8 opacity-100"
+          : "w-0 opacity-0 group-hover:w-8 group-hover:opacity-100",
+      )}
+    >
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 w-8 p-0"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <DotsVertical size={20} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+          {children}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Grouped card: collapsible row for connections sharing the same app_name
@@ -104,41 +144,17 @@ export function ConnectionGroupCard({
                 </span>
               </div>
             )}
-            <div
-              className={cn(
-                "overflow-hidden transition-all duration-150 ease-out",
-                selectionMode
-                  ? "w-8 opacity-100"
-                  : "w-0 opacity-0 group-hover:w-8 group-hover:opacity-100",
-              )}
-            >
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 p-0"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <DotsVertical size={20} />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  align="end"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onOpen();
-                    }}
-                  >
-                    <Eye size={16} />
-                    Open
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
+            <HeaderActionsMenu selectionMode={selectionMode}>
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpen();
+                }}
+              >
+                <Eye size={16} />
+                Open
+              </DropdownMenuItem>
+            </HeaderActionsMenu>
           </div>
         }
       />
@@ -185,83 +201,62 @@ export function ConnectionCardHeaderActions({
           Connected
         </span>
       )}
-      <div
-        className={cn(
-          "overflow-hidden transition-all duration-150 ease-out",
-          selectionMode
-            ? "w-8 opacity-100"
-            : "w-0 opacity-0 group-hover:w-8 group-hover:opacity-100",
+      <HeaderActionsMenu selectionMode={selectionMode}>
+        <DropdownMenuItem
+          onClick={(e) => {
+            e.stopPropagation();
+            onOpen();
+          }}
+        >
+          <Eye size={16} />
+          Open
+        </DropdownMenuItem>
+        {(canManage || canManageAgents) && (
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleSelect();
+            }}
+          >
+            <CheckSquare size={16} />
+            Select
+          </DropdownMenuItem>
         )}
-      >
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 w-8 p-0"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <DotsVertical size={20} />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+        {canManage &&
+          (connection.status === "active" ? (
             <DropdownMenuItem
               onClick={(e) => {
                 e.stopPropagation();
-                onOpen();
+                onToggleStatus("inactive");
               }}
             >
-              <Eye size={16} />
-              Open
+              <SlashCircle01 size={16} />
+              Disable
             </DropdownMenuItem>
-            {(canManage || canManageAgents) && (
-              <DropdownMenuItem
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onToggleSelect();
-                }}
-              >
-                <CheckSquare size={16} />
-                Select
-              </DropdownMenuItem>
-            )}
-            {canManage &&
-              (connection.status === "active" ? (
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onToggleStatus("inactive");
-                  }}
-                >
-                  <SlashCircle01 size={16} />
-                  Disable
-                </DropdownMenuItem>
-              ) : (
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onToggleStatus("active");
-                  }}
-                >
-                  <Power01 size={16} />
-                  Enable
-                </DropdownMenuItem>
-              ))}
-            {canManage && (
-              <DropdownMenuItem
-                variant="destructive"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDelete();
-                }}
-              >
-                <Trash01 size={16} />
-                Delete
-              </DropdownMenuItem>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+          ) : (
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleStatus("active");
+              }}
+            >
+              <Power01 size={16} />
+              Enable
+            </DropdownMenuItem>
+          ))}
+        {canManage && (
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+          >
+            <Trash01 size={16} />
+            Delete
+          </DropdownMenuItem>
+        )}
+      </HeaderActionsMenu>
     </div>
   );
 }


### PR DESCRIPTION
Source: reduction — duplication found while auditing `connection-selection-ui.tsx` (recently-changed file, high churn from prior connections-page dedup PRs #4860/#4851/#4836/#4832).

`ConnectionGroupCard` and `ConnectionCardHeaderActions` (same file) each hand-rolled an identical hide-until-selection-mode-or-hover dropdown wrapper: same `cn("overflow-hidden transition-all duration-150 ease-out", ...)` className, same `DropdownMenu`/`DropdownMenuTrigger`/ghost `Button`/`DotsVertical` structure, same `stopPropagation` handlers on trigger and content. Only the menu items inside differed. Extracted the shared shell into a local `HeaderActionsMenu({ selectionMode, children })` component and had both call sites pass their existing `DropdownMenuItem`s as children.

Net line delta: -105 / +100 (net -5, plus removal of the duplicated block). Behavior is unchanged — this is a byte-for-byte relocation of the wrapper JSX into one shared component; no className, prop, or handler was altered, confirmed by re-reading the diff line-by-line.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` (clean), and open the Connections page in selection mode / hover a card to confirm the dropdown toggle still animates and each menu (group vs single-connection) still shows its correct items.

Local verification: `bun run fmt` (no changes needed) and `bunx tsc --noEmit` in `apps/mesh` — both clean. No test file covers this pure-JSX component, so full CI will validate the rest (lint, build).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated the header-actions dropdown wrapper by extracting a shared `HeaderActionsMenu` in `connection-selection-ui.tsx`. This removes duplicate markup while keeping the hover/selection-mode behavior unchanged.

- **Refactors**
  - Extracted `HeaderActionsMenu` and replaced duplicate wrappers in `ConnectionGroupCard` and `ConnectionCardHeaderActions`.
  - No prop/class/handler changes; menu items and animations remain the same.

<sup>Written for commit 3334b60e40c71a163df73b6b5b5176f8ff15a53c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

