### PR TITLE
refactor(home): dedupe tile config-form footer in add-tile drawer

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -782,6 +782,62 @@ function resolveToolInput(
   return Object.keys(coerced).length > 0 ? { toolInput: coerced } : {};
 }
 
+/** Shared config-form footer for a tile's tool-input schema — used by both
+ * the pinned-tile edit flow and the add-tile flow, which only differ in the
+ * cancel behavior and the submit button's label/handler. */
+function TileConfigForm({
+  properties,
+  required,
+  values,
+  onChange,
+  onCancel,
+  onSubmit,
+  submitting,
+  submitLabel,
+}: {
+  properties: Record<string, ToolInputProperty>;
+  required?: string[];
+  values: Record<string, unknown>;
+  onChange: (key: string, value: unknown) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+  submitting: boolean;
+  submitLabel: string;
+}) {
+  return (
+    <div className="px-3 pb-2 pt-1 flex flex-col gap-2">
+      <ToolInputForm
+        properties={properties}
+        required={required}
+        values={values}
+        onChange={onChange}
+      />
+      <div className="flex items-center gap-2 justify-end">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 text-xs"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          className="h-7 text-xs"
+          disabled={submitting}
+          onClick={onSubmit}
+        >
+          {submitting ? (
+            <Loading01 size={12} className="animate-spin" />
+          ) : (
+            submitLabel
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 /** Row for a pinned tile instance — shows a summary, gear to edit, minus to remove. */
 function PinnedTileRow({
   agent,
@@ -884,38 +940,18 @@ function PinnedTileRow({
         />
       </div>
       {showForm && hasProps && tool.inputSchema?.properties && (
-        <div className="px-3 pb-2 pt-1 flex flex-col gap-2">
-          <ToolInputForm
-            properties={tool.inputSchema.properties}
-            required={tool.inputSchema.required}
-            values={formValues}
-            onChange={(key, value) =>
-              setFormValues((prev) => ({ ...prev, [key]: value }))
-            }
-          />
-          <div className="flex items-center gap-2 justify-end">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 text-xs"
-              onClick={() => setShowForm(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              size="sm"
-              className="h-7 text-xs"
-              disabled={submitting}
-              onClick={handleSave}
-            >
-              {submitting ? (
-                <Loading01 size={12} className="animate-spin" />
-              ) : (
-                "Save"
-              )}
-            </Button>
-          </div>
-        </div>
+        <TileConfigForm
+          properties={tool.inputSchema.properties}
+          required={tool.inputSchema.required}
+          values={formValues}
+          onChange={(key, value) =>
+            setFormValues((prev) => ({ ...prev, [key]: value }))
+          }
+          onCancel={() => setShowForm(false)}
+          onSubmit={handleSave}
+          submitting={submitting}
+          submitLabel="Save"
+        />
       )}
     </div>
   );
@@ -1005,41 +1041,21 @@ function AddToolRow({
         />
       </div>
       {showForm && hasProps && tool.inputSchema?.properties && (
-        <div className="px-3 pb-2 pt-1 flex flex-col gap-2">
-          <ToolInputForm
-            properties={tool.inputSchema.properties}
-            required={tool.inputSchema.required}
-            values={formValues}
-            onChange={(key, value) =>
-              setFormValues((prev) => ({ ...prev, [key]: value }))
-            }
-          />
-          <div className="flex items-center gap-2 justify-end">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 text-xs"
-              onClick={() => {
-                setShowForm(false);
-                setFormValues({});
-              }}
-            >
-              Cancel
-            </Button>
-            <Button
-              size="sm"
-              className="h-7 text-xs"
-              disabled={submitting}
-              onClick={saveTile}
-            >
-              {submitting ? (
-                <Loading01 size={12} className="animate-spin" />
-              ) : (
-                "Pin"
-              )}
-            </Button>
-          </div>
-        </div>
+        <TileConfigForm
+          properties={tool.inputSchema.properties}
+          required={tool.inputSchema.required}
+          values={formValues}
+          onChange={(key, value) =>
+            setFormValues((prev) => ({ ...prev, [key]: value }))
+          }
+          onCancel={() => {
+            setShowForm(false);
+            setFormValues({});
+          }}
+          onSubmit={saveTile}
+          submitting={submitting}
+          submitLabel="Pin"
+        />
       )}
     </div>
   );


### PR DESCRIPTION
**Source:** reduction/dedupe — no issue, follows the same in-file extraction pattern as #4862 (TriggerCard cron-replace dedupe).

**Why:** `PinnedTileRow` and `AddToolRow` in `add-tile-drawer.tsx` each rendered an identical `ToolInputForm` + Cancel/Submit footer block (same wrapper divs, same button classes, same loading-spinner logic), differing only in the cancel behavior and the submit button's label/handler. Any future tweak to that footer (styling, a11y, a new button) had to be applied twice and could silently drift out of sync.

**Change:** Extracted the duplicated block into a shared `TileConfigForm` component (properties/required/values/onChange/onCancel/onSubmit/submitting/submitLabel props) and call it from both rows. Behavior-preserving — same JSX, same class names, same handlers, just parameterized. Net: -83 removed duplicate lines / +67 for the new shared component and callers (net diff +16 lines, but the duplicate 35-line block is now a single definition).

**Verification:** `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (passes). No existing test file covers this component (not covered by unit or e2e tests currently), so there's no regression test to update — this is a pure structural move with identical JSX output, not a behavior change.

**Reviewer check:** `cd apps/mesh && bunx tsc --noEmit` should stay clean; diff the two call sites against the old blocks to confirm identical markup/handlers modulo the extracted props.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the tile config form/footer in the Add Tile drawer. Extracts a shared `TileConfigForm` used by both pinned-tile edit and add-tile flows, preserving behavior and styling.

- **Refactors**
  - Extracts duplicated `ToolInputForm` + Cancel/Submit footer into `TileConfigForm`.
  - Replaces blocks in `PinnedTileRow` and `AddToolRow`; cancel/submit passed via props (`onCancel`, `onSubmit`, `submitLabel`).
  - No UI or behavior changes.

<sup>Written for commit 88dc9bd9d221d58fcb1a418cf642a16d285dee01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

