### PR TITLE
refactor(thread-connection): replace as any casts with typed tool-part narrowing

### DIFF
--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -208,37 +208,43 @@ function applyLocally(
   return null;
 }
 
+type ToolLikePart = Extract<UIMessage["parts"][number], { toolCallId: string }>;
+
+function isToolLikePart(
+  part: UIMessage["parts"][number],
+): part is ToolLikePart {
+  return part.type === "dynamic-tool" || part.type.startsWith("tool-");
+}
+
 function findTargetPartIndex(
   parts: UIMessage["parts"],
   action: Exclude<SubmitAction, { kind: "message" }>,
 ): number {
   if (action.kind === "toolOutput") {
     return parts.findIndex(
-      // biome-ignore lint/suspicious/noExplicitAny: heterogeneous AI SDK part union
-      (p) => (p as any)?.toolCallId === action.toolCallId,
+      (p) => isToolLikePart(p) && p.toolCallId === action.toolCallId,
     );
   }
-  return parts.findIndex((p) => {
-    // biome-ignore lint/suspicious/noExplicitAny: heterogeneous AI SDK part union
-    const x = p as any;
-    return (
-      x?.state === "approval-requested" && x?.approval?.id === action.approvalId
-    );
-  });
+  return parts.findIndex(
+    (p) =>
+      isToolLikePart(p) &&
+      p.state === "approval-requested" &&
+      p.approval?.id === action.approvalId,
+  );
 }
 
 function patchPart(
   part: UIMessage["parts"][number],
   action: Exclude<SubmitAction, { kind: "message" }>,
 ): UIMessage["parts"][number] | null {
+  if (!isToolLikePart(part)) return null;
   if (action.kind === "toolOutput") {
     return {
       ...part,
       state: action.state ?? "output-available",
       output: action.output,
       errorText: action.errorText,
-      // biome-ignore lint/suspicious/noExplicitAny: heterogeneous AI SDK part union
-    } as any;
+    } as ToolLikePart;
   }
   return {
     ...part,
@@ -248,8 +254,7 @@ function patchPart(
       approved: action.approved,
       ...(action.reason ? { reason: action.reason } : {}),
     },
-    // biome-ignore lint/suspicious/noExplicitAny: heterogeneous AI SDK part union
-  } as any;
+  } as ToolLikePart;
 }
 
 function describe(action: SubmitAction): string {


### PR DESCRIPTION
Follows the debt-hunt list flagging `apps/mesh/src/web/components/chat/store/thread-connection.ts` as having 5 `any` uses (palette 0, any 5) in an otherwise clean file.

`findTargetPartIndex`/`patchPart` cast message parts to `any` (each wrapped in a `biome-ignore lint/suspicious/noExplicitAny` comment) to read `toolCallId`/`state`/`approval` off the heterogeneous AI SDK message-part union. The `ai` package already exports `ToolUIPart`/`DynamicToolUIPart` types with those exact fields typed (verified in `node_modules/ai/dist/index.d.ts`), and `message/parts/utils.ts` already has an `isToolLike` guard for the same union — so the `any` casts were avoidable, not an intentional type-safety escape hatch.

Added a local `isToolLikePart` type guard (`part.type === "dynamic-tool" || part.type.startsWith("tool-")`) narrowing to `Extract<UIMessage["parts"][number], { toolCallId: string }>`, and used it in both functions instead of the `any` casts. `patchPart`'s construction of the discriminated-union return still needs one narrow `as ToolLikePart` per branch (state transitions can't be checked structurally at compile time), replacing the blanket `as any`. Behavior is unchanged: `findTargetPartIndex` only ever matched tool-like parts before (via `toolCallId`/`approval` presence), so `patchPart` is always called with an already-tool-like part.

Net diff: +18/-13 in one file, no other files touched.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` (clean) and `bun test apps/mesh/src/web/components/chat/store/thread-connection.test.ts` (70 pass, unchanged from before).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace), and the single targeted test file above. Full CI covers lint/e2e.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced unsafe any casts in thread-connection with a typed tool-part guard to improve type safety without changing behavior.

- **Refactors**
  - Added ToolLikePart and isToolLikePart (matches "dynamic-tool" or "tool-*" types) to narrow UIMessage parts.
  - Updated findTargetPartIndex and patchPart to use the guard; removed five any casts and retained precise casts per branch using `ai`’s ToolUIPart/DynamicToolUIPart fields.

<sup>Written for commit 1d98517297059a606a0e02de06cad12dc4a55e7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

