### PR TITLE
refactor(role-color): replace raw Tailwind palette with design-system tokens

### DIFF
--- a/apps/mesh/src/web/lib/role-color.test.ts
+++ b/apps/mesh/src/web/lib/role-color.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { getRoleColor, getRoleDotColor } from "./role-color";
+
+const DESIGN_SYSTEM_TOKEN_CLASSES = new Set([
+  "bg-chart-1",
+  "bg-chart-2",
+  "bg-chart-3",
+  "bg-chart-4",
+  "bg-chart-5",
+  "bg-destructive",
+  "bg-success",
+  "bg-neutral-400",
+]);
+
+describe("role-color", () => {
+  test("builtin roles resolve to existing design-system token classes", () => {
+    expect(
+      DESIGN_SYSTEM_TOKEN_CLASSES.has(getRoleDotColor("owner", true)),
+    ).toBe(true);
+    expect(
+      DESIGN_SYSTEM_TOKEN_CLASSES.has(getRoleDotColor("admin", true)),
+    ).toBe(true);
+    expect(DESIGN_SYSTEM_TOKEN_CLASSES.has(getRoleDotColor("user", true))).toBe(
+      true,
+    );
+  });
+
+  test("custom roles hash to a rotating design-system token class", () => {
+    expect(DESIGN_SYSTEM_TOKEN_CLASSES.has(getRoleColor("editor"))).toBe(true);
+    expect(DESIGN_SYSTEM_TOKEN_CLASSES.has(getRoleColor("viewer"))).toBe(true);
+  });
+
+  test("empty role name falls back to neutral", () => {
+    expect(getRoleColor("")).toBe("bg-neutral-400");
+  });
+});

--- a/apps/mesh/src/web/lib/role-color.ts
+++ b/apps/mesh/src/web/lib/role-color.ts
@@ -1,27 +1,15 @@
 const ROLE_COLORS = [
-  "bg-red-500",
-  "bg-orange-500",
-  "bg-amber-500",
-  "bg-yellow-500",
-  "bg-lime-500",
-  "bg-green-500",
-  "bg-emerald-500",
-  "bg-teal-500",
-  "bg-cyan-500",
-  "bg-sky-500",
-  "bg-blue-500",
-  "bg-indigo-500",
-  "bg-violet-500",
-  "bg-purple-500",
-  "bg-fuchsia-500",
-  "bg-pink-500",
-  "bg-rose-500",
+  "bg-chart-1",
+  "bg-chart-2",
+  "bg-chart-3",
+  "bg-chart-4",
+  "bg-chart-5",
 ] as const;
 
 const BUILTIN_ROLE_COLORS: Record<string, string> = {
-  owner: "bg-red-500",
-  admin: "bg-blue-500",
-  user: "bg-green-500",
+  owner: "bg-destructive",
+  admin: "bg-chart-1",
+  user: "bg-success",
 };
 
 export function getRoleColor(roleName: string): string {


### PR DESCRIPTION
Follows the debt-hunt list: `role-color.ts` was flagged with 21 raw-Tailwind-palette hits (`bg-red-500`, `bg-blue-500`, ... a 17-color rainbow) that drifted from the app's actual design system — this repo defines its palette as semantic CSS-variable tokens (`--color-chart-1..5`, `--color-destructive`, `--color-success`, etc. in `packages/ui/src/styles/global.css`), and a disabled oxlint rule (`plugins/ensure-tailwind-design-system-tokens.js`) exists specifically to ban raw `-500` style classes like these.

Why a maintainer wants it: keeps role-avatar colors consistent with the rest of the app's theme (including dark mode, which the raw `-500` palette didn't adapt to), and removes one of the largest 'raw palette' debt hits in the frontend.

What changed:
- `ROLE_COLORS` (the hash-based rotating palette for custom roles) now uses the 5 categorical `bg-chart-1..5` tokens instead of 17 raw Tailwind swatches.
- `BUILTIN_ROLE_COLORS` now maps `owner` -> `bg-destructive` (was red), `admin` -> `bg-chart-1` (was blue), `user` -> `bg-success` (was green, semantically unchanged) - the app's design system has no direct 'blue' token, so admin maps to the closest categorical chart hue.
- Added `role-color.test.ts` asserting the real builtin roles (`owner`, `admin`, `user` - the schema's actual builtin roles, confirmed via `BUILTIN_ROLE_COLORS`/`BUILTIN_ROLES` usage in `members.tsx`) and hashed custom roles all resolve to classes that exist as design-system tokens, plus the existing empty-name fallback.

Reviewer command: `cd apps/mesh && bun test src/web/lib/role-color.test.ts`

Locally ran: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test above (3 pass). Full CI covers lint/build/e2e.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace raw Tailwind palette in role color utilities with design-system tokens to keep role avatars consistent with the app theme and dark mode. Updates builtin role mappings and adds tests to ensure only valid tokens are used.

- **Refactors**
  - Use bg-chart-1..5 for rotating custom role colors (replaces 17 raw swatches).
  - Map builtin roles: owner → bg-destructive, admin → bg-chart-1, user → bg-success.
  - Add role-color.test.ts to validate token classes and the empty-name neutral fallback.

<sup>Written for commit 60af9724be1fa62d77d4804fdc2730389f63aa4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

