### PR TITLE
fix(task-board): enable wheel scroll on assignee list inside dialog

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -368,7 +368,16 @@ export function TaskBoardItemDialog({
               </DropdownMenu>
 
               <div className="flex flex-col">
-                <Popover open={assigneeOpen} onOpenChange={setAssigneeOpen}>
+                {/* modal: without it the parent Dialog's scroll-lock
+                    (react-remove-scroll) swallows wheel events over this
+                    portalled popover, so the member list only scrolls via
+                    keyboard/click. modal wraps the content in its own
+                    RemoveScroll that whitelists the popover. */}
+                <Popover
+                  open={assigneeOpen}
+                  onOpenChange={setAssigneeOpen}
+                  modal
+                >
                   <PopoverTrigger asChild>
                     <button
                       type="button"


### PR DESCRIPTION
## Summary
The "Assign to…" member list in the task dialog could only be scrolled by clicking/keyboard — the mouse wheel did nothing.

**Root cause:** The task card opens inside a modal Radix `Dialog`, which uses `react-remove-scroll` to lock page scrolling. The assignee `Popover` renders in a portal *outside* the Dialog's DOM subtree, so it isn't on the scroll-lock's whitelist. `react-remove-scroll` blocks `wheel`/`touchmove` events on anything outside that whitelist while still letting clicks/keyboard through — hence click-only scrolling.

**Fix:** Added `modal` to the assignee `Popover`. A modal Popover wraps its content in its own `RemoveScroll` that whitelists the popover, so wheel events over the member list are allowed again (verified against the Radix `react-popover` source: `modal` switches to `PopoverContentModal`, the only variant wrapped in `RemoveScroll`).

The due-date Popover in the same dialog is left unchanged since its calendar doesn't scroll.

## Testing
- `bun run fmt` passes.
- Manual: open a task → click **Assign** → scroll the member list with the mouse wheel.

## Notes
`modal` also traps focus and blocks outside pointer interaction until the popover closes (clicking outside still dismisses it) — expected behavior for a picker like this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables mouse wheel scrolling in the "Assign to…" member list inside the task dialog. Sets the assignee `Popover` to `modal`, giving it its own `react-remove-scroll` context so the parent `Dialog` no longer blocks wheel events.

<sup>Written for commit 4fc55e9a09b884b9224789a63b0268d26e027985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

