### PR TITLE
fix(slides): don't strip theme CSS when using a deck as a theme

### DIFF
--- a/packages/sandbox/image/skills/slides/slides-create.mjs
+++ b/packages/sandbox/image/skills/slides/slides-create.mjs
@@ -209,8 +209,13 @@ function main() {
     html = Mustache.render(theme, { title: deck.title, slides: slidesHtml });
   } else {
     const titled = Mustache.render(theme, { title: deck.title });
+    // Match the real `<deck-viewer width=… height=…>` element by requiring a
+    // whitespace-led attribute after the tag name. Without the `\s`, the regex
+    // also matches the bare `<deck-viewer>` mention inside the head authoring
+    // comment that every generated deck ships, swallowing the <style>/<head>
+    // and stripping all theme CSS from the output.
     html = titled.replace(
-      /(<deck-viewer[^>]*>)[\s\S]*?(<\/deck-viewer>)/i,
+      /(<deck-viewer\s[^>]*>)[\s\S]*?(<\/deck-viewer>)/i,
       (_m, open, close) => `${open}\n${slidesHtml}\n${close}`,
     );
     if (html === titled) {

--- a/packages/sandbox/slides-create.test.ts
+++ b/packages/sandbox/slides-create.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLI = fileURLToPath(
+  new URL("./image/skills/slides/slides-create.mjs", import.meta.url),
+);
+
+// A "deck-as-theme": a complete deck whose <deck-viewer> body is example
+// slides. Note the head authoring comment mentions a bare `<deck-viewer>` —
+// exactly what every generated deck ships, and what used to break the swap.
+const DECK_AS_THEME = `<!DOCTYPE html>
+<html>
+<head>
+<!--
+  Studio deck (deck-viewer v1). Authoring rules:
+  - Slides are the direct <section> children of <deck-viewer>; the canvas
+-->
+<style>--deck-accent: #0af; .deck-h1 { color: var(--deck-accent); }</style>
+</head>
+<body>
+<deck-viewer width="1920" height="1080">
+<section><h1 class="deck-h1">Example</h1></section>
+</deck-viewer>
+<script src="/deck-runtime/v1/deck-viewer.js"></script>
+</body>
+</html>`;
+
+const DECK_DATA = JSON.stringify({
+  title: "Generated",
+  slides: [{ template: "title", data: { heading: "New Deck" } }],
+});
+
+function run(dir: string) {
+  const themePath = join(dir, "theme.html");
+  const dataPath = join(dir, "deck.json");
+  const outPath = join(dir, "out.html");
+  writeFileSync(themePath, DECK_AS_THEME);
+  writeFileSync(dataPath, DECK_DATA);
+  const res = Bun.spawnSync([
+    "bun",
+    CLI,
+    "--data",
+    `@${dataPath}`,
+    "--theme",
+    themePath,
+    "--output",
+    outPath,
+  ]);
+  if (res.exitCode !== 0) {
+    throw new Error(`slides-create failed: ${res.stderr.toString()}`);
+  }
+  return readFileSync(outPath, "utf8");
+}
+
+describe("slides-create deck-as-theme", () => {
+  it("preserves the theme <style> and canvas when swapping slides", () => {
+    const html = run(mkdtempSync(join(tmpdir(), "slides-")));
+    // The head <style> (theme CSS) must survive — the bug stripped it because
+    // the swap regex matched the `<deck-viewer>` inside the head comment.
+    expect(html).toContain("--deck-accent: #0af");
+    // The real 1920×1080 canvas element must survive too.
+    expect(html).toContain('<deck-viewer width="1920" height="1080">');
+    // The generated slide replaced the theme's example slide.
+    expect(html).toContain("New Deck");
+    expect(html).not.toContain(">Example<");
+  });
+});


### PR DESCRIPTION
## Summary

The `slides` skill's `slides-create.mjs` supports **deck-as-theme**: passing a complete deck HTML as `--theme`, whose `<deck-viewer>` body gets swapped for the freshly generated slides (so one file is both an editable sample deck and the generation shell). This is the officially-documented way to keep an org brand deck as a template.

It's broken. The swap uses:

```js
titled.replace(/(<deck-viewer[^>]*>)[\s\S]*?(<\/deck-viewer>)/i, …)
```

Every deck `slides-create` generates ships this boilerplate in its `<head>`:

```html
<!--
  Studio deck (deck-viewer v1). Authoring rules:
  - Slides are the direct <section> children of <deck-viewer>; the canvas
-->
```

`<deck-viewer[^>]*>` matches the bare `<deck-viewer>` **inside that comment**, so the replace starts there and lazily runs to the real `</deck-viewer>` — swallowing the entire `<style>` block, `</head>` and `<body>`, and dropping the real `<deck-viewer width="1920" height="1080">` opening tag. The output keeps the `deck-*` class names but has **no CSS defining them and no canvas**, so any deck built on such a theme renders as unstyled, stacked HTML instead of the branded template.

Since `slides-create` emits that comment in every deck, **any generated deck reused as a theme hits this** — which is exactly the intended brand-template workflow.

## Fix

Require a whitespace-led attribute after the tag name so only the real `<deck-viewer width=… height=…>` element matches; the comment's attribute-less `<deck-viewer>` is skipped.

```diff
-/(<deck-viewer[^>]*>)[\s\S]*?(<\/deck-viewer>)/i
+/(<deck-viewer\s[^>]*>)[\s\S]*?(<\/deck-viewer>)/i
```

## Testing

- `bun test packages/sandbox/slides-create.test.ts` — new black-box test spawns the CLI against a deck-as-theme fixture carrying the head comment and asserts the theme `<style>` and the 1920×1080 canvas survive, and that the generated slide replaced the example one. Fails on the old regex, passes on the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deck-as-theme in `slides-create` so theme CSS and the 1920×1080 canvas are preserved. The regex now targets the real <deck-viewer …> element instead of the tag mention inside the head comment.

- Bug Fixes
  - Update swap regex to require whitespace after `<deck-viewer`, matching only the real element and preventing `<style>`, `</head>`, and `<body>` from being stripped.
  - Add a black-box CLI test for deck-as-theme to verify the theme `<style>` and canvas remain and the example slide is replaced.

<sup>Written for commit affc92d922d118feb33e7b9f5b0a5df0a0666ff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

