### PR TITLE
feat(auth): mint a Better Auth session from an MCP OAuth bearer (desktop system-browser login)

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -49,6 +49,7 @@ import {
 } from "../observability";
 import { posthog } from "../posthog";
 import authRoutes from "./routes/auth";
+import desktopSessionBridgeRoutes from "./routes/desktop-session-bridge";
 import {
   ADMIN_API_PREFIX,
   createAdminRoutes,
@@ -1280,6 +1281,12 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Auth routes (API key management via web UI)
   app.route("/api/auth/custom", authRoutes);
+  // POST /api/auth/desktop/session-from-oauth — mints a real Better Auth
+  // session from a valid MCP OAuth bearer, for the desktop app's
+  // system-browser (Google/GitHub/SAML) login path. Mounted BEFORE the
+  // `/api/auth/*` catchall (`auth.handler`) so it never reaches it. See
+  // `./routes/desktop-session-bridge.ts`'s module doc for why this exists.
+  app.route("/api/auth/desktop", desktopSessionBridgeRoutes);
 
   // Fence off the raw Better Auth admin plugin (/api/auth/admin/*) from
   // external callers — see fenceRawAdminSurface's doc in routes/admin.ts for

--- a/apps/mesh/src/api/routes/desktop-session-bridge.test.ts
+++ b/apps/mesh/src/api/routes/desktop-session-bridge.test.ts
@@ -1,0 +1,62 @@
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "bun:test";
+import { signSessionCookieValue } from "./desktop-session-bridge";
+
+describe("signSessionCookieValue", () => {
+  it("matches better-auth's own HMAC-SHA256 + base64 + URI-escape scheme", () => {
+    const token = "raw-session-token-abc123";
+    const secret = "test-secret-value";
+
+    const expectedSignature = createHmac("sha256", secret)
+      .update(token)
+      .digest("base64");
+    const expected = encodeURIComponent(`${token}.${expectedSignature}`);
+
+    expect(signSessionCookieValue(token, secret)).toBe(expected);
+  });
+
+  it("is deterministic for the same token+secret", () => {
+    const a = signSessionCookieValue("tok", "secret");
+    const b = signSessionCookieValue("tok", "secret");
+    expect(a).toBe(b);
+  });
+
+  it("changes when the token changes", () => {
+    const a = signSessionCookieValue("tok-1", "secret");
+    const b = signSessionCookieValue("tok-2", "secret");
+    expect(a).not.toBe(b);
+  });
+
+  it("changes when the secret changes", () => {
+    const a = signSessionCookieValue("tok", "secret-1");
+    const b = signSessionCookieValue("tok", "secret-2");
+    expect(a).not.toBe(b);
+  });
+
+  it("percent-escapes the standard-base64 signature's special characters", () => {
+    // Standard (non-url-safe) base64 can contain '+', '/', '='. The cookie
+    // value must be URI-escaped so those never collide with cookie
+    // delimiters (';', ',') or get mangled in transit.
+    const value = signSessionCookieValue("token", "secret");
+    expect(value).not.toContain("+");
+    expect(value).not.toContain("/");
+    // A trailing '=' from base64 padding would appear un-escaped as '=' —
+    // confirm any literal padding survived only in escaped form.
+    expect(value.includes("%3D") || !value.includes("=")).toBe(true);
+  });
+
+  it("round-trips through decodeURIComponent back to token.signature", () => {
+    const token = "another-token";
+    const secret = "another-secret";
+    const value = signSessionCookieValue(token, secret);
+    const decoded = decodeURIComponent(value);
+    const dot = decoded.lastIndexOf(".");
+    expect(dot).toBeGreaterThan(0);
+    expect(decoded.slice(0, dot)).toBe(token);
+    const signature = decoded.slice(dot + 1);
+    const expectedSignature = createHmac("sha256", secret)
+      .update(token)
+      .digest("base64");
+    expect(signature).toBe(expectedSignature);
+  });
+});

--- a/apps/mesh/src/api/routes/desktop-session-bridge.ts
+++ b/apps/mesh/src/api/routes/desktop-session-bridge.ts
@@ -1,0 +1,120 @@
+/**
+ * Desktop system-browser session bridge.
+ *
+ * `POST /api/auth/desktop/session-from-oauth` — the one mesh-side change
+ * `apps/desktop/docs/real-ui-auth-recon.md` concluded was unavoidable to fix
+ * the Google/GitHub/SAML system-browser desktop login path: an MCP OAuth
+ * access token (the `oauthAccessToken` row both desktop login paths
+ * ultimately hold) satisfies org-scoped `/api/:org/*` routes but is REJECTED
+ * by Better Auth's native session endpoints (`get-session`,
+ * `organization.list`, ...), which only recognize a session cookie (or an
+ * API key, via the `apiKey()` plugin's `enableSessionForAPIKeys`) — see that
+ * doc's §0-§3 for the empirical trail. The embedded email/password/OTP
+ * desktop login path sidesteps this by capturing the REAL session cookie
+ * Better Auth sets during that flow (`crates/upstream/src/bridge.rs`'s
+ * cookie-relay bridge); the system-browser path has no equivalent capture
+ * point — the cookie lands in the system browser's OWN cookie jar, a
+ * separate OS process this app never has access to. This endpoint is the
+ * missing piece: given a valid MCP OAuth bearer, mint a REAL Better Auth
+ * session server-side and hand the caller the signed cookie VALUE (not a
+ * `Set-Cookie` header — this caller is a native app process, not a browser
+ * that would capture one) so it can forward that value itself, byte for
+ * byte, as `Cookie: better-auth.session_token=<value>` — see
+ * `apps/desktop/crates/upstream/src/login.rs`'s
+ * `mint_session_from_access_token`, the Rust-side caller.
+ *
+ * ## Auth guard
+ *
+ * Dual-auth via the SAME `resolveLinkBearer` resolver `GET /api/links/me`
+ * uses (MCP OAuth session primary, Better Auth API key fallback) — reusing
+ * a reviewed, already-tested resolver rather than a bespoke check. In
+ * practice the desktop app only ever presents a fresh MCP OAuth access
+ * token here (never an API key), but there's no reason to special-case that
+ * narrower expectation when the shared resolver already does the right
+ * thing for either credential shape. A caller presenting neither gets
+ * `401`.
+ *
+ * ## Minting the session + signing the cookie value
+ *
+ * `auth.$context` (typed and documented as part of the `Auth<Options>`
+ * shape the installed `better-auth` package exports — see its
+ * `dist/types/auth.d.mts`) exposes the same
+ * `internalAdapter.createSession(userId, dontRememberMe)` Better Auth's own
+ * `admin.impersonateUser` endpoint calls server-side
+ * (`better-auth/dist/plugins/admin/routes.mjs`) to create a real session
+ * row with a fresh, random token. That raw token is not by itself a valid
+ * cookie value: Better Auth signs every session-cookie value with
+ * HMAC-SHA256 over the raw token using `context.secret`, then
+ * `${token}.${signature}` gets `encodeURIComponent`-escaped before it's set
+ * as the cookie's value (read verbatim from the installed `better-call`
+ * package `better-auth` depends on for this: `dist/context.mjs`'s
+ * `setSignedCookie` -> `dist/cookies.mjs`'s `serializeSignedCookie` ->
+ * `dist/crypto.mjs`'s `signCookieValue`/`makeSignature`).
+ * `signSessionCookieValue` below reproduces exactly that algorithm rather
+ * than reaching into `better-call` directly — it is a transitive
+ * dependency of `better-auth`, not a direct dependency of this package, so
+ * importing its internals would be fragile. The signing scheme itself is a
+ * small, stable primitive (HMAC-SHA256 + base64 + URI-escape) pinned down
+ * independently by this file's co-located unit test.
+ */
+
+import { createHmac } from "node:crypto";
+import { Hono } from "hono";
+import { auth } from "@/auth";
+import {
+  resolveLinkBearer,
+  type LinkBearerAuthApi,
+} from "./decopilot/link-bearer-auth";
+
+const app = new Hono();
+
+/**
+ * Reproduces Better Auth's own session-cookie signing (see this file's
+ * module doc for the exact source trail): HMAC-SHA256 the raw session
+ * token with the auth secret, base64-encode the signature (standard
+ * alphabet, not url-safe — matches `btoa` in `better-call`'s
+ * `makeSignature`), concatenate as `${token}.${signature}`, then
+ * `encodeURIComponent` the whole thing — the exact string Better Auth would
+ * have set as the `better-auth.session_token` cookie's VALUE. A browser
+ * stores and re-sends a cookie value verbatim (percent-escapes and all), so
+ * encoding it here up front is what makes the caller's later `Cookie:
+ * better-auth.session_token=<this value>` byte-identical to what a real
+ * sign-in would have produced — and therefore something
+ * `getSignedCookie`'s own decode-then-verify round trip accepts.
+ */
+export function signSessionCookieValue(token: string, secret: string): string {
+  const signature = createHmac("sha256", secret).update(token).digest("base64");
+  return encodeURIComponent(`${token}.${signature}`);
+}
+
+app.post("/session-from-oauth", async (c) => {
+  const authHeader = c.req.header("authorization") ?? "";
+  const match = /^Bearer\s+(.+)$/i.exec(authHeader);
+  const token = match?.[1]?.trim();
+  if (!token) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  const userId = await resolveLinkBearer(
+    token,
+    auth.api as unknown as LinkBearerAuthApi,
+  );
+  if (!userId) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  try {
+    const ctx = await auth.$context;
+    const session = await ctx.internalAdapter.createSession(userId, false);
+    const sessionToken = signSessionCookieValue(session.token, ctx.secret);
+    return c.json({ sessionToken });
+  } catch (err) {
+    console.error(
+      "[desktop-session-bridge] failed to mint a session from an OAuth bearer:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return c.json({ error: "failed to mint a session" }, 500);
+  }
+});
+
+export default app;

--- a/packages/e2e/fixtures/mcp-oauth.ts
+++ b/packages/e2e/fixtures/mcp-oauth.ts
@@ -1,0 +1,136 @@
+/**
+ * Mints a real MCP OAuth 2.1 + PKCE access token against the live mesh —
+ * the exact primitive both `apps/mesh/src/cli/commands/auth/login.ts` and
+ * `apps/desktop/crates/upstream/src/login.rs` produce for a signed-in user.
+ *
+ * Drives the real wire dance: dynamic client registration
+ * (`POST /api/auth/mcp/register`) → authorize
+ * (`GET /api/auth/mcp/authorize`, presenting the request context's already-
+ * established Better Auth session cookie — e.g. from `signUpViaApi` —
+ * instead of opening a browser, mirroring
+ * `crates/upstream/src/bridge.rs::complete_via_cookie_jar`'s non-interactive
+ * approach) → token exchange (`POST /api/auth/mcp/token`). `request` must
+ * already carry a session cookie.
+ *
+ * Inlined here (not imported from `apps/mesh/src/cli/lib/pkce.ts` or
+ * similar) per this package's isolation rule — `packages/e2e` never imports
+ * app source (see `plugins/ban-e2e-app-imports.js`); a black-box test owning
+ * its own contract is correct, not duplication.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import type { APIRequestContext } from "@playwright/test";
+
+const SCOPES = "openid profile email offline_access";
+
+export interface MintedMcpAccessToken {
+  accessToken: string;
+  refreshToken?: string;
+  idToken?: string;
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function generatePkcePair(): { verifier: string; challenge: string } {
+  const verifier = base64UrlEncode(randomBytes(32));
+  const challenge = base64UrlEncode(
+    createHash("sha256").update(verifier).digest(),
+  );
+  return { verifier, challenge };
+}
+
+export async function mintMcpAccessToken(
+  request: APIRequestContext,
+): Promise<MintedMcpAccessToken> {
+  // Never actually connected to — only compared for exact string equality by
+  // the authorize endpoint's redirect_uri check. A fixed placeholder is safe
+  // across parallel workers: each registration mints its own fresh
+  // `client_id`, so an identical string never collides across tests.
+  const redirectUri = "http://127.0.0.1:0/callback";
+  const state = `e2e-state-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const pkce = generatePkcePair();
+
+  const registerRes = await request.post("/api/auth/mcp/register", {
+    data: {
+      client_name: "e2e-mcp-oauth-fixture",
+      redirect_uris: [redirectUri],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+      application_type: "native",
+    },
+  });
+  if (!registerRes.ok()) {
+    throw new Error(
+      `mintMcpAccessToken: register failed HTTP ${registerRes.status()} — ${await registerRes.text().catch(() => "")}`,
+    );
+  }
+  const { client_id: clientId } = (await registerRes.json()) as {
+    client_id: string;
+  };
+
+  const authorizeRes = await request.get("/api/auth/mcp/authorize", {
+    params: {
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      state,
+      scope: SCOPES,
+      code_challenge: pkce.challenge,
+      code_challenge_method: "S256",
+    },
+    maxRedirects: 0,
+  });
+  if (authorizeRes.status() < 300 || authorizeRes.status() >= 400) {
+    throw new Error(
+      `mintMcpAccessToken: authorize did not redirect — HTTP ${authorizeRes.status()} — ${await authorizeRes.text().catch(() => "")}`,
+    );
+  }
+  const location = authorizeRes.headers()["location"];
+  if (!location) {
+    throw new Error("mintMcpAccessToken: authorize redirect had no Location");
+  }
+  const landed = new URL(location, redirectUri);
+  const code = landed.searchParams.get("code");
+  const returnedState = landed.searchParams.get("state");
+  if (returnedState !== state) {
+    throw new Error("mintMcpAccessToken: authorize state mismatch");
+  }
+  if (!code) {
+    throw new Error("mintMcpAccessToken: authorize redirect had no code param");
+  }
+
+  const tokenRes = await request.post("/api/auth/mcp/token", {
+    form: {
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+      client_id: clientId,
+      code_verifier: pkce.verifier,
+    },
+  });
+  if (!tokenRes.ok()) {
+    throw new Error(
+      `mintMcpAccessToken: token exchange failed HTTP ${tokenRes.status()} — ${await tokenRes.text().catch(() => "")}`,
+    );
+  }
+  const tokenBody = (await tokenRes.json()) as {
+    access_token: string;
+    refresh_token?: string;
+    id_token?: string;
+  };
+  if (!tokenBody.access_token) {
+    throw new Error("mintMcpAccessToken: token response had no access_token");
+  }
+  return {
+    accessToken: tokenBody.access_token,
+    refreshToken: tokenBody.refresh_token,
+    idToken: tokenBody.id_token,
+  };
+}

--- a/packages/e2e/tests/desktop-session-bridge.spec.ts
+++ b/packages/e2e/tests/desktop-session-bridge.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * `POST /api/auth/desktop/session-from-oauth` — the mesh-side bridge that
+ * closes the desktop system-browser (Google/GitHub/SAML) login gap: an MCP
+ * OAuth access token satisfies org-scoped `/api/:org/*` routes but is
+ * rejected by Better Auth's native session endpoints (`get-session`,
+ * `organization.list`), which only recognize a session cookie. This bridge
+ * mints a real Better Auth session from a valid MCP OAuth bearer and returns
+ * the signed cookie VALUE, so a native caller (the desktop app) can forward
+ * it itself as `Cookie: better-auth.session_token=<value>`.
+ *
+ * See `apps/desktop/docs/real-ui-auth-recon.md` for the full empirical
+ * trail and `apps/desktop/crates/upstream/src/login.rs`'s
+ * `mint_session_from_access_token` for the Rust-side caller.
+ */
+import { expect, newApiContext, test } from "../fixtures/test";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { mintMcpAccessToken } from "../fixtures/mcp-oauth";
+
+test.describe("desktop session bridge: POST /api/auth/desktop/session-from-oauth", () => {
+  test("exchanges a valid MCP OAuth bearer for a Better Auth session cookie the native endpoints accept", async ({
+    playwright,
+  }) => {
+    const signedUpCtx = await newApiContext(playwright);
+    const user = await signUpViaApi(signedUpCtx);
+
+    const { accessToken } = await mintMcpAccessToken(signedUpCtx);
+
+    const bridgeRes = await signedUpCtx.post(
+      "/api/auth/desktop/session-from-oauth",
+      { headers: { authorization: `Bearer ${accessToken}` } },
+    );
+    expect(bridgeRes.status()).toBe(200);
+    const { sessionToken } = (await bridgeRes.json()) as {
+      sessionToken: string;
+    };
+    expect(typeof sessionToken).toBe("string");
+    expect(sessionToken.length).toBeGreaterThan(0);
+
+    // A brand-new, cookie-free context — proves the bridged value ALONE
+    // (nothing carried over from `signUpViaApi`'s own session) satisfies
+    // Better Auth's native endpoints, exactly what the real production
+    // shell's sign-in gate (`useSession`) and org switcher
+    // (`organization.list`) call.
+    const bareCtx = await newApiContext(playwright);
+    const cookieHeader = `better-auth.session_token=${sessionToken}`;
+
+    const sessionRes = await bareCtx.get("/api/auth/get-session", {
+      headers: { cookie: cookieHeader },
+    });
+    expect(sessionRes.status()).toBe(200);
+    const sessionBody = (await sessionRes.json()) as {
+      user?: { id?: string };
+    };
+    expect(sessionBody.user?.id).toBe(user.userId);
+
+    const orgListRes = await bareCtx.get("/api/auth/organization/list", {
+      headers: { cookie: cookieHeader },
+    });
+    expect(orgListRes.status()).toBe(200);
+    const orgs = (await orgListRes.json()) as Array<{ slug: string }>;
+    expect(orgs.some((o) => o.slug === user.orgSlug)).toBe(true);
+
+    await signedUpCtx.dispose();
+    await bareCtx.dispose();
+  });
+
+  test("rejects a missing or invalid bearer", async ({ playwright }) => {
+    const ctx = await newApiContext(playwright);
+
+    const noAuthRes = await ctx.post("/api/auth/desktop/session-from-oauth");
+    expect(noAuthRes.status()).toBe(401);
+
+    const badAuthRes = await ctx.post("/api/auth/desktop/session-from-oauth", {
+      headers: { authorization: "Bearer not-a-real-token" },
+    });
+    expect(badAuthRes.status()).toBe(401);
+
+    await ctx.dispose();
+  });
+});


### PR DESCRIPTION
## What

Adds `POST /api/auth/desktop/session-from-oauth` — mints a real Better Auth session from a validated MCP OAuth bearer and returns the signed session-cookie **value**.

## Why

The desktop app's **system-browser (Google/GitHub/SAML)** login yields an MCP OAuth access token. That token satisfies org-scoped `/api/:org/*` routes, but Better Auth's **native** session endpoints (`get-session`, `organization.list`, …) reject it — they only accept a session cookie. The desktop app renders the real web UI, whose sign-in gate (`authClient.useSession()`) and org switcher (`authClient.organization.list()`) hit exactly those endpoints, so without a real session the UI stays "logged out".

The embedded **email/password/OTP** desktop path sidesteps this by capturing the real cookie Better Auth sets during that flow. The system-browser path has no equivalent capture point — the cookie lands in the system browser's own jar, a separate OS process the app can't read. This endpoint is that missing piece.

The CLI (`bunx decocms auth login` / `decocms link`) never needed this: it's headless and only ever sends the OAuth bearer to Studio's own routes (`/api/links/*`, tunnel, org-scoped tools) which accept it — it never touches Better Auth's session endpoints.

## How

1. Validate `Authorization: Bearer <mcp_oauth_token>` via the existing `resolveLinkBearer` (the same resolver `GET /api/links/me` uses). Neither valid credential → `401`.
2. `auth.$context.internalAdapter.createSession(userId, false)` — the same internal API Better Auth's own `admin.impersonateUser` calls. **No privilege escalation**: a session is minted only for the user the presented token already authenticates.
3. `signSessionCookieValue()` reproduces Better Auth's own cookie signing (HMAC-SHA256 + base64 + `encodeURIComponent`) — since `better-call` is a *transitive* dep, importing its internals would be fragile; the scheme is pinned by a co-located unit test.
4. Returns `{ sessionToken }` in the JSON body (not `Set-Cookie` — the caller is a native process that forwards `Cookie: better-auth.session_token=<value>` itself).

Purely additive: one new route, mounted **before** the `/api/auth/*` catchall so it never reaches `auth.handler`. No change to any existing auth behavior.

## Testing

- **Unit** (`desktop-session-bridge.test.ts`): the signing scheme.
- **E2E** (`desktop-session-bridge.spec.ts`, real Postgres): full PKCE dance → this endpoint → `get-session` **200** + `organization.list` **200** using only the returned session value.
- Verified manually against a fresh dev mesh (same 200/200 chain).

## Reviewer note

`signSessionCookieValue` mirrors Better Auth's cookie signing; a major `better-auth` bump could change that scheme — the unit test fails loudly if it drifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bridge endpoint that exchanges an MCP OAuth access token for a signed `better-auth` session cookie value, so the desktop system-browser login works with session-only endpoints in the embedded UI. Purely additive; existing auth behavior is unchanged.

- New Features
  - Added POST /api/auth/desktop/session-from-oauth returning { sessionToken } (the signed cookie value).
  - Auth: validates Authorization: Bearer via resolveLinkBearer; missing/invalid -> 401.
  - Session: uses auth.$context.internalAdapter.createSession(userId, false) for the authenticated user.
  - Cookie signing: matches `better-auth`/`better-call` (HMAC-SHA256 → base64 → encodeURIComponent).
  - Routing: mounted before /api/auth/* catchall; no changes to other routes.

<sup>Written for commit bd155059fb886cdb55607d9922320d1ed9db134d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

