### PR TITLE
chore(sandbox-env): bump default image tag 1.12.0 -> 1.17.8

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,10 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.9.6: default studio-sandbox image tag bumped to 1.17.8 — catches the chart
+# up to the current sandbox image (the tag lockstep had drifted from 1.12.0,
+# missing 5 minors of image changes, incl. the slides deck-as-theme CSS fix
+# #4868). Image-tag change only; no chart template changes.
 # 0.9.5: housekeeper reaps orphaned phase=Failed sandbox pods (left when the
 # orgfs-sidecar is SIGKILLed on teardown and its Sandbox CR is already gone) +
 # grants the housekeeper Role `delete` on pods. Additive; existing reap paths
@@ -36,7 +40,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.5
+version: 0.9.6
 # appVersion tracks the studio-sandbox image version (image.tag default).
-appVersion: "1.12.0"
+appVersion: "1.17.8"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -40,7 +40,7 @@ image:
   # instead of silently moving with `:latest`. Bump in lockstep with
   # packages/sandbox/package.json — release-studio-sandbox.yaml tags
   # images using that version. NEVER set this to "latest" in prod.
-  tag: "1.12.0"
+  tag: "1.17.8"
   # Override to Never on local kind clusters that load via `kind load`.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

The `studio-sandbox` image auto-builds and publishes on every push to `main` touching `packages/sandbox/**`, tagged from `packages/sandbox/package.json` (`release-studio-sandbox.yaml`). But the `sandbox-env` chart's `image.tag` (and `appVersion`) is a **manual lockstep pin** that the release automation does not touch — and it had drifted **5 minors behind**: chart pinned `1.12.0` while the current image is `1.17.8`.

Consequence: Helm installs/upgrades pull a stale sandbox image, missing everything merged into the sandbox since 1.12.0 — including the slides deck-as-theme CSS fix (#4868) that motivated this.

## Change

- `deploy/helm/sandbox-env/values.yaml`: `image.tag` `1.12.0` → `1.17.8`
- `deploy/helm/sandbox-env/Chart.yaml`: `appVersion` `1.12.0` → `1.17.8`, chart `version` `0.9.5` → `0.9.6`, changelog entry

Image-tag catch-up only — **no chart template changes**. The `1.17.8` image is already published to `ghcr.io/decocms/studio/studio-sandbox` (green `release-studio-sandbox.yaml` run).

## What's picked up (packages/sandbox, 1.12.0 → 1.17.8)

All fixes/additive feats, no breaking changes. Highlights:
- fix(slides): deck-as-theme no longer strips theme CSS (#4868)
- fix(sandbox): refuse force-push / daemon push to protected branches (#4743, #4739)
- fix(sandbox): exclude org-fs mount from git at boot (#4745)
- feat(sandbox): flagless in-sandbox tool calls via materialized endpoint (#4638); mint real MCP endpoint for hosted tool-scripting (#4661)
- feat(sandbox): flip to running the instant the dev server announces its port (#4631)
- several PTY/UTF-8 stream + shutdown-sync robustness fixes

## Testing

- `helm lint deploy/helm/sandbox-env` → 1 chart linted, 0 failed (the `studio-sandbox-` naming warning is pre-existing — lint runs with an empty `envName`).

## Note

Merging publishes chart `0.9.6` (`release-sandbox-charts.yaml` triggers on `deploy/helm/sandbox-env/**`). Running environments still need a `helm upgrade` to actually roll the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `sandbox-env` Helm chart to default to the `studio-sandbox` image 1.17.8 (was 1.12.0) so installs/upgrades use the current image and include recent fixes (e.g., slides deck-as-theme CSS fix). Bumps chart version to 0.9.6 and sets `appVersion` to 1.17.8; no template changes.

- **Migration**
  - Run a Helm upgrade to roll out the new image.

<sup>Written for commit 97534604ed77c7279013ad9a8aea2fdbaf5393dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

