### PR TITLE
refactor(monitoring): use design-system warning token for truncated indicator

### DIFF
--- a/apps/mesh/src/web/components/monitoring/types.tsx
+++ b/apps/mesh/src/web/components/monitoring/types.tsx
@@ -617,7 +617,7 @@ export function ExpandedLogContent({ log }: ExpandedLogContentProps) {
                   Input
                 </span>
                 {inputJson.isTruncated && (
-                  <span className="text-xs text-amber-600 dark:text-amber-400">
+                  <span className="text-xs text-warning">
                     ({formatBytes(inputJson.originalSize)} - truncated)
                   </span>
                 )}
@@ -684,7 +684,7 @@ export function ExpandedLogContent({ log }: ExpandedLogContentProps) {
                   Output
                 </span>
                 {outputJson.isTruncated && (
-                  <span className="text-xs text-amber-600 dark:text-amber-400">
+                  <span className="text-xs text-warning">
                     ({formatBytes(outputJson.originalSize)} - truncated)
                   </span>
                 )}


### PR DESCRIPTION
Design-token debt cleanup (C-DEBT) in `apps/mesh/src/web/components/monitoring/types.tsx`: the "truncated" input/output indicator in the tool-call log viewer used raw `text-amber-600 dark:text-amber-400` instead of the design system's `--warning` token.

The mapping is unambiguous: this codebase already treats "truncated" content as a warning-severity event elsewhere (`file-explorer.tsx` calls `toast.warning("File list truncated — some files may be hidden")` for the identical concept), and `text-warning` is defined in `packages/ui/src/styles/global.css` with both light and dark values, so the manual `dark:` override could be dropped entirely.

This is a deliberate visual change, not just a refactor: `--warning` (`oklch(0.62 0.17 70)` light / `oklch(0.65 0.15 70)` dark) is a different shade than the old `amber-600`/`amber-400`, so the truncation note's exact color shifts slightly in both themes. It's still an amber/warning hue, just now sourced from the design-system token instead of a raw Tailwind color.

Net change: -2 / +2, no logic touched (pure CSS class swap on a `<span>`).

How to verify: open a tool-call log with a truncated input/output (Monitoring tab) and confirm the truncation note renders in the design-system warning color, correctly in both light and dark mode.

Locally ran: `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (clean, no type changes). No test file covers this component's rendering, so no targeted test was run — full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use design-system `text-warning` for truncated Input/Output indicators in Monitoring logs, replacing `text-amber-600 dark:text-amber-400` in `apps/mesh/src/web/components/monitoring/types.tsx`. This standardizes warning colors across themes; slight hue change, no logic changes.

<sup>Written for commit 7bd32893678b618bcded8ad8639e9af2c945fa54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

