### PR TITLE
ci(release): auto-bump sandbox-env chart image tag in lockstep

### DIFF
--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -228,7 +228,56 @@ jobs:
             };
           });
 
-          const summary = updated
+          // Charts that pin an image tag in lockstep with a workspace package
+          // version. The package.json bump above publishes a new image
+          // (release-studio-sandbox.yaml tags it from package.json); without
+          // this the chart's image.tag / appVersion silently drift behind it
+          // (they had drifted 5 minors — #4870). Sync both to the new version
+          // and patch-bump the chart's own version so release-sandbox-charts
+          // republishes it. All committed in this same [release]: commit, whose
+          // App-token push re-triggers the chart publish workflow.
+          const CHART_IMAGE_LOCKSTEP = {
+            "packages/sandbox/package.json": "deploy/helm/sandbox-env",
+          };
+          const extra = [];
+          for (const { manifest, newVersion } of updated) {
+            const chartDir = CHART_IMAGE_LOCKSTEP[manifest];
+            if (!chartDir) continue;
+
+            const valuesPath = `${chartDir}/values.yaml`;
+            const values = fs.readFileSync(valuesPath, "utf8");
+            const nextValues = values.replace(
+              /(repository: ghcr\.io\/decocms\/studio\/studio-sandbox[\s\S]*?\n\s*tag: )"[^"]*"/,
+              `$1"${newVersion}"`,
+            );
+            if (nextValues === values) {
+              throw new Error(`could not find studio-sandbox image tag in ${valuesPath}`);
+            }
+            fs.writeFileSync(valuesPath, nextValues);
+
+            const chartPath = `${chartDir}/Chart.yaml`;
+            const chart = fs.readFileSync(chartPath, "utf8");
+            let chartVersion;
+            const nextChart = chart
+              .replace(/(\nappVersion: )"[^"]*"/, `$1"${newVersion}"`)
+              .replace(/\nversion: (\d+)\.(\d+)\.(\d+)/, (_m, a, b, c) => {
+                chartVersion = `${a}.${b}.${Number(c) + 1}`;
+                return `\nversion: ${chartVersion}`;
+              });
+            if (!chartVersion) {
+              throw new Error(`could not bump chart version in ${chartPath}`);
+            }
+            fs.writeFileSync(chartPath, nextChart);
+
+            extra.push({
+              name: `${chartDir} (chart ${chartVersion})`,
+              manifest: `${valuesPath} ${chartPath}`,
+              currentVersion: "image.tag/appVersion",
+              newVersion,
+            });
+          }
+
+          const summary = [...updated, ...extra]
             .map(({ name, manifest, currentVersion, newVersion }) =>
               `- ${name} (${manifest}): ${currentVersion} -> ${newVersion}`,
             )
@@ -251,7 +300,7 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `updated=true\n`);
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
-            `changed_paths=${updated.map(({ manifest }) => manifest).join(" ")}\n`,
+            `changed_paths=${[...updated, ...extra].map(({ manifest }) => manifest).join(" ")}\n`,
           );
 
           console.log(summary);


### PR DESCRIPTION
## Problem

The sandbox image ships fully automatically:
- `release-tagging.yaml` bumps changed workspace `package.json` versions on merge.
- `release-studio-sandbox.yaml` builds + pushes `studio-sandbox:<packages/sandbox version>`.

But the `sandbox-env` chart pins that image via `image.tag` (and `appVersion`) **by hand** — the release bot never touched it. So it silently drifts: it had fallen **5 minors behind** (chart `1.12.0` vs image `1.17.8`), and Helm installs/upgrades were pulling a stale sandbox, missing everything since 1.12.0 including the slides deck-as-theme CSS fix (#4868). #4870 is the one-time catch-up; this PR stops it from ever drifting again.

## Change

In `release-tagging.yaml`'s version-bump step, add a lockstep map:

```js
const CHART_IMAGE_LOCKSTEP = {
  "packages/sandbox/package.json": "deploy/helm/sandbox-env",
};
```

When the bot bumps a mapped package, it also:
1. rewrites the chart's `studio-sandbox` `image.tag` (values.yaml) to the new version,
2. sets `appVersion` to the new version (Chart.yaml),
3. patch-bumps the chart's own `version` (Chart.yaml),
4. includes both chart files in the same `[release]:` commit.

That commit's App-token push already re-triggers downstream workflows, so `release-sandbox-charts.yaml` republishes the chart automatically (its version-exists guard needs the `version` bump to actually publish — hence step 3).

The tag rewrite is anchored to the `ghcr.io/decocms/studio/studio-sandbox` repository line, so the unrelated `sandbox-netinit` image tag in the same values.yaml is left untouched. Both rewrites throw if their anchor isn't found, so a future rename fails the release loudly instead of silently drifting again.

## Testing

- Dry-ran the transform against the real `deploy/helm/sandbox-env/{values.yaml,Chart.yaml}` with a simulated `1.17.9` bump: `image.tag` → `1.17.9`, `appVersion` → `1.17.9`, chart `version` `0.9.5` → `0.9.6`, `apiVersion` and the `sandbox-netinit` tag untouched.
- `yaml.safe_load` parses the edited workflow.

## Notes

- Scoped to `sandbox-env` (the drift the client hit). The same `sandbox-netinit` / `orgfs-sidecar` charts pin their own image tags and could be added to the map later if they show the same drift — deliberately not doing speculative work here.
- Independent of #4870: this only acts on *future* `packages/sandbox` bumps. #4870 does the one-time 1.12.0 → 1.17.8 catch-up; merge that too (or the next sandbox change will auto-correct the tag anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates keeping the `sandbox-env` Helm chart in sync with the sandbox image version so Helm installs always pull the latest `studio-sandbox` image. When `packages/sandbox` is version-bumped, the chart’s `image.tag`, `appVersion`, and patch `version` are updated in lockstep.

- **New Features**
  - Adds a lockstep map in `.github/workflows/release-tagging.yaml`: `packages/sandbox/package.json` -> `deploy/helm/sandbox-env`.
  - On sandbox bumps, rewrites `values.yaml` `image.tag` for `ghcr.io/decocms/studio/studio-sandbox`, sets `appVersion`, patch-bumps `Chart.yaml` `version`, and includes these files in the same `[release]:` commit to re-trigger `release-sandbox-charts.yaml`.
  - Uses anchored replaces to only touch the `studio-sandbox` tag; `sandbox-netinit` stays untouched, and missing anchors fail the release.

<sup>Written for commit 1bf1d2ab8a88e3630e5452a6e270cefa2700f0a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

