### PR TITLE
fix(sandbox): log benign config-timeout bring-up failures at warn, not error

### DIFF
--- a/apps/mesh/src/link-daemon/user-desktop-provider.test.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -513,6 +513,73 @@ describe("desktop sandbox provider", () => {
       expect(err.message).toContain("sandbox failed to start");
       expect(err.message.toLowerCase()).toContain("config");
     } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("logs a config timeout bring-up failure at warn, not error", async () => {
+    const dataDir = tmpDataDir();
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      let portCounter = 33000;
+      const timeout = new Error("The operation timed out.");
+      timeout.name = "TimeoutError";
+      const provider = createDesktopSandboxProvider({
+        dataDir,
+        spawnDaemon: () => fakeDaemonSpawner(),
+        waitForHealth: async () => {},
+        postConfig: async () => {
+          throw timeout;
+        },
+        pickPort: () => portCounter++,
+      });
+      await provider
+        .ensureSandbox({ handle: "h3", repo: undefined })
+        .catch(() => {});
+
+      expect(
+        errorSpy.mock.calls.some((call) =>
+          String(call[0]).includes("sandbox bring-up failed"),
+        ),
+      ).toBe(false);
+      expect(
+        warnSpy.mock.calls.some((call) =>
+          String(call[0]).includes("sandbox bring-up failed"),
+        ),
+      ).toBe(true);
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("logs a non-timeout bring-up failure at error", async () => {
+    const dataDir = tmpDataDir();
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      let portCounter = 34000;
+      const provider = createDesktopSandboxProvider({
+        dataDir,
+        spawnDaemon: () => fakeDaemonSpawner(),
+        postConfig: async () => {},
+        waitForHealth: async () => {
+          throw new Error("boom");
+        },
+        pickPort: () => portCounter++,
+      });
+      await provider
+        .ensureSandbox({ handle: "h4", repo: undefined })
+        .catch(() => {});
+
+      expect(
+        errorSpy.mock.calls.some((call) =>
+          String(call[0]).includes("sandbox bring-up failed"),
+        ),
+      ).toBe(true);
+    } finally {
+      errorSpy.mockRestore();
       rmSync(dataDir, { recursive: true, force: true });
     }
   });

--- a/apps/mesh/src/link-daemon/user-desktop-provider.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.ts
@@ -486,7 +486,13 @@ export function createDesktopSandboxProvider(
         );
       }
     } catch (err) {
-      console.error(
+      // A config-post timeout is expected under cold-start load, not a real
+      // failure — console.error is wired to error tracking (see
+      // observability/index.ts), so logging it at ERROR here was the #1
+      // chronic error in prod (20k+ hits, issue #3763). Log it at WARN
+      // instead; genuine bring-up failures still hit console.error.
+      const log = isTimeoutLike(err) ? console.warn : console.error;
+      log(
         `[user-desktop] sandbox bring-up failed handle=${input.handle} port=${port ?? "(none)"}${spawned ? " (killing daemon)" : ""}:`,
         err,
       );


### PR DESCRIPTION
Closes part of #3763 (path 1 — the config-timeout leak; path 2's idle-abort code lives in a different repo and isn't present here).

`apps/mesh/src/observability/index.ts` overrides `console.error` to emit an OTLP ERROR-severity log picked up by error tracking. In `user-desktop-provider.ts`'s `buildEntry`, every bring-up failure — including a benign `AbortSignal.timeout()` on `POST /_sandbox/config` during a cold sandbox start — went through `console.error`. Per #3763 this is the platform's #1 chronic error (20k+ lifetime hits), polluting error tracking with expected control-flow aborts rather than real failures.

Fix: reuse the existing `isTimeoutLike()` classifier (already used to word the user-facing error message) to pick `console.warn` instead of `console.error` for timeout-classified bring-up failures. Non-timeout failures (daemon crash, rejected config, etc.) are unaffected and still log at `error`.

Failure scenario: a slow/cold sandbox startup causes `postConfig` to hit the 30s abort timeout → `console.error(...)` fires → OTLP emits an ERROR log → shows up as a spike in error tracking even though the sandbox subsequently retries/succeeds or fails for an unrelated benign reason.

Regression tests added: one asserting a `TimeoutError` from `postConfig` logs via `console.warn` (not `console.error`), and one asserting a genuine `waitForHealth` failure still logs via `console.error` (no behavior regression for real failures).

Reviewer check: `cd apps/mesh && bun test src/link-daemon/user-desktop-provider.test.ts`

Locally ran: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and the targeted test file above (17 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lower the log level for benign config-timeout failures during desktop sandbox bring-up from error to warn to stop polluting error tracking. Partially addresses #3763 by fixing the config-timeout leak in `apps/mesh`.

- **Bug Fixes**
  - Use `isTimeoutLike()` in `user-desktop-provider.ts` to log timeout-classified bring-up failures with `console.warn`; non-timeouts still use `console.error`.
  - Add tests ensuring a `postConfig` timeout logs at warn and a `waitForHealth` failure logs at error.
  - Reduces false ERROR logs wired via `observability/index.ts` (removes the top chronic error, 20k+ hits).

<sup>Written for commit 230487f92a4c3a54071a80792d9f2c77b1a0c84c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

