### PR TITLE
fix(web): replace explicit any with ToolInputProperty in tool detail form

### DIFF
--- a/apps/mesh/src/web/components/details/tool.tsx
+++ b/apps/mesh/src/web/components/details/tool.tsx
@@ -69,6 +69,7 @@ import {
 } from "@/web/components/chat/context.tsx";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { MonacoCodeEditor } from "../monaco-editor";
+import type { ToolInputProperty } from "@/web/components/tool-input-form";
 
 export interface ToolDetailsViewProps {
   itemId: string;
@@ -281,33 +282,32 @@ function ToolDetailsAuthenticated({
           })();
 
       if (hasToolProperties && tool?.inputSchema?.properties) {
-        Object.entries(tool.inputSchema.properties).forEach(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ([key, prop]: [string, any]) => {
-            if (
-              (prop.type === "object" || prop.type === "array") &&
-              typeof args[key] === "string"
-            ) {
-              try {
-                args[key] = JSON.parse(args[key]);
-              } catch {
-                // Parsing failed, send as string (will likely fail validation but let server handle it)
-              }
-            } else if (
-              (prop.type === "number" || prop.type === "integer") &&
-              typeof args[key] === "string" &&
-              args[key] !== ""
-            ) {
-              // Text inputs yield strings; coerce numeric fields so the tool's
-              // schema (e.g. z.number()) doesn't reject "7776000". Leave
-              // non-numeric strings untouched for the server to reject.
-              const n = Number(args[key]);
-              if (!Number.isNaN(n)) {
-                args[key] = n;
-              }
+        Object.entries(
+          tool.inputSchema.properties as Record<string, ToolInputProperty>,
+        ).forEach(([key, prop]) => {
+          if (
+            (prop.type === "object" || prop.type === "array") &&
+            typeof args[key] === "string"
+          ) {
+            try {
+              args[key] = JSON.parse(args[key]);
+            } catch {
+              // Parsing failed, send as string (will likely fail validation but let server handle it)
             }
-          },
-        );
+          } else if (
+            (prop.type === "number" || prop.type === "integer") &&
+            typeof args[key] === "string" &&
+            args[key] !== ""
+          ) {
+            // Text inputs yield strings; coerce numeric fields so the tool's
+            // schema (e.g. z.number()) doesn't reject "7776000". Leave
+            // non-numeric strings untouched for the server to reject.
+            const n = Number(args[key]);
+            if (!Number.isNaN(n)) {
+              args[key] = n;
+            }
+          }
+        });
       }
 
       const result = (await client.callTool({
@@ -439,67 +439,66 @@ function ToolDetailsAuthenticated({
 
       <div className="space-y-4">
         {hasToolProperties && tool?.inputSchema?.properties ? (
-          Object.entries(tool.inputSchema.properties).map(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ([key, prop]: [string, any]) => (
-              <div key={key} className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <label className="text-sm font-medium leading-none flex items-center gap-1.5">
-                    {key}
-                    {tool.inputSchema?.required?.includes(key) && (
-                      <span className="text-destructive text-xs">*</span>
-                    )}
-                  </label>
-                  <span className="text-xs text-muted-foreground font-mono">
-                    {prop.type}
-                  </span>
-                </div>
-                {prop.description && (
-                  <p className="text-xs text-muted-foreground leading-relaxed">
-                    {prop.description}
-                  </p>
-                )}
-                {prop.type === "object" || prop.type === "array" ? (
-                  <Textarea
-                    className="font-mono text-xs"
-                    value={
-                      hasEditedKey(key)
-                        ? ((editedParams[key] as string) ?? "")
-                        : ((defaultParams[key] as string) ?? "")
-                    }
-                    onChange={(e) => handleInputChange(key, e.target.value)}
-                    placeholder={`Enter ${key} as JSON...`}
-                    rows={3}
-                  />
-                ) : prop.type === "boolean" ? (
-                  <Select
-                    value={
-                      hasEditedKey(key) ? String(editedParams[key] ?? "") : ""
-                    }
-                    onValueChange={(v) => handleInputChange(key, v === "true")}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select true or false..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="true">true</SelectItem>
-                      <SelectItem value="false">false</SelectItem>
-                    </SelectContent>
-                  </Select>
-                ) : (
-                  <Input
-                    value={
-                      hasEditedKey(key)
-                        ? ((editedParams[key] as string) ?? "")
-                        : ((defaultParams[key] as string) ?? "")
-                    }
-                    onChange={(e) => handleInputChange(key, e.target.value)}
-                    placeholder={`Enter ${key}...`}
-                  />
-                )}
+          Object.entries(
+            tool.inputSchema.properties as Record<string, ToolInputProperty>,
+          ).map(([key, prop]) => (
+            <div key={key} className="space-y-2">
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-medium leading-none flex items-center gap-1.5">
+                  {key}
+                  {tool.inputSchema?.required?.includes(key) && (
+                    <span className="text-destructive text-xs">*</span>
+                  )}
+                </label>
+                <span className="text-xs text-muted-foreground font-mono">
+                  {prop.type}
+                </span>
               </div>
-            ),
-          )
+              {prop.description && (
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  {prop.description}
+                </p>
+              )}
+              {prop.type === "object" || prop.type === "array" ? (
+                <Textarea
+                  className="font-mono text-xs"
+                  value={
+                    hasEditedKey(key)
+                      ? ((editedParams[key] as string) ?? "")
+                      : ((defaultParams[key] as string) ?? "")
+                  }
+                  onChange={(e) => handleInputChange(key, e.target.value)}
+                  placeholder={`Enter ${key} as JSON...`}
+                  rows={3}
+                />
+              ) : prop.type === "boolean" ? (
+                <Select
+                  value={
+                    hasEditedKey(key) ? String(editedParams[key] ?? "") : ""
+                  }
+                  onValueChange={(v) => handleInputChange(key, v === "true")}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select true or false..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="true">true</SelectItem>
+                    <SelectItem value="false">false</SelectItem>
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input
+                  value={
+                    hasEditedKey(key)
+                      ? ((editedParams[key] as string) ?? "")
+                      : ((defaultParams[key] as string) ?? "")
+                  }
+                  onChange={(e) => handleInputChange(key, e.target.value)}
+                  placeholder={`Enter ${key}...`}
+                />
+              )}
+            </div>
+          ))
         ) : tool?.inputSchema && !hasToolProperties ? (
           <div className="space-y-2">
             <label className="text-sm font-medium">Raw JSON Input</label>


### PR DESCRIPTION
**Source:** debt reduction — un-CI-enforced `no-explicit-any` (`warn`-level, not blocked by CI) in `apps/mesh/src/web/components/details/tool.tsx`.

**Why:** the tool-execution panel (used from the connection detail view to run any MCP tool interactively) destructured `inputSchema.properties` entries as `[string, any]` (with an `eslint-disable` for `no-explicit-any`) in two places — one preparing call args, one rendering the form fields. `tile-form-values.ts` (`apps/mesh/src/web/components/home/tile-form-values.ts`) already defines `ToolInputProperty` (`{ type: string; description?: string }`) as the typed shape for this exact MCP tool-input-property data and uses it elsewhere in the app (`add-tile-drawer.tsx`), so a rename/retype here is a small, real type-safety win: a future rename or shape change to `ToolInputProperty` now surfaces as a compile error at both call sites instead of silently passing through `any`.

**Change:** replaced both `[key, prop]: [string, any]` destructures with a single `Object.entries(... as Record<string, ToolInputProperty>)` cast (matching the existing cast pattern already used for the same SDK-loosely-typed `inputSchema` in `add-tile-drawer.tsx`), and dropped the now-unused `eslint-disable` comments. No behavior change — `prop.type`/`prop.description` access is identical, just type-checked now instead of `any`.

**Verification:** `cd apps/mesh && bunx tsc --noEmit` passes clean. No existing test covers this component (none added — this is a pure type-safety fix, not new logic); `bun run fmt` applied.

**Reviewer check:** `cd apps/mesh && bunx tsc --noEmit`. Full CI validates lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced explicit any in the tool execution form with the `ToolInputProperty` type to improve type safety. No behavior change.

- **Refactors**
  - Cast `inputSchema.properties` to `Record<string, ToolInputProperty>` and iterate via `Object.entries(...)` in both arg prep and form rendering.
  - Removed `no-explicit-any` disables; `prop.type` and `prop.description` are now type-checked.

<sup>Written for commit 7b922b5828c23d5959a34ac9802589779bfa9b46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

