### PR TITLE
feat(task-board): prompt to connect GitHub when Auto-fixing without a connection

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -19,6 +19,18 @@ import {
   Plus,
 } from "@untitledui/icons";
 import { SuperAgentIcon } from "@/web/components/super-agent-icon";
+import { GitHubIcon } from "@/web/components/icons/github-icon";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { useConnections } from "@decocms/mesh-sdk";
+import { getOrgGithubConnections } from "@/shared/github-repo-scope";
+import { useConnectApp } from "@/web/hooks/use-connect-app";
 import { useMembers } from "@/web/hooks/use-members";
 import {
   useTaskBoardItemActions,
@@ -174,6 +186,12 @@ export function TaskBoardPage() {
   const { items, isLoading } = useTaskBoardItems();
   const actions = useTaskBoardItemActions();
   const reportsOnly = useReportsOnly();
+  // Auto-fix hands the task to the Super Agent, which opens a PR — so it needs
+  // an org-level GitHub connection. If the org has none, prompt to connect
+  // instead of enqueueing a run that can't push.
+  const hasGithub =
+    getOrgGithubConnections(useConnections({ slug: "mcp-github" })).length > 0;
+  const [connectGithubOpen, setConnectGithubOpen] = useState(false);
   const { data: membersData } = useMembers();
   const members = (membersData?.data?.members ?? []) as Member[];
   const memberByUserId = new Map(members.map((m) => [m.userId, m]));
@@ -306,11 +324,16 @@ export function TaskBoardPage() {
           onMove={(id, status) => actions.update.mutate({ id, status })}
           onAutoFix={
             reportsOnly
-              ? (item) =>
+              ? (item) => {
+                  if (!hasGithub) {
+                    setConnectGithubOpen(true);
+                    return;
+                  }
                   actions.update.mutate({
                     id: item.id,
                     assigneeId: SUPER_AGENT_ASSIGNEE_ID,
-                  })
+                  });
+                }
               : undefined
           }
         />
@@ -373,7 +396,57 @@ export function TaskBoardPage() {
           });
         }}
       />
+
+      <ConnectGitHubDialog
+        open={connectGithubOpen}
+        onOpenChange={setConnectGithubOpen}
+      />
     </div>
+  );
+}
+
+/**
+ * Small prompt shown when Auto-fix is used in an org with no GitHub connection.
+ * The Super Agent needs GitHub to open a PR, so we connect first. Once the
+ * connection lands the card's Auto-fix button works on the next click.
+ */
+function ConnectGitHubDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { connect, isConnecting } = useConnectApp("deco/mcp-github");
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Connect GitHub</DialogTitle>
+          <DialogDescription>
+            Auto-fix hands the task to the Super Agent, which opens a pull
+            request with the change. Connect GitHub so it can push and open PRs.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            onClick={async () => {
+              await connect();
+              onOpenChange(false);
+            }}
+            disabled={isConnecting}
+            className="gap-2"
+          >
+            {isConnecting ? (
+              <Loading01 size={16} className="animate-spin" />
+            ) : (
+              <GitHubIcon className="size-4" />
+            )}
+            Connect GitHub
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 


### PR DESCRIPTION
## Summary

In `reports_only` orgs, the **Auto-fix** button on task cards hands the task to the Super Agent, which then opens a GitHub pull request with the change. That silently requires an org-level GitHub connection — but nothing prompted for one, so Auto-fixing in an org without GitHub enqueued a run that couldn't push.

This gates the Auto-fix click on the org's GitHub connection: if there's none, clicking Auto-fix opens a small modal to connect GitHub instead of enqueueing the Super Agent. Once connected, the next Auto-fix click proceeds normally.

## Changes

- `apps/mesh/src/web/layouts/task-board/index.tsx`
  - Read org GitHub connection state via the existing idiom `getOrgGithubConnections(useConnections({ slug: "mcp-github" }))`.
  - When `onAutoFix` fires with no connection, open a `ConnectGitHubDialog` instead of assigning to the Super Agent.
  - New small `ConnectGitHubDialog` component reusing the existing `useConnectApp("deco/mcp-github")` connect flow (same one the home "Connect GitHub" tile uses).

## Testing notes

- `bun run fmt` — clean
- `tsc --noEmit` (apps/mesh) — 0 errors
- `bun run lint` — 0 errors
- UI-only change; affects only the Auto-fix path in `reports_only` orgs.

## Screenshots

_UI change — modal appears on Auto-fix when GitHub isn't connected._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Auto-fix on an org GitHub connection. If no connection exists, clicking Auto-fix opens a small dialog to connect GitHub instead of enqueuing a run that can’t push.

- **New Features**
  - Check org connection via `getOrgGithubConnections(useConnections({ slug: "mcp-github" }))`.
  - Show `ConnectGitHubDialog` when missing; reuses `useConnectApp("deco/mcp-github")` and closes after a successful connect.
  - Applies to Auto-fix in `reports_only` orgs; after connecting, the next Auto-fix proceeds normally.

<sup>Written for commit ed23a8beb178e5c63aeef9616918d1e34cb8796e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

