### PR TITLE
fix(chat): don't clobber stop()'s ready state with the aborted POST's error

### DIFF
--- a/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.test.ts
@@ -640,6 +640,44 @@ describe("stop", () => {
     const ids = conn.messages.get().map((m) => m.id);
     expect(ids).toEqual(["m-1", "u-2", "m-2"]);
   });
+
+  test("clicking Stop while the POST is still in flight lands on ready, not error", async () => {
+    globalThis.fetch = makeFetchMock({
+      messages: (init) =>
+        new Promise((_, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("aborted", "AbortError")),
+          );
+        }),
+    }) as unknown as typeof globalThis.fetch;
+
+    const conn = getOrOpenStream("acme", "thread-stop-mid-post", {
+      client: null,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    const submitPromise = conn.submit(
+      {
+        kind: "message",
+        message: {
+          id: "u-1",
+          role: "user",
+          parts: [{ type: "text", text: "hi" }],
+        },
+      },
+      baseOpts,
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(conn.status.get().kind).toBe("submitted");
+
+    conn.stop();
+    expect(conn.status.get().kind).toBe("ready");
+
+    await submitPromise;
+    // The aborted POST's rejection must not clobber the ready state stop()
+    // already set with an error.
+    expect(conn.status.get().kind).toBe("ready");
+  });
 });
 
 // ─── submit() — single mutator entry point ───────────────────────────────────

--- a/apps/mesh/src/web/components/chat/store/thread-connection.ts
+++ b/apps/mesh/src/web/components/chat/store/thread-connection.ts
@@ -387,8 +387,12 @@ export class ThreadConnection {
     try {
       await this.post(last, opts, abort.signal);
     } catch (err) {
-      const e = err instanceof Error ? err : new Error(String(err));
       this.clearRunStatusStage();
+      // stop() aborts `abort.signal` and already reset status to "ready"
+      // synchronously; the POST's rejection lands here asynchronously after
+      // that. Don't clobber the deliberate cancel with an error state.
+      if (abort.signal.aborted) return;
+      const e = err instanceof Error ? err : new Error(String(err));
       this.failTo(e);
     } finally {
       if (this.inflightPost === abort) this.inflightPost = null;


### PR DESCRIPTION
Follows #4873 — a hardening follow-up to the same bug class (control-flow aborts leaking in as failures), on the client side of issue #3763's "idle abort path" (#4873 only fixed the daemon-side config-timeout path).

**Failure scenario:** a user clicks Stop while the initial `POST /messages` is still in flight (status `"submitted"`, before streaming starts). `stop()` aborts `inflightPost` and synchronously resets `status` to `"ready"`. The aborted POST's promise then rejects *asynchronously*, and `submit()`'s catch block unconditionally calls `failTo()`, which overwrites `"ready"` with `{ kind: "error", error: AbortError }` — the chat flashes an error banner for a deliberate cancel.

**Fix:** in `submit()`'s catch, skip `failTo()` when the rejection came from our own `abort.signal` (the same signal `post()` already uses to distinguish caller-abort from server timeout at line ~772).

**Regression test:** `thread-connection.test.ts` — "clicking Stop while the POST is still in flight lands on ready, not error". Confirmed it fails on the old code (`status` ends as `"error"`) and passes after the fix.

**To verify:** `bun test apps/mesh/src/web/components/chat/store/thread-connection.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the full `thread-connection.test.ts` file (71 pass, including the new test). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where clicking Stop during the initial in-flight POST would show an error banner. We now keep the chat in "ready" after a deliberate cancel and ignore the aborted request error.

- **Bug Fixes**
  - In `submit()` catch, return early if `abort.signal.aborted` to avoid calling `failTo()` on user-initiated cancel.
  - Added regression test to ensure Stop during in-flight POST ends in "ready", not "error".

<sup>Written for commit 1dc4f57224cd1ef7b03179676b3df6fcd47edb25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

