### PR TITLE
feat(decopilot): reference the open Library file in chat context

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.test.ts
@@ -124,4 +124,63 @@ describe("buildDurableDispatchInput", () => {
     );
     expect(durable.runMetadata).toEqual({ org_id: "org-xyz", url: "shop.com" });
   });
+
+  test("folds the per-turn system message text into systemContext", () => {
+    const durable = buildDurableDispatchInput(
+      {
+        messages: [
+          {
+            id: "sys-1",
+            role: "system",
+            parts: [
+              { type: "text", text: "### Currently Open File\nhome/x.md" },
+            ],
+          } as ChatMessage,
+          {
+            id: "msg-user",
+            role: "user",
+            parts: [{ type: "text", text: "change the h1" }],
+          } as ChatMessage,
+        ],
+        models: { credentialId: "cred-1", thinking: { id: "model-1" } },
+        agent: { id: "agent-1" },
+        temperature: 0.2,
+        toolApprovalLevel: "auto",
+        mode: "default",
+        organizationId: "org-1",
+        userId: "user-1",
+        taskId: "thread-1",
+      },
+      { messageId: "msg-user", runFenceToken: "fence-1" },
+    );
+    // The raw messages array is still dropped from the durable snapshot…
+    expect("messages" in durable).toBe(false);
+    // …but the ephemeral system context survives it (it isn't persisted as a
+    // thread message, so the durable branch would otherwise lose it).
+    expect(durable.systemContext).toBe("### Currently Open File\nhome/x.md");
+  });
+
+  test("omits systemContext when the turn carries no system message", () => {
+    const durable = buildDurableDispatchInput(
+      {
+        messages: [
+          {
+            id: "msg-user",
+            role: "user",
+            parts: [{ type: "text", text: "hi" }],
+          } as ChatMessage,
+        ],
+        models: { credentialId: "cred-1", thinking: { id: "model-1" } },
+        agent: { id: "agent-1" },
+        temperature: 0.2,
+        toolApprovalLevel: "auto",
+        mode: "default",
+        organizationId: "org-1",
+        userId: "user-1",
+        taskId: "thread-1",
+      },
+      { messageId: "msg-user", runFenceToken: "fence-1" },
+    );
+    expect("systemContext" in durable).toBe(false);
+  });
 });

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -436,6 +436,18 @@ export interface FrozenRunSnapshot {
   sandboxProviderKind?: SandboxProviderKind | null;
   harnessId?: HarnessId | null;
   target?: DispatchTarget;
+  /**
+   * Per-turn system context the client attached to this user turn (the
+   * `role:"system"` message in the POST body — e.g. the currently-open file,
+   * selected agent, viewed resource; see `useContext` on the web client).
+   *
+   * Carried in the frozen snapshot rather than reloaded from history because
+   * it is ephemeral: the system message is NOT persisted as a thread message,
+   * so the durable dispatch branch (which reloads history from the DB) would
+   * otherwise lose it. Rehydrated into `systemMessages` and appended to the
+   * server-built base system prompt for this run only.
+   */
+  systemContext?: string;
 }
 
 export interface DurableDispatchRunInput extends FrozenRunSnapshot {
@@ -472,6 +484,20 @@ export function buildDurableDispatchInput(
   if (!input.taskId) {
     throw new Error("buildDurableDispatchInput: taskId is required");
   }
+
+  // The client attaches per-turn context as a `role:"system"` message that is
+  // never persisted, so fold its text into the frozen snapshot before the
+  // durable branch drops the `messages` array entirely.
+  const systemContext = input.messages
+    .filter((m) => m.role === "system")
+    .flatMap((m) => m.parts)
+    .filter(
+      (p): p is { type: "text"; text: string } =>
+        p.type === "text" && typeof p.text === "string",
+    )
+    .map((p) => p.text)
+    .join("\n\n")
+    .trim();
 
   return {
     models: input.models,
@@ -510,6 +536,7 @@ export function buildDurableDispatchInput(
       ? { runFenceToken: options.runFenceToken }
       : {}),
     ...(input.isResume !== undefined ? { isResume: input.isResume } : {}),
+    ...(systemContext ? { systemContext } : {}),
   };
 }
 
@@ -1171,6 +1198,18 @@ async function prepareRun(
         durableHistory,
         input.messageId,
       );
+      // Rehydrate the per-turn system context folded into the frozen snapshot
+      // (it isn't a persisted thread message, so it's absent from history).
+      // Deterministic id keyed by messageId so DBOS replay is stable.
+      if (input.systemContext) {
+        systemMessages = [
+          {
+            id: `system-${input.messageId}`,
+            role: "system",
+            parts: [{ type: "text", text: input.systemContext }],
+          } as ChatMessage,
+        ];
+      }
     } else {
       // Split system messages from user message.
       systemMessages = input.messages.filter((m) => m.role === "system");

--- a/apps/mesh/src/web/hooks/use-context.ts
+++ b/apps/mesh/src/web/hooks/use-context.ts
@@ -3,13 +3,17 @@
  *
  * Provides dynamic context for the AI assistant based on:
  * - Current route parameters (connection, collection, item)
+ * - The Library file the user currently has open (`?main=library-file:…`
+ *   side tab, or `?preview=`/`?skill=`/`?brand=` panel/dialog)
  * - Selected virtual MCP (agent) and its custom instructions
  *
  * This hook only returns context information; base system instructions
  * are handled server-side in models.ts (DECOPILOT_SYSTEM_PROMPT).
  */
 
-import { useMatch } from "@tanstack/react-router";
+import { useMatch, useSearch } from "@tanstack/react-router";
+import { basename, orgFsMountPath } from "@/web/layouts/library/location";
+import { parseLibraryFileTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 
 /**
  * Hook that generates context for the AI assistant based on current state
@@ -24,12 +28,51 @@ export function useContext(virtualMcpId?: string | null): string {
     shouldThrow: false,
   });
 
+  // Library file the user currently has open. Desktop opens it as a
+  // main-panel side tab (`?main=library-file:<encoded browse path>`); the
+  // Library's own right panel and the mobile dialog use the raw browse-path
+  // params (`?preview=`/`?skill=`/`?brand=`). Precedence mirrors the panel's
+  // own (preview › skill › brand); the side tab wins when both are set.
+  const search = useSearch({ strict: false }) as {
+    main?: string | 0;
+    preview?: string;
+    skill?: string;
+    brand?: string;
+  };
+  const openFilePath =
+    (typeof search.main === "string"
+      ? parseLibraryFileTabId(search.main)?.path
+      : undefined) ??
+    search.preview ??
+    search.skill ??
+    search.brand ??
+    null;
+
   const contextParts: string[] = [];
 
   // Add virtual MCP context if selected
   if (virtualMcpId) {
     contextParts.push(`### Selected Agent
 - ID: ${virtualMcpId}`);
+  }
+
+  // Point the assistant at the file the user is looking at, so an ambiguous
+  // request ("change the h1") resolves to it instead of guessing. We give the
+  // sandbox mount path so the agent can read/edit it directly with its file
+  // tools — the browse path alone isn't where those tools operate.
+  if (openFilePath) {
+    const mountPath = orgFsMountPath(openFilePath);
+    contextParts.push(`### Currently Open File
+The user has this file open in the Library and is most likely referring to it:
+- Name: ${basename(openFilePath)}
+- Library path: ${openFilePath}${
+      mountPath
+        ? `
+- Read/edit it with your file tools at: \`${mountPath}\``
+        : ""
+    }
+
+When a request is ambiguous about which file or resource it targets (e.g. "change the h1", "fix this", "what's in this file", "update the title"), assume it means this file unless the user clearly indicates otherwise.`);
   }
 
   // Add route context based on available params

--- a/apps/mesh/src/web/layouts/library/location.ts
+++ b/apps/mesh/src/web/layouts/library/location.ts
@@ -75,3 +75,27 @@ export function basename(path: string): string {
   const i = path.lastIndexOf("/");
   return i === -1 ? path : path.slice(i + 1);
 }
+
+/**
+ * Sandbox mount path for a Library browse path — where the agent's file tools
+ * (`read`/`edit`/`grep`) actually reach the file: `org/home/…`,
+ * `org/public/<set>/…`, etc.
+ *
+ * Client mirror of the server's `orgFsSandboxPath`
+ * (`apps/mesh/src/file-storage/mount/provisioning.ts`); the browse-path →
+ * mount mapping must stay in sync with the mount table there. Returns null for
+ * the root / public-sets listing (no single file).
+ */
+export function orgFsMountPath(browsePath: string): string | null {
+  const { volume, dirPath } = parseLibraryPath(browsePath);
+  if (!volume) return null;
+  let base: string;
+  if (volume === "home") base = "org/home";
+  else if (volume === "outputs") base = "org/.outputs";
+  else if (volume === "uploads") base = "org/.uploads";
+  else {
+    const set = publicSetOf(volume);
+    base = set ? `org/public/${set}` : `org/${volume}`;
+  }
+  return dirPath ? `${base}/${dirPath}` : base;
+}


### PR DESCRIPTION
## Summary

When a user has a Library file open and asks the decopilot chat something ambiguous — "mude o h1", "o que tem nesse arquivo?" — the agent now knows they're most likely referring to that file, instead of guessing or claiming no file is attached.

This is **reference-only**: the context carries the file's name, Library path, and the `org/…` sandbox mount path — not its contents. The agent reads it on demand with its own file tools.

## What changed

**Client — surface the open file as context**
- `use-context.ts`: injects a `### Currently Open File` section derived from the open-file URL state (`?main=library-file:` side tab on desktop; `?preview=` / `?skill=` / `?brand=` for the Library panel and mobile dialog). Includes the `org/…` mount path so the agent's `read`/`edit` tools operate on the right location.
- `location.ts`: adds `orgFsMountPath()` — a client mirror of the server's `orgFsSandboxPath` (it can't be imported across the web↔server boundary, enforced by `ban-web-server-imports`), with a comment tying it to the source of truth.

**Server — stop dropping the per-turn system context (pre-existing regression)**

While tracing why the open file wasn't reaching the model, I found the client's per-turn `system` message was being **silently discarded** on the durable dispatch path (the DBOS migration): the `role:"system"` message is filtered at `routes.ts:695`, never persisted, and not copied into the frozen snapshot — so the durable branch reloaded history with `systemMessages = []`. This dropped **both** this feature and the existing `### Current Resource` / `### Selected Agent` context.

- `dispatch-run.ts`: `buildDurableDispatchInput` folds the system-message text into the frozen snapshot as `systemContext`; the durable branch rehydrates it into `systemMessages` (deterministic id keyed by `messageId` for stable DBOS replay). Now the per-turn context reaches the model again.

## Testing

- `bun run check` (all workspaces) ✅
- `bun test dispatch-run.test.ts` — 8/8 ✅ (2 new: folds `systemContext`; omits it when no system message)
- `bun test context-loader.test.ts` ✅
- `bun run lint` (0 errors), `knip` (clean), `bun run fmt` ✅

The full chain (URL → client `system` → POST → durable snapshot → `splitMessages` → model system prompt) is traced and unit-covered. End-to-end validation in a running app (needs a model credential) is still worth a manual pass: open a Library file, ask "mude o h1" / "o que tem nesse arquivo?".

## Follow-up (not in this PR)
- Visual chip in the composer showing the "file in focus" (with a way to remove it), so the referenced file is explicit to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decopilot chat now references the currently open Library file so ambiguous requests target the right file. Also restores per-turn system context on durable dispatch.

- **New Features**
  - Adds a "Currently Open File" context with file name, Library path, and `org/...` mount path for file tools, derived from `?main=library-file:` or `?preview`/`?skill`/`?brand`.
  - Introduces `orgFsMountPath()` to map Library paths to sandbox paths.

- **Bug Fixes**
  - Per-turn `system` context is preserved in durable runs by folding it into the frozen snapshot as `systemContext` and rehydrating it for the model.
  - Restores the "Current Resource" and "Selected Agent" context blocks.

<sup>Written for commit 396e1023d4dffcaccffe877104035ae38af2523e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

