### PR TITLE
refactor(monitoring): replace any[] KPI tooltip payload with a typed shape

### DIFF
--- a/apps/mesh/src/web/components/monitoring/monitoring-stats-row.tsx
+++ b/apps/mesh/src/web/components/monitoring/monitoring-stats-row.tsx
@@ -219,6 +219,11 @@ function formatYAxisValue(value: number): string {
   return String(value);
 }
 
+interface KPITooltipPayloadItem {
+  value?: unknown;
+  payload?: BucketPoint;
+}
+
 function KPITooltipContent({
   active,
   payload,
@@ -226,8 +231,7 @@ function KPITooltipContent({
   colorVar,
 }: {
   active?: boolean;
-  // biome-ignore lint: recharts payload is loosely typed
-  payload?: any[];
+  payload?: KPITooltipPayloadItem[];
   dataKey: string;
   colorVar: string;
 }) {


### PR DESCRIPTION
Un-CI-enforced `no-explicit-any` debt (C-DEBT): `KPITooltipContent`'s `payload` prop was typed as `any[]` with a `biome-ignore` comment claiming recharts' payload is loosely typed.

The real payoff: the code only ever reads `payload[0].value` and `payload[0].payload.{t,label}` — the latter is the original `BucketPoint` datum the chart was fed via `data={data}` on the enclosing `AreaChart`/`BarChart`, so the real shape is recoverable without guessing, not a case where `any` needs to stay.

Change: added a local `KPITooltipPayloadItem { value?: unknown; payload?: BucketPoint }` interface and typed the prop with it, dropping the `biome-ignore` comment. `value` stays `unknown` (not `number`) because recharts' own `Payload.value` is `string | number | Array<...>` and the component already narrows it with `typeof rawValue === "number"` before use — so `unknown` is the precise recoverable type, not a guess.

Behavior-preserving: no runtime logic changed, only the static type of an existing prop.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` (green).

Local checks run: `bun run fmt` and `bunx tsc --noEmit` in `apps/mesh` (green). No test file exists for this pure chart-tooltip formatting component and none is warranted (display-only, not a trust boundary) — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `any[]` payload in `KPITooltipContent` with a precise typed shape to improve type safety and remove the lint ignore, with no runtime changes.

- **Refactors**
  - Introduced `KPITooltipPayloadItem { value?: unknown; payload?: BucketPoint }` and typed `payload?: KPITooltipPayloadItem[]`.
  - Kept `value` as `unknown` to match `recharts`’ flexible `value` type and rely on existing runtime narrowing.

<sup>Written for commit 10687179c3edd97da7c04182a673399923f08370. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

