### PR TITLE
refactor(web): use bg-muted-foreground token for unknown-role dot color

### DIFF
--- a/apps/mesh/src/web/lib/role-color.test.ts
+++ b/apps/mesh/src/web/lib/role-color.test.ts
@@ -9,7 +9,7 @@ const DESIGN_SYSTEM_TOKEN_CLASSES = new Set([
   "bg-chart-5",
   "bg-destructive",
   "bg-success",
-  "bg-neutral-400",
+  "bg-muted-foreground",
 ]);
 
 describe("role-color", () => {
@@ -31,6 +31,6 @@ describe("role-color", () => {
   });
 
   test("empty role name falls back to neutral", () => {
-    expect(getRoleColor("")).toBe("bg-neutral-400");
+    expect(getRoleColor("")).toBe("bg-muted-foreground");
   });
 });

--- a/apps/mesh/src/web/lib/role-color.ts
+++ b/apps/mesh/src/web/lib/role-color.ts
@@ -13,7 +13,7 @@ const BUILTIN_ROLE_COLORS: Record<string, string> = {
 };
 
 export function getRoleColor(roleName: string): string {
-  if (!roleName) return "bg-neutral-400";
+  if (!roleName) return "bg-muted-foreground";
   let hash = 0;
   for (let i = 0; i < roleName.length; i++) {
     const char = roleName.charCodeAt(i);
@@ -25,6 +25,6 @@ export function getRoleColor(roleName: string): string {
 }
 
 export function getRoleDotColor(role: string, isBuiltin: boolean): string {
-  if (isBuiltin) return BUILTIN_ROLE_COLORS[role] ?? "bg-neutral-400";
+  if (isBuiltin) return BUILTIN_ROLE_COLORS[role] ?? "bg-muted-foreground";
   return getRoleColor(role);
 }


### PR DESCRIPTION
C-DEBT: design-token drift in `apps/mesh/src/web/lib/role-color.ts` — the "unknown/empty role" fallback in `getRoleColor` and `getRoleDotColor` used a raw `bg-neutral-400` instead of the design-system muted token.

Mapping: `bg-neutral-400` -> `bg-muted-foreground`. This is unambiguous: the rest of the codebase already uses `bg-muted-foreground` (with opacity variants) for the exact same meaning — a neutral/no-active-state dot indicator, e.g. `apps/mesh/src/web/layouts/task-board/config.tsx` (`dotClassName: "bg-muted-foreground/40"`), `apps/mesh/src/web/views/automations/automation-list-row.tsx`, and `apps/mesh/src/web/components/github-repo-picker.tsx`. This aligns the shade to the design-system muted token rather than a hardcoded gray — it is not guaranteed pixel-identical to neutral-400, but it is the established semantic equivalent used everywhere else in the app for this exact case.

Behavior-preserving: only the CSS class string changes, no logic touched. Updated `role-color.test.ts` (which encodes the allowed class set) to match.

Reviewer check: `bun test apps/mesh/src/web/lib/role-color.test.ts`

Locally verified: `bun run fmt` and the targeted test file above both pass. Full CI covers typecheck/lint for the rest of the workspace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the unknown/empty role fallback color from `bg-neutral-400` to the design token `bg-muted-foreground` in `getRoleColor` and `getRoleDotColor` to align with the design system and match existing usage across the app. Behavior-preserving change; updated tests to expect the new token.

<sup>Written for commit 52cf3b5db6562d90c02c1ce9ef1c81f858fb1895. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

