### PR TITLE
refactor(web): use bg-muted-foreground token for unknown-role dot fallback in members table

### DIFF
--- a/apps/mesh/src/web/routes/orgs/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/members.tsx
@@ -118,7 +118,7 @@ function RoleSelector({
   size = "xs",
   className,
 }: RoleSelectorProps) {
-  const roleColor = roleColorMap.get(role) ?? "bg-neutral-400";
+  const roleColor = roleColorMap.get(role) ?? "bg-muted-foreground";
 
   if (isOwner) {
     return (
@@ -146,7 +146,8 @@ function RoleSelector({
                 </SelectTrigger>
                 <SelectContent>
                   {selectableRoles.map((r) => {
-                    const color = roleColorMap.get(r.role) ?? "bg-neutral-400";
+                    const color =
+                      roleColorMap.get(r.role) ?? "bg-muted-foreground";
                     return (
                       <SelectItem key={r.role} value={r.role}>
                         <div className="flex items-center gap-2">
@@ -184,7 +185,7 @@ function RoleSelector({
       </SelectTrigger>
       <SelectContent>
         {selectableRoles.map((r) => {
-          const color = roleColorMap.get(r.role) ?? "bg-neutral-400";
+          const color = roleColorMap.get(r.role) ?? "bg-muted-foreground";
           return (
             <SelectItem key={r.role} value={r.role}>
               <div className="flex items-center gap-2">


### PR DESCRIPTION
Design-token debt cleanup (C-DEBT), no linked issue.

Three call sites in `members.tsx`'s `RoleSelector` fall back to the raw palette class `bg-neutral-400` for the role-dot color when a role isn't found in `roleColorMap` (an unrecognized/unknown role). This is the identical semantic case already handled inside `role-color.ts` itself (`getRoleColor`/`getRoleDotColor`'s own internal `bg-neutral-400` fallback), which open PR #4879 migrates to the semantic `bg-muted-foreground` token. This PR applies the same, already-established mapping to the sibling fallback occurrences in `members.tsx` so the two stay consistent — same meaning, same target token, not a new judgment call.

Behavior: `bg-muted-foreground` aligns the shade to the design-system muted-foreground token; it is not necessarily pixel-identical to the old `neutral-400` gray but represents the same intent (a neutral/unknown-state indicator).

How to confirm: open the org Members page for an account with a custom/unrecognized role name not covered by `ROLE_COLORS`/`BUILTIN_ROLE_COLORS` — the role-selector dot renders in the muted-foreground gray instead of raw neutral-400.

Verification run locally: `bun run fmt` (no changes needed) and `cd apps/mesh && bunx tsc --noEmit` (clean). No test file covers this presentational fallback; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hard-coded `bg-neutral-400` with `bg-muted-foreground` for the role dot when a role is unknown in the members table. This keeps `RoleSelector` consistent with the `role-color` utilities and the design token system.

<sup>Written for commit e1d814f538f1b036075e9555d4df0821f962d4a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

