### PR TITLE
fix(decopilot): don't show a streaming thread as expired

### DIFF
--- a/apps/mesh/src/api/watch.test.ts
+++ b/apps/mesh/src/api/watch.test.ts
@@ -135,6 +135,7 @@ function makeThread(overrides: Partial<Thread>): Thread {
     run_owner_pod: overrides.run_owner_pod ?? null,
     run_config: overrides.run_config ?? null,
     run_started_at: overrides.run_started_at ?? null,
+    last_progress_at: overrides.last_progress_at ?? null,
     virtual_mcp_id: overrides.virtual_mcp_id ?? "",
     branch: overrides.branch ?? null,
     sandbox_provider_kind: overrides.sandbox_provider_kind ?? null,

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -1001,6 +1001,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
     run_owner_pod?: string | null;
     run_config?: Record<string, unknown> | null;
     run_started_at?: Date | string | null;
+    last_progress_at?: Date | string | null;
     virtual_mcp_id?: string | null;
     branch?: string | null;
     sandbox_provider_kind?: string | null;
@@ -1043,6 +1044,9 @@ export class SqlThreadStorage implements ThreadStoragePort {
       run_config: row.run_config ?? null,
       run_started_at: row.run_started_at
         ? toIsoString(row.run_started_at)
+        : null,
+      last_progress_at: row.last_progress_at
+        ? toIsoString(row.last_progress_at)
         : null,
       virtual_mcp_id: row.virtual_mcp_id ?? "",
       branch: row.branch ?? null,

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -1041,6 +1041,13 @@ export interface Thread {
   run_owner_pod: string | null;
   run_config: Record<string, unknown> | null;
   run_started_at: string | null;
+  /**
+   * Progress-liveness heartbeat, bumped per streamed chunk (throttled). Used to
+   * derive the virtual "expired" status while a run is streaming — the same
+   * signal the reaper trusts — so a still-streaming thread never shows expired.
+   * Null when the run has never streamed a chunk.
+   */
+  last_progress_at: string | null;
   /** Virtual MCP (agent) this thread was initiated with */
   virtual_mcp_id: string;
   /** Git branch this thread is pinned to (GitHub-linked virtualmcps only) */

--- a/apps/mesh/src/tools/thread/helpers.test.ts
+++ b/apps/mesh/src/tools/thread/helpers.test.ts
@@ -22,6 +22,7 @@ const BASE_THREAD: Thread = {
   run_owner_pod: null,
   run_config: null,
   run_started_at: null,
+  last_progress_at: null,
   virtual_mcp_id: "",
   branch: null,
   sandbox_provider_kind: null,
@@ -71,6 +72,39 @@ describe("normalizeThreadForResponse", () => {
     const staleUpdate = new Date(NOW - 31 * 60 * 1000).toISOString(); // 31 min ago
     const result = normalizeThreadForResponse(
       { ...BASE_THREAD, status: "in_progress", updated_at: staleUpdate },
+      NOW,
+    );
+    expect(result.status).toBe("expired");
+  });
+
+  test("stale updated_at but fresh last_progress_at stays in_progress (streaming)", () => {
+    // The bug: a long/resumed run streams chunks (bumping last_progress_at)
+    // but updated_at only moves at terminal, so keying off updated_at alone
+    // falsely flipped an actively-streaming thread to "expired".
+    const staleUpdate = new Date(NOW - 90 * 60 * 1000).toISOString(); // 90 min ago
+    const recentProgress = new Date(NOW - 5 * 1000).toISOString(); // 5s ago
+    const result = normalizeThreadForResponse(
+      {
+        ...BASE_THREAD,
+        status: "in_progress",
+        updated_at: staleUpdate,
+        last_progress_at: recentProgress,
+      },
+      NOW,
+    );
+    expect(result.status).toBe("in_progress");
+  });
+
+  test("both updated_at and last_progress_at stale becomes expired", () => {
+    const staleUpdate = new Date(NOW - 90 * 60 * 1000).toISOString();
+    const staleProgress = new Date(NOW - 31 * 60 * 1000).toISOString();
+    const result = normalizeThreadForResponse(
+      {
+        ...BASE_THREAD,
+        status: "in_progress",
+        updated_at: staleUpdate,
+        last_progress_at: staleProgress,
+      },
       NOW,
     );
     expect(result.status).toBe("expired");

--- a/apps/mesh/src/tools/thread/helpers.ts
+++ b/apps/mesh/src/tools/thread/helpers.ts
@@ -39,8 +39,24 @@ export function normalizeThreadForResponse(
   let status: ThreadStatusForResponse = thread.status;
 
   if (status === "in_progress") {
+    // Liveness = the most recent of `updated_at` (bumped by terminal writers)
+    // and `last_progress_at` (bumped per streamed chunk, throttled). A
+    // still-streaming run keeps `last_progress_at` fresh even though
+    // `updated_at` stays stale for the whole turn, so keying only off
+    // `updated_at` would falsely flip an actively-streaming thread to
+    // "expired" after 30 min. Use the same heartbeat the reaper trusts.
     const updatedAtMs = new Date(thread.updated_at).getTime();
-    if (!Number.isFinite(updatedAtMs) || now - updatedAtMs > THREAD_EXPIRY_MS) {
+    const progressAtMs = thread.last_progress_at
+      ? new Date(thread.last_progress_at).getTime()
+      : Number.NaN;
+    const lastActiveMs = Math.max(
+      Number.isFinite(updatedAtMs) ? updatedAtMs : Number.NEGATIVE_INFINITY,
+      Number.isFinite(progressAtMs) ? progressAtMs : Number.NEGATIVE_INFINITY,
+    );
+    if (
+      !Number.isFinite(lastActiveMs) ||
+      now - lastActiveMs > THREAD_EXPIRY_MS
+    ) {
       status = "expired";
     }
   }


### PR DESCRIPTION
## Summary

A thread that was actively streaming showed as **timed-out ("expired")** mid-run, then snapped back to its real status (`done`) at the very end — reported on a real staging thread ([gimenes-carnival-workspace/9f5130e1…](https://studio-stg.decocms.com/gimenes-carnival-workspace/9f5130e1-342f-44b2-8967-66c148f2d7b0)).

There are **two independent "timeout" concepts** that read **different columns**:

| Concept | Where | Column read | Bumped by chunks? |
|---|---|---|---|
| Progress reaper (force-fails zombies) | `run-registry.ts` | `last_progress_at` | ✅ yes |
| Virtual `"expired"` display status (what the UI shows) | `tools/thread/helpers.ts` | `updated_at` | ❌ **no** |

The per-chunk progress heartbeat (`bumpProgress`) writes **only** `last_progress_at` and deliberately never touches `updated_at` (to avoid churning thread-list ordering). `updated_at` is only rewritten by the terminal writers (`completeRunIfNotCompleted` / `markRunFailed` / …). So a long or DBOS-resumed run that keeps streaming has `updated_at` frozen at turn start → `normalizeThreadForResponse` flips it to `"expired"` after 30 min even though chunks are flowing and the reaper correctly considers it alive.

The reaper isn't dead — it's progress-aware and correctly left the run alone. The **display** derivation was using a different, stale signal.

## Fix

Derive `"expired"` from the most recent of `updated_at` **and** `last_progress_at` — the same liveness heartbeat the reaper already trusts — so a still-streaming thread never shows expired. `last_progress_at` is surfaced on the read-path `Thread` (mapper + type) purely for this computation; it is **not** added to the API response shape (`normalizeThreadForResponse` still strips internal fields).

## Testing

- `apps/mesh/src/tools/thread/helpers.test.ts` — added: stale `updated_at` + fresh `last_progress_at` stays `in_progress` (the streaming case); both stale → `expired`. Existing cases (updated_at-only fallback) unchanged.
- `bun run --cwd=apps/mesh check` passes; `bun run fmt` clean.

## Affected areas

Read-path thread status only. No write-path or list-ordering change (`bumpProgress` still touches only `last_progress_at`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where an actively streaming thread could show as expired mid-run. The "expired" status now uses the latest of updated_at and last_progress_at, so streaming threads stay in_progress.

- **Bug Fixes**
  - Derive UI "expired" from the most recent of updated_at and last_progress_at.
  - Surface last_progress_at on the read-path `Thread` and in the storage mapper; not included in API responses.
  - Added tests for streaming liveness and both-stale cases.
  - No write-path or list ordering changes; `bumpProgress` still updates only last_progress_at.

<sup>Written for commit f65e7836b78da1aeb4deb841ba32e834452e8e68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

