### PR TITLE
docs(helm): document agent sandbox deployment

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
@@ -1,208 +1,336 @@
 ---
 title: "Kubernetes"
-description: Deploy deco Studio on Kubernetes using Helm
+description: Deploy deco Studio and agent sandboxes on Kubernetes using Helm
 icon: Rocket
 ---
 
 import Callout from "../../../../../../components/ui/Callout.astro";
 
-This guide explains how to deploy deco Studio on Kubernetes using the Helm chart.
+This guide deploys deco Studio and its hosted agent sandboxes on Kubernetes.
 
-Chart source: [decocms/studio → deploy/helm/studio](https://github.com/decocms/studio/tree/main/deploy/helm/studio)
+Chart sources:
 
-For how the pieces fit together at runtime (web / API / worker split, Postgres, NATS, sandboxes), see [Architecture](/en/studio/architecture).
+- [Studio](https://github.com/decocms/studio/tree/main/deploy/helm/studio)
+- [Sandbox operator](https://github.com/decocms/studio/tree/main/deploy/helm/sandbox-operator)
+- [Sandbox environment](https://github.com/decocms/studio/tree/main/deploy/helm/sandbox-env)
 
-## What the chart deploys
+For the runtime architecture (web/API/worker split, Postgres, NATS, and sandbox providers), see [Architecture](/en/studio/architecture).
 
-- **Deployment** — the application pods (security context, health checks)
-- **Service** — in-cluster exposure (ClusterIP by default)
-- **ConfigMap / Secret** — non-sensitive config and secrets (`BETTER_AUTH_SECRET`, DB URL)
-- **PersistentVolumeClaim** — persistent storage at `/app/data`
-- **ServiceAccount** and an optional **HorizontalPodAutoscaler**
+## Deployment model
+
+A production deployment uses three Helm releases:
+
+| Chart | Scope | Purpose |
+| --- | --- | --- |
+| `chart-deco-studio` | Once per Studio environment | Runs an nginx front door with two API containers per pod, queue workers, NATS, persistence, and optional observability components |
+| `sandbox-operator` | Once per Kubernetes cluster | Installs the upstream Kubernetes SIGs [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) controller and CRDs |
+| `sandbox-env` | Once per Studio environment | Installs the environment's `SandboxTemplate`, runner RBAC, sentinel Secret, and optional warm pool, preview Gateway, and idle housekeeper |
+
+The operator is shared cluster infrastructure. Each `sandbox-env` release is isolated by `envName`, so production, staging, and other Studio releases can share the operator and the `agent-sandbox-system` namespace without resource-name collisions.
+
+When a hosted agent needs a sandbox, Studio creates a `SandboxClaim`. The operator turns that claim into an ephemeral sandbox pod from the environment's `SandboxTemplate`. Studio reaches the daemon through Kubernetes port-forward for control traffic. If preview routing is enabled, Studio also creates one `HTTPRoute` per claim so the wildcard Gateway routes directly to the sandbox Service on port 9000.
 
 ## Prerequisites
 
-- Kubernetes 1.32+
-- Helm 3.0+
-- `kubectl` configured for your cluster
-- A StorageClass (for the PVC), and — for any real deployment — a **PostgreSQL** database
+- Kubernetes 1.32+ and Helm 3
+- `kubectl` configured for the cluster
+- A PostgreSQL database; the current API/worker topology requires PostgreSQL
+- A StorageClass for Studio and the chart-managed NATS JetStream PVCs
+- Support for `spec.hostUsers: true` and privileged sidecars in `agent-sandbox-system`; the mandatory org-fs sidecar uses FUSE and bidirectional mount propagation
+- For public preview URLs only: Gateway API CRDs, a Gateway controller, wildcard DNS, and either cert-manager with a DNS-01 `ClusterIssuer` or load-balancer TLS termination
 
-## Quick Start
+For production, schedule sandbox pods on a dedicated, tainted node pool. Sandbox pods run user-authored code and should not share nodes with Studio, Postgres, NATS, or observability workloads.
 
-Run from the chart directory (`deploy/helm/studio`):
+## Install Studio with agent sandboxes
+
+The commands below use the versions currently declared by the charts. Pin versions in your own deployment instead of tracking `latest`.
 
 ```bash
-# 1. Generate a secure secret for authentication
-SECRET=$(openssl rand -base64 32)
-
-# 2. Install the chart
-helm install deco-studio . \
-  --namespace deco-studio \
-  --create-namespace \
-  --set secret.BETTER_AUTH_SECRET="$SECRET"
-
-# 3. Wait for pods to be ready
-kubectl wait --for=condition=ready pod \
-  -l app.kubernetes.io/instance=deco-studio \
-  -n deco-studio \
-  --timeout=300s
-
-# 4. Access via port-forward
-kubectl port-forward svc/deco-studio 8080:80 -n deco-studio
+export STUDIO_CHART_VERSION=0.12.2
+export SANDBOX_OPERATOR_CHART_VERSION=0.1.3
+export SANDBOX_ENV_CHART_VERSION=0.9.6
 ```
 
-The application will be available at `http://localhost:8080`.
+### 1. Install the cluster-wide sandbox operator
+
+The operator chart has no configurable values and must be installed in `agent-sandbox-system` because the vendored controller manifest targets that namespace.
+
+```bash
+helm install sandbox-operator \
+  oci://ghcr.io/decocms/studio/charts/sandbox-operator \
+  --version "$SANDBOX_OPERATOR_CHART_VERSION" \
+  --namespace agent-sandbox-system \
+  --create-namespace
+```
+
+Verify the controller and CRDs:
+
+```bash
+kubectl rollout status deployment/agent-sandbox-controller \
+  -n agent-sandbox-system --timeout=300s
+kubectl get crd sandboxclaims.extensions.agents.x-k8s.io \
+  sandboxtemplates.extensions.agents.x-k8s.io \
+  sandboxwarmpools.extensions.agents.x-k8s.io
+```
+
+### 2. Configure and install Studio
+
+Create `studio-values.yaml`. `envName`, the template suffix, Studio namespace, release name, and service-account name must agree with the `sandbox-env` release installed in the next step.
+
+```yaml
+database:
+  engine: postgresql
+  url: "postgresql://studio_user:studio_password@postgres.example.com:5432/studio"
+
+serviceAccount:
+  create: true
+  name: deco-studio
+  automount: true
+
+configMap:
+  meshConfig:
+    BETTER_AUTH_URL: "https://studio.example.com"
+    BASE_URL: "https://studio.example.com"
+    STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
+    STUDIO_ENV: "production"
+    STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-production"
+
+secret:
+  BETTER_AUTH_SECRET: "replace-with-openssl-rand-base64-32"
+  ENCRYPTION_KEY: "replace-with-another-openssl-rand-base64-32"
+```
 
 <Callout type="warning">
-  **Use PostgreSQL for anything real.** Studio's runtime is PostgreSQL-based, and only PostgreSQL supports more than one replica. The chart ships a single-node default for evaluation; for staging or production, set `database.engine: postgresql` with a `database.url`, and enable autoscaling/multiple replicas from there (see [Database](#database) and [Scaling](#replicas-scaling-and-strategy)).
+  **Do not commit this example with real credentials.** For production, use `secret.secretName` or `externalSecret` so `DATABASE_URL`, `BETTER_AUTH_SECRET`, and `ENCRYPTION_KEY` come from a Secret manager.
 </Callout>
 
-## Installation
+Install the application chart:
 
 ```bash
-# Install with default values
-helm install deco-studio . --namespace deco-studio --create-namespace
-
-# Install with custom values
-helm install deco-studio . -f my-values.yaml -n deco-studio --create-namespace
+helm install deco-studio \
+  oci://ghcr.io/decocms/chart-deco-studio \
+  --version "$STUDIO_CHART_VERSION" \
+  --namespace deco-studio \
+  --create-namespace \
+  --values studio-values.yaml
 ```
 
-### Verify
+The main Deployment contains nginx and two API containers. The separate worker Deployment is required and enabled by default. The chart also enables its NATS dependency by default and requires PostgreSQL so API and worker pods share the DBOS run queue.
+
+### 3. Install the per-environment sandbox resources
+
+```bash
+helm install sandbox-env-production \
+  oci://ghcr.io/decocms/studio/charts/sandbox-env \
+  --version "$SANDBOX_ENV_CHART_VERSION" \
+  --namespace agent-sandbox-system \
+  --set envName=production \
+  --set mesh.namespace=deco-studio \
+  --set mesh.serviceAccountName=deco-studio
+```
+
+This creates `SandboxTemplate/studio-sandbox-production` and grants only the named Studio service account permission to manage claims, read sandboxes, port-forward to sandbox pods, patch their Services, and manage per-claim `HTTPRoute` objects in `agent-sandbox-system`.
+
+<Callout type="note">
+  `mesh.serviceName`, `mesh.servicePort`, and `mesh.podSelectorLabels` are deprecated and unused by the current per-claim preview routing design. New installations do not need to set them.
+</Callout>
+
+### 4. Verify the complete deployment
 
 ```bash
 helm status deco-studio -n deco-studio
-kubectl get all -l app.kubernetes.io/instance=deco-studio -n deco-studio
-kubectl logs -l app.kubernetes.io/instance=deco-studio -n deco-studio
+helm status sandbox-operator -n agent-sandbox-system
+helm status sandbox-env-production -n agent-sandbox-system
+
+kubectl get deployments,pods -n deco-studio
+kubectl get deployment -n agent-sandbox-system
+kubectl get sandboxtemplate,sandboxwarmpool -n agent-sandbox-system
+kubectl auth can-i create sandboxclaims.extensions.agents.x-k8s.io \
+  --as=system:serviceaccount:deco-studio:deco-studio \
+  -n agent-sandbox-system
 ```
 
-### Uninstall
+To access Studio before configuring ingress:
 
 ```bash
-helm uninstall deco-studio -n deco-studio
+kubectl port-forward svc/deco-studio 8080:80 -n deco-studio
 ```
 
-## Using external Secrets
+Studio is then available at `http://localhost:8080`.
 
-To keep sensitive values out of `values.yaml` (e.g. for GitOps/ArgoCD), create Kubernetes Secrets and reference them. When `secret.secretName` is set, the chart references that Secret instead of creating one. The Secret must contain at least `BETTER_AUTH_SECRET`, plus `DATABASE_URL` when using PostgreSQL.
+## Sandbox configuration
+
+### Isolation and egress
+
+The sandbox container runs as a non-root user with privilege escalation disabled, all Linux capabilities dropped, a `RuntimeDefault` seccomp profile, and a read-only root filesystem. Writable `emptyDir` volumes are mounted where the runtime needs them.
+
+The org-fs sidecar is mandatory: it uses privileged FUSE mounts to expose organization skills, uploads, outputs, and home directories under `/app/org`. Only this sidecar is privileged. `disableFsSidecar: true` is a debugging escape hatch, not a supported production mode.
+
+By default, a short-lived `NET_ADMIN` init container installs iptables rules and exits before user code starts. It blocks private, link-local, and shared-address IPv4/IPv6 ranges—which cover the pod and Service CIDRs on most clusters—and allows outbound DNS plus HTTPS. Override the CIDR lists when your cluster uses different ranges. The chart does not currently create a Kubernetes `NetworkPolicy`. If your CNI or external firewall owns sandbox egress, set `netinit.enabled: false` and supply equivalent controls.
+
+Recommended production scheduling:
 
 ```yaml
-secret:
-  secretName: "deco-studio-secrets"
-  authConfigSecretName: "deco-studio-auth-secrets"
+nodeSelector:
+  workload: sandbox
 
-database:
-  engine: postgresql
-  url: "" # comes from DATABASE_URL in the Secret
+tolerations:
+  - key: workload
+    operator: Equal
+    value: sandbox
+    effect: NoSchedule
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: studio-sandbox-production
 ```
 
-For deployment-wide enforced SSO, pass the SSO env vars through the auth-config Secret — see [Authentication → Deployment-wide SSO](/en/studio/self-hosting/authentication).
+### Warm pool
 
-## Configuration
+Warm pools are disabled by default because every idle warm pod consumes the full sandbox resource request. Enabling one also requires Studio and the sandbox template to share a sentinel token. Studio uses it only for the first daemon configuration request and immediately rotates the daemon to a per-claim token.
 
-### Main values
+Generate the token once, store it in the Studio Secret as `STUDIO_SANDBOX_SENTINEL_TOKEN`, and pass the same value to `sandbox-env`:
 
-These are the actual chart defaults (`deploy/helm/studio/values.yaml`):
+```bash
+export SANDBOX_SENTINEL_TOKEN="$(openssl rand -base64 48)"
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `replicaCount` | Number of replicas | `1` |
-| `image.repository` | Image repository | `ghcr.io/decocms/studio/studio` |
-| `image.tag` | Image tag | `latest` |
-| `image.pullPolicy` | Pull policy | `IfNotPresent` |
-| `service.type` / `port` / `targetPort` | Service exposure | `ClusterIP` / `80` / `3000` |
-| `persistence.enabled` | Create a PVC | `true` |
-| `persistence.accessMode` | PVC access mode | `ReadWriteOnce` |
-| `persistence.storageClass` | PVC StorageClass | `gp3` |
-| `persistence.distributed` | Storage supports ReadWriteMany | `false` |
-| `persistence.size` | PVC size | `10Gi` |
-| `autoscaling.enabled` | Enable HPA | `false` |
-| `database.engine` | `sqlite` \| `postgresql` | `sqlite` |
-| `database.url` | DB URL (required for PostgreSQL) | `""` |
-
-### Database
-
-```yaml
-database:
-  engine: postgresql
-  url: "postgresql://studio_user:studio_password@postgres.example.com:5432/studio_db"
-  caCert: "" # optional CA cert for managed-Postgres SSL validation
+helm upgrade sandbox-env-production \
+  oci://ghcr.io/decocms/studio/charts/sandbox-env \
+  --version "$SANDBOX_ENV_CHART_VERSION" \
+  --namespace agent-sandbox-system \
+  --reuse-values \
+  --set-string sentinel.token="$SANDBOX_SENTINEL_TOKEN" \
+  --set warmPool.enabled=true \
+  --set warmPool.size=2
 ```
 
-PostgreSQL is required for multiple replicas, autoscaling, and production use. For managed databases (AWS RDS, Cloud SQL, etc.) that require SSL validation, supply `database.caCert` and set `configMap.meshConfig.DATABASE_PG_SSL: "true"`.
+If `sentinel.token` is omitted, the chart generates and preserves a Secret for sandbox pods, but Studio still needs the same value before it can consume warm-pool pods. For GitOps, generate the value in your secret manager and deliver it to both namespaces. Do not place it in `configMap.meshConfig`.
 
-### Replicas, scaling, and strategy
+The optional warm-pool HPA requires `warmPool.enabled: true`, `warmPool.autoscaling.enabled: true`, and at least one explicit `autoscaling/v2` metric. The chart intentionally provides no default metric.
 
-```yaml
-replicaCount: 1 # ignored if autoscaling.enabled: true
+### Idle housekeeper
 
-autoscaling:
-  enabled: false
-  minReplicas: 3
-  maxReplicas: 6
-  targetMemoryUtilizationPercentage: 80
-```
-
-`replicaCount > 1` or `autoscaling.enabled: true` is only valid with **PostgreSQL** or **distributed storage** (`persistence.distributed: true` / `accessMode: ReadWriteMany`). The chart auto-selects a `RollingUpdate` strategy in those cases and `Recreate` for single-writer storage.
-
-### Persistence
+Studio refreshes claim activity, while the optional housekeeper CronJob cleans up idle or unrecoverable claims and orphaned routes/pods. Its defaults run every five minutes and reap claims idle for 15 minutes.
 
 ```yaml
-persistence:
+housekeeper:
   enabled: true
-  accessMode: ReadWriteOnce
-  storageClass: "gp3"
-  size: 10Gi
-  claimName: ""       # if set, an existing PVC is referenced
-  distributed: false  # set true (or accessMode: ReadWriteMany) for multi-replica file storage
+  schedule: "*/5 * * * *"
+  idleTtlSeconds: 900
 ```
 
-### Resources
+`STUDIO_ENV` is required when the housekeeper is enabled because its default selectors are environment-scoped. Without the matching label, it intentionally selects no claims.
+
+### Preview Gateway
+
+Without a preview Gateway, Studio can use its legacy in-process preview proxy when a preview URL pattern and the required external routing are provided. The current production design uses Gateway API and routes each preview directly to its sandbox daemon:
+
+```text
+Browser -> load balancer -> Gateway -> per-claim HTTPRoute -> sandbox Service:9000
+```
+
+Configure `sandbox-env`:
 
 ```yaml
-resources:
-  requests:
-    memory: "2Gi"
-    cpu: "2000m"
-  limits:
-    memory: "2Gi"
+previewGateway:
+  enabled: true
+  gatewayClassName: istio
+  namespace: istio-system
+  domain: preview.example.com
+  tlsTermination: gateway
+  clusterIssuer: letsencrypt-dns
 ```
 
-## Maintenance
+Then add the matching values to Studio:
 
-```bash
-# Upgrade with new values
-helm upgrade deco-studio . -f custom-values.yaml -n deco-studio
-
-# Update the image tag
-helm upgrade deco-studio . --set image.tag=v1.2.3 -n deco-studio
-
-# Render/diff before applying
-helm template deco-studio . -n deco-studio
-helm diff upgrade deco-studio . -n deco-studio   # with the helm-diff plugin
-
-# History / rollback
-helm history deco-studio -n deco-studio
-helm rollback deco-studio -n deco-studio
+```yaml
+configMap:
+  meshConfig:
+    STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.preview.example.com"
+    STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME: "agent-sandbox-preview-production"
+    STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE: "istio-system"
 ```
 
-## Security
+The Gateway name and namespace must either both be set or both be absent. Create wildcard DNS for `*.preview.example.com` pointing to the Gateway load balancer. With `tlsTermination: gateway`, the `ClusterIssuer` must support DNS-01 because wildcard certificates cannot use HTTP-01. Set `tlsTermination: loadBalancer` instead when the external load balancer owns the certificate.
 
 <Callout type="warning">
-  **Do not commit secrets to Git.** Prefer External Secrets Operator (or similar), or pass secrets at install time.
+  The sandbox handle in the hostname is the preview route's only built-in authorization. Treat preview URLs as secrets: handles can appear in CDN, load-balancer, and proxy logs. Add Gateway-level authorization (for example, Istio `AuthorizationPolicy` or Envoy external auth) when hostname secrecy is not sufficient.
 </Callout>
 
+Each environment that enables previews needs a distinct `previewGateway.domain`; two Gateways cannot safely bind the same wildcard hostname.
+
+## Main Studio values
+
+These defaults come from `deploy/helm/studio/values.yaml`:
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `replicaCount` | API pod replicas | `1` |
+| `image.repository` | Studio API/worker image | `ghcr.io/decocms/studio/studio` |
+| `nginx.image.repository` | Front-door image | `ghcr.io/decocms/studio/studio-nginx` |
+| `service.type` / `service.port` | Service exposure | `ClusterIP` / `80` |
+| `database.engine` | Database engine | `postgresql` |
+| `worker.enabled` / `worker.replicaCount` | Queue worker Deployment | `true` / `2` |
+| `worker.autoscaling.enabled` | Worker HPA | `true` |
+| `nats.enabled` | NATS subchart with JetStream | `true` |
+| `persistence.enabled` / `persistence.size` | Studio PVC | `true` / `10Gi` |
+| `autoscaling.enabled` | API HPA | `false` |
+| `metrics.scrape` | Prometheus pod annotations | `true` |
+
+## Main sandbox values
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `envName` | DNS-label suffix for environment resources | Required |
+| `image.repository` / `image.tag` | Sandbox daemon image | `ghcr.io/decocms/studio/studio-sandbox` / `1.17.8` |
+| `resources.requests` | Per-sandbox request | `500m` CPU / `1Gi` memory |
+| `resources.limits` | Per-sandbox limit | `2` CPU / `4Gi` memory / `10Gi` ephemeral storage |
+| `terminationGracePeriodSeconds` | Time for final git sync and unmount | `90` |
+| `netinit.enabled` | Install default iptables egress policy | `true` |
+| `readOnlyRootFilesystem` | Read-only sandbox root filesystem | `true` |
+| `depsCache.enabled` / `depsCache.golden` | Node-local dependency caches | `false` / `false` |
+| `warmPool.enabled` / `warmPool.size` | Pre-warmed sandboxes | `false` / `0` |
+| `previewGateway.enabled` | Wildcard preview Gateway | `false` |
+| `housekeeper.enabled` | Idle-claim cleanup CronJob | `false` |
+
+## Upgrades and removal
+
+Render and lint all three charts before applying changes:
+
 ```bash
-helm install deco-studio . \
-  --set secret.BETTER_AUTH_SECRET="$(openssl rand -base64 32)" \
-  -n deco-studio --create-namespace
+helm lint deploy/helm/studio \
+  --set database.url=postgresql://user:pass@postgres.example.com:5432/studio
+helm lint deploy/helm/sandbox-operator \
+  --namespace agent-sandbox-system
+helm lint deploy/helm/sandbox-env \
+  --namespace agent-sandbox-system \
+  --set envName=production
+
+helm template deco-studio deploy/helm/studio --values studio-values.yaml
+helm template sandbox-operator deploy/helm/sandbox-operator \
+  --namespace agent-sandbox-system
+helm template sandbox-env-production deploy/helm/sandbox-env \
+  --namespace agent-sandbox-system \
+  --set envName=production
 ```
 
-The chart runs as a non-root user (`runAsNonRoot: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: ALL`).
-
-## Monitoring
+Files under a Helm chart's `crds/` directory are installed once but are not upgraded by `helm upgrade`. When the sandbox operator's upstream `appVersion` changes, apply the new CRDs before upgrading the operator:
 
 ```bash
-kubectl get all -l app.kubernetes.io/instance=deco-studio -n deco-studio
-kubectl logs -l app.kubernetes.io/instance=deco-studio -n deco-studio
-kubectl top pods -l app.kubernetes.io/instance=deco-studio -n deco-studio
+kubectl apply -f deploy/helm/sandbox-operator/crds/agent-sandbox-crds.yaml
+helm upgrade sandbox-operator deploy/helm/sandbox-operator \
+  --namespace agent-sandbox-system
+```
+
+Uninstall environment resources before the shared operator. Removing the operator first leaves claims and custom resources without a controller.
+
+```bash
+helm uninstall sandbox-env-production -n agent-sandbox-system
+helm uninstall deco-studio -n deco-studio
+# Only after every environment has removed sandbox-env:
+helm uninstall sandbox-operator -n agent-sandbox-system
 ```

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
@@ -1,208 +1,336 @@
 ---
 title: "Kubernetes"
-description: Faça deploy do deco Studio no Kubernetes usando Helm
+description: Faça deploy do deco Studio e dos sandboxes de agentes no Kubernetes usando Helm
 icon: Rocket
 ---
 
 import Callout from "../../../../../../components/ui/Callout.astro";
 
-Este guia explica como fazer deploy do deco Studio no Kubernetes usando o Helm chart.
+Este guia faz o deploy do deco Studio e dos sandboxes hospedados de agentes no Kubernetes.
 
-Código-fonte do chart: [decocms/studio → deploy/helm/studio](https://github.com/decocms/studio/tree/main/deploy/helm/studio)
+Código-fonte dos charts:
 
-Para entender como as peças se encaixam em runtime (separação web / API / worker, Postgres, NATS, sandboxes), veja [Architecture](/pt-br/studio/architecture).
+- [Studio](https://github.com/decocms/studio/tree/main/deploy/helm/studio)
+- [Operador de sandbox](https://github.com/decocms/studio/tree/main/deploy/helm/sandbox-operator)
+- [Ambiente de sandbox](https://github.com/decocms/studio/tree/main/deploy/helm/sandbox-env)
 
-## O que o chart faz deploy
+Para entender a arquitetura em runtime (separação web/API/worker, Postgres, NATS e providers de sandbox), veja [Arquitetura](/pt-br/studio/architecture).
 
-- **Deployment** — os pods da aplicação (security context, health checks)
-- **Service** — exposição dentro do cluster (ClusterIP por padrão)
-- **ConfigMap / Secret** — config não sensível e secrets (`BETTER_AUTH_SECRET`, DB URL)
-- **PersistentVolumeClaim** — armazenamento persistente em `/app/data`
-- **ServiceAccount** e um **HorizontalPodAutoscaler** opcional
+## Modelo de deployment
+
+Um deployment de produção usa três releases Helm:
+
+| Chart | Escopo | Finalidade |
+| --- | --- | --- |
+| `chart-deco-studio` | Uma vez por ambiente do Studio | Executa um front door nginx com dois containers de API por pod, workers de fila, NATS, persistência e componentes opcionais de observabilidade |
+| `sandbox-operator` | Uma vez por cluster Kubernetes | Instala o controller e os CRDs do [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) do Kubernetes SIGs |
+| `sandbox-env` | Uma vez por ambiente do Studio | Instala o `SandboxTemplate`, o RBAC do runner, o Secret sentinela e, opcionalmente, warm pool, Gateway de preview e housekeeper de recursos ociosos |
+
+O operador é uma infraestrutura compartilhada no cluster. Cada release `sandbox-env` é isolada por `envName`, portanto produção, staging e outros ambientes do Studio podem compartilhar o operador e o namespace `agent-sandbox-system` sem colisões de nomes.
+
+Quando um agente hospedado precisa de um sandbox, o Studio cria um `SandboxClaim`. O operador transforma o claim em um pod efêmero baseado no `SandboxTemplate` do ambiente. O Studio acessa o daemon via port-forward do Kubernetes para o tráfego de controle. Se o roteamento de preview estiver habilitado, o Studio também cria um `HTTPRoute` por claim para que o Gateway wildcard encaminhe diretamente para o Service do sandbox na porta 9000.
 
 ## Pré-requisitos
 
-- Kubernetes 1.32+
-- Helm 3.0+
-- `kubectl` configurado para o seu cluster
-- Uma StorageClass (para o PVC) e — para qualquer deployment real — um banco **PostgreSQL**
+- Kubernetes 1.32+ e Helm 3
+- `kubectl` configurado para o cluster
+- Um banco PostgreSQL; a topologia atual de API/worker exige PostgreSQL
+- Uma StorageClass para os PVCs do Studio e do NATS JetStream gerenciado pelo chart
+- Suporte a `spec.hostUsers: true` e sidecars privilegiados em `agent-sandbox-system`; o sidecar obrigatório org-fs usa FUSE e propagação bidirecional de mounts
+- Somente para URLs públicas de preview: CRDs de Gateway API, um Gateway controller, DNS wildcard e cert-manager com um `ClusterIssuer` DNS-01 ou terminação TLS no load balancer
 
-## Início rápido
+Em produção, agende pods de sandbox em um node pool dedicado e com taint. Esses pods executam código criado por usuários e não devem compartilhar nodes com Studio, Postgres, NATS ou workloads de observabilidade.
 
-Execute a partir do diretório do chart (`deploy/helm/studio`):
+## Instalar o Studio com sandboxes de agentes
+
+Os comandos abaixo usam as versões declaradas atualmente pelos charts. Fixe versões no seu deployment em vez de acompanhar `latest`.
 
 ```bash
-# 1. Gere um secret seguro para autenticação
-SECRET=$(openssl rand -base64 32)
-
-# 2. Instale o chart
-helm install deco-studio . \
-  --namespace deco-studio \
-  --create-namespace \
-  --set secret.BETTER_AUTH_SECRET="$SECRET"
-
-# 3. Aguarde os pods ficarem prontos
-kubectl wait --for=condition=ready pod \
-  -l app.kubernetes.io/instance=deco-studio \
-  -n deco-studio \
-  --timeout=300s
-
-# 4. Acesse via port-forward
-kubectl port-forward svc/deco-studio 8080:80 -n deco-studio
+export STUDIO_CHART_VERSION=0.12.2
+export SANDBOX_OPERATOR_CHART_VERSION=0.1.3
+export SANDBOX_ENV_CHART_VERSION=0.9.6
 ```
 
-A aplicação estará disponível em `http://localhost:8080`.
+### 1. Instale o operador de sandbox do cluster
+
+O chart do operador não tem valores configuráveis e precisa ser instalado em `agent-sandbox-system`, pois o manifesto versionado do controller usa esse namespace.
+
+```bash
+helm install sandbox-operator \
+  oci://ghcr.io/decocms/studio/charts/sandbox-operator \
+  --version "$SANDBOX_OPERATOR_CHART_VERSION" \
+  --namespace agent-sandbox-system \
+  --create-namespace
+```
+
+Verifique o controller e os CRDs:
+
+```bash
+kubectl rollout status deployment/agent-sandbox-controller \
+  -n agent-sandbox-system --timeout=300s
+kubectl get crd sandboxclaims.extensions.agents.x-k8s.io \
+  sandboxtemplates.extensions.agents.x-k8s.io \
+  sandboxwarmpools.extensions.agents.x-k8s.io
+```
+
+### 2. Configure e instale o Studio
+
+Crie `studio-values.yaml`. `envName`, o sufixo do template, o namespace do Studio, o nome da release e o nome da service account precisam corresponder à release `sandbox-env` instalada na próxima etapa.
+
+```yaml
+database:
+  engine: postgresql
+  url: "postgresql://studio_user:studio_password@postgres.example.com:5432/studio"
+
+serviceAccount:
+  create: true
+  name: deco-studio
+  automount: true
+
+configMap:
+  meshConfig:
+    BETTER_AUTH_URL: "https://studio.example.com"
+    BASE_URL: "https://studio.example.com"
+    STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
+    STUDIO_ENV: "production"
+    STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-production"
+
+secret:
+  BETTER_AUTH_SECRET: "substitua-por-openssl-rand-base64-32"
+  ENCRYPTION_KEY: "substitua-por-outro-openssl-rand-base64-32"
+```
 
 <Callout type="warning">
-  **Use PostgreSQL para qualquer coisa real.** O runtime do Studio é baseado em PostgreSQL, e somente o PostgreSQL suporta mais de uma replica. O chart vem com um padrão de nó único para avaliação; para staging ou produção, defina `database.engine: postgresql` com um `database.url`, e habilite autoscaling/múltiplas replicas a partir daí (veja [Database](#database) e [Scaling](#replicas-scaling-and-strategy)).
+  **Não faça commit deste exemplo com credenciais reais.** Em produção, use `secret.secretName` ou `externalSecret` para que `DATABASE_URL`, `BETTER_AUTH_SECRET` e `ENCRYPTION_KEY` venham de um gerenciador de secrets.
 </Callout>
 
-## Instalação
+Instale o chart da aplicação:
 
 ```bash
-# Instale com os valores padrão
-helm install deco-studio . --namespace deco-studio --create-namespace
-
-# Instale com valores customizados
-helm install deco-studio . -f my-values.yaml -n deco-studio --create-namespace
+helm install deco-studio \
+  oci://ghcr.io/decocms/chart-deco-studio \
+  --version "$STUDIO_CHART_VERSION" \
+  --namespace deco-studio \
+  --create-namespace \
+  --values studio-values.yaml
 ```
 
-### Verificar
+O Deployment principal contém nginx e dois containers de API. O Deployment separado de workers é obrigatório e vem habilitado por padrão. O chart também habilita sua dependência NATS por padrão e exige PostgreSQL para que pods de API e worker compartilhem a fila DBOS.
+
+### 3. Instale os recursos de sandbox do ambiente
+
+```bash
+helm install sandbox-env-production \
+  oci://ghcr.io/decocms/studio/charts/sandbox-env \
+  --version "$SANDBOX_ENV_CHART_VERSION" \
+  --namespace agent-sandbox-system \
+  --set envName=production \
+  --set mesh.namespace=deco-studio \
+  --set mesh.serviceAccountName=deco-studio
+```
+
+Isso cria `SandboxTemplate/studio-sandbox-production` e concede somente à service account indicada do Studio permissão para gerenciar claims, ler sandboxes, abrir port-forward para pods de sandbox, alterar seus Services e gerenciar objetos `HTTPRoute` por claim em `agent-sandbox-system`.
+
+<Callout type="note">
+  `mesh.serviceName`, `mesh.servicePort` e `mesh.podSelectorLabels` estão obsoletos e não são usados pelo design atual de roteamento de preview por claim. Novas instalações não precisam defini-los.
+</Callout>
+
+### 4. Verifique o deployment completo
 
 ```bash
 helm status deco-studio -n deco-studio
-kubectl get all -l app.kubernetes.io/instance=deco-studio -n deco-studio
-kubectl logs -l app.kubernetes.io/instance=deco-studio -n deco-studio
+helm status sandbox-operator -n agent-sandbox-system
+helm status sandbox-env-production -n agent-sandbox-system
+
+kubectl get deployments,pods -n deco-studio
+kubectl get deployment -n agent-sandbox-system
+kubectl get sandboxtemplate,sandboxwarmpool -n agent-sandbox-system
+kubectl auth can-i create sandboxclaims.extensions.agents.x-k8s.io \
+  --as=system:serviceaccount:deco-studio:deco-studio \
+  -n agent-sandbox-system
 ```
 
-### Desinstalar
+Para acessar o Studio antes de configurar ingress:
 
 ```bash
-helm uninstall deco-studio -n deco-studio
+kubectl port-forward svc/deco-studio 8080:80 -n deco-studio
 ```
 
-## Usando Secrets externos
+O Studio estará disponível em `http://localhost:8080`.
 
-Para manter valores sensíveis fora do `values.yaml` (por exemplo, para GitOps/ArgoCD), crie Secrets do Kubernetes e referencie-os. Quando `secret.secretName` está definido, o chart referencia esse Secret em vez de criar um. O Secret deve conter pelo menos `BETTER_AUTH_SECRET`, mais `DATABASE_URL` quando estiver usando PostgreSQL.
+## Configuração de sandbox
+
+### Isolamento e egress
+
+O container de sandbox roda como usuário não-root, com elevação de privilégio desabilitada, todas as capabilities Linux removidas, perfil seccomp `RuntimeDefault` e root filesystem somente leitura. Volumes `emptyDir` graváveis são montados onde o runtime precisa deles.
+
+O sidecar org-fs é obrigatório: ele usa mounts FUSE privilegiados para expor skills, uploads, outputs e diretórios home da organização em `/app/org`. Somente esse sidecar é privilegiado. `disableFsSidecar: true` é uma saída para debugging, não um modo suportado em produção.
+
+Por padrão, um init container de curta duração com `NET_ADMIN` instala regras de iptables e termina antes do início do código do usuário. Ele bloqueia ranges privados, link-local e de endereços compartilhados em IPv4/IPv6—que cobrem os CIDRs de pods e Services na maioria dos clusters—e permite DNS e HTTPS de saída. Sobrescreva as listas de CIDRs se o cluster usar ranges diferentes. Atualmente o chart não cria um `NetworkPolicy` do Kubernetes. Se o CNI ou firewall externo gerenciar o egress dos sandboxes, defina `netinit.enabled: false` e forneça controles equivalentes.
+
+Agendamento recomendado para produção:
 
 ```yaml
-secret:
-  secretName: "deco-studio-secrets"
-  authConfigSecretName: "deco-studio-auth-secrets"
+nodeSelector:
+  workload: sandbox
 
-database:
-  engine: postgresql
-  url: "" # vem do DATABASE_URL no Secret
+tolerations:
+  - key: workload
+    operator: Equal
+    value: sandbox
+    effect: NoSchedule
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: studio-sandbox-production
 ```
 
-Para SSO forçado em todo o deployment, passe as variáveis de ambiente de SSO pelo Secret de auth-config — veja [Autenticação → SSO em todo o deployment](/pt-br/studio/self-hosting/authentication).
+### Warm pool
 
-## Configuração
+Warm pools vêm desabilitados por padrão porque cada pod ocioso consome todo o resource request do sandbox. Habilitar um também exige que o Studio e o template de sandbox compartilhem um token sentinela. O Studio o usa somente na primeira requisição de configuração do daemon e imediatamente troca para um token específico do claim.
 
-### Valores principais
+Gere o token uma vez, armazene-o no Secret do Studio como `STUDIO_SANDBOX_SENTINEL_TOKEN` e passe o mesmo valor para `sandbox-env`:
 
-Estes são os valores padrão reais do chart (`deploy/helm/studio/values.yaml`):
+```bash
+export SANDBOX_SENTINEL_TOKEN="$(openssl rand -base64 48)"
 
-| Parâmetro | Descrição | Padrão |
-|-----------|-------------|---------|
-| `replicaCount` | Número de replicas | `1` |
-| `image.repository` | Repositório da imagem | `ghcr.io/decocms/studio/studio` |
-| `image.tag` | Tag da imagem | `latest` |
-| `image.pullPolicy` | Pull policy | `IfNotPresent` |
-| `service.type` / `port` / `targetPort` | Exposição do service | `ClusterIP` / `80` / `3000` |
-| `persistence.enabled` | Criar um PVC | `true` |
-| `persistence.accessMode` | Access mode do PVC | `ReadWriteOnce` |
-| `persistence.storageClass` | StorageClass do PVC | `gp3` |
-| `persistence.distributed` | Storage suporta ReadWriteMany | `false` |
-| `persistence.size` | Tamanho do PVC | `10Gi` |
-| `autoscaling.enabled` | Habilitar HPA | `false` |
-| `database.engine` | `sqlite` \| `postgresql` | `sqlite` |
-| `database.url` | DB URL (obrigatório para PostgreSQL) | `""` |
-
-### Database
-
-```yaml
-database:
-  engine: postgresql
-  url: "postgresql://studio_user:studio_password@postgres.example.com:5432/studio_db"
-  caCert: "" # CA cert opcional para validação SSL de Postgres gerenciado
+helm upgrade sandbox-env-production \
+  oci://ghcr.io/decocms/studio/charts/sandbox-env \
+  --version "$SANDBOX_ENV_CHART_VERSION" \
+  --namespace agent-sandbox-system \
+  --reuse-values \
+  --set-string sentinel.token="$SANDBOX_SENTINEL_TOKEN" \
+  --set warmPool.enabled=true \
+  --set warmPool.size=2
 ```
 
-PostgreSQL é obrigatório para múltiplas replicas, autoscaling e uso em produção. Para bancos gerenciados (AWS RDS, Cloud SQL, etc.) que exigem validação SSL, forneça `database.caCert` e defina `configMap.meshConfig.DATABASE_PG_SSL: "true"`.
+Se `sentinel.token` for omitido, o chart gera e preserva um Secret para os pods, mas o Studio ainda precisa do mesmo valor para consumir pods do warm pool. Em GitOps, gere o valor no seu gerenciador de secrets e entregue-o aos dois namespaces. Não o coloque em `configMap.meshConfig`.
 
-### Replicas, scaling e estratégia
+O HPA opcional do warm pool exige `warmPool.enabled: true`, `warmPool.autoscaling.enabled: true` e pelo menos uma métrica explícita no formato `autoscaling/v2`. O chart intencionalmente não fornece uma métrica padrão.
 
-```yaml
-replicaCount: 1 # ignorado se autoscaling.enabled: true
+### Housekeeper de recursos ociosos
 
-autoscaling:
-  enabled: false
-  minReplicas: 3
-  maxReplicas: 6
-  targetMemoryUtilizationPercentage: 80
-```
-
-`replicaCount > 1` ou `autoscaling.enabled: true` só é válido com **PostgreSQL** ou **storage distribuído** (`persistence.distributed: true` / `accessMode: ReadWriteMany`). Nesses casos o chart seleciona automaticamente a estratégia `RollingUpdate`, e `Recreate` para storage de escritor único.
-
-### Persistência
+O Studio atualiza a atividade dos claims, enquanto o CronJob housekeeper opcional remove claims ociosos ou irrecuperáveis, além de routes e pods órfãos. Os padrões executam a cada cinco minutos e removem claims ociosos há 15 minutos.
 
 ```yaml
-persistence:
+housekeeper:
   enabled: true
-  accessMode: ReadWriteOnce
-  storageClass: "gp3"
-  size: 10Gi
-  claimName: ""       # se definido, referencia um PVC existente
-  distributed: false  # defina true (ou accessMode: ReadWriteMany) para file storage multi-replica
+  schedule: "*/5 * * * *"
+  idleTtlSeconds: 900
 ```
 
-### Resources
+`STUDIO_ENV` é obrigatório quando o housekeeper está habilitado, pois seus seletores padrão são limitados ao ambiente. Sem o label correspondente, ele intencionalmente não seleciona nenhum claim.
+
+### Gateway de preview
+
+Sem um Gateway de preview, o Studio pode usar seu proxy de preview legado em processo quando um padrão de URL e o roteamento externo necessário são fornecidos. O design atual de produção usa Gateway API e encaminha cada preview diretamente para seu daemon de sandbox:
+
+```text
+Browser -> load balancer -> Gateway -> HTTPRoute por claim -> Service do sandbox:9000
+```
+
+Configure `sandbox-env`:
 
 ```yaml
-resources:
-  requests:
-    memory: "2Gi"
-    cpu: "2000m"
-  limits:
-    memory: "2Gi"
+previewGateway:
+  enabled: true
+  gatewayClassName: istio
+  namespace: istio-system
+  domain: preview.example.com
+  tlsTermination: gateway
+  clusterIssuer: letsencrypt-dns
 ```
 
-## Manutenção
+Depois adicione os valores correspondentes ao Studio:
 
-```bash
-# Upgrade com novos valores
-helm upgrade deco-studio . -f custom-values.yaml -n deco-studio
-
-# Atualize a tag da imagem
-helm upgrade deco-studio . --set image.tag=v1.2.3 -n deco-studio
-
-# Renderize/compare antes de aplicar
-helm template deco-studio . -n deco-studio
-helm diff upgrade deco-studio . -n deco-studio   # com o plugin helm-diff
-
-# Histórico / rollback
-helm history deco-studio -n deco-studio
-helm rollback deco-studio -n deco-studio
+```yaml
+configMap:
+  meshConfig:
+    STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.preview.example.com"
+    STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME: "agent-sandbox-preview-production"
+    STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE: "istio-system"
 ```
 
-## Segurança
+Nome e namespace do Gateway precisam estar ambos definidos ou ambos ausentes. Crie o DNS wildcard `*.preview.example.com` apontando para o load balancer do Gateway. Com `tlsTermination: gateway`, o `ClusterIssuer` precisa suportar DNS-01 porque certificados wildcard não podem usar HTTP-01. Use `tlsTermination: loadBalancer` quando o load balancer externo for responsável pelo certificado.
 
 <Callout type="warning">
-  **Não faça commit de secrets no Git.** Prefira o External Secrets Operator (ou similar), ou passe os secrets no momento da instalação.
+  O handle do sandbox no hostname é a única autorização embutida da route de preview. Trate URLs de preview como secrets: handles podem aparecer em logs do CDN, load balancer e proxies. Adicione autorização no Gateway (por exemplo, `AuthorizationPolicy` do Istio ou autenticação externa do Envoy) quando o sigilo do hostname não for suficiente.
 </Callout>
 
+Cada ambiente que habilita previews precisa de um `previewGateway.domain` distinto; dois Gateways não podem associar com segurança o mesmo hostname wildcard.
+
+## Valores principais do Studio
+
+Estes padrões vêm de `deploy/helm/studio/values.yaml`:
+
+| Parâmetro | Descrição | Padrão |
+| --- | --- | --- |
+| `replicaCount` | Réplicas de pods de API | `1` |
+| `image.repository` | Imagem de API/worker do Studio | `ghcr.io/decocms/studio/studio` |
+| `nginx.image.repository` | Imagem do front door | `ghcr.io/decocms/studio/studio-nginx` |
+| `service.type` / `service.port` | Exposição do Service | `ClusterIP` / `80` |
+| `database.engine` | Engine do banco | `postgresql` |
+| `worker.enabled` / `worker.replicaCount` | Deployment de workers de fila | `true` / `2` |
+| `worker.autoscaling.enabled` | HPA dos workers | `true` |
+| `nats.enabled` | Subchart NATS com JetStream | `true` |
+| `persistence.enabled` / `persistence.size` | PVC do Studio | `true` / `10Gi` |
+| `autoscaling.enabled` | HPA da API | `false` |
+| `metrics.scrape` | Anotações Prometheus nos pods | `true` |
+
+## Valores principais do sandbox
+
+| Parâmetro | Descrição | Padrão |
+| --- | --- | --- |
+| `envName` | Sufixo DNS-label dos recursos do ambiente | Obrigatório |
+| `image.repository` / `image.tag` | Imagem do daemon do sandbox | `ghcr.io/decocms/studio/studio-sandbox` / `1.17.8` |
+| `resources.requests` | Request por sandbox | `500m` CPU / `1Gi` memória |
+| `resources.limits` | Limite por sandbox | `2` CPU / `4Gi` memória / `10Gi` armazenamento efêmero |
+| `terminationGracePeriodSeconds` | Tempo para sync final do git e unmount | `90` |
+| `netinit.enabled` | Instalar política padrão de egress no iptables | `true` |
+| `readOnlyRootFilesystem` | Root filesystem do sandbox somente leitura | `true` |
+| `depsCache.enabled` / `depsCache.golden` | Caches de dependências locais ao node | `false` / `false` |
+| `warmPool.enabled` / `warmPool.size` | Sandboxes pré-aquecidos | `false` / `0` |
+| `previewGateway.enabled` | Gateway wildcard de preview | `false` |
+| `housekeeper.enabled` | CronJob de limpeza de claims ociosos | `false` |
+
+## Upgrades e remoção
+
+Renderize e valide os três charts antes de aplicar mudanças:
+
 ```bash
-helm install deco-studio . \
-  --set secret.BETTER_AUTH_SECRET="$(openssl rand -base64 32)" \
-  -n deco-studio --create-namespace
+helm lint deploy/helm/studio \
+  --set database.url=postgresql://user:pass@postgres.example.com:5432/studio
+helm lint deploy/helm/sandbox-operator \
+  --namespace agent-sandbox-system
+helm lint deploy/helm/sandbox-env \
+  --namespace agent-sandbox-system \
+  --set envName=production
+
+helm template deco-studio deploy/helm/studio --values studio-values.yaml
+helm template sandbox-operator deploy/helm/sandbox-operator \
+  --namespace agent-sandbox-system
+helm template sandbox-env-production deploy/helm/sandbox-env \
+  --namespace agent-sandbox-system \
+  --set envName=production
 ```
 
-O chart roda como usuário não-root (`runAsNonRoot: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: ALL`).
-
-## Monitoring
+Arquivos no diretório `crds/` de um chart Helm são instalados uma vez, mas não são atualizados por `helm upgrade`. Quando o `appVersion` upstream do operador mudar, aplique os novos CRDs antes de atualizar o operador:
 
 ```bash
-kubectl get all -l app.kubernetes.io/instance=deco-studio -n deco-studio
-kubectl logs -l app.kubernetes.io/instance=deco-studio -n deco-studio
-kubectl top pods -l app.kubernetes.io/instance=deco-studio -n deco-studio
+kubectl apply -f deploy/helm/sandbox-operator/crds/agent-sandbox-crds.yaml
+helm upgrade sandbox-operator deploy/helm/sandbox-operator \
+  --namespace agent-sandbox-system
+```
+
+Desinstale os recursos de ambiente antes do operador compartilhado. Remover o operador primeiro deixa claims e custom resources sem um controller.
+
+```bash
+helm uninstall sandbox-env-production -n agent-sandbox-system
+helm uninstall deco-studio -n deco-studio
+# Somente depois que todos os ambientes removerem sandbox-env:
+helm uninstall sandbox-operator -n agent-sandbox-system
 ```

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -8,12 +8,14 @@ is suffixed with `envName` so multiple releases coexist in the shared
 Renders:
 
 - `SandboxTemplate` `studio-sandbox-<envName>`
-- `Role` + `RoleBinding` `studio-sandbox-runner-<envName>` (for the mesh
+- `Role` + `RoleBinding` `studio-sandbox-runner-<envName>` (for the Studio
   ServiceAccount of THIS env's studio install)
-- `NetworkPolicy` `studio-sandbox-<envName>` (per-env podSelector)
+- `Secret` `studio-sandbox-sentinel-<envName>` (initial daemon token)
 - `SandboxWarmPool` `studio-sandbox-<envName>` (optional)
+- `HorizontalPodAutoscaler` for the warm pool (optional; requires explicit metrics)
 - `Gateway` + `Certificate` `agent-sandbox-preview-<envName>` (optional;
   per-claim HTTPRoutes are minted by the mesh runner, not by this chart)
+- `CronJob` + scoped RBAC for idle-claim cleanup (optional)
 
 Requires the [`sandbox-operator`](../sandbox-operator/) chart to already be
 installed (it ships the CRDs + controller).
@@ -22,6 +24,12 @@ installed (it ships the CRDs + controller).
 
 - `sandbox-operator` chart installed in `agent-sandbox-system`.
 - Kubernetes with `spec.hostUsers: true` privileged-sidecar support (org-fs FUSE mount).
+- A named ServiceAccount for the Studio release. Its namespace and name must
+  match `mesh.namespace` and `mesh.serviceAccountName`; this chart grants that
+  identity the runner permissions in `agent-sandbox-system`.
+- The Studio release must explicitly set
+  `STUDIO_SANDBOX_PROVIDER=agent-sandbox`. The default provider is the user's
+  linked desktop and is not a production cluster configuration.
 - The studio release for THIS environment must point its mesh runner at
   the env-suffixed SandboxTemplate by setting
   `STUDIO_SANDBOX_TEMPLATE_NAME=studio-sandbox-<envName>` in the studio
@@ -32,9 +40,29 @@ installed (it ships the CRDs + controller).
   so mesh stamps `studio.decocms.com/env=<envName>` on every SandboxClaim,
   pod, and HTTPRoute it creates. The housekeeper's default selectors
   scope sweeps to that env label — without it the housekeeper matches
-  zero claims and reaps nothing. Single-env installs that don't enable
-  the housekeeper can leave `STUDIO_ENV` unset (the label is then
-  omitted and behavior is unchanged).
+  zero claims and reaps nothing. Set it for every new installation even when
+  the housekeeper is initially disabled so claims remain ready for later
+  cleanup and multi-environment operation.
+
+## Sandbox isolation
+
+The untrusted sandbox container runs non-root with privilege escalation
+disabled, all capabilities dropped, `RuntimeDefault` seccomp, and a read-only
+root filesystem by default. Writable `emptyDir` mounts cover `/app`, `/tmp`,
+and `/home/sandbox`.
+
+The mandatory org-fs sidecar is the only privileged container. It uses FUSE
+and bidirectional mount propagation to expose organization files under
+`/app/org`, which requires `hostUsers: true`. `disableFsSidecar=true` is a
+debug-only escape hatch, not a supported production mode.
+
+Egress is enforced by the `netinit` init container, not by a Kubernetes
+`NetworkPolicy`. With `netinit.enabled=true`, the init container temporarily
+uses `NET_ADMIN` to install iptables rules, then exits before user code starts.
+The default CIDR lists cover private, link-local, shared-address, and common
+cluster ranges; override them for clusters with different pod or Service
+CIDRs. If another CNI or firewall owns egress, disable `netinit` and provide
+equivalent controls.
 
 ## Preview gateway auth model
 
@@ -65,13 +93,11 @@ Published as an OCI artifact at
 ```bash
 helm install sandbox-env-staging \
   oci://ghcr.io/decocms/studio/charts/sandbox-env \
-  --version 0.5.0 \
+  --version 0.9.6 \
   --namespace agent-sandbox-system \
   --set envName=staging \
   --set mesh.namespace=deco-studio-staging \
-  --set mesh.serviceAccountName=deco-studio-staging \
-  --set mesh.serviceName=deco-studio-staging \
-  --set mesh.servicePort=80
+  --set mesh.serviceAccountName=deco-studio-staging
 ```
 
 Then point the studio (chart-deco-studio) release for the same env at
@@ -79,11 +105,17 @@ this runner:
 
 ```yaml
 # in your studio values.yaml (for the staging install)
+serviceAccount:
+  create: true
+  name: deco-studio-staging
+  automount: true
+
 configMap:
   meshConfig:
-    STUDIO_SANDBOX_PROVIDER: "cluster"
+    STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
     STUDIO_ENV: "staging"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-staging"
+    # The next three values are required only when previewGateway.enabled=true.
     STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.preview.staging.example.com"
     # Per-claim HTTPRoute attaches to this Gateway. Both required whenever
     # previewGateway.enabled=true — without them mesh falls back to its
@@ -94,6 +126,20 @@ configMap:
     STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME: "agent-sandbox-preview-staging"
     STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE: "istio-system"
 ```
+
+### Warm-pool token wiring
+
+`warmPool.enabled` is off by default. When enabling it, generate one sentinel
+token and deliver the same value to both charts:
+
+- Set `sandbox-env`'s `sentinel.token` so the template and pool pods use it.
+- Put it in the Studio Secret as `STUDIO_SANDBOX_SENTINEL_TOKEN`.
+
+Studio uses the sentinel only for the first configuration request after a pool
+pod is bound, then rotates the daemon to a per-claim token. If
+`sentinel.token` is omitted, this chart generates and preserves its own value,
+but Studio cannot consume warm-pool pods until it receives that same value.
+Keep it in a Secret, never `configMap.meshConfig`.
 
 ### ArgoCD Application (one per env)
 
@@ -108,15 +154,13 @@ spec:
   source:
     repoURL: ghcr.io/decocms/studio/charts
     chart: sandbox-env
-    targetRevision: 0.5.0
+    targetRevision: 0.9.6
     helm:
       values: |
         envName: staging
         mesh:
           namespace: deco-studio-staging
           serviceAccountName: deco-studio-staging
-          serviceName: deco-studio-staging
-          servicePort: 80
   destination:
     server: https://kubernetes.default.svc
     namespace: agent-sandbox-system
@@ -139,7 +183,7 @@ values file:
 ```bash
 helm upgrade sandbox-env-staging \
   oci://ghcr.io/decocms/studio/charts/sandbox-env \
-  --version 0.5.0 \
+  --version 0.9.6 \
   --namespace agent-sandbox-system \
   --reset-then-reuse-values \
   --set housekeeper.enabled=true
@@ -161,10 +205,12 @@ sandbox-env/
     ├── validations.yaml                 # envName + Gateway API + cert-manager preflight
     ├── sandbox-template.yaml            # SandboxTemplate (per-env)
     ├── sandbox-warm-pool.yaml           # SandboxWarmPool (optional)
-    ├── sandbox-network-policy.yaml      # NetworkPolicy on sandbox pods (per-env)
+    ├── sandbox-warmpool-hpa.yaml         # Warm-pool HPA (optional)
+    ├── sandbox-sentinel-secret.yaml      # Initial daemon token
     ├── sandbox-rbac.yaml                # Role + cross-ns RoleBinding to mesh SA
     ├── sandbox-preview-cert.yaml        # cert-manager Certificate (optional)
-    └── sandbox-preview-gateway.yaml     # Gateway only — per-claim HTTPRoutes are minted by mesh
+    ├── sandbox-preview-gateway.yaml     # Gateway only — per-claim HTTPRoutes are minted by mesh
+    └── sandbox-housekeeper.yaml         # Idle cleanup CronJob + RBAC (optional)
 ```
 
 ## Values
@@ -180,11 +226,15 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `nodeSelector` / `tolerations` / `affinity` | `{}` | for sandbox isolation NodePool |
 | `topologySpreadConstraints` | `[]` | spread sandbox pods across AZs; see `values.yaml` for the recommended config |
 | `readOnlyRootFilesystem` | `true` | RO rootfs + emptyDirs on /app, /tmp, /home |
-| `networkPolicy.enabled` | `true` | locks down ingress/egress |
+| `netinit.enabled` | `true` | installs the iptables egress policy before user code starts |
+| `disableFsSidecar` | `false` | debug-only opt-out from the mandatory privileged org-fs sidecar |
+| `depsCache.enabled` / `depsCache.golden` | `false` / `false` | opt-in node-local dependency caches |
 | `warmPool.enabled` / `warmPool.size` | `false` / `0` | only after measuring cold-start pain |
+| `warmPool.autoscaling.enabled` | `false` | HPA; requires at least one explicit metric |
 | `previewGateway.enabled` | `false` | wildcard `*.preview.<domain>` Gateway + cert |
+| `housekeeper.enabled` | `false` | idle-claim and orphan cleanup CronJob |
 | `mesh.namespace` | `deco-studio` | studio release namespace (this env's) |
-| `mesh.serviceAccountName` | `deco-studio` | mesh ServiceAccount that gets the RoleBinding |
+| `mesh.serviceAccountName` | `deco-studio` | Studio ServiceAccount that gets the RoleBinding |
 | `mesh.serviceName` | `deco-studio` | _deprecated, unused since per-claim HTTPRoutes_ |
 | `mesh.servicePort` | `80` | _deprecated, unused since per-claim HTTPRoutes_ |
-| `mesh.podSelectorLabels` | `chart-deco-studio` / `deco-studio` | for the NetworkPolicy ingress rule |
+| `mesh.podSelectorLabels` | `chart-deco-studio` / `deco-studio` | _deprecated, unused since chart-managed NetworkPolicy removal_ |

--- a/deploy/helm/sandbox-operator/README.md
+++ b/deploy/helm/sandbox-operator/README.md
@@ -3,7 +3,7 @@
 Pure packaging of the upstream
 [`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox)
 operator + CRDs (vendored — upstream does not publish a Helm chart as of
-v0.4.2). Installs:
+v0.4.5). Installs:
 
 - `Namespace` `agent-sandbox-system` (with PodSecurity admission labels)
 - `ServiceAccount`, `Service`, `Deployment` for the controller
@@ -11,12 +11,13 @@ v0.4.2). Installs:
 - All `CustomResourceDefinition`s the operator owns
 
 This chart **deliberately exposes no tunables**. Studio-side resources
-(`SandboxTemplate`, RBAC for the mesh runner, `NetworkPolicy`,
-`SandboxWarmPool`, preview `Gateway`/`HTTPRoute`/`Certificate`) live in the
-companion [`sandbox-env`](../sandbox-env/) chart and are installed once per
-environment alongside this one.
+(`SandboxTemplate`, RBAC for the Studio runner, sentinel Secret, optional
+`SandboxWarmPool`, preview `Gateway`/`Certificate`, and idle housekeeper) live
+in the companion [`sandbox-env`](../sandbox-env/) chart and are installed once
+per environment. Per-claim `HTTPRoute` objects are created by Studio at
+runtime, not by either chart.
 
-Pinned upstream version: **v0.4.2** (see `Chart.yaml` `appVersion`).
+Pinned upstream version: **v0.4.5** (see `Chart.yaml` `appVersion`).
 
 ## Prerequisites
 
@@ -34,7 +35,7 @@ Published as an OCI artifact at
 ```bash
 helm install sandbox-operator \
   oci://ghcr.io/decocms/studio/charts/sandbox-operator \
-  --version 0.1.0 \
+  --version 0.1.3 \
   --namespace agent-sandbox-system --create-namespace
 ```
 
@@ -54,7 +55,7 @@ spec:
   source:
     repoURL: ghcr.io/decocms/studio/charts
     chart: sandbox-operator
-    targetRevision: 0.1.0
+    targetRevision: 0.1.3
   destination:
     server: https://kubernetes.default.svc
     namespace: agent-sandbox-system
@@ -98,9 +99,9 @@ Uninstall + reinstall also works but drops existing `SandboxClaim`s.
 ## Bumping upstream version
 
 ```bash
-./vendor.sh v0.4.3               # re-fetches + re-splits, requires sha256 in KNOWN_CHECKSUMS
-# edit Chart.yaml: appVersion -> "0.4.3"
-# bump version: 0.1.0 -> 0.2.0
+./vendor.sh v0.4.6               # re-fetches + re-splits, requires sha256 in KNOWN_CHECKSUMS
+# edit Chart.yaml: appVersion -> "0.4.6"
+# bump version: 0.1.3 -> 0.1.4 (or the appropriate semver increment)
 ```
 
 Push to `main` — `release-sandbox-charts.yaml` packages and pushes the new
@@ -113,7 +114,7 @@ may need corresponding edits.
 
 ## Why not an upstream Helm chart?
 
-Upstream hasn't published one as of v0.4.2. Filing a request with prior art
+Upstream hasn't published one as of v0.4.5. Filing a request with prior art
 pointing at this chart is worthwhile — if upstream ships an official chart,
 the vendored copy goes away and this chart switches to a `dependencies:`
 entry pointing at upstream's repo.


### PR DESCRIPTION
## Summary

- document the current three-chart Kubernetes deployment model for Studio, sandbox-operator, and sandbox-env
- add agent-sandbox installation, service-account/RBAC wiring, isolation, warm-pool, housekeeper, and preview Gateway guidance in English and Portuguese
- update sandbox chart READMEs to current versions and replace stale NetworkPolicy guidance with the current netinit/iptables model

## Validation

- bun run --cwd=apps/docs build
- bun run --cwd=apps/docs check
- helm lint for studio, sandbox-operator, and sandbox-env
- helm template for the base charts and preview Gateway variant
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents how to deploy Studio with agent sandboxes on Kubernetes using a three‑chart setup (`chart-deco-studio`, `sandbox-operator`, `sandbox-env`). Adds step‑by‑step install, isolation and egress via netinit iptables, warm‑pool with sentinel token, housekeeper, and preview Gateway routing; updates English/Portuguese guides and Helm READMEs to match current behavior.

- Dependencies
  - Pin `sandbox-operator` chart `0.1.3` (upstream `appVersion` `v0.4.5`)
  - Pin `sandbox-env` chart `0.9.6`
  - Example pin for `chart-deco-studio` `0.12.2`

- Migration
  - Use provider `agent-sandbox`; set `STUDIO_SANDBOX_TEMPLATE_NAME` and `STUDIO_ENV`.
  - Egress is now via `netinit.enabled: true`; `mesh.serviceName`, `mesh.servicePort`, `mesh.podSelectorLabels` are deprecated.
  - Warm pool requires a shared sentinel token; HPA needs explicit metrics.
  - Apply new CRDs before upgrading the operator; previews need a wildcard Gateway and `STUDIO_SANDBOX_PREVIEW_*` values.

<sup>Written for commit 9ec7af48d8925bdb9d7417370178bba11c5495ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

