### PR TITLE
feat(sandbox): user-provided git submodule credentials per virtual MCP

### DIFF
--- a/apps/mesh/src/link-daemon/index.ts
+++ b/apps/mesh/src/link-daemon/index.ts
@@ -197,6 +197,10 @@ export async function startLinkDaemon(
             repository: {
               cloneUrl: config.repo.cloneUrl,
               branch: config.repo.branch,
+              ...(config.repo.submoduleCredentials &&
+              config.repo.submoduleCredentials.length > 0
+                ? { submoduleCredentials: config.repo.submoduleCredentials }
+                : {}),
             },
             ...(config.repo.userName && config.repo.userEmail
               ? {

--- a/apps/mesh/src/link-daemon/user-desktop-provider.ts
+++ b/apps/mesh/src/link-daemon/user-desktop-provider.ts
@@ -67,6 +67,9 @@ export interface RepoRef {
    *  `git commit`. Optional — clone works without them. */
   userName?: string;
   userEmail?: string;
+  /** Resolved per-host PATs for fetching private submodules. Forwarded to the
+   *  spawned daemon so `git submodule update` can authenticate. Optional. */
+  submoduleCredentials?: { host: string; token: string }[];
 }
 
 /**

--- a/apps/mesh/src/tools/sandbox/helpers.test.ts
+++ b/apps/mesh/src/tools/sandbox/helpers.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "bun:test";
-import { resolveRuntimeConfig } from "./helpers";
+import {
+  readValidatedSubmoduleCredentials,
+  resolveRuntimeConfig,
+} from "./helpers";
 type VmMetadata = Record<string, unknown>;
 
 describe("resolveRuntimeConfig", () => {
@@ -84,5 +87,46 @@ describe("resolveRuntimeConfig", () => {
     const metadata: VmMetadata = { runtime: { selected: "npm" } };
     const result = resolveRuntimeConfig(metadata);
     expect(result.port).toBeNull();
+  });
+});
+
+describe("readValidatedSubmoduleCredentials", () => {
+  it("returns null when metadata / runtime / array is absent", () => {
+    expect(readValidatedSubmoduleCredentials(null)).toBeNull();
+    expect(readValidatedSubmoduleCredentials({})).toBeNull();
+    expect(readValidatedSubmoduleCredentials({ runtime: {} })).toBeNull();
+    expect(
+      readValidatedSubmoduleCredentials({
+        runtime: { submoduleCredentials: "nope" },
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps only entries with a non-empty host and secretId", () => {
+    const result = readValidatedSubmoduleCredentials({
+      runtime: {
+        submoduleCredentials: [
+          { host: "github.com", secretId: "sec_1" },
+          { host: "", secretId: "sec_2" }, // no host
+          { host: "gitlab.com", secretId: "" }, // no secretId
+          { host: "bitbucket.org" }, // missing secretId
+          "garbage",
+          null,
+          { host: "gitea.example.com", secretId: "sec_3" },
+        ],
+      },
+    });
+    expect(result).toEqual([
+      { host: "github.com", secretId: "sec_1" },
+      { host: "gitea.example.com", secretId: "sec_3" },
+    ]);
+  });
+
+  it("returns null when every entry is invalid", () => {
+    expect(
+      readValidatedSubmoduleCredentials({
+        runtime: { submoduleCredentials: [{ host: "", secretId: "" }] },
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/mesh/src/tools/sandbox/helpers.ts
+++ b/apps/mesh/src/tools/sandbox/helpers.ts
@@ -10,6 +10,7 @@ import {
   ENV_VAR_KEY_RE,
   type RuntimeEnvEntry,
   type SandboxRecord,
+  type SubmoduleCredential,
 } from "@decocms/mesh-sdk";
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
 
@@ -29,6 +30,7 @@ export type RuntimeConfigMeta = {
     port?: string | null;
     path?: string | null;
     env?: RuntimeEnvEntry[] | null;
+    submoduleCredentials?: SubmoduleCredential[] | null;
   } | null;
 };
 
@@ -63,6 +65,36 @@ export function readValidatedRuntimeEnv(
       e.secretId.length > 0
     ) {
       out.push({ key: e.key, kind: "secret", secretId: e.secretId });
+    }
+  }
+  return out.length === 0 ? null : out;
+}
+
+/**
+ * Defensive reader for `metadata.runtime.submoduleCredentials`. Same rationale
+ * as `readValidatedRuntimeEnv`: the JSON metadata column is untrusted, so drop
+ * any entry missing a string `host`/`secretId` rather than trusting the cast.
+ */
+export function readValidatedSubmoduleCredentials(
+  metadata: Record<string, unknown> | null | undefined,
+): SubmoduleCredential[] | null {
+  if (!metadata) return null;
+  const runtime = (metadata as { runtime?: unknown }).runtime;
+  if (!runtime || typeof runtime !== "object") return null;
+  const creds = (runtime as { submoduleCredentials?: unknown })
+    .submoduleCredentials;
+  if (!Array.isArray(creds)) return null;
+  const out: SubmoduleCredential[] = [];
+  for (const item of creds) {
+    if (!item || typeof item !== "object") continue;
+    const c = item as Record<string, unknown>;
+    if (
+      typeof c.host === "string" &&
+      c.host.length > 0 &&
+      typeof c.secretId === "string" &&
+      c.secretId.length > 0
+    ) {
+      out.push({ host: c.host, secretId: c.secretId });
     }
   }
   return out.length === 0 ? null : out;

--- a/apps/mesh/src/tools/sandbox/resolve-submodule-creds.ts
+++ b/apps/mesh/src/tools/sandbox/resolve-submodule-creds.ts
@@ -1,0 +1,57 @@
+import type { SubmoduleCredential } from "@decocms/mesh-sdk";
+import {
+  SecretAccessDeniedError,
+  SecretNotFoundError,
+} from "../../storage/secrets";
+import type { StudioContext } from "../../core/studio-context";
+
+interface ResolveParams {
+  ctx: StudioContext;
+  orgId: string;
+  userId: string;
+  entries: SubmoduleCredential[] | null | undefined;
+}
+
+/**
+ * Resolves the per-host submodule credentials declared on a virtual MCP
+ * ({ host, secretId }) into { host, token } by reading each secret from the
+ * credential vault. Unlike env (pushed after boot), these must be resolved
+ * before `runner.ensure` so the token rides the INITIAL daemon config — the
+ * clone (and its `git submodule update`) happens during provisioning.
+ *
+ * Secrets that fail to resolve (deleted, or user-scoped to another caller) are
+ * logged and skipped so a stale reference doesn't block the whole start — the
+ * affected submodule just fails auth (best-effort) in the daemon.
+ */
+export async function resolveSubmoduleCredentials({
+  ctx,
+  orgId,
+  userId,
+  entries,
+}: ResolveParams): Promise<{ host: string; token: string }[]> {
+  if (!entries || entries.length === 0) return [];
+
+  const resolved: { host: string; token: string }[] = [];
+  for (const entry of entries) {
+    try {
+      const { value } = await ctx.storage.secrets.resolveById(
+        entry.secretId,
+        orgId,
+        userId,
+      );
+      resolved.push({ host: entry.host, token: value });
+    } catch (err) {
+      if (
+        err instanceof SecretNotFoundError ||
+        err instanceof SecretAccessDeniedError
+      ) {
+        console.warn(
+          `[SANDBOX_START] skipping submodule credential for ${entry.host}: ${err.message}. Re-link or recreate the secret to restore.`,
+        );
+        continue;
+      }
+      throw err;
+    }
+  }
+  return resolved;
+}

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -24,8 +24,13 @@ import {
   requireOrganization,
   type StudioContext,
 } from "../../core/studio-context";
-import { resolveRuntimeConfig, type RuntimeConfigMeta } from "./helpers";
+import {
+  readValidatedSubmoduleCredentials,
+  resolveRuntimeConfig,
+  type RuntimeConfigMeta,
+} from "./helpers";
 import { resolveAndPushEnv } from "./resolve-env";
+import { resolveSubmoduleCredentials } from "./resolve-submodule-creds";
 import {
   readSandboxMap,
   removeSandboxMapEntry,
@@ -330,6 +335,7 @@ async function provisionSandbox(
         userEmail: string;
         branch: string;
         displayName: string;
+        submoduleCredentials?: { host: string; token: string }[];
       }
     | undefined;
 
@@ -410,6 +416,17 @@ async function provisionSandbox(
     const gitBranch = branch.startsWith("thread:")
       ? syntheticBranchToGitRef(branch)
       : branch;
+
+    // Private submodules live in repos the per-repo clone token can't reach;
+    // resolve the user's per-host PATs here so they ride the initial daemon
+    // config (the clone + `git submodule update` run during provisioning).
+    const submoduleCredentials = await resolveSubmoduleCredentials({
+      ctx,
+      orgId,
+      userId,
+      entries: readValidatedSubmoduleCredentials(metadata),
+    });
+
     repoOpts = {
       cloneUrl,
       // Persisted so the runner can re-mint on recovery; absent for anonymous.
@@ -420,6 +437,7 @@ async function provisionSandbox(
       userEmail: gitUserEmail,
       branch: gitBranch,
       displayName: `${githubRepo.owner}/${githubRepo.name}`,
+      ...(submoduleCredentials.length > 0 ? { submoduleCredentials } : {}),
     };
   }
 

--- a/apps/mesh/src/web/components/sandbox/runtime-card/env-vars-field.tsx
+++ b/apps/mesh/src/web/components/sandbox/runtime-card/env-vars-field.tsx
@@ -44,21 +44,22 @@ import {
   RefreshCw01,
   Save01,
   Trash01,
-  User01,
-  Users01,
 } from "@untitledui/icons";
 import { useT } from "@/web/i18n/use-t.ts";
 import { authClient } from "@/web/lib/auth-client";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { parseDotenv } from "@/web/components/sandbox/preview/drawer/parse-dotenv";
 import {
+  SECRET_NAME_RE,
+  ScopeIcon,
+  SecretPickerValue,
+} from "@/web/components/sandbox/runtime-card/secret-picker";
+import {
   type SecretInfo,
   type SecretScopeKind,
   useCreateSecret,
   useSecrets,
 } from "@/web/hooks/use-secrets";
-
-const SECRET_NAME_RE = /^[A-Za-z0-9_.-]+$/;
 
 export interface EnvVarsFieldProps<T extends FieldValues> {
   control: Control<T>;
@@ -703,37 +704,6 @@ function EnvRow<T extends FieldValues>({
       </div>
     </div>
   );
-}
-
-function SecretPickerValue({
-  field,
-  secretById,
-}: {
-  field: { value: unknown };
-  secretById: Map<string, SecretInfo>;
-}) {
-  const t = useT();
-  const id = (field.value as string | undefined) || "";
-  if (!id) return null;
-  const secret = secretById.get(id);
-  if (!secret) {
-    return (
-      <span className="text-destructive">
-        {t("sandbox.envVarsField.missingSecret", { id })}
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center gap-1.5 truncate">
-      <ScopeIcon scope={secret.scope} />
-      <span className="truncate font-mono">{secret.name}</span>
-    </span>
-  );
-}
-
-function ScopeIcon({ scope }: { scope: SecretScopeKind }) {
-  const Icon = scope === "user" ? User01 : Users01;
-  return <Icon className="size-3 text-muted-foreground" />;
 }
 
 interface SaveAsSecretDialogProps {

--- a/apps/mesh/src/web/components/sandbox/runtime-card/secret-picker.tsx
+++ b/apps/mesh/src/web/components/sandbox/runtime-card/secret-picker.tsx
@@ -1,0 +1,44 @@
+import { User01, Users01 } from "@untitledui/icons";
+import { useT } from "@/web/i18n/use-t.ts";
+import type { SecretInfo, SecretScopeKind } from "@/web/hooks/use-secrets";
+
+/**
+ * Shared secret-picker primitives used by both the env-vars and submodule-
+ * credentials editors in the Sandbox card. Kept in one place so the two
+ * editors can't drift (they previously carried byte-identical copies).
+ */
+
+// Secret names: letters, digits, underscore, dot, hyphen.
+export const SECRET_NAME_RE = /^[A-Za-z0-9_.-]+$/;
+
+/** Renders the selected secret (scope icon + name) inside a Select trigger. */
+export function SecretPickerValue({
+  field,
+  secretById,
+}: {
+  field: { value: unknown };
+  secretById: Map<string, SecretInfo>;
+}) {
+  const t = useT();
+  const id = (field.value as string | undefined) || "";
+  if (!id) return null;
+  const secret = secretById.get(id);
+  if (!secret) {
+    return (
+      <span className="text-destructive">
+        {t("sandbox.envVarsField.missingSecret", { id })}
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 truncate">
+      <ScopeIcon scope={secret.scope} />
+      <span className="truncate font-mono">{secret.name}</span>
+    </span>
+  );
+}
+
+export function ScopeIcon({ scope }: { scope: SecretScopeKind }) {
+  const Icon = scope === "user" ? User01 : Users01;
+  return <Icon className="size-3 text-muted-foreground" />;
+}

--- a/apps/mesh/src/web/components/sandbox/runtime-card/submodule-credentials-field.tsx
+++ b/apps/mesh/src/web/components/sandbox/runtime-card/submodule-credentials-field.tsx
@@ -1,0 +1,461 @@
+import { Suspense, useState } from "react";
+import type {
+  Control,
+  FieldPath,
+  FieldValues,
+  UseFormReturn,
+} from "react-hook-form";
+import { Controller, useFieldArray } from "react-hook-form";
+import { toast } from "sonner";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@deco/ui/components/select.tsx";
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import { Textarea } from "@deco/ui/components/textarea.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Plus, Trash01, User01, Users01 } from "@untitledui/icons";
+import { ErrorBoundary } from "@/web/components/error-boundary";
+import {
+  type SecretInfo,
+  type SecretScopeKind,
+  useCreateSecret,
+  useSecrets,
+} from "@/web/hooks/use-secrets";
+
+// Bare hostname with an optional port — must match the daemon's
+// VALID_SUBMODULE_HOST guard (packages/sandbox/daemon/setup/clone.ts) so the UI
+// rejects the same shapes the backend would silently skip.
+const VALID_HOST_RE = /^[a-zA-Z0-9.-]+(?::[0-9]+)?$/;
+const SECRET_NAME_RE = /^[A-Za-z0-9_.-]+$/;
+
+export interface SubmoduleCredentialsFieldProps<T extends FieldValues> {
+  control: Control<T>;
+  form: UseFormReturn<T>;
+}
+
+/**
+ * Form-bound editor for `metadata.runtime.submoduleCredentials` on a virtual
+ * MCP. Each entry maps a host (e.g. "github.com") to a vault secret holding a
+ * PAT. Studio resolves the secret on every SANDBOX_START and hands the token to
+ * the daemon on a git-only channel so `git submodule update` can fetch private
+ * submodules the main clone token can't reach.
+ *
+ * The secret list is read via Suspense; the wrapper renders a skeleton while it
+ * loads so the rest of the Sandbox card stays interactive.
+ */
+export function SubmoduleCredentialsField<T extends FieldValues>({
+  control,
+  form,
+}: SubmoduleCredentialsFieldProps<T>) {
+  return (
+    <div className="space-y-2">
+      <Label className="font-normal text-foreground">
+        Submodule credentials
+      </Label>
+      <p className="text-xs text-muted-foreground">
+        Personal access tokens for cloning private git submodules that live in
+        other repositories. Reference an org/user secret per host; SSH submodule
+        URLs are rewritten to HTTPS so the token applies.
+      </p>
+      <ErrorBoundary
+        fallback={({ error }) => (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+            {error?.message ?? "Failed to load secrets"}
+          </div>
+        )}
+      >
+        <Suspense fallback={<Skeleton className="h-9 w-full" />}>
+          <SubmoduleCredentialsEditor control={control} form={form} />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+}
+
+interface EditorProps<T extends FieldValues> {
+  control: Control<T>;
+  form: UseFormReturn<T>;
+}
+
+function SubmoduleCredentialsEditor<T extends FieldValues>({
+  control,
+  form,
+}: EditorProps<T>) {
+  const fieldPath = "metadata.runtime.submoduleCredentials" as FieldPath<T>;
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: fieldPath as never,
+  });
+
+  const secrets = useSecrets();
+  const secretById = new Map<string, SecretInfo>();
+  for (const s of secrets) secretById.set(s.id, s);
+
+  // Index of the row whose "create new secret" dialog is open, or null.
+  const [dialogIndex, setDialogIndex] = useState<number | null>(null);
+
+  return (
+    <div className="space-y-2">
+      <ul className="space-y-2">
+        {fields.map((field, index) => (
+          <li
+            key={field.id}
+            className="rounded-md border border-border bg-background"
+          >
+            <SubmoduleRow
+              index={index}
+              control={control}
+              fieldPath={fieldPath}
+              secrets={secrets}
+              secretById={secretById}
+              onCreateNewSecret={() => setDialogIndex(index)}
+              onRemove={() => remove(index)}
+            />
+          </li>
+        ))}
+      </ul>
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => append({ host: "", secretId: "" } as never)}
+        className="w-full"
+      >
+        <Plus className="size-3.5" />
+        Add submodule credential
+      </Button>
+
+      {dialogIndex !== null ? (
+        <CreateSecretDialog
+          onClose={() => setDialogIndex(null)}
+          onSaved={(secretId) => {
+            form.setValue(
+              `${fieldPath}.${dialogIndex}.secretId` as FieldPath<T>,
+              secretId as never,
+              { shouldDirty: true, shouldTouch: true },
+            );
+            setDialogIndex(null);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+interface SubmoduleRowProps<T extends FieldValues> {
+  index: number;
+  control: Control<T>;
+  fieldPath: FieldPath<T>;
+  secrets: SecretInfo[];
+  secretById: Map<string, SecretInfo>;
+  onCreateNewSecret: () => void;
+  onRemove: () => void;
+}
+
+function SubmoduleRow<T extends FieldValues>({
+  index,
+  control,
+  fieldPath,
+  secrets,
+  secretById,
+  onCreateNewSecret,
+  onRemove,
+}: SubmoduleRowProps<T>) {
+  const hostName = `${fieldPath}.${index}.host` as FieldPath<T>;
+  const secretIdName = `${fieldPath}.${index}.secretId` as FieldPath<T>;
+
+  return (
+    <div className="flex flex-col gap-2 p-2 sm:flex-row sm:items-center">
+      <div className="flex-1 min-w-0">
+        <Controller
+          control={control}
+          name={hostName}
+          render={({ field }) => {
+            const v = ((field.value as string | undefined) ?? "").trim();
+            const invalid = v.length > 0 && !VALID_HOST_RE.test(v);
+            return (
+              <div className="space-y-1">
+                <Input
+                  {...field}
+                  value={(field.value as string | undefined) ?? ""}
+                  placeholder="github.com"
+                  spellCheck={false}
+                  autoComplete="off"
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  className={cn(
+                    "font-mono",
+                    invalid &&
+                      "border-destructive focus-visible:ring-destructive",
+                  )}
+                  aria-invalid={invalid}
+                  aria-label={`Submodule credential ${index + 1} host`}
+                  onBlur={(e) => {
+                    field.onChange(e.target.value.trim());
+                    field.onBlur();
+                  }}
+                />
+                {invalid ? (
+                  <p className="text-[11px] text-destructive">
+                    Bare hostname, e.g. github.com (no scheme or path).
+                  </p>
+                ) : null}
+              </div>
+            );
+          }}
+        />
+      </div>
+
+      <div className="flex flex-[2] min-w-0 items-center gap-1">
+        <Controller
+          control={control}
+          name={secretIdName}
+          render={({ field }) => (
+            <Select
+              value={(field.value as string | undefined) || ""}
+              onValueChange={(val) => field.onChange(val)}
+            >
+              <SelectTrigger
+                className={cn(
+                  "h-9 w-full",
+                  !field.value && "text-muted-foreground",
+                )}
+              >
+                <SelectValue placeholder="Pick a secret…">
+                  <SecretPickerValue field={field} secretById={secretById} />
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {secrets.length === 0 ? (
+                  <div className="px-2 py-2 text-xs text-muted-foreground">
+                    No secrets yet. Use the “+” to create one.
+                  </div>
+                ) : (
+                  secrets.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      <span className="inline-flex items-center gap-2">
+                        <ScopeIcon scope={s.scope} />
+                        <span className="font-mono">{s.name}</span>
+                      </span>
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          )}
+        />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Create new secret"
+              onClick={onCreateNewSecret}
+            >
+              <Plus className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Create new secret</TooltipContent>
+        </Tooltip>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Remove submodule credential"
+              onClick={onRemove}
+            >
+              <Trash01 className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Remove</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}
+
+function SecretPickerValue({
+  field,
+  secretById,
+}: {
+  field: { value: unknown };
+  secretById: Map<string, SecretInfo>;
+}) {
+  const id = (field.value as string | undefined) || "";
+  if (!id) return null;
+  const secret = secretById.get(id);
+  if (!secret) {
+    return <span className="text-destructive">Missing secret ({id})</span>;
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 truncate">
+      <ScopeIcon scope={secret.scope} />
+      <span className="truncate font-mono">{secret.name}</span>
+    </span>
+  );
+}
+
+function ScopeIcon({ scope }: { scope: SecretScopeKind }) {
+  const Icon = scope === "user" ? User01 : Users01;
+  return <Icon className="size-3 text-muted-foreground" />;
+}
+
+interface CreateSecretDialogProps {
+  onClose: () => void;
+  onSaved: (secretId: string) => void;
+}
+
+function CreateSecretDialog({ onClose, onSaved }: CreateSecretDialogProps) {
+  const [name, setName] = useState("");
+  const [scope, setScope] = useState<SecretScopeKind>("organization");
+  const [value, setValue] = useState("");
+  const [description, setDescription] = useState("");
+  const createSecret = useCreateSecret();
+
+  const trimmedName = name.trim();
+  const canSubmit =
+    value.length > 0 &&
+    trimmedName.length > 0 &&
+    SECRET_NAME_RE.test(trimmedName);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    try {
+      const result = await createSecret.mutateAsync({
+        scope,
+        name: trimmedName,
+        value,
+        description: description.trim() || undefined,
+      });
+      toast.success(`Saved secret "${result.name}"`);
+      onSaved(result.id);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to save");
+    }
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create new secret</DialogTitle>
+          <DialogDescription>
+            Stored encrypted in the credential vault. The submodule credential
+            will reference the new secret by id — its value never leaves the
+            server.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="submodule-secret-scope">Scope</Label>
+            <Select
+              value={scope}
+              onValueChange={(v) => setScope(v as SecretScopeKind)}
+            >
+              <SelectTrigger id="submodule-secret-scope">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="organization">
+                  Organization — visible to all members
+                </SelectItem>
+                <SelectItem value="user">
+                  Private — only visible to me
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="submodule-secret-name">Name</Label>
+            <Input
+              id="submodule-secret-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="GITHUB_SUBMODULE_PAT"
+              autoComplete="off"
+              required
+            />
+            <p className="text-xs text-muted-foreground">
+              Letters, digits, underscore, dot, hyphen.
+            </p>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="submodule-secret-value">
+              Personal access token
+            </Label>
+            <Input
+              id="submodule-secret-value"
+              type="password"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder="ghp_…"
+              autoComplete="new-password"
+              required
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="submodule-secret-description">
+              Description (optional)
+            </Label>
+            <Textarea
+              id="submodule-secret-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+              placeholder="What is this token used for?"
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={createSecret.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={!canSubmit || createSecret.isPending}
+            >
+              {createSecret.isPending ? "Saving…" : "Save secret"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/runtime-card/submodule-credentials-field.tsx
+++ b/apps/mesh/src/web/components/sandbox/runtime-card/submodule-credentials-field.tsx
@@ -33,20 +33,20 @@ import {
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { Plus, Trash01, User01, Users01 } from "@untitledui/icons";
+import { Plus, Trash01 } from "@untitledui/icons";
+import { SUBMODULE_HOST_RE } from "@decocms/mesh-sdk";
 import { ErrorBoundary } from "@/web/components/error-boundary";
+import {
+  SECRET_NAME_RE,
+  ScopeIcon,
+  SecretPickerValue,
+} from "@/web/components/sandbox/runtime-card/secret-picker";
 import {
   type SecretInfo,
   type SecretScopeKind,
   useCreateSecret,
   useSecrets,
 } from "@/web/hooks/use-secrets";
-
-// Bare hostname with an optional port — must match the daemon's
-// VALID_SUBMODULE_HOST guard (packages/sandbox/daemon/setup/clone.ts) so the UI
-// rejects the same shapes the backend would silently skip.
-const VALID_HOST_RE = /^[a-zA-Z0-9.-]+(?::[0-9]+)?$/;
-const SECRET_NAME_RE = /^[A-Za-z0-9_.-]+$/;
 
 export interface SubmoduleCredentialsFieldProps<T extends FieldValues> {
   control: Control<T>;
@@ -193,7 +193,7 @@ function SubmoduleRow<T extends FieldValues>({
           name={hostName}
           render={({ field }) => {
             const v = ((field.value as string | undefined) ?? "").trim();
-            const invalid = v.length > 0 && !VALID_HOST_RE.test(v);
+            const invalid = v.length > 0 && !SUBMODULE_HOST_RE.test(v);
             return (
               <div className="space-y-1">
                 <Input
@@ -299,32 +299,6 @@ function SubmoduleRow<T extends FieldValues>({
       </div>
     </div>
   );
-}
-
-function SecretPickerValue({
-  field,
-  secretById,
-}: {
-  field: { value: unknown };
-  secretById: Map<string, SecretInfo>;
-}) {
-  const id = (field.value as string | undefined) || "";
-  if (!id) return null;
-  const secret = secretById.get(id);
-  if (!secret) {
-    return <span className="text-destructive">Missing secret ({id})</span>;
-  }
-  return (
-    <span className="inline-flex items-center gap-1.5 truncate">
-      <ScopeIcon scope={secret.scope} />
-      <span className="truncate font-mono">{secret.name}</span>
-    </span>
-  );
-}
-
-function ScopeIcon({ scope }: { scope: SecretScopeKind }) {
-  const Icon = scope === "user" ? User01 : Users01;
-  return <Icon className="size-3 text-muted-foreground" />;
 }
 
 interface CreateSecretDialogProps {

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -78,6 +78,7 @@ import { getActiveGithubRepo } from "@/web/lib/github-repo";
 import { agentHasConnectedGithub } from "@/web/lib/agent-capabilities";
 import { DevAgentSetup } from "@/web/components/dev-agent/dev-agent-setup.tsx";
 import { EnvVarsField } from "@/web/components/sandbox/runtime-card/env-vars-field";
+import { SubmoduleCredentialsField } from "@/web/components/sandbox/runtime-card/submodule-credentials-field";
 import { RepoRow } from "@/web/components/sandbox/runtime-card/repo-row";
 import { RuntimeFields } from "@/web/components/sandbox/runtime-card/runtime-fields";
 
@@ -160,6 +161,10 @@ function editSessionReducer(
   }
 }
 
+// Bare hostname with an optional port — mirrors the daemon's
+// VALID_SUBMODULE_HOST guard and the field editor's VALID_HOST_RE.
+const SUBMODULE_HOST_RE = /^[a-zA-Z0-9.-]+(?::[0-9]+)?$/;
+
 /**
  * Drops in-progress / invalid env rows from the autosave payload. A row is
  * stripped when: key is empty, key fails the shell-portable regex, or it's a
@@ -191,6 +196,36 @@ function stripIncompleteEnvEntries(
       runtime: {
         ...(data.metadata?.runtime ?? {}),
         env: cleaned,
+      },
+    },
+  };
+}
+
+/**
+ * Drop half-filled submodule-credential rows (no host, invalid host, or no
+ * secretId) before autosave, same rationale as `stripIncompleteEnvEntries`:
+ * the partial row stays in form state so the user keeps editing, but the
+ * request body only carries entries the server schema accepts.
+ */
+function stripIncompleteSubmoduleCredentials(
+  data: VirtualMcpFormData,
+): VirtualMcpFormData {
+  const creds = data.metadata?.runtime?.submoduleCredentials;
+  if (!creds || creds.length === 0) return data;
+  const cleaned = creds.filter((entry) => {
+    if (!entry || typeof entry !== "object") return false;
+    const host = ((entry as { host?: string }).host ?? "").trim();
+    if (!host || !SUBMODULE_HOST_RE.test(host)) return false;
+    return Boolean((entry as { secretId?: string }).secretId);
+  });
+  if (cleaned.length === creds.length) return data;
+  return {
+    ...data,
+    metadata: {
+      ...data.metadata,
+      runtime: {
+        ...(data.metadata?.runtime ?? {}),
+        submoduleCredentials: cleaned,
       },
     },
   };
@@ -399,10 +434,13 @@ function VirtualMcpDetailViewWithData({
     // current form values; only _defaultValues advances.
     form.reset(formData, { keepValues: true });
 
-    // Strip in-progress env rows (no key, or kind=secret with no secretId).
-    // The partial row stays in the form state so the user keeps editing it,
-    // but the request body only carries entries the server schema accepts.
-    const payload = stripIncompleteEnvEntries(formData);
+    // Strip in-progress env rows (no key, or kind=secret with no secretId) and
+    // submodule-credential rows (no host / no secretId). The partial rows stay
+    // in form state so the user keeps editing, but the request body only
+    // carries entries the server schema accepts.
+    const payload = stripIncompleteSubmoduleCredentials(
+      stripIncompleteEnvEntries(formData),
+    );
 
     await actions.update.mutateAsync({
       id: virtualMcp.id,
@@ -1144,6 +1182,10 @@ Define step-by-step how the agent should handle requests.
                     form={form}
                     virtualMcpId={virtualMcp.id}
                     orgSlug={org.slug}
+                  />
+                  <SubmoduleCredentialsField
+                    control={form.control}
+                    form={form}
                   />
                 </CardContent>
               </Card>

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -48,6 +48,7 @@ import {
 import {
   ENV_VAR_KEY_RE,
   StudioPackAgentId,
+  SUBMODULE_HOST_RE,
   useConnectionActions,
   useProjectContext,
   useVirtualMCP,
@@ -160,10 +161,6 @@ function editSessionReducer(
       return null;
   }
 }
-
-// Bare hostname with an optional port — mirrors the daemon's
-// VALID_SUBMODULE_HOST guard and the field editor's VALID_HOST_RE.
-const SUBMODULE_HOST_RE = /^[a-zA-Z0-9.-]+(?::[0-9]+)?$/;
 
 /**
  * Drops in-progress / invalid env rows from the autosave payload. A row is

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -133,6 +133,7 @@ export {
   type RuntimeMetadata,
   type RuntimeEnvEntry,
   type SubmoduleCredential,
+  SUBMODULE_HOST_RE,
   ENV_VAR_KEY_RE,
   parseSandboxRecord,
   parseBranchMap,

--- a/packages/mesh-sdk/src/index.ts
+++ b/packages/mesh-sdk/src/index.ts
@@ -132,6 +132,7 @@ export {
   type SandboxRecord,
   type RuntimeMetadata,
   type RuntimeEnvEntry,
+  type SubmoduleCredential,
   ENV_VAR_KEY_RE,
   parseSandboxRecord,
   parseBranchMap,

--- a/packages/mesh-sdk/src/types/index.ts
+++ b/packages/mesh-sdk/src/types/index.ts
@@ -39,6 +39,7 @@ export {
   type SandboxRecord,
   type RuntimeMetadata,
   type RuntimeEnvEntry,
+  type SubmoduleCredential,
   ENV_VAR_KEY_RE,
   parseSandboxRecord,
   parseBranchMap,

--- a/packages/mesh-sdk/src/types/index.ts
+++ b/packages/mesh-sdk/src/types/index.ts
@@ -40,6 +40,7 @@ export {
   type RuntimeMetadata,
   type RuntimeEnvEntry,
   type SubmoduleCredential,
+  SUBMODULE_HOST_RE,
   ENV_VAR_KEY_RE,
   parseSandboxRecord,
   parseBranchMap,

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -251,10 +251,20 @@ export type RuntimeEnvEntry = z.infer<typeof RuntimeEnvEntrySchema>;
  * bare hostname (e.g. "github.com"); the daemon rewrites `git@<host>:` SSH
  * submodule URLs to HTTPS so the token applies.
  */
+/**
+ * A bare submodule hostname with an optional port (e.g. "github.com",
+ * "gitlab.example.com:8443"). Single source of truth for the shape: the schema
+ * below enforces it, and the sandbox UI imports it. The daemon keeps its own
+ * copy (it can't depend on mesh-sdk) — see `VALID_SUBMODULE_HOST` in
+ * packages/sandbox/daemon/setup/clone.ts; keep the two in sync.
+ */
+export const SUBMODULE_HOST_RE = /^[a-zA-Z0-9.-]+(?::[0-9]+)?$/;
+
 const SubmoduleCredentialSchema = z.object({
   host: z
     .string()
     .min(1)
+    .regex(SUBMODULE_HOST_RE)
     .describe("Submodule host, e.g. 'github.com' (bare hostname, no scheme)."),
   secretId: z
     .string()

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -242,6 +242,29 @@ const RuntimeEnvEntrySchema = z.discriminatedUnion("kind", [
 export type RuntimeEnvEntry = z.infer<typeof RuntimeEnvEntrySchema>;
 
 /**
+ * One git submodule credential on a virtual MCP. Submodules live in other
+ * repositories/orgs that the main clone's per-repo GitHub App token cannot
+ * reach, so the user supplies a PAT (stored as a vault secret) keyed by the
+ * submodule's host. mesh resolves `secretId` against the credential vault on
+ * every SANDBOX_START and posts the token to the daemon on a git-only channel
+ * (never the env bag) so `git submodule update` can authenticate. `host` is the
+ * bare hostname (e.g. "github.com"); the daemon rewrites `git@<host>:` SSH
+ * submodule URLs to HTTPS so the token applies.
+ */
+const SubmoduleCredentialSchema = z.object({
+  host: z
+    .string()
+    .min(1)
+    .describe("Submodule host, e.g. 'github.com' (bare hostname, no scheme)."),
+  secretId: z
+    .string()
+    .min(1)
+    .describe("Vault secret id holding the PAT used to fetch this host."),
+});
+
+export type SubmoduleCredential = z.infer<typeof SubmoduleCredentialSchema>;
+
+/**
  * User-pinned runtime configuration stored under `metadata.runtime`. Empty
  * fields fall back to autodetect on the next SANDBOX_START.
  */
@@ -273,6 +296,13 @@ const RuntimeMetadataSchema = z.object({
     .optional()
     .describe(
       "Env vars injected on every SANDBOX_START. Literal entries inline their value; secret entries store a secretId that mesh resolves via the credential vault before posting /_sandbox/config.",
+    ),
+  submoduleCredentials: z
+    .array(SubmoduleCredentialSchema)
+    .nullable()
+    .optional()
+    .describe(
+      "Git submodule credentials injected on every SANDBOX_START. Each entry maps a host to a vault secret (PAT) that mesh resolves before posting /_sandbox/config; the daemon uses it to authenticate `git submodule update` for submodules on that host.",
     ),
 });
 

--- a/packages/sandbox/daemon/routes/config.test.ts
+++ b/packages/sandbox/daemon/routes/config.test.ts
@@ -198,4 +198,49 @@ describe("makeConfigReadHandler", () => {
     const body = (await res.json()) as { repoDir: string | null };
     expect(body.repoDir).toBeNull();
   });
+
+  it("redacts submodule credential tokens from the response", async () => {
+    await store.apply({
+      git: {
+        repository: {
+          cloneUrl: "https://example.com/repo.git",
+          submoduleCredentials: [{ host: "github.com", token: "ghp_secret" }],
+        },
+      },
+    });
+    const h = makeConfigReadHandler({ daemonBootId: BOOT_ID, store });
+    const res = await h();
+    const text = await res.text();
+    // The PAT must never cross the (browser-reachable) /config boundary.
+    expect(text).not.toContain("ghp_secret");
+    const body = JSON.parse(text) as { config: TenantConfig };
+    expect(body.config.git?.repository?.submoduleCredentials).toBeUndefined();
+    // Non-secret repository fields still round-trip.
+    expect(body.config.git?.repository?.cloneUrl).toBe(
+      "https://example.com/repo.git",
+    );
+  });
+});
+
+describe("makeConfigUpdateHandler — token redaction", () => {
+  it("redacts submodule tokens from the PUT/POST config echo", async () => {
+    const store = new TenantConfigStore();
+    const h = makeConfigUpdateHandler({ daemonBootId: BOOT_ID, store });
+    const res = await h(
+      buildReq("POST", {
+        git: {
+          repository: {
+            cloneUrl: "https://example.com/repo.git",
+            submoduleCredentials: [{ host: "github.com", token: "ghp_echo" }],
+          },
+        },
+      }),
+    );
+    const text = await res.text();
+    expect(text).not.toContain("ghp_echo");
+    // But the daemon's in-memory store keeps the token so the clone can use it.
+    expect(store.read()?.git?.repository?.submoduleCredentials).toEqual([
+      { host: "github.com", token: "ghp_echo" },
+    ]);
+  });
 });

--- a/packages/sandbox/daemon/routes/config.ts
+++ b/packages/sandbox/daemon/routes/config.ts
@@ -146,8 +146,27 @@ function makeApplyResponse(bootId: string, result: ApplyResult): Response {
   return jsonResponse({
     bootId,
     transition: result.transition.kind,
-    config: result.after,
+    // Both GET /config and this PUT/POST echo are proxied to the browser
+    // (sandbox-proxy.ts). Never let the resolved submodule PATs back out —
+    // they're needed only in the in-memory store for the clone step.
+    config: redactSubmoduleTokens(result.after),
   });
+}
+
+/**
+ * Strip resolved submodule PAT `token`s from a config before it crosses an
+ * HTTP boundary. The daemon keeps them in its in-memory store (clone.ts reads
+ * them there); they must never appear in a `/config` response, which is
+ * browser-reachable — otherwise any referenceable org secret becomes readable.
+ * Mirrors how `env` values never leave the daemon (only `envKeys` do).
+ */
+function redactSubmoduleTokens<T extends TenantConfig | null>(config: T): T {
+  if (!config?.git?.repository?.submoduleCredentials) return config;
+  const { submoduleCredentials: _drop, ...rest } = config.git.repository;
+  return {
+    ...config,
+    git: { ...config.git, repository: rest },
+  } as T;
 }
 
 function inferStatus(reason: string): number {
@@ -160,9 +179,11 @@ function stripDerived(
   enriched: ReturnType<TenantConfigStore["read"]>,
 ): TenantConfig | null {
   if (!enriched) return null;
-  return {
+  // Redact resolved submodule PATs — see redactSubmoduleTokens. `env` is
+  // likewise never returned here (only `envKeys`, in the read handler).
+  return redactSubmoduleTokens({
     git: enriched.git,
     operator: enriched.operator,
     application: enriched.application,
-  };
+  });
 }

--- a/packages/sandbox/daemon/setup/clone.test.ts
+++ b/packages/sandbox/daemon/setup/clone.test.ts
@@ -502,3 +502,146 @@ describe("submoduleUpdateArgs", () => {
     ]);
   });
 });
+
+/**
+ * Like setupBareRepo but the default branch carries a real submodule gitlink
+ * (+ `.gitmodules`) pointing at a `file://` sub-repo. The seed uses
+ * `protocol.file.allow=always` to register it, but `spawnClone`'s submodule
+ * update runs WITHOUT that flag — so git ≥2.38 blocks the file transport
+ * (CVE-2022-39253) and the fetch fails fast. That's exactly the best-effort
+ * path we want to prove doesn't take down the clone. (The top-level `git clone`
+ * of the main repo still works — the block is submodule-initiated only.)
+ */
+function setupBareRepoWithGitmodules(): {
+  url: string;
+  root: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "clonetest-sm-"));
+  const bare = join(root, "origin.git");
+  const seed = join(root, "seed");
+  const subBare = join(root, "sub.git");
+  const subSeed = join(root, "sub-seed");
+  const gitOpts = { stdio: "ignore" as const };
+  const gitcfg = `-c init.defaultBranch=main -c user.email=test@example.com -c user.name=test -c commit.gpgsign=false`;
+  // A tiny bare sub-repo to serve as the submodule source.
+  execSync(`git ${gitcfg} init --bare ${subBare}`, gitOpts);
+  execSync(`git ${gitcfg} init ${subSeed}`, gitOpts);
+  writeFileSync(join(subSeed, "lib.txt"), "lib\n");
+  execSync(`git ${gitcfg} -C ${subSeed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${subSeed} commit -m sub`, gitOpts);
+  execSync(`git ${gitcfg} -C ${subSeed} branch -M main`, gitOpts);
+  execSync(`git ${gitcfg} -C ${subSeed} remote add origin ${subBare}`, gitOpts);
+  execSync(`git ${gitcfg} -C ${subSeed} push -u origin main`, gitOpts);
+
+  execSync(`git ${gitcfg} init --bare ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} init ${seed}`, gitOpts);
+  writeFileSync(join(seed, "README.md"), "hello\n");
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m initial`, gitOpts);
+  // `submodule add` needs protocol.file.allow at seed time to register a
+  // file:// submodule; the clone under test deliberately does not set it.
+  execSync(
+    `git ${gitcfg} -c protocol.file.allow=always -C ${seed} submodule add file://${subBare} vendor/lib`,
+    gitOpts,
+  );
+  execSync(`git ${gitcfg} -C ${seed} commit -m submodule`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} branch -M main`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} remote add origin ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push -u origin main`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${bare} symbolic-ref HEAD refs/heads/main`,
+    gitOpts,
+  );
+  return {
+    url: `file://${bare}`,
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function configWithSubmoduleCreds(
+  repoDir: string,
+  cloneUrl: string,
+  submoduleCredentials: { host: string; token: string }[],
+): Config {
+  return {
+    git: { repository: { cloneUrl, submoduleCredentials } },
+    application: {},
+    repoDir,
+  } as unknown as Config;
+}
+
+describe("spawnClone — submodules", () => {
+  it("is best-effort: a failing submodule fetch warns but the clone succeeds", async () => {
+    const { url, root, cleanup } = setupBareRepoWithGitmodules();
+    try {
+      const repoDir = join(root, "workspace");
+      // credFile is written next to askpass — point it at the writable test
+      // root, not the daemon's /data (which the test env may not have).
+      const askpassPath = join(root, "askpass.sh");
+      let out = "";
+      const { code } = await spawnClone({
+        config: configWithSubmoduleCreds(repoDir, url, [
+          { host: "github.com", token: "ghp_dummy" },
+        ]),
+        askpassPath,
+        onChunk: (_src, data) => {
+          out += data;
+        },
+      });
+      // The bogus submodule fetch fails, but the working tree is intact.
+      expect(code).toBe(0);
+      expect(existsSync(join(repoDir, "README.md"))).toBe(true);
+      expect(out).toContain("submodule update failed");
+      // The temp credentials file must not survive the run.
+      expect(existsSync(join(root, "submodule-git-credentials"))).toBe(false);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("warns and skips an invalid host without running the submodule fetch", async () => {
+    const { url, root, cleanup } = setupBareRepoWithGitmodules();
+    try {
+      const repoDir = join(root, "workspace");
+      let out = "";
+      const { code } = await spawnClone({
+        config: configWithSubmoduleCreds(repoDir, url, [
+          { host: "https://evil.com", token: "ghp_dummy" },
+        ]),
+        askpassPath: join(root, "askpass.sh"),
+        onChunk: (_src, data) => {
+          out += data;
+        },
+      });
+      expect(code).toBe(0);
+      expect(out).toContain("invalid host");
+      // No valid host → the git submodule step never runs.
+      expect(out).not.toContain("submodule update failed");
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  it("no-ops when credentials are set but the repo has no .gitmodules", async () => {
+    const { url, root, cleanup } = setupBareRepo();
+    try {
+      const repoDir = join(root, "workspace");
+      let out = "";
+      const { code } = await spawnClone({
+        config: configWithSubmoduleCreds(repoDir, url, [
+          { host: "github.com", token: "ghp_dummy" },
+        ]),
+        askpassPath: join(root, "askpass.sh"),
+        onChunk: (_src, data) => {
+          out += data;
+        },
+      });
+      expect(code).toBe(0);
+      expect(out).not.toContain("submodule");
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+});

--- a/packages/sandbox/daemon/setup/clone.test.ts
+++ b/packages/sandbox/daemon/setup/clone.test.ts
@@ -11,7 +11,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { computeBranchDivergence } from "../git/branch-divergence";
 import type { Config } from "../types";
-import { cloneCommand, spawnClone } from "./clone";
+import {
+  cloneCommand,
+  prepareSubmoduleCredentials,
+  spawnClone,
+  submoduleUpdateArgs,
+} from "./clone";
 
 const ASKPASS = "/data/askpass.sh";
 
@@ -402,4 +407,98 @@ describe("spawnClone", () => {
       cleanup();
     }
   }, 30_000);
+});
+
+describe("prepareSubmoduleCredentials", () => {
+  it("builds one store-file line per host with a percent-encoded token", () => {
+    const { lines, hosts, invalidHosts } = prepareSubmoduleCredentials([
+      { host: "github.com", token: "ghp_abc" },
+    ]);
+    expect(hosts).toEqual(["github.com"]);
+    expect(lines).toEqual(["https://x-access-token:ghp_abc@github.com"]);
+    expect(invalidHosts).toEqual([]);
+  });
+
+  it("percent-encodes tokens with URL-unsafe characters", () => {
+    const { lines } = prepareSubmoduleCredentials([
+      { host: "github.com", token: "a/b@c:d e" },
+    ]);
+    expect(lines).toEqual([
+      "https://x-access-token:a%2Fb%40c%3Ad%20e@github.com",
+    ]);
+  });
+
+  it("dedupes by host, last token wins", () => {
+    const { lines, hosts } = prepareSubmoduleCredentials([
+      { host: "github.com", token: "first" },
+      { host: "github.com", token: "second" },
+    ]);
+    expect(hosts).toEqual(["github.com"]);
+    expect(lines).toEqual(["https://x-access-token:second@github.com"]);
+  });
+
+  it("rejects hosts with a scheme, path, userinfo, or whitespace", () => {
+    const { hosts, invalidHosts } = prepareSubmoduleCredentials([
+      { host: "https://github.com", token: "t" },
+      { host: "github.com/foo", token: "t" },
+      { host: "evil@github.com", token: "t" },
+      { host: "git hub.com", token: "t" },
+      { host: "github.com:443", token: "ok" },
+    ]);
+    // Only the bare host (optionally with a port) survives.
+    expect(hosts).toEqual(["github.com:443"]);
+    expect(invalidHosts).toEqual([
+      "https://github.com",
+      "github.com/foo",
+      "evil@github.com",
+      "git hub.com",
+    ]);
+  });
+});
+
+describe("submoduleUpdateArgs", () => {
+  it("emits SSH→HTTPS insteadOf rewrites (no token) then the store helper", () => {
+    const args = submoduleUpdateArgs({
+      hosts: ["github.com"],
+      credFile: "/data/submodule-git-credentials",
+    });
+    expect(args).toEqual([
+      "-c",
+      "url.https://github.com/.insteadOf=git@github.com:",
+      "-c",
+      "url.https://github.com/.insteadOf=ssh://git@github.com/",
+      "-c",
+      "credential.helper=store --file=/data/submodule-git-credentials",
+      "submodule",
+      "update",
+      "--init",
+      "--recursive",
+      "--depth",
+      "1",
+    ]);
+    // The token must never appear in argv — only the credentials file holds it.
+    expect(args.join(" ")).not.toContain("x-access-token");
+  });
+
+  it("emits rewrites for every host before the shared helper", () => {
+    const args = submoduleUpdateArgs({
+      hosts: ["github.com", "gitlab.example.com"],
+      credFile: "/data/creds",
+    });
+    expect(args.filter((a) => a.startsWith("url.")).length).toBe(4);
+    expect(args).toContain(
+      "url.https://gitlab.example.com/.insteadOf=git@gitlab.example.com:",
+    );
+    // The store helper + subcommand always come last, after every rewrite.
+    expect(args.slice(-8)).toEqual([
+      "-c",
+      "credential.helper=store --file=/data/creds",
+      "submodule",
+      "update",
+      "--init",
+      "--recursive",
+      "--depth",
+      "1",
+    ]);
+  });
 });

--- a/packages/sandbox/daemon/setup/clone.test.ts
+++ b/packages/sandbox/daemon/setup/clone.test.ts
@@ -644,4 +644,28 @@ describe("spawnClone — submodules", () => {
       cleanup();
     }
   }, 30_000);
+
+  it("swallows a credentials-file write error and still succeeds", async () => {
+    const { url, root, cleanup } = setupBareRepoWithGitmodules();
+    try {
+      const repoDir = join(root, "workspace");
+      // askpass dir doesn't exist → the credFile write throws ENOENT, which the
+      // best-effort catch must swallow rather than fail the clone.
+      let out = "";
+      const { code } = await spawnClone({
+        config: configWithSubmoduleCreds(repoDir, url, [
+          { host: "github.com", token: "ghp_dummy" },
+        ]),
+        askpassPath: join(root, "does-not-exist", "askpass.sh"),
+        onChunk: (_src, data) => {
+          out += data;
+        },
+      });
+      expect(code).toBe(0);
+      expect(existsSync(join(repoDir, "README.md"))).toBe(true);
+      expect(out).toContain("submodule update errored");
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
 });

--- a/packages/sandbox/daemon/setup/clone.ts
+++ b/packages/sandbox/daemon/setup/clone.ts
@@ -1,13 +1,14 @@
 import { sleep } from "@decocms/std";
 import { existsSync, readdirSync } from "node:fs";
-import { isAbsolute } from "node:path";
+import { rm, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join } from "node:path";
 import { isSyntheticBranch } from "../constants";
 import { isValidRemoteBranchName } from "../git/ref-name";
 import {
   formatCommand,
   type StructuredCommand,
 } from "../process/structured-command";
-import type { Config } from "../types";
+import type { Config, SubmoduleCredential } from "../types";
 import { gitBaseArgv, gitStepEnv } from "./git-command";
 import { spawnSetupStep } from "./spawn-step";
 
@@ -262,6 +263,125 @@ export interface CloneResult {
   ) => Promise<void>;
 }
 
+// A submodule host flows into a `git -c url.<…>.insteadOf` argv and into a
+// git-credentials file line (`https://x-access-token:<token>@<host>`). Argv/
+// file form makes shell injection impossible, but a host with a slash, `@`,
+// whitespace, or control chars would corrupt the insteadOf prefix or the
+// credential URL — so allow only a bare hostname with an optional port.
+const VALID_SUBMODULE_HOST = /^[a-zA-Z0-9.-]+(?::[0-9]+)?$/;
+
+/**
+ * Exported for unit tests. Validates + dedupes submodule credentials by host
+ * (last write wins), returning the git-credential-store file lines for the
+ * valid hosts plus the rejected hosts. Deterministic: no fs/network.
+ */
+export function prepareSubmoduleCredentials(
+  credentials: readonly SubmoduleCredential[],
+): { lines: string[]; hosts: string[]; invalidHosts: string[] } {
+  const invalidHosts: string[] = [];
+  const tokenByHost = new Map<string, string>();
+  for (const c of credentials) {
+    if (!VALID_SUBMODULE_HOST.test(c.host)) {
+      invalidHosts.push(c.host);
+      continue;
+    }
+    tokenByHost.set(c.host, c.token);
+  }
+  const hosts = [...tokenByHost.keys()];
+  const lines = [...tokenByHost].map(
+    ([host, token]) =>
+      `https://x-access-token:${encodeURIComponent(token)}@${host}`,
+  );
+  return { lines, hosts, invalidHosts };
+}
+
+/**
+ * Exported for unit tests. The exact `git` extra-args for a submodule update:
+ * per-host SSH→HTTPS `insteadOf` rewrites (no token) followed by the
+ * store-helper pointer and the shallow recursive `submodule update`. Combined
+ * with `gitBaseArgv()`'s leading `-c credential.helper=` (which resets the
+ * helper list), the store helper is the only one in effect for this command
+ * and its submodule subprocesses (they inherit `-c` via GIT_CONFIG_PARAMETERS).
+ */
+export function submoduleUpdateArgs(p: {
+  hosts: readonly string[];
+  credFile: string;
+}): string[] {
+  const rewriteArgs = p.hosts.flatMap((host) => [
+    "-c",
+    `url.https://${host}/.insteadOf=git@${host}:`,
+    "-c",
+    `url.https://${host}/.insteadOf=ssh://git@${host}/`,
+  ]);
+  return [
+    ...rewriteArgs,
+    "-c",
+    `credential.helper=store --file=${p.credFile}`,
+    "submodule",
+    "update",
+    "--init",
+    "--recursive",
+    "--depth",
+    "1",
+  ];
+}
+
+/**
+ * Fetch git submodules after the working tree is materialized, authenticating
+ * private submodules with user-supplied per-host PATs. Best-effort: a failure
+ * warns and leaves the (bare) working tree intact rather than failing the whole
+ * clone, mirroring `fetchBaseBranch`.
+ *
+ * Credentials are delivered on a git-only channel — never the env bag the dev
+ * server sees. The token lives only in a short-lived credentials file (mode
+ * 0o600, next to the no-op askpass, outside the repo) read by
+ * `git-credential-store` for the submodule fetch, then deleted. `insteadOf`
+ * rewrites (which carry NO token) turn `git@<host>:` / `ssh://git@<host>/`
+ * submodule URLs into HTTPS so the store credential applies; the token is never
+ * placed in argv and never persisted into the repo's `.git/config`.
+ *
+ * No-op when no credentials are configured (feature is opt-in) or the repo
+ * declares no submodules.
+ */
+async function runSubmoduleUpdate(p: {
+  deps: CloneDeps;
+  dir: string;
+  askpassPath: string;
+  credentials: readonly SubmoduleCredential[] | undefined;
+}): Promise<void> {
+  const { deps, dir, askpassPath, credentials } = p;
+  if (!credentials || credentials.length === 0) return;
+  if (!existsSync(join(dir, ".gitmodules"))) return;
+
+  const { lines, hosts, invalidHosts } =
+    prepareSubmoduleCredentials(credentials);
+  for (const host of invalidHosts) {
+    deps.onChunk(
+      "setup",
+      `\r\n[clone] warning: skipping submodule credential with invalid host ${JSON.stringify(host)}\r\n`,
+    );
+  }
+  if (hosts.length === 0) return;
+
+  const credFile = join(dirname(askpassPath), "submodule-git-credentials");
+  await writeFile(credFile, `${lines.join("\n")}\n`, { mode: 0o600 });
+
+  try {
+    const cmd = git(submoduleUpdateArgs({ hosts, credFile }), askpassPath, {
+      cwd: dir,
+    });
+    const code = await runNetworkStep(cmd, deps);
+    if (code !== 0) {
+      deps.onChunk(
+        "setup",
+        `\r\n[clone] warning: submodule update failed (exit ${code}); continuing without submodules\r\n`,
+      );
+    }
+  } finally {
+    await rm(credFile, { force: true });
+  }
+}
+
 /**
  * Acquires the repo working tree (0 on success). Emits progress via `onChunk`.
  * The returned `fetchBase` thunk (when present) does the off-critical-path
@@ -344,6 +464,23 @@ export async function spawnClone(deps: CloneDeps): Promise<CloneResult> {
         onChunk,
       });
 
+  // Funnels every success return through the (best-effort, opt-in) submodule
+  // fetch so both acquisition paths and both branch cases get submodules.
+  const finalize = async (
+    code: number,
+    extra: Omit<CloneResult, "code"> = {},
+  ): Promise<CloneResult> => {
+    if (code === 0) {
+      await runSubmoduleUpdate({
+        deps,
+        dir,
+        askpassPath,
+        credentials: config.git?.repository?.submoduleCredentials,
+      });
+    }
+    return { code, ...extra };
+  };
+
   // When repoDir already has files (e.g. .decocms/daemon.json written before
   // the first clone) but no .git, `git clone` would fail with "already exists
   // and is not an empty directory". Use init+fetch+checkout instead — it
@@ -409,34 +546,34 @@ export async function spawnClone(deps: CloneDeps): Promise<CloneResult> {
     const checkoutCode = await runStep(checkoutCmd, deps);
     if (checkoutCode !== 0) return { code: checkoutCode };
     if (branchToForkLocally) {
-      return {
-        code: await runStep(
+      return finalize(
+        await runStep(
           git(["checkout", "-B", branchToForkLocally], askpassPath, {
             cwd: dir,
           }),
           deps,
         ),
-      };
+      );
     }
-    return {
-      code: 0,
-      ...(branchToTrack ? { fetchBase: deferBaseFetch(branchToTrack) } : {}),
-    };
+    return finalize(
+      0,
+      branchToTrack ? { fetchBase: deferBaseFetch(branchToTrack) } : {},
+    );
   }
 
   const cloneCmd = cloneCommand({ cloneUrl, dir, branchOnRemote, askpassPath });
   const cloneCode = await runNetworkStep(cloneCmd, deps);
   if (cloneCode !== 0) return { code: cloneCode };
   if (branchToForkLocally) {
-    return {
-      code: await runStep(
+    return finalize(
+      await runStep(
         git(["checkout", "-B", branchToForkLocally], askpassPath, { cwd: dir }),
         deps,
       ),
-    };
+    );
   }
-  return {
-    code: 0,
-    ...(branchOnRemote ? { fetchBase: deferBaseFetch(branchOnRemote) } : {}),
-  };
+  return finalize(
+    0,
+    branchOnRemote ? { fetchBase: deferBaseFetch(branchOnRemote) } : {},
+  );
 }

--- a/packages/sandbox/daemon/setup/clone.ts
+++ b/packages/sandbox/daemon/setup/clone.ts
@@ -268,6 +268,8 @@ export interface CloneResult {
 // file form makes shell injection impossible, but a host with a slash, `@`,
 // whitespace, or control chars would corrupt the insteadOf prefix or the
 // credential URL — so allow only a bare hostname with an optional port.
+// Duplicated (not imported) because the daemon can't depend on mesh-sdk — keep
+// in sync with `SUBMODULE_HOST_RE` in packages/mesh-sdk/src/types/virtual-mcp.ts.
 const VALID_SUBMODULE_HOST = /^[a-zA-Z0-9.-]+(?::[0-9]+)?$/;
 
 /**
@@ -363,10 +365,15 @@ async function runSubmoduleUpdate(p: {
   }
   if (hosts.length === 0) return;
 
+  // Best-effort, end to end: the credentials-file write (EACCES/ENOSPC) or the
+  // spawn can throw, and this runs inside `finalize` on the clone's critical
+  // path — an uncaught throw would reject spawnClone and fail the whole clone
+  // for an opt-in, non-essential step. Swallow to a warning; the working tree
+  // (sans submodules) stays intact. `rm` always runs so the token file never
+  // lingers, even if the write half-completed.
   const credFile = join(dirname(askpassPath), "submodule-git-credentials");
-  await writeFile(credFile, `${lines.join("\n")}\n`, { mode: 0o600 });
-
   try {
+    await writeFile(credFile, `${lines.join("\n")}\n`, { mode: 0o600 });
     const cmd = git(submoduleUpdateArgs({ hosts, credFile }), askpassPath, {
       cwd: dir,
     });
@@ -377,8 +384,13 @@ async function runSubmoduleUpdate(p: {
         `\r\n[clone] warning: submodule update failed (exit ${code}); continuing without submodules\r\n`,
       );
     }
+  } catch (err) {
+    deps.onChunk(
+      "setup",
+      `\r\n[clone] warning: submodule update errored (${(err as Error).message}); continuing without submodules\r\n`,
+    );
   } finally {
-    await rm(credFile, { force: true });
+    await rm(credFile, { force: true }).catch(() => {});
   }
 }
 

--- a/packages/sandbox/daemon/types.ts
+++ b/packages/sandbox/daemon/types.ts
@@ -32,10 +32,27 @@ import type { CoAuthorIdentity } from "../git-co-author";
 /** Studio user operating the sandbox — appended as git co-author on commits. */
 export type OperatorIdentity = CoAuthorIdentity;
 
+/**
+ * A credential for fetching git submodules whose remotes the main clone token
+ * can't reach (different repo/org). `token` is a PAT; the daemon writes it to a
+ * git-only credentials file and rewrites `git@<host>:` SSH submodule URLs to
+ * HTTPS so the token authenticates. Never placed in the process env bag.
+ */
+export interface SubmoduleCredential {
+  readonly host: string;
+  readonly token: string;
+}
+
 export interface GitRepository {
   readonly cloneUrl: string;
   readonly branch?: string;
   readonly repoName?: string;
+  /**
+   * Credentials for private submodules, keyed by host. Absent/empty means
+   * submodules are fetched with only the ambient (no-credential) git config —
+   * public submodules work, private ones on other hosts fail auth.
+   */
+  readonly submoduleCredentials?: readonly SubmoduleCredential[];
 }
 
 export interface GitConfig {

--- a/packages/sandbox/server/provider/shared/build-config-payload.test.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.test.ts
@@ -37,4 +37,55 @@ describe("buildConfigPayload", () => {
       operator: { userName: "Jane Doe" },
     });
   });
+
+  it("builds git.repository from a repo and derives repoName from the clone URL", () => {
+    const payload = buildConfigPayload({
+      runtime: "node",
+      packageManager: null,
+      repo: {
+        cloneUrl: "https://github.com/acme/widgets.git",
+        userName: "Jane",
+        userEmail: "jane@example.com",
+        branch: "main",
+      },
+    });
+
+    expect(payload?.git?.repository).toEqual({
+      cloneUrl: "https://github.com/acme/widgets.git",
+      repoName: "acme/widgets",
+      branch: "main",
+    });
+  });
+
+  it("forwards submoduleCredentials into git.repository when present", () => {
+    const payload = buildConfigPayload({
+      runtime: "node",
+      packageManager: null,
+      repo: {
+        cloneUrl: "https://github.com/acme/widgets.git",
+        userName: "Jane",
+        userEmail: "jane@example.com",
+        submoduleCredentials: [{ host: "github.com", token: "ghp_x" }],
+      },
+    });
+
+    expect(payload?.git?.repository.submoduleCredentials).toEqual([
+      { host: "github.com", token: "ghp_x" },
+    ]);
+  });
+
+  it("omits submoduleCredentials when the array is empty", () => {
+    const payload = buildConfigPayload({
+      runtime: "node",
+      packageManager: null,
+      repo: {
+        cloneUrl: "https://github.com/acme/widgets.git",
+        userName: "Jane",
+        userEmail: "jane@example.com",
+        submoduleCredentials: [],
+      },
+    });
+
+    expect(payload?.git?.repository).not.toHaveProperty("submoduleCredentials");
+  });
 });

--- a/packages/sandbox/server/provider/shared/build-config-payload.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.ts
@@ -21,6 +21,9 @@ export function buildConfigPayload(args: {
           cloneUrl: repo.cloneUrl,
           repoName: repo.displayName ?? deriveRepoLabel(repo.cloneUrl),
           ...(repo.branch ? { branch: repo.branch } : {}),
+          ...(repo.submoduleCredentials && repo.submoduleCredentials.length > 0
+            ? { submoduleCredentials: repo.submoduleCredentials }
+            : {}),
         },
         identity: {
           userName: repo.userName,

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -79,6 +79,14 @@ export interface EnsureOptions {
     branch?: string;
     /** Human-readable label for logs/UI; no functional effect. */
     displayName?: string;
+    /**
+     * Resolved per-host PATs for fetching private git submodules whose remotes
+     * the main clone's per-repo token can't reach. Delivered to the daemon on
+     * the git-only config channel (never the env bag). Absent/empty → submodules
+     * are only fetched if public. Like `cloneUrl`, these are resolved fresh on
+     * every ensure.
+     */
+    submoduleCredentials?: { host: string; token: string }[];
   };
   /** Image override. Non-image runners MUST ignore. */
   image?: string;


### PR DESCRIPTION
## Summary

Private git submodules live in repositories the main clone's per-repo GitHub App token can't reach (a different repo/org), so today a sandbox clone leaves them empty and the dev server fails with `module not found`. This lets a user supply a **per-host PAT** (stored as a vault secret) on the virtual MCP; Studio resolves it on every `SANDBOX_START` and hands the token to the daemon on a **git-only channel** so `git submodule update` can authenticate.

### How it works
```
UI (Sandbox card)  →  metadata.runtime.submoduleCredentials [{host, secretId}]
  →  start.ts resolves secretId in the vault → [{host, token}]
  →  runner.ensure → buildConfigPayload → git.repository.submoduleCredentials
  →  daemon config-store (deep-merge)
  →  clone.ts: write .git-credentials (0o600) + insteadOf SSH→HTTPS
     → git submodule update --init --recursive --depth 1 → delete the file
```

- The token **never enters the `env` bag** the dev server sees, **never appears in argv**, and is **never persisted into the repo's `.git/config`**. It lives only in a short-lived credentials file (mode `0o600`, next to the no-op askpass, outside the repo) read by `credential.helper=store`, then deleted.
- `insteadOf` rewrites (which carry **no** token) turn `git@host:` / `ssh://git@host/` submodule URLs into HTTPS so the store credential applies — covering SSH-form submodules like `git@github.com:ZeeDog/zee.git`.
- **Opt-in and best-effort**: no-op without credentials or a `.gitmodules`; a fetch failure warns and leaves the working tree intact rather than failing the whole clone.

## UI
A "Submodule credentials" editor in the virtual MCP **Sandbox** card (below Environment variables), reusing the existing secret picker + create-secret dialog. Each row = `{ host, secret }`. Incomplete rows are stripped from the autosave payload.

## Testing
- `bun run check` (all workspaces) ✓ · `bun run lint` 0 errors ✓ · `knip` clean ✓ · `bun run fmt` ✓
- New unit tests: `clone.test.ts` (+7 — host validation, dedupe, token percent-encoding, insteadOf/helper argv, no-token-in-argv), `helpers.test.ts` (+3 — defensive metadata reader).
- Existing suites green: sandbox setup + `start.test.ts` 101/101, config-store/payload 47/47.
- **Not exercised end-to-end here** (requires a real sandbox + a PAT with access to a private submodule repo). To test the Zee case: create a secret with a PAT for `ZeeDog/zee`, add `github.com` → that secret in the virtual MCP UI, then start the sandbox.

## Notes for reviewers
1. **PAT persistence on recovery.** `submoduleCredentials` rides through `ensureOpts.repo` (preserved by `withFreshCloneUrl`), so autonomous recovery re-clones **with** submodules. Cost: the long-lived PAT is persisted in `sandbox_runner_state` alongside the `cloneUrl` token (which is short-lived ~1h by design). If we'd rather not persist it, we can strip it and accept that recovery drops submodules until the next `SANDBOX_START` — happy to change.
2. **Username `x-access-token`** is correct for GitHub (the target case). GitLab accepts it; Bitbucket may need a different username — extensible later.

### Out of scope (agreed)
Native SSH deploy keys · active token rotation · per-host username.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-host submodule PATs to virtual MCPs so sandboxes can fetch private submodules during clone. Tokens are resolved at start, forwarded to the daemon over a git-only channel, and never exposed to the app or config APIs.

- **New Features**
  - Submodule credentials editor in the Sandbox card; each row maps a host to a secret. Incomplete rows are stripped before autosave. Shared `SecretPicker` extracted for consistency.
  - Secrets resolved on SANDBOX_START to `{host, token}`; missing or inaccessible secrets are skipped (best-effort). Forwarded through the link daemon/provider so linked desktop sandboxes receive them.
  - Daemon writes a short-lived 0600 `.git-credentials` file, applies SSH→HTTPS `insteadOf` rewrites, runs a shallow recursive `git submodule update`, then deletes the file. Tokens are percent-encoded, never placed in env/argv, and never persisted in repo config.
  - Host validation centralized via `SUBMODULE_HOST_RE` in `@decocms/mesh-sdk` and enforced in the schema/UI; invalid hosts are skipped and hosts are deduped. `submoduleCredentials` added to SDK and provider types and forwarded in the config payload.

- **Bug Fixes**
  - Redacts resolved PATs from both GET and PUT/POST `/_sandbox/config` responses; tokens remain only in the daemon’s in-memory store.
  - Enforces best-effort: wraps credentials-file write/spawn errors and always deletes the temp file; no submodules or failures leave the clone intact.
  - Adds tests for redaction (read/echo), payload pass-through, helpers validation, submodule integration (invalid-host skip, no `.gitmodules` no-op), and the credentials-file write failure catch.

<sup>Written for commit c086ee6eed451042a06ec29631c63edcef0958ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

