### PR TITLE
docs(helm): document required S3 storage

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
@@ -36,6 +36,7 @@ When a hosted agent needs a sandbox, Studio creates a `SandboxClaim`. The operat
 - `kubectl` configured for the cluster
 - A PostgreSQL database; the current API/worker topology requires PostgreSQL
 - A StorageClass for Studio and the chart-managed NATS JetStream PVCs
+- An S3-compatible object store and credentials for the organization filesystem (org-fs)
 - Support for `spec.hostUsers: true` and privileged sidecars in `agent-sandbox-system`; the mandatory org-fs sidecar uses FUSE and bidirectional mount propagation
 - For public preview URLs only: Gateway API CRDs, a Gateway controller, wildcard DNS, and either cert-manager with a DNS-01 `ClusterIssuer` or load-balancer TLS termination
 
@@ -75,12 +76,27 @@ kubectl get crd sandboxclaims.extensions.agents.x-k8s.io \
 
 ### 2. Configure and install Studio
 
+Hosted sandboxes require S3-compatible object storage. Studio considers it configured only when all four required variables are present:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `S3_ENDPOINT` | Yes | Full S3-compatible API endpoint, such as `https://s3.us-east-1.amazonaws.com` |
+| `S3_BUCKET` | Yes | Bucket that backs org-fs |
+| `S3_ACCESS_KEY_ID` | Yes | Access key used by Studio |
+| `S3_SECRET_ACCESS_KEY` | Yes | Secret key used by Studio |
+| `S3_REGION` | Provider-specific | Defaults to `auto`; set the actual region for AWS S3 |
+| `S3_FORCE_PATH_STYLE` | Provider-specific | Set `false` for AWS S3 virtual-hosted addressing; commonly `true` for MinIO and other path-style providers |
+
+The credentials need `s3:ListBucket` on the bucket and `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on its objects. These variables configure the org filesystem and are separate from the optional `s3Sync.*` backup sidecar and `MONITORING_S3_*` settings.
+
+Store the S3 variables alongside `DATABASE_URL`, `BETTER_AUTH_SECRET`, and `ENCRYPTION_KEY` in the Kubernetes Secret consumed by Studio. Do not put credentials in `configMap.meshConfig` or in the `sandbox-env` release; sandbox pods access org-fs through Studio's authenticated API and do not receive the S3 keys directly.
+
 Create `studio-values.yaml`. `envName`, the template suffix, Studio namespace, release name, and service-account name must agree with the `sandbox-env` release installed in the next step.
 
 ```yaml
 database:
   engine: postgresql
-  url: "postgresql://studio_user:studio_password@postgres.example.com:5432/studio"
+  url: "" # supplied as DATABASE_URL by the existing Secret
 
 serviceAccount:
   create: true
@@ -96,13 +112,14 @@ configMap:
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-production"
 
 secret:
-  BETTER_AUTH_SECRET: "replace-with-openssl-rand-base64-32"
-  ENCRYPTION_KEY: "replace-with-another-openssl-rand-base64-32"
+  secretName: deco-studio-secrets
 ```
 
 <Callout type="warning">
-  **Do not commit this example with real credentials.** For production, use `secret.secretName` or `externalSecret` so `DATABASE_URL`, `BETTER_AUTH_SECRET`, and `ENCRYPTION_KEY` come from a Secret manager.
+  The existing `deco-studio-secrets` Secret must contain `DATABASE_URL`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY_ID`, and `S3_SECRET_ACCESS_KEY`, plus provider-specific `S3_REGION` and `S3_FORCE_PATH_STYLE`. Prefer `externalSecret` or another secret manager in production; do not commit these values to Git.
 </Callout>
+
+Provision `deco-studio-secrets` in the `deco-studio` namespace before running the Helm install below. Alternatively, configure the chart's `externalSecret` values to create it from AWS Secrets Manager.
 
 Install the application chart:
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
@@ -36,6 +36,7 @@ Quando um agente hospedado precisa de um sandbox, o Studio cria um `SandboxClaim
 - `kubectl` configurado para o cluster
 - Um banco PostgreSQL; a topologia atual de API/worker exige PostgreSQL
 - Uma StorageClass para os PVCs do Studio e do NATS JetStream gerenciado pelo chart
+- Um object store compatível com S3 e credenciais para o sistema de arquivos da organização (org-fs)
 - Suporte a `spec.hostUsers: true` e sidecars privilegiados em `agent-sandbox-system`; o sidecar obrigatório org-fs usa FUSE e propagação bidirecional de mounts
 - Somente para URLs públicas de preview: CRDs de Gateway API, um Gateway controller, DNS wildcard e cert-manager com um `ClusterIssuer` DNS-01 ou terminação TLS no load balancer
 
@@ -75,12 +76,27 @@ kubectl get crd sandboxclaims.extensions.agents.x-k8s.io \
 
 ### 2. Configure e instale o Studio
 
+Sandboxes hospedados exigem object storage compatível com S3. O Studio só o considera configurado quando as quatro variáveis obrigatórias estão presentes:
+
+| Variável | Obrigatória | Descrição |
+| --- | --- | --- |
+| `S3_ENDPOINT` | Sim | Endpoint completo da API compatível com S3, como `https://s3.us-east-1.amazonaws.com` |
+| `S3_BUCKET` | Sim | Bucket que armazena o org-fs |
+| `S3_ACCESS_KEY_ID` | Sim | Access key usada pelo Studio |
+| `S3_SECRET_ACCESS_KEY` | Sim | Secret key usada pelo Studio |
+| `S3_REGION` | Depende do provider | O padrão é `auto`; defina a região real para AWS S3 |
+| `S3_FORCE_PATH_STYLE` | Depende do provider | Defina `false` para endereçamento virtual-hosted do AWS S3; normalmente `true` para MinIO e providers path-style |
+
+As credenciais precisam de `s3:ListBucket` no bucket e `s3:GetObject`, `s3:PutObject` e `s3:DeleteObject` nos objetos. Essas variáveis configuram o sistema de arquivos da organização e são separadas do sidecar opcional de backup `s3Sync.*` e das configurações `MONITORING_S3_*`.
+
+Armazene as variáveis S3 junto com `DATABASE_URL`, `BETTER_AUTH_SECRET` e `ENCRYPTION_KEY` no Secret do Kubernetes consumido pelo Studio. Não coloque credenciais em `configMap.meshConfig` nem na release `sandbox-env`; os pods de sandbox acessam o org-fs pela API autenticada do Studio e não recebem as chaves S3 diretamente.
+
 Crie `studio-values.yaml`. `envName`, o sufixo do template, o namespace do Studio, o nome da release e o nome da service account precisam corresponder à release `sandbox-env` instalada na próxima etapa.
 
 ```yaml
 database:
   engine: postgresql
-  url: "postgresql://studio_user:studio_password@postgres.example.com:5432/studio"
+  url: "" # fornecido como DATABASE_URL pelo Secret existente
 
 serviceAccount:
   create: true
@@ -96,13 +112,14 @@ configMap:
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-production"
 
 secret:
-  BETTER_AUTH_SECRET: "substitua-por-openssl-rand-base64-32"
-  ENCRYPTION_KEY: "substitua-por-outro-openssl-rand-base64-32"
+  secretName: deco-studio-secrets
 ```
 
 <Callout type="warning">
-  **Não faça commit deste exemplo com credenciais reais.** Em produção, use `secret.secretName` ou `externalSecret` para que `DATABASE_URL`, `BETTER_AUTH_SECRET` e `ENCRYPTION_KEY` venham de um gerenciador de secrets.
+  O Secret existente `deco-studio-secrets` precisa conter `DATABASE_URL`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY_ID` e `S3_SECRET_ACCESS_KEY`, além de `S3_REGION` e `S3_FORCE_PATH_STYLE` específicos do provider. Prefira `externalSecret` ou outro gerenciador de secrets em produção; não faça commit desses valores no Git.
 </Callout>
+
+Provisione `deco-studio-secrets` no namespace `deco-studio` antes de executar a instalação Helm abaixo. Como alternativa, configure os valores `externalSecret` do chart para criá-lo a partir do AWS Secrets Manager.
 
 Instale o chart da aplicação:
 

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -24,6 +24,11 @@ installed (it ships the CRDs + controller).
 
 - `sandbox-operator` chart installed in `agent-sandbox-system`.
 - Kubernetes with `spec.hostUsers: true` privileged-sidecar support (org-fs FUSE mount).
+- Studio object storage configured with `S3_ENDPOINT`, `S3_BUCKET`,
+  `S3_ACCESS_KEY_ID`, and `S3_SECRET_ACCESS_KEY` (plus provider-appropriate
+  `S3_REGION` and `S3_FORCE_PATH_STYLE`). Org-fs is mandatory for hosted
+  sandboxes. Keep these values in the Studio Secret: the sidecar mounts org-fs
+  through Studio's authenticated API and must not receive S3 credentials.
 - A named ServiceAccount for the Studio release. Its namespace and name must
   match `mesh.namespace` and `mesh.serviceAccountName`; this chart grants that
   identity the runner permissions in `agent-sandbox-system`.


### PR DESCRIPTION
## Summary

- mark S3-compatible object storage as required for hosted agent sandboxes and org-fs
- document required S3 variables, provider-specific region/path-style settings, and minimum IAM permissions
- keep credentials in the Studio Secret and distinguish org-fs storage from s3Sync and monitoring storage
- update the English, Portuguese, and sandbox-env deployment guides

## Validation

- bun run --cwd=apps/docs check
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document S3-compatible object storage as required for hosted agent sandboxes and org-fs, including exact env vars, provider-specific settings, and minimum IAM. Updates EN/PT Kubernetes guides and the `sandbox-env` Helm README; clarifies creds live in the Studio Secret (not `sandbox-env`) and are separate from `s3Sync.*`/`MONITORING_S3_*`.

- **Migration**
  - Set `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY` (+ `S3_REGION`, `S3_FORCE_PATH_STYLE` when needed).
  - Grant IAM: `s3:ListBucket` on the bucket; `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject` on objects.
  - Store these in the `deco-studio-secrets` Secret in `deco-studio`; pre-provision or use `externalSecret`.
  - Do not place S3 creds in `configMap.meshConfig` or `sandbox-env`; sandboxes use Studio’s API to access org-fs.

<sup>Written for commit db8f8ef051161f210b5d2daab05838b13d1e15f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

