### PR TITLE
feat(blocks): guide users through content editing setup

### DIFF
--- a/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
+++ b/apps/mesh/src/web/components/sandbox/blocks/blocks-panel.tsx
@@ -25,6 +25,17 @@ const SectionsEditor = lazy(() =>
   })),
 );
 
+function errorStatus(error: unknown): number | undefined {
+  if (
+    error instanceof Error &&
+    "status" in error &&
+    typeof error.status === "number"
+  ) {
+    return error.status;
+  }
+  return undefined;
+}
+
 export function BlocksPanel({
   virtualMcpId,
   externalSelectedIndex = null,
@@ -56,8 +67,13 @@ export function BlocksPanel({
     decofile: {
       status: decofile.status,
       hasData: decofile.data !== undefined,
+      errorStatus: errorStatus(decofile.error),
     },
-    meta: { status: meta.status, hasData: meta.data !== undefined },
+    meta: {
+      status: meta.status,
+      hasData: meta.data !== undefined,
+      errorStatus: errorStatus(meta.error),
+    },
     hasEditableContent: hasEditableDecoContent(decofile.data, meta.data),
   });
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
@@ -55,10 +55,22 @@ describe("resolveBlocksTabState", () => {
     });
   });
 
-  test("renders a data error when an initial request fails", () => {
+  test("renders setup when a Blocks endpoint is missing", () => {
     expect(
       resolveBlocksTabState(
-        input({ meta: { status: "error", hasData: false } }),
+        input({
+          meta: { status: "error", hasData: false, errorStatus: 404 },
+        }),
+      ),
+    ).toEqual({ kind: "empty" });
+  });
+
+  test("renders a data error when another initial request fails", () => {
+    expect(
+      resolveBlocksTabState(
+        input({
+          meta: { status: "error", hasData: false, errorStatus: 500 },
+        }),
       ),
     ).toEqual({ kind: "error", source: "data" });
   });

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
@@ -5,6 +5,7 @@ type QueryStatus = "pending" | "error" | "success";
 export interface BlocksQueryState {
   status: QueryStatus;
   hasData: boolean;
+  errorStatus?: number;
 }
 
 export interface BlocksTabStateInput {
@@ -34,6 +35,12 @@ export function resolveBlocksTabState(
     return { kind: "error", source: "sandbox" };
   }
   if (input.lifecyclePhase !== "running") return { kind: "loading" };
+
+  const blocksFrameworkMissing = [input.decofile, input.meta].some(
+    (query) =>
+      query.status === "error" && !query.hasData && query.errorStatus === 404,
+  );
+  if (blocksFrameworkMissing) return { kind: "empty" };
 
   const initialDataFailed =
     (input.decofile.status === "error" && !input.decofile.hasData) ||

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-states.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-states.tsx
@@ -7,13 +7,14 @@ const BLOCKS_DOCS_URL = "https://github.com/decocms/blocks";
 export function BlocksEmptyState() {
   return (
     <EmptyState
+      className="h-full w-full"
       image={<Box size={48} className="text-muted-foreground" />}
-      title="No editable Blocks found"
-      description="This project does not expose editable Blocks content yet. Learn how to add Blocks to your project."
+      title="Want to edit this website with easy-to-use forms?"
+      description="Set up rich content editing so anyone can update pages without touching code."
       actions={
-        <Button variant="outline" size="sm" asChild>
+        <Button size="sm" asChild>
           <a href={BLOCKS_DOCS_URL} target="_blank" rel="noreferrer">
-            View Blocks docs
+            Set up content editing
             <LinkExternal01 size={14} />
           </a>
         </Button>

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab.test.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab.test.tsx
@@ -7,9 +7,20 @@ import { describe, expect, test } from "bun:test";
 import { BlocksEmptyState, BlocksErrorState } from "./blocks-tab-states";
 
 describe("Blocks tab states", () => {
-  test("links the empty state to the Blocks documentation", () => {
-    const { getByRole } = render(<BlocksEmptyState />);
-    const link = getByRole("link", { name: "View Blocks docs" });
+  test("offers non-technical Blocks setup guidance", () => {
+    const { getByRole, getByText } = render(<BlocksEmptyState />);
+    const link = getByRole("link", { name: "Set up content editing" });
+
+    expect(
+      getByRole("heading", {
+        name: "Want to edit this website with easy-to-use forms?",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      getByText(
+        "Set up rich content editing so anyone can update pages without touching code.",
+      ),
+    ).toBeInTheDocument();
 
     expect(link).toHaveAttribute("href", "https://github.com/decocms/blocks");
     expect(link).toHaveAttribute("target", "_blank");


### PR DESCRIPTION
## Summary

- replace the missing Blocks endpoint error with a centered onboarding state
- use non-technical content-editing copy and link to the Blocks setup guide
- preserve retry behavior for genuine preview and metadata failures

## Testing

- bun test src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts src/web/layouts/main-panel-tabs/blocks-tab.test.tsx
- bun run --cwd=apps/mesh check
- targeted oxlint and Biome formatting
- bun run knip

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a friendly onboarding state for the Blocks tab when the Blocks endpoint is missing (404), guiding users to set up content editing. Keeps retry/error behavior for real data or preview failures.

- **New Features**
  - Detects 404s in `decofile`/`meta` queries and shows a centered onboarding state instead of an error.
  - Uses non-technical copy with a “Set up content editing” link to the Blocks guide.
  - Extracts HTTP status from errors to drive state resolution; tests updated for setup and error cases.

<sup>Written for commit 3c29cdd1a39fb8ae2f914cfc3599d049744255e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

