### PR TITLE
feat(studio-pack): add task manager agent

### DIFF
--- a/apps/mesh/src/auth/install-studio-pack-workflow.ts
+++ b/apps/mesh/src/auth/install-studio-pack-workflow.ts
@@ -87,8 +87,9 @@ const installStudioPackWorkflow = DBOS.registerWorkflow(
  * v2: added Usage Manager.
  * v3: added API Key Manager.
  * v4: overrides configuration for already-installed Studio Pack agents.
+ * v5: added Task Manager.
  */
-const INSTALL_VERSION = "v4";
+const INSTALL_VERSION = "v5";
 
 /**
  * Fire-and-forget enqueue from the Better Auth org.afterCreate callback.

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,5 +1,5 @@
 {
-  "auth/install-studio-pack-workflow.ts": "1cf06645663602989054ec171a7b06fe4c16d5c40e4348bcc86c725e3769c5a0",
+  "auth/install-studio-pack-workflow.ts": "fe506448bcbd657194f72999b8196b842a3cc52e2685997462f1d4715cc734f1",
   "automations/dbos-workflow.ts": "088986a214dd803913438f51bdbaa14dfef25b151422e117605a7907dc2bd987",
   "dispatch-queue/hosted-harness-workflow.ts": "1ee53df2391d0b73f10630be7f7d947db16653d5b8740b799e64a98cb2f49c86",
   "dispatch-queue/thread-gate-workflow.ts": "674cd393ad3b06806e967389dfe7e87bd0de6ba933fd54df1e5cd24a08b99e43",

--- a/apps/mesh/src/storage/virtual.ts
+++ b/apps/mesh/src/storage/virtual.ts
@@ -136,7 +136,7 @@ export class VirtualMCPStorage implements VirtualMCPStoragePort {
   ): Promise<VirtualMCPEntity | null> {
     // Handle Decopilot ID — Decopilot is a pure orchestrator with no
     // aggregated tools. Every platform action goes through a Studio Pack
-    // manager (Agent / Automation / Connection / Store) via `subtask`,
+    // manager (Agent / Automation / Connection / Store / Task) via `subtask`,
     // and every product action goes to a custom org agent the same way.
     // The model uses the <available-agents> catalog as its routing table.
     const decopilotOrgId = isDecopilot(id);

--- a/apps/mesh/src/tools/virtual/studio-pack.integration.test.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack.integration.test.ts
@@ -146,6 +146,24 @@ describe("installStudioPack", () => {
     ]);
   });
 
+  test("Task Manager binds to self with only task-board tools", async () => {
+    await installStudioPack(orgId, userId, virtualMcpStorage);
+    const managerId = StudioPackAgentId.TASK_MANAGER(orgId);
+    const manager = await virtualMcpStorage.findById(managerId, orgId);
+
+    expect(manager?.connections).toHaveLength(1);
+    expect(manager?.connections[0]?.connection_id).toBe(
+      WellKnownOrgMCPId.SELF(orgId),
+    );
+    expect(manager?.connections[0]?.selected_tools).toEqual([
+      "TASK_BOARD_ITEM_CREATE",
+      "TASK_BOARD_ITEM_LIST",
+      "TASK_BOARD_ITEM_UPDATE",
+      "TASK_BOARD_ITEM_DELETE",
+      "TASK_BOARD_ITEM_PRS_GET",
+    ]);
+  });
+
   test("overwrites stale tool selections on an existing API Key Manager", async () => {
     await installStudioPack(orgId, userId, virtualMcpStorage);
     const managerId = StudioPackAgentId.API_KEY_MANAGER(orgId);

--- a/apps/mesh/src/tools/virtual/studio-pack/agent-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/agent-manager.ts
@@ -47,7 +47,7 @@ You are the Agent Manager. You create, configure, and maintain agents (Virtual M
 - When adding connections to an agent, verify the connection exists by listing or getting it first.
 - Do not broaden an agent's scope unless the user explicitly requests it.
 - Preserve existing behavior when updating — apply the smallest necessary change set.
-- Never modify or delete the Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Usage Manager). They are system-managed.
+- Never modify or delete the Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Task Manager, Usage Manager). They are system-managed.
 - Never repeat tool result data in your reply. The UI renders agent results (list rows, detail cards) — do not restate the same fields as a table or paragraph. Reply with a single short line: confirm what happened and offer the next step.
 </constraints>
 
@@ -83,7 +83,7 @@ You are the Agent Manager. You create, configure, and maintain agents (Virtual M
    f. Re-read with COLLECTION_VIRTUAL_MCP_GET to verify the stored result.
 
 5. Auditing and optimizing existing agents:
-   a. List all agents with COLLECTION_VIRTUAL_MCP_LIST. Ignore the Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Usage Manager) — those are system-managed.
+   a. List all agents with COLLECTION_VIRTUAL_MCP_LIST. Ignore the Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Task Manager, Usage Manager) — those are system-managed.
    b. For each candidate, fetch details with COLLECTION_VIRTUAL_MCP_GET.
    c. Flag agents for cleanup based on config quality:
       - Vague, missing, or non-XML-structured instructions.

--- a/apps/mesh/src/tools/virtual/studio-pack/automation-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/automation-manager.ts
@@ -25,7 +25,7 @@ You are the Automation Manager. You create, configure, and manage automations �
 
 <workflows>
 1. Suggesting automations from existing agents (first-contact default):
-   a. List agents with COLLECTION_VIRTUAL_MCP_LIST. Filter out the Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Usage Manager) — they're not meant to be automated.
+   a. List agents with COLLECTION_VIRTUAL_MCP_LIST. Filter out the Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Task Manager, Usage Manager) — they're not meant to be automated.
    b. If no custom agents exist, tell the user they need to create one first via the Agent Manager. Do not propose automations against the Studio Pack agents.
    c. For each candidate agent, read its title, description, and instructions (use COLLECTION_VIRTUAL_MCP_GET if needed) to infer what recurring work it does.
    d. Propose 2-3 concrete automation ideas: name the agent, the schedule or trigger ("every weekday at 9am", "when a new GitHub issue lands"), and what the run should accomplish in one sentence.

--- a/apps/mesh/src/tools/virtual/studio-pack/index.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/index.ts
@@ -8,6 +8,7 @@ import { automationManagerAgent } from "./automation-manager";
 import { brandManagerAgent } from "./brand-manager";
 import { connectionManagerAgent } from "./connection-manager";
 import { storeManagerAgent } from "./store-manager";
+import { taskManagerAgent } from "./task-manager";
 import { usageManagerAgent } from "./usage-manager";
 import type {
   ChecklistContext,
@@ -35,6 +36,7 @@ export const STUDIO_PACK_AGENTS = [
   connectionManagerAgent,
   apiKeyManagerAgent,
   storeManagerAgent,
+  taskManagerAgent,
   usageManagerAgent,
 ] as const;
 

--- a/apps/mesh/src/tools/virtual/studio-pack/task-manager.test.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/task-manager.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { taskManagerAgent } from "./task-manager";
+
+describe("taskManagerAgent", () => {
+  test("uses an org-scoped id", () => {
+    expect(taskManagerAgent.getId("org_xyz")).toBe(
+      "studio-task-manager_org_xyz",
+    );
+  });
+
+  test("exposes only task-board tools", () => {
+    expect(taskManagerAgent.selectedTools).toEqual([
+      "TASK_BOARD_ITEM_CREATE",
+      "TASK_BOARD_ITEM_LIST",
+      "TASK_BOARD_ITEM_UPDATE",
+      "TASK_BOARD_ITEM_DELETE",
+      "TASK_BOARD_ITEM_PRS_GET",
+    ]);
+  });
+
+  test("handles disabled boards, safe deletion, and Super Agent delegation", () => {
+    expect(taskManagerAgent.instructions).toContain(
+      "enable Task board in organization settings",
+    );
+    expect(taskManagerAgent.instructions).toContain(
+      "explicit confirmation immediately before deleting a task",
+    );
+    expect(taskManagerAgent.instructions).toContain(
+      "assignee id `super-agent`",
+    );
+    expect(taskManagerAgent.instructions).toContain(
+      "editing it does not enqueue a fresh run",
+    );
+  });
+});

--- a/apps/mesh/src/tools/virtual/studio-pack/task-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/task-manager.ts
@@ -1,0 +1,75 @@
+import { StudioPackAgentId } from "@decocms/mesh-sdk";
+import type { StudioPackConnectionKey } from "./types";
+
+const INSTRUCTIONS = `<role>
+You are the Task Manager. You organize and maintain this organization's task board so the team can see what needs attention, what is underway, and what is complete.
+</role>
+
+<capabilities>
+- Create task board items with a clear title, useful description, status, priority, assignee, and due date.
+- List and summarize the board by status, priority, due date, assignee, and linked thread state.
+- Update task details and move work through triage, to do, in progress, in review, and done.
+- Delegate a task to the Super Agent, which queues the task for execution.
+- Inspect the live state of pull requests linked to a task.
+- Delete obsolete or duplicate tasks after explicit confirmation.
+</capabilities>
+
+<constraints>
+- The task board must be enabled for the organization. If a tool reports that it is disabled, tell the user to enable Task board in organization settings; do not claim the board is empty or unavailable for another reason.
+- Always list the board before updating, deleting, or inspecting a task unless the user supplied its exact id in the current message.
+- Match tasks by id. If the user identifies a task only by title and more than one item matches, ask which one they mean before mutating anything.
+- Never invent task ids, assignee ids, dates, or pull-request state.
+- Use the assignee id \`super-agent\` only when the user explicitly asks to delegate work to the Super Agent. For a human assignee, require an exact member id; if the user supplies only a name, explain that they can assign the person from the board UI instead of guessing.
+- Due dates must be ISO 8601 timestamps. When a date or timezone is ambiguous, ask before saving it.
+- Do not silently create a duplicate. When a new task appears to match an existing open item, ask whether to update the existing task or create another.
+- Always get explicit confirmation immediately before deleting a task. For bulk status changes or deletions, show the exact affected tasks and confirm the complete batch.
+- Do not mark work done merely because an agent run completed. Only move a task to done when the user requests it or the available task and pull-request state clearly establishes completion.
+- When a task is already assigned to the Super Agent, editing it does not enqueue a fresh run. Do not promise that a plain update will rerun it.
+</constraints>
+
+<workflows>
+1. Reviewing the board:
+   a. Call TASK_BOARD_ITEM_LIST.
+   b. Summarize counts by status, then highlight urgent/high-priority items, overdue or soon-due items, and tasks whose linked thread requires action or failed.
+   c. Keep the response concise. Offer a concrete next action only when the board shows one.
+
+2. Creating a task:
+   a. Call TASK_BOARD_ITEM_LIST to check for a matching open task.
+   b. Confirm the title and clarify only missing details that materially affect execution. Description, priority, assignee, and due date are optional.
+   c. Call TASK_BOARD_ITEM_CREATE. Use \`super-agent\` as assigneeId only for an explicit Super Agent delegation; that delegation always enters To Do and queues a run.
+   d. Confirm the created task and its initial status. Do not claim the delegated work is complete.
+
+3. Updating or moving a task:
+   a. Resolve the exact item with TASK_BOARD_ITEM_LIST unless its id is already known.
+   b. Apply only the fields the user requested with TASK_BOARD_ITEM_UPDATE; preserve every other field by omitting it.
+   c. If assigning to the Super Agent, explain that the transition queues a new run and moves the task to To Do.
+   d. Confirm the resulting status, priority, assignee, or due date without repeating unchanged fields.
+
+4. Inspecting delivery progress:
+   a. Resolve the exact item with TASK_BOARD_ITEM_LIST.
+   b. Review its linked thread states. If the user asks about code delivery or pull requests, call TASK_BOARD_ITEM_PRS_GET with the task id.
+   c. Report whether each linked pull request is open, closed, draft, or merged. If live state is unavailable, say so and retain the link as the source of truth.
+
+5. Deleting a task:
+   a. Resolve the exact item with TASK_BOARD_ITEM_LIST unless its id is already known.
+   b. Show the task title and explain that deleting the card is irreversible. Get explicit confirmation immediately before the tool call.
+   c. Call TASK_BOARD_ITEM_DELETE only after confirmation, then briefly confirm removal.
+</workflows>`;
+
+export const taskManagerAgent = {
+  id: "studio-task-manager",
+  title: "Task Manager",
+  icon: "icon://Flag01?color=indigo",
+  description: "Create, prioritize, assign, and track work on the task board",
+  selectedTools: [
+    "TASK_BOARD_ITEM_CREATE",
+    "TASK_BOARD_ITEM_LIST",
+    "TASK_BOARD_ITEM_UPDATE",
+    "TASK_BOARD_ITEM_DELETE",
+    "TASK_BOARD_ITEM_PRS_GET",
+  ] as readonly string[] | null,
+  selectedConnections: null as readonly StudioPackConnectionKey[] | null,
+  selectedPrompts: [] as readonly string[],
+  instructions: INSTRUCTIONS,
+  getId: StudioPackAgentId.TASK_MANAGER,
+} as const;

--- a/apps/mesh/src/tools/virtual/studio-pack/usage-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/usage-manager.ts
@@ -16,7 +16,7 @@ You are the Usage Manager. You analyze how this workspace is actually used — w
 
 <constraints>
 - You are an analyst first. Never delete anything without showing the evidence (last-used date, call counts in the window) and getting explicit confirmation.
-- Never delete Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Usage Manager) or well-known connections (ids ending in _self, _registry, _community-registry, _dev-assets).
+- Never delete Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Task Manager, Usage Manager) or well-known connections (ids ending in _self, _registry, _community-registry, _dev-assets).
 - Resolve user IDs to names with ORGANIZATION_MEMBER_LIST before presenting per-user numbers; never show raw user IDs to the user.
 - Always state the time window behind any "unused" or "top" claim. Default to the last 30 days when the user doesn't specify one.
 - Lead with the top 5 rows of any ranking and offer to expand.

--- a/packages/mesh-sdk/src/lib/constants.test.ts
+++ b/packages/mesh-sdk/src/lib/constants.test.ts
@@ -10,6 +10,9 @@ describe("StudioPackAgentId", () => {
     expect(StudioPackAgentId.API_KEY_MANAGER("org_xyz")).toBe(
       "studio-api-key-manager_org_xyz",
     );
+    expect(StudioPackAgentId.TASK_MANAGER("org_xyz")).toBe(
+      "studio-task-manager_org_xyz",
+    );
   });
 });
 
@@ -21,6 +24,7 @@ describe("isStudioPackAgent", () => {
     expect(isStudioPackAgent("studio-api-key-manager_org_xyz")).toBe(true);
     expect(isStudioPackAgent("studio-store-manager_org_xyz")).toBe(true);
     expect(isStudioPackAgent("studio-brand-manager_org_xyz")).toBe(true);
+    expect(isStudioPackAgent("studio-task-manager_org_xyz")).toBe(true);
     expect(isStudioPackAgent("studio-usage-manager_org_xyz")).toBe(true);
   });
 

--- a/packages/mesh-sdk/src/lib/constants.ts
+++ b/packages/mesh-sdk/src/lib/constants.ts
@@ -417,6 +417,7 @@ const studioPackAgentPrefixes = {
   API_KEY_MANAGER: createWellKnownAgentPrefix("studio-api-key-manager_"),
   STORE_MANAGER: createWellKnownAgentPrefix("studio-store-manager_"),
   BRAND_MANAGER: createWellKnownAgentPrefix("studio-brand-manager_"),
+  TASK_MANAGER: createWellKnownAgentPrefix("studio-task-manager_"),
   USAGE_MANAGER: createWellKnownAgentPrefix("studio-usage-manager_"),
 } as const;
 
@@ -430,6 +431,7 @@ export const StudioPackAgentId = {
   API_KEY_MANAGER: studioPackAgentPrefixes.API_KEY_MANAGER.get,
   STORE_MANAGER: studioPackAgentPrefixes.STORE_MANAGER.get,
   BRAND_MANAGER: studioPackAgentPrefixes.BRAND_MANAGER.get,
+  TASK_MANAGER: studioPackAgentPrefixes.TASK_MANAGER.get,
   USAGE_MANAGER: studioPackAgentPrefixes.USAGE_MANAGER.get,
 } as const;
 


### PR DESCRIPTION
## Summary

- add a first-class Task Manager to the Studio Pack with the five task-board tools
- add its org-scoped well-known ID and v5 installer backfill for existing organizations
- protect Task Manager from Studio Pack modification, deletion, and automation workflows
- cover its configuration and persisted self-MCP tool selection

## Testing

- bun test apps/mesh/src/tools/virtual/studio-pack/task-manager.test.ts packages/mesh-sdk/src/lib/constants.test.ts
- bun run check
- bun run lint (passes with existing warnings)
- bun run knip
- bun run fmt

The real-Postgres Studio Pack integration test was attempted locally but PostgreSQL was not listening on localhost:5432; CI provides the required Postgres service.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first-class Task Manager agent to the Studio Pack to create, update, and track work on the org task board with safe deletion and Super Agent delegation rules. Bumps the installer to v5 to auto-install it for new orgs and backfill existing ones, and protects it from edits and automations.

- New Features
  - Added Task Manager agent: org-scoped ID, binds to self, exposes only task-board tools (create, list, update, delete, PRs).
  - Installer v5: installs/backfills Task Manager for all orgs.
  - SDK updates in `@decocms/mesh-sdk`: `StudioPackAgentId.TASK_MANAGER` and studio-pack detection.
  - Safeguards: included in “do not modify/delete/automate” rules (Agent, Automation, Usage Managers).
  - Tests: unit + integration for ID, selected tools, and binding.

- Bug Fixes
  - Refreshed DBOS workflow source snapshot to track the v5 installer change.

<sup>Written for commit 205773a1c9e4b54f18e459c3c7fdfda79c466e50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

