### PR TITLE
fix(chat): linkify org/output & org/upload file paths to the Library

### DIFF
--- a/apps/mesh/src/web/components/chat/markdown.tsx
+++ b/apps/mesh/src/web/components/chat/markdown.tsx
@@ -220,7 +220,7 @@ function MarkdownCode({ node: _n, className, children, ...p }: MdProps) {
   const text = typeof children === "string" ? children : null;
   const browsePath =
     ctx && !isBlock && text
-      ? resolveOrgFileBrowsePath(text, ctx.orgSlug)
+      ? resolveOrgFileBrowsePath(text, ctx.orgSlug, ctx.threadId)
       : null;
   if (!ctx || !browsePath) {
     return (
@@ -257,7 +257,9 @@ function MarkdownAnchor({
   const ctx = useContext(OrgFileOpenContext);
   const href = typeof p.href === "string" ? p.href : undefined;
   const browsePath =
-    ctx && href ? resolveOrgFileBrowsePath(href, ctx.orgSlug) : null;
+    ctx && href
+      ? resolveOrgFileBrowsePath(href, ctx.orgSlug, ctx.threadId)
+      : null;
   const label = animate ? animateText(children) : children;
   if (ctx && browsePath) {
     return (

--- a/apps/mesh/src/web/components/chat/org-file-open-context.tsx
+++ b/apps/mesh/src/web/components/chat/org-file-open-context.tsx
@@ -19,6 +19,9 @@ import { formatLibraryFileTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 export interface OrgFileOpenValue {
   /** Current org slug, for resolving `org/<slug>/…` references. */
   orgSlug: string | undefined;
+  /** Current thread id (URL taskId), for resolving `org/output|upload/…`
+   *  references into their `<threadId>/` subtree of the shared volume. */
+  threadId: string | undefined;
   /** Open a Library browse path ("<volume>/<path…>"). */
   open: (browsePath: string) => void;
 }
@@ -28,7 +31,10 @@ export const OrgFileOpenContext = createContext<OrgFileOpenValue | null>(null);
 export function OrgFileOpenProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
-  const { org } = useParams({ strict: false }) as { org?: string };
+  const { org, taskId } = useParams({ strict: false }) as {
+    org?: string;
+    taskId?: string;
+  };
 
   // Mirror the Library's panel/dialog split: desktop opens the file as a
   // main-panel side tab (`?main=library-file:<path>`); mobile opens the dialog
@@ -46,7 +52,9 @@ export function OrgFileOpenProvider({ children }: { children: ReactNode }) {
     });
 
   return (
-    <OrgFileOpenContext.Provider value={{ orgSlug: org, open }}>
+    <OrgFileOpenContext.Provider
+      value={{ orgSlug: org, threadId: taskId, open }}
+    >
       {children}
     </OrgFileOpenContext.Provider>
   );

--- a/apps/mesh/src/web/components/chat/org-file-ref.test.ts
+++ b/apps/mesh/src/web/components/chat/org-file-ref.test.ts
@@ -43,7 +43,19 @@ describe("resolveOrgFileBrowsePath", () => {
     );
   });
 
-  it("skips thread-scoped upload/output mounts (they have their own chips)", () => {
+  it("resolves thread-scoped output/upload mounts against the thread's subtree", () => {
+    expect(resolveOrgFileBrowsePath("org/output/report.md", SLUG, "t_1")).toBe(
+      "outputs/t_1/report.md",
+    );
+    expect(
+      resolveOrgFileBrowsePath("org/output/sub/deck.html", SLUG, "t_1"),
+    ).toBe("outputs/t_1/sub/deck.html");
+    expect(resolveOrgFileBrowsePath("org/upload/report.pdf", SLUG, "t_1")).toBe(
+      "uploads/t_1/report.pdf",
+    );
+  });
+
+  it("leaves output/upload unlinked without a thread id", () => {
     expect(resolveOrgFileBrowsePath("org/upload/report.pdf", SLUG)).toBeNull();
     expect(resolveOrgFileBrowsePath("org/output/deck.html", SLUG)).toBeNull();
   });

--- a/apps/mesh/src/web/components/chat/org-file-ref.ts
+++ b/apps/mesh/src/web/components/chat/org-file-ref.ts
@@ -7,11 +7,14 @@
  *   org/<orgSlug>/<rest…>    → home/<rest…>
  *   org/home/<rest…>         → home/<rest…>        (slug-reserved fallback)
  *   org/public/<set>/<rest…> → public/<set>/<rest…>
+ *   org/output/<rest…>       → outputs/<threadId>/<rest…>   (needs threadId)
+ *   org/upload/<rest…>       → uploads/<threadId>/<rest…>   (needs threadId)
  *
- * Thread-scoped mounts (`org/upload/…`, `org/output/…`) are intentionally NOT
- * linked: they resolve through a per-run symlink into a thread subtree, so the
- * volume path can't be derived from the text alone — and those files already
- * surface as their own chips (thread outputs / produced files).
+ * The thread-scoped mounts (`org/output/…`, `org/upload/…`) resolve through a
+ * per-run symlink into a `<threadId>/` subtree, so the text alone can't name
+ * the volume path — but the chat knows its own thread, so passing `threadId`
+ * makes the deliverable the agent prints ("saved to org/output/report.md")
+ * a click-through into the Library. Without a `threadId` they stay unlinked.
  */
 
 // Trailing `:line` / `:line:col` citation suffix (the `path:line` convention).
@@ -26,6 +29,7 @@ const HAS_EXTENSION = /\.[A-Za-z0-9]+$/;
 export function resolveOrgFileBrowsePath(
   raw: string,
   orgSlug: string | undefined,
+  threadId?: string | undefined,
 ): string | null {
   const text = raw.trim().replace(LINE_SUFFIX, "");
   // Single-token path under the org/ mount; a trailing slash marks a directory.
@@ -49,6 +53,18 @@ export function resolveOrgFileBrowsePath(
   // org/<orgSlug>/<rest…> or org/home/<rest…> → home/<rest…>
   if (top === "home" || (!!orgSlug && top === orgSlug)) {
     return `home/${segments.slice(2).join("/")}`;
+  }
+
+  // Thread-scoped mounts resolve into the current thread's subtree of the
+  // shared volume (org/output → outputs, org/upload → uploads). Only linkable
+  // with a threadId. ponytail: assumes the file is under THIS thread's folder,
+  // which holds unless a shared sandbox misrouted the per-run symlink (rare);
+  // a stale link just 404s the preview — no worse than the unlinked text.
+  if (threadId) {
+    if (top === "output")
+      return `outputs/${threadId}/${segments.slice(2).join("/")}`;
+    if (top === "upload")
+      return `uploads/${threadId}/${segments.slice(2).join("/")}`;
   }
 
   return null;


### PR DESCRIPTION
## Problem

Users report that files an agent creates in a conversation's **output folder** (e.g. `org/output/zeedog_zeenow_relatorio_pagamentos.md`) "can never be found in the library."

The agent tells the user *"it's available for download in the output folder of this conversation"* and prints the path. But that path rendered as **dead plain text**: `resolveOrgFileBrowsePath` deliberately returned `null` for the thread-scoped `org/output/…` and `org/upload/…` mounts, because their Library location — `outputs/<threadId>/<file>` — can't be derived from the path text alone (it needs the thread id).

So there was **no click-through** from chat to the file, and in the Library the file sits under an opaque per-conversation id folder in the "Agent run outputs" volume that a user can't map back to "this conversation."

## Fix

The chat already knows its own thread id (the URL `taskId`, the same id the download chips and the daemon's per-run `org/output → .outputs/<threadId>` symlink use). Thread it through `OrgFileOpenContext` so the resolver can map:

- `org/output/<rest…>` → `outputs/<threadId>/<rest…>`
- `org/upload/<rest…>` → `uploads/<threadId>/<rest…>`

Now the exact path the agent prints opens the file in the Library preview on click. Without a thread id (e.g. the Library's own file previews, which have no thread context) the paths stay unlinked, exactly as before.

## Notes / scope

- I could **not** reproduce the exact production scenario (no prod data; the local dev DB has zero `outputs`-volume rows). The read (recent/search/browse) and write (mount → WebDAV → manifest) paths are both structurally sound and *do* include the `outputs` volume, so a file that reaches the manifest **is** in the Library — it's just undiscoverable without this bridge. This PR fixes the discoverability gap, which is the most likely cause of the report and a clear defect on its own (dead plain-text path).
- **Separate follow-up worth checking:** the daemon's `repointOutputLinkForRun` (`packages/sandbox/daemon/entry.ts`) *fails soft* — if the org-fs mount isn't up, writes to `org/output/` land on local sandbox disk and never reach the manifest (no chip, no Library entry) while the agent still reports success. That's an infra path I couldn't exercise here; flagging it in case the report is actually stranded writes rather than discoverability.

## Testing

- `apps/mesh/src/web/components/chat/org-file-ref.test.ts`: inverted the old "output/upload are never linked" assertions (they now resolve with a thread id) and added the no-thread-id unlinked case. 11 pass.
- `bun run check` (typecheck, all workspaces) and `bun run lint` clean (no new warnings). `bun run fmt` applied.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chat references to `org/output/...` and `org/upload/...` clickable so users can open generated files in the Library with one click. Uses the conversation’s thread id to resolve the correct Library path; without it, paths stay unlinked.

- **Bug Fixes**
  - Thread the URL `taskId` through `OrgFileOpenContext` as `threadId`.
  - Update `resolveOrgFileBrowsePath` to map `org/output/...` → `outputs/<threadId>/...` and `org/upload/...` → `uploads/<threadId>/...`.
  - Use the new resolver in chat markdown code blocks and anchors.
  - Keep paths unlinked when no `threadId` is available.
  - Add tests for both linked (with `threadId`) and unlinked cases.

<sup>Written for commit ac3ecdb5f285f4e31c7327431b952ce2428d424c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

