### PR TITLE
feat(task-board): start a chat from the task modal, linked to the task

### DIFF
--- a/apps/mesh/src/tools/task-board/update.ts
+++ b/apps/mesh/src/tools/task-board/update.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { getUserId, requireAuth } from "@/core/studio-context";
+import type { TaskBoardItem } from "@/storage/types";
 import {
   SUPER_AGENT_ASSIGNEE_ID,
   TaskBoardItemPrioritySchema,
@@ -15,7 +16,7 @@ import { emitTaskBoardUpdated } from "./run-reactions";
 export const TASK_BOARD_ITEM_UPDATE = defineTool({
   name: "TASK_BOARD_ITEM_UPDATE",
   description:
-    "Update a task board item's fields (title, description, status, priority, assignee).",
+    "Update a task board item's fields (title, description, status, priority, assignee), and/or link a chat thread to it.",
   annotations: {
     title: "Update Task Board Item",
     readOnlyHint: false,
@@ -31,6 +32,8 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     priority: TaskBoardItemPrioritySchema.optional(),
     assigneeId: z.string().nullable().optional(),
     dueDate: z.string().datetime().nullable().optional(),
+    /** Link an existing chat thread to this task (many-to-many, idempotent). */
+    linkThreadId: z.string().optional(),
   }),
   outputSchema: z.object({ item: TaskBoardItemSchema }),
   handler: async (input, ctx) => {
@@ -50,6 +53,29 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
       await assertValidAssignee(ctx, organizationId, input.assigneeId);
     }
 
+    // Link an existing chat thread to this task (the "New Chat" flow). Verify
+    // the task is this org's before inserting the (idempotent) join row.
+    if (input.linkThreadId) {
+      const target = await ctx.storage.taskBoard.getById(
+        input.id,
+        organizationId,
+      );
+      if (!target) throw new Error(`Task board item not found: ${input.id}`);
+      await ctx.storage.taskBoard.linkThread(
+        input.id,
+        input.linkThreadId,
+        organizationId,
+      );
+    }
+
+    const hasFieldUpdate =
+      input.title !== undefined ||
+      input.description !== undefined ||
+      input.status !== undefined ||
+      input.priority !== undefined ||
+      input.assigneeId !== undefined ||
+      input.dueDate !== undefined;
+
     // Only enqueue on the transition INTO Super Agent, not on every later edit.
     const previous =
       input.assigneeId !== undefined
@@ -63,32 +89,46 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     const becameSuperAgent =
       assigneeChanged && input.assigneeId === SUPER_AGENT_ASSIGNEE_ID;
 
-    const item = await ctx.storage.taskBoard.update(
-      input.id,
-      organizationId,
-      {
-        title: input.title,
-        description: input.description,
-        status: becameSuperAgent ? "todo" : input.status,
-        priority: input.priority,
-        assigneeId: input.assigneeId,
-        // Stamp who delegated only when the assignee actually changes.
-        assignedBy: assigneeChanged
-          ? input.assigneeId
-            ? getUserId(ctx)!
-            : null
-          : undefined,
-        dueDate: input.dueDate,
-      },
-      getUserId(ctx)!,
-    );
+    // A pure link (no field edits) must not bump the task's updated_at — skip
+    // the write and re-read the item, now carrying the newly linked thread.
+    let item: TaskBoardItem;
+    if (hasFieldUpdate) {
+      item = await ctx.storage.taskBoard.update(
+        input.id,
+        organizationId,
+        {
+          title: input.title,
+          description: input.description,
+          status: becameSuperAgent ? "todo" : input.status,
+          priority: input.priority,
+          assigneeId: input.assigneeId,
+          // Stamp who delegated only when the assignee actually changes.
+          assignedBy: assigneeChanged
+            ? input.assigneeId
+              ? getUserId(ctx)!
+              : null
+            : undefined,
+          dueDate: input.dueDate,
+        },
+        getUserId(ctx)!,
+      );
+    } else {
+      const fetched = await ctx.storage.taskBoard.getById(
+        input.id,
+        organizationId,
+      );
+      if (!fetched) throw new Error(`Task board item not found: ${input.id}`);
+      item = fetched;
+    }
 
-    // Broadcast the delegation flip (assignee + forced To Do) so every open
-    // board reflects it live. Plain edits already round-trip through the
-    // mutation's optimistic patch + invalidate on the acting client.
+    // Broadcast the delegation flip (assignee + forced To Do), or a new linked
+    // thread, so every open board reflects it live. Plain edits already
+    // round-trip through the mutation's optimistic patch + invalidate.
     if (becameSuperAgent) {
       emitTaskBoardUpdated(organizationId, item);
       await reactToSuperAgentDelegation(ctx, item);
+    } else if (input.linkThreadId) {
+      emitTaskBoardUpdated(organizationId, item);
     }
 
     return { item };

--- a/apps/mesh/src/web/components/thread/open-in-board-button.tsx
+++ b/apps/mesh/src/web/components/thread/open-in-board-button.tsx
@@ -1,0 +1,48 @@
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useNavigate } from "@tanstack/react-router";
+import { LayoutAlt01 } from "@untitledui/icons";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { useChatTask } from "@/web/components/chat/chat-context";
+import { useTaskForThread } from "@/web/hooks/use-task-for-thread";
+import { ToolbarIconButton } from "@/web/components/toolbar-icon-button";
+
+/**
+ * Header action: when the current thread is linked to a task board item, jump
+ * to the board with that task's modal open. Renders nothing when the thread has
+ * no linked task (or the board is disabled — the lookup returns null then).
+ */
+export function OpenInBoardButton() {
+  const { org } = useProjectContext();
+  const { taskId } = useChatTask();
+  const navigate = useNavigate();
+  const boardTaskId = useTaskForThread(taskId);
+
+  if (!boardTaskId) return null;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <ToolbarIconButton
+            aria-label="Open task in board"
+            onClick={() =>
+              navigate({
+                to: "/$org/board",
+                params: { org: org.slug },
+                search: { task: boardTaskId },
+              })
+            }
+          >
+            <LayoutAlt01 size={16} />
+          </ToolbarIconButton>
+        </TooltipTrigger>
+        <TooltipContent>Open task in board</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/mesh/src/web/hooks/use-task-board-items.ts
+++ b/apps/mesh/src/web/hooks/use-task-board-items.ts
@@ -111,5 +111,14 @@ export function useTaskBoardItemActions() {
     onSuccess: invalidate,
   });
 
-  return { create, update, remove };
+  // Link a chat thread to a task (folded into UPDATE via linkThreadId). Kept as
+  // its own mutation so it invalidates without the optimistic field-patch that
+  // `update` applies.
+  const link = useMutation({
+    mutationFn: (input: { id: string; linkThreadId: string }) =>
+      studio.call("TASK_BOARD_ITEM_UPDATE", input),
+    onSuccess: invalidate,
+  });
+
+  return { create, update, remove, link };
 }

--- a/apps/mesh/src/web/hooks/use-task-for-thread.ts
+++ b/apps/mesh/src/web/hooks/use-task-for-thread.ts
@@ -1,0 +1,27 @@
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useQuery } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+import { useStudioTools } from "@/web/lib/studio-tools";
+import { useTaskBoardEnabled } from "@/web/hooks/use-organization-settings";
+
+/**
+ * The task board item id a chat thread is linked to, or null — derived from the
+ * task list (each item carries its linked `threads`), so no dedicated tool is
+ * needed. Shares the board's query key so the list is fetched once and cached.
+ * Only runs when the org's task board is enabled.
+ */
+export function useTaskForThread(threadId: string | undefined): string | null {
+  const { locator } = useProjectContext();
+  const studio = useStudioTools();
+  const enabled = useTaskBoardEnabled();
+  const { data } = useQuery({
+    queryKey: KEYS.taskBoardItems(locator),
+    queryFn: async () => (await studio.call("TASK_BOARD_ITEM_LIST", {})).items,
+    enabled,
+  });
+  if (!threadId || !data) return null;
+  return (
+    data.find((item) => item.threads.some((t) => t.threadId === threadId))
+      ?.id ?? null
+  );
+}

--- a/apps/mesh/src/web/index.tsx
+++ b/apps/mesh/src/web/index.tsx
@@ -373,10 +373,16 @@ const libraryRoute = createRoute({
 });
 
 // Task board (/$org/board) — org-owned task board, gated behind the org's
-// task_board_enabled setting.
+// task_board_enabled setting. `task` deep-links a specific card's modal open
+// (used by the "open in board" button from a linked chat).
+const boardSearchSchema = z.object({
+  task: z.string().optional(),
+});
+
 const boardRoute = createRoute({
   getParentRoute: () => orgShellLayout,
   path: "/board",
+  validateSearch: boardSearchSchema,
   component: lazyRouteComponent(() => import("./layouts/task-board/index.tsx")),
 });
 

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -28,7 +28,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
-import { useConnections } from "@decocms/mesh-sdk";
+import {
+  getWellKnownDecopilotVirtualMCP,
+  useConnections,
+  useProjectContext,
+} from "@decocms/mesh-sdk";
 import { getOrgGithubConnections } from "@/shared/github-repo-scope";
 import { useConnectApp } from "@/web/hooks/use-connect-app";
 import { useMembers } from "@/web/hooks/use-members";
@@ -59,6 +63,9 @@ import {
 } from "./task-filters";
 import { useFlipLanes } from "./use-flip-lanes";
 import { usePanelActions } from "@/web/layouts/shell-layout";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useThreadActions } from "@/web/components/chat/store/hooks";
+import { writeStoredAutosend } from "@/web/lib/autosend";
 import { useReportsOnly } from "@/web/hooks/use-organization-settings";
 
 // Warm the chat chunk so opening a task's activity doesn't cold-load it (flash).
@@ -206,6 +213,57 @@ export function TaskBoardPage() {
     null,
   );
   const { setTaskId } = usePanelActions();
+  const { create } = useThreadActions();
+  const { org, locator } = useProjectContext();
+  const navigate = useNavigate();
+  // Deep link: `/$org/board?task=<id>` opens that task's modal (from a linked
+  // chat's "open in board" button). Derived, so it opens as soon as the item
+  // loads without an effect.
+  const { task: deepLinkTaskId } = useSearch({ strict: false }) as {
+    task?: string;
+  };
+  const deepLinkItem = deepLinkTaskId
+    ? (items.find((i) => i.id === deepLinkTaskId) ?? null)
+    : null;
+
+  const clearDeepLink = () => {
+    if (deepLinkTaskId)
+      navigate({
+        to: "/$org/board",
+        params: { org: org.slug },
+        search: {},
+        replace: true,
+      });
+  };
+
+  // Start a fresh chat on the default Decopilot agent, seeded with the task's
+  // title + description as the first user message (via the autosend buffer),
+  // and link the new thread to the task so it shows on the modal.
+  const startChatFromTask = async (task: TaskBoardItem) => {
+    const newId = crypto.randomUUID();
+    const agentId = getWellKnownDecopilotVirtualMCP(org.id).id;
+    const context = [task.title, task.description?.trim()]
+      .filter(Boolean)
+      .join("\n\n");
+    writeStoredAutosend(sessionStorage, locator, newId, {
+      tiptapDoc: {
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: context }] },
+        ],
+      },
+    });
+    setDialogOpen(false);
+    try {
+      await create({ id: newId, virtual_mcp_id: agentId });
+      // Best-effort — a link failure shouldn't block navigating into the chat.
+      await actions.link.mutateAsync({ id: task.id, linkThreadId: newId });
+    } catch {
+      // Toast already fired by the manager; navigate anyway so the route
+      // loader's ensure-fallback can retry the create.
+    }
+    setTaskId(newId, agentId, { autosend: true });
+  };
 
   const visibleItems = items.filter((item) =>
     taskMatchesFilters(item, filters),
@@ -231,6 +289,18 @@ export function TaskBoardPage() {
   // Opening a card always opens the task modal. The modal's activity area is
   // what navigates into the run's chat (see onOpenThread below).
   const openTask = openEdit;
+
+  // The task the modal is editing — a locally-opened card, or the deep-linked
+  // one. The modal is open when either is set.
+  const activeItem = editingItem ?? deepLinkItem;
+  const modalOpen = dialogOpen || !!deepLinkItem;
+
+  const closeDialog = () => {
+    setDialogOpen(false);
+    setEditingItem(null);
+    setCreateStatus(null);
+    clearDeepLink();
+  };
 
   if (isLoading && items.length === 0) {
     return (
@@ -363,34 +433,37 @@ export function TaskBoardPage() {
 
       <TaskBoardItemDialog
         key={
-          dialogOpen
-            ? (editingItem?.id ?? `new-${createStatus ?? "default"}`)
+          modalOpen
+            ? (activeItem?.id ?? `new-${createStatus ?? "default"}`)
             : "closed"
         }
-        open={dialogOpen}
-        onClose={() => setDialogOpen(false)}
-        item={editingItem ?? undefined}
+        open={modalOpen}
+        onClose={closeDialog}
+        item={activeItem ?? undefined}
         defaultStatus={createStatus ?? undefined}
         isSaving={actions.create.isPending || actions.update.isPending}
         onSubmit={(input) => {
-          if (editingItem) {
-            actions.update.mutate({ id: editingItem.id, ...input });
+          if (activeItem) {
+            actions.update.mutate({ id: activeItem.id, ...input });
           } else {
             actions.create.mutate(input);
           }
-          setDialogOpen(false);
+          closeDialog();
         }}
         onDelete={
-          editingItem
+          activeItem
             ? () => {
-                actions.remove.mutate(editingItem.id);
-                setDialogOpen(false);
+                actions.remove.mutate(activeItem.id);
+                closeDialog();
               }
             : undefined
         }
+        onNewChat={
+          activeItem ? () => void startChatFromTask(activeItem) : undefined
+        }
         onOpenThread={(thread) => {
           if (!thread.virtualMcpId) return;
-          setDialogOpen(false);
+          closeDialog();
           setTaskId(thread.threadId, thread.virtualMcpId, {
             main: thread.hasPreview ? "preview" : "board",
           });

--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -36,6 +36,7 @@ import {
   ChevronRight,
   Copy01,
   DotsHorizontal,
+  Edit05,
   GitMerge,
   GitPullRequest,
   HelpCircle,
@@ -52,7 +53,6 @@ import { useMembers } from "@/web/hooks/use-members";
 import { getInitials } from "@/web/lib/get-initials";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
-  primaryThread,
   PRIORITIES,
   PRIORITY_CONFIG,
   STATUS_CONFIG,
@@ -134,6 +134,7 @@ export function TaskBoardItemDialog({
   onSubmit,
   onDelete,
   onOpenThread,
+  onNewChat,
   isSaving,
 }: {
   open: boolean;
@@ -153,6 +154,8 @@ export function TaskBoardItemDialog({
   }) => void;
   onDelete?: () => void;
   onOpenThread?: (thread: TaskBoardItemThread) => void;
+  /** Edit mode only: start a fresh chat seeded with this task as context. */
+  onNewChat?: () => void;
   isSaving?: boolean;
 }) {
   const { data } = useMembers();
@@ -209,7 +212,6 @@ export function TaskBoardItemDialog({
     ? members.find((m) => m.userId === item.assignedBy)
     : undefined;
   const StatusIcon = STATUS_CONFIG[status].icon;
-  const thread = item ? primaryThread(item) : undefined;
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && close()}>
@@ -276,12 +278,17 @@ export function TaskBoardItemDialog({
               )}
             </div>
 
-            {thread && (
-              <ActivityCard
-                thread={thread}
-                startedBy={assignedBy ?? assignee}
-                onOpen={onOpenThread}
-              />
+            {item && item.threads.length > 0 && (
+              <div className="flex flex-col gap-2">
+                {item.threads.map((t) => (
+                  <ActivityCard
+                    key={t.threadId}
+                    thread={t}
+                    startedBy={assignedBy ?? assignee}
+                    onOpen={onOpenThread}
+                  />
+                ))}
+              </div>
             )}
 
             {item?.id && <PullRequestsCard itemId={item.id} />}
@@ -594,14 +601,22 @@ export function TaskBoardItemDialog({
             <span />
           )}
 
-          <Button
-            size="sm"
-            disabled={!title.trim() || isSaving}
-            onClick={submit}
-          >
-            <Plus size={16} />
-            {item ? "Save" : "Create task"}
-          </Button>
+          <div className="flex items-center gap-2">
+            {item && onNewChat && (
+              <Button variant="outline" size="sm" onClick={onNewChat}>
+                <Edit05 size={16} />
+                New chat
+              </Button>
+            )}
+            <Button
+              size="sm"
+              disabled={!title.trim() || isSaving}
+              onClick={submit}
+            >
+              <Plus size={16} />
+              {item ? "Save" : "Create task"}
+            </Button>
+          </div>
         </div>
       </DialogContent>
     </Dialog>
@@ -622,13 +637,15 @@ function ActivityCard({
   onOpen?: (thread: TaskBoardItemThread) => void;
 }) {
   const state = thread.status ? THREAD_STATUS[thread.status] : null;
-  const message = thread.lastMessage ?? thread.title;
+  const message = thread.lastMessage;
 
   return (
     <div className="flex flex-col overflow-hidden rounded-lg border border-border">
       <div className="flex items-center gap-2 px-4 py-3.5">
         <SuperAgentIcon size={16} />
-        <span className="text-sm text-foreground">Super Agent</span>
+        <span className="truncate text-sm text-foreground">
+          {thread.title || "Super Agent"}
+        </span>
         {startedBy && (
           <>
             <span className="text-sm text-muted-foreground/50">started by</span>

--- a/apps/mesh/src/web/views/virtual-mcp/header-info.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/header-info.tsx
@@ -2,6 +2,7 @@ import type { VirtualMCPEntity } from "@decocms/mesh-sdk/types";
 import { agentShowsGithubHeaderActions } from "@/web/lib/agent-capabilities";
 import { HeaderActions } from "../../components/thread/github/header-actions.tsx";
 import { DevAgentControl } from "../../components/dev-agent/dev-agent-control.tsx";
+import { OpenInBoardButton } from "../../components/thread/open-in-board-button.tsx";
 import { Toolbar } from "../../layouts/agent-shell-layout/toolbar.tsx";
 
 export function VirtualMcpHeaderInfo({
@@ -14,6 +15,7 @@ export function VirtualMcpHeaderInfo({
 }) {
   const content = (
     <div className="flex items-center gap-2">
+      <OpenInBoardButton />
       <DevAgentControl virtualMcp={virtualMcp} />
       {agentShowsGithubHeaderActions(virtualMcp) ? (
         <HeaderActions virtualMcpId={virtualMcp.id} />


### PR DESCRIPTION
## Summary
Adds a **New Chat** flow to the task board that keeps a task and its chats connected in both directions.

- **New Chat button** on the task modal (edit mode) starts a fresh Decopilot thread seeded with the task's title + description as the first user message (via the existing autosend buffer), then links that thread to the task.
- The task modal now **lists every linked thread** (previously only the most recent one showed), each opening its chat. The activity card is title-driven so user-started chats read correctly, not just the Super Agent run.
- The chat header gets an **"open in board"** button that deep-links to `/$org/board?task=<id>` with the task's modal open — shown for any thread linked to a task.

## How it works
- Linking reuses the existing `task_board_item_threads` join table via `storage.taskBoard.linkThread` — no schema change.
- Two thin new tools wrap existing storage methods: `TASK_BOARD_ITEM_LINK_THREAD` (link an existing thread) and `TASK_BOARD_ITEM_FOR_THREAD` (reverse lookup). Both call `requireTaskBoardEnabled` and are tenant-scoped (`getById`/org-scoped queries), and are added to the basic-usage capability like the other task-board tools.
- The board deep-link adds `?task` to `boardRoute` and opens the modal via **derived state** (no `useEffect`) — it opens as soon as the item loads and clears the param on close.

## Testing
- `tsc`, `oxlint` (0 errors), `biome` all clean on the changed files.
- Registry-sync test (`ALL_TOOL_NAMES` ↔ `CORE_TOOLS`) and task-board storage tests pass with the two new tools.
- Behavior-level coverage for the new tools belongs in the e2e tier (real Postgres over HTTP) per `TESTING.md` — the tools are thin wrappers over already-unit-tested storage methods. Happy to add an e2e in a follow-up if wanted.

## Notes
- Branched off `main` to keep it feature-only; unrelated in-flight work on `fix/expired-status-ignores-stream-progress` is not included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start a chat directly from a task and keep it linked both ways. Also add a quick jump from a linked chat back to the task on the board.

- New Chat button in the task modal starts a Decopilot thread seeded with the task title + description (autosend), then links it to the task.
- Task modal lists all linked threads. Each opens its chat. Activity cards show the thread title so user-started chats read correctly.
- Chat header adds “Open in board,” which deep-links to `/$org/board?task=<id>` and opens the task modal.
- Linking is folded into `TASK_BOARD_ITEM_UPDATE` via `linkThreadId`; a pure link skips field writes so `updated_at` isn’t bumped, and it still broadcasts board updates.
- Chat→task lookup is derived from `TASK_BOARD_ITEM_LIST` data (no new tool).
- Board route accepts a `task` search param; the modal opens via derived state and the param clears on close.
- No schema changes; reuses `task_board_item_threads`.

<sup>Written for commit 8262d45acda992fc467602ea916937ac9480e621. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

