### PR TITLE
fix(ui): center empty state titles

### DIFF
--- a/apps/mesh/src/web/components/empty-state.tsx
+++ b/apps/mesh/src/web/components/empty-state.tsx
@@ -53,7 +53,9 @@ export function EmptyState({
       {/* Text content */}
       <div className="flex flex-col items-center gap-4">
         <div className="flex flex-col items-center gap-2">
-          <h3 className="text-lg font-medium text-foreground">{title}</h3>
+          <h3 className="text-center text-lg font-medium text-foreground">
+            {title}
+          </h3>
           <div
             className={cn(
               "text-sm text-muted-foreground text-center max-w-[300px]",


### PR DESCRIPTION
## Summary

- center shared empty-state titles
- keep wrapped Blocks editor guidance aligned with its description

## Testing

- `bun run fmt`
- `bun test apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab.test.tsx` (2 passed)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Center empty-state titles to match the centered descriptions, fixing uneven alignment when text wraps (e.g., Blocks editor guidance). Improves visual consistency across empty states.

<sup>Written for commit fc04e5fc11ef7c0afd3d27aaa44095962d40d2d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

