### PR TITLE
fix(tasks): remove stale task board enablement guidance

### DIFF
--- a/apps/mesh/src/api/routes/task-board-import.integration.test.ts
+++ b/apps/mesh/src/api/routes/task-board-import.integration.test.ts
@@ -103,7 +103,9 @@ describe("Task Board Import Route", () => {
     expect(wrongToken.status).toBe(401);
   });
 
-  it("creates items for an org that never touched the board before", async () => {
+  it("imports tasks without creating organization settings", async () => {
+    // org_1 (seeded) has no settings row. The task board is always available,
+    // so importing tasks must not create unrelated configuration state.
     const res = await app.fetch(post("org_1", "svc-secret", BODY));
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({
@@ -111,6 +113,13 @@ describe("Task Board Import Route", () => {
       updated: 0,
       delegated: 0,
     });
+
+    const settings = await database.db
+      .selectFrom("organization_settings")
+      .select(["organizationId"])
+      .where("organizationId", "=", "org_1")
+      .executeTakeFirst();
+    expect(settings).toBeUndefined();
   });
 
   it("rejects an invalid body", async () => {

--- a/apps/mesh/src/tools/virtual/studio-pack/task-manager.test.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/task-manager.test.ts
@@ -18,10 +18,7 @@ describe("taskManagerAgent", () => {
     ]);
   });
 
-  test("handles disabled boards, safe deletion, and Super Agent delegation", () => {
-    expect(taskManagerAgent.instructions).toContain(
-      "enable Task board in organization settings",
-    );
+  test("handles safe deletion and Super Agent delegation", () => {
     expect(taskManagerAgent.instructions).toContain(
       "explicit confirmation immediately before deleting a task",
     );

--- a/apps/mesh/src/tools/virtual/studio-pack/task-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/task-manager.ts
@@ -15,7 +15,6 @@ You are the Task Manager. You organize and maintain this organization's task boa
 </capabilities>
 
 <constraints>
-- The task board must be enabled for the organization. If a tool reports that it is disabled, tell the user to enable Task board in organization settings; do not claim the board is empty or unavailable for another reason.
 - Always list the board before updating, deleting, or inspecting a task unless the user supplied its exact id in the current message.
 - Match tasks by id. If the user identifies a task only by title and more than one item matches, ask which one they mean before mutating anything.
 - Never invent task ids, assignee ids, dates, or pull-request state.

--- a/apps/mesh/src/web/components/home/home-tasks.tsx
+++ b/apps/mesh/src/web/components/home/home-tasks.tsx
@@ -155,7 +155,7 @@ export function HomeTasks({ afterSummary }: { afterSummary?: ReactNode }) {
   const [tab, setTab] = useState<TaskTab>("all");
   const [createOpen, setCreateOpen] = useState(false);
 
-  // Task board can be off for an org (list errors) — treat as no tasks.
+  // Keep the home surface usable if the task query fails.
   const tasks = error ? [] : items;
   const sorted = [...tasks].sort((a, b) =>
     (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""),

--- a/packages/e2e/tests/task-board-always-enabled.spec.ts
+++ b/packages/e2e/tests/task-board-always-enabled.spec.ts
@@ -1,0 +1,87 @@
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, test } from "../fixtures/test";
+
+interface TaskBoardItem {
+  id: string;
+  title: string;
+  status: string;
+}
+
+test.describe("always-available task board", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  test("all task-board tools work without an organization-settings row", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const request = page.context().request;
+    const orgResult = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [orgSlug],
+    );
+    const organizationId = orgResult.rows[0]?.id;
+    if (!organizationId) throw new Error("organization not found after signup");
+
+    await db.query(
+      `DELETE FROM "organization_settings" WHERE "organizationId" = $1`,
+      [organizationId],
+    );
+
+    const created = await callSelfMcpTool<{ item: TaskBoardItem }>(
+      request,
+      orgSlug,
+      "TASK_BOARD_ITEM_CREATE",
+      { title: "Always available" },
+    );
+    expect(created.item.title).toBe("Always available");
+
+    const listed = await callSelfMcpTool<{ items: TaskBoardItem[] }>(
+      request,
+      orgSlug,
+      "TASK_BOARD_ITEM_LIST",
+      {},
+    );
+    expect(listed.items.map((item) => item.id)).toContain(created.item.id);
+
+    const updated = await callSelfMcpTool<{ item: TaskBoardItem }>(
+      request,
+      orgSlug,
+      "TASK_BOARD_ITEM_UPDATE",
+      { id: created.item.id, status: "todo" },
+    );
+    expect(updated.item.status).toBe("todo");
+
+    const prs = await callSelfMcpTool<{ prs: unknown[] }>(
+      request,
+      orgSlug,
+      "TASK_BOARD_ITEM_PRS_GET",
+      { taskBoardItemId: created.item.id },
+    );
+    expect(prs.prs).toEqual([]);
+
+    await expect(
+      callSelfMcpTool<{ success: boolean }>(
+        request,
+        orgSlug,
+        "TASK_BOARD_ITEM_DELETE",
+        { id: created.item.id },
+      ),
+    ).resolves.toEqual({ success: true });
+
+    const settings = await db.query(
+      `SELECT 1 FROM "organization_settings" WHERE "organizationId" = $1`,
+      [organizationId],
+    );
+    expect(settings.rowCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## What is this contribution about?

The core task-board flag removal landed independently in #4883 while this PR was open. After rebasing, this PR keeps the remaining hardening work:

- removes stale Task Manager guidance that still told users to enable the board in organization settings
- updates the home tasks error-path comment to reflect that the board is always available
- strengthens the task import integration test to prove it does not create organization settings
- adds black-box coverage for create, list, update, PR lookup, and delete with no organization-settings row

## Screenshots/Demonstration

Not applicable. There is no remaining UI layout change in this rebased diff.

## How to Test

- `bun run check`
- `bun test apps/mesh/src/tools/virtual/studio-pack/task-manager.test.ts apps/mesh/src/api/routes/task-board-import.test.ts` (7 passing)
- `packages/e2e/tests/task-board-always-enabled.spec.ts` runs with the CI PostgreSQL service

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Stale documentation and guidance are removed
- [x] No migration remains in this rebased diff