### PR TITLE
refactor(chat): use --special design token for tools-popover active states

### DIFF
--- a/apps/mesh/src/web/components/chat/tools-popover.tsx
+++ b/apps/mesh/src/web/components/chat/tools-popover.tsx
@@ -372,17 +372,17 @@ export function ToolsPopover({
 
           <DropdownMenuItem
             onClick={handleTogglePlanMode}
-            className={cn(isPlanMode && "text-violet-600 dark:text-violet-400")}
+            className={cn(isPlanMode && "text-special")}
           >
             <BookOpen01
               size={16}
-              className={cn(isPlanMode && "text-violet-500")}
+              className={cn(isPlanMode && "text-special")}
             />
             <span className="flex-1">Plan mode</span>
             <span
               className={cn(
                 "text-xs text-muted-foreground",
-                isPlanMode && "text-violet-500 font-medium",
+                isPlanMode && "text-special font-medium",
               )}
             >
               {PLAN_MODE_SHORTCUT}
@@ -392,49 +392,45 @@ export function ToolsPopover({
           {/* Create image */}
           <DropdownMenuItem
             onClick={handleForceImageGeneration}
-            className={cn(isImageActive && "text-pink-600 dark:text-pink-400")}
+            className={cn(isImageActive && "text-special")}
           >
             <Image01
               size={16}
-              className={cn(isImageActive && "text-pink-500")}
+              className={cn(isImageActive && "text-special")}
             />
             <span className="flex-1">Create image</span>
             {isImageActive && (
-              <span className="text-xs text-pink-500 font-medium">On</span>
+              <span className="text-xs text-special font-medium">On</span>
             )}
           </DropdownMenuItem>
 
           {/* Web search */}
           <DropdownMenuItem
             onClick={handleForceWebSearch}
-            className={cn(
-              isWebSearchActive && "text-blue-600 dark:text-blue-400",
-            )}
+            className={cn(isWebSearchActive && "text-special")}
           >
             <Globe02
               size={16}
-              className={cn(isWebSearchActive && "text-blue-500")}
+              className={cn(isWebSearchActive && "text-special")}
             />
             <span className="flex-1">Web search</span>
             {isWebSearchActive && (
-              <span className="text-xs text-blue-500 font-medium">On</span>
+              <span className="text-xs text-special font-medium">On</span>
             )}
           </DropdownMenuItem>
 
           {/* Deep research */}
           <DropdownMenuItem
             onClick={handleForceDeepResearch}
-            className={cn(
-              isDeepResearchActive && "text-blue-600 dark:text-blue-400",
-            )}
+            className={cn(isDeepResearchActive && "text-special")}
           >
             <Telescope
               size={16}
-              className={cn(isDeepResearchActive && "text-blue-500")}
+              className={cn(isDeepResearchActive && "text-special")}
             />
             <span className="flex-1">Deep research</span>
             {isDeepResearchActive && (
-              <span className="text-xs text-blue-500 font-medium">On</span>
+              <span className="text-xs text-special font-medium">On</span>
             )}
           </DropdownMenuItem>
 


### PR DESCRIPTION
**Source:** debt-hunt target from the injected "highest-debt frontend files" list — `tools-popover.tsx` had `palette=16` raw-Tailwind-palette hits flagged by the (currently disabled, per its own top-of-file comment) `plugins/ensure-tailwind-design-system-tokens.js` oxlint rule.

**Why a maintainer wants this:** all 16 hits were raw `violet-*`/`pink-*`/`blue-*` classes marking the four "mode is on" indicators (Plan mode, Create image, Web search, Deep research). None of these hues map to any real semantic state (they don't mean success/warning/error) and two of the four already reused the exact same blue — the differentiation was arbitrary, not intentional. The design system already ships a semantic token, `--special` (violet-hued, oklch hue ~290), used elsewhere for exactly this kind of "feature is active" indicator (`task-dialog.tsx`'s "Merged" status). Swapping all four to `text-special` removes 100% of this file's raw-palette debt, keeps a single consistent "active" visual language (only one mode can be active at a time, so no distinction was needed), and re-themes automatically with the token instead of being frozen to hardcoded dark:-mode variants.

**Change:** pure Tailwind class swap, no logic touched — `text-violet-600 dark:text-violet-400` / `text-violet-500` / `text-pink-*` / `text-blue-*` → `text-special` (single class works in both themes since the CSS var flips in `.dark`). Net diff: -16/+12 lines (some `cn()` calls collapsed to single-line since dark: variants are no longer needed).

**Test:** No new test file. `ToolsPopover` sits behind `useProjectContext`/`useMCPClient`/`useChatPrefs`/`usePreferences`/tiptap's `useCurrentEditor` — rendering it would require `mock.module`-ing all of those, which `TESTING.md` explicitly says disqualifies a test from the unit tier ("if a test needs `vi.mock`, `mock.module`, a stubbed context... it's not a unit test — move it to e2e"), and this repo's e2e suite isn't runnable in this environment. The change itself has no branching logic to regress (it's a literal string swap), so `bunx tsc --noEmit` is the correct-weight check here.

**Commands to verify:**
```
cd apps/mesh && bunx tsc --noEmit   # passes clean
grep -noE '\b(bg|text|border|ring|shadow|outline|ring-offset)-[a-z]+-(50|100|200|300|400|500|600|700|800|900)\b' apps/mesh/src/web/components/chat/tools-popover.tsx   # zero matches now (was 16)
```

**Locally ran:** `bun run fmt` (clean) and `bunx tsc --noEmit` scoped to `apps/mesh` (clean, no output). Full CI validates lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized active-state styling in `ToolsPopover` by switching from hardcoded Tailwind colors to the `--special` design token via `text-special`. This removes palette debt and ensures consistent theming in light/dark modes.

- **Refactors**
  - Replaced `violet-*`, `pink-*`, and `blue-*` classes with `text-special` in `apps/mesh/src/web/components/chat/tools-popover.tsx`.
  - Removed `dark:` variants and simplified `cn()` usage; no logic changes.
  - Kept a single semantic color since only one mode can be active at a time.

<sup>Written for commit f99e56ed1954785ac2a1eae465bc08dbb91c7bef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

