### PR TITLE
test(auth): regression-guard canAssignRole against member self-promotion (#3388)

### DIFF
--- a/apps/mesh/src/auth/roles.test.ts
+++ b/apps/mesh/src/auth/roles.test.ts
@@ -29,4 +29,15 @@ describe("canAssignRole", () => {
     expect(canAssignRole(undefined, "user")).toBe(false);
     expect(canAssignRole(undefined, "owner")).toBe(false);
   });
+
+  // Regression for #3388: a member's caller role is the org plugin's
+  // default "member" string, not the built-in "user" role. canAssignRole
+  // must deny it just like any other non-admin/owner role — a member must
+  // not be able to self-promote to admin by calling
+  // ORGANIZATION_MEMBER_UPDATE_ROLE against their own member row.
+  it("plain member role cannot self-promote to admin or owner", () => {
+    expect(canAssignRole("member", "admin")).toBe(false);
+    expect(canAssignRole("member", "owner")).toBe(false);
+    expect(canAssignRole("member", "member")).toBe(false);
+  });
 });


### PR DESCRIPTION
Follows #3388 ("Org member can self-promote to admin and bypass role boundaries").

`canAssignRole` in `apps/mesh/src/auth/roles.ts` is the authorization gate `ORGANIZATION_MEMBER_UPDATE_ROLE`/`ORGANIZATION_MEMBER_ADD` call before mutating a member's role — it's the RBAC trust boundary that stops privilege escalation (a real vuln class: an org `member` promoting themselves to `admin`/`owner`).

The issue's root-cause hypothesis is that Better Auth's organization plugin assigns new members the literal role string `"member"`, which isn't one of this app's `BUILTIN_ROLES` (`owner`/`admin`/`user`) — a plausible gap for that exact string to fall through unguarded. The existing test suite only exercised `"owner"`, `"admin"`, `"user"`, and `undefined` as caller roles; `"member"` (the string an actual invited member's session carries) was never asserted. This PR adds that missing case so any future change to `canAssignRole` that special-cases or forgets an unrecognized role string breaks a test immediately, instead of only being caught by manual pentesting.

No runtime code changed — `canAssignRole`'s existing `if (callerRole === "owner") ... if (callerRole === "admin") ... return false` structure already denies `"member"` for any target role, confirmed by the new test. This closes the specific untested gap called out in #3388, not the broader in-flight scoping/UI work also referenced there.

Reviewer command: `bun test apps/mesh/src/auth/roles.test.ts`

Local checks run: `bun run fmt` (clean) and the targeted test file above (6 pass / 0 fail). No `tsc` run since no type-level change. Full CI covers everything else.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test for `canAssignRole` to ensure an org `member` cannot self-promote to `admin` or `owner`, addressing the gap from #3388. Confirms current logic denies `member` for all target roles, including `member`.

<sup>Written for commit 26845823e804dae281e1db60ab486251bc9b000d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

