### PR TITLE
refactor(home): extract ToggleButton out of add-tile-drawer.tsx

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -67,7 +67,6 @@ import {
   ChevronDown,
   DotsGrid,
   Loading01,
-  Minus,
   Plus,
   SearchSm,
   Settings01,
@@ -84,6 +83,7 @@ import {
 import { KEYS } from "@/web/lib/query-keys";
 import { useStudioTools } from "@/web/lib/studio-tools";
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
+import { ToggleButton } from "./toggle-button";
 
 /** How many agents the home view can actually display — adding past this is
  * blocked so the user never pins something that silently won't show. */
@@ -1058,42 +1058,6 @@ function AddToolRow({
         />
       )}
     </div>
-  );
-}
-
-export function ToggleButton({
-  isPinned,
-  submitting,
-  onClick,
-  label,
-}: {
-  isPinned: boolean;
-  submitting: boolean;
-  onClick: () => void;
-  label: string;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={submitting}
-      aria-label={label}
-      title={label}
-      className={cn(
-        "inline-flex size-7 shrink-0 items-center justify-center rounded-md text-xs transition-colors disabled:opacity-50 disabled:cursor-progress",
-        isPinned
-          ? "text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-          : "bg-foreground text-background hover:opacity-90",
-      )}
-    >
-      {submitting ? (
-        <Loading01 size={12} className="animate-spin" />
-      ) : isPinned ? (
-        <Minus size={14} />
-      ) : (
-        <Plus size={14} />
-      )}
-    </button>
   );
 }
 

--- a/apps/mesh/src/web/components/home/agent-prompt-list.tsx
+++ b/apps/mesh/src/web/components/home/agent-prompt-list.tsx
@@ -10,7 +10,8 @@ import { toast } from "sonner";
 import { useHomeNextActions } from "@/web/hooks/use-home-next-actions";
 import { KEYS } from "@/web/lib/query-keys";
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
-import { HOME_LIMIT, ToggleButton, type HomeBoard } from "./add-tile-drawer";
+import { HOME_LIMIT, type HomeBoard } from "./add-tile-drawer";
+import { ToggleButton } from "./toggle-button";
 
 interface AgentPrompt {
   name: string;

--- a/apps/mesh/src/web/components/home/toggle-button.tsx
+++ b/apps/mesh/src/web/components/home/toggle-button.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Loading01, Minus, Plus } from "@untitledui/icons";
+
+export function ToggleButton({
+  isPinned,
+  submitting,
+  onClick,
+  label,
+}: {
+  isPinned: boolean;
+  submitting: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={submitting}
+      aria-label={label}
+      title={label}
+      className={cn(
+        "inline-flex size-7 shrink-0 items-center justify-center rounded-md text-xs transition-colors disabled:opacity-50 disabled:cursor-progress",
+        isPinned
+          ? "text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+          : "bg-foreground text-background hover:opacity-90",
+      )}
+    >
+      {submitting ? (
+        <Loading01 size={12} className="animate-spin" />
+      ) : isPinned ? (
+        <Minus size={14} />
+      ) : (
+        <Plus size={14} />
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
Source: C5 bounded extraction — `add-tile-drawer.tsx` is a ~1100-line God-component on the largest-frontend-files list.

Why: `ToggleButton` is a pure presentational atom — it only reads its own props (`isPinned`, `submitting`, `onClick`, `label`) and has no closures over the drawer's state. It was already imported cross-file by `agent-prompt-list.tsx` via `./add-tile-drawer`, meaning that file pulled in the entire drawer module just to grab one small button. Moving it to its own `toggle-button.tsx` removes that unnecessary coupling and shrinks the God-component by ~35 lines.

Change: byte-identical relocation — the component body is unchanged, only its file location moved. `add-tile-drawer.tsx` now imports it from `./toggle-button`; `agent-prompt-list.tsx` imports it directly instead of through the drawer. Removed the now-unused `Minus` icon import from `add-tile-drawer.tsx` (only `ToggleButton` used it).

Net diff: +41 / -38 across 3 files (1 new file, 2 trimmed).

How to verify: `cd apps/mesh && bunx tsc --noEmit` (clean), and confirm the "Manage home" drawer (org home → Add tile) still renders pin/unpin buttons — no behavior change, just the import path.

Local checks run: `bun run fmt` and `bunx tsc --noEmit` in `apps/mesh` (both clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `ToggleButton` from `add-tile-drawer.tsx` into `toggle-button.tsx` to decouple it from the drawer and trim the large file. No behavior changes.

- **Refactors**
  - Moved `ToggleButton` with identical code to `toggle-button.tsx`.
  - Updated imports in `add-tile-drawer.tsx` and `agent-prompt-list.tsx` to use the new module.
  - Removed unused `Minus` icon import from `add-tile-drawer.tsx`.

<sup>Written for commit ff36f320a1cbd9a031a67fc7a51d56e26932269e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

