### PR TITLE
fix(auth): validate every role in a multi-role assignment, not just the first

### DIFF
--- a/apps/mesh/src/auth/roles.test.ts
+++ b/apps/mesh/src/auth/roles.test.ts
@@ -40,4 +40,20 @@ describe("canAssignRole", () => {
     expect(canAssignRole("member", "owner")).toBe(false);
     expect(canAssignRole("member", "member")).toBe(false);
   });
+
+  // Better Auth's organization plugin supports multi-role members, and
+  // callers forward the whole role array to it. An admin must not be able
+  // to smuggle "owner" in alongside an allowed role by relying on a caller
+  // that only validates the first array entry.
+  it("admin cannot assign owner by hiding it in a multi-role array", () => {
+    expect(canAssignRole("admin", ["user", "owner"])).toBe(false);
+    expect(canAssignRole("admin", ["owner", "user"])).toBe(false);
+    expect(canAssignRole("admin", ["user", "admin"])).toBe(true);
+  });
+
+  it("owner can assign a multi-role array, empty array is denied", () => {
+    expect(canAssignRole("owner", ["admin", "owner"])).toBe(true);
+    expect(canAssignRole("admin", [])).toBe(false);
+    expect(canAssignRole("owner", [])).toBe(false);
+  });
 });

--- a/apps/mesh/src/auth/roles.ts
+++ b/apps/mesh/src/auth/roles.ts
@@ -22,15 +22,22 @@ export type BuiltinRole = (typeof BUILTIN_ROLES)[number];
 export const ADMIN_ROLES: BuiltinRole[] = ["owner", "admin"];
 
 /**
- * Validate that the caller's role is allowed to assign the target role.
+ * Validate that the caller's role is allowed to assign the target role(s).
  * Owners can assign any role. Admins can assign "user" or "admin" but NOT
  * "owner" — preventing vertical privilege escalation.
+ *
+ * `targetRole` may be an array: Better Auth's organization plugin supports
+ * multi-role members (stored comma-joined), so every entry must be checked —
+ * validating only the first element would let an admin smuggle "owner" in
+ * alongside an allowed role (e.g. `["user", "owner"]`).
  */
 export function canAssignRole(
   callerRole: string | undefined,
-  targetRole: string,
+  targetRole: string | string[],
 ): boolean {
+  const targetRoles = Array.isArray(targetRole) ? targetRole : [targetRole];
+  if (targetRoles.length === 0) return false;
   if (callerRole === "owner") return true;
-  if (callerRole === "admin") return targetRole !== "owner";
+  if (callerRole === "admin") return targetRoles.every((r) => r !== "owner");
   return false;
 }

--- a/apps/mesh/src/tools/organization/member-add.ts
+++ b/apps/mesh/src/tools/organization/member-add.ts
@@ -57,11 +57,12 @@ export const ORGANIZATION_MEMBER_ADD = defineTool({
       );
     }
 
-    // Validate the caller is allowed to assign the target role.
+    // Validate the caller is allowed to assign every target role.
     // Admins cannot assign "owner" — only owners can.
-    const targetRole = Array.isArray(input.role) ? input.role[0] : input.role;
-    if (targetRole && !canAssignRole(ctx.auth.user?.role, targetRole)) {
-      throw new Error(`Insufficient privileges to assign role "${targetRole}"`);
+    if (!canAssignRole(ctx.auth.user?.role, input.role)) {
+      throw new Error(
+        `Insufficient privileges to assign role "${input.role.join(",")}"`,
+      );
     }
 
     // Add member via Better Auth

--- a/apps/mesh/src/tools/organization/member-update-role.ts
+++ b/apps/mesh/src/tools/organization/member-update-role.ts
@@ -59,11 +59,12 @@ export const ORGANIZATION_MEMBER_UPDATE_ROLE = defineTool({
       );
     }
 
-    // Validate the caller is allowed to assign the target role.
+    // Validate the caller is allowed to assign every target role.
     // Admins cannot assign "owner" — only owners can.
-    const targetRole = Array.isArray(input.role) ? input.role[0] : input.role;
-    if (targetRole && !canAssignRole(ctx.auth.user?.role, targetRole)) {
-      throw new Error(`Insufficient privileges to assign role "${targetRole}"`);
+    if (!canAssignRole(ctx.auth.user?.role, input.role)) {
+      throw new Error(
+        `Insufficient privileges to assign role "${input.role.join(",")}"`,
+      );
     }
 
     // Update member role via bound auth client


### PR DESCRIPTION
Follows #4898 (post-merge hardening on the same role-assignment path).

**The gap:** `canAssignRole` in `apps/mesh/src/auth/roles.ts` only validated `input.role[0]`, but both call sites — `ORGANIZATION_MEMBER_ADD` and `ORGANIZATION_MEMBER_UPDATE_ROLE` — forward the *entire* `input.role` array to Better Auth's organization plugin via `ctx.boundAuth.organization.{addMember,updateMemberRole}`. That plugin supports multi-role members (stored comma-joined — see the `role.includes(",")` handling in `apps/mesh/src/auth/builtin-role-permission.ts:150`), and `StudioContext`'s `addMember`/`updateMemberRole` types already declare `role: string | string[]`.

**Failure scenario:** an admin (who `canAssignRole` is supposed to block from ever granting "owner", per the existing comment/tests) calls `ORGANIZATION_MEMBER_UPDATE_ROLE` with `role: ["user", "owner"]`. The check only inspected `"user"` (index 0), which passes, so the full array — including `"owner"` — is forwarded to Better Auth and applied to the member. Same bypass exists in `ORGANIZATION_MEMBER_ADD`. This is a vertical-privilege-escalation gap in the same code path #4898 just added regression coverage for (member self-promotion via a different vector).

**Fix:** `canAssignRole` now accepts `string | string[]` and requires every entry in the array to pass (`targetRoles.every((r) => r !== "owner")` for admins), plus denies an empty array outright (previously an empty/falsy `targetRole` silently skipped the check). Both call sites now pass `input.role` directly instead of extracting only the first element.

**Regression test:** added to `apps/mesh/src/auth/roles.test.ts` — `canAssignRole("admin", ["user", "owner"])` and `canAssignRole("admin", ["owner", "user"])` must both be `false`; `canAssignRole("admin", ["user", "admin"])` stays `true`; empty arrays are denied for both admin and owner.

**To verify:** `cd apps/mesh && bun test src/auth/roles.test.ts`

**Checks run locally:** `bun run fmt` (clean), `cd apps/mesh && bunx tsc --noEmit` (clean), and the single targeted test file above (8 pass). Full CI validates the rest — no e2e/integration tests exist for `member-add.ts`/`member-update-role.ts` themselves (those tools have no unit-test coverage; only the pure `canAssignRole` logic is unit-testable per this repo's testing tiers).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a security gap in role assignment by validating every role in multi-role inputs. Prevents admins from granting `owner` when sending arrays like `["user","owner"]`.

- **Bug Fixes**
  - Updated `canAssignRole` to accept `string | string[]`, check every role, and deny empty arrays.
  - `ORGANIZATION_MEMBER_ADD` and `ORGANIZATION_MEMBER_UPDATE_ROLE` now validate the full `input.role` array and return clearer errors with joined roles.
  - Added regression tests covering multi-role scenarios for admin and owner.

<sup>Written for commit 8ce1d6f2d690a6509a4d4f7e134cc96129238ae0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

