### PR TITLE
refactor(web): extract shared IconAvatar to dedupe AgentAvatar render paths

### DIFF
--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -304,6 +304,35 @@ interface AgentAvatarProps {
   className?: string;
 }
 
+/** Colored background + centered icon — shared by all icon-rendering paths. */
+function IconAvatar({
+  Icon,
+  color,
+  size,
+  className,
+}: {
+  Icon: IconComponent;
+  color: AgentIconColor;
+  size: AgentAvatarSize;
+  className?: string;
+}) {
+  const sizeConfig = SIZES[size];
+  return (
+    <div
+      className={cn(
+        sizeConfig.container,
+        sizeConfig.radius,
+        color.bg,
+        color.text,
+        "flex items-center justify-center shrink-0 outline-none ring-0 shadow-none",
+        className,
+      )}
+    >
+      <Icon size={sizeConfig.icon} />
+    </div>
+  );
+}
+
 export function AgentAvatar({
   icon,
   name,
@@ -311,32 +340,14 @@ export function AgentAvatar({
   className,
 }: AgentAvatarProps) {
   const parsed = parseIconString(icon);
-  const sizeConfig = SIZES[size];
 
   if (parsed.type === "icon") {
     const IconComp = getIconComponent(parsed.name);
     const color = getIconColor(parsed.color);
+    const Icon = IconComp ?? getDeterministicIcon(name).IconComp;
 
     return (
-      <div
-        className={cn(
-          sizeConfig.container,
-          sizeConfig.radius,
-          color.bg,
-          color.text,
-          "flex items-center justify-center shrink-0 outline-none ring-0 shadow-none",
-          className,
-        )}
-      >
-        {IconComp ? (
-          <IconComp size={sizeConfig.icon} />
-        ) : (
-          (() => {
-            const { IconComp: Fallback } = getDeterministicIcon(name);
-            return <Fallback size={sizeConfig.icon} />;
-          })()
-        )}
-      </div>
+      <IconAvatar Icon={Icon} color={color} size={size} className={className} />
     );
   }
 
@@ -353,22 +364,15 @@ export function AgentAvatar({
   }
 
   // Fallback: deterministic color + icon
-  const { IconComp: FallbackIcon, color: fallbackColor } =
-    getDeterministicIcon(name);
+  const { IconComp, color } = getDeterministicIcon(name);
 
   return (
-    <div
-      className={cn(
-        sizeConfig.container,
-        sizeConfig.radius,
-        fallbackColor.bg,
-        fallbackColor.text,
-        "flex items-center justify-center shrink-0 outline-none ring-0 shadow-none",
-        className,
-      )}
-    >
-      <FallbackIcon size={sizeConfig.icon} />
-    </div>
+    <IconAvatar
+      Icon={IconComp}
+      color={color}
+      size={size}
+      className={className}
+    />
   );
 }
 
@@ -398,22 +402,14 @@ function AgentAvatarImage({
   const bgClass = color ? (URL_COLOR_BG[color] ?? "") : "";
 
   if (errored) {
-    const { IconComp: FallbackIcon, color: fallbackColor } =
-      getDeterministicIcon(name);
-
+    const { IconComp, color } = getDeterministicIcon(name);
     return (
-      <div
-        className={cn(
-          sizeConfig.container,
-          sizeConfig.radius,
-          fallbackColor.bg,
-          fallbackColor.text,
-          "flex items-center justify-center shrink-0 outline-none ring-0 shadow-none",
-          className,
-        )}
-      >
-        <FallbackIcon size={sizeConfig.icon} />
-      </div>
+      <IconAvatar
+        Icon={IconComp}
+        color={color}
+        size={size}
+        className={className}
+      />
     );
   }
 


### PR DESCRIPTION
**Source:** reduction found while auditing `apps/mesh/src/web/components/agent-icon.tsx` (this tick's assigned focus area).

**Why:** `AgentAvatar`'s icon-type branch, its no-icon fallback branch, and `AgentAvatarImage`'s image-load-error branch each hand-rolled the identical "colored background + centered icon" div (same Tailwind class list, same `cn(...)` call) — one real block, copy-pasted three times. Collapsed into a single internal `IconAvatar` component that all three paths call.

**Net change:** -4 lines (45 insertions / 49 deletions) in one file; despite the small net delta, ~35 duplicated lines were deleted and replaced with call sites. Behavior is unchanged: every render path passes through the exact same class list and icon size it did before — verified by inlining the same `color`/`Icon` values each branch already computed (no new logic, no new conditions), so this is a pure code relocation, not a rewrite.

**How to verify:** `cd apps/mesh && bunx tsc --noEmit` (clean). No existing test file covers this component (pure presentational JSX with no branching logic worth a regression test); manually diffing each branch's old vs. new className list confirms they're identical.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` in `apps/mesh`, and `bunx oxlint apps/mesh/src/web/components/agent-icon.tsx` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated AgentAvatar icon rendering by extracting a shared `IconAvatar` component that handles the colored background + centered icon used across the icon, fallback, and image-load-error paths. No behavior changes; same classes, colors, and icon sizes, with ~35 duplicated lines removed (net −4).

<sup>Written for commit 348ef33e68aeb151c99d59ffa9a32977733ee7f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

