### PR TITLE
refactor(ai-providers): use existing getPreset() helper instead of re-implementing the lookup

### DIFF
--- a/apps/mesh/src/web/views/settings/ai-providers/connect-provider-dialog.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/connect-provider-dialog.tsx
@@ -17,7 +17,7 @@ import type { ToolInput } from "@/tools/io-types";
 import { useAiProviders } from "@/web/hooks/collections/use-ai-providers";
 import { KEYS } from "@/web/lib/query-keys";
 import { track } from "@/web/lib/posthog-client";
-import { OPENAI_COMPATIBLE_PRESETS } from "@/web/utils/openai-compatible-presets";
+import { getPreset } from "@/web/utils/openai-compatible-presets";
 import { ProviderGrid, type ProviderSelection } from "./provider-grid";
 import {
   ConnectApiKeyForm,
@@ -279,9 +279,7 @@ export function ConnectProviderDialog({
     ? providers.find((p) => p.id === currentProviderId)
     : null;
   const currentPreset =
-    state.kind === "form" && state.presetId
-      ? OPENAI_COMPATIBLE_PRESETS.find((p) => p.id === state.presetId)
-      : null;
+    state.kind === "form" && state.presetId ? getPreset(state.presetId) : null;
   const currentTitle =
     currentPreset?.name ?? currentProvider?.name ?? "Connect an AI provider";
   const showBack = state.kind !== "grid" && state.kind !== "closed";
@@ -324,13 +322,7 @@ export function ConnectProviderDialog({
         {state.kind === "form" &&
           (state.providerId === "openai-compatible" ? (
             <ConnectOpenAICompatibleForm
-              preset={
-                state.presetId
-                  ? OPENAI_COMPATIBLE_PRESETS.find(
-                      (p) => p.id === state.presetId,
-                    )
-                  : undefined
-              }
+              preset={state.presetId ? getPreset(state.presetId) : undefined}
               onCancel={() => dispatch({ type: "back" })}
               onSuccess={() => {
                 invalidateKeys();

--- a/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
@@ -23,7 +23,7 @@ import {
 import { KEYS } from "@/web/lib/query-keys";
 import { useStudioTools } from "@/web/lib/studio-tools";
 import {
-  OPENAI_COMPATIBLE_PRESETS,
+  getPreset,
   type OpenAICompatiblePreset,
 } from "@/web/utils/openai-compatible-presets";
 
@@ -220,7 +220,7 @@ export function EditProviderKeyDialog({
 
   const preset: OpenAICompatiblePreset | undefined =
     provider.id === "openai-compatible" && providerKey.presetId
-      ? OPENAI_COMPATIBLE_PRESETS.find((p) => p.id === providerKey.presetId)
+      ? getPreset(providerKey.presetId)
       : undefined;
 
   const displayName = preset?.name ?? provider.name;

--- a/apps/mesh/src/web/views/settings/ai-providers/provider-grid.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/provider-grid.tsx
@@ -7,6 +7,7 @@ import {
   SettingsSection,
 } from "@/web/components/settings/settings-section";
 import {
+  getPreset,
   OPENAI_COMPATIBLE_PRESETS,
   type OpenAICompatiblePreset,
 } from "@/web/utils/openai-compatible-presets";
@@ -82,7 +83,7 @@ export function ProviderGrid({
       return ai - bi;
     });
   const openaiCompatible = providers.find((p) => p.id === "openai-compatible");
-  const openaiPreset = OPENAI_COMPATIBLE_PRESETS.find((p) => p.id === "openai");
+  const openaiPreset = getPreset("openai");
 
   const allCloudTiles = [
     ...cloud.map((provider) => (

--- a/apps/mesh/src/web/views/settings/ai-providers/provider-key-row.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/provider-key-row.tsx
@@ -24,7 +24,7 @@ import {
 import { useStudioTools } from "@/web/lib/studio-tools";
 import { KEYS } from "@/web/lib/query-keys";
 import {
-  OPENAI_COMPATIBLE_PRESETS,
+  getPreset,
   type OpenAICompatiblePreset,
 } from "@/web/utils/openai-compatible-presets";
 import { EditProviderKeyDialog } from "./edit-provider-dialog";
@@ -45,7 +45,7 @@ export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
 
   const preset: OpenAICompatiblePreset | undefined =
     isOpenAICompatible && providerKey.presetId
-      ? OPENAI_COMPATIBLE_PRESETS.find((p) => p.id === providerKey.presetId)
+      ? getPreset(providerKey.presetId)
       : undefined;
 
   const displayName = preset


### PR DESCRIPTION
**Source:** reduction found while auditing the AI-provider settings grid (`apps/mesh/src/web/views/settings/ai-providers/`).

`openai-compatible-presets.ts` already exports `getPreset(presetId)` as the canonical lookup — it's used correctly in `chat/select-model/decopilot.tsx` — but four sibling files in this same feature directory re-implement the identical `OPENAI_COMPATIBLE_PRESETS.find((p) => p.id === X)` logic instead of calling it. Consolidating onto the existing helper removes the duplication so future changes to preset lookup (e.g. normalization, logging) only need to happen in one place.

**Change:** `provider-grid.tsx`, `provider-key-row.tsx`, `edit-provider-dialog.tsx`, and `connect-provider-dialog.tsx` now call `getPreset(id)` instead of hand-rolling `.find()`. Net diff: +9/-16. Behavior is unchanged — `getPreset` is byte-for-byte the same lookup (`OPENAI_COMPATIBLE_PRESETS.find((p) => p.id === presetId)`, guarded against falsy ids), confirmed by reading its implementation in `openai-compatible-presets.ts:78-83`. `provider-grid.tsx` still imports `OPENAI_COMPATIBLE_PRESETS` directly for its one remaining `.filter()` use.

**Reviewer command:** `cd apps/mesh && bunx tsc --noEmit` (no type errors) — the diff is pure lookup substitution, no new logic, so this typecheck plus `rg getPreset apps/mesh/src/web` (showing the helper now has 6 call sites instead of 2) is the verification.

**Verified locally:** `bun run fmt`, `bunx tsc --noEmit` in `apps/mesh` (clean). No existing test covers these components (they're dialog/UI wiring, not pure logic) so none needed re-running; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace duplicated OpenAI-compatible preset lookups with the existing getPreset helper across the AI provider settings UI. Centralizes the logic and reduces maintenance; behavior is unchanged.

- Refactors
  - Updated connect-provider-dialog.tsx, edit-provider-dialog.tsx, provider-key-row.tsx, and provider-grid.tsx to use `getPreset(id)` instead of reimplementing `OPENAI_COMPATIBLE_PRESETS.find(...)`.
  - Kept `OPENAI_COMPATIBLE_PRESETS` in provider-grid.tsx for its existing filter use.

<sup>Written for commit 6de5e55c3fe88e8eb228660faaf61f2857633a4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

