### PR TITLE
fix(registry): add aria-label to icon-only actions menu triggers

### DIFF
--- a/apps/mesh/src/web/views/registry/registry-item-card.tsx
+++ b/apps/mesh/src/web/views/registry/registry-item-card.tsx
@@ -104,7 +104,12 @@ export function RegistryItemCard({
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 p-0"
+              aria-label={`Actions for ${item.title}`}
+            >
               <DotsVertical size={18} />
             </Button>
           </DropdownMenuTrigger>

--- a/apps/mesh/src/web/views/registry/registry-items-page.tsx
+++ b/apps/mesh/src/web/views/registry/registry-items-page.tsx
@@ -503,6 +503,7 @@ export default function RegistryItemsPage() {
                               variant="ghost"
                               size="sm"
                               className="h-8 w-8 p-0"
+                              aria-label={`Actions for ${item.title}`}
                             >
                               <DotsVertical size={18} />
                             </Button>


### PR DESCRIPTION
**Source:** debt cleanup in the registry UI area (accessibility gap, no linked issue).

**Why:** the per-item "⋮" `DropdownMenuTrigger` `Button` in `registry-item-card.tsx` (grid view) and `registry-items-page.tsx` (table view) has no visible text and no `aria-label` — a screen reader announces it with no name, so a keyboard/AT user in the registry catalog can't tell what the button does before opening it. The rest of the codebase already has an established fix for this exact shape (`aria-label={\`Actions for ${name}\`}` on icon-only `DropdownMenuTrigger` buttons — see `apps/mesh/src/web/layouts/library/cards.tsx` and `apps/mesh/src/web/components/file-picker/file-picker-dialog.tsx`); this PR brings the two registry views in line with that convention.

**Change:** added `aria-label={\`Actions for ${item.title}\`}` to the two icon-only dots-menu triggers. No behavior change, no visual change — purely an accessible-name fix. +2/-0 lines of real change (plus reflow from Biome).

**How to verify:** open the registry catalog (grid and table view) and inspect the "⋮" button in the accessibility tree / with a screen reader — it now announces "Actions for `<item title>`" instead of nothing.

**Checks run locally:** `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean, no type errors). No test file covers this (pure JSX attribute addition, not logic) — full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added aria-labels to the icon-only "⋮" actions buttons in the registry card and table so screen readers announce "Actions for <item title>". No visual or behavior changes; aligns with the existing "Actions for ${name}" pattern used elsewhere.

<sup>Written for commit dc16e23c1d2a3045b73faaab246b3e6e717d1107. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

