### PR TITLE
fix(registry): add aria-label to icon-only actions menu trigger in monitor panel

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -358,7 +358,12 @@ function ConnectionRow({
         <div className="flex items-center gap-1.5 shrink-0">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0"
+                aria-label={`Actions for ${title}`}
+              >
                 <DotsVertical size={16} />
               </Button>
             </DropdownMenuTrigger>


### PR DESCRIPTION
Follows #4903, which added `aria-label` to the icon-only dots-vertical actions-menu trigger in `registry-item-card.tsx` and `registry-items-page.tsx`. It missed the identical pattern in `monitor-connections-panel.tsx`'s `ConnectionRow`, so that trigger was still an unlabeled icon-only button for screen readers.

Why a maintainer wants this: it's the same accessibility gap #4903 just closed, left over in a sibling registry view — a one-line-pattern fix, not a new concern.

Change: add `aria-label={`Actions for ${title}`}` to the `DropdownMenuTrigger`'s `Button` (`title` was already in scope in this component), matching the exact wording/pattern from #4903. No behavior change — purely an accessibility attribute.

To verify: open the registry monitor connections panel and inspect the actions trigger button's accessible name (or grep `apps/mesh/src/web/views/registry` for `DotsVertical` — all three actions triggers now carry `aria-label`).

Locally ran `bun run fmt` and `cd apps/mesh && bunx tsc --noEmit`, both clean. No test needed — pure JSX attribute addition, no logic branch to cover.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an aria-label to the icon-only actions menu button in the registry monitor connections panel (ConnectionRow) to provide a clear accessible name for screen readers. Sets aria-label to "Actions for ${title}" on the trigger Button; no UI or behavior changes.

<sup>Written for commit 318fd291b7085990757d554b0018eac5db22659e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

