### PR TITLE
docs(selfhost): surface the interactive install skill in the quickstart

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/quickstart.mdx
@@ -20,6 +20,16 @@ folder has ready-made scripts, example values, and the full dependency map.
 | **Local — Kubernetes** | one `helm install` of the umbrella `selfhost/examples/k8s-local` | all bundled (dev Postgres + MinIO + NATS + sandbox) |
 | **Production — Kubernetes** | `helm install` [the chart](/en/studio/self-hosting/deploy/kubernetes) | external/managed Postgres + S3 + NATS + ClickHouse |
 
+<Callout type="tip">
+  **Prefer a guided install?** Add the interactive **self-host skill** to Claude Code — it walks you through the tiers below, asking what you have (dependencies managed or in-cluster, secrets, sandbox), filling the Helm values, validating with `helm template`, and installing.
+</Callout>
+
+Add it once (the repo is public), then tell Claude Code **"install Studio"**:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/decocms/studio/main/selfhost/skills/install.sh | sh
+```
+
 ### Option A: one-command local (CLI)
 
 ```bash

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/quickstart.mdx
@@ -20,6 +20,16 @@ do repositório tem scripts prontos, values de exemplo e o mapa completo de depe
 | **Local — Kubernetes** | um `helm install` do umbrella `selfhost/examples/k8s-local` | tudo embutido (Postgres + MinIO de dev + NATS + sandbox) |
 | **Produção — Kubernetes** | `helm install` [o chart](/pt-br/studio/self-hosting/deploy/kubernetes) | Postgres + S3 + NATS + ClickHouse externos/gerenciados |
 
+<Callout type="tip">
+  **Prefere uma instalação guiada?** Adicione a **skill de self-host** interativa ao Claude Code — ela te conduz pelos tiers abaixo, perguntando o que você tem (dependências gerenciadas ou no cluster, secrets, sandbox), preenchendo os values do Helm, validando com `helm template` e instalando.
+</Callout>
+
+Adicione uma vez (o repositório é público) e diga ao Claude Code **"install Studio"**:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/decocms/studio/main/selfhost/skills/install.sh | sh
+```
+
 ### Opção A: local com um comando (CLI)
 
 ```bash


### PR DESCRIPTION
Follow-up to #4890. The interactive self-host skill (`self-host-studio`) was only mentioned in passing in the Kubernetes reference, and its one-liner installer wasn't in the docs at all — so a reader on the Quickstart couldn't discover it.

Adds a short **guided-install** callout + the `curl … install.sh | sh` one-liner to the self-hosting **Quickstart** (en + pt-br), pointing readers at the skill that interviews them, fills the Helm values, validates, and installs.

Docs-only (`apps/docs/**`); auto-builds + deploys via `deploy-docs.yaml` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced the interactive self-host install skill in the self-hosting Quickstart (EN and PT‑BR) with a guided-install callout and the `curl -fsSL https://raw.githubusercontent.com/decocms/studio/main/selfhost/skills/install.sh | sh` one-liner. Readers can add the skill to Claude Code, answer a few prompts, auto-fill Helm values, validate with `helm template`, and install.

<sup>Written for commit f374cf11740f7e09b62b1efa9f897c2dba023acc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

