### PR TITLE
fix(registry): invalidate public list cache on registry item writes

### DIFF
--- a/apps/mesh/src/api/routes/registry/public-mcp-server.ts
+++ b/apps/mesh/src/api/routes/registry/public-mcp-server.ts
@@ -28,6 +28,15 @@ const publicListCache = createTtlLruCache<PrivateRegistryListResult>({
 });
 
 /**
+ * Clear the public list cache. Call this after any write to registry items
+ * (create/update/delete) so the unauthenticated public endpoint doesn't keep
+ * serving a deleted or newly-private item for up to LIST_CACHE_TTL_MS.
+ */
+export function invalidatePublicRegistryListCache(): void {
+  publicListCache.clear();
+}
+
+/**
  * Create public MCP tools for the registry
  * These tools only expose public items
  */

--- a/apps/mesh/src/tools/registry/bulk-create.ts
+++ b/apps/mesh/src/tools/registry/bulk-create.ts
@@ -1,5 +1,6 @@
 import { defineTool } from "@/core/define-tool";
 import { requireOrganization } from "@/core/studio-context";
+import { invalidatePublicRegistryListCache } from "@/api/routes/registry/public-mcp-server";
 import {
   RegistryBulkCreateInputSchema,
   RegistryBulkCreateOutputSchema,
@@ -34,6 +35,9 @@ export const REGISTRY_ITEM_BULK_CREATE = defineTool({
       }
     }
 
+    if (created > 0) {
+      invalidatePublicRegistryListCache();
+    }
     return { created, errors };
   },
 });

--- a/apps/mesh/src/tools/registry/create.ts
+++ b/apps/mesh/src/tools/registry/create.ts
@@ -1,5 +1,6 @@
 import { defineTool } from "@/core/define-tool";
 import { requireOrganization } from "@/core/studio-context";
+import { invalidatePublicRegistryListCache } from "@/api/routes/registry/public-mcp-server";
 import {
   RegistryCreateInputSchema,
   RegistryCreateOutputSchema,
@@ -20,6 +21,7 @@ export const REGISTRY_ITEM_CREATE = defineTool({
       organization_id: organization.id,
       created_by: ctx.auth.user?.id ?? null,
     });
+    invalidatePublicRegistryListCache();
     return { item };
   },
 });

--- a/apps/mesh/src/tools/registry/delete.ts
+++ b/apps/mesh/src/tools/registry/delete.ts
@@ -1,5 +1,6 @@
 import { defineTool } from "@/core/define-tool";
 import { requireOrganization } from "@/core/studio-context";
+import { invalidatePublicRegistryListCache } from "@/api/routes/registry/public-mcp-server";
 import {
   RegistryDeleteInputSchema,
   RegistryDeleteOutputSchema,
@@ -19,6 +20,7 @@ export const REGISTRY_ITEM_DELETE = defineTool({
     if (!item) {
       throw new Error(`Registry item not found: ${input.id}`);
     }
+    invalidatePublicRegistryListCache();
     return { item };
   },
 });

--- a/apps/mesh/src/tools/registry/update.ts
+++ b/apps/mesh/src/tools/registry/update.ts
@@ -1,5 +1,6 @@
 import { defineTool } from "@/core/define-tool";
 import { requireOrganization } from "@/core/studio-context";
+import { invalidatePublicRegistryListCache } from "@/api/routes/registry/public-mcp-server";
 import {
   RegistryUpdateInputSchema,
   RegistryUpdateOutputSchema,
@@ -20,6 +21,7 @@ export const REGISTRY_ITEM_UPDATE = defineTool({
       input.id,
       input.data,
     );
+    invalidatePublicRegistryListCache();
     return { item };
   },
 });


### PR DESCRIPTION
**Bug**: `apps/mesh/src/api/routes/registry/public-mcp-server.ts` caches `COLLECTION_REGISTRY_APP_LIST` results in a module-level `publicListCache` with a 1-hour TTL, keyed by `${orgId}:${JSON.stringify(query)}`. Nothing ever invalidated this cache. `REGISTRY_ITEM_CREATE`, `REGISTRY_ITEM_UPDATE`, `REGISTRY_ITEM_DELETE`, and `REGISTRY_ITEM_BULK_CREATE` all write straight to storage and return, with no call to clear the cache.

**Failure scenario**: an org admin deletes a registry item (e.g. a broken or malicious MCP server) or flips `is_public` off on an item — the unauthenticated public listing endpoint (used to browse/install MCP servers from the store) keeps serving the stale cached page for up to 60 minutes afterward, to any anonymous caller.

**Fix**: export `invalidatePublicRegistryListCache()` from `public-mcp-server.ts` (thin wrapper over the cache's already-tested `.clear()`) and call it from the four mutating tool handlers after a successful write.

**Verify**: `cd apps/mesh && bunx tsc --noEmit` (clean). The underlying `clear()` primitive is already covered by `apps/mesh/src/lib/ttl-lru-cache.test.ts` ("clear removes all entries"); this change is straight-line wiring with no new branches, so no new unit test was added — full CI covers the rest.

Net change: +19/-0, one concern (cache invalidation on write), four call sites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invalidate the public MCP server list cache after any registry item write to prevent stale results on the public listing. Public changes now appear immediately instead of after up to 60 minutes.

- **Bug Fixes**
  - Added `invalidatePublicRegistryListCache()` to clear the module-level public list cache.
  - Call it after successful create, update, delete, and bulk-create so deletions and privacy changes reflect instantly for anonymous users.

<sup>Written for commit 3535f30ad2fe9654bdf500e1c79cc4865838d665. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

