### PR TITLE
fix(monitoring): label KPI charts for screen readers

### DIFF
--- a/apps/mesh/src/web/components/monitoring/monitoring-stats-row.tsx
+++ b/apps/mesh/src/web/components/monitoring/monitoring-stats-row.tsx
@@ -212,6 +212,8 @@ export interface KPIChartProps {
   colorNum: number;
   chartHeight: string;
   variant?: "bar" | "area";
+  /** Accessible label describing what this chart shows, e.g. "Tool calls over time". */
+  ariaLabel: string;
 }
 
 function formatYAxisValue(value: number): string {
@@ -278,6 +280,7 @@ export function KPIChart({
   colorNum,
   chartHeight,
   variant = "bar",
+  ariaLabel,
 }: KPIChartProps) {
   const colorVar = `var(--chart-${colorNum})`;
   const gradientId = `kpi-gradient-${dataKey}-${colorNum}`;
@@ -288,6 +291,8 @@ export function KPIChart({
   if (variant === "area") {
     return (
       <ChartContainer
+        role="img"
+        aria-label={ariaLabel}
         className={cn(chartHeight, "w-full")}
         config={{ [dataKey]: { label: dataKey, color: colorVar } }}
       >
@@ -366,6 +371,8 @@ export function KPIChart({
 
   return (
     <ChartContainer
+      role="img"
+      aria-label={ariaLabel}
       className={cn(chartHeight, "w-full")}
       config={{ [dataKey]: { label: dataKey, color: colorVar } }}
     >

--- a/apps/mesh/src/web/routes/orgs/monitoring/overview.tsx
+++ b/apps/mesh/src/web/routes/orgs/monitoring/overview.tsx
@@ -391,6 +391,7 @@ export function OverviewTabContent({
           colorNum={1}
           chartHeight="h-[120px] md:h-[180px]"
           variant="area"
+          ariaLabel="Tool calls over time"
         />
         <ConnectionLeaderboardTable
           metrics={connectionBreakdown}
@@ -427,6 +428,7 @@ export function OverviewTabContent({
             dataKey={latencyMetric}
             colorNum={4}
             chartHeight="h-[120px] md:h-[180px]"
+            ariaLabel={`${latencyMetric === "avg" ? "Average" : "P95"} latency over time`}
           />
           <ConnectionLeaderboardTable
             metrics={connectionBreakdown}
@@ -445,6 +447,7 @@ export function OverviewTabContent({
             dataKey="errors"
             colorNum={3}
             chartHeight="h-[120px] md:h-[180px]"
+            ariaLabel="Errors over time"
           />
           {stats.totalErrors === 0 ? (
             <div className="flex items-center justify-center h-20 text-sm text-muted-foreground">
@@ -481,6 +484,7 @@ export function OverviewTabContent({
             dataKey="calls"
             colorNum={1}
             chartHeight="h-[80px] md:h-[120px]"
+            ariaLabel="AI calls over time"
           />
           <ModelLeaderboardTable models={llmModels} mode="calls" />
         </MonitoringMetricCard>
@@ -500,6 +504,7 @@ export function OverviewTabContent({
             dataKey="totalTokens"
             colorNum={2}
             chartHeight="h-[80px] md:h-[120px]"
+            ariaLabel="Total tokens over time"
           />
           <ModelLeaderboardTable models={llmModels} mode="tokens" />
         </MonitoringMetricCard>
@@ -520,6 +525,7 @@ export function OverviewTabContent({
             dataKey="costUsd"
             colorNum={5}
             chartHeight="h-[80px] md:h-[120px]"
+            ariaLabel="Cost over time"
           />
           {totalCostUsd > 0 ? (
             <ModelLeaderboardTable models={llmModels} mode="cost" />
@@ -548,6 +554,7 @@ export function OverviewTabContent({
             dataKey="avg"
             colorNum={4}
             chartHeight="h-[80px] md:h-[120px]"
+            ariaLabel="AI latency over time"
           />
           <ModelLeaderboardTable models={llmModels} mode="calls" />
         </MonitoringMetricCard>
@@ -561,6 +568,7 @@ export function OverviewTabContent({
             dataKey="errors"
             colorNum={3}
             chartHeight="h-[80px] md:h-[120px]"
+            ariaLabel="AI errors over time"
           />
           {llmStatsData.totalErrors === 0 ? (
             <div className="flex items-center justify-center h-20 text-sm text-muted-foreground">


### PR DESCRIPTION
The KPI charts in the org monitoring dashboard (Tool Calls, Latency, Errors, and the AI Usage row) render as bare recharts SVGs with no accessible name — a screen reader user landing on one gets either silence or a jumble of raw SVG element announcements, with no indication of what metric the chart shows.

Adds a required `ariaLabel` prop to `KPIChart` and forwards it to the underlying `ChartContainer` div as `role="img"` + `aria-label`, then supplies a concrete label at each of the 8 call sites in the monitoring overview tab (e.g. "Tool calls over time", "Average latency over time", "AI errors over time").

This directly improves accessibility of the monitoring widgets, the stated focus for this area, with no behavior change to the rendered chart itself — only an added ARIA label.

To verify: open a browser's accessibility tree / VoiceOver on the org monitoring page and confirm each chart card now announces a descriptive label instead of nothing.

Locally ran: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean, confirms the now-required `ariaLabel` prop is supplied everywhere `KPIChart` is used). Full CI validates lint and the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds accessible names to monitoring KPI charts so screen readers announce what each chart shows. No visual changes.

- **Bug Fixes**
  - Made `ariaLabel` required on `KPIChart` and forwarded as `role="img"` + `aria-label` on the container.
  - Labeled all 8 charts in the org monitoring overview (Tool calls, Latency avg/P95, Errors, AI usage: calls, tokens, cost, latency, errors).

<sup>Written for commit b2862b79c428c8be6ea2fbc082944489ac035c3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

