### PR TITLE
refactor(sections-editor): dedupe basename/extension helpers between image and file fields

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/file-field.tsx
@@ -15,6 +15,7 @@ import { useFilePickerUpload } from "@/web/hooks/use-file-picker";
 import { ClickToReplaceOverlay } from "./click-to-replace-overlay";
 import { extractUrl } from "./extract-url";
 import type { FieldProps } from "./field-props";
+import { basename, extension } from "./media-filename";
 import { MediaTransformControls } from "./media-transform-controls";
 
 function ExtBadge({ ext }: { ext: string }) {
@@ -24,21 +25,6 @@ function ExtBadge({ ext }: { ext: string }) {
       {ext}
     </span>
   );
-}
-
-function basename(url: string): string {
-  try {
-    const path = new URL(url).pathname;
-    return decodeURIComponent(path.split("/").pop() ?? url);
-  } catch {
-    return url.split("/").pop() ?? url;
-  }
-}
-
-function extension(filename: string): string {
-  const dot = filename.lastIndexOf(".");
-  if (dot < 0 || dot === filename.length - 1) return "";
-  return filename.slice(dot + 1).toLowerCase();
 }
 
 export function FileField({

--- a/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/image-field.tsx
@@ -15,22 +15,8 @@ import { useFilePickerUpload } from "@/web/hooks/use-file-picker";
 import { ClickToReplaceOverlay } from "./click-to-replace-overlay";
 import { extractUrl } from "./extract-url";
 import type { FieldProps } from "./field-props";
+import { basename, extension } from "./media-filename";
 import { MediaTransformControls } from "./media-transform-controls";
-
-function basename(url: string): string {
-  try {
-    const path = new URL(url).pathname;
-    return decodeURIComponent(path.split("/").pop() ?? url);
-  } catch {
-    return url.split("/").pop() ?? url;
-  }
-}
-
-function extension(filename: string): string {
-  const dot = filename.lastIndexOf(".");
-  if (dot < 0 || dot === filename.length - 1) return "";
-  return filename.slice(dot + 1).toLowerCase();
-}
 
 const ACCEPTED_IMAGE_TYPES = new Set([
   "image/png",

--- a/apps/mesh/src/web/components/sections-editor/fields/media-filename.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/media-filename.ts
@@ -1,0 +1,15 @@
+/** Shared filename helpers for ImageField/FileField previews (URL → display name/extension). */
+export function basename(url: string): string {
+  try {
+    const path = new URL(url).pathname;
+    return decodeURIComponent(path.split("/").pop() ?? url);
+  } catch {
+    return url.split("/").pop() ?? url;
+  }
+}
+
+export function extension(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  if (dot < 0 || dot === filename.length - 1) return "";
+  return filename.slice(dot + 1).toLowerCase();
+}


### PR DESCRIPTION
**Source:** C1 code reduction — found while auditing `sections-editor/fields` for duplication.

`ImageField` and `FileField` each defined byte-identical `basename()`/`extension()` helpers (URL → display filename / lowercase extension, used to render the preview file name and extension badge). Collapsed both into a new local module `fields/media-filename.ts` and import from there.

**Payoff:** one copy to maintain instead of two that can silently drift; net -30/+2 across the two field files (+13-line new shared module).

**Behavior:** unchanged — the extracted functions are copied verbatim, only their location changed, so `ImageField`/`FileField` render identically.

**Reviewer check:** `cd apps/mesh && bunx tsc --noEmit` (green). No existing unit test covers these pure UI-formatting helpers (no trust boundary — they only affect a displayed filename), so no test was added per the coverage-gate policy.

**Locally verified:** `bun run fmt` (no changes) and `bunx tsc --noEmit` in `apps/mesh` (green). Full CI (lint, full test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped filename helpers in the sections editor by extracting identical `basename` and `extension` logic from `ImageField` and `FileField` into a shared module. No UI or behavior changes.

- **Refactors**
  - Moved helpers to `apps/mesh/src/web/components/sections-editor/fields/media-filename.ts` and updated imports in `image-field.tsx` and `file-field.tsx`.
  - Reduces duplication and keeps filename/extension rendering consistent.

<sup>Written for commit 6d4f5b534e8aca22a964e90bb88d5635ac15cd5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

