### PR TITLE
fix(organization): widen ORGANIZATION_MEMBER_UPDATE_ROLE outputSchema to accept custom roles

### DIFF
--- a/apps/mesh/src/tools/organization/member-update-role.test.ts
+++ b/apps/mesh/src/tools/organization/member-update-role.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { ORGANIZATION_MEMBER_UPDATE_ROLE } from "./member-update-role";
+
+describe("ORGANIZATION_MEMBER_UPDATE_ROLE outputSchema", () => {
+  const base = {
+    id: "member-1",
+    organizationId: "org-1",
+    userId: "user-1",
+    createdAt: new Date().toISOString(),
+    user: { email: "a@b.com", name: "A" },
+  };
+
+  it("accepts a custom (non-builtin) role name", () => {
+    // Regression: the schema used to hardcode role to
+    // z.union([literal("admin"), literal("member"), literal("owner")]),
+    // which made the MCP SDK reject the tool's own successful result for
+    // any org-defined custom role (e.g. "editor") with an output
+    // validation error, even though the DB write already succeeded.
+    const result = ORGANIZATION_MEMBER_UPDATE_ROLE.outputSchema.safeParse({
+      ...base,
+      role: "editor",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a multi-role array, matching Better Auth's return shape", () => {
+    const result = ORGANIZATION_MEMBER_UPDATE_ROLE.outputSchema.safeParse({
+      ...base,
+      role: ["user", "admin"],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/mesh/src/tools/organization/member-update-role.ts
+++ b/apps/mesh/src/tools/organization/member-update-role.ts
@@ -31,11 +31,7 @@ export const ORGANIZATION_MEMBER_UPDATE_ROLE = defineTool({
     id: z.string(),
     organizationId: z.string(),
     userId: z.string(),
-    role: z.union([
-      z.literal("admin"),
-      z.literal("member"),
-      z.literal("owner"),
-    ]),
+    role: z.union([z.string(), z.array(z.string())]), // Better Auth can return string or array
     createdAt: z.string().datetime().describe("ISO 8601 timestamp"),
     user: z.object({
       email: z.string(),


### PR DESCRIPTION
Bug found while auditing `apps/mesh/src/auth/roles.ts` and its callers for hardening opportunities.

**The bug:** `ORGANIZATION_MEMBER_UPDATE_ROLE`'s `outputSchema.role` was hardcoded to `z.union([literal("admin"), literal("member"), literal("owner")])`. But organizations can define custom roles (see `org-role-detail.tsx` / the `organizationRole` storage table), and `canAssignRole` already permits an owner/admin assigning any non-owner custom role name — it's not restricted to the three built-ins.

**Why it matters:** the MCP SDK (`@modelcontextprotocol/sdk`'s `McpServer.validateToolOutput`) parses a tool's returned `structuredContent` against its declared `outputSchema` before returning the result to the caller, throwing an `McpError` on mismatch. So assigning a member to any custom role (e.g. `"editor"`) — or returning a multi-role array, which Better Auth's organization plugin supports — succeeds in the DB but the tool call itself throws an "Output validation error" back to the caller, even though the write already happened. This is misleading for any agent/client acting on the tool result (retries, error surfacing, etc).

The sibling tool `ORGANIZATION_MEMBER_ADD` (same `role` field, same underlying Better Auth data) already uses the correct permissive shape: `z.union([z.string(), z.array(z.string())])`. This PR just brings `ORGANIZATION_MEMBER_UPDATE_ROLE` in line with it.

**Fix:** widen `outputSchema.role` to `z.union([z.string(), z.array(z.string())])`, matching `ORGANIZATION_MEMBER_ADD`.

**Regression test:** `apps/mesh/src/tools/organization/member-update-role.test.ts` — parses the tool's `outputSchema` directly (pure Zod logic, no mocks/DB) against a custom-role string and a multi-role array, both of which fail against the old schema and pass against the fix.

**To verify:** `bun test apps/mesh/src/tools/organization/member-update-role.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` in `apps/mesh` (clean), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened ORGANIZATION_MEMBER_UPDATE_ROLE output schema to accept custom roles and arrays, preventing tool output validation errors. Aligns with the existing shape used by ORGANIZATION_MEMBER_ADD.

- **Bug Fixes**
  - `role` now accepts `string | string[]` to cover custom and multi-role returns.
  - Prevents `@modelcontextprotocol/sdk` output validation errors after successful writes.
  - Added regression test: validates custom role and multi-role array parsing.

<sup>Written for commit cddd58fc0c0597ac876be2130bd01535e93b6a42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

