### PR TITLE
refactor(chat): drop redundant latency guard duplicated across brand-context tool parts

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/brand-context.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/brand-context.tsx
@@ -261,11 +261,7 @@ export function BrandContextPart({ part, latency }: BrandContextPartProps) {
         title="Brand extraction failed"
         summary={result?.error ?? "Unknown error"}
         state="error"
-        trailing={
-          latency != null && latency > 0 ? (
-            <LatencyLabel latency={latency} />
-          ) : undefined
-        }
+        trailing={<LatencyLabel latency={latency} />}
       />
     );
   }
@@ -277,11 +273,7 @@ export function BrandContextPart({ part, latency }: BrandContextPartProps) {
         title={result?.name ? `Brand set: ${result.name}` : "Brand context set"}
         summary={result?.domain}
         state="idle"
-        trailing={
-          latency != null && latency > 0 ? (
-            <LatencyLabel latency={latency} />
-          ) : undefined
-        }
+        trailing={<LatencyLabel latency={latency} />}
       />
       <BrandCard
         logo={result?.logo}
@@ -341,11 +333,7 @@ export function BrandContextGetPart({
         icon={<Palette />}
         title="Couldn't load brand"
         state="error"
-        trailing={
-          latency != null && latency > 0 ? (
-            <LatencyLabel latency={latency} />
-          ) : undefined
-        }
+        trailing={<LatencyLabel latency={latency} />}
       />
     );
   }
@@ -357,11 +345,7 @@ export function BrandContextGetPart({
         title={result.name ? `Brand · ${result.name}` : "Brand"}
         summary={result.domain}
         state="idle"
-        trailing={
-          latency != null && latency > 0 ? (
-            <LatencyLabel latency={latency} />
-          ) : undefined
-        }
+        trailing={<LatencyLabel latency={latency} />}
       />
       <BrandCard
         logo={result.logo}
@@ -413,11 +397,7 @@ export function BrandContextListPart({
         icon={<Palette />}
         title="Couldn't load brands"
         state="error"
-        trailing={
-          latency != null && latency > 0 ? (
-            <LatencyLabel latency={latency} />
-          ) : undefined
-        }
+        trailing={<LatencyLabel latency={latency} />}
       />
     );
   }
@@ -429,11 +409,7 @@ export function BrandContextListPart({
         title="No brands yet"
         summary="The organization hasn't set up any brand context."
         state="idle"
-        trailing={
-          latency != null && latency > 0 ? (
-            <LatencyLabel latency={latency} />
-          ) : undefined
-        }
+        trailing={<LatencyLabel latency={latency} />}
       />
     );
   }
@@ -444,11 +420,7 @@ export function BrandContextListPart({
         icon={<Palette className="text-fuchsia-500" />}
         title={items.length === 1 ? "1 brand" : `${items.length} brands`}
         state="idle"
-        trailing={
-          latency != null && latency > 0 ? (
-            <LatencyLabel latency={latency} />
-          ) : undefined
-        }
+        trailing={<LatencyLabel latency={latency} />}
       />
       <div className="mt-2 flex flex-col gap-1.5">
         {items.map((brand) => {


### PR DESCRIPTION
This is a bounded code-reduction, not tied to an issue.

Every `trailing` prop in `brand-context.tsx` (7 call sites across `BrandContextPart`, `BrandContextGetPart`, `BrandContextListPart`) wrapped `<LatencyLabel latency={latency} />` in an external `latency != null && latency > 0 ? (...) : undefined` check. `LatencyLabel` (in `common.tsx`) already has the exact same guard internally (`if (latency == null || latency <= 0) return null;`), so the outer conditional was dead duplicate logic repeated 7 times.

Why a maintainer wants this: -28/+7 lines, removes copy-pasted dead-guard boilerplate that every future tool-call-part edit in this file would have had to keep copying.

Behavior is unchanged: `LatencyLabel` returns `null` for the same inputs (`latency == null` or `latency <= 0`) that previously produced `undefined` via the outer ternary — React renders neither, so the DOM output is identical in every case.

How a reviewer can confirm: read `apps/mesh/src/web/components/chat/message/parts/tool-call-part/common.tsx` lines 261-268 (`LatencyLabel`) alongside the diff — the guard condition is byte-identical.

Locally verified: `bun run fmt` (no changes needed) and `cd apps/mesh && bunx tsc --noEmit` (clean). No test file covers this component; full CI runs the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant latency checks around `LatencyLabel` across `BrandContextPart`, `BrandContextGetPart`, and `BrandContextListPart`. We now always render `LatencyLabel` and rely on its internal guard, preserving behavior and cutting duplicate code (-35/+7).

<sup>Written for commit c589ca276dee0dc6a542be8ca3debb99f6f49548. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

