### PR TITLE
refactor(role-color): remove dead null-coalesce fallback in getRoleColor

### DIFF
--- a/apps/mesh/src/web/lib/role-color.ts
+++ b/apps/mesh/src/web/lib/role-color.ts
@@ -21,7 +21,7 @@ export function getRoleColor(roleName: string): string {
     hash = hash & hash;
   }
   const index = Math.abs(hash) % ROLE_COLORS.length;
-  return ROLE_COLORS[index] ?? ROLE_COLORS[0];
+  return ROLE_COLORS[index]!;
 }
 
 export function getRoleDotColor(role: string, isBuiltin: boolean): string {


### PR DESCRIPTION
## Summary
Removed unreachable null-coalesce operator from `getRoleColor`. The modulo arithmetic `Math.abs(hash) % ROLE_COLORS.length` always returns an in-bounds index, making the `?? ROLE_COLORS[0]` fallback dead code.

## Why
The null-coalesce operator can never trigger because `a % b` always returns a value in `[0, b)`. Replaced with non-null assertion (`!`) to satisfy TypeScript's bounds checking.

## Verification
- `bun test apps/mesh/src/web/lib/role-color.test.ts`: ✓ all 3 tests pass
- Behavior unchanged: the fallback was unreachable, so removing it has no effect
- `-1 / +0` net lines deleted

## Test command
```bash
bun test apps/mesh/src/web/lib/role-color.test.ts
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unreachable null-coalesce fallback in `getRoleColor` by replacing `?? ROLE_COLORS[0]` with a non-null assertion. The index from `Math.abs(hash) % ROLE_COLORS.length` is always valid, so behavior is unchanged.

<sup>Written for commit 642d1fd4f7d0095387c12a4767b55b8b1c2c6f53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

