### PR TITLE
refactor(monaco-editor): remove dead foldOnMount prop and containerRef

### DIFF
--- a/apps/mesh/src/web/components/monaco-editor.tsx
+++ b/apps/mesh/src/web/components/monaco-editor.tsx
@@ -22,7 +22,6 @@ interface MonacoCodeEditorProps {
   readOnly?: boolean;
   height?: string | number;
   language?: "typescript" | "json" | "shell";
-  foldOnMount?: boolean;
   // Suppresses TS error squiggles. Useful when displaying snippets
   // (e.g. top-level `await`) that aren't valid programs on their own.
   disableDiagnostics?: boolean;
@@ -164,12 +163,10 @@ function InternalMonacoEditor({
   readOnly = false,
   height = 300,
   language = "typescript",
-  foldOnMount = false,
   disableDiagnostics = false,
   mountKey = 0,
 }: InternalEditorProps) {
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
   const onSaveRef = useRef(onSave);
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
   onSaveRef.current = onSave;
@@ -244,13 +241,6 @@ function InternalMonacoEditor({
   const handleEditorDidMount: OnMount = async (editor, monaco) => {
     editorRef.current = editor;
 
-    // Fold first level regions if requested, then reveal
-    if (foldOnMount && containerRef.current) {
-      containerRef.current.style.visibility = "hidden";
-      await editor.getAction("editor.foldLevel2")?.run();
-      containerRef.current.style.visibility = "visible";
-    }
-
     // Configure TypeScript AFTER mount (beforeMount was causing value not to display)
     if (language === "typescript") {
       monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
@@ -287,7 +277,7 @@ function InternalMonacoEditor({
   };
 
   return (
-    <div ref={containerRef} className="h-full">
+    <div className="h-full">
       <Editor
         key={editorKey}
         height={height}


### PR DESCRIPTION
## Summary
Removed unused `foldOnMount` prop and its associated `containerRef` that were never exercised. No caller passes `foldOnMount={true}`, making the folding logic and container ref dead code.

## Why this matters
- **-10 lines, +0 additions**: Net reduction of unused complexity
- The `foldOnMount` prop defaults to `false` and is never set to `true` anywhere in the codebase (verified via `rg`)
- Simplifies the component by removing a ref-management pattern that only existed to support an unused feature

## Verification
- **Behavior**: Behavior-preserving; no callers use the removed feature
- **Type checking**: `bunx tsc --noEmit` in apps/mesh/ passes
- **Formatting**: `bun run fmt` run and applied
- **Dead code proof**: `rg foldOnMount` returns zero non-definition matches; no code passes this prop

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead `foldOnMount` prop and its `containerRef` from the Monaco editor component to simplify the code. No callers used `foldOnMount`, so behavior is unchanged.

<sup>Written for commit cfd99861ea03918e1bb55fbcb1cc9d9a7bc81487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

