### PR TITLE
fix(chat): clear stale main-panel tab when opening an org file on mobile

### DIFF
--- a/apps/mesh/src/web/components/chat/org-file-open-context.test.ts
+++ b/apps/mesh/src/web/components/chat/org-file-open-context.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { nextOrgFileOpenSearch } from "./org-file-open-context";
+
+describe("nextOrgFileOpenSearch", () => {
+  it("desktop: sets `main` and drops a stale `preview`", () => {
+    expect(
+      nextOrgFileOpenSearch({ preview: "home/old.md" }, "home/new.md", false),
+    ).toEqual({ main: "library-file:home%2Fnew.md" });
+  });
+
+  it("mobile: sets `preview` and drops a stale `main`", () => {
+    expect(
+      nextOrgFileOpenSearch(
+        { main: "library-file:home/old.md" },
+        "home/new.md",
+        true,
+      ),
+    ).toEqual({ preview: "home/new.md" });
+  });
+
+  it("preserves unrelated search params", () => {
+    expect(
+      nextOrgFileOpenSearch({ virtualmcpid: "abc" }, "home/new.md", true),
+    ).toEqual({ virtualmcpid: "abc", preview: "home/new.md" });
+  });
+});

--- a/apps/mesh/src/web/components/chat/org-file-open-context.tsx
+++ b/apps/mesh/src/web/components/chat/org-file-open-context.tsx
@@ -28,6 +28,25 @@ export interface OrgFileOpenValue {
 
 export const OrgFileOpenContext = createContext<OrgFileOpenValue | null>(null);
 
+/**
+ * Next `search` state for opening `browsePath`: mobile gets the dialog overlay
+ * (`?preview=`), desktop gets the main-panel side tab (`?main=`). Each branch
+ * drops the OTHER model's stale param so a leftover from before a viewport
+ * resize can never resolve alongside the freshly-opened file.
+ */
+export function nextOrgFileOpenSearch(
+  prev: Record<string, unknown>,
+  browsePath: string,
+  isMobile: boolean,
+): Record<string, unknown> {
+  if (isMobile) {
+    const { main: _omit, ...rest } = prev;
+    return { ...rest, preview: browsePath };
+  }
+  const { preview: _omit, ...rest } = prev;
+  return { ...rest, main: formatLibraryFileTabId(browsePath) };
+}
+
 export function OrgFileOpenProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
@@ -42,13 +61,8 @@ export function OrgFileOpenProvider({ children }: { children: ReactNode }) {
   const open = (browsePath: string) =>
     navigate({
       to: ".",
-      search: (prev: Record<string, unknown>) => {
-        if (isMobile) return { ...prev, preview: browsePath };
-        // Desktop: side tab. Drop any stale `?preview=` so the two models
-        // never both resolve to a file at once.
-        const { preview: _omit, ...rest } = prev;
-        return { ...rest, main: formatLibraryFileTabId(browsePath) };
-      },
+      search: (prev: Record<string, unknown>) =>
+        nextOrgFileOpenSearch(prev, browsePath, isMobile),
     });
 
   return (


### PR DESCRIPTION
Bug found while auditing `org-file-open-context.tsx` (recently touched by #4891, `fix(chat): linkify org/output & org/upload file paths`).

`OrgFileOpenProvider.open()` swaps between two mutually-exclusive URL-param models for showing an opened org file: desktop uses `?main=<tab>` (a main-panel side tab), mobile uses `?preview=<path>` (a dialog overlay). The desktop branch already dropped a stale `?preview=` so the two models could never both resolve to a file at once — but the mobile branch never dropped a stale `?main=`. If a user had a file open as a desktop side tab, shrank the window to the mobile breakpoint, and then clicked another org-file reference in chat, the resulting URL kept both `?main=<old tab>` and `?preview=<new file>`. Since the mobile layout ignores `?main=` entirely, nothing looked wrong immediately — but resizing back to desktop without any further navigation would resurface the stale old tab, silently dropping the file the user had actually just clicked.

Fix: extracted the search-transition into a pure `nextOrgFileOpenSearch(prev, browsePath, isMobile)` helper and made it symmetric — the mobile branch now also drops the stale `main` key, mirroring what desktop already did for `preview`.

Failure scenario: desktop with `?main=library-file:A` open → resize to mobile → click an org-file reference for B in chat (`?preview=B` added, `?main=A` left stale) → resize back to desktop → tab A reappears instead of B.

Regression test: `apps/mesh/src/web/components/chat/org-file-open-context.test.ts` — asserts both directions drop the other model's stale param and that unrelated search params are preserved.

Reviewer check: `bun test apps/mesh/src/web/components/chat/org-file-open-context.test.ts`

Locally ran: `bun test apps/mesh/src/web/components/chat/org-file-open-context.test.ts` and `apps/mesh/src/web/components/chat/org-file-ref.test.ts` (both green), `cd apps/mesh && bunx tsc --noEmit` (clean), `bun run fmt`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a mobile/desktop URL-param mismatch when opening org files. Mobile now clears a stale `?main=` so the correct file stays open after resizing back to desktop.

- **Bug Fixes**
  - Added `nextOrgFileOpenSearch(prev, path, isMobile)` to unify URL param updates.
  - Mobile sets `preview` and drops stale `main`; desktop sets `main` and drops stale `preview`.
  - Preserves unrelated search params.
  - Added unit tests for both directions.

<sup>Written for commit 2c0fb3ac3742465802007de30b814f7aea07be95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

