### PR TITLE
fix(chat): add aria-label to icon-only mic and send/stop buttons

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -701,6 +701,11 @@ export function ChatInput({
                               ? "Microphone access denied — click to try again"
                               : "Voice input"
                           }
+                          aria-label={
+                            voice.status === "permission-denied"
+                              ? "Microphone access denied — click to try again"
+                              : "Voice input"
+                          }
                         >
                           <Microphone01 size={18} />
                         </Button>
@@ -732,6 +737,13 @@ export function ChatInput({
                               ? "Stop generating"
                               : "Cancel run"
                             : "Send message (Enter)"
+                        }
+                        aria-label={
+                          composerAction === "stop"
+                            ? isStreaming
+                              ? "Stop generating"
+                              : "Cancel run"
+                            : "Send message"
                         }
                       >
                         {showStopOrCancel ? (


### PR DESCRIPTION
Follows the same pattern already merged in #4904 and #4907 (icon-only actions need an aria-label, not just title).

The chat composer's microphone button and send/stop button are icon-only (no visible text) and only had a `title` attribute. `title` is not a reliable accessible name for screen readers on a button — `aria-label` is the correct semantic attribute, and other icon-only buttons in this same file (voice cancel/confirm) already use it correctly.

Fix: add `aria-label` mirroring the existing `title` text on both buttons, covering all their state variants (recording/permission-denied for mic; send/stop/cancel for the submit button).

To verify: inspect the rendered composer with a screen reader or the accessibility tree — both buttons should now expose a non-empty accessible name in every state.

Locally ran: `bun run fmt` (clean) and `bunx tsc --noEmit` in apps/mesh (clean, no new errors). Full CI validates lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-labels to the icon-only mic and send/stop buttons in the chat composer so screen readers announce them correctly in all states. Mirrors the existing title text for permission-denied/voice input and send/stop/cancel variants.

<sup>Written for commit 31cfe5bf7bca951bdb60e9d552c0829ed244200e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

