### PR TITLE
fix(preview): guard cross-origin iframe read and surface clipboard feedback in Copy Current URL

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -742,12 +742,24 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     setPreviewDeviceSize(DEVICE_CYCLE[(idx + 1) % DEVICE_CYCLE.length]!);
   };
 
-  const handleCopyUrl = () => {
-    const url =
-      previewIframeRef.current?.contentWindow?.location?.href ??
-      iframeSrc ??
-      previewUrl;
-    if (url) navigator.clipboard.writeText(url);
+  const handleCopyUrl = async () => {
+    // The iframe's live location is cross-origin (sandbox preview domain), so
+    // reading `.location.href` throws — same reason the onLoad handler below
+    // guards the analogous `.pathname` read.
+    let liveUrl: string | null = null;
+    try {
+      liveUrl = previewIframeRef.current?.contentWindow?.location?.href ?? null;
+    } catch {
+      // Cross-origin — fall back below.
+    }
+    const url = liveUrl ?? iframeSrc ?? previewUrl;
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success("URL copied to clipboard");
+    } catch {
+      toast.error("Failed to copy URL");
+    }
   };
 
   const previewLabel = (() => {


### PR DESCRIPTION
**Source:** bug found while auditing the sandbox preview toolbar (`apps/mesh/src/web/components/sandbox/preview/preview.tsx`), not tied to an open issue.

**Why a maintainer wants this:** the "Copy Current URL" dropdown item read `previewIframeRef.current?.contentWindow?.location?.href` with no try/catch. Since the sandbox dev-server preview iframe is served from a different origin than the Studio app, reading any property off a cross-origin `Location` object throws a `SecurityError` synchronously — optional chaining only guards against `null`/`undefined`, not a thrown exception. This exact risk is already known and handled elsewhere in the *same file*: the iframe's `onLoad` handler reads the analogous `.pathname` property wrapped in a try/catch with the comment `// Cross-origin — can't read, keep current value`. `handleCopyUrl` skipped that guard, so clicking the action while viewing a cross-origin preview threw uncaught instead of falling back to `iframeSrc`/`previewUrl`. Separately, the clipboard write itself had no success/failure feedback — every other copy-to-clipboard action in the codebase (`file-explorer.tsx`, `virtual-mcp-share-modal.tsx`, `monitoring/types.tsx`, etc.) shows a toast; this one showed nothing even on success, and a `clipboard.writeText` rejection (e.g. permissions) would surface as an unhandled promise rejection.

**Failure scenario:** viewing any sandbox preview (which runs on its own domain) and clicking the toolbar's "⋯" → "Copy Current URL" throws an uncaught `SecurityError` in the click handler, aborting the fallback chain, and the user gets no confirmation the URL was copied (or silent failure if the clipboard write itself rejects).

**Fix:** wrap the `contentWindow.location.href` read in try/catch (falling back to `iframeSrc ?? previewUrl` on failure, mirroring the existing `.pathname` pattern in this file), and add `toast.success`/`toast.error` around the clipboard write to match the rest of the codebase's convention.

**Verify:** open a sandbox preview whose dev server is on a different origin, click the toolbar overflow menu → "Copy Current URL" — it should copy successfully (or show a failure toast) instead of throwing.

**Checks run locally:** `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean, exit 0). No unit test added — the fix guards a browser cross-origin `Location` read, which requires DOM/cross-origin simulation beyond the pure-logic unit tier this repo restricts `bun test` to; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Copy Current URL" action in the sandbox preview toolbar so it no longer throws on cross-origin iframes and provides clear clipboard feedback. Safely falls back to `iframeSrc` or `previewUrl` when the live URL can't be read.

- **Bug Fixes**
  - Wrap cross-origin `contentWindow.location.href` access in try/catch and fall back to `iframeSrc` → `previewUrl`.
  - Add `toast.success`/`toast.error` around `navigator.clipboard.writeText` to show copy success or failure.

<sup>Written for commit 65aaa56dd92d9ad0db8452b46e46e9e16801b20a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

