### PR TITLE
fix(auth): recognize a comma-joined multi-role caller in canAssignRole

### DIFF
--- a/apps/mesh/src/auth/roles.test.ts
+++ b/apps/mesh/src/auth/roles.test.ts
@@ -56,4 +56,16 @@ describe("canAssignRole", () => {
     expect(canAssignRole("admin", [])).toBe(false);
     expect(canAssignRole("owner", [])).toBe(false);
   });
+
+  // Better Auth's `parseRoles` joins an assigned role array with "," before
+  // storing `member.role`, so a multi-role owner/admin's OWN role — the
+  // `callerRole` here — can arrive as that same comma-joined string, not just
+  // as a lone "owner"/"admin". A caller check that only does `=== "owner"`
+  // would wrongly deny a legitimate multi-role owner/admin.
+  it("recognizes a multi-role caller from a comma-joined callerRole", () => {
+    expect(canAssignRole("owner,billing-manager", "admin")).toBe(true);
+    expect(canAssignRole("admin,billing-manager", "user")).toBe(true);
+    expect(canAssignRole("admin,billing-manager", "owner")).toBe(false);
+    expect(canAssignRole("billing-manager,user", "admin")).toBe(false);
+  });
 });

--- a/apps/mesh/src/auth/roles.ts
+++ b/apps/mesh/src/auth/roles.ts
@@ -30,6 +30,11 @@ export const ADMIN_ROLES: BuiltinRole[] = ["owner", "admin"];
  * multi-role members (stored comma-joined), so every entry must be checked —
  * validating only the first element would let an admin smuggle "owner" in
  * alongside an allowed role (e.g. `["user", "owner"]`).
+ *
+ * `callerRole` can ALSO be that same comma-joined string (Better Auth's
+ * `parseRoles` joins an assigned role array before storing `member.role`), so
+ * a multi-role owner/admin — e.g. `"owner,billing-manager"` — must still be
+ * recognized. A plain `=== "owner"` check would silently deny them.
  */
 export function canAssignRole(
   callerRole: string | undefined,
@@ -37,7 +42,10 @@ export function canAssignRole(
 ): boolean {
   const targetRoles = Array.isArray(targetRole) ? targetRole : [targetRole];
   if (targetRoles.length === 0) return false;
-  if (callerRole === "owner") return true;
-  if (callerRole === "admin") return targetRoles.every((r) => r !== "owner");
+  const callerRoles = callerRole ? callerRole.split(",") : [];
+  if (callerRoles.includes("owner")) return true;
+  if (callerRoles.includes("admin")) {
+    return targetRoles.every((r) => r !== "owner");
+  }
   return false;
 }


### PR DESCRIPTION
**Source:** bug found while hardening `apps/mesh/src/auth/roles.ts` (Auth & role hardening sweep).

**Why a maintainer wants this:** Better Auth's organization plugin's `parseRoles` joins an assigned role array with `","` before storing `member.role` (confirmed in the installed `@decocms/better-auth` dist: `Array.isArray(roles) ? roles.join(",") : roles`, used by both `addMember` and `updateMemberRole`). `canAssignRole`'s caller-role check only handled `callerRole === "owner"` / `=== "admin"`, so a legitimate multi-role owner/admin — e.g. one whose `member.role` is stored as `"owner,billing-manager"` — was silently denied ANY role assignment, even though they hold owner/admin. This is the same multi-role-caller pattern the codebase already handles correctly elsewhere (see the comma-split fallback in `builtin-role-permission.ts`), just missing here.

**Failure scenario:** An org owner who also carries an extra custom role (assigned via `ORGANIZATION_MEMBER_UPDATE_ROLE`/`ORGANIZATION_MEMBER_ADD` with a multi-entry `role` array, which Better Auth stores comma-joined) calls `ORGANIZATION_MEMBER_UPDATE_ROLE` to promote another member. `ctx.auth.user?.role` for that owner is `"owner,billing-manager"`, which fails the old `=== "owner"` check, so `canAssignRole` incorrectly returns `false` and the tool throws "Insufficient privileges" for an actual owner.

**Fix:** split `callerRole` on `","` and check membership (`includes("owner")` / `includes("admin")`) instead of exact equality — mirrors the existing multi-role handling pattern in `builtin-role-permission.ts`. Added a regression test (`recognizes a multi-role caller from a comma-joined callerRole`) covering multi-role owner, multi-role admin, an admin-with-extra-role still denied `owner`, and a caller with no owner/admin component still denied.

**Reviewer command:** `bun test apps/mesh/src/auth/roles.test.ts`

**Local checks run:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), `bun test apps/mesh/src/auth/roles.test.ts` (9 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes role assignment for multi‑role owners/admins when `callerRole` is comma-joined by `@decocms/better-auth` (e.g. `owner,billing-manager`). Owners/admins are now correctly recognized and no longer blocked.

- **Bug Fixes**
  - Update `canAssignRole` to split `callerRole` on commas and check for `owner`/`admin`.
  - Preserve admin rules: admin can’t assign `owner`.
  - Add tests for comma-joined multi‑role callers.

<sup>Written for commit c3f696562dcefb64e340626d33a6cd10389b033d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

