### PR TITLE
fix(task-board): New chat prefills a task ref chip instead of auto-sending

### DIFF
--- a/apps/mesh/src/web/components/chat/derive-parts.test.ts
+++ b/apps/mesh/src/web/components/chat/derive-parts.test.ts
@@ -142,3 +142,65 @@ describe("derivePartsFromTiptapDoc — skill mentions", () => {
     expect(text).toContain("Say hello");
   });
 });
+
+describe("derivePartsFromTiptapDoc — task ref mention", () => {
+  /** A doc with a task @ref chip, optionally followed by the user's own text. */
+  function taskDoc(
+    metadata: { title?: string; description?: string | null },
+    trailing = " ",
+  ) {
+    return {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "mention",
+              attrs: {
+                char: "@",
+                kind: "task",
+                id: "task-1",
+                name: metadata.title,
+                metadata,
+              },
+            },
+            { type: "text", text: trailing },
+          ],
+        },
+      ],
+    };
+  }
+
+  test("expands to title + description, not the '@name' label", () => {
+    const text = joinText(
+      taskDoc({ title: "Add SRI to scripts", description: "Risk of XSS." }),
+    );
+    expect(text).toContain("Add SRI to scripts");
+    expect(text).toContain("Risk of XSS.");
+    // The chip must NOT leak its "@..." label into the message text.
+    expect(text).not.toContain("@Add SRI to scripts");
+  });
+
+  test("omits the description block when there is none", () => {
+    const text = joinText(
+      taskDoc({ title: "Just a title", description: null }),
+    );
+    expect(text).toBe("Just a title");
+  });
+
+  test("keeps the user's own words as a separate part", () => {
+    const parts = derivePartsFromTiptapDoc(
+      taskDoc(
+        { title: "Fix login", description: "Broken on Safari." },
+        " please prioritize",
+      ) as Parameters<typeof derivePartsFromTiptapDoc>[0],
+    );
+    const texts = parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text);
+    // User text is unshifted to the front; the task body is its own part.
+    expect(texts).toContain("please prioritize");
+    expect(texts.some((t) => t.includes("Broken on Safari."))).toBe(true);
+  });
+});

--- a/apps/mesh/src/web/components/chat/derive-parts.ts
+++ b/apps/mesh/src/web/components/chat/derive-parts.ts
@@ -238,6 +238,22 @@ export function derivePartsFromTiptapDoc(
       const char = (node.attrs.char as string | undefined) ?? "/";
       const mentionName = `${char}${node.attrs.name}`;
 
+      if (node.attrs.kind === "task") {
+        // Task ref chip: expand to the task's title + description as its own
+        // text part. Kept out of `inlineText` so the user's own words (if any)
+        // read as the message and the task is context alongside them.
+        const meta = node.attrs.metadata as {
+          title?: string;
+          description?: string | null;
+        } | null;
+        const title = meta?.title ?? (node.attrs.name as string) ?? "";
+        const body = [title, meta?.description?.trim()]
+          .filter(Boolean)
+          .join("\n\n");
+        if (body) parts.push({ type: "text", text: body });
+        return;
+      }
+
       // Add label to inline text
       inlineText += mentionName;
 

--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
@@ -22,8 +22,9 @@ export interface MentionAttrs<T = unknown> {
   metadata: T;
   /** Character that triggered the mention ("/" prompts+resources, "@" agents) */
   char?: "/" | "@";
-  /** Discriminator for "/" mentions; "@" mentions are always agents. */
-  kind?: "prompt" | "resource" | "skill";
+  /** Discriminator for "/" mentions ("@" mentions are agents), plus "task" for
+   * a task-board reference chip (char "@", metadata carries title/description). */
+  kind?: "prompt" | "resource" | "skill" | "task";
   /** Argument values the user typed in PromptArgsDialog. Only meaningful for prompt mentions. */
   args?: Record<string, string>;
 }
@@ -90,6 +91,7 @@ function MentionNodeView(props: NodeViewProps) {
   const { name, char, kind, id, args } = node.attrs as MentionAttrs;
 
   const isSelected = selected && view.editable;
+  const isTask = kind === "task";
   const isAgent = char === "@";
   // Clickable when editable AND it's a "/" mention that's either a known
   // prompt or a legacy chip without `kind` (we'll re-verify in the handler).
@@ -129,11 +131,21 @@ function MentionNodeView(props: NodeViewProps) {
           : "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
         isSelected && "outline-2 outline-blue-300 outline-offset-0",
         isClickable && "hover:brightness-95",
-        "capitalize",
+        // Task titles are full sentences — render them verbatim (no title-case)
+        // and clamp the width so a long title stays a compact chip.
+        !isTask && "capitalize",
       )}
     >
       {char}
-      {name ? toTitleCase(name) : ""}
+      {isTask ? (
+        <span className="inline-block max-w-[220px] truncate align-bottom">
+          {name ?? ""}
+        </span>
+      ) : name ? (
+        toTitleCase(name)
+      ) : (
+        ""
+      )}
     </NodeViewWrapper>
   );
 }

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -65,7 +65,9 @@ import { useFlipLanes } from "./use-flip-lanes";
 import { usePanelActions } from "@/web/layouts/shell-layout";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useThreadActions } from "@/web/components/chat/store/hooks";
-import { writeStoredAutosend } from "@/web/lib/autosend";
+import { writeChatDraft } from "@/web/lib/chat-draft";
+import { createMentionDoc } from "@/web/components/chat/tiptap/mention";
+import type { TiptapDoc } from "@/web/components/chat/types";
 import { useReportsOnly } from "@/web/hooks/use-organization-settings";
 
 // Warm the chat chunk so opening a task's activity doesn't cold-load it (flash).
@@ -242,17 +244,28 @@ export function TaskBoardPage() {
   const startChatFromTask = async (task: TaskBoardItem) => {
     const newId = crypto.randomUUID();
     const agentId = getWellKnownDecopilotVirtualMCP(org.id).id;
-    const context = [task.title, task.description?.trim()]
-      .filter(Boolean)
-      .join("\n\n");
-    writeStoredAutosend(sessionStorage, locator, newId, {
-      tiptapDoc: {
-        type: "doc",
-        content: [
-          { type: "paragraph", content: [{ type: "text", text: context }] },
-        ],
-      },
-    });
+    // Prefill the composer with a removable task @ref chip (not raw text) and
+    // do NOT auto-send — the user reviews/adds to it, then hits send. The chip
+    // expands to the task's title + description at send time (see derive-parts).
+    const doc: TiptapDoc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            createMentionDoc({
+              id: task.id,
+              name: task.title,
+              char: "@",
+              kind: "task",
+              metadata: { title: task.title, description: task.description },
+            }),
+            { type: "text", text: " " },
+          ],
+        },
+      ],
+    };
+    writeChatDraft(sessionStorage, locator, newId, doc);
     setDialogOpen(false);
     try {
       await create({ id: newId, virtual_mcp_id: agentId });
@@ -262,7 +275,7 @@ export function TaskBoardPage() {
       // Toast already fired by the manager; navigate anyway so the route
       // loader's ensure-fallback can retry the create.
     }
-    setTaskId(newId, agentId, { autosend: true });
+    setTaskId(newId, agentId);
   };
 
   const visibleItems = items.filter((item) =>


### PR DESCRIPTION
## Summary

The task dialog's **New chat** button was creating a thread, flattening the task title+description into raw message text, and **auto-sending** it. This changes it to prefill the composer with a removable **task `@ref` chip** and **not** auto-send — the user reviews/edits, then hits send.

## Changes

- **`task-board/index.tsx`** — `startChatFromTask` builds a `TiptapDoc` with a task `@ref` mention and writes it to the *chat-draft* store (what the composer hydrates from on mount), instead of the *autosend* store. `setTaskId` is called **without** `{ autosend: true }`.
- **`tiptap/mention/node.tsx`** — adds `"task"` to `MentionAttrs.kind`; renders the raw title (no title-casing) clamped to a compact chip.
- **`derive-parts.ts`** — a task chip serializes to `title\n\ndescription` at send time, kept out of the inline label so it neither leaks `@Title` into the message nor swallows the user's own words (which stay a separate part).
- **`derive-parts.test.ts`** — 3 cases: expansion to title+description (not `@name`), empty-description omission, user's trailing words preserved.

## Design note

The chip **expands to the task's title+description text** at send — same content the agent received before, now as a removable chip rather than pre-flattened text. It is **not** an id-only reference resolved by a tool, since no task-lookup tool is exposed to the agent today.

Out of scope: the **server-side** Super Agent delegation (`enqueue-super-agent.ts`) still auto-dispatches a hardwired prompt when a task is *assigned* to the Super Agent — a separate path, left untouched.

## Testing

- `bun run --cwd=apps/mesh check` — clean
- `bun test .../derive-parts.test.ts` — 11 pass
- `bun run fmt` — applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New chat from a task now pre-fills the composer with a removable task `@ref` chip and does not auto-send, letting users review or add context first. The chip expands to the task’s title and description when sending.

- **Bug Fixes**
  - Build a `TiptapDoc` with an `@` mention `kind: "task"` and write to `chat-draft`; removed `autosend` from `setTaskId`.
  - Mention node supports `kind: "task"`; renders raw title (no title-case) clamped to a compact chip.
  - `derive-parts` expands the chip to `title\n\ndescription`, omits empty descriptions, preserves the user’s own text, and avoids leaking the `@name` label.
  - Added tests covering expansion, omission, and user text preservation.

<sup>Written for commit 7130db4c7f033a5b676695f291ab3694ebc1665a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

