### PR TITLE
fix(chat): plain-language run status copy

### DIFF
--- a/apps/mesh/src/web/components/chat/run-status.test.ts
+++ b/apps/mesh/src/web/components/chat/run-status.test.ts
@@ -15,14 +15,14 @@ describe("run status copy", () => {
     }
   });
 
-  test("uses the agreed cluster runtime labels", () => {
+  test("uses plain, user-friendly copy", () => {
     expect(RUN_STATUS_COPY["waiting-runner"]).toEqual({
-      label: "Waiting for an available runner",
-      detail: "Waiting for the per-chat dispatch slot",
+      label: "Waiting to start",
+      detail: "Finishing up the previous message in this chat",
     });
     expect(RUN_STATUS_COPY["analyzing-scope"]).toEqual({
-      label: "Analyzing scope",
-      detail: "The model loop is running before first output",
+      label: "Thinking",
+      detail: "Working out how to respond",
     });
   });
 });

--- a/apps/mesh/src/web/components/chat/run-status.ts
+++ b/apps/mesh/src/web/components/chat/run-status.ts
@@ -20,39 +20,39 @@ export interface RunStatusCopy {
 export const RUN_STATUS_COPY: Record<RunStatusStage, RunStatusCopy> = {
   sending: {
     label: "Sending your message",
-    detail: "Posting the message to the chat",
+    detail: "Adding your message to the chat",
   },
   received: {
-    label: "Request received",
-    detail: "The run was accepted and queued",
+    label: "Message received",
+    detail: "Your message is in line to be worked on",
   },
   "waiting-runner": {
-    label: "Waiting for an available runner",
-    detail: "Waiting for the per-chat dispatch slot",
+    label: "Waiting to start",
+    detail: "Finishing up the previous message in this chat",
   },
   "starting-run": {
-    label: "Starting the run",
-    detail: "A worker picked up the queued message",
+    label: "Getting started",
+    detail: "Setting up to work on your message",
   },
   "gathering-context": {
-    label: "Gathering context",
-    detail: "Loading history, memory, files, and agent context",
+    label: "Reading the chat",
+    detail: "Looking through the history, files, and notes",
   },
   "preparing-tools": {
-    label: "Preparing tools",
-    detail: "Resolving models, permissions, MCP tools, and built-ins",
+    label: "Getting ready",
+    detail: "Setting up the tools it can use",
   },
   "starting-assistant": {
-    label: "Starting the assistant",
-    detail: "Opening the cluster runtime",
+    label: "Warming up",
+    detail: "Almost ready to reply",
   },
   "analyzing-scope": {
-    label: "Analyzing scope",
-    detail: "The model loop is running before first output",
+    label: "Thinking",
+    detail: "Working out how to respond",
   },
   "choosing-next-steps": {
-    label: "Choosing next steps",
-    detail: "The assistant is planning the next action",
+    label: "Thinking",
+    detail: "Deciding what to do next",
   },
 };
 


### PR DESCRIPTION
## Summary

The chat run-status feedback read like backend logs, and two lines were factually wrong:

- **"A worker picked up the queued message"** — there is no worker; `starting-run` fires from the DBOS thread-gate when the per-chat slot opens.
- **"The model loop is running before first output"** — `analyzing-scope` fires right before the assistant stream is consumed, not while a model loop runs.

Rewrote all nine stages in plain language aimed at non-technical users. No behavior change — copy only.

| Stage | Label | Detail |
|---|---|---|
| sending | Sending your message | Adding your message to the chat |
| received | Message received | Your message is in line to be worked on |
| waiting-runner | Waiting to start | Finishing up the previous message in this chat |
| starting-run | Getting started | Setting up to work on your message |
| gathering-context | Reading the chat | Looking through the history, files, and notes |
| preparing-tools | Getting ready | Setting up the tools it can use |
| starting-assistant | Warming up | Almost ready to reply |
| analyzing-scope | Thinking | Working out how to respond |
| choosing-next-steps | Thinking | Deciding what to do next |

## Testing

- `bun test apps/mesh/src/web/components/chat/run-status.test.ts` (inverted the stale copy assertions to match) — 7 pass
- `bun run fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote chat run-status messages in plain, user-friendly language and corrected two inaccurate lines. Copy-only change with no behavior or API changes.

- **Bug Fixes**
  - Updated labels and details for all nine stages to plain language.
  - Fixed inaccuracies: replaced “worker picked up message” and “model loop running before first output” with correct descriptions.
  - Updated unit tests to reflect the new copy.

<sup>Written for commit e092f989edf365ddb9cb5e596f2dd9d0d8bbb87b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

