### PR TITLE
refactor(runtime): share TriggerState type between triggers.ts and trigger-storage.ts

### DIFF
--- a/packages/runtime/src/trigger-storage.ts
+++ b/packages/runtime/src/trigger-storage.ts
@@ -5,7 +5,7 @@
  * - JsonFileStorage: Persists to a local JSON file (for dev/simple deployments)
  */
 
-import type { TriggerStorage } from "./triggers.ts";
+import type { TriggerState, TriggerStorage } from "./triggers.ts";
 
 // ============================================================================
 // StudioKV — backed by Studio's /api/kv endpoint
@@ -52,7 +52,7 @@ export class StudioKV implements TriggerStorage {
     return `${this.prefix}:${connectionId}`;
   }
 
-  async get(connectionId: string) {
+  async get(connectionId: string): Promise<TriggerState | null> {
     const res = await fetch(
       `${this.baseUrl}/api/kv/${encodeURIComponent(this.key(connectionId))}`,
       {
@@ -67,22 +67,11 @@ export class StudioKV implements TriggerStorage {
       return null;
     }
 
-    const body = (await res.json()) as {
-      value?: {
-        credentials: { callbackUrl: string; callbackToken: string };
-        activeTriggerTypes: string[];
-      };
-    };
+    const body = (await res.json()) as { value?: TriggerState };
     return body.value ?? null;
   }
 
-  async set(
-    connectionId: string,
-    state: {
-      credentials: { callbackUrl: string; callbackToken: string };
-      activeTriggerTypes: string[];
-    },
-  ) {
+  async set(connectionId: string, state: TriggerState): Promise<void> {
     const res = await fetch(
       `${this.baseUrl}/api/kv/${encodeURIComponent(this.key(connectionId))}`,
       {
@@ -143,18 +132,18 @@ interface JsonFileStorageOptions {
  */
 export class JsonFileStorage implements TriggerStorage {
   private path: string;
-  private cache: Map<string, unknown> | null = null;
+  private cache: Map<string, TriggerState> | null = null;
 
   constructor(options: JsonFileStorageOptions) {
     this.path = options.path;
   }
 
-  private async load(): Promise<Map<string, unknown>> {
+  private async load(): Promise<Map<string, TriggerState>> {
     if (this.cache) return this.cache;
     try {
       const fs = await import("node:fs/promises");
       const raw = await fs.readFile(this.path, "utf-8");
-      const data = JSON.parse(raw) as Record<string, unknown>;
+      const data = JSON.parse(raw) as Record<string, TriggerState>;
       this.cache = new Map(Object.entries(data));
     } catch (err: unknown) {
       if (
@@ -176,12 +165,12 @@ export class JsonFileStorage implements TriggerStorage {
     await fs.writeFile(this.path, JSON.stringify(data, null, 2));
   }
 
-  async get(connectionId: string) {
+  async get(connectionId: string): Promise<TriggerState | null> {
     const map = await this.load();
-    return (map.get(connectionId) as any) ?? null;
+    return map.get(connectionId) ?? null;
   }
 
-  async set(connectionId: string, state: unknown) {
+  async set(connectionId: string, state: TriggerState): Promise<void> {
     const map = await this.load();
     map.set(connectionId, state);
     await this.save();

--- a/packages/runtime/src/triggers.ts
+++ b/packages/runtime/src/triggers.ts
@@ -7,12 +7,12 @@ import { z, type ZodObject, type ZodRawShape } from "zod";
 import type { DefaultEnv } from "./index.ts";
 import { createTool, type CreatedTool } from "./tools.ts";
 
-interface CallbackCredentials {
+export interface CallbackCredentials {
   callbackUrl: string;
   callbackToken: string;
 }
 
-interface TriggerState {
+export interface TriggerState {
   credentials: CallbackCredentials;
   activeTriggerTypes: string[];
 }


### PR DESCRIPTION
This is a reduction/type-safety cleanup, not tied to an issue.

Why: `packages/runtime/src/trigger-storage.ts` hand-rolled the exact same `{ credentials: { callbackUrl, callbackToken }; activeTriggerTypes: string[] }` shape twice (once for `StudioKV.get`'s cast, once for `StudioKV.set`'s param), duplicating the `TriggerState`/`CallbackCredentials` interfaces already defined in `triggers.ts`. Worse, `JsonFileStorage.get()` dropped to `map.get(connectionId) as any` on the read path, and `JsonFileStorage.set()` typed its `state` param as `unknown` — both classes formally `implements TriggerStorage` but weren't actually type-checked against that contract's real shape.

Fix: export `TriggerState`/`CallbackCredentials` from `triggers.ts` and reuse them in both `StudioKV` and `JsonFileStorage`, removing the `as any` cast and the duplicated inline type literal. Net: -23/+12, no behavior change — same JSON shape read/written, same runtime logic untouched.

How behavior is preserved: pure type-annotation change, no logic touched; confirmed via `bunx tsc --noEmit` (green) and the existing `triggers.test.ts` suite.

Reviewer command: `cd packages/runtime && bunx tsc --noEmit && bun test src/triggers.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in `packages/runtime`, and `bun test packages/runtime/src/triggers.test.ts` (14 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share the `TriggerState` (and `CallbackCredentials`) type between `triggers.ts` and `trigger-storage.ts` to remove duplicated shapes and unsafe casts. No runtime behavior changes; storage keeps the same JSON format.

- **Refactors**
  - Export `TriggerState` and `CallbackCredentials` from `triggers.ts`.
  - Type `StudioKV.get/set` and `JsonFileStorage.get/set` to use `TriggerState`.
  - Remove inline type literals, `as any` casts, and `unknown` params.

<sup>Written for commit 2468210516f86fc8f49c045edbaf098f954d7f21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

