### PR TITLE
fix(settings): add aria-label to icon-only edit/delete buttons on AI provider keys

### DIFF
--- a/apps/mesh/src/web/views/settings/ai-providers/provider-key-row.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/provider-key-row.tsx
@@ -102,6 +102,7 @@ export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
             <Button
               variant="ghost"
               size="icon"
+              aria-label="Edit provider key"
               className="h-7 w-7 text-muted-foreground hover:text-foreground"
               onClick={() => setEditOpen(true)}
             >
@@ -110,6 +111,7 @@ export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
             <Button
               variant="ghost"
               size="icon"
+              aria-label="Delete provider key"
               className="h-7 w-7 text-muted-foreground hover:text-destructive"
               disabled={isDeleting}
               onClick={() => setConfirmDelete(true)}


### PR DESCRIPTION
## Why
This follows the same accessibility hardening pattern as #4904, #4907, and #4915 (which added aria-labels to icon-only actions-menu, KPI-chart, and mic/send buttons). The Edit and Delete buttons on each AI provider key row (`apps/mesh/src/web/views/settings/ai-providers/provider-key-row.tsx`) render only an `Edit01`/`Trash01` icon with no `aria-label`, no `title`, and no wrapping `Tooltip` — so a screen reader announces both as an unlabeled "button" in a list where every row's controls are visually identical, giving no way to distinguish edit from delete non-visually.

## Fix
Added `aria-label="Edit provider key"` and `aria-label="Delete provider key"` to the two icon-only `Button`s. Pure additive attribute change — no logic, styling, or behavior touched.

## Verification
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — clean (exit 0)
- No existing test covers this component's rendering; the change is a static JSX attribute addition with no logic branch, so no regression test is needed. Full CI validates the rest.

## How to confirm
Open Org Settings → AI Providers, add a provider key, then inspect the Edit/Delete icon buttons in the accessibility tree (or with a screen reader) — each now announces its action instead of just "button".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-labels to the icon-only Edit and Delete buttons on AI provider key rows so screen readers announce the correct action. They now read "Edit provider key" and "Delete provider key" instead of an unlabeled "button".

<sup>Written for commit 17408fddd0ab0327fa419ef579839e521e4ddcf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

