### PR TITLE
fix(auth): recognize comma-joined multi-role principal in admin/owner bypass

### DIFF
--- a/apps/mesh/src/auth/roles.test.ts
+++ b/apps/mesh/src/auth/roles.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { canAssignRole } from "./roles";
+import { canAssignRole, hasAdminRole } from "./roles";
 
 describe("canAssignRole", () => {
   it("owner can assign any role", () => {
@@ -67,5 +67,26 @@ describe("canAssignRole", () => {
     expect(canAssignRole("admin,billing-manager", "user")).toBe(true);
     expect(canAssignRole("admin,billing-manager", "owner")).toBe(false);
     expect(canAssignRole("billing-manager,user", "admin")).toBe(false);
+  });
+});
+
+describe("hasAdminRole", () => {
+  it("recognizes a plain admin/owner role", () => {
+    expect(hasAdminRole("owner")).toBe(true);
+    expect(hasAdminRole("admin")).toBe(true);
+  });
+
+  it("denies non-admin roles", () => {
+    expect(hasAdminRole("user")).toBe(false);
+    expect(hasAdminRole("member")).toBe(false);
+    expect(hasAdminRole(undefined)).toBe(false);
+  });
+
+  // Same comma-joined multi-role string canAssignRole's callerRole handles —
+  // an exact-match check must not deny a legitimate multi-role owner/admin.
+  it("recognizes an admin/owner role inside a comma-joined multi-role string", () => {
+    expect(hasAdminRole("admin,billing-manager")).toBe(true);
+    expect(hasAdminRole("billing-manager,owner")).toBe(true);
+    expect(hasAdminRole("billing-manager,user")).toBe(false);
   });
 });

--- a/apps/mesh/src/auth/roles.ts
+++ b/apps/mesh/src/auth/roles.ts
@@ -22,6 +22,19 @@ export type BuiltinRole = (typeof BUILTIN_ROLES)[number];
 export const ADMIN_ROLES: BuiltinRole[] = ["owner", "admin"];
 
 /**
+ * True if `role` — a single role OR Better Auth's comma-joined multi-role
+ * string (see `parseRoles`) — includes an admin/owner grant. A plain
+ * `ADMIN_ROLES.includes(role)` exact-match silently denies a legitimate
+ * multi-role owner/admin (e.g. `"admin,billing-manager"`) the runtime bypass,
+ * same failure mode already fixed for `canAssignRole`'s caller check.
+ */
+export function hasAdminRole(role: string | undefined): boolean {
+  if (!role) return false;
+  const roles = role.split(",");
+  return roles.some((r) => (ADMIN_ROLES as readonly string[]).includes(r));
+}
+
+/**
  * Validate that the caller's role is allowed to assign the target role(s).
  * Owners can assign any role. Admins can assign "user" or "admin" but NOT
  * "owner" — preventing vertical privilege escalation.

--- a/apps/mesh/src/core/context-factory.bound-auth.test.ts
+++ b/apps/mesh/src/core/context-factory.bound-auth.test.ts
@@ -70,4 +70,20 @@ describe("createBoundAuthClient — API-key authorization", () => {
     expect(client.isApiKeyPrincipal).toBe(false);
     expect(await client.hasPermission({ self: ["API_KEY_CREATE"] })).toBe(true);
   });
+
+  // Better Auth's `parseRoles` joins an assigned role array with "," before
+  // storing `member.role`, so a multi-role owner/admin's role can arrive here
+  // as e.g. "admin,billing-manager", not a lone "admin". An exact-match bypass
+  // check would wrongly fall through to the narrower stored `permissions`
+  // (e.g. a studio JWT payload) and deny an action the role actually grants.
+  it("keeps the admin/owner bypass for a comma-joined multi-role principal", async () => {
+    const client = createBoundAuthClient({
+      auth: stubAuth,
+      headers: new Headers(),
+      role: "admin,billing-manager",
+      permissions: { self: ["ORGANIZATION_GET"] },
+    });
+
+    expect(await client.hasPermission({ self: ["API_KEY_CREATE"] })).toBe(true);
+  });
 });

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -237,7 +237,10 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
       // built-in `user` role is enforced like any member: it gets basic-usage
       // (granted out-of-band in AccessControl) plus its explicit Better Auth /
       // connection grants, and nothing else. See ADMIN_ROLES in auth/roles.ts.
-      if (role && ADMIN_ROLES.includes(role as (typeof ADMIN_ROLES)[number])) {
+      // `role` may be Better Auth's comma-joined multi-role string, so a
+      // plain exact-match here would deny a legitimate multi-role
+      // owner/admin the bypass — see `hasAdminRole`.
+      if (hasAdminRole(role)) {
         return true;
       }
 
@@ -446,7 +449,7 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
 
 import { createMCPProxy } from "@/api/routes/mcp-proxy-factory";
 import { ConnectionEntity } from "@/tools/connection/schema";
-import { ADMIN_ROLES, BUILTIN_ROLES } from "../auth/roles";
+import { BUILTIN_ROLES, hasAdminRole } from "../auth/roles";
 import { checkApiKeyPermission } from "../auth/api-key-permissions";
 import {
   getCachedBuiltinRoleStatements,


### PR DESCRIPTION
Follows #4918 hardening — same comma-joined multi-role bug class, found in a more critical spot: the actual runtime authorization gate.

`createBoundAuthClient`'s admin/owner bypass in `apps/mesh/src/core/context-factory.ts` did `ADMIN_ROLES.includes(role)`, a strict equality match. Better Auth's organization plugin joins an assigned role array with `,` before storing `member.role` (`parseRoles`), so a legitimate multi-role owner/admin's own role can arrive here as e.g. `"admin,billing-manager"`, not a lone `"admin"`/`"owner"`. The exact-match check silently missed the bypass and fell through to the narrower stored `permissions` (a studio JWT / MCP OAuth payload) — incorrectly denying an action the role actually grants.

A maintainer wants this because it's a real, reachable denial-of-legitimate-access bug for any org that assigns a custom role alongside admin/owner (the exact scenario #4918 already fixed one instance of), and it sits at the primary tool-authorization bypass check (`AccessControl`/`hasPermission`), not a peripheral one.

Fix: added `hasAdminRole(role)` to `apps/mesh/src/auth/roles.ts` — splits on `,` and checks each segment against `ADMIN_ROLES`, mirroring the same pattern already used for `canAssignRole`'s `callerRole`. Swapped the one call site in `context-factory.ts` to use it.

Failure scenario + regression test: `context-factory.bound-auth.test.ts` — a principal with `role: "admin,billing-manager"` and narrower stored `permissions: { self: ["ORGANIZATION_GET"] }` (e.g. a studio JWT payload) must still get the full admin bypass for `API_KEY_CREATE`; before the fix this returned `false`. Also added `hasAdminRole` unit coverage in `roles.test.ts`.

Net diff: +56/-3, one concern (the bypass check), no behavior change for single-role principals (existing bound-auth tests for `"admin"`/`"owner"`/`"user"` still pass unchanged).

Reviewer check: `bun test apps/mesh/src/auth/roles.test.ts apps/mesh/src/core/context-factory.bound-auth.test.ts`

Locally ran: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file above (17 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix admin/owner bypass in runtime auth to recognize comma-joined multi-role principals from `Better Auth`, preventing false denials for multi-role admins/owners.

- **Bug Fixes**
  - Added `hasAdminRole` in `apps/mesh/src/auth/roles.ts` to split comma-joined roles and check against `ADMIN_ROLES`.
  - Updated `createBoundAuthClient` in `apps/mesh/src/core/context-factory.ts` to use `hasAdminRole` instead of `ADMIN_ROLES.includes(...)`.
  - Added tests in `roles.test.ts` and `context-factory.bound-auth.test.ts` to cover multi-role admin bypass.

<sup>Written for commit 8c31e21330d706670f33de7c30f4ea82695f4879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

