### PR TITLE
fix(settings): add aria-label to icon-only back button in connect-provider dialog

### DIFF
--- a/apps/mesh/src/web/views/settings/ai-providers/connect-provider-dialog.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/connect-provider-dialog.tsx
@@ -300,6 +300,7 @@ export function ConnectProviderDialog({
               <Button
                 variant="ghost"
                 size="icon"
+                aria-label="Back"
                 className="h-7 w-7"
                 onClick={handleBack}
               >


### PR DESCRIPTION
Follows #4922 (which added `aria-label` to the edit/delete icon buttons in `provider-key-row.tsx`) — this is the same icon-only-button accessibility gap in the sibling file in the same directory, missed by that PR.

**Payoff:** the dialog's back button (`<ArrowLeft>` icon, no visible text) had no accessible name, so screen-reader users landing on the provider-connect flow (grid → form → back) couldn't tell what the control does.

**Change:** added `aria-label="Back"` to the icon-only `Button` at `connect-provider-dialog.tsx` (the only icon-only, unlabeled button in the file — the other two buttons in the error state have visible text and don't need one).

**Verify:** `bunx tsc --noEmit` in `apps/mesh` (passes) — this is a one-line JSX attribute addition with no logic change, so no test is needed.

Ran locally: `bun run fmt` (no changes) and `cd apps/mesh && bunx tsc --noEmit` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-label "Back" to the icon-only back button in the provider connect dialog so screen readers announce it correctly. This closes the remaining accessibility gap in that flow with no logic changes.

<sup>Written for commit 1d44b688ec24d1f8e91624cd3f856750eda44abf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

