### PR TITLE
fix(auth): stop admin/owner bypass from using a stale cross-org role

### DIFF
--- a/apps/mesh/src/core/context-factory.bound-auth.test.ts
+++ b/apps/mesh/src/core/context-factory.bound-auth.test.ts
@@ -86,4 +86,28 @@ describe("createBoundAuthClient — API-key authorization", () => {
 
     expect(await client.hasPermission({ self: ["API_KEY_CREATE"] })).toBe(true);
   });
+
+  // `role` here is resolved once, from the session's active org, at
+  // context-creation time — and `boundAuth` is never rebuilt when
+  // `resolveOrgFromPath` targets a different org. AccessControl.setRole
+  // keeps its OWN `this.role` in sync with the path-resolved org and passes
+  // it as `options.role` on every hasPermission() call; that must win over
+  // the stale closure role, or an owner of the session's active org would
+  // bypass every permission check on an unrelated org where they hold only
+  // a lesser role.
+  it("prefers options.role (path-resolved org) over the stale session-org role", async () => {
+    const client = createBoundAuthClient({
+      auth: stubAuth,
+      headers: new Headers(),
+      role: "owner", // session's active org — NOT the org being checked
+      // no `permissions` — this is the browser-session flow (Flow 2)
+    });
+
+    expect(
+      await client.hasPermission(
+        { self: ["API_KEY_CREATE"] },
+        { role: "user" }, // path-resolved org: caller is only a plain member
+      ),
+    ).toBe(false);
+  });
 });

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -240,7 +240,15 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
       // `role` may be Better Auth's comma-joined multi-role string, so a
       // plain exact-match here would deny a legitimate multi-role
       // owner/admin the bypass — see `hasAdminRole`.
-      if (hasAdminRole(role)) {
+      //
+      // Prefer `options.role` (the path-resolved org's role, kept fresh via
+      // AccessControl.setRole) over the closure `role` (resolved once, from
+      // the session's active org, at context-creation time). `boundAuth` is
+      // never rebuilt when `resolveOrgFromPath` targets a different org — so
+      // using the closure role here would let an owner/admin of the SESSION's
+      // active org bypass permission checks on an unrelated path-resolved org
+      // where they hold only a lesser role.
+      if (hasAdminRole(options?.role ?? role)) {
         return true;
       }
 


### PR DESCRIPTION
**Source:** bug found while auditing `apps/mesh/src/auth/*` and its callers in this focus area (role & permission hardening), same neighborhood as #4923's comma-joined-role fix but a separate defect.

**Why a maintainer wants this:** it's a cross-org privilege-escalation path in the core permission gate hit by every `ctx.access.check()` call.

**The bug:** `createBoundAuthClient` (apps/mesh/src/core/context-factory.ts) closes over `role` at context-creation time — resolved from the request's session/header-hinted org, *before* the `/api/:org/...` path is routed. `resolveOrgFromPath` middleware later calls `ctx.access.setRole(pathRole)` to correct `AccessControl`'s own `this.role` for the path-resolved org, and passes it through as `options.role` on every `hasPermission()` call — but `boundAuth` itself is never rebuilt for the new org (`rebindOrgScope` only rebinds storage/object-storage/org-fs). So `hasPermission`'s admin/owner bypass check, `hasAdminRole(role)`, kept reading the stale closure role instead of `options.role`.

**Failure scenario:** a user who is owner/admin of their own org (session's active org) calls a tool against a *different* org's path (`/api/other-org/...`) where they hold only a lesser role (e.g. `user`, or no membership at all beyond a public-share path). `AccessControl.checkMemberAccess`'s own exact-match check on `this.role` correctly fails, but the fallback to `boundAuth.hasPermission()` re-granted full owner/admin bypass anyway, because it checked the wrong org's role.

**Fix:** the bypass check now prefers `options?.role ?? role`, so the path-resolved org's role (the only thing `AccessControl` ever passes as `options.role`) wins over the stale closure role.

**Regression test:** added to `apps/mesh/src/core/context-factory.bound-auth.test.ts` — constructs a client with closure `role: "owner"` (simulating the session's active org) and calls `hasPermission({...}, { role: "user" })` (simulating the path-resolved org); asserts it now denies instead of bypassing.

**To confirm:** `bun test apps/mesh/src/core/context-factory.bound-auth.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file above (6 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a cross-org privilege escalation where admin/owner bypass read a stale role from the session’s org. `hasPermission()` now respects the path-resolved org role to prevent unintended access.

- **Bug Fixes**
  - In `createBoundAuthClient`, `hasPermission()` now checks `hasAdminRole(options?.role ?? role)` so the path-resolved org’s role takes precedence.
  - Added a regression test to ensure an `owner` session role does not bypass checks when `options.role` is `user`.

<sup>Written for commit 3b2b54ed6e5f1afc0a5bddb97d11a27c36a89be6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

