### PR TITLE
fix(auth): recognize comma-joined multi-role admin in AccessControl's fast-path bypass

### DIFF
--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -143,6 +143,24 @@ describe("AccessControl", () => {
       expect(ac.granted()).toBe(true);
     });
 
+    it("bypasses checks for a comma-joined multi-role admin without calling boundAuth", async () => {
+      // Better Auth's organization plugin joins an assigned role array with
+      // "," before storing member.role, so a multi-role owner/admin (e.g.
+      // "admin,billing-manager") arrives here as that comma-joined string —
+      // a plain exact-match would miss it and fall through to boundAuth.
+      const mockBoundAuth = createMockBoundAuth({}); // no permissions
+      const ac = new AccessControl(
+        "user_1",
+        "TEST_TOOL",
+        mockBoundAuth,
+        "admin,billing-manager",
+      );
+
+      await ac.check();
+      expect(ac.granted()).toBe(true);
+      expect(mockBoundAuth.hasPermission).not.toHaveBeenCalled();
+    });
+
     it("does NOT bypass the admin role for an API-key principal", async () => {
       // A key scoped to ORGANIZATION_GET is authorized solely by that allowlist —
       // the owner's admin/owner role must not widen it. The flag lives on

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -11,6 +11,7 @@
 
 import { MCP_MESH_KEY } from "@/core/constants";
 import { BASIC_USAGE_TOOLS } from "@/tools/registry-metadata";
+import { hasAdminRole } from "@/auth/roles";
 import type { BoundAuthClient } from "./studio-context";
 
 // ============================================================================
@@ -219,7 +220,11 @@ export class AccessControl {
     if (this.userId && this.role && BASIC_USAGE_TOOLS.has(resource)) {
       return true;
     }
-    if (this.role === "admin" || this.role === "owner") {
+    // `this.role` may be Better Auth's comma-joined multi-role string (e.g.
+    // "admin,billing-manager") when set via `setRole()` for a path-resolved
+    // org — a plain exact-match here would miss it and fall through to the
+    // slower `boundAuth.hasPermission` DB round-trip. See `hasAdminRole`.
+    if (hasAdminRole(this.role)) {
       return true;
     }
     if (!this.boundAuth) {


### PR DESCRIPTION
Follows #4918/#4923 hardening: same failure mode, third site.

`AccessControl.checkMemberAccess` (apps/mesh/src/core/access-control.ts) checked `this.role === "admin" || this.role === "owner"` with a strict equality match. Better Auth's organization plugin joins an assigned role array with "," before storing `member.role`, and `AccessControl.setRole()` can set `this.role` to a path-resolved org's role (per its own docstring), so a legitimate multi-role owner/admin (e.g. `"admin,billing-manager"`) arrives here as that comma-joined string. The exact-match check misses it and falls through to `boundAuth.hasPermission`, which — per `builtin-role-permission.ts`'s own docstring — hits a DB-backed Better Auth round-trip specifically because the in-memory fast path exists to avoid "~40ms event-loop hitches" per request.

This is not a live authz bypass (the downstream Better Auth path still grants correctly for multi-role admins), but it closes the gap so `AccessControl`'s own bypass is self-contained, matching the shared `hasAdminRole` helper already used by `canAssignRole` (#4918) and `context-factory.ts`'s runtime bypass (#4923). Multi-role admins now take the fast in-memory path instead of an avoidable DB round-trip on every tool call.

Added a regression test asserting the multi-role admin bypasses without ever calling `boundAuth.hasPermission` — before the fix it fell through to the mock, which (having no stored permissions) denied.

Reviewer check: `bun test apps/mesh/src/core/access-control.test.ts`

Locally verified: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file (26/26 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `AccessControl` to recognize comma-joined multi-role admins/owners, so they hit the fast in-memory bypass instead of a DB round-trip. This prevents unnecessary permission checks and improves request latency.

- **Bug Fixes**
  - Use shared `hasAdminRole` to detect admin/owner in `checkMemberAccess`, including values like "admin,billing-manager".
  - Add regression test ensuring multi-role admins bypass without calling `boundAuth.hasPermission`.

<sup>Written for commit bcb2716d5e93cc3251712d6f2dc891d01a4d472b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

