### PR TITLE
fix(ai-providers): drop redundant as-cast in simple mode model resolution

### DIFF
--- a/apps/mesh/src/web/views/settings/ai-providers/simple-mode-section.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/simple-mode-section.tsx
@@ -113,7 +113,7 @@ function SimpleModeModelRow({
     : true;
 
   const resolvedModel: AiProviderModel | null = slot
-    ? ({
+    ? {
         modelId: slot.modelId,
         title: slot.title ?? slot.modelId,
         keyId: slot.keyId,
@@ -123,7 +123,7 @@ function SimpleModeModelRow({
         capabilities: [],
         limits: null,
         costs: null,
-      } as AiProviderModel)
+      }
     : null;
 
   if (filterModels && !hasFilteredModels) {


### PR DESCRIPTION
**Source**: reduction/compile-time-safety fix found while auditing the AI-provider settings UI (`simple-mode-section.tsx`), per the repo checklist item on keeping type-safety at compile time (avoid `as`-casts that hide a future field mismatch).

**Why**: `resolvedModel` in `SimpleModeModelRow` was built as an object literal then force-cast with `as AiProviderModel`. The literal already satisfies the `AiProviderModel` interface structurally (all required fields present with matching types) — confirmed by removing the cast and running `tsc --noEmit` with zero errors. The cast added no value and would have silently masked a real type error if the `AiProviderModel` shape or this literal ever drifted (e.g. a renamed/added required field), turning what should be a compile error into a silent runtime bug.

**Change**: -2/+2, purely removing the `as AiProviderModel` cast and its wrapping parens. No behavior change — same object, same runtime value.

**Verify**: `cd apps/mesh && bunx tsc --noEmit` (clean, confirms the literal type-checks without the cast).

**Local checks run**: `bun run fmt` (no changes) and `bunx tsc --noEmit` in `apps/mesh` (clean). No test file exists for this component and none is warranted for a pure type-safety cleanup with no behavior change; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove a redundant `as AiProviderModel` cast in `SimpleModeModelRow` to keep compile-time type safety and avoid masking future field mismatches. No behavior change; the object literal already satisfies `AiProviderModel` and passes `tsc --noEmit`.

<sup>Written for commit 5ec0b1f320771bdd5d3abdc72b71793967d37712. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

