### PR TITLE
fix(agent-icon): restore contrasting color palette

### DIFF
--- a/apps/mesh/src/api/org-scoped.integration.test.ts
+++ b/apps/mesh/src/api/org-scoped.integration.test.ts
@@ -125,7 +125,12 @@ describe("org-scoped API coexistence", () => {
     logSpy?.mockRestore();
     logSpy = undefined;
     vi.restoreAllMocks();
-    await closeTestPgDatabase(database);
+    if (app) {
+      await app.shutdown();
+    }
+    if (database) {
+      await closeTestPgDatabase(database);
+    }
   });
 
   it("new path serves the route AND does NOT log deprecation", async () => {

--- a/apps/mesh/src/tools/virtual/studio-pack/agent-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/agent-manager.ts
@@ -96,7 +96,7 @@ You are the Agent Manager. You create, configure, and maintain agents (Virtual M
 export const agentManagerAgent = {
   id: "studio-agent-manager",
   title: "Agent Manager",
-  icon: "icon://Bot?color=chart-5",
+  icon: "icon://Bot?color=violet",
   description: "Create, configure, and manage agents",
   selectedTools: [
     "COLLECTION_VIRTUAL_MCP_CREATE",

--- a/apps/mesh/src/tools/virtual/studio-pack/api-key-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/api-key-manager.ts
@@ -64,7 +64,7 @@ You are the API Key Manager. You create and manage the current user's API keys f
 export const apiKeyManagerAgent = {
   id: "studio-api-key-manager",
   title: "API Key Manager",
-  icon: "icon://Key01?color=destructive",
+  icon: "icon://Key01?color=red",
   description: "Create, scope, audit, rotate, and revoke API keys safely",
   selectedTools: [
     "API_KEY_CREATE",

--- a/apps/mesh/src/tools/virtual/studio-pack/automation-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/automation-manager.ts
@@ -64,7 +64,7 @@ You are the Automation Manager. You create, configure, and manage automations â€
 export const automationManagerAgent = {
   id: "studio-automation-manager",
   title: "Automation Manager",
-  icon: "icon://Zap?color=chart-4",
+  icon: "icon://Zap?color=amber",
   description: "Create, configure, and run automations with triggers",
   selectedTools: [
     "AUTOMATION_CREATE",

--- a/apps/mesh/src/tools/virtual/studio-pack/brand-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/brand-manager.ts
@@ -80,7 +80,7 @@ You are the Brand Manager. You manage the organization's brand contexts (company
 export const brandManagerAgent = {
   id: "studio-brand-manager",
   title: "Brand Manager",
-  icon: "icon://Brand?color=chart-5",
+  icon: "icon://Brand?color=orange",
   description:
     "Create, configure, and manage brand contexts (company profiles) for the organization.",
   selectedTools: [

--- a/apps/mesh/src/tools/virtual/studio-pack/connection-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/connection-manager.ts
@@ -43,7 +43,7 @@ You are the Connection Manager. You create, configure, test, and manage MCP conn
 export const connectionManagerAgent = {
   id: "studio-connection-manager",
   title: "Connection Manager",
-  icon: "icon://Link01?color=chart-3",
+  icon: "icon://Link01?color=cyan",
   description: "Create, configure, test, and manage connections",
   selectedTools: [
     "COLLECTION_CONNECTIONS_CREATE",

--- a/apps/mesh/src/tools/virtual/studio-pack/store-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/store-manager.ts
@@ -46,7 +46,7 @@ Registry, propose installable MCPs to the user, and guide their installation.
 export const storeManagerAgent = {
   id: "studio-store-manager",
   title: "Store Manager",
-  icon: "icon://Store01?color=success",
+  icon: "icon://Store01?color=emerald",
   description:
     "Browse the Deco Store and Community Registry, recommend MCPs, and guide installations.",
   // null = all tools from the connection(s) below

--- a/apps/mesh/src/tools/virtual/studio-pack/task-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/task-manager.ts
@@ -59,7 +59,7 @@ You are the Task Manager. You organize and maintain this organization's task boa
 export const taskManagerAgent = {
   id: "studio-task-manager",
   title: "Task Manager",
-  icon: "icon://Flag01?color=chart-1",
+  icon: "icon://Flag01?color=indigo",
   description: "Create, prioritize, assign, and track work on the task board",
   selectedTools: [
     "TASK_BOARD_ITEM_CREATE",

--- a/apps/mesh/src/tools/virtual/studio-pack/usage-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/usage-manager.ts
@@ -57,7 +57,7 @@ You are the Usage Manager. You analyze how this workspace is actually used — w
 export const usageManagerAgent = {
   id: "studio-usage-manager",
   title: "Usage Manager",
-  icon: "icon://BarChart10?color=chart-2",
+  icon: "icon://BarChart10?color=blue",
   description: "Analyze usage, costs, and clean up idle agents and connections",
   selectedTools: [
     "MONITORING_STATS",

--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -15,58 +15,112 @@ import * as AllIcons from "@untitledui/icons";
 import { useState, type ComponentType, type SVGProps } from "react";
 
 // ---------------------------------------------------------------------------
-// Color palette (semantic design-system tokens)
+// Color palette
 // ---------------------------------------------------------------------------
 
 export interface AgentIconColor {
   name: string;
-  bg: string; // bg-{semantic-token}
-  text: string; // text-{semantic-token}
-  dot: string; // bg-{semantic-token} (for picker dots)
+  bg: string; // bg-{color}-100
+  text: string; // text-{color}-600
+  dot: string; // bg-{color}-400 (for picker dots)
 }
 
 export const AGENT_ICON_COLORS: AgentIconColor[] = [
   {
-    name: "chart-1",
-    bg: "bg-chart-1",
-    text: "text-chart-1",
-    dot: "bg-chart-1",
+    name: "red",
+    bg: "bg-red-100 dark:bg-red-950",
+    text: "text-red-600 dark:text-red-400",
+    dot: "bg-red-400",
   },
   {
-    name: "chart-2",
-    bg: "bg-chart-2",
-    text: "text-chart-2",
-    dot: "bg-chart-2",
+    name: "orange",
+    bg: "bg-orange-100 dark:bg-orange-950",
+    text: "text-orange-600 dark:text-orange-400",
+    dot: "bg-orange-400",
   },
   {
-    name: "chart-3",
-    bg: "bg-chart-3",
-    text: "text-chart-3",
-    dot: "bg-chart-3",
+    name: "amber",
+    bg: "bg-amber-100 dark:bg-amber-950",
+    text: "text-amber-600 dark:text-amber-400",
+    dot: "bg-amber-400",
   },
   {
-    name: "chart-4",
-    bg: "bg-chart-4",
-    text: "text-chart-4",
-    dot: "bg-chart-4",
+    name: "yellow",
+    bg: "bg-yellow-100 dark:bg-yellow-950",
+    text: "text-yellow-600 dark:text-yellow-400",
+    dot: "bg-yellow-400",
   },
   {
-    name: "chart-5",
-    bg: "bg-chart-5",
-    text: "text-chart-5",
-    dot: "bg-chart-5",
+    name: "lime",
+    bg: "bg-lime-100 dark:bg-lime-950",
+    text: "text-lime-600 dark:text-lime-400",
+    dot: "bg-lime-400",
   },
   {
-    name: "success",
-    bg: "bg-success",
-    text: "text-success",
-    dot: "bg-success",
+    name: "green",
+    bg: "bg-green-100 dark:bg-green-950",
+    text: "text-green-600 dark:text-green-400",
+    dot: "bg-green-400",
   },
   {
-    name: "destructive",
-    bg: "bg-destructive",
-    text: "text-destructive",
-    dot: "bg-destructive",
+    name: "emerald",
+    bg: "bg-emerald-100 dark:bg-emerald-950",
+    text: "text-emerald-600 dark:text-emerald-400",
+    dot: "bg-emerald-400",
+  },
+  {
+    name: "cyan",
+    bg: "bg-cyan-100 dark:bg-cyan-950",
+    text: "text-cyan-600 dark:text-cyan-400",
+    dot: "bg-cyan-400",
+  },
+  {
+    name: "sky",
+    bg: "bg-sky-100 dark:bg-sky-950",
+    text: "text-sky-600 dark:text-sky-400",
+    dot: "bg-sky-400",
+  },
+  {
+    name: "blue",
+    bg: "bg-blue-100 dark:bg-blue-950",
+    text: "text-blue-600 dark:text-blue-400",
+    dot: "bg-blue-400",
+  },
+  {
+    name: "indigo",
+    bg: "bg-indigo-100 dark:bg-indigo-950",
+    text: "text-indigo-600 dark:text-indigo-400",
+    dot: "bg-indigo-400",
+  },
+  {
+    name: "violet",
+    bg: "bg-violet-100 dark:bg-violet-950",
+    text: "text-violet-600 dark:text-violet-400",
+    dot: "bg-violet-400",
+  },
+  {
+    name: "purple",
+    bg: "bg-purple-100 dark:bg-purple-950",
+    text: "text-purple-600 dark:text-purple-400",
+    dot: "bg-purple-400",
+  },
+  {
+    name: "fuchsia",
+    bg: "bg-fuchsia-100 dark:bg-fuchsia-950",
+    text: "text-fuchsia-600 dark:text-fuchsia-400",
+    dot: "bg-fuchsia-400",
+  },
+  {
+    name: "pink",
+    bg: "bg-pink-100 dark:bg-pink-950",
+    text: "text-pink-600 dark:text-pink-400",
+    dot: "bg-pink-400",
+  },
+  {
+    name: "rose",
+    bg: "bg-rose-100 dark:bg-rose-950",
+    text: "text-rose-600 dark:text-rose-400",
+    dot: "bg-rose-400",
   },
 ];
 
@@ -125,7 +179,7 @@ export function parseIconString(icon: string | null | undefined): ParsedIcon {
     const name = qIndex >= 0 ? rest.slice(0, qIndex) : rest;
     const params =
       qIndex >= 0 ? new URLSearchParams(rest.slice(qIndex + 1)) : null;
-    const color = params?.get("color") ?? "chart-1";
+    const color = params?.get("color") ?? "blue";
     return { type: "icon", name, color };
   }
 

--- a/apps/mesh/src/web/components/icon-picker.tsx
+++ b/apps/mesh/src/web/components/icon-picker.tsx
@@ -73,7 +73,7 @@ export function IconPicker({
   // Local fallback color used only when `value` does not encode a color
   // (i.e. fallback type). When `value` carries a color it wins, so prop
   // updates stay in sync with the picker UI.
-  const [fallbackColor, setFallbackColor] = useState("chart-1");
+  const [fallbackColor, setFallbackColor] = useState("blue");
   const parsedValue = parseIconString(value);
   const selectedColor =
     parsedValue.type === "icon"


### PR DESCRIPTION
## Summary

- revert the agent icon palette changes from #4910
- restore contrasting background and foreground shades for icon visibility
- restore compatibility with persisted and server-generated legacy color names
- restore the original Studio Pack agent colors and picker fallback

The shared IconAvatar refactor from #4901 remains intact.

## Regression

PR #4910 assigned the same semantic token to both the avatar background and its glyph, making the glyph visually disappear. It also removed all legacy color names while the creation tool still emits those names, causing existing and newly created agents to collapse to the first fallback color.

## Verification

- bun run fmt
- cd apps/mesh && bunx tsc --noEmit
- confirmed all ten affected files match their state immediately before #4910

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores a contrasting agent icon color palette and re-enables legacy color names so icons are visible again. Resets Studio Pack defaults to their original colors while keeping the shared IconAvatar refactor.

- **Bug Fixes**
  - Switched to a Tailwind hue palette with contrasting text/background (incl. dark) for clear glyphs.
  - Restored legacy color names and reset Studio Pack defaults (e.g., `violet`, `red`, `amber`, `orange`, `cyan`, `emerald`, `indigo`, `blue`).
  - Defaulted parser and picker fallback color to `blue`, ensuring legacy and persisted colors render correctly.
  - Shut down the org-scoped app in integration test teardown to prevent hanging resources.

<sup>Written for commit b58f97818283cb86a9a449e60e8fb39ff3984ddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

