### PR TITLE
fix(registry): block IPv6 6to4/NAT64-embedded private IPv4 in discover-tools SSRF guard

### DIFF
--- a/apps/mesh/src/tools/registry/discover-tools.test.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { isPrivateUrl } from "./discover-tools";
+
+describe("isPrivateUrl", () => {
+  it("blocks plain private/loopback/link-local IPv4", () => {
+    expect(isPrivateUrl("http://127.0.0.1/")).toBe(true);
+    expect(isPrivateUrl("http://10.0.0.5/")).toBe(true);
+    expect(isPrivateUrl("http://169.254.169.254/")).toBe(true);
+  });
+
+  it("blocks a 6to4-embedded private IPv4 address", () => {
+    // 2002:7f00:1:: embeds 127.0.0.1 (6to4: 2002:WWXX:YYZZ::)
+    expect(isPrivateUrl("http://[2002:7f00:1::]/")).toBe(true);
+    // 2002:a9fe:a9fe:: embeds 169.254.169.254 (cloud metadata endpoint)
+    expect(isPrivateUrl("http://[2002:a9fe:a9fe::]/")).toBe(true);
+  });
+
+  it("blocks a NAT64-embedded private IPv4 address", () => {
+    // 64:ff9b::/96 well-known prefix + embedded IPv4 in the last 32 bits
+    expect(isPrivateUrl("http://[64:ff9b::127.0.0.1]/")).toBe(true);
+    expect(isPrivateUrl("http://[64:ff9b::169.254.169.254]/")).toBe(true);
+  });
+
+  it("does not block a public IPv4 embedded via 6to4/NAT64", () => {
+    // 2002:0808:0808:: embeds 8.8.8.8
+    expect(isPrivateUrl("http://[2002:808:808::]/")).toBe(false);
+    expect(isPrivateUrl("http://[64:ff9b::8.8.8.8]/")).toBe(false);
+  });
+
+  it("does not block ordinary public URLs", () => {
+    expect(isPrivateUrl("https://example.com/mcp")).toBe(false);
+    expect(isPrivateUrl("http://8.8.8.8/")).toBe(false);
+  });
+});

--- a/apps/mesh/src/tools/registry/discover-tools.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.ts
@@ -6,7 +6,48 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { z } from "zod";
 
-function isPrivateUrl(url: string): boolean {
+/** RFC 1918 / loopback / link-local ranges, keyed off the first two IPv4 octets. */
+function isPrivateIPv4Octets(a: number, b: number | undefined): boolean {
+  if (a === 10) return true;
+  if (a === 172 && b !== undefined && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 0) return true;
+  return false;
+}
+
+/** Decode the first IPv6 hex word (16 bits) into the first two IPv4 octets. */
+function hexWordToIPv4(word: string): [number, number] {
+  const value = Number.parseInt(word.padStart(4, "0"), 16);
+  return [value >> 8, value & 0xff];
+}
+
+/**
+ * IPv6 transition mechanisms (6to4, NAT64) embed a literal IPv4 address in the
+ * hostname. A private IPv4 embedded this way must be blocked the same as the
+ * plain dotted form, or it bypasses the SSRF guard below.
+ */
+function isPrivateEmbeddedIPv4(ipv6: string): boolean {
+  const groups = ipv6.split(":").filter((g) => g.length > 0);
+
+  // 6to4: 2002:WWXX:YYZZ:... — embedded IPv4's first two octets are word WWXX.
+  if (ipv6.startsWith("2002:") && groups.length >= 2) {
+    const [a, b] = hexWordToIPv4(groups[1]!);
+    if (isPrivateIPv4Octets(a, b)) return true;
+  }
+
+  // NAT64: 64:ff9b::WWXX:YYZZ — embedded IPv4's first two octets are the
+  // second-to-last word (well-known /96 prefix, IPv4 in the last 32 bits).
+  if (ipv6.startsWith("64:ff9b::") && groups.length >= 4) {
+    const [a, b] = hexWordToIPv4(groups[groups.length - 2]!);
+    if (isPrivateIPv4Octets(a, b)) return true;
+  }
+
+  return false;
+}
+
+export function isPrivateUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     const hostname = parsed.hostname.toLowerCase();
@@ -24,12 +65,7 @@ function isPrivateUrl(url: string): boolean {
     const ipv4Match = hostname.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
     if (ipv4Match) {
       const [, a, b] = ipv4Match.map(Number);
-      if (a === 10) return true;
-      if (a === 172 && b !== undefined && b >= 16 && b <= 31) return true;
-      if (a === 192 && b === 168) return true;
-      if (a === 127) return true;
-      if (a === 169 && b === 254) return true;
-      if (a === 0) return true;
+      if (isPrivateIPv4Octets(a!, b)) return true;
     }
 
     if (hostname.startsWith("[") && hostname.endsWith("]")) {
@@ -40,6 +76,7 @@ function isPrivateUrl(url: string): boolean {
       if (ipv6.startsWith("fe80")) return true;
       if (ipv6.startsWith("100:")) return true;
       if (ipv6.startsWith("::1")) return true;
+      if (isPrivateEmbeddedIPv4(ipv6)) return true;
 
       const v4compat = ipv6.match(/^::(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
       if (v4compat) {


### PR DESCRIPTION
**Source:** bug found while auditing the registry area (my assigned target, `apps/mesh/src/registry-catalog/*`, doesn't exist on `main` yet — it's still unmerged in open PR #4169 — so I hunted the adjacent, already-merged registry tool code instead).

**Why a maintainer wants this:** `REGISTRY_ITEM_DISCOVER_TOOLS` (`apps/mesh/src/tools/registry/discover-tools.ts`) takes a user-supplied URL and fetches it server-side (no CORS, so no browser-origin protection). `isPrivateUrl()` is the sole SSRF guard before that fetch. It already blocks plain private IPv4 (`10.x`, `127.x`, `169.254.x`, ...) and the `::ffff:`-mapped IPv6 form, but not IPv6 addresses that embed a literal IPv4 via the standard transition mechanisms:
- 6to4: `2002:WWXX:YYZZ::` (embeds the IPv4 in the first two hex words after the prefix)
- NAT64: `64:ff9b::WWXX:YYZZ` (embeds the IPv4 in the last 32 bits of the well-known /96 prefix)

**Failure scenario:** `new URL()` normalizes these to canonical hex form but does not resolve them back to dotted IPv4 for us — I verified `http://[2002:7f00:1::]/` parses to hostname `[2002:7f00:1::]`, which is the 6to4 encoding of `127.0.0.1`, and it sailed through `isPrivateUrl()` returning `false`. Same for `http://[2002:a9fe:a9fe::]/`, encoding `169.254.169.254` (the cloud-metadata IMDS endpoint) — a classic SSRF target. Any org member could pass either as the `url` input to reach internal services or cloud metadata that the plain-IPv4 checks were explicitly written to block.

**Fix:** `isPrivateUrl()` now decodes the embedded IPv4 octets from both the 6to4 and NAT64 forms and re-checks them against the same private-range logic (`isPrivateIPv4Octets`, extracted from the existing dotted-IPv4 branch — no behavior change there). Regression test added in `discover-tools.test.ts` (new file) covering: plain private IPv4 (unchanged), 6to4/NAT64-embedded private IPv4 (the fix), 6to4/NAT64-embedded *public* IPv4 like `8.8.8.8` (must NOT be blocked — false positives would break legitimate discovery), and ordinary public URLs.

**Reviewer command:** `bun test apps/mesh/src/tools/registry/discover-tools.test.ts`

**Local checks run:** `bun run fmt`, `bunx tsc --noEmit` in `apps/mesh` (clean), and the targeted test above (5 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SSRF guard in `discover-tools` by blocking IPv6 6to4 and NAT64 hostnames that embed private IPv4 addresses. Prevents access to loopback, link-local, and cloud metadata via encoded IPv6.

- **Bug Fixes**
  - Detect and block embedded private IPv4 in 6to4 (`2002:WWXX:YYZZ::`) and NAT64 (`64:ff9b::WWXX:YYZZ`) hostnames.
  - Extracted `isPrivateIPv4Octets` and reused it for both dotted IPv4 and embedded IPv4; no change to public IPv4 behavior.
  - Added tests in `apps/mesh/src/tools/registry/discover-tools.test.ts` covering private IPv4, embedded private IPv4, embedded public IPv4, and normal public URLs.

<sup>Written for commit 6da7c8103cd8d07d739a9b173cdabc4511030c84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

