### PR TITLE
fix(sections-editor): use declared item schema for block-ref array labels

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/block-ref-array-inference.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-ref-array-inference.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import {
+  blockRefArrayItemSchemaFromRefs,
+  inferBlockRefArrayItemSchema,
+} from "./block-ref-array-inference";
+import type { SchemaProperty } from "./resolve-schema";
+
+describe("inferBlockRefArrayItemSchema", () => {
+  test("infers primitive props from the first element", () => {
+    const items = inferBlockRefArrayItemSchema([
+      { route: "/x", count: 3, flag: true, nested: {} },
+    ]);
+    expect(items?.type).toBe("object");
+    expect(items?.properties).toEqual({
+      route: { type: "string" },
+      count: { type: "number" },
+      flag: { type: "boolean" },
+    });
+    // nested objects are intentionally skipped, and the inferred schema carries
+    // no titleBy — hence blockRefArrayItemSchemaFromRefs is preferred.
+    expect(items?.titleBy).toBeUndefined();
+  });
+
+  test("returns undefined for an empty array", () => {
+    expect(inferBlockRefArrayItemSchema([])).toBeUndefined();
+  });
+});
+
+describe("blockRefArrayItemSchemaFromRefs", () => {
+  // A deco loader that injects an `X[]` prop exposes the array as one of its
+  // own props with the declared item schema (incl. `@title {{{route}}}`).
+  const seoTextsItems: SchemaProperty = {
+    type: "object",
+    title: "{{{route}}}",
+    titleBy: "{{{route}}}",
+    properties: {
+      route: { type: "string" },
+      title: { type: "string" },
+      text: { type: "string" },
+      bottomText: { type: "string", format: "rich-text" },
+    },
+  };
+  const blockRefSchema: SchemaProperty = {
+    type: "block-ref",
+    anyOfRefs: [
+      { resolveType: "site/loaders/seoTexts.ts", title: "SeoTexts" },
+      {
+        resolveType: "site/loaders/seoTexts.ts",
+        title: "SeoTexts",
+        schema: {
+          type: "object",
+          properties: {
+            seoTexts: { type: "array", items: seoTextsItems },
+          },
+        },
+      },
+    ],
+  };
+
+  test("recovers the declared item schema (with titleBy) from a loader branch", () => {
+    const value = [{ route: "/eletroportateis", text: "Na Le Biscuit..." }];
+    const items = blockRefArrayItemSchemaFromRefs(blockRefSchema, value);
+    expect(items?.titleBy).toBe("{{{route}}}");
+    expect(items?.properties?.bottomText?.format).toBe("rich-text");
+  });
+
+  test("recovers item schema from a branch that is the array itself", () => {
+    const schema: SchemaProperty = {
+      type: "block-ref",
+      anyOfRefs: [
+        {
+          resolveType: "site/loaders/x.ts",
+          title: "x",
+          schema: { type: "array", items: seoTextsItems },
+        },
+      ],
+    };
+    const items = blockRefArrayItemSchemaFromRefs(schema, [{ route: "/a" }]);
+    expect(items?.titleBy).toBe("{{{route}}}");
+  });
+
+  test("picks the array whose properties cover the data keys", () => {
+    const schema: SchemaProperty = {
+      type: "block-ref",
+      anyOfRefs: [
+        {
+          resolveType: "site/loaders/multi.ts",
+          title: "multi",
+          schema: {
+            type: "object",
+            properties: {
+              tags: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: { name: { type: "string" } },
+                },
+              },
+              seoTexts: { type: "array", items: seoTextsItems },
+            },
+          },
+        },
+      ],
+    };
+    const value = [{ route: "/a", text: "b" }];
+    const items = blockRefArrayItemSchemaFromRefs(schema, value);
+    expect(items?.titleBy).toBe("{{{route}}}");
+  });
+
+  test("returns undefined when no branch array covers the data keys", () => {
+    const schema: SchemaProperty = {
+      type: "block-ref",
+      anyOfRefs: [
+        {
+          resolveType: "site/loaders/other.ts",
+          title: "other",
+          schema: {
+            type: "object",
+            properties: {
+              tags: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: { name: { type: "string" } },
+                },
+              },
+            },
+          },
+        },
+      ],
+    };
+    const value = [{ route: "/a", text: "b" }];
+    expect(blockRefArrayItemSchemaFromRefs(schema, value)).toBeUndefined();
+  });
+
+  test("uses the sole candidate for an empty array value", () => {
+    const items = blockRefArrayItemSchemaFromRefs(blockRefSchema, []);
+    expect(items?.titleBy).toBe("{{{route}}}");
+  });
+
+  test("returns undefined when there are no anyOfRefs", () => {
+    const schema: SchemaProperty = { type: "block-ref" };
+    expect(
+      blockRefArrayItemSchemaFromRefs(schema, [{ route: "/a" }]),
+    ).toBeUndefined();
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/block-ref-array-inference.ts
+++ b/apps/mesh/src/web/components/sections-editor/block-ref-array-inference.ts
@@ -1,6 +1,73 @@
 import type { SchemaProperty } from "./resolve-schema";
 
 /**
+ * When a block-ref field holds a resolved plain array, prefer the real item
+ * schema declared by one of the block-ref's loader/section branches
+ * (`anyOfRefs`) over one inferred from the runtime data. The declared schema
+ * carries metadata that data inference cannot recover — the `titleBy` array-item
+ * label template (e.g. `@title {{{route}}}`), field `format` (rich-text), and
+ * `@image` thumbnail templates.
+ *
+ * A deco loader that injects an `X[]` prop exposes that array as one of its own
+ * props with the same shape, so the item schema lives at
+ * `ref.schema.properties.<k>.items` — or directly at `ref.schema.items` when a
+ * branch is the array itself. We pick the candidate whose properties best cover
+ * the keys present in the data, so an unrelated array prop on the same loader
+ * can't hijack the render.
+ */
+export function blockRefArrayItemSchemaFromRefs(
+  schema: SchemaProperty,
+  value: unknown[],
+): SchemaProperty | undefined {
+  const refs = schema.anyOfRefs;
+  if (!refs?.length) return undefined;
+
+  const first = value.find(
+    (v) => v != null && typeof v === "object" && !Array.isArray(v),
+  ) as Record<string, unknown> | undefined;
+  const dataKeys = first
+    ? Object.keys(first).filter((k) => !k.startsWith("__"))
+    : [];
+
+  const candidates: SchemaProperty[] = [];
+  const collect = (items?: SchemaProperty) => {
+    if (items?.type === "object" && items.properties) candidates.push(items);
+  };
+  for (const ref of refs) {
+    const s = ref.schema;
+    if (!s) continue;
+    if (s.type === "array") collect(s.items);
+    if (s.properties) {
+      for (const prop of Object.values(s.properties)) {
+        if (prop?.type === "array") collect(prop.items);
+      }
+    }
+  }
+  if (candidates.length === 0) return undefined;
+
+  // No data to disambiguate (empty array) — only safe with a single candidate.
+  if (dataKeys.length === 0) {
+    return candidates.length === 1 ? candidates[0] : undefined;
+  }
+
+  let best: SchemaProperty | undefined;
+  let bestScore = -1;
+  for (const cand of candidates) {
+    const props = cand.properties ?? {};
+    // Prefer higher key coverage; break ties toward a declared titleBy.
+    const score =
+      dataKeys.filter((k) => k in props).length * 2 + (cand.titleBy ? 1 : 0);
+    if (score > bestScore) {
+      bestScore = score;
+      best = cand;
+    }
+  }
+  // Require at least one overlapping key so an unrelated array (coverage 0)
+  // can't win purely on a titleBy tie-break.
+  return bestScore >= 2 ? best : undefined;
+}
+
+/**
  * When a block-ref field holds a resolved plain array (the loader has already
  * been evaluated), infer a minimal item schema from the first element so the
  * array can be rendered as an editable ArrayField.

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -31,7 +31,10 @@ import {
   isArrayDrillDownField,
   resolveActiveFieldKey,
 } from "./schema-form-breadcrumb";
-import { inferBlockRefArrayItemSchema } from "./block-ref-array-inference";
+import {
+  blockRefArrayItemSchemaFromRefs,
+  inferBlockRefArrayItemSchema,
+} from "./block-ref-array-inference";
 
 /** Skip internal deco properties that shouldn't be user-editable. */
 const HIDDEN_PROPS = new Set(["__resolveType", "@type"]);
@@ -155,7 +158,11 @@ export function renderField(props: FieldProps) {
     !isMultivariateArrayWrapper(value) &&
     schema.type === "block-ref"
   ) {
-    const items = inferBlockRefArrayItemSchema(value);
+    // Prefer the real item schema from the block-ref's loader/section branches
+    // (carries `titleBy`/`format`/`@image`); fall back to inferring from data.
+    const items =
+      blockRefArrayItemSchemaFromRefs(schema, value) ??
+      inferBlockRefArrayItemSchema(value);
     if (items) {
       const arraySchema: SchemaProperty = { ...schema, type: "array", items };
       return (


### PR DESCRIPTION
## Summary

Array-item labels for a block-ref array prop rendered a content field instead of the declared `@title` template. In `lebiscuit-tanstack`'s `SearchResult`, the `SeoTexts` items showed the SEO body text (*"Na Le Biscuit, você encontra diversos…"*) instead of the `route` declared via `@title {{{route}}}`.

<img width="380" src="https://github.com/user-attachments/assets/placeholder" alt="SeoTexts list showing body text instead of route" />

## Root cause

A section prop typed `X[]` that a loader can inject resolves to a `block-ref` schema (`anyOf: [Resolvable, <loader>]`). When the stored value is a plain inline array, `renderField` inferred the item schema from the runtime data alone (`inferBlockRefArrayItemSchema`), which only recovers primitive field types — dropping:

- `titleBy` (the array-item label template, e.g. `@title {{{route}}}`)
- field `format` (rich-text)
- `@image` thumbnail templates

With no `titleBy`, `getArrayItemLabel` fell through its heuristic key scan (`name → label → title → alt → text → …`) and picked the `text` field. The real `titleBy: "{{{route}}}"` was available all along, nested in `schema.anyOfRefs[…].schema.properties.<key>.items`.

## Fix

- **`block-ref-array-inference.ts`** — new `blockRefArrayItemSchemaFromRefs(schema, value)` recovers the declared item schema from the block-ref's `anyOfRefs` branches, choosing the candidate array whose properties best cover the data keys (so an unrelated array prop on the same loader can't hijack the render).
- **`schema-form.tsx`** — prefer the declared schema, falling back to data inference only when no branch matches.
- **`block-ref-array-inference.test.ts`** — 8 unit tests (titleBy recovery, array-branch case, key-coverage disambiguation, no-match, empty array, no refs).

Side effect: the item editor now surfaces all declared fields (`metaTitle`, `metaDescription`, rich-text `bottomText`, …), not just the ones inference could guess from data.

## Testing

- `bun run --cwd=apps/mesh check` — passes
- `bun test apps/mesh/src/web/components/sections-editor/` — 456 pass, 0 fail
- Verified against real `lebiscuit-tanstack` schema + data: label now resolves to `/eletroportateis` (the route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes block-ref array item labels by using the declared item schema (`@title` template) instead of inferring from data, so labels show the intended route instead of body text. Also surfaces all declared fields in the item editor.

- **Bug Fixes**
  - Prefer item schema from `anyOfRefs` to recover `titleBy`, `format`, and `@image`; fall back to data inference only if no match.
  - Disambiguate multiple arrays by matching property coverage with the data.
  - Added 8 unit tests for schema recovery and edge cases.

<sup>Written for commit a17558062e3d075e260499639b36fca3c9078b8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

