### PR TITLE
refactor(agent-icon): remove unused text field from size config

### DIFF
--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -2,7 +2,7 @@
  * Agent Icon System
  *
  * Renders agent avatars as colored background + icon, custom image, or
- * deterministic fallback (color + first letter).
+ * deterministic fallback (color + icon).
  *
  * Icon format stored in the `icon` string field:
  *   - "icon://IconName?color=emerald" → colored icon
@@ -257,38 +257,13 @@ function hashString(input: string): number {
 // ---------------------------------------------------------------------------
 
 const SIZES = {
-  "2xs": {
-    container: "w-5 h-5",
-    icon: 12,
-    text: "text-[9px]",
-    radius: "rounded-md",
-  },
-  xs: { container: "w-6 h-6", icon: 14, text: "text-xs", radius: "rounded-md" },
-  sm: { container: "w-8 h-8", icon: 16, text: "text-sm", radius: "rounded-lg" },
-  "sm+": {
-    container: "w-10 h-10",
-    icon: 20,
-    text: "text-base",
-    radius: "rounded-lg",
-  },
-  md: {
-    container: "w-12 h-12",
-    icon: 24,
-    text: "text-xl",
-    radius: "rounded-xl",
-  },
-  lg: {
-    container: "w-16 h-16",
-    icon: 32,
-    text: "text-3xl",
-    radius: "rounded-2xl",
-  },
-  xl: {
-    container: "w-20 h-20",
-    icon: 40,
-    text: "text-4xl",
-    radius: "rounded-2xl",
-  },
+  "2xs": { container: "w-5 h-5", icon: 12, radius: "rounded-md" },
+  xs: { container: "w-6 h-6", icon: 14, radius: "rounded-md" },
+  sm: { container: "w-8 h-8", icon: 16, radius: "rounded-lg" },
+  "sm+": { container: "w-10 h-10", icon: 20, radius: "rounded-lg" },
+  md: { container: "w-12 h-12", icon: 24, radius: "rounded-xl" },
+  lg: { container: "w-16 h-16", icon: 32, radius: "rounded-2xl" },
+  xl: { container: "w-20 h-20", icon: 40, radius: "rounded-2xl" },
 } as const;
 
 export type AgentAvatarSize = keyof typeof SIZES;


### PR DESCRIPTION
Dead-code cleanup in `apps/mesh/src/web/components/agent-icon.tsx`, the file this tick's focus area pointed at (recently touched by the color-palette fix in #4928).

Each entry in the `SIZES` map carried a `text: "text-XXpx"` field (7 entries total) that is never read anywhere — `rg -n "sizeConfig\.text" apps/mesh/src` and a repo-wide `rg -n "SIZES\["` show only the two live reads of `.container`/`.radius`/`.icon`, never `.text`. It's a leftover from an earlier design where the deterministic fallback rendered an initial letter (the file's top comment still said "deterministic fallback (color + first letter)", also stale — the fallback has rendered a deterministic icon component for a while, never a letter). Fixed the comment to match and deleted the dead field.

Net: -33/+8 lines, behavior-preserving (the removed field was never consumed, so no rendered output changes).

How to confirm:
- `rg -n "sizeConfig\.text|SIZES\[" apps/mesh/src` shows no remaining reads of the removed field.
- `cd apps/mesh && bunx tsc --noEmit` passes.

Locally ran: `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (clean, 0 errors). No dedicated test file exists for this component (`agent-icon.test.ts` doesn't exist); full CI will run the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `text` field from the `SIZES` config in `apps/mesh/src/web/components/agent-icon.tsx` and updated the fallback comment to reflect color + icon. No functional or UI changes.

- **Refactors**
  - Dropped `text` from all `SIZES` entries; keep `container`, `icon`, `radius`.
  - Updated header comment to match the current deterministic fallback (color + icon).

<sup>Written for commit 9f99cd8e8afa096b9964fdc05afd85420011b5cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

