### PR TITLE
fix(studio-pack): check the org's default brand, not the oldest one

### DIFF
--- a/apps/mesh/src/tools/virtual/studio-pack/brand-manager.test.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/brand-manager.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import type { StudioContext } from "@/core/studio-context";
+import type { BrandContext } from "@/storage/types";
+import { brandManagerAgent } from "./brand-manager";
+
+function brand(overrides: Partial<BrandContext>): BrandContext {
+  return {
+    id: "brand_1",
+    organizationId: "org_1",
+    name: "Brand",
+    domain: "example.com",
+    overview: "",
+    logo: null,
+    favicon: null,
+    ogImage: null,
+    fonts: null,
+    colors: null,
+    images: null,
+    metadata: null,
+    archivedAt: null,
+    isDefault: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function ctxWithBrands(brands: BrandContext[]): StudioContext {
+  return {
+    storage: { brandContext: { list: async () => brands } },
+  } as unknown as StudioContext;
+}
+
+describe("brandManagerAgent checklist", () => {
+  const completeBrandProfile = brandManagerAgent.checklist.find(
+    (item) => item.label === "Complete your brand profile",
+  );
+  if (!completeBrandProfile) throw new Error("checklist item not found");
+
+  test("checks the default brand, not the oldest one, when the org has several", async () => {
+    const oldestIncomplete = brand({ id: "brand_old", isDefault: false });
+    const defaultComplete = brand({
+      id: "brand_default",
+      isDefault: true,
+      logo: "https://example.com/logo.png",
+      colors: { primary: "#000" },
+      fonts: { heading: "Inter" },
+    });
+
+    const completed = await completeBrandProfile.isCompleted({
+      orgId: "org_1",
+      ctx: ctxWithBrands([oldestIncomplete, defaultComplete]),
+    });
+
+    expect(completed).toBe(true);
+  });
+
+  test("falls back to the oldest brand when none is marked default", async () => {
+    const onlyBrand = brand({ id: "brand_1", isDefault: false, logo: null });
+
+    const completed = await completeBrandProfile.isCompleted({
+      orgId: "org_1",
+      ctx: ctxWithBrands([onlyBrand]),
+    });
+
+    expect(completed).toBe(false);
+  });
+});

--- a/apps/mesh/src/tools/virtual/studio-pack/brand-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/brand-manager.ts
@@ -1,10 +1,17 @@
 import { StudioPackAgentId } from "@decocms/mesh-sdk";
+import type { BrandContext } from "@/storage/types";
 import { hasAnyObject } from "./helpers";
 import type {
   ResolveRuntime,
   StudioPackChecklistItem,
   StudioPackConnectionKey,
 } from "./types";
+
+function getActiveBrand(
+  brands: readonly BrandContext[],
+): BrandContext | undefined {
+  return brands.find((b) => b.isDefault) ?? brands[0];
+}
 
 const INSTRUCTIONS_BOOTSTRAP = `<role>
 You are the Brand Manager. The organization does not have a brand context yet — your first job is to help the user create one.
@@ -101,7 +108,7 @@ export const brandManagerAgent = {
   instructions: INSTRUCTIONS_MANAGE,
   resolveRuntime: (async ({ orgId, ctx }) => {
     const brands = await ctx.storage.brandContext.list(orgId);
-    const active = brands.find((b) => b.isDefault) ?? brands[0];
+    const active = getActiveBrand(brands);
     if (!active) {
       return {
         instructions: INSTRUCTIONS_BOOTSTRAP,
@@ -156,9 +163,9 @@ export const brandManagerAgent = {
       },
       isCompleted: async ({ orgId, ctx }) => {
         const brands = await ctx.storage.brandContext.list(orgId);
-        const primary = brands[0];
-        if (!primary) return false;
-        return Boolean(primary.logo && primary.colors && primary.fonts);
+        const active = getActiveBrand(brands);
+        if (!active) return false;
+        return Boolean(active.logo && active.colors && active.fonts);
       },
     },
     {


### PR DESCRIPTION
**Source:** bug found while auditing `apps/mesh/src/tools/virtual/studio-pack/` for the recent churn in this suite (roles/automation/usage managers).

**Why a maintainer wants this:** the Brand Manager's home-checklist "Complete your brand profile" item always read `brands[0]` (oldest by `created_at`) to decide whether the profile is complete, while `resolveRuntime` right above it correctly resolves the org's `isDefault`-flagged brand (falling back to the oldest only when none is marked default) — `BrandContext.create` sets `is_default: false` and a separate set-default path exists, so for any org with 2+ brand contexts where the default isn't the one created first, the checklist item would stay stuck on "incomplete" forever even after the user fully configures (logo/colors/fonts) their actual active brand.

**Failure scenario:** org creates brand A (incomplete, stays first by creation order), later creates brand B and marks it default, then fully fills out B's logo/colors/fonts. The home checklist still shows "Complete your brand profile" as pending because it checked A instead of B.

**Fix:** extracted the existing `find(b => b.isDefault) ?? brands[0]` lookup (already used correctly in `resolveRuntime`) into a shared `getActiveBrand` helper and used it in the checklist's `isCompleted` too, so both code paths agree on which brand is "active". Added `brand-manager.test.ts` covering: (1) the default-but-not-oldest brand is what's checked, (2) falls back to the oldest brand when none is default.

**Reviewer command:** `bun test apps/mesh/src/tools/virtual/studio-pack/brand-manager.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Brand Manager home checklist to check the org’s default brand instead of the oldest, so “Complete your brand profile” completes when the active brand has logo/colors/fonts. Aligns the checklist with the runtime brand selection to avoid stuck “incomplete” states in multi-brand orgs.

- **Bug Fixes**
  - Added `getActiveBrand` (choose `isDefault` brand, fallback to oldest) and used it in both `resolveRuntime` and the checklist’s `isCompleted`.
  - Added `brand-manager.test.ts` covering default-not-oldest and no-default fallback cases.

<sup>Written for commit 4fd655be954dcb11a40b7162c6f30b1c44c213c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

