### PR TITLE
fix(chat): insert voice transcript as plain text, not HTML

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/input.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/input.tsx
@@ -199,9 +199,14 @@ export function TiptapInput({
         if (voiceText) {
           editor.commands.focus("end");
           const hasBaseline = editor.state.doc.textContent.trim().length > 0;
-          editor.commands.insertContent(
-            hasBaseline ? " " + voiceText : voiceText,
-          );
+          // Insert as a plain-text JSON node, not a string — insertContent
+          // parses string content as HTML, so a transcript containing
+          // tag-like substrings (e.g. "<b>", "<ul><li>") would silently be
+          // reformatted/restructured instead of kept as literal text.
+          editor.commands.insertContent({
+            type: "text",
+            text: hasBaseline ? " " + voiceText : voiceText,
+          });
         }
       },
       restoreContent: (baseline: Metadata["tiptapDoc"]) => {

--- a/apps/mesh/src/web/components/chat/tiptap/voice-text-insert.test.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/voice-text-insert.test.ts
@@ -1,0 +1,31 @@
+import { setupComponentTest } from "../../../../test/setup";
+setupComponentTest();
+import { describe, expect, test } from "bun:test";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+
+/**
+ * Regression test for the voice-transcript insertion path in
+ * TiptapInputHandle.syncVoiceText: it must insert the transcript as a
+ * plain-text JSON node, not a string, since `insertContent(string)`
+ * parses its argument as HTML and would reformat/restructure a
+ * transcript containing tag-like substrings.
+ */
+describe("voice transcript insertion", () => {
+  const TAG_LIKE_TRANSCRIPTS = [
+    "please say <b>bold</b> now",
+    "<em onmouseover=alert(1)>hover</em>",
+    "list: <ul><li>one</li></ul> done",
+  ];
+
+  for (const text of TAG_LIKE_TRANSCRIPTS) {
+    test(`preserves literal text for: ${text}`, () => {
+      const editor = new Editor({
+        extensions: [StarterKit],
+        content: { type: "doc", content: [] },
+      });
+      editor.commands.insertContent({ type: "text", text });
+      expect(editor.getText()).toBe(text);
+    });
+  }
+});


### PR DESCRIPTION
**Source:** bug found while hardening `apps/mesh/src/web/components/chat/input.tsx` (voice input flow, `TiptapInputHandle.syncVoiceText` in the sibling `tiptap/input.tsx` it drives via ref).

**Why a maintainer wants this:** the voice-to-text sync path (`handleVoiceStart`/`handleVoiceConfirm` in `input.tsx`) fed the raw speech-to-text transcript into `editor.commands.insertContent(voiceText)`. Tiptap parses a *string* argument to `insertContent` as HTML (`elementFromString` + ProseMirror's schema-aware `DOMParser`, confirmed by tracing `@tiptap/core`'s `createNodeFromContent`). So a transcript containing incidental tag-like substrings silently gets reformatted or restructured instead of inserted as the literal text the user spoke — untrusted/uncontrolled speech-recognition output shouldn't be trusted as safe HTML input.

**Failure scenario (reproduced with a real headless Tiptap editor + happy-dom):**
- Transcript `please say <b>bold</b> now` → renders as *please say **bold** now* (the literal `<b>`/`</b>` text vanishes, replaced by an actual bold mark).
- Transcript `list: <ul><li>one</li></ul> done` → splits the single paragraph into three blocks (a leading paragraph, an actual bullet list, a trailing paragraph), eating the surrounding words onto separate lines.
- Transcript `<em onmouseover=alert(1)>hover</em>` → parsed into an italic mark; ProseMirror's schema drops the `onmouseover` attribute (no script execution demonstrated), but it shows arbitrary HTML-like transcript content gets parsed as markup rather than treated as literal text.

**Fix:** insert the transcript as a JSON text node (`{ type: "text", text }`) instead of a string — `createNodeFromContent` routes JSON content straight to `schema.nodeFromJSON`, bypassing the HTML parser entirely, so the transcript is preserved verbatim regardless of its contents.

**Regression test:** `apps/mesh/src/web/components/chat/tiptap/voice-text-insert.test.ts` — instantiates a real `@tiptap/core` `Editor` (StarterKit schema) and asserts `editor.getText()` matches the input verbatim for tag-like transcripts, using the app's existing happy-dom test setup.

**Commands to verify:**
```
bun test apps/mesh/src/web/components/chat/tiptap/voice-text-insert.test.ts
cd apps/mesh && bunx tsc --noEmit
```

**Locally run:** `bun run fmt`, the targeted test above (3/3 pass), and `bunx tsc --noEmit` in `apps/mesh` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Insert voice transcripts into the chat editor as plain text instead of HTML, so tag-like content isn’t parsed or reformatted. This preserves exactly what the user dictated.

- **Bug Fixes**
  - In `apps/mesh/src/web/components/chat/tiptap/input.tsx`, use `editor.commands.insertContent({ type: "text", text })` to bypass HTML parsing in `@tiptap/core` and keep transcripts verbatim (maintains the existing leading-space behavior when appending).
  - Added `apps/mesh/src/web/components/chat/tiptap/voice-text-insert.test.ts` to verify literal insertion with `@tiptap/core` and `@tiptap/starter-kit` for tag-like transcripts (e.g., "<b>", "<ul><li>").

<sup>Written for commit 4e218c896b9ecb81bd1653b282d54e76883e7f82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

