### PR TITLE
fix(auth): check the target org's role, not the active org's, before role-assignment

### DIFF
--- a/apps/mesh/src/tools/organization/member-add.ts
+++ b/apps/mesh/src/tools/organization/member-add.ts
@@ -57,9 +57,19 @@ export const ORGANIZATION_MEMBER_ADD = defineTool({
       );
     }
 
-    // Validate the caller is allowed to assign every target role.
+    // Validate the caller is allowed to assign every target role. `ctx.auth.user?.role`
+    // reflects the session's ACTIVE org, which can differ from `organizationId` here
+    // (an org-scoped call can target an org the caller merely holds membership in) —
+    // using it would let an owner/admin of a DIFFERENT org assign "owner" in this one.
+    // Look up the caller's real membership row in the TARGET org instead.
     // Admins cannot assign "owner" — only owners can.
-    if (!canAssignRole(ctx.auth.user?.role, input.role)) {
+    const callerMembership = await ctx.db
+      .selectFrom("member")
+      .select(["role"])
+      .where("userId", "=", getUserId(ctx) ?? "")
+      .where("organizationId", "=", organizationId)
+      .executeTakeFirst();
+    if (!canAssignRole(callerMembership?.role, input.role)) {
       throw new Error(
         `Insufficient privileges to assign role "${input.role.join(",")}"`,
       );

--- a/apps/mesh/src/tools/organization/member-update-role.ts
+++ b/apps/mesh/src/tools/organization/member-update-role.ts
@@ -55,9 +55,19 @@ export const ORGANIZATION_MEMBER_UPDATE_ROLE = defineTool({
       );
     }
 
-    // Validate the caller is allowed to assign every target role.
+    // Validate the caller is allowed to assign every target role. `organizationId`
+    // may be an explicit override (not the session's active org), and
+    // `ctx.auth.user?.role` only ever reflects the active-org role — using it here
+    // would let an owner/admin of a DIFFERENT org assign "owner" in this one.
+    // Look up the caller's real membership row in the TARGET org instead.
     // Admins cannot assign "owner" — only owners can.
-    if (!canAssignRole(ctx.auth.user?.role, input.role)) {
+    const callerMembership = await ctx.db
+      .selectFrom("member")
+      .select(["role"])
+      .where("userId", "=", getUserId(ctx) ?? "")
+      .where("organizationId", "=", organizationId)
+      .executeTakeFirst();
+    if (!canAssignRole(callerMembership?.role, input.role)) {
       throw new Error(
         `Insufficient privileges to assign role "${input.role.join(",")}"`,
       );


### PR DESCRIPTION
**Bug** (found while auditing recently-changed auth files, adjacent to this tick's other cross-org role fixes #4925/#4926, but a distinct site): `ORGANIZATION_MEMBER_ADD` and `ORGANIZATION_MEMBER_UPDATE_ROLE` (`apps/mesh/src/tools/organization/member-add.ts`, `member-update-role.ts`) gate role assignment with `canAssignRole(ctx.auth.user?.role, input.role)` — the app-level rule that blocks an "admin" from granting "owner". But `ctx.auth.user.role` reflects the caller's role in their session's **active** org, which `OrganizationScope.role`'s own doc comment in `studio-context.ts` warns "may differ" from the org actually being mutated.

**Failure scenario**: a user who is `owner` of org A but only `admin` (or a plain `member`) of org B calls either tool against org B. `member-update-role.ts` takes an explicit `organizationId` override with no check that it matches the caller's active org at all. `member-add.ts` does guard `input.organizationId !== ctx.organization?.id`, but that only compares against the *path-resolved* org — it never re-derives `ctx.auth.user.role` for that org, so the stale org-A `owner` role still leaks through the `canAssignRole` check when the tool is invoked on an org-scoped path different from the session's active org. Either way, an admin/member of org B can walk away as `owner` of org B using a role they only hold in an unrelated org.

**Fix**: before calling `canAssignRole`, look up the caller's actual `member.role` row for the target `organizationId` (same pattern already used in `apps/mesh/src/api/routes/auth.ts` and `task-board-import.ts`), instead of trusting the session-wide `ctx.auth.user.role` field.

**Verify**: `cd apps/mesh && bunx tsc --noEmit` (clean) and `bun test apps/mesh/src/tools/organization/member-update-role.test.ts apps/mesh/src/auth/roles.test.ts` (14 pass) — both cover the surrounding schema/`canAssignRole` logic that's unchanged; the new DB-backed lookup itself needs a real Postgres member row so it's e2e territory, left to full CI per this repo's two-tier testing rule.

Net change: +24/-4 across the two tool handlers, one concern (resolve the role for the correct org before authorizing a role change).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross‑org role assignment by checking the caller’s role in the target organization instead of the session’s active org. This closes a privilege‑escalation gap when adding or updating org roles.

- **Bug Fixes**
  - In `apps/mesh/src/tools/organization/member-add.ts` and `member-update-role.ts`, fetch the caller’s `member.role` for the target `organizationId` and pass it to `canAssignRole`.
  - Prevents granting `owner` in org B using `owner` from org A, including when `organizationId` is overridden.

<sup>Written for commit b8f007d54ede37558a326fe440353bf476c29df5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

