### PR TITLE
fix(reports): polish report login gate

### DIFF
--- a/apps/mesh/src/web/routes/reports/auth-gate.tsx
+++ b/apps/mesh/src/web/routes/reports/auth-gate.tsx
@@ -3,7 +3,7 @@ import type {
   AuthFlowEvent,
   UnifiedAuthFormCopy,
 } from "@/web/components/unified-auth-form";
-import { brandFromDomain, faviconForDomain } from "@/shared/report-seo";
+import { faviconForDomain } from "@/shared/report-seo";
 import { isPostHogInitialized } from "@/web/lib/posthog-client";
 import { ReportSocialProof } from "./report-social-proof";
 import {
@@ -44,13 +44,33 @@ function callbackUrl(domain: string): string {
   return `${path}${window.location.search}${window.location.hash}`;
 }
 
+// Mock findings mirroring the deck cover's clickable TOC.
+const BACKDROP_FINDINGS = [
+  "Velocidade de carregamento abaixo do ideal",
+  "Meta tags de SEO incompletas",
+  "Checkout com etapas em excesso",
+  "Imagens de produto sem otimização",
+  "Concorrentes com melhor cobertura",
+] as const;
+
+const BACKDROP_SCORE = 72;
+
+/** A blurred, non-interactive stand-in for the real Signal Deck (see
+ *  `signal-deck.tsx` + `cover-template.tsx`): the translucent header pill,
+ *  the holographic cover card (score ring + headline + findings on the left,
+ *  a rainbow art panel with a browser preview on the right), the side progress
+ *  rail, and the footer bar. It's a mock, but it reads as the same product —
+ *  just wider — so the auth gate sits on the report it unlocks. */
 export function ReportBackdrop({ domain }: { domain: string }) {
-  const brand = brandFromDomain(domain);
+  const ringSize = 104;
+  const ringW = 10;
+  const r = (ringSize - ringW) / 2;
+  const circumference = 2 * Math.PI * r;
 
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none absolute inset-[-18px] select-none overflow-hidden"
+      className="pointer-events-none absolute inset-[-18px] flex select-none flex-col overflow-hidden"
       style={{
         background: DECK.bg,
         color: DECK.ink,
@@ -59,190 +79,269 @@ export function ReportBackdrop({ domain }: { domain: string }) {
         transform: "scale(1.025)",
       }}
     >
-      <div className="flex h-full min-h-[640px] flex-col px-6 py-5 sm:px-10 sm:py-8 lg:px-16">
-        <header
-          className="flex items-center justify-between border-b pb-5"
-          style={{ borderColor: DECK.border }}
+      {/* header — rounded translucent pill bar with the deco logo + Share */}
+      <div className="shrink-0 px-6 pt-6 sm:px-10">
+        <div
+          className="mx-auto flex h-[60px] max-w-[1440px] items-center gap-3 rounded-full border pl-6 pr-4"
+          style={{
+            borderColor: DECK.cardBorder,
+            background: "rgba(255,255,255,0.82)",
+            boxShadow:
+              "0 1px 2px rgba(40,37,36,0.05), 0 10px 30px -20px rgba(40,37,36,0.35)",
+          }}
         >
-          <div className="flex items-center gap-3">
-            <img
-              src={faviconForDomain(domain)}
-              alt=""
-              className="h-8 w-8 rounded-lg object-contain"
-            />
-            <div>
-              <p className="text-sm font-medium">{brand}</p>
-              <p className="text-xs" style={{ color: DECK.faint }}>
-                {domain}
-              </p>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <span
-              className="h-2 w-16 rounded-full"
-              style={{ background: DECK.border }}
-            />
-            <span
-              className="h-9 w-24 rounded-full"
-              style={{ background: DECK.ink }}
-            />
-          </div>
-        </header>
+          <img
+            src="/logos/deco-logo.svg"
+            alt=""
+            width={54}
+            height={22}
+            className="h-[22px] w-auto"
+          />
+          <span
+            className="ml-auto flex h-9 w-24 items-center justify-center rounded-full text-sm font-medium"
+            style={{ background: DECK.primary, color: DECK.primaryFg }}
+          >
+            Share
+          </span>
+        </div>
+      </div>
 
-        <main className="grid min-h-0 flex-1 items-center gap-8 py-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(420px,1.1fr)] lg:gap-14">
-          <div className="space-y-7">
-            <div className="space-y-4">
-              <p
-                className="text-xs font-medium uppercase tracking-[0.08em]"
-                style={{ color: DECK.soft }}
+      {/* stage — the cover card */}
+      <div className="relative min-h-0 flex-1 px-6 py-8 sm:px-10">
+        <div
+          className="mx-auto flex h-full w-full max-w-[1280px] flex-col overflow-hidden rounded-[26px]"
+          style={{
+            background:
+              "radial-gradient(120% 80% at 30% 0%, #ffffff 0%, #fafaf9 45%, #f6f4f1 100%)",
+            boxShadow:
+              "inset 0 1px 0 rgba(255,255,255,0.9), inset 0 0 0 1px rgba(40,37,36,0.05), 0 1px 2px rgba(40,37,36,0.04)",
+          }}
+        >
+          <div className="grid min-h-0 flex-1 grid-cols-1 gap-2 p-2 lg:grid-cols-2">
+            {/* left: favicon header + score + headline + findings */}
+            <div className="flex min-h-0 flex-col px-5 py-5">
+              <div
+                className="flex shrink-0 items-center gap-3 pb-4"
+                style={{ borderBottom: `1px solid ${DECK.border}` }}
               >
-                Relatório de comércio digital
-              </p>
-              <h1 className="max-w-[13ch] text-4xl font-normal leading-[1.04] tracking-[-0.035em] sm:text-6xl">
-                Uma visão completa da sua loja.
-              </h1>
-              <p
-                className="max-w-[38rem] text-base leading-7"
-                style={{ color: DECK.muted }}
-              >
-                Oportunidades, comparativos e próximos passos reunidos em um
-                único relatório.
-              </p>
-            </div>
+                <div
+                  className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white"
+                  style={{ border: `1px solid ${DECK.border}` }}
+                >
+                  <img
+                    src={faviconForDomain(domain)}
+                    alt=""
+                    className="h-full w-full object-contain p-1.5"
+                  />
+                </div>
+                <span className="min-w-0 flex-1 truncate text-base">
+                  <span style={{ color: DECK.faint }}>https://</span>
+                  {domain}
+                </span>
+                <span
+                  className="shrink-0 text-[11px] font-medium uppercase tracking-[0.04em]"
+                  style={{ color: DECK.soft }}
+                >
+                  Relatório
+                </span>
+              </div>
 
-            <div className="grid gap-3 sm:grid-cols-2">
-              {["Experiência", "Descoberta", "Conversão", "Operação"].map(
-                (label, index) => (
-                  <div
-                    key={label}
-                    className="rounded-2xl border p-4"
-                    style={{ borderColor: DECK.border, background: "#fff" }}
+              {/* Deco Score — static ring + number */}
+              <div className="mt-4 flex shrink-0 items-center gap-5">
+                <svg
+                  width={ringSize}
+                  height={ringSize}
+                  className="-rotate-90 shrink-0"
+                >
+                  <circle
+                    cx={ringSize / 2}
+                    cy={ringSize / 2}
+                    r={r}
+                    fill="none"
+                    stroke={DECK.border}
+                    strokeWidth={ringW}
+                  />
+                  <circle
+                    cx={ringSize / 2}
+                    cy={ringSize / 2}
+                    r={r}
+                    fill="none"
+                    stroke={DECK.soft}
+                    strokeWidth={ringW}
+                    strokeLinecap="round"
+                    strokeDasharray={circumference}
+                    strokeDashoffset={
+                      circumference * (1 - BACKDROP_SCORE / 100)
+                    }
+                  />
+                </svg>
+                <div className="flex flex-col gap-0.5">
+                  <div className="flex items-baseline gap-2">
+                    <span
+                      className="text-[4rem] font-light leading-[0.9] tracking-[-0.02em] tabular-nums"
+                      style={{ color: DECK.soft }}
+                    >
+                      {BACKDROP_SCORE}
+                    </span>
+                    <span className="text-xl" style={{ color: DECK.faint }}>
+                      / 100
+                    </span>
+                  </div>
+                  <span
+                    className="text-[12px] font-medium uppercase tracking-[0.04em]"
+                    style={{ color: DECK.soft }}
                   >
-                    <div className="flex items-center justify-between">
-                      <span className="text-sm" style={{ color: DECK.muted }}>
-                        {label}
+                    Deco Score
+                  </span>
+                </div>
+              </div>
+
+              <h1
+                className="mt-4 max-w-[24ch] text-[1.7rem] font-normal leading-[1.16] tracking-[-0.02em]"
+                style={{ color: DECK.ink }}
+              >
+                Uma visão completa da sua loja e onde crescer primeiro.
+              </h1>
+
+              <ul className="mt-auto flex flex-col pt-4">
+                {BACKDROP_FINDINGS.map((title, i) => (
+                  <li
+                    key={title}
+                    style={
+                      i < BACKDROP_FINDINGS.length - 1
+                        ? { borderBottom: `1px solid ${DECK.border}` }
+                        : undefined
+                    }
+                  >
+                    <div className="flex w-full items-center gap-3.5 py-2.5">
+                      <span
+                        className="shrink-0 text-[12px] tabular-nums"
+                        style={{ color: DECK.soft }}
+                      >
+                        {String(i + 1).padStart(2, "0")}
                       </span>
-                      <span className="text-2xl font-light">
-                        {72 + index * 5}
+                      <span
+                        className="min-w-0 flex-1 truncate text-left text-[15px] opacity-55"
+                        style={{ color: DECK.ink, lineHeight: 1.3 }}
+                      >
+                        {title}
                       </span>
                     </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* right: holographic art panel with a browser preview */}
+            <div className="hidden lg:block">
+              <div
+                className="relative h-full w-full overflow-hidden rounded-2xl"
+                style={{
+                  background:
+                    "radial-gradient(circle at 18% 18%, rgba(208,236,26,.45), transparent 35%), radial-gradient(circle at 82% 30%, rgba(152,221,255,.7), transparent 34%), radial-gradient(circle at 60% 86%, rgba(255,183,214,.65), transparent 42%), #f7f5ef",
+                }}
+              >
+                <div
+                  className="absolute inset-x-8 top-8 rounded-2xl border bg-white p-3 shadow-xl"
+                  style={{ borderColor: DECK.border }}
+                >
+                  <div
+                    className="mb-3 flex items-center gap-2 border-b pb-3"
+                    style={{ borderColor: DECK.border }}
+                  >
+                    <span className="h-2.5 w-2.5 rounded-full bg-[#ff6b67]" />
+                    <span className="h-2.5 w-2.5 rounded-full bg-[#f5c451]" />
+                    <span className="h-2.5 w-2.5 rounded-full bg-[#65c466]" />
+                    <span
+                      className="ml-3 h-6 flex-1 rounded-full"
+                      style={{ background: DECK.bg }}
+                    />
+                  </div>
+                  <div className="grid h-[330px] grid-cols-[0.72fr_1.28fr] gap-3">
                     <div
-                      className="mt-4 h-1.5 overflow-hidden rounded-full"
-                      style={{ background: DECK.border }}
+                      className="space-y-3 rounded-xl p-4"
+                      style={{ background: DECK.forest }}
                     >
-                      <div
-                        className="h-full rounded-full"
-                        style={{
-                          background: DECK.soft,
-                          width: `${54 + index * 9}%`,
-                        }}
-                      />
+                      <div className="h-3 w-16 rounded-full bg-white/30" />
+                      <div className="h-8 w-full rounded-lg bg-white/80" />
+                      <div className="h-3 w-4/5 rounded-full bg-white/30" />
+                      <div className="mt-8 h-24 rounded-xl bg-white/10" />
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      {[0, 1, 2, 3].map((item) => (
+                        <div
+                          key={item}
+                          className="rounded-xl border bg-white p-3"
+                          style={{ borderColor: DECK.border }}
+                        >
+                          <div
+                            className="h-24 rounded-lg"
+                            style={{ background: DECK.bg }}
+                          />
+                          <div
+                            className="mt-3 h-3 w-4/5 rounded-full"
+                            style={{ background: DECK.border }}
+                          />
+                          <div
+                            className="mt-2 h-3 w-1/2 rounded-full"
+                            style={{ background: DECK.border }}
+                          />
+                        </div>
+                      ))}
                     </div>
                   </div>
-                ),
-              )}
+                </div>
+              </div>
             </div>
           </div>
+        </div>
 
-          <div
-            className="relative hidden h-[min(68vh,660px)] min-h-[430px] overflow-hidden rounded-[2rem] border p-8 lg:block"
+        {/* side progress rail */}
+        <div className="absolute right-8 top-1/2 flex -translate-y-1/2 flex-col gap-1.5">
+          {[0, 1, 2, 3, 4, 5].map((item) => (
+            <span
+              key={item}
+              className="rounded-full"
+              style={{
+                height: item === 0 ? 3 : 2,
+                width: item === 0 ? 28 : 12,
+                background: item === 0 ? DECK.ink : "rgba(40,37,36,0.22)",
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* footer bar */}
+      <footer
+        className="flex shrink-0 items-center gap-2 px-6 py-4 sm:px-10"
+        style={{ borderTop: `1px solid ${DECK.border}` }}
+      >
+        <span
+          className="text-sm tabular-nums opacity-50"
+          style={{ color: DECK.ink }}
+        >
+          01/06
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          <span
+            className="flex h-12 items-center gap-2 rounded-full border px-6 text-sm font-medium"
             style={{
-              borderColor: DECK.border,
-              background:
-                "radial-gradient(circle at 18% 18%, rgba(208,236,26,.45), transparent 35%), radial-gradient(circle at 82% 30%, rgba(152,221,255,.7), transparent 34%), radial-gradient(circle at 60% 86%, rgba(255,183,214,.65), transparent 42%), #f7f5ef",
+              borderColor: DECK.inputBorder,
+              color: DECK.ink,
+              background: DECK.surface,
             }}
           >
-            <div
-              className="absolute inset-x-8 top-8 rounded-2xl border bg-white p-3 shadow-xl"
-              style={{ borderColor: DECK.border }}
-            >
-              <div
-                className="mb-3 flex items-center gap-2 border-b pb-3"
-                style={{ borderColor: DECK.border }}
-              >
-                <span className="h-2.5 w-2.5 rounded-full bg-[#ff6b67]" />
-                <span className="h-2.5 w-2.5 rounded-full bg-[#f5c451]" />
-                <span className="h-2.5 w-2.5 rounded-full bg-[#65c466]" />
-                <span
-                  className="ml-3 h-6 flex-1 rounded-full"
-                  style={{ background: DECK.bg }}
-                />
-              </div>
-              <div className="grid h-[330px] grid-cols-[0.72fr_1.28fr] gap-3">
-                <div
-                  className="space-y-3 rounded-xl p-4"
-                  style={{ background: DECK.forest }}
-                >
-                  <div className="h-3 w-16 rounded-full bg-white/30" />
-                  <div className="h-8 w-full rounded-lg bg-white/80" />
-                  <div className="h-3 w-4/5 rounded-full bg-white/30" />
-                  <div className="mt-8 h-24 rounded-xl bg-white/10" />
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  {[0, 1, 2, 3].map((item) => (
-                    <div
-                      key={item}
-                      className="rounded-xl border bg-white p-3"
-                      style={{ borderColor: DECK.border }}
-                    >
-                      <div
-                        className="h-24 rounded-lg"
-                        style={{ background: DECK.bg }}
-                      />
-                      <div
-                        className="mt-3 h-3 w-4/5 rounded-full"
-                        style={{ background: DECK.border }}
-                      />
-                      <div
-                        className="mt-2 h-3 w-1/2 rounded-full"
-                        style={{ background: DECK.border }}
-                      />
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-            <div className="absolute bottom-8 left-8 right-8 flex items-center justify-between rounded-2xl bg-white/85 px-5 py-4 shadow-lg">
-              <div className="space-y-2">
-                <div
-                  className="h-3 w-28 rounded-full"
-                  style={{ background: DECK.border }}
-                />
-                <div
-                  className="h-5 w-44 rounded-full"
-                  style={{ background: DECK.ink }}
-                />
-              </div>
-              <div
-                className="h-12 w-12 rounded-full"
-                style={{ background: DECK.soft }}
-              />
-            </div>
-          </div>
-        </main>
-
-        <footer
-          className="flex items-center justify-between border-t pt-5"
-          style={{ borderColor: DECK.border }}
-        >
+            Compartilhar
+          </span>
           <span
-            className="h-2 w-24 rounded-full"
-            style={{ background: DECK.border }}
-          />
-          <div className="flex gap-2">
-            {[0, 1, 2, 3].map((item) => (
-              <span
-                key={item}
-                className="h-2 rounded-full"
-                style={{
-                  background: item === 0 ? DECK.ink : DECK.border,
-                  width: item === 0 ? 28 : 8,
-                }}
-              />
-            ))}
-          </div>
-        </footer>
-      </div>
+            className="flex h-12 items-center rounded-full px-6 text-sm font-medium"
+            style={{ background: DECK.primary, color: DECK.primaryFg }}
+          >
+            Próximo
+          </span>
+        </div>
+      </footer>
     </div>
   );
 }
@@ -305,7 +404,7 @@ export function ReportAuthGate({
   return (
     <div
       ref={trackGateRef}
-      className="fixed inset-0 overflow-y-auto"
+      className="fixed inset-0 overflow-hidden"
       style={{
         color: DECK.ink,
         fontFamily: "Switzer, 'Inter var', Helvetica, Arial, sans-serif",
@@ -313,12 +412,12 @@ export function ReportAuthGate({
       }}
     >
       <ReportBackdrop domain={domain} />
-      <div className="pointer-events-none absolute inset-0 bg-white/35" />
+      <div className="pointer-events-none absolute inset-0 bg-white/55" />
 
-      <div className="relative z-10 flex min-h-full items-center justify-center px-3 py-5 sm:px-6 sm:py-10">
+      <div className="relative z-10 flex h-full items-center justify-center px-3 py-5 sm:px-6 sm:py-10">
         {loading ? (
           <div
-            className="h-[330px] w-full max-w-[440px] animate-pulse rounded-3xl bg-white/90"
+            className="h-[330px] w-full max-w-[440px] animate-pulse rounded-3xl bg-white card-shadow"
             aria-label="Carregando sessão"
           />
         ) : (
@@ -326,7 +425,7 @@ export function ReportAuthGate({
             role="dialog"
             aria-modal="true"
             aria-label="Acesse seu relatório"
-            className="w-full max-w-[440px] rounded-2xl bg-white px-5 py-5 shadow-2xl sm:rounded-3xl sm:px-7 sm:py-7"
+            className="w-full max-w-[440px] rounded-2xl bg-white px-6 py-6 card-shadow sm:rounded-3xl sm:px-8 sm:py-8"
           >
             <AuthEntry
               callbackUrl={callbackUrl(domain)}
@@ -364,7 +463,7 @@ export function ReportAuthGate({
               copy={REPORT_AUTH_COPY}
             />
             <p
-              className="mt-5 text-center text-xs leading-5"
+              className="mt-4 text-xs leading-5"
               style={{ color: DECK.faint }}
             >
               Acesso gratuito. Leva menos de um minuto.

--- a/apps/mesh/src/web/routes/reports/auth-gate.tsx
+++ b/apps/mesh/src/web/routes/reports/auth-gate.tsx
@@ -462,10 +462,7 @@ export function ReportAuthGate({
               }
               copy={REPORT_AUTH_COPY}
             />
-            <p
-              className="mt-4 text-xs leading-5"
-              style={{ color: DECK.faint }}
-            >
+            <p className="mt-4 text-xs leading-5" style={{ color: DECK.faint }}>
               Acesso gratuito. Leva menos de um minuto.
             </p>
             <ReportSocialProof compact />

--- a/apps/mesh/src/web/routes/reports/report-social-proof.tsx
+++ b/apps/mesh/src/web/routes/reports/report-social-proof.tsx
@@ -10,12 +10,6 @@ const CAROUSEL_LOGOS = [
   { src: "/logos/summit/farm-rio.svg", alt: "Farm Rio", w: 159, h: 23 },
   { src: "/logos/summit/electrolux.svg", alt: "Electrolux", w: 154, h: 35 },
   { src: "/logos/summit/monte-carlo.svg", alt: "Monte Carlo", w: 116, h: 61 },
-  {
-    src: "/logos/summit/leroy-merlin.svg",
-    alt: "Leroy Merlin",
-    w: 109,
-    h: 62,
-  },
   { src: "/logos/summit/technos.svg", alt: "Technos", w: 141, h: 29 },
   { src: "/logos/summit/bagaggio.svg", alt: "Bagaggio", w: 149, h: 22 },
   { src: "/logos/summit/le-biscuit.svg", alt: "Le Biscuit", w: 141, h: 24 },

--- a/packages/e2e/tests/report-auth-gate.spec.ts
+++ b/packages/e2e/tests/report-auth-gate.spec.ts
@@ -12,9 +12,9 @@ test("anonymous shared report shows login over a blurred preview", async ({
   await expect(dialog).toBeVisible();
   await expect(dialog.getByText("Já receberam")).toBeVisible();
 
-  const preview = page
-    .locator('div[aria-hidden="true"]')
-    .filter({ hasText: "Uma visão completa da sua loja." });
+  const preview = page.locator('div[aria-hidden="true"]').filter({
+    hasText: "Uma visão completa da sua loja e onde crescer primeiro.",
+  });
   await expect(preview).toHaveCSS("filter", "blur(9px)");
   await expect(page).toHaveURL(/share_id=example%3Aslide%3Atest/);
   await expect(page).toHaveURL(/#overview$/);


### PR DESCRIPTION
## What is this contribution about?
Polishes the `/report/:domain` login gate. The blurred backdrop behind the auth card is remocked to mirror the real Signal Deck cover (translucent header pill, Deco Score ring, findings list, rainbow art panel), just wider, so the gate visually sits on the report it unlocks. The gate is now locked to the viewport (no page scroll), the login card uses the design-system `card-shadow` for a crisp hairline border, the backdrop overlay is faded a bit more, padding is roomier, and the footer note is left-aligned. The Leroy Merlin logo is removed from the "Já receberam" social-proof carousel.

## Screenshots/Demonstration
UI change to the report auth gate — see the redesigned deck-style backdrop, bordered card, and faded overlay. (Verified locally at 1440×900 and a short viewport; the gate does not scroll.)

## How to Test
1. Run `bun run dev --no-local-mode` (local mode auto-logs-in and skips the gate).
2. In a logged-out session (private window), open `http://localhost:4000/report/nike.com`.
3. Expected: the login card renders over a deck-style backdrop, the page does not scroll, the card has the design-system border/shadow, and the social-proof strip has no Leroy Merlin logo.

## Migration Notes
Not applicable.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the `/report/:domain` login gate with a deck-style blurred backdrop and a fixed, centered auth card for a more integrated experience. Updated tests and formatting to keep CI green.

- **UI Improvements**
  - Rebuilt the backdrop to mirror the report cover (translucent header pill with Share, Deco Score ring, findings list, art panel).
  - Locked the gate to the viewport so the page doesn’t scroll; increased padding, applied design-system `card-shadow` to the card and loading state, and softened the overlay.
  - Left-aligned the footer note.
  - Removed the "Leroy Merlin" logo from the “Já receberam” carousel.

- **Bug Fixes**
  - Updated the e2e to assert the blurred preview against the new headline copy.
  - Ran formatter on the auth-gate to satisfy CI.

<sup>Written for commit b5c9ce381f881b4970a324b460d539d4143f07d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

