### PR TITLE
feat(file-explorer): search inside file contents and across the whole repo

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -500,6 +500,12 @@ export const createSandboxRoutes = () => {
       signal: quickFileOpSignal(c),
     }),
   );
+  app.post("/:virtualMcpId/:branch/grep", (c) =>
+    proxyDaemon(c, "/_sandbox/grep", {
+      forwardJsonBody: true,
+      signal: quickFileOpSignal(c),
+    }),
+  );
 
   // -- Script exec/kill -----------------------------------------------------
   app.post("/:virtualMcpId/:branch/exec/:script", (c) => {

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -45,15 +45,20 @@ import {
   getFileVisual,
   getLanguageFromPath,
   getParentTreePath,
+  buildGrepHighlight,
+  groupGrepMatches,
   isSafeExplorerOpenPath,
   joinTreePath,
+  matchFileNames,
   mergeGlobLists,
+  parseGrepContent,
   pathExistsInFileList,
   stripLineNumbers,
   toDaemonPath,
   toTreePath,
   validateExplorerEntryName,
   type GlobListResult,
+  type GrepContentMatch,
 } from "./utils";
 
 // Configure Monaco CDN (shared with workflow editor)
@@ -62,6 +67,15 @@ loader.config({
     vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs",
   },
 });
+
+/** Max content-search hits requested from the daemon grep endpoint. */
+const CONTENT_SEARCH_LIMIT = 200;
+/** Minimum query length before firing a (whole-repo) content search. */
+const CONTENT_SEARCH_MIN_CHARS = 2;
+/** Debounce before firing the search as the user types. */
+const SEARCH_DEBOUNCE_MS = 250;
+/** Max filename matches rendered in the search results. */
+const FILENAME_MATCH_LIMIT = 200;
 
 interface FileExplorerProps {
   orgSlug: string;
@@ -84,6 +98,29 @@ function buildApiUrl(
   return `/api/${orgSlug}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/${endpoint}`;
 }
 
+/** A grep result line with the matched query runs highlighted (VS Code-style). */
+function GrepMatchLine({ text, query }: { text: string; query: string }) {
+  const { leadingEllipsis, segments } = buildGrepHighlight(text, query);
+  return (
+    <span className="truncate font-mono text-muted-foreground">
+      {leadingEllipsis && <span className="text-muted-foreground/50">…</span>}
+      {segments.map((segment, index) =>
+        segment.match ? (
+          <span
+            // Segments are positional within a single line; index is stable.
+            key={index}
+            className="rounded-[2px] bg-primary/20 text-foreground"
+          >
+            {segment.text}
+          </span>
+        ) : (
+          <span key={index}>{segment.text}</span>
+        ),
+      )}
+    </span>
+  );
+}
+
 export function FileExplorer({
   orgSlug,
   virtualMcpId,
@@ -104,6 +141,16 @@ export function FileExplorer({
   );
   const [openTabs, setOpenTabs] = useState<string[]>([]);
   const [search, setSearch] = useState("");
+  // Filename matches across the WHOLE repo (not just the loaded tree). `null` =
+  // not searching; `[]` = searched, no hits. Tree paths (leading slash).
+  const [fileNameMatches, setFileNameMatches] = useState<string[] | null>(null);
+  // Content search (ripgrep over the whole repo). `null` = not searching /
+  // query too short; `[]` = searched, no hits.
+  const [contentMatches, setContentMatches] = useState<
+    GrepContentMatch[] | null
+  >(null);
+  const [contentSearching, setContentSearching] = useState(false);
+  const [contentSearchTruncated, setContentSearchTruncated] = useState(false);
   const [loading, setLoading] = useState(false);
   const [treeLoaded, setTreeLoaded] = useState(false);
   const [, setLoadedLazyDirs] = useState<Set<string>>(new Set());
@@ -113,6 +160,20 @@ export function FileExplorer({
   const initialTreeLoadRef = useRef<Promise<void> | null>(null);
   const loadedLazyDirsRef = useRef<Set<string>>(new Set());
   const lazyLoadInflightRef = useRef<Map<string, Promise<boolean>>>(new Map());
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Bumped on every query change so a slow in-flight search (filename glob or
+  // content grep) can't clobber a newer one (or a cleared search) on resolve.
+  const searchGenRef = useRef(0);
+  // Cache of the whole-repo path list (all depths) used for filename search, so
+  // matches aren't limited to the lazily-loaded/expanded tree. Keyed by tree
+  // generation so it's invalidated whenever the tree is reloaded.
+  const allPathsRef = useRef<{
+    generation: number;
+    files: string[];
+  } | null>(null);
+  // Line to reveal once the target file's editor mounts (set when opening a
+  // content-search hit).
+  const pendingRevealRef = useRef<{ path: string; line: number } | null>(null);
 
   function updateLoadedLazyDirs(
     updater: Set<string> | ((prev: Set<string>) => Set<string>),
@@ -527,6 +588,7 @@ export function FileExplorer({
 
   async function fetchFileTree() {
     const generation = ++treeGenerationRef.current;
+    allPathsRef.current = null;
     lazyLoadInflightRef.current.clear();
     setLoading(true);
     updateLoadedLazyDirs(new Set());
@@ -580,6 +642,113 @@ export function FileExplorer({
     } catch {
       // Failed to load — leave buffer empty
     }
+  }
+
+  function clearSearchResults() {
+    // Invalidate any in-flight search so its result can't land after we clear.
+    searchGenRef.current++;
+    setFileNameMatches(null);
+    setContentMatches(null);
+    setContentSearching(false);
+    setContentSearchTruncated(false);
+  }
+
+  /** Whole-repo path list (all depths), cached per tree generation. */
+  async function ensureAllPaths(): Promise<string[]> {
+    const generation = treeGenerationRef.current;
+    const cached = allPathsRef.current;
+    if (cached && cached.generation === generation) return cached.files;
+    // No maxDepth → every file, unlike the eager tree (depth-capped) and the
+    // lazy per-directory loads.
+    const result = await fetchGlob({
+      pattern: "**/*",
+      limit: EXPLORER_GLOB_LIMIT,
+    });
+    if (treeGenerationRef.current === generation) {
+      allPathsRef.current = { generation, files: result.files };
+    }
+    return result.files;
+  }
+
+  async function runFileNameSearch(term: string, gen: number) {
+    try {
+      const files = await ensureAllPaths();
+      if (gen !== searchGenRef.current) return; // superseded
+      setFileNameMatches(matchFileNames(files, term, FILENAME_MATCH_LIMIT));
+    } catch {
+      if (gen !== searchGenRef.current) return;
+      setFileNameMatches([]);
+    }
+  }
+
+  async function runContentSearch(term: string, gen: number) {
+    setContentSearching(true);
+    try {
+      const data = (await postSandbox("grep", {
+        pattern: term,
+        output_mode: "content",
+        ignore_case: true,
+        // Literal substring match, mirroring the filename filter — the user
+        // isn't writing a regex in the file-search box.
+        fixed_strings: true,
+        limit: CONTENT_SEARCH_LIMIT,
+      })) as { results?: string; matchCount?: number };
+      if (gen !== searchGenRef.current) return; // superseded
+      setContentMatches(parseGrepContent(data.results ?? ""));
+      setContentSearchTruncated((data.matchCount ?? 0) >= CONTENT_SEARCH_LIMIT);
+    } catch {
+      if (gen !== searchGenRef.current) return;
+      setContentMatches([]);
+      setContentSearchTruncated(false);
+    } finally {
+      if (gen === searchGenRef.current) setContentSearching(false);
+    }
+  }
+
+  function runSearch(term: string) {
+    const trimmed = term.trim();
+    const gen = ++searchGenRef.current;
+    // Filename search fires from the first character; content search waits for
+    // 2+ chars (a whole-repo grep on a single char is noise).
+    void runFileNameSearch(trimmed, gen);
+    if (trimmed.length < CONTENT_SEARCH_MIN_CHARS) {
+      setContentMatches(null);
+      setContentSearching(false);
+      setContentSearchTruncated(false);
+    } else {
+      void runContentSearch(trimmed, gen);
+    }
+  }
+
+  function handleSearchChange(value: string) {
+    setSearch(value);
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    if (!value.trim()) {
+      clearSearchResults();
+      return;
+    }
+    searchDebounceRef.current = setTimeout(() => {
+      runSearch(value);
+    }, SEARCH_DEBOUNCE_MS);
+  }
+
+  function applyPendingReveal(editor: Parameters<OnMount>[0]) {
+    const pending = pendingRevealRef.current;
+    if (!pending || pending.path !== selectedFile) return;
+    pendingRevealRef.current = null;
+    const line = Math.max(1, pending.line);
+    editor.revealLineInCenter(line);
+    editor.setPosition({ lineNumber: line, column: 1 });
+    editor.focus();
+  }
+
+  function openContentMatch(match: GrepContentMatch) {
+    pendingRevealRef.current = { path: match.path, line: match.line };
+    const alreadyOpen =
+      selectedFile === match.path && buffers.get(match.path)?.loaded;
+    void handleFileClick(match.path);
+    // Same file already mounted → no remount fires, so reveal immediately.
+    if (alreadyOpen && editorRef.current) applyPendingReveal(editorRef.current);
   }
 
   async function saveFile(path: string, content: string) {
@@ -721,12 +890,9 @@ export function FileExplorer({
   const tree = buildFileTree(files, directories);
   const flatNodes = flattenTree(tree, expandedDirs);
 
-  // Filter by search
-  const filteredNodes = search
-    ? flatNodes.filter((row) =>
-        row.node.name.toLowerCase().includes(search.toLowerCase()),
-      )
-    : flatNodes;
+  const fileNameMatchCount = fileNameMatches?.length ?? 0;
+  const contentGroups = groupGrepMatches(contentMatches ?? []);
+  const contentMatchCount = contentMatches?.length ?? 0;
 
   const currentBuffer = selectedFile ? buffers.get(selectedFile) : null;
   const isDirty =
@@ -739,6 +905,9 @@ export function FileExplorer({
 
   const handleEditorMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
+
+    // Jump to a content-search hit's line once the editor is ready.
+    applyPendingReveal(editor);
 
     // Ctrl+S / Cmd+S to save
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, async () => {
@@ -806,7 +975,7 @@ export function FileExplorer({
             <input
               type="text"
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => handleSearchChange(e.target.value)}
               placeholder="Search files..."
               aria-label="Search files"
               className="w-full rounded-md border border-input bg-transparent pl-7 pr-2 py-1.5 text-xs outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring"
@@ -847,63 +1016,165 @@ export function FileExplorer({
         {/* Tree */}
         <ScrollArea className="flex-1">
           <div className="py-1">
-            {filteredNodes.map((row) => {
-              const { node, depth } = row;
-              const isDir = node.kind === "directory";
-              const isExpanded = expandedDirs.has(node.path);
-              const isSelected = selectedTreeNode?.path === node.path;
-              const parentDir = getDirectoryContextPath(node.path, node.kind);
-              const isDirLoading = isDir && loadingDirs.has(node.path);
+            {/* Lazy file tree (shown when not searching) */}
+            {!search &&
+              flatNodes.map((row) => {
+                const { node, depth } = row;
+                const isDir = node.kind === "directory";
+                const isExpanded = expandedDirs.has(node.path);
+                const isSelected = selectedTreeNode?.path === node.path;
+                const parentDir = getDirectoryContextPath(node.path, node.kind);
+                const isDirLoading = isDir && loadingDirs.has(node.path);
 
-              return (
-                <FileTreeRow
-                  key={node.path}
-                  node={node}
-                  depth={depth}
-                  isExpanded={isExpanded}
-                  isSelected={isSelected}
-                  isLoading={isDirLoading}
-                  fileVisual={getFileVisual(node.name)}
-                  onSelect={() => setSelectedTreeNode(node)}
-                  onOpen={() => {
-                    if (isDir) {
-                      void handleDirectoryOpen(node.path, isExpanded);
-                    } else {
-                      void handleFileClick(node.path);
+                return (
+                  <FileTreeRow
+                    key={node.path}
+                    node={node}
+                    depth={depth}
+                    isExpanded={isExpanded}
+                    isSelected={isSelected}
+                    isLoading={isDirLoading}
+                    fileVisual={getFileVisual(node.name)}
+                    onSelect={() => setSelectedTreeNode(node)}
+                    onOpen={() => {
+                      if (isDir) {
+                        void handleDirectoryOpen(node.path, isExpanded);
+                      } else {
+                        void handleFileClick(node.path);
+                      }
+                    }}
+                    onNewFile={() =>
+                      setNameDialog({
+                        mode: "new-file",
+                        node,
+                        parentDir,
+                      })
                     }
-                  }}
-                  onNewFile={() =>
-                    setNameDialog({
-                      mode: "new-file",
-                      node,
-                      parentDir,
-                    })
-                  }
-                  onNewFolder={() =>
-                    setNameDialog({
-                      mode: "new-folder",
-                      node,
-                      parentDir,
-                    })
-                  }
-                  onCopyPath={() => copyText("Path", toTreePath(node.path))}
-                  onCopyRelativePath={() =>
-                    copyText("Relative path", toDaemonPath(node.path))
-                  }
-                  onRename={() =>
-                    setNameDialog({
-                      mode: "rename",
-                      node,
-                      parentDir,
-                    })
-                  }
-                  onDelete={() => setDeleteTarget(node)}
-                />
-              );
-            })}
-            {treeLoaded && filteredNodes.length === 0 && (
+                    onNewFolder={() =>
+                      setNameDialog({
+                        mode: "new-folder",
+                        node,
+                        parentDir,
+                      })
+                    }
+                    onCopyPath={() => copyText("Path", toTreePath(node.path))}
+                    onCopyRelativePath={() =>
+                      copyText("Relative path", toDaemonPath(node.path))
+                    }
+                    onRename={() =>
+                      setNameDialog({
+                        mode: "rename",
+                        node,
+                        parentDir,
+                      })
+                    }
+                    onDelete={() => setDeleteTarget(node)}
+                  />
+                );
+              })}
+            {!search && treeLoaded && flatNodes.length === 0 && (
               <div className="px-3 py-4 text-center text-xs text-muted-foreground">
-                {search ? `No files match "${search}"` : "No files found"}
+                No files found
+              </div>
+            )}
+
+            {/* Filename matches (whole repo, independent of tree expansion) */}
+            {search && (
+              <>
+                <div className="flex items-center gap-1.5 px-3 pb-0.5 pt-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  <span>Files</span>
+                  {fileNameMatchCount > 0 && (
+                    <span className="normal-case tracking-normal text-muted-foreground/70">
+                      {fileNameMatchCount}
+                      {fileNameMatchCount >= FILENAME_MATCH_LIMIT ? "+" : ""}
+                    </span>
+                  )}
+                </div>
+                {fileNameMatches !== null && fileNameMatches.length === 0 && (
+                  <div className="px-3 py-1 text-xs text-muted-foreground">
+                    No file names match
+                  </div>
+                )}
+                {fileNameMatches?.map((path) => {
+                  const name = path.split("/").pop() ?? path;
+                  const dir = getParentTreePath(path);
+                  const { Icon, color } = getFileVisual(name);
+                  const isSelected = selectedFile === path;
+                  return (
+                    <button
+                      key={path}
+                      type="button"
+                      onClick={() => void handleFileClick(path)}
+                      title={path}
+                      className={cn(
+                        "flex w-full items-center gap-1.5 px-3 py-1 text-left text-xs hover:bg-accent",
+                        isSelected && "bg-accent",
+                      )}
+                    >
+                      <Icon size={14} className={cn("shrink-0", color)} />
+                      <span className="max-w-40 shrink-0 truncate">{name}</span>
+                      {dir !== "/" && (
+                        <span className="truncate text-muted-foreground/60">
+                          {dir}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </>
+            )}
+
+            {/* Content matches (ripgrep over the whole repo) */}
+            {search && (
+              <div className="mt-1 border-t pt-1">
+                <div className="flex items-center gap-1.5 px-3 pb-0.5 pt-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  <span>In files</span>
+                  {contentMatchCount > 0 && (
+                    <span className="text-muted-foreground/70 normal-case tracking-normal">
+                      {contentMatchCount}
+                      {contentSearchTruncated ? "+" : ""}
+                    </span>
+                  )}
+                  {contentSearching && (
+                    <Loading01 size={10} className="animate-spin" />
+                  )}
+                </div>
+                {!contentSearching &&
+                  contentMatches !== null &&
+                  contentGroups.length === 0 && (
+                    <div className="px-3 py-1 text-xs text-muted-foreground">
+                      No matches in file contents
+                    </div>
+                  )}
+                {contentGroups.map((group) => {
+                  const name = group.path.split("/").pop() ?? group.path;
+                  const { Icon, color } = getFileVisual(name);
+                  return (
+                    <div key={group.path}>
+                      <div className="flex items-center gap-1.5 px-3 py-1 text-xs text-muted-foreground">
+                        <Icon size={14} className={cn("shrink-0", color)} />
+                        <span className="truncate">{name}</span>
+                        <span className="text-muted-foreground/60">
+                          {group.matches.length}
+                        </span>
+                      </div>
+                      {group.matches.map((match) => (
+                        <button
+                          key={`${group.path}:${match.line}`}
+                          type="button"
+                          onClick={() => openContentMatch(match)}
+                          title={`${group.path}:${match.line}`}
+                          className="flex w-full items-baseline gap-2 pl-8 pr-3 py-0.5 text-left text-xs hover:bg-accent"
+                        >
+                          <span className="shrink-0 tabular-nums text-muted-foreground">
+                            {match.line}
+                          </span>
+                          <GrepMatchLine text={match.text} query={search} />
+                        </button>
+                      ))}
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -171,6 +171,13 @@ export function FileExplorer({
     generation: number;
     files: string[];
   } | null>(null);
+  // In-flight whole-repo glob (keyed by generation), so two searches that
+  // both miss the cache before the first glob resolves share one request
+  // instead of each firing their own full-repo walk.
+  const allPathsInflightRef = useRef<{
+    generation: number;
+    promise: Promise<string[]>;
+  } | null>(null);
   // Line to reveal once the target file's editor mounts (set when opening a
   // content-search hit).
   const pendingRevealRef = useRef<{ path: string; line: number } | null>(null);
@@ -589,6 +596,7 @@ export function FileExplorer({
   async function fetchFileTree() {
     const generation = ++treeGenerationRef.current;
     allPathsRef.current = null;
+    allPathsInflightRef.current = null;
     lazyLoadInflightRef.current.clear();
     setLoading(true);
     updateLoadedLazyDirs(new Set());
@@ -653,21 +661,38 @@ export function FileExplorer({
     setContentSearchTruncated(false);
   }
 
-  /** Whole-repo path list (all depths), cached per tree generation. */
+  /**
+   * Whole-repo path list (all depths), cached per tree generation. Two
+   * searches that both miss the cache before the first glob resolves share
+   * the same in-flight request rather than each firing a full-repo walk.
+   */
   async function ensureAllPaths(): Promise<string[]> {
     const generation = treeGenerationRef.current;
     const cached = allPathsRef.current;
     if (cached && cached.generation === generation) return cached.files;
-    // No maxDepth → every file, unlike the eager tree (depth-capped) and the
-    // lazy per-directory loads.
-    const result = await fetchGlob({
-      pattern: "**/*",
-      limit: EXPLORER_GLOB_LIMIT,
-    });
-    if (treeGenerationRef.current === generation) {
-      allPathsRef.current = { generation, files: result.files };
+    const inflight = allPathsInflightRef.current;
+    if (inflight && inflight.generation === generation) return inflight.promise;
+
+    const promise = (async () => {
+      // No maxDepth → every file, unlike the eager tree (depth-capped) and
+      // the lazy per-directory loads.
+      const result = await fetchGlob({
+        pattern: "**/*",
+        limit: EXPLORER_GLOB_LIMIT,
+      });
+      if (treeGenerationRef.current === generation) {
+        allPathsRef.current = { generation, files: result.files };
+      }
+      return result.files;
+    })();
+    allPathsInflightRef.current = { generation, promise };
+    try {
+      return await promise;
+    } finally {
+      if (allPathsInflightRef.current?.generation === generation) {
+        allPathsInflightRef.current = null;
+      }
     }
-    return result.files;
   }
 
   async function runFileNameSearch(term: string, gen: number) {

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
@@ -225,6 +225,34 @@ describe("file-explorer utils", () => {
     expect(hl.segments[0]?.text.length).toBeLessThanOrEqual(24);
   });
 
+  it("buildGrepHighlight highlights every occurrence after clipping a long prefix", () => {
+    const line = `${"x".repeat(60)}NEEDLE bar NEEDLE tail`;
+    const hl = buildGrepHighlight(line, "needle");
+    expect(hl.leadingEllipsis).toBe(true);
+    const matchCount = hl.segments.filter((s) => s.match).length;
+    expect(matchCount).toBe(2);
+    // Reconstructing the (clipped) segments must reproduce the clipped tail
+    // exactly — no characters dropped or duplicated by the clip + scan logic.
+    const reconstructed = hl.segments.map((s) => s.text).join("");
+    expect(line.endsWith(reconstructed)).toBe(true);
+  });
+
+  it("buildGrepHighlight has no ellipsis exactly at the clip boundary", () => {
+    // First match starts right at GREP_HIGHLIGHT_PREFIX (24 context chars) —
+    // the `first > 24` check must not clip on the boundary itself.
+    const line = `${"x".repeat(24)}NEEDLE`;
+    const hl = buildGrepHighlight(line, "needle");
+    expect(hl.leadingEllipsis).toBe(false);
+  });
+
+  it("buildGrepHighlight matches back-to-back overlapping-alphabet runs without dropping chars", () => {
+    const hl = buildGrepHighlight("aaaa", "aa");
+    expect(hl.segments).toEqual([
+      { text: "aa", match: true },
+      { text: "aa", match: true },
+    ]);
+  });
+
   it("buildGrepHighlight returns a single plain run when nothing matches", () => {
     expect(buildGrepHighlight("  no hits here", "zzz")).toEqual({
       leadingEllipsis: false,

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from "bun:test";
 import {
   buildFileTree,
+  buildGrepHighlight,
   decoBlockKeyFromTreePath,
   directoryNeedsLazyLoad,
   flattenTree,
   getDirectoryContextPath,
   getParentTreePath,
   getPathDepth,
+  groupGrepMatches,
   isSafeExplorerOpenPath,
   joinTreePath,
+  matchFileNames,
   mergeGlobLists,
+  parseGrepContent,
   pathExistsInFileList,
   toDaemonPath,
   toTreePath,
@@ -137,5 +141,116 @@ describe("file-explorer utils", () => {
       directories: ["src"],
       truncated: true,
     });
+  });
+
+  it("parseGrepContent maps repo-relative rows to tree paths", () => {
+    const matches = parseGrepContent(
+      'src/index.ts:12:const x = 1;\n.deco/blocks/Header.json:3:  "title": "hi"',
+    );
+    expect(matches).toEqual([
+      { path: "/src/index.ts", line: 12, text: "const x = 1;" },
+      { path: "/.deco/blocks/Header.json", line: 3, text: '  "title": "hi"' },
+    ]);
+  });
+
+  it("parseGrepContent keeps colons in the matched text", () => {
+    const [match] = parseGrepContent("a.ts:7:const url = 'http://x';");
+    expect(match).toEqual({
+      path: "/a.ts",
+      line: 7,
+      text: "const url = 'http://x';",
+    });
+  });
+
+  it("parseGrepContent skips rows without a valid file:line prefix", () => {
+    expect(parseGrepContent("")).toEqual([]);
+    // ripgrep context separators / malformed rows are dropped
+    expect(parseGrepContent("--\nnot-a-match\nfile.ts:nope:text")).toEqual([]);
+  });
+
+  it("matchFileNames finds deep files by leaf name, regardless of tree depth", () => {
+    const files = [
+      "src/index.ts",
+      ".deco/blocks/analytics.json",
+      ".deco/blocks/pages/home.json",
+      "README.md",
+    ];
+    // The whole point of the fix: a deep, unexpanded file still matches.
+    expect(matchFileNames(files, "analytics.json", 50)).toEqual([
+      "/.deco/blocks/analytics.json",
+    ]);
+    // Case-insensitive, leaf-name substring.
+    expect(matchFileNames(files, "JSON", 50)).toEqual([
+      "/.deco/blocks/analytics.json",
+      "/.deco/blocks/pages/home.json",
+    ]);
+  });
+
+  it("matchFileNames matches on the leaf name, not the directory path", () => {
+    const files = ["blocks/index.ts", "src/util.ts"];
+    // "blocks" is a directory segment, not part of any leaf name → no match.
+    expect(matchFileNames(files, "blocks", 50)).toEqual([]);
+    expect(matchFileNames(files, "index", 50)).toEqual(["/blocks/index.ts"]);
+  });
+
+  it("matchFileNames caps results and treats blank queries as no-op", () => {
+    const files = Array.from({ length: 10 }, (_, i) => `f${i}.ts`);
+    expect(matchFileNames(files, ".ts", 3)).toHaveLength(3);
+    expect(matchFileNames(files, "   ", 3)).toEqual([]);
+  });
+
+  it("buildGrepHighlight highlights every case-insensitive occurrence", () => {
+    const hl = buildGrepHighlight("  const Foo = foo(bar);", "foo");
+    expect(hl.leadingEllipsis).toBe(false);
+    // Leading whitespace trimmed; both "Foo" and "foo" highlighted.
+    expect(hl.segments).toEqual([
+      { text: "const ", match: false },
+      { text: "Foo", match: true },
+      { text: " = ", match: false },
+      { text: "foo", match: true },
+      { text: "(bar);", match: false },
+    ]);
+    expect(hl.segments.map((s) => s.text).join("")).toBe(
+      "const Foo = foo(bar);",
+    );
+  });
+
+  it("buildGrepHighlight clips a long prefix so the match stays visible", () => {
+    const line = `${"x".repeat(60)}NEEDLE tail`;
+    const hl = buildGrepHighlight(line, "needle");
+    expect(hl.leadingEllipsis).toBe(true);
+    // Prefix trimmed to ~24 context chars before the match.
+    const firstMatch = hl.segments.find((s) => s.match);
+    expect(firstMatch).toEqual({ text: "NEEDLE", match: true });
+    expect(hl.segments[0]?.text.length).toBeLessThanOrEqual(24);
+  });
+
+  it("buildGrepHighlight returns a single plain run when nothing matches", () => {
+    expect(buildGrepHighlight("  no hits here", "zzz")).toEqual({
+      leadingEllipsis: false,
+      segments: [{ text: "no hits here", match: false }],
+    });
+    expect(buildGrepHighlight("anything", "  ")).toEqual({
+      leadingEllipsis: false,
+      segments: [{ text: "anything", match: false }],
+    });
+  });
+
+  it("groupGrepMatches groups by file preserving first-seen order", () => {
+    const groups = groupGrepMatches([
+      { path: "/b.ts", line: 1, text: "a" },
+      { path: "/a.ts", line: 2, text: "b" },
+      { path: "/b.ts", line: 5, text: "c" },
+    ]);
+    expect(groups).toEqual([
+      {
+        path: "/b.ts",
+        matches: [
+          { path: "/b.ts", line: 1, text: "a" },
+          { path: "/b.ts", line: 5, text: "c" },
+        ],
+      },
+      { path: "/a.ts", matches: [{ path: "/a.ts", line: 2, text: "b" }] },
+    ]);
   });
 });

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -341,6 +341,11 @@ interface GrepFileGroup {
  * separated `file:line:text` rows (ripgrep `--line-number`, repo-relative
  * paths) — into structured hits. Rows that don't match the shape (e.g. ripgrep
  * context separators) are skipped.
+ *
+ * `packages/sandbox/server/provider/sandbox-fs-hooks.ts` has an equivalent
+ * `parseGrepResults` for the LLM-facing grep tool — same wire shape, kept
+ * separate because packages can't import app code. Update both if the shape
+ * changes.
  */
 export function parseGrepContent(results: string): GrepContentMatch[] {
   const matches: GrepContentMatch[] = [];
@@ -385,12 +390,12 @@ export function matchFileNames(
 }
 
 /** One run of a grep result line — `match` runs are the highlighted query. */
-export interface GrepHighlightSegment {
+interface GrepHighlightSegment {
   text: string;
   match: boolean;
 }
 
-export interface GrepHighlight {
+interface GrepHighlight {
   /** True when the prefix was clipped so the first match stays visible. */
   leadingEllipsis: boolean;
   segments: GrepHighlightSegment[];

--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -322,6 +322,158 @@ export function flattenTree(
   return rows;
 }
 
+/** A single content-search hit inside a file. */
+export interface GrepContentMatch {
+  /** Tree path (leading slash), matching the file-tree node paths. */
+  path: string;
+  line: number;
+  text: string;
+}
+
+/** Content-search hits for one file, in the order ripgrep reported them. */
+interface GrepFileGroup {
+  path: string;
+  matches: GrepContentMatch[];
+}
+
+/**
+ * Parse the daemon grep route's `output_mode: "content"` output — newline-
+ * separated `file:line:text` rows (ripgrep `--line-number`, repo-relative
+ * paths) — into structured hits. Rows that don't match the shape (e.g. ripgrep
+ * context separators) are skipped.
+ */
+export function parseGrepContent(results: string): GrepContentMatch[] {
+  const matches: GrepContentMatch[] = [];
+  for (const row of results.split("\n")) {
+    if (!row) continue;
+    const firstColon = row.indexOf(":");
+    if (firstColon < 0) continue;
+    const secondColon = row.indexOf(":", firstColon + 1);
+    if (secondColon < 0) continue;
+    const line = Number.parseInt(row.slice(firstColon + 1, secondColon), 10);
+    if (!Number.isFinite(line)) continue;
+    matches.push({
+      path: toTreePath(row.slice(0, firstColon)),
+      line,
+      text: row.slice(secondColon + 1),
+    });
+  }
+  return matches;
+}
+
+/**
+ * Files whose leaf name contains `query` (case-insensitive), across the whole
+ * repo file list, mapped to tree paths and capped at `limit`. Powers the
+ * file-search box so matches aren't limited to the lazily-loaded/expanded tree.
+ */
+export function matchFileNames(
+  files: readonly string[],
+  query: string,
+  limit: number,
+): string[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [];
+  const matches: string[] = [];
+  for (const file of files) {
+    const name = file.split("/").pop() ?? file;
+    if (name.toLowerCase().includes(needle)) {
+      matches.push(toTreePath(file));
+      if (matches.length >= limit) break;
+    }
+  }
+  return matches;
+}
+
+/** One run of a grep result line — `match` runs are the highlighted query. */
+export interface GrepHighlightSegment {
+  text: string;
+  match: boolean;
+}
+
+export interface GrepHighlight {
+  /** True when the prefix was clipped so the first match stays visible. */
+  leadingEllipsis: boolean;
+  segments: GrepHighlightSegment[];
+}
+
+/** Context characters kept before the first match when clipping a long line. */
+const GREP_HIGHLIGHT_PREFIX = 24;
+
+/**
+ * Split a grep result line into highlighted/plain runs around each
+ * case-insensitive occurrence of `query` (the search box does literal,
+ * case-insensitive matching via ripgrep `-F -i`). Leading whitespace is
+ * trimmed, and when the first match sits far into a long line the prefix is
+ * clipped (`leadingEllipsis`) so the highlighted text stays visible under the
+ * row's CSS truncation — mirroring VS Code's search results.
+ */
+export function buildGrepHighlight(
+  lineText: string,
+  query: string,
+): GrepHighlight {
+  const trimmed = lineText.replace(/^\s+/, "");
+  const needle = query.trim().toLowerCase();
+  if (!needle) {
+    return {
+      leadingEllipsis: false,
+      segments: [{ text: trimmed, match: false }],
+    };
+  }
+
+  const first = trimmed.toLowerCase().indexOf(needle);
+  if (first < 0) {
+    return {
+      leadingEllipsis: false,
+      segments: [{ text: trimmed, match: false }],
+    };
+  }
+
+  const leadingEllipsis = first > GREP_HIGHLIGHT_PREFIX;
+  const clipped = leadingEllipsis
+    ? trimmed.slice(first - GREP_HIGHLIGHT_PREFIX)
+    : trimmed;
+  const haystack = clipped.toLowerCase();
+
+  const segments: GrepHighlightSegment[] = [];
+  let cursor = 0;
+  for (;;) {
+    const idx = haystack.indexOf(needle, cursor);
+    if (idx < 0) {
+      if (cursor < clipped.length) {
+        segments.push({ text: clipped.slice(cursor), match: false });
+      }
+      break;
+    }
+    if (idx > cursor) {
+      segments.push({ text: clipped.slice(cursor, idx), match: false });
+    }
+    segments.push({
+      text: clipped.slice(idx, idx + needle.length),
+      match: true,
+    });
+    cursor = idx + needle.length;
+  }
+  return { leadingEllipsis, segments };
+}
+
+/** Group content matches by file, preserving first-seen file order. */
+export function groupGrepMatches(
+  matches: readonly GrepContentMatch[],
+): GrepFileGroup[] {
+  const groups: GrepFileGroup[] = [];
+  const byPath = new Map<string, GrepFileGroup>();
+  for (const match of matches) {
+    let group = byPath.get(match.path);
+    if (!group) {
+      group = { path: match.path, matches: [] };
+      byPath.set(match.path, group);
+      groups.push(group);
+    }
+    group.matches.push(match);
+  }
+  return groups;
+}
+
 /**
  * Strip the line-number prefix from the daemon's read endpoint.
  * The daemon returns content in `"1\tcontent\n2\tcontent"` format.

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -25,6 +25,9 @@ import {
   GLOB_RESULT_LIMIT,
   GLOB_MAX_RESULT_LIMIT,
   resolveGlobResultLimit,
+  GREP_RESULT_LIMIT,
+  GREP_MAX_RESULT_LIMIT,
+  resolveGrepResultLimit,
   toRepoRelativePath,
 } from "./fs";
 
@@ -487,6 +490,16 @@ describe("fs handlers", () => {
     expect(resolveGlobResultLimit(GLOB_MAX_RESULT_LIMIT + 999)).toBe(
       GLOB_MAX_RESULT_LIMIT,
     );
+  });
+
+  it("resolveGrepResultLimit caps at GREP_MAX_RESULT_LIMIT", () => {
+    expect(resolveGrepResultLimit(undefined)).toBe(GREP_RESULT_LIMIT);
+    expect(resolveGrepResultLimit(GREP_MAX_RESULT_LIMIT + 999)).toBe(
+      GREP_MAX_RESULT_LIMIT,
+    );
+    expect(resolveGrepResultLimit(0)).toBe(GREP_RESULT_LIMIT);
+    expect(resolveGrepResultLimit(-5)).toBe(GREP_RESULT_LIMIT);
+    expect(resolveGrepResultLimit(50)).toBe(50);
   });
 
   it("glob: default limit remains GLOB_RESULT_LIMIT for agents", async () => {

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -278,6 +278,58 @@ describe("fs handlers", () => {
     expect(body.results).toContain("hello world");
   });
 
+  (hasRg ? it : it.skip)(
+    "grep: content rows use repo-relative paths",
+    async () => {
+      mkdirSync(join(appRoot, "src"), { recursive: true });
+      writeFileSync(join(appRoot, "src/needle.txt"), "hello world\n");
+      const h = makeGrepHandler({ appRoot, repoDir: appRoot });
+      const res = await h(
+        post("/_sandbox/grep", {
+          pattern: "hello",
+          output_mode: "content",
+        }),
+      );
+      const body = (await res.json()) as { results: string };
+      // Repo-relative (no absolute appRoot prefix), so the UI/agents can map
+      // the hit straight onto glob paths.
+      expect(body.results).toBe("src/needle.txt:1:hello world");
+    },
+  );
+
+  (hasRg ? it : it.skip)(
+    "grep: files mode uses repo-relative paths",
+    async () => {
+      mkdirSync(join(appRoot, "src"), { recursive: true });
+      writeFileSync(join(appRoot, "src/needle.txt"), "hello world\n");
+      const h = makeGrepHandler({ appRoot, repoDir: appRoot });
+      const res = await h(
+        post("/_sandbox/grep", { pattern: "hello", output_mode: "files" }),
+      );
+      const body = (await res.json()) as { results: string };
+      expect(body.results).toBe("src/needle.txt");
+    },
+  );
+
+  (hasRg ? it : it.skip)(
+    "grep: fixed_strings matches the pattern literally",
+    async () => {
+      writeFileSync(join(appRoot, "dots.txt"), "a.b\naxb\n");
+      const h = makeGrepHandler({ appRoot, repoDir: appRoot });
+      const res = await h(
+        post("/_sandbox/grep", {
+          pattern: "a.b",
+          output_mode: "content",
+          fixed_strings: true,
+        }),
+      );
+      const body = (await res.json()) as { results: string };
+      // Without -F the regexp "a.b" would also match "axb"; with it, only the
+      // literal "a.b" line matches.
+      expect(body.results).toBe("dots.txt:1:a.b");
+    },
+  );
+
   (hasRg ? it : it.skip)("glob: returns matching file names", async () => {
     writeFileSync(join(appRoot, "x.txt"), "");
     const h = makeGlobHandler({ appRoot, repoDir: appRoot });

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -330,6 +330,64 @@ describe("fs handlers", () => {
     },
   );
 
+  (hasRg ? it : it.skip)(
+    "grep: content rows stay repoDir-relative (not searchPath-relative) when a subdir path is searched",
+    async () => {
+      mkdirSync(join(appRoot, "src"), { recursive: true });
+      writeFileSync(join(appRoot, "src/needle.txt"), "hello world\n");
+      const h = makeGrepHandler({ appRoot, repoDir: appRoot });
+      const res = await h(
+        post("/_sandbox/grep", {
+          pattern: "hello",
+          output_mode: "content",
+          path: "src",
+        }),
+      );
+      const body = (await res.json()) as { results: string };
+      // Relative to repoDir (the workspace root), not the narrower searchPath
+      // — so the "src/" prefix is kept and the row maps onto the same paths
+      // glob returns.
+      expect(body.results).toBe("src/needle.txt:1:hello world");
+    },
+  );
+
+  (hasRg ? it : it.skip)(
+    "grep: context rows (-C) are relativized despite their '-' separator",
+    async () => {
+      writeFileSync(join(appRoot, "ctx.txt"), "before\nhello world\nafter\n");
+      const h = makeGrepHandler({ appRoot, repoDir: appRoot });
+      const res = await h(
+        post("/_sandbox/grep", {
+          pattern: "hello",
+          output_mode: "content",
+          context: 1,
+        }),
+      );
+      const body = (await res.json()) as { results: string };
+      // rg emits context rows as `path-line-text` (vs `path:line:text` for the
+      // match itself) — every row's path must still be stripped to
+      // repo-relative, not just the ":"-delimited match row.
+      for (const row of body.results.split("\n")) {
+        if (row === "--") continue;
+        expect(row.startsWith(appRoot)).toBe(false);
+        expect(row.startsWith("ctx.txt")).toBe(true);
+      }
+    },
+  );
+
+  (hasRg ? it : it.skip)(
+    "grep: a colon in the filename doesn't defeat relativization",
+    async () => {
+      writeFileSync(join(appRoot, "foo:bar.txt"), "hello world\n");
+      const h = makeGrepHandler({ appRoot, repoDir: appRoot });
+      const res = await h(
+        post("/_sandbox/grep", { pattern: "hello", output_mode: "content" }),
+      );
+      const body = (await res.json()) as { results: string };
+      expect(body.results).toBe("foo:bar.txt:1:hello world");
+    },
+  );
+
   (hasRg ? it : it.skip)("glob: returns matching file names", async () => {
     writeFileSync(join(appRoot, "x.txt"), "");
     const h = makeGlobHandler({ appRoot, repoDir: appRoot });

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -397,6 +397,7 @@ export function makeGrepHandler(deps: FsDeps) {
       path?: string;
       output_mode?: "files" | "count" | "content";
       ignore_case?: boolean;
+      fixed_strings?: boolean;
       context?: number;
       glob?: string;
       limit?: number;
@@ -419,12 +420,32 @@ export function makeGrepHandler(deps: FsDeps) {
     else if (mode === "count") args.push("--count");
     else args.push("--line-number");
     if (body.ignore_case) args.push("-i");
+    if (body.fixed_strings) args.push("-F");
     if (body.context && mode === "content")
       args.push("-C", String(body.context));
     if (body.glob) args.push("--glob", body.glob);
     args.push("--", body.pattern, searchPath);
 
     const limit = body.limit ?? 250;
+    // rg prints paths prefixed with the (absolute) search path argument. Strip
+    // that back to a repo-relative path so grep matches glob's wire contract
+    // (agents/tools glob+grep over repo-relative, POSIX-style paths). "files"
+    // mode emits a bare path per line; "content"/"count" emit `path:rest`
+    // (paths never contain ":" on the Linux daemon), so relativize the segment
+    // before the first colon.
+    const relativizeGrepLine = (line: string): string => {
+      if (mode === "files") {
+        return toRepoRelativePath(line, searchPath, deps.repoDir);
+      }
+      const colon = line.indexOf(":");
+      if (colon < 0) return line;
+      const rel = toRepoRelativePath(
+        line.slice(0, colon),
+        searchPath,
+        deps.repoDir,
+      );
+      return rel + line.slice(colon);
+    };
     const child = spawn(
       "rg",
       args,
@@ -448,7 +469,7 @@ export function makeGrepHandler(deps: FsDeps) {
           break;
         }
         if (line) {
-          stdout += (stdout ? "\n" : "") + line;
+          stdout += (stdout ? "\n" : "") + relativizeGrepLine(line);
           lineCount++;
         }
       }

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -426,26 +426,17 @@ export function makeGrepHandler(deps: FsDeps) {
     if (body.glob) args.push("--glob", body.glob);
     args.push("--", body.pattern, searchPath);
 
-    const limit = body.limit ?? 250;
+    const limit = resolveGrepResultLimit(body.limit);
     // rg prints paths prefixed with the (absolute) search path argument. Strip
     // that back to a repo-relative path so grep matches glob's wire contract
-    // (agents/tools glob+grep over repo-relative, POSIX-style paths). "files"
-    // mode emits a bare path per line; "content"/"count" emit `path:rest`
-    // (paths never contain ":" on the Linux daemon), so relativize the segment
-    // before the first colon.
-    const relativizeGrepLine = (line: string): string => {
-      if (mode === "files") {
-        return toRepoRelativePath(line, searchPath, deps.repoDir);
-      }
-      const colon = line.indexOf(":");
-      if (colon < 0) return line;
-      const rel = toRepoRelativePath(
-        line.slice(0, colon),
-        searchPath,
-        deps.repoDir,
-      );
-      return rel + line.slice(colon);
-    };
+    // (agents/tools glob+grep over repo-relative, POSIX-style paths). Every
+    // mode's path is a literal prefix of the line — "files" mode emits a bare
+    // path, "content"/"count" emit `path:rest`, and `-C` context rows emit
+    // `path-rest` — so strip the known absolute prefix directly rather than
+    // splitting on ":" (which misparses context rows' "-" separator and any
+    // path that itself contains a colon).
+    const relativizeGrepLine = (line: string): string =>
+      toRepoRelativePath(line, searchPath, deps.repoDir);
     const child = spawn(
       "rg",
       args,
@@ -457,12 +448,19 @@ export function makeGrepHandler(deps: FsDeps) {
     let stdout = "";
     let lineCount = 0;
     let truncated = false;
+    // rg's stdout arrives in arbitrary chunk boundaries, which don't align
+    // with line boundaries — buffer the trailing partial line across `data`
+    // events instead of treating every chunk as whole lines (that would
+    // corrupt/drop a match line split across two chunks).
+    let pendingLine = "";
     child.stdout!.on("data", (chunk: Buffer) => {
       if (truncated) return;
-      const lines = chunk.toString("utf-8").split("\n");
-      for (const line of lines) {
+      const pieces = (pendingLine + chunk.toString("utf-8")).split("\n");
+      pendingLine = pieces.pop() ?? "";
+      for (const line of pieces) {
         if (lineCount >= limit) {
           truncated = true;
+          pendingLine = "";
           try {
             child.kill("SIGTERM");
           } catch {}
@@ -499,6 +497,12 @@ export function makeGrepHandler(deps: FsDeps) {
         { error: stderr || `rg failed with code ${code}` },
         500,
       );
+    // Flush a final line left in the buffer with no trailing newline (rg was
+    // killed or exited before emitting one).
+    if (!truncated && pendingLine && lineCount < limit) {
+      stdout += (stdout ? "\n" : "") + relativizeGrepLine(pendingLine);
+      lineCount++;
+    }
     return jsonResponse({ results: stdout, matchCount: lineCount });
   };
 }
@@ -736,6 +740,19 @@ export function registerGlobAncestorDirectories(
   for (let i = 1; i <= Math.min(dirParts.length, maxDepth); i++) {
     directoryPaths.add(dirParts.slice(0, i).join("/"));
   }
+}
+
+/** Default cap for agent grep calls. */
+export const GREP_RESULT_LIMIT = 250;
+/** Hard ceiling when callers pass an explicit `limit` (file explorer). */
+export const GREP_MAX_RESULT_LIMIT = 10_000;
+
+/** Same shape as `resolveGlobResultLimit`, just a lower default (grep rows are wider than glob paths). */
+export function resolveGrepResultLimit(limit: unknown): number {
+  if (limit === undefined || limit === null) return GREP_RESULT_LIMIT;
+  const n = typeof limit === "number" ? limit : Number(limit);
+  if (!Number.isFinite(n) || n < 1) return GREP_RESULT_LIMIT;
+  return Math.min(Math.floor(n), GREP_MAX_RESULT_LIMIT);
 }
 
 export function resolveGlobResultLimit(limit: unknown): number {

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.ts
@@ -274,6 +274,11 @@ async function daemonRequest(
  * separated `file:line:text` rows (ripgrep `--line-number`) — into structured
  * hits. Rows that don't match the shape (e.g. ripgrep context separators) are
  * skipped.
+ *
+ * The file-explorer UI has an equivalent `parseGrepContent` in
+ * `apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts` —
+ * same wire shape, kept separate because packages can't import app code.
+ * Update both if the shape changes.
  */
 function parseGrepResults(results: string): SandboxFsGrepHit[] {
   const hits: SandboxFsGrepHit[] = [];


### PR DESCRIPTION
## Summary

The file-explorer's "Search files…" box had two limitations:
1. It only matched file **names**, never file **contents**.
2. It only searched the **lazily-loaded/expanded** tree — so deep files in unopened folders (e.g. `.deco/blocks/analytics.json`) were invisible to search until you manually expanded the folder.

This PR makes search work over the whole repo, for both names and contents.

### Content search (new)
- Wires the search box to the sandbox daemon's ripgrep-backed `grep` endpoint (literal + case-insensitive, mirroring the filename filter — the user isn't writing a regex).
- Results grouped by file under an **"In files"** section, with the matched substring highlighted **VS Code-style** — every occurrence highlighted, leading whitespace trimmed, and the prefix of long lines clipped (`…`) so the match stays visible under CSS truncation.
- Clicking a hit opens the file and jumps to the line.

### Filename search (fixed)
- Now runs over the **whole repo** via a full-depth glob, cached per tree generation and invalidated on any create/rename/delete — independent of which folders are expanded.
- Rendered as a flat **"Files"** section (name + dimmed directory path).

### Plumbing
- Exposed `grep` through the org-scoped sandbox proxy allowlist (`sandbox-proxy.ts`) — the daemon already had the endpoint; only the proxy was missing.
- Daemon `grep` now returns **repo-relative paths** (matching `glob`'s documented wire contract; fixes a latent absolute-path inconsistency that also affected the LLM grep tool) and supports **`fixed_strings`** (`rg -F`) for literal matching.

## Testing
- **Unit** (`utils.test.ts`): pure helpers `parseGrepContent`, `groupGrepMatches`, `buildGrepHighlight`, `matchFileNames` — including a regression test reproducing the original bug (deep unexpanded `analytics.json` now matches).
- **Daemon** (`fs.test.ts`): repo-relative output in `content`/`files` modes + `fixed_strings` literal matching (run against real ripgrep).
- `bun run check` (all workspaces), `bun run lint` (0 errors), `bun run fmt` all pass. Existing `sandbox-fs-hooks` grep-consumer test still green.
- **Not** exercised end-to-end in a running sandbox — the daemon change means running sandboxes return repo-relative grep paths only after the daemon binary is rebuilt/redeployed (local `bun run dev` runs from source, so it's fine there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds content search to the file explorer and runs search across the whole repo. Fixes grep path handling and dropped-match edge cases, enforces a safe result limit, and speeds up filename search.

- **New Features**
  - Search file contents across the repo via daemon `grep` (literal, case-insensitive).
  - Results grouped by file with VS Code-style highlighting; clicking a hit opens the file at that line.

- **Bug Fixes**
  - Filename search now scans the full repo via a cached full-depth glob and deduped in-flight walks, so deep unexpanded files are found without extra repo traversals.
  - Exposed `grep` through the sandbox proxy; daemon now returns repo-relative paths for all modes (including `-C` context rows and colon-in-filenames) and supports `fixed_strings` for literal matching.
  - Grep streaming buffers output across chunks and clamps result limits (with direct tests), preventing dropped lines and runaway output.

<sup>Written for commit 5131fb398badf3e99b50c7a73e813b52224abc5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

