### PR TITLE
feat(task-board): paywall CTA on empty kanban for commerce orgs

### DIFF
--- a/apps/mesh/src/web/components/home/commerce-report-banner-status.ts
+++ b/apps/mesh/src/web/components/home/commerce-report-banner-status.ts
@@ -16,6 +16,9 @@
 export interface CommerceDiagnosticRunState {
   scanned_at?: string | null;
   run_in_progress?: boolean;
+  /** Paywall state — true until the org buys the one-time unlock. The board
+   *  paywall banner shows while this is true; it clears itself on payment. */
+  locked?: boolean;
 }
 
 export type CommerceReportBannerStatus = "generating" | "ready" | "none";

--- a/apps/mesh/src/web/components/home/commerce-report-banner.tsx
+++ b/apps/mesh/src/web/components/home/commerce-report-banner.tsx
@@ -6,7 +6,7 @@
  * slightly tilted, and straightens on hover. While the run is live the page
  * shimmers and the copy says so; once the deck exists the page shows a score
  * ring and the arrow invites the click. State comes live from
- * `get_my_diagnostic` (see commerce-report-banner-status.ts), polled gently
+ * `get_my_diagnostic` (see hooks/commerce-diagnostic-status.ts), polled gently
  * only while generating.
  *
  * Orgs without the Commerce Discovery connection never get past the first
@@ -27,7 +27,7 @@ import {
 import {
   type CommerceReportBannerStatus,
   deriveCommerceReportBannerStatus,
-} from "./commerce-report-banner-status";
+} from "@/web/hooks/commerce-diagnostic-status";
 
 /** The tilted miniature report page bleeding out of the banner's bottom
  *  edge. Pure decoration (aria-hidden); `generating` swaps the score ring

--- a/apps/mesh/src/web/components/home/commerce-report-banner.tsx
+++ b/apps/mesh/src/web/components/home/commerce-report-banner.tsx
@@ -14,44 +14,20 @@
  * external MCP is ever created. Every failure path also renders nothing —
  * home must never break because of this banner.
  */
-import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { ArrowRight } from "@untitledui/icons";
-import {
-  COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
-  getCommerceDiscoveryAgentId,
-  mcpClientQueryOptions,
-  SELF_MCP_ALIAS_ID,
-  useProjectContext,
-  WellKnownOrgMCPId,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { ErrorBoundary } from "@/web/components/error-boundary";
-import { formatPinnedViewTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 import { track } from "@/web/lib/posthog-client";
-import { KEYS } from "@/web/lib/query-keys";
-import { unwrapToolResult } from "@/web/routes/commerce-onboarding/companions-core";
 import {
-  type CommerceDiagnosticRunState,
+  commerceReportNavTarget,
+  useCommerceDiagnostic,
+} from "@/web/hooks/use-commerce-diagnostic";
+import {
   type CommerceReportBannerStatus,
   deriveCommerceReportBannerStatus,
 } from "./commerce-report-banner-status";
-
-/** Poll cadence while a run is live; a run takes minutes, not seconds. */
-const GENERATING_POLL_MS = 20_000;
-
-interface ConnectionItem {
-  metadata?: Record<string, unknown> | null;
-}
-
-function hostFromSiteUrl(siteUrl: unknown): string | null {
-  if (typeof siteUrl !== "string" || !siteUrl) return null;
-  try {
-    return new URL(siteUrl).hostname || null;
-  } catch {
-    return null;
-  }
-}
 
 /** The tilted miniature report page bleeding out of the banner's bottom
  *  edge. Pure decoration (aria-hidden); `generating` swaps the score ring
@@ -212,73 +188,12 @@ function BannerShell({
 function CommerceReportBannerInner() {
   const { org } = useProjectContext();
   const navigate = useNavigate();
-  const connectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
+  const { diagnostic, isSuccess, host, connectionId } = useCommerceDiagnostic();
 
-  const { data: selfClient } = useQuery(
-    mcpClientQueryOptions({
-      connectionId: SELF_MCP_ALIAS_ID,
-      orgId: org.id,
-      orgSlug: org.slug,
-    }),
-  );
-
-  // Gate 1 (cheap, in-house): does this org have the CD connection at all?
-  // Same key + shape as the onboarding query, so the caches cooperate.
-  const connectionQuery = useQuery({
-    queryKey: KEYS.commerceDiscoveryConnection(org.id, connectionId),
-    enabled: !!selfClient,
-    retry: false,
-    staleTime: 60_000,
-    queryFn: async () => {
-      if (!selfClient) throw new Error("selfClient not ready");
-      const result = await selfClient.callTool({
-        name: "COLLECTION_CONNECTIONS_GET",
-        arguments: { id: connectionId },
-      });
-      return unwrapToolResult<{ item: ConnectionItem | null }>(result);
-    },
-  });
-  const connectionItem = connectionQuery.data?.item ?? null;
-
-  // Gate 2 (external): only orgs that passed gate 1 ever open a client to the
-  // Commerce Discovery MCP and read the diagnostic.
-  const { data: cdClient } = useQuery({
-    ...mcpClientQueryOptions({
-      connectionId,
-      orgId: org.id,
-      orgSlug: org.slug,
-    }),
-    enabled: !!connectionItem,
-  });
-
-  const diagnosticQuery = useQuery({
-    queryKey: KEYS.commerceDiscoveryDiagnostic(org.id, connectionId),
-    enabled: !!cdClient,
-    retry: 1,
-    refetchInterval: (query) =>
-      query.state.status !== "error" &&
-      deriveCommerceReportBannerStatus(query.state.data) === "generating"
-        ? GENERATING_POLL_MS
-        : false,
-    queryFn: async () => {
-      if (!cdClient) throw new Error("cdClient not ready");
-      const result = await cdClient.callTool({
-        name: COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
-        arguments: {},
-      });
-      const parsed = unwrapToolResult<{
-        diagnostic?: CommerceDiagnosticRunState | null;
-      }>(result);
-      return parsed.diagnostic ?? null;
-    },
-  });
-
-  const status = diagnosticQuery.isSuccess
-    ? deriveCommerceReportBannerStatus(diagnosticQuery.data)
+  const status = isSuccess
+    ? deriveCommerceReportBannerStatus(diagnostic)
     : "none";
   if (status === "none") return null;
-
-  const host = hostFromSiteUrl(connectionItem?.metadata?.siteUrl);
 
   const openReport = () => {
     track("home_report_banner_clicked", {
@@ -286,17 +201,7 @@ function CommerceReportBannerInner() {
       status,
       domain: host ?? undefined,
     });
-    navigate({
-      to: "/$org/$taskId",
-      params: { org: org.slug, taskId: crypto.randomUUID() },
-      search: {
-        virtualmcpid: getCommerceDiscoveryAgentId(org.id),
-        main: formatPinnedViewTabId(
-          connectionId,
-          COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
-        ),
-      },
-    });
+    navigate(commerceReportNavTarget(org, connectionId));
   };
 
   return <BannerShell status={status} host={host} onOpen={openReport} />;

--- a/apps/mesh/src/web/hooks/commerce-diagnostic-status.test.ts
+++ b/apps/mesh/src/web/hooks/commerce-diagnostic-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { deriveCommerceReportBannerStatus } from "./commerce-report-banner-status";
+import { deriveCommerceReportBannerStatus } from "./commerce-diagnostic-status";
 
 describe("deriveCommerceReportBannerStatus", () => {
   test("no diagnostic hides the banner", () => {
@@ -48,5 +48,20 @@ describe("deriveCommerceReportBannerStatus", () => {
         scanned_at: "2026-07-01T00:00:00.000Z",
       }),
     ).toBe("ready");
+  });
+
+  test("locked is orthogonal to run status — doesn't affect the derived banner state", () => {
+    expect(
+      deriveCommerceReportBannerStatus({
+        scanned_at: "2026-07-01T00:00:00.000Z",
+        locked: true,
+      }),
+    ).toBe("ready");
+    expect(
+      deriveCommerceReportBannerStatus({
+        run_in_progress: true,
+        locked: false,
+      }),
+    ).toBe("generating");
   });
 });

--- a/apps/mesh/src/web/hooks/commerce-diagnostic-status.ts
+++ b/apps/mesh/src/web/hooks/commerce-diagnostic-status.ts
@@ -1,7 +1,8 @@
 /**
- * Pure derivation of the home report banner state from `get_my_diagnostic`
- * (Commerce Discovery's owner view). Kept UI-free so the truth table is
- * unit-testable.
+ * Pure derivation of Commerce Discovery diagnostic state from
+ * `get_my_diagnostic` (Commerce Discovery's owner view). Kept UI-free so the
+ * truth table is unit-testable. Shared by the home report banner and the
+ * task-board paywall banner (see use-commerce-diagnostic.ts).
  *
  * The tool is the single source of truth for run state:
  * - `run_in_progress` is computed server-side (run_started_at > last_run_at,
@@ -17,7 +18,10 @@ export interface CommerceDiagnosticRunState {
   scanned_at?: string | null;
   run_in_progress?: boolean;
   /** Paywall state — true until the org buys the one-time unlock. The board
-   *  paywall banner shows while this is true; it clears itself on payment. */
+   *  paywall banner shows while this is true; it clears itself on payment.
+   *  UI hint only, not an authorization boundary — actual enforcement is
+   *  server-side (see commerce-skills). Never gate a privileged action on
+   *  this value. */
   locked?: boolean;
 }
 

--- a/apps/mesh/src/web/hooks/use-commerce-diagnostic.ts
+++ b/apps/mesh/src/web/hooks/use-commerce-diagnostic.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared Commerce Discovery diagnostic read — the two-gate query the home
+ * report banner and the task-board paywall banner both need.
+ *
+ * Gate 1 (cheap, in-house): does this org even have the CD connection? Only orgs
+ * that pass it ever open a client to the external CD MCP (gate 2) and read the
+ * owner diagnostic. Every failure path degrades to a null diagnostic so a caller
+ * renders nothing rather than breaking the page.
+ *
+ * The returned diagnostic carries run state (`scanned_at`, `run_in_progress`)
+ * AND the paywall state (`locked` — true until the org buys the one-time
+ * unlock), so callers can gate on either without a second round-trip.
+ */
+import { useQuery } from "@tanstack/react-query";
+import {
+  COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+  getCommerceDiscoveryAgentId,
+  mcpClientQueryOptions,
+  SELF_MCP_ALIAS_ID,
+  useProjectContext,
+  WellKnownOrgMCPId,
+} from "@decocms/mesh-sdk";
+import { formatPinnedViewTabId } from "@/web/layouts/main-panel-tabs/tab-id";
+import { KEYS } from "@/web/lib/query-keys";
+import { unwrapToolResult } from "@/web/routes/commerce-onboarding/companions-core";
+import {
+  type CommerceDiagnosticRunState,
+  deriveCommerceReportBannerStatus,
+} from "@/web/components/home/commerce-report-banner-status";
+
+/** Poll cadence while a run is live; a run takes minutes, not seconds. */
+const GENERATING_POLL_MS = 20_000;
+
+interface ConnectionItem {
+  metadata?: Record<string, unknown> | null;
+}
+
+function hostFromSiteUrl(siteUrl: unknown): string | null {
+  if (typeof siteUrl !== "string" || !siteUrl) return null;
+  try {
+    return new URL(siteUrl).hostname || null;
+  } catch {
+    return null;
+  }
+}
+
+export interface UseCommerceDiagnosticResult {
+  /** The owner diagnostic, or null (no CD connection, never run, or an error). */
+  diagnostic: CommerceDiagnosticRunState | null;
+  /** True once the diagnostic query has resolved (vs still loading / disabled). */
+  isSuccess: boolean;
+  /** The store's hostname from the connection metadata, for copy. */
+  host: string | null;
+  connectionId: string;
+}
+
+export function useCommerceDiagnostic(): UseCommerceDiagnosticResult {
+  const { org } = useProjectContext();
+  const connectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
+
+  const { data: selfClient } = useQuery(
+    mcpClientQueryOptions({
+      connectionId: SELF_MCP_ALIAS_ID,
+      orgId: org.id,
+      orgSlug: org.slug,
+    }),
+  );
+
+  // Gate 1: does this org have the CD connection at all? Same key + shape as the
+  // onboarding query, so the caches cooperate.
+  const connectionQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryConnection(org.id, connectionId),
+    enabled: !!selfClient,
+    retry: false,
+    staleTime: 60_000,
+    queryFn: async () => {
+      if (!selfClient) throw new Error("selfClient not ready");
+      const result = await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_GET",
+        arguments: { id: connectionId },
+      });
+      return unwrapToolResult<{ item: ConnectionItem | null }>(result);
+    },
+  });
+  const connectionItem = connectionQuery.data?.item ?? null;
+
+  // Gate 2: only orgs that passed gate 1 open a client to the CD MCP.
+  const { data: cdClient } = useQuery({
+    ...mcpClientQueryOptions({
+      connectionId,
+      orgId: org.id,
+      orgSlug: org.slug,
+    }),
+    enabled: !!connectionItem,
+  });
+
+  const diagnosticQuery = useQuery({
+    queryKey: KEYS.commerceDiscoveryDiagnostic(org.id, connectionId),
+    enabled: !!cdClient,
+    retry: 1,
+    refetchInterval: (query) =>
+      query.state.status !== "error" &&
+      deriveCommerceReportBannerStatus(query.state.data) === "generating"
+        ? GENERATING_POLL_MS
+        : false,
+    queryFn: async () => {
+      if (!cdClient) throw new Error("cdClient not ready");
+      const result = await cdClient.callTool({
+        name: COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+        arguments: {},
+      });
+      const parsed = unwrapToolResult<{
+        diagnostic?: CommerceDiagnosticRunState | null;
+      }>(result);
+      return parsed.diagnostic ?? null;
+    },
+  });
+
+  return {
+    diagnostic: diagnosticQuery.data ?? null,
+    isSuccess: diagnosticQuery.isSuccess,
+    host: hostFromSiteUrl(connectionItem?.metadata?.siteUrl),
+    connectionId,
+  };
+}
+
+/** Navigate args that open the Commerce Discovery report app (where the unlock /
+ *  checkout lives) as a pinned view on a fresh thread. Shared by the home banner
+ *  and the board paywall so the target stays identical. */
+export function commerceReportNavTarget(
+  org: { id: string; slug: string },
+  connectionId: string,
+) {
+  return {
+    to: "/$org/$taskId" as const,
+    params: { org: org.slug, taskId: crypto.randomUUID() },
+    search: {
+      virtualmcpid: getCommerceDiscoveryAgentId(org.id),
+      main: formatPinnedViewTabId(
+        connectionId,
+        COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+      ),
+    },
+  };
+}

--- a/apps/mesh/src/web/hooks/use-commerce-diagnostic.ts
+++ b/apps/mesh/src/web/hooks/use-commerce-diagnostic.ts
@@ -44,6 +44,15 @@ function hostFromSiteUrl(siteUrl: unknown): string | null {
   }
 }
 
+/** Minimal shape of the Commerce Discovery MCP client we use — enough to call
+ *  a tool (e.g. start_checkout) without pulling the full SDK client type in. */
+export interface CommerceDiscoveryClient {
+  callTool: (input: {
+    name: string;
+    arguments: Record<string, unknown>;
+  }) => Promise<unknown>;
+}
+
 export interface UseCommerceDiagnosticResult {
   /** The owner diagnostic, or null (no CD connection, never run, or an error). */
   diagnostic: CommerceDiagnosticRunState | null;
@@ -52,6 +61,8 @@ export interface UseCommerceDiagnosticResult {
   /** The store's hostname from the connection metadata, for copy. */
   host: string | null;
   connectionId: string;
+  /** The CD MCP client (once gate 2 opens), for tool calls like start_checkout. */
+  cdClient: CommerceDiscoveryClient | null;
 }
 
 export function useCommerceDiagnostic(): UseCommerceDiagnosticResult {
@@ -121,6 +132,7 @@ export function useCommerceDiagnostic(): UseCommerceDiagnosticResult {
     isSuccess: diagnosticQuery.isSuccess,
     host: hostFromSiteUrl(connectionItem?.metadata?.siteUrl),
     connectionId,
+    cdClient: (cdClient as CommerceDiscoveryClient | undefined) ?? null,
   };
 }
 

--- a/apps/mesh/src/web/hooks/use-commerce-diagnostic.ts
+++ b/apps/mesh/src/web/hooks/use-commerce-diagnostic.ts
@@ -26,7 +26,7 @@ import { unwrapToolResult } from "@/web/routes/commerce-onboarding/companions-co
 import {
   type CommerceDiagnosticRunState,
   deriveCommerceReportBannerStatus,
-} from "@/web/components/home/commerce-report-banner-status";
+} from "./commerce-diagnostic-status";
 
 /** Poll cadence while a run is live; a run takes minutes, not seconds. */
 const GENERATING_POLL_MS = 20_000;

--- a/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
+++ b/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
@@ -1,71 +1,65 @@
 /**
- * Board paywall CTA — shown in place of the empty state for commerce
- * (reports-only) orgs whose plano de trabalho hasn't been generated yet.
+ * Board paywall banner — a persistent strip at the top of the task board for
+ * commerce orgs whose diagnostic is still locked (unpaid).
  *
- * The backlog is paid content: the diagnostic run computes it but withholds the
- * push to this board until the org unlocks the enriched diagnostic (see
- * commerce-skills task-sync / the Stripe unlock). So an empty commerce board is
- * the "not unlocked yet" state — this card turns it into a second paywall
- * surface (the report deck being the first), opening the report app where the
- * unlock lives. Once unlocked, the backlog lands and this card is replaced by
- * the cards themselves.
+ * The board itself stays fully usable: the user can create and run their own
+ * tasks freely. What's paywalled is the auto-generated plano de trabalho — the
+ * diagnostic run computes it but withholds the push until the org unlocks the
+ * enriched diagnostic (see commerce-skills). This banner is the in-product CTA
+ * for that unlock; it reads the diagnostic's `locked` flag, so it clears itself
+ * the moment payment lands. Renders nothing for non-commerce orgs, orgs without
+ * a diagnostic, or once unlocked.
  */
 import { useNavigate } from "@tanstack/react-router";
 import { ArrowRight, Lightning01 } from "@untitledui/icons";
-import {
-  COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
-  getCommerceDiscoveryAgentId,
-  useProjectContext,
-  WellKnownOrgMCPId,
-} from "@decocms/mesh-sdk";
+import { useProjectContext } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
-import { formatPinnedViewTabId } from "@/web/layouts/main-panel-tabs/tab-id";
+import { ErrorBoundary } from "@/web/components/error-boundary";
+import {
+  commerceReportNavTarget,
+  useCommerceDiagnostic,
+} from "@/web/hooks/use-commerce-diagnostic";
 import { track } from "@/web/lib/posthog-client";
 
-export function BacklogPaywall() {
+function BacklogPaywallBannerInner() {
   const { org } = useProjectContext();
   const navigate = useNavigate();
-  const connectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
+  const { diagnostic, connectionId } = useCommerceDiagnostic();
+
+  // Only while the diagnostic exists and is still locked (unpaid).
+  if (!diagnostic?.locked) return null;
 
   const openReport = () => {
-    track("board_paywall_cta_clicked", { organization_id: org.id });
-    navigate({
-      to: "/$org/$taskId",
-      params: { org: org.slug, taskId: crypto.randomUUID() },
-      search: {
-        virtualmcpid: getCommerceDiscoveryAgentId(org.id),
-        main: formatPinnedViewTabId(
-          connectionId,
-          COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
-        ),
-      },
-    });
+    track("board_paywall_banner_clicked", { organization_id: org.id });
+    navigate(commerceReportNavTarget(org, connectionId));
   };
 
   return (
-    <div className="relative flex flex-col items-center gap-5 overflow-hidden rounded-xl bg-card px-6 py-12 text-center card-shadow">
-      {/* soft glow to lift the card without a raw palette */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute -top-16 left-1/2 size-56 -translate-x-1/2 rounded-full bg-success/15 blur-3xl"
-      />
-      <div className="relative flex size-12 items-center justify-center rounded-full border border-border bg-background">
-        <Lightning01 size={22} className="text-success" />
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-3 rounded-xl border border-border bg-card px-4 py-3 card-shadow">
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/10">
+        <Lightning01 size={16} className="text-success" />
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="text-sm font-medium text-foreground">
+          Seu plano de trabalho completo está bloqueado
+        </span>
+        <span className="text-sm text-muted-foreground">
+          Desbloqueie o diagnóstico e as tarefas priorizadas entram no quadro,
+          da maior prioridade para a menor.
+        </span>
       </div>
-      <div className="relative flex max-w-md flex-col gap-2">
-        <h2 className="text-lg font-medium text-foreground">
-          Gere seu plano de trabalho
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          Desbloqueie seu diagnóstico enriquecido com dados privados e gere seu
-          plano de trabalho. As tarefas priorizadas caem direto aqui no quadro,
-          prontas para você executar ou delegar.
-        </p>
-      </div>
-      <Button className="relative gap-2" onClick={openReport}>
+      <Button size="sm" className="shrink-0 gap-2" onClick={openReport}>
         Desbloquear diagnóstico
         <ArrowRight size={16} />
       </Button>
     </div>
+  );
+}
+
+export function BacklogPaywallBanner() {
+  return (
+    <ErrorBoundary fallback={null}>
+      <BacklogPaywallBannerInner />
+    </ErrorBoundary>
   );
 }

--- a/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
+++ b/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
@@ -41,11 +41,11 @@ function BacklogPaywallBannerInner() {
       </span>
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="text-sm font-medium text-foreground">
-          Seu plano de trabalho completo está bloqueado
+          Seu plano de ação está a um clique
         </span>
         <span className="text-sm text-muted-foreground">
-          Desbloqueie o diagnóstico e as tarefas priorizadas entram no quadro,
-          da maior prioridade para a menor.
+          Desbloqueie o diagnóstico completo e as tarefas entram aqui, da maior
+          prioridade para a menor.
         </span>
       </div>
       <Button size="sm" className="shrink-0 gap-2" onClick={openReport}>

--- a/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
+++ b/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
@@ -51,7 +51,7 @@ const OFFER = { price: "R$ 99", anchor: "R$ 499" };
 
 /** Pure presentational banner — no hooks, so it renders anywhere (incl. the
  *  dev preview). The container below wires the data + navigation. */
-export function BacklogPaywallCard({ onOpen }: { onOpen: () => void }) {
+function BacklogPaywallCard({ onOpen }: { onOpen: () => void }) {
   return (
     <div className="flex flex-col gap-3 rounded-xl bg-card p-4 card-shadow sm:flex-row sm:items-center sm:gap-4">
       <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center">
@@ -82,7 +82,7 @@ export function BacklogPaywallCard({ onOpen }: { onOpen: () => void }) {
 
 /** The unlock modal. Presentational + the checkout call; `onDismiss` closes it
  *  ("Agora não"), leaving the board and banner usable. */
-export function BacklogPaywallModal({
+function BacklogPaywallModal({
   open,
   onOpenChange,
   cdClient,

--- a/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
+++ b/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
@@ -1,0 +1,71 @@
+/**
+ * Board paywall CTA — shown in place of the empty state for commerce
+ * (reports-only) orgs whose plano de trabalho hasn't been generated yet.
+ *
+ * The backlog is paid content: the diagnostic run computes it but withholds the
+ * push to this board until the org unlocks the enriched diagnostic (see
+ * commerce-skills task-sync / the Stripe unlock). So an empty commerce board is
+ * the "not unlocked yet" state — this card turns it into a second paywall
+ * surface (the report deck being the first), opening the report app where the
+ * unlock lives. Once unlocked, the backlog lands and this card is replaced by
+ * the cards themselves.
+ */
+import { useNavigate } from "@tanstack/react-router";
+import { ArrowRight, Lightning01 } from "@untitledui/icons";
+import {
+  COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+  getCommerceDiscoveryAgentId,
+  useProjectContext,
+  WellKnownOrgMCPId,
+} from "@decocms/mesh-sdk";
+import { Button } from "@deco/ui/components/button.tsx";
+import { formatPinnedViewTabId } from "@/web/layouts/main-panel-tabs/tab-id";
+import { track } from "@/web/lib/posthog-client";
+
+export function BacklogPaywall() {
+  const { org } = useProjectContext();
+  const navigate = useNavigate();
+  const connectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
+
+  const openReport = () => {
+    track("board_paywall_cta_clicked", { organization_id: org.id });
+    navigate({
+      to: "/$org/$taskId",
+      params: { org: org.slug, taskId: crypto.randomUUID() },
+      search: {
+        virtualmcpid: getCommerceDiscoveryAgentId(org.id),
+        main: formatPinnedViewTabId(
+          connectionId,
+          COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+        ),
+      },
+    });
+  };
+
+  return (
+    <div className="relative flex flex-col items-center gap-5 overflow-hidden rounded-xl bg-card px-6 py-12 text-center card-shadow">
+      {/* soft glow to lift the card without a raw palette */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -top-16 left-1/2 size-56 -translate-x-1/2 rounded-full bg-success/15 blur-3xl"
+      />
+      <div className="relative flex size-12 items-center justify-center rounded-full border border-border bg-background">
+        <Lightning01 size={22} className="text-success" />
+      </div>
+      <div className="relative flex max-w-md flex-col gap-2">
+        <h2 className="text-lg font-medium text-foreground">
+          Gere seu plano de trabalho
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Desbloqueie seu diagnóstico enriquecido com dados privados e gere seu
+          plano de trabalho. As tarefas priorizadas caem direto aqui no quadro,
+          prontas para você executar ou delegar.
+        </p>
+      </div>
+      <Button className="relative gap-2" onClick={openReport}>
+        Desbloquear diagnóstico
+        <ArrowRight size={16} />
+      </Button>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
+++ b/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
@@ -1,58 +1,247 @@
 /**
- * Board paywall banner — a persistent strip at the top of the task board for
- * commerce orgs whose diagnostic is still locked (unpaid).
+ * Board paywall — a persistent banner at the top of the task board for commerce
+ * orgs whose diagnostic is still locked (unpaid), plus an unlock modal.
  *
- * The board itself stays fully usable: the user can create and run their own
- * tasks freely. What's paywalled is the auto-generated plano de trabalho — the
- * diagnostic run computes it but withholds the push until the org unlocks the
- * enriched diagnostic (see commerce-skills). This banner is the in-product CTA
- * for that unlock; it reads the diagnostic's `locked` flag, so it clears itself
- * the moment payment lands. Renders nothing for non-commerce orgs, orgs without
- * a diagnostic, or once unlocked.
+ * The board stays fully usable: the user can create and run their own tasks.
+ * What's paywalled is the auto-generated plano de trabalho — the diagnostic run
+ * computes it but withholds the push until the org unlocks the enriched
+ * diagnostic (see commerce-skills). The modal auto-opens once per session and
+ * can be dismissed ("Agora não"); the banner stays and re-opens it on click.
+ * "Desbloquear" starts the Stripe checkout via the CD MCP. Everything reads the
+ * diagnostic's `locked` flag, so it all clears itself the moment payment lands.
  */
+import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { ArrowRight, Lightning01 } from "@untitledui/icons";
+import {
+  ArrowRight,
+  CheckCircle,
+  Lightning01,
+  Loading01,
+} from "@untitledui/icons";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import {
+  type CommerceDiscoveryClient,
   commerceReportNavTarget,
   useCommerceDiagnostic,
 } from "@/web/hooks/use-commerce-diagnostic";
+import { unwrapToolResult } from "@/web/routes/commerce-onboarding/companions-core";
 import { track } from "@/web/lib/posthog-client";
 
-function BacklogPaywallBannerInner() {
-  const { org } = useProjectContext();
-  const navigate = useNavigate();
-  const { diagnostic, connectionId } = useCommerceDiagnostic();
+/** A preview of the unlocked board (carries the brand-lime edge), used as the
+ *  modal hero — hosted on the deco CDN. */
+const KANBAN_PREVIEW_SRC =
+  "https://decoims.com/image?src=decocms%2F7263a67f-fb83-410b-a5f2-e54e87deaaac%2Freport-kanban.png&quality=original&fit=cover";
 
-  // Only while the diagnostic exists and is still locked (unpaid).
-  if (!diagnostic?.locked) return null;
+/** What the unlock buys — kept true to what the paid product delivers. */
+const BENEFITS = [
+  "Todas as tarefas do diagnóstico, priorizadas no seu quadro",
+  "Um relatório recorrente do seu site, sempre atualizado",
+  "O agente resolve cada tarefa e deixa pronta para a sua revisão",
+];
 
-  const openReport = () => {
-    track("board_paywall_banner_clicked", { organization_id: org.id });
-    navigate(commerceReportNavTarget(org, connectionId));
-  };
+/** Display-only offer strings (mirrors the report's one-time unlock). */
+const OFFER = { price: "R$ 99", anchor: "R$ 499" };
 
+/** Pure presentational banner — no hooks, so it renders anywhere (incl. the
+ *  dev preview). The container below wires the data + navigation. */
+export function BacklogPaywallCard({ onOpen }: { onOpen: () => void }) {
   return (
-    <div className="flex flex-wrap items-center gap-x-4 gap-y-3 rounded-xl border border-border bg-card px-4 py-3 card-shadow">
-      <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/10">
-        <Lightning01 size={16} className="text-success" />
-      </span>
-      <div className="flex min-w-0 flex-1 flex-col">
-        <span className="text-sm font-medium text-foreground">
-          Seu plano de ação está a um clique
+    <div className="flex flex-col gap-3 rounded-xl bg-card p-4 card-shadow sm:flex-row sm:items-center sm:gap-4">
+      <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center">
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/10">
+          <Lightning01 size={16} className="text-success" />
         </span>
-        <span className="text-sm text-muted-foreground">
-          Desbloqueie o diagnóstico completo e as tarefas entram aqui, da maior
-          prioridade para a menor.
-        </span>
+        <div className="flex min-w-0 flex-col">
+          <span className="text-sm font-medium text-foreground">
+            Seu plano de ação está a um clique
+          </span>
+          <span className="text-sm text-muted-foreground">
+            Desbloqueie o diagnóstico completo e as tarefas entram aqui, da
+            maior prioridade para a menor.
+          </span>
+        </div>
       </div>
-      <Button size="sm" className="shrink-0 gap-2" onClick={openReport}>
+      <Button
+        size="sm"
+        onClick={onOpen}
+        className="w-full gap-2 sm:w-auto sm:shrink-0"
+      >
         Desbloquear diagnóstico
         <ArrowRight size={16} />
       </Button>
     </div>
+  );
+}
+
+/** The unlock modal. Presentational + the checkout call; `onDismiss` closes it
+ *  ("Agora não"), leaving the board and banner usable. */
+export function BacklogPaywallModal({
+  open,
+  onOpenChange,
+  cdClient,
+  onExpired,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  cdClient: CommerceDiscoveryClient | null;
+  /** Called when checkout can't start because the report app is the only place
+   *  that can (no client) — falls back to opening it. */
+  onExpired: () => void;
+}) {
+  const [starting, setStarting] = useState(false);
+
+  const startCheckout = async () => {
+    if (!cdClient) {
+      onExpired();
+      return;
+    }
+    setStarting(true);
+    try {
+      const result = await cdClient.callTool({
+        name: "start_checkout",
+        arguments: {},
+      });
+      const { url } = unwrapToolResult<{ url: string }>(result);
+      // Stripe hosted checkout opens in a new tab; on return the diagnostic
+      // re-polls and unlocks (locked → false), clearing the banner/modal.
+      window.open(url, "_blank", "noopener,noreferrer");
+      onOpenChange(false);
+    } catch {
+      // Couldn't start checkout here — fall back to the report app, which owns
+      // the full paywall + checkout flow.
+      onExpired();
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="gap-0 p-3 sm:max-w-[500px]"
+        closeButtonClassName="z-10 rounded-full bg-background/70 p-1 text-foreground backdrop-blur transition-colors hover:bg-background"
+      >
+        {/* Hero — a preview of the unlocked board (brand-lime edge baked in),
+            inset with padding around it like the rest of the content. */}
+        <div className="overflow-hidden rounded-xl bg-muted">
+          <img
+            src={KANBAN_PREVIEW_SRC}
+            alt="Prévia do seu quadro de tarefas desbloqueado"
+            className="h-[208px] w-full object-cover object-left-top"
+          />
+        </div>
+
+        {/* Body */}
+        <div className="flex flex-col gap-7 px-3 pb-3 pt-7">
+          <div className="flex flex-col gap-5">
+            <DialogTitle className="text-xl font-semibold text-foreground">
+              Desbloqueie seu plano de trabalho
+            </DialogTitle>
+            <ul className="flex flex-col gap-3.5">
+              {BENEFITS.map((b) => (
+                <li key={b} className="flex items-start gap-3 text-sm">
+                  <CheckCircle
+                    size={18}
+                    className="mt-0.5 shrink-0 text-success"
+                    aria-hidden
+                  />
+                  <span className="leading-snug text-foreground">{b}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Price + actions — stacked full-width on mobile, price-left /
+              buttons-right on sm+. */}
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-semibold text-foreground">
+                {OFFER.price}
+              </span>
+              <span className="text-sm text-muted-foreground line-through">
+                {OFFER.anchor}
+              </span>
+            </div>
+            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+              <Button
+                variant="ghost"
+                onClick={() => onOpenChange(false)}
+                disabled={starting}
+                className="order-2 w-full sm:order-none sm:w-auto"
+              >
+                Explorar
+              </Button>
+              <Button
+                onClick={startCheckout}
+                disabled={starting}
+                className="order-1 w-full gap-2 sm:order-none sm:w-auto"
+              >
+                {starting ? (
+                  <Loading01 size={16} className="animate-spin" />
+                ) : null}
+                Desbloquear diagnóstico
+                {!starting && <ArrowRight size={16} />}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** sessionStorage key: once the modal is dismissed this session, it won't
+ *  auto-open again (the banner still re-opens it on click). */
+function seenKey(orgId: string) {
+  return `board-paywall-seen:${orgId}`;
+}
+
+function BacklogPaywallBannerInner() {
+  const { org } = useProjectContext();
+  const navigate = useNavigate();
+  const { diagnostic, cdClient, connectionId } = useCommerceDiagnostic();
+
+  // Auto-open once per session (read synchronously — no effect needed). The
+  // component only renders while locked, so this only fires for unpaid orgs.
+  const [modalOpen, setModalOpen] = useState(
+    () => !sessionStorage.getItem(seenKey(org.id)),
+  );
+
+  // Only while the diagnostic exists and is still locked (unpaid).
+  if (!diagnostic?.locked) return null;
+
+  const dismiss = (next: boolean) => {
+    setModalOpen(next);
+    if (!next) sessionStorage.setItem(seenKey(org.id), "1");
+  };
+
+  const openReport = () => {
+    track("board_paywall_report_opened", { organization_id: org.id });
+    navigate(commerceReportNavTarget(org, connectionId));
+  };
+
+  return (
+    <>
+      <BacklogPaywallCard
+        onOpen={() => {
+          track("board_paywall_banner_clicked", { organization_id: org.id });
+          setModalOpen(true);
+        }}
+      />
+      <BacklogPaywallModal
+        open={modalOpen}
+        onOpenChange={dismiss}
+        cdClient={cdClient}
+        onExpired={openReport}
+      />
+    </>
   );
 }
 

--- a/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
+++ b/apps/mesh/src/web/layouts/task-board/backlog-paywall.tsx
@@ -109,6 +109,8 @@ export function BacklogPaywallModal({
         arguments: {},
       });
       const { url } = unwrapToolResult<{ url: string }>(result);
+      if (new URL(url).protocol !== "https:")
+        throw new Error("unsafe checkout url");
       // Stripe hosted checkout opens in a new tab; on return the diagnostic
       // re-polls and unlocks (locked → false), clearing the banner/modal.
       window.open(url, "_blank", "noopener,noreferrer");
@@ -208,14 +210,25 @@ function BacklogPaywallBannerInner() {
   const navigate = useNavigate();
   const { diagnostic, cdClient, connectionId } = useCommerceDiagnostic();
 
-  // Auto-open once per session (read synchronously — no effect needed). The
-  // component only renders while locked, so this only fires for unpaid orgs.
-  const [modalOpen, setModalOpen] = useState(
-    () => !sessionStorage.getItem(seenKey(org.id)),
-  );
+  // Auto-open once per session per org (read synchronously — no effect
+  // needed). Stored alongside the org it was computed for so switching orgs
+  // re-derives fresh from sessionStorage instead of inheriting a dismissal
+  // from the previous org. The component only renders while locked, so this
+  // only fires for unpaid orgs.
+  const [modalState, setModalState] = useState(() => ({
+    orgId: org.id,
+    open: !sessionStorage.getItem(seenKey(org.id)),
+  }));
+  const modalOpen =
+    modalState.orgId === org.id
+      ? modalState.open
+      : !sessionStorage.getItem(seenKey(org.id));
 
   // Only while the diagnostic exists and is still locked (unpaid).
   if (!diagnostic?.locked) return null;
+
+  const setModalOpen = (open: boolean) =>
+    setModalState({ orgId: org.id, open });
 
   const dismiss = (next: boolean) => {
     setModalOpen(next);

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -69,6 +69,7 @@ import { writeChatDraft } from "@/web/lib/chat-draft";
 import { createMentionDoc } from "@/web/components/chat/tiptap/mention";
 import type { TiptapDoc } from "@/web/components/chat/types";
 import { useReportsOnly } from "@/web/hooks/use-organization-settings";
+import { BacklogPaywall } from "./backlog-paywall";
 
 // Warm the chat chunk so opening a task's activity doesn't cold-load it (flash).
 void import("../agent-shell-layout/index.tsx").catch(() => {});
@@ -381,9 +382,13 @@ export function TaskBoardPage() {
 
       {items.length === 0 ? (
         <div className="mx-auto w-full max-w-[1680px] px-4 pt-6 sm:px-8">
-          <div className="rounded-xl bg-card px-4 py-12 text-center text-sm text-muted-foreground card-shadow">
-            No tasks yet. Start one with New task.
-          </div>
+          {reportsOnly ? (
+            <BacklogPaywall />
+          ) : (
+            <div className="rounded-xl bg-card px-4 py-12 text-center text-sm text-muted-foreground card-shadow">
+              No tasks yet. Start one with New task.
+            </div>
+          )}
         </div>
       ) : visibleItems.length === 0 ? (
         <div className="mx-auto w-full max-w-[1680px] px-4 pt-6 sm:px-8">

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -69,7 +69,7 @@ import { writeChatDraft } from "@/web/lib/chat-draft";
 import { createMentionDoc } from "@/web/components/chat/tiptap/mention";
 import type { TiptapDoc } from "@/web/components/chat/types";
 import { useReportsOnly } from "@/web/hooks/use-organization-settings";
-import { BacklogPaywall } from "./backlog-paywall";
+import { BacklogPaywallBanner } from "./backlog-paywall";
 
 // Warm the chat chunk so opening a task's activity doesn't cold-load it (flash).
 void import("../agent-shell-layout/index.tsx").catch(() => {});
@@ -334,6 +334,10 @@ export function TaskBoardPage() {
       <div className="mx-auto flex w-full max-w-[1680px] flex-col gap-4 px-4 pt-6 sm:px-8 sm:pt-8">
         <h1 className="text-xl font-medium text-foreground">Tasks</h1>
 
+        {/* Commerce orgs: a persistent unlock CTA that self-hides once the
+            diagnostic is paid. The board stays usable in the meantime. */}
+        {reportsOnly && <BacklogPaywallBanner />}
+
         {/* Toolbar — filters on the left (inline bar on desktop, a single
             drawer button on mobile), view toggle + New task on the right. */}
         <div className="flex flex-wrap items-center gap-2">
@@ -382,13 +386,9 @@ export function TaskBoardPage() {
 
       {items.length === 0 ? (
         <div className="mx-auto w-full max-w-[1680px] px-4 pt-6 sm:px-8">
-          {reportsOnly ? (
-            <BacklogPaywall />
-          ) : (
-            <div className="rounded-xl bg-card px-4 py-12 text-center text-sm text-muted-foreground card-shadow">
-              No tasks yet. Start one with New task.
-            </div>
-          )}
+          <div className="rounded-xl bg-card px-4 py-12 text-center text-sm text-muted-foreground card-shadow">
+            No tasks yet. Start one with New task.
+          </div>
         </div>
       ) : visibleItems.length === 0 ? (
         <div className="mx-auto w-full max-w-[1680px] px-4 pt-6 sm:px-8">


### PR DESCRIPTION
## What is this contribution about?
The diagnostic backlog ("plano de trabalho") is now paid content — gated on entitlement in the report backend (decocms/reports#246). The kanban stays fully usable (users can create and run their own tasks); what's paywalled is the auto-generated backlog. This adds a persistent unlock banner at the top of the board for commerce (`reports_only`) orgs that reads the diagnostic's `locked` flag and clears itself once payment lands, opening the report app where the unlock lives. The Commerce Discovery diagnostic read the home report banner already did is extracted into a shared `useCommerceDiagnostic` hook so both banners stay in sync.

## Screenshots/Demonstration
> Open `/$org/board` as a commerce org whose diagnostic is still locked: a "Seu plano de trabalho completo está bloqueado" banner sits above the board with a "Desbloquear diagnóstico" button. The board below is fully usable.

## How to Test
1. Sign in to a commerce (`reports_only`) org whose diagnostic is unlocked-pending (locked) and visit `/$org/board`.
2. Confirm the paywall banner sits at the top and the board is still usable (create a task, it works); click the CTA → opens the report app / unlock.
3. After unlocking (via decocms/reports#246), the banner disappears on the next diagnostic read; non-commerce orgs never see it.

## Migration Notes
None. Requires the companion backend change decocms/reports#246 (gates the backlog push on entitlement, pushes it on payment).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes