### PR TITLE
fix(registry): surface errors when saving monitor connection auth status fails

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -121,7 +121,13 @@ function ConnectionRow({
   const markAuthenticated = () => {
     updateAuth.mutate(
       { connectionId, authStatus: "authenticated" },
-      { onSuccess: () => onAuthChanged() },
+      {
+        onSuccess: () => onAuthChanged(),
+        onError: (err) =>
+          toast.error(
+            `Failed to save auth status for "${title}": ${err instanceof Error ? err.message : String(err)}`,
+          ),
+      },
     );
   };
 


### PR DESCRIPTION
**Source:** bug found while auditing `monitor-connections-panel.tsx` (registry monitoring UI focus area).

**Payoff:** `markAuthenticated()` — called from both the OAuth flow and the manual-token-save flow after a success toast is already shown — fires `updateAuth.mutate()` with only an `onSuccess` callback. The app's `QueryClient` has no global mutation error handler (checked `providers.tsx`), so if `REGISTRY_MONITOR_CONNECTION_UPDATE_AUTH` fails (network blip, server error), the failure is swallowed entirely: the user sees a success toast and the connection's `auth_status` silently stays stale in the DB, with no way to know the row needs re-auth.

**Fix:** add an `onError` to the mutation that toasts the failure, matching the error-handling pattern already used elsewhere in the same file (e.g. `applyVisibility`, `handleSaveToken`).

**Verify:** `cd apps/mesh && bunx tsc --noEmit` — clean. No existing test covers this component; the change is a pure additive error-handling branch (the success path is untouched), so behavior for the happy path is unchanged.

**Local checks run:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces errors when saving a monitor connection’s auth status. Adds an onError handler to updateAuth.mutate so failures toast an error instead of silently succeeding while leaving auth_status unchanged.

<sup>Written for commit c56d3abce48e0a9d008d0b6b3589db9c58c7d28e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

