### PR TITLE
fix(ai-providers): add aria-label to icon-only API-key show/hide toggles

### DIFF
--- a/apps/mesh/src/web/views/settings/ai-providers/connect-forms.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/connect-forms.tsx
@@ -97,6 +97,7 @@ export function ConnectApiKeyForm({
           <button
             type="button"
             onClick={() => setShowKey(!showKey)}
+            aria-label={showKey ? "Hide API key" : "Show API key"}
             className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
@@ -246,6 +247,7 @@ export function ConnectOpenAICompatibleForm({
           <button
             type="button"
             onClick={() => setShowKey(!showKey)}
+            aria-label={showKey ? "Hide API key" : "Show API key"}
             className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             {showKey ? <EyeOff size={14} /> : <Eye size={14} />}

--- a/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
@@ -179,6 +179,7 @@ function EditForm({
               <button
                 type="button"
                 onClick={() => setShowKey(!showKey)}
+                aria-label={showKey ? "Hide API key" : "Show API key"}
                 className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
               >
                 {showKey ? <EyeOff size={14} /> : <Eye size={14} />}


### PR DESCRIPTION
The eye/eye-off toggle buttons that reveal/hide a typed API key in the AI-providers settings flow render only an icon (`Eye`/`EyeOff`) with no accessible name — a screen reader announces them as an unlabeled "button" in a form where every field looks the same. Same accessibility gap this bot has already fixed 5x elsewhere in the codebase (#4903, #4904, #4907, #4915, #4922), applied here to the three remaining unlabeled instances in the ai-providers folder.

Fixed in:
- `connect-forms.tsx` — `ConnectApiKeyForm` and `ConnectOpenAICompatibleForm` (the "Connect provider" dialogs)
- `edit-provider-dialog.tsx` — `EditForm` (the "Edit provider key" dialog)

Each button now gets `aria-label={showKey ? "Hide API key" : "Show API key"}`, reflecting the current toggle state rather than a static label.

No behavior change — purely an added `aria-label` attribute, same onClick/state logic.

To confirm: open Settings → AI Providers → connect any provider or edit an existing key, inspect the eye-icon button — it now has an accessible name in the a11y tree (verify with a screen reader or the browser's Accessibility inspector).

Ran locally: `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (clean, no type errors). No test file covers this component; full CI validates lint/build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-labels to the icon-only API key visibility toggles in the AI provider connect and edit dialogs. Screen readers now announce “Show API key” or “Hide API key” based on the current state.

<sup>Written for commit 7f68bb022442ad151b2e97d9e55977a7bf187bcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

