### PR TITLE
fix(chat): key the propose-plan highlight off the plan it actually shows

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/extract-pending-plans.test.ts
+++ b/apps/mesh/src/web/components/chat/highlight/extract-pending-plans.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatMessage } from "../types.ts";
+import {
+  extractPendingPlans,
+  selectActivePlan,
+  type PendingPlan,
+} from "./extract-pending-plans";
+
+describe("extractPendingPlans", () => {
+  test("no propose_plan part → []", () => {
+    const parts = [
+      { type: "text", text: "hi" },
+    ] as unknown as ChatMessage["parts"];
+    expect(extractPendingPlans(parts)).toEqual([]);
+  });
+
+  test("input-available propose_plan part → extracted", () => {
+    const parts = [
+      {
+        type: "tool-propose_plan",
+        toolCallId: "c1",
+        state: "input-available",
+        input: { plan: "Do the thing" },
+      },
+    ] as unknown as ChatMessage["parts"];
+    expect(extractPendingPlans(parts)).toEqual([
+      { toolCallId: "c1", plan: "Do the thing", state: "input-available" },
+    ]);
+  });
+
+  test("non-input-available state is ignored", () => {
+    const parts = [
+      {
+        type: "tool-propose_plan",
+        toolCallId: "c1",
+        state: "output-available",
+        input: { plan: "Do the thing" },
+      },
+    ] as unknown as ChatMessage["parts"];
+    expect(extractPendingPlans(parts)).toEqual([]);
+  });
+});
+
+describe("selectActivePlan", () => {
+  test("empty list → undefined", () => {
+    expect(selectActivePlan([])).toBeUndefined();
+  });
+
+  test("multiple pending plans → the most recent one", () => {
+    const plans: PendingPlan[] = [
+      { toolCallId: "c1", plan: "First plan", state: "input-available" },
+      { toolCallId: "c2", plan: "Second plan", state: "input-available" },
+    ];
+    expect(selectActivePlan(plans)).toEqual(plans[1]);
+  });
+});

--- a/apps/mesh/src/web/components/chat/highlight/extract-pending-plans.ts
+++ b/apps/mesh/src/web/components/chat/highlight/extract-pending-plans.ts
@@ -21,6 +21,15 @@ export interface PendingPlan {
 // Utility: extract pending propose_plan parts from message
 // ============================================================================
 
+// The highlight banner only ever shows the most recently proposed plan —
+// callers must key off this same plan so a dismiss/expand doesn't get
+// reused for a different plan's card once a new one arrives.
+export function selectActivePlan(
+  plans: PendingPlan[],
+): PendingPlan | undefined {
+  return plans.at(-1);
+}
+
 export function extractPendingPlans(
   parts: ChatMessage["parts"],
 ): PendingPlan[] {

--- a/apps/mesh/src/web/components/chat/highlight/index.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/index.tsx
@@ -9,7 +9,11 @@ import {
 import { useChatPrefs, useChatStream, useChatTask } from "../context";
 import type { RequestOptions } from "../store/thread-connection";
 import { ApprovalHighlight, extractPendingApprovals } from "./approval";
-import { ProposePlanHighlight, extractPendingPlans } from "./propose-plan";
+import {
+  ProposePlanHighlight,
+  extractPendingPlans,
+  selectActivePlan,
+} from "./propose-plan";
 import { UserAskQuestionHighlight } from "./user-ask-question";
 import { TodosHighlight } from "./todos";
 import { CollapsibleHighlight } from "./collapsible-highlight";
@@ -274,7 +278,7 @@ export function ChatHighlight() {
 
   const { showError, showWarning, hasApprovals } = flags;
   const userAskKey = userAskParts.map((p) => p.toolCallId).join("|");
-  const planKey = pendingPlans[0]?.toolCallId ?? "";
+  const planKey = selectActivePlan(pendingPlans)?.toolCallId ?? "";
   const approvalKey = pendingApprovals.map((a) => a.approvalId).join("|");
 
   return (

--- a/apps/mesh/src/web/components/chat/highlight/propose-plan.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/propose-plan.tsx
@@ -4,9 +4,10 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { Check, ClipboardCheck } from "@untitledui/icons";
 import { CollapsibleHighlight } from "./collapsible-highlight";
 import { MessageTextPart } from "../message/parts/text-part.tsx";
-import { type PendingPlan } from "./extract-pending-plans";
+import { selectActivePlan, type PendingPlan } from "./extract-pending-plans";
 export {
   extractPendingPlans,
+  selectActivePlan,
   type PendingPlan,
 } from "./extract-pending-plans";
 
@@ -106,7 +107,7 @@ export function ProposePlanHighlight({
   }
 
   // Show only the last pending plan
-  const activePlan = plans.at(-1);
+  const activePlan = selectActivePlan(plans);
   if (!activePlan) {
     return null;
   }


### PR DESCRIPTION
**Source**: a bug found while auditing `chat/highlight/propose-plan.tsx` and its wrapper `chat/highlight/index.tsx`.

**Why a maintainer wants this**: `index.tsx` computed the highlight banner's React `key` from `pendingPlans[0]` (the *first* proposed plan in the message), while `ProposePlanHighlight` always renders `plans.at(-1)` (the *most recent* one) — a mismatch that `collapsible-highlight.tsx`'s own doc comment warns against ("Parents pass a stable key so React remounts on identity change ... both states reset on remount").

**Failure scenario**: an assistant message proposes plan A, the user dismisses its card (setting `closed=true` inside `CollapsibleHighlight`'s local state), then the same message proposes a second plan B. Because `pendingPlans[0]` is still A's `toolCallId`, the `key` doesn't change, so React reuses the same component instance — including its `closed=true` state — and plan B's card never renders. The user has no way to see or act on the new plan.

**Fix**: extracted a single pure `selectActivePlan()` helper (in `extract-pending-plans.ts`) that both the `key` computation in `index.tsx` and the render logic in `propose-plan.tsx` now call, so the two can't drift apart again. Added `extract-pending-plans.test.ts` covering `extractPendingPlans` and the new `selectActivePlan` (including the multi-plan "most recent wins" case that encodes this fix).

**Reviewer check**: `bun test apps/mesh/src/web/components/chat/highlight/extract-pending-plans.test.ts`

**Local verification**: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (both clean), plus the targeted test above (5/5 pass). Full CI covers the rest.

Diff: +18/-4 across `extract-pending-plans.ts`, `index.tsx`, `propose-plan.tsx`, plus a new 47-line test file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Key the propose-plan highlight off the most recent plan it actually renders, fixing a bug where a new plan stayed hidden after dismissing the previous one.

- **Bug Fixes**
  - Added `selectActivePlan()` to pick the active (most recent) plan.
  - Used `selectActivePlan()` for both the banner key in `index.tsx` and rendering in `propose-plan.tsx` to avoid state reuse.
  - Added tests for `extractPendingPlans` and `selectActivePlan`, including the multi-plan case.

<sup>Written for commit 35139cf00e29f4a5d022e99498772afdceff385d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

