### PR TITLE
fix(storage): cascade-delete task board thread/PR links when the task is gone

### DIFF
--- a/apps/mesh/migrations/135-task-board-item-fk-cascade.ts
+++ b/apps/mesh/migrations/135-task-board-item-fk-cascade.ts
@@ -1,0 +1,46 @@
+import type { Kysely } from "kysely";
+
+/**
+ * `task_board_item_threads.task_board_item_id` and
+ * `task_board_item_prs.task_board_item_id` had no FK back to
+ * `task_board_items` — deleting an org cascades away its `task_board_items`
+ * rows (organization_id has ON DELETE CASCADE, migration 126) but leaves
+ * these link rows orphaned forever, pointing at a task that no longer exists.
+ * Same problem migration 131 fixed for `thread_id`; add the matching
+ * cascade here.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_item_threads")
+    .addForeignKeyConstraint(
+      "task_board_item_threads_task_board_item_id_fkey",
+      ["task_board_item_id"],
+      "task_board_items",
+      ["id"],
+      (cb) => cb.onDelete("cascade"),
+    )
+    .execute();
+
+  await db.schema
+    .alterTable("task_board_item_prs")
+    .addForeignKeyConstraint(
+      "task_board_item_prs_task_board_item_id_fkey",
+      ["task_board_item_id"],
+      "task_board_items",
+      ["id"],
+      (cb) => cb.onDelete("cascade"),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_item_prs")
+    .dropConstraint("task_board_item_prs_task_board_item_id_fkey")
+    .execute();
+
+  await db.schema
+    .alterTable("task_board_item_threads")
+    .dropConstraint("task_board_item_threads_task_board_item_id_fkey")
+    .execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -133,6 +133,7 @@ import * as migration131taskboardthreadlinkcascade from "./131-task-board-thread
 import * as migration132taskboarditemprs from "./132-task-board-item-prs.ts";
 import * as migration133dedupeduplicatemembers from "./133-dedupe-duplicate-members.ts";
 import * as migration134droptaskboardenabled from "./134-drop-task-board-enabled.ts";
+import * as migration135taskboarditemfkcascade from "./135-task-board-item-fk-cascade.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -291,6 +292,7 @@ const migrations: Record<string, Migration> = {
   "132-task-board-item-prs": migration132taskboarditemprs,
   "133-dedupe-duplicate-members": migration133dedupeduplicatemembers,
   "134-drop-task-board-enabled": migration134droptaskboardenabled,
+  "135-task-board-item-fk-cascade": migration135taskboarditemfkcascade,
 };
 
 export default migrations;


### PR DESCRIPTION
Follows the task-board schema work in #4883 and the same-shaped fix in migration 131 (`131-task-board-thread-link-cascade.ts`), which added `ON DELETE CASCADE` for `task_board_item_threads.thread_id` because deleting a thread left an orphaned link row forever. The same gap existed for `task_board_item_id`: neither `task_board_item_threads` nor `task_board_item_prs` has any foreign key on that column.

**Why a maintainer wants this:** `task_board_items.organization_id` has `ON DELETE CASCADE` back to `organization` (migration 126), so deleting an org already cascades away its task_board_items rows — but `task_board_item_threads`/`task_board_item_prs` have no FK on `task_board_item_id` at all, so their rows survive, permanently orphaned, pointing at a task row that no longer exists. Same class of leak migration 131 fixed for `thread_id`, just on the other FK of the same tables.

**Failure scenario:** delete an org that has any task board items with linked threads or PRs → the org and its `task_board_items` rows disappear, but `task_board_item_threads`/`task_board_item_prs` rows for those tasks stay in the table forever with no way to clean them up (no FK to cascade on, and the app-level `TaskBoardStorage.delete()` transaction is never invoked for an org-level delete).

**Fix:** migration 135 adds `task_board_item_threads_task_board_item_id_fkey` and `task_board_item_prs_task_board_item_id_fkey`, both `ON DELETE CASCADE` from `task_board_item_id` → `task_board_items.id`, mirroring the exact convention migration 131 used for `thread_id`.

**Reviewer command:** `bun run --cwd=apps/mesh migrate` against a scratch DB, then verify the new constraints exist via `\d task_board_item_threads` / `\d task_board_item_prs` in psql (or just read the migration — it's a direct copy of 131's pattern onto the other column).

**Locally verified:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the migrations-index guardrail test `bun test apps/mesh/migrations/index.test.ts` (2 pass) — this test exists specifically to catch an unregistered migration file, per its own docstring citing a past incident. Full CI runs the actual Postgres migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add cascade-delete FKs for task board link tables so thread/PR links are removed when their task is deleted. This prevents orphaned rows after org or task deletions by adding `ON DELETE CASCADE` from `task_board_item_threads.task_board_item_id` and `task_board_item_prs.task_board_item_id` to `task_board_items.id` (mirrors migration 131 for `thread_id`).

- **Migration**
  - Run `bun run --cwd=apps/mesh migrate` to apply.

<sup>Written for commit 8621c29c4d2303f2a8a389db2fbe6daee0d764c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

