### PR TITLE
feat(commerce): pin Overview+Report tabs for reports-only orgs and improve preview empty state

### DIFF
--- a/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/preview-tab.tsx
@@ -1,12 +1,17 @@
+import { useState } from "react";
 import { useChatTask } from "@/web/components/chat/chat-context";
 import { PreviewContent } from "@/web/components/sandbox/preview/preview";
 import { agentHasClonableSource } from "@/web/lib/agent-capabilities";
 import { useVirtualMCP } from "@decocms/mesh-sdk";
-import { AlertCircle } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import { EmptyState } from "@/web/components/empty-state";
+import { GitHubIcon } from "@/web/components/icons/github-icon";
+import { GitHubRepoPicker } from "@/web/components/github-repo-picker";
 
 export function PreviewTab({ virtualMcpId }: { virtualMcpId: string }) {
   const entity = useVirtualMCP(virtualMcpId);
   const { activeTask } = useChatTask();
+  const [pickerOpen, setPickerOpen] = useState(false);
   // A thread-scoped repo (bound by `load_repo`) is previewable even when the
   // agent itself has no clonable source (e.g. the ephemeral Decopilot agent).
   const hasClonableSource =
@@ -15,14 +20,29 @@ export function PreviewTab({ virtualMcpId }: { virtualMcpId: string }) {
 
   if (!hasClonableSource) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground p-6">
-        <AlertCircle size={24} className="text-muted-foreground/60" />
-        <div>No source to preview.</div>
-        <div className="text-xs text-muted-foreground/80">
-          Connect a GitHub repository from the Connections tab to enable
-          Preview.
-        </div>
-      </div>
+      <>
+        <EmptyState
+          className="h-full"
+          image={
+            <div className="flex size-14 items-center justify-center rounded-full bg-muted">
+              <GitHubIcon className="size-7 text-foreground" />
+            </div>
+          }
+          title="No source to preview"
+          description="Connect a GitHub repository to build and preview your site here."
+          actions={
+            <Button onClick={() => setPickerOpen(true)}>
+              <GitHubIcon className="size-4" />
+              Connect GitHub
+            </Button>
+          }
+        />
+        <GitHubRepoPicker
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          mode="agent"
+        />
+      </>
     );
   }
 

--- a/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -15,6 +15,8 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Globe01, Monitor01 } from "@untitledui/icons";
 import { createElement, useSyncExternalStore } from "react";
 import {
+  COMMERCE_DISCOVERY_ICON,
+  COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
   getCommerceDiscoveryAgentId,
   getDevConnectionId,
   useConnections,
@@ -22,6 +24,7 @@ import {
   useMCPToolsListQuery,
   useProjectContext,
   useVirtualMCP,
+  WellKnownOrgMCPId,
 } from "@decocms/mesh-sdk";
 import { getUIResourceUri } from "@/mcp-apps/types";
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils";
@@ -317,7 +320,13 @@ export function useMainPanelTabs(ctx: {
   const leadingSystemTabs: Array<{ id: string; title: string }> = [];
   // Library is agent-independent, so it lives in the LEFT toolbar group next to
   // the Chat toggle (see LibraryToggle), NOT in this per-agent tab bar.
-  if (effectiveDefaultMainView?.type === "overview") {
+  //
+  // Overview (the Super Agent's home board) is agent-independent — it renders
+  // in place on any shell (see MainPanelContent's `overview` branch). Reports-
+  // only orgs pin it as the first tab on EVERY agent, so the top bar stays a
+  // stable Overview · Preview · Code · Report set regardless of which agent the
+  // thread happens to be on. Clicking it never switches agents.
+  if (effectiveDefaultMainView?.type === "overview" || reportsOnly) {
     leadingSystemTabs.push({ id: "overview", title: "Overview" });
   }
   // Reports-only orgs get a persistent Preview/Code entry point to their
@@ -377,6 +386,29 @@ export function useMainPanelTabs(ctx: {
       iconKey: pv.toolName,
       iconUrl: pv.icon ?? null,
     });
+  }
+
+  // Reports-only orgs surface the Report app on EVERY agent, not just the
+  // Report Agent. It renders in place from the Commerce Discovery connection —
+  // AppViewContent fetches that connection directly, so no aggregation into the
+  // current agent (and no agent switch) is needed. On the Report Agent itself
+  // the loop above already added it with its configured label/icon, so this is
+  // a no-op there (dedup by tab id).
+  if (reportsOnly) {
+    const reportConnectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
+    const reportTabId = formatPinnedViewTabId(
+      reportConnectionId,
+      COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+    );
+    if (!pinnedTabMap.has(reportTabId)) {
+      pinnedTabMap.set(reportTabId, {
+        id: reportTabId,
+        title: "Report",
+        appId: reportConnectionId,
+        iconKey: COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+        iconUrl: COMMERCE_DISCOVERY_ICON,
+      });
+    }
   }
 
   // Ephemeral file-preview tab (`?main=file:<key>`): surfaces as a pill


### PR DESCRIPTION
## What is this contribution about?

Two related improvements for commerce/reports-only orgs:

1. **Stable tab bar for reports-only orgs** (`use-main-panel-tabs.ts`): Overview and Report tabs are now pinned on every agent for reports-only orgs, so the tab bar always shows a consistent Overview · Preview · Code · Report set regardless of which agent the current thread is on. Clicking either tab never triggers an agent switch.

2. **Preview tab empty state** (`preview-tab.tsx`): Replaces the plain text "No source to preview" message with an `EmptyState` component featuring a GitHub icon and a "Connect GitHub" button that opens the `GitHubRepoPicker` directly.

## Screenshots/Demonstration

> UI changes — see preview tab empty state and tab bar behavior in a reports-only org.

## How to Test

1. Open a reports-only org in Studio.
2. Switch between agents — Overview and Report tabs should appear on all of them.
3. Navigate to the Preview tab on an agent with no connected repo — the new empty state with the GitHub connect CTA should appear.
4. Click "Connect GitHub" — the repo picker should open.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Overview and Report tabs across all agents for reports-only orgs, keeping the tab bar stable. Also updates the Preview tab empty state with a clearer CTA that opens the GitHub repo picker.

- **New Features**
  - Pin Overview on every agent for reports-only orgs; clicking it never switches agents.
  - Add Report tab on every agent via the Commerce Discovery connection; no agent switch, deduped on the Report Agent.
  - Replace Preview empty state with an `EmptyState` showing a GitHub icon and a “Connect GitHub” button that opens the repo picker.

<sup>Written for commit 881217743770fcf9d965beee85fd8c2a02351e41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

