### PR TITLE
fix(auth): check the target org's role, not the active org's, in org-SSO gates

### DIFF
--- a/apps/mesh/src/api/routes/org-sso.test.ts
+++ b/apps/mesh/src/api/routes/org-sso.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import type { StudioContext } from "../../core/studio-context";
+import { isOrgAdmin, isOrgOwner } from "./org-sso";
+
+function ctxWith(opts: {
+  activeOrgRole?: string;
+  targetOrgRole?: string;
+}): StudioContext {
+  return {
+    auth: { user: { id: "user-1", role: opts.activeOrgRole } },
+    organization: { id: "org-target", role: opts.targetOrgRole },
+  } as unknown as StudioContext;
+}
+
+describe("isOrgAdmin / isOrgOwner", () => {
+  test("ignore the session's active-org role when it differs from the target org", () => {
+    // Owner in the active org, but only a plain member in the org this
+    // request actually targets (ctx.organization, set by resolveOrgFromPath).
+    const ctx = ctxWith({ activeOrgRole: "owner", targetOrgRole: "user" });
+    expect(isOrgAdmin(ctx)).toBe(false);
+    expect(isOrgOwner(ctx)).toBe(false);
+  });
+
+  test("grant admin/owner based on the target org's role", () => {
+    const admin = ctxWith({ activeOrgRole: "user", targetOrgRole: "admin" });
+    expect(isOrgAdmin(admin)).toBe(true);
+    expect(isOrgOwner(admin)).toBe(false);
+
+    const owner = ctxWith({ activeOrgRole: "user", targetOrgRole: "owner" });
+    expect(isOrgAdmin(owner)).toBe(true);
+    expect(isOrgOwner(owner)).toBe(true);
+  });
+
+  test("recognize comma-joined multi-role owner/admin in the target org", () => {
+    const ctx = ctxWith({
+      activeOrgRole: "user",
+      targetOrgRole: "owner,billing-manager",
+    });
+    expect(isOrgAdmin(ctx)).toBe(true);
+    expect(isOrgOwner(ctx)).toBe(true);
+  });
+
+  test("deny when the target org has no resolved role", () => {
+    const ctx = ctxWith({ activeOrgRole: "owner", targetOrgRole: undefined });
+    expect(isOrgAdmin(ctx)).toBe(false);
+    expect(isOrgOwner(ctx)).toBe(false);
+  });
+});

--- a/apps/mesh/src/api/routes/org-sso.ts
+++ b/apps/mesh/src/api/routes/org-sso.ts
@@ -12,7 +12,7 @@ import { setCookie, getCookie } from "hono/cookie";
 import * as jose from "jose";
 import { getSettings } from "../../settings";
 import type { StudioContext } from "../../core/studio-context";
-import { ADMIN_ROLES } from "../../auth/roles";
+import { hasAdminRole } from "../../auth/roles";
 
 type Variables = {
   studioContext: StudioContext;
@@ -606,12 +606,19 @@ async function getOrgMembership(
   return row ?? null;
 }
 
-function isOrgAdmin(ctx: StudioContext): boolean {
-  const role = ctx.auth.user?.role;
-  if (!role) return false;
-  return (ADMIN_ROLES as readonly string[]).includes(role);
+/**
+ * `ctx.auth.user?.role` reflects the session's ACTIVE org, which can differ
+ * from `ctx.organization` here (an org-scoped call can target an org the
+ * caller merely holds a lower-privileged membership in) — using it would let
+ * an owner/admin of a DIFFERENT org manage this org's SSO config. Use the
+ * path-resolved role on `ctx.organization` instead, which `resolveOrgFromPath`
+ * sets to the caller's real membership row in the TARGET org.
+ */
+export function isOrgAdmin(ctx: StudioContext): boolean {
+  return hasAdminRole(ctx.organization?.role);
 }
 
-function isOrgOwner(ctx: StudioContext): boolean {
-  return ctx.auth.user?.role === "owner";
+export function isOrgOwner(ctx: StudioContext): boolean {
+  const role = ctx.organization?.role;
+  return !!role && role.split(",").includes("owner");
 }


### PR DESCRIPTION
Follows the same bug class fixed in #4934 (member-add/update-role) and #4926 (AccessControl fast-path). `isOrgAdmin`/`isOrgOwner` in `org-sso.ts` gated SSO config read/write/enforce/delete on `ctx.auth.user?.role`, which reflects the session's *active* organization — not `ctx.organization` (the path-resolved *target* org that `resolveOrgFromPath` sets for `/api/:org/sso/*` routes). A user who is owner/admin of one org but only a plain member of another could read, create, enforce, or delete that other org's SSO config (OIDC issuer/client secret) simply by navigating to its org-scoped SSO settings route, since `ctx.organization.role` is exactly the field `resolveOrgFromPath` documents for this purpose (`apps/mesh/src/core/studio-context.ts:230-236`) but the file never used it.

Fix: read `ctx.organization?.role` instead, via the existing `hasAdminRole` helper (also picks up comma-joined multi-role owners/admins, matching #4926).

Failure scenario + regression test: `apps/mesh/src/api/routes/org-sso.test.ts` constructs a context where the active-org role is `"owner"` but the target org's (`ctx.organization.role`) is `"user"` — asserts `isOrgAdmin`/`isOrgOwner` return `false`. This test fails on the pre-fix code (confirmed locally by reverting the fix) and passes after.

Reviewer check: `cd apps/mesh && bun test src/api/routes/org-sso.test.ts`

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/mesh), and the targeted test above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes org SSO access control by checking the target org’s role, not the session’s active org. Prevents users with admin/owner role in a different org from managing another org’s SSO settings.

- **Bug Fixes**
  - `isOrgAdmin` and `isOrgOwner` now read `ctx.organization.role` and use `hasAdminRole`.
  - Support comma-joined multi-role memberships and correctly detect `owner`.
  - Added regression tests to cover active-org vs target-org role mismatches and missing roles.

<sup>Written for commit 5e1ffd9147095cd0418c99202ba80bd71286525f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

