### PR TITLE
fix(auth): resolve model permissions off the target org's role, not the session's active-org role

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/routes.ts
+++ b/apps/mesh/src/api/routes/decopilot/routes.ts
@@ -452,7 +452,10 @@ async function validate(
   const allowedModels = await fetchModelPermissions(
     ctx.db,
     organization.id,
-    ctx.auth.user?.role,
+    // `organization.role` is the path-resolved role (set by resolveOrgFromPath);
+    // ctx.auth.user?.role is the session's active-org role and may belong to a
+    // different org than `organization` if the caller's active org differs.
+    organization.role ?? ctx.auth.user?.role,
   );
   if (
     allowedModels !== undefined &&
@@ -518,7 +521,10 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
     try {
       const ctx = c.get("studioContext");
       const organization = ensureOrganization(c);
-      const role = ctx.auth.user?.role;
+      // `organization.role` is the path-resolved role (set by resolveOrgFromPath);
+      // ctx.auth.user?.role is the session's active-org role and may belong to a
+      // different org than `organization` if the caller's active org differs.
+      const role = organization.role ?? ctx.auth.user?.role;
 
       const models = await fetchModelPermissions(ctx.db, organization.id, role);
 

--- a/apps/mesh/src/tools/ai-providers/key-list.ts
+++ b/apps/mesh/src/tools/ai-providers/key-list.ts
@@ -40,7 +40,10 @@ export const AI_PROVIDER_KEY_LIST = defineTool({
         organizationId: org.id,
         providerId: input.providerId,
       }),
-      fetchModelPermissions(ctx.db, org.id, ctx.auth.user?.role),
+      // `org.role` is the path-resolved role (set by resolveOrgFromPath);
+      // ctx.auth.user?.role is the session's active-org role and may belong
+      // to a different org than `org` if this MCP call targets a non-active one.
+      fetchModelPermissions(ctx.db, org.id, org.role ?? ctx.auth.user?.role),
     ]);
 
     const filtered = keys.filter((k) =>

--- a/apps/mesh/src/tools/ai-providers/list-models.ts
+++ b/apps/mesh/src/tools/ai-providers/list-models.ts
@@ -64,7 +64,10 @@ export const AI_PROVIDERS_LIST_MODELS = defineTool({
 
     const [models, allowedModels] = await Promise.all([
       ctx.aiProviders.listModels(input.keyId, org.id),
-      fetchModelPermissions(ctx.db, org.id, ctx.auth.user?.role),
+      // `org.role` is the path-resolved role (set by resolveOrgFromPath);
+      // ctx.auth.user?.role is the session's active-org role and may belong
+      // to a different org than `org` if this MCP call targets a non-active one.
+      fetchModelPermissions(ctx.db, org.id, org.role ?? ctx.auth.user?.role),
     ]);
 
     const filtered = models.filter((m) =>


### PR DESCRIPTION
**Source:** bug found while auditing remaining `ctx.auth.user?.role` call sites after #4934/#4926/#8ece109 fixed the same active-org-vs-target-org role confusion elsewhere (member-add, member-update-role, AuthTransport's connection AccessControl).

**Why a maintainer wants this:** `AI_PROVIDER_KEY_LIST`, `AI_PROVIDERS_LIST_MODELS`, and the decopilot chat dispatch / `GET /api/:org/decopilot/allowed-models` paths all resolve model permissions with `fetchModelPermissions(db, org.id, ctx.auth.user?.role)`. `ctx.auth.user.role` reflects the caller's role in their session's *active* organization (documented on `OrganizationScope.role` in `studio-context.ts`), while `org`/`organization` here is the path-resolved *target* org set by `resolveOrgFromPath` — every org-scoped route, including these MCP tool calls, runs through it. The two can differ.

**Failure scenario:** a user who is `admin` (unrestricted models) in their session's active org but holds only a custom, model-restricted role in a different org B calls `AI_PROVIDER_KEY_LIST` / `AI_PROVIDERS_LIST_MODELS` / `GET /api/:org/decopilot/allowed-models` scoped to org B. `fetchModelPermissions` resolves permissions using the stale active-org role instead of the caller's real role in B, silently bypassing B's model restrictions (they see/use provider keys and models their B-role should have blocked).

**Fix:** prefer the path-resolved `org.role` / `organization.role`, falling back to `ctx.auth.user?.role` only when it's unset — the exact pattern `mcp-clients/outbound/transports/auth.ts` already uses for its connection-scoped AccessControl (`ctx.organization?.role ?? ctx.auth.user?.role`).

**Net change:** +12/-4 across 3 files, one concern (role source for model-permission checks).

**Reviewer verification:** `bunx tsc --noEmit` in `apps/mesh`; the existing `bun test apps/mesh/src/api/routes/decopilot/model-permissions.test.ts` still passes (untouched pure logic, only the caller-supplied role changed). No test added — same as the precedent fix in #4934, this needs a real Postgres-backed org/member setup to exercise end-to-end and isn't unit-testable without a stubbed StudioContext (banned per TESTING.md); full e2e coverage runs in CI.

**Locally run:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, `bun test apps/mesh/src/api/routes/decopilot/model-permissions.test.ts` — all green. Full CI (lint, e2e) validates the rest.

Note: `dispatch-run.ts`'s analogous call site (line ~915) was deliberately left alone — it's shared by multiple entry points (HTTP, durable-workflow resume, legacy automation) where the relationship between `ctx.organization` and `input.organizationId` isn't uniformly guaranteed, so a blind swap there risks introducing a new mismatch rather than fixing one. Also left `org-sso.ts` untouched — the same-tick reactive session already opened #4943 for it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes model-permission checks to use the target org’s role, not the session’s active-org role, preventing cross-org permission bypass. Affects `AI_PROVIDER_KEY_LIST`, `AI_PROVIDERS_LIST_MODELS`, and `GET /api/:org/decopilot/allowed-models`.

- Bug Fixes
  - Pass `organization.role ?? ctx.auth.user?.role` to `fetchModelPermissions` in `decopilot/routes.ts`, `ai-providers/key-list.ts`, and `ai-providers/list-models.ts`.
  - Prevents users with an active-org `admin` role from seeing models/keys in another org where they have a restricted role.

<sup>Written for commit 5952ebd9bc2ef27c25b45a106d3bf645a5dac03f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

