### PR TITLE
fix(registry): surface error when OAuth token save fails with no fallback token in monitor panel

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -201,6 +201,9 @@ function ConnectionRow({
           // Fallback: save as plain token
           if (authResult.token) {
             await saveTokenInternal(authResult.token);
+          } else {
+            toast.error(`Failed to save OAuth tokens for "${title}".`);
+            return;
           }
         }
       } else if (authResult.token) {


### PR DESCRIPTION
In `MonitorConnectionsPanel.handleAuthenticate`, after a successful OAuth flow the tokens are POSTed to `/api/:org/connections/:id/oauth-token`. If that POST fails (`!res.ok`) the code only had a fallback path when `authResult.token` (a plain token) was also returned — when it wasn't, the failure was silently swallowed and execution fell through to `toast.success(...)` + `markAuthenticated()`, telling the user the connection was authenticated and writing `auth_status: "authenticated"` to the DB even though no credential was actually persisted.

Why a maintainer wants this: this mirrors the exact bug just fixed in #4938 (silently swallowed `updateAuth` failure) — same panel, same failure shape, one call earlier in the same flow. Left as-is, the row shows "Authenticated" while the connection has no working credential, so the next MCP call fails with no indication why.

Fix: when the OAuth-token save fails and there's no fallback plain token to fall back to, show an error toast and return before marking the connection authenticated.

Failure scenario: OAuth flow completes, `/oauth-token` POST returns non-2xx (e.g. transient 500), `authResult.token` is undefined (pure OAuth response) → old code shows "authenticated!" and flips `auth_status` to `authenticated` with no token actually stored. New code shows `Failed to save OAuth tokens for "<title>".` and leaves auth status untouched.

How to confirm: `cd apps/mesh && bunx tsc --noEmit` (clean). This is UI logic behind `useMCPClient`/mutation hooks — the existing test suite for this component is e2e-only and not runnable in this environment; full CI will run the suite.

Checks run locally: `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace) — both clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show an error and stop when saving OAuth tokens fails without a fallback token in the Monitor Connections panel, preventing false “Authenticated” states and bad DB writes.

- **Bug Fixes**
  - If `/api/:org/connections/:id/oauth-token` fails and `authResult.token` is missing, show `Failed to save OAuth tokens for "<title>".` and return.
  - Do not mark the connection as authenticated or update `auth_status` in this failure path.

<sup>Written for commit 3c64461556ac2a185a65dc79600f01f9c3c0c40e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

