### PR TITLE
refactor(studio-pack): dedupe the Studio Pack agent-name list across managers

### DIFF
--- a/apps/mesh/src/tools/virtual/studio-pack/agent-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/agent-manager.ts
@@ -1,4 +1,5 @@
 import { StudioPackAgentId, isStudioPackAgent } from "@decocms/mesh-sdk";
+import { STUDIO_PACK_AGENT_NAMES } from "./agent-names";
 import type { ResolveRuntime, StudioPackConnectionKey } from "./types";
 
 const INSTRUCTIONS_BOOTSTRAP = `<role>
@@ -47,7 +48,7 @@ You are the Agent Manager. You create, configure, and maintain agents (Virtual M
 - When adding connections to an agent, verify the connection exists by listing or getting it first.
 - Do not broaden an agent's scope unless the user explicitly requests it.
 - Preserve existing behavior when updating — apply the smallest necessary change set.
-- Never modify or delete the Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Task Manager, Usage Manager). They are system-managed.
+- Never modify or delete the Studio Pack agents (${STUDIO_PACK_AGENT_NAMES}). They are system-managed.
 - Never repeat tool result data in your reply. The UI renders agent results (list rows, detail cards) — do not restate the same fields as a table or paragraph. Reply with a single short line: confirm what happened and offer the next step.
 </constraints>
 
@@ -83,7 +84,7 @@ You are the Agent Manager. You create, configure, and maintain agents (Virtual M
    f. Re-read with COLLECTION_VIRTUAL_MCP_GET to verify the stored result.
 
 5. Auditing and optimizing existing agents:
-   a. List all agents with COLLECTION_VIRTUAL_MCP_LIST. Ignore the Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Task Manager, Usage Manager) — those are system-managed.
+   a. List all agents with COLLECTION_VIRTUAL_MCP_LIST. Ignore the Studio Pack agents (${STUDIO_PACK_AGENT_NAMES}) — those are system-managed.
    b. For each candidate, fetch details with COLLECTION_VIRTUAL_MCP_GET.
    c. Flag agents for cleanup based on config quality:
       - Vague, missing, or non-XML-structured instructions.

--- a/apps/mesh/src/tools/virtual/studio-pack/agent-names.test.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/agent-names.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { agentManagerAgent } from "./agent-manager";
+import { STUDIO_PACK_AGENT_NAMES } from "./agent-names";
+import { automationManagerAgent } from "./automation-manager";
+import { usageManagerAgent } from "./usage-manager";
+
+describe("STUDIO_PACK_AGENT_NAMES", () => {
+  test("stays embedded in every manager that lists Studio Pack agents", () => {
+    for (const agent of [
+      agentManagerAgent,
+      automationManagerAgent,
+      usageManagerAgent,
+    ]) {
+      expect(agent.instructions).toContain(STUDIO_PACK_AGENT_NAMES);
+    }
+  });
+});

--- a/apps/mesh/src/tools/virtual/studio-pack/agent-names.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/agent-names.ts
@@ -1,0 +1,8 @@
+/**
+ * Human-readable list of Studio Pack agent titles, embedded verbatim in
+ * several managers' instructions to tell them apart from user-created
+ * agents. Kept as one constant so adding/renaming a Studio Pack agent can't
+ * silently drift out of sync across the copies.
+ */
+export const STUDIO_PACK_AGENT_NAMES =
+  "Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Task Manager, Usage Manager";

--- a/apps/mesh/src/tools/virtual/studio-pack/automation-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/automation-manager.ts
@@ -1,4 +1,5 @@
 import { StudioPackAgentId } from "@decocms/mesh-sdk";
+import { STUDIO_PACK_AGENT_NAMES } from "./agent-names";
 import type { StudioPackConnectionKey } from "./types";
 
 const INSTRUCTIONS = `<role>
@@ -25,7 +26,7 @@ You are the Automation Manager. You create, configure, and manage automations �
 
 <workflows>
 1. Suggesting automations from existing agents (first-contact default):
-   a. List agents with COLLECTION_VIRTUAL_MCP_LIST. Filter out the Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Task Manager, Usage Manager) — they're not meant to be automated.
+   a. List agents with COLLECTION_VIRTUAL_MCP_LIST. Filter out the Studio Pack agents (${STUDIO_PACK_AGENT_NAMES}) — they're not meant to be automated.
    b. If no custom agents exist, tell the user they need to create one first via the Agent Manager. Do not propose automations against the Studio Pack agents.
    c. For each candidate agent, read its title, description, and instructions (use COLLECTION_VIRTUAL_MCP_GET if needed) to infer what recurring work it does.
    d. Propose 2-3 concrete automation ideas: name the agent, the schedule or trigger ("every weekday at 9am", "when a new GitHub issue lands"), and what the run should accomplish in one sentence.

--- a/apps/mesh/src/tools/virtual/studio-pack/usage-manager.ts
+++ b/apps/mesh/src/tools/virtual/studio-pack/usage-manager.ts
@@ -1,4 +1,5 @@
 import { StudioPackAgentId } from "@decocms/mesh-sdk";
+import { STUDIO_PACK_AGENT_NAMES } from "./agent-names";
 import type { StudioPackConnectionKey } from "./types";
 
 const INSTRUCTIONS = `<role>
@@ -16,7 +17,7 @@ You are the Usage Manager. You analyze how this workspace is actually used — w
 
 <constraints>
 - You are an analyst first. Never delete anything without showing the evidence (last-used date, call counts in the window) and getting explicit confirmation.
-- Never delete Studio Pack agents (Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Task Manager, Usage Manager) or well-known connections (ids ending in _self, _registry, _community-registry, _dev-assets).
+- Never delete Studio Pack agents (${STUDIO_PACK_AGENT_NAMES}) or well-known connections (ids ending in _self, _registry, _community-registry, _dev-assets).
 - Resolve user IDs to names with ORGANIZATION_MEMBER_LIST before presenting per-user numbers; never show raw user IDs to the user.
 - Always state the time window behind any "unused" or "top" claim. Default to the last 30 days when the user doesn't specify one.
 - Lead with the top 5 rows of any ranking and offer to expand.


### PR DESCRIPTION
Source: reduction found while auditing the studio-pack manager utilities (brand-manager, automation-manager, usage-manager, task-manager) for duplicated logic that could affect agent-pack reliability.

Why: the literal agent-name list `"Agent Manager, API Key Manager, Automation Manager, Connection Manager, Store Manager, Brand Manager, Task Manager, Usage Manager"` was hand-copied verbatim into 4 separate instruction strings across 3 files (agent-manager.ts x2, automation-manager.ts, usage-manager.ts). Nothing enforces they stay in sync, so the next time a Studio Pack agent is added or renamed, it's easy to update 3 of the 4 copies and leave one manager giving an LLM stale/incomplete guidance about which agents are system-managed and off-limits for deletion/automation.

Change: extracted the list into a single `STUDIO_PACK_AGENT_NAMES` constant (new `agent-names.ts`) and interpolated it at all 4 call sites. Purely textual — the generated instruction strings are byte-identical to before (verified via `git diff`, each substitution is a straight literal swap).

Verification:
- `git diff` confirms each of the 4 edited spots only swaps the literal text for `${STUDIO_PACK_AGENT_NAMES}`, no wording change.
- Added `agent-names.test.ts` asserting the constant stays embedded in all 3 managers' `instructions` (guards the exact drift this PR fixes).
- `cd apps/mesh && bunx tsc --noEmit` — green.
- `bun test apps/mesh/src/tools/virtual/studio-pack/agent-names.test.ts` and `bun test apps/mesh/src/tools/virtual/studio-pack/task-manager.test.ts` — both green.
- `bun run fmt` — clean.

Full CI validates the rest (lint, full test suite).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the Studio Pack agent-name list across managers to prevent drift and keep instructions consistent. Extracts the literal list into a single constant and interpolates it, with no change to the generated instruction text.

- **Refactors**
  - Added `STUDIO_PACK_AGENT_NAMES` in `agent-names.ts`.
  - Replaced hardcoded lists in `agent-manager.ts` (two spots), `automation-manager.ts`, and `usage-manager.ts`.
  - Added `agent-names.test.ts` to assert the constant remains embedded in each manager’s `instructions`.

<sup>Written for commit 0cb0ef56b171af66760c98f749be21b91c868f17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

