### PR TITLE
fix(decopilot): resolve model permissions off the target org's role in dispatch-run

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -912,7 +912,11 @@ async function prepareRun(
       const allowedModels = await fetchModelPermissions(
         ctx.db,
         input.organizationId,
-        ctx.auth.user?.role,
+        // `ctx.organization?.role` is the path-resolved role for
+        // `input.organizationId` (set by resolveOrgFromPath); ctx.auth.user?.role
+        // is the session's active-org role and may belong to a different org
+        // when the caller's active org differs from the dispatch target.
+        ctx.organization?.role ?? ctx.auth.user?.role,
       );
 
       if (


### PR DESCRIPTION
Follows #4943 (org-SSO gate fix) and the just-opened #4944 (model-permissions active-org-role fix in routes.ts/key-list.ts/list-models.ts) — same bug class, a call site those PRs missed.

`dispatchRunAndWait`'s model-permission check (in `apps/mesh/src/api/routes/decopilot/dispatch-run.ts`) calls `fetchModelPermissions(ctx.db, input.organizationId, ctx.auth.user?.role)`. `ctx.auth.user?.role` reflects the session's ACTIVE org, not `input.organizationId` (the dispatch target) — the code comment right above it even says this is the resume/automation re-entry path that bypasses the HTTP-layer gate in routes.ts. An owner/admin of one org whose active session role is `owner`/`admin` could dispatch a run against a different org where they hold only a lower-privileged custom role, and `fetchModelPermissions` would treat them as admin (bypassing the role's model-tier restrictions) for that other org's models.

Fix: read `ctx.organization?.role ?? ctx.auth.user?.role` instead — `ctx.organization.role` is the path-resolved role for the target org (set by `resolveOrgFromPath` for HTTP-originated calls); for background automation contexts (`automationContextFactory`) `ctx.organization.role` is unset but `ctx.auth.user.role` is already correctly scoped to `input.organizationId` there, so the fallback preserves existing behavior. This mirrors the exact fix already applied to `routes.ts`/`key-list.ts`/`list-models.ts` in #4944.

No test added — the underlying `fetchModelPermissions` logic already has unit coverage (`model-permissions.test.ts`); this is a one-line call-site correction, same precedent as #4944 (which also shipped without a new test since `dispatchRunAndWait` requires heavy StudioContext mocking to invoke directly).

To verify: `cd apps/mesh && bunx tsc --noEmit` (clean) and read the diff against `apps/mesh/src/api/routes/decopilot/routes.ts`'s equivalent fix in #4944 to confirm the same pattern is applied correctly.

Locally ran: `bun run fmt` and `bunx tsc --noEmit` in `apps/mesh` (both clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a permission gap in Decopilot dispatch-run by resolving model permissions using the target org’s role. This prevents cross-org privilege escalation when the active session org differs from the dispatch target.

- **Bug Fixes**
  - Resolve permissions in `dispatchRunAndWait` with `ctx.organization?.role ?? ctx.auth.user?.role` when calling `fetchModelPermissions`.
  - Preserves automation behavior by falling back to `ctx.auth.user.role` if `ctx.organization.role` is unset.

<sup>Written for commit 929ad80d57d10a3140056e7db21505b0b79d74f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

