### PR TITLE
fix(auth): recognize multi-role owner/admin in my-capabilities endpoint

### DIFF
--- a/apps/mesh/src/api/routes/auth.ts
+++ b/apps/mesh/src/api/routes/auth.ts
@@ -25,7 +25,7 @@ import {
   findEmailProvider,
 } from "../../auth/email-providers";
 import { emailButton, emailTemplate } from "../../auth/email-template";
-import { ADMIN_ROLES } from "../../auth/roles";
+import { ADMIN_ROLES, hasAdminRole } from "../../auth/roles";
 import { isOrgArchived } from "../../core/org-archived";
 import { getBaseUrl } from "../../core/server-constants";
 import { BrandContextStorage } from "../../storage/brand-context";
@@ -246,7 +246,11 @@ app.get("/my-capabilities/:slug", async (c) => {
   }
 
   // owner / admin bypass every permission check — match AccessControl.
-  if (role === "owner" || role === "admin") {
+  // `role` can be Better Auth's comma-joined multi-role string (e.g.
+  // "admin,billing-manager"); a plain `=== "admin"` would silently deny a
+  // multi-role owner/admin the bypass, same failure mode `hasAdminRole`
+  // already guards against for AccessControl.
+  if (hasAdminRole(role)) {
     return c.json({ role, capabilities: allCapabilitiesGranted() });
   }
 


### PR DESCRIPTION
**Source:** found while sweeping recent auth-related merges (#4944, #4947, #4943 — all fixed the same active-org-vs-target-org role confusion) for other latent multi-role bugs in the same neighborhood.

**Why a maintainer wants this:** `GET /api/auth/custom/my-capabilities/:slug` is documented as "the single source of truth for proactive UI gating" and is supposed to mirror `AccessControl`'s owner/admin bypass. `AccessControl` uses `hasAdminRole(this.role)` (`access-control.ts:227`), which correctly splits Better Auth's comma-joined multi-role string and checks each entry. This route instead did a plain `role === "owner" || role === "admin"`, which only matches a single-role member.

**Failure scenario:** a member holds a multi-role assignment like `"admin,billing-manager"` (assignable via `ORGANIZATION_MEMBER_ADD`/`member-update-role`, which take `role: string[]` and store it comma-joined — see `auth/roles.ts`'s `hasAdminRole`/`canAssignRole` docstrings for the same failure mode already fixed there). For such a member, `role === "admin"` is false, so the endpoint falls through to the custom-role permission lookup instead of returning `allCapabilitiesGranted()` — the UI hides admin capabilities from a user the server would actually treat as a full admin. Not a privilege escalation (real enforcement is in `AccessControl`, unaffected), but a real, user-visible capability-gating bug matching this repo's established multi-role-correctness bug class (#4900, #4909, #4918, #4923).

**Fix:** swap the manual `===` check for the already-existing, already-tested `hasAdminRole()` helper (imported alongside `ADMIN_ROLES`, which this file already uses elsewhere in `notifyAdminsOfJoinRequest` with the same comma-split pattern).

**Command a reviewer runs:** `cd apps/mesh && bunx tsc --noEmit`; `bun test apps/mesh/src/auth/roles.test.ts` (covers `hasAdminRole`, including the `"admin,billing-manager"` multi-role case this fix now relies on).

**Locally run:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, `bun test apps/mesh/src/auth/roles.test.ts` — all green. No new test added: the swapped-in helper is already exhaustively tested, and the route itself needs a live DB session to exercise (not unit-testable per TESTING.md). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the my-capabilities endpoint to honor multi‑role owner/admin. Uses hasAdminRole so comma‑joined roles (e.g. "admin,billing-manager") get full capabilities, matching AccessControl and preventing incorrect UI gating.

<sup>Written for commit 61df2a34c9692d829609f3b9365a48822a399db6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

