### PR TITLE
fix(sandbox): stop preview reload from stealing focus back 3s after a Blocks save

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -711,14 +711,18 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
       const src = iframeSrcRef.current;
       if (src) iframe.src = src;
     }
+    let fallbackTimer: ReturnType<typeof setTimeout>;
     const restore = () => {
+      clearTimeout(fallbackTimer);
       iframe.tabIndex = prevTabIndex;
       iframe.style.pointerEvents = "";
       focused?.focus();
       iframe.removeEventListener("load", restore);
     };
     iframe.addEventListener("load", restore);
-    setTimeout(restore, 3000);
+    // Safety net only — cleared above once `load` fires first, so `restore`
+    // (and its focus() steal) can't fire a second time 3s after a normal load.
+    fallbackTimer = setTimeout(restore, 3000);
   };
 
   const [handledPreviewRevision, setHandledPreviewRevision] = useState(


### PR DESCRIPTION
Bug found while auditing `preview.tsx` (sandbox preview overhaul focus area) — not tied to an issue.

`reloadPreviewPreservingScroll` (used to reload the preview iframe after a Blocks save without losing keyboard focus) blurs the iframe, reloads it, then restores focus via a `load` listener with a 3s fallback `setTimeout` in case `load` never fires. Both call the same `restore()`, but the fallback timer was never cleared once `load` fired first — so on every normal (fast) reload, `restore()` runs a second time 3 seconds later, calling `focused?.focus()` again and silently yanking keyboard focus back to whatever element was focused at save-time, even if the user has since clicked or typed into something else.

Fix: track the fallback timer and `clearTimeout` it inside `restore()`, so it only ever fires once, whichever path (load event or timeout) gets there first. Net effect: no unexpected focus theft a few seconds after saving in the Blocks editor.

Reviewer check: read `reloadPreviewPreservingScroll` in `apps/mesh/src/web/components/sandbox/preview/preview.tsx` — confirm `restore()` can now only execute once per reload (either via `load` or the 3s fallback, not both).

Local checks run: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean, no new errors). No existing unit test covers this iframe/focus DOM interaction (it's UI event wiring, not pure logic), so I did not add one; full CI/e2e will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the sandbox preview from stealing focus 3s after a Blocks save by clearing the fallback timeout when the iframe load event fires. This ensures `restore()` runs only once per reload and preserves the user's current focus.

<sup>Written for commit 226a60753449ccac8b2f1694b4e29fb0a1435fb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

