### PR TITLE
refactor(sections-editor): extract shared VariantRuleEditor for page/section rule forms

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -42,11 +42,7 @@ import { defaultPageSeoResolveType } from "./seo-schema";
 import { activeSeoResolveType, buildSeoSavePayload } from "./seo-save";
 import { isSeoEnabled, unwrapSeoConfig } from "./seo-lazy-render";
 import { PageSeoForm } from "./page-seo-form";
-import {
-  MatcherPicker,
-  extractMatcherGlobals,
-  extractMatchers,
-} from "./matcher-picker";
+import { extractMatcherGlobals, extractMatchers } from "./matcher-picker";
 import { PageVariantTabs, VariantTabIcon } from "./page-variant-tabs";
 import { MakeReusableModal } from "./make-reusable-modal";
 import { AddSectionModal } from "./add-section-modal";
@@ -109,8 +105,8 @@ import {
   parsePageVariantsForEditor,
   SchemaFormPanel,
   VARIANT_TAB_ACTIVE_CLASS,
-  VariantRuleForm,
 } from "./sections-editor-panels";
+import { VariantRuleEditor } from "./variant-rule-editor";
 
 /**
  * Side panel for editing deco.cx page sections.
@@ -2500,7 +2496,7 @@ export function SectionsEditor({
                   <span className="text-xs font-medium text-muted-foreground">
                     Variant rule
                   </span>
-                  <MatcherPicker
+                  <VariantRuleEditor
                     currentRt={sectionRuleResolveType ?? ""}
                     currentLabel={resolveVariantRuleLabel(
                       activeSectionFlagVariant?.rule,
@@ -2519,21 +2515,16 @@ export function SectionsEditor({
                     globals={availableMatcherGlobals}
                     onSelect={handleSectionMatcherTypeChange}
                     onSelectGlobal={handleSectionVariantSelectGlobal}
+                    schema={sectionRuleSchema}
+                    formValue={sectionRuleFormValue}
+                    onChange={handleSectionRuleFormChange}
+                    formKey={`${selectedSectionIndex ?? "none"}:${safeSectionVariantIndex}:${sectionRuleResolveType ?? ""}`}
+                    formWrapperClassName="pt-1"
+                    meta={meta ?? undefined}
+                    decofile={decofile}
+                    onSaveReferencedBlock={saveReferencedBlock}
+                    sandbox={sandbox}
                   />
-                  {sectionRuleSchema && sectionRuleFormValue && (
-                    <div className="pt-1">
-                      <VariantRuleForm
-                        key={`${selectedSectionIndex ?? "none"}:${safeSectionVariantIndex}:${sectionRuleResolveType ?? ""}`}
-                        schema={sectionRuleSchema}
-                        value={sectionRuleFormValue}
-                        onChange={handleSectionRuleFormChange}
-                        meta={meta ?? undefined}
-                        decofile={decofile}
-                        onSaveReferencedBlock={saveReferencedBlock}
-                        sandbox={sandbox}
-                      />
-                    </div>
-                  )}
                 </div>
               )}
             </>
@@ -2617,7 +2608,7 @@ export function SectionsEditor({
                     renameVariantPending && "pointer-events-none opacity-50",
                   )}
                 >
-                  <MatcherPicker
+                  <VariantRuleEditor
                     currentRt={ruleResolveType}
                     currentLabel={resolveVariantRuleLabel(
                       activeVariant?.rule,
@@ -2636,21 +2627,16 @@ export function SectionsEditor({
                     globals={availableMatcherGlobals}
                     onSelect={handleMatcherTypeChange}
                     onSelectGlobal={handlePageVariantSelectGlobal}
+                    schema={ruleSchema}
+                    formValue={ruleFormValue}
+                    onChange={handleRuleFormChange}
+                    formKey={`${safeVariantIndex}:${ruleResolveType ?? ""}`}
+                    formWrapperClassName="space-y-3"
+                    meta={meta ?? undefined}
+                    decofile={decofile}
+                    onSaveReferencedBlock={saveReferencedBlock}
+                    sandbox={sandbox}
                   />
-                  {ruleSchema && ruleFormValue && (
-                    <div className="space-y-3">
-                      <VariantRuleForm
-                        key={`${safeVariantIndex}:${ruleResolveType ?? ""}`}
-                        schema={ruleSchema}
-                        value={ruleFormValue}
-                        onChange={handleRuleFormChange}
-                        meta={meta ?? undefined}
-                        decofile={decofile}
-                        onSaveReferencedBlock={saveReferencedBlock}
-                        sandbox={sandbox}
-                      />
-                    </div>
-                  )}
                 </div>
               )}
             </div>

--- a/apps/mesh/src/web/components/sections-editor/variant-rule-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/variant-rule-editor.tsx
@@ -1,0 +1,80 @@
+import {
+  MatcherPicker,
+  type MatcherEntry,
+  type MatcherGlobalEntry,
+} from "./matcher-picker";
+import { VariantRuleForm } from "./sections-editor-panels";
+import { type LiveMeta, type SchemaProperty } from "./resolve-schema";
+import type { SandboxConfig } from "./fields/field-props";
+
+/**
+ * Matcher picker + variant rule form, shared by the page-variant and
+ * section-variant rule editors. Caller owns the resolveType/formValue state
+ * and any surrounding chrome (label, collapse toggle, disabled overlay).
+ */
+export function VariantRuleEditor({
+  currentRt,
+  currentLabel,
+  currentGlobalKey,
+  matchers,
+  globals,
+  onSelect,
+  onSelectGlobal,
+  schema,
+  formValue,
+  onChange,
+  formKey,
+  formWrapperClassName,
+  meta,
+  decofile,
+  onSaveReferencedBlock,
+  sandbox,
+}: {
+  currentRt: string;
+  currentLabel: string;
+  currentGlobalKey?: string;
+  matchers: MatcherEntry[];
+  globals: MatcherGlobalEntry[];
+  onSelect: (resolveType: string) => void;
+  onSelectGlobal: (blockKey: string) => void;
+  schema: SchemaProperty | null;
+  formValue: Record<string, unknown> | null;
+  onChange: (v: unknown) => void;
+  formKey: string;
+  formWrapperClassName: string;
+  meta?: LiveMeta;
+  decofile?: Record<string, unknown>;
+  onSaveReferencedBlock?: (
+    blockKey: string,
+    data: Record<string, unknown>,
+  ) => void;
+  sandbox?: SandboxConfig | null;
+}) {
+  return (
+    <>
+      <MatcherPicker
+        currentRt={currentRt}
+        currentLabel={currentLabel}
+        currentGlobalKey={currentGlobalKey}
+        matchers={matchers}
+        globals={globals}
+        onSelect={onSelect}
+        onSelectGlobal={onSelectGlobal}
+      />
+      {schema && formValue && (
+        <div className={formWrapperClassName}>
+          <VariantRuleForm
+            key={formKey}
+            schema={schema}
+            value={formValue}
+            onChange={onChange}
+            meta={meta}
+            decofile={decofile}
+            onSaveReferencedBlock={onSaveReferencedBlock}
+            sandbox={sandbox}
+          />
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
**Source:** C1 duplication reduction inside `sections-editor.tsx` (2786-line monolith, this tick's focus area for W4).

**Why:** The page-variant and section-variant rule editors both render the identical matcher-picker + variant-rule-form combo (~25 lines each), copy-pasted with only the resolveType/schema/handler variable names swapped. Collapsing them into one `VariantRuleEditor` component removes the duplication and is one fewer place to keep the two editors in sync when this UI changes next.

**What changed:** New `apps/mesh/src/web/components/sections-editor/variant-rule-editor.tsx` wraps `MatcherPicker` + the conditional `VariantRuleForm` block. Both call sites in `sections-editor.tsx` now pass their existing (unchanged) props/handlers through it instead of inlining the JSX — a pure relocation, no logic or class changes (the page-level call site's `space-y-3` form-wrapper class and the section-level call site's `pt-1` are preserved via an explicit `formWrapperClassName` prop, so visual output is byte-identical). Net: `sections-editor.tsx` -36/+22, one new 80-line file.

**Verification:** `bunx tsc --noEmit` in `apps/mesh` is clean (confirmed locally). No behavior change to confirm beyond typecheck — a reviewer can diff the two call sites against the removed inline blocks to see the prop values are passed through unchanged. Full CI (lint, tests) validates the rest.

**Locally run:** `bun run fmt` (clean), `cd apps/mesh && bunx tsc --noEmit` (clean, 0 errors).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared `VariantRuleEditor` to remove duplicated matcher-picker + rule-form code in the page and section variant editors, keeping the UI and behavior identical.

- **Refactors**
  - Added `variant-rule-editor.tsx` wrapping `MatcherPicker` + `VariantRuleForm`.
  - Replaced duplicated inline blocks in `sections-editor.tsx` with `VariantRuleEditor`.
  - Preserved layout via a `formWrapperClassName` prop (`pt-1` and `space-y-3`).
  - No logic changes; props are passed through exactly as before.

<sup>Written for commit 680d9e51d8968247cf06b478aa7926bc93ebb1ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

