### PR TITLE
feat(task-board): two idempotency keys for the diagnostic import

### DIFF
--- a/apps/mesh/migrations/136-task-board-import-idempotency.ts
+++ b/apps/mesh/migrations/136-task-board-import-idempotency.ts
@@ -1,0 +1,56 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Two idempotency keys for the task-board import (the diagnostic worker's
+ * batch push — see api/routes/task-board-import.ts):
+ *
+ * 1. `task_board_import_runs` — one row per processed import request,
+ *    PK (organization_id, run_id). The import claims the row up front inside
+ *    its transaction; losing the claim means the same run was already
+ *    imported, so a replay (the payment success page and the Stripe webhook
+ *    fire seconds apart on the reports side) is a no-op instead of a 2×
+ *    board.
+ *
+ * 2. `task_board_items.external_key` — the FINDING's identity, minted by the
+ *    sender (e.g. `diag:{domain}:{check_id}:{scope}`). A re-import whose key
+ *    matches an OPEN item refreshes it instead of creating a duplicate —
+ *    recurring diagnostic runs converge on the same card. Non-unique on
+ *    purpose: a done item keeps its key, and a regression legitimately
+ *    creates a fresh open card with the same key.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("task_board_import_runs")
+    .addColumn("organization_id", "text", (col) =>
+      col.notNull().references("organization.id").onDelete("cascade"),
+    )
+    .addColumn("run_id", "text", (col) => col.notNull())
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .addPrimaryKeyConstraint("task_board_import_runs_pkey", [
+      "organization_id",
+      "run_id",
+    ])
+    .execute();
+
+  await db.schema
+    .alterTable("task_board_items")
+    .addColumn("external_key", "text")
+    .execute();
+
+  await db.schema
+    .createIndex("idx_task_board_items_org_external_key")
+    .on("task_board_items")
+    .columns(["organization_id", "external_key"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_task_board_items_org_external_key").execute();
+  await db.schema
+    .alterTable("task_board_items")
+    .dropColumn("external_key")
+    .execute();
+  await db.schema.dropTable("task_board_import_runs").execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -134,6 +134,7 @@ import * as migration132taskboarditemprs from "./132-task-board-item-prs.ts";
 import * as migration133dedupeduplicatemembers from "./133-dedupe-duplicate-members.ts";
 import * as migration134droptaskboardenabled from "./134-drop-task-board-enabled.ts";
 import * as migration135taskboarditemfkcascade from "./135-task-board-item-fk-cascade.ts";
+import * as migration136taskboardimportidempotency from "./136-task-board-import-idempotency.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -293,6 +294,7 @@ const migrations: Record<string, Migration> = {
   "133-dedupe-duplicate-members": migration133dedupeduplicatemembers,
   "134-drop-task-board-enabled": migration134droptaskboardenabled,
   "135-task-board-item-fk-cascade": migration135taskboarditemfkcascade,
+  "136-task-board-import-idempotency": migration136taskboardimportidempotency,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/routes/task-board-import.integration.test.ts
+++ b/apps/mesh/src/api/routes/task-board-import.integration.test.ts
@@ -106,7 +106,11 @@ describe("Task Board Import Route", () => {
   it("creates items for an org that never touched the board before", async () => {
     const res = await app.fetch(post("org_1", "svc-secret", BODY));
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ created: 2, delegated: 0 });
+    await expect(res.json()).resolves.toEqual({
+      created: 2,
+      updated: 0,
+      delegated: 0,
+    });
   });
 
   it("rejects an invalid body", async () => {
@@ -117,7 +121,11 @@ describe("Task Board Import Route", () => {
   it("creates triage items as the system principal, resolving the org by id", async () => {
     const res = await app.fetch(post("org_board", "svc-secret", BODY));
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ created: 2, delegated: 0 });
+    await expect(res.json()).resolves.toEqual({
+      created: 2,
+      updated: 0,
+      delegated: 0,
+    });
 
     const rows = await database.db
       .selectFrom("task_board_items")
@@ -155,7 +163,11 @@ describe("Task Board Import Route", () => {
     expect(res.status).toBe(200);
     // The enqueue itself is best-effort (no model configured in tests) — the
     // delegation must still land on the row.
-    await expect(res.json()).resolves.toEqual({ created: 2, delegated: 1 });
+    await expect(res.json()).resolves.toEqual({
+      created: 2,
+      updated: 0,
+      delegated: 1,
+    });
 
     const rows = await database.db
       .selectFrom("task_board_items")
@@ -196,5 +208,128 @@ describe("Task Board Import Route", () => {
       }),
     );
     expect(bad.status).toBe(400);
+  });
+
+  it("replays of the same run_id no-op (request idempotency)", async () => {
+    const body = {
+      items: [{ title: "Adicionar H1 na home" }],
+      source: { url: "shop.com", run_id: "run_double_fire" },
+    };
+    const first = await app.fetch(post("org_board", "svc-secret", body));
+    await expect(first.json()).resolves.toEqual({
+      created: 1,
+      updated: 0,
+      delegated: 0,
+    });
+
+    // The success page and the webhook fire the SAME import seconds apart —
+    // the second one must not double the board.
+    const replay = await app.fetch(post("org_board", "svc-secret", body));
+    await expect(replay.json()).resolves.toEqual({
+      created: 0,
+      updated: 0,
+      delegated: 0,
+      deduped: true,
+    });
+
+    const rows = await database.db
+      .selectFrom("task_board_items")
+      .selectAll()
+      .where("organization_id", "=", "org_board")
+      .execute();
+    expect(rows).toHaveLength(1);
+  });
+
+  it("an externalKey matching an open item refreshes it instead of duplicating", async () => {
+    const key = "diag:shop.com:GEO-001";
+    const run1 = await app.fetch(
+      post("org_board", "svc-secret", {
+        items: [
+          {
+            title: "Liberar o GPTBot no WAF",
+            description: "403 no WAF (run 1).",
+            priority: "medium",
+            externalKey: key,
+          },
+        ],
+        source: { url: "shop.com", run_id: "run_1" },
+      }),
+    );
+    await expect(run1.json()).resolves.toEqual({
+      created: 1,
+      updated: 0,
+      delegated: 0,
+    });
+
+    // A month later the diagnostic re-runs, finds the same issue with fresh
+    // evidence and a worse severity — the card is refreshed, not duplicated,
+    // and the human-facing title is left alone.
+    const run2 = await app.fetch(
+      post("org_board", "svc-secret", {
+        items: [
+          {
+            title: "GPTBot ainda bloqueado",
+            description: "403 no WAF (run 2).",
+            priority: "high",
+            externalKey: key,
+          },
+        ],
+        source: { url: "shop.com", run_id: "run_2" },
+      }),
+    );
+    await expect(run2.json()).resolves.toEqual({
+      created: 0,
+      updated: 1,
+      delegated: 0,
+    });
+
+    const rows = await database.db
+      .selectFrom("task_board_items")
+      .selectAll()
+      .where("organization_id", "=", "org_board")
+      .execute();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.title).toBe("Liberar o GPTBot no WAF");
+    expect(rows[0]?.description).toBe("403 no WAF (run 2).");
+    expect(rows[0]?.priority).toBe("high");
+    expect(rows[0]?.external_key).toBe(key);
+  });
+
+  it("a done item does not match — a regression creates a fresh card", async () => {
+    const key = "diag:shop.com:SEO-002";
+    await app.fetch(
+      post("org_board", "svc-secret", {
+        items: [{ title: "Adicionar H1 na home", externalKey: key }],
+        source: { url: "shop.com", run_id: "run_a" },
+      }),
+    );
+    await database.db
+      .updateTable("task_board_items")
+      .set({ status: "done" })
+      .where("organization_id", "=", "org_board")
+      .execute();
+
+    const regression = await app.fetch(
+      post("org_board", "svc-secret", {
+        items: [{ title: "Adicionar H1 na home", externalKey: key }],
+        source: { url: "shop.com", run_id: "run_b" },
+      }),
+    );
+    await expect(regression.json()).resolves.toEqual({
+      created: 1,
+      updated: 0,
+      delegated: 0,
+    });
+
+    const rows = await database.db
+      .selectFrom("task_board_items")
+      .selectAll()
+      .where("organization_id", "=", "org_board")
+      .orderBy("created_at")
+      .execute();
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.status).sort()).toEqual(["done", "triage"]);
+    // Both carry the key — identity survives the lifecycle.
+    expect(rows.every((r) => r.external_key === key)).toBe(true);
   });
 });

--- a/apps/mesh/src/api/routes/task-board-import.test.ts
+++ b/apps/mesh/src/api/routes/task-board-import.test.ts
@@ -9,18 +9,27 @@ describe("importBodySchema", () => {
     expect(parsed.success).toBe(true);
   });
 
-  it("accepts description, priority and source", () => {
+  it("accepts description, priority, externalKey and source", () => {
     const parsed = importBodySchema.safeParse({
       items: [
         {
           title: "Liberar o GPTBot no WAF",
           description: "Crawlers de IA recebem 403.",
           priority: "high",
+          externalKey: "diag:shop.com:GEO-001",
         },
       ],
       source: { url: "shop.com", run_id: "run_1" },
     });
     expect(parsed.success).toBe(true);
+  });
+
+  it("rejects an empty externalKey", () => {
+    expect(
+      importBodySchema.safeParse({
+        items: [{ title: "t", externalKey: "" }],
+      }).success,
+    ).toBe(false);
   });
 
   it("rejects an empty batch, an empty title and an unknown priority", () => {

--- a/apps/mesh/src/api/routes/task-board-import.ts
+++ b/apps/mesh/src/api/routes/task-board-import.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { StudioContext } from "@/core/studio-context";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@/shared/task-board";
+import { TaskBoardStorage } from "@/storage/task-board";
+import type { TaskBoardItem } from "@/storage/types";
 import { reactToSuperAgentDelegation } from "@/tools/task-board/enqueue-super-agent";
 import { emitTaskBoardUpdated } from "@/tools/task-board/run-reactions";
 import { TaskBoardItemPrioritySchema } from "@/tools/task-board/schema";
@@ -22,7 +24,20 @@ import { bearerToken, isVaultServiceToken } from "./credential-vault";
  *
  * Items land as status "triage" with `created_by = "system"` (the established
  * sentinel for non-user principals).
- * `source` is accepted for observability / future dedup and not persisted yet.
+ *
+ * TWO IDEMPOTENCY KEYS, different jobs:
+ * - `source.run_id` protects the REQUEST: the whole import runs in one
+ *   transaction that first claims (org, run_id) in `task_board_import_runs`;
+ *   a replay (the reports worker's payment success page and Stripe webhook
+ *   both push, seconds apart) loses the claim and no-ops with
+ *   `{deduped: true}`. A FAILED import aborts the claim with it, so the
+ *   run_id isn't burned. Absent run_id ⇒ no claim (backward compatible).
+ * - `item.externalKey` identifies the FINDING: a key matching an OPEN item
+ *   refreshes that item (description/priority — never title/status/assignee,
+ *   a human may have touched those) instead of creating a duplicate, so
+ *   recurring diagnostic runs converge on the same card. A done item is NOT
+ *   matched — a regression creates a fresh card. Refreshes never re-trigger
+ *   the Super Agent delegation.
  *
  * An item may carry `assigneeId` — a real org member, or the Super Agent
  * sentinel to queue the task for an agent run (status forced to To Do, same as
@@ -44,6 +59,9 @@ export const importBodySchema = z.object({
         description: z.string().max(4000).nullable().optional(),
         priority: TaskBoardItemPrioritySchema.optional(),
         assigneeId: z.string().nullable().optional(),
+        /** Sender-minted finding identity (e.g. `diag:{domain}:{check_id}`) —
+         *  dedups against open items on re-import. */
+        externalKey: z.string().min(1).max(200).optional(),
       }),
     )
     .min(1)
@@ -119,34 +137,112 @@ export const createTaskBoardImportRoutes = () => {
       ownerId = owner?.userId ?? null;
     }
 
-    let created = 0;
-    let delegated = 0;
-    for (const item of items) {
-      const toSuperAgent = item.assigneeId === SUPER_AGENT_ASSIGNEE_ID;
-      const row = await ctx.storage.taskBoard.create({
-        organizationId,
-        title: item.title,
-        description: item.description ?? null,
-        // A task handed to the Super Agent is queued to run — land it in To Do.
-        status: toSuperAgent ? "todo" : undefined,
-        priority: item.priority,
-        assigneeId: item.assigneeId ?? null,
-        // The delegation principal: the run executes as this user, so the
-        // Super Agent case pins the org owner; a plain member assignment keeps
-        // the honest non-user sentinel.
-        assignedBy: toSuperAgent ? ownerId : item.assigneeId ? "system" : null,
-        by: "system",
-      });
-      created++;
-      // Broadcast each imported card so open boards fill in live.
-      emitTaskBoardUpdated(organizationId, row);
-      if (toSuperAgent) {
-        delegated++;
-        await reactToSuperAgentDelegation(ctx, row);
-      }
-    }
+    const runId = parsed.data.source?.run_id;
 
-    return c.json({ created, delegated });
+    // One transaction: claim the run_id, then reconcile the batch. Losing the
+    // claim means this exact import already ran (double-fire) — no-op. An
+    // abort rolls the claim back with the items, so a failed import can be
+    // retried under the same run_id.
+    const outcome = await ctx.db.transaction().execute(async (trx) => {
+      if (runId) {
+        const claim = await trx
+          .insertInto("task_board_import_runs")
+          .values({ organization_id: organizationId, run_id: runId })
+          .onConflict((oc) =>
+            oc.columns(["organization_id", "run_id"]).doNothing(),
+          )
+          .executeTakeFirst();
+        if ((claim.numInsertedOrUpdatedRows ?? 0n) === 0n) return null;
+      }
+
+      // Open items matching the batch's external keys — these get refreshed
+      // instead of duplicated. Done items don't match: a regression is a new
+      // card.
+      const keys = items.flatMap((i) => i.externalKey ?? []);
+      const openByKey = new Map<string, string>();
+      if (keys.length > 0) {
+        const open = await trx
+          .selectFrom("task_board_items")
+          .select(["id", "external_key"])
+          .where("organization_id", "=", organizationId)
+          .where("external_key", "in", keys)
+          .where("status", "!=", "done")
+          .execute();
+        for (const row of open)
+          if (row.external_key) openByKey.set(row.external_key, row.id);
+      }
+
+      const storage = new TaskBoardStorage(trx);
+      const touched: TaskBoardItem[] = [];
+      const delegations: TaskBoardItem[] = [];
+      let created = 0;
+      let updated = 0;
+      for (const item of items) {
+        const existingId = item.externalKey
+          ? openByKey.get(item.externalKey)
+          : undefined;
+        if (existingId) {
+          // Refresh the finding's card: new evidence + severity. Title,
+          // status and assignee stay — a human may have touched them, and a
+          // refresh must never re-queue a delegation.
+          touched.push(
+            await storage.update(
+              existingId,
+              organizationId,
+              {
+                description: item.description ?? null,
+                priority: item.priority,
+              },
+              "system",
+            ),
+          );
+          updated++;
+          continue;
+        }
+        const toSuperAgent = item.assigneeId === SUPER_AGENT_ASSIGNEE_ID;
+        const row = await storage.create({
+          organizationId,
+          title: item.title,
+          description: item.description ?? null,
+          // A task handed to the Super Agent is queued to run — land it in To Do.
+          status: toSuperAgent ? "todo" : undefined,
+          priority: item.priority,
+          assigneeId: item.assigneeId ?? null,
+          // The delegation principal: the run executes as this user, so the
+          // Super Agent case pins the org owner; a plain member assignment keeps
+          // the honest non-user sentinel.
+          assignedBy: toSuperAgent
+            ? ownerId
+            : item.assigneeId
+              ? "system"
+              : null,
+          externalKey: item.externalKey ?? null,
+          by: "system",
+        });
+        // A within-batch duplicate key folds into the row just created.
+        if (item.externalKey) openByKey.set(item.externalKey, row.id);
+        touched.push(row);
+        created++;
+        if (toSuperAgent) delegations.push(row);
+      }
+      return { touched, delegations, created, updated };
+    });
+
+    if (!outcome)
+      return c.json({ created: 0, updated: 0, delegated: 0, deduped: true });
+
+    // Side effects only after commit — a rolled-back import must not
+    // broadcast cards or enqueue agent runs.
+    for (const row of outcome.touched)
+      emitTaskBoardUpdated(organizationId, row);
+    for (const row of outcome.delegations)
+      await reactToSuperAgentDelegation(ctx, row);
+
+    return c.json({
+      created: outcome.created,
+      updated: outcome.updated,
+      delegated: outcome.delegations.length,
+    });
   });
 
   return app;

--- a/apps/mesh/src/storage/task-board.ts
+++ b/apps/mesh/src/storage/task-board.ts
@@ -108,6 +108,8 @@ export class TaskBoardStorage {
     assigneeId?: string | null;
     assignedBy?: string | null;
     dueDate?: string | null;
+    /** Sender-minted finding identity — see task-board-import. */
+    externalKey?: string | null;
     by: string;
   }): Promise<TaskBoardItem> {
     const id = generatePrefixedId("board");
@@ -125,6 +127,7 @@ export class TaskBoardStorage {
         assignee_id: params.assigneeId ?? null,
         assigned_by: params.assignedBy ?? null,
         due_date: params.dueDate ?? null,
+        external_key: params.externalKey ?? null,
         created_by: params.by,
         created_at: now,
         updated_by: params.by,

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -1526,10 +1526,28 @@ export interface TaskBoardItemTable {
     Date | string | null | undefined,
     Date | string | null
   >;
+  /** Sender-minted finding identity (e.g. `diag:{domain}:{check_id}`) — the
+   *  import refreshes an OPEN item with the same key instead of duplicating
+   *  it. Null for human-created cards. */
+  external_key: ColumnType<
+    string | null,
+    string | null | undefined,
+    string | null
+  >;
   created_by: string;
   created_at: ColumnType<Date, Date | string | undefined, never>;
   updated_by: string;
   updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
+}
+
+/** One processed task-board import request: PK (organization_id, run_id).
+ *  Claimed inside the import's transaction — a replay of the same run (the
+ *  reports worker's payment success page and Stripe webhook both push) loses
+ *  the claim and no-ops instead of duplicating the board. */
+export interface TaskBoardImportRunTable {
+  organization_id: string;
+  run_id: string;
+  created_at: ColumnType<Date, Date | string | undefined, never>;
 }
 
 /** Join row: a task board item ↔ an agent thread (many-to-many). */
@@ -1744,6 +1762,7 @@ export interface Database extends PrivateRegistryDatabase {
   task_board_items: TaskBoardItemTable;
   task_board_item_threads: TaskBoardItemThreadTable;
   task_board_item_prs: TaskBoardItemPrTable;
+  task_board_import_runs: TaskBoardImportRunTable;
 
   sandbox_runner_state: SandboxProviderStateTable;
 }


### PR DESCRIPTION
## What is this contribution about?
The diagnostic worker's task-board import is a blind create today, and it's about to be called from paths that can double-fire (payment success page + Stripe webhook, seconds apart — see decocms/reports#246) and from recurring re-runs of the same site over time. Two idempotency keys, different jobs:

**`source.run_id` protects the request.** The whole import now runs in one transaction that first claims `(org, run_id)` in the new `task_board_import_runs` table. A replay loses the claim and no-ops with `{deduped: true}` — no 2× board. A *failed* import aborts the claim together with the items, so the run_id isn't burned and the caller can retry. Absent `run_id` ⇒ no claim (backward compatible; the field was already reserved in the schema).

**`item.externalKey` identifies the finding.** A sender-minted key (e.g. `diag:{domain}:{check_id}`) persisted on `task_board_items`. On import, a key matching an **open** item refreshes its description/priority instead of creating a duplicate — recurring diagnostic runs converge on the same card. Deliberate boundaries: title/status/assignee are never touched (a human may have refined them), a refresh never re-triggers the Super Agent delegation, and a **done** item doesn't match — a regression creates a fresh card, so identity survives the lifecycle without resurrecting closed work.

Side effects (board broadcast, delegation enqueue) moved after commit so a rolled-back import can't announce cards that don't exist. Response gains `{updated}`.

Reports-side wiring (minting keys + sending run_id) is a follow-up over there; this endpoint change is backward compatible with today's caller.

## How to Test
1. `DATABASE_URL=... bun test apps/mesh/src/api/routes/task-board-import` — covers: same run_id replay no-ops, externalKey refresh (1 card after 2 runs, fresh evidence, title preserved), done item + same key ⇒ new card.
2. POST the import twice with the same `source.run_id` — second response is `{created: 0, updated: 0, delegated: 0, deduped: true}`.
3. POST with an `externalKey` matching an open imported card — `{updated: 1}`, no new row.

## Migration Notes
Migration 136: creates `task_board_import_runs` (PK org+run_id, FK cascade) and adds nullable `task_board_items.external_key` + index. No backfill needed; both features are opt-in per request.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds request-level and item-level idempotency to the diagnostic task-board import to prevent duplicate boards and dedupe recurring findings. Imports now run in a single transaction; replays no-op, and matching items are refreshed instead of duplicated.

- **New Features**
  - Request idempotency via `source.run_id`: claim `(org, run_id)` in `task_board_import_runs` inside the import transaction; replays return `{deduped: true}`; failures roll back the claim.
  - Finding id via `item.externalKey`: on re-import, an open item with the same key is updated (description/priority only); title/status/assignee are left as-is; done items don’t match; refreshes don’t re-trigger Super Agent.
  - Response now includes `{updated}` and optional `{deduped}`.
  - Side effects (board broadcast, Super Agent enqueue) moved to after commit.
  - Backward compatible: omitting `run_id`/`externalKey` keeps current behavior.

- **Migration**
  - Create `task_board_import_runs` with PK `(organization_id, run_id)`.
  - Add nullable `task_board_items.external_key` and index `idx_task_board_items_org_external_key`.
  - No backfill; both features are opt-in per request.

<sup>Written for commit aa3466cafc1e129338ee9dc958e64316f2c0cedb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

