### PR TITLE
refactor(chat): extract shared getColorEntries helper in brand-context

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/brand-context.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/brand-context.tsx
@@ -49,6 +49,15 @@ function domainHref(domain: string): string {
   return domain.startsWith("http") ? domain : `https://${domain}`;
 }
 
+function getColorEntries(
+  colors?: BrandColors | null,
+): Array<[keyof BrandColors, string]> {
+  if (!colors) return [];
+  return (Object.entries(colors) as Array<[keyof BrandColors, string]>).filter(
+    ([, v]) => typeof v === "string" && v.trim().length > 0,
+  );
+}
+
 function SectionLabel({ children }: { children: string }) {
   return (
     <span className="text-sm font-medium text-foreground">{children}</span>
@@ -120,9 +129,7 @@ function BrandLogo({
 }
 
 function ColorStrip({ colors }: { colors: BrandColors }) {
-  const entries = (
-    Object.entries(colors) as Array<[keyof BrandColors, string]>
-  ).filter(([, v]) => typeof v === "string" && v.trim().length > 0);
+  const entries = getColorEntries(colors);
   if (entries.length === 0) return null;
   return (
     <div className="flex h-1.5">
@@ -160,11 +167,7 @@ function BrandCard({
   showDefaultBadge?: boolean;
   isDefault?: boolean;
 }) {
-  const colorEntries = colors
-    ? (Object.entries(colors) as Array<[keyof BrandColors, string]>).filter(
-        ([, v]) => typeof v === "string" && v.trim().length > 0,
-      )
-    : [];
+  const colorEntries = getColorEntries(colors);
   const fontEntries = fonts
     ? (Object.entries(fonts) as Array<[keyof BrandFonts, string]>).filter(
         ([, v]) => typeof v === "string" && v.trim().length > 0,
@@ -424,13 +427,7 @@ export function BrandContextListPart({
       />
       <div className="mt-2 flex flex-col gap-1.5">
         {items.map((brand) => {
-          const colorEntries = brand.colors
-            ? (
-                Object.entries(brand.colors) as Array<
-                  [keyof BrandColors, string]
-                >
-              ).filter(([, v]) => typeof v === "string" && v.trim().length > 0)
-            : [];
+          const colorEntries = getColorEntries(brand.colors);
           return (
             <div
               key={brand.id ?? `${brand.name}-${brand.domain}`}


### PR DESCRIPTION
**Source:** C1 duplication cleanup found while auditing `brand-context.tsx` in the ai-provider-tool-calls area.

**Why:** The same "filter a `BrandColors` object down to its non-empty string entries" logic was copy-pasted verbatim three times in this one file (`ColorStrip`, `BrandCard`, and the per-brand loop in `BrandContextListPart`). Any future change to the filter predicate (e.g. supporting a new color key or a different emptiness check) would need to be made in three places and would silently drift if one was missed.

**Change:** Extracted a single `getColorEntries(colors)` helper and pointed all three call sites at it. Purely mechanical — same filter predicate, same types, same output shape. Net: -15/+12 lines.

**How I confirmed behavior is unchanged:** Read each of the three original filter expressions side-by-side — identical `Object.entries(...).filter(([, v]) => typeof v === "string" && v.trim().length > 0)` logic in all three. No test currently covers this component (UI-rendering only, not a trust boundary), so this is a pure refactor verified by typecheck.

**Command a reviewer runs to confirm:** `cd apps/mesh && bunx tsc --noEmit`

**Checks run locally:** `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (clean, 0 errors). Full CI validates lint/tests on the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared getColorEntries helper to centralize color filtering in brand-context, replacing three copy-pasted filters in ColorStrip, BrandCard, and BrandContextListPart. No behavior change.

<sup>Written for commit 1d850f41f8aa193cf0d60b6c57a584c2d0c5ae7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

