### PR TITLE
refactor(chat): narrow propose_plan parts by discriminant instead of as-casts

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/extract-pending-plans.ts
+++ b/apps/mesh/src/web/components/chat/highlight/extract-pending-plans.ts
@@ -36,19 +36,11 @@ export function extractPendingPlans(
   const result: PendingPlan[] = [];
 
   for (const part of parts) {
-    if (
-      "type" in part &&
-      (part as { type: string }).type === "tool-propose_plan" &&
-      "state" in part &&
-      (part as { state: string }).state === "input-available" &&
-      "toolCallId" in part &&
-      "input" in part
-    ) {
-      const input = (part as { input: { plan: string } }).input;
+    if (part.type === "tool-propose_plan" && part.state === "input-available") {
       result.push({
-        toolCallId: (part as { toolCallId: string }).toolCallId,
-        plan: input.plan,
-        state: (part as { state: string }).state,
+        toolCallId: part.toolCallId,
+        plan: part.input.plan,
+        state: part.state,
       });
     }
   }


### PR DESCRIPTION
**Source:** C-DEBT type-safety debt in the chat-input focus area — no linked issue.

**Why:** `extractPendingPlans` (`apps/mesh/src/web/components/chat/highlight/extract-pending-plans.ts`) receives `parts: ChatMessage["parts"]`, which is a fully-typed discriminated union — `assistant.tsx`'s `switch (part.type) { case "tool-propose_plan": ... }` already narrows the same union with zero casts, and the `propose_plan` tool's Zod schema (`packages/harness/src/decopilot/built-in-tools/propose-plan.ts`) guarantees `input: { plan: string }` once `part.type === "tool-propose_plan"`. Instead, the function re-derived the same check with four `in`/`as` casts (`(part as { type: string }).type`, `(part as { input: { plan: string } }).input`, etc.), which means a future rename of the propose_plan input shape would compile fine and only blow up at runtime instead of failing `tsc`.

**Change:** replaced the `in`-check + `as`-cast chain with direct discriminant narrowing (`part.type === "tool-propose_plan" && part.state === "input-available"`), then read `part.toolCallId` / `part.input.plan` / `part.state` off the narrowed type directly. Purely a type-level tightening — the runtime check (same two conditions) and returned `PendingPlan[]` shape are unchanged. -12/+4 lines.

**Verify:** `cd apps/mesh && bunx tsc --noEmit` (clean) and `bun test apps/mesh/src/web/components/chat/highlight/extract-pending-plans.test.ts` (5/5 pass, unchanged) confirm behavior is identical.

**Command for reviewer:** `bun test apps/mesh/src/web/components/chat/highlight/extract-pending-plans.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace), targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened type safety in `extractPendingPlans` by narrowing `ChatMessage["parts"]` with discriminants instead of `as` casts. No behavior change; returned `PendingPlan[]` is the same.

- **Refactors**
  - Replaced `in`/`as` checks with `part.type === "tool-propose_plan" && part.state === "input-available"`.
  - Read `toolCallId`, `input.plan`, and `state` from the narrowed type to surface schema changes at compile time.

<sup>Written for commit 612d32202d45a08321249092ba2e30a6dc486b33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

