### PR TITLE
fix(decopilot): recognize multi-role owner/admin in fetchModelPermissions

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/model-permissions.ts
+++ b/apps/mesh/src/api/routes/decopilot/model-permissions.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Kysely } from "kysely";
-import { ADMIN_ROLES } from "@/auth/roles";
+import { hasAdminRole } from "@/auth/roles";
 import type { Database, Permission } from "@/storage/types";
 
 /**
@@ -163,8 +163,10 @@ export async function fetchModelPermissions(
   organizationId: string,
   role: string | undefined,
 ): Promise<string[] | undefined> {
-  // No role or admin/owner = all models allowed
-  if (!role || ADMIN_ROLES.includes(role as (typeof ADMIN_ROLES)[number])) {
+  // No role or admin/owner = all models allowed. `hasAdminRole` recognizes a
+  // comma-joined multi-role owner/admin (e.g. "admin,billing-manager"), which
+  // a plain ADMIN_ROLES.includes(role) exact match would miss.
+  if (!role || hasAdminRole(role)) {
     return undefined;
   }
 


### PR DESCRIPTION
Follows #4949/#4947/#4944 hardening on the same multi-role-owner/admin failure mode.

`fetchModelPermissions` in `apps/mesh/src/api/routes/decopilot/model-permissions.ts` — called from `dispatch-run.ts`'s model-permission gate — used `ADMIN_ROLES.includes(role)`, an exact-string-match check. Better Auth stores a member's roles as a comma-joined string when they hold multiple roles (e.g. `"admin,billing-manager"`), so this exact match silently fails to recognize a legitimate owner/admin and routes them into the custom-role permission lookup instead of the admin bypass. The same failure mode was already fixed for `canAssignRole`, `AccessControl`, and the `my-capabilities` endpoint via the `hasAdminRole` helper (`apps/mesh/src/auth/roles.ts`) — this call site was missed.

Failure scenario: an org member whose role is stored as `"admin,billing-manager"` hits the decopilot model-permission check with a role that doesn't exactly equal `"admin"` or `"owner"`, so instead of the intended all-models-allowed admin bypass, they fall through to a custom-role permission lookup keyed on the literal comma-joined string (which won't match any `organizationRole` row), producing an unintended/undefined restriction path instead of the explicit admin bypass.

Fix: replace the ADMIN_ROLES exact-match with the existing `hasAdminRole(role)` helper, matching the pattern already used by `AccessControl`, `context-factory.ts`, `org-sso.ts`, and `auth.ts`.

A reviewer can confirm with: `bun test apps/mesh/src/auth/roles.test.ts` (existing `hasAdminRole` coverage, including the comma-joined cases) and `bun test apps/mesh/src/api/routes/decopilot/model-permissions.test.ts` (unchanged, still green).

Locally verified: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted `model-permissions.test.ts` (29 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the model-permission check to recognize multi‑role admin/owner values. Uses hasAdminRole instead of an exact match so users like "admin,billing-manager" correctly get the admin bypass instead of falling into custom-role checks.

<sup>Written for commit 19219428506fbc1a0e932aa6240da6ba7f47e3a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

