### PR TITLE
fix(agent-avatar): add aria-label and role props for better accessibility

### DIFF
--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -277,6 +277,8 @@ interface AgentAvatarProps {
   name: string;
   size?: AgentAvatarSize;
   className?: string;
+  "aria-label"?: string;
+  role?: string;
 }
 
 /** Colored background + centered icon — shared by all icon-rendering paths. */
@@ -285,11 +287,15 @@ function IconAvatar({
   color,
   size,
   className,
+  "aria-label": ariaLabel,
+  role,
 }: {
   Icon: IconComponent;
   color: AgentIconColor;
   size: AgentAvatarSize;
   className?: string;
+  "aria-label"?: string;
+  role?: string;
 }) {
   const sizeConfig = SIZES[size];
   return (
@@ -302,6 +308,8 @@ function IconAvatar({
         "flex items-center justify-center shrink-0 outline-none ring-0 shadow-none",
         className,
       )}
+      aria-label={ariaLabel}
+      role={role}
     >
       <Icon size={sizeConfig.icon} />
     </div>
@@ -313,6 +321,8 @@ export function AgentAvatar({
   name,
   size = "md",
   className,
+  "aria-label": ariaLabel,
+  role,
 }: AgentAvatarProps) {
   const parsed = parseIconString(icon);
 
@@ -322,7 +332,14 @@ export function AgentAvatar({
     const Icon = IconComp ?? getDeterministicIcon(name).IconComp;
 
     return (
-      <IconAvatar Icon={Icon} color={color} size={size} className={className} />
+      <IconAvatar
+        Icon={Icon}
+        color={color}
+        size={size}
+        className={className}
+        aria-label={ariaLabel}
+        role={role}
+      />
     );
   }
 
@@ -334,6 +351,8 @@ export function AgentAvatar({
         name={name}
         size={size}
         className={className}
+        aria-label={ariaLabel}
+        role={role}
       />
     );
   }
@@ -347,6 +366,8 @@ export function AgentAvatar({
       color={color}
       size={size}
       className={className}
+      aria-label={ariaLabel}
+      role={role}
     />
   );
 }
@@ -365,12 +386,16 @@ function AgentAvatarImage({
   name,
   size = "md",
   className,
+  "aria-label": ariaLabel,
+  role,
 }: {
   url: string;
   color?: string;
   name: string;
   size?: AgentAvatarSize;
   className?: string;
+  "aria-label"?: string;
+  role?: string;
 }) {
   const [errored, setErrored] = useState(false);
   const sizeConfig = SIZES[size];
@@ -384,6 +409,8 @@ function AgentAvatarImage({
         color={color}
         size={size}
         className={className}
+        aria-label={ariaLabel}
+        role={role}
       />
     );
   }
@@ -397,6 +424,8 @@ function AgentAvatarImage({
         "shrink-0 overflow-hidden outline-none ring-0 shadow-none",
         className,
       )}
+      aria-label={ariaLabel}
+      role={role}
     >
       <img
         src={url}


### PR DESCRIPTION
## Summary
The AgentAvatar component now accepts optional `aria-label` and `role` props, allowing callers to enhance accessibility when the avatar is used outside of button wrappers or in contexts requiring semantic roles.

## Motivation
AgentAvatar is used throughout the codebase in various contexts — inside buttons (where the parent provides aria-label), in list rows (where it's part of a larger semantic structure), and standalone. This change enables proper accessibility labeling for all use cases without requiring wrapper elements.

## Changes
- Added optional `aria-label` and `role` props to `AgentAvatarProps` interface
- Updated `IconAvatar` and `AgentAvatarImage` helper components to accept and forward these props
- Updated `AgentAvatar` function to destructure and pass through these props
- All changes are backward compatible (new props optional)

## Verification
- `bun run fmt` passes
- `tsc --noEmit` in apps/mesh passes
- No existing tests modified (this is a non-breaking enhancement)
- Diff: +30 lines, -1 line (net +29, one concern, tight area)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional `aria-label` and `role` props to `AgentAvatar`, forwarding them to the rendered elements to improve accessibility when used standalone or when a semantic role is needed.

- **New Features**
  - `AgentAvatar`, `IconAvatar`, and `AgentAvatarImage` accept and pass `aria-label` and `role` to the underlying DOM.
  - Backward compatible; props are optional.

<sup>Written for commit 7446fadfed4a858a4f46afab1ccd4304916a58f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

