### PR TITLE
fix(registry): avoid token-field flash while auth probe is loading in monitor panel

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -259,8 +259,14 @@ function ConnectionRow({
   };
 
   const showMaskedToken =
+    !isProbeLoading &&
     authStatus === "authenticated" &&
     !hasOAuthToken &&
+    !isReplacingToken &&
+    tokenValue.length === 0;
+  const isCheckingTokenField =
+    isProbeLoading &&
+    authStatus === "authenticated" &&
     !isReplacingToken &&
     tokenValue.length === 0;
   const applyVisibility = async (patch: {
@@ -427,7 +433,11 @@ function ConnectionRow({
         <p className="text-[10px] text-muted-foreground">
           Token/API key (for MCPs that require manual auth)
         </p>
-        {showMaskedToken ? (
+        {isCheckingTokenField ? (
+          <div className="h-8 px-3 flex items-center rounded-md border border-border bg-muted/30 text-muted-foreground text-xs">
+            Checking auth...
+          </div>
+        ) : showMaskedToken ? (
           <div className="relative group">
             <div className="h-8 px-3 flex items-center rounded-md border border-border bg-muted/50 text-muted-foreground font-mono text-xs">
               ••••••••••••••••


### PR DESCRIPTION
Bug found while auditing the registry monitor-connections panel (highest-debt frontend file, W4 area).

**The bug**: in `ConnectionRow`, `showMaskedToken` derives from `hasOAuthToken` (sourced from the per-row `probeQuery`), but defaults `hasOAuthToken` to `false` while that query is still loading (`probeResult?.hasOAuthToken ?? false`). For a connection whose `auth_status` is already `"authenticated"` via OAuth, this means on first mount — and every time a new row appears after clicking "Sync" — the token field briefly renders as if it needs a manual API key (or the masked-token view, depending on the other case), then flips to the correct view a moment later once the probe resolves. Reviewers/users see a visible flash and could click "Edit"/"Save" on a transient, incorrect UI state.

**Fix**: gate `showMaskedToken` on `!isProbeLoading`, and render a lightweight "Checking auth..." placeholder in the token-field slot while the probe is in flight, instead of committing to either the masked-token or plain-input layout before the real auth state is known.

Net effect: no visual flash between two different token-field UIs while the per-connection OAuth probe is still loading (first mount, and after Sync brings in new connections).

How to verify: open the registry monitor panel with a connection that has `auth_status: "authenticated"` via OAuth — the token field area should show "Checking auth..." briefly (or nothing perceptible if cached) rather than flashing the manual-token input before settling on the masked-token view.

Checks run locally: `bun run fmt` and `cd apps/mesh && bunx tsc --noEmit` (both clean). No existing test covers this component; full CI runs the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the token-field UI from flashing in the registry monitor connections panel by showing a "Checking auth..." placeholder while the per-row OAuth probe loads. This avoids a brief, incorrect masked/manual token view for OAuth-authenticated connections on mount and after Sync.

- **Bug Fixes**
  - Gate masked-token rendering until the probe is not loading.
  - Add a lightweight "Checking auth..." placeholder via `isCheckingTokenField`.

<sup>Written for commit 3faf9b1d183b42c409c6003b851bfae307e0d7ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

