### PR TITLE
fix(decopilot): honor each role's model limits for multi-role members

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/model-permissions.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/model-permissions.test.ts
@@ -10,6 +10,7 @@ import {
   checkModelPermission,
   extractModelPermissions,
   filterToolTiersByPermission,
+  mergeModelPermissions,
   parseModelsToMap,
 } from "./model-permissions";
 
@@ -267,5 +268,44 @@ describe("parseModelsToMap", () => {
   it("should return empty map for empty array", () => {
     const result = parseModelsToMap([]);
     expect(result).toEqual({ allowAll: false, models: {} });
+  });
+});
+
+// ============================================================================
+// mergeModelPermissions
+// ============================================================================
+
+describe("mergeModelPermissions", () => {
+  it("unions the allowed models across roles", () => {
+    const result = mergeModelPermissions([
+      ["connA:model-1"],
+      ["connB:model-2"],
+    ]);
+    expect(result).toEqual(
+      expect.arrayContaining(["connA:model-1", "connB:model-2"]),
+    );
+    expect(result).toHaveLength(2);
+  });
+
+  it("deduplicates overlapping entries", () => {
+    const result = mergeModelPermissions([
+      ["connA:model-1", "connB:model-2"],
+      ["connB:model-2"],
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("allows all models if any role is unrestricted (undefined)", () => {
+    expect(
+      mergeModelPermissions([["connA:model-1"], undefined]),
+    ).toBeUndefined();
+  });
+
+  it("denies all models when every role has an empty models array", () => {
+    expect(mergeModelPermissions([[], []])).toEqual([]);
+  });
+
+  it("returns undefined for a single unrestricted role", () => {
+    expect(mergeModelPermissions([undefined])).toBeUndefined();
   });
 });

--- a/apps/mesh/src/api/routes/decopilot/model-permissions.ts
+++ b/apps/mesh/src/api/routes/decopilot/model-permissions.ts
@@ -153,10 +153,37 @@ export function parseModelsToMap(models: string[] | undefined): {
 }
 
 /**
+ * Merge the per-role "models" arrays of a multi-role member into one effective
+ * allow-list, matching Better Auth's OR-over-roles semantics (permission.mjs
+ * splits `member.role` on "," and grants access if ANY role allows it): a
+ * model is allowed if any single role allows it. If any role has no "models"
+ * key (that role permits all models), the merged result is "all allowed".
+ */
+export function mergeModelPermissions(
+  perRoleModels: Array<string[] | undefined>,
+): string[] | undefined {
+  if (perRoleModels.some((models) => models === undefined)) {
+    return undefined;
+  }
+  const merged = new Set<string>();
+  for (const models of perRoleModels) {
+    for (const entry of models ?? []) merged.add(entry);
+  }
+  return [...merged];
+}
+
+/**
  * Fetch model permissions for a user's role.
  * Returns undefined for admin/owner roles (they bypass all checks).
  * Returns the "models" array for custom roles.
  * Returns undefined if no "models" key exists (all allowed).
+ *
+ * `role` may be Better Auth's comma-joined multi-role string (e.g.
+ * "editor,billing-manager" — ORGANIZATION_MEMBER_UPDATE_ROLE takes an array of
+ * roles). Each individual role is looked up and the results are OR-merged via
+ * `mergeModelPermissions` — a single-string `where("role", "=", role)` lookup
+ * would never match a stored per-role record for a multi-role string, silently
+ * falling back to "all models allowed" instead of honoring each role's limits.
  */
 export async function fetchModelPermissions(
   db: Kysely<Database>,
@@ -170,27 +197,36 @@ export async function fetchModelPermissions(
     return undefined;
   }
 
+  const roles = role.split(",");
+
   // Query custom role permissions from the organizationRole table
-  const roleRecord = await db
+  const roleRecords = await db
     .selectFrom("organizationRole")
-    .select(["permission"])
+    .select(["role", "permission"])
     .where("organizationId", "=", organizationId)
-    .where("role", "=", role)
-    .executeTakeFirst();
+    .where("role", "in", roles)
+    .execute();
 
-  if (!roleRecord?.permission) {
-    return undefined;
-  }
+  const permissionByRole = new Map(
+    roleRecords.map((record) => [record.role, record.permission]),
+  );
 
-  try {
-    const permission = JSON.parse(roleRecord.permission) as Permission;
-    return extractModelPermissions(permission);
-  } catch {
-    console.error(
-      `[model-permissions] Failed to parse permissions for role: ${role}`,
-    );
-    // Fail-closed: corrupted permission data should deny access, not grant it.
-    // Returning undefined would mean "all models allowed" per the data model.
-    return [];
-  }
+  const perRoleModels = roles.map((r) => {
+    const permissionJson = permissionByRole.get(r);
+    if (!permissionJson) return undefined;
+
+    try {
+      const permission = JSON.parse(permissionJson) as Permission;
+      return extractModelPermissions(permission);
+    } catch {
+      console.error(
+        `[model-permissions] Failed to parse permissions for role: ${r}`,
+      );
+      // Fail-closed: corrupted permission data should deny access, not grant it.
+      // Returning undefined would mean "all models allowed" per the data model.
+      return [];
+    }
+  });
+
+  return mergeModelPermissions(perRoleModels);
 }


### PR DESCRIPTION
Follows #4955 (multi-role owner/admin fix in the same file) — a different multi-role gap in `fetchModelPermissions`.

**Bug:** `ORGANIZATION_MEMBER_UPDATE_ROLE`'s `role` input is `z.array(z.string())` — assigning a member two custom (non-admin) roles at once is a supported, first-class flow. Better Auth stores that as a comma-joined string on `member.role` (e.g. `"editor,billing-manager"`), and its own `hasPermissionFn` splits on `,` and ORs each role's grant. `fetchModelPermissions`, however, did a single exact-match lookup: `where("role", "=", role)`. Since `organizationRole` stores one row per single role name, that lookup can never match a comma-joined value, so `roleRecord` comes back empty and the function silently returns `undefined` — "all models allowed" — for every multi-custom-role member, regardless of how restrictive each individual role's `models` permission is meant to be. Fail-open on a permission gate.

**Fix:** split `role` on `,`, look up every individual role's stored permission, and OR-merge the resulting `models` arrays via a new pure `mergeModelPermissions` (mirrors Better Auth's OR-over-roles authorize semantics — a model is allowed if any one of the member's roles allows it; if any role is unrestricted, the merged result is unrestricted too).

**Regression test:** `model-permissions.test.ts` — `mergeModelPermissions` unions per-role allow-lists, dedupes overlaps, stays restrictive when every role has an explicit (possibly empty) `models` list, and only opens up when a role is genuinely unrestricted (`undefined`).

Command to confirm: `bun test apps/mesh/src/api/routes/decopilot/model-permissions.test.ts`

Locally ran: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and the targeted test file above (all green). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a fail-open in model permissions for multi‑role members by honoring each role’s limits. We now split comma‑joined roles, fetch each role’s permission, and OR‑merge the allowed models so access matches auth semantics.

- **Bug Fixes**
  - Updated fetchModelPermissions to split roles, query with IN, parse each role’s permission, and merge via mergeModelPermissions.
  - Added mergeModelPermissions: unions and dedupes model lists; if any role is unrestricted (undefined), all models are allowed; otherwise stays restrictive (including empty).
  - Regression tests cover union, dedupe, unrestricted role, and empty-list behavior.

<sup>Written for commit 525ce4463924f6307a50d5a4d75612ba18447a22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

