### PR TITLE
feat(sidebar): show code agents before plain agents in agents list

### DIFF
--- a/apps/mesh/src/web/components/sidebar/agents-section.tsx
+++ b/apps/mesh/src/web/components/sidebar/agents-section.tsx
@@ -274,17 +274,6 @@ function PinAgentPopoverContent({
           />
         )}
 
-        {/* Agents */}
-        {plainAgents.length > 0 && <SectionLabel>Agents</SectionLabel>}
-        {plainAgents.map((agent) => (
-          <AgentRow
-            key={agent.id}
-            agent={agent}
-            selected={onSelectAgent ? selectedAgentId === agent.id : undefined}
-            onClick={() => handleSelect(agent)}
-          />
-        ))}
-
         {/* Code Agents — repo-backed. The Import button is always available
             when not filtering, so a repo can be imported even with none yet. */}
         {(codeAgents.length > 0 || !search) && (
@@ -304,6 +293,17 @@ function PinAgentPopoverContent({
           </SectionLabel>
         )}
         {codeAgents.map((agent) => (
+          <AgentRow
+            key={agent.id}
+            agent={agent}
+            selected={onSelectAgent ? selectedAgentId === agent.id : undefined}
+            onClick={() => handleSelect(agent)}
+          />
+        ))}
+
+        {/* Agents */}
+        {plainAgents.length > 0 && <SectionLabel>Agents</SectionLabel>}
+        {plainAgents.map((agent) => (
           <AgentRow
             key={agent.id}
             agent={agent}


### PR DESCRIPTION
## Summary
- In the sidebar agents picker, the **Code Agents** group (with the Import button) now renders **before** the plain **Agents** group. Previously plain agents were listed first.

Only the render order of the two existing groups was swapped in `apps/mesh/src/web/components/sidebar/agents-section.tsx`. The grouping predicate (`agentHasClonableSource`) and all other logic are unchanged.

## Testing
- `bunx biome format` on the changed file passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the sidebar agent picker so Code Agents (with the Import button) appear before plain Agents, surfacing repo-backed agents first. Only the render order changed; grouping and selection logic are unchanged.

<sup>Written for commit d7b76ca29a8252a28c4bb66d514b672e6098da18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

