### PR TITLE
fix(registry): block RFC 6598 CGNAT range in discover-tools SSRF guard

### DIFF
--- a/apps/mesh/src/tools/registry/discover-tools.test.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.test.ts
@@ -8,6 +8,21 @@ describe("isPrivateUrl", () => {
     expect(isPrivateUrl("http://169.254.169.254/")).toBe(true);
   });
 
+  it("blocks RFC 6598 CGNAT shared address space (100.64.0.0/10)", () => {
+    // Alibaba Cloud's internal metadata endpoint lives in this range.
+    expect(isPrivateUrl("http://100.100.100.200/")).toBe(true);
+    expect(isPrivateUrl("http://100.64.0.1/")).toBe(true);
+    expect(isPrivateUrl("http://100.127.255.255/")).toBe(true);
+    // Outside the /10: 100.63.x.x and 100.128.x.x are ordinary public space.
+    expect(isPrivateUrl("http://100.63.255.255/")).toBe(false);
+    expect(isPrivateUrl("http://100.128.0.0/")).toBe(false);
+  });
+
+  it("blocks a 6to4-embedded CGNAT IPv4 address", () => {
+    // 2002:6464:6464:: embeds 100.100.100.100 (within 100.64.0.0/10)
+    expect(isPrivateUrl("http://[2002:6464:6464::]/")).toBe(true);
+  });
+
   it("blocks a 6to4-embedded private IPv4 address", () => {
     // 2002:7f00:1:: embeds 127.0.0.1 (6to4: 2002:WWXX:YYZZ::)
     expect(isPrivateUrl("http://[2002:7f00:1::]/")).toBe(true);

--- a/apps/mesh/src/tools/registry/discover-tools.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.ts
@@ -14,6 +14,10 @@ function isPrivateIPv4Octets(a: number, b: number | undefined): boolean {
   if (a === 127) return true;
   if (a === 169 && b === 254) return true;
   if (a === 0) return true;
+  // RFC 6598 Shared Address Space (100.64.0.0/10) — CGNAT range also used by
+  // cloud providers for internal service/metadata endpoints (e.g. Alibaba
+  // Cloud's 100.100.100.200 metadata server).
+  if (a === 100 && b !== undefined && b >= 64 && b <= 127) return true;
   return false;
 }
 


### PR DESCRIPTION
Follows #4929's 6to4/NAT64-embedded-IPv4 fix in the same SSRF guard.

`isPrivateUrl` (used by `REGISTRY_DISCOVER_TOOLS`, which connects server-side to a user-supplied MCP server URL — a classic SSRF trust boundary) blocked RFC 1918, loopback, and link-local ranges, but missed RFC 6598 Shared Address Space (100.64.0.0/10). That range is used for CGNAT and, notably, by some cloud providers for internal service/metadata endpoints (e.g. Alibaba Cloud's `100.100.100.200` metadata server) — the same class of target 169.254.169.254 is already blocked for. A URL pointed at that range would reach it unblocked through this tool, same as any other unfiltered private target.

Fix: add the /10 range check to `isPrivateIPv4Octets`, the helper shared by both the plain-IPv4 hostname check and the 6to4/NAT64 IPv6-embedded-IPv4 check, so both paths are covered by one change.

Regression tests added to `discover-tools.test.ts`: blocks `100.100.100.200` and the /10 boundaries, confirms `100.63.x.x`/`100.128.x.x` (just outside the range) stay unblocked, and confirms a 6to4-embedded CGNAT address is blocked too.

Reviewer command: `bun test apps/mesh/src/tools/registry/discover-tools.test.ts` (7 pass).

Locally verified: `bun run fmt` (clean) and the targeted test file above. No types changed, so no `tsc --noEmit` was needed — full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks RFC 6598 (100.64.0.0/10) in the `REGISTRY_DISCOVER_TOOLS` SSRF guard to prevent access to CGNAT/internal metadata endpoints (e.g., 100.100.100.200). Applies to both IPv4 and IPv6 6to4/NAT64-embedded IPv4.

- **Bug Fixes**
  - Added check in `isPrivateIPv4Octets` (used by `isPrivateUrl`) so both direct IPv4 and embedded IPv4 paths are covered.
  - Tests: block 100.100.100.200 and /10 bounds; allow 100.63.x.x and 100.128.x.x; block a 6to4-embedded address.

<sup>Written for commit 199dcbabcb6f3d4de37717c265f15e4d3f44d55c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

