### PR TITLE
fix(registry): fall back to initials when connection icon fails to load in monitor panel

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -73,6 +73,7 @@ function ConnectionRow({
   const [busy, setBusy] = useState(false);
   const [tokenValue, setTokenValue] = useState("");
   const [isReplacingToken, setIsReplacingToken] = useState(false);
+  const [iconFailed, setIconFailed] = useState(false);
 
   const updateAuth = useUpdateMonitorConnectionAuth();
   const { updateMutation } = useRegistryMutations();
@@ -300,12 +301,13 @@ function ConnectionRow({
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-3 min-w-0">
           <div className="size-10 rounded-lg border border-border bg-muted/20 overflow-hidden shrink-0 flex items-center justify-center">
-            {icon ? (
+            {icon && !iconFailed ? (
               <img
                 src={icon}
                 alt={title}
                 className="h-full w-full object-cover"
                 loading="lazy"
+                onError={() => setIconFailed(true)}
               />
             ) : (
               <span className="text-xs font-semibold text-muted-foreground">


### PR DESCRIPTION
The QA Connections cards in the monitor panel render the MCP server's icon URL (`entry.item?.server?.icons?.[0]?.src`) directly in an `<img>` with no `onError` handler. Registry items can carry a stale, malformed, or unreachable icon URL (e.g. a deleted asset, a bad request-source entry), so instead of the initials fallback the row silently shows the browser's broken-image glyph.

**Fix**: track load failure per row (`iconFailed` state) and set it in the `<img>`'s `onError`; the initials badge (same fallback already used when there's no icon) now also renders once the icon 404s/fails, so a bad icon URL degrades gracefully instead of showing a broken-image icon.

Behavior-preserving otherwise: valid icons render exactly as before.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit`, or in the browser point a connection's icon at a broken URL and confirm the initials badge shows instead of a broken-image glyph.

Locally ran: `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (green). Full CI covers lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the monitor panel so connections fall back to initials when an icon URL fails to load, instead of showing a broken-image glyph. Adds an `onError` handler with per-row `iconFailed` state; valid icons still render as before.

<sup>Written for commit 80bc4d6d9c666644db209c7e39c74d1da241773e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

