### PR TITLE
perf(file-explorer): avoid O(n^2) child lookup when building the file tree

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts
@@ -232,6 +232,19 @@ export function buildFileTree(
     children: [],
   };
 
+  // Name -> child lookup per directory, keyed by the directory's path. Avoids
+  // an O(children) linear scan per inserted entry (O(n^2) for a directory with
+  // many siblings, e.g. up to EXPLORER_GLOB_LIMIT files in one folder).
+  const childByName = new Map<string, Map<string, TreeNode>>();
+  const getChildMap = (node: TreeNode) => {
+    let map = childByName.get(node.path);
+    if (!map) {
+      map = new Map();
+      childByName.set(node.path, map);
+    }
+    return map;
+  };
+
   const ensureDirectory = (dirPath: string) => {
     const normalized = normalizePath(dirPath);
     const parts = normalized.split("/").filter(Boolean);
@@ -240,7 +253,8 @@ export function buildFileTree(
 
     for (const part of parts) {
       currentPath += `/${part}`;
-      let child = current.children.find((entry) => entry.name === part);
+      const map = getChildMap(current);
+      let child = map.get(part);
       if (!child) {
         child = {
           name: part,
@@ -249,6 +263,7 @@ export function buildFileTree(
           children: [],
         };
         current.children.push(child);
+        map.set(part, child);
       } else if (child.kind === "file") {
         child.kind = "directory";
       }
@@ -265,7 +280,8 @@ export function buildFileTree(
     parts.forEach((part, index) => {
       currentPath += `/${part}`;
       const isFile = index === parts.length - 1;
-      let child = current.children.find((entry) => entry.name === part);
+      const map = getChildMap(current);
+      let child = map.get(part);
 
       if (!child) {
         child = {
@@ -275,6 +291,7 @@ export function buildFileTree(
           children: [],
         };
         current.children.push(child);
+        map.set(part, child);
       }
 
       current = child;


### PR DESCRIPTION
**Source:** a real optimization found in `apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.ts` — `buildFileTree` is called on every render (`file-explorer.tsx:915`) with the full glob result, capped at `EXPLORER_GLOB_LIMIT = 10_000` files.

**Payoff:** `buildFileTree` located an existing child by scanning `current.children.find((entry) => entry.name === part)` on every inserted path segment. For a directory holding many siblings in one flat folder (e.g. a large `content/` or asset directory — realistic up to the 10k glob cap), each insertion into that directory does an O(k) scan against the k entries already added, so building the tree for n siblings costs O(n^2) rather than O(n). This runs synchronously in the render path every time the file list changes, so a large flat directory measurably slows down opening/refreshing the file explorer.

**Fix:** track children with a `Map<string, TreeNode>` keyed by the parent directory's path (alongside the existing `children` array, whose order is preserved), so lookups are O(1). Insertion order, sorting, and the resulting `TreeNode[]` shape are unchanged — this is a pure algorithmic swap, not a behavior change.

**Verify:** `bun test apps/mesh/src/web/components/sandbox/preview/file-explorer/utils.test.ts` — all 27 tests (including the `buildFileTree` cases) pass unchanged.

**Checks run locally:** `bun run fmt` (clean) and the targeted test file above (27/27 pass). No type signatures changed (`TreeNode`, `buildFileTree`'s signature are untouched — only the internal lookup structure), so `bunx tsc --noEmit` wasn't needed for this change; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids O(n^2) child lookups in the file explorer by using a per-directory `Map` for O(1) inserts when building the tree. This speeds up renders for large flat directories (up to 10k entries) without changing behavior or ordering.

- **Performance**
  - Replaced `children.find(...)` with a `Map` keyed by parent path to fetch children by name in O(1).
  - Keeps insertion order, sorting, and the `TreeNode[]` output identical.
  - Existing tests pass unchanged (27/27).

<sup>Written for commit a3840533296b8cc97476a4845d784bf268b09086. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

