### PR TITLE
fix(sidebar): add aria-label to icon-only buttons in collapsed rail

### DIFF
--- a/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/mesh/src/web/components/sidebar/task-groups/task-groups-list.tsx
@@ -362,6 +362,7 @@ export function TaskGroupsList({
           </SidebarMenuItem>
           <SidebarMenuItem>
             <SidebarMenuButton
+              aria-label="New chat"
               tooltip="New chat"
               onClick={() => void handleNewThread()}
             >
@@ -373,6 +374,7 @@ export function TaskGroupsList({
             return (
               <SidebarMenuItem key={t.id}>
                 <SidebarMenuButton
+                  aria-label={t.title || "New chat"}
                   tooltip={t.title || "New chat"}
                   isActive={t.id === activeTaskId}
                   onClick={() => handleSelectTask(t)}


### PR DESCRIPTION
Found while auditing the agent-icon avatar family for accessibility gaps: two `SidebarMenuButton`s in the collapsed sidebar rail (`task-groups-list.tsx`) render only an icon (Edit05 / an `AgentAvatar`) with no `aria-label` — their only text is a `tooltip` prop, which renders a hover/focus popup but does not set the button's accessible name, so screen readers announce nothing for "New chat" and each pinned scoped-thread button. Every sibling `SidebarMenuButton` in the same block (e.g. `Toggle sidebar`) already pairs `tooltip` with an explicit `aria-label`, so this closes the one inconsistency in that established pattern.

Failure scenario: a screen-reader user tabs through the collapsed sidebar rail and reaches the "New chat" button or a pinned scoped-thread button — both are announced as unlabeled buttons.

Fix: added `aria-label` mirroring the existing `tooltip` value on both buttons (`"New chat"`, and `t.title || "New chat"` for scoped threads), matching the convention already used two lines above for the sidebar-toggle button.

How to verify: open the app, collapse the sidebar, and inspect the accessibility tree (or tab through with a screen reader) for the "New chat" and pinned-thread icon buttons — both now expose an accessible name.

Locally ran: `bun run fmt` and `cd apps/mesh && bunx tsc --noEmit` (both clean). This is a markup-only change with no logic to unit test; full CI (lint, typecheck across workspaces) will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-labels to the icon-only "New chat" button and pinned scoped-thread buttons in the collapsed sidebar rail so screen readers announce them correctly. Mirrors the existing tooltip text and matches the pattern used for the sidebar-toggle button.

<sup>Written for commit 6bc3322bddd2aee62080b32baa4f1961de7c9506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

