### PR TITLE
feat(branch-picker): "Last 7 days" group + Branches/PRs tabs

### DIFF
--- a/apps/mesh/src/web/components/thread/github/branch-picker.tsx
+++ b/apps/mesh/src/web/components/thread/github/branch-picker.tsx
@@ -1,5 +1,9 @@
 import { type UIEvent, useRef, useState } from "react";
-import type { SandboxMap } from "@decocms/mesh-sdk";
+import { KEYS, type SandboxMap, useProjectContext } from "@decocms/mesh-sdk";
+import { useQuery } from "@tanstack/react-query";
+import { useOrgAuthClient } from "@/web/hooks/use-org-auth-client";
+import { getInitials } from "@/web/lib/get-initials";
+import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
@@ -16,14 +20,17 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@deco/ui/components/popover.tsx";
+import { Tabs, TabsList, TabsTrigger } from "@deco/ui/components/tabs.tsx";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
-import { ChevronDown, GitBranch01 } from "@untitledui/icons";
+import { ChevronDown, GitBranch01, GitPullRequest } from "@untitledui/icons";
 import { generateBranchName } from "@/shared/branch-name";
+import { decodeHtmlEntities } from "./decode-html-entities.ts";
 import { useBranches } from "./use-branches";
+import { useOpenPrs } from "./use-pr-data.ts";
 
 interface Props {
   orgId: string;
@@ -70,11 +77,13 @@ export function BranchPicker({
 }: Props) {
   const isHeader = placement === "header";
   const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<"branches" | "prs">("branches");
   const [search, setSearch] = useState("");
   const [isSearchingRemote, setIsSearchingRemote] = useState(false);
   const searchRequestId = useRef(0);
 
   const {
+    recent,
     yours,
     others,
     isLoading,
@@ -94,6 +103,37 @@ export function BranchPicker({
     enabled: open,
   });
 
+  // userId -> { name, image } for contributor avatars on recent branches.
+  // Non-suspense so the trigger button never blocks on member loading.
+  const { locator } = useProjectContext();
+  const orgAuth = useOrgAuthClient();
+  const { data: membersData } = useQuery({
+    queryKey: KEYS.members(locator),
+    queryFn: () => orgAuth.organization.listMembers(),
+    staleTime: 5 * 60 * 1000,
+    enabled: open,
+  });
+  const memberById = new Map<string, MemberUser | undefined>(
+    ((membersData?.data?.members ?? []) as OrgMember[]).map(
+      (m) => [m.userId, m.user] as const,
+    ),
+  );
+
+  // Open PRs for the repo — a PR is just a branch, so selecting one starts a
+  // sandbox on its head branch, exactly like picking a branch.
+  const {
+    data: prs = [],
+    isLoading: prsLoading,
+    isError: prsError,
+  } = useOpenPrs({
+    orgId,
+    orgSlug,
+    connectionId: connectionId ?? "",
+    owner,
+    repo,
+    enabled: open && tab === "prs",
+  });
+
   const pick = (name: string) => {
     onChange(name);
     setOpen(false);
@@ -106,7 +146,8 @@ export function BranchPicker({
 
     const requestId = searchRequestId.current;
     const trimmedSearch = nextSearch.trim();
-    if (!trimmedSearch) {
+    // PRs are all loaded up-front, so only branches need remote search paging.
+    if (!trimmedSearch || tab !== "branches") {
       setIsSearchingRemote(false);
       return;
     }
@@ -127,7 +168,7 @@ export function BranchPicker({
     const distanceFromBottom =
       target.scrollHeight - target.scrollTop - target.clientHeight;
 
-    if (distanceFromBottom < 48) {
+    if (tab === "branches" && distanceFromBottom < 48) {
       fetchMore();
     }
   };
@@ -190,92 +231,227 @@ export function BranchPicker({
         <Command>
           <div className="*:data-[slot=command-input-wrapper]:flex-1 *:data-[slot=command-input-wrapper]:border-b-0 flex items-center border-b pr-2">
             <CommandInput
-              placeholder="Search loaded branches…"
+              placeholder={
+                tab === "branches"
+                  ? "Search loaded branches…"
+                  : "Search pull requests…"
+              }
               value={search}
               onValueChange={handleSearchChange}
             />
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 shrink-0"
-              onClick={() => pick(generateBranchName(userLabel))}
-            >
-              New
-            </Button>
+            {tab === "branches" && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 shrink-0"
+                onClick={() => pick(generateBranchName(userLabel))}
+              >
+                New
+              </Button>
+            )}
           </div>
+          <Tabs
+            className="px-2 pt-2 pb-1"
+            value={tab}
+            onValueChange={(v) => {
+              setTab(v as "branches" | "prs");
+              setSearch("");
+            }}
+          >
+            <TabsList
+              className="h-auto w-fit justify-start gap-1 bg-accent p-1"
+              variant="pill"
+            >
+              <TabsTrigger value="branches" className="h-6 px-2.5 text-xs">
+                Branches
+              </TabsTrigger>
+              <TabsTrigger value="prs" className="h-6 px-2.5 text-xs">
+                PRs
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
           <CommandList onScroll={onListScroll}>
-            {isError && (
-              <div className="p-3 text-xs text-muted-foreground">
-                Couldn't load branches from GitHub. You can still pick from your
-                branches.
-              </div>
-            )}
-            {!isError && !isLoading && (
-              <CommandEmpty>
-                {hasMore
-                  ? "Looking through more branches..."
-                  : "No branches found."}
-              </CommandEmpty>
-            )}
-            {yours.length > 0 && (
-              <CommandGroup heading="Your branches">
-                {yours.map((b) => (
-                  <CommandItem
-                    key={b.name}
-                    value={b.name}
-                    onSelect={() => pick(b.name)}
-                  >
-                    <GitBranch01 className="mr-2 h-4 w-4" />
-                    <span className="flex-1 truncate">{b.name}</span>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            )}
-            {others.length > 0 && (
+            {tab === "prs" ? (
               <>
-                <CommandSeparator />
-                <CommandGroup heading="Other branches in repo">
-                  {others.map((b) => (
-                    <CommandItem
-                      key={b.name}
-                      value={b.name}
-                      onSelect={() => pick(b.name)}
-                    >
-                      <GitBranch01 className="mr-2 h-4 w-4" />
-                      <span className="flex-1 truncate">{b.name}</span>
-                      {b.author && (
-                        <span className="text-xs text-muted-foreground">
-                          @{b.author}
-                        </span>
-                      )}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
+                {prsError && (
+                  <div className="p-3 text-xs text-muted-foreground">
+                    Couldn't load pull requests from GitHub.
+                  </div>
+                )}
+                {prsLoading && (
+                  <div className="p-3 text-xs text-muted-foreground">
+                    Loading pull requests…
+                  </div>
+                )}
+                {!prsError && !prsLoading && (
+                  <CommandEmpty>No open pull requests.</CommandEmpty>
+                )}
+                {prs.length > 0 && (
+                  <CommandGroup heading="Open pull requests">
+                    {prs.map((pr) => (
+                      <CommandItem
+                        key={pr.number}
+                        value={`#${pr.number} ${pr.title} ${pr.head}`}
+                        className="cursor-pointer"
+                        onSelect={() => pick(pr.head)}
+                      >
+                        <GitPullRequest className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
+                        <div className="flex min-w-0 flex-1 flex-col">
+                          <span className="truncate">
+                            {decodeHtmlEntities(pr.title)}
+                          </span>
+                          <span className="truncate text-xs text-muted-foreground">
+                            #{pr.number} · {pr.head}
+                            {pr.author ? ` · @${pr.author}` : ""}
+                          </span>
+                        </div>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
               </>
-            )}
-            {hasMore && (
-              <div className="border-t p-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 w-full text-xs"
-                  disabled={isFetchingMore}
-                  onClick={fetchMore}
-                >
-                  {isFetchingMore || isSearchingRemote
-                    ? "Loading more…"
-                    : "Load more branches"}
-                </Button>
-              </div>
-            )}
-            {!hasMore && others.length > 0 && (
-              <div className="border-t p-2 text-center text-xs text-muted-foreground">
-                All loaded
-              </div>
+            ) : (
+              <>
+                {isError && (
+                  <div className="p-3 text-xs text-muted-foreground">
+                    Couldn't load branches from GitHub. You can still pick from
+                    your branches.
+                  </div>
+                )}
+                {!isError && !isLoading && (
+                  <CommandEmpty>
+                    {hasMore
+                      ? "Looking through more branches..."
+                      : "No branches found."}
+                  </CommandEmpty>
+                )}
+                {recent.length > 0 && (
+                  <CommandGroup heading="Last 7 days">
+                    {recent.map((b) => (
+                      <CommandItem
+                        key={b.name}
+                        value={b.name}
+                        className="cursor-pointer"
+                        onSelect={() => pick(b.name)}
+                      >
+                        <GitBranch01 className="mr-2 h-4 w-4 shrink-0" />
+                        <span className="flex-1 truncate">{b.name}</span>
+                        <ContributorAvatars
+                          userIds={b.contributors ?? []}
+                          memberById={memberById}
+                        />
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+                {yours.length > 0 && (
+                  <>
+                    {recent.length > 0 && <CommandSeparator />}
+                    <CommandGroup heading="Your branches">
+                      {yours.map((b) => (
+                        <CommandItem
+                          key={b.name}
+                          value={b.name}
+                          className="cursor-pointer"
+                          onSelect={() => pick(b.name)}
+                        >
+                          <GitBranch01 className="mr-2 h-4 w-4 shrink-0" />
+                          <span className="flex-1 truncate">{b.name}</span>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </>
+                )}
+                {others.length > 0 && (
+                  <>
+                    <CommandSeparator />
+                    <CommandGroup heading="Other branches in repo">
+                      {others.map((b) => (
+                        <CommandItem
+                          key={b.name}
+                          value={b.name}
+                          className="cursor-pointer"
+                          onSelect={() => pick(b.name)}
+                        >
+                          <GitBranch01 className="mr-2 h-4 w-4" />
+                          <span className="flex-1 truncate">{b.name}</span>
+                          {b.author && (
+                            <span className="text-xs text-muted-foreground">
+                              @{b.author}
+                            </span>
+                          )}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </>
+                )}
+                {hasMore && (
+                  <div className="border-t p-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-full text-xs"
+                      disabled={isFetchingMore}
+                      onClick={fetchMore}
+                    >
+                      {isFetchingMore || isSearchingRemote
+                        ? "Loading more…"
+                        : "Load more branches"}
+                    </Button>
+                  </div>
+                )}
+                {!hasMore && others.length > 0 && (
+                  <div className="border-t p-2 text-center text-xs text-muted-foreground">
+                    All loaded
+                  </div>
+                )}
+              </>
             )}
           </CommandList>
         </Command>
       </PopoverContent>
     </Popover>
+  );
+}
+
+type MemberUser = { name?: string | null; image?: string | null };
+type OrgMember = { userId: string; user?: MemberUser };
+
+/**
+ * Overlapping avatar stack for the people with an active sandbox on a branch.
+ * Shows up to 3 faces, then a "+N" chip. Unknown userIds fall back to initials.
+ */
+function ContributorAvatars({
+  userIds,
+  memberById,
+}: {
+  userIds: string[];
+  memberById: Map<string, MemberUser | undefined>;
+}) {
+  if (userIds.length === 0) return null;
+  const shown = userIds.slice(0, 3);
+  const extra = userIds.length - shown.length;
+
+  return (
+    <span className="ml-2 flex shrink-0 items-center -space-x-1.5">
+      {shown.map((uid) => {
+        const user = memberById.get(uid);
+        return (
+          <Avatar
+            key={uid}
+            url={user?.image ?? undefined}
+            fallback={getInitials(user?.name ?? undefined)}
+            shape="circle"
+            size="xs"
+            className="ring-2 ring-background"
+          />
+        );
+      })}
+      {extra > 0 && (
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-[9px] font-semibold text-muted-foreground ring-2 ring-background">
+          +{extra}
+        </span>
+      )}
+    </span>
   );
 }

--- a/apps/mesh/src/web/components/thread/github/branch-picker.tsx
+++ b/apps/mesh/src/web/components/thread/github/branch-picker.tsx
@@ -1,7 +1,6 @@
 import { type UIEvent, useRef, useState } from "react";
-import { KEYS, type SandboxMap, useProjectContext } from "@decocms/mesh-sdk";
-import { useQuery } from "@tanstack/react-query";
-import { useOrgAuthClient } from "@/web/hooks/use-org-auth-client";
+import type { SandboxMap } from "@decocms/mesh-sdk";
+import { useMembersQuery } from "@/web/hooks/use-members";
 import { getInitials } from "@/web/lib/get-initials";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -104,15 +103,8 @@ export function BranchPicker({
   });
 
   // userId -> { name, image } for contributor avatars on recent branches.
-  // Non-suspense so the trigger button never blocks on member loading.
-  const { locator } = useProjectContext();
-  const orgAuth = useOrgAuthClient();
-  const { data: membersData } = useQuery({
-    queryKey: KEYS.members(locator),
-    queryFn: () => orgAuth.organization.listMembers(),
-    staleTime: 5 * 60 * 1000,
-    enabled: open,
-  });
+  // Non-suspense variant so the trigger button never blocks on member loading.
+  const { data: membersData } = useMembersQuery({ enabled: open });
   const memberById = new Map<string, MemberUser | undefined>(
     ((membersData?.data?.members ?? []) as OrgMember[]).map(
       (m) => [m.userId, m.user] as const,
@@ -133,6 +125,15 @@ export function BranchPicker({
     repo,
     enabled: open && tab === "prs",
   });
+
+  // Only same-repo PRs are openable: a fork PR's head.ref names a branch in the
+  // fork, not this repo, so picking it would fail or hit a same-named local
+  // branch. Hide those, but surface a count so the drop isn't silent.
+  const repoFullName = `${owner}/${repo}`.toLowerCase();
+  const openablePrs = prs.filter(
+    (pr) => pr.headRepoFullName?.toLowerCase() === repoFullName,
+  );
+  const hiddenForkPrs = prs.length - openablePrs.length;
 
   const pick = (name: string) => {
     onChange(name);
@@ -284,11 +285,15 @@ export function BranchPicker({
                   </div>
                 )}
                 {!prsError && !prsLoading && (
-                  <CommandEmpty>No open pull requests.</CommandEmpty>
+                  <CommandEmpty>
+                    {search.trim()
+                      ? "No pull requests match your search."
+                      : "No open pull requests."}
+                  </CommandEmpty>
                 )}
-                {prs.length > 0 && (
+                {openablePrs.length > 0 && (
                   <CommandGroup heading="Open pull requests">
-                    {prs.map((pr) => (
+                    {openablePrs.map((pr) => (
                       <CommandItem
                         key={pr.number}
                         value={`#${pr.number} ${pr.title} ${pr.head}`}
@@ -308,6 +313,12 @@ export function BranchPicker({
                       </CommandItem>
                     ))}
                   </CommandGroup>
+                )}
+                {hiddenForkPrs > 0 && (
+                  <div className="border-t p-2 text-center text-xs text-muted-foreground">
+                    {hiddenForkPrs} PR{hiddenForkPrs > 1 ? "s" : ""} from forks
+                    hidden — open on a branch in this repo
+                  </div>
                 )}
               </>
             ) : (

--- a/apps/mesh/src/web/components/thread/github/group-branches.test.ts
+++ b/apps/mesh/src/web/components/thread/github/group-branches.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import type { SandboxMap } from "@decocms/mesh-sdk";
+import { groupBranches, RECENT_WINDOW_MS } from "./group-branches";
+
+const NOW = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+/** Minimal sandbox record — groupBranches only reads `createdAt`. */
+const rec = (createdAt?: number) =>
+  ({ sandboxHandle: "h", previewUrl: null, createdAt }) as unknown;
+
+/** Build a SandboxMap[userId][branch] = { "agent-sandbox": rec } shape. */
+function sandboxMap(
+  entries: Record<string, Record<string, number | undefined>>,
+): SandboxMap {
+  const out: Record<string, unknown> = {};
+  for (const [uid, branches] of Object.entries(entries)) {
+    const byBranch: Record<string, unknown> = {};
+    for (const [branch, createdAt] of Object.entries(branches)) {
+      byBranch[branch] = { "agent-sandbox": rec(createdAt) };
+    }
+    out[uid] = byBranch;
+  }
+  return out as SandboxMap;
+}
+
+describe("groupBranches", () => {
+  test("returns empty groups for empty/undefined sandbox map", () => {
+    const result = groupBranches({
+      sandboxMap: undefined,
+      userId: "u1",
+      rawBranches: [],
+      now: NOW,
+    });
+    expect(result).toEqual({ recent: [], yours: [], others: [] });
+  });
+
+  test("github branches with no sandbox land in `others`", () => {
+    const result = groupBranches({
+      sandboxMap: undefined,
+      userId: "u1",
+      rawBranches: [
+        { name: "main", author: "octocat" },
+        { name: "feature", author: null },
+      ],
+      now: NOW,
+    });
+    expect(result.others.map((b) => b.name)).toEqual(["main", "feature"]);
+    expect(result.others[0]?.author).toBe("octocat");
+    expect(result.others[1]?.author).toBeNull();
+  });
+
+  test("recent = branches with sandbox activity inside the 7-day window, newest first", () => {
+    const result = groupBranches({
+      sandboxMap: sandboxMap({
+        u1: { "branch-old": NOW - 8 * DAY, "branch-new": NOW - 1 * DAY },
+        u2: { "branch-mid": NOW - 3 * DAY },
+      }),
+      userId: "u1",
+      rawBranches: [],
+      now: NOW,
+    });
+    // branch-old is outside the window -> excluded from recent
+    expect(result.recent.map((b) => b.name)).toEqual([
+      "branch-new",
+      "branch-mid",
+    ]);
+    // branch-old (owned by u1) falls back to "yours"
+    expect(result.yours.map((b) => b.name)).toEqual(["branch-old"]);
+  });
+
+  test("branch with no createdAt is excluded from recent but still shows in yours", () => {
+    const result = groupBranches({
+      sandboxMap: sandboxMap({ u1: { "no-ts": undefined } }),
+      userId: "u1",
+      rawBranches: [],
+      now: NOW,
+    });
+    expect(result.recent).toEqual([]);
+    expect(result.yours.map((b) => b.name)).toEqual(["no-ts"]);
+  });
+
+  test("exactly on the 7-day boundary counts as recent", () => {
+    const result = groupBranches({
+      sandboxMap: sandboxMap({ u1: { edge: NOW - RECENT_WINDOW_MS } }),
+      userId: "u1",
+      rawBranches: [],
+      now: NOW,
+    });
+    expect(result.recent.map((b) => b.name)).toEqual(["edge"]);
+  });
+
+  test("a recent branch owned by the user appears only in recent, not yours", () => {
+    const result = groupBranches({
+      sandboxMap: sandboxMap({ u1: { hot: NOW - DAY } }),
+      userId: "u1",
+      rawBranches: [{ name: "hot", author: "someone" }],
+      now: NOW,
+    });
+    expect(result.recent.map((b) => b.name)).toEqual(["hot"]);
+    expect(result.yours).toEqual([]);
+    // and it must not be duplicated into `others`
+    expect(result.others).toEqual([]);
+  });
+
+  test("contributors are de-duplicated across users and take the max createdAt", () => {
+    const result = groupBranches({
+      sandboxMap: sandboxMap({
+        u1: { shared: NOW - 5 * DAY },
+        u2: { shared: NOW - 2 * DAY },
+      }),
+      userId: "u1",
+      rawBranches: [],
+      now: NOW,
+    });
+    expect(result.recent).toHaveLength(1);
+    const branch = result.recent[0]!;
+    expect(branch.name).toBe("shared");
+    expect([...(branch.contributors ?? [])].sort()).toEqual(["u1", "u2"]);
+    expect(branch.lastActiveAt).toBe(NOW - 2 * DAY);
+  });
+
+  test("others excludes both your-sandbox and recent branches", () => {
+    const result = groupBranches({
+      sandboxMap: sandboxMap({
+        u1: { mine: NOW - 40 * DAY, "mine-recent": NOW - DAY },
+      }),
+      userId: "u1",
+      rawBranches: [
+        { name: "mine" },
+        { name: "mine-recent" },
+        { name: "external" },
+      ],
+      now: NOW,
+    });
+    expect(result.others.map((b) => b.name)).toEqual(["external"]);
+    expect(result.yours.map((b) => b.name)).toEqual(["mine"]);
+    expect(result.recent.map((b) => b.name)).toEqual(["mine-recent"]);
+  });
+});

--- a/apps/mesh/src/web/components/thread/github/group-branches.ts
+++ b/apps/mesh/src/web/components/thread/github/group-branches.ts
@@ -1,0 +1,86 @@
+import type { SandboxMap } from "@decocms/mesh-sdk";
+import type { Branch } from "./use-branches";
+
+export const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface GroupBranchesArgs {
+  sandboxMap: SandboxMap | undefined;
+  /** Current user id — used to derive "your branches". */
+  userId: string;
+  /** Branch names from github-mcp-server's list_branches (+ optional author). */
+  rawBranches: { name: string; author?: string | null }[];
+  /** Epoch ms "now" — injected so the 7-day cutoff is testable/deterministic. */
+  now: number;
+}
+
+export interface GroupedBranches {
+  recent: Branch[];
+  yours: Branch[];
+  others: Branch[];
+}
+
+/**
+ * Splits branches into three groups for the picker:
+ * - `recent`: any branch with sandbox activity in the last 7 days (across ALL
+ *   users), most-recent-first, carrying `contributors` + `lastActiveAt`.
+ * - `yours`: the current user's sandbox branches, minus recent ones.
+ * - `others`: github branches, minus your-sandbox and recent ones.
+ *
+ * Precedence is recent > yours > others, so a branch appears in exactly one
+ * group. Pure/deterministic given `now`; the hook injects `Date.now()`.
+ */
+export function groupBranches({
+  sandboxMap,
+  userId,
+  rawBranches,
+  now,
+}: GroupBranchesArgs): GroupedBranches {
+  // Aggregate sandbox activity across ALL users: who is on each branch and when
+  // it was last started. sandboxMap shape: sandboxMap[userId][branch][kind].
+  const activityByBranch = new Map<
+    string,
+    { userIds: Set<string>; lastActiveAt: number }
+  >();
+  for (const [uid, branches] of Object.entries(sandboxMap ?? {})) {
+    for (const [branch, kinds] of Object.entries(branches ?? {})) {
+      let entry = activityByBranch.get(branch);
+      if (!entry) {
+        entry = { userIds: new Set(), lastActiveAt: 0 };
+        activityByBranch.set(branch, entry);
+      }
+      entry.userIds.add(uid);
+      for (const record of Object.values(kinds ?? {})) {
+        const createdAt = record?.createdAt ?? 0;
+        if (createdAt > entry.lastActiveAt) entry.lastActiveAt = createdAt;
+      }
+    }
+  }
+
+  const recentCutoff = now - RECENT_WINDOW_MS;
+  const recent: Branch[] = [...activityByBranch.entries()]
+    .filter(([, activity]) => activity.lastActiveAt >= recentCutoff)
+    .sort((a, b) => b[1].lastActiveAt - a[1].lastActiveAt)
+    .map(([name, activity]) => ({
+      name,
+      source: "recent" as const,
+      contributors: [...activity.userIds],
+      lastActiveAt: activity.lastActiveAt,
+    }));
+  const recentNames = new Set(recent.map((b) => b.name));
+
+  const yourBranchNames = new Set(Object.keys(sandboxMap?.[userId] ?? {}));
+  const yours: Branch[] = [...yourBranchNames]
+    .filter((name) => !recentNames.has(name))
+    .sort()
+    .map((name) => ({ name, source: "yours" as const }));
+
+  const others: Branch[] = rawBranches
+    .filter((b) => !yourBranchNames.has(b.name) && !recentNames.has(b.name))
+    .map((b) => ({
+      name: b.name,
+      source: "other" as const,
+      author: b.author ?? null,
+    }));
+
+  return { recent, yours, others };
+}

--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -60,6 +60,7 @@ function pr(over: Partial<PrSummary> = {}): PrSummary {
     base: "main",
     head: "feat/x",
     headSha: "abc123",
+    headRepoFullName: "acme/web",
     htmlUrl: "https://github.com/acme/web/pull/42",
     author: "me",
     ...over,

--- a/apps/mesh/src/web/components/thread/github/use-branches.ts
+++ b/apps/mesh/src/web/components/thread/github/use-branches.ts
@@ -3,11 +3,20 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 
 export interface Branch {
   name: string;
-  source: "yours" | "other";
+  source: "yours" | "other" | "recent";
   author?: string | null;
+  /** userIds with an active sandbox on this branch (from sandboxMap). */
+  contributors?: string[];
+  /** Most recent sandbox createdAt (epoch ms) across all users on the branch. */
+  lastActiveAt?: number;
 }
 
 export interface UseBranchesResult {
+  /**
+   * Branches with sandbox activity in the last 7 days (any user), most recent
+   * first. Carries `contributors` so the picker can show who's working on it.
+   */
+  recent: Branch[];
   yours: Branch[];
   others: Branch[];
   defaultBase: string | null;
@@ -56,6 +65,7 @@ interface BranchesPage {
 }
 
 const BRANCHES_PER_PAGE = 100;
+const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 function pageHasBranchMatch(
   pages: BranchesPage[] | undefined,
@@ -178,8 +188,43 @@ export function useBranches({
     },
   });
 
+  // Aggregate sandbox activity across ALL users: who is on each branch and
+  // when it was last started. Powers the "Last 7 days" group + contributor
+  // avatars. sandboxMap shape: sandboxMap[userId][branch][kind] -> record.
+  const activityByBranch = new Map<
+    string,
+    { userIds: Set<string>; lastActiveAt: number }
+  >();
+  for (const [uid, branches] of Object.entries(sandboxMap ?? {})) {
+    for (const [branch, kinds] of Object.entries(branches ?? {})) {
+      let entry = activityByBranch.get(branch);
+      if (!entry) {
+        entry = { userIds: new Set(), lastActiveAt: 0 };
+        activityByBranch.set(branch, entry);
+      }
+      entry.userIds.add(uid);
+      for (const record of Object.values(kinds ?? {})) {
+        const createdAt = record?.createdAt ?? 0;
+        if (createdAt > entry.lastActiveAt) entry.lastActiveAt = createdAt;
+      }
+    }
+  }
+
+  const recentCutoff = Date.now() - RECENT_WINDOW_MS;
+  const recent: Branch[] = [...activityByBranch.entries()]
+    .filter(([, activity]) => activity.lastActiveAt >= recentCutoff)
+    .sort((a, b) => b[1].lastActiveAt - a[1].lastActiveAt)
+    .map(([name, activity]) => ({
+      name,
+      source: "recent" as const,
+      contributors: [...activity.userIds],
+      lastActiveAt: activity.lastActiveAt,
+    }));
+  const recentNames = new Set(recent.map((b) => b.name));
+
   const yourBranchNames = new Set(Object.keys(sandboxMap?.[userId] ?? {}));
   const yours: Branch[] = [...yourBranchNames]
+    .filter((name) => !recentNames.has(name))
     .sort()
     .map((name) => ({ name, source: "yours" as const }));
 
@@ -198,7 +243,7 @@ export function useBranches({
     .filter(
       (b): b is RawBranch & { name: string } => typeof b.name === "string",
     )
-    .filter((b) => !yourBranchNames.has(b.name))
+    .filter((b) => !yourBranchNames.has(b.name) && !recentNames.has(b.name))
     .map((b) => ({
       name: b.name,
       source: "other" as const,
@@ -241,6 +286,7 @@ export function useBranches({
   };
 
   return {
+    recent,
     yours,
     others,
     defaultBase,

--- a/apps/mesh/src/web/components/thread/github/use-branches.ts
+++ b/apps/mesh/src/web/components/thread/github/use-branches.ts
@@ -1,5 +1,6 @@
 import { KEYS, type SandboxMap, useMCPClient } from "@decocms/mesh-sdk";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { groupBranches } from "./group-branches";
 
 export interface Branch {
   name: string;
@@ -65,7 +66,6 @@ interface BranchesPage {
 }
 
 const BRANCHES_PER_PAGE = 100;
-const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 function pageHasBranchMatch(
   pages: BranchesPage[] | undefined,
@@ -188,46 +188,6 @@ export function useBranches({
     },
   });
 
-  // Aggregate sandbox activity across ALL users: who is on each branch and
-  // when it was last started. Powers the "Last 7 days" group + contributor
-  // avatars. sandboxMap shape: sandboxMap[userId][branch][kind] -> record.
-  const activityByBranch = new Map<
-    string,
-    { userIds: Set<string>; lastActiveAt: number }
-  >();
-  for (const [uid, branches] of Object.entries(sandboxMap ?? {})) {
-    for (const [branch, kinds] of Object.entries(branches ?? {})) {
-      let entry = activityByBranch.get(branch);
-      if (!entry) {
-        entry = { userIds: new Set(), lastActiveAt: 0 };
-        activityByBranch.set(branch, entry);
-      }
-      entry.userIds.add(uid);
-      for (const record of Object.values(kinds ?? {})) {
-        const createdAt = record?.createdAt ?? 0;
-        if (createdAt > entry.lastActiveAt) entry.lastActiveAt = createdAt;
-      }
-    }
-  }
-
-  const recentCutoff = Date.now() - RECENT_WINDOW_MS;
-  const recent: Branch[] = [...activityByBranch.entries()]
-    .filter(([, activity]) => activity.lastActiveAt >= recentCutoff)
-    .sort((a, b) => b[1].lastActiveAt - a[1].lastActiveAt)
-    .map(([name, activity]) => ({
-      name,
-      source: "recent" as const,
-      contributors: [...activity.userIds],
-      lastActiveAt: activity.lastActiveAt,
-    }));
-  const recentNames = new Set(recent.map((b) => b.name));
-
-  const yourBranchNames = new Set(Object.keys(sandboxMap?.[userId] ?? {}));
-  const yours: Branch[] = [...yourBranchNames]
-    .filter((name) => !recentNames.has(name))
-    .sort()
-    .map((name) => ({ name, source: "yours" as const }));
-
   const branchesByName = new Map<string, RawBranch>();
   for (const page of data?.pages ?? []) {
     for (const branch of page.branches) {
@@ -237,21 +197,28 @@ export function useBranches({
     }
   }
 
-  const rawBranches: RawBranch[] = [...branchesByName.values()];
-
-  const others: Branch[] = rawBranches
+  const rawBranches = [...branchesByName.values()]
     .filter(
       (b): b is RawBranch & { name: string } => typeof b.name === "string",
     )
-    .filter((b) => !yourBranchNames.has(b.name) && !recentNames.has(b.name))
     .map((b) => ({
       name: b.name,
-      source: "other" as const,
       author:
         typeof b.commit?.author === "string"
           ? b.commit.author
           : (b.commit?.author?.login ?? null),
     }));
+
+  const { recent, yours, others } = groupBranches({
+    sandboxMap,
+    userId,
+    rawBranches,
+    now: Date.now(),
+  });
+
+  // Branch names we can match locally without paging github — all
+  // sandbox-derived (recent + yours). Used to short-circuit remote search.
+  const localBranchNames = new Set([...recent, ...yours].map((b) => b.name));
 
   const defaultBase =
     data?.pages.find((page) => page.default_branch)?.default_branch ?? null;
@@ -261,7 +228,7 @@ export function useBranches({
   ) => {
     if (
       !shouldContinue() ||
-      branchNamesHaveMatch(yourBranchNames, search) ||
+      branchNamesHaveMatch(localBranchNames, search) ||
       isFetchingNextPage
     ) {
       return;
@@ -270,7 +237,7 @@ export function useBranches({
     let pages = data?.pages ?? [];
     while (
       shouldContinue() &&
-      !pageHasBranchMatch(pages, search, yourBranchNames) &&
+      !pageHasBranchMatch(pages, search, localBranchNames) &&
       (pages.at(-1)?.branches.length ?? BRANCHES_PER_PAGE) >= BRANCHES_PER_PAGE
     ) {
       const result = await fetchNextPage();

--- a/apps/mesh/src/web/components/thread/github/use-pr-data.ts
+++ b/apps/mesh/src/web/components/thread/github/use-pr-data.ts
@@ -29,6 +29,12 @@ export interface PrSummary {
   head: string;
   /** SHA of the PR head commit — used to fetch check runs. */
   headSha: string;
+  /**
+   * `owner/name` of the repo the head branch lives in. Differs from the base
+   * repo for cross-fork PRs (or null when the fork was deleted) — such PRs
+   * can't be opened as a local branch. Same as the base repo for internal PRs.
+   */
+  headRepoFullName: string | null;
   htmlUrl: string;
   author: string;
 }
@@ -90,6 +96,7 @@ export interface PrComment {
 function mapRawPr(p: Record<string, unknown>): PrSummary {
   const base = p.base as Record<string, unknown> | undefined;
   const head = p.head as Record<string, unknown> | undefined;
+  const headRepo = head?.repo as Record<string, unknown> | undefined;
   const user = p.user as Record<string, unknown> | undefined;
   return {
     number: (p.number as number) ?? 0,
@@ -101,6 +108,7 @@ function mapRawPr(p: Record<string, unknown>): PrSummary {
     base: (base?.ref as string) ?? "main",
     head: (head?.ref as string) ?? "",
     headSha: (head?.sha as string) ?? "",
+    headRepoFullName: (headRepo?.full_name as string) ?? null,
     htmlUrl: (p.html_url as string) ?? "",
     author: (user?.login as string) ?? "",
   };
@@ -140,10 +148,15 @@ export function usePrByBranch(args: RepoArgs & { branch: string | null }) {
   });
 }
 
+/** Max open PRs fetched for the picker; the tail beyond this is not shown. */
+const OPEN_PRS_PER_PAGE = 50;
+
 /**
- * Lists all OPEN pull requests for the repo (most recent first, as GitHub
- * returns them). Powers the branch picker's "PRs" tab — selecting a PR is
- * equivalent to selecting its head branch (a PR is just a branch).
+ * Lists open pull requests for the repo (most recent first, as GitHub returns
+ * them), capped at {@link OPEN_PRS_PER_PAGE}. Powers the branch picker's "PRs"
+ * tab — selecting a PR is equivalent to selecting its head branch (a PR is
+ * just a branch). No polling: the picker is an ephemeral popover, so it relies
+ * on refetch-on-open + `staleTime` rather than a background interval.
  */
 export function useOpenPrs(args: RepoArgs & { enabled?: boolean }) {
   const client = useMCPClient({
@@ -159,15 +172,13 @@ export function useOpenPrs(args: RepoArgs & { enabled?: boolean }) {
       owner: args.owner,
       repo: args.repo,
       state: "open",
-      perPage: 50,
+      perPage: OPEN_PRS_PER_PAGE,
     },
     enabled:
       (args.enabled ?? true) &&
       !!args.connectionId &&
       !!args.owner &&
       !!args.repo,
-    refetchInterval: POLL,
-    refetchIntervalInBackground: false,
     staleTime: STALE,
     select: (r) => extractPullRequestList(r).map(mapRawPr),
   });

--- a/apps/mesh/src/web/components/thread/github/use-pr-data.ts
+++ b/apps/mesh/src/web/components/thread/github/use-pr-data.ts
@@ -86,6 +86,26 @@ export interface PrComment {
   htmlUrl: string;
 }
 
+/** Maps a raw github-mcp list/get PR object into the app's PrSummary. */
+function mapRawPr(p: Record<string, unknown>): PrSummary {
+  const base = p.base as Record<string, unknown> | undefined;
+  const head = p.head as Record<string, unknown> | undefined;
+  const user = p.user as Record<string, unknown> | undefined;
+  return {
+    number: (p.number as number) ?? 0,
+    title: (p.title as string) ?? "",
+    body: (p.body as string) ?? "",
+    state: p.state === "closed" ? ("closed" as const) : ("open" as const),
+    merged: (p.merged_at as string | null) != null,
+    mergedAt: (p.merged_at as string | null) ?? null,
+    base: (base?.ref as string) ?? "main",
+    head: (head?.ref as string) ?? "",
+    headSha: (head?.sha as string) ?? "",
+    htmlUrl: (p.html_url as string) ?? "",
+    author: (user?.login as string) ?? "",
+  };
+}
+
 /**
  * Fetches the first PR matching a branch head (open or closed).
  * Returns null when no PR exists yet for that branch.
@@ -115,24 +135,41 @@ export function usePrByBranch(args: RepoArgs & { branch: string | null }) {
     select: (r) => {
       const arr = extractPullRequestList(r);
       if (arr.length === 0) return null;
-      const p = arr[0]!;
-      const base = p.base as Record<string, unknown> | undefined;
-      const head = p.head as Record<string, unknown> | undefined;
-      const user = p.user as Record<string, unknown> | undefined;
-      return {
-        number: (p.number as number) ?? 0,
-        title: (p.title as string) ?? "",
-        body: (p.body as string) ?? "",
-        state: p.state === "closed" ? ("closed" as const) : ("open" as const),
-        merged: (p.merged_at as string | null) != null,
-        mergedAt: (p.merged_at as string | null) ?? null,
-        base: (base?.ref as string) ?? "main",
-        head: (head?.ref as string) ?? "",
-        headSha: (head?.sha as string) ?? "",
-        htmlUrl: (p.html_url as string) ?? "",
-        author: (user?.login as string) ?? "",
-      };
+      return mapRawPr(arr[0]!);
     },
+  });
+}
+
+/**
+ * Lists all OPEN pull requests for the repo (most recent first, as GitHub
+ * returns them). Powers the branch picker's "PRs" tab — selecting a PR is
+ * equivalent to selecting its head branch (a PR is just a branch).
+ */
+export function useOpenPrs(args: RepoArgs & { enabled?: boolean }) {
+  const client = useMCPClient({
+    connectionId: args.connectionId,
+    orgId: args.orgId,
+    orgSlug: args.orgSlug,
+  });
+
+  return useMCPToolCallQuery<PrSummary[]>({
+    client,
+    toolName: "list_pull_requests",
+    toolArguments: {
+      owner: args.owner,
+      repo: args.repo,
+      state: "open",
+      perPage: 50,
+    },
+    enabled:
+      (args.enabled ?? true) &&
+      !!args.connectionId &&
+      !!args.owner &&
+      !!args.repo,
+    refetchInterval: POLL,
+    refetchIntervalInBackground: false,
+    staleTime: STALE,
+    select: (r) => extractPullRequestList(r).map(mapRawPr),
   });
 }
 

--- a/apps/mesh/src/web/hooks/use-members.ts
+++ b/apps/mesh/src/web/hooks/use-members.ts
@@ -8,7 +8,9 @@
 import { useOrgAuthClient } from "@/web/hooks/use-org-auth-client";
 import { KEYS } from "@/web/lib/query-keys";
 import { useProjectContext } from "@decocms/mesh-sdk";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+
+const MEMBERS_STALE_TIME = 5 * 60 * 1000;
 
 /**
  * Hook to get all organization members
@@ -37,5 +39,27 @@ export function useMembers() {
   return useSuspenseQuery({
     queryKey: KEYS.members(locator),
     queryFn: () => orgAuth.organization.listMembers(),
+  });
+}
+
+/**
+ * Non-Suspense variant of {@link useMembers}, sharing the same query key/cache.
+ * Use in components that must render before members resolve (e.g. a picker
+ * trigger that can't be allowed to suspend). `enabled` lets callers defer the
+ * fetch until the data is actually needed.
+ */
+export function useMembersQuery({
+  enabled = true,
+}: {
+  enabled?: boolean;
+} = {}) {
+  const { locator } = useProjectContext();
+  const orgAuth = useOrgAuthClient();
+
+  return useQuery({
+    queryKey: KEYS.members(locator),
+    queryFn: () => orgAuth.organization.listMembers(),
+    staleTime: MEMBERS_STALE_TIME,
+    enabled,
   });
 }


### PR DESCRIPTION
## Summary

Enhances the branch picker (`branch-picker.tsx`) with two additions:

1. **"Last 7 days" group** — aggregates sandbox activity across **all** users (not just the current one) from `sandboxMap`, surfacing recently-active branches most-recent-first, each with a stack of **contributor avatars** (resolved from org members via `listMembers`). "Recent" is derived from `SandboxRecord.createdAt` (7-day window). These branches are de-duped out of "Your branches" / "Other branches in repo".

2. **Branches | PRs toggle** — a compact tab toggle below the search. The **PRs** tab lists all open PRs for the repo via a new `useOpenPrs` hook (`list_pull_requests`, `state: "open"`). Selecting a PR calls `pick(pr.head)` → starts a sandbox on the PR's head branch, since **a PR is just a branch**.

## Changes
- `use-pr-data.ts` — new `useOpenPrs` hook; extracted a shared `mapRawPr` helper (dedups the raw→`PrSummary` mapping with `usePrByBranch`).
- `use-branches.ts` — new `recent` group + `contributors`/`lastActiveAt` on `Branch`, aggregated across all users; recent branches excluded from the other groups.
- `branch-picker.tsx` — tab toggle, PR list UI, contributor avatar stack, `cursor-pointer` on rows.

## Notes / limitations
- PR author is shown as the GitHub `@login` (text), **not** a face — the avatar stack maps org `userId`s from `sandboxMap`, which don't correspond to arbitrary GitHub PR authors. Real PR-author avatars would need the GitHub avatar (GraphQL), out of scope here.
- "Last 7 days" only covers branches with a **Studio sandbox** in the window (uses sandbox `createdAt`, i.e. when the sandbox was started — not last git commit). Plain repo branches without a sandbox stay under "Other branches in repo".

## Testing
- `bun run fmt`, typecheck (`apps/mesh`) and lint pass for the changed files.
- No automated tests: the logic lives inside react-query hooks (not the unit tier); would be e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Last 7 days” group and Branches | PRs tabs in the branch picker to highlight recent org activity and let users start sandboxes from open PRs. Fork PRs are filtered out to avoid broken selections, with a hidden count shown.

- **New Features**
  - “Last 7 days” aggregates all-user sandbox activity from `sandboxMap`, sorts by most recent, shows contributor avatars (resolved via `listMembers`), and de-dupes from “Your branches” and “Other branches”.
  - PRs tab lists all open PRs via `useOpenPrs` (`list_pull_requests`, state: "open"); selecting a PR picks `pr.head`; titles decode HTML; cross-fork PRs are hidden and the hidden count is shown.
  - Branches tab keeps “New”; search and infinite scroll apply only to branches; rows are clickable.

- **Refactors**
  - Extracted `groupBranches(now)` for deterministic recent/yours/others grouping; added unit tests.
  - Introduced `mapRawPr` and `headRepoFullName` in `PrSummary`; unified PR mapping; removed polling in `useOpenPrs` (refetch-on-open + `staleTime`).
  - Reused shared non-suspense `useMembersQuery` for avatar data.

<sup>Written for commit f4b9271a87dedc50e7c7d5e00467c88ed50556c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

