### PR TITLE
refactor(preview): dedupe iframe reload-with-fallback logic

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -222,6 +222,22 @@ function withDeviceHint(url: string, device: PreviewDeviceSize): string {
   return parsed.href;
 }
 
+/**
+ * Reload the iframe in place; falls back to reassigning `src` when the
+ * iframe's live location is cross-origin (sandbox preview domain) and
+ * `.reload()` throws.
+ */
+function reloadIframeOrFallback(
+  iframe: HTMLIFrameElement,
+  fallbackSrc: string | null,
+) {
+  try {
+    iframe.contentWindow?.location.reload();
+  } catch {
+    if (fallbackSrc) iframe.src = fallbackSrc;
+  }
+}
+
 export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const isMobile = useIsMobile();
   const navigate = useNavigate();
@@ -705,12 +721,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     iframe.tabIndex = -1;
     iframe.style.pointerEvents = "none";
     iframe.blur();
-    try {
-      iframe.contentWindow?.location.reload();
-    } catch {
-      const src = iframeSrcRef.current;
-      if (src) iframe.src = src;
-    }
+    reloadIframeOrFallback(iframe, iframeSrcRef.current);
     let fallbackTimer: ReturnType<typeof setTimeout>;
     const restore = () => {
       clearTimeout(fallbackTimer);
@@ -1523,12 +1534,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
               setTimeout(() => {
                 const iframe = previewIframeRef.current;
                 if (!iframe) return;
-                try {
-                  iframe.contentWindow?.location.reload();
-                } catch {
-                  const src = iframeSrcRef.current;
-                  if (src) iframe.src = src;
-                }
+                reloadIframeOrFallback(iframe, iframeSrcRef.current);
               }, DEV_SERVER_SETTLE_MS);
             }}
             target={{ kind: "site" }}


### PR DESCRIPTION
**Source:** Reduction found while auditing `apps/mesh/src/web/components/sandbox/preview/preview.tsx` for the sandbox-preview-polishing focus area — not tied to an open issue.

**Why:** `reloadPreviewPreservingScroll` and the `SeoSheet`'s `onSaved` handler both reimplemented the identical "reload the iframe in place, and if `.reload()` throws because the live location is cross-origin, fall back to reassigning `src`" logic verbatim. Collapsing it into one `reloadIframeOrFallback` helper removes the duplication and gives future reload call sites a single place to extend (e.g. if the fallback ever needs to change).

**Change:** Pure extraction, behavior-preserving — same try/catch, same fallback condition, just called from both sites instead of copy-pasted. Net diff: +18/-12 (net +6 lines for the extracted helper + its doc comment, but removes the duplicated 6-line block from two call sites).

**How I verified behavior is unchanged:** Read both call sites; the extracted function is a byte-for-byte lift of the shared block with `iframeSrcRef.current` passed in as `fallbackSrc` (was already a ref read at both sites). No control flow, timing, or dependency changed.

**Command for a reviewer:** `cd apps/mesh && bunx tsc --noEmit` (green). No test file exists for this component (large stateful UI component, not pure logic), so no `bun test` target applies.

**Checks run locally:** `bun run fmt` (clean, no changes needed) and `bunx tsc --noEmit` in `apps/mesh` (clean). Full CI validates lint and the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped the iframe reload-with-fallback logic in the sandbox preview by extracting a shared helper. Both `reloadPreviewPreservingScroll` and the SEO sheet’s `onSaved` now use it to reload in place and fall back to reassigning `src` when cross-origin reload throws; behavior unchanged.

<sup>Written for commit affb9e892b2194defcf53fb45523851990cd6685. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

