### PR TITLE
fix(registry): block IPv4-compatible IPv6 addresses in discover-tools SSRF guard

### DIFF
--- a/apps/mesh/src/tools/registry/discover-tools.test.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.test.ts
@@ -36,6 +36,16 @@ describe("isPrivateUrl", () => {
     expect(isPrivateUrl("http://[64:ff9b::169.254.169.254]/")).toBe(true);
   });
 
+  it("blocks a private IPv4 embedded via deprecated IPv4-compatible IPv6 (::a.b.c.d)", () => {
+    // `new URL()` normalizes ::127.0.0.1 to ::7f00:1 before isPrivateUrl sees
+    // it — the old dotted-quad regex never matched, silently letting these
+    // through despite looking like an active guard.
+    expect(isPrivateUrl("http://[::127.0.0.1]/")).toBe(true);
+    expect(isPrivateUrl("http://[::10.0.0.5]/")).toBe(true);
+    expect(isPrivateUrl("http://[::192.168.1.1]/")).toBe(true);
+    expect(isPrivateUrl("http://[::100.100.100.200]/")).toBe(true);
+  });
+
   it("does not block a public IPv4 embedded via 6to4/NAT64", () => {
     // 2002:0808:0808:: embeds 8.8.8.8
     expect(isPrivateUrl("http://[2002:808:808::]/")).toBe(false);
@@ -45,5 +55,6 @@ describe("isPrivateUrl", () => {
   it("does not block ordinary public URLs", () => {
     expect(isPrivateUrl("https://example.com/mcp")).toBe(false);
     expect(isPrivateUrl("http://8.8.8.8/")).toBe(false);
+    expect(isPrivateUrl("http://[::8.8.8.8]/")).toBe(false);
   });
 });

--- a/apps/mesh/src/tools/registry/discover-tools.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.ts
@@ -48,6 +48,15 @@ function isPrivateEmbeddedIPv4(ipv6: string): boolean {
     if (isPrivateIPv4Octets(a, b)) return true;
   }
 
+  // IPv4-compatible IPv6 (deprecated, RFC 4291): dotted ::a.b.c.d input is
+  // always normalized by `new URL()` into compressed hex (e.g. ::127.0.0.1
+  // becomes ::7f00:1) before we ever see the hostname, so it collapses to
+  // exactly "::" + 2 hex words — same shape as the 6to4 case above.
+  if (ipv6.startsWith("::") && groups.length === 2) {
+    const [a, b] = hexWordToIPv4(groups[0]!);
+    if (isPrivateIPv4Octets(a, b)) return true;
+  }
+
   return false;
 }
 
@@ -81,12 +90,6 @@ export function isPrivateUrl(url: string): boolean {
       if (ipv6.startsWith("100:")) return true;
       if (ipv6.startsWith("::1")) return true;
       if (isPrivateEmbeddedIPv4(ipv6)) return true;
-
-      const v4compat = ipv6.match(/^::(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
-      if (v4compat) {
-        const [, a] = v4compat.map(Number);
-        if (a === 127 || a === 10 || a === 0) return true;
-      }
     }
 
     return false;


### PR DESCRIPTION
Follows #4961 (the RFC 6598 CGNAT SSRF hardening merged this tick) — same file, same guard, a related bypass in the IPv6 handling right below it.

**The bug:** `isPrivateUrl`'s `v4compat` branch matched a literal dotted-quad after `::` via `/^::(\d+)\.(\d+)\.(\d+)\.(\d+)$/`, but `new URL()` always normalizes that notation into compressed hex before the hostname ever reaches this function — `::127.0.0.1` becomes `::7f00:1`, `::192.168.1.1` becomes `::c0a8:101`, etc. The regex can never match, so this branch was dead code that looked like an active guard. Verified directly: `isPrivateUrl("http://[::127.0.0.1]/")` returned `false` before this fix (should be `true`) — same for `10.x`, `192.168.x`, and the just-added `100.64.0.0/10` CGNAT range, all reachable through this deprecated IPv6 notation, none of them caught by any other branch in the function.

**The fix:** decode the embedded IPv4 from the already-normalized hex form (`::WWWW:XXXX` → 2 trailing hex groups after `::`), reusing the same `hexWordToIPv4`/`isPrivateIPv4Octets` helpers already used for the 6to4/NAT64 cases immediately above it in the same function — no new logic shape, just fixing the input pattern to match what the hostname actually looks like at this point.

**Regression tests added** in `discover-tools.test.ts`: `[::127.0.0.1]`, `[::10.0.0.5]`, `[::192.168.1.1]`, `[::100.100.100.200]` now correctly block, and `[::8.8.8.8]` (public) still passes through.

Reviewer check: `bun test apps/mesh/src/tools/registry/discover-tools.test.ts` (8 pass, 0 fail).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in `apps/mesh` (clean), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SSRF guard to correctly block IPv4-compatible IPv6 hosts (e.g., [::127.0.0.1]) that were bypassing due to URL normalization. We now decode the embedded IPv4 from the normalized hex form and block private ranges as intended.

- **Bug Fixes**
  - Decode IPv4 from normalized `::WWWW:XXXX` and reuse existing `hexWordToIPv4`/`isPrivateIPv4Octets` helpers.
  - Remove the unreachable dotted-quad regex branch.
  - Add regression tests for `[::127.0.0.1]`, `[::10.0.0.5]`, `[::192.168.1.1]`, `[::100.100.100.200]`; ensure `[::8.8.8.8]` still allowed.

<sup>Written for commit 5aca4a344d1eca31c53f0e2bc0dcac537792b19a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

