### PR TITLE
fix(chat): return the real outcome from voice startRecording instead of a stale status read

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -287,17 +287,16 @@ export function ChatInput({
 
   const handleVoiceStart = async () => {
     voiceBaselineDocRef.current = tiptapDoc;
-    await voice.startRecording();
-    // Fire with the real outcome — voice.status is set inside startRecording
-    // before the promise resolves ("recording" on success, "unsupported" or
-    // "permission-denied" on failure). Button click on its own doesn't tell
-    // us if the mic actually started.
+    // Fire with the real outcome returned by startRecording — reading
+    // voice.status here instead would be a stale closure over the status
+    // from before the click, since setState doesn't mutate it in place.
+    const finalStatus = await voice.startRecording();
     const outcome =
-      voice.status === "recording"
+      finalStatus === "recording"
         ? "started"
-        : voice.status === "unsupported"
+        : finalStatus === "unsupported"
           ? "unsupported"
-          : voice.status === "permission-denied"
+          : finalStatus === "permission-denied"
             ? "permission_denied"
             : "unknown";
     track("chat_voice_started", { thread_id: taskId, outcome });

--- a/apps/mesh/src/web/hooks/use-voice-input.test.ts
+++ b/apps/mesh/src/web/hooks/use-voice-input.test.ts
@@ -1,0 +1,61 @@
+import { setupComponentTest } from "../../test/setup";
+setupComponentTest();
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+import { useVoiceInput } from "./use-voice-input";
+
+describe("useVoiceInput.startRecording", () => {
+  const win = window as unknown as Record<string, unknown>;
+  let originalSpeechRecognition: unknown;
+
+  beforeEach(() => {
+    originalSpeechRecognition = win.SpeechRecognition;
+  });
+
+  afterEach(() => {
+    win.SpeechRecognition = originalSpeechRecognition;
+    delete win.webkitSpeechRecognition;
+  });
+
+  it("resolves 'unsupported' when the browser has no SpeechRecognition", async () => {
+    delete win.SpeechRecognition;
+    delete win.webkitSpeechRecognition;
+
+    const { result } = renderHook(() => useVoiceInput());
+
+    let outcome: string | undefined;
+    await act(async () => {
+      outcome = await result.current.startRecording();
+    });
+
+    expect(outcome).toBe("unsupported");
+    expect(result.current.status).toBe("unsupported");
+  });
+
+  it("resolves 'permission-denied' when getUserMedia rejects", async () => {
+    win.SpeechRecognition =
+      function () {} as unknown as typeof SpeechRecognition;
+    const originalGetUserMedia = navigator.mediaDevices?.getUserMedia;
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: {
+        getUserMedia: () => Promise.reject(new Error("denied")),
+      },
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useVoiceInput());
+
+    let outcome: string | undefined;
+    await act(async () => {
+      outcome = await result.current.startRecording();
+    });
+
+    expect(outcome).toBe("permission-denied");
+    expect(result.current.status).toBe("permission-denied");
+
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia: originalGetUserMedia },
+      configurable: true,
+    });
+  });
+});

--- a/apps/mesh/src/web/hooks/use-voice-input.ts
+++ b/apps/mesh/src/web/hooks/use-voice-input.ts
@@ -2,21 +2,25 @@ import { useRef, useState } from "react";
 
 const WAVEFORM_BARS = 48;
 
+export type VoiceInputStatus =
+  | "idle"
+  | "recording"
+  | "unsupported"
+  | "permission-denied";
+
 export interface UseVoiceInputReturn {
-  status: "idle" | "recording" | "unsupported" | "permission-denied";
+  status: VoiceInputStatus;
   transcript: string;
   interimTranscript: string;
   waveformData: number[];
   isSupported: boolean;
-  startRecording: () => Promise<void>;
+  startRecording: () => Promise<VoiceInputStatus>;
   stopRecording: () => string;
   cancelRecording: () => void;
 }
 
 export function useVoiceInput(): UseVoiceInputReturn {
-  const [status, setStatus] = useState<
-    "idle" | "recording" | "unsupported" | "permission-denied"
-  >("idle");
+  const [status, setStatus] = useState<VoiceInputStatus>("idle");
   const [transcript, setTranscript] = useState("");
   const [interimTranscript, setInterimTranscript] = useState("");
   const [waveformData, setWaveformData] = useState<number[]>(() =>
@@ -82,14 +86,14 @@ export function useVoiceInput(): UseVoiceInputReturn {
     tick();
   };
 
-  const startRecording = async () => {
+  const startRecording = async (): Promise<VoiceInputStatus> => {
     const SpeechRecognitionCtor =
       (window as unknown as Record<string, unknown>).SpeechRecognition ||
       (window as unknown as Record<string, unknown>).webkitSpeechRecognition;
 
     if (!SpeechRecognitionCtor) {
       setStatus("unsupported");
-      return;
+      return "unsupported";
     }
 
     // Request microphone permission first — this triggers the browser prompt
@@ -98,7 +102,7 @@ export function useVoiceInput(): UseVoiceInputReturn {
       stream = await navigator.mediaDevices.getUserMedia({ audio: true });
     } catch {
       setStatus("permission-denied");
-      return;
+      return "permission-denied";
     }
 
     setTranscript("");
@@ -152,7 +156,9 @@ export function useVoiceInput(): UseVoiceInputReturn {
       recognition.start();
     } catch {
       setStatus("idle");
+      return "idle";
     }
+    return "recording";
   };
 
   const stopRecording = (): string => {


### PR DESCRIPTION
**Source:** bug found while auditing `apps/mesh/src/web/components/chat/input.tsx` (chat input overhaul focus area).

**Why a maintainer wants it:** the `chat_voice_started` analytics event is meant to record whether the mic actually started (per an explicit comment: "Fire with the real outcome"), but it silently always reports `unknown` today, so the unsupported/permission-denied/success breakdown in that event is dead data.

**Failure scenario:** `handleVoiceStart` in `input.tsx` does `await voice.startRecording(); ... voice.status === "recording" ? ...`. `voice` is the object returned by `useVoiceInput()` for the render that was active when the button was clicked — it's a plain closure, not a ref, so `voice.status` inside this async function stays frozen at whatever it was before the click (always `"idle"`). Meanwhile `startRecording()` calls `setStatus(...)` internally, which only updates state for the *next* render, and schedules a fresh `handleVoiceStart` closure that this in-flight call never sees. Net effect: none of the three status checks ever match, so every voice-start attempt (success, unsupported browser, denied permission) gets tracked as `outcome: "unknown"`.

**Fix:** `startRecording()` now returns the terminal `VoiceInputStatus` it reached (`"recording" | "unsupported" | "permission-denied" | "idle"`) instead of `Promise<void>`, and `handleVoiceStart` branches on that returned value instead of re-reading the stale `voice.status`. Added `apps/mesh/src/web/hooks/use-voice-input.test.ts` covering the unsupported and permission-denied paths via `renderHook`, asserting the exact bug (return value now matches the resulting status) — these are the two paths that were silently broken.

**Reviewer check:** `bun test apps/mesh/src/web/hooks/use-voice-input.test.ts` (2 pass).

**Locally verified:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes voice input analytics to report the real outcome by returning the final status from `startRecording` and using it in `ChatInput` instead of reading a stale `voice.status`. Adds tests for unsupported and permission-denied cases.

- **Bug Fixes**
  - `useVoiceInput.startRecording` now returns `VoiceInputStatus` (`"recording" | "unsupported" | "permission-denied" | "idle"`).
  - `ChatInput` computes `chat_voice_started` from the returned status to avoid stale closure reads.
  - Added `apps/mesh/src/web/hooks/use-voice-input.test.ts` covering unsupported and permission-denied paths.

- **Migration**
  - Update any `startRecording()` call sites to handle the returned `VoiceInputStatus` instead of assuming `Promise<void>`.

<sup>Written for commit d9a462d45d43912d77186f974bd6ec6f8050550a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

