### PR TITLE
refactor(agent-icon): dedupe icon-name search filter into shared helper

### DIFF
--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -240,6 +240,18 @@ export function humanizeIconName(name: string): string {
     .toLowerCase();
 }
 
+/** Filter icon names by search term, matching raw and humanized forms. */
+export function filterIconNames(names: string[], search: string): string[] {
+  const trimmed = search.trim();
+  if (!trimmed) return names;
+  const searchLower = trimmed.toLowerCase();
+  return names.filter(
+    (name) =>
+      humanizeIconName(name).includes(searchLower) ||
+      name.toLowerCase().includes(searchLower),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Hash utility
 // ---------------------------------------------------------------------------

--- a/apps/mesh/src/web/components/icon-picker.tsx
+++ b/apps/mesh/src/web/components/icon-picker.tsx
@@ -22,10 +22,10 @@ import {
   AgentAvatar,
   buildIconString,
   buildImageIconString,
+  filterIconNames,
   getIconColor,
   getIconComponent,
   getIconNames,
-  humanizeIconName,
   parseIconString,
   type AgentAvatarSize,
 } from "./agent-icon";
@@ -285,17 +285,7 @@ function IconsTab({
 }) {
   const allNames = getIconNames();
   const color = getIconColor(selectedColor);
-
-  const filteredNames = search.trim()
-    ? allNames.filter((name) => {
-        const humanized = humanizeIconName(name);
-        const searchLower = search.toLowerCase();
-        return (
-          humanized.includes(searchLower) ||
-          name.toLowerCase().includes(searchLower)
-        );
-      })
-    : allNames;
+  const filteredNames = filterIconNames(allNames, search);
 
   return (
     <div className="flex flex-col">

--- a/apps/mesh/src/web/components/simple-icon-picker.tsx
+++ b/apps/mesh/src/web/components/simple-icon-picker.tsx
@@ -17,6 +17,7 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { LayoutLeft, SearchMd } from "@untitledui/icons";
 import { useState } from "react";
 import {
+  filterIconNames,
   getIconComponent,
   getIconNames,
   humanizeIconName,
@@ -54,15 +55,7 @@ export function SimpleIconPicker({
   const currentIconName = parsed.type === "icon" ? parsed.name : null;
 
   const allNames = getIconNames();
-  const filteredNames = search.trim()
-    ? allNames.filter((n) => {
-        const searchLower = search.toLowerCase();
-        return (
-          humanizeIconName(n).includes(searchLower) ||
-          n.toLowerCase().includes(searchLower)
-        );
-      })
-    : allNames;
+  const filteredNames = filterIconNames(allNames, search);
 
   return (
     <Popover open={disabled ? false : open} onOpenChange={setOpen}>


### PR DESCRIPTION
## Summary

`icon-picker.tsx` and `simple-icon-picker.tsx` each hand-rolled the identical icon-name search filter (match against both the raw `@untitledui/icons` export name and its humanized form). Extracted the shared logic into `filterIconNames()` in `agent-icon.tsx` and pointed both call sites at it.

This is a pure C1 reduction — no color-palette or accessibility changes (the design-token collapse in #4910 was reverted in #4928 for breaking icon contrast/legacy color names, so this PR intentionally leaves the palette untouched), and no overlap with the open aria-label PR #4948 (different lines in both files).

## Why

Same filter predicate copy-pasted in two files is exactly the kind of drift-prone duplication the repo wants collapsed into one home — a future tweak to the matching rule (e.g. fuzzy match) now only needs to change in one place.

## Verification

- Net line delta: -21 / +16 (removes the two duplicated filter blocks, adds one shared function)
- Behavior unchanged: same predicate (`humanizeIconName(name).includes(searchLower) || name.toLowerCase().includes(searchLower)`), same early-return-all-names-when-search-is-blank behavior, just called from a single shared function instead of two inline copies
- `bun run fmt` — clean, no changes needed
- `cd apps/mesh && bunx tsc --noEmit` — passes with no errors

## To confirm

Open the icon picker (agent/virtual-MCP icon editor) and the simple icon picker, type in the search box, and confirm filtering still matches on both raw icon names (e.g. "SearchMd") and humanized names (e.g. "search md") exactly as before.

Full CI suite (typecheck across all workspaces, lint, tests) will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated the icon-name search logic by introducing a shared `filterIconNames()` helper in `agent-icon.tsx`. This removes duplicate code in both pickers and keeps filtering behavior the same (raw and humanized name matches).

- **Refactors**
  - Added `filterIconNames(names, search)` in `agent-icon.tsx`.
  - Replaced inline filters in `icon-picker.tsx` and `simple-icon-picker.tsx`.
  - Behavior unchanged: matches raw and humanized names; empty search returns all.

<sup>Written for commit b7a4b232e99cfa2d8c4f2cd2cb1531f287b7f46a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

