### PR TITLE
refactor(sections-editor): extract array-item row renderers into their own module

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-field.tsx
@@ -13,33 +13,11 @@ import {
 import {
   SortableContext,
   sortableKeyboardCoordinates,
-  useSortable,
   verticalListSortingStrategy,
   arrayMove,
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import {
-  Copy01,
-  DotsGrid,
-  DotsHorizontal,
-  Eye,
-  EyeOff,
-  Plus,
-  Trash01,
-} from "@untitledui/icons";
+import { Plus } from "@untitledui/icons";
 import { toast } from "sonner";
-import { Button } from "@deco/ui/components/button.tsx";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@deco/ui/components/dropdown-menu.tsx";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { getArrayItemImageSrc, getArrayItemLabel } from "../array-item-display";
 import {
@@ -64,6 +42,7 @@ import {
   resizeArrayEntries,
 } from "./array-entries";
 import type { FieldProps } from "./field-props";
+import { ArrayRowContent, SortableArrayRow } from "./array-row";
 import { SchemaForm, renderField } from "../schema-form";
 import {
   resolveSchema,
@@ -116,161 +95,6 @@ function itemEditorSchema(
 function arrayFieldKeyFromPath(path: string): string {
   const segments = path.split(".").filter((segment) => !/^\d+$/.test(segment));
   return segments[segments.length - 1] ?? path;
-}
-
-function ArrayRowContent({
-  labelText,
-  imageSrc,
-}: {
-  labelText: string;
-  imageSrc?: string;
-}) {
-  return (
-    <>
-      <DotsGrid className="size-3.5 shrink-0 text-muted-foreground/40" />
-      <div className="flex min-w-0 flex-1 items-center gap-2.5 text-sm">
-        {imageSrc && (
-          <img
-            src={imageSrc}
-            alt=""
-            referrerPolicy="no-referrer"
-            className="h-12 max-w-[100px] shrink-0 rounded object-cover"
-          />
-        )}
-        <span className="min-w-0 truncate">{labelText}</span>
-      </div>
-    </>
-  );
-}
-
-function SortableArrayRow({
-  sortableId,
-  labelText,
-  imageSrc,
-  hidden,
-  onToggleHidden,
-  onOpen,
-  onDuplicate,
-  onRemove,
-}: {
-  sortableId: string;
-  labelText: string;
-  imageSrc?: string;
-  hidden?: boolean;
-  onToggleHidden?: () => void;
-  onOpen: () => void;
-  onDuplicate: () => void;
-  onRemove: () => void;
-}) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } =
-    useSortable({
-      id: sortableId,
-      animateLayoutChanges: () => false,
-    });
-
-  const style = {
-    transform: CSS.Transform.toString(
-      transform ? { ...transform, x: 0 } : null,
-    ),
-    opacity: isDragging ? 0 : undefined,
-  };
-
-  return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      {...attributes}
-      {...listeners}
-      role="button"
-      tabIndex={0}
-      onClick={onOpen}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onOpen();
-        }
-      }}
-      className={cn(
-        "group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground touch-none",
-        isDragging ? "cursor-grabbing" : "cursor-pointer",
-      )}
-      title={labelText}
-    >
-      <DotsGrid className="size-3.5 shrink-0 text-muted-foreground/40" />
-      {imageSrc && (
-        <img
-          src={imageSrc}
-          alt=""
-          referrerPolicy="no-referrer"
-          className="h-12 max-w-[100px] shrink-0 rounded object-cover"
-        />
-      )}
-      <span
-        className={cn(
-          "min-w-0 flex-1 truncate text-sm",
-          hidden && "line-through opacity-50",
-        )}
-      >
-        {labelText}
-      </span>
-      {onToggleHidden && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label={hidden ? "Show item" : "Hide item"}
-              className={cn(
-                "size-6 shrink-0",
-                hidden
-                  ? "opacity-100"
-                  : "opacity-0 transition-opacity group-hover:opacity-100",
-              )}
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleHidden();
-              }}
-              onPointerDown={(e) => e.stopPropagation()}
-            >
-              {hidden ? <EyeOff size={14} /> : <Eye size={14} />}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {hidden ? "Show item" : "Hide item"}
-          </TooltipContent>
-        </Tooltip>
-      )}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label={`Open actions for ${labelText}`}
-            className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
-            onClick={(e) => e.stopPropagation()}
-            onPointerDown={(e) => e.stopPropagation()}
-          >
-            <DotsHorizontal size={14} />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={onDuplicate}>
-            <Copy01 size={14} />
-            Duplicate
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="text-destructive focus:text-destructive"
-            onClick={onRemove}
-          >
-            <Trash01 size={14} />
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
-  );
 }
 
 export function ArrayField({

--- a/apps/mesh/src/web/components/sections-editor/fields/array-row.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/array-row.tsx
@@ -1,0 +1,178 @@
+import {
+  Copy01,
+  DotsGrid,
+  DotsHorizontal,
+  Eye,
+  EyeOff,
+  Trash01,
+} from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@deco/ui/components/dropdown-menu.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+export function ArrayRowContent({
+  labelText,
+  imageSrc,
+}: {
+  labelText: string;
+  imageSrc?: string;
+}) {
+  return (
+    <>
+      <DotsGrid className="size-3.5 shrink-0 text-muted-foreground/40" />
+      <div className="flex min-w-0 flex-1 items-center gap-2.5 text-sm">
+        {imageSrc && (
+          <img
+            src={imageSrc}
+            alt=""
+            referrerPolicy="no-referrer"
+            className="h-12 max-w-[100px] shrink-0 rounded object-cover"
+          />
+        )}
+        <span className="min-w-0 truncate">{labelText}</span>
+      </div>
+    </>
+  );
+}
+
+export function SortableArrayRow({
+  sortableId,
+  labelText,
+  imageSrc,
+  hidden,
+  onToggleHidden,
+  onOpen,
+  onDuplicate,
+  onRemove,
+}: {
+  sortableId: string;
+  labelText: string;
+  imageSrc?: string;
+  hidden?: boolean;
+  onToggleHidden?: () => void;
+  onOpen: () => void;
+  onDuplicate: () => void;
+  onRemove: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useSortable({
+      id: sortableId,
+      animateLayoutChanges: () => false,
+    });
+
+  const style = {
+    transform: CSS.Transform.toString(
+      transform ? { ...transform, x: 0 } : null,
+    ),
+    opacity: isDragging ? 0 : undefined,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className={cn(
+        "group flex min-w-0 items-center gap-2.5 rounded-lg px-2 py-2.5 hover:bg-accent hover:text-accent-foreground touch-none",
+        isDragging ? "cursor-grabbing" : "cursor-pointer",
+      )}
+      title={labelText}
+    >
+      <DotsGrid className="size-3.5 shrink-0 text-muted-foreground/40" />
+      {imageSrc && (
+        <img
+          src={imageSrc}
+          alt=""
+          referrerPolicy="no-referrer"
+          className="h-12 max-w-[100px] shrink-0 rounded object-cover"
+        />
+      )}
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-sm",
+          hidden && "line-through opacity-50",
+        )}
+      >
+        {labelText}
+      </span>
+      {onToggleHidden && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={hidden ? "Show item" : "Hide item"}
+              className={cn(
+                "size-6 shrink-0",
+                hidden
+                  ? "opacity-100"
+                  : "opacity-0 transition-opacity group-hover:opacity-100",
+              )}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleHidden();
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              {hidden ? <EyeOff size={14} /> : <Eye size={14} />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {hidden ? "Show item" : "Hide item"}
+          </TooltipContent>
+        </Tooltip>
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={`Open actions for ${labelText}`}
+            className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <DotsHorizontal size={14} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={onDuplicate}>
+            <Copy01 size={14} />
+            Duplicate
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={onRemove}
+          >
+            <Trash01 size={14} />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}


### PR DESCRIPTION
## Why
The sections-editor area (apps/mesh/src/web/components/sections-editor) is flagged as a God-component debt hotspot. `fields/array-field.tsx` (704 lines) defined two fully self-contained, props-only presentational components — `ArrayRowContent` (the drag-overlay row) and `SortableArrayRow` (the sortable list row) — inline, ahead of the `ArrayField` component itself. Neither reads or closes over any of `ArrayField`'s local state (`openIndex`, entries, etc.), so they're a clean, byte-identical relocation, not a rewrite.

## What changed
- Moved `ArrayRowContent` and `SortableArrayRow` verbatim into a new `fields/array-row.tsx`, along with their exact imports (dnd-kit's `useSortable`/`CSS`, the icon set, `Button`/`Tooltip`/`DropdownMenu`, `cn`).
- `array-field.tsx` now imports both from `./array-row` and dropped the now-unused imports.
- Net: -178/+180 lines, same total logic, just relocated — no behavior change.

## How to verify
- `cd apps/mesh && bunx tsc --noEmit` — passes.
- `bun run fmt` — clean, no reformatting needed beyond this diff.
- Visual diff of the two extracted functions vs. their new location is identical (only import list changed).

## Local checks run
- `bunx tsc --noEmit` in `apps/mesh` (green)
- `bun run fmt` (clean)
- No existing test file covers `array-field.tsx` directly (only `array-entries.test.ts`, unaffected pure-logic tests, still pass by inspection since untouched); full CI will run the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the array row renderers from `fields/array-field.tsx` into `fields/array-row.tsx` to slim the file and make the row UI reusable and easier to test. No behavior change; sorting and actions work as before.

- **Refactors**
  - Added `fields/array-row.tsx` with `ArrayRowContent` and `SortableArrayRow`, along with `@dnd-kit/sortable`, `@dnd-kit/utilities`, icon, and UI imports.
  - Updated `fields/array-field.tsx` to import from `./array-row` and removed unused imports.

<sup>Written for commit f7940e31f4f0b6decffd1794fce9dede4b7fce77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

