### PR TITLE
fix(agent-icon): reset image-load-error fallback when the icon URL changes

### DIFF
--- a/apps/mesh/src/web/components/agent-icon.test.tsx
+++ b/apps/mesh/src/web/components/agent-icon.test.tsx
@@ -1,0 +1,32 @@
+import { setupComponentTest } from "../../test/setup";
+setupComponentTest();
+
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "bun:test";
+import { AgentAvatar } from "./agent-icon";
+
+describe("AgentAvatar", () => {
+  it("recovers after an image load error once a new URL is set", () => {
+    const { container, rerender } = render(
+      <AgentAvatar icon="https://example.com/broken.png" name="Test Agent" />,
+    );
+
+    const brokenImg = container.querySelector("img");
+    expect(brokenImg).toBeInTheDocument();
+    fireEvent.error(brokenImg!);
+
+    // Falls back to the deterministic icon avatar (no <img>).
+    expect(container.querySelector("img")).not.toBeInTheDocument();
+
+    rerender(
+      <AgentAvatar icon="https://example.com/good.png" name="Test Agent" />,
+    );
+
+    // A new URL must render as an image again, not stay stuck on fallback.
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      "https://example.com/good.png",
+    );
+  });
+});

--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -358,6 +358,9 @@ export function AgentAvatar({
   if (parsed.type === "url") {
     return (
       <AgentAvatarImage
+        // Remount on URL change so a prior load failure doesn't stick
+        // around as a permanent fallback once the user picks a new image.
+        key={parsed.url}
         url={parsed.url}
         color={parsed.color}
         name={name}


### PR DESCRIPTION
A bug I found while reading `apps/mesh/src/web/components/agent-icon.tsx` (this tick's focus area).

**Bug**: `AgentAvatarImage`'s `errored` state (`useState(false)`, set via the `<img>`'s `onError`) is never reset. Every caller (`IconPicker`'s live preview, `AgentAvatar` used across the app) re-renders the *same* `AgentAvatarImage` instance whenever the `icon` prop's URL changes — React keeps the instance since it's the same component type at the same tree position. So once a single image URL fails to load once, the component permanently falls back to the deterministic icon avatar: any later (perfectly valid) image URL set for that same avatar slot will never render, because `errored` stays `true` forever.

**Failure scenario**: open the icon picker, paste a broken/unreachable image URL (fails to load → falls back to icon), then paste a working image URL in the same picker session. The working image never shows — it's stuck showing the fallback icon.

**Fix**: key the `AgentAvatarImage` element by `url` in `AgentAvatar`'s "url" branch, so React remounts (and resets `errored` to `false`) whenever the icon URL actually changes.

**Regression test**: `apps/mesh/src/web/components/agent-icon.test.tsx` — renders `AgentAvatar` with a broken URL, fires the `<img>`'s error event (fallback icon shows, no `<img>`), then re-renders with a different URL and asserts the `<img>` renders again. Verified the test fails without the fix (stashed the fix, test failed as expected) and passes with it.

**Reviewer check**: `bun test apps/mesh/src/web/components/agent-icon.test.tsx`

**Local verification**: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (both clean), plus the targeted test above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where avatar images stayed on the fallback after one load error. Changing to a working URL now renders the image correctly.

- **Bug Fixes**
  - Keyed `AgentAvatarImage` by URL in `AgentAvatar` to remount and reset the `errored` state on URL change.
  - Added a regression test to confirm the image renders again after a prior error.

<sup>Written for commit 3a0cc154586c7b5dfb2c47456cfe03702f2203ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

