### PR TITLE
fix(registry): apply the SSRF private-URL guard to monitor connections

### DIFF
--- a/apps/mesh/src/tools/registry/monitor-connection-sync.ts
+++ b/apps/mesh/src/tools/registry/monitor-connection-sync.ts
@@ -55,10 +55,20 @@ export const REGISTRY_MONITOR_CONNECTION_SYNC = defineTool({
     let created = 0;
     for (const item of targets) {
       if (!item.server.remotes?.some((r) => r.url)) continue;
-      await ensureMonitorConnection(
-        ctx as Parameters<typeof ensureMonitorConnection>[0],
-        item,
-      );
+      try {
+        await ensureMonitorConnection(
+          ctx as Parameters<typeof ensureMonitorConnection>[0],
+          item,
+        );
+      } catch (error) {
+        // One item's URL failing validation (e.g. a private-network SSRF
+        // target) must not abort syncing the rest of the batch.
+        console.warn(
+          `[REGISTRY_MONITOR_CONNECTION_SYNC] Skipping ${item.id}:`,
+          error instanceof Error ? error.message : error,
+        );
+        continue;
+      }
       if (!existingByItem.has(item.id)) created += 1;
     }
 

--- a/apps/mesh/src/tools/registry/monitor-run-start.test.ts
+++ b/apps/mesh/src/tools/registry/monitor-run-start.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { PrivateRegistryItemEntity } from "@/storage/registry";
+import { ensureMonitorConnection } from "./monitor-run-start";
+
+function makeItem(url: string): PrivateRegistryItemEntity {
+  return {
+    id: "item-1",
+    title: "Test item",
+    description: null,
+    server: { name: "test", remotes: [{ type: "http", url }] },
+    is_public: true,
+    is_unlisted: false,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function makeCtx(create = mock(async () => ({ id: "conn-1" }))) {
+  return {
+    organization: { id: "org-1" },
+    user: { id: "user-1" },
+    storage: {
+      registry: {
+        monitorConnections: {
+          findByItemId: mock(async () => null),
+          upsert: mock(async () => {}),
+        },
+      },
+      connections: {
+        findById: mock(async () => null),
+        create,
+      },
+    },
+  } as unknown as Parameters<typeof ensureMonitorConnection>[0];
+}
+
+describe("ensureMonitorConnection", () => {
+  it("refuses to create a connection for a private-network remote URL", async () => {
+    // Publish requests carry an unreviewed, user-supplied URL — without this
+    // guard the monitor connects server-side to whatever was submitted.
+    const create = mock(async () => ({ id: "conn-1" }));
+    const ctx = makeCtx(create);
+    const item = makeItem("http://169.254.169.254/latest/meta-data/");
+
+    await expect(ensureMonitorConnection(ctx, item)).rejects.toThrow(
+      /private network/,
+    );
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("creates a connection for an ordinary public remote URL", async () => {
+    const create = mock(async () => ({ id: "conn-1" }));
+    const ctx = makeCtx(create);
+    const item = makeItem("https://example.com/mcp");
+
+    const connectionId = await ensureMonitorConnection(ctx, item);
+
+    expect(connectionId).toBe("conn-1");
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mesh/src/tools/registry/monitor-run-start.ts
+++ b/apps/mesh/src/tools/registry/monitor-run-start.ts
@@ -10,6 +10,7 @@ import {
   type ToolSet,
 } from "ai";
 import { z } from "zod";
+import { isPrivateUrl } from "./discover-tools";
 import {
   MONITOR_AGENT_DEFAULT_SYSTEM_PROMPT,
   PLUGIN_ID,
@@ -748,6 +749,15 @@ export async function ensureMonitorConnection(
   const remoteUrl = getRemoteUrl(item);
   if (!remoteUrl) {
     throw new Error(`Registry item ${item.id} has no remote URL`);
+  }
+  if (isPrivateUrl(remoteUrl)) {
+    // Publish requests carry a remote URL supplied by whoever submitted them —
+    // an untrusted, unreviewed source. Without this guard, the monitor would
+    // create a live connection and have the server itself call out to it,
+    // an SSRF vector into private networks/cloud metadata endpoints.
+    throw new Error(
+      `Registry item ${item.id} targets a private network URL, refusing to create a monitor connection`,
+    );
   }
 
   const userId = resolveUserId(ctx);


### PR DESCRIPTION
Follows the discover-tools SSRF-guard hardening series (#4973, #4961, #4929) — this closes the same class of bug in a different, unguarded code path.

`REGISTRY_DISCOVER_TOOLS` validates every target URL with `isPrivateUrl()` before connecting. `ensureMonitorConnection` (used both by `REGISTRY_MONITOR_CONNECTION_SYNC` and every `REGISTRY_MONITOR_RUN_START` run) had no such check: it takes `item.server.remotes[].url` straight from the registry item — including from **pending publish requests**, i.e. URLs supplied by an unreviewed, potentially external submitter — and has the server itself open a live connection and issue JSON-RPC calls to it. A publish request pointing at `http://169.254.169.254/latest/meta-data/...` or an internal service would get probed by the org's monitor run, a textbook SSRF.

Fix: reuse the existing, already-hardened `isPrivateUrl()` from `discover-tools.ts` inside `ensureMonitorConnection`, refusing to create a connection for a private-network target. Since `REGISTRY_MONITOR_CONNECTION_SYNC` loops over many items, I wrapped its call in a try/catch so one bad item is skipped (logged) instead of aborting the whole batch — `REGISTRY_MONITOR_RUN_START`'s per-item `testSingleItem` already had a try/catch, so it naturally reports the rejected item as an `error` result.

Regression test: `apps/mesh/src/tools/registry/monitor-run-start.test.ts` — asserts `ensureMonitorConnection` rejects a private-network URL without calling `connections.create`, and still creates a connection for an ordinary public URL.

Reviewer check: `bun test apps/mesh/src/tools/registry/monitor-run-start.test.ts` and `bun test apps/mesh/src/tools/registry/discover-tools.test.ts` (unaffected, still green).

Locally ran: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and both targeted test files above — all green. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents SSRF by validating monitor connection URLs with the existing private-network guard. Invalid items are skipped during batch sync instead of aborting the run.

- **Bug Fixes**
  - Use `isPrivateUrl()` in `ensureMonitorConnection` to reject private/internal URLs from unreviewed publish requests, matching `REGISTRY_DISCOVER_TOOLS`.
  - Wrap `REGISTRY_MONITOR_CONNECTION_SYNC` calls in try/catch to skip and log bad items; per-item errors in `REGISTRY_MONITOR_RUN_START` are already handled.
  - Added regression test `apps/mesh/src/tools/registry/monitor-run-start.test.ts` to ensure private URLs are blocked and public URLs still create connections.

<sup>Written for commit 0f5546ab8e9cbf643d2e4356d36f92a65428211b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

