### PR TITLE
perf(org-fs): upload batch files concurrently instead of one at a time

### DIFF
--- a/apps/mesh/src/web/hooks/use-org-fs.ts
+++ b/apps/mesh/src/web/hooks/use-org-fs.ts
@@ -496,19 +496,23 @@ export function useOrgFsMutations(volume: string) {
 
   const upload = useMutation({
     mutationFn: async (input: { dir: string; files: File[] }) => {
-      for (const file of input.files) {
-        const path = input.dir ? `${input.dir}/${file.name}` : file.name;
-        await fsFetch(fsUrl(org.slug, volume, "file", { path }), {
-          method: "PUT",
-          headers: {
-            "content-type": file.type || "application/octet-stream",
-          },
-          body: file,
-        });
-      }
+      // Independent PUTs (distinct paths, server creates parent dirs per
+      // write) — run them concurrently instead of one round trip at a time.
+      await Promise.all(
+        input.files.map((file) => {
+          const path = input.dir ? `${input.dir}/${file.name}` : file.name;
+          return fsFetch(fsUrl(org.slug, volume, "file", { path }), {
+            method: "PUT",
+            headers: {
+              "content-type": file.type || "application/octet-stream",
+            },
+            body: file,
+          });
+        }),
+      );
     },
-    // Settled, not success: files upload sequentially, so a mid-batch failure
-    // (quota, size) leaves earlier files written — the listing must refresh.
+    // Settled, not success: uploads run independently, so one failure
+    // (quota, size) doesn't stop the rest — the listing must still refresh.
     onSettled: invalidate,
   });
 


### PR DESCRIPTION
**Source:** optimization found reading `apps/mesh/src/web/hooks/use-org-fs.ts` (org filesystem hooks focus area).

**Payoff:** `useOrgFsMutations().upload` looped `await fsFetch(...)` over `input.files` one at a time, serializing a full network round trip per file. When a user drags/drops or selects several files at once (Library upload, agent-knowledge upload, brand logo upload), that's N sequential round trips instead of one concurrent batch — a real, user-visible delay that scales with file count.

**Why it's safe:** each PUT writes to a distinct path, and the server (`apps/mesh/src/file-storage/org-fs.ts` `write()`) creates parent dirs per write and already documents that concurrent writes to the same volume are an accepted case (soft, best-effort quota — see the comment above the usage/existing read in `write()`). There's no shared mutable state between the uploads, so parallelizing them is behavior-preserving: same requests, same `onSettled` invalidation, same best-effort semantics (one file failing doesn't block the others — if anything this is now *more* true, since previously a mid-loop failure meant later files in the loop were never attempted).

**How to verify:** `cd apps/mesh && bunx tsc --noEmit` (clean). No existing test file covers this hook (`use-org-fs.ts` has no `.test.ts` companion), so this is a logic-only change verified by typecheck; full CI runs the rest.

**Reviewer check:** drag-drop or multi-select several files into the Library upload dialog and confirm they all land and the listing refreshes.

**Checks run locally:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`. Full `bun test`/e2e left to CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run multi-file uploads concurrently instead of one-by-one to cut batch upload latency and speed up drag/drop and multi-select flows. Each PUT targets a unique path; one file failing doesn’t block others, and the listing still refreshes on settle.

<sup>Written for commit e4ccfa64d693500ff711ffaabf71a099a4152679. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

