### PR TITLE
fix(registry): reset stale image-load-error fallback in monitor connection icon

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.test.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.test.tsx
@@ -1,0 +1,36 @@
+import { setupComponentTest } from "../../../test/setup";
+setupComponentTest();
+
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "bun:test";
+import { ConnectionIcon } from "./monitor-connections-panel";
+
+// Mirrors how ConnectionRow renders ConnectionIcon: keyed by the icon URL so
+// a URL change remounts (and resets) the child's internal error state.
+function KeyedConnectionIcon({ icon }: { icon: string }) {
+  return <ConnectionIcon key={icon} icon={icon} title="Test MCP" />;
+}
+
+describe("ConnectionIcon", () => {
+  it("recovers after an image load error once a new icon URL is set", () => {
+    const { container, rerender } = render(
+      <KeyedConnectionIcon icon="https://example.com/broken.png" />,
+    );
+
+    const brokenImg = container.querySelector("img");
+    expect(brokenImg).toBeInTheDocument();
+    fireEvent.error(brokenImg!);
+
+    // Falls back to the initials avatar (no <img>).
+    expect(container.querySelector("img")).not.toBeInTheDocument();
+
+    rerender(<KeyedConnectionIcon icon="https://example.com/good.png" />);
+
+    // A new URL must render as an image again, not stay stuck on fallback.
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      "https://example.com/good.png",
+    );
+  });
+});

--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -59,6 +59,34 @@ function authBadgeLabel(status: MonitorConnectionAuthStatus) {
   }
 }
 
+export function ConnectionIcon({
+  icon,
+  title,
+}: {
+  icon: string | null;
+  title: string;
+}) {
+  const [iconFailed, setIconFailed] = useState(false);
+
+  return (
+    <div className="size-10 rounded-lg border border-border bg-muted/20 overflow-hidden shrink-0 flex items-center justify-center">
+      {icon && !iconFailed ? (
+        <img
+          src={icon}
+          alt={title}
+          className="h-full w-full object-cover"
+          loading="lazy"
+          onError={() => setIconFailed(true)}
+        />
+      ) : (
+        <span className="text-xs font-semibold text-muted-foreground">
+          {title.charAt(0).toUpperCase()}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function ConnectionRow({
   entry,
   onAuthChanged,
@@ -73,7 +101,6 @@ function ConnectionRow({
   const [busy, setBusy] = useState(false);
   const [tokenValue, setTokenValue] = useState("");
   const [isReplacingToken, setIsReplacingToken] = useState(false);
-  const [iconFailed, setIconFailed] = useState(false);
 
   const updateAuth = useUpdateMonitorConnectionAuth();
   const { updateMutation } = useRegistryMutations();
@@ -300,21 +327,9 @@ function ConnectionRow({
     <Card className="p-3 space-y-3 h-full">
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-3 min-w-0">
-          <div className="size-10 rounded-lg border border-border bg-muted/20 overflow-hidden shrink-0 flex items-center justify-center">
-            {icon && !iconFailed ? (
-              <img
-                src={icon}
-                alt={title}
-                className="h-full w-full object-cover"
-                loading="lazy"
-                onError={() => setIconFailed(true)}
-              />
-            ) : (
-              <span className="text-xs font-semibold text-muted-foreground">
-                {title.charAt(0).toUpperCase()}
-              </span>
-            )}
-          </div>
+          {/* Remount on icon URL change so a prior load failure doesn't stick
+              around as a permanent fallback once a new icon is synced in. */}
+          <ConnectionIcon key={icon ?? title} icon={icon} title={title} />
           <div className="min-w-0">
             <p className="text-sm font-medium truncate">{title}</p>
             <p className="text-xs text-muted-foreground break-all">


### PR DESCRIPTION
Bug found while hunting the registry-monitor UI (`monitor-connections-panel.tsx`) for issues after the recent SSRF-guard hardening pass.

`ConnectionRow`'s `iconFailed` state lived on the row itself. Since the row component instance is reused across re-renders (same connection, same React key), once an icon URL failed to load once, it stayed permanently stuck showing the initials fallback — even if a later `Sync` brought in a different, working icon URL for that same connection. This is the exact same bug just fixed for `AgentAvatarImage` in #4977 ("reset image-load-error fallback when the icon URL changes"), just in a different component that hadn't gotten the same treatment.

Fix: extracted the icon block into its own `ConnectionIcon` component and key it by the icon URL in the parent (`<ConnectionIcon key={icon ?? title} .../>`), so a URL change remounts the component and resets its internal error state — mirroring the `AgentAvatar`/`AgentAvatarImage` pattern.

Regression test: `apps/mesh/src/web/views/registry/monitor-connections-panel.test.tsx` — renders a keyed wrapper (mirroring how `ConnectionRow` uses it), fires an `error` event on the `<img>` to trigger the fallback, then rerenders with a new icon URL and asserts the `<img>` reappears instead of staying stuck on the fallback.

A reviewer can confirm with:
```
bun test apps/mesh/src/web/views/registry/monitor-connections-panel.test.tsx
```

Locally verified: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file above (1 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stale image-load-error state in the registry monitor connection icon so icons recover when the URL changes. Prevents connections from getting stuck on the initials fallback after a failed image load.

- **Bug Fixes**
  - Extracted the icon into a `ConnectionIcon` component keyed by the icon URL to remount and reset its error state.
  - Added a regression test (`apps/mesh/src/web/views/registry/monitor-connections-panel.test.tsx`) that verifies the image re-renders after switching to a working URL.

<sup>Written for commit 9649eff0ba032cfe26465e75a3a11eee7e9b9be2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

