### PR TITLE
fix(org-fs): wait for every concurrent upload to settle before invalidating

### DIFF
--- a/apps/mesh/src/web/hooks/use-org-fs.ts
+++ b/apps/mesh/src/web/hooks/use-org-fs.ts
@@ -498,7 +498,11 @@ export function useOrgFsMutations(volume: string) {
     mutationFn: async (input: { dir: string; files: File[] }) => {
       // Independent PUTs (distinct paths, server creates parent dirs per
       // write) — run them concurrently instead of one round trip at a time.
-      await Promise.all(
+      // Promise.allSettled (not Promise.all): Promise.all rejects as soon as
+      // the first PUT fails, while the rest are still in flight — that would
+      // invalidate the listing (and resolve the caller's catch) before those
+      // uploads landed, silently dropping them from the refreshed view.
+      const results = await Promise.allSettled(
         input.files.map((file) => {
           const path = input.dir ? `${input.dir}/${file.name}` : file.name;
           return fsFetch(fsUrl(org.slug, volume, "file", { path }), {
@@ -510,9 +514,13 @@ export function useOrgFsMutations(volume: string) {
           });
         }),
       );
+      const failure = results.find(
+        (r): r is PromiseRejectedResult => r.status === "rejected",
+      );
+      if (failure) throw failure.reason;
     },
-    // Settled, not success: uploads run independently, so one failure
-    // (quota, size) doesn't stop the rest — the listing must still refresh.
+    // Settled, not success: one failure (quota, size) doesn't stop the rest
+    // — the listing must still refresh once every upload has landed.
     onSettled: invalidate,
   });
 


### PR DESCRIPTION
Follows #4980 ("perf(org-fs): upload batch files concurrently instead of one at a time"), which switched the batch-upload `mutationFn` from sequential PUTs to `Promise.all`.

**Why a maintainer wants this:** `Promise.all` rejects as soon as the *first* PUT fails, without waiting for the sibling uploads still in flight. Because the mutation's `onSettled` fires the moment the returned promise settles, the file-listing query gets invalidated (and a caller's `catch` runs) while other files in the same batch are still being written — so the refreshed listing can silently omit files that land a moment later. Every caller of `useOrgFsMutations().upload` (library browser, file/image fields, brand logo, virtual-mcp knowledge files) is affected whenever a batch has a mix of a failing file (quota/size) and other files still uploading.

**Failure scenario:** drop 5 files where file #1 is oversized and instantly 413s while files #2-#5 (larger, slower) are still uploading. `Promise.all` rejects on file #1, `onSettled` invalidates the listing immediately, the UI refetches and shows only what had landed so far, then #2-#5 finish writing seconds later with no further invalidation — they're missing from the view until something else happens to trigger a refetch.

**Fix:** use `Promise.allSettled` and only throw (the first failure's reason, preserving the existing error-message contract callers rely on) after every PUT has completed. `onSettled`/invalidate and callers' `catch` now always run after the full batch has landed.

**To confirm:** `cd apps/mesh && bunx tsc --noEmit`.

**Checks run locally:** `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (clean, no output). No unit test added — this hook composes `fetch` + react-query `useMutation`, so a real regression test needs the mocking this repo's unit tier explicitly disallows (see TESTING.md); a proper regression test belongs in the e2e tier. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wait for all concurrent org file uploads to finish before invalidating the listing, so refreshed views always show the full batch even if one file fails.

- **Bug Fixes**
  - Switched upload mutation from `Promise.all` to `Promise.allSettled`.
  - Throw the first error only after all uploads settle, preserving the existing error message.
  - Invalidate in `onSettled` after the full batch completes to prevent missing files in the UI.

<sup>Written for commit 7eb14f63c7209aa2347e4ef816243f5d7df8a870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

