### PR TITLE
fix(registry): validate raw tools/list fallback response shape

### DIFF
--- a/apps/mesh/src/tools/registry/discover-tools.test.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { isPrivateUrl } from "./discover-tools";
+import { isPrivateUrl, parseToolsListResponse } from "./discover-tools";
 
 describe("isPrivateUrl", () => {
   it("blocks plain private/loopback/link-local IPv4", () => {
@@ -56,5 +56,43 @@ describe("isPrivateUrl", () => {
     expect(isPrivateUrl("https://example.com/mcp")).toBe(false);
     expect(isPrivateUrl("http://8.8.8.8/")).toBe(false);
     expect(isPrivateUrl("http://[::8.8.8.8]/")).toBe(false);
+  });
+});
+
+describe("parseToolsListResponse", () => {
+  it("parses a plain JSON-RPC tools/list response", () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { tools: [{ name: "search", description: "Search the web" }] },
+    });
+    expect(parseToolsListResponse(body)).toEqual([
+      { name: "search", description: "Search the web" },
+    ]);
+  });
+
+  it("parses an SSE-framed tools/list response", () => {
+    const body = `event: message\ndata: ${JSON.stringify({
+      result: { tools: [{ name: "search" }] },
+    })}\n\n`;
+    expect(parseToolsListResponse(body)).toEqual([
+      { name: "search", description: null },
+    ]);
+  });
+
+  it("rejects a malformed tool shape instead of passing it through", () => {
+    // A remote MCP server isn't a trusted source — unlike the SDK client
+    // path (which validates via zod), this raw fallback path is the only
+    // thing standing between a malformed response and the UI, which renders
+    // `tool.name` as a React child and uses it as a list key.
+    const body = JSON.stringify({
+      result: { tools: [{ name: { evil: true } }] },
+    });
+    expect(parseToolsListResponse(body)).toBeNull();
+  });
+
+  it("returns null for non-array tools or unparsable JSON", () => {
+    expect(parseToolsListResponse(JSON.stringify({ result: {} }))).toBeNull();
+    expect(parseToolsListResponse("not json")).toBeNull();
   });
 });

--- a/apps/mesh/src/tools/registry/discover-tools.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.ts
@@ -139,6 +139,11 @@ interface DiscoverTool {
   description?: string | null;
 }
 
+const RawDiscoverToolSchema = z.object({
+  name: z.string(),
+  description: z.string().nullable().optional(),
+});
+
 function isAuthRequiredError(message: string): boolean {
   const lower = message.toLowerCase();
   return (
@@ -148,6 +153,42 @@ function isAuthRequiredError(message: string): boolean {
     lower.includes("403") ||
     lower.includes('"code":-32000')
   );
+}
+
+/**
+ * Parse a raw `tools/list` JSON-RPC response body (plain JSON or SSE-framed)
+ * into a validated tool list. Unlike the MCP SDK client path, this fallback
+ * talks to the server over a bare `fetch`, so nothing validates the shape of
+ * the remote server's response until this function does — a malformed or
+ * malicious `name`/`description` here would otherwise flow straight into the
+ * UI (rendered as a React child, used as a list key).
+ */
+export function parseToolsListResponse(text: string): DiscoverTool[] | null {
+  let json: Record<string, unknown> | null = null;
+
+  try {
+    if (text.includes("event:") || text.includes("data:")) {
+      const dataLine = text.split("\n").find((l) => l.startsWith("data:"));
+      if (dataLine) {
+        json = JSON.parse(dataLine.slice(5).trim());
+      }
+    } else {
+      json = JSON.parse(text);
+    }
+  } catch {
+    return null;
+  }
+
+  if (!json) return null;
+
+  const result = (json.result as Record<string, unknown>) ?? json;
+  const parsed = z.array(RawDiscoverToolSchema).safeParse(result?.tools);
+  if (!parsed.success) return null;
+
+  return parsed.data.map((t) => ({
+    name: t.name,
+    description: t.description ?? null,
+  }));
 }
 
 async function tryRawToolsList(
@@ -176,27 +217,7 @@ async function tryRawToolsList(
     if (!res.ok) return null;
 
     const text = await res.text();
-    let json: Record<string, unknown> | null = null;
-
-    if (text.includes("event:") || text.includes("data:")) {
-      const dataLine = text.split("\n").find((l) => l.startsWith("data:"));
-      if (dataLine) {
-        json = JSON.parse(dataLine.slice(5).trim());
-      }
-    } else {
-      json = JSON.parse(text);
-    }
-
-    if (!json) return null;
-
-    const result = (json.result as Record<string, unknown>) ?? json;
-    const tools = result?.tools as DiscoverTool[] | undefined;
-    if (!Array.isArray(tools)) return null;
-
-    return tools.map((t) => ({
-      name: t.name,
-      description: t.description ?? null,
-    }));
+    return parseToolsListResponse(text);
   } catch {
     return null;
   } finally {


### PR DESCRIPTION
Follows the recent SSRF-hardening series on `discover-tools.ts` (#4929, #4961, #4973) — auditing that file for remaining type-safety gaps now that the SSRF guard is solid.

**The gap:** `REGISTRY_DISCOVER_TOOLS` normally connects via the MCP SDK `Client`, which validates the `tools/list` response against a zod schema internally. But when the target server returns an auth-required error, the tool falls back to `tryRawToolsList`, which talks to the server over a bare `fetch` and previously did `result?.tools as DiscoverTool[]` — a blind cast with zero runtime validation. `defineTool`'s `outputSchema` is not actually enforced at runtime (verified in `apps/mesh/src/core/define-tool.ts` — it's typing only), so nothing else catches a malformed response before it reaches the client.

**Failure scenario:** a remote MCP server (or a malicious one) returns `{ tools: [{ name: { evil: true } }] }` from its raw `tools/list` fallback. That object flows straight through to `apps/mesh/src/web/views/registry/tools-editor.tsx`, which renders `{tool.name}` as a React child and uses `tool.name` as the list `key` — a non-string/non-number child there throws "Objects are not valid as a React child", crashing that panel.

**Fix:** extracted the response parsing into a pure `parseToolsListResponse` function and replaced the `as` cast with a zod `safeParse` against a `{ name: string, description?: string|null }` schema — a malformed shape now returns `null` (same as any other discovery failure) instead of passing through.

**Regression tests** (`discover-tools.test.ts`): plain-JSON tools/list, SSE-framed tools/list, a malformed `name` shape (asserts `null`, i.e. the bug this fixes), and unparsable/non-array input.

**To verify:** `cd apps/mesh && bun test src/tools/registry/discover-tools.test.ts`

**Locally ran:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh, clean), and the targeted test file above (12 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates the raw fallback response for `tools/list` in registry discovery to block malformed tool data from reaching the UI and crashing the tools editor. Adds a schema-validated parser and tests, fixing the case where a non-string `name` could break rendering.

- **Bug Fixes**
  - Replaced blind cast with `zod` `safeParse` against `{ name: string, description?: string|null }`.
  - Added `parseToolsListResponse` to parse JSON or SSE and return `null` on invalid input.
  - Added unit tests for plain JSON, SSE-framed, malformed shape, and unparsable input.

<sup>Written for commit 6276b12a3559fbb0c3ead01ecde0834b4a4c4cb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

