### PR TITLE
ci(release-mesh): notify docs agent webhook after release

### DIFF
--- a/.github/workflows/release-studio.yaml
+++ b/.github/workflows/release-studio.yaml
@@ -614,3 +614,54 @@ jobs:
       - name: Summary
         if: env.DISPATCH_TOKEN != ''
         run: echo "Dispatched \`studio-image-bump\` (version ${{ needs.prepare.outputs.version }}, scope ${{ steps.scope.outputs.scope }}) to decocms/deco-apps-cd" >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Notify the docs agent that a new Studio version shipped. The agent decides
+  # whether the docs need updating from the payload (version + commit range).
+  # This is a convenience hook and must NEVER red the release: it no-ops when
+  # the webhook isn't configured, and a failed call is logged, not fatal.
+  #   * URL   -> repo variable  DOCS_AGENT_WEBHOOK_URL   (not sensitive)
+  #   * token -> repo secret    DOCS_AGENT_WEBHOOK_TOKEN (sent as Bearer)
+  # Runs only after `release` actually cut a release, so re-runs where the
+  # version already existed don't re-ping the agent.
+  # ---------------------------------------------------------------------------
+  notify-docs-agent:
+    name: Notify docs agent
+    needs: [prepare, release]
+    if: always() && needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    env:
+      WEBHOOK_URL: ${{ vars.DOCS_AGENT_WEBHOOK_URL }}
+      WEBHOOK_TOKEN: ${{ secrets.DOCS_AGENT_WEBHOOK_TOKEN }}
+    steps:
+      - name: Skip notice (webhook not configured)
+        if: env.WEBHOOK_URL == '' || env.WEBHOOK_TOKEN == ''
+        run: echo "::notice::DOCS_AGENT_WEBHOOK_URL / DOCS_AGENT_WEBHOOK_TOKEN not set — skipping the docs-agent notification."
+      - name: Call docs-agent webhook
+        if: env.WEBHOOK_URL != '' && env.WEBHOOK_TOKEN != ''
+        run: |
+          set -euo pipefail
+          payload=$(cat <<EOF
+          {
+            "event": "studio.released",
+            "version": "${{ needs.prepare.outputs.version }}",
+            "tag": "v${{ needs.prepare.outputs.version }}",
+            "repository": "${{ github.repository }}",
+            "sha": "${{ inputs.ref || github.sha }}",
+            "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }
+          EOF
+          )
+          code=$(curl -sS -o /tmp/resp.txt -w '%{http_code}' \
+            --retry 3 --retry-connrefused --max-time 30 \
+            -X POST "$WEBHOOK_URL" \
+            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$payload") || true
+          echo "Webhook responded HTTP $code"
+          echo "::group::Response body"; cat /tmp/resp.txt || true; echo; echo "::endgroup::"
+          if [ "${code:0:1}" != "2" ]; then
+            echo "::warning::docs-agent webhook returned HTTP $code (non-blocking)"
+          else
+            echo "Notified docs agent for v${{ needs.prepare.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
Adds a terminal `notify-docs-agent` job to the Release Mesh pipeline that POSTs to a configurable webhook once a Studio release is actually cut, so a docs agent can decide whether the docs need updating for the new version.

### Behavior
- Fires only after the `release` job succeeds — no re-ping on re-runs where the version already existed.
- URL from repo **variable** `DOCS_AGENT_WEBHOOK_URL`; bearer from repo **secret** `DOCS_AGENT_WEBHOOK_TOKEN` (sent as `Authorization: Bearer`).
- **Non-blocking**: no-ops when unconfigured and downgrades a non-2xx response to a warning — mirrors the existing `bump-deco-apps-cd` convenience-hook pattern, so it never reds the release.

### Payload
```json
{ "event": "studio.released", "version": "...", "tag": "v...",
  "repository": "decocms/studio", "sha": "...", "run_url": "..." }
```

### Config required in repo settings
| Where | Name | Value |
|---|---|---|
| Secrets → Actions | `DOCS_AGENT_WEBHOOK_TOKEN` | bearer token |
| Variables → Actions | `DOCS_AGENT_WEBHOOK_URL` | webhook URL |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a terminal `notify-docs-agent` job to the Release Studio workflow that POSTs to a webhook after a successful Studio release, so the docs agent can decide if docs need updates.

- **New Features**
  - Triggers only after the `release` job succeeds; no re-ping on reruns with an existing version.
  - Non-blocking and resilient: skips when unconfigured, retries the POST, and downgrades non-2xx responses to warnings; never fails the release.
  - Config via `DOCS_AGENT_WEBHOOK_URL` (Actions variable) and `DOCS_AGENT_WEBHOOK_TOKEN` (secret). Payload includes `event`, `version`, `tag`, `repository`, `sha`, and `run_url`.

<sup>Written for commit 594e6668ce16b63ff0419d192a8344bd0cf41be0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

