### PR TITLE
fix(registry): stop discover-tools raw fallback from following redirects

### DIFF
--- a/apps/mesh/src/tools/registry/discover-tools.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.ts
@@ -170,6 +170,11 @@ async function tryRawToolsList(
         method: "tools/list",
         params: {},
       }),
+      // `isPrivateUrl` only vets the URL we're about to fetch — a remote
+      // server could otherwise 3xx-redirect this request to an internal
+      // address (e.g. the cloud metadata endpoint) and bypass that check
+      // entirely, since fetch follows redirects by default.
+      redirect: "manual",
       signal: controller.signal,
     });
 


### PR DESCRIPTION
This is a bug fix in the tool-registry discovery logic (`REGISTRY_DISCOVER_TOOLS`), not tied to a specific issue — found while auditing the raw `tools/list` fallback path in `apps/mesh/src/tools/registry/discover-tools.ts` (already a hotspot this cycle; #4984 just hardened its response-shape validation).

**Why a maintainer wants this:** `isPrivateUrl()` is the SSRF guard meant to stop this tool from being used to probe internal/cloud-metadata endpoints, but it only validates the URL the caller supplied. The raw fallback's `fetch()` call (used when the SDK client hits an auth-required error) kept the default `redirect: "follow"` behavior, so a remote MCP server under attacker control could pass the initial `isPrivateUrl` check with a public-looking URL and then respond with a 3xx redirecting the actual request to an internal address (e.g. a cloud metadata endpoint) — fetch would transparently follow it, completely bypassing the guard.

**Failure scenario:** an org member calls `REGISTRY_DISCOVER_TOOLS` with `https://attacker.example.com/mcp` (passes `isPrivateUrl`); that server replies 401 (triggering the raw fallback), then the raw fallback's own POST to the same URL gets a 302 to `http://169.254.169.254/...`; the current code follows it and returns whatever the metadata endpoint serves as "discovered tools".

**The fix:** set `redirect: "manual"` on the raw fallback's fetch call. I confirmed locally (via a throwaway `Bun.serve` reproduction) that with `redirect: "manual"` a 3xx response comes back as a non-ok response (status 302, `ok: false`), so the existing `if (!res.ok) return null;` branch already rejects it — no follow-on logic needed. Without this flag, the same reproduction transparently followed the redirect and returned the internal server's body.

I didn't add an automated regression test: exercising this requires a real HTTP round-trip (a mock of `global.fetch` is explicitly the anti-pattern this repo's TESTING.md bans), which puts it outside the unit tier and this bot's sandbox has no e2e/Docker infra to add a Playwright case. Prior scoped security fixes in this repo (#4121, #4113) shipped the same way — comment-documented, no dedicated test file.

**To confirm:** review the single 5-line diff in `apps/mesh/src/tools/registry/discover-tools.ts`; optionally reproduce with a local `Bun.serve` responding 302 to a `tools/list` POST and confirm the fallback returns `null` instead of following it.

**Verified locally:**
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — passes
- `bun test apps/mesh/src/tools/registry/discover-tools.test.ts` — 8/8 pass

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents SSRF in tool discovery by stopping the raw `tools/list` fallback in `REGISTRY_DISCOVER_TOOLS` from following redirects. Sets fetch `redirect: "manual"` so 3xx responses aren’t followed and are rejected by the existing `!res.ok` check.

<sup>Written for commit 7e9448877c02a1221dd9aa291139464d7d9b6bbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

