### PR TITLE
fix(agent-icon): apply picker palette color to uploaded image icons

### DIFF
--- a/apps/mesh/src/web/components/agent-icon.test.tsx
+++ b/apps/mesh/src/web/components/agent-icon.test.tsx
@@ -4,9 +4,22 @@ setupComponentTest();
 import { fireEvent, render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { describe, expect, it } from "bun:test";
-import { AgentAvatar } from "./agent-icon";
+import { AgentAvatar, buildImageIconString } from "./agent-icon";
 
 describe("AgentAvatar", () => {
+  it("applies the picker's palette color as a background for an uploaded image icon", () => {
+    const { container } = render(
+      <AgentAvatar
+        icon={buildImageIconString("https://example.com/logo.png", "red")}
+        name="Test Agent"
+      />,
+    );
+
+    const img = container.querySelector("img");
+    expect(img).toBeInTheDocument();
+    expect(img?.parentElement?.className).toContain("bg-red-100");
+  });
+
   it("recovers after an image load error once a new URL is set", () => {
     const { container, rerender } = render(
       <AgentAvatar icon="https://example.com/broken.png" name="Test Agent" />,

--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -391,9 +391,19 @@ export function AgentAvatar({
 // Image sub-component (handles load errors)
 // ---------------------------------------------------------------------------
 
+// Special-case brand colors that aren't part of the selectable palette.
 const URL_COLOR_BG: Record<string, string> = {
   "brand-green": "bg-[var(--brand-green-light)]",
 };
+
+/** Resolve the background class for a URL icon's encoded color: special
+ * brand colors first, falling back to the shared picker palette so a color
+ * chosen in `IconPicker` (e.g. for an uploaded image) actually renders. */
+function resolveUrlBgClass(color: string | undefined): string {
+  if (!color) return "";
+  if (URL_COLOR_BG[color]) return URL_COLOR_BG[color];
+  return COLOR_MAP.has(color) ? getIconColor(color).bg : "";
+}
 
 function AgentAvatarImage({
   url,
@@ -414,7 +424,7 @@ function AgentAvatarImage({
 }) {
   const [errored, setErrored] = useState(false);
   const sizeConfig = SIZES[size];
-  const bgClass = color ? (URL_COLOR_BG[color] ?? "") : "";
+  const bgClass = resolveUrlBgClass(color);
 
   if (errored) {
     const { IconComp, color } = getDeterministicIcon(name);


### PR DESCRIPTION
**Bug**: `IconPicker`'s `ColorPickerDropdown` lets a user pick any of the 16 `AGENT_ICON_COLORS` for the current icon, even when the current icon is an uploaded image (`buildImageIconString` encodes the color into the URL via `#agentcolor=`). `AgentAvatarImage` only resolved that color against `URL_COLOR_BG`, a map with a single entry (`"brand-green"`) left over from the now-removed "deco Site Editor" tile feature (introduced in #3204). Since no code path produces `#agentcolor=brand-green` anymore, and the picker's swatches only ever emit the 16 real palette color names, picking a background color for an uploaded image is a guaranteed no-op today — the value is persisted but never rendered.

**Why a maintainer wants this**: this is a real, always-reproducible dead feature in a shipped UI control (the color swatches under the Icons tab apply to whatever the current icon value is, including an uploaded image) — users see zero visual feedback after picking a color for their custom logo/image icon.

**Failure scenario**: open `IconPicker`, go to Upload tab, upload an image; switch to the Icons tab and click a color swatch (e.g. red). The avatar preview and every place that renders this agent's icon show no background tint — the color silently has no effect.

**Fix**: `AgentAvatarImage` now resolves the URL icon's encoded color against the shared palette (`getIconColor`) when it matches a known color name, falling back to the special-case brand map otherwise. This makes image icons pick up a real background tint consistent with icon-type avatars, exactly as the picker UI implies.

**Regression test**: `apps/mesh/src/web/components/agent-icon.test.tsx` renders `AgentAvatar` with `buildImageIconString("https://example.com/logo.png", "red")` and asserts the rendered container carries `bg-red-100`. Verified the test fails without the fix (falls back to the old `URL_COLOR_BG[color] ?? ""` logic, which yields an empty class) and passes with it.

**Reviewer check**: `bun test apps/mesh/src/web/components/agent-icon.test.tsx`

**Local verification**: `bun run fmt` and `cd apps/mesh && bunx tsc --noEmit` both clean, plus the targeted test above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where color selections in `IconPicker` were ignored for uploaded image icons. Image avatars now render the selected palette color as their background across the app.

- **Bug Fixes**
  - Resolve URL icon colors via the shared palette (`getIconColor`) when they match `AGENT_ICON_COLORS`, falling back to the brand map as needed.
  - Added a regression test ensuring `buildImageIconString(..., "red")` applies `bg-red-100`.

<sup>Written for commit 7818fbfea30e0fac33785f89af2f73e09ca70da0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

