### PR TITLE
fix(registry): clear stale UI HTML cache after OAuth re-auth in monitor panel

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -150,7 +150,18 @@ function ConnectionRow({
     updateAuth.mutate(
       { connectionId, authStatus: "authenticated" },
       {
-        onSuccess: () => onAuthChanged(),
+        onSuccess: () => {
+          onAuthChanged();
+          // Auth changed → upstream may return different content; drop cached
+          // UI HTML for this connection (IDB + in-memory query) so it re-reads
+          // fresh, regardless of whether auth happened via OAuth or a token.
+          void clearHtmlResourceCacheForConnection(connectionId);
+          queryClient.invalidateQueries({
+            predicate: (query) =>
+              query.queryKey[1] === UI_RESOURCE_HTML_KEY &&
+              query.queryKey[3] === connectionId,
+          });
+        },
         onError: (err) =>
           toast.error(
             `Failed to save auth status for "${title}": ${err instanceof Error ? err.message : String(err)}`,
@@ -268,14 +279,6 @@ function ConnectionRow({
       setIsReplacingToken(false);
       setTokenValue("");
       markAuthenticated();
-      // Auth changed → upstream may return different content; drop cached UI
-      // HTML for this connection (IDB + in-memory query) so it re-reads fresh.
-      void clearHtmlResourceCacheForConnection(connectionId);
-      queryClient.invalidateQueries({
-        predicate: (query) =>
-          query.queryKey[1] === UI_RESOURCE_HTML_KEY &&
-          query.queryKey[3] === connectionId,
-      });
       await probeQuery.refetch();
     } catch (err) {
       toast.error(


### PR DESCRIPTION
Bug found while auditing the registry monitor connections panel (`apps/mesh/src/web/views/registry/monitor-connections-panel.tsx`) for the discovery-flow focus area.

**Failure scenario:** `handleSaveToken` (manual token auth) already calls `clearHtmlResourceCacheForConnection(connectionId)` plus a targeted `queryClient.invalidateQueries` after saving auth, with a comment explaining why: once auth changes, the upstream MCP may return different UI resource HTML, so the stale cached HTML (IndexedDB + in-memory query) must be dropped so it's re-fetched. `handleAuthenticate` (the OAuth path) calls the same `markAuthenticated()` helper on success but never ran this cleanup — so after re-authenticating via OAuth, a previously-cached UI resource HTML blob for that connection could keep being served stale instead of reflecting the newly-authenticated content.

**Fix:** moved the cache-clear + invalidate call into `markAuthenticated()` itself (the single success path both `handleAuthenticate` and `handleSaveToken` funnel through) instead of duplicating it in only one of the two call sites. Removed the now-redundant call from `handleSaveToken`. Net effect: both auth paths get the same stale-cache cleanup; net line count: +12/-9 in one file, no new duplication.

**Verification:** `bun run fmt` (no changes needed) and `cd apps/mesh && bunx tsc --noEmit` (clean) — this is a pure UI-state-consistency fix with no new types, so no targeted test was added; a reviewer can confirm by re-authenticating a monitor connection via OAuth and checking the sandbox preview snapshot in the codebase to see the shared `markAuthenticated` cleanup now fires on both paths. Full CI validates formatting/lint/build as usual.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale UI HTML after OAuth re-auth in the registry monitor connections panel by moving the cache clear and query invalidation into the shared markAuthenticated path. Both OAuth and manual token auth now drop IndexedDB + in-memory cached UI resource HTML and refetch fresh content.

<sup>Written for commit 8d4689c72eefd723ce5afdb488493e6cb8e3a5ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

