### PR TITLE
fix(agent-icon): add aria-label to icon-only picker triggers and icon grid

### DIFF
--- a/apps/mesh/src/web/components/icon-picker.tsx
+++ b/apps/mesh/src/web/components/icon-picker.tsx
@@ -26,6 +26,7 @@ import {
   getIconColor,
   getIconComponent,
   getIconNames,
+  humanizeIconName,
   parseIconString,
   type AgentAvatarSize,
 } from "./agent-icon";
@@ -124,6 +125,7 @@ export function IconPicker({
         <button
           type="button"
           data-testid="icon-picker-trigger"
+          aria-label="Change icon"
           disabled={disabled}
           className={cn(
             "relative group overflow-hidden",
@@ -232,6 +234,7 @@ function ColorPickerDropdown({
             "ring-foreground/20",
           )}
           title="Change color"
+          aria-label="Change color"
         />
       </PopoverTrigger>
       <PopoverContent
@@ -258,6 +261,7 @@ function ColorPickerDropdown({
                   : "hover:scale-110",
               )}
               title={c.name}
+              aria-label={c.name}
             />
           ))}
         </div>
@@ -308,6 +312,7 @@ function IconsTab({
           onClick={onRandom}
           className="h-8 w-8 flex items-center justify-center rounded-md border border-border hover:bg-accent transition-colors shrink-0"
           title="Random icon"
+          aria-label="Random icon"
         >
           <Shuffle01 size={14} className="text-muted-foreground" />
         </button>
@@ -336,6 +341,7 @@ function IconsTab({
                     : cn(color.text, "hover:bg-accent"),
                 )}
                 title={iconName}
+                aria-label={humanizeIconName(iconName)}
               >
                 <IconComp size={18} />
               </button>

--- a/apps/mesh/src/web/components/simple-icon-picker.tsx
+++ b/apps/mesh/src/web/components/simple-icon-picker.tsx
@@ -63,6 +63,7 @@ export function SimpleIconPicker({
         <button
           type="button"
           disabled={disabled}
+          aria-label="Change icon"
           className={cn(
             "size-7 shrink-0 rounded-md transition-colors flex items-center justify-center",
             disabled


### PR DESCRIPTION
## Summary
Icon picker components expose several icon-only buttons and color swatches without proper `aria-label` attributes. Screen-reader users cannot identify these controls, creating an accessibility barrier.

## Changes
Added `aria-label` to all icon-only controls in `icon-picker.tsx` and `simple-icon-picker.tsx`:
- Main icon picker trigger: "Change icon"
- Color picker dropdown trigger: "Change color"
- Random icon button: "Random icon"
- Icon grid buttons: humanized icon names (e.g., "search md" vs raw "SearchMd")
- Color swatches: color names (e.g., "red", "blue")
- Simple icon picker trigger: "Change icon"

## Test plan
- `bun test apps/mesh/src/web/components/agent-icon.test.tsx` — all tests pass, no regressions
- `cd apps/mesh && bunx tsc --noEmit` — type check clean
- `bun run fmt` — formatting verified

## Verification
Targeted test and type check run locally. Full CI suite validates behavior preservation and integration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `aria-label` to icon-only controls in the icon pickers to make them accessible to screen readers. Improves usability for the main triggers, the icon grid, color swatches, and the random icon action.

- **Bug Fixes**
  - Main icon picker trigger: "Change icon"
  - Color dropdown trigger: "Change color"
  - Random icon button: "Random icon"
  - Icon grid buttons: humanized names (e.g., "search md")
  - Color swatches: color names (e.g., "red", "blue")

<sup>Written for commit 880920863e69965c6d53e2a4b9a094b5e61821bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

