### PR TITLE
fix(registry): scope QA monitor query cache by organization

### DIFF
--- a/apps/mesh/src/web/hooks/registry/use-monitor.ts
+++ b/apps/mesh/src/web/hooks/registry/use-monitor.ts
@@ -63,8 +63,10 @@ export function useMonitorRunStart() {
       }),
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: KEYS.monitorRuns() }),
-        queryClient.invalidateQueries({ queryKey: KEYS.monitorResults() }),
+        queryClient.invalidateQueries({ queryKey: KEYS.monitorRuns(org.id) }),
+        queryClient.invalidateQueries({
+          queryKey: KEYS.monitorResults(org.id),
+        }),
       ]);
     },
   });
@@ -86,8 +88,10 @@ export function useMonitorRunCancel() {
       }),
     onSuccess: async (_res, runId) => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: KEYS.monitorRuns() }),
-        queryClient.invalidateQueries({ queryKey: KEYS.monitorRun(runId) }),
+        queryClient.invalidateQueries({ queryKey: KEYS.monitorRuns(org.id) }),
+        queryClient.invalidateQueries({
+          queryKey: KEYS.monitorRun(org.id, runId),
+        }),
       ]);
     },
   });
@@ -102,7 +106,7 @@ export function useMonitorRuns(status?: MonitorRunStatus) {
   });
 
   return useQuery({
-    queryKey: KEYS.monitorRunsList(status),
+    queryKey: KEYS.monitorRunsList(org.id, status),
     queryFn: async () =>
       callTool<MonitorRunListResponse>(client, "REGISTRY_MONITOR_RUN_LIST", {
         status,
@@ -121,7 +125,7 @@ export function useMonitorRun(runId?: string) {
   });
 
   return useQuery({
-    queryKey: KEYS.monitorRun(runId),
+    queryKey: KEYS.monitorRun(org.id, runId),
     queryFn: async () =>
       callTool<{ run: MonitorRun | null }>(client, "REGISTRY_MONITOR_RUN_GET", {
         runId,
@@ -147,7 +151,7 @@ export function useMonitorResults(
   });
 
   return useQuery({
-    queryKey: KEYS.monitorResultsList(runId, status),
+    queryKey: KEYS.monitorResultsList(org.id, runId, status),
     queryFn: async () =>
       callTool<MonitorResultListResponse>(
         client,
@@ -174,7 +178,7 @@ export function useMonitorConnections() {
   });
 
   return useQuery({
-    queryKey: KEYS.monitorConnections(),
+    queryKey: KEYS.monitorConnections(org.id),
     queryFn: async () =>
       callTool<MonitorConnectionListResponse>(
         client,
@@ -203,7 +207,7 @@ export function useSyncMonitorConnections() {
       ),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: KEYS.monitorConnections(),
+        queryKey: KEYS.monitorConnections(org.id),
       });
     },
   });
@@ -233,7 +237,7 @@ export function useUpdateMonitorConnectionAuth() {
       ),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: KEYS.monitorConnections(),
+        queryKey: KEYS.monitorConnections(org.id),
       });
     },
   });

--- a/apps/mesh/src/web/lib/registry/query-keys.ts
+++ b/apps/mesh/src/web/lib/registry/query-keys.ts
@@ -48,20 +48,22 @@ export const KEYS = {
   publishRequestsCountByOrg: (orgId: string) =>
     [...KEYS.publishRequestsByOrg(orgId), "count"] as const,
   publishApiKeys: () => [...KEYS.all, "publish-api-keys"] as const,
-  monitor: () => [...KEYS.all, "monitor"] as const,
-  monitorRuns: () => [...KEYS.monitor(), "runs"] as const,
-  monitorRunsList: (status?: string) =>
-    [...KEYS.monitorRuns(), "list", { status: status ?? "all" }] as const,
-  monitorRun: (runId?: string) =>
-    [...KEYS.monitorRuns(), "run", runId ?? "none"] as const,
-  monitorResults: () => [...KEYS.monitor(), "results"] as const,
-  monitorResultsList: (runId?: string, status?: string) =>
+  monitor: (orgId: string) => [...KEYS.all, "monitor", orgId] as const,
+  monitorRuns: (orgId: string) => [...KEYS.monitor(orgId), "runs"] as const,
+  monitorRunsList: (orgId: string, status?: string) =>
+    [...KEYS.monitorRuns(orgId), "list", { status: status ?? "all" }] as const,
+  monitorRun: (orgId: string, runId?: string) =>
+    [...KEYS.monitorRuns(orgId), "run", runId ?? "none"] as const,
+  monitorResults: (orgId: string) =>
+    [...KEYS.monitor(orgId), "results"] as const,
+  monitorResultsList: (orgId: string, runId?: string, status?: string) =>
     [
-      ...KEYS.monitorResults(),
+      ...KEYS.monitorResults(orgId),
       "list",
       { runId: runId ?? "none", status: status ?? "all" },
     ] as const,
-  monitorConnections: () => [...KEYS.monitor(), "connections"] as const,
-  monitorConnectionAuthProbe: (connectionId: string) =>
-    [...KEYS.monitorConnections(), "auth-probe", connectionId] as const,
+  monitorConnections: (orgId: string) =>
+    [...KEYS.monitor(orgId), "connections"] as const,
+  monitorConnectionAuthProbe: (orgId: string, connectionId: string) =>
+    [...KEYS.monitorConnections(orgId), "auth-probe", connectionId] as const,
 };

--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -115,7 +115,7 @@ function ConnectionRow({
   const isUnlisted = entry.item?.is_unlisted ?? false;
   const isRequestSource = entry.source === "request";
   const probeQuery = useQuery({
-    queryKey: KEYS.monitorConnectionAuthProbe(connectionId),
+    queryKey: KEYS.monitorConnectionAuthProbe(org.id, connectionId),
     queryFn: async () =>
       isConnectionAuthenticated({
         url: `/api/${org.slug}/mcp/${connectionId}`,


### PR DESCRIPTION
**Bug**: the registry QA monitor's react-query cache keys (`KEYS.monitor*` — runs, results, connections, and the per-connection OAuth/token auth probe) carried no organization identifier. Switching orgs in this app is a client-side TanStack Router navigation (`OrgSwitcherPopover` calls `navigate({ to: "/$org", params: { org: slug } })`, no full reload), so the shared `QueryClient` cache persists across the switch.

**Failure scenario**: a user opens `Settings → Registry → QA` in org A (caching its connections list, auth statuses, and monitor run results under the unscoped key), switches to org B via the org switcher, and later re-opens the QA tab in org B. Because the query key is identical across orgs, React Query serves org A's cached connections/auth-status/results instantly (`staleTime` is 5-10s) before the background refetch replaces them with org B's data — a cross-tenant data flash of another org's registered MCP connections and auth state.

**Fix**: add `org.id` to every `KEYS.monitor*` key in `apps/mesh/src/web/lib/registry/query-keys.ts` and thread it through the query/mutation calls in `apps/mesh/src/web/hooks/registry/use-monitor.ts` plus the panel's own auth-probe query in `monitor-connections-panel.tsx`. This mirrors the org-scoping already used by the sibling `monitoring*` (audit/threads) key family in the same file — same file, same bug class, just not yet applied to the QA-monitor family.

**To confirm**: `cd apps/mesh && bunx tsc --noEmit` (verifies every `KEYS.monitor*` call site was updated in lockstep — a mismatched arity is a compile error, not a silent bug) and open Settings → Registry → QA in two different orgs back-to-back to see the connections list is now always fresh per org.

**Locally verified**: `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace, clean), and the targeted `bun test apps/mesh/src/web/views/registry/monitor-connections-panel.test.tsx` (passes, unaffected by this change). Full CI runs the rest of the suite.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped the registry QA monitor `react-query` cache by organization to prevent cross-tenant data flashes when switching orgs via `@tanstack/router`. Keys now include `org.id` across runs, results, connections, and auth probes.

- **Bug Fixes**
  - Add `org.id` to all `KEYS.monitor*` keys in `apps/mesh/src/web/lib/registry/query-keys.ts`.
  - Thread the org-scoped keys through `apps/mesh/src/web/hooks/registry/use-monitor.ts` and the auth probe in `apps/mesh/src/web/views/registry/monitor-connections-panel.tsx`, including query invalidations.

<sup>Written for commit f1bf9177815f7aa7c9c667dab0036c246d380aea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

