### PR TITLE
fix(sandbox-preview): pin postMessage target origin to the preview site

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -222,6 +222,16 @@ function withDeviceHint(url: string, device: PreviewDeviceSize): string {
   return parsed.href;
 }
 
+/** Origin of the preview iframe's own site, or `null` if `previewUrl` is unset/invalid. */
+function previewOrigin(previewUrl: string | null): string | null {
+  if (!previewUrl) return null;
+  try {
+    return new URL(previewUrl, window.location.href).origin;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Reload the iframe in place; falls back to reassigning `src` when the
  * iframe's live location is cross-origin (sandbox preview domain) and
@@ -607,13 +617,8 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — DOM event subscription
   useEffect(() => {
-    if (!previewUrl) return;
-    let allowedOrigin: string;
-    try {
-      allowedOrigin = new URL(previewUrl, window.location.href).origin;
-    } catch {
-      return;
-    }
+    const allowedOrigin = previewOrigin(previewUrl);
+    if (!allowedOrigin) return;
     const handler = (e: MessageEvent) => {
       if (e.origin !== allowedOrigin) return;
       if (e.data?.type === "visual-editor::element-clicked") {
@@ -643,27 +648,33 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     return () => document.removeEventListener("pointerdown", handler);
   }, [pagesOpen]);
 
+  // Target origin is pinned to the preview site itself: with "*" the parent
+  // would still hand the editor script and page-structure metadata to
+  // whatever origin currently occupies the iframe if it cross-navigated away.
   const injectVisualEditor = () => {
     const win = previewIframeRef.current?.contentWindow;
-    if (!win) return;
+    const origin = previewOrigin(previewUrl);
+    if (!win || !origin) return;
     win.postMessage(
       { type: "visual-editor::activate", script: VISUAL_EDITOR_SCRIPT },
-      "*",
+      origin,
     );
   };
 
   const deactivateVisualEditor = () => {
     const win = previewIframeRef.current?.contentWindow;
-    if (!win) return;
-    win.postMessage({ type: "visual-editor::deactivate" }, "*");
+    const origin = previewOrigin(previewUrl);
+    if (!win || !origin) return;
+    win.postMessage({ type: "visual-editor::deactivate" }, origin);
   };
 
   const injectCmsEditor = () => {
     const win = previewIframeRef.current?.contentWindow;
-    if (!win) return;
+    const origin = previewOrigin(previewUrl);
+    if (!win || !origin) return;
     win.postMessage(
       { type: "visual-editor::activate", script: CMS_EDITOR_SCRIPT },
-      "*",
+      origin,
     );
     // Ordered after activate, so the script's listener is registered by the
     // time this arrives. Re-sent on every (re)injection (mode switch, page
@@ -675,14 +686,15 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
         kinds: cmsSectionKinds,
         keys: cmsSectionKeys,
       },
-      "*",
+      origin,
     );
   };
 
   const deactivateCmsEditor = () => {
     const win = previewIframeRef.current?.contentWindow;
-    if (!win) return;
-    win.postMessage({ type: "cms-editor::deactivate" }, "*");
+    const origin = previewOrigin(previewUrl);
+    if (!win || !origin) return;
+    win.postMessage({ type: "cms-editor::deactivate" }, origin);
   };
 
   const activateEditingMode = (mode: PreviewEditingMode) => {


### PR DESCRIPTION
A hardening follow-up in the sandbox preview area: `preview.tsx` already validates `e.origin` on incoming postMessage from the iframe (see the `visual-editor::element-clicked` / `cms-editor::section-clicked` listener), but every outgoing `postMessage()` call to that same iframe — `injectVisualEditor`, `deactivateVisualEditor`, `injectCmsEditor` (which also sends `cmsSectionLabels`/`kinds`/`keys`), and `deactivateCmsEditor` — used `"*"` as `targetOrigin`.

Why this matters: `targetOrigin: "*"` means the browser delivers the message to whatever origin currently occupies that frame, not necessarily the preview site. If the previewed page cross-navigates away (a link inside the site under edit, an open redirect, an ad/embed) while the parent still holds a reference to `contentWindow`, the next inject/deactivate call would hand the visual-editor script and page-structure metadata (section labels/keys — real content model info) to that unintended origin.

Fix: factored the existing origin-derivation logic (`previewUrl` -> `new URL(...).origin`) out of the incoming-listener effect into one `previewOrigin()` helper, and reused it as the `targetOrigin` for all four outgoing sends instead of `"*"`. If the origin can't be resolved, the send is skipped rather than falling back to a wildcard. Behavior is unchanged for the working case — these functions are only invoked while `previewState.kind === "iframe"`, where `previewUrl` is already relied on elsewhere (e.g. the receive listener, `buildGlobalSectionPreviewUrl`) as the canonical same-origin source.

No test added: this is a same-origin-vs-wildcard postMessage argument change with no branchable pure logic to unit-test in isolation (it requires an actual cross-origin iframe to observe); the existing e2e/manual visual-editor and blocks-editor flows exercise the send paths behaviorally.

Reviewer check: `rg 'postMessage' apps/mesh/src/web/components/sandbox/preview/preview.tsx` — confirm all four outgoing sends now pass `origin` instead of `"*"`, and the incoming listener's `allowedOrigin` computation now reuses the same `previewOrigin()` helper.

Locally verified: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean, no new errors). Full CI (lint, unit, e2e) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins all sandbox preview postMessage calls to the preview site’s origin to avoid leaking editor scripts and section metadata if the iframe cross-navigates. Security hardening with no behavior change in normal use.

- **Bug Fixes**
  - Added `previewOrigin(previewUrl)` and used it to validate incoming messages.
  - Replaced `"*"` with the computed origin for all outgoing sends (visual/CMS activate/deactivate and section-label sync); skip sends if the origin can’t be resolved.

<sup>Written for commit f240f0bb648e15fa5868203ab19e30194faafea8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

