### PR TITLE
fix(ai-providers): stop silently wiping the API key when editing base URL only

### DIFF
--- a/apps/mesh/src/web/i18n/en/settings.ts
+++ b/apps/mesh/src/web/i18n/en/settings.ts
@@ -302,6 +302,8 @@ export const settings = {
   "settings.domainSettings.verified": "Verified",
   "settings.domainSettings.verify": "Verify",
   "settings.editProviderDialog.apiKey": "API key",
+  "settings.editProviderDialog.apiKeyRequiredForBaseUrlChange":
+    "Enter the API key again to confirm changing the base URL",
   "settings.editProviderDialog.baseUrl": "Base URL",
   "settings.editProviderDialog.baseUrlPlaceholder": "http://localhost:4000/v1",
   "settings.editProviderDialog.cancel": "Cancel",

--- a/apps/mesh/src/web/i18n/pt-br/settings.ts
+++ b/apps/mesh/src/web/i18n/pt-br/settings.ts
@@ -312,6 +312,8 @@ export const settings = {
   "settings.domainSettings.verified": "Verificado",
   "settings.domainSettings.verify": "Verificar",
   "settings.editProviderDialog.apiKey": "Chave de API",
+  "settings.editProviderDialog.apiKeyRequiredForBaseUrlChange":
+    "Informe a chave de API novamente para confirmar a mudança da URL base",
   "settings.editProviderDialog.baseUrl": "URL base",
   "settings.editProviderDialog.baseUrlPlaceholder": "http://localhost:4000/v1",
   "settings.editProviderDialog.cancel": "Cancelar",

--- a/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.test.ts
+++ b/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { needsApiKeyForBaseUrlChange } from "./edit-provider-dialog";
+
+describe("needsApiKeyForBaseUrlChange", () => {
+  test("requires a fresh API key when the base URL changes without one", () => {
+    expect(
+      needsApiKeyForBaseUrlChange({
+        isOpenAICompatible: true,
+        baseUrl: "https://new.example.com/v1",
+        currentBaseUrl: "https://old.example.com/v1",
+        apiKey: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  test("allows the base URL change when a fresh API key is provided", () => {
+    expect(
+      needsApiKeyForBaseUrlChange({
+        isOpenAICompatible: true,
+        baseUrl: "https://new.example.com/v1",
+        currentBaseUrl: "https://old.example.com/v1",
+        apiKey: "sk-new",
+      }),
+    ).toBe(false);
+  });
+
+  test("allows saving when the base URL is unchanged", () => {
+    expect(
+      needsApiKeyForBaseUrlChange({
+        isOpenAICompatible: true,
+        baseUrl: "https://old.example.com/v1",
+        currentBaseUrl: "https://old.example.com/v1",
+        apiKey: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not apply to non openai-compatible providers", () => {
+    expect(
+      needsApiKeyForBaseUrlChange({
+        isOpenAICompatible: false,
+        baseUrl: "https://new.example.com/v1",
+        currentBaseUrl: "https://old.example.com/v1",
+        apiKey: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.tsx
@@ -47,6 +47,28 @@ const createEditFormSchema = (t: TFunction) =>
 
 type EditFormData = z.infer<ReturnType<typeof createEditFormSchema>>;
 
+/**
+ * The stored apiKey blob for openai-compatible keys encodes {baseUrl, apiKey}
+ * together. If the base URL changes without a freshly typed apiKey, the
+ * previous plaintext key isn't available client-side (only a masked preview
+ * is) to re-encode — so submitting would silently wipe the stored credential.
+ */
+export function needsApiKeyForBaseUrlChange({
+  isOpenAICompatible,
+  baseUrl,
+  currentBaseUrl,
+  apiKey,
+}: {
+  isOpenAICompatible: boolean;
+  baseUrl?: string;
+  currentBaseUrl?: string;
+  apiKey?: string;
+}): boolean {
+  return (
+    isOpenAICompatible && !!baseUrl && baseUrl !== currentBaseUrl && !apiKey
+  );
+}
+
 interface EditFormProps {
   providerKey: AiProviderKey;
   provider: AiProviderInfo;
@@ -83,6 +105,7 @@ function EditForm({
     register,
     handleSubmit,
     watch,
+    setError,
     formState: { errors },
   } = useForm<EditFormData>({
     resolver: zodResolver(editFormSchema),
@@ -108,17 +131,6 @@ function EditForm({
         } else {
           apiKeyValue = data.apiKey;
         }
-      } else if (
-        isOpenAICompatible &&
-        data.baseUrl &&
-        data.baseUrl !== currentBaseUrl
-      ) {
-        // Base URL changed but no new API key — re-encode with existing masked key not possible.
-        // We encode the new baseUrl with empty apiKey so the connection still works.
-        apiKeyValue = JSON.stringify({
-          baseUrl: data.baseUrl,
-          apiKey: "",
-        });
       }
 
       await studio.call("AI_PROVIDER_KEY_UPDATE", {
@@ -140,7 +152,27 @@ function EditForm({
   });
 
   return (
-    <form onSubmit={handleSubmit((data) => save(data))} className="space-y-3">
+    <form
+      onSubmit={handleSubmit((data) => {
+        if (
+          needsApiKeyForBaseUrlChange({
+            isOpenAICompatible,
+            baseUrl: data.baseUrl,
+            currentBaseUrl,
+            apiKey: data.apiKey,
+          })
+        ) {
+          setError("apiKey", {
+            message: t(
+              "settings.editProviderDialog.apiKeyRequiredForBaseUrlChange",
+            ),
+          });
+          return;
+        }
+        save(data);
+      })}
+      className="space-y-3"
+    >
       <div className="space-y-1">
         <label className="text-xs font-medium text-muted-foreground">
           {t("settings.editProviderDialog.label")}
@@ -202,6 +234,9 @@ function EditForm({
               </button>
             )}
           </div>
+          {errors.apiKey && (
+            <p className="text-xs text-destructive">{errors.apiKey.message}</p>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
**Source:** a bug found while auditing the AI Provider Settings UI (`apps/mesh/src/web/views/settings/ai-providers/`) for hardening opportunities.

**Why a maintainer wants this:** editing an openai-compatible provider connection's base URL without retyping the API key currently saves the connection with an empty key, silently breaking it — the acknowledging comment in the old code ("re-encode with existing masked key not possible... we encode the new baseUrl with empty apiKey so the connection still works") was actually wrong: the connection stops working.

**Failure scenario:** a user opens "Edit" on a custom OpenAI-compatible key, changes only the Base URL field (leaving the API key field blank, per the "leave blank to keep current" hint), and saves. `AI_PROVIDER_KEY_UPDATE` is called with `apiKey: JSON.stringify({ baseUrl: newUrl, apiKey: "" })`, permanently discarding the previously stored credential — the client only ever sees a masked preview of the key, never the plaintext, so there was no way to re-encode it with the old value. The provider then fails auth on every call until the user re-enters the key from scratch.

**Fix:** the stored plaintext key can't be recovered client-side, so instead of silently wiping it, the form now blocks that specific submission (base URL changed + no new API key typed, for openai-compatible providers) and shows an inline error asking the user to re-enter the API key to confirm the change. All other paths (API key retyped, base URL unchanged, non-openai-compatible providers) are unaffected. Added `edit-provider-dialog.test.ts` covering the extracted pure guard (`needsApiKeyForBaseUrlChange`) as regression proof for the fix.

**Verify:** `cd apps/mesh && bunx tsc --noEmit` and `bun test apps/mesh/src/web/views/settings/ai-providers/edit-provider-dialog.test.ts`.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace, clean), and the targeted test file above (4/4 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where editing an OpenAI-compatible provider’s base URL without retyping the API key would save an empty key and break the connection. The form now blocks that submission and asks for the API key again to confirm the change.

- **Bug Fixes**
  - Added `needsApiKeyForBaseUrlChange` to prevent saving when the base URL changes without a fresh API key for OpenAI-compatible providers.
  - Shows an inline error prompting the user to re-enter the key; other paths remain unchanged.
  - Added unit tests for the guard and updated `en`/`pt-br` i18n strings.

<sup>Written for commit dba6c745aed311042b5639d02b8a7c96229e0e39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

