### PR TITLE
fix(chat): disable file drop/paste while voice recording is active

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -93,6 +93,7 @@ function ChatInputDisabledState({ message }: { message: string }) {
 function useWindowFileDrop(
   selectedModel: AiProviderModel | null | undefined,
   onUnsupportedFile?: (info: UnsupportedFileInfo) => void,
+  disabled?: boolean,
 ) {
   const { editor } = useCurrentEditor();
   const [isDraggingOver, setIsDraggingOver] = useState(false);
@@ -124,7 +125,12 @@ function useWindowFileDrop(
       dragCounterRef.current = 0;
       setIsDraggingOver(false);
 
-      if (!editor || !selectedModel || !modelSupportsFiles(selectedModel))
+      if (
+        disabled ||
+        !editor ||
+        !selectedModel ||
+        !modelSupportsFiles(selectedModel)
+      )
         return;
 
       const files = e.dataTransfer?.files;
@@ -146,7 +152,7 @@ function useWindowFileDrop(
       window.removeEventListener("dragover", onDragOver);
       window.removeEventListener("drop", onDrop);
     };
-  }, [editor, selectedModel, onUnsupportedFile]);
+  }, [editor, selectedModel, onUnsupportedFile, disabled]);
 
   return isDraggingOver;
 }
@@ -158,11 +164,17 @@ function useWindowFileDrop(
 function FileDropZone({
   selectedModel,
   onUnsupportedFile,
+  disabled,
 }: {
   selectedModel: AiProviderModel | null | undefined;
   onUnsupportedFile?: (info: UnsupportedFileInfo) => void;
+  disabled?: boolean;
 }) {
-  const isDraggingOver = useWindowFileDrop(selectedModel, onUnsupportedFile);
+  const isDraggingOver = useWindowFileDrop(
+    selectedModel,
+    onUnsupportedFile,
+    disabled,
+  );
   const supportsFiles = modelSupportsFiles(selectedModel);
 
   return (
@@ -496,6 +508,7 @@ export function ChatInput({
               <FileDropZone
                 selectedModel={selectedModel}
                 onUnsupportedFile={onUnsupportedFile}
+                disabled={voice.status === "recording"}
               />
 
               <div className="group/input relative flex flex-col gap-2 flex-1">

--- a/apps/mesh/src/web/components/chat/tiptap/input.test.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/input.test.tsx
@@ -3,8 +3,10 @@ setupComponentTest();
 import { describe, expect, it } from "bun:test";
 import { render } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { EditorContent, useCurrentEditor } from "@tiptap/react";
+import { EditorContent, useCurrentEditor, type Editor } from "@tiptap/react";
 import { TiptapProvider } from "./input";
+import { FileUploader } from "./file";
+import type { AiProviderModel } from "@/web/hooks/collections/use-ai-providers.ts";
 
 function EditableProbe() {
   const { editor } = useCurrentEditor();
@@ -34,5 +36,63 @@ describe("TiptapProvider disabled", () => {
     const { container } = renderProvider(false);
     const editable = container.querySelector("[contenteditable]");
     expect(editable?.getAttribute("contenteditable")).toBe("true");
+  });
+});
+
+const fakeModel = {
+  modelId: "m",
+  capabilities: [],
+} as unknown as AiProviderModel;
+
+function EditorProbe({
+  onEditor,
+}: {
+  onEditor: (editor: Editor | null) => void;
+}) {
+  const { editor } = useCurrentEditor();
+  onEditor(editor ?? null);
+  return null;
+}
+
+function hasFileDropPlugin(editor: Editor) {
+  return editor.state.plugins.some((p) =>
+    (p.spec.key as { key?: string } | undefined)?.key?.startsWith(
+      "fileDropHandler$",
+    ),
+  );
+}
+
+// TiptapInput only mounts <FileUploader> when `showFileUploader && selectedModel
+// && !disabled` (see input.tsx). These tests exercise FileUploader directly —
+// mirroring that mount/unmount condition — instead of rendering TiptapInput,
+// which would additionally require QueryClientProvider/ProjectContext for its
+// SlashMention/AtMention children (per this file's no-stubbed-context policy).
+describe("FileUploader mount (mirrors TiptapInput's disabled gate)", () => {
+  it("does not register the file-drop/paste handler while unmounted (disabled)", () => {
+    let editor: Editor | null = null;
+    render(
+      <TiptapProvider tiptapDoc={undefined} setTiptapDoc={() => {}}>
+        <EditorProbe onEditor={(e) => (editor = e)} />
+      </TiptapProvider>,
+    );
+    expect(editor).not.toBeNull();
+    expect(hasFileDropPlugin(editor!)).toBe(false);
+  });
+
+  it("registers the file-drop/paste handler when mounted (not disabled)", () => {
+    let editor: Editor | null = null;
+    function MountedFileUploader() {
+      const { editor } = useCurrentEditor();
+      if (!editor) return null;
+      return <FileUploader editor={editor} selectedModel={fakeModel} />;
+    }
+    render(
+      <TiptapProvider tiptapDoc={undefined} setTiptapDoc={() => {}}>
+        <EditorProbe onEditor={(e) => (editor = e)} />
+        <MountedFileUploader />
+      </TiptapProvider>,
+    );
+    expect(editor).not.toBeNull();
+    expect(hasFileDropPlugin(editor!)).toBe(true);
   });
 });

--- a/apps/mesh/src/web/components/chat/tiptap/input.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/input.tsx
@@ -251,7 +251,7 @@ export function TiptapInput({
       </Suspense>
 
       {/* Render file upload handler */}
-      {showFileUploader && selectedModel ? (
+      {showFileUploader && selectedModel && !disabled ? (
         <FileUploader
           editor={editor}
           selectedModel={selectedModel}


### PR DESCRIPTION
**Source:** hardening follow-up to #4990 ("actually disable the composer while voice recording is active"), found while auditing that fix's blast radius across every content-insertion path in the composer.

**Bug:** #4990 fixed typing during voice recording by wiring `disabled={voice.status === "recording"}` into `TiptapProvider`/`TiptapInput`, which flips the editor's `contentEditable` off. But two other insertion paths bypass `contentEditable` entirely and were left unguarded:
- `useWindowFileDrop` (`apps/mesh/src/web/components/chat/input.tsx`) listens for `drop` on `window` and calls `editor.commands...` directly to insert a dropped file — it never checks `editor.isEditable` or the recording state.
- `FileUploader`'s ProseMirror plugin (`handleDrop`/`handlePaste`) was unconditionally mounted by `TiptapInput` regardless of `disabled`, so dropping a file onto the editor or pasting one from the clipboard still inserted content mid-recording.

**Failure scenario:** user starts voice recording, then drags a file onto the composer (or pastes one from the clipboard). The file gets inserted into the doc. On the very next transcript tick, the `syncVoiceText` effect calls `editor.commands.setContent(baseline)` (baseline captured before recording started) and re-inserts only the transcript text — silently wiping the just-attached file with no error or warning to the user.

**Fix:** thread the same `voice.status === "recording"` flag into `useWindowFileDrop`'s guard (skip processing while disabled) and into `TiptapInput`'s file-uploader mount condition (`showFileUploader && selectedModel && !disabled`), so drop/paste are inert exactly when typing already is — one boolean gate applied consistently across all three insertion paths.

**Regression test:** `apps/mesh/src/web/components/chat/tiptap/input.test.tsx` adds two tests asserting whether `FileUploader`'s ProseMirror plugin (`fileDropHandler$`) is registered on the editor's plugin list when mounted vs. unmounted — mirroring `TiptapInput`'s disabled gate. It renders `FileUploader` directly rather than `TiptapInput` itself, since `TiptapInput`'s `SlashMention`/`AtMention` children need `QueryClientProvider`/`ProjectContext`, consistent with this file's existing no-stubbed-context test for the #4990 fix.

**Reviewer check:** `cd apps/mesh && bun test src/web/components/chat/tiptap/input.test.tsx`

**Local verification:** `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/mesh` (clean), targeted test above (4 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable file drop and paste while voice recording is active in the chat composer. This aligns all insertion paths with the existing typing lock and prevents attachments from being wiped by transcript sync.

- **Bug Fixes**
  - Added a `disabled` guard to `useWindowFileDrop` when `voice.status === "recording"`.
  - Gate-mounted `FileUploader` in `TiptapInput` (`showFileUploader && selectedModel && !disabled`) so drop/paste handlers are inactive during recording.
  - Added tests to verify the file drop/paste plugin is only registered when not disabled.

<sup>Written for commit 6994326fbd1c5b6614f4d3bf6c6768727248a92b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

