### PR TITLE
fix(sandbox): cap PhaseManager finished-phase history to stop unbounded growth

### DIFF
--- a/packages/sandbox/daemon/process/phase-manager.test.ts
+++ b/packages/sandbox/daemon/process/phase-manager.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { PhaseManager } from "./phase-manager";
+
+describe("PhaseManager", () => {
+  test("caps finished phases so a long-lived daemon doesn't leak memory", () => {
+    const pm = new PhaseManager();
+    for (let i = 0; i < 500; i++) {
+      pm.done(pm.begin(`task-${i}`));
+    }
+    expect(pm.list().length).toBeLessThanOrEqual(200);
+  });
+
+  test("keeps running phases regardless of finished count", () => {
+    const pm = new PhaseManager();
+    const runningId = pm.begin("still-running");
+    for (let i = 0; i < 500; i++) {
+      pm.done(pm.begin(`task-${i}`));
+    }
+    expect(pm.list({ status: ["running"] }).map((p) => p.id)).toEqual([
+      runningId,
+    ]);
+  });
+
+  test("recent() still surfaces the newest finished phases after trimming", () => {
+    const pm = new PhaseManager();
+    for (let i = 0; i < 500; i++) {
+      pm.done(pm.begin(`task-${i}`));
+    }
+    const recent = pm.recent(5);
+    expect(recent.map((p) => p.name)).toEqual([
+      "task-495",
+      "task-496",
+      "task-497",
+      "task-498",
+      "task-499",
+    ]);
+  });
+});

--- a/packages/sandbox/daemon/process/phase-manager.ts
+++ b/packages/sandbox/daemon/process/phase-manager.ts
@@ -13,6 +13,12 @@ export interface PhaseManagerDeps {
   onChange?: (phases: Phase[]) => void;
 }
 
+// A long-lived daemon can run many thousands of tasks (every /exec call
+// registers a phase); without a cap, finished phases accumulate in `all`
+// forever. `recent()` only ever surfaces the last 20 anyway, so anything
+// beyond this cap is unreachable dead weight.
+const MAX_FINISHED_PHASES = 200;
+
 /**
  * Lightweight in-memory phase registry. Tracks named setup phases (clone,
  * install, transition) so the LLM and the SSE stream have a structured view
@@ -47,6 +53,7 @@ export class PhaseManager {
     if (!t) return;
     t.status = "done";
     t.doneAt = Date.now();
+    this.trim();
     this.emit();
   }
 
@@ -56,6 +63,7 @@ export class PhaseManager {
     t.status = "failed";
     t.doneAt = Date.now();
     if (error) t.error = error;
+    this.trim();
     this.emit();
   }
 
@@ -75,6 +83,18 @@ export class PhaseManager {
 
   private findRunning(id: string): Phase | undefined {
     return this.all.find((t) => t.id === id && t.status === "running");
+  }
+
+  /** Drop the oldest finished phases once they exceed MAX_FINISHED_PHASES,
+   *  keeping all running ones regardless of count. */
+  private trim(): void {
+    const finished = this.all.filter((t) => t.status !== "running");
+    if (finished.length <= MAX_FINISHED_PHASES) return;
+    const drop = new Set(
+      finished.slice(0, finished.length - MAX_FINISHED_PHASES).map((t) => t.id),
+    );
+    const kept = this.all.filter((t) => !drop.has(t.id));
+    this.all.splice(0, this.all.length, ...kept);
   }
 
   private emit(): void {


### PR DESCRIPTION
**Source:** bug found while auditing subprocess orchestration in `packages/sandbox/daemon` (the harness-runner/task-manager area) for resource leaks.

**Payoff:** `PhaseManager.all` (`packages/sandbox/daemon/process/phase-manager.ts`) is a single long-lived array that receives a push on every `begin()` call and is never trimmed. `TaskManager.create()` calls `phaseManager.begin()` for every spawned task (every `/exec` request), so a sandbox daemon that stays up for a while and runs many commands (dev-server restarts, ad-hoc scripts, etc.) accumulates an ever-growing array of finished phase records that are never freed for the lifetime of the process — a straightforward memory leak. `recent()`, the only consumer used by the daemon's status route, already only ever surfaces the last 20 finished phases, so anything beyond that is unreachable dead weight kept alive for no reason.

**Fix:** cap finished phases at 200 (`MAX_FINISHED_PHASES`), trimming the oldest ones in `done()`/`fail()` — mirrors the existing reap pattern `TaskManager` already uses for its own task history. Running phases are never dropped regardless of count.

**Regression test:** `packages/sandbox/daemon/process/phase-manager.test.ts` — asserts that after 500 begin/done cycles the phase list stays capped at 200, that in-flight running phases always survive trimming, and that `recent()` still returns the newest finished phases after trimming kicks in.

**To confirm:** `bun test packages/sandbox/daemon/process/phase-manager.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox`, and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops unbounded memory growth in the sandbox daemon by capping finished phase history in `PhaseManager` at 200. Running phases are never dropped and `recent()` still returns the newest items.

- **Bug Fixes**
  - Added `MAX_FINISHED_PHASES = 200` and trim oldest finished phases in `done()`/`fail()` in `packages/sandbox/daemon/process/phase-manager.ts`.
  - Never drop running phases.
  - Added tests in `packages/sandbox/daemon/process/phase-manager.test.ts` to verify capping, running-phase retention, and `recent()` behavior.

<sup>Written for commit 6e0b50186614f39417ce7fda342e7e6a92177d08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

