### PR TITLE
fix(auth): recognize comma-joined multi-role owner/admin in org-pin gate

### DIFF
--- a/apps/mesh/src/tools/virtual/require-org-admin-for-pin.test.ts
+++ b/apps/mesh/src/tools/virtual/require-org-admin-for-pin.test.ts
@@ -21,6 +21,12 @@ describe("requireOrgAdminForPinnedField", () => {
     ).not.toThrow();
   });
 
+  test("allows a comma-joined multi-role owner/admin", () => {
+    expect(() =>
+      requireOrgAdminForPinnedField(ctxWithRole("admin,billing-manager")),
+    ).not.toThrow();
+  });
+
   test("rejects member and missing role", () => {
     expect(() => requireOrgAdminForPinnedField(ctxWithRole("user"))).toThrow(
       ForbiddenError,

--- a/apps/mesh/src/tools/virtual/require-org-admin-for-pin.ts
+++ b/apps/mesh/src/tools/virtual/require-org-admin-for-pin.ts
@@ -2,13 +2,13 @@
  * Org-wide agent pin (`connections.pinned`) is an admin/owner action.
  */
 
-import { ADMIN_ROLES, type BuiltinRole } from "../../auth/roles";
+import { hasAdminRole } from "../../auth/roles";
 import { ForbiddenError } from "../../core/access-control";
 import type { StudioContext } from "../../core/studio-context";
 
 export function requireOrgAdminForPinnedField(ctx: StudioContext): void {
   const role = ctx.access.getRole();
-  if (!role || !ADMIN_ROLES.includes(role as BuiltinRole)) {
+  if (!hasAdminRole(role)) {
     throw new ForbiddenError(
       "Only organization owners and admins can change org-wide pin status",
     );


### PR DESCRIPTION
Follows the same bug family already fixed in canAssignRole/context-factory/model-permissions (#4900, #4918, #4923, #4955, #4958): a lingering exact-match role check.

`requireOrgAdminForPinnedField` (apps/mesh/src/tools/virtual/require-org-admin-for-pin.ts), used by the `virtual/create.ts` and `virtual/update.ts` tools to gate the org-wide agent pin (`connections.pinned`) action, checked `ADMIN_ROLES.includes(role as BuiltinRole)` — an exact string match. Better Auth returns comma-joined multi-role strings (e.g. `"admin,billing-manager"`) for members with more than one role. That caller-role format silently fails the exact match, so a legitimate multi-role owner/admin gets a 403 `ForbiddenError` trying to pin/unpin an org-wide connection, even though they hold the admin role.

A maintainer wants this because it's a real functional regression for any org using custom multi-role assignments (a real, shipped feature) combined with the org-pin action — not a hypothetical.

Failure scenario: a member with role string `"admin,billing-manager"` calls `VIRTUAL_UPDATE`/`VIRTUAL_CREATE` with `pinned: true` → `requireOrgAdminForPinnedField` throws `ForbiddenError` despite the member being an org admin.

Fix: swap the exact-match check for the existing `hasAdminRole(role)` helper (apps/mesh/src/auth/roles.ts), which already splits on comma and checks each role — the same helper used to fix this exact bug pattern elsewhere. Added a regression test case (`allows a comma-joined multi-role owner/admin`) to the existing test file, which already covered the single-role owner/admin/user/undefined cases.

Reviewer command: `bun test apps/mesh/src/tools/virtual/require-org-admin-for-pin.test.ts`

Locally ran: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file above (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the org-wide pin gate to recognize comma-joined multi-role admin/owner strings, preventing false 403s for legit admins when pinning/unpinning org-wide connections.

- **Bug Fixes**
  - Switched to `hasAdminRole(role)` in `requireOrgAdminForPinnedField` instead of exact string match.
  - Added a regression test for a multi-role value like "admin,billing-manager".

<sup>Written for commit 31a8f44e14281dfb0496c850ee7e89368cc03d7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

