### PR TITLE
fix(sandbox): sweep expired cancel tombstones to stop unbounded growth

### DIFF
--- a/packages/sandbox/daemon/routes/dispatch.test.ts
+++ b/packages/sandbox/daemon/routes/dispatch.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { fixtures } from "../../dispatch/index";
-import { handleCancelRequest, handleDispatchRequest } from "./dispatch";
+import {
+  getTombstoneCountForTests,
+  handleCancelRequest,
+  handleDispatchRequest,
+  resetDispatchStateForTests,
+} from "./dispatch";
 
 const DAEMON_TOKEN = "test-daemon-token-32-chars-min-aaaa";
 
@@ -421,5 +426,32 @@ describe("DELETE /_sandbox/runs/:runId", () => {
       { daemonToken: DAEMON_TOKEN },
     );
     expect(res.status).toBe(401);
+  });
+
+  it("sweeps expired tombstones instead of growing forever", async () => {
+    // Most cancelled runs are never re-dispatched, so the only other read
+    // site (the dispatch handler's own-runId check) never fires for them.
+    // Without a sweep, every cancel the daemon ever handles leaks one entry
+    // for the lifetime of the process.
+    resetDispatchStateForTests();
+    const originalNow = Date.now;
+    try {
+      let now = 1_000_000;
+      Date.now = () => now;
+
+      await handleCancelRequest(authedCancel("run-leak-1"), {
+        daemonToken: DAEMON_TOKEN,
+      });
+      expect(getTombstoneCountForTests()).toBe(1);
+
+      now += 61_000; // past the 60s tombstone TTL
+      await handleCancelRequest(authedCancel("run-leak-2"), {
+        daemonToken: DAEMON_TOKEN,
+      });
+      // run-leak-1's entry expired and was swept; only the fresh one remains.
+      expect(getTombstoneCountForTests()).toBe(1);
+    } finally {
+      Date.now = originalNow;
+    }
   });
 });

--- a/packages/sandbox/daemon/routes/dispatch.ts
+++ b/packages/sandbox/daemon/routes/dispatch.ts
@@ -116,6 +116,24 @@ export function resetDispatchStateForTests(): void {
   tombstones.clear();
 }
 
+/** Test-visible peek at the tombstone map size — see `sweepExpiredTombstones`. */
+export function getTombstoneCountForTests(): number {
+  return tombstones.size;
+}
+
+/** Drop expired tombstone entries. A cancelled run whose runId is never
+ *  re-dispatched (the common case — most cancels are final) otherwise sits
+ *  in `tombstones` for the lifetime of the daemon process, since the only
+ *  other read site deletes by that exact runId. Called on every cancel so
+ *  the map stays bounded by "cancels within the last `TOMBSTONE_MS`", not by
+ *  total cancels ever issued. */
+function sweepExpiredTombstones(): void {
+  const now = Date.now();
+  for (const [runId, expiry] of tombstones) {
+    if (expiry <= now) tombstones.delete(runId);
+  }
+}
+
 /** SSE response headers. Shared by both the synchronous (non-offload) and the
  *  deferred (offload) paths so the cluster's dispatcher sees the identical
  *  first frame regardless of which path served the request. */
@@ -504,6 +522,7 @@ export async function handleCancelRequest(
 
   const ctrl = activeRuns.get(runId);
   if (ctrl) ctrl.abort();
+  sweepExpiredTombstones();
   tombstones.set(runId, Date.now() + TOMBSTONE_MS);
 
   // Idempotent: 204 whether or not the runId was active. The caller fires


### PR DESCRIPTION
A reduction/bug-fix in the sandbox daemon's dispatch route (`packages/sandbox/daemon/routes/dispatch.ts`), found while hunting for resource leaks in the daemon's dispatch/routing code (same shape as the already-merged #4995, which capped PhaseManager's unbounded finished-phase history).

**The bug:** `DELETE /_sandbox/runs/:id` writes a 60s tombstone into a module-scoped `Map<runId, expiry>` so a dispatch racing in right after a cancel resolves to 410 instead of starting an orphan harness. The only place that ever deletes an entry is the dispatch handler's own tombstone check for *that exact* `runId` — but the common case is a cancel that's final: the run is never re-dispatched. Every such cancel leaves its tombstone in the map forever, for the lifetime of the daemon process. A long-lived sandbox daemon that serves many cancelled runs over time accumulates an unbounded number of stale entries.

**The fix:** sweep expired entries out of the map on every cancel call (the only site that grows it), bounding its size to "cancels within the last 60s" instead of "cancels ever issued". Behavior-preserving: the 410-on-race semantics for genuinely recent tombstones are unchanged (verified by the existing test `returns 410 Gone for a tombstoned runId`), and the sweep only removes entries whose TTL already lapsed.

**Regression test:** `sweeps expired tombstones instead of growing forever` in `dispatch.test.ts` — fakes `Date.now()` to cancel one run, advance past the 60s TTL, cancel a second run, and assert the map holds only the fresh entry instead of 2.

**To verify:** `bun test packages/sandbox/daemon/routes/dispatch.test.ts` (16 pass, including the new test and the pre-existing tombstone-race test).

**Locally ran:** `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit` (clean), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sweep expired cancel tombstones in the sandbox daemon to prevent the tombstone map from growing without bound. Keeps memory bounded while preserving the 410-on-race behavior.

- **Bug Fixes**
  - Added `sweepExpiredTombstones()` in `packages/sandbox/daemon/routes/dispatch.ts` and call it on each cancel; the map now keeps only entries within the 60s TTL.
  - Added test-only helpers and a regression test in `packages/sandbox/daemon/routes/dispatch.test.ts` to confirm expired entries are removed.

<sup>Written for commit 8c240b255ff17d1f72a2d35e109cc49fda4c6813. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/4998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

