### PR TITLE
fix(dev-assets): use constant-time compare for presigned URL signatures

### DIFF
--- a/apps/mesh/src/api/routes/dev-assets.test.ts
+++ b/apps/mesh/src/api/routes/dev-assets.test.ts
@@ -1,0 +1,49 @@
+import { createHmac } from "node:crypto";
+import { describe, expect, test } from "bun:test";
+import { getSettings } from "../../settings";
+import { verifySignature } from "./dev-assets";
+
+function sign(
+  orgId: string,
+  key: string,
+  expires: number,
+  method: "GET" | "PUT",
+): string {
+  const secret = getSettings().encryptionKey || "dev-secret";
+  return createHmac("sha256", secret)
+    .update(`${orgId}:${key}:${expires}:${method}`)
+    .digest("hex");
+}
+
+describe("verifySignature", () => {
+  test("accepts a signature matching the expected HMAC", () => {
+    const signature = sign("org_1", "logo.png", 9999999999, "GET");
+    expect(
+      verifySignature("org_1", "logo.png", 9999999999, "GET", signature),
+    ).toBe(true);
+  });
+
+  test("rejects a same-length signature that doesn't match", () => {
+    const signature = sign("org_1", "logo.png", 9999999999, "GET");
+    const tampered = `${signature.slice(0, -1)}${signature.at(-1) === "0" ? "1" : "0"}`;
+    expect(
+      verifySignature("org_1", "logo.png", 9999999999, "GET", tampered),
+    ).toBe(false);
+  });
+
+  test("rejects a mismatched-length signature without throwing", () => {
+    expect(() =>
+      verifySignature("org_1", "logo.png", 9999999999, "GET", "short"),
+    ).not.toThrow();
+    expect(
+      verifySignature("org_1", "logo.png", 9999999999, "GET", "short"),
+    ).toBe(false);
+  });
+
+  test("rejects a signature minted for a different method", () => {
+    const signature = sign("org_1", "logo.png", 9999999999, "GET");
+    expect(
+      verifySignature("org_1", "logo.png", 9999999999, "PUT", signature),
+    ).toBe(false);
+  });
+});

--- a/apps/mesh/src/api/routes/dev-assets.ts
+++ b/apps/mesh/src/api/routes/dev-assets.ts
@@ -17,6 +17,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { StudioContext } from "../../core/studio-context";
 import { getSettings } from "../../settings";
+import { safeEqual } from "./credential-vault";
 
 // Base directory for dev assets (relative to cwd)
 const DEV_ASSETS_BASE_DIR = "./data/assets";
@@ -55,7 +56,7 @@ function getFilePath(orgId: string, key: string): string {
 /**
  * Verify a presigned URL signature
  */
-function verifySignature(
+export function verifySignature(
   orgId: string,
   key: string,
   expires: number,
@@ -67,7 +68,10 @@ function verifySignature(
   const expectedSignature = createHmac("sha256", secret)
     .update(data)
     .digest("hex");
-  return signature === expectedSignature;
+  // Constant-time compare — a plain `===` leaks timing info an attacker can
+  // use to forge a valid signature byte-by-byte, same class of bug the vault
+  // service token guards against (see credential-vault.ts's `safeEqual`).
+  return safeEqual(signature, expectedSignature);
 }
 
 /**


### PR DESCRIPTION
Trust-boundary hardening in `apps/mesh/src/api/routes/dev-assets.ts` — this is not a duplicate of the open CORS PR (#4120) or the other open security PRs, which touch `app.ts`/`auth/roles.ts` instead.

**The bug**: `verifySignature()` (the presigned-URL auth gate for the dev-assets GET/PUT file routes, used whenever the deployment runs without S3 configured) compared the caller-supplied HMAC signature with `===`, a non-constant-time string compare. This is CWE-208 (Observable Timing Discrepancy) — an attacker probing byte-by-byte can use response-time differences to forge a valid signature and read or overwrite another org's files without holding the real `encryptionKey` secret. The codebase already has an established fix for exactly this class of bug: `credential-vault.ts` exports `safeEqual()` (a length-check + `timingSafeEqual`) specifically for its service-token comparison, with a comment calling out "constant-time compare" as the requirement.

**Fix**: reuse that existing `safeEqual` helper in `verifySignature` instead of `===`. Same true/false result for every legitimate input — this only closes the timing side-channel — verified by re-running the exact same signature round-trip through both paths in the new test.

**Trust-boundary gate**: `verifySignature` gates auth for an untrusted request (URL query params `signature`/`expires`/`method`) that authorizes filesystem reads/writes — meets both the "auth for a network call" and "security vuln class" trust-boundary criteria in the review checklist, so a standalone regression test is warranted alongside the fix.

**Regression test** (`dev-assets.test.ts`, new file): asserts a correctly-signed request still verifies, a same-length tampered signature is rejected, a *different-length* signature is rejected **without throwing** (this is the one behavior that would regress if `timingSafeEqual` were used directly without the length guard `safeEqual` already provides — `timingSafeEqual` throws on a buffer-length mismatch), and a signature minted for the other HTTP method is rejected.

**To verify**: `cd apps/mesh && bun test src/api/routes/dev-assets.test.ts`

**Locally ran**: `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace, clean), and the targeted test file above (4/4 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use constant-time compare for dev-asset presigned URL signatures to prevent timing attacks. Adds regression tests; no behavior change for valid requests.

- **Bug Fixes**
  - Replaced `===` with `safeEqual` in `verifySignature` for dev-assets GET/PUT routes to close a timing side-channel.
  - Exported `verifySignature` for testing.
  - Added `dev-assets.test.ts` covering: valid signature, same-length tamper, different-length (no throw), and method mismatch.

<sup>Written for commit a96a236604eccc65ebfa420d57329254e6ae651d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

