### PR TITLE
refactor(registry): drop unnecessary any-cast on ctx.db in getRegistryPluginSettings

### DIFF
--- a/apps/mesh/src/tools/registry/utils.ts
+++ b/apps/mesh/src/tools/registry/utils.ts
@@ -27,7 +27,7 @@ export async function getRegistryPluginSettings(
   ctx: StudioContext,
   organizationId: string,
 ): Promise<PrivateRegistryPluginSettings> {
-  const rows = await (ctx.db as any)
+  const rows = await ctx.db
     .selectFrom("virtual_mcp_plugin_configs")
     .innerJoin(
       "connections",
@@ -39,9 +39,7 @@ export async function getRegistryPluginSettings(
     .where("virtual_mcp_plugin_configs.plugin_id", "=", PLUGIN_ID)
     .execute();
 
-  const parsedSettings = (rows as Array<{ settings: unknown }>).map((row) =>
-    parsePluginSettings(row.settings),
-  );
+  const parsedSettings = rows.map((row) => parsePluginSettings(row.settings));
 
   // Plugin settings are persisted per-project. For org-wide Store behavior, we
   // treat booleans as enabled when any project has them enabled.


### PR DESCRIPTION
**Source:** C-DEBT type-safety cleanup found while hunting the registry area (the `registry-catalog` static-JSON-catalog module this tick's focus area pointed at doesn't exist in this checkout yet — it's part of still-open #4169 — so I widened to the existing `apps/mesh/src/tools/registry/` surface and grepped it for `as any`).

**Why:** `getRegistryPluginSettings` cast `ctx.db` to `any` and then re-cast the query result to `Array<{ settings: unknown }>`, silencing type-checking on a real DB query for no reason — `StudioContext.db` is already `Kysely<Database>` and `virtual_mcp_plugin_configs` is a real table in `Database`, so Kysely already infers the correct row shape.

**Change:** removed both casts; `ctx.db.selectFrom(...)` now flows through Kysely's normal type inference, and the mapped rows use their inferred `settings` field directly. Purely type-level — no runtime behavior change (net -4/+2 lines).

**Verified:** `cd apps/mesh && bunx tsc --noEmit` is clean (no new errors, and none previously suppressed by the cast surfaced). No existing test covers this function, and none needed — this is a compile-time-only change with a clean typecheck as its proof, per the C-DEBT gate for `any` removal.

**Reviewer check:** `cd apps/mesh && bunx tsc --noEmit`.

Full CI (lint, full test suite) covers everything else.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unnecessary any-casts in getRegistryPluginSettings to rely on `Kysely`-inferred row types and restore type safety. No runtime changes; code now uses the inferred settings field directly.

<sup>Written for commit 14810be2cfc07aa023f357c13ae62915988f6eef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

