### PR TITLE
fix(settings): replace native confirm() with AlertDialog for SSO removal

### DIFF
--- a/apps/mesh/src/web/views/settings/org-sso.tsx
+++ b/apps/mesh/src/web/views/settings/org-sso.tsx
@@ -2,6 +2,15 @@ import { useState } from "react";
 import { DomainSettings } from "@/web/components/settings/domain-settings";
 import { toast } from "sonner";
 import { Page } from "@/web/components/page";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@deco/ui/components/alert-dialog.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Switch } from "@deco/ui/components/switch.tsx";
@@ -40,6 +49,7 @@ export function OrgSsoPage() {
     scopes: "openid email profile",
   });
   const [isEditing, setIsEditing] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const isConfigured = ssoData?.configured && ssoData.config;
   const config = ssoData?.config;
@@ -96,12 +106,12 @@ export function OrgSsoPage() {
   };
 
   const handleDelete = async () => {
-    if (!confirm(t("settings.orgSso.removeConfirmation"))) return;
     try {
       await deleteMutation.mutateAsync();
       track("sso_config_removed", { organization_id: org.id });
       toast.success(t("settings.orgSso.configurationRemovedSuccess"));
       setIsEditing(false);
+      setConfirmDeleteOpen(false);
     } catch {
       toast.error(t("settings.orgSso.removeSsoConfigError"));
     }
@@ -185,7 +195,7 @@ export function OrgSsoPage() {
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={handleDelete}
+                          onClick={() => setConfirmDeleteOpen(true)}
                           disabled={deleteMutation.isPending}
                           className="text-destructive hover:text-destructive mr-auto"
                         >
@@ -375,6 +385,28 @@ export function OrgSsoPage() {
           </SettingsPage>
         </Page.Body>
       </Page.Content>
+
+      <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("settings.orgSso.removeConfirmation")}
+            </AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMutation.isPending}>
+              {t("settings.orgSso.cancelButton")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {t("settings.orgSso.removeButton")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Page>
   );
 }


### PR DESCRIPTION
Bug/polish fix in `apps/mesh/src/web/views/settings/org-sso.tsx`, found while auditing the settings-ui-cleanup area.

`handleDelete` used the browser's native `confirm()` to gate removing an org's SSO configuration — the only destructive action in this file (and the only one in the settings area) not using the design system's `AlertDialog`. Every sibling destructive action in this same area (`DeleteOrganizationSection`, the buckets page's `DeleteFileConfigDialog`) already uses the themed, accessible `AlertDialog` pattern; `confirm()` is unstyled, ignores the app's dark/light theme, isn't focus-trapped consistently with the rest of the app, and blocks the main thread synchronously.

Change: swapped the `confirm()` gate for a controlled `AlertDialog` (open state + Cancel/Action), matching the exact pattern already used in this file's sibling components. No new behavior — same delete mutation, same toasts, same tracking call — only the confirmation UI changed. Reused existing i18n keys (`removeConfirmation`, `cancelButton`, `removeButton`) rather than adding new translation strings.

To confirm: open an org's Security settings page with SSO configured, click "Remove", verify the app's styled AlertDialog appears (matching the org-delete and bucket-delete dialogs) instead of a native browser confirm popup, and that Cancel/Remove behave as before.

Local checks run: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (both clean). No test file exists for this component (pure UI wiring, no branching logic), so no targeted test was added; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the browser confirm with a controlled `AlertDialog` from `@deco/ui` for removing an org’s SSO in Security settings. This aligns with other destructive dialogs, keeps theme/accessibility consistent, and avoids blocking; the delete mutation, toasts, and tracking are unchanged.

<sup>Written for commit 04d8b7c6e40e4598008a5791942e6c1d5b05dfe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

