### PR TITLE
refactor(agent-icon): remove unused role prop

### DIFF
--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -290,7 +290,6 @@ interface AgentAvatarProps {
   size?: AgentAvatarSize;
   className?: string;
   "aria-label"?: string;
-  role?: string;
 }
 
 /** Colored background + centered icon — shared by all icon-rendering paths. */
@@ -300,14 +299,12 @@ function IconAvatar({
   size,
   className,
   "aria-label": ariaLabel,
-  role,
 }: {
   Icon: IconComponent;
   color: AgentIconColor;
   size: AgentAvatarSize;
   className?: string;
   "aria-label"?: string;
-  role?: string;
 }) {
   const sizeConfig = SIZES[size];
   return (
@@ -321,7 +318,6 @@ function IconAvatar({
         className,
       )}
       aria-label={ariaLabel}
-      role={role}
     >
       <Icon size={sizeConfig.icon} />
     </div>
@@ -334,7 +330,6 @@ export function AgentAvatar({
   size = "md",
   className,
   "aria-label": ariaLabel,
-  role,
 }: AgentAvatarProps) {
   const parsed = parseIconString(icon);
 
@@ -350,7 +345,6 @@ export function AgentAvatar({
         size={size}
         className={className}
         aria-label={ariaLabel}
-        role={role}
       />
     );
   }
@@ -367,7 +361,6 @@ export function AgentAvatar({
         size={size}
         className={className}
         aria-label={ariaLabel}
-        role={role}
       />
     );
   }
@@ -382,7 +375,6 @@ export function AgentAvatar({
       size={size}
       className={className}
       aria-label={ariaLabel}
-      role={role}
     />
   );
 }
@@ -412,7 +404,6 @@ function AgentAvatarImage({
   size = "md",
   className,
   "aria-label": ariaLabel,
-  role,
 }: {
   url: string;
   color?: string;
@@ -420,7 +411,6 @@ function AgentAvatarImage({
   size?: AgentAvatarSize;
   className?: string;
   "aria-label"?: string;
-  role?: string;
 }) {
   const [errored, setErrored] = useState(false);
   const sizeConfig = SIZES[size];
@@ -435,7 +425,6 @@ function AgentAvatarImage({
         size={size}
         className={className}
         aria-label={ariaLabel}
-        role={role}
       />
     );
   }
@@ -450,7 +439,6 @@ function AgentAvatarImage({
         className,
       )}
       aria-label={ariaLabel}
-      role={role}
     >
       <img
         src={url}


### PR DESCRIPTION
## Summary

The `role` prop was added in PR #4956 alongside `aria-label` for accessibility, but no callers actually pass it. Removing this unused parameter simplifies the component API and reduces maintenance surface.

## Changes

- Removed `role?: string` parameter from AgentAvatarProps, IconAvatar, and AgentAvatarImage
- Removed all `role={role}` prop forwarding throughout the component hierarchy
- No behavioral changes; aria-label accessibility support remains intact

## Verification

- Ran `bun run fmt` — no changes needed
- Ran `cd apps/mesh && bunx tsc --noEmit` — passes
- Ran `bun test src/web/components/agent-icon.test.tsx --cwd=apps/mesh` — all 2 tests pass
- `rg` confirms zero callers pass the `role` prop to AgentAvatar

## Diff

-12 lines / +0 lines (pure deletion)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `role` prop from `AgentAvatar`, `IconAvatar`, and `AgentAvatarImage` to simplify the component API. No behavior changes; accessibility via `aria-label` remains.

<sup>Written for commit 04102d1f603f69d896b90b8fdab5cb513e4360ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

