### PR TITLE
refactor(tiptap): type MentionStorage via Tiptap's Storage augmentation

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
@@ -44,10 +44,14 @@ export interface MentionStorage {
   onEditChip: ((req: EditMentionRequest) => void) | null;
 }
 
+declare module "@tiptap/core" {
+  interface Storage {
+    mention: MentionStorage;
+  }
+}
+
 export function getMentionStorage(editor: Editor): MentionStorage | undefined {
-  return (editor.storage as unknown as Record<string, unknown>).mention as
-    | MentionStorage
-    | undefined;
+  return editor.storage.mention;
 }
 
 // ============================================================================


### PR DESCRIPTION
**Source:** reduction/type-safety cleanup found while hunting the tiptap mention node for debt (no issue).

**Why:** `getMentionStorage` read `editor.storage.mention` through a `(editor.storage as unknown as Record<string, unknown>).mention as MentionStorage | undefined` double-cast, which fully opts the read out of type-checking — a typo in the key or a shape drift in `MentionStorage` would silently pass `tsc`. Tiptap's own escape hatch for this is module augmentation of its `Storage` interface (documented at https://tiptap.dev/docs/editor/guide/custom-extensions#storage), which is the idiomatic fix here rather than a narrower cast.

**Change:** added `declare module "@tiptap/core" { interface Storage { mention: MentionStorage } }` next to the `MentionStorage` type, and simplified `getMentionStorage` to `return editor.storage.mention;` — no casts. Verified `editor.storage` has no other untyped-key readers in `apps/mesh/src/web` (`grep -rn "editor.storage\."`), so widening the `Storage` interface can't break unrelated call sites. Behavior is unchanged — same runtime property read, now type-checked.

**Command to verify:** `cd apps/mesh && bunx tsc --noEmit`

**Checks run locally:** `bun run fmt`, targeted `bunx tsc --noEmit` in `apps/mesh` (clean, no errors). No existing test file covers this node and none was warranted — pure type-safety change with no behavior delta. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed the `mention` storage via `@tiptap/core` Storage augmentation and removed the unsafe double-cast in `getMentionStorage`. This restores type safety for `editor.storage.mention` with no runtime behavior change.

<sup>Written for commit 59f5081ee27782fe5f67b2e7942c50a633d75fab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

