### PR TITLE
fix(icon-picker): add aria-label to SimpleIconPicker grid icon buttons

### DIFF
--- a/apps/mesh/src/web/components/simple-icon-picker.tsx
+++ b/apps/mesh/src/web/components/simple-icon-picker.tsx
@@ -115,6 +115,7 @@ export function SimpleIconPicker({
                         : "text-muted-foreground hover:bg-accent hover:text-foreground",
                     )}
                     title={humanizeIconName(iconName)}
+                    aria-label={humanizeIconName(iconName)}
                   >
                     <IconComp size={16} />
                   </button>


### PR DESCRIPTION
Source: bug hunt over recently-changed files (SimpleIconPicker is in this tick's churn list alongside icon-picker.tsx).

Each icon in `SimpleIconPicker`'s grid is an icon-only `<button>` with only a `title` attribute — screen readers announce nothing for it. The sibling `IconPicker`'s equivalent grid (`icon-picker.tsx`) already sets `aria-label={humanizeIconName(iconName)}` on its icon buttons (its trigger and color-swatch buttons already have aria-labels too); this grid was the one spot missed, so keyboard/screen-reader users picking an agent icon here get no accessible name per option.

Fix: add the same `aria-label={humanizeIconName(iconName)}` used by `icon-picker.tsx`'s grid. Net diff: +1 line.

Reviewer check: `bunx tsc --noEmit` in `apps/mesh` (no type changes, but confirms nothing broke) and visually confirm the grid buttons in a screen reader / accessibility tree now expose a name (e.g. via browser devtools Accessibility panel).

Locally ran: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean). No test added — this mirrors the repo's existing aria-label PRs (#4903, #4904, #4948), which also shipped without a dedicated test since it's a static JSX attribute, not branching logic. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `aria-label={humanizeIconName(iconName)}` to `SimpleIconPicker` grid icon buttons so screen readers announce each icon’s name. Matches `icon-picker.tsx` and improves accessibility for keyboard and screen-reader users.

<sup>Written for commit f8d1d566b23cc4089a9a3cecf071b4e77989672c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

