### PR TITLE
fix(sandbox): stop logging cancelled-run AbortErrors as harness crashes

### DIFF
--- a/packages/sandbox/daemon/routes/dispatch.test.ts
+++ b/packages/sandbox/daemon/routes/dispatch.test.ts
@@ -301,6 +301,86 @@ describe("POST /_sandbox/dispatch", () => {
     await reader.cancel();
   });
 
+  it("does not log an aborted run's AbortError via console.error (#3763)", async () => {
+    // A cancelled run (DELETE /_sandbox/runs/:id) aborts the injected signal,
+    // which makes the harness's in-flight fetch/streamText throw an AbortError
+    // — expected control flow, not a crash. It must not flood error tracking.
+    const runId = "run-abort-no-error-log";
+    let capturedSignal: AbortSignal | undefined;
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((r) => {
+      releaseGate = r;
+    });
+
+    const deps = makeDeps({
+      lookupHarness: (_id, input) => {
+        capturedSignal = (input as { signal?: AbortSignal }).signal;
+        return {
+          async *stream() {
+            yield { type: "start", id: "m1" } as const;
+            await gate;
+            throw new DOMException("The operation was aborted.", "AbortError");
+          },
+        };
+      },
+    });
+
+    const body = JSON.stringify({
+      runId,
+      harnessId: "fake",
+      input: {
+        ...fixtures.FIXTURE_MINIMAL_INPUT,
+        threadId: "thread-abort-no-error-log",
+      },
+    });
+
+    const errorArgs: unknown[][] = [];
+    const logArgs: unknown[][] = [];
+    const originalConsoleError = console.error;
+    const originalConsoleLog = console.log;
+    console.error = (...args: unknown[]) => {
+      errorArgs.push(args);
+    };
+    console.log = (...args: unknown[]) => {
+      logArgs.push(args);
+    };
+
+    try {
+      const res = await handleDispatchRequest(authedDispatch(body), deps);
+      const reader = res.body!.getReader();
+
+      await reader.read(); // consume "start" chunk → lookupHarness ran
+
+      await handleCancelRequest(authedCancel(runId), {
+        daemonToken: DAEMON_TOKEN,
+      });
+      expect(capturedSignal?.aborted).toBe(true);
+
+      releaseGate(); // let the harness throw the AbortError now
+
+      // Once aborted, `write()` is a deliberate no-op (the consumer is gone —
+      // see the guard above `streamHarnessRun`'s catch), so no further SSE
+      // frames arrive; just drain until the controller closes.
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    } finally {
+      console.error = originalConsoleError;
+      console.log = originalConsoleLog;
+    }
+
+    const crashLogged = errorArgs.some((args) =>
+      args.some((a) => typeof a === "string" && a.includes("harness crashed")),
+    );
+    expect(crashLogged).toBe(false);
+
+    const abortLogged = logArgs.some((args) =>
+      args.some((a) => typeof a === "string" && a.includes("harness aborted")),
+    );
+    expect(abortLogged).toBe(true);
+  });
+
   it("rebases symbolic workspace.cwd onto the daemon's sandbox root before the harness sees it", async () => {
     // The wire carries the symbolic value "/repo"; the daemon must rebase it
     // onto its own sandbox root (daemonAppRoot()) before handing the input to

--- a/packages/sandbox/daemon/routes/dispatch.ts
+++ b/packages/sandbox/daemon/routes/dispatch.ts
@@ -164,10 +164,22 @@ async function streamHarnessRun(
       `[dispatch] done harness=${harnessId} runId=${runId} chunks=${chunkCount} aborted=${ctrl.signal.aborted}`,
     );
   } catch (err) {
-    console.error(
-      `[dispatch] harness crashed harness=${harnessId} runId=${runId} chunks=${chunkCount}:`,
-      err,
-    );
+    // An aborted run (DELETE /_sandbox/runs/:id, or a daemon-side timeout
+    // aborting `ctrl`) makes the harness's in-flight fetch/streamText throw
+    // "The operation was aborted." — expected control flow, not a crash.
+    // Logging it via console.error floods error tracking with noise on every
+    // cancelled run. `harness_crashed` still fires below so cluster-side
+    // cleanup is unchanged.
+    if (ctrl.signal.aborted) {
+      console.log(
+        `[dispatch] harness aborted harness=${harnessId} runId=${runId} chunks=${chunkCount}`,
+      );
+    } else {
+      console.error(
+        `[dispatch] harness crashed harness=${harnessId} runId=${runId} chunks=${chunkCount}:`,
+        err,
+      );
+    }
     const code: LinkErrorCode = "harness_crashed";
     write({
       type: "error",


### PR DESCRIPTION
Closes #3763.

When a run is cancelled (`DELETE /_sandbox/runs/:id`) or the daemon aborts a stalled run via its per-run `AbortController`, the harness's in-flight fetch/`streamText` call throws `"The operation was aborted."` (a DOMException `AbortError`). `streamHarnessRun`'s catch block logged this identically to a real crash — `console.error("[dispatch] harness crashed", err)` — so every cancelled/aborted run flooded error tracking with a benign, expected-control-flow message. A maintainer wants this because it's pure log noise masking real crash signals, on a path (cancel) that fires on every user-navigated-away or timed-out run.

**Fix**: in `packages/sandbox/daemon/routes/dispatch.ts`'s `streamHarnessRun`, the catch block now branches on `ctrl.signal.aborted` — an intentional abort logs via `console.log("[dispatch] harness aborted ...")` instead of `console.error`, while a genuine harness throw (unrelated to abort) still goes through `console.error` unchanged. The SSE `harness_crashed` error frame + `done` framing and `activeRuns` cleanup are untouched, so cluster-side behavior is identical — only the log level for the abort case changes.

**Regression test**: `packages/sandbox/daemon/routes/dispatch.test.ts` — "does not log an aborted run's AbortError via console.error (#3763)" cancels a run mid-stream, lets the harness throw a `DOMException("The operation was aborted.", "AbortError")`, and asserts `console.error` was never called with "harness crashed" while `console.log` was called with "harness aborted". The existing "harness crashed" test (a harness throwing an unrelated `Error("boom")` with no abort) continues to hit `console.error` as before, confirming real crashes are still logged.

**To verify**: `bun test packages/sandbox/daemon/routes/dispatch.test.ts`

**Checks run locally**: `bun run fmt` (clean), `cd packages/sandbox && bunx tsc --noEmit` (clean), targeted test file above (16 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating cancelled runs’ AbortErrors as harness crashes. We now log aborted runs at info level to cut error noise and keep real crash signals visible. Fixes #3763.

- **Bug Fixes**
  - In `streamHarnessRun` (`packages/sandbox/daemon/routes/dispatch.ts`), branch on `ctrl.signal.aborted`: log `[dispatch] harness aborted ...` via `console.log`; non-abort errors still use `console.error`. SSE/error framing and cleanup are unchanged.
  - Added a regression test (`packages/sandbox/daemon/routes/dispatch.test.ts`) to ensure aborted runs don’t hit `console.error` and do log the aborted message.

<sup>Written for commit 487d860e2e8dc877e6d01a6494fc01e79baf97c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

