### PR TITLE
fix(auth): exempt canonical org-scoped oauth-proxy from SSO enforcement

### DIFF
--- a/apps/mesh/src/api/app.test.ts
+++ b/apps/mesh/src/api/app.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { isSsoExemptPath } from "./app";
+
+describe("isSsoExemptPath", () => {
+  test("exempts the legacy unscoped oauth-proxy mount", () => {
+    expect(isSsoExemptPath("/oauth-proxy/conn_123/token")).toBe(true);
+  });
+
+  test("exempts the canonical org-scoped oauth-proxy mount", () => {
+    expect(isSsoExemptPath("/api/acme-corp/oauth-proxy/conn_123/token")).toBe(
+      true,
+    );
+    expect(
+      isSsoExemptPath("/api/acme-corp/oauth-proxy/conn_123/register"),
+    ).toBe(true);
+  });
+
+  test("exempts SSO, auth, tools-management, and admin routes", () => {
+    expect(isSsoExemptPath("/api/org-sso/acme-corp")).toBe(true);
+    expect(isSsoExemptPath("/api/auth/sign-in")).toBe(true);
+    expect(isSsoExemptPath("/api/tools/management")).toBe(true);
+    expect(isSsoExemptPath("/api/_admin/orgs")).toBe(true);
+  });
+
+  test("does not exempt other org-scoped routes", () => {
+    expect(isSsoExemptPath("/api/acme-corp/connections")).toBe(false);
+    expect(isSsoExemptPath("/api/acme-corp/mcp/conn_123")).toBe(false);
+  });
+});

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -315,6 +315,27 @@ function buildDecoOAuthParams(projectLocator: string | null): URLSearchParams {
 // ============================================================================
 
 /**
+ * Paths exempt from the server-side SSO enforcement middleware: SSO/auth
+ * routes, the OAuth proxy (legacy `/oauth-proxy/...` and canonical
+ * `/api/:org/oauth-proxy/...` — both must stay reachable so a browser
+ * session mid-connect to a downstream MCP isn't 403'd before it can
+ * establish an SSO session), and the instance-level admin surface.
+ */
+export function isSsoExemptPath(path: string): boolean {
+  return (
+    path.startsWith("/api/org-sso/") ||
+    path.startsWith("/api/auth/") ||
+    path.startsWith("/api/tools/management") ||
+    path.startsWith("/oauth-proxy/") ||
+    /^\/api\/[^/]+\/oauth-proxy\//.test(path) ||
+    // Instance-level operator surface — not governed by any single org's SSO
+    // policy. Without this, an admin whose active org enforces SSO gets 403'd
+    // off the whole dashboard, and the UI reads that as "not an admin".
+    path.startsWith(`${ADMIN_API_PREFIX}/`)
+  );
+}
+
+/**
  * Handle OAuth-proxy requests for an MCP connection.
  *
  * On the org-scoped mount (`/api/:org/oauth-proxy/...`) `resolveOrgFromPath`
@@ -1771,18 +1792,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // who haven't completed the SSO flow. Exempt paths: SSO routes themselves,
   // auth routes, and non-org-scoped endpoints.
   app.use("*", async (c, next) => {
-    const path = c.req.path;
-    // Skip SSO enforcement for SSO routes, auth routes, and public endpoints
-    if (
-      path.startsWith("/api/org-sso/") ||
-      path.startsWith("/api/auth/") ||
-      path.startsWith("/api/tools/management") ||
-      path.startsWith("/oauth-proxy/") ||
-      // Instance-level operator surface — not governed by any single org's SSO
-      // policy. Without this, an admin whose active org enforces SSO gets 403'd
-      // off the whole dashboard, and the UI reads that as "not an admin".
-      path.startsWith(`${ADMIN_API_PREFIX}/`)
-    ) {
+    if (isSsoExemptPath(c.req.path)) {
       return next();
     }
 


### PR DESCRIPTION
**What**: the server-side SSO-enforcement middleware in `apps/mesh/src/api/app.ts` exempts specific paths from the "block until SSO session is established" check. The exemption list included the legacy `/oauth-proxy/...` mount but not the canonical `/api/:org/oauth-proxy/...` mount added later by the `/api/:org/*` path migration (#3272, merged 2026-05-04 — after the SSO-enforcement exemption list was written in #2736, merged 2026-03-23).

**Why a maintainer wants this**: for an org with SSO enforcement turned on, a browser session mid-flow connecting a new downstream MCP (authorize/token/DCR-register against `/api/:org/oauth-proxy/:connectionId/*`) gets a hard 403 ("SSO authentication required for this organization") on the canonical path, while the exact same flow works fine on the legacy path. This is an inconsistency between the two mounts for identical functionality, not an intentional restriction — the legacy exemption's own comment states the rationale (avoid blocking users mid-OAuth-connect), and that rationale applies equally to the canonical mount.

**Fix**: extracted the exemption check into a pure, exported function `isSsoExemptPath(path)` and added a regex match for `/api/:org/oauth-proxy/...` (any org slug) alongside the existing legacy-path check. No other behavior changes — same exemptions, same fallthrough logic.

**Regression test**: `apps/mesh/src/api/app.test.ts` (new, unit tier, no DB/mocks) exercises `isSsoExemptPath` directly: confirms the canonical `/api/acme-corp/oauth-proxy/conn_123/token` and `/register` paths are now exempt (previously false), the legacy path and other existing exemptions (`/api/org-sso/`, `/api/auth/`, `/api/tools/management`, admin prefix) still are, and non-oauth-proxy org-scoped routes (`/api/acme-corp/connections`, `/api/acme-corp/mcp/...`) are correctly still NOT exempt (i.e. still SSO-gated).

**Reviewer command**: `cd apps/mesh && bun test src/api/app.test.ts`

**Locally verified**: `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace, clean), and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSO enforcement so OAuth-proxy requests on the canonical org-scoped path `/api/:org/oauth-proxy/...` are exempt, matching the legacy `/oauth-proxy/...`. This unblocks authorize/token/register flows when connecting MCPs under SSO.

- **Bug Fixes**
  - Added `isSsoExemptPath(path)` and included a regex to exempt `/api/:org/oauth-proxy/...` alongside the legacy path.
  - Kept existing exemptions (`/api/org-sso/`, `/api/auth/`, `/api/tools/management`, and admin routes) unchanged.
  - Added unit tests to cover the new exemption and ensure other org-scoped routes remain SSO-gated.

<sup>Written for commit 9b86287901c80c1957c92fe14fab7a2b588cb596. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

