### PR TITLE
fix(icon-picker): give the Icons/Upload switcher real ARIA tab semantics

### DIFF
--- a/apps/mesh/src/web/components/icon-picker.tsx
+++ b/apps/mesh/src/web/components/icon-picker.tsx
@@ -159,9 +159,25 @@ export function IconPicker({
           </div>
 
           {/* Tab bar */}
-          <div className="flex items-center border-b border-border px-3">
+          <div
+            role="tablist"
+            aria-label="Icon source"
+            className="flex items-center border-b border-border px-3"
+            onKeyDown={(e) => {
+              if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+              e.preventDefault();
+              const nextTab = tab === "icons" ? "upload" : "icons";
+              setTab(nextTab);
+              document.getElementById(`icon-picker-tab-${nextTab}`)?.focus();
+            }}
+          >
             <button
+              id="icon-picker-tab-icons"
               type="button"
+              role="tab"
+              aria-selected={tab === "icons"}
+              aria-controls="icon-picker-panel-icons"
+              tabIndex={tab === "icons" ? 0 : -1}
               onClick={() => setTab("icons")}
               className={cn(
                 "px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
@@ -173,7 +189,12 @@ export function IconPicker({
               Icons
             </button>
             <button
+              id="icon-picker-tab-upload"
               type="button"
+              role="tab"
+              aria-selected={tab === "upload"}
+              aria-controls="icon-picker-panel-upload"
+              tabIndex={tab === "upload" ? 0 : -1}
               onClick={() => setTab("upload")}
               className={cn(
                 "px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
@@ -189,19 +210,31 @@ export function IconPicker({
 
           {/* Tab content */}
           {tab === "icons" ? (
-            <IconsTab
-              search={search}
-              onSearchChange={setSearch}
-              selectedColor={selectedColor}
-              onColorChange={handleColorChange}
-              onSelectIcon={handleSelectIcon}
-              onRandom={handleRandomIcon}
-              currentIconName={
-                parsedValue.type === "icon" ? parsedValue.name : null
-              }
-            />
+            <div
+              id="icon-picker-panel-icons"
+              role="tabpanel"
+              aria-labelledby="icon-picker-tab-icons"
+            >
+              <IconsTab
+                search={search}
+                onSearchChange={setSearch}
+                selectedColor={selectedColor}
+                onColorChange={handleColorChange}
+                onSelectIcon={handleSelectIcon}
+                onRandom={handleRandomIcon}
+                currentIconName={
+                  parsedValue.type === "icon" ? parsedValue.name : null
+                }
+              />
+            </div>
           ) : (
-            <UploadTab onUpload={handleUpload} />
+            <div
+              id="icon-picker-panel-upload"
+              role="tabpanel"
+              aria-labelledby="icon-picker-tab-upload"
+            >
+              <UploadTab onUpload={handleUpload} />
+            </div>
           )}
         </div>
       </PopoverContent>


### PR DESCRIPTION
**Source:** icon-picker accessibility focus area (WCAG basics) — `apps/mesh/src/web/components/icon-picker.tsx`.

**Why:** The Icons/Upload switcher inside `IconPicker` was rendered as two plain `<button>`s toggling a plain `<div>`, with no ARIA tab semantics at all. A screen reader user hears two unrelated buttons with no indication of which is selected or that they form a set, and there's no way to jump between them with arrow keys the way every native tab widget behaves (the ARIA Authoring Practices Guide "tabs" pattern). This is a real accessibility gap, not cosmetic polish.

**What changed:**
- Tab bar gets `role="tablist"` with an `aria-label`.
- Each button gets `role="tab"`, `aria-selected`, `aria-controls`, and a roving `tabIndex` (only the active tab is in the normal Tab order, per APG).
- Each content pane is wrapped in a `role="tabpanel"` with `aria-labelledby` pointing back at its tab.
- ArrowLeft/ArrowRight on the tablist switches the active tab and moves focus to it (APG-required "activation follows focus" behavior for a 2-item tablist).

No visual/behavioral change for mouse users — only ARIA attributes, `tabIndex`, and a keydown handler were added; existing Tailwind classes are untouched.

**How to verify:** `cd apps/mesh && bunx tsc --noEmit` (green). Manually: open any icon picker (e.g. agent icon editor), Tab to the tablist, confirm Left/Right arrow switches between "Icons" and "Upload" and moves focus with it.

**Checks run locally:** `bun run fmt` (clean, no diffs), `bunx tsc --noEmit` in `apps/mesh` (clean). No existing test file covers this component; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the IconPicker’s Icons/Upload toggle a proper ARIA tabs widget to improve screen reader support and arrow-key navigation. No visual changes; added roles, states, and key handling only.

- **Bug Fixes**
  - Tab bar uses `role="tablist"` with an `aria-label`.
  - Tabs use `role="tab"`, `aria-selected`, `aria-controls`, and roving `tabIndex`.
  - Panels use `role="tabpanel"` with `aria-labelledby`.
  - Left/Right arrows switch tabs and move focus to the active tab.

<sup>Written for commit 3ba568fda7d4f71e7ee4496a858bed86483f89bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

