### PR TITLE
fix(ai-providers): restore bold key label in delete-key confirmation dialog

### DIFF
--- a/apps/mesh/src/web/i18n/en/settings.ts
+++ b/apps/mesh/src/web/i18n/en/settings.ts
@@ -509,8 +509,6 @@ export const settings = {
   "settings.providerKeyRow.cancel": "Cancel",
   "settings.providerKeyRow.delete": "Delete",
   "settings.providerKeyRow.deleteApiKey": "Delete API key",
-  "settings.providerKeyRow.deleteApiKeyWarning":
-    "This action cannot be undone. This will permanently delete {label}.",
   "settings.providerKeyRow.deleteProviderKey": "Delete provider key",
   "settings.providerKeyRow.editProviderKey": "Edit provider key",
   "settings.providerKeyRow.failedToDeleteKey": "Failed to delete key: {error}",

--- a/apps/mesh/src/web/i18n/pt-br/settings.ts
+++ b/apps/mesh/src/web/i18n/pt-br/settings.ts
@@ -539,8 +539,6 @@ export const settings = {
   "settings.providerKeyRow.cancel": "Cancelar",
   "settings.providerKeyRow.delete": "Excluir",
   "settings.providerKeyRow.deleteApiKey": "Excluir chave de API",
-  "settings.providerKeyRow.deleteApiKeyWarning":
-    "Esta a\u00e7\u00e3o n\u00e3o pode ser desfeita. Isso excluir\u00e1 permanentemente {label}.",
   "settings.providerKeyRow.deleteProviderKey": "Excluir chave do provedor",
   "settings.providerKeyRow.editProviderKey": "Editar chave do provedor",
   "settings.providerKeyRow.failedToDeleteKey":

--- a/apps/mesh/src/web/views/settings/ai-providers/provider-key-row.tsx
+++ b/apps/mesh/src/web/views/settings/ai-providers/provider-key-row.tsx
@@ -141,9 +141,12 @@ export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
               {t("settings.providerKeyRow.deleteApiKey")}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {t("settings.providerKeyRow.deleteApiKeyWarning", {
-                label: providerKey.label,
-              })}
+              {/* TODO(i18n): rich text — bolded label can't round-trip through t()'s plain-string interpolation */}
+              This action cannot be undone. This will permanently delete{" "}
+              <span className="font-medium text-foreground">
+                {providerKey.label}
+              </span>
+              .
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
Follows #4964 (fleet i18n extraction) hardening.

#4964 collapsed the delete-provider-key confirmation warning into `t("settings.providerKeyRow.deleteApiKeyWarning", { label })`. `interpolate()` only does plain `{var}` string substitution (see `apps/mesh/src/web/i18n/interpolate.ts`), so the original `<span className="font-medium text-foreground">{providerKey.label}</span>` bold styling silently disappeared from a destructive-action confirmation dialog — a real (if small) visual regression a maintainer would want caught.

The repo's own i18n convention (CLAUDE.md) already covers exactly this case: "Strings interleaved with JSX elements ... that can't be expressed as a single template: mark with `// TODO(i18n): rich text` and leave hardcoded for a manual pass." This PR follows that convention instead of splitting the sentence into translated prefix/suffix fragments (which would risk breaking word order in pt-BR) — reverts to hardcoded English with the bold span restored, plus the TODO(i18n) comment, and drops the now-unused `deleteApiKeyWarning` key from both `en/settings.ts` and `pt-br/settings.ts` (kept `satisfies` parity).

How to confirm: open Settings > AI Providers, click delete on any provider key — the confirmation dialog's key name should render bold again.

Local checks run: `bun run fmt` (clean), `cd apps/mesh && bunx tsc --noEmit` (clean, confirms no orphaned dictionary-key references and en/pt-br `satisfies` parity still holds). No behavior/logic touched beyond this one string's rendering, so no test needed; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the bold styling of the provider key label in the delete-key confirmation dialog in Settings > AI Providers. Switches the warning back to JSX to support rich text and removes the unused i18n key.

- **Bug Fixes**
  - Render the delete warning as JSX with a bolded span for `providerKey.label`.
  - Add `// TODO(i18n): rich text` per repo guideline for future translation.
  - Remove unused `settings.providerKeyRow.deleteApiKeyWarning` from `en/settings.ts` and `pt-br/settings.ts`.

<sup>Written for commit a68585b85d65d881921c2a7956054ae78faa53a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

