### PR TITLE
refactor(chat): stop double-deriving current todos in ChatHighlight

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/index.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/index.tsx
@@ -283,7 +283,7 @@ export function ChatHighlight() {
 
   return (
     <div className="absolute bottom-full left-0 right-0">
-      <TodosHighlight />
+      <TodosHighlight todos={flags.todos} />
       <DesktopOfflineBanner />
       {showError && (
         <StatusHighlight

--- a/apps/mesh/src/web/components/chat/highlight/todos.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/todos.tsx
@@ -1,13 +1,9 @@
 import { cn } from "@deco/ui/lib/utils.ts";
 import type { Todo } from "@decocms/harness/decopilot/built-in-tools/todo-write";
-import { useChatStream } from "../context";
 import { CollapsibleHighlight } from "./collapsible-highlight";
-import { deriveCurrentTodos } from "./derive-current-todos";
 import { type ChipIcon, deriveChipLabel } from "./derive-chip-label";
 
-export function TodosHighlight() {
-  const { messages } = useChatStream();
-  const todos = deriveCurrentTodos(messages);
+export function TodosHighlight({ todos }: { todos: Todo[] }) {
   if (todos.length === 0) return null;
 
   const label = deriveChipLabel(todos);

--- a/apps/mesh/src/web/components/chat/highlight/use-highlight-count.test.ts
+++ b/apps/mesh/src/web/components/chat/highlight/use-highlight-count.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { UIMessage } from "ai";
-import { deriveHighlightFlags } from "./use-highlight-count";
+import {
+  deriveHighlightFlags,
+  type HighlightFlags,
+} from "./use-highlight-count";
 
-const noFlags = {
+const noFlags: HighlightFlags = {
   isCreditExhausted: false,
   hasTodos: false,
   showError: false,
@@ -10,7 +13,8 @@ const noFlags = {
   hasApprovals: false,
   hasPlans: false,
   isWaitingForUserInput: false,
-} as const;
+  todos: [],
+};
 
 const baseInput = {
   messages: [] as UIMessage[],
@@ -97,7 +101,14 @@ describe("deriveHighlightFlags", () => {
     ).toEqual({ ...noFlags, isWaitingForUserInput: true });
   });
 
-  test("todos present → hasTodos true", () => {
+  test("todos present → hasTodos true, todos exposed for reuse", () => {
+    const todos = [
+      {
+        content: "A",
+        activeForm: "Doing A",
+        status: "pending" as const,
+      },
+    ];
     const messages: UIMessage[] = [
       {
         id: "a1",
@@ -107,15 +118,7 @@ describe("deriveHighlightFlags", () => {
             type: "tool-todo_write",
             toolCallId: "c1",
             state: "input-available",
-            input: {
-              todos: [
-                {
-                  content: "A",
-                  activeForm: "Doing A",
-                  status: "pending" as const,
-                },
-              ],
-            },
+            input: { todos },
           },
         ],
       } as unknown as UIMessage,
@@ -123,6 +126,7 @@ describe("deriveHighlightFlags", () => {
     expect(deriveHighlightFlags({ ...baseInput, messages })).toEqual({
       ...noFlags,
       hasTodos: true,
+      todos,
     });
   });
 

--- a/apps/mesh/src/web/components/chat/highlight/use-highlight-count.ts
+++ b/apps/mesh/src/web/components/chat/highlight/use-highlight-count.ts
@@ -12,6 +12,7 @@
  */
 
 import type { UIMessage } from "ai";
+import type { Todo } from "@decocms/harness/decopilot/built-in-tools/todo-write";
 import { deriveCurrentTodos } from "./derive-current-todos";
 import { extractPendingApprovals } from "./extract-pending-approvals";
 import { extractPendingPlans } from "./extract-pending-plans";
@@ -26,6 +27,9 @@ export interface HighlightFlags {
   hasApprovals: boolean;
   hasPlans: boolean;
   isWaitingForUserInput: boolean;
+  // Exposed so `TodosHighlight` doesn't re-run the same backward scan over
+  // `messages` that this hook already did to compute `hasTodos`.
+  todos: Todo[];
 }
 
 export interface DeriveHighlightFlagsInput {
@@ -44,6 +48,7 @@ const EMPTY_FLAGS: HighlightFlags = {
   hasApprovals: false,
   hasPlans: false,
   isWaitingForUserInput: false,
+  todos: [],
 };
 
 export function deriveHighlightFlags(
@@ -111,6 +116,7 @@ export function deriveHighlightFlags(
     hasApprovals,
     hasPlans,
     isWaitingForUserInput,
+    todos,
   };
 }
 


### PR DESCRIPTION
Follows the same dedupe pattern as #4963 (which fixes pending plans/approvals) but for the separate `deriveCurrentTodos` path, which #4963 does not touch.

`TodosHighlight` called `useChatStream()` + `deriveCurrentTodos(messages)` on every render to build its own todos list, while `useHighlightFlags()` (consumed by `ChatHighlight` in the same render tree) already runs the identical backward scan over `messages` just to compute the `hasTodos` boolean. Two independent components were re-deriving the same array from the same input every render.

Fix: expose the already-computed `todos: Todo[]` on `HighlightFlags` and have `TodosHighlight` take it as a prop (`<TodosHighlight todos={flags.todos} />`) instead of recomputing it. Behavior-preserving — same derivation, computed once instead of twice.

Net diff: +25/-19, no logic changes to `deriveCurrentTodos` or `deriveChipLabel` themselves.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` and `bun test apps/mesh/src/web/components/chat/highlight/use-highlight-count.test.ts`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace, clean), and the targeted test file (9 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops double-deriving current todos in chat highlights by computing them once in `useHighlightFlags` and passing them to `TodosHighlight`. Behavior is unchanged, but we avoid a second backward scan over `messages` on each render.

- **Refactors**
  - Add `todos: Todo[]` to `HighlightFlags`; `ChatHighlight` passes `flags.todos` to `TodosHighlight`.
  - Remove `useChatStream` and `deriveCurrentTodos` from `TodosHighlight`.
  - Update tests to assert `todos` exposure alongside `hasTodos`.

<sup>Written for commit bdca7cd6931fe3154a5bbfd7242d1090d1629f2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

