### PR TITLE
fix(monitoring): validate property-filter operator from stale/malformed URLs

### DIFF
--- a/apps/mesh/src/web/components/monitoring/types.test.ts
+++ b/apps/mesh/src/web/components/monitoring/types.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { deserializePropertyFilters } from "./types.tsx";
+
+describe("deserializePropertyFilters", () => {
+  test("parses a known operator", () => {
+    expect(deserializePropertyFilters("status:contains:error")).toEqual([
+      { key: "status", operator: "contains", value: "error" },
+    ]);
+  });
+
+  test("falls back to eq for an unrecognized/stale operator", () => {
+    expect(deserializePropertyFilters("status:regex:error")).toEqual([
+      { key: "status", operator: "eq", value: "error" },
+    ]);
+  });
+
+  test("falls back to eq when the operator segment is missing", () => {
+    expect(deserializePropertyFilters("status")).toEqual([
+      { key: "status", operator: "eq", value: "" },
+    ]);
+  });
+});

--- a/apps/mesh/src/web/components/monitoring/types.tsx
+++ b/apps/mesh/src/web/components/monitoring/types.tsx
@@ -119,6 +119,19 @@ export interface MonitoringSearchParams {
 
 export type PropertyFilterOperator = "eq" | "contains" | "exists" | "in";
 
+const PROPERTY_FILTER_OPERATORS: readonly PropertyFilterOperator[] = [
+  "eq",
+  "contains",
+  "exists",
+  "in",
+];
+
+function isPropertyFilterOperator(
+  value: string,
+): value is PropertyFilterOperator {
+  return (PROPERTY_FILTER_OPERATORS as readonly string[]).includes(value);
+}
+
 export interface PropertyFilter {
   key: string;
   operator: PropertyFilterOperator;
@@ -149,7 +162,8 @@ export function deserializePropertyFilters(str: string): PropertyFilter[] {
     const [key, operator, ...valueParts] = part.split(":");
     return {
       key: decodeURIComponent(key || ""),
-      operator: (operator as PropertyFilterOperator) || "eq",
+      operator:
+        operator && isPropertyFilterOperator(operator) ? operator : "eq",
       value: decodeURIComponent(valueParts.join(":") || ""),
     };
   });


### PR DESCRIPTION
Found while auditing `apps/mesh/src/web/components/monitoring/types.tsx` for type-safety gaps around untrusted data.

`deserializePropertyFilters` (the reverse of `serializePropertyFilters`, used to hydrate property filters from the `propertyFilters` URL search param) blindly cast the URL-decoded operator segment to `PropertyFilterOperator` with `operator as PropertyFilterOperator`, with no validation that the string is actually one of `eq | contains | exists | in`.

**Failure scenario:** a bookmarked/shared monitoring URL with a stale or hand-edited `propertyFilters` param (e.g. an operator that no longer exists, or a typo) produces a `PropertyFilter` whose `operator` field doesn't match any case in `propertyFiltersToApiParams`'s switch — the filter is then silently dropped from the actual API query (no properties/patterns/keys populated for it) while still showing up in the raw-filter textarea, so the user believes a filter is applied when it isn't.

Fix: added an `isPropertyFilterOperator` type guard against the known operator list and used it in `deserializePropertyFilters`, falling back to `"eq"` for anything unrecognized — matching the behavior already used for the `?`/`=`/`~`/`@` raw-text parser. This makes the `PropertyFilter.operator` invariant ("always one of the four known operators") actually enforced at the point untrusted input enters the type, not just asserted by a cast.

Regression test added in `types.test.ts` covering: a known operator, an unrecognized/stale operator, and a missing operator segment.

Reviewer command: `cd apps/mesh && bun test src/web/components/monitoring/types.test.ts`

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace), and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `PropertyFilter.operator` when parsing `propertyFilters` from the URL to prevent stale or malformed operators from silently dropping filters in monitoring queries. Unrecognized or missing operators now default to `eq`, matching the raw-text parser.

- **Bug Fixes**
  - Added `isPropertyFilterOperator` with a whitelist of known operators and used it in `deserializePropertyFilters`.
  - Enforced known operators and fallback to `eq`; added tests for valid, unrecognized, and missing operator cases.

<sup>Written for commit 245252167dfba8f461a66139057cc55c2854068c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

