### PR TITLE
fix(home): link expand/collapse toggle to its panel via aria-controls

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -397,6 +397,7 @@ function HomeAgentRow({
     isDragging,
   } = useSortable({ id: agent.id });
   const subtitle = useAgentSubtitle(agent) || "Quick access";
+  const expansionId = `home-agent-expansion-${agent.id}`;
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -429,6 +430,7 @@ function HomeAgentRow({
           onClick={() => setExpanded((v) => !v)}
           className="flex min-w-0 flex-1 items-center gap-2.5 text-left outline-none"
           aria-expanded={expanded}
+          aria-controls={expansionId}
         >
           <AgentAvatar
             icon={agent.icon}
@@ -467,7 +469,9 @@ function HomeAgentRow({
           <X size={14} />
         </button>
       </div>
-      {expanded && <AgentExpansion agent={agent} home={home} />}
+      {expanded && (
+        <AgentExpansion id={expansionId} agent={agent} home={home} />
+      )}
     </div>
   );
 }
@@ -482,6 +486,7 @@ function AvailableAgentRow({
   const [expanded, setExpanded] = useState(false);
   const [adding, setAdding] = useState(false);
   const subtitle = useAgentSubtitle(agent);
+  const expansionId = `available-agent-expansion-${agent.id}`;
 
   const handleAdd = async () => {
     if (home.atLimit) return;
@@ -503,6 +508,7 @@ function AvailableAgentRow({
           onClick={() => setExpanded((v) => !v)}
           className="flex min-w-0 flex-1 items-center gap-3 text-left outline-none"
           aria-expanded={expanded}
+          aria-controls={expansionId}
         >
           <AgentAvatar
             icon={agent.icon}
@@ -546,7 +552,9 @@ function AvailableAgentRow({
           )}
         </button>
       </div>
-      {expanded && <AgentExpansion agent={agent} home={home} />}
+      {expanded && (
+        <AgentExpansion id={expansionId} agent={agent} home={home} />
+      )}
     </div>
   );
 }
@@ -555,9 +563,11 @@ function AvailableAgentRow({
  * Toggling any of these also pulls the agent onto the home (via the home
  * board's saveAgentMetadata). */
 function AgentExpansion({
+  id,
   agent,
   home,
 }: {
+  id: string;
   agent: VirtualMCPEntity;
   home: HomeBoard;
 }) {
@@ -568,7 +578,10 @@ function AgentExpansion({
   const curatedPrompts = agent.metadata?.ui?.homePrompts;
 
   return (
-    <div className="border-t border-border px-3 py-2 flex flex-col gap-3">
+    <div
+      id={id}
+      className="border-t border-border px-3 py-2 flex flex-col gap-3"
+    >
       <AgentToolList
         agent={agent}
         home={home}


### PR DESCRIPTION
Follows the accessibility pattern already used in `object-field.tsx`/`any-of-field.tsx` (aria-expanded + aria-controls + matching `id`), applied to the add-tile drawer's per-agent expand/collapse rows.

Both `HomeAgentRow` and `AvailableAgentRow` in `add-tile-drawer.tsx` toggle an `AgentExpansion` panel with only `aria-expanded` set on the trigger button — there's no `aria-controls`, so a screen reader has no programmatic link between the toggle and the region it reveals (relies purely on DOM adjacency).

Fix: give `AgentExpansion` an `id` prop, generate a stable id per row (`home-agent-expansion-<id>` / `available-agent-expansion-<id>`), and wire `aria-controls` on each toggle button to match. Purely additive ARIA wiring — no behavior, layout, or class changes.

How to confirm: open the "Manage home" drawer, inspect an agent row's expand button in devtools — `aria-controls` should reference the `id` of the expansion panel below it once expanded.

Checks run locally: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean, no new type errors). No existing test covers this component's markup, so nothing to run there; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link expand/collapse buttons in the add-tile drawer to their panels using aria-controls and stable ids so screen readers can associate the control with the revealed region. No visual or behavior changes.

- **Bug Fixes**
  - Generate a stable expansionId per row (`home-agent-expansion-<id>` / `available-agent-expansion-<id>`) and set aria-controls on the toggle.
  - Add id prop to `AgentExpansion` and apply it to the panel container.

<sup>Written for commit e828c13b0b5cffa26dbdb2f6464a37cb36a60f5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

