### PR TITLE
fix(settings): add aria-label to org-role member remove buttons

### DIFF
--- a/apps/mesh/src/web/i18n/en/settings.ts
+++ b/apps/mesh/src/web/i18n/en/settings.ts
@@ -392,6 +392,7 @@ export const settings = {
   "settings.orgRoleDetail.owner": "Owner",
   "settings.orgRoleDetail.ownerMembershipCannotBeChanged":
     "Owner membership cannot be changed",
+  "settings.orgRoleDetail.removeMember": "Remove {name} from role",
   "settings.orgRoleDetail.roleCreatedSuccessfully":
     "Role created successfully!",
   "settings.orgRoleDetail.roleName": "Role name",

--- a/apps/mesh/src/web/i18n/pt-br/settings.ts
+++ b/apps/mesh/src/web/i18n/pt-br/settings.ts
@@ -410,6 +410,7 @@ export const settings = {
   "settings.orgRoleDetail.owner": "Propriet\u00e1rio",
   "settings.orgRoleDetail.ownerMembershipCannotBeChanged":
     "A associa\u00e7\u00e3o de propriet\u00e1rio n\u00e3o pode ser alterada",
+  "settings.orgRoleDetail.removeMember": "Remover {name} do papel",
   "settings.orgRoleDetail.roleCreatedSuccessfully": "Papel criado com sucesso!",
   "settings.orgRoleDetail.roleName": "Nome do papel",
   "settings.orgRoleDetail.roleNameIsRequired":

--- a/apps/mesh/src/web/views/settings/org-role-detail.tsx
+++ b/apps/mesh/src/web/views/settings/org-role-detail.tsx
@@ -944,7 +944,19 @@ function MembersTabContent({
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <div>
-                          <Button variant="ghost" size="sm" disabled>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            disabled
+                            aria-label={t(
+                              "settings.orgRoleDetail.removeMember",
+                              {
+                                name:
+                                  member.user?.name ||
+                                  t("settings.orgRoleDetail.unknown"),
+                              },
+                            )}
+                          >
                             <X size={16} />
                           </Button>
                         </div>
@@ -958,6 +970,11 @@ function MembersTabContent({
                   <Button
                     variant="ghost"
                     size="sm"
+                    aria-label={t("settings.orgRoleDetail.removeMember", {
+                      name:
+                        member.user?.name ||
+                        t("settings.orgRoleDetail.unknown"),
+                    })}
                     onClick={() =>
                       onMemberIdsChange(
                         memberIds.filter((id) => id !== member.id),


### PR DESCRIPTION
**Source:** accessibility gap found while auditing `apps/mesh/src/web/views/settings/org-role-detail.tsx` (the org-role detail view) per this cycle's focus area.

**Payoff:** the per-member "remove from role" button in the Members tab of a role's detail page renders only an `X` icon with no text, and had no `aria-label` — so a screen-reader user landing on it hears just "button" with no indication of what it does or which member it removes (both the enabled and the disabled/read-only variant). This mirrors the same fix already merged for icon-only controls elsewhere in the repo (#5007, #4948, #4915).

**Fix:** add `aria-label={t("settings.orgRoleDetail.removeMember", { name })}` ("Remove {name} from role") to both the enabled and disabled `Button` variants, using the member's display name (falling back to "Unknown") so each button has a distinct, meaningful accessible name. Added the new key to both `en` and `pt-br` i18n dictionaries per the i18n convention in this repo.

**Command to verify:** `cd apps/mesh && bunx tsc --noEmit` (passes). No behavior change — pure additive `aria-label` attributes plus two i18n dictionary entries.

**Checks run locally:** `bun run fmt` and a targeted `bunx tsc --noEmit` in `apps/mesh` (both clean). Full CI will run lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-labels to the icon-only “remove member” buttons in the org role Members tab so screen readers announce “Remove {name} from role” for each user. Adds the `settings.orgRoleDetail.removeMember` i18n key in `en` and `pt-br`; no behavior change.

<sup>Written for commit 7c8e365d2f7227b1d4a9ec398d50c03df97a7daf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

