### PR TITLE
refactor(tiptap): drop redundant attrs reconstruction in mention renderHTML

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
@@ -1,6 +1,6 @@
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { JSONContent, Node } from "@tiptap/core";
+import { JSONContent, mergeAttributes, Node } from "@tiptap/core";
 import {
   NodeViewWrapper,
   ReactNodeViewRenderer,
@@ -240,33 +240,14 @@ export const MentionNode = Node.create({
     ];
   },
 
-  renderHTML({ node, HTMLAttributes }) {
-    // Required by ProseMirror (maps to toDOM)
-    // React component handles actual visual rendering
-    const attrs: Record<string, string> = {
-      "data-type": "mention",
-    };
-
-    if (node.attrs.id) {
-      attrs["data-id"] = node.attrs.id;
-    }
-    if (node.attrs.name) {
-      attrs["data-name"] = node.attrs.name;
-    }
-    if (node.attrs.char) {
-      attrs["data-char"] = node.attrs.char;
-    }
-    if (node.attrs.metadata) {
-      attrs["data-metadata"] = JSON.stringify(node.attrs.metadata);
-    }
-    if (node.attrs.kind) {
-      attrs["data-kind"] = node.attrs.kind;
-    }
-    if (node.attrs.args) {
-      attrs["data-args"] = JSON.stringify(node.attrs.args);
-    }
-
-    return ["span", { ...HTMLAttributes, ...attrs }];
+  renderHTML({ HTMLAttributes }) {
+    // React component handles actual visual rendering; this only satisfies
+    // ProseMirror's toDOM requirement. HTMLAttributes already carries every
+    // data-* entry from each attribute's own renderHTML (see addAttributes above).
+    return [
+      "span",
+      mergeAttributes(HTMLAttributes, { "data-type": "mention" }),
+    ];
   },
 
   renderText({ node }) {


### PR DESCRIPTION
**Source:** code reduction (C1) found while auditing `apps/mesh/src/web/components/chat/tiptap/mention/node.tsx`.

**Why:** `MentionNode.renderHTML` manually re-derived `data-id`/`data-name`/`data-char`/`data-metadata`/`data-kind`/`data-args` straight off `node.attrs`. That's duplicate work: Tiptap core's `getRenderedAttributes()` already runs every attribute's own `renderHTML` (defined right above in `addAttributes()`) and merges the results into the `HTMLAttributes` param before calling the node's `renderHTML` — so the manual block recomputed the exact same six values a second time.

**Change:** collapsed the 27-line manual reconstruction into `mergeAttributes(HTMLAttributes, { "data-type": "mention" })`. Net -22/+9 lines, behavior-preserving.

**How I confirmed behavior is unchanged:** read Tiptap core's `getRenderedAttributes` source (`@tiptap/core/dist/index.js`) to confirm `HTMLAttributes` already contains every attribute's rendered output, then ran a throwaway script instantiating a real `Editor` with `MentionNode` + a mention node carrying all attrs (id/name/char/metadata/kind/args) and diffed `editor.schema.nodes.mention.spec.toDOM(node)` before and after the change — identical output both times:
```json
["span",{"data-id":"abc","data-name":"my-prompt","data-char":"/","data-metadata":"{\"foo\":\"bar\"}","data-kind":"prompt","data-args":"{\"x\":\"1\"}","data-type":"mention"}]
```

**Reviewer check:** `cd apps/mesh && bunx tsc --noEmit` (green). No existing test file covers this node's `renderHTML`, so there's nothing to run beyond the typecheck; full CI covers the rest.

**Locally run:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace only) — both clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `MentionNode.renderHTML` to use `@tiptap/core`’s provided `HTMLAttributes` with `mergeAttributes`, removing redundant `data-*` reconstruction while keeping the DOM output identical. Smaller code, no behavior change.

- **Refactors**
  - Replaced manual `data-*` rebuild with `mergeAttributes(HTMLAttributes, { "data-type": "mention" })`.
  - Relies on `getRenderedAttributes` from `@tiptap/core`; final `span` and all `data-*` attrs remain the same.

<sup>Written for commit a004727e0e530291e1b25e825ab094a4bffccfae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

