### PR TITLE
fix(auth): block wildcard "*" configuration scope on connections

### DIFF
--- a/apps/mesh/src/auth/configuration-scopes.test.ts
+++ b/apps/mesh/src/auth/configuration-scopes.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import {
+  assertNoWildcardScopes,
+  extractConnectionPermissions,
+  getReferencedConnectionIds,
+} from "./configuration-scopes";
+
+// Pure-logic unit tests (TESTING.md unit tier). These guard the privilege-
+// escalation fix: a connection's configuration scopes must never be able to
+// mint an unconditional `{"*":["*"]}` grant. See WILDCARD_SCOPE for context.
+
+describe("assertNoWildcardScopes", () => {
+  it("throws when the wildcard '*' scope is present", () => {
+    expect(() => assertNoWildcardScopes(["*"])).toThrow(/Wildcard/);
+    expect(() =>
+      assertNoWildcardScopes(["CONN::READ", "*", "CONN::WRITE"]),
+    ).toThrow(/Wildcard/);
+  });
+
+  it("allows resource-scoped scopes and empty/absent inputs", () => {
+    expect(() =>
+      assertNoWildcardScopes(["CONN::READ", "SELF::WRITE"]),
+    ).not.toThrow();
+    expect(() => assertNoWildcardScopes([])).not.toThrow();
+    expect(() => assertNoWildcardScopes(null)).not.toThrow();
+    expect(() => assertNoWildcardScopes(undefined)).not.toThrow();
+  });
+});
+
+describe("extractConnectionPermissions", () => {
+  it("never expands '*' into a full wildcard grant (defense-in-depth)", () => {
+    // Even if a legacy connection persisted "*" before write-time validation
+    // existed, minting must not produce the escalation-enabling grant.
+    expect(extractConnectionPermissions({ x: 1 }, ["*"])).toEqual({});
+    expect(
+      extractConnectionPermissions({ CONN: { value: "conn_abc" } }, [
+        "*",
+        "CONN::READ",
+      ]),
+    ).toEqual({ conn_abc: ["READ"] });
+  });
+
+  it("maps resource-scoped scopes to their referenced connection", () => {
+    expect(
+      extractConnectionPermissions({ CONN: { value: "conn_abc" } }, [
+        "CONN::READ",
+        "CONN::WRITE",
+      ]),
+    ).toEqual({ conn_abc: ["READ", "WRITE"] });
+  });
+});
+
+describe("getReferencedConnectionIds", () => {
+  it("excludes the wildcard sentinel", () => {
+    expect(
+      getReferencedConnectionIds({ CONN: { value: "conn_abc" } }, [
+        "*",
+        "CONN::READ",
+      ]),
+    ).toEqual(new Set(["conn_abc"]));
+  });
+});

--- a/apps/mesh/src/auth/configuration-scopes.ts
+++ b/apps/mesh/src/auth/configuration-scopes.ts
@@ -12,6 +12,43 @@
 import { prop } from "@/tools/connection/json-path";
 
 /**
+ * The literal "*" scope grants `permissions["*"] = ["*"]` — an unconditional
+ * "all resources, all tools" grant that downstream `checkApiKeyPermission`
+ * treats as full access, bypassing every role check. A connection's
+ * configuration scopes must never be able to mint that: it is a privilege
+ * escalation primitive (any org member could create a connection, harvest the
+ * resulting wildcard mesh JWT, and replay it to reach admin/owner-only tools).
+ *
+ * Legitimate connection scopes are always resource-scoped ("KEY::SCOPE"), which
+ * only ever grant access to the specific connection referenced in state. The
+ * genuine full-access credential path (per-run sandbox keys) goes through
+ * API key creation directly, not through connection configuration scopes.
+ */
+const WILDCARD_SCOPE = "*";
+
+/**
+ * Reject the wildcard "*" scope in a connection's configuration scopes.
+ *
+ * Enforced at write time (connection create/update) so a wildcard can never be
+ * stored — regardless of whether it arrives in the request body or is
+ * self-reported by a (potentially attacker-controlled) MCP server during tool
+ * discovery. See {@link WILDCARD_SCOPE} for why.
+ *
+ * @throws Error if any scope is the literal "*"
+ */
+export function assertNoWildcardScopes(
+  scopes: string[] | null | undefined,
+): void {
+  if (scopes?.includes(WILDCARD_SCOPE)) {
+    throw new Error(
+      'Wildcard configuration scope "*" is not allowed. Connection scopes ' +
+        'must be resource-scoped ("KEY::SCOPE"); a wildcard would grant ' +
+        "unconditional access to every tool and resource.",
+    );
+  }
+}
+
+/**
  * Parse scope string to extract key and scope parts
  * @param scope - Scope string in format "KEY::SCOPE"
  * @returns Tuple of [key, scopeName]
@@ -81,8 +118,10 @@ export function extractConnectionPermissions(
   }
 
   for (const scope of scopes) {
-    if (scope === "*") {
-      permissions["*"] = ["*"];
+    // Defense-in-depth: never expand a connection's "*" scope into a full
+    // wildcard grant, even if one was persisted before write-time validation
+    // existed (or via any path that bypassed it). See WILDCARD_SCOPE.
+    if (scope === WILDCARD_SCOPE) {
       continue;
     }
     const parsed = tryParseScope(scope);

--- a/apps/mesh/src/tools/connection/credential-grants.ts
+++ b/apps/mesh/src/tools/connection/credential-grants.ts
@@ -1,4 +1,5 @@
 import {
+  assertNoWildcardScopes,
   getReferencedConnectionIds,
   parseScope,
 } from "@/auth/configuration-scopes";
@@ -84,12 +85,16 @@ export async function validateConfiguration(
   organizationId: string,
   ctx: StudioContext,
 ): Promise<void> {
+  // Reject the wildcard "*" scope outright: it would mint an unconditional
+  // full-access mesh JWT and is a privilege-escalation primitive. This is the
+  // primary, fail-fast enforcement point — it covers scopes supplied in the
+  // request body as well as scopes self-reported by the target MCP server
+  // during tool discovery, since both are merged before reaching here.
+  assertNoWildcardScopes(scopes);
+
   // Validate scope format and state keys.
   for (const scope of scopes) {
     // Parse scope format: "KEY::SCOPE" (throws on invalid format).
-    if (scope === "*") {
-      continue;
-    }
     const [key] = parseScope(scope);
     const value = prop(key, state);
 


### PR DESCRIPTION
## Summary

Blocks a privilege-escalation path where a plain `user`-role member (or a brand-new self-signup) could obtain unconditional admin/owner-equivalent access.

A connection whose `configuration_scopes` contained the literal `"*"` caused `extractConnectionPermissions` to emit `{"*":["*"]}`, which is embedded into the outbound `x-mesh-token` JWT (`mcp-clients/outbound/headers.ts`). Downstream `checkApiKeyPermission` treats `{"*":["*"]}` as **all resources, all tools**, bypassing every role check. So any org member could:

1. Create a connection with `configuration_scopes: ["*"]` (allowed for `user` role via `connections:manage`),
2. Trigger the outbound proxy and harvest the wildcard `x-mesh-token`,
3. Replay it to reach admin/owner-only tools such as `API_KEY_CREATE`, minting a persistent wildcard API key.

The wildcard could arrive **either** in the request body **or** be self-reported by a (potentially attacker-controlled) target MCP server during tool discovery — the server-reported scopes win the ternary in `create.ts`. So enforcement lives at the shared choke points, not the request body.

## Changes

Defense-in-depth, two layers:

1. **Write-time / fail-fast** — `validateConfiguration` now calls a new `assertNoWildcardScopes()` that throws on any `"*"` scope. Runs in both `COLLECTION_CONNECTIONS_CREATE` and `COLLECTION_CONNECTIONS_UPDATE`, so the wildcard can never be stored — covering both the request-body and server-reported paths.
2. **Grant-time backstop** — `extractConnectionPermissions` no longer expands `"*"` into a wildcard grant, so any already-persisted `"*"` (pre-fix data, or a path that skipped validation) can never mint the escalation-enabling JWT.

Legitimate connection scopes are always resource-scoped (`"KEY::SCOPE"`) and only grant access to the referenced connection. The genuine full-access credential path (per-run sandbox keys) goes through API-key creation directly, not connection configuration scopes — so nothing legitimate relies on the wildcard connection scope.

## Testing

- New `apps/mesh/src/auth/configuration-scopes.test.ts` (5 tests) covering rejection, the grant-time backstop, and that legitimate `"KEY::SCOPE"` scopes still map correctly. **5 pass.**
- Full auth suite: **77 pass, 0 fail.**
- `tsc --noEmit`: zero errors in the changed files. (The one remaining repo-wide error is a pre-existing `ajv` 8.18-vs-8.20 duplicate-version clash in `node_modules`, unrelated to this change.)

## Notes / follow-ups

- **Legacy data:** an existing connection that already has `"*"` stored will have any future config-touching *update* rejected until the scope is cleaned up. Intentional — and the grant-time backstop already neutralizes such connections regardless.
- **Scope:** this closes the wildcard-scope escalation only. The deeper root cause — the mesh JWT being usable as a generic bearer credential (no `aud`/`purpose` claim) — and the `connection_url` SSRF remain separate, larger hardening items tracked elsewhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block the `"*"` configuration scope on connections and stop wildcard grant minting to prevent all‑access `x-mesh-token` escalation. Closes a path where plain users could bypass role checks.

- **Bug Fixes**
  - Reject `"*"` via `assertNoWildcardScopes` in `validateConfiguration` on create/update (covers body and server‑reported scopes).
  - Do not expand `"*"` in `extractConnectionPermissions`; legacy `"*"` yields no grant.
  - `getReferencedConnectionIds` excludes `"*"`; added focused unit tests for rejection and `"KEY::SCOPE"` mapping.

- **Migration**
  - Existing connections with `"*"` must remove it before updating; tokens from such connections no longer get wildcard access.

<sup>Written for commit 927e158fc25e60e019730f65835b273bab4e00de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

