### PR TITLE
fix(chat): stop leaking the mic stream when SpeechRecognition.start() throws

### DIFF
--- a/apps/mesh/src/web/hooks/use-voice-input.test.ts
+++ b/apps/mesh/src/web/hooks/use-voice-input.test.ts
@@ -58,4 +58,60 @@ describe("useVoiceInput.startRecording", () => {
       configurable: true,
     });
   });
+
+  it("stops the mic stream when recognition.start() throws", async () => {
+    let stopCalls = 0;
+    win.SpeechRecognition = function () {
+      return {
+        start() {
+          throw new Error("already started");
+        },
+        stop() {},
+        abort() {},
+      };
+    } as unknown as typeof SpeechRecognition;
+
+    const originalAudioContext = win.AudioContext;
+    win.AudioContext = function () {
+      return {
+        createMediaStreamSource: () => ({ connect: () => {} }),
+        createAnalyser: () => ({
+          fftSize: 0,
+          smoothingTimeConstant: 0,
+          frequencyBinCount: 0,
+          getByteFrequencyData: () => {},
+        }),
+        close: () => Promise.resolve(),
+      };
+    };
+
+    const track = { stop: () => stopCalls++ };
+    const originalGetUserMedia = navigator.mediaDevices?.getUserMedia;
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: {
+        getUserMedia: () =>
+          Promise.resolve({
+            getTracks: () => [track],
+          } as unknown as MediaStream),
+      },
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useVoiceInput());
+
+    let outcome: string | undefined;
+    await act(async () => {
+      outcome = await result.current.startRecording();
+    });
+
+    expect(outcome).toBe("idle");
+    expect(result.current.status).toBe("idle");
+    expect(stopCalls).toBe(1);
+
+    win.AudioContext = originalAudioContext;
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia: originalGetUserMedia },
+      configurable: true,
+    });
+  });
 });

--- a/apps/mesh/src/web/hooks/use-voice-input.ts
+++ b/apps/mesh/src/web/hooks/use-voice-input.ts
@@ -155,6 +155,9 @@ export function useVoiceInput(): UseVoiceInputReturn {
     try {
       recognition.start();
     } catch {
+      isRecordingRef.current = false;
+      recognitionRef.current = null;
+      stopVisualizer();
       setStatus("idle");
       return "idle";
     }


### PR DESCRIPTION
**Source:** bug found while hardening voice-recording robustness in `apps/mesh/src/web/components/chat/input.tsx`'s voice flow (the underlying logic lives in `use-voice-input.ts`, which `input.tsx` drives via `handleVoiceStart`).

**The bug:** in `useVoiceInput.startRecording`, `getUserMedia` is awaited and `startVisualizerWithStream(stream)` opens an `AudioContext` + starts a `requestAnimationFrame` waveform loop *before* `recognition.start()` is called. If `recognition.start()` throws (e.g. a browser-level `InvalidStateError`), the catch block reset `status` to `"idle"` but never called `stopVisualizer()` — so the mic `MediaStream` track, the `AudioContext`, and the animation-frame loop all kept running indefinitely. Since the composer only renders the recording controls (cancel/confirm) while `status === "recording"`, the user has no way to stop it — the mic stays hot with the browser's recording indicator on until the tab is closed.

**Why a maintainer wants this:** a silent, unstoppable mic leak is a real privacy/resource issue that's easy to trigger (any environment where `SpeechRecognition.start()` can throw synchronously) and impossible for the user to recover from without reloading the page.

**Fix + regression test:** the catch block now also resets `isRecordingRef`, clears `recognitionRef`, and calls `stopVisualizer()` (which stops the media track, closes the `AudioContext`, and cancels the animation frame) before returning `"idle"`. Added a test in `use-voice-input.test.ts` that makes a stub `SpeechRecognition.start()` throw and asserts the mic track's `stop()` is called.

**Verify:** `bun test apps/mesh/src/web/hooks/use-voice-input.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace), and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a hot mic when `SpeechRecognition.start()` throws by fully stopping the mic stream and audio resources in the voice input flow. This avoids the browser recording indicator sticking on and halts the waveform loop.

- **Bug Fixes**
  - On `recognition.start()` error in `useVoiceInput.startRecording`, reset `isRecordingRef`, clear `recognitionRef`, call `stopVisualizer()`, and set status to `"idle"`.
  - Added a regression test that stubs a throwing `start()` and verifies the mic track’s `stop()` is called.

<sup>Written for commit 3cfd05246be644bca79b29f4f8a84d7ce5b0fa13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

