### PR TITLE
fix(registry): scope monitor-run cancellation to the caller's organization

### DIFF
--- a/apps/mesh/src/tools/registry/monitor-run-cancel.test.ts
+++ b/apps/mesh/src/tools/registry/monitor-run-cancel.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { MonitorRunEntity } from "@/storage/registry";
+import { REGISTRY_MONITOR_RUN_CANCEL } from "./monitor-run-cancel";
+import { cancelMonitorRun } from "./monitor-run-start";
+
+function makeRun(overrides: Partial<MonitorRunEntity> = {}): MonitorRunEntity {
+  return {
+    id: "run-1",
+    organization_id: "org-1",
+    status: "running",
+    config_snapshot: null,
+    total_items: 0,
+    tested_items: 0,
+    passed_items: 0,
+    failed_items: 0,
+    skipped_items: 0,
+    current_item_id: null,
+    started_at: null,
+    finished_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeCtx(orgId: string, findById: ReturnType<typeof mock>) {
+  return {
+    organization: { id: orgId },
+    access: { check: mock(async () => {}) },
+    storage: {
+      registry: {
+        monitorRuns: {
+          findById,
+          update: mock(async () => makeRun({ organization_id: orgId })),
+        },
+      },
+    },
+  } as unknown as Parameters<typeof REGISTRY_MONITOR_RUN_CANCEL.handler>[1];
+}
+
+describe("REGISTRY_MONITOR_RUN_CANCEL", () => {
+  it("does not abort a running monitor run that belongs to a different organization", async () => {
+    // findById is org-scoped in storage, so a run owned by another org
+    // resolves to null here — the handler must reject before ever touching
+    // the process-wide (org-agnostic) abort-controller map.
+    const findById = mock(async () => null);
+    const ctx = makeCtx("org-b", findById);
+
+    await expect(
+      REGISTRY_MONITOR_RUN_CANCEL.handler({ runId: "run-owned-by-org-a" }, ctx),
+    ).rejects.toThrow(/not found/i);
+
+    expect(findById).toHaveBeenCalledWith("org-b", "run-owned-by-org-a");
+    expect(
+      (
+        ctx as unknown as {
+          storage: {
+            registry: { monitorRuns: { update: ReturnType<typeof mock> } };
+          };
+        }
+      ).storage.registry.monitorRuns.update,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("cancels a run that belongs to the caller's organization", async () => {
+    const findById = mock(async () => makeRun());
+    const ctx = makeCtx("org-1", findById);
+
+    const result = await REGISTRY_MONITOR_RUN_CANCEL.handler(
+      { runId: "run-1" },
+      ctx,
+    );
+
+    expect(result.run.status).toBe("running"); // from the mocked update stub
+    expect(findById).toHaveBeenCalledWith("org-1", "run-1");
+  });
+});
+
+describe("cancelMonitorRun", () => {
+  it("returns false for an unknown runId without throwing", () => {
+    expect(cancelMonitorRun("does-not-exist")).toBe(false);
+  });
+});

--- a/apps/mesh/src/tools/registry/monitor-run-cancel.ts
+++ b/apps/mesh/src/tools/registry/monitor-run-cancel.ts
@@ -15,8 +15,15 @@ export const REGISTRY_MONITOR_RUN_CANCEL = defineTool({
   handler: async (input, ctx) => {
     const organization = requireOrganization(ctx);
     await ctx.access.check();
-    cancelMonitorRun(input.runId);
     const storage = ctx.storage.registry;
+    const existing = await storage.monitorRuns.findById(
+      organization.id,
+      input.runId,
+    );
+    if (!existing) {
+      throw new Error(`Monitor run not found: ${input.runId}`);
+    }
+    cancelMonitorRun(input.runId);
     const run = await storage.monitorRuns.update(organization.id, input.runId, {
       status: "cancelled",
       current_item_id: null,


### PR DESCRIPTION
Bug found while reviewing recent registry/monitor-run hardening fixes (#4995, #4998) in the same subsystem.

`REGISTRY_MONITOR_RUN_CANCEL` called `cancelMonitorRun(runId)` — which aborts a process-wide `AbortController` keyed only by `runId`, with no organization check — *before* verifying the run belongs to the caller's organization. The only org check was the subsequent `storage.monitorRuns.update(organization.id, runId, ...)` call, which is org-scoped and throws "not found" for a run owned by another org — but by then the abort side effect had already fired.

Failure scenario: an authenticated user in org B calls `REGISTRY_MONITOR_RUN_CANCEL` with a runId belonging to org A (runIds are UUIDs returned from `REGISTRY_MONITOR_RUN_START`/list endpoints and not secret across orgs sharing the same registry). Org A's in-flight monitor run silently aborts — a cross-tenant denial-of-service — even though org B's call itself ends in a thrown "not found" error and never touches org A's DB row.

Fix: look up the run via the existing org-scoped `storage.monitorRuns.findById(organization.id, runId)` and reject with "not found" before calling `cancelMonitorRun`, so the global abort only ever fires once org ownership is confirmed.

Regression test: `apps/mesh/src/tools/registry/monitor-run-cancel.test.ts` — asserts that a cross-org cancel attempt rejects before `storage.monitorRuns.update` is ever invoked (proving the abort path can't have fired first either).

Reviewer command: `bun test apps/mesh/src/tools/registry/monitor-run-cancel.test.ts`

Locally verified: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (green), and the targeted test file above (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes monitor-run cancellation to the caller’s organization to prevent cross-org aborts. We now verify ownership before firing the global abort, closing a denial-of-service gap.

- **Bug Fixes**
  - Check `(organizationId, runId)` via `storage.monitorRuns.findById` and throw “not found” if missing before calling `cancelMonitorRun`.
  - Call `cancelMonitorRun` only after ownership is confirmed, then update the run status to `cancelled` in org scope.
  - Added regression test to ensure cross-org cancel attempts reject early and that `cancelMonitorRun` returns false for unknown IDs.

<sup>Written for commit 74d104b3183ae9d73df517ea1b7b6341c9d8cae0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

