### PR TITLE
refactor(agent-icon): dedupe IconPicker's radius map into agent-icon's SIZES config

### DIFF
--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -280,6 +280,11 @@ const SIZES = {
 
 export type AgentAvatarSize = keyof typeof SIZES;
 
+/** Corner radius class for a given avatar size — kept in sync with `SIZES`. */
+export function getSizeRadius(size: AgentAvatarSize): string {
+  return SIZES[size].radius;
+}
+
 // ---------------------------------------------------------------------------
 // AgentAvatar
 // ---------------------------------------------------------------------------

--- a/apps/mesh/src/web/components/icon-picker.tsx
+++ b/apps/mesh/src/web/components/icon-picker.tsx
@@ -26,6 +26,7 @@ import {
   getIconColor,
   getIconComponent,
   getIconNames,
+  getSizeRadius,
   humanizeIconName,
   parseIconString,
   type AgentAvatarSize,
@@ -110,15 +111,6 @@ export function IconPicker({
     onChange(buildIconString(randomName, selectedColor));
   };
 
-  const sizeRadius: Record<string, string> = {
-    xs: "rounded-md",
-    sm: "rounded-lg",
-    "sm+": "rounded-xl",
-    md: "rounded-xl",
-    lg: "rounded-2xl",
-    xl: "rounded-2xl",
-  };
-
   return (
     <Popover open={disabled ? false : open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -130,7 +122,7 @@ export function IconPicker({
           className={cn(
             "relative group overflow-hidden",
             disabled ? "cursor-default opacity-50" : "cursor-pointer",
-            sizeRadius[size],
+            getSizeRadius(size),
             className,
           )}
         >


### PR DESCRIPTION
**Source**: reduction/consolidation found while auditing `agent-icon.tsx` (highest-debt frontend file in this tick's focus area) and its consumers in `icon-picker.tsx`.

**Why**: `IconPicker` hand-rolled its own local `sizeRadius` map duplicating the `radius` field already defined per-size in `agent-icon.tsx`'s `SIZES` config. The two had drifted out of sync: `"sm+"` resolved to `rounded-xl` in `IconPicker`'s copy but `rounded-lg` in the real `SIZES` config (the one `AgentAvatar` actually renders with), and `"2xs"` was missing from the copy entirely (would silently apply no radius class). This is exactly the kind of copy-pasted-logic-drifts-out-of-sync bug the `SIZES` config was meant to prevent.

**Fix**: export a `getSizeRadius(size)` helper from `agent-icon.tsx` that reads directly from `SIZES`, and have `IconPicker` use it instead of its own duplicate map. Deletes the duplicate map (net -3 lines) and makes `IconPicker`'s trigger button radius provably match `AgentAvatar`'s radius for every size, including `"2xs"` and `"sm+"` which were wrong/missing before.

Behavior-preserving for the one live call site (`IconPicker` is only invoked with `size="md"` today, where both old and new values already agreed on `rounded-xl`) and fixes the latent bug for any future `size="sm+"` or `"2xs"` usage.

**Verify**: `cd apps/mesh && bunx tsc --noEmit` (green) and `bun test src/web/components/agent-icon.test.tsx` (2 pass, unchanged).

**Checked locally**: `bun run fmt`, targeted `tsc --noEmit` in `apps/mesh`, and the existing `agent-icon.test.tsx` suite. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated avatar corner radius logic by exporting `getSizeRadius(size)` from the `SIZES` config in `agent-icon.tsx` and using it in `IconPicker`. This removes the duplicate map and ensures the trigger’s radius matches `AgentAvatar` across all sizes.

- **Refactors**
  - Added `getSizeRadius(size)` that returns `SIZES[size].radius`.
  - Replaced `IconPicker`’s local `sizeRadius` map with the helper for a single source of truth.
  - Preserves current behavior for `size="md"` and prevents future drift.

<sup>Written for commit 7e20f5fd96a981bceaaab4e8c94c44ffc53e523a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

