### PR TITLE
fix(chat): make editable prompt mention chips keyboard-accessible

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
@@ -1,4 +1,5 @@
 import { toTitleCase } from "@/web/components/chat/message/parts/tool-call-part/utils.tsx";
+import { useT } from "@/web/i18n/use-t.ts";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { JSONContent, mergeAttributes, Node } from "@tiptap/core";
 import {
@@ -93,6 +94,7 @@ export function createMentionDoc<T>(attrs: MentionAttrs<T>): JSONContent {
 function MentionNodeView(props: NodeViewProps) {
   const { node, selected, view, editor, getPos } = props;
   const { name, char, kind, id, args } = node.attrs as MentionAttrs;
+  const t = useT();
 
   const isSelected = selected && view.editable;
   const isTask = kind === "task";
@@ -103,16 +105,13 @@ function MentionNodeView(props: NodeViewProps) {
   const isClickable =
     view.editable && char === "/" && (kind === "prompt" || kind == null);
 
-  const handleClick = (e: React.MouseEvent) => {
-    if (!isClickable) return;
+  const triggerEdit = () => {
     const storage = getMentionStorage(editor);
     const onEdit = storage?.onEditChip;
     if (!onEdit) return;
     if (typeof getPos !== "function") return;
     const pos = getPos();
     if (typeof pos !== "number") return;
-    e.preventDefault();
-    e.stopPropagation();
     onEdit({
       promptId: id,
       promptName: name,
@@ -121,9 +120,32 @@ function MentionNodeView(props: NodeViewProps) {
     });
   };
 
+  const handleClick = (e: React.MouseEvent) => {
+    if (!isClickable) return;
+    e.preventDefault();
+    e.stopPropagation();
+    triggerEdit();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!isClickable) return;
+    if (e.key !== "Enter" && e.key !== " ") return;
+    e.preventDefault();
+    e.stopPropagation();
+    triggerEdit();
+  };
+
   return (
     <NodeViewWrapper
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      role={isClickable ? "button" : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      aria-label={
+        isClickable
+          ? t("chat.mention.editPrompt", { name: name ?? "" })
+          : undefined
+      }
       className={cn(
         "px-1 py-1 rounded",
         "inline-flex items-center gap-1",

--- a/apps/mesh/src/web/i18n/en/chat.ts
+++ b/apps/mesh/src/web/i18n/en/chat.ts
@@ -1,0 +1,3 @@
+export const chat = {
+  "chat.mention.editPrompt": "Edit {name} prompt arguments",
+} as const;

--- a/apps/mesh/src/web/i18n/en/index.ts
+++ b/apps/mesh/src/web/i18n/en/index.ts
@@ -1,4 +1,5 @@
 import { announcements } from "./announcements.ts";
+import { chat } from "./chat.ts";
 import { settings } from "./settings.ts";
 
 // English is the source of truth: every domain file is spread here and
@@ -6,6 +7,7 @@ import { settings } from "./settings.ts";
 // and is type-checked against it, so `bun run check` proves completeness.
 export const en = {
   ...announcements,
+  ...chat,
   ...settings,
 } as const;
 

--- a/apps/mesh/src/web/i18n/pt-br/chat.ts
+++ b/apps/mesh/src/web/i18n/pt-br/chat.ts
@@ -1,0 +1,5 @@
+import type { chat as chatEn } from "../en/chat.ts";
+
+export const chat = {
+  "chat.mention.editPrompt": "Editar argumentos do prompt {name}",
+} satisfies Record<keyof typeof chatEn, string>;

--- a/apps/mesh/src/web/i18n/pt-br/index.ts
+++ b/apps/mesh/src/web/i18n/pt-br/index.ts
@@ -1,8 +1,10 @@
 import type { TranslationKey } from "../en/index.ts";
 import { announcements } from "./announcements.ts";
+import { chat } from "./chat.ts";
 import { settings } from "./settings.ts";
 
 export const ptBR = {
   ...announcements,
+  ...chat,
   ...settings,
 } satisfies Record<TranslationKey, string>;


### PR DESCRIPTION
**Source**: accessibility debt in the tiptap mention node (`apps/mesh/src/web/components/chat/tiptap/mention/node.tsx`), flagged as a high-debt frontend file (inconsistent prop handling, missing aria attributes).

**Why**: the `/` prompt mention chip renders as a clickable `<div>` (via `NodeViewWrapper`) with an `onClick` handler but no `role`, no `tabIndex`, no keyboard handler, and no accessible name — a keyboard or screen-reader user editing a chat message has no way to discover or trigger the "edit prompt arguments" action on it.

**Change**: when the chip is clickable (editable `/` mention with `kind === "prompt"` or no `kind`), it now gets `role="button"`, `tabIndex={0}`, an `onKeyDown` handler firing the same edit action on Enter/Space, and an `aria-label` (via the existing i18n `useT()` mechanism — added a new `chat` i18n domain with en/pt-BR entries). Non-clickable chips (resources, skills, task refs) are unaffected — those props resolve to `undefined` for them, same as before. The click-handling logic itself was only refactored into a shared `triggerEdit()` function so click and keyboard share it; no behavior change for mouse users.

**How to verify**: `cd apps/mesh && bunx tsc --noEmit` (confirms the pt-BR dictionary stays a complete mirror of the new `chat.ts` en keys — `bun run check` proves this repo-wide in CI). No existing test covers this file's rendering, so no test needed to invert; this is additive markup, not a behavior fix.

**Checks run locally**: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (both clean). Full CI (lint, `bun test`, etc.) covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the editable "/" prompt mention chip keyboard- and screen-reader-accessible in the chat editor. Adds button role, tab focus, Enter/Space handling, and an aria-label using new `chat` i18n keys (en, pt-BR); non-clickable chips are unchanged.

<sup>Written for commit 8c2b4ecd1d3737b4e0e05dafce896cffff116c48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

