### PR TITLE
refactor(chat): remove propose-plan's unreachable streaming-loading branch

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/propose-plan.test.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/propose-plan.test.tsx
@@ -1,0 +1,68 @@
+import { setupComponentTest } from "../../../../test/setup"; // happy-dom + jest-dom matchers
+setupComponentTest();
+import { describe, expect, it, mock } from "bun:test";
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ProposePlanHighlight } from "./propose-plan";
+import type { PendingPlan } from "./extract-pending-plans";
+
+describe("ProposePlanHighlight", () => {
+  const plan = (toolCallId: string, text: string): PendingPlan => ({
+    toolCallId,
+    plan: text,
+    state: "input-available",
+  });
+
+  it("renders nothing when there is no pending plan", () => {
+    const { container } = render(
+      <ProposePlanHighlight
+        plans={[]}
+        isStreaming={false}
+        onApprove={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders only the most recently proposed plan", () => {
+    const { getByText, queryByText } = render(
+      <ProposePlanHighlight
+        plans={[plan("c1", "First plan"), plan("c2", "Second plan")]}
+        isStreaming={false}
+        onApprove={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(getByText("Second plan")).toBeInTheDocument();
+    expect(queryByText("First plan")).toBeNull();
+  });
+
+  it("approve button passes the active plan's text to onApprove", () => {
+    const onApprove = mock();
+    const { getByText } = render(
+      <ProposePlanHighlight
+        plans={[plan("c1", "Do the thing")]}
+        isStreaming={false}
+        onApprove={onApprove}
+        onDismiss={() => {}}
+      />,
+    );
+    fireEvent.click(getByText("Let's go"));
+    expect(onApprove).toHaveBeenCalledWith("Do the thing");
+  });
+
+  it("dismiss button calls onDismiss", () => {
+    const onDismiss = mock();
+    const { getByText } = render(
+      <ProposePlanHighlight
+        plans={[plan("c1", "Do the thing")]}
+        isStreaming={false}
+        onApprove={() => {}}
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.click(getByText("Keep iterating"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mesh/src/web/components/chat/highlight/propose-plan.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/propose-plan.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@deco/ui/components/button.tsx";
-import { Check, ClipboardCheck } from "@untitledui/icons";
+import { ClipboardCheck } from "@untitledui/icons";
 import { CollapsibleHighlight } from "./collapsible-highlight";
 import { MessageTextPart } from "../message/parts/text-part.tsx";
 import { selectActivePlan, type PendingPlan } from "./extract-pending-plans";
@@ -73,39 +73,22 @@ function ProposePlanPrompt({
 }
 
 // ============================================================================
-// ProposePlanLoadingUI
-// ============================================================================
-
-function ProposePlanLoadingUI() {
-  return (
-    <div className="flex items-center gap-2 p-4 border border-dashed border-purple-500/30 rounded-lg bg-purple-500/5 w-[calc(100%-16px)] max-w-[640px] mx-auto mb-2">
-      <Check className="size-5 text-purple-500 shimmer" />
-      <span className="text-sm text-muted-foreground shimmer">
-        Preparing plan...
-      </span>
-    </div>
-  );
-}
-
-// ============================================================================
 // ProposePlanHighlight - wrapper for ChatHighlight
 // ============================================================================
 
 export function ProposePlanHighlight({
   plans,
-  isStreaming,
   onApprove,
   onDismiss,
 }: {
   plans: PendingPlan[];
+  // The caller only ever mounts this component once a plan already exists
+  // (see `flags.hasPlans` in ChatHighlight), so `plans` is never empty here.
+  // Kept in the props contract for symmetry with the other highlight cards.
   isStreaming: boolean;
   onApprove: (planText: string) => void;
   onDismiss: () => void;
 }) {
-  if (isStreaming && plans.length === 0) {
-    return <ProposePlanLoadingUI />;
-  }
-
   // Show only the last pending plan
   const activePlan = selectActivePlan(plans);
   if (!activePlan) {


### PR DESCRIPTION
**Source:** dead-code reduction found while auditing `propose-plan.tsx` (assigned focus area), not tied to a specific issue.

**Payoff:** `ProposePlanHighlight`'s `if (isStreaming && plans.length === 0) return <ProposePlanLoadingUI />` branch has been unreachable since the component was introduced — its sole caller, `ChatHighlight` (`highlight/index.tsx`), only ever mounts it inside `{flags.hasPlans && (...)}`, and `hasPlans` is defined as `pendingPlans.length > 0` over the exact same `plans` array passed as the prop. So whenever the component renders, `plans.length > 0` is guaranteed, making the branch (and the `ProposePlanLoadingUI` component + its `Check` icon import) permanently dead. Confirmed by walking the full git history of every `ChatHighlight`/`ProposePlanHighlight` call site back to its introduction (commit 1281bb13d) — the `pendingPlans.length > 0` gating condition has never changed.

**Fix:** deleted the dead branch, the `ProposePlanLoadingUI` function, and the now-unused `Check` import. `isStreaming` stays in the props type (unused internally, with a comment explaining why) because the only caller — `highlight/index.tsx` — is currently being touched by an unrelated open PR (#4963, dedup of pending-plan/approval extraction) and I wanted to avoid any file/line collision with that in-flight work. Net: -21 lines / +7 lines (7 of which are the explanatory comment), behavior-preserving.

Also added `propose-plan.test.tsx`, a component test (previously this file had zero test coverage) exercising the actual render flow: no pending plan → renders nothing, multiple pending plans → only the most recent renders, approve button passes the active plan's text through, dismiss button fires `onDismiss`. This is the regression proof that removing the dead branch didn't change any *reachable* behavior.

**Reviewer check:** `cd apps/mesh && bun test src/web/components/chat/highlight/propose-plan.test.tsx` (4 pass) and `bunx tsc --noEmit` (clean).

**Local verification:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit`, and the targeted test file above all pass locally. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unreachable `isStreaming` loading path from `ProposePlanHighlight`, simplifying the component without changing behavior.

- **Refactors**
  - Deleted `isStreaming && plans.length === 0` branch and the `ProposePlanLoadingUI` plus `Check` icon import.
  - Kept `isStreaming` in props for compatibility with the current `ChatHighlight` caller.
  - Added `propose-plan.test.tsx` covering: no plans renders nothing, only the latest plan shows, approve passes plan text, dismiss triggers handler.

<sup>Written for commit 76e6c68610e94b4f829dfa3644421c2b55b8f4d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

