### PR TITLE
fix(registry): surface a fetch-error state in the QA connections panel

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -619,13 +619,26 @@ export function MonitorConnectionsPanel() {
         </Button>
       </div>
       <div className="space-y-2">
-        {filteredItems.length === 0 && (
-          <p className="text-xs text-muted-foreground text-center py-3">
-            No QA connections for this filter. Click &quot;Sync&quot; to create
-            mappings from store items and pending requests.
-          </p>
+        {listQuery.isError ? (
+          <div className="p-8 text-center rounded-lg border border-border">
+            <p className="text-sm text-destructive">
+              Failed to load QA connections.
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {listQuery.error instanceof Error
+                ? listQuery.error.message
+                : "Unknown error"}
+            </p>
+          </div>
+        ) : (
+          filteredItems.length === 0 && (
+            <p className="text-xs text-muted-foreground text-center py-3">
+              No QA connections for this filter. Click &quot;Sync&quot; to
+              create mappings from store items and pending requests.
+            </p>
+          )
         )}
-        {filteredItems.length > 0 && (
+        {!listQuery.isError && filteredItems.length > 0 && (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
             {filteredItems.map((entry) => {
               const counts = failuresByItem[entry.mapping.item_id] ?? {


### PR DESCRIPTION
**Source:** bug found while hunting the `monitor-connections-panel-ui` focus area ("reconcile error handling ... under silent-run and cross-org scenarios").

**Why:** `MonitorConnectionsPanel` only branched on `filteredItems.length === 0` to render its empty state. When `useMonitorConnections()`'s underlying `REGISTRY_MONITOR_CONNECTION_LIST` call fails (network blip, cross-org auth hiccup, backend error), `listQuery.data` stays `undefined`, `items` falls back to `[]`, and the UI silently renders "No QA connections for this filter. Click Sync to create mappings..." — telling the user there's simply nothing to sync when the real problem is a fetch failure. That's misleading and can send someone repeatedly clicking Sync for a transient network error.

**Fix:** added a `listQuery.isError` branch that renders a distinct error state (`Failed to load QA connections.` + the underlying error message), matching the exact pattern already used one file over in `registry-requests-page.tsx` for its own list query. The genuine-empty and populated-grid branches are now gated on `!listQuery.isError` so they don't render simultaneously with the error state.

**Failure scenario before the fix:** org membership resolves but the monitor-connection list tool call throws (e.g. a cross-org auth edge case or a flaky network request) — the panel shows the empty-list copy instead of any indication that data failed to load.

**Reviewer check:** `cd apps/mesh && bunx tsc --noEmit` (green). This is a pure presentational branch on an existing query's `isError`/`error` fields — no new state, no behavior change to the happy path.

**Locally verified:** `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (green). No existing test covers this render path; full CI runs the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface a dedicated fetch-error state in the QA Connections panel when `REGISTRY_MONITOR_CONNECTION_LIST` fails, replacing the misleading empty state. This makes network/auth/backend failures clear to users.

- **Bug Fixes**
  - Render "Failed to load QA connections." plus the error message when `listQuery.isError` is true.
  - Gate empty and grid views behind `!listQuery.isError` to avoid mixed states.
  - Aligns with the error handling pattern in `registry-requests-page.tsx`.

<sup>Written for commit dba11e35a094010cf47257b2958350c8b2f02d2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

