### PR TITLE
refactor(chat): dedupe brand-context field typings and font-entry helper

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/brand-context.test.ts
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/brand-context.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import {
+  domainHref,
+  getColorEntries,
+  getFontEntries,
+} from "./brand-context.tsx";
+
+describe("domainHref", () => {
+  test("adds https:// to a bare domain", () => {
+    expect(domainHref("example.com")).toBe("https://example.com/");
+  });
+
+  test("keeps an existing https:// domain", () => {
+    expect(domainHref("https://example.com")).toBe("https://example.com/");
+  });
+
+  test("rejects a javascript: scheme, falling back to about:blank", () => {
+    expect(domainHref("javascript:alert(1)")).toBe("about:blank");
+  });
+
+  test("rejects a data: scheme, falling back to about:blank", () => {
+    expect(domainHref("data:text/html,<script>alert(1)</script>")).toBe(
+      "about:blank",
+    );
+  });
+
+  test("falls back to about:blank on an unparsable URL", () => {
+    expect(domainHref("not a url")).toBe("about:blank");
+  });
+});
+
+describe("getColorEntries", () => {
+  test("returns empty array for null/undefined colors", () => {
+    expect(getColorEntries(null)).toEqual([]);
+    expect(getColorEntries(undefined)).toEqual([]);
+  });
+
+  test("filters out empty and non-string values", () => {
+    expect(
+      getColorEntries({
+        primary: "#fff",
+        secondary: "",
+        accent: "   ",
+      }),
+    ).toEqual([["primary", "#fff"]]);
+  });
+
+  test("keeps all populated color entries", () => {
+    expect(getColorEntries({ primary: "#fff", background: "#000" })).toEqual([
+      ["primary", "#fff"],
+      ["background", "#000"],
+    ]);
+  });
+});
+
+describe("getFontEntries", () => {
+  test("returns empty array for null/undefined fonts", () => {
+    expect(getFontEntries(null)).toEqual([]);
+    expect(getFontEntries(undefined)).toEqual([]);
+  });
+
+  test("filters out empty and non-string values", () => {
+    expect(getFontEntries({ heading: "Inter", body: "" })).toEqual([
+      ["heading", "Inter"],
+    ]);
+  });
+
+  test("keeps all populated font entries", () => {
+    expect(getFontEntries({ heading: "Inter", code: "Mono" })).toEqual([
+      ["heading", "Inter"],
+      ["code", "Mono"],
+    ]);
+  });
+});

--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/brand-context.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/brand-context.tsx
@@ -19,9 +19,7 @@ interface BrandFonts {
   code?: string;
 }
 
-interface BrandContextResult {
-  success?: boolean;
-  error?: string;
+interface BrandContextFields {
   name?: string;
   domain?: string;
   overview?: string;
@@ -30,6 +28,11 @@ interface BrandContextResult {
   ogImage?: string | null;
   colors?: BrandColors | null;
   fonts?: BrandFonts | null;
+}
+
+interface BrandContextResult extends BrandContextFields {
+  success?: boolean;
+  error?: string;
 }
 
 interface BrandContextPartProps {
@@ -45,7 +48,7 @@ const COLOR_LABELS: Record<keyof BrandColors, string> = {
   foreground: "Foreground",
 };
 
-function domainHref(domain: string): string {
+export function domainHref(domain: string): string {
   try {
     const url = new URL(
       domain.startsWith("http") ? domain : `https://${domain}`,
@@ -59,11 +62,20 @@ function domainHref(domain: string): string {
   }
 }
 
-function getColorEntries(
+export function getColorEntries(
   colors?: BrandColors | null,
 ): Array<[keyof BrandColors, string]> {
   if (!colors) return [];
   return (Object.entries(colors) as Array<[keyof BrandColors, string]>).filter(
+    ([, v]) => typeof v === "string" && v.trim().length > 0,
+  );
+}
+
+export function getFontEntries(
+  fonts?: BrandFonts | null,
+): Array<[keyof BrandFonts, string]> {
+  if (!fonts) return [];
+  return (Object.entries(fonts) as Array<[keyof BrandFonts, string]>).filter(
     ([, v]) => typeof v === "string" && v.trim().length > 0,
   );
 }
@@ -178,11 +190,7 @@ function BrandCard({
   isDefault?: boolean;
 }) {
   const colorEntries = getColorEntries(colors);
-  const fontEntries = fonts
-    ? (Object.entries(fonts) as Array<[keyof BrandFonts, string]>).filter(
-        ([, v]) => typeof v === "string" && v.trim().length > 0,
-      )
-    : [];
+  const fontEntries = getFontEntries(fonts);
 
   return (
     <div className="mt-2 rounded-lg overflow-hidden border border-border">
@@ -301,18 +309,10 @@ export function BrandContextPart({ part, latency }: BrandContextPartProps) {
   );
 }
 
-interface BrandContextRecord {
+interface BrandContextRecord extends BrandContextFields {
   id?: string;
   success?: boolean;
   error?: string;
-  name?: string;
-  domain?: string;
-  overview?: string;
-  logo?: string | null;
-  favicon?: string | null;
-  ogImage?: string | null;
-  colors?: BrandColors | null;
-  fonts?: BrandFonts | null;
   isDefault?: boolean;
 }
 
@@ -436,11 +436,11 @@ export function BrandContextListPart({
         trailing={<LatencyLabel latency={latency} />}
       />
       <div className="mt-2 flex flex-col gap-1.5">
-        {items.map((brand) => {
+        {items.map((brand, index) => {
           const colorEntries = getColorEntries(brand.colors);
           return (
             <div
-              key={brand.id ?? `${brand.name}-${brand.domain}`}
+              key={brand.id ?? `${brand.name}-${brand.domain}-${index}`}
               className="rounded-lg border border-border overflow-hidden"
             >
               {brand.colors && <ColorStrip colors={brand.colors} />}


### PR DESCRIPTION
Source: bounded C1/C-DEBT cleanup of the brand-context tool-call part (assigned focus area: tool-call-brand-context-refactor), not tied to a specific issue.

Why a maintainer wants it: `BrandContextResult` and `BrandContextRecord` hand-duplicated the same 8 optional brand fields (name/domain/overview/logo/favicon/ogImage/colors/fonts) verbatim; a future field add/rename now only needs to happen once. Same idea for fonts: `BrandCard` inlined the exact same filter-non-empty-string logic that `getColorEntries` already had a named helper for, so I extracted `getFontEntries` to match it.

What changed:
- New shared `BrandContextFields` interface; `BrandContextResult`/`BrandContextRecord` now `extends` it instead of repeating the fields (net -21/+? but the real win is one source of truth for the shape, not raw line count).
- Extracted `getFontEntries(fonts)` mirroring the existing `getColorEntries(colors)`, and pointed `BrandCard`'s inline logic at it.
- Guarded the brand-list React `key`: `brand.id ?? \`${name}-${domain}\`` collapsed to the same key (`undefined-undefined`) for any two brands missing id/name/domain; added the array index to disambiguate.
- Exported the three now-reusable helpers (`domainHref`, `getColorEntries`, `getFontEntries`) and added `brand-context.test.ts` covering them, including `domainHref`'s existing `javascript:`/`data:` scheme rejection (it builds an href for an external-link anchor from tool-output-controlled domain text, so validating the scheme is a real trust-boundary guard, not incidental).

Behavior is unchanged — this is a pure type/helper extraction plus a defensive key fix; no JSX structure, styling, or rendered output changed.

Reviewer command: `bun test apps/mesh/src/web/components/chat/message/parts/tool-call-part/brand-context.test.ts`

Locally ran: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean for this file — the only errors reported are pre-existing in an unrelated file), and the targeted test file above (11/11 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dedupes brand-context field typings with a shared interface and extracts a font-entry helper for consistency. Behavior is unchanged. Also fixes a brand list key collision.

- **Refactors**
  - Added `BrandContextFields`; `BrandContextResult` and `BrandContextRecord` now extend it.
  - Extracted and exported `getFontEntries(fonts)` to mirror `getColorEntries(colors)`; `BrandCard` now uses it.
  - Exported `domainHref` and added tests for all helpers, including scheme validation.

- **Bug Fixes**
  - Prevented React key collisions by appending the array index when `id`, `name`, and `domain` are missing.

<sup>Written for commit c7a455692e923d6f80214dd50dcf88a93c45f7b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

