### PR TITLE
fix(registry): block DNS-based SSRF bypass in discover-tools

### DIFF
--- a/apps/mesh/src/tools/registry/discover-tools.test.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   isPrivateUrl,
   parseToolsListResponse,
+  resolvesToPrivateAddress,
   withTimeout,
 } from "./discover-tools";
 
@@ -60,6 +61,45 @@ describe("isPrivateUrl", () => {
     expect(isPrivateUrl("https://example.com/mcp")).toBe(false);
     expect(isPrivateUrl("http://8.8.8.8/")).toBe(false);
     expect(isPrivateUrl("http://[::8.8.8.8]/")).toBe(false);
+  });
+});
+
+describe("resolvesToPrivateAddress", () => {
+  it("blocks a domain whose DNS record points at a private/metadata address", async () => {
+    // e.g. an attacker-controlled domain with an A record for the cloud
+    // metadata endpoint — isPrivateUrl never sees a literal IP to catch this.
+    const resolveHost = async () => ["169.254.169.254"];
+    expect(await resolvesToPrivateAddress("evil.com", resolveHost)).toBe(true);
+  });
+
+  it("allows a domain that resolves only to public addresses", async () => {
+    const resolveHost = async () => ["93.184.216.34"];
+    expect(await resolvesToPrivateAddress("example.com", resolveHost)).toBe(
+      false,
+    );
+  });
+
+  it("blocks if any resolved address (v4 or v6) is private, even alongside public ones", async () => {
+    const resolveHost = async () => ["8.8.8.8", "10.0.0.5"];
+    expect(await resolvesToPrivateAddress("mixed.example", resolveHost)).toBe(
+      true,
+    );
+    const resolveHostV6 = async () => ["2001:db8::1", "::1"];
+    expect(
+      await resolvesToPrivateAddress("mixed-v6.example", resolveHostV6),
+    ).toBe(true);
+  });
+
+  it("fails closed when resolution throws or returns nothing", async () => {
+    const throwing = async () => {
+      throw new Error("NXDOMAIN");
+    };
+    expect(await resolvesToPrivateAddress("nowhere.example", throwing)).toBe(
+      true,
+    );
+
+    const empty = async () => [];
+    expect(await resolvesToPrivateAddress("empty.example", empty)).toBe(true);
   });
 });
 

--- a/apps/mesh/src/tools/registry/discover-tools.ts
+++ b/apps/mesh/src/tools/registry/discover-tools.ts
@@ -4,6 +4,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { lookup } from "node:dns/promises";
 import { z } from "zod";
 
 /** RFC 1918 / loopback / link-local ranges, keyed off the first two IPv4 octets. */
@@ -94,6 +95,45 @@ export function isPrivateUrl(url: string): boolean {
 
     return false;
   } catch {
+    return true;
+  }
+}
+
+/** Checks a bare resolved IP literal (v4 or v6, no brackets) against private/loopback/link-local ranges — used to vet DNS resolution results, since `isPrivateUrl` only sees the literal hostname written in the URL. */
+function isPrivateIpAddress(ip: string): boolean {
+  const ipv4Match = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (ipv4Match) {
+    const [, a, b] = ipv4Match.map(Number);
+    return isPrivateIPv4Octets(a!, b);
+  }
+
+  const ipv6 = ip.toLowerCase();
+  if (ipv6 === "::1" || ipv6 === "::") return true;
+  if (ipv6.startsWith("::ffff:")) return true;
+  if (ipv6.startsWith("fc") || ipv6.startsWith("fd")) return true;
+  if (ipv6.startsWith("fe80")) return true;
+  if (ipv6.startsWith("100:")) return true;
+  return isPrivateEmbeddedIPv4(ipv6);
+}
+
+/**
+ * A hostname's IP-literal form is vetted synchronously by `isPrivateUrl`, but
+ * a plain domain name only reveals its real destination after DNS
+ * resolution — an attacker who controls DNS for their own domain (e.g. an A
+ * record pointing at the 169.254.169.254 cloud metadata endpoint) bypasses
+ * the literal-IP guard entirely. Resolve first and vet every returned
+ * address before connecting.
+ */
+export async function resolvesToPrivateAddress(
+  hostname: string,
+  resolveHost: (host: string) => Promise<string[]> = async (host) =>
+    (await lookup(host, { all: true })).map((r) => r.address),
+): Promise<boolean> {
+  try {
+    const addresses = await resolveHost(hostname);
+    return addresses.length === 0 || addresses.some(isPrivateIpAddress);
+  } catch {
+    // Can't verify where this hostname actually points — fail closed.
     return true;
   }
 }
@@ -271,12 +311,40 @@ export const REGISTRY_DISCOVER_TOOLS = defineTool({
       };
     }
 
+    const timeoutMs = 10_000;
+
+    // isPrivateUrl already fully vets an IP-literal hostname; only a plain
+    // domain name needs a DNS lookup to catch a domain whose DNS record
+    // points at a private/metadata address.
+    const hostname = new URL(url).hostname;
+    const isIpLiteral =
+      /^\d+\.\d+\.\d+\.\d+$/.test(hostname) ||
+      (hostname.startsWith("[") && hostname.endsWith("]"));
+
+    let blockedByDns = false;
+    if (!isIpLiteral) {
+      try {
+        blockedByDns = await withTimeout(
+          resolvesToPrivateAddress(hostname),
+          5_000,
+          "DNS resolution timeout",
+        );
+      } catch {
+        blockedByDns = true; // can't verify in time — fail closed
+      }
+    }
+
+    if (blockedByDns) {
+      return {
+        tools: [],
+        error: "URLs targeting private networks are not allowed",
+      };
+    }
+
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       Accept: "application/json, text/event-stream",
     };
-
-    const timeoutMs = 10_000;
 
     const urlVariants = getUrlVariants(url);
     const transportTypes: TransportType[] =


### PR DESCRIPTION
Follows the SSRF-hardening work already in flight on this module (open PR #4999 fixes the redirect-based bypass on the MCP SDK client path). This closes a separate, unaddressed gap in the same guard.

`isPrivateUrl` only vets a hostname's *literal* IP form (dotted-quad, bracketed IPv6, embedded-IPv4 IPv6 forms, etc.) — it never resolves a plain domain name. An attacker who controls DNS for their own domain (e.g. `evil.com` with an A record pointing at `169.254.169.254`, a cloud metadata endpoint, or any RFC1918 address) sails straight past the guard, since nothing performs a DNS lookup before `REGISTRY_DISCOVER_TOOLS` connects to the server.

**Fix**: added `resolvesToPrivateAddress(hostname, resolveHost?)`, which resolves the hostname (via `node:dns/promises`, dependency-injectable for tests) and checks every returned address against the same private/loopback/link-local ranges `isPrivateUrl` already enforces. Wired into the tool handler right after the existing `isPrivateUrl` check, skipped only for hostnames that are already IP literals (those are fully vetted synchronously already). Fails closed (blocks) on a lookup error, an empty result, or a lookup that exceeds a 5s timeout — a domain we can't resolve in time doesn't get the benefit of the doubt.

**Failure scenario prevented**: a user submits `http://evil.com/mcp` where `evil.com`'s DNS resolves to `169.254.169.254`. Previously `isPrivateUrl("http://evil.com/mcp")` returns `false` (no literal IP to catch), and the tool proceeds to connect straight to the cloud metadata endpoint. Now the DNS check resolves `evil.com` first, sees the private address, and blocks with "URLs targeting private networks are not allowed."

Note: this doesn't fully close DNS-rebinding TOCTOU (DNS could theoretically change between this check and the actual connect a few lines later) — that would need IP-pinning the outbound connection, a bigger change. This closes the much more common direct case: pointing a domain's DNS straight at an internal address.

**Verify**: `bun test apps/mesh/src/tools/registry/discover-tools.test.ts` — new `resolvesToPrivateAddress` tests cover: private-address block, public-address allow, mixed v4/v6 results, and fail-closed on throw/empty-result.

**Local checks run**: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the single targeted test file above (18/18 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks DNS-based SSRF in `REGISTRY_DISCOVER_TOOLS` by resolving hostnames and rejecting any that point to private, loopback, or link-local addresses. Prevents requests to internal endpoints via attacker-controlled DNS.

- **Bug Fixes**
  - Added `resolvesToPrivateAddress` using `node:dns/promises` to vet all resolved IPs (IPv4/IPv6).
  - Runs after `isPrivateUrl`; skipped for IP-literal hosts already vetted.
  - Fails closed on DNS errors, empty results, or a 5s lookup timeout via `withTimeout`.
  - Returns error: "URLs targeting private networks are not allowed."
  - Added tests covering private/public resolutions, mixed results, and fail-closed paths.

<sup>Written for commit 2f3822ade1791c2f21aec79ef22e1e8ed193f703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

