### PR TITLE
feat(task-board): seed new chat with linked PRs and other chats

### DIFF
--- a/apps/mesh/src/web/components/chat/derive-parts.ts
+++ b/apps/mesh/src/web/components/chat/derive-parts.ts
@@ -245,11 +245,15 @@ export function derivePartsFromTiptapDoc(
         const meta = node.attrs.metadata as {
           title?: string;
           description?: string | null;
+          // Prebuilt at chat-start (buildTaskChatContext): title + description
+          // plus the task's linked PRs and other chats. Older drafts lack it,
+          // so fall back to title + description.
+          context?: string;
         } | null;
         const title = meta?.title ?? (node.attrs.name as string) ?? "";
-        const body = [title, meta?.description?.trim()]
-          .filter(Boolean)
-          .join("\n\n");
+        const body =
+          meta?.context?.trim() ||
+          [title, meta?.description?.trim()].filter(Boolean).join("\n\n");
         if (body) parts.push({ type: "text", text: body });
         return;
       }

--- a/apps/mesh/src/web/layouts/task-board/build-task-chat-context.test.ts
+++ b/apps/mesh/src/web/layouts/task-board/build-task-chat-context.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { buildTaskChatContext } from "./build-task-chat-context";
+import type { TaskBoardItemPr, TaskBoardItemThread } from "./config";
+
+const thread = (o: Partial<TaskBoardItemThread>): TaskBoardItemThread => ({
+  threadId: "t",
+  virtualMcpId: null,
+  status: null,
+  title: null,
+  lastMessage: null,
+  hasPreview: false,
+  createdAt: "",
+  ...o,
+});
+
+const pr = (o: Partial<TaskBoardItemPr>): TaskBoardItemPr => ({
+  url: "https://gh/x/y/pull/1",
+  number: 1,
+  repoOwner: "x",
+  repoName: "y",
+  createdAt: "",
+  title: null,
+  body: null,
+  state: "open",
+  draft: false,
+  merged: false,
+  ...o,
+});
+
+describe("buildTaskChatContext", () => {
+  test("title-only task yields just the heading", () => {
+    expect(
+      buildTaskChatContext({
+        title: "Fix login",
+        description: null,
+        threads: [],
+      }),
+    ).toBe("# Task: Fix login");
+  });
+
+  test("includes description, PRs, and other chats", () => {
+    const out = buildTaskChatContext(
+      {
+        title: "Fix login",
+        description: "Broken on Safari.",
+        threads: [thread({ title: "First attempt", status: "failed" })],
+      },
+      [
+        pr({
+          number: 42,
+          title: "Patch auth",
+          merged: true,
+          url: "https://pr/42",
+        }),
+      ],
+    );
+    expect(out).toContain("# Task: Fix login");
+    expect(out).toContain("Broken on Safari.");
+    expect(out).toContain("## Linked pull requests");
+    expect(out).toContain("#42 Patch auth [merged] https://pr/42");
+    expect(out).toContain("## Other chats on this task");
+    expect(out).toContain("First attempt [failed]");
+  });
+
+  test("PR state falls back to draft/open when live state is null", () => {
+    const out = buildTaskChatContext(
+      { title: "T", description: null, threads: [] },
+      [pr({ state: null, draft: true, repoOwner: "o", repoName: "r" })],
+    );
+    expect(out).toContain("o/r [draft]");
+  });
+});

--- a/apps/mesh/src/web/layouts/task-board/build-task-chat-context.ts
+++ b/apps/mesh/src/web/layouts/task-board/build-task-chat-context.ts
@@ -1,0 +1,39 @@
+import type { TaskBoardItem, TaskBoardItemPr } from "./config";
+
+/**
+ * The context text seeded into a fresh chat started from a task. Beyond the
+ * task's own title + description, it references the task's linked PRs and the
+ * other chats already on the task, so the agent picks up where prior work left
+ * off instead of starting cold. Pure so it's unit-testable.
+ */
+export function buildTaskChatContext(
+  task: Pick<TaskBoardItem, "title" | "description" | "threads">,
+  prs: TaskBoardItemPr[] = [],
+): string {
+  const sections: string[] = [
+    [`# Task: ${task.title}`, task.description?.trim()]
+      .filter(Boolean)
+      .join("\n\n"),
+  ];
+
+  if (prs.length > 0) {
+    const lines = prs.map((pr) => {
+      const state = pr.merged
+        ? "merged"
+        : (pr.state ?? (pr.draft ? "draft" : "open"));
+      const label = pr.title?.trim() || `${pr.repoOwner}/${pr.repoName}`;
+      return `- #${pr.number} ${label} [${state}] ${pr.url}`;
+    });
+    sections.push(["## Linked pull requests", ...lines].join("\n"));
+  }
+
+  if (task.threads.length > 0) {
+    const lines = task.threads.map((t) => {
+      const title = t.title?.trim() || "Untitled chat";
+      return t.status ? `- ${title} [${t.status}]` : `- ${title}`;
+    });
+    sections.push(["## Other chats on this task", ...lines].join("\n"));
+  }
+
+  return sections.join("\n\n");
+}

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -53,6 +53,8 @@ import {
   type Member,
 } from "./config";
 import { TaskBoardItemDialog } from "./task-dialog";
+import { buildTaskChatContext } from "./build-task-chat-context";
+import { useStudioTools } from "@/web/lib/studio-tools";
 import {
   EMPTY_FILTERS,
   TaskFiltersBar,
@@ -216,6 +218,7 @@ export function TaskBoardPage() {
   );
   const { setTaskId } = usePanelActions();
   const { create } = useThreadActions();
+  const studio = useStudioTools();
   const { org, locator } = useProjectContext();
   const navigate = useNavigate();
   // Deep link: `/$org/board?task=<id>` opens that task's modal (from a linked
@@ -244,9 +247,16 @@ export function TaskBoardPage() {
   const startChatFromTask = async (task: TaskBoardItem) => {
     const newId = crypto.randomUUID();
     const agentId = getWellKnownDecopilotVirtualMCP(org.id).id;
+    // Pull the task's linked PRs (best-effort — the chat still opens without
+    // them) so the seeded context references prior work, not just the title.
+    const prs = await studio
+      .call("TASK_BOARD_ITEM_PRS_GET", { taskBoardItemId: task.id })
+      .then((r) => r.prs)
+      .catch(() => []);
+    const context = buildTaskChatContext(task, prs);
     // Prefill the composer with a removable task @ref chip (not raw text) and
     // do NOT auto-send — the user reviews/adds to it, then hits send. The chip
-    // expands to the task's title + description at send time (see derive-parts).
+    // expands to the task context at send time (see derive-parts).
     const doc: TiptapDoc = {
       type: "doc",
       content: [
@@ -258,7 +268,11 @@ export function TaskBoardPage() {
               name: task.title,
               char: "@",
               kind: "task",
-              metadata: { title: task.title, description: task.description },
+              metadata: {
+                title: task.title,
+                description: task.description,
+                context,
+              },
             }),
             { type: "text", text: " " },
           ],


### PR DESCRIPTION
## Summary
The task dialog's **New chat** button previously seeded the fresh chat with only the task title + description. Now it also references the task's **linked PRs** and its **other chats**, so the agent picks up prior work instead of starting cold.

- New `buildTaskChatContext(task, prs)` (`layouts/task-board/build-task-chat-context.ts`) — pure, unit-tested. Builds:
  - `# Task: <title>` + description
  - `## Linked pull requests` — `#<num> <title> [state] <url>` (state derived merged/closed/draft/open)
  - `## Other chats on this task` — `<title> [status]`
- `startChatFromTask` fetches the task's PRs (best-effort — chat still opens if it fails) and stashes the built string in the task `@ref` chip's `metadata.context`.
- `derive-parts` prefers `metadata.context`, falling back to title+description for older drafts still in `sessionStorage`.

## Testing
- `bun test build-task-chat-context.test.ts derive-parts.test.ts` — 14 pass (title-only, full context with PRs+chats, PR state fallback).
- `bun run --cwd=apps/mesh check` clean for the touched files.

## Notes
- PRs are refetched on click rather than shared from the dialog's `useTaskBoardItemPrs` cache — one extra call, no coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seed new chats from a task with full context (title, description, linked PRs, and other chats) so the agent can continue prior work. We build the context at chat start and prefer it during parsing, with best‑effort PR fetching.

- **New Features**
  - Added buildTaskChatContext (pure, unit-tested) to compose the task header plus “Linked pull requests” and “Other chats.”
  - startChatFromTask fetches PRs via `TASK_BOARD_ITEM_PRS_GET` and stores the context in the task `@ref` chip metadata.
  - `derive-parts` prefers `metadata.context`, falling back to title + description for older drafts.

<sup>Written for commit 3acfca62679101b3abfb1145489ca7745478991a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

