### PR TITLE
fix(decopilot): make load_repo usable in the same turn (live fs rebind)

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/index.ts
@@ -43,6 +43,7 @@ import { type VirtualClient } from "@decocms/harness/decopilot/built-in-tools/sa
 import { createVmTools } from "@decocms/harness/decopilot/built-in-tools/vm-tools/index";
 import type { HtmlArtifactBuffer } from "@decocms/harness/decopilot/built-in-tools/vm-tools/types";
 import { buildClusterSandboxFs } from "./cluster-sandbox-fs";
+import { createSwappableFs } from "./swappable-fs";
 import { createLoadRepoTool } from "./load-repo";
 import { createSubtaskTool, SubtaskInputSchema } from "./subtask";
 import { userAskTool } from "@decocms/harness/decopilot/built-in-tools/user-ask";
@@ -236,14 +237,19 @@ async function buildAllTools(
     // layer) are built by the cluster glue so the portable tools never import
     // `@decocms/sandbox` (spec §4.3). Provisioning stays lazy inside the hooks —
     // `ensureSandbox` runs on the first VM-tool call, not here.
-    const fs = await buildClusterSandboxFs(ctx, {
+    const initialFs = await buildClusterSandboxFs(ctx, {
       virtualMcpId: vmContext.virtualMcpId,
       branch: vmContext.branch,
       userId: vmContext.userId,
       syncTools: vmContext.syncTools,
     });
+    // The VM tools are built once and close over the fs. `load_repo` switches
+    // the thread's repo mid-run onto a new sandbox branch — so the tools call
+    // through a swappable forwarder that `load_repo` re-points after the clone
+    // lands, making the repo usable THIS turn instead of only the next message.
+    const swappableFs = createSwappableFs(initialFs);
     vmTools = createVmTools({
-      fs,
+      fs: swappableFs.fs,
       htmlArtifactBuffer,
       toolOutputMap,
       needsApproval: vmNeedsApproval,
@@ -263,6 +269,19 @@ async function buildAllTools(
       userId: vmContext.userId,
       threadId: vmContext.threadId,
       writer,
+      // Re-point the live fs tools at the newly-cloned repo sandbox. Built with
+      // the same syncTools flag so the switched-in sandbox also materializes the
+      // tool catalog. Provisioning stays lazy — the next VM-tool call ensures it.
+      rebindFs: async (branch) => {
+        swappableFs.swap(
+          await buildClusterSandboxFs(ctx, {
+            virtualMcpId: vmContext.virtualMcpId,
+            branch,
+            userId: vmContext.userId,
+            syncTools: vmContext.syncTools,
+          }),
+        );
+      },
     });
     if (loadRepo) tools.load_repo = loadRepo;
   }

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -13,11 +13,13 @@
  *
  * The tool clones EAGERLY and waits: it provisions the repo sandbox and blocks
  * until the git checkout is present before returning, then signals the client
- * to open the Preview panel. File tools the model calls in the SAME turn are
- * still bound to the pre-load branch (the turn's binding is fixed at
- * turn-start); they pick up the repo from the next message — by which point the
- * eager clone has it hot. The returned root listing lets the model confirm the
- * repo without a same-turn `bash`.
+ * to open the Preview panel. Once the clone is confirmed it re-points the run's
+ * live VM file tools at the new sandbox branch (`rebindFs`), so the model can
+ * read/edit/bash the repo in the SAME turn — without this the tools stay bound
+ * to the turn-start branch and only pick up the repo on the next message, which
+ * an autonomous single-turn run (e.g. a delegated task) never sends, so it
+ * loops on an empty `/app/repo`. The returned root listing lets the model
+ * confirm the repo without a same-turn `bash`.
  *
  * CLUSTER-GLUE: `@/`-coupled, same tier as `cluster-sandbox-fs.ts`.
  */
@@ -138,8 +140,15 @@ export async function createLoadRepoTool(opts: {
   userId: string;
   threadId: string;
   writer: UIMessageStreamWriter;
+  /**
+   * Re-point the run's live VM file tools at the sandbox branch this load
+   * provisioned, so the model can use the repo in the SAME turn. Called once
+   * the checkout is confirmed present. Omitted in contexts with no swappable
+   * fs (tests) — then the legacy "next message" binding still applies.
+   */
+  rebindFs?: (branch: string) => Promise<void>;
 }) {
-  const { ctx, orgId, virtualMcpId, userId, threadId, writer } = opts;
+  const { ctx, orgId, virtualMcpId, userId, threadId, writer, rebindFs } = opts;
   const repos = await listOrgRepos(ctx, orgId);
   // Nothing to switch between — don't expose the tool at all.
   if (repos.length === 0) return null;
@@ -276,17 +285,34 @@ export async function createLoadRepoTool(opts: {
         await sleep(CLONE_POLL_MS);
       }
 
+      // Re-point the run's live VM file tools at this repo's sandbox so the
+      // model can read/edit/bash it in the SAME turn. Only after the clone is
+      // confirmed present — swapping earlier would bind the tools to an empty
+      // checkout and reproduce the original loop. Best-effort: a rebind failure
+      // just falls back to the next-message binding, so never fail the load.
+      let reboundThisTurn = false;
+      if (cloned && rebindFs) {
+        try {
+          await rebindFs(branch);
+          reboundThisTurn = true;
+        } catch (err) {
+          console.warn("[load_repo] live fs rebind failed", err);
+        }
+      }
+
       return {
         success: true,
         repo: `${repo.owner}/${repo.repo}`,
         previewUrl: entry.previewUrl ?? null,
         cloned,
         files: listing,
-        message: cloned
-          ? `Loaded ${repo.owner}/${repo.repo} and opened the Preview. The repo is cloned and its dev server is booting. Your file tools operate on it from your next message.`
-          : `Loaded ${repo.owner}/${repo.repo} and opened the Preview, but the clone did not finish within ${Math.round(
+        message: !cloned
+          ? `Loaded ${repo.owner}/${repo.repo} and opened the Preview, but the clone did not finish within ${Math.round(
               CLONE_TIMEOUT_MS / 1000,
-            )}s. It may still be in progress — your file tools will use it next message.`,
+            )}s. It may still be in progress — your file tools will use it next message.`
+          : reboundThisTurn
+            ? `Loaded ${repo.owner}/${repo.repo} and opened the Preview. The repo is cloned and its dev server is booting. Your file tools (read/write/edit/bash/grep/glob) now operate on it — you can use it right away.`
+            : `Loaded ${repo.owner}/${repo.repo} and opened the Preview. The repo is cloned and its dev server is booting. Your file tools operate on it from your next message.`,
       };
     },
   });

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/swappable-fs.test.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/swappable-fs.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import type { SandboxFsHooks } from "@decocms/harness/decopilot/built-in-tools/vm-tools/sandbox-fs-hooks-types";
+import { createSwappableFs } from "./swappable-fs";
+
+/** A stub fs whose every hook resolves a value tagged with `label`, so a test
+ *  can tell which backing fs a call was routed to. */
+function stubFs(label: string): SandboxFsHooks {
+  return {
+    onRead: async () => label,
+    onWrite: async () => {},
+    onEdit: async () => {},
+    onBash: async () => ({ stdout: label, stderr: "", exitCode: 0 }),
+    onGlob: async () => [label],
+    onGrep: async () => [{ file: label, line: 1, text: label }],
+    onProxy: async () => ({ label }),
+  };
+}
+
+test("forwards calls to the initial fs before any swap", async () => {
+  const { fs } = createSwappableFs(stubFs("old"));
+  expect((await fs.onBash("ls")).stdout).toBe("old");
+  expect(await fs.onRead("/x")).toBe("old");
+});
+
+test("swap re-points subsequent calls at the new fs", async () => {
+  const { fs, swap } = createSwappableFs(stubFs("old"));
+  const bash = fs.onBash; // capture the reference the way createVmTools does
+  expect((await bash("ls")).stdout).toBe("old");
+
+  swap(stubFs("new"));
+
+  // The captured method reference now routes to the swapped-in fs — this is the
+  // property that makes load_repo usable in the same turn.
+  expect((await bash("ls")).stdout).toBe("new");
+  expect(await fs.onGlob("**/*")).toEqual(["new"]);
+});

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/swappable-fs.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/swappable-fs.ts
@@ -1,0 +1,46 @@
+/**
+ * A `SandboxFsHooks` whose backing target can be swapped at runtime.
+ *
+ * Why: the six VM file tools (read/write/edit/bash/grep/glob) are built ONCE
+ * per run, closing over the fs hooks resolved from `vmContext.branch` at
+ * run-start. When `load_repo` switches the thread's repo mid-run it provisions
+ * a NEW sandbox on a new branch, but the already-built tools keep calling the
+ * old (repo-less) fs — so `ls /app/repo` shows an empty checkout and the agent
+ * loops waiting for files that live in a sandbox its tools aren't bound to.
+ *
+ * The tools instead call through this thin forwarder. `load_repo` calls `swap`
+ * with the freshly-built fs after the clone lands, so the SAME turn's next
+ * bash/read/glob hits the new sandbox — no "wait for the next message" contract.
+ *
+ * Pure: forwards every hook to the current target read at call time. No `@/` or
+ * `@decocms/sandbox` imports, so it's trivially unit-testable.
+ */
+
+import type { SandboxFsHooks } from "@decocms/harness/decopilot/built-in-tools/vm-tools/sandbox-fs-hooks-types";
+
+export interface SwappableFs {
+  /** The forwarder to hand to `createVmTools` — a stable reference. */
+  fs: SandboxFsHooks;
+  /** Point the forwarder at a new backing fs (called by `load_repo`). */
+  swap(next: SandboxFsHooks): void;
+}
+
+export function createSwappableFs(initial: SandboxFsHooks): SwappableFs {
+  let current = initial;
+  const fs: SandboxFsHooks = {
+    onRead: (path) => current.onRead(path),
+    onWrite: (path, content) => current.onWrite(path, content),
+    onEdit: (path, edits) => current.onEdit(path, edits),
+    onBash: (cmd, opts) => current.onBash(cmd, opts),
+    onGlob: (pattern) => current.onGlob(pattern),
+    onGrep: (pattern, opts) => current.onGrep(pattern, opts),
+    onProxy: (path, body, method, signal) =>
+      current.onProxy(path, body, method, signal),
+  };
+  return {
+    fs,
+    swap(next) {
+      current = next;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Debugging a task-board **"review this PR"** run in prod (thread `4f83a3f3-7fa9-49c9-9b42-b32d0028b467`, org `fila`) surfaced why the agent loops: **`load_repo` is a no-op within the run that calls it.**

The six VM file tools (`read`/`write`/`edit`/`bash`/`grep`/`glob`) are built once at run-start, closing over the fs hooks resolved from `vmContext.branch` — which, for a thread with no repo yet, is the repo-less `"ephemeral"` sandbox. `load_repo` mid-run writes the thread's repo, provisions a **new** sandbox on a repo-specific branch, clones into it, and reports `cloned: true` with a file manifest — but the already-built tools keep calling the **old** fs. So:

- `ls /app/repo` → only `.deco` + the `org` symlink (files live in a sandbox the tools aren't bound to)
- the model assumes a clone race and loops: `sleep 5` → re-glob → re-`load_repo` → `sleep 20` → give up → `requires_action`

`load_repo`'s "your file tools work from your next message" contract only holds for an **interactive** run. An autonomous single-turn run (a delegated task, the task-board PR actions) sends no next message, so the repo is never picked up.

Confirmed against prod Postgres (read-only): the thread's `branch` and `sandboxMap` were correctly rewritten and the clone succeeded — the tools simply never rebound to it.

## Fix

The VM tools now call through a **swappable fs forwarder** (`swappable-fs.ts`). Once `load_repo` confirms the checkout is present, it re-points the forwarder at the freshly-cloned sandbox (`rebindFs`), so the **same turn's** next `bash`/`read`/`glob` hits the repo. Best-effort: a rebind failure falls back to the previous next-message binding and never fails the load.

This is the root-cause fix and covers every load-then-use path — interactive or autonomous, first load or repo switch.

## Changes

- `swappable-fs.ts` — pure `SandboxFsHooks` forwarder with a `swap()` (+ unit test)
- `built-in-tools/index.ts` — wrap the VM fs; hand `load_repo` a `rebindFs` that rebuilds the cluster fs for the new branch and swaps it in
- `load-repo.ts` — call `rebindFs(branch)` after the clone stabilizes; message now tells the model the repo is usable right away; docstring corrected

## Testing

- New unit test proves a captured method reference (the way `createVmTools` closes over the fs) routes to the swapped-in fs after `swap()`.
- `bun test` on the built-in-tools dir: 86 pass (1 pre-existing `web_search` integration failure — ECONNREFUSED, needs a live service, unrelated).
- `bun run check`, `bun run lint` (0 errors), `bun run fmt`, `knip` all clean.

## Follow-up (deliberately out of scope)

- **Pre-bind at dispatch** for known-repo flows (task-board / `enqueue-super-agent`) so the run starts repo-bound and skips the `load_repo` round-trip entirely.
- **PR-head checkout**: `load_repo` clones the default branch; a true PR review should check out the PR's head ref. Today the agent can still read the diff via the GitHub MCP tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where `load_repo` was a no-op within the same run. VM file tools now rebind to the freshly cloned repo so the agent can use it immediately, stopping loops in single-turn runs.

- **Bug Fixes**
  - Route VM tools through a swappable fs forwarder (`swappable-fs`) and build tools with `swappableFs.fs`.
  - Rebind the live fs in `load_repo` after the checkout is present (`rebindFs(branch)`), making the repo usable in the same turn.
  - Make rebind best-effort (fallback to next-message binding on failure) and update the tool message to reflect immediate usability.
  - Add a unit test proving captured method references route to the swapped fs after `swap()`.

<sup>Written for commit ea1808812e519aafcf8a36058768af3b3651c06b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

