### PR TITLE
fix(sections-editor): prevent date picker popover from stealing focus on close

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
@@ -125,7 +125,11 @@ function DatePickerInput({
             <CalendarIcon className="h-4 w-4" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="end">
+        <PopoverContent
+          className="w-auto p-0"
+          align="end"
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
           <Calendar
             mode="single"
             selected={selected ?? undefined}


### PR DESCRIPTION
## Summary
- Fixes focus jumping back to the date field when editing a sibling field (e.g. title) right after typing/picking a date in the sections editor (banner carousel and any array item with a date field).
- Root cause: Radix `Popover`'s default `onCloseAutoFocus` refocuses the trigger element (the calendar icon button) whenever the popover closes, including when the user clicks away into a different field — overriding the click's natural focus target.
- Same class of bug was already patched elsewhere in the repo (`account-popover.tsx`, `org-switcher.tsx`, `icon-picker.tsx`, `simple-icon-picker.tsx`, tiptap `uploader.tsx`) via `onCloseAutoFocus={(e) => e.preventDefault()}`; the date field's popover in `string-field.tsx` had been missed.

## Test plan
- [x] `bun run fmt`
- [x] `bun run --cwd=apps/mesh check`
- [ ] Manually edit a section with a date field + a sibling text field (e.g. a carousel banner item) and confirm focus stays on the field you click into after typing a date

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the sections editor date picker popover from stealing focus on close, so focus stays on the field you click into after selecting a date. Adds `onCloseAutoFocus={(e) => e.preventDefault()}` to the date field’s `PopoverContent` in `string-field.tsx`, matching behavior used in other popovers.

<sup>Written for commit 1e159fcc9c22cd4eb01badb3b8bd55da7c9c069a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

