### PR TITLE
fix(chat): make long follow-up questions readable and scrollable

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
@@ -203,34 +203,41 @@ export function CollapsibleHighlight({
       >
         <div style={{ overflow: "hidden", minHeight: 0 }}>
           <div
+            className="flex flex-col"
             style={{
               opacity: expanded ? 1 : 0,
               transition: `opacity 120ms ${EASE}`,
+              // Cap the card so a long question can't grow off the top of the
+              // screen (it floats above the composer). Title + options scroll;
+              // the footer stays pinned so Skip/Next are always reachable.
+              maxHeight: "60vh",
             }}
           >
-            {title ? (
-              <div className="flex items-start gap-2 px-4 pt-4 pb-5 border-t border-dashed border-border/60">
-                <p className="flex-1 text-base font-medium text-foreground min-w-0">
-                  {title}
-                </p>
-              </div>
-            ) : (
-              <div className="border-t border-dashed border-border/60" />
-            )}
+            <div className="flex-1 min-h-0 overflow-y-auto">
+              {title ? (
+                <div className="flex items-start gap-2 px-4 pt-4 pb-5 border-t border-dashed border-border/60">
+                  <p className="flex-1 text-base font-medium text-foreground min-w-0">
+                    {title}
+                  </p>
+                </div>
+              ) : (
+                <div className="border-t border-dashed border-border/60" />
+              )}
 
-            {/* When a title is present, the title block's `pt-4` already
-                provides the 16px gap from the dashed divider to the first
-                body element. When no title is present (e.g. TodosHighlight),
-                the children must carry that top padding themselves so every
-                card has the same chip → body distance. */}
-            {children ? (
-              <div className={cn("overflow-clip pb-4", !title && "pt-4")}>
-                {children}
-              </div>
-            ) : null}
+              {/* When a title is present, the title block's `pt-4` already
+                  provides the 16px gap from the dashed divider to the first
+                  body element. When no title is present (e.g. TodosHighlight),
+                  the children must carry that top padding themselves so every
+                  card has the same chip → body distance. */}
+              {children ? (
+                <div className={cn("overflow-clip pb-4", !title && "pt-4")}>
+                  {children}
+                </div>
+              ) : null}
+            </div>
 
             {footerLeft || footerRight ? (
-              <div className="border-t border-border px-3 py-3 pb-6">
+              <div className="shrink-0 border-t border-border px-3 py-3 pb-6">
                 <div className="flex items-center justify-between">
                   <div>{footerLeft}</div>
                   <div className="flex items-center gap-2">{footerRight}</div>

--- a/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
@@ -163,7 +163,7 @@ function ChoiceInput({
                 type="button"
                 onClick={() => optionField.onChange(option)}
                 className={cn(
-                  "flex items-center gap-3 px-2 py-3 rounded-lg text-left transition-colors w-full",
+                  "flex items-start gap-3 px-2 py-3 rounded-lg text-left transition-colors w-full",
                   isSelected && "bg-accent/50",
                   !isSelected && "hover:bg-accent/30",
                 )}
@@ -179,7 +179,7 @@ function ChoiceInput({
                 >
                   {index + 1}
                 </span>
-                <span className="text-sm text-foreground truncate">
+                <span className="text-sm text-foreground min-w-0 break-words">
                   {option}
                 </span>
               </button>


### PR DESCRIPTION
## Summary

A long "ask user question" follow-up (like the one reported over Telegram) was unreadable in the chat: the highlight card floats `absolute bottom-full` above the composer with **no height cap and no scroll**, so a tall question grew off the top of the screen — you couldn't read it or scroll to it, and long option labels were truncated mid-word.

## Fix

- **Cap the highlight card at `60vh`** and make the title + options region `overflow-y-auto`, so any long card scrolls instead of growing off-screen.
- **Pin the footer** (`shrink-0`) so Skip/Next stay reachable while the body scrolls.
- **Wrap long option labels** (`break-words` + `items-start`) instead of `truncate`, so full option text is readable.

Both changes live in the shared `CollapsibleHighlight` shell and the `ChoiceInput` options list, so the same scrollability applies to every highlight card (todos, errors, approvals, plans, questions).

## Affected areas

- `apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx`
- `apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx`

## Testing

- `bun run fmt` ✅
- `bun run --cwd=apps/mesh check` — no errors in changed files ✅
- Visual/manual verification of scroll + wrap on a long multi-option question recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make long follow-up questions readable by capping the highlight card height and adding scroll. The footer stays pinned, and option labels now wrap so full text is visible.

- **Bug Fixes**
  - Capped highlight card at 60vh and made title + options scroll; footer remains reachable.
  - Wrapped long option labels (`break-words`, `items-start`) instead of truncating, applied in the shared `CollapsibleHighlight` and the follow-up `ChoiceInput`.

<sup>Written for commit c9c6effe4c660442e89685e96b5fbdf1e5399897. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

