### PR TITLE
fix(thread): sanitize NUL and lone surrogates before persisting parts

### DIFF
--- a/apps/mesh/src/storage/thread-message-parts.test.ts
+++ b/apps/mesh/src/storage/thread-message-parts.test.ts
@@ -27,4 +27,33 @@ describe("serializePayload", () => {
     const out = JSON.parse(serializePayload(pathological));
     expect(out.truncated).toBe(true);
   });
+
+  // Postgres jsonb rejects U+0000 with SQLSTATE 22P05, which would strand the
+  // whole run in_progress. A tool result that inlined raw binary (e.g. a PNG)
+  // is the real-world trigger.
+  it("strips NUL bytes so the payload is storable in jsonb", () => {
+    const payload = { type: "text", text: "before\u0000after" };
+    const serialized = serializePayload(payload);
+    expect(serialized).not.toContain("\\u0000");
+    expect(JSON.parse(serialized).text).toBe("beforeafter");
+  });
+
+  it("strips NUL bytes nested deep in the payload tree", () => {
+    const payload = { a: { b: [{ c: "x\u0000y" }] } };
+    const out = JSON.parse(serializePayload(payload));
+    expect(out.a.b[0].c).toBe("xy");
+  });
+
+  // Postgres jsonb also rejects unpaired UTF-16 surrogates as an unsupported
+  // Unicode escape sequence; replace them with the Unicode replacement char.
+  it("replaces lone surrogates with U+FFFD", () => {
+    const payload = { text: `lead\uD800 trail\uDC00 pair\u{1F600}` };
+    const out = JSON.parse(serializePayload(payload));
+    expect(out.text).toBe("lead\uFFFD trail\uFFFD pair\u{1F600}");
+  });
+
+  it("leaves a well-formed emoji (surrogate pair) intact", () => {
+    const payload = { text: "hi \u{1F600}" };
+    expect(serializePayload(payload)).toBe(JSON.stringify(payload));
+  });
 });

--- a/apps/mesh/src/storage/thread-message-parts.ts
+++ b/apps/mesh/src/storage/thread-message-parts.ts
@@ -49,6 +49,23 @@ function estimatePayloadBytes(value: unknown, budget: number): number {
   return total;
 }
 
+// Postgres `jsonb`/`text` cannot store U+0000, and rejects unpaired UTF-16
+// surrogates, with SQLSTATE 22P05 ("unsupported Unicode escape sequence").
+// A part whose payload carries either — e.g. a tool result that inlined raw
+// binary such as a PNG (full of NUL bytes) — fails the INSERT and, because the
+// projection step is the sole writer of terminal thread status, strands the
+// whole run `in_progress` forever. Content arriving from the harness/desktop is
+// untrusted, so sanitize it here at the storage boundary rather than trusting
+// every producer. Clean strings are returned unchanged, so ids derived from the
+// serialized payload stay stable.
+const NUL = /\u0000/g;
+const LONE_SURROGATE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+function sanitizeForPg(value: string): string {
+  return value.replace(NUL, "").replace(LONE_SURROGATE, "\uFFFD");
+}
+
 export function serializePayload(payload: unknown): string {
   if (
     estimatePayloadBytes(payload, MAX_PART_PAYLOAD_BYTES) >
@@ -59,7 +76,12 @@ export function serializePayload(payload: unknown): string {
       reason: "payload exceeds max stored size",
     });
   }
-  return JSON.stringify(payload);
+  // A JSON replacer visits every string in the payload tree; clean strings pass
+  // through untouched (byte-identical output, so ids derived from the payload
+  // stay stable).
+  return JSON.stringify(payload, (_key, value) =>
+    typeof value === "string" ? sanitizeForPg(value) : value,
+  );
 }
 
 export class SqlThreadMessagePartStorage {


### PR DESCRIPTION
## Summary

A thread on stg (`ae17237c…`, org `gimenes-carnival-workspace`) hung in `in_progress` forever with an empty assistant reply. Root cause: the agent (auditing `/public` **image** assets) produced a message part whose payload inlined **raw PNG bytes**, and persisting it blew up with Postgres:

```
SQLSTATE 22P05: unsupported Unicode escape sequence ( cannot be converted to text)
payload: ...</svg>\n‰PNG\r\n... (raw binary, incl. NUL)
```

`jsonb`/`text` columns can't store `U+0000` (nor unpaired UTF-16 surrogates). `serializePayload` only had a *size* guard — no content sanitization — so binary content went straight into the INSERT and threw.

Because the projection step (`consumeRunProjection`) is the **sole writer of terminal thread status**, the throw meant the run never settled: thread stuck `status=in_progress`, `failure_reason=null`. It's a **poison pill** — DBOS retried and gave up (`recovery_attempts=2` → `ERROR`); re-running can never persist a payload Postgres will always reject.

## Fix

Sanitize at the storage trust boundary in `serializePayload` (single choke point — covers both the `appendParts` and `replaceMessageParts` paths, payload and metadata):

- strip `U+0000`
- replace unpaired UTF-16 surrogates with `U+FFFD`

Implemented via a `JSON.stringify` replacer that touches only string values. **Clean payloads serialize byte-identically to before**, so content-derived part ids (the `ON CONFLICT (id)` dedup key) stay stable.

## Testing

- `bun test apps/mesh/src/storage/thread-message-parts.test.ts` — 8 pass. Added cases: NUL stripped (top-level + nested), lone surrogates → `U+FFFD`, well-formed emoji left intact, plus the existing pass-through/size-guard cases still hold.
- `bun run fmt`, `bun run lint` (0 errors) pass. `bun run check` is clean for these files.

## Out of scope (follow-ups)

- **Fail-close robustness** — the projection catch already fail-closes via `markRunFailed` on a pooled connection (not the aborted tx). With the poison gone, the parts INSERT no longer throws, so the run completes normally. The `failure_reason=null` on the stg row is best explained by the **concurrent OOM** below killing the process mid-catch, not a defect in the fail-close path.
- **`studio-api` OOM (600Mi limit)** — the stg pod was `OOMKilled` repeatedly around the same window (baseline working-set 300–470 MiB against a 600Mi cap). Real but separate infra issue; the limit bump lives in the deploy/helm config, not this repo, and needs node headroom (nodes reported `Insufficient memory` during rollouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitize message part payload strings before storing to prevent Postgres SQLSTATE 22P05 errors and avoid threads getting stuck in_progress. Uses a JSON replacer to remove NUL bytes and replace lone surrogates; clean payloads serialize identically, so part IDs stay stable.

- **Bug Fixes**
  - In `serializePayload`, strip `U+0000` and replace unpaired UTF-16 surrogates with `U+FFFD` (covers append/replace paths and metadata).
  - Added tests for NUL stripping (nested), surrogate replacement, and preserving well-formed emoji.

<sup>Written for commit 3030d4517cb0ae39590a3bd7a15bb559f6aec8f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

