### PR TITLE
fix(ask-user): fix option truncation and improve prompt brevity

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
@@ -224,7 +224,7 @@ export function CollapsibleHighlight({
                 the children must carry that top padding themselves so every
                 card has the same chip → body distance. */}
             {children ? (
-              <div className={cn("overflow-clip pb-4", !title && "pt-4")}>
+              <div className={cn("pb-4", !title && "pt-4")}>
                 {children}
               </div>
             ) : null}

--- a/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/collapsible-highlight.tsx
@@ -230,9 +230,7 @@ export function CollapsibleHighlight({
                   the children must carry that top padding themselves so every
                   card has the same chip → body distance. */}
               {children ? (
-                <div className={cn("pb-4", !title && "pt-4")}>
-                  {children}
-                </div>
+                <div className={cn("pb-4", !title && "pt-4")}>{children}</div>
               ) : null}
             </div>
 

--- a/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
@@ -163,7 +163,7 @@ function ChoiceInput({
                 type="button"
                 onClick={() => optionField.onChange(option)}
                 className={cn(
-                  "flex items-center gap-3 px-2 py-3 rounded-lg text-left transition-colors w-full",
+                  "flex items-start gap-3 px-2 py-3 rounded-lg text-left transition-colors w-full",
                   isSelected && "bg-accent/50",
                   !isSelected && "hover:bg-accent/30",
                 )}
@@ -171,7 +171,7 @@ function ChoiceInput({
               >
                 <span
                   className={cn(
-                    "flex items-center justify-center size-6 rounded-md text-sm shrink-0",
+                    "flex items-center justify-center size-6 rounded-md text-sm shrink-0 mt-0.5",
                     isSelected
                       ? "bg-chart-1 text-white"
                       : "bg-muted text-foreground",
@@ -179,7 +179,7 @@ function ChoiceInput({
                 >
                   {index + 1}
                 </span>
-                <span className="text-sm text-foreground truncate">
+                <span className="text-sm text-foreground">
                   {option}
                 </span>
               </button>

--- a/packages/harness/src/decopilot/built-in-tools/user-ask.ts
+++ b/packages/harness/src/decopilot/built-in-tools/user-ask.ts
@@ -14,13 +14,23 @@ import { z } from "zod";
  */
 export const UserAskInputSchema = z
   .object({
-    prompt: z.string().min(1).describe("The question to display"),
+    prompt: z
+      .string()
+      .min(1)
+      .describe(
+        "One short question (1 sentence max, ≤15 words). The conversation already provides context, do not repeat it here.",
+      ),
     type: z
       .enum(["text", "choice", "confirm"])
       .describe(
         "'text': free-form, 'choice': pick from options (UI adds 'Other' automatically), 'confirm': yes/no",
       ),
-    options: z.array(z.string()).optional().describe("Required for 'choice'"),
+    options: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Required for 'choice'. Each option must be a short label (3–6 words, no leading numbers like '1)' — the UI adds them).",
+      ),
     default: z.string().optional(),
   })
   .refine(
@@ -53,7 +63,8 @@ const description =
   "Ask the user instead of guessing when requirements are ambiguous, multiple valid approaches exist, " +
   "or before actions with significant consequences. Prefer this tool over asking in plain text.\n\n" +
   "Guidelines:\n" +
-  "- For 'choice' type: put the recommended option first. Provide 2-5 options.\n" +
+  "- Keep `prompt` to one short question (1 sentence max, ≤15 words). Never repeat context already visible in the conversation.\n" +
+  "- For 'choice' type: put the recommended option first. Provide 2-5 options. Each option label must be 3–6 words — no leading '1)' numbering (the UI adds numbers automatically).\n" +
   "- For 'confirm' type: use for yes/no decisions, especially before destructive or hard-to-reverse actions.\n" +
   "- For 'text' type: use when the answer is open-ended and cannot be anticipated with options.";
 


### PR DESCRIPTION
## What is this contribution about?

The `ask_user` UI had two readability problems: choice options were truncated with ellipsis instead of wrapping, and agents were generating verbose multi-sentence prompts that repeated context already visible in the chat.

**UI fixes** (`user-ask-question.tsx`, `collapsible-highlight.tsx`):
- Removed `truncate` from option label span so text wraps instead of cutting off
- Changed option button alignment to `items-start` with `mt-0.5` on the number badge so it stays optically aligned with the first line of wrapped text
- Removed `overflow-clip` from the collapsible body's children wrapper, which was clipping wrapped content at the container edge

**Prompt guidance** (`user-ask.ts`):
- Tightened `prompt` field description: "One short question (1 sentence max, ≤15 words). The conversation already provides context, do not repeat it here."
- Tightened `options` field description: "Each option must be a short label (3–6 words, no leading numbers like '1)' — the UI adds them)."
- Added explicit brevity rule to the top-level tool description

## Screenshots/Demonstration

Before: option rows truncated with `…`, prompt contained full verbose context + numbered options.
After: options wrap cleanly, prompt is one short question, option labels are concise.

## How to Test

1. Open any chat and trigger an agent that uses `user_ask` with `type: "choice"`
2. Verify option text wraps instead of truncating
3. Verify the question title is short (≤15 words), not a paragraph
4. Verify option labels don't start with `1)`, `2)`, etc.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes truncated choice options and tightens `user_ask` prompt rules so questions stay short and options remain readable.

- **Bug Fixes**
  - Options wrap; number badge aligns with first line; removed overflow clipping; collapsed single-child div per `biome`.
  - Updated `user_ask` schema: prompt ≤15 words, 1 sentence; choices 3–6 words, no leading numbers (UI adds them).

<sup>Written for commit ea0cdb22fb868b692346182339c98f523651b4bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

