### PR TITLE
fix(decopilot): treat a post-terminal stream gap as benign, not a failure

### DIFF
--- a/apps/mesh/src/api/routes/decopilot/projector-redelivery.test.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-redelivery.test.ts
@@ -322,6 +322,25 @@ describe("projector workflow — StreamGapError terminal mapping", () => {
     expect(calls.some((c) => c.kind === "record-fail")).toBe(true);
     expect(calls.some((c) => c.kind === "purge")).toBe(true);
   });
+
+  test("gap on an already-settled same fence: benign, clears bubble, no fail", async () => {
+    // A purge (terminal or next-turn dispatch-start) racing an in-flight or
+    // redelivered projection on the shared per-thread subject beheads chunks and
+    // surfaces a gap AFTER the run already reached terminal for this fence. That
+    // is not a truncation — drop the spurious "missing seq" bubble the fold just
+    // wrote and return cleanly instead of stamping a failure over a settled run.
+    const { rt, calls } = makeRuntime({ status: "completed" });
+    const projectFn = async () => {
+      throw new StreamGapError(61, null);
+    };
+    await expect(
+      runProjectorWorkflowBody(input, rt, projectFn),
+    ).resolves.toBeUndefined();
+    expect(calls.filter((c) => c.kind === "fail")).toEqual([]);
+    expect(calls.some((c) => c.kind === "record-fail")).toBe(false);
+    expect(calls.some((c) => c.kind === "clear-error")).toBe(true);
+    expect(calls.some((c) => c.kind === "purge")).toBe(true);
+  });
 });
 
 describe("projector workflow — stale synthesized error cleanup", () => {

--- a/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
+++ b/apps/mesh/src/api/routes/decopilot/projector-workflow.ts
@@ -207,6 +207,26 @@ export async function projectFromJetStreamStep(
 }
 
 /**
+ * True when the run already reached a terminal state for THIS fence — i.e. a
+ * prior attempt of the same fence finished it. A silent or gapped subject on a
+ * settled run is benign (the subject was legitimately purged after the run
+ * ended, not truncated mid-flight), so the caller returns clean instead of
+ * re-failing an already-terminal run.
+ */
+async function runSettledForFence(
+  rt: ProjectorWorkflowRuntime,
+  runId: string,
+  fenceToken: string,
+): Promise<boolean> {
+  const row = await rt.resolveRun(runId).catch(() => null);
+  return (
+    row !== null &&
+    row.runFenceToken === fenceToken &&
+    ["completed", "failed", "requires_action"].includes(row.status)
+  );
+}
+
+/**
  * Core workflow logic extracted for testability. Accepts an explicit runtime
  * and a `projectFn` (production: `projectFromJetStreamStep`; tests: a stub)
  * so the branching logic can be exercised without DBOS or JetStream.
@@ -318,6 +338,19 @@ export async function runProjectorWorkflowBody(
     // "missing seq N" (stg incident 2026-07-14 follow-up; repro in
     // projector-redelivery.test.ts).
     if (error instanceof StreamGapError) {
+      // A purge racing an in-flight or redelivered projection on the shared
+      // per-thread subject (purge is subject-scoped, one subject per thread
+      // across all turns) can behead chunks THIS attempt still needs — surfacing
+      // a hole even though nothing was truly lost. When the run already reached a
+      // terminal for this fence, the gap is BENIGN: the subject was legitimately
+      // purged after the run finished. Drop the spurious "missing seq" bubble the
+      // fold just persisted (deterministic id, same as the settled-completion
+      // path) and return clean instead of stamping a failure over a settled run.
+      if (await runSettledForFence(rt, input.runId, input.fenceToken)) {
+        await rt.clearSynthesizedError(input.runId, input.fenceToken);
+        await rt.purgeRun(input.runId, input.fenceToken);
+        return;
+      }
       const reason = `stream truncated before projection could replay it: ${error.message}`;
       recordPoison(input.runId, orgId);
       const flipped = await rt.markRunFailed(
@@ -355,16 +388,12 @@ export async function runProjectorWorkflowBody(
     // Return cleanly instead of re-failing a settled run and rethrowing into
     // retries that would idle-wait the full window again each time.
     const isLivenessBreach = error instanceof StreamIdleTimeoutError;
-    if (isLivenessBreach) {
-      const row = await rt.resolveRun(input.runId).catch(() => null);
-      const settled =
-        row !== null &&
-        row.runFenceToken === input.fenceToken &&
-        ["completed", "failed", "requires_action"].includes(row.status);
-      if (settled) {
-        await rt.purgeRun(input.runId, input.fenceToken);
-        return;
-      }
+    if (
+      isLivenessBreach &&
+      (await runSettledForFence(rt, input.runId, input.fenceToken))
+    ) {
+      await rt.purgeRun(input.runId, input.fenceToken);
+      return;
     }
     const reason = isLivenessBreach
       ? livenessFailureReason((error as StreamIdleTimeoutError).idleTimeoutMs)


### PR DESCRIPTION
## Summary

Threads on stg showed a standalone **"Error: missing seq N (stream ended at the fenced done)"** bubble even though the run's content had projected fine:

- `0a94179f…` — `completed` with full assistant content, but carrying a stale `missing seq 61` bubble (its own message has only `error + finish`, no reply content).
- `6587bbe3…` — same spurious `missing seq 86` bubble (plus a separate idle-wait on a disconnected desktop that self-heals via the 10-min idle timeout).

## Root cause: a purge-vs-projection race, not truncation

The decopilot run-stream uses **one JetStream subject per thread** (`streamSubject(taskId)`, `taskId = runId = threadId`) shared across **all turns**, and `purge()` is **subject-scoped** with two callers — the projector after a terminal projection, and `dispatchRun` at the next turn's start (`nats-stream-buffer.ts:13-15`).

`ingestRun` only publishes `done(finalSeq=ackSeq)` after seqs `1..ackSeq` are confirmed to JetStream, so the missing chunk *was* stored, then **deleted before projection**. Retention is ruled out — the stg stream is **190 KB of its 4 GB cap** (`num_deleted` = explicit purges). Under DBOS redeliveries / turn overlap (amplified by the OOM churn from the sibling incident), a purge beheads chunks an in-flight or redelivered projection still needs → `StreamGapError` → the fold persists a "missing seq" bubble over a run that already reached terminal for this fence. `run-reactor.ts:193-200` already documents this exact hazard.

Evidence: the `0a94179f` bubble was written at `14:41:09.253` — **10 ms before** the next turn's workflow started (`14:41:09.263`), i.e. the new dispatch's purge beheading the previous turn's tail.

## Fix

The `StreamGapError` branch already fails the run cleanly (no retry burn), but — unlike the idle-timeout branch — it had **no "already settled for this fence" escape hatch**. Add it:

- Extract `runSettledForFence(rt, runId, fenceToken)` (the check the idle branch already used) and share it between both branches.
- In the gap branch: if the run is already terminal for this fence, the gap is benign (subject legitimately purged after the run ended). Drop the synthesized error bubble the fold just wrote (`clearSynthesizedError`, the same deterministic id as the settled-completion path), purge, and return clean — **no `markRunFailed`, no spurious bubble**.

A **genuine** gap on a non-settled run still fails with `kind="projection"`, unchanged. No DBOS step-sequence change (edit is inside the existing `consumeRunProjection` step body), so no workflow-version bump.

## Scope / follow-ups

This is the lowest-risk fix and stops the spurious bubbles. The complete root-cause isolation — **fence-scoped subjects** (`decopilot.<threadId>.<fenceToken>`) so a purge can never cross turns — was deliberately deferred (bigger, touches the producer/projector/consumer/purge wire contract). The **OOM memory-limit bump** (infra, other repo) remains the upstream driver that makes these races frequent.

## Testing

- `bun test apps/mesh/src/api/routes/decopilot/projector-redelivery.test.ts apps/mesh/src/api/routes/decopilot/projector-workflow.test.ts` — 32 pass. Added: gap on an already-settled fence → clean no-op, clears the bubble, purges, no fail. The existing gap-on-`in_progress` test still asserts `markRunFailed(kind="projection")` (no regression).
- `bun run fmt` clean; `bun run check` clean for these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat a stream gap after a run has already reached terminal for the same fence as benign in the decopilot projector. This removes the standalone “missing seq N” bubble and avoids false `projection` failures.

- **Bug Fixes**
  - Add `runSettledForFence` and use it for both gap and idle branches.
  - On benign gap: clear the synthesized error, purge, and return clean; non-settled gaps still fail.
  - Tests: add coverage for benign post-terminal gap; existing in-progress gap test unchanged.

<sup>Written for commit 29cb1641f250167474e562cc0cd20cbef7fc2bd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

