### PR TITLE
feat(task-board): inline assign circle on kanban cards

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/assignee-picker.tsx
+++ b/apps/mesh/src/web/layouts/task-board/assignee-picker.tsx
@@ -1,0 +1,66 @@
+import { Avatar } from "@deco/ui/components/avatar.tsx";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@deco/ui/components/command.tsx";
+import { User01 } from "@untitledui/icons";
+import { SuperAgentIcon } from "@/web/components/super-agent-icon";
+import { getInitials } from "@/web/lib/get-initials";
+import { SUPER_AGENT_ASSIGNEE_ID, type Member } from "./config";
+
+export function AssigneePickerContent({
+  members,
+  onSelect,
+}: {
+  members: Member[];
+  onSelect: (userId: string | null) => void;
+}) {
+  return (
+    <Command>
+      <CommandInput placeholder="Assign to…" className="h-9" />
+      <CommandList>
+        <CommandEmpty>No members found.</CommandEmpty>
+        <CommandGroup>
+          <CommandItem
+            value="Super Agent"
+            onSelect={() => onSelect(SUPER_AGENT_ASSIGNEE_ID)}
+            className="gap-2"
+          >
+            <SuperAgentIcon size={16} />
+            <span className="truncate">Super Agent</span>
+          </CommandItem>
+          <CommandItem
+            value="Unassigned"
+            onSelect={() => onSelect(null)}
+            className="gap-2"
+          >
+            <User01 size={16} className="text-muted-foreground" />
+            <span className="truncate">Unassigned</span>
+          </CommandItem>
+        </CommandGroup>
+        <CommandGroup heading="Members">
+          {members.map((m) => (
+            <CommandItem
+              key={m.userId}
+              value={m.user?.name ?? m.userId}
+              onSelect={() => onSelect(m.userId)}
+              className="gap-2"
+            >
+              <Avatar
+                url={m.user?.image ?? undefined}
+                fallback={getInitials(m.user?.name)}
+                shape="circle"
+                size="2xs"
+              />
+              <span className="truncate">{m.user?.name ?? m.userId}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}

--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -16,7 +16,13 @@ import {
   List,
   Loading01,
   Plus,
+  UserPlus01,
 } from "@untitledui/icons";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@deco/ui/components/popover.tsx";
 import { SuperAgentIcon } from "@/web/components/super-agent-icon";
 import { GitHubIcon } from "@/web/components/icons/github-icon";
 import {
@@ -53,6 +59,7 @@ import {
   type Member,
 } from "./config";
 import { TaskBoardItemDialog } from "./task-dialog";
+import { AssigneePickerContent } from "./assignee-picker";
 import { buildTaskChatContext } from "./build-task-chat-context";
 import { useStudioTools } from "@/web/lib/studio-tools";
 import {
@@ -152,11 +159,17 @@ function AssigneeDisplay({
   item,
   assignee,
   assignedBy,
+  members,
+  onAssign,
 }: {
   item: TaskBoardItem;
   assignee?: Member;
   assignedBy?: Member;
+  members?: Member[];
+  onAssign?: (userId: string | null) => void;
 }) {
+  const [open, setOpen] = useState(false);
+
   if (item.assigneeId === SUPER_AGENT_ASSIGNEE_ID) {
     return (
       <span
@@ -172,11 +185,11 @@ function AssigneeDisplay({
             url={assignedBy.user?.image ?? undefined}
             fallback={getInitials(assignedBy.user?.name)}
             shape="circle"
-            size="2xs"
-            className="-mr-1.5 ring-2 ring-background"
+            size="xs"
+            className="-mr-2 ring-2 ring-background"
           />
         )}
-        <SuperAgentIcon size={16} className="ring-2 ring-background" />
+        <SuperAgentIcon size={20} className="ring-2 ring-background" />
       </span>
     );
   }
@@ -186,11 +199,42 @@ function AssigneeDisplay({
         url={assignee.user?.image ?? undefined}
         fallback={getInitials(assignee.user?.name)}
         shape="circle"
-        size="2xs"
+        size="xs"
       />
     );
   }
-  return null;
+  if (!onAssign || !members?.length) return null;
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          title="Assign"
+          onClick={(e) => {
+            e.stopPropagation();
+            setOpen(true);
+          }}
+          className="flex size-6 shrink-0 items-center justify-center rounded-full border border-dashed border-muted-foreground/40 text-muted-foreground/40 transition-colors hover:border-muted-foreground hover:text-muted-foreground"
+        >
+          <UserPlus01 size={13} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-56 p-0"
+        align="end"
+        side="bottom"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <AssigneePickerContent
+          members={members}
+          onSelect={(userId) => {
+            onAssign(userId);
+            setOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
 }
 
 export function TaskBoardPage() {
@@ -419,10 +463,14 @@ export function TaskBoardPage() {
       ) : layout === "board" ? (
         <Lanes
           items={visibleItems}
+          members={members}
           memberByUserId={memberByUserId}
           onOpen={openTask}
           onCreate={openCreateInLane}
           onMove={(id, status) => actions.update.mutate({ id, status })}
+          onAssign={(id, userId) =>
+            actions.update.mutate({ id, assigneeId: userId ?? undefined })
+          }
           onAutoFix={
             reportsOnly
               ? (item) => {
@@ -586,18 +634,22 @@ function LayoutToggle({
 
 function Lanes({
   items,
+  members,
   memberByUserId,
   onOpen,
   onCreate,
   onMove,
   onAutoFix,
+  onAssign,
 }: {
   items: TaskBoardItem[];
+  members: Member[];
   memberByUserId: Map<string, Member>;
   onOpen: (item: TaskBoardItem) => void;
   onCreate: (status: TaskBoardItemStatus) => void;
   onMove: (id: string, status: TaskBoardItemStatus) => void;
   onAutoFix?: (item: TaskBoardItem) => void;
+  onAssign?: (id: string, userId: string | null) => void;
 }) {
   const [overLane, setOverLane] = useState<TaskBoardItemStatus | null>(null);
   const boardRef = useRef<HTMLDivElement>(null);
@@ -683,8 +735,14 @@ function Lanes({
                         ? memberByUserId.get(item.assignedBy)
                         : undefined
                     }
+                    members={members}
                     onOpen={() => onOpen(item)}
                     onAutoFix={onAutoFix ? () => onAutoFix(item) : undefined}
+                    onAssign={
+                      onAssign
+                        ? (userId) => onAssign(item.id, userId)
+                        : undefined
+                    }
                   />
                 ))}
               </div>
@@ -700,14 +758,18 @@ function TaskCard({
   item,
   assignee,
   assignedBy,
+  members,
   onOpen,
   onAutoFix,
+  onAssign,
 }: {
   item: TaskBoardItem;
   assignee?: Member;
   assignedBy?: Member;
+  members?: Member[];
   onOpen: () => void;
   onAutoFix?: () => void;
+  onAssign?: (userId: string | null) => void;
 }) {
   const statusConfig = STATUS_CONFIG[item.status];
   const StatusIcon = statusConfig.icon;
@@ -743,6 +805,8 @@ function TaskCard({
           item={item}
           assignee={assignee}
           assignedBy={assignedBy}
+          members={members}
+          onAssign={onAssign}
         />
       </div>
 

--- a/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
+++ b/apps/mesh/src/web/layouts/task-board/task-dialog.tsx
@@ -15,14 +15,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@deco/ui/components/popover.tsx";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@deco/ui/components/command.tsx";
 import { Calendar as DayPickerCalendar } from "@deco/ui/components/calendar.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Avatar } from "@deco/ui/components/avatar.tsx";
@@ -44,7 +36,6 @@ import {
   Loading02,
   Plus,
   Trash03,
-  User01,
   UserPlus01,
   X,
 } from "@untitledui/icons";
@@ -66,6 +57,7 @@ import {
   type TaskBoardItemThread,
 } from "./config";
 import { useTaskBoardItemPrs } from "@/web/hooks/use-task-board-item-prs";
+import { AssigneePickerContent } from "./assignee-picker";
 
 // ponytail: pinned to end-of-day so "due today" doesn't flip to overdue
 // mid-morning. Local zone in, UTC out.
@@ -457,62 +449,13 @@ export function TaskBoardItemDialog({
                     </button>
                   </PopoverTrigger>
                   <PopoverContent align="start" className="w-56 p-0">
-                    <Command>
-                      <CommandInput placeholder="Assign to…" className="h-9" />
-                      <CommandList>
-                        <CommandEmpty>No members found.</CommandEmpty>
-                        <CommandGroup>
-                          <CommandItem
-                            value="Super Agent"
-                            onSelect={() => {
-                              setAssigneeId(SUPER_AGENT_ASSIGNEE_ID);
-                              setAssigneeOpen(false);
-                            }}
-                            className="gap-2"
-                          >
-                            <SuperAgentIcon size={16} />
-                            <span className="truncate">Super Agent</span>
-                          </CommandItem>
-                          <CommandItem
-                            value="Unassigned"
-                            onSelect={() => {
-                              setAssigneeId(null);
-                              setAssigneeOpen(false);
-                            }}
-                            className="gap-2"
-                          >
-                            <User01
-                              size={16}
-                              className="text-muted-foreground"
-                            />
-                            <span className="truncate">Unassigned</span>
-                          </CommandItem>
-                        </CommandGroup>
-                        <CommandGroup heading="Members">
-                          {members.map((m) => (
-                            <CommandItem
-                              key={m.userId}
-                              value={m.user?.name ?? m.userId}
-                              onSelect={() => {
-                                setAssigneeId(m.userId);
-                                setAssigneeOpen(false);
-                              }}
-                              className="gap-2"
-                            >
-                              <Avatar
-                                url={m.user?.image ?? undefined}
-                                fallback={getInitials(m.user?.name)}
-                                shape="circle"
-                                size="2xs"
-                              />
-                              <span className="truncate">
-                                {m.user?.name ?? m.userId}
-                              </span>
-                            </CommandItem>
-                          ))}
-                        </CommandGroup>
-                      </CommandList>
-                    </Command>
+                    <AssigneePickerContent
+                      members={members}
+                      onSelect={(userId) => {
+                        setAssigneeId(userId);
+                        setAssigneeOpen(false);
+                      }}
+                    />
                   </PopoverContent>
                 </Popover>
 


### PR DESCRIPTION
## What is this contribution about?

Adds a dashed circle button (with a user-plus icon) to unassigned kanban cards so members can be assigned directly from the board without opening the card. Selecting a member from the popover calls the existing update mutation immediately. Also extracts the assignee picker into a shared `AssigneePickerContent` component — used identically by both the inline card popover and the task dialog — and bumps assignee avatar sizes from `2xs` to `xs` for better legibility.

## Screenshots/Demonstration

> Dashed circle appears on unassigned cards; clicking opens the same Command-based assignee picker used in the task dialog (search + Super Agent + Unassigned + Members list).

## How to Test

1. Open `/$org/board` and find an unassigned task card.
2. A dashed circle with a user-plus icon should be visible in the top-right of the card.
3. Click it — the assignee picker opens without navigating into the card.
4. Select a member; the avatar should appear on the card immediately.
5. Open the same task via the card to confirm the assignee is saved correctly.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an inline Assign button to unassigned kanban cards so you can assign members directly from the board. Also shares the assignee picker between the board and dialog and bumps avatar size for better legibility.

- **New Features**
  - Inline assign popover on unassigned cards using a dashed circle button; selecting a member updates the task instantly and shows the avatar on the card.

- **Refactors**
  - Extracted a shared `AssigneePickerContent` used by both the card popover and the task dialog.
  - Increased assignee avatar size from `2xs` to `xs`.

<sup>Written for commit 3c2332c21e2d6d430472b2d405d6afe9af12a7ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

