### PR TITLE
feat(mesh): feed the Studio UI language into MCP app iframes

### DIFF
--- a/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
+++ b/apps/mesh/src/mcp-apps/mcp-app-renderer.tsx
@@ -12,6 +12,7 @@ import { injectCSP } from "./csp-injector.ts";
 import type { McpUiResourceCsp } from "./types.ts";
 import { useAppBridge } from "./use-app-bridge.ts";
 import { track } from "../web/lib/posthog-client";
+import { usePreferences } from "../web/hooks/use-preferences.ts";
 
 // Module-level dedup so a given MCP app resource fires `mcp_app_opened` at
 // most once per page session. Different resources still fire their own events.
@@ -106,12 +107,19 @@ function MCPAppFrame({
     });
   }
 
+  // Feed Studio's UI language into the iframe's host context so the embedded
+  // MCP app localizes to match Studio (not the raw browser locale). Reactive:
+  // changing the language re-renders here, useAppBridge detects the new locale
+  // and pushes a host-context-changed notification to the live iframe.
+  const [preferences] = usePreferences();
+
   const { height, isLoading, error, iframeRef } = useAppBridge({
     client,
     displayMode,
     minHeight,
     maxHeight,
     orgId,
+    locale: preferences.language,
     toolInfo,
     toolInput,
     toolResult,

--- a/apps/mesh/src/mcp-apps/use-app-bridge.ts
+++ b/apps/mesh/src/mcp-apps/use-app-bridge.ts
@@ -61,13 +61,17 @@ function buildHostContext(
   toolInfo?: McpUiHostContext["toolInfo"],
   maxHeight?: number,
   orgId?: string,
+  // The Studio UI language (preferences.language), so the embedded MCP app
+  // localizes to match Studio rather than the raw browser locale. Falls back to
+  // the detected browser locale when not supplied.
+  locale?: string,
 ): McpUiHostContext {
   return {
     theme: getDocumentTheme(),
     styles: readHostStyles(),
     displayMode,
     availableDisplayModes: ["inline", "fullscreen"],
-    locale: detectLocale(),
+    locale: locale ?? detectLocale(),
     timeZone: detectTimeZone(),
     platform: detectPlatform(),
     ...(toolInfo != null && { toolInfo }),
@@ -130,6 +134,8 @@ interface BridgeStoreConfig {
   minHeight: number;
   maxHeight: number;
   orgId?: string;
+  /** Studio UI language (BCP 47) fed into hostContext.locale. */
+  locale?: string;
   toolInfo?: McpUiHostContext["toolInfo"];
   toolInput?: Record<string, unknown>;
   toolResult?: CallToolResult;
@@ -189,7 +195,10 @@ class BridgeStore {
 
     if (!this.bridge || this.disposed) return;
 
-    if (config.displayMode !== prev.displayMode) {
+    if (
+      config.displayMode !== prev.displayMode ||
+      config.locale !== prev.locale
+    ) {
       this.pushHostContext();
     }
     if (config.toolInput !== prev.toolInput && config.toolInput != null) {
@@ -203,9 +212,9 @@ class BridgeStore {
   /** Rebuild and push full host context to the bridge (e.g. on theme change). */
   private pushHostContext() {
     if (!this.bridge || this.disposed) return;
-    const { displayMode, maxHeight, toolInfo, orgId } = this.config;
+    const { displayMode, maxHeight, toolInfo, orgId, locale } = this.config;
     this.bridge.setHostContext(
-      buildHostContext(displayMode, toolInfo, maxHeight, orgId),
+      buildHostContext(displayMode, toolInfo, maxHeight, orgId, locale),
     );
   }
 
@@ -302,12 +311,14 @@ class BridgeStore {
     }
 
     try {
-      const { client, displayMode, maxHeight, toolInfo, orgId } = this.config;
+      const { client, displayMode, maxHeight, toolInfo, orgId, locale } =
+        this.config;
       const hostContext = buildHostContext(
         displayMode,
         toolInfo,
         maxHeight,
         orgId,
+        locale,
       );
 
       // Pass the MCP client directly — AppBridge auto-wires oncalltool,
@@ -470,6 +481,8 @@ interface UseAppBridgeOptions {
   minHeight: number;
   maxHeight: number;
   orgId?: string;
+  /** Studio UI language (BCP 47) fed into hostContext.locale. */
+  locale?: string;
   toolInfo?: McpUiHostContext["toolInfo"];
   toolInput?: Record<string, unknown>;
   toolResult?: CallToolResult;


### PR DESCRIPTION
## What

When a user switches the Studio UI language (`preferences.language`, driven by the existing i18n system in `apps/mesh/src/web/i18n/`), embedded **MCP app iframes didn't follow** — the host context sent `locale: detectLocale()` (raw `navigator.language`). So an MCP app that localizes off `hostContext.locale` (e.g. the diagnostic report) stayed on the browser language regardless of the Studio setting.

This threads the **existing** `preferences.language` into `hostContext.locale`. No new preference, no UI changes — it reuses the language the user already picks and that `useT()` already reads.

## How

- **`use-app-bridge.ts`** — `buildHostContext` takes an optional `locale` (falls back to `detectLocale()` when absent). It's carried on `BridgeStoreConfig` / `UseAppBridgeOptions` and used on both the initial `connectBridge` and `pushHostContext()`. `updateConfig` now re-pushes host context when `locale` changes, so switching language emits a `host-context-changed` notification to the **live** iframe — no reload needed.
- **`mcp-app-renderer.tsx`** — `MCPAppFrame` reads `preferences.language` and passes it as `locale`.

`Locale` (`"en" | "pt-BR"`) is already valid BCP 47, so it maps straight through.

## Pairs with
The reports MCP app i18n PR (`decocms/reports#249`), whose `useT()` reads `hostContext.locale` and falls back to English. Together: pick a language in Studio → the diagnostic report re-renders in that language, live.

## Verification
- `bun run check` (tsc, mesh app) — 0 errors
- `oxlint` on the two changed files — 0 warnings / 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
MCP app iframes now follow the Studio language preference instead of the browser language. `preferences.language` is passed to `hostContext.locale`, and language changes re-localize apps without reloading.

- New Features
  - Added optional `locale` to host context and bridge config; falls back to `detectLocale()`.
  - Re-push host context when `locale` changes, emitting `host-context-changed` to the live iframe.
  - `MCPAppFrame` reads `preferences.language` and forwards it as `locale`.

<sup>Written for commit a41a68be85ab321dc4bc39f99de5659f8ffd5537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

