### PR TITLE
fix(preview): loosen blocks editor panel min width

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -697,7 +697,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const activateEditingMode = (mode: PreviewEditingMode) => {
     const previousMode = editingMode;
     if (!isMobile && mode !== previousMode) {
-      if (mode === "blocks") blocksPanelRef.current?.resize(40);
+      if (mode === "blocks") blocksPanelRef.current?.resize(30);
       else blocksPanelRef.current?.collapse();
     }
     setEditingMode(mode);
@@ -1363,14 +1363,11 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
               ref={blocksPanelRef}
               id="preview-blocks-editor"
               order={1}
-              defaultSize={effectiveEditingMode === "blocks" ? 40 : 0}
-              minSize={30}
+              defaultSize={effectiveEditingMode === "blocks" ? 30 : 0}
+              minSize={20}
               collapsible
               collapsedSize={0}
-              className={cn(
-                "overflow-hidden",
-                effectiveEditingMode === "blocks" ? "min-w-[320px]" : "min-w-0",
-              )}
+              className="min-w-0 overflow-hidden"
             >
               {effectiveEditingMode === "blocks" && (
                 <BlocksPanel


### PR DESCRIPTION
## Summary

The Blocks editor panel (section list, next to the Preview canvas in `preview.tsx`) enforced two minimum-width constraints that made it feel cramped and squeezed the preview to a sliver on narrow layouts. This loosens them:

- **Opens at 30%** of the Blocks|Preview split (was 40%) — both the initial `defaultSize` and the toggle-driven `resize()`.
- **Drag minimum 20%** (was `minSize={30}`).
- **Removed the `min-w-[320px]` CSS floor** — the panel is now just `min-w-0 overflow-hidden`, so it shrinks freely with the preview.

The preview canvas is unchanged (`minSize={35}`, `min-w-0`). With the editor floor now at 20%, the two panels' minimums no longer contend for space on a narrow main panel.

## Testing

- `bun run fmt` — clean.
- Manual: drag the Blocks|Preview divider; the editor panel now collapses down to 20% and reopens at 30% via the mode toggle.

## Affected areas

- `apps/mesh/src/web/components/sandbox/preview/preview.tsx` — Blocks editor `ResizablePanel` sizing + the mode-toggle resize target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loosened the Blocks editor panel sizing so it collapses further and no longer squeezes the preview on narrow screens. This makes the Blocks | Preview split more flexible.

- **Bug Fixes**
  - Opens at 30% of the split (was 40%).
  - Drag minimum is 20% (was 30%).
  - Removed `min-w-[320px]`; panel now uses `min-w-0 overflow-hidden`.

<sup>Written for commit c667f73b51baa7350f744905c61cdc44a860ef7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

