### PR TITLE
fix(sandbox): don't yank focus back after a preview save-reload

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -743,7 +743,15 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
       clearTimeout(fallbackTimer);
       iframe.tabIndex = prevTabIndex;
       iframe.style.pointerEvents = "";
-      focused?.focus();
+      // Only restore focus if the reload itself stole it (focus was on/inside the
+      // iframe, so blurring it dropped focus to <body>). If the user has since
+      // moved to another element — e.g. tabbed from a date field to a text input
+      // in the Blocks form while the debounced save-reload was in flight — leave
+      // it there; re-focusing `focused` would yank them back to the stale field.
+      const active = document.activeElement;
+      if (!active || active === document.body || active === iframe) {
+        focused?.focus();
+      }
       iframe.removeEventListener("load", restore);
     };
     iframe.addEventListener("load", restore);

--- a/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/string-field.tsx
@@ -72,15 +72,30 @@ function DatePickerInput({
 }) {
   const [open, setOpen] = useState(false);
 
-  const inputValue = withTime
-    ? isoToDateTimeInput(value)
-    : isoToDateInput(value);
+  const toInput = (iso: string) =>
+    withTime ? isoToDateTimeInput(iso) : isoToDateInput(iso);
+  const toIso = (input: string) =>
+    withTime ? dateTimeInputToIso(input) : dateInputToIso(input);
+
+  // Buffer the native input's string locally so a parent re-render (autosave,
+  // decofile refetch) mid-edit doesn't reassign the controlled <input>.value and
+  // yank focus/caret off the field — a Chrome quirk on date/datetime-local inputs
+  // that's most visible while typing the time segment of a datetime. Same
+  // local-state-with-external-resync pattern as PageHeaderInputs.
+  const [inputValue, setInputValue] = useState(() => toInput(value));
+  const [prevValue, setPrevValue] = useState(value);
+  // Resync only on genuine external value changes (calendar pick, section/item
+  // switch), never on our own edits echoing back — those round-trip to the same
+  // string, so the buffer already matches and we leave the in-progress edit alone.
+  if (value !== prevValue) {
+    setPrevValue(value);
+    const next = toInput(value);
+    if (next !== inputValue) setInputValue(next);
+  }
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onChange(
-      withTime
-        ? dateTimeInputToIso(e.target.value)
-        : dateInputToIso(e.target.value),
-    );
+    setInputValue(e.target.value);
+    onChange(toIso(e.target.value));
   };
 
   const parsed = value ? new Date(value) : null;
@@ -98,7 +113,12 @@ function DatePickerInput({
     } else {
       next.setHours(0, 0, 0, 0);
     }
-    onChange(next.toISOString());
+    const iso = next.toISOString();
+    // Keep the local buffer and resync guard in step so the committed pick shows
+    // immediately and the value echoing back doesn't re-trigger a resync.
+    setInputValue(toInput(iso));
+    setPrevValue(iso);
+    onChange(iso);
     setOpen(false);
   };
 
@@ -111,6 +131,7 @@ function DatePickerInput({
         max={withTime ? DATETIME_MAX : DATE_MAX}
         value={inputValue}
         onChange={handleInputChange}
+        onBlur={() => setInputValue(toInput(value))}
         className="h-10 flex-1 [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:opacity-0"
       />
       <Popover open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
## Summary

Follow-up to #5034. Editing a field in the Blocks editor (e.g. a **date-time** widget) still stole focus back after a moment — this is the real root cause.

Editing a field debounces an autosave that writes a `.deco/` file, which reloads the preview iframe. `reloadPreviewPreservingScroll` captured `document.activeElement` at reload start and re-focused it on the iframe's `load` event. So if you moved to another field **while the reload was in flight** (datetime → text input), the `load` event snapped focus back to the field you'd just left. It happened in both directions and was timed to the preview re-render, not to the widget itself — it was never a remount.

The blur/restore dance is only meaningful when focus was **on/inside the iframe** (reloading a focused iframe drops focus to `<body>`). When focus is in the Blocks form, the reload doesn't touch it, so `focused.focus()` is purely harmful. Now we only restore focus when the reload actually stole it; if the user has since focused another element, we leave it there.

Also hardens `DatePickerInput`: buffer the native date/datetime input's string locally so a parent re-render mid-edit can't reassign the controlled `<input>.value` and reset the editing segment (a Chrome quirk on `date`/`datetime-local`), matching the existing `PageHeaderInputs` local-state pattern.

## Changes
- `preview.tsx` — guard `restore()` so it only re-focuses when focus fell to the iframe/`<body>`, never overriding a field the user intentionally moved to.
- `string-field.tsx` — local-buffer the native date/datetime input; resync only on genuine external value changes (calendar pick, section/item switch).

## Test plan
- [x] `bun run fmt`
- [x] `bun run --cwd=apps/mesh check`
- [x] Manually: edit a date-time field in a banner section, move to a sibling text field while the preview reloads — focus stays where you moved it (confirmed by reporter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the preview reload from yanking focus back to the previous field, and make the date/datetime input stable while typing. This keeps focus where the user moved it and prevents caret resets during autosave reloads.

- **Bug Fixes**
  - Preview iframe: only restore focus after reload if it fell to `<body>`/iframe; don’t override a new field the user focused.
  - Date/datetime input: buffer the input string locally and resync only on external changes; update buffer on calendar pick and onBlur to avoid Chrome segment/caret resets.

<sup>Written for commit 00cf7a477a27aa30654706e7869c337d01dd5e0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

