### PR TITLE
fix(agents): remove avatar image padding

### DIFF
--- a/apps/mesh/src/web/components/agent-icon.test.tsx
+++ b/apps/mesh/src/web/components/agent-icon.test.tsx
@@ -18,6 +18,8 @@ describe("AgentAvatar", () => {
     const img = container.querySelector("img");
     expect(img).toBeInTheDocument();
     expect(img?.parentElement?.className).toContain("bg-red-100");
+    expect(img).toHaveClass("h-full", "w-full", "object-contain");
+    expect(img).not.toHaveClass("p-3");
   });
 
   it("recovers after an image load error once a new URL is set", () => {

--- a/apps/mesh/src/web/components/agent-icon.tsx
+++ b/apps/mesh/src/web/components/agent-icon.tsx
@@ -450,7 +450,7 @@ function AgentAvatarImage({
         alt={name}
         className={cn(
           "h-full w-full",
-          bgClass ? "object-contain p-3" : "object-cover",
+          bgClass ? "object-contain" : "object-cover",
         )}
         onError={() => setErrored(true)}
       />


### PR DESCRIPTION
## Summary
- remove padding from color-backed agent avatar images
- cover the resulting image classes with a component test

## Testing
- bun run fmt
- bun test apps/mesh/src/web/components/agent-icon.test.tsx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed padding from agent avatar images when a background color is present, so avatars fill the container without inset spacing. Added a component test to assert the image has h-full w-full object-contain and does not include p-3 to prevent regressions.

<sup>Written for commit 7256a1bd2fd92a1ac54cee12068250d80bf53029. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

