### PR TITLE
feat(i18n): translate /commerce-onboarding route

### DIFF
--- a/apps/mesh/src/web/i18n/en/routes.ts
+++ b/apps/mesh/src/web/i18n/en/routes.ts
@@ -17,108 +17,137 @@ export const routes = {
   "routes.agentsList.searchPlaceholder": "Search for an agent...",
   "routes.agentsList.title": "Agents",
   "routes.commerceOnboarding.authCopy.accountExists":
-    "Já existe uma conta com este e-mail. Tente entrar em vez de criar uma nova conta.",
-  "routes.commerceOnboarding.authCopy.alreadyHaveAccount": "Já tem uma conta? ",
+    "An account with this email already exists. Try signing in instead.",
+  "routes.commerceOnboarding.authCopy.alreadyHaveAccount":
+    "Already have an account? ",
   "routes.commerceOnboarding.authCopy.authenticationFailed":
-    "Falha na autenticação",
-  "routes.commerceOnboarding.authCopy.backToSignIn": "Voltar para entrar",
-  "routes.commerceOnboarding.authCopy.codeSentTo":
-    "Código enviado para {email}",
-  "routes.commerceOnboarding.authCopy.continue": "Continuar",
-  "routes.commerceOnboarding.authCopy.continueWith": "Continuar com {provider}",
-  "routes.commerceOnboarding.authCopy.creatingAccount": "Criando conta...",
+    "Authentication failed",
+  "routes.commerceOnboarding.authCopy.backToSignIn": "Back to sign in",
+  "routes.commerceOnboarding.authCopy.codeSentTo": "Code sent to {email}",
+  "routes.commerceOnboarding.authCopy.continue": "Continue",
+  "routes.commerceOnboarding.authCopy.continueWith": "Continue with {provider}",
+  "routes.commerceOnboarding.authCopy.creatingAccount": "Creating account...",
   "routes.commerceOnboarding.authCopy.defaultSubtitle":
-    "Entre ou crie uma nova conta",
+    "Sign in or create a new account",
   "routes.commerceOnboarding.authCopy.divider": "or",
-  "routes.commerceOnboarding.authCopy.dontHaveAccount": "Não tem uma conta? ",
-  "routes.commerceOnboarding.authCopy.emailLabel": "E-mail",
-  "routes.commerceOnboarding.authCopy.emailPlaceholder": "Endereço de e-mail",
-  "routes.commerceOnboarding.authCopy.enterCodePlaceholder": "Informe o código",
-  "routes.commerceOnboarding.authCopy.forgotPassword": "Esqueceu a senha?",
+  "routes.commerceOnboarding.authCopy.dontHaveAccount":
+    "Don't have an account? ",
+  "routes.commerceOnboarding.authCopy.emailLabel": "Email",
+  "routes.commerceOnboarding.authCopy.emailPlaceholder": "Email address",
+  "routes.commerceOnboarding.authCopy.enterCodePlaceholder": "Enter code",
+  "routes.commerceOnboarding.authCopy.forgotPassword": "Forgot password?",
   "routes.commerceOnboarding.authCopy.genericError":
-    "Algo deu errado. Tente novamente.",
-  "routes.commerceOnboarding.authCopy.invalidCode": "Código inválido",
-  "routes.commerceOnboarding.authCopy.invalidEmail": "E-mail inválido",
+    "Something went wrong. Please try again.",
+  "routes.commerceOnboarding.authCopy.invalidCode": "Invalid code",
+  "routes.commerceOnboarding.authCopy.invalidEmail": "Invalid email",
   "routes.commerceOnboarding.authCopy.invalidEmailOrPassword":
-    "E-mail ou senha inválidos. Tente novamente.",
+    "Invalid email or password. Please try again.",
   "routes.commerceOnboarding.authCopy.invalidOrExpiredCode":
-    "Código inválido ou expirado. Tente novamente.",
+    "Invalid or expired code. Please try again.",
   "routes.commerceOnboarding.authCopy.nameLabel": "Name",
-  "routes.commerceOnboarding.authCopy.namePlaceholder": "Seu nome",
+  "routes.commerceOnboarding.authCopy.namePlaceholder": "Your name",
   "routes.commerceOnboarding.authCopy.networkError":
-    "Erro de rede. Verifique sua conexão e tente novamente.",
-  "routes.commerceOnboarding.authCopy.otpSendFailed":
-    "Não foi possível enviar o código",
+    "Network error. Check your connection and try again.",
+  "routes.commerceOnboarding.authCopy.otpSendFailed": "Could not send code",
   "routes.commerceOnboarding.authCopy.passwordLabel": "Password",
   "routes.commerceOnboarding.authCopy.resetEmailFailed":
-    "Não foi possível enviar o e-mail de redefinição",
+    "Could not send reset email",
   "routes.commerceOnboarding.authCopy.resetEmailSent":
-    "Verifique seu e-mail para redefinir a senha.",
+    "Check your email to reset your password.",
   "routes.commerceOnboarding.authCopy.resetPasswordSubtitle":
-    "Enviaremos um link de redefinição",
+    "We'll send you a reset link",
   "routes.commerceOnboarding.authCopy.resetPasswordTitle":
-    "Redefinir sua senha",
-  "routes.commerceOnboarding.authCopy.sendCode": "Enviar código",
-  "routes.commerceOnboarding.authCopy.sendResetLink":
-    "Enviar link de redefinição",
-  "routes.commerceOnboarding.authCopy.sending": "Enviando...",
-  "routes.commerceOnboarding.authCopy.signIn": "Entrar",
-  "routes.commerceOnboarding.authCopy.signInFailed": "Falha ao entrar",
+    "Reset your password",
+  "routes.commerceOnboarding.authCopy.sendCode": "Send code",
+  "routes.commerceOnboarding.authCopy.sendResetLink": "Send reset link",
+  "routes.commerceOnboarding.authCopy.sending": "Sending...",
+  "routes.commerceOnboarding.authCopy.signIn": "Sign in",
+  "routes.commerceOnboarding.authCopy.signInFailed": "Sign in failed",
   "routes.commerceOnboarding.authCopy.signInWithEmailCode":
-    "Entrar com código por e-mail",
-  "routes.commerceOnboarding.authCopy.signInWithPassword": "Entrar com senha",
-  "routes.commerceOnboarding.authCopy.signUp": "Criar conta",
-  "routes.commerceOnboarding.authCopy.signUpFailed": "Falha ao criar conta",
-  "routes.commerceOnboarding.authCopy.signingIn": "Entrando...",
+    "Sign in with email code",
+  "routes.commerceOnboarding.authCopy.signInWithPassword":
+    "Sign in with password",
+  "routes.commerceOnboarding.authCopy.signUp": "Create account",
+  "routes.commerceOnboarding.authCopy.signUpFailed": "Sign up failed",
+  "routes.commerceOnboarding.authCopy.signingIn": "Signing in...",
   "routes.commerceOnboarding.authCopy.tooManyAttempts":
-    "Muitas tentativas. Aguarde um momento e tente novamente.",
-  "routes.commerceOnboarding.authCopy.useDifferentEmail": "Usar outro e-mail",
+    "Too many attempts. Wait a moment and try again.",
+  "routes.commerceOnboarding.authCopy.useDifferentEmail":
+    "Use a different email",
   "routes.commerceOnboarding.authCopy.verificationCodeLabel":
-    "Código de verificação",
+    "Verification code",
   "routes.commerceOnboarding.authCopy.verificationCodeTitle":
-    "Informe o código de verificação",
-  "routes.commerceOnboarding.authCopy.verify": "Verificar",
-  "routes.commerceOnboarding.authCopy.verifying": "Verificando...",
-  "routes.commerceOnboarding.authCopy.welcomeTitle": "Bem-vindo à deco",
-  "routes.commerceOnboarding.chooseOrg": "Escolha uma organização",
-  "routes.commerceOnboarding.commerceDiagnostic": "Diagnóstico de commerce",
+    "Enter verification code",
+  "routes.commerceOnboarding.authCopy.verify": "Verify",
+  "routes.commerceOnboarding.authCopy.verifying": "Verifying...",
+  "routes.commerceOnboarding.authCopy.welcomeTitle": "Welcome to deco",
+  "routes.commerceOnboarding.chooseOrg": "Choose an organization",
+  "routes.commerceOnboarding.commerceDiagnostic": "Commerce diagnostic",
   "routes.commerceOnboarding.commerceDiscoveryBeingPrepared":
-    "O Commerce Discovery está sendo preparado para {url}.",
+    "Commerce Discovery is being prepared for {url}.",
   "routes.commerceOnboarding.configurationFailed":
-    "A configuração do Commerce Discovery falhou.",
+    "Commerce Discovery configuration failed.",
   "routes.commerceOnboarding.configurationWillContinueIn":
-    "A configuração de commerce continuará em {orgName}.",
+    "Commerce setup will continue in {orgName}.",
   "routes.commerceOnboarding.couldNotDetermineOrg":
-    "Não conseguimos determinar uma organização de commerce para esta conta.",
+    "We could not determine a commerce organization for this account.",
   "routes.commerceOnboarding.couldNotFindOrg":
-    "Não conseguimos encontrar essa organização na sua conta.",
+    "We could not find that organization in your account.",
   "routes.commerceOnboarding.couldNotLoadOrgs":
-    "Não foi possível carregar suas organizações",
+    "Could not load your organizations",
   "routes.commerceOnboarding.couldNotPrepareOrg":
-    "Não foi possível preparar uma organização para a configuração de commerce. Tente novamente por esta página ou fale com o suporte.",
+    "Could not prepare an organization for commerce setup. Try again from this page or contact support.",
   "routes.commerceOnboarding.couldNotVerifyCommerceSetting":
     "Unable to verify Commerce Discovery configuration.",
   "routes.commerceOnboarding.emailAccessMultipleOrgs":
-    "Seu e-mail pode acessar mais de uma organização. Escolha onde a configuração de commerce deve continuar.",
+    "Your email can access more than one organization. Choose where commerce setup should continue.",
   "routes.commerceOnboarding.onboardingNeedsSupport":
-    "O onboarding de commerce precisa de suporte",
+    "Commerce onboarding needs support",
   "routes.commerceOnboarding.onboardingUnavailable":
-    "Onboarding de commerce indisponível",
-  "routes.commerceOnboarding.orgNotFound": "Organização não encontrada",
-  "routes.commerceOnboarding.retryAgain": "Tentar novamente",
+    "Commerce onboarding unavailable",
+  "routes.commerceOnboarding.orgNotFound": "Organization not found",
+  "routes.commerceOnboarding.retryAgain": "Try again",
   "routes.commerceOnboarding.retryToConfigureCommerce":
-    "Tente novamente para continuar a configuração de commerce nesta página.",
+    "Try again to continue commerce setup from this page.",
   "routes.commerceOnboarding.selectWhereCommerceContinues":
-    "Selecione onde o diagnóstico de commerce deve continuar.",
-  "routes.commerceOnboarding.siteUrl.enterUrl": "Informe a URL de um site.",
+    "Select where the commerce diagnostic should continue.",
+  "routes.commerceOnboarding.siteUrl.enterUrl": "Enter a website URL.",
   "routes.commerceOnboarding.siteUrl.enterValidUrl":
-    "Informe uma URL de site válida.",
+    "Enter a valid website URL.",
   "routes.commerceOnboarding.siteUrl.useHttpOrHttps":
-    "Use uma URL de site HTTP ou HTTPS.",
-  "routes.commerceOnboarding.siteUrlLabel": "URL do site",
+    "Use an HTTP or HTTPS website URL.",
+  "routes.commerceOnboarding.siteUrlLabel": "Site URL",
   "routes.commerceOnboarding.siteUrlPlaceholder": "https://example.com",
-  "routes.commerceOnboarding.unlockDiagnostic":
-    "Desbloqueie seu diagnóstico completo",
+  "routes.commerceOnboarding.unlockDiagnostic": "Unlock your full diagnostic",
+  "routes.commerceOnboarding.loading.preparingWorkspace":
+    "Preparing your commerce workspace...",
+  "routes.commerceOnboarding.loading.preparing": "Preparing...",
+  "routes.commerceOnboarding.scheduleMeeting.headline": "Need help? Talk to us",
+  "routes.commerceOnboarding.scheduleMeeting.body":
+    "Schedule a call and we'll help you connect your tools.",
+  "routes.commerceOnboarding.scheduleMeeting.scheduleButton":
+    "Schedule a meeting",
+  "routes.commerceOnboarding.scheduleMeeting.expertAlt": "deco specialist",
+  "routes.commerceOnboarding.connectModal.dialogTitle":
+    "Connect your tools to see the full diagnostic",
+  "routes.commerceOnboarding.connectModal.loadError":
+    "Could not load integrations. You can continue and open the report anyway.",
+  "routes.commerceOnboarding.connectModal.continueButton": "Continue",
+  "routes.commerceOnboarding.connectModal.couldNotGenerateReport":
+    "Could not generate the report for this site. Reload the page and try again.",
+  "routes.commerceOnboarding.connectModal.somethingWentWrong":
+    "Something went wrong generating your report. Try again in a moment.",
+  "routes.commerceOnboarding.connectModal.openingReport": "Opening report...",
+  "routes.commerceOnboarding.connectModal.connectToolToContinue":
+    "Connect a tool to continue",
+  "routes.commerceOnboarding.connectModal.viewFullReport": "View full report",
+  "routes.commerceOnboarding.companionSection.title":
+    "Connect your tools to see the full diagnostic",
+  "routes.commerceOnboarding.companionSection.loadError":
+    "Could not load companion integrations.",
+  "routes.commerceOnboarding.companionSection.loadErrorDescription":
+    "Something went wrong loading your integrations.",
+  "routes.commerceOnboarding.companionSection.retry": "Try again",
   "routes.oauthCallback.authenticationComplete": "Authentication complete.",
   "routes.oauthCallback.authenticationFailed": "MCP authentication failed",
   "routes.oauthCallback.authenticationFailedTitle": "Authentication Failed",

--- a/apps/mesh/src/web/i18n/pt-br/routes.ts
+++ b/apps/mesh/src/web/i18n/pt-br/routes.ts
@@ -121,6 +121,38 @@ export const routes = {
   "routes.commerceOnboarding.siteUrlPlaceholder": "https://example.com",
   "routes.commerceOnboarding.unlockDiagnostic":
     "Desbloqueie seu diagnóstico completo",
+  "routes.commerceOnboarding.loading.preparingWorkspace":
+    "Preparando seu workspace de commerce...",
+  "routes.commerceOnboarding.loading.preparing": "Preparando...",
+  "routes.commerceOnboarding.scheduleMeeting.headline":
+    "Precisa de ajuda? Fale conosco",
+  "routes.commerceOnboarding.scheduleMeeting.body":
+    "Agende uma chamada e ajudamos você a conectar suas ferramentas.",
+  "routes.commerceOnboarding.scheduleMeeting.scheduleButton":
+    "Agendar uma reunião",
+  "routes.commerceOnboarding.scheduleMeeting.expertAlt": "Especialista da deco",
+  "routes.commerceOnboarding.connectModal.dialogTitle":
+    "Conecte suas ferramentas para ver o diagnóstico completo",
+  "routes.commerceOnboarding.connectModal.loadError":
+    "Não foi possível carregar as integrações. Você pode continuar e abrir o relatório mesmo assim.",
+  "routes.commerceOnboarding.connectModal.continueButton": "Continuar",
+  "routes.commerceOnboarding.connectModal.couldNotGenerateReport":
+    "Não foi possível gerar o relatório para este site. Recarregue a página e tente novamente.",
+  "routes.commerceOnboarding.connectModal.somethingWentWrong":
+    "Algo deu errado ao gerar seu relatório. Tente novamente em instantes.",
+  "routes.commerceOnboarding.connectModal.openingReport":
+    "Abrindo relatório...",
+  "routes.commerceOnboarding.connectModal.connectToolToContinue":
+    "Conecte uma ferramenta para continuar",
+  "routes.commerceOnboarding.connectModal.viewFullReport":
+    "Ver relatório completo",
+  "routes.commerceOnboarding.companionSection.title":
+    "Conecte suas ferramentas para ver o diagnóstico completo",
+  "routes.commerceOnboarding.companionSection.loadError":
+    "Não foi possível carregar as integrações complementares.",
+  "routes.commerceOnboarding.companionSection.loadErrorDescription":
+    "Algo deu errado ao carregar suas integrações.",
+  "routes.commerceOnboarding.companionSection.retry": "Tentar novamente",
   "routes.oauthCallback.authenticationComplete": "Autenticação concluída.",
   "routes.oauthCallback.authenticationFailed": "Falha na autenticação do MCP",
   "routes.oauthCallback.authenticationFailedTitle": "Autenticação Falhou",

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -142,9 +142,11 @@ function CommerceOnboardingLayout({
 }: CommerceOnboardingLayoutProps) {
   const search = useSearch({ from: "/commerce-onboarding" });
   const { data: session } = authClient.useSession();
+  const [preferences] = usePreferences();
   const meetingUrl = buildScheduleMeetingUrl({
     siteUrl: search.siteUrl,
     email: session?.user?.email,
+    locale: preferences.language,
   });
 
   return (
@@ -238,10 +240,10 @@ function getCommerceAuthCopy(t: ReturnType<typeof useT>) {
   };
 }
 
-function commerceSiteUrlErrorPtBr(
-  t: ReturnType<typeof useT>,
-  error: string,
-): string {
+// Translates raw error strings (from normalizeReportsSiteUrl or well-known
+// internal sentinels) into the current locale. Dynamic server errors fall
+// through to the default and are shown as-is.
+function translateSiteError(t: ReturnType<typeof useT>, error: string): string {
   switch (error) {
     case "Enter a website URL.":
       return t("routes.commerceOnboarding.siteUrl.enterUrl");
@@ -249,6 +251,8 @@ function commerceSiteUrlErrorPtBr(
       return t("routes.commerceOnboarding.siteUrl.useHttpOrHttps");
     case "Enter a valid website URL.":
       return t("routes.commerceOnboarding.siteUrl.enterValidUrl");
+    case "__configurationFailed":
+      return t("routes.commerceOnboarding.configurationFailed");
     default:
       return error;
   }
@@ -640,9 +644,11 @@ function CommerceSetup({
   initialSiteUrl?: string;
 }) {
   const { data: session } = authClient.useSession();
+  const [preferences] = usePreferences();
   const meetingUrl = buildScheduleMeetingUrl({
     siteUrl: initialSiteUrl,
     email: session?.user?.email,
+    locale: preferences.language,
   });
   const meetingVisual = (
     <ScheduleMeetingVisual href={meetingUrl} orgId={org.id} />
@@ -795,11 +801,10 @@ function CommerceSetupContent({
         organization_id: org.id,
         error: error instanceof Error ? error.message : String(error),
       });
-      // ponytail: error.message is dynamic; only fallback is translated
+      // Dynamic server errors pass through; the static fallback uses a sentinel
+      // translated at render time so it respects language switches.
       setInlineError(
-        error instanceof Error
-          ? error.message
-          : t("routes.commerceOnboarding.configurationFailed"),
+        error instanceof Error ? error.message : "__configurationFailed",
       );
     },
   });
@@ -833,20 +838,26 @@ function CommerceSetupContent({
   const setupReady = connectionExists && claimedForRequestedSite;
   const currentSiteUrl =
     initialSiteUrl || siteUrlInput || connectionSiteUrl || "";
+  const t = useT();
+  const [preferences] = usePreferences();
+
   const currentMeetingUrl = buildScheduleMeetingUrl({
     siteUrl: currentSiteUrl,
     email: sessionEmail,
+    locale: preferences.language,
   });
   const currentMeetingVisual = (
     <ScheduleMeetingVisual href={currentMeetingUrl} orgId={org.id} />
   );
 
-  const t = useT();
+  const translatedError = inlineError
+    ? translateSiteError(t, inlineError)
+    : null;
 
   const runSetup = (rawSiteUrl: string) => {
     const normalized = normalizeReportsSiteUrl(rawSiteUrl);
     if (!normalized.ok) {
-      setInlineError(commerceSiteUrlErrorPtBr(t, normalized.error));
+      setInlineError(normalized.error);
       return;
     }
     setInlineError(null);
@@ -913,12 +924,10 @@ function CommerceSetupContent({
                 { orgName: org.name },
               )}
             />
-            <InlineError
-              message={commerceSiteUrlErrorPtBr(t, normalized.error)}
-            />
+            <InlineError message={translateSiteError(t, normalized.error)} />
             <SiteUrlForm
               siteUrl={siteUrlInput}
-              error={inlineError}
+              error={translatedError}
               isSubmitting={setupMutation.isPending}
               onSiteUrlChange={setSiteUrlInput}
               onSubmit={handleSubmit}
@@ -938,9 +947,9 @@ function CommerceSetupContent({
               { url: normalized.value },
             )}
           />
-          {inlineError ? (
+          {translatedError ? (
             <>
-              <InlineError message={inlineError} />
+              <InlineError message={translatedError} />
               <SiteUrlForm
                 siteUrl={siteUrlInput}
                 error={null}
@@ -969,7 +978,7 @@ function CommerceSetupContent({
         />
         <SiteUrlForm
           siteUrl={siteUrlInput}
-          error={inlineError}
+          error={translatedError}
           isSubmitting={setupMutation.isPending}
           onSiteUrlChange={setSiteUrlInput}
           onSubmit={handleSubmit}

--- a/apps/mesh/src/web/routes/commerce-onboarding/commerce-connect-modal.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/commerce-connect-modal.tsx
@@ -1,6 +1,8 @@
 import { normalizeReportsSiteUrl, siteUrlToHost } from "@/reports/site-url";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { authClient } from "@/web/lib/auth-client";
+import { useT } from "@/web/i18n/use-t.ts";
+import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { track } from "@/web/lib/posthog-client";
 import { KEYS } from "@/web/lib/query-keys";
@@ -49,6 +51,7 @@ import { SiteBadge } from "./site-badge.tsx";
 export function CommerceConnectModal({ siteUrl }: { siteUrl?: string }) {
   const navigate = useNavigate();
   const { org } = useProjectContext();
+  const t = useT();
 
   // Completing the connect step opens the diagnostic report in a fresh thread.
   // That navigation also drops the `?connect=1` param, which unmounts this modal
@@ -86,14 +89,13 @@ export function CommerceConnectModal({ siteUrl }: { siteUrl?: string }) {
           className="bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 flex h-[calc(100dvh-1rem)] w-full max-w-[calc(100%-1rem)] translate-x-[-50%] translate-y-[-50%] flex-col overflow-hidden rounded-2xl border p-0 shadow-md duration-200 sm:max-w-lg md:h-auto md:max-h-[calc(100dvh-2rem)] lg:max-h-[calc(100dvh-4rem)] lg:max-w-5xl"
         >
           <DialogTitle className="sr-only">
-            Conecte suas ferramentas para ver o diagnóstico completo
+            {t("routes.commerceOnboarding.connectModal.dialogTitle")}
           </DialogTitle>
           <ErrorBoundary
             fallback={() => (
               <div className="grid gap-4 p-6">
                 <p className="text-sm text-muted-foreground">
-                  Não foi possível carregar as integrações. Você pode continuar
-                  e abrir o relatório mesmo assim.
+                  {t("routes.commerceOnboarding.connectModal.loadError")}
                 </p>
                 <Button
                   type="button"
@@ -101,7 +103,7 @@ export function CommerceConnectModal({ siteUrl }: { siteUrl?: string }) {
                   className="w-full"
                   onClick={goToReport}
                 >
-                  Continuar
+                  {t("routes.commerceOnboarding.connectModal.continueButton")}
                   <ArrowRight size={18} />
                 </Button>
               </div>
@@ -127,6 +129,8 @@ function CommerceConnectModalContent({
   siteUrlFromUrl?: string;
   onComplete: () => void;
 }) {
+  const t = useT();
+  const [preferences] = usePreferences();
   const { org } = useProjectContext();
   const { data: session } = authClient.useSession();
   const connectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
@@ -190,6 +194,7 @@ function CommerceConnectModalContent({
   const meetingUrl = buildScheduleMeetingUrl({
     siteUrl,
     email: session?.user?.email,
+    locale: preferences.language,
   });
 
   const openReport = async () => {
@@ -227,7 +232,7 @@ function CommerceConnectModalContent({
             error: runResult.reason ?? "not_triggered",
           });
           setRunError(
-            "Não foi possível gerar o relatório para este site. Recarregue a página e tente novamente.",
+            t("routes.commerceOnboarding.connectModal.couldNotGenerateReport"),
           );
           return;
         }
@@ -238,7 +243,7 @@ function CommerceConnectModalContent({
           error: err instanceof Error ? err.message : String(err),
         });
         setRunError(
-          "Algo deu errado ao gerar seu relatório. Tente novamente em instantes.",
+          t("routes.commerceOnboarding.connectModal.somethingWentWrong"),
         );
         return;
       }
@@ -283,10 +288,12 @@ function CommerceConnectModalContent({
             disabled={runMutation.isPending || !hasConnectedSource}
           >
             {runMutation.isPending
-              ? "Abrindo relatório..."
+              ? t("routes.commerceOnboarding.connectModal.openingReport")
               : !hasConnectedSource
-                ? "Conecte uma ferramenta para continuar"
-                : "Ver relatório completo"}
+                ? t(
+                    "routes.commerceOnboarding.connectModal.connectToolToContinue",
+                  )
+                : t("routes.commerceOnboarding.connectModal.viewFullReport")}
             {!runMutation.isPending && hasConnectedSource ? (
               <ArrowRight size={18} />
             ) : null}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -2,6 +2,7 @@ import { normalizeReportsSiteUrl } from "@/reports/site-url";
 import { ErrorBoundary } from "@/web/components/error-boundary";
 import { ScrollReveal } from "@/web/components/scroll-reveal";
 import { authClient } from "@/web/lib/auth-client";
+import { useT } from "@/web/i18n/use-t.ts";
 import { SELF_MCP_ALIAS_ID, useMCPClient } from "@decocms/mesh-sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { QueryErrorResetBoundary } from "@tanstack/react-query";
@@ -22,11 +23,12 @@ const SECTION_CONTAINER_CLASS =
   "flex min-h-0 flex-1 flex-col gap-4 md:grid md:flex-none md:gap-4";
 
 function SectionIntro() {
+  const t = useT();
   // Matches the onboarding title scale (CommerceHeader / auth screen use the
   // same text-2xl font-medium leading-8).
   return (
     <h1 className="text-lg font-medium leading-6 text-foreground lg:text-2xl lg:leading-8">
-      Conecte suas ferramentas para ver o diagnóstico completo
+      {t("routes.commerceOnboarding.companionSection.title")}
     </h1>
   );
 }
@@ -55,6 +57,7 @@ export function CompanionMcpsSectionSkeleton() {
 }
 
 function CompanionMcpsSectionError({ onRetry }: { onRetry: () => void }) {
+  const t = useT();
   return (
     <div className={SECTION_CONTAINER_CLASS}>
       <SectionIntro />
@@ -63,10 +66,10 @@ function CompanionMcpsSectionError({ onRetry }: { onRetry: () => void }) {
         className="rounded-2xl border border-border bg-card p-4"
       >
         <p className="text-sm text-foreground">
-          Não foi possível carregar as integrações complementares.
+          {t("routes.commerceOnboarding.companionSection.loadError")}
         </p>
         <p className="mt-1 text-sm text-muted-foreground">
-          Algo deu errado ao carregar suas integrações.
+          {t("routes.commerceOnboarding.companionSection.loadErrorDescription")}
         </p>
         <Button
           type="button"
@@ -75,7 +78,7 @@ function CompanionMcpsSectionError({ onRetry }: { onRetry: () => void }) {
           className="mt-3"
           onClick={onRetry}
         >
-          Tentar novamente
+          {t("routes.commerceOnboarding.companionSection.retry")}
         </Button>
       </div>
     </div>

--- a/apps/mesh/src/web/routes/commerce-onboarding/loading-state.test.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/loading-state.test.tsx
@@ -1,23 +1,26 @@
 import { setupComponentTest } from "../../../test/setup";
 setupComponentTest();
 
-import { render } from "@testing-library/react";
+import { render as renderBare } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { describe, expect, test } from "bun:test";
-import {
-  CommerceOnboardingLoading,
-  getCommerceOnboardingLoadingLabel,
-} from "./loading-state";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { CommerceOnboardingLoading } from "./loading-state";
 import { CompanionMcpsSectionSkeleton } from "./companion-mcps-section";
 
-describe("commerce onboarding loading state", () => {
-  test("centralizes copy for full-page loading variants", () => {
-    expect(getCommerceOnboardingLoadingLabel("workspace")).toBe(
-      "Preparando seu workspace de commerce...",
-    );
-    expect(getCommerceOnboardingLoadingLabel("generic")).toBe("Preparando...");
+// useT() reads language preference through TanStack Query — renders need a
+// QueryClientProvider.
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
   });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+const render = (ui: Parameters<typeof renderBare>[0]) =>
+  renderBare(ui, { wrapper });
 
+describe("commerce onboarding loading state", () => {
   test("renders the full-page loading shell", () => {
     const { getByRole, getByText } = render(
       <CommerceOnboardingLoading variant="workspace" />,
@@ -25,7 +28,7 @@ describe("commerce onboarding loading state", () => {
 
     expect(getByRole("status")).toBeInTheDocument();
     expect(
-      getByText("Preparando seu workspace de commerce..."),
+      getByText("Preparing your commerce workspace..."),
     ).toBeInTheDocument();
   });
 
@@ -33,7 +36,7 @@ describe("commerce onboarding loading state", () => {
     const { getByText, container } = render(<CompanionMcpsSectionSkeleton />);
 
     expect(
-      getByText("Conecte suas ferramentas para ver o diagnóstico completo"),
+      getByText("Connect your tools to see the full diagnostic"),
     ).toBeInTheDocument();
     // 4 skeleton cards × 4 pulse nodes each (icon, title, benefit line, action)
     expect(container.querySelectorAll(".animate-pulse")).toHaveLength(16);

--- a/apps/mesh/src/web/routes/commerce-onboarding/loading-state.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/loading-state.tsx
@@ -1,21 +1,8 @@
 import { AuthSplitLayout } from "@/web/components/auth-split-layout";
+import { useT } from "@/web/i18n/use-t.ts";
 import { LoadingIndicator } from "./loading-indicator.tsx";
 
 export type CommerceOnboardingLoadingVariant = "workspace" | "generic";
-
-const COMMERCE_ONBOARDING_LOADING_LABELS: Record<
-  CommerceOnboardingLoadingVariant,
-  string
-> = {
-  workspace: "Preparando seu workspace de commerce...",
-  generic: "Preparando...",
-};
-
-export function getCommerceOnboardingLoadingLabel(
-  variant: CommerceOnboardingLoadingVariant,
-): string {
-  return COMMERCE_ONBOARDING_LOADING_LABELS[variant];
-}
 
 export function CommerceOnboardingLoading({
   variant,
@@ -34,12 +21,15 @@ export function CommerceOnboardingLoadingIndicator({
 }: {
   variant: CommerceOnboardingLoadingVariant;
 }) {
+  const t = useT();
+  const label =
+    variant === "workspace"
+      ? t("routes.commerceOnboarding.loading.preparingWorkspace")
+      : t("routes.commerceOnboarding.loading.preparing");
+
   return (
     <div className="flex justify-center py-4" role="status" aria-live="polite">
-      <LoadingIndicator
-        label={getCommerceOnboardingLoadingLabel(variant)}
-        className="text-muted-foreground"
-      />
+      <LoadingIndicator label={label} className="text-muted-foreground" />
     </div>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
@@ -1,3 +1,4 @@
+import { useT } from "@/web/i18n/use-t.ts";
 import { track } from "@/web/lib/posthog-client";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
@@ -5,33 +6,15 @@ import { ArrowUpRight } from "@untitledui/icons";
 
 type MeetingCtaPlacement = "visual_card" | "mobile_banner";
 
-/**
- * Where "Schedule a meeting" sends people who'd rather have us run the
- * diagnostic live, don't have access to their tools yet, or aren't ready to
- * grant it. Books onto the deco commerce team calendar. Swap the URL to
- * repoint the calendar.
- */
-const SCHEDULE_MEETING_URL = "https://decocms.com/agendar";
+const SCHEDULE_MEETING_URLS: Record<string, string> = {
+  "pt-BR": "https://decocms.com/agendar",
+  en: "https://www.decocms.com/en/schedule",
+};
 
-const HEADLINE = "Precisa de ajuda? Fale conosco";
-const BODY = "Agende uma chamada e ajudamos você a conectar suas ferramentas.";
-
-const TEAM = [
-  {
-    photo:
-      "https://decoims.com/image?src=decocms%2Fb07a1c19-0cd6-49c8-b326-86055ee78605%2Fauthor-1763423987973-baby.jpeg&quality=original&fit=cover&width=200&height=200",
-    alt: "Especialista da deco",
-  },
-  {
-    photo:
-      "https://decoims.com/decocms/07c2daf4-a3c2-485e-a1a8-341585a06e3b/cecilia.png",
-    alt: "Especialista da deco",
-  },
-  {
-    photo:
-      "https://decoims.com/decocms/48013ca2-3277-464b-b0f1-dd5f1f08d986/tavano.png",
-    alt: "Especialista da deco",
-  },
+const TEAM_PHOTOS = [
+  "https://decoims.com/image?src=decocms%2Fb07a1c19-0cd6-49c8-b326-86055ee78605%2Fauthor-1763423987973-baby.jpeg&quality=original&fit=cover&width=200&height=200",
+  "https://decoims.com/decocms/07c2daf4-a3c2-485e-a1a8-341585a06e3b/cecilia.png",
+  "https://decoims.com/decocms/48013ca2-3277-464b-b0f1-dd5f1f08d986/tavano.png",
 ] as const;
 
 const GREEN_DARK = "var(--brand-green-dark)";
@@ -39,23 +22,30 @@ const GREEN_DARK = "var(--brand-green-dark)";
 /**
  * Build the scheduling link, prefilling the site under diagnosis and the
  * signed-in user's email as query params so the booking page arrives with
- * context (both omitted when unknown).
+ * context (both omitted when unknown). Pass `locale` to get the right
+ * language-specific booking page.
  */
 export function buildScheduleMeetingUrl({
   siteUrl,
   email,
+  locale,
 }: {
   siteUrl?: string | null;
   email?: string | null;
+  locale?: string | null;
 }): string {
-  const url = new URL(SCHEDULE_MEETING_URL);
+  const base =
+    (locale && SCHEDULE_MEETING_URLS[locale]) ??
+    SCHEDULE_MEETING_URLS["pt-BR"] ??
+    "https://decocms.com/agendar";
+  const url = new URL(base);
   if (siteUrl) url.searchParams.set("siteUrl", siteUrl);
   if (email) url.searchParams.set("email", email);
   return url.toString();
 }
 
 function ScheduleMeetingCta({
-  href = SCHEDULE_MEETING_URL,
+  href,
   size = "lg",
   className,
   orgId,
@@ -65,6 +55,7 @@ function ScheduleMeetingCta({
   className?: string;
   orgId?: string;
 }) {
+  const t = useT();
   return (
     // Same style as the left-side "Conectar" buttons (outline) for consistency
     // across the onboarding screen.
@@ -85,7 +76,7 @@ function ScheduleMeetingCta({
           })
         }
       >
-        Agendar uma reunião
+        {t("routes.commerceOnboarding.scheduleMeeting.scheduleButton")}
         <ArrowUpRight size={16} />
       </a>
     </Button>
@@ -93,24 +84,26 @@ function ScheduleMeetingCta({
 }
 
 function TeamAvatars({ size = 72 }: { size?: number }) {
+  const t = useT();
+  const alt = t("routes.commerceOnboarding.scheduleMeeting.expertAlt");
   const overlap = Math.round(size * 0.3);
   return (
     <div className="flex items-end" style={{ height: size }}>
-      {TEAM.map((member, i) => (
+      {TEAM_PHOTOS.map((photo, i) => (
         <div
-          key={member.photo}
+          key={photo}
           className="relative shrink-0"
           style={{
             width: size,
             height: size,
             marginLeft: i === 0 ? 0 : -overlap,
-            zIndex: TEAM.length - i,
+            zIndex: TEAM_PHOTOS.length - i,
           }}
         >
           <div className="h-full w-full overflow-hidden rounded-full border-4 border-card bg-muted">
             <img
-              src={member.photo}
-              alt={member.alt}
+              src={photo}
+              alt={alt}
               className="h-full w-full object-cover"
               loading="lazy"
             />
@@ -146,6 +139,7 @@ export function ScheduleMeetingVisual({
   href?: string;
   orgId?: string;
 }) {
+  const t = useT();
   return (
     <div className="relative flex h-full w-full items-center justify-center p-10">
       {/* Bigger footprint (wide card + generous padding); content stays at its
@@ -162,9 +156,11 @@ export function ScheduleMeetingVisual({
 
           <div className="grid gap-1.5">
             <h2 className="text-lg font-medium leading-6 text-foreground">
-              {HEADLINE}
+              {t("routes.commerceOnboarding.scheduleMeeting.headline")}
             </h2>
-            <p className="text-sm leading-5 text-muted-foreground">{BODY}</p>
+            <p className="text-sm leading-5 text-muted-foreground">
+              {t("routes.commerceOnboarding.scheduleMeeting.body")}
+            </p>
           </div>
 
           <ScheduleMeetingCta
@@ -186,13 +182,15 @@ export function ScheduleMeetingVisual({
  */
 export function ScheduleMeetingBanner({
   className,
-  href = SCHEDULE_MEETING_URL,
+  href,
   orgId,
 }: {
   className?: string;
   href?: string;
   orgId?: string;
 }) {
+  const t = useT();
+  const alt = t("routes.commerceOnboarding.scheduleMeeting.expertAlt");
   return (
     <a
       href={href}
@@ -213,15 +211,18 @@ export function ScheduleMeetingBanner({
         className="relative flex shrink-0 items-center"
         style={{ height: 32, width: 32 + 2 * Math.round(32 * 0.7) }}
       >
-        {TEAM.map((member, i) => (
+        {TEAM_PHOTOS.map((photo, i) => (
           <span
-            key={member.photo}
+            key={photo}
             className="absolute block h-8 w-8 overflow-hidden rounded-full border-2 border-card"
-            style={{ left: i * Math.round(32 * 0.7), zIndex: TEAM.length - i }}
+            style={{
+              left: i * Math.round(32 * 0.7),
+              zIndex: TEAM_PHOTOS.length - i,
+            }}
           >
             <img
-              src={member.photo}
-              alt={member.alt}
+              src={photo}
+              alt={alt}
               className="h-full w-full object-cover"
               loading="lazy"
             />
@@ -230,13 +231,13 @@ export function ScheduleMeetingBanner({
         <span
           className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full border-2 border-card bg-success"
           aria-hidden
-          style={{ zIndex: TEAM.length + 1 }}
+          style={{ zIndex: TEAM_PHOTOS.length + 1 }}
         />
       </span>
       {/* Mobile-only banner: compact single line (the desktop
           ScheduleMeetingVisual keeps the full headline + description). */}
       <span className="flex-1 text-sm font-medium leading-tight text-foreground">
-        Precisa de ajuda? Fale conosco
+        {t("routes.commerceOnboarding.scheduleMeeting.headline")}
       </span>
       <ArrowUpRight size={16} className="shrink-0 text-muted-foreground" />
     </a>

--- a/packages/e2e/tests/commerce-onboarding.spec.ts
+++ b/packages/e2e/tests/commerce-onboarding.spec.ts
@@ -50,20 +50,22 @@ function commerceDiscoveryVirtualMcpId(orgId: string) {
 }
 
 async function signUpOnCurrentLoginPage(page: Page, email: string) {
-  const nameField = page.getByPlaceholder("Seu nome");
+  const nameField = page.getByPlaceholder(/Your name|Seu nome/);
   const inSignupMode = await nameField
     .waitFor({ state: "visible", timeout: 2000 })
     .then(() => true)
     .catch(() => false);
   if (!inSignupMode) {
-    await page.getByRole("button", { name: /^(Sign up|Criar conta)$/ }).click();
+    await page
+      .getByRole("button", { name: /^(Sign up|Create account|Criar conta)$/ })
+      .click();
     await nameField.waitFor({ state: "visible" });
   }
 
   await nameField.fill(`Commerce ${Date.now()}`);
   await page.getByPlaceholder("you@example.com").fill(email);
   await page.getByPlaceholder("••••••••").fill(PASSWORD);
-  await page.getByRole("button", { name: "Continuar" }).click();
+  await page.getByRole("button", { name: /^(Continue|Continuar)$/ }).click();
 }
 
 async function waitForConnection(db: Client, id: string) {
@@ -245,7 +247,7 @@ test.describe("Commerce onboarding route isolation", () => {
     await expect(page.getByPlaceholder("you@example.com")).toBeVisible();
     await expect(
       page.getByRole("heading", {
-        name: "Precisa de ajuda? Fale conosco",
+        name: "Need help? Talk to us",
       }),
     ).toBeVisible();
 
@@ -253,12 +255,12 @@ test.describe("Commerce onboarding route isolation", () => {
 
     // After site setup the flow hands off to the org: it redirects off
     // /commerce-onboarding to the report route, where the blocking connections
-    // modal (with the "Ver relatório completo" CTA) opens over the report.
+    // modal (with the "View full report" CTA) opens over the report.
     await page.waitForURL((url) => url.pathname !== "/commerce-onboarding", {
       timeout: 20_000,
     });
     await expect(
-      page.getByRole("button", { name: "Ver relatório completo" }),
+      page.getByRole("button", { name: "View full report" }),
     ).toBeVisible({
       timeout: 20_000,
     });
@@ -281,7 +283,7 @@ test.describe("Commerce onboarding route isolation", () => {
     await page.goto("/commerce-onboarding?siteUrl=https://example.com/path");
 
     await expect(
-      page.getByRole("button", { name: "Ver relatório completo" }),
+      page.getByRole("button", { name: "View full report" }),
     ).toBeVisible({
       timeout: 20_000,
     });
@@ -342,16 +344,16 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding?siteUrl=example.com");
     await expect(
-      page.getByRole("button", { name: "Ver relatório completo" }),
+      page.getByRole("button", { name: "View full report" }),
     ).toBeVisible({
       timeout: 20_000,
     });
 
     await page.goto("/commerce-onboarding");
 
-    await expect(page.getByLabel("URL do site")).toHaveCount(0);
+    await expect(page.getByLabel("Site URL")).toHaveCount(0);
     await expect(
-      page.getByRole("button", { name: "Ver relatório completo" }),
+      page.getByRole("button", { name: "View full report" }),
     ).toBeVisible({
       timeout: 20_000,
     });
@@ -384,10 +386,10 @@ test.describe("Commerce onboarding route isolation", () => {
     await page.goto("/commerce-onboarding?siteUrl=example.com");
 
     const loading = page.getByText(
-      "Conecte suas ferramentas para ver o diagnóstico completo",
+      "Connect your tools to see the full diagnostic",
     );
     const meetingHeading = page.getByRole("heading", {
-      name: "Precisa de ajuda? Fale conosco",
+      name: "Need help? Talk to us",
     });
 
     await expect(loading).toBeVisible();
@@ -398,7 +400,7 @@ test.describe("Commerce onboarding route isolation", () => {
       timeout: 1_000,
     });
     await expect(
-      page.getByRole("button", { name: "Ver relatório completo" }),
+      page.getByRole("button", { name: "View full report" }),
     ).toBeVisible({ timeout: 20_000 });
   });
 
@@ -413,17 +415,17 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding");
 
-    await expect(page.getByLabel("URL do site")).toBeVisible();
-    await page.getByLabel("URL do site").fill("ftp://example.com");
-    await page.getByRole("button", { name: "Continuar" }).click();
+    await expect(page.getByLabel("Site URL")).toBeVisible();
+    await page.getByLabel("Site URL").fill("ftp://example.com");
+    await page.getByRole("button", { name: "Continue" }).click();
     await expect(
-      page.getByText("Use uma URL de site HTTP ou HTTPS."),
+      page.getByText("Use an HTTP or HTTPS website URL."),
     ).toBeVisible();
 
-    await page.getByLabel("URL do site").fill("example.com");
-    await page.getByRole("button", { name: "Continuar" }).click();
+    await page.getByLabel("Site URL").fill("example.com");
+    await page.getByRole("button", { name: "Continue" }).click();
     await expect(
-      page.getByRole("button", { name: "Ver relatório completo" }),
+      page.getByRole("button", { name: "View full report" }),
     ).toBeVisible({
       timeout: 20_000,
     });
@@ -444,9 +446,9 @@ test.describe("Commerce onboarding route isolation", () => {
 
     // The connect step is a blocking modal over the org: it must NOT be
     // dismissable. Pressing Escape leaves it open; the only way forward is the
-    // "Ver relatório completo" CTA.
+    // "View full report" CTA.
     const reportCta = page.getByRole("button", {
-      name: "Ver relatório completo",
+      name: "View full report",
     });
     await expect(reportCta).toBeVisible({ timeout: 20_000 });
     await page.keyboard.press("Escape");
@@ -501,7 +503,7 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding");
 
-    await expect(page.getByLabel("URL do site")).toBeVisible();
+    await expect(page.getByLabel("Site URL")).toBeVisible();
     expect(new URL(page.url()).pathname).toBe("/commerce-onboarding");
 
     const orgId = await orgIdForSlug(db, expectedSlug);
@@ -547,7 +549,7 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding");
 
-    await expect(page.getByLabel("URL do site")).toBeVisible();
+    await expect(page.getByLabel("Site URL")).toBeVisible();
     expect(new URL(page.url()).pathname).toBe("/commerce-onboarding");
 
     const memberRow = await db.query<{ id: string }>(
@@ -617,7 +619,7 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding");
 
-    await expect(page.getByLabel("URL do site")).toBeVisible();
+    await expect(page.getByLabel("Site URL")).toBeVisible();
     expect(new URL(page.url()).pathname).toBe("/commerce-onboarding");
 
     const createdOrgId = await orgIdForSlug(db, expectedSlug);
@@ -678,7 +680,7 @@ test.describe("Commerce onboarding route isolation", () => {
     await page.goto("/onboarding");
 
     await expect(page).toHaveURL((url) => url.pathname === "/onboarding");
-    await expect(page.getByLabel("URL do site")).toHaveCount(0);
+    await expect(page.getByLabel("Site URL")).toHaveCount(0);
     await expect(page.getByText("Commerce Discovery")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## What is this contribution about?

Wires the entire `/commerce-onboarding` route and its sub-components (`loading-state`, `schedule-meeting`, `commerce-connect-modal`, `companion-mcps-section`) through the i18n system. All previously hardcoded Portuguese strings now go through `useT()`. The EN dictionary (`en/routes.ts`) had incorrect Portuguese values for all `commerceOnboarding.*` keys — these are corrected to English, and 18 new keys are added for previously uncovered strings. URL validation error messages are made locale-reactive by storing raw sentinel strings in state and translating at render time instead of pre-translating at `setInlineError` call time. The schedule-meeting CTA links to `https://www.decocms.com/en/schedule` in EN and `https://decocms.com/agendar` in PT-BR.

## Screenshots/Demonstration

> Switch language to EN in preferences and visit `/commerce-onboarding` — all copy, error messages, and the scheduling CTA should render in English.

## How to Test

1. Go to `/commerce-onboarding` with language set to PT-BR — verify all copy is Portuguese.
2. Switch language to English in preferences — verify all copy, loading labels, modal strings, error messages, and the schedule-meeting card update to English.
3. Submit an invalid URL in the site URL field — verify the error message shows in the selected language.
4. Confirm the "Schedule a meeting" button in EN mode links to `https://www.decocms.com/en/schedule`.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internationalized the `/commerce-onboarding` route and its sub-components using `useT()`. EN copy is fixed, new keys are added, and URL errors and scheduling links now respect the selected language.

- **New Features**
  - Wired `loading-state`, `schedule-meeting`, `commerce-connect-modal`, and `companion-mcps-section` to `useT()`.
  - Added i18n keys for loading, schedule, connect modal, and companion sections in `en/routes.ts` and `pt-br/routes.ts`.
  - Locale-reactive site URL errors via raw sentinels translated at render; meeting URL now uses `usePreferences()` locale (EN → https://www.decocms.com/en/schedule, PT-BR → https://decocms.com/agendar).

- **Bug Fixes**
  - Fixed `en/routes.ts` where `commerceOnboarding.*` strings were in Portuguese.
  - Updated loading-state tests to wrap with `QueryClientProvider` from `@tanstack/react-query`.
  - Updated e2e tests to assert EN strings and use regex selectors to tolerate either locale.

<sup>Written for commit 6b55e6df4320bbd42e93e4e658c8885efedc120f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

