### PR TITLE
fix(pwa): remove titleless chat inset

### DIFF
--- a/apps/mesh/index.css
+++ b/apps/mesh/index.css
@@ -35,15 +35,15 @@
 /* Window Controls Overlay (installed PWA on Chromium):
    The toolbar header is already the top element of the flex shell, so all
    we need to do is (1) make its background act as the OS drag region,
-   (2) inset its content to clear the OS title-bar controls on the left
-   and right, (3) hide elements that duplicate the chrome (e.g. app logo),
-   and (4) opt buttons back to clickable.
+   (2) inset its content on the right to clear the OS title-bar controls,
+   (3) hide elements that duplicate the chrome (e.g. app logo),
+   and (4) opt buttons back to clickable. The sidebar owns the left control
+   area, so the app toolbar must not reserve it again.
 
    Lives outside @layer base so it wins against Tailwind utilities like
    h-12, pl-1, pr-2 that would otherwise cascade later. */
 @media (display-mode: window-controls-overlay) {
   .app-titlebar {
-    padding-left: env(titlebar-area-x, 0);
     padding-right: calc(
       100vw -
       env(titlebar-area-x, 0) -


### PR DESCRIPTION
## Summary
- remove the duplicate left Window Controls Overlay inset from the app toolbar
- preserve the sidebar reservation for native window controls

## Verification
- bun run fmt
- bun run fmt:check
- bun run --cwd=apps/mesh build:client

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the left inset from the PWA titlebar to stop double-reserving space for window controls. The sidebar keeps the left control area, and the toolbar now only reserves space on the right.

<sup>Written for commit 75b9c52a914c96af9cc9c1e03df26ec1c50c3b00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

