### PR TITLE
fix(sandbox-preview): add aria-label to icon-only toolbar buttons

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -1014,7 +1014,12 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
               <div className="flex w-full min-w-0 max-w-[500px] items-center gap-0.5">
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button variant="ghost" size="icon" onClick={handleRefresh}>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={handleRefresh}
+                      aria-label={t("sandbox.preview.refresh")}
+                    >
                       <RefreshCw01 size={14} />
                     </Button>
                   </TooltipTrigger>
@@ -1268,6 +1273,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                         const url = iframeSrc ?? previewState.previewUrl;
                         if (url) window.open(url, "_blank", "noopener");
                       }}
+                      aria-label={t("sandbox.preview.openInNewTab")}
                     >
                       <LinkExternal01 size={14} />
                     </Button>
@@ -1281,7 +1287,11 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
               <div className="flex shrink-0 items-center">
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="icon">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label={t("sandbox.preview.moreOptions")}
+                    >
                       <DotsHorizontal size={14} />
                     </Button>
                   </DropdownMenuTrigger>

--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -369,6 +369,7 @@ export const sandbox = {
   "sandbox.preview.globalComponents": "Global components",
   "sandbox.preview.hardReload": "Hard Reload",
   "sandbox.preview.invalidPageBlockKey": "Invalid page block key",
+  "sandbox.preview.moreOptions": "More options",
   "sandbox.preview.noPagesFound": "No pages found in this site.",
   "sandbox.preview.noSearchResults": "No results match your search.",
   "sandbox.preview.noServerRunning": "No server running",

--- a/apps/mesh/src/web/i18n/pt-br/sandbox.ts
+++ b/apps/mesh/src/web/i18n/pt-br/sandbox.ts
@@ -384,6 +384,7 @@ export const sandbox = {
   "sandbox.preview.globalComponents": "Componentes globais",
   "sandbox.preview.hardReload": "Recarregamento forçado",
   "sandbox.preview.invalidPageBlockKey": "Chave de bloco de página inválida",
+  "sandbox.preview.moreOptions": "Mais opções",
   "sandbox.preview.noPagesFound": "Nenhuma página encontrada neste site.",
   "sandbox.preview.noSearchResults":
     "Nenhum resultado corresponde à sua pesquisa.",


### PR DESCRIPTION
Bug found while auditing `apps/mesh/src/web/components/sandbox/preview/preview.tsx` (the sandbox preview toolbar) for accessibility gaps.

Three icon-only `<Button size="icon">` controls in the preview toolbar — Refresh, "Open in new tab", and the overflow (`DotsHorizontal`) menu trigger — had no `aria-label`. Each is wrapped in a `Tooltip`, but tooltip content is not exposed as the accessible name by default (it's not wired via `aria-describedby`/`aria-labelledby`), so a screen reader announces these as unlabeled "button" elements — a real a11y gap for anyone navigating the toolbar non-visually.

Fix: added `aria-label` to all three, reusing the existing tooltip copy (`sandbox.preview.refresh`, `sandbox.preview.openInNewTab`) plus one new i18n key (`sandbox.preview.moreOptions`, mirrored in `en`/`pt-br` dictionaries) for the overflow trigger, which had no existing label.

To confirm: open the sandbox preview toolbar with a screen reader (or inspect the accessible name in devtools) and check the Refresh, Open-in-new-tab, and "..." buttons now have a name.

Verified locally: `bun run fmt` and `cd apps/mesh && bunx tsc --noEmit` both pass. No behavior change — purely additive `aria-label` attributes and one new translation key. Full CI (lint/test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-labels to icon-only buttons in the sandbox preview toolbar so screen readers announce clear names.
Labels applied to Refresh, Open in new tab, and More options (new `sandbox.preview.moreOptions` i18n key added in `en` and `pt-br`).

<sup>Written for commit ea66f081b47c01dcf9b4cc9c661b5a63559c14d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

