### PR TITLE
fix(registry): i18n the QA connections load-error state

### DIFF
--- a/apps/mesh/src/web/i18n/en/registry.ts
+++ b/apps/mesh/src/web/i18n/en/registry.ts
@@ -145,6 +145,8 @@ export const registry = {
     "Hide from private store",
   "registry.monitorConnectionsPanel.hideFromPublicStore":
     "Hide from public store",
+  "registry.monitorConnectionsPanel.loadFailed":
+    "Failed to load QA connections.",
   "registry.monitorConnectionsPanel.needsAuth": "Needs Auth",
   "registry.monitorConnectionsPanel.noConnectionsForFilter":
     'No QA connections for this filter. Click "Sync" to create mappings from store items and pending requests.',
@@ -186,6 +188,7 @@ export const registry = {
     "Token cannot be empty.",
   "registry.monitorConnectionsPanel.tokenManualAuth": "Token/manual auth",
   "registry.monitorConnectionsPanel.tokenSaved": 'Token saved for "{title}"!',
+  "registry.monitorConnectionsPanel.unknownError": "Unknown error",
   "registry.monitorConnectionsPanel.visibilityOnlyForStore":
     "Visibility controls are available only for store items.",
   "registry.monitorConnectionsPanel.visibilityUpdated": "Visibility updated",

--- a/apps/mesh/src/web/i18n/pt-br/registry.ts
+++ b/apps/mesh/src/web/i18n/pt-br/registry.ts
@@ -153,6 +153,8 @@ export const registry = {
     "Ocultar da loja privada",
   "registry.monitorConnectionsPanel.hideFromPublicStore":
     "Ocultar da loja pública",
+  "registry.monitorConnectionsPanel.loadFailed":
+    "Falha ao carregar conexões de QA.",
   "registry.monitorConnectionsPanel.needsAuth": "Requer Autenticação",
   "registry.monitorConnectionsPanel.noConnectionsForFilter":
     'Nenhuma conexão de QA para este filtro. Clique em "Sincronizar" para criar mapeamentos de itens da loja e solicitações pendentes.',
@@ -196,6 +198,7 @@ export const registry = {
   "registry.monitorConnectionsPanel.tokenManualAuth":
     "Token/autenticação manual",
   "registry.monitorConnectionsPanel.tokenSaved": 'Token salvo para "{title}"!',
+  "registry.monitorConnectionsPanel.unknownError": "Erro desconhecido",
   "registry.monitorConnectionsPanel.visibilityOnlyForStore":
     "Os controles de visibilidade estão disponíveis apenas para itens da loja.",
   "registry.monitorConnectionsPanel.visibilityUpdated":

--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -696,12 +696,12 @@ export function MonitorConnectionsPanel() {
         {listQuery.isError ? (
           <div className="p-8 text-center rounded-lg border border-border">
             <p className="text-sm text-destructive">
-              Failed to load QA connections.
+              {t("registry.monitorConnectionsPanel.loadFailed")}
             </p>
             <p className="text-xs text-muted-foreground mt-1">
               {listQuery.error instanceof Error
                 ? listQuery.error.message
-                : "Unknown error"}
+                : t("registry.monitorConnectionsPanel.unknownError")}
             </p>
           </div>
         ) : (


### PR DESCRIPTION
Follows #5029 (fetch-error state for the QA connections panel) and #4971 (i18n extraction sweep, merged the same day) — the two new strings in #5029's error branch (`Failed to load QA connections.` / `Unknown error`) were hardcoded English and slipped past the sweep, even though every other string in this file already goes through `t()`.

A maintainer wants this because `apps/mesh/src/web` has a hard project rule against hardcoded user-facing strings, and this is the one spot in an otherwise fully-translated file that regresses it — a pt-br user hitting a QA-connections fetch failure currently sees English.

Change: added `registry.monitorConnectionsPanel.loadFailed` / `.unknownError` keys to both `en/registry.ts` and `pt-br/registry.ts`, and swapped the two hardcoded strings in `monitor-connections-panel.tsx` for `t()` calls. No logic change — same error branch, same conditions, just translated text.

To confirm: `cd apps/mesh && bunx tsc --noEmit` (clean — proves the new i18n keys typecheck against `TranslationKey`), and read the diff — it's a pure string swap.

Locally ran: `bun run fmt` (no changes) and `bunx tsc --noEmit` in `apps/mesh` (clean). No test file covers this component's render tree, so nothing targeted to run; full CI will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internationalized the QA connections load-error state by replacing hardcoded English strings with `t()` keys, so users see localized messages on fetch failures. No logic changes.

- **Bug Fixes**
  - Added `registry.monitorConnectionsPanel.loadFailed` and `registry.monitorConnectionsPanel.unknownError` to `en/registry.ts` and `pt-br/registry.ts`.
  - Updated `monitor-connections-panel.tsx` to use these keys via `t()`.

<sup>Written for commit 961b067814dabf7455d88e6944292f8c5073c257. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

