### PR TITLE
fix(chat): don't submit the draft when Enter is pressed to select a suggestion

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -423,6 +423,11 @@ export function ChatInput({
     selectedModel?.limits?.contextWindow;
 
   const tiptapRef = useRef<TiptapInputHandle | null>(null);
+  // True while the @/ suggestion dropdown is open — read by TiptapProvider's
+  // Enter-to-submit handler so selecting a suggestion doesn't also send the
+  // still-unresolved draft (ProseMirror's keydown listener runs before the
+  // suggestion's own, see tiptap/input.tsx).
+  const suggestionOpenRef = useRef(false);
 
   const isPlanMode = chatMode === "plan";
 
@@ -531,6 +536,7 @@ export function ChatInput({
             enterToSubmit={true}
             placeholder={t("chat.input.placeholder")}
             onSubmit={handleSubmit}
+            suggestionOpenRef={suggestionOpenRef}
           >
             <form
               onSubmit={handleSubmit}
@@ -552,6 +558,7 @@ export function ChatInput({
                   showFileUploader={true}
                   selectedModel={selectedModel}
                   onUnsupportedFile={onUnsupportedFile}
+                  suggestionOpenRef={suggestionOpenRef}
                 />
               </div>
 

--- a/apps/mesh/src/web/components/chat/tiptap/input.test.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/input.test.tsx
@@ -1,7 +1,7 @@
 import { setupComponentTest } from "../../../../test/setup";
 setupComponentTest();
 import { describe, expect, it } from "bun:test";
-import { render as renderBare } from "@testing-library/react";
+import { fireEvent, render as renderBare } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
@@ -48,6 +48,40 @@ describe("TiptapProvider disabled", () => {
     const { container } = renderProvider(false);
     const editable = container.querySelector("[contenteditable]");
     expect(editable?.getAttribute("contenteditable")).toBe("true");
+  });
+});
+
+describe("TiptapProvider enter-to-submit vs. an open suggestion dropdown", () => {
+  // ProseMirror's own keydown listener runs before the @/ mention picker's
+  // (it's registered at editor mount, well before the picker ever opens —
+  // see the comment on suggestionOpenRef in input.tsx). Without the guard,
+  // pressing Enter to select a suggestion would also submit the draft.
+  function renderSubmittable(suggestionOpenRef: { current: boolean }) {
+    let submitCount = 0;
+    const { container } = render(
+      <TiptapProvider
+        tiptapDoc={undefined}
+        setTiptapDoc={() => {}}
+        enterToSubmit={true}
+        onSubmit={() => {
+          submitCount++;
+        }}
+        suggestionOpenRef={suggestionOpenRef}
+      >
+        <EditableProbe />
+      </TiptapProvider>,
+    );
+    const editable = container.querySelector("[contenteditable]")!;
+    fireEvent.keyDown(editable, { key: "Enter", code: "Enter" });
+    return submitCount;
+  }
+
+  it("submits on Enter when no suggestion dropdown is open", () => {
+    expect(renderSubmittable({ current: false })).toBe(1);
+  });
+
+  it("does not submit on Enter while a suggestion dropdown is open", () => {
+    expect(renderSubmittable({ current: true })).toBe(0);
   });
 });
 

--- a/apps/mesh/src/web/components/chat/tiptap/input.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/input.tsx
@@ -52,6 +52,13 @@ interface TiptapProviderProps {
   enterToSubmit?: boolean;
   placeholder?: string;
   onSubmit?: () => void;
+  /**
+   * Set to true while an @/ suggestion dropdown is open. ProseMirror's own
+   * keydown listener runs before the suggestion's — see mention-at.tsx /
+   * mention-slash.tsx — so without this check, Enter-to-select a suggestion
+   * would also submit the still-unresolved draft first.
+   */
+  suggestionOpenRef?: { current: boolean };
   children: React.ReactNode;
 }
 
@@ -66,6 +73,7 @@ export function TiptapProvider({
   enterToSubmit = false,
   placeholder,
   onSubmit,
+  suggestionOpenRef,
   children,
 }: TiptapProviderProps) {
   // Store callbacks and config in refs to avoid recreating the editor on every render
@@ -88,7 +96,8 @@ export function TiptapProvider({
         if (
           event.key === "Enter" &&
           !event.shiftKey &&
-          enterToSubmitRef.current
+          enterToSubmitRef.current &&
+          !suggestionOpenRef?.current
         ) {
           event.preventDefault();
           onSubmitRef.current?.();
@@ -156,6 +165,8 @@ interface TiptapInputProps {
   showFileUploader?: boolean;
   selectedModel?: AiProviderModel | null;
   onUnsupportedFile?: (info: UnsupportedFileInfo) => void;
+  /** Forwarded to AtMention/SlashMention — see TiptapProviderProps. */
+  suggestionOpenRef?: { current: boolean };
   ref?: Ref<TiptapInputHandle>;
   className?: string;
 }
@@ -170,6 +181,7 @@ export function TiptapInput({
   showFileUploader = false,
   selectedModel,
   onUnsupportedFile,
+  suggestionOpenRef,
   ref,
   className,
 }: TiptapInputProps) {
@@ -242,12 +254,20 @@ export function TiptapInput({
 
       {/* Render slash dropdown menu for prompts + resources (/) */}
       <Suspense fallback={null}>
-        <SlashMention editor={editor} virtualMcpId={virtualMcpId ?? null} />
+        <SlashMention
+          editor={editor}
+          virtualMcpId={virtualMcpId ?? null}
+          suggestionOpenRef={suggestionOpenRef}
+        />
       </Suspense>
 
       {/* Render @ dropdown menu (agents + resources) */}
       <Suspense fallback={null}>
-        <AtMention editor={editor} virtualMcpId={virtualMcpId ?? null} />
+        <AtMention
+          editor={editor}
+          virtualMcpId={virtualMcpId ?? null}
+          suggestionOpenRef={suggestionOpenRef}
+        />
       </Suspense>
 
       {/* Render file upload handler */}

--- a/apps/mesh/src/web/components/chat/tiptap/mention-at.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention-at.tsx
@@ -25,6 +25,8 @@ import { useT } from "@/web/i18n/use-t.ts";
 interface AtMentionProps {
   editor: Editor;
   virtualMcpId: string | null;
+  /** Set to true while this dropdown is open — see TiptapProviderProps. */
+  suggestionOpenRef?: { current: boolean };
 }
 
 type AtMode = "categories" | "agents" | "resources";
@@ -38,7 +40,11 @@ interface AtItem extends BaseItem {
   uri?: string;
 }
 
-export const AtMention = ({ editor, virtualMcpId }: AtMentionProps) => {
+export const AtMention = ({
+  editor,
+  virtualMcpId,
+  suggestionOpenRef,
+}: AtMentionProps) => {
   const t = useT();
   const queryClient = useQueryClient();
   const { org } = useProjectContext();
@@ -258,6 +264,7 @@ export const AtMention = ({ editor, virtualMcpId }: AtMentionProps) => {
   };
 
   const handleOpenChange = (open: boolean) => {
+    if (suggestionOpenRef) suggestionOpenRef.current = open;
     if (open) {
       // Fires when the @ picker dropdown actually renders (TipTap's onStart).
       // NOT when a literal "@" is typed — e.g. inside an email address the

--- a/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
@@ -53,6 +53,8 @@ import { track } from "@/web/lib/posthog-client";
 interface SlashMentionProps {
   editor: Editor;
   virtualMcpId: string | null;
+  /** Set to true while this dropdown is open — see TiptapProviderProps. */
+  suggestionOpenRef?: { current: boolean };
 }
 
 interface SlashItem extends BaseItem {
@@ -174,7 +176,11 @@ async function fetchAndInsertSkill(
   }
 }
 
-export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
+export const SlashMention = ({
+  editor,
+  virtualMcpId,
+  suggestionOpenRef,
+}: SlashMentionProps) => {
   const t = useT();
   const queryClient = useQueryClient();
   const { org } = useProjectContext();
@@ -415,6 +421,7 @@ export const SlashMention = ({ editor, virtualMcpId }: SlashMentionProps) => {
         queryFn={fetchItems}
         onSelect={handleItemSelect}
         onOpenChange={(open) => {
+          if (suggestionOpenRef) suggestionOpenRef.current = open;
           // Fires when the / picker dropdown actually renders (TipTap's
           // onStart). NOT when a literal "/" is typed — e.g. inside a URL
           // the picker won't open so the event won't fire.


### PR DESCRIPTION
**Source:** bug found while auditing keyboard navigation/suggestion handling in the chat input widget (`apps/mesh/src/web/components/chat/input.tsx` and its Tiptap suggestion pickers).

**Why a maintainer wants this:** every @ (agents/resources) or / (prompts/skills) mention selection made with Enter is a real, everyday interaction in the composer — this bug silently corrupts that flow.

**The bug:** ProseMirror registers its own native `keydown` listener on the editor DOM node when the editor mounts (very early). The suggestion dropdown's own keyboard-navigation listener (`useMenuNavigation` in `tiptap/mention/hooks.ts`) is a *separate*, plain `addEventListener` attached only once the dropdown mounts (i.e. much later, when the user types `/` or `@`). Both listeners sit on the exact same DOM node, so per the DOM spec they fire in registration order for a same-target event — ProseMirror's fires first.

`TiptapProvider`'s `editorProps.handleKeyDown` (in `tiptap/input.tsx`) treats a bare Enter as "submit the message" whenever `enterToSubmit` is on, with no check for whether a suggestion dropdown is currently open. I traced this end-to-end through the installed `prosemirror-view`/`@tiptap/suggestion` sources (`someProp` checks `editorProps.handleKeyDown` *before* any plugin's `handleKeyDown`) to confirm the ordering.

**Concretely:** open the `/` or `@` picker, arrow down to an item, press Enter to select it. Today: the still-unresolved raw text (e.g. `/reviewpr`) gets sent as the message *first* (composer clears), and only afterward does the picker insert the resolved mention into what is now stale, already-cleared editor state — so the resolved mention silently leaks into whatever the user types next instead of the message they meant to send.

**The fix:** a `suggestionOpenRef` (created once in `ChatInput`, a plain `{ current: boolean }` ref) is threaded through `TiptapProvider`/`TiptapInput` down to `AtMention`/`SlashMention`, which already have an `onOpenChange` callback (previously used only for analytics) — extended to also flip this ref. `TiptapProvider`'s enter-to-submit check now bails out while `suggestionOpenRef.current` is true, leaving Enter for the suggestion's own selection handler.

**Regression test:** `apps/mesh/src/web/components/chat/tiptap/input.test.tsx` — two new cases directly exercise `TiptapProvider`'s `handleKeyDown` via a real `fireEvent.keyDown(..., { key: "Enter" })` on the contenteditable, asserting `onSubmit` fires when no suggestion is open and does *not* fire while `suggestionOpenRef.current` is true. Confirmed the first assertion fails without the fix (reproducing the bug) and both pass with it.

**To confirm:** `bun test apps/mesh/src/web/components/chat/tiptap/input.test.tsx`

**Locally ran:** `bun run fmt` (no changes), `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file above (6/6 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the chat composer from submitting the draft when you press Enter to select an `@` or `/` suggestion. Enter-to-submit is now ignored while a suggestion dropdown is open, so raw `/name` or `@name` text is not sent.

- **Bug Fixes**
  - Added a `suggestionOpenRef` tracked in `ChatInput` and passed to `TiptapProvider`, `AtMention`, and `SlashMention`; toggled via existing `onOpenChange`.
  - Guarded `TiptapProvider`’s Enter-to-submit handler to bail out when a suggestion is open.
  - Added regression tests in `apps/mesh/src/web/components/chat/tiptap/input.test.tsx` to verify submit behavior with and without an open suggestion.

<sup>Written for commit b88afcd673898c0d8180bbaa5aea93e21419635b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

