### PR TITLE
fix(chat): make prompt mention chip aria-label match its title-cased text

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.test.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.test.tsx
@@ -1,0 +1,56 @@
+import { setupComponentTest } from "../../../../../test/setup";
+setupComponentTest();
+import { describe, expect, test } from "bun:test";
+import { render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { Editor } from "@tiptap/core";
+import { EditorContent, EditorContext } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { insertMention, MentionNode } from "./node.tsx";
+
+// useT() reads the language preference via TanStack Query.
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("mention chip aria-label", () => {
+  test("matches the title-cased text shown on screen, not the raw name", async () => {
+    const editor = new Editor({
+      extensions: [StarterKit, MentionNode],
+      content: { type: "doc", content: [{ type: "paragraph", content: [] }] },
+    });
+    insertMention(
+      editor,
+      { from: 1, to: 1 },
+      {
+        id: "1",
+        name: "my_prompt_name",
+        metadata: null,
+        char: "/",
+        kind: "prompt",
+      },
+    );
+
+    const { container } = render(
+      <EditorContext.Provider value={{ editor }}>
+        <EditorContent editor={editor} />
+      </EditorContext.Provider>,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[role="button"]')).toBeInTheDocument();
+    });
+    const chip = container.querySelector('[role="button"]');
+
+    expect(chip?.textContent).toBe("/My Prompt Name");
+    expect(chip?.getAttribute("aria-label")).toBe(
+      "Edit My Prompt Name prompt arguments",
+    );
+  });
+});

--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
@@ -143,7 +143,9 @@ function MentionNodeView(props: NodeViewProps) {
       tabIndex={isClickable ? 0 : undefined}
       aria-label={
         isClickable
-          ? t("chat.mention.editPrompt", { name: name ?? "" })
+          ? t("chat.mention.editPrompt", {
+              name: name ? toTitleCase(name) : "",
+            })
           : undefined
       }
       className={cn(


### PR DESCRIPTION
**Source**: bug found while auditing `apps/mesh/src/web/components/chat/tiptap/mention/node.tsx` (this tick's assigned focus area) for parsing/rendering/cursor-behaviour correctness.

**Payoff**: `MentionNodeView` renders a `/`-prompt mention chip's visible text through `toTitleCase(name)` (e.g. `my_prompt_name` -> `My Prompt Name`), but built the chip's `aria-label` from the raw `name` attribute instead. A screen-reader user focusing/editing the chip hears "Edit my_prompt_name prompt arguments" while sighted users see "My Prompt Name" — the two disagree on every prompt mention whose machine name isn't already title-cased.

**Failure scenario**: insert a `/`-mention for a prompt named `my_prompt_name`; the rendered chip shows "My Prompt Name" but `aria-label` reads "Edit my_prompt_name prompt arguments". Fixed by running `name` through the same `toTitleCase` used for the visible text before interpolating it into the aria-label.

**Regression test**: `apps/mesh/src/web/components/chat/tiptap/mention/node.test.tsx` mounts a real headless `@tiptap/core` `Editor` with `MentionNode` + `insertMention`, renders it via `EditorContent`, and asserts the rendered chip's `textContent` ("/My Prompt Name") and `aria-label` ("Edit My Prompt Name prompt arguments") now match — it fails against the old code (which asserted the raw-name label).

**Reviewer command**: `bun test apps/mesh/src/web/components/chat/tiptap/mention/node.test.tsx`

**Local checks run**: `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean aside from pre-existing unrelated errors in an untracked `src/storage/types.test.ts` from a different in-progress change, not touched by this PR), and the targeted test above. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the prompt mention chip aria-label to use the same title-cased name shown on the chip, so screen readers announce what users see.

- **Bug Fixes**
  - Updated `MentionNodeView` to pass `toTitleCase(name)` into `aria-label`.
  - Added a test with `@tiptap/core` and `@tiptap/react` to assert chip text and `aria-label` both use title case.

<sup>Written for commit 8258e19fd98d8266c9310cb4b09815a2d9a77a00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

