### PR TITLE
refactor(sandbox-preview): extract PathParamInput to its own module

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/path-param-input.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-input.tsx
@@ -1,0 +1,75 @@
+import { useRef, useState } from "react";
+import { CornerDownLeft } from "@untitledui/icons";
+
+/**
+ * Inline editor for one `:param` or `*` (catch-all) token, rendered in place
+ * inside the URL label. Grows with its content and commits on Enter/blur.
+ */
+export function PathParamInput({
+  name,
+  value,
+  onCommit,
+}: {
+  name: string;
+  value: string;
+  onCommit: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState(value);
+  const [focused, setFocused] = useState(false);
+  const cancelledRef = useRef(false);
+  const label = name === "*" ? "path" : `:${name}`;
+  const sizer = draft || label;
+  return (
+    <>
+      <span className="relative inline-flex max-w-64 shrink-0 items-center overflow-hidden">
+        {/* Invisible sizer: the box hugs the rendered text exactly. Must
+          mirror the input's font size and horizontal padding. */}
+        <span
+          aria-hidden
+          className="invisible whitespace-pre px-1 py-0.5 text-[12px]"
+        >
+          {sizer}
+        </span>
+        <input
+          type="text"
+          value={draft}
+          placeholder={label}
+          title={`Value for ${label}`}
+          spellCheck={false}
+          className="absolute inset-0 rounded-sm bg-violet-500/15 px-1 text-[12px] text-violet-600 outline-none placeholder:text-violet-500/60 focus:bg-violet-500/25 dark:text-violet-400"
+          onClick={(e) => e.stopPropagation()}
+          onChange={(e) => setDraft(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") e.currentTarget.blur();
+            if (e.key === "Escape") {
+              cancelledRef.current = true;
+              setDraft(value);
+              e.currentTarget.blur();
+            }
+          }}
+          onBlur={() => {
+            setFocused(false);
+            if (cancelledRef.current) {
+              cancelledRef.current = false;
+              return;
+            }
+            // Blank values are not accepted: clearing the input reverts to the
+            // bare `:param` token (placeholder) and the template URL.
+            const next = draft.trim();
+            setDraft(next);
+            if (next !== value) onCommit(next);
+          }}
+        />
+      </span>
+      {/* Editing hint, outside the value box */}
+      {focused && (
+        <span className="pointer-events-none ml-1.5 flex shrink-0 items-center gap-1 whitespace-nowrap rounded-sm border border-border bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
+          <CornerDownLeft size={10} />
+          {/* TODO(i18n): "Enter to go" is part of inline editing hint; needs component context for t() */}
+          Enter to go
+        </span>
+      )}
+    </>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -12,7 +12,6 @@ import type { TranslationKey } from "@/web/i18n/use-t.ts";
 import {
   ChevronDown,
   Code01,
-  CornerDownLeft,
   CursorClick01,
   DotsHorizontal,
   Globe02,
@@ -99,6 +98,7 @@ import {
   PathParamAutoFill,
   PathParamPickerChip,
 } from "./path-param-picker-chip";
+import { PathParamInput } from "./path-param-input";
 import { manifestLoaderResolveTypes } from "@/web/components/sandbox/content/runnable-catalog";
 import { track } from "@/web/lib/posthog-client";
 import { useSandboxRepoDir } from "../hooks/use-sandbox-repo-dir";
@@ -146,79 +146,6 @@ const DEVICE_LABEL_KEYS: Record<PreviewDeviceSize, TranslationKey> = {
   tablet: "sandbox.preview.deviceTablet",
   desktop: "sandbox.preview.deviceDesktop",
 };
-
-/**
- * Inline editor for one `:param` or `*` (catch-all) token, rendered in place
- * inside the URL label. Grows with its content and commits on Enter/blur.
- */
-function PathParamInput({
-  name,
-  value,
-  onCommit,
-}: {
-  name: string;
-  value: string;
-  onCommit: (value: string) => void;
-}) {
-  const [draft, setDraft] = useState(value);
-  const [focused, setFocused] = useState(false);
-  const cancelledRef = useRef(false);
-  const label = name === "*" ? "path" : `:${name}`;
-  const sizer = draft || label;
-  return (
-    <>
-      <span className="relative inline-flex max-w-64 shrink-0 items-center overflow-hidden">
-        {/* Invisible sizer: the box hugs the rendered text exactly. Must
-          mirror the input's font size and horizontal padding. */}
-        <span
-          aria-hidden
-          className="invisible whitespace-pre px-1 py-0.5 text-[12px]"
-        >
-          {sizer}
-        </span>
-        <input
-          type="text"
-          value={draft}
-          placeholder={label}
-          title={`Value for ${label}`}
-          spellCheck={false}
-          className="absolute inset-0 rounded-sm bg-violet-500/15 px-1 text-[12px] text-violet-600 outline-none placeholder:text-violet-500/60 focus:bg-violet-500/25 dark:text-violet-400"
-          onClick={(e) => e.stopPropagation()}
-          onChange={(e) => setDraft(e.target.value)}
-          onFocus={() => setFocused(true)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") e.currentTarget.blur();
-            if (e.key === "Escape") {
-              cancelledRef.current = true;
-              setDraft(value);
-              e.currentTarget.blur();
-            }
-          }}
-          onBlur={() => {
-            setFocused(false);
-            if (cancelledRef.current) {
-              cancelledRef.current = false;
-              return;
-            }
-            // Blank values are not accepted: clearing the input reverts to the
-            // bare `:param` token (placeholder) and the template URL.
-            const next = draft.trim();
-            setDraft(next);
-            if (next !== value) onCommit(next);
-          }}
-        />
-      </span>
-      {/* Editing hint, outside the value box */}
-      {focused && (
-        <span className="pointer-events-none ml-1.5 flex shrink-0 items-center gap-1 whitespace-nowrap rounded-sm border border-border bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
-          <CornerDownLeft size={10} />
-          {/* TODO(i18n): "Enter to go" is part of inline editing hint; needs component context for t() */}
-          Enter to go
-        </span>
-      )}
-    </>
-  );
-}
 
 /** Deco reads `deviceHint` to force SSR device matchers (see deco `deviceOf`). */
 function withDeviceHint(url: string, device: PreviewDeviceSize): string {


### PR DESCRIPTION
**Source:** Debt reduction (C5, bounded extraction) — `preview.tsx` is the largest palette-debt file in the sandbox-preview area (1599 lines, 7 raw-Tailwind hits) and was flagged in the highest-debt frontend files list.

**Payoff:** `PathParamInput` (the inline `:param`/`*` token editor rendered in the URL bar) only reads its own `name`/`value`/`onCommit` props — no closures over `PreviewContent` state — so it's a clean, self-contained unit to pull out. This mirrors `PathParamPickerChip`, which already lives in its own file (`path-param-picker-chip.tsx`) right next to it; `PathParamInput` was the one sibling left inline. Net effect: `preview.tsx` drops by ~74 lines with zero behavior change.

**Verification:** Byte-identical logic move — the component body, JSX, and comments are unchanged, only relocated to `path-param-input.tsx` with its own imports (`useState`/`useRef` from react, `CornerDownLeft` from `@untitledui/icons`) and a named import added at the call site in `preview.tsx`. No exports, props, or behavior changed.

**To confirm:** `cd apps/mesh && bunx tsc --noEmit` (clean) — the moved component's prop and hook usage type-checks identically in its new location.

**Locally ran:** `bun run fmt` (no changes needed) and `bunx tsc --noEmit` in `apps/mesh` (clean). No test file covers this component directly (it's a small UI unit with no logic to break); full CI runs the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted PathParamInput from `preview.tsx` into `path-param-input.tsx` to simplify the preview module and isolate the URL param editor. No behavior changes; `preview.tsx` shrinks by ~74 lines, and the new module imports `CornerDownLeft` from `@untitledui/icons`.

<sup>Written for commit 1098f6ad93807db9f5474ccd99080c04977e3b8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

