### PR TITLE
fix(chat): i18n the empty-state in the @/ mention suggestion dropdown

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/mention/suggestion.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/suggestion.tsx
@@ -22,6 +22,7 @@ import { PluginKey } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
 import type { Ref } from "react";
 import { PropsWithChildren, Suspense } from "react";
+import { useT } from "@/web/i18n/use-t.ts";
 import {
   BaseItem,
   OnSelectProps,
@@ -190,6 +191,7 @@ const MentionItemList = <T extends BaseItem>({
   queryFn,
   onSelect,
 }: MentionItemListProps<T>) => {
+  const t = useT();
   const {
     items,
     selectedIndex,
@@ -205,7 +207,7 @@ const MentionItemList = <T extends BaseItem>({
   if (!items.length) {
     return (
       <div className="min-w-[360px] max-w-[520px] bg-popover text-popover-foreground rounded-md border shadow-md p-3 text-sm">
-        No items found
+        {t("chat.mention.noItemsFound")}
       </div>
     );
   }

--- a/apps/mesh/src/web/i18n/en/chat.ts
+++ b/apps/mesh/src/web/i18n/en/chat.ts
@@ -441,4 +441,5 @@ export const chat = {
   "chat.webSearch.showMore": "+{count} more",
   "chat.webSearch.title": "Web search",
   "chat.mention.editPrompt": "Edit {name} prompt arguments",
+  "chat.mention.noItemsFound": "No items found",
 } as const;

--- a/apps/mesh/src/web/i18n/pt-br/chat.ts
+++ b/apps/mesh/src/web/i18n/pt-br/chat.ts
@@ -455,4 +455,5 @@ export const chat = {
   "chat.webSearch.showMore": "+{count} mais",
   "chat.webSearch.title": "Busca na web",
   "chat.mention.editPrompt": "Editar argumentos do prompt {name}",
+  "chat.mention.noItemsFound": "Nenhum item encontrado",
 } satisfies Record<keyof typeof chatEn, string>;


### PR DESCRIPTION
Follows #5048/#5050/#5049, which just hardened the same chat mention/aria surface — found while auditing that hardening trail for lingering gaps.

The shared `Suggestion`/`MentionItemList` component (`apps/mesh/src/web/components/chat/tiptap/mention/suggestion.tsx`) backs both the `@` and `/` chat mention dropdowns and had a hardcoded English "No items found" string with no `t()` call — every other empty-state string in this app goes through i18n (e.g. `registry.registryItemsPage.noItemsFound`, `collections.collectionTableWrapper.noItemsFound`), so a pt-br user typing `/` or `@` with no matches sees English text.

Added `chat.mention.noItemsFound` to both `en/chat.ts` and `pt-br/chat.ts` and wired it into the component via `useT()`.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` (green), or manually open the chat input, type `@nonexistentquery` or `/nonexistentquery` with the pt-br language preference set and confirm the empty state renders "Nenhum item encontrado".

Local checks run: `bun run fmt`, `bunx tsc --noEmit` in apps/mesh (both clean). No existing test covers this display string so none was added; full CI will run the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the empty-state text in the chat `@` and `/` mention suggestion dropdown by adding `chat.mention.noItemsFound` and wiring it through `useT()`, so non-English users (e.g., pt-br) see the correct translation instead of English.

<sup>Written for commit fe124d4976c4c7548f2b703dfc3c3691a2f7549b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

