### PR TITLE
feat(i18n): translate the /reset-password route

### DIFF
--- a/apps/mesh/src/web/i18n/en/routes.ts
+++ b/apps/mesh/src/web/i18n/en/routes.ts
@@ -231,4 +231,20 @@ export const routes = {
   "routes.reports.failedToLoadReportTitle":
     "Não foi possível carregar este relatório.",
   "routes.reports.retryButton": "Tentar novamente",
+  "routes.resetPassword.passwordResetSuccessful": "Password reset successful",
+  "routes.resetPassword.setNewPassword": "Set a new password",
+  "routes.resetPassword.invalidOrExpiredLink":
+    "This reset link is invalid or has expired.",
+  "routes.resetPassword.backToLogin": "Back to login",
+  "routes.resetPassword.failedToReset":
+    "Failed to reset password. Please try again.",
+  "routes.resetPassword.passwordResetDescription":
+    "Your password has been reset. You can now sign in with your new password.",
+  "routes.resetPassword.goToLogin": "Go to login",
+  "routes.resetPassword.newPasswordLabel": "New password",
+  "routes.resetPassword.confirmPasswordLabel": "Confirm password",
+  "routes.resetPassword.passwordsDoNotMatch": "Passwords do not match",
+  "routes.resetPassword.resetting": "Resetting...",
+  "routes.resetPassword.resetPassword": "Reset password",
+  "routes.resetPassword.backToSignIn": "Back to sign in",
 } as const;

--- a/apps/mesh/src/web/i18n/pt-br/routes.ts
+++ b/apps/mesh/src/web/i18n/pt-br/routes.ts
@@ -236,4 +236,21 @@ export const routes = {
   "routes.reports.failedToLoadReportTitle":
     "Não foi possível carregar este relatório.",
   "routes.reports.retryButton": "Tentar novamente",
+  "routes.resetPassword.passwordResetSuccessful":
+    "Senha redefinida com sucesso",
+  "routes.resetPassword.setNewPassword": "Defina uma nova senha",
+  "routes.resetPassword.invalidOrExpiredLink":
+    "Este link de redefinição é inválido ou expirou.",
+  "routes.resetPassword.backToLogin": "Voltar para o login",
+  "routes.resetPassword.failedToReset":
+    "Falha ao redefinir a senha. Tente novamente.",
+  "routes.resetPassword.passwordResetDescription":
+    "Sua senha foi redefinida. Agora você pode entrar com sua nova senha.",
+  "routes.resetPassword.goToLogin": "Ir para o login",
+  "routes.resetPassword.newPasswordLabel": "Nova senha",
+  "routes.resetPassword.confirmPasswordLabel": "Confirmar senha",
+  "routes.resetPassword.passwordsDoNotMatch": "As senhas não coincidem",
+  "routes.resetPassword.resetting": "Redefinindo...",
+  "routes.resetPassword.resetPassword": "Redefinir senha",
+  "routes.resetPassword.backToSignIn": "Voltar para o login",
 } satisfies Record<keyof typeof routesEn, string>;

--- a/apps/mesh/src/web/routes/reset-password.tsx
+++ b/apps/mesh/src/web/routes/reset-password.tsx
@@ -4,8 +4,10 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { authClient } from "@/web/lib/auth-client";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
+import { useT } from "@/web/i18n/use-t.ts";
 
 export default function ResetPasswordRoute() {
+  const t = useT();
   const { token, error: tokenError } = useSearch({ from: "/reset-password" });
   const navigate = useNavigate();
   const [newPassword, setNewPassword] = useState("");
@@ -74,7 +76,9 @@ export default function ResetPasswordRoute() {
           {/* Header */}
           <div className="text-center space-y-1">
             <p className="text-sm text-foreground/70">
-              {success ? "Password reset successful" : "Set a new password"}
+              {success
+                ? t("routes.resetPassword.passwordResetSuccessful")
+                : t("routes.resetPassword.setNewPassword")}
             </p>
           </div>
 
@@ -82,14 +86,14 @@ export default function ResetPasswordRoute() {
           {(hasTokenError || (!token && !success)) && (
             <>
               <div className="rounded-xl bg-destructive/10 p-3 text-sm text-destructive text-center">
-                This reset link is invalid or has expired.
+                {t("routes.resetPassword.invalidOrExpiredLink")}
               </div>
               <Button
                 onClick={() => navigate({ to: "/login" })}
                 className="w-full font-semibold"
                 size="lg"
               >
-                Back to login
+                {t("routes.resetPassword.backToLogin")}
               </Button>
             </>
           )}
@@ -97,7 +101,7 @@ export default function ResetPasswordRoute() {
           {/* Error from API */}
           {error && (
             <div className="rounded-xl bg-destructive/10 p-3 text-sm text-destructive text-center">
-              {error.message || "Failed to reset password. Please try again."}
+              {error.message || t("routes.resetPassword.failedToReset")}
             </div>
           )}
 
@@ -105,15 +109,14 @@ export default function ResetPasswordRoute() {
           {success && (
             <>
               <div className="rounded-xl bg-success/10 p-3 text-sm text-success text-center">
-                Your password has been reset. You can now sign in with your new
-                password.
+                {t("routes.resetPassword.passwordResetDescription")}
               </div>
               <Button
                 onClick={() => navigate({ to: "/login" })}
                 className="w-full font-semibold"
                 size="lg"
               >
-                Go to login
+                {t("routes.resetPassword.goToLogin")}
               </Button>
             </>
           )}
@@ -123,7 +126,7 @@ export default function ResetPasswordRoute() {
             <form onSubmit={handleSubmit} className="grid gap-4">
               <div>
                 <label className="block text-sm font-medium text-foreground mb-2">
-                  New password
+                  {t("routes.resetPassword.newPasswordLabel")}
                 </label>
                 <Input
                   type="password"
@@ -137,7 +140,7 @@ export default function ResetPasswordRoute() {
               </div>
               <div>
                 <label className="block text-sm font-medium text-foreground mb-2">
-                  Confirm password
+                  {t("routes.resetPassword.confirmPasswordLabel")}
                 </label>
                 <Input
                   type="password"
@@ -150,7 +153,7 @@ export default function ResetPasswordRoute() {
                 />
                 {confirmPassword && !passwordsMatch && (
                   <p className="text-xs text-destructive mt-1.5">
-                    Passwords do not match
+                    {t("routes.resetPassword.passwordsDoNotMatch")}
                   </p>
                 )}
               </div>
@@ -161,7 +164,9 @@ export default function ResetPasswordRoute() {
                 className="w-full font-semibold"
                 size="lg"
               >
-                {isLoading ? "Resetting..." : "Reset password"}
+                {isLoading
+                  ? t("routes.resetPassword.resetting")
+                  : t("routes.resetPassword.resetPassword")}
               </Button>
             </form>
           )}
@@ -175,7 +180,7 @@ export default function ResetPasswordRoute() {
                 onClick={() => navigate({ to: "/login" })}
                 className="text-sm text-muted-foreground hover:text-foreground"
               >
-                Back to sign in
+                {t("routes.resetPassword.backToSignIn")}
               </Button>
             </div>
           )}


### PR DESCRIPTION
**Source:** i18n gap — the `/reset-password` route (`apps/mesh/src/web/routes/reset-password.tsx`) had zero i18n coverage: every heading, button label, form label, and error/success message was hardcoded in English, unlike the rest of the auth flow (login, onboarding, commerce-onboarding) which already goes through `useT()`.

**Why a maintainer wants this:** a Portuguese-locale user resetting their password currently sees an all-English page in the middle of a security-sensitive flow — the one screen in the auth funnel that was missed when i18n coverage was extended to the rest of auth.

**What changed:**
- Added 15 new `routes.resetPassword.*` keys to `apps/mesh/src/web/i18n/en/routes.ts` and their `pt-br` translations to `apps/mesh/src/web/i18n/pt-br/routes.ts`.
- Wired `apps/mesh/src/web/routes/reset-password.tsx` to `useT()` for all headings, button labels, form labels, and success/error copy. Left the internal `mutationFn`'s fallback `Error` message untouched (API-adjacent, out of i18n scope per repo convention).

**How a reviewer can confirm:** open `/reset-password?token=...` with the app's language preference set to Português — copy should render in Portuguese; switch back to English to confirm parity with the previous copy.

**Verification run locally:**
- `bun run fmt` — clean.
- `cd apps/mesh && bunx tsc --noEmit` — no errors in the touched files (the `pt-br/routes.ts` `satisfies Record<keyof typeof routesEn, string>` check confirms every new English key has a Portuguese counterpart). Two unrelated pre-existing untracked test files in the workspace produce errors independent of this change.

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the `/reset-password` route by wiring UI copy to `useT()` and adding `routes.resetPassword.*` keys in `en` and `pt-br`. This aligns the screen with the rest of auth so Portuguese users see the correct language.

- New Features
  - Added 15 `routes.resetPassword.*` i18n keys to `en` and `pt-br`.
  - Switched all headings, labels, and success/error messages in `reset-password.tsx` to `useT()`.
  - Left the internal mutation fallback error as-is (out of i18n scope by convention).

<sup>Written for commit f7da7d1dfa956287b65d8ba5cfb2076a38a9ea40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

