### PR TITLE
feat(reports): commerce-diagnostic share-invite route

### DIFF
--- a/apps/mesh/src/api/middleware/resolve-org-from-path.test.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.test.ts
@@ -12,6 +12,11 @@ describe("isServiceTokenPath", () => {
     expect(isServiceTokenPath("/api/org_1/internal/task-board/import")).toBe(
       true,
     );
+    expect(
+      isServiceTokenPath(
+        "/api/org_1/internal/commerce-diagnostic/share-invite",
+      ),
+    ).toBe(true);
   });
 
   it("rejects everything else", () => {

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -66,6 +66,7 @@ const SERVICE_TOKEN_ROUTES: readonly (readonly string[])[] = [
   ["vault", "connections", "*", "access-token"],
   ["vault", "connections", "*", "configuration"],
   ["internal", "task-board", "import"],
+  ["internal", "commerce-diagnostic", "share-invite"],
 ];
 
 /**

--- a/apps/mesh/src/api/routes/commerce-diagnostic-share.test.ts
+++ b/apps/mesh/src/api/routes/commerce-diagnostic-share.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import {
+  diagnosticDeepLinkPath,
+  shareInviteBodySchema,
+} from "./commerce-diagnostic-share";
+
+describe("diagnosticDeepLinkPath", () => {
+  it("builds the org-home deep link that opens the diagnostic app view", () => {
+    const path = diagnosticDeepLinkPath("acme", "org_123", "task_abc");
+    // Relative (safe redirectTo), correct slug + taskId, and the pinned-view
+    // main tab grammar app:<orgId>_commerce-discovery:get_my_diagnostic.
+    expect(path.startsWith("/acme/task_abc?")).toBe(true);
+    const search = new URLSearchParams(path.slice(path.indexOf("?") + 1));
+    expect(search.get("main")).toBe(
+      "app:org_123_commerce-discovery:get_my_diagnostic",
+    );
+    expect(search.get("virtualmcpid")).toBeTruthy();
+  });
+
+  it("is a relative path (never absolute/protocol-relative)", () => {
+    const path = diagnosticDeepLinkPath("acme", "org_123", "t");
+    expect(path.startsWith("/")).toBe(true);
+    expect(path.startsWith("//")).toBe(false);
+  });
+});
+
+describe("shareInviteBodySchema", () => {
+  it("accepts and lowercases-in-caller a valid email, rejects junk", () => {
+    expect(
+      shareInviteBodySchema.safeParse({ invitee_email: "a@b.com" }).success,
+    ).toBe(true);
+    expect(
+      shareInviteBodySchema.safeParse({ invitee_email: "nope" }).success,
+    ).toBe(false);
+    expect(shareInviteBodySchema.safeParse({}).success).toBe(false);
+  });
+});

--- a/apps/mesh/src/api/routes/commerce-diagnostic-share.ts
+++ b/apps/mesh/src/api/routes/commerce-diagnostic-share.ts
@@ -1,0 +1,189 @@
+import {
+  COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+  getCommerceDiscoveryAgentId,
+  WellKnownOrgMCPId,
+} from "@decocms/mesh-sdk";
+import { Hono } from "hono";
+import { sql } from "kysely";
+import { z } from "zod";
+import { getBaseUrl } from "@/core/server-constants";
+import type { StudioContext } from "@/core/studio-context";
+import { bearerToken, isVaultServiceToken } from "./credential-vault";
+
+/**
+ * Commerce-diagnostic share invite — the "different invite path" behind the
+ * Share button on a claimed (private) diagnostic.
+ *
+ *   POST /api/:org/internal/commerce-diagnostic/share-invite
+ *
+ * Auth mirrors the task-board import + credential vault: the shared
+ * VAULT_SERVICE_TOKEN bearer alone authenticates (constant-time compare), the
+ * org is resolved by id from the path (see SERVICE_TOKEN_ROUTES). The caller is
+ * commerce-discovery's `share_my_diagnostic` tool.
+ *
+ * Why a bespoke path instead of Better Auth's `inviteMember`:
+ * `createInvitation` unconditionally fires the org plugin's generic
+ * `sendInvitationEmail`. The share flow needs a *different* email — one with a
+ * preview of the private diagnostic — sent by commerce-discovery (it owns the
+ * diagnostic data + the branded report-email template). So we create the
+ * invitation row directly (no generic email) and hand the caller the accept
+ * URL; commerce-discovery sends the preview email with that URL as its CTA.
+ *
+ * The accept URL's `redirectTo` is the org-home deep link that OPENS the
+ * diagnostic app view — the exact shape `commerceReportNavTarget()`
+ * (web/hooks/use-commerce-diagnostic.ts) and setup.ts's completion-email link
+ * build: `/{slug}/{taskId}?virtualmcpid=..&main=app:{conn}:get_my_diagnostic`.
+ *
+ * Branching by invitee (requirement: "invite to studio, or if already a user
+ * only invite for the org"): an existing user who is already a member of this
+ * org needs no invitation — they get the deep link straight away
+ * (`invitee_status: "member"`). Everyone else gets a pending invitation
+ * (`"existing"` when they already have a Studio account, `"new"` otherwise);
+ * Better Auth branches signup-vs-accept at accept time.
+ */
+
+type Variables = {
+  studioContext: StudioContext;
+};
+
+export const shareInviteBodySchema = z.object({
+  invitee_email: z.string().trim().email().max(320),
+});
+
+/** Org-home deep link that opens the org's commerce-diagnostic app view.
+ *  Mirrors commerceReportNavTarget() and setup.ts's completion-email link.
+ *  Relative (path + query) so it is a safe `redirectTo` (login.tsx rejects
+ *  absolute/protocol-relative targets). Exported for unit tests. */
+export function diagnosticDeepLinkPath(
+  orgSlug: string,
+  orgId: string,
+  taskId: string,
+): string {
+  const connectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(orgId);
+  const search = new URLSearchParams({
+    virtualmcpid: getCommerceDiscoveryAgentId(orgId),
+    main: `app:${connectionId}:${COMMERCE_DISCOVERY_REPORT_TOOL_NAME}`,
+  });
+  return `/${orgSlug}/${taskId}?${search.toString()}`;
+}
+
+export const createCommerceDiagnosticShareRoutes = () => {
+  const app = new Hono<{ Variables: Variables }>();
+
+  app.post("/internal/commerce-diagnostic/share-invite", async (c) => {
+    const token = bearerToken(c.req.header("authorization"));
+    if (!token || !isVaultServiceToken(token)) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    const ctx = c.get("studioContext");
+    const org = ctx.organization;
+    if (!org?.id) {
+      return c.json({ error: "Organization context required" }, 403);
+    }
+
+    const parsed = shareInviteBodySchema.safeParse(
+      await c.req.json().catch(() => null),
+    );
+    if (!parsed.success) {
+      return c.json(
+        { error: "Invalid body", issues: parsed.error.issues },
+        400,
+      );
+    }
+
+    const email = parsed.data.invitee_email.toLowerCase();
+    const db = ctx.db;
+
+    // The deep link opens the diagnostic once the recipient is in the org. A
+    // fresh taskId per share matches commerceReportNavTarget (a new home thread).
+    const orgSlug = org.slug ?? org.id;
+    const redirectPath = diagnosticDeepLinkPath(
+      orgSlug,
+      org.id,
+      crypto.randomUUID(),
+    );
+    const baseUrl = getBaseUrl();
+    const absoluteRedirect = `${baseUrl}${redirectPath}`;
+
+    // Existing Studio account? (email is reserved in Postgres → quoted table.)
+    const userRow = await sql<{ id: string }>`
+      select id from "user" where lower(email) = ${email} limit 1
+    `.execute(db);
+    const existingUserId = userRow.rows[0]?.id;
+
+    // Already a member of THIS org ⇒ no invite needed, deep-link straight in.
+    if (existingUserId) {
+      const member = await db
+        .selectFrom("member")
+        .select(["id"])
+        .where("organizationId", "=", org.id)
+        .where("userId", "=", existingUserId)
+        .executeTakeFirst();
+      if (member) {
+        return c.json({
+          invitee_status: "member" as const,
+          accept_url: absoluteRedirect,
+          redirect_url: absoluteRedirect,
+          org_name: org.name,
+          org_slug: orgSlug,
+        });
+      }
+    }
+
+    // Reuse a live pending invitation (idempotent re-share), else insert one.
+    // The invitation table is Better-Auth-managed and not in the Kysely schema,
+    // so it's raw SQL (camelCase columns are quoted). This is the path that
+    // bypasses the generic sendInvitationEmail — see the header comment.
+    const existing = await sql<{ id: string }>`
+      select id from invitation
+      where lower(email) = ${email}
+        and "organizationId" = ${org.id}
+        and status = 'pending'
+        and "expiresAt" > now()
+      order by "expiresAt" desc
+      limit 1
+    `.execute(db);
+    let invitationId = existing.rows[0]?.id;
+
+    if (!invitationId) {
+      // inviterId must reference a real member (threads/audits FK against it).
+      // Attribute the share to the org's first owner — a live org always has one.
+      const owner = await db
+        .selectFrom("member")
+        .select(["userId"])
+        .where("organizationId", "=", org.id)
+        .where("role", "=", "owner")
+        .orderBy("createdAt", "asc")
+        .executeTakeFirst();
+      if (!owner?.userId) {
+        return c.json(
+          { error: "organization has no owner to attribute the invite" },
+          409,
+        );
+      }
+
+      invitationId = crypto.randomUUID();
+      await sql`
+        insert into invitation
+          (id, "organizationId", email, role, status, "inviterId", "expiresAt", "createdAt", "teamId")
+        values
+          (${invitationId}, ${org.id}, ${email}, 'user', 'pending', ${owner.userId}, now() + interval '7 days', now(), null)
+      `.execute(db);
+    }
+
+    const acceptUrl =
+      `${baseUrl}/auth/accept-invitation?invitationId=${encodeURIComponent(invitationId)}` +
+      `&redirectTo=${encodeURIComponent(redirectPath)}`;
+
+    return c.json({
+      invitee_status: existingUserId ? ("existing" as const) : ("new" as const),
+      accept_url: acceptUrl,
+      redirect_url: absoluteRedirect,
+      org_name: org.name,
+      org_slug: orgSlug,
+    });
+  });
+
+  return app;
+};

--- a/apps/mesh/src/api/routes/commerce-diagnostic-share.ts
+++ b/apps/mesh/src/api/routes/commerce-diagnostic-share.ts
@@ -166,9 +166,9 @@ export const createCommerceDiagnosticShareRoutes = () => {
       invitationId = crypto.randomUUID();
       await sql`
         insert into invitation
-          (id, "organizationId", email, role, status, "inviterId", "expiresAt", "createdAt", "teamId")
+          (id, "organizationId", email, role, status, "inviterId", "expiresAt", "createdAt")
         values
-          (${invitationId}, ${org.id}, ${email}, 'user', 'pending', ${owner.userId}, now() + interval '7 days', now(), null)
+          (${invitationId}, ${org.id}, ${email}, 'user', 'pending', ${owner.userId}, now() + interval '7 days', now())
       `.execute(db);
     }
 

--- a/apps/mesh/src/api/routes/commerce-diagnostic-share.ts
+++ b/apps/mesh/src/api/routes/commerce-diagnostic-share.ts
@@ -95,9 +95,17 @@ export const createCommerceDiagnosticShareRoutes = () => {
     const email = parsed.data.invitee_email.toLowerCase();
     const db = ctx.db;
 
+    // The deep link is `/{slug}/...` and the home resolves the org by slug, so
+    // an org without a slug can't produce a working link. Slugs are non-null in
+    // practice (Better Auth mints one on create); fail loud rather than emit a
+    // `/{id}/...` link that 404s.
+    const orgSlug = org.slug;
+    if (!orgSlug) {
+      return c.json({ error: "organization has no slug" }, 409);
+    }
+
     // The deep link opens the diagnostic once the recipient is in the org. A
     // fresh taskId per share matches commerceReportNavTarget (a new home thread).
-    const orgSlug = org.slug ?? org.id;
     const redirectPath = diagnosticDeepLinkPath(
       orgSlug,
       org.id,
@@ -131,7 +139,11 @@ export const createCommerceDiagnosticShareRoutes = () => {
       }
     }
 
-    // Reuse a live pending invitation (idempotent re-share), else insert one.
+    // Reuse a live pending invitation, else insert one. This collapses repeated
+    // shares of the same diagnostic to one row in the common (serial) case; two
+    // truly-concurrent shares to the same email can still both miss the select
+    // and insert — there's no unique constraint to dedup them, and accepting
+    // either lands the recipient in the org, so the duplicate is harmless.
     // The invitation table is Better-Auth-managed and not in the Kysely schema,
     // so it's raw SQL (camelCase columns are quoted). This is the path that
     // bypasses the generic sendInvitationEmail — see the header comment.

--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -24,6 +24,7 @@ import { createSsoRoutes } from "./org-sso";
 import { createProxyRoutes } from "./proxy";
 import { createSelfRoutes } from "./self";
 import { createHomeNextActionsRoutes } from "./home-next-actions";
+import { createCommerceDiagnosticShareRoutes } from "./commerce-diagnostic-share";
 import { createTaskBoardImportRoutes } from "./task-board-import";
 import { createObjectStorageRoutes } from "./object-storage";
 import { createThreadOutputsRoutes } from "./thread-outputs";
@@ -87,6 +88,7 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   app.route("/", createDownstreamTokenRoutes()); // /api/:org/connections/:connectionId/oauth-token
   app.route("/", createCredentialVaultRoutes()); // /api/:org/vault/connections/:connectionId/access-token
   app.route("/", createTaskBoardImportRoutes()); // /api/:org/internal/task-board/import — service-token batch import
+  app.route("/", createCommerceDiagnosticShareRoutes()); // /api/:org/internal/commerce-diagnostic/share-invite — service-token share invite
   app.route("/", createThreadOutputsRoutes()); // /api/:org/threads/:threadId/outputs
   app.route("/tools", createToolsRestRoutes()); // /api/:org/tools[/:toolName] — REST builtin-tool dispatch
   app.route("/", createObjectStorageRoutes()); // /api/:org/object-storage/*

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -35,7 +35,13 @@ const commerceMockKey = "e2e-commerce-key";
 // run rule). The second admin exists so an admin-impersonating-an-admin test can
 // reach the 409 re-impersonation guard — impersonating a NON-admin is rejected
 // by requireDeploymentAdmin first, before that guard runs.
-const webServerCommand = `MCP_CACHE_ENABLED=true COMMERCE_DISCOVERY_INTERNAL_API_URL=${commerceMockOrigin} COMMERCE_DISCOVERY_INTERNAL_API_KEY=${commerceMockKey} BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 DEPLOYMENT_ADMIN_EMAILS=deployment-admin@e2e.local,deployment-admin-2@e2e.local bun run dev:servers`;
+// Shared internal service bearer for the service-token routes (credential
+// vault, task-board import, commerce-diagnostic share-invite). Kept in sync by
+// hand with the literal in commerce-diagnostic-share.spec.ts (no shared import:
+// the config isn't a spec module).
+const vaultServiceToken = "e2e-vault-service-token";
+
+const webServerCommand = `MCP_CACHE_ENABLED=true VAULT_SERVICE_TOKEN=${vaultServiceToken} COMMERCE_DISCOVERY_INTERNAL_API_URL=${commerceMockOrigin} COMMERCE_DISCOVERY_INTERNAL_API_KEY=${commerceMockKey} BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 DEPLOYMENT_ADMIN_EMAILS=deployment-admin@e2e.local,deployment-admin-2@e2e.local bun run dev:servers`;
 
 export default defineConfig({
   testDir: "./tests",

--- a/packages/e2e/tests/commerce-diagnostic-share.spec.ts
+++ b/packages/e2e/tests/commerce-diagnostic-share.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * Commerce-diagnostic share-invite route — the service-token path behind the
+ * "Share this diagnostic" button (commerce-discovery's `share_my_diagnostic`
+ * tool calls it).
+ *
+ *   POST /api/:org/internal/commerce-diagnostic/share-invite
+ *
+ * The raw-SQL `insert into invitation` here writes a Better-Auth-managed table
+ * that isn't in the Kysely schema, so an in-memory fake would happily accept a
+ * column Postgres rejects (exactly the `teamId` bug this route already shipped
+ * and reverted). This exercises it over the wire against real Postgres and
+ * asserts the invitation rows it writes.
+ *
+ * Kept in sync by hand with playwright.config.ts's `vaultServiceToken`.
+ */
+
+import type { PlaywrightWorkerArgs } from "@playwright/test";
+import { type Client } from "pg";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { connectDevDb } from "../fixtures/db";
+import { expect, getE2EAppOrigin, test } from "../fixtures/test";
+
+type Playwright = PlaywrightWorkerArgs["playwright"];
+
+const TOKEN = "e2e-vault-service-token";
+const ROUTE = (org: string) =>
+  `/api/${org}/internal/commerce-diagnostic/share-invite`;
+
+// Unique email domain per run keeps invitee addresses from colliding across
+// parallel workers (the one global namespace, per TESTING.md).
+const EMAIL_DOMAIN = `share-e2e-${Date.now()}.test`;
+
+test.describe("commerce-diagnostic share-invite", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  async function svcContext(playwright: Playwright) {
+    const baseURL = getE2EAppOrigin();
+    return playwright.request.newContext({
+      baseURL,
+      extraHTTPHeaders: { Origin: baseURL, authorization: `Bearer ${TOKEN}` },
+    });
+  }
+
+  async function pendingInvites(orgId: string, email: string) {
+    const { rows } = await db.query<{ id: string }>(
+      `select id from invitation
+         where lower(email) = lower($1) and "organizationId" = $2
+           and status = 'pending' and "expiresAt" > now()`,
+      [email, orgId],
+    );
+    return rows;
+  }
+
+  async function orgIdForSlug(slug: string) {
+    const { rows } = await db.query<{ id: string }>(
+      `select id from "organization" where slug = $1`,
+      [slug],
+    );
+    return rows[0]?.id;
+  }
+
+  test("new invitee → pending invitation + accept URL that deep-links the report", async ({
+    page,
+    playwright,
+  }) => {
+    const owner = await signUpViaApi(page.context().request);
+    const orgId = await orgIdForSlug(owner.orgSlug);
+    expect(orgId).toBeTruthy();
+    const invitee = `newbie-${Date.now()}@${EMAIL_DOMAIN}`;
+
+    const svc = await svcContext(playwright);
+    const res = await svc.post(ROUTE(owner.orgSlug), {
+      data: { invitee_email: invitee },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.invitee_status).toBe("new");
+    // Accept URL carries the invitation and a relative redirectTo that opens
+    // the report on the org home.
+    expect(body.accept_url).toContain("/auth/accept-invitation?invitationId=");
+    const redirectTo = new URL(body.accept_url).searchParams.get("redirectTo");
+    expect(redirectTo?.startsWith(`/${owner.orgSlug}/`)).toBe(true);
+    expect(redirectTo).toContain("get_my_diagnostic");
+
+    const invites = await pendingInvites(orgId!, invitee);
+    expect(invites).toHaveLength(1);
+
+    // Re-share the same email: reuse the row, don't stack a second one.
+    const again = await svc.post(ROUTE(owner.orgSlug), {
+      data: { invitee_email: invitee },
+    });
+    expect(again.status()).toBe(200);
+    expect((await again.json()).invitee_status).toBe("new");
+    expect(await pendingInvites(orgId!, invitee)).toHaveLength(1);
+
+    await db.query(`delete from invitation where "organizationId" = $1`, [
+      orgId,
+    ]);
+    await svc.dispose();
+  });
+
+  test("existing member → no invitation, direct deep link", async ({
+    page,
+    playwright,
+  }) => {
+    const owner = await signUpViaApi(page.context().request);
+    const orgId = await orgIdForSlug(owner.orgSlug);
+
+    const svc = await svcContext(playwright);
+    const res = await svc.post(ROUTE(owner.orgSlug), {
+      data: { invitee_email: owner.email },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.invitee_status).toBe("member");
+    // The member skips the invite: the CTA is the report deep link itself.
+    expect(body.accept_url).not.toContain("accept-invitation");
+    expect(body.accept_url).toContain(`/${owner.orgSlug}/`);
+    expect(await pendingInvites(orgId!, owner.email)).toHaveLength(0);
+
+    await svc.dispose();
+  });
+
+  test("existing account, not a member → pending invitation, status existing", async ({
+    page,
+    playwright,
+  }) => {
+    const owner = await signUpViaApi(page.context().request);
+    const orgId = await orgIdForSlug(owner.orgSlug);
+    // A second real Studio account (in its own org, not the owner's).
+    const outsider = await signUpViaApi(
+      await playwright.request.newContext({ baseURL: getE2EAppOrigin() }),
+    );
+
+    const svc = await svcContext(playwright);
+    const res = await svc.post(ROUTE(owner.orgSlug), {
+      data: { invitee_email: outsider.email },
+    });
+    expect(res.status()).toBe(200);
+    expect((await res.json()).invitee_status).toBe("existing");
+    expect(await pendingInvites(orgId!, outsider.email)).toHaveLength(1);
+
+    await db.query(`delete from invitation where "organizationId" = $1`, [
+      orgId,
+    ]);
+    await svc.dispose();
+  });
+
+  test("rejects a missing/invalid bearer and a bad body", async ({
+    page,
+    playwright,
+  }) => {
+    const owner = await signUpViaApi(page.context().request);
+    const baseURL = getE2EAppOrigin();
+
+    const noAuth = await playwright.request.newContext({
+      baseURL,
+      extraHTTPHeaders: { Origin: baseURL },
+    });
+    const unauth = await noAuth.post(ROUTE(owner.orgSlug), {
+      data: { invitee_email: `x@${EMAIL_DOMAIN}` },
+    });
+    expect(unauth.status()).toBe(401);
+    await noAuth.dispose();
+
+    const svc = await svcContext(playwright);
+    const bad = await svc.post(ROUTE(owner.orgSlug), {
+      data: { invitee_email: "not-an-email" },
+    });
+    expect(bad.status()).toBe(400);
+    await svc.dispose();
+  });
+});


### PR DESCRIPTION
## What

Adds the Studio side of "share a private commerce diagnostic": a service-token route that mints an org invitation for the recipient and returns an accept URL whose `redirectTo` opens the shared diagnostic on the org home.

`POST /api/:org/internal/commerce-diagnostic/share-invite` — auth + org-by-id resolution mirror the existing `internal/task-board/import` route (shared `VAULT_SERVICE_TOKEN` bearer). The caller is commerce-discovery's new `share_my_diagnostic` tool.

## Why a bespoke path (not `inviteMember`)

Better Auth's `createInvitation` unconditionally fires the org plugin's generic `sendInvitationEmail`. The share flow needs a **different** email — a preview of the shared diagnostic — sent by commerce-discovery (which owns the diagnostic data + the branded report-email template). So this route creates the invitation row directly (no generic email) and hands back the accept URL; commerce-discovery sends the preview email with that URL as its CTA.

## Behaviour

- Existing org **member** → no invitation; returns the diagnostic deep link directly (`invitee_status: "member"`).
- Existing account, non-member → pending invitation (`"existing"`).
- New person → pending invitation (`"new"`); Better Auth branches signup-vs-accept at accept time.
- `redirectTo` is the exact home deep link `commerceReportNavTarget()` / `setup.ts` build: `/{slug}/{taskId}?virtualmcpid=..&main=app:{conn}:get_my_diagnostic` (relative → safe for login.tsx's redirect guard).

## Test

`bun test apps/mesh/src/api/routes/commerce-diagnostic-share.test.ts apps/mesh/src/api/middleware/resolve-org-from-path.test.ts` — deep-link builder, body schema, service-token path allowlist. `bun run check` clean for the touched files.

Pairs with commerce-discovery PR (the Share button + `share_my_diagnostic` tool + preview email).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a service-token route to share a private commerce diagnostic by minting an org invitation and returning an accept URL that deep-links to the report in org home. Adds real-Postgres e2e coverage and returns 409 when the org has no slug to avoid broken deep links.

- **New Features**
  - `POST /api/:org/internal/commerce-diagnostic/share-invite`: returns `accept_url` and `redirect_url` that open the diagnostic via the org-home deep link.
  - Auth mirrors task-board import: `VAULT_SERVICE_TOKEN` bearer; org resolved from path; route allowlisted and wired into the org-scoped API.
  - Invitation behavior: skip if invitee is an org member; otherwise reuse/create a pending invite and return status `member` | `existing` | `new`. Invitations are created via SQL (no generic email); commerce-discovery sends the preview email with the returned URL.

- **Bug Fixes**
  - Return 409 when the organization has no slug (prevents emitting a broken deep link).
  - Dropped nonexistent `teamId` from the invitation insert to avoid invite creation errors.

<sup>Written for commit 025b87cfc972a75bcccb8bc3759444e3c9d1a738. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

