### PR TITLE
fix(registry): show a loading state in the QA connections panel

### DIFF
--- a/apps/mesh/src/web/i18n/en/registry.ts
+++ b/apps/mesh/src/web/i18n/en/registry.ts
@@ -147,6 +147,8 @@ export const registry = {
     "Hide from public store",
   "registry.monitorConnectionsPanel.loadFailed":
     "Failed to load QA connections.",
+  "registry.monitorConnectionsPanel.loadingConnections":
+    "Loading QA connections...",
   "registry.monitorConnectionsPanel.needsAuth": "Needs Auth",
   "registry.monitorConnectionsPanel.noConnectionsForFilter":
     'No QA connections for this filter. Click "Sync" to create mappings from store items and pending requests.',

--- a/apps/mesh/src/web/i18n/pt-br/registry.ts
+++ b/apps/mesh/src/web/i18n/pt-br/registry.ts
@@ -155,6 +155,8 @@ export const registry = {
     "Ocultar da loja pública",
   "registry.monitorConnectionsPanel.loadFailed":
     "Falha ao carregar conexões de QA.",
+  "registry.monitorConnectionsPanel.loadingConnections":
+    "Carregando conexões de QA...",
   "registry.monitorConnectionsPanel.needsAuth": "Requer Autenticação",
   "registry.monitorConnectionsPanel.noConnectionsForFilter":
     'Nenhuma conexão de QA para este filtro. Clique em "Sincronizar" para criar mapeamentos de itens da loja e solicitações pendentes.',

--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -693,7 +693,11 @@ export function MonitorConnectionsPanel() {
         </Button>
       </div>
       <div className="space-y-2">
-        {listQuery.isError ? (
+        {listQuery.isLoading ? (
+          <p className="text-xs text-muted-foreground text-center py-3">
+            {t("registry.monitorConnectionsPanel.loadingConnections")}
+          </p>
+        ) : listQuery.isError ? (
           <div className="p-8 text-center rounded-lg border border-border">
             <p className="text-sm text-destructive">
               {t("registry.monitorConnectionsPanel.loadFailed")}
@@ -711,25 +715,27 @@ export function MonitorConnectionsPanel() {
             </p>
           )
         )}
-        {!listQuery.isError && filteredItems.length > 0 && (
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
-            {filteredItems.map((entry) => {
-              const counts = failuresByItem[entry.mapping.item_id] ?? {
-                failedTools: 0,
-                failedResults: 0,
-              };
-              return (
-                <ConnectionRow
-                  key={entry.mapping.id}
-                  entry={entry}
-                  onAuthChanged={() => listQuery.refetch()}
-                  failedToolsCount={counts.failedTools}
-                  failedResultCount={counts.failedResults}
-                />
-              );
-            })}
-          </div>
-        )}
+        {!listQuery.isLoading &&
+          !listQuery.isError &&
+          filteredItems.length > 0 && (
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+              {filteredItems.map((entry) => {
+                const counts = failuresByItem[entry.mapping.item_id] ?? {
+                  failedTools: 0,
+                  failedResults: 0,
+                };
+                return (
+                  <ConnectionRow
+                    key={entry.mapping.id}
+                    entry={entry}
+                    onAuthChanged={() => listQuery.refetch()}
+                    failedToolsCount={counts.failedTools}
+                    failedResultCount={counts.failedResults}
+                  />
+                );
+              })}
+            </div>
+          )}
       </div>
     </Card>
   );


### PR DESCRIPTION
**Source:** bug found while auditing the registry monitor-connections panel for the "registry monitor panel polish" focus area — `MonitorConnectionsPanel` never checked `listQuery.isLoading`.

**Why a maintainer wants it:** before the first `REGISTRY_MONITOR_CONNECTION_LIST` fetch resolves, `items` is `[]` (since `listQuery.data` is `undefined`), so the panel rendered "No connections match this filter" during every initial load and after every org switch — misleadingly telling the user there are zero QA connections when the list simply hasn't loaded yet. Fixed by rendering a dedicated loading message when `listQuery.isLoading` is true, before falling through to the error/empty/list branches.

**Command to verify:** `cd apps/mesh && bunx tsc --noEmit` (green). Manually: open the registry monitor page on a slow connection/throttled network — the panel now shows "Loading QA connections..." instead of the empty-filter message during the initial fetch.

**Checks run locally:** `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (no errors). No behavior-affecting test exists for this component per the repo's unit-test rule (no mocking `useProjectContext`/`useMCPClient` react-query hooks is allowed at the unit tier); this is a pure conditional-render fix verified by typecheck plus the existing i18n completeness check (`en`/`pt-br` dictionaries stay in sync, which `bun run check` also validates). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a proper loading state in the Registry Monitor Connections panel so users don’t see an empty message before data loads. This removes the “No QA connections…” flash on first load and org switches.

- **Bug Fixes**
  - Render a loading indicator when `listQuery.isLoading` is true.
  - Gate list rendering until data is loaded to avoid false empty states.
  - Add i18n strings for loading in `en` and `pt-br`.

<sup>Written for commit ec506e18219e99e88b9dc7013e61cab7d1f3ff22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

