### PR TITLE
fix(chat): stop editing a prompt mention chip from crashing the editor on a stale position

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention-slash.tsx
@@ -44,6 +44,7 @@ import {
   createMentionDoc,
   getMentionStorage,
   insertMention,
+  isMentionNodeAt,
   OnSelectProps,
   Suggestion,
   type EditMentionRequest,
@@ -294,6 +295,14 @@ export const SlashMention = ({
 
   const handleEditDialogSubmit = async (newValues: PromptArgumentValues) => {
     if (!editingMention || !client) return;
+    // The dialog captured `pos` when the chip was clicked; the doc may have
+    // changed since (chip deleted, text shifted) while the prompt fetch and
+    // the dialog were open. Bail instead of crashing the editor on a stale pos.
+    if (!isMentionNodeAt(editor, editingMention.pos, editingMention.promptId)) {
+      toast.error(t("chat.mentionSlash.failedUpdatePrompt"));
+      setEditingMention(null);
+      return;
+    }
     try {
       const result = await getPrompt(
         client,

--- a/apps/mesh/src/web/components/chat/tiptap/mention/index.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/index.ts
@@ -3,6 +3,7 @@ export {
   createMentionDoc,
   getMentionStorage,
   insertMention,
+  isMentionNodeAt,
   MentionNode,
   type EditMentionRequest,
   type MentionAttrs,

--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.test.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.test.tsx
@@ -8,7 +8,7 @@ import type { ReactNode } from "react";
 import { Editor } from "@tiptap/core";
 import { EditorContent, EditorContext } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { insertMention, MentionNode } from "./node.tsx";
+import { insertMention, isMentionNodeAt, MentionNode } from "./node.tsx";
 
 // useT() reads the language preference via TanStack Query.
 function wrapper({ children }: { children: ReactNode }) {
@@ -52,5 +52,54 @@ describe("mention chip aria-label", () => {
     expect(chip?.getAttribute("aria-label")).toBe(
       "Edit My Prompt Name prompt arguments",
     );
+  });
+});
+
+describe("isMentionNodeAt", () => {
+  test("is true right after inserting a mention at that position", () => {
+    const editor = new Editor({
+      extensions: [StarterKit, MentionNode],
+      content: { type: "doc", content: [{ type: "paragraph", content: [] }] },
+    });
+    insertMention(
+      editor,
+      { from: 1, to: 1 },
+      {
+        id: "1",
+        name: "my_prompt",
+        metadata: null,
+        char: "/",
+        kind: "prompt",
+      },
+    );
+
+    expect(isMentionNodeAt(editor, 1, "1")).toBe(true);
+  });
+
+  // The edit dialog captures `pos` when a chip is clicked, then resolves
+  // later (after an async prompt fetch). If the chip was deleted or the doc
+  // shifted in the meantime, `pos` no longer points at that mention node —
+  // this must be detected so the caller can bail instead of calling
+  // `setNodeSelection(pos)`, which throws on a stale/empty position.
+  test("is false once the doc changes and the position no longer holds that mention", () => {
+    const editor = new Editor({
+      extensions: [StarterKit, MentionNode],
+      content: { type: "doc", content: [{ type: "paragraph", content: [] }] },
+    });
+    insertMention(
+      editor,
+      { from: 1, to: 1 },
+      {
+        id: "1",
+        name: "my_prompt",
+        metadata: null,
+        char: "/",
+        kind: "prompt",
+      },
+    );
+
+    editor.chain().selectAll().deleteSelection().run();
+
+    expect(isMentionNodeAt(editor, 1, "1")).toBe(false);
   });
 });

--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
@@ -87,6 +87,23 @@ export function createMentionDoc<T>(attrs: MentionAttrs<T>): JSONContent {
   };
 }
 
+/**
+ * Confirms a mention chip with the given id still exists at `pos`. The
+ * edit dialog captures `pos` at click time and only resolves later (after an
+ * async prompt fetch) — if the doc changed in the meantime (chip deleted, or
+ * text inserted/removed before it), `pos` may no longer point at that node.
+ * `setNodeSelection` on such a stale/empty position throws (ProseMirror's
+ * NodeSelection reads `.nodeSize` off a null `nodeAfter`), crashing the editor.
+ */
+export function isMentionNodeAt(
+  editor: Editor,
+  pos: number,
+  id: string,
+): boolean {
+  const node = editor.state.doc.nodeAt(pos);
+  return node?.type.name === "mention" && node.attrs.id === id;
+}
+
 // ============================================================================
 // React Node View Component
 // ============================================================================


### PR DESCRIPTION
**Bug** found while auditing the `@/` mention tiptap node for edge-case crashes (not tied to an open issue).

**Failure scenario:** click a prompt mention chip to open its edit dialog (`MentionNodeView.triggerEdit` in `mention/node.tsx` captures the chip's ProseMirror position via `getPos()`). `mention-slash.tsx`'s `onEditChip` bridge then does an async prompt fetch before opening the dialog, and the dialog itself stays open until the user submits. If the document changes in that window — the chip gets deleted, or text is inserted/removed before it — the captured `pos` no longer points at that mention node. `handleEditDialogSubmit` called `editor.chain().focus().setNodeSelection(editingMention.pos)...` unconditionally; ProseMirror's `NodeSelection` constructor reads `.nodeSize` off `$pos.nodeAfter`, which is `null`/`undefined` at a stale position, so it throws and crashes the chat editor.

I reproduced this directly against the installed `@tiptap/core`/`prosemirror-state` version: build an editor, insert a mention, delete the doc content, then call `setNodeSelection(originalPos)` — it throws every time.

**Fix:** added `isMentionNodeAt(editor, pos, id)` in `mention/node.tsx` (real node-at-position check, no mocks) and call it as a guard at the top of `handleEditDialogSubmit` in `mention-slash.tsx` — if the chip is no longer there, show the existing `failedUpdatePrompt` toast and close the dialog instead of mutating the doc.

**Regression test:** `mention/node.test.tsx` now covers `isMentionNodeAt` both for the happy path (mention present at pos) and the crash-inducing case (doc changed, pos stale) using a real Tiptap `Editor` instance, matching the existing test pattern in that file.

**To verify:** `cd apps/mesh && bun test src/web/components/chat/tiptap/mention/node.test.tsx`

**Locally ran:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace, clean), and the targeted test file above (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the chat editor from crashing when editing a prompt mention chip after its stored position becomes stale. If the chip moved or was deleted, we detect it and exit gracefully with the existing toast.

- **Bug Fixes**
  - Added `isMentionNodeAt(editor, pos, id)` in `mention/node.tsx` to confirm the chip still exists at the captured position.
  - Guarded `handleEditDialogSubmit` in `mention-slash.tsx` to avoid calling `setNodeSelection` on a stale position; shows `failedUpdatePrompt` and closes the dialog.
  - Exported `isMentionNodeAt` and added regression tests in `mention/node.test.tsx`.

<sup>Written for commit cee30c49641845b4025c393a1a0627f830a73a35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

