### PR TITLE
fix(sandbox-preview): i18n the two hardcoded strings in PathParamInput

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/path-param-input.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-input.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import { CornerDownLeft } from "@untitledui/icons";
+import { useT } from "@/web/i18n/use-t.ts";
 
 /**
  * Inline editor for one `:param` or `*` (catch-all) token, rendered in place
@@ -14,6 +15,7 @@ export function PathParamInput({
   value: string;
   onCommit: (value: string) => void;
 }) {
+  const t = useT();
   const [draft, setDraft] = useState(value);
   const [focused, setFocused] = useState(false);
   const cancelledRef = useRef(false);
@@ -34,7 +36,7 @@ export function PathParamInput({
           type="text"
           value={draft}
           placeholder={label}
-          title={`Value for ${label}`}
+          title={t("sandbox.preview.valueForParam", { label })}
           spellCheck={false}
           className="absolute inset-0 rounded-sm bg-violet-500/15 px-1 text-[12px] text-violet-600 outline-none placeholder:text-violet-500/60 focus:bg-violet-500/25 dark:text-violet-400"
           onClick={(e) => e.stopPropagation()}
@@ -66,8 +68,7 @@ export function PathParamInput({
       {focused && (
         <span className="pointer-events-none ml-1.5 flex shrink-0 items-center gap-1 whitespace-nowrap rounded-sm border border-border bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
           <CornerDownLeft size={10} />
-          {/* TODO(i18n): "Enter to go" is part of inline editing hint; needs component context for t() */}
-          Enter to go
+          {t("sandbox.preview.enterToGo")}
         </span>
       )}
     </>

--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -364,6 +364,7 @@ export const sandbox = {
   "sandbox.preview.deviceMobile": "Mobile (375px)",
   "sandbox.preview.deviceTablet": "Tablet (768px)",
   "sandbox.preview.editSeo": "Edit SEO",
+  "sandbox.preview.enterToGo": "Enter to go",
   "sandbox.preview.failedToCopyUrl": "Failed to copy URL",
   "sandbox.preview.failedToCreatePage": "Failed to create page",
   "sandbox.preview.globalComponents": "Global components",
@@ -386,6 +387,7 @@ export const sandbox = {
   "sandbox.preview.templateNoLongerExists":
     "Selected template no longer exists.",
   "sandbox.preview.urlCopiedToClipboard": "URL copied to clipboard",
+  "sandbox.preview.valueForParam": "Value for {label}",
   "sandbox.preview.viewJson": "View JSON",
   "sandbox.preview.visualEditor": "Visual editor",
   "sandbox.productBlocks.addProductIdButton": "Add product ID",

--- a/apps/mesh/src/web/i18n/pt-br/sandbox.ts
+++ b/apps/mesh/src/web/i18n/pt-br/sandbox.ts
@@ -379,6 +379,7 @@ export const sandbox = {
   "sandbox.preview.deviceMobile": "Celular (375px)",
   "sandbox.preview.deviceTablet": "Tablet (768px)",
   "sandbox.preview.editSeo": "Editar SEO",
+  "sandbox.preview.enterToGo": "Enter para ir",
   "sandbox.preview.failedToCopyUrl": "Falha ao copiar URL",
   "sandbox.preview.failedToCreatePage": "Falha ao criar página",
   "sandbox.preview.globalComponents": "Componentes globais",
@@ -405,6 +406,7 @@ export const sandbox = {
     "O modelo selecionado não existe mais.",
   "sandbox.preview.urlCopiedToClipboard":
     "URL copiada para a área de transferência",
+  "sandbox.preview.valueForParam": "Valor de {label}",
   "sandbox.preview.viewJson": "Visualizar JSON",
   "sandbox.preview.visualEditor": "Editor visual",
   "sandbox.productBlocks.addProductIdButton": "Adicionar ID do produto",


### PR DESCRIPTION
Follow-up to #5051, which extracted `PathParamInput` from `preview.tsx` into its own module. The extraction carried over a hardcoded "Enter to go" hint behind a `TODO(i18n)` comment claiming it "needs component context for t()" - that's not true once the JSX lives in its own component; `useT()` is just a hook and can be called directly. This PR removes the TODO and routes both that hint and the input's `title` tooltip (`Value for :param`, also never i18n'd) through `t()`.

Why a maintainer wants this: the repo's i18n convention (CLAUDE.md) requires all user-facing strings in `apps/mesh/src/web` to go through `t()` - this is real, previously-missed coverage in a file that already has i18n infrastructure everywhere else in it (`sandbox.preview.*` keys).

Changes:
- `apps/mesh/src/web/components/sandbox/preview/path-param-input.tsx`: `useT()` + replace the two hardcoded strings.
- `apps/mesh/src/web/i18n/en/sandbox.ts` / `pt-br/sandbox.ts`: add `sandbox.preview.enterToGo` and `sandbox.preview.valueForParam` (interpolated with `{label}`).

No behavior change - same DOM output in English, translated in pt-BR. To confirm: switch the language preference to Portuguese and focus a `:param` token in a sandbox preview URL bar; the inline hint and input tooltip should render in Portuguese instead of falling back to hardcoded English.

Local checks run: `bun run fmt`, `bunx tsc --noEmit` in `apps/mesh` (clean for the touched files - the two pre-existing untracked `.test.ts` errors reported are unrelated to this change and predate this branch). Full CI (lint, full typecheck, test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internationalized the inline hint and tooltip in `PathParamInput` using `t()` so sandbox preview strings are translated. English stays the same; pt‑BR now shows proper translations.

- **Bug Fixes**
  - Use `useT()` in `PathParamInput` to translate the "Enter to go" hint and input `title` via `t()` (`sandbox.preview.enterToGo`, `sandbox.preview.valueForParam` with `{label}`).
  - Add the new keys in `apps/mesh/src/web/i18n/en/sandbox.ts` and `apps/mesh/src/web/i18n/pt-br/sandbox.ts`.

<sup>Written for commit 215ba9303b28edd9afe171e6682f8eaa492eea96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

