### PR TITLE
fix(mesh): retry smoke-link's online check to avoid a startup race

### DIFF
--- a/apps/mesh/scripts/smoke-link.ts
+++ b/apps/mesh/scripts/smoke-link.ts
@@ -5,6 +5,10 @@
  * fails fast if the status isn't "online". Useful as a quick check
  * before running an integration test that depends on a live link.
  *
+ * The link daemon can take a moment to finish registering right after
+ * `bun run dev --local-sandbox-provider` or `deco link` starts, so a
+ * single check is flaky — this retries with backoff before giving up.
+ *
  * Run with: `bun run smoke:link` from `apps/mesh/`.
  *
  * Required env:
@@ -13,6 +17,25 @@
  * Optional env:
  *   MESH_BASE_URL      Cluster base URL (default http://localhost:4000)
  */
+
+import { retry, RetryError } from "@decocms/std";
+
+async function checkOnline(baseUrl: string, token: string): Promise<string[]> {
+  const res = await fetch(`${baseUrl}/api/links/me`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`/api/links/me returned ${res.status}`);
+  }
+  const body = (await res.json()) as {
+    status?: string;
+    capabilities?: string[];
+  };
+  if (body.status !== "online") {
+    throw new Error(`link status is "${body.status}", not "online"`);
+  }
+  return body.capabilities ?? [];
+}
 
 async function main(): Promise<void> {
   const baseUrl = process.env.MESH_BASE_URL ?? "http://localhost:4000";
@@ -23,26 +46,21 @@ async function main(): Promise<void> {
     );
     process.exit(2);
   }
-  const res = await fetch(`${baseUrl}/api/links/me`, {
-    headers: { authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) {
+  try {
+    const capabilities = await retry(() => checkOnline(baseUrl, token), {
+      maxAttempts: 5,
+      minTimeout: 500,
+      maxTimeout: 3000,
+    });
+    console.log("smoke: link online — capabilities", capabilities);
+  } catch (err) {
+    const cause = err instanceof RetryError ? err.cause : err;
+    const message = cause instanceof Error ? cause.message : String(cause);
     console.error(
-      `smoke: /api/links/me returned ${res.status} — start the link with \`bun run dev --local-sandbox-provider\` or \`deco link <studio-url>\``,
+      `smoke: ${message} — start the link with \`bun run dev --local-sandbox-provider\` or \`deco link <studio-url>\``,
     );
     process.exit(1);
   }
-  const body = (await res.json()) as {
-    status?: string;
-    capabilities?: string[];
-  };
-  if (body.status !== "online") {
-    console.error(
-      "smoke: link is not online; start it with `bun run dev --local-sandbox-provider` or `deco link <studio-url>`",
-    );
-    process.exit(1);
-  }
-  console.log("smoke: link online — capabilities", body.capabilities);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
**Source**: bug in `apps/mesh/scripts/smoke-link.ts` (dev/CI helper, no linked issue).

**Why**: `smoke:link` does a single `fetch` and fails immediately if the link daemon isn't yet reporting `status: "online"`. Right after `bun run dev --local-sandbox-provider` or `deco link <studio-url>` starts, the daemon can take a moment to finish registering, so this check is flaky by construction — it can fail even though the link comes online a second later, forcing a manual re-run.

**Fix**: wrap the check in `retry()` from `@decocms/std` (the repo's canonical retry helper — see CLAUDE.md's "Async primitives" section) instead of hand-rolling a loop: up to 5 attempts, 500ms-3000ms exponential backoff. A non-2xx response or a non-"online" status is now retriable; a missing `MESH_TEST_SESSION` still exits immediately (that's a config error, not a race). Behavior for the genuinely-offline case is unchanged — it still exits 1 with the same actionable message, just after giving the daemon a few seconds to catch up.

**Net**: +33/-15 lines, one file, no new dependency (`@decocms/std` is already a workspace dependency and already used elsewhere in `apps/mesh/src`).

**To confirm**: run `MESH_TEST_SESSION=<token> bun run --cwd=apps/mesh smoke:link` against a freshly-starting `bun run dev --local-sandbox-provider` — it should now succeed once the daemon comes online instead of racing it.

**Verified locally**: `bun run fmt` and `cd apps/mesh && bunx tsc --noEmit` (both clean). This is a standalone dev script with no existing test harness; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries the link daemon online check in `apps/mesh/scripts/smoke-link.ts` to remove the startup race and stop flaky failures during dev/CI. Uses `@decocms/std` retry with backoff so the script waits a few seconds for the daemon to come online.

- **Bug Fixes**
  - Wrapped `/api/links/me` check in `retry` from `@decocms/std` (5 attempts, 500–3000ms backoff).
  - Non-2xx responses and non-"online" status are retried; missing `MESH_TEST_SESSION` still exits immediately.
  - Keeps the same exit code and message when the link stays offline; prints capabilities on success.

<sup>Written for commit 96810dc2d3b1b44d3eee94e4ef5ed38498288f23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

