### PR TITLE
fix(mcp-utils): keep GatewayClient.resolveClient's promise contract on synchronous factory throws

### DIFF
--- a/packages/mcp-utils/src/aggregate/gateway-client.test.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.test.ts
@@ -494,6 +494,26 @@ describe("GatewayClient", () => {
       const gw = new GatewayClient({});
       await expect(gw.getResolvedClient("x")).rejects.toThrow();
     });
+
+    it("rejects (does not throw synchronously) when the factory throws synchronously", async () => {
+      const gw = new GatewayClient({
+        broken: {
+          client: () => {
+            throw new Error("Unauthorized: Authentication required");
+          },
+        },
+      });
+
+      // Must not throw here — resolveClient's Promise<IClient> contract
+      // requires a rejected promise, not a synchronous exception.
+      let result: Promise<IClient> | undefined;
+      expect(() => {
+        result = gw.getResolvedClient("broken");
+      }).not.toThrow();
+      await expect(result).rejects.toThrow(
+        "Unauthorized: Authentication required",
+      );
+    });
   });
 
   describe("refresh()", () => {

--- a/packages/mcp-utils/src/aggregate/gateway-client.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.ts
@@ -293,10 +293,20 @@ export class GatewayClient extends Client {
     }
 
     const clientOrFactory = entry.client;
-    const promise =
-      typeof clientOrFactory === "function"
-        ? Promise.resolve(clientOrFactory())
-        : Promise.resolve(clientOrFactory);
+    let promise: Promise<IClient>;
+    try {
+      promise =
+        typeof clientOrFactory === "function"
+          ? Promise.resolve(clientOrFactory())
+          : Promise.resolve(clientOrFactory);
+    } catch (err) {
+      // A factory that throws synchronously (vs. returning a rejected
+      // promise) must still surface as a rejection — resolveClient's
+      // Promise<IClient> contract otherwise breaks for sync callers like
+      // getResolvedClient(), which would throw instead of returning a
+      // rejected promise.
+      return Promise.reject(err);
+    }
 
     // Remove from cache on failure so subsequent calls retry
     const guarded = promise.catch((err) => {


### PR DESCRIPTION
Bug found while reading `packages/mcp-utils/src/aggregate/gateway-client.ts` (this tick's focus area: mcp-utils-gateway).

**The gap:** `resolveClient()` builds its promise with `Promise.resolve(clientOrFactory())` — if the factory throws *synchronously* (rather than returning a rejected promise), the exception escapes before `Promise.resolve` is even reached. The `listTools`/`listResources`/`listResourceTemplates`/`listPrompts` aggregation paths happen to tolerate this by accident because they're `async` functions with a `try`/`catch` around the `await` (an existing test, "skips a connection whose lazy factory throws on resolve", already covers that path). But the public `getResolvedClient(key): Promise<IClient>` method is a plain (non-async) method that just returns `this.resolveClient(key)` directly — so for a synchronously-throwing factory it throws an uncaught exception instead of returning a rejected promise, breaking the method's own declared contract for any caller that does `gw.getResolvedClient(key).catch(...)`.

**Fix:** wrap the factory invocation in `resolveClient()` in a `try`/`catch` and convert a synchronous throw into `Promise.reject(err)`, so the method never throws synchronously regardless of caller.

**Regression test:** added `getResolvedClient > rejects (does not throw synchronously) when the factory throws synchronously` in `gateway-client.test.ts`, asserting the call itself doesn't throw and the returned promise rejects with the original error. Confirmed the test fails against the pre-fix code (reproduced via a standalone repro script before editing) and passes after.

**To verify:** `bun test packages/mcp-utils/src/aggregate/gateway-client.test.ts` (43 pass, 0 fail).

**Checks run locally:** `bun run fmt`, `cd packages/mcp-utils && bunx tsc --noEmit` (clean), and the targeted test file above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures `GatewayClient.resolveClient` in `mcp-utils` returns a rejected promise when a client factory throws synchronously, so `getResolvedClient` never throws and callers can reliably use `.catch()`.

- **Bug Fixes**
  - Wrap factory invocation in a try/catch and convert sync throws to `Promise.reject(err)`.
  - Add regression test verifying `getResolvedClient('broken')` rejects instead of throwing.

<sup>Written for commit 012625efd7a79052bccbd44c2a8fb13ce665f226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

