### PR TITLE
fix(sandbox-preview): localize the path-param picker's product/category labels

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
@@ -34,10 +34,20 @@ import {
 
 const PICKER_FETCH_TIMEOUT_MS = 10_000;
 
-const KIND_LABELS: Record<PathParamKind, { noun: string; heading: string }> = {
-  product: { noun: "product", heading: "Products" },
-  category: { noun: "category", heading: "Categories" },
-};
+function kindLabels(
+  t: ReturnType<typeof useT>,
+): Record<PathParamKind, { noun: string; heading: string }> {
+  return {
+    product: {
+      noun: t("sandbox.pathParamPickerChip.kindProductNoun"),
+      heading: t("sandbox.pathParamPickerChip.kindProductHeading"),
+    },
+    category: {
+      noun: t("sandbox.pathParamPickerChip.kindCategoryNoun"),
+      heading: t("sandbox.pathParamPickerChip.kindCategoryHeading"),
+    },
+  };
+}
 
 /**
  * Invoke a loader via the studio preview-invoke proxy (same-origin,
@@ -144,7 +154,7 @@ function PickerSourceGroup({
     retry: 1,
   });
 
-  const { noun, heading } = KIND_LABELS[source.kind];
+  const { noun, heading } = kindLabels(t)[source.kind];
   const options = source.clientFilter
     ? filterPickerOptions(query.data ?? [], search)
     : (query.data ?? []);
@@ -226,7 +236,8 @@ export function PathParamPickerChip({
 
   // The `*` catch-all reads badly in the URL bar; show a friendly word instead.
   const paramLabel = paramName === "*" ? "path" : `:${paramName}`;
-  const nouns = [...new Set(sources.map((s) => KIND_LABELS[s.kind].noun))];
+  const labels = kindLabels(t);
+  const nouns = [...new Set(sources.map((s) => labels[s.kind].noun))];
   const placeholder = t("sandbox.pathParamPickerChip.searchPlaceholder", {
     options: nouns.join(" or "),
   });

--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -284,6 +284,10 @@ export const sandbox = {
     "Value for {paramLabel} — click to pick",
   "sandbox.pathParamPickerChip.couldNotLoad":
     "Couldn't load — is the dev server running?",
+  "sandbox.pathParamPickerChip.kindCategoryHeading": "Categories",
+  "sandbox.pathParamPickerChip.kindCategoryNoun": "category",
+  "sandbox.pathParamPickerChip.kindProductHeading": "Products",
+  "sandbox.pathParamPickerChip.kindProductNoun": "product",
   "sandbox.pathParamPickerChip.loading": "Loading {noun}…",
   "sandbox.pathParamPickerChip.noResults": "No results.",
   "sandbox.pathParamPickerChip.pickValueHeading": "Pick a value for",

--- a/apps/mesh/src/web/i18n/pt-br/sandbox.ts
+++ b/apps/mesh/src/web/i18n/pt-br/sandbox.ts
@@ -292,6 +292,10 @@ export const sandbox = {
     "Valor para {paramLabel} — clique para escolher",
   "sandbox.pathParamPickerChip.couldNotLoad":
     "Não foi possível carregar — o servidor de desenvolvimento está rodando?",
+  "sandbox.pathParamPickerChip.kindCategoryHeading": "Categorias",
+  "sandbox.pathParamPickerChip.kindCategoryNoun": "categoria",
+  "sandbox.pathParamPickerChip.kindProductHeading": "Produtos",
+  "sandbox.pathParamPickerChip.kindProductNoun": "produto",
   "sandbox.pathParamPickerChip.loading": "Carregando {noun}…",
   "sandbox.pathParamPickerChip.noResults": "Nenhum resultado.",
   "sandbox.pathParamPickerChip.pickValueHeading": "Escolha um valor para",


### PR DESCRIPTION
Follows #5059 (i18n hardening of sandbox preview strings), same file family.

`path-param-picker-chip.tsx` had a module-level `KIND_LABELS` map with hardcoded English literals (`"product"`/`"Products"`, `"category"`/`"Categories"`) that fed the picker's `CommandGroup` heading directly and the `{noun}` interpolation inside the already-translated `sandbox.pathParamPickerChip.loading` string. A pt-br user opening the path-param picker would see the group heading as `Products`/`Categories` in English, and the loading state as `Carregando product…`/`Carregando category…` — an English noun spliced into an otherwise-translated sentence.

Fix: replaced the static map with a `kindLabels(t)` helper built from four new i18n keys (`kindProductNoun`, `kindProductHeading`, `kindCategoryNoun`, `kindCategoryHeading`), added to both `en/sandbox.ts` and `pt-br/sandbox.ts`. Behavior-preserving for English (identical strings), fixes the pt-br leak.

To confirm: switch the UI language to Português (Brasil), open a dynamic sandbox route with a `:product` or `:category` param, click the param chip to open the picker — the group heading and the loading text should now read in Portuguese ("Produtos"/"Carregando produto…") instead of English.

Locally ran: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (no new errors — the two pre-existing errors are unrelated to this change). No existing unit test covers this UI-text path; full CI (lint, type-check across workspaces) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the path-param picker chip’s product/category labels by replacing hardcoded English with i18n keys, fixing mixed-language text in Portuguese. English behavior is unchanged; Portuguese now shows correct nouns and headings.

- **Bug Fixes**
  - Added `kindLabels(t)` to read labels from i18n.
  - Introduced four keys in `en/sandbox.ts` and `pt-br/sandbox.ts` for product/category noun and heading.
  - Updated `path-param-picker-chip.tsx` to use localized labels for the group heading, loading text, and search placeholder.

<sup>Written for commit 22d72b927c7a9ebf652aac7f079ccf6e93e8ab28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

