### PR TITLE
fix(i18n): translate sandbox header action buttons into pt-br

### DIFF
--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -42,15 +42,17 @@ interface Props {
   virtualMcpId: string;
 }
 
-// Note: LOADING_BRANCH_BUTTON is module-scope and not component-rendered text directly;
-// will be replaced with i18n in HeaderActions component
-const LOADING_BRANCH_BUTTON: HeaderButton = {
-  label: "Loading branch…",
-  disabled: true,
-  loading: true,
-  variant: "outline",
-  tooltip: "Waiting for sandbox branch",
-};
+// Sentinel for the branch-not-yet-selected state; labels are filled in
+// at render time using the translated versions from the component.
+function makeBranchLoadingButton(t: TFunction): HeaderButton {
+  return {
+    label: t("thread.headerActions.loadingBranch"),
+    disabled: true,
+    loading: true,
+    variant: "outline",
+    tooltip: t("thread.headerActions.waitingForSandboxBranchTooltip"),
+  };
+}
 
 /**
  * HeaderActions renders the next-action button for the current branch + PR
@@ -204,8 +206,9 @@ export function HeaderActions({ virtualMcpId }: Props) {
         checks: checksQuery.data ?? [],
         reviews: reviewsQuery.data ?? null,
         loading: isPrStateActivelyLoading(prQuery),
+        t,
       })
-    : LOADING_BRANCH_BUTTON;
+    : makeBranchLoadingButton(t);
 
   const debugKey = JSON.stringify({
     label: button.label,

--- a/apps/mesh/src/web/components/thread/github/merge-split-button.tsx
+++ b/apps/mesh/src/web/components/thread/github/merge-split-button.tsx
@@ -31,7 +31,7 @@ export function MergeSplitButton({
   onReview,
 }: Props) {
   const t = useT();
-  const publishLabel = publishToBaseLabel(baseBranch);
+  const publishLabel = publishToBaseLabel(baseBranch, t);
   return (
     <div className="inline-flex items-stretch rounded-md">
       <Button

--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -4,6 +4,19 @@ import type { ClaimPhase } from "@/web/components/sandbox/hooks/sandbox-events-c
 import { selectHeaderButton } from "./panel-state";
 import type { CheckRun, PrSummary } from "./use-pr-data";
 import type { PrReviewSignals } from "./use-pr-reviews";
+import type { TFunction, TranslationKey } from "@/web/i18n/use-t.ts";
+import type { InterpolationVars } from "@/web/i18n/interpolate.ts";
+import { thread as threadEn } from "@/web/i18n/en/thread.ts";
+
+const mockT: TFunction = (key: TranslationKey, vars?: InterpolationVars) => {
+  const template =
+    (threadEn as Record<string, string>)[key as string] ?? (key as string);
+  if (!vars) return template;
+  return Object.entries(vars).reduce(
+    (s, [k, v]) => s.replace(`{${k}}`, String(v)),
+    template,
+  );
+};
 
 type ReadyBranch = Extract<BranchMeta, { kind: "ready" }>;
 
@@ -35,6 +48,7 @@ interface BaseInput {
   checks: CheckRun[];
   reviews: PrReviewSignals | null;
   loading?: boolean;
+  t: TFunction;
 }
 
 function happyInput(over: Partial<BaseInput> = {}): BaseInput {
@@ -45,6 +59,7 @@ function happyInput(over: Partial<BaseInput> = {}): BaseInput {
     pr: null,
     checks: [],
     reviews: null,
+    t: mockT,
     ...over,
   };
 }

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -5,6 +5,7 @@ import type { CheckRun, PrSummary } from "./use-pr-data.ts";
 import type { PrReviewSignals } from "./use-pr-reviews.ts";
 import { publishToBaseLabel } from "./publish-label.ts";
 import { saveChangesDebug } from "./save-changes-debug.ts";
+import type { TFunction } from "@/web/i18n/use-t.ts";
 
 /**
  * Header copy for claim-phase variants while lifecycle is still `idle`.
@@ -90,6 +91,7 @@ export interface SelectHeaderButtonInput {
   checks: CheckRun[];
   reviews: PrReviewSignals | null;
   loading?: boolean;
+  t: TFunction;
 }
 
 export function isPrStateActivelyLoading(query: {
@@ -102,15 +104,15 @@ export function isPrStateActivelyLoading(query: {
 export function selectHeaderButton(
   input: SelectHeaderButtonInput,
 ): HeaderButton {
-  const { lifecycle, branch, pr, checks, reviews, loading } = input;
+  const { lifecycle, branch, pr, checks, reviews, loading, t } = input;
 
   if (loading) {
     return {
-      label: "Loading…",
+      label: t("thread.headerActions.loading"),
       disabled: true,
       loading: true,
       variant: "outline",
-      tooltip: "Loading branch and pull request status",
+      tooltip: t("thread.headerActions.loadingBranchTooltip"),
     };
   }
 
@@ -125,37 +127,43 @@ export function selectHeaderButton(
     case "idle": {
       const label =
         (input.claimPhase && idleClaimCopy(input.claimPhase.kind)) ||
-        "Starting sandbox…";
+        t("thread.headerActions.startingSandbox");
       return {
         label,
         disabled: true,
         loading: true,
         variant: "outline",
-        tooltip: "Waiting for the sandbox daemon to come online",
+        tooltip: t("thread.headerActions.waitingForDaemonTooltip"),
       };
     }
     case "cloning":
       return {
-        label: "Cloning repo…",
+        label: t("thread.headerActions.cloningRepo"),
         disabled: true,
         loading: true,
         variant: "outline",
-        tooltip: "Cloning the project repository",
+        tooltip: t("thread.headerActions.cloningRepoTooltip"),
       };
     case "clone-failed":
       return {
-        label: "Clone failed",
+        label: t("thread.headerActions.cloneFailed"),
         disabled: true,
         variant: "outline",
-        tooltip: lifecycle.error || "git clone failed — see setup logs",
+        tooltip:
+          lifecycle.error ||
+          t("thread.headerActions.cloneFailedDefaultTooltip"),
       };
     case "checking-out":
       return {
-        label: `Switching to ${lifecycle.to}…`,
+        label: t("thread.headerActions.switchingTo", {
+          branch: lifecycle.to,
+        }),
         disabled: true,
         loading: true,
         variant: "outline",
-        tooltip: `Checking out ${lifecycle.to}`,
+        tooltip: t("thread.headerActions.checkingOutTooltip", {
+          branch: lifecycle.to,
+        }),
       };
     // installing / starting / running / install-failed / start-failed /
     // crashed: intentionally fall through to git/PR logic below.
@@ -166,21 +174,24 @@ export function selectHeaderButton(
   // the daemon emits it within a few hundred ms of checkout.
   if (branch.kind !== "ready") {
     return {
-      label: "Loading branch…",
+      label: t("thread.headerActions.loadingBranch"),
       disabled: true,
       loading: true,
       variant: "outline",
-      tooltip: "Waiting for branch metadata from the sandbox daemon",
+      tooltip: t("thread.headerActions.waitingForBranchTooltip"),
     };
   }
   const ready = branch;
 
   if (ready.workingTreeDirty) {
     return {
-      label: "Submit for review",
+      label: t("thread.headerActions.submitForReview"),
       action: "create-pr",
       variant: "default",
-      tooltip: `Push and open a PR for ${ready.branch} → ${ready.base}`,
+      tooltip: t("thread.headerActions.pushAndOpenPrTooltip", {
+        branch: ready.branch,
+        base: ready.base,
+      }),
       showPublishSide: true,
     };
   }
@@ -196,18 +207,23 @@ export function selectHeaderButton(
   if (trulyUnpushed) {
     if (!pr) {
       return {
-        label: "Submit for review",
+        label: t("thread.headerActions.submitForReview"),
         action: "create-pr",
         variant: "default",
-        tooltip: `Push and open a PR for ${ready.branch} → ${ready.base}`,
+        tooltip: t("thread.headerActions.pushAndOpenPrTooltip", {
+          branch: ready.branch,
+          base: ready.base,
+        }),
         showPublishSide: true,
       };
     }
     return {
-      label: "Submit for review",
+      label: t("thread.headerActions.submitForReview"),
       action: "create-pr",
       variant: "default",
-      tooltip: `Push local commits to PR #${pr.number}`,
+      tooltip: t("thread.headerActions.pushLocalCommitsTooltip", {
+        prNumber: String(pr.number),
+      }),
       showPublishSide: true,
     };
   }
@@ -235,36 +251,44 @@ export function selectHeaderButton(
       !!ready.headSha && !!pr.headSha && ready.headSha !== pr.headSha;
     if (branchAdvanced) {
       return {
-        label: "Continue",
+        label: t("thread.headerActions.continue"),
         action: "create-pr",
         variant: "special",
-        tooltip: "Open a new PR with the latest commits",
+        tooltip: t("thread.headerActions.openNewPrTooltip"),
         showPublishSide: true,
       };
     }
     return {
-      label: "Published",
+      label: t("thread.headerActions.published"),
       disabled: true,
       variant: "outline",
-      tooltip: `PR #${pr.number} merged into ${pr.base}`,
+      tooltip: t("thread.headerActions.prMergedTooltip", {
+        prNumber: String(pr.number),
+        base: pr.base,
+      }),
     };
   }
 
   if (ready.aheadOfBase > 0) {
     if (pr && pr.state === "closed" && !pr.merged) {
       return {
-        label: "Reopen",
+        label: t("thread.headerActions.reopen"),
         action: "reopen",
         variant: "default",
-        tooltip: `Reopen PR #${pr.number}`,
+        tooltip: t("thread.headerActions.reopenPrTooltip", {
+          prNumber: String(pr.number),
+        }),
       };
     }
     if (!pr) {
       return {
-        label: "Submit for review",
+        label: t("thread.headerActions.submitForReview"),
         action: "create-pr",
         variant: "default",
-        tooltip: `Open a PR for ${ready.branch} → ${ready.base}`,
+        tooltip: t("thread.headerActions.openPrForBranchTooltip", {
+          branch: ready.branch,
+          base: ready.base,
+        }),
         showPublishSide: true,
       };
     }
@@ -274,20 +298,24 @@ export function selectHeaderButton(
 
     if (mergeableState === "dirty") {
       return {
-        label: `Sync with ${pr.base}`,
+        label: t("thread.headerActions.syncWith", { base: pr.base }),
         action: "rebase",
         variant: "default",
-        tooltip: `Resolve conflicts with ${pr.base} before merging`,
+        tooltip: t("thread.headerActions.resolveConflictsTooltip", {
+          base: pr.base,
+        }),
       };
     }
 
     const failing = checks.filter(isCheckFailed).map((c) => c.name);
     if (failing.length > 0) {
       return {
-        label: "Fix tests",
+        label: t("thread.headerActions.fixTests"),
         action: "fix-checks",
         variant: "default",
-        tooltip: `Failing: ${failing.join(", ")}`,
+        tooltip: t("thread.headerActions.failingChecksTooltip", {
+          checks: failing.join(", "),
+        }),
         meta: { failingChecks: failing },
       };
     }
@@ -295,58 +323,63 @@ export function selectHeaderButton(
     const inProgress = checks.filter(isCheckInProgress);
     if (inProgress.length > 0) {
       return {
-        label: "Running tests…",
+        label: t("thread.headerActions.runningTests"),
         disabled: true,
         loading: true,
         variant: "outline",
-        tooltip: `Waiting on ${inProgress.length} check${
-          inProgress.length === 1 ? "" : "s"
-        } to finish`,
+        tooltip: t("thread.headerActions.waitingOnChecksTooltip", {
+          count: String(inProgress.length),
+        }),
       };
     }
 
     if (reviews?.draft) {
       return {
-        label: "Mark ready",
+        label: t("thread.headerActions.markReady"),
         action: "mark-ready",
         variant: "default",
-        tooltip: "Mark draft PR ready for review",
+        tooltip: t("thread.headerActions.markDraftReadyTooltip"),
       };
     }
 
     const unresolved = reviews?.unresolvedConversations ?? 0;
     if (unresolved > 0) {
       return {
-        label: "Address feedback",
+        label: t("thread.headerActions.addressFeedback"),
         action: "resolve-comments",
         variant: "default",
-        tooltip: `${unresolved} unresolved conversation${
-          unresolved === 1 ? "" : "s"
-        }`,
+        tooltip: t("thread.headerActions.unresolvedConversationsTooltip", {
+          count: String(unresolved),
+        }),
       };
     }
 
     if (reviews?.missingRequiredApprovals) {
       return {
-        label: "Awaiting review",
+        label: t("thread.headerActions.awaitingReview"),
         disabled: true,
         variant: "outline",
-        tooltip: "Waiting for required approvals",
+        tooltip: t("thread.headerActions.waitingForApprovalsTooltip"),
       };
     }
 
     return {
-      label: publishToBaseLabel(pr.base),
+      label: publishToBaseLabel(pr.base, t),
       action: "merge-split",
       variant: "success",
-      tooltip: `Squash-merge PR #${pr.number} into ${pr.base}`,
+      tooltip: t("thread.headerActions.prMergedTooltip", {
+        prNumber: String(pr.number),
+        base: pr.base,
+      }),
     };
   }
 
   return {
-    label: "Up to date",
+    label: t("thread.headerActions.upToDate"),
     disabled: true,
     variant: "outline",
-    tooltip: `Branch is in sync with ${ready.base}`,
+    tooltip: t("thread.headerActions.branchInSyncTooltip", {
+      base: ready.base,
+    }),
   };
 }

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -270,7 +270,7 @@ function PublishDialogBody({
   }
 
   const githubHeadBranch = readGitHeadBranch(gitStatus) ?? branch;
-  const publishLabel = publishToBaseLabel(baseBranch);
+  const publishLabel = publishToBaseLabel(baseBranch, t);
 
   const regenerateSuggestion = () => {
     if (!gitStatus || !gitDiff) return;

--- a/apps/mesh/src/web/components/thread/github/publish-label.test.ts
+++ b/apps/mesh/src/web/components/thread/github/publish-label.test.ts
@@ -1,18 +1,30 @@
 import { describe, expect, test } from "bun:test";
 import { publishToBaseLabel } from "./publish-label.ts";
 
+const mockT = (key: string) => key;
+
 describe("publishToBaseLabel", () => {
-  test("main → Publish to production", () => {
-    expect(publishToBaseLabel("main")).toBe("Publish to production");
-    expect(publishToBaseLabel("Main")).toBe("Publish to production");
+  test("main → publishToProduction key", () => {
+    expect(publishToBaseLabel("main", mockT as never)).toBe(
+      "thread.headerActions.publishToProduction",
+    );
+    expect(publishToBaseLabel("Main", mockT as never)).toBe(
+      "thread.headerActions.publishToProduction",
+    );
   });
 
-  test("master → Publish to production", () => {
-    expect(publishToBaseLabel("master")).toBe("Publish to production");
+  test("master → publishToProduction key", () => {
+    expect(publishToBaseLabel("master", mockT as never)).toBe(
+      "thread.headerActions.publishToProduction",
+    );
   });
 
-  test("other bases → Publish", () => {
-    expect(publishToBaseLabel("develop")).toBe("Publish");
-    expect(publishToBaseLabel("staging")).toBe("Publish");
+  test("other bases → publish key", () => {
+    expect(publishToBaseLabel("develop", mockT as never)).toBe(
+      "thread.headerActions.publish",
+    );
+    expect(publishToBaseLabel("staging", mockT as never)).toBe(
+      "thread.headerActions.publish",
+    );
   });
 });

--- a/apps/mesh/src/web/components/thread/github/publish-label.ts
+++ b/apps/mesh/src/web/components/thread/github/publish-label.ts
@@ -1,8 +1,10 @@
+import type { TFunction } from "@/web/i18n/use-t.ts";
+
 const PRODUCTION_BASE_BRANCHES = new Set(["main", "master"]);
 
 /** Squash-merge / publish action label for a target base branch. */
-export function publishToBaseLabel(base: string): string {
+export function publishToBaseLabel(base: string, t: TFunction): string {
   return PRODUCTION_BASE_BRANCHES.has(base.trim().toLowerCase())
-    ? "Publish to production"
-    : "Publish";
+    ? t("thread.headerActions.publishToProduction")
+    : t("thread.headerActions.publish");
 }

--- a/apps/mesh/src/web/i18n/en/thread.ts
+++ b/apps/mesh/src/web/i18n/en/thread.ts
@@ -42,16 +42,68 @@ export const thread = {
   "thread.gitTab.pickBranchForPrStatus":
     "Pick a branch from the header to see PR status.",
   "thread.gitTab.prNumber": "PR #{number}",
+  "thread.headerActions.addressFeedback": "Address feedback",
+  "thread.headerActions.awaitingReview": "Awaiting review",
+  "thread.headerActions.branchInSyncTooltip": "Branch is in sync with {base}",
   "thread.headerActions.chatIsRunning": "Chat is running",
+  "thread.headerActions.checkingOutTooltip": "Checking out {branch}",
+  "thread.headerActions.cloneFailed": "Clone failed",
+  "thread.headerActions.cloneFailedDefaultTooltip":
+    "git clone failed — see setup logs",
+  "thread.headerActions.cloningRepo": "Cloning repo…",
+  "thread.headerActions.cloningRepoTooltip": "Cloning the project repository",
+  "thread.headerActions.continue": "Continue",
   "thread.headerActions.failedToMergePullRequest":
     "Failed to merge pull request",
+  "thread.headerActions.failingChecksTooltip": "Failing: {checks}",
+  "thread.headerActions.fixTests": "Fix tests",
   "thread.headerActions.githubConnectionRemoved":
     "GitHub connection was removed — relink the repository in Settings to save changes",
+  "thread.headerActions.loading": "Loading…",
+  "thread.headerActions.loadingBranch": "Loading branch…",
+  "thread.headerActions.loadingBranchTooltip":
+    "Loading branch and pull request status",
+  "thread.headerActions.markReady": "Mark ready",
+  "thread.headerActions.markDraftReadyTooltip":
+    "Mark draft PR ready for review",
+  "thread.headerActions.openNewPrTooltip":
+    "Open a new PR with the latest commits",
+  "thread.headerActions.openPrForBranchTooltip":
+    "Open a PR for {branch} → {base}",
+  "thread.headerActions.prMergedTooltip": "PR #{prNumber} merged into {base}",
   "thread.headerActions.publish": "Publish",
   "thread.headerActions.publishDirectlySkipReview":
     "Publish directly, skipping review",
   "thread.headerActions.publishedPr": "Published PR #{prNumber}",
+  "thread.headerActions.published": "Published",
+  "thread.headerActions.publishToProduction": "Publish to production",
+  "thread.headerActions.pushAndOpenPrTooltip":
+    "Push and open a PR for {branch} → {base}",
+  "thread.headerActions.pushLocalCommitsTooltip":
+    "Push local commits to PR #{prNumber}",
   "thread.headerActions.reconnectGithub": "Reconnect GitHub",
+  "thread.headerActions.reopen": "Reopen",
+  "thread.headerActions.reopenPrTooltip": "Reopen PR #{prNumber}",
+  "thread.headerActions.resolveConflictsTooltip":
+    "Resolve conflicts with {base} before merging",
+  "thread.headerActions.runningTests": "Running tests…",
+  "thread.headerActions.startingSandbox": "Starting sandbox…",
+  "thread.headerActions.submitForReview": "Submit for review",
+  "thread.headerActions.switchingTo": "Switching to {branch}…",
+  "thread.headerActions.syncWith": "Sync with {base}",
+  "thread.headerActions.unresolvedConversationsTooltip":
+    "{count} unresolved conversation(s)",
+  "thread.headerActions.upToDate": "Up to date",
+  "thread.headerActions.waitingForApprovalsTooltip":
+    "Waiting for required approvals",
+  "thread.headerActions.waitingForBranchTooltip":
+    "Waiting for branch metadata from the sandbox daemon",
+  "thread.headerActions.waitingForDaemonTooltip":
+    "Waiting for the sandbox daemon to come online",
+  "thread.headerActions.waitingForSandboxBranchTooltip":
+    "Waiting for sandbox branch",
+  "thread.headerActions.waitingOnChecksTooltip":
+    "Waiting on {count} check(s) to finish",
   "thread.mergeSplitButton.moreActionsAriaLabel": "More actions",
   "thread.mergeSplitButton.review": "Review",
   "thread.openInBoardButton.openTaskAriaLabel": "Open task in board",

--- a/apps/mesh/src/web/i18n/pt-br/thread.ts
+++ b/apps/mesh/src/web/i18n/pt-br/thread.ts
@@ -45,16 +45,69 @@ export const thread = {
   "thread.gitTab.pickBranchForPrStatus":
     "Escolha uma branch no cabeçalho para ver o status da PR.",
   "thread.gitTab.prNumber": "PR #{number}",
+  "thread.headerActions.addressFeedback": "Tratar feedback",
+  "thread.headerActions.awaitingReview": "Aguardando revisão",
+  "thread.headerActions.branchInSyncTooltip": "Branch sincronizada com {base}",
   "thread.headerActions.chatIsRunning": "Chat está em execução",
+  "thread.headerActions.checkingOutTooltip": "Fazendo checkout de {branch}",
+  "thread.headerActions.cloneFailed": "Clone falhou",
+  "thread.headerActions.cloneFailedDefaultTooltip":
+    "git clone falhou — veja os logs de configuração",
+  "thread.headerActions.cloningRepo": "Clonando repositório…",
+  "thread.headerActions.cloningRepoTooltip":
+    "Clonando o repositório do projeto",
+  "thread.headerActions.continue": "Continuar",
   "thread.headerActions.failedToMergePullRequest":
     "Falha ao mesclar a pull request",
+  "thread.headerActions.failingChecksTooltip": "Falhando: {checks}",
+  "thread.headerActions.fixTests": "Corrigir testes",
   "thread.headerActions.githubConnectionRemoved":
     "A conexão do GitHub foi removida — revincula o repositório em Configurações para salvar alterações",
+  "thread.headerActions.loading": "Carregando…",
+  "thread.headerActions.loadingBranch": "Carregando branch…",
+  "thread.headerActions.loadingBranchTooltip":
+    "Carregando branch e status do pull request",
+  "thread.headerActions.markReady": "Marcar como pronto",
+  "thread.headerActions.markDraftReadyTooltip":
+    "Marcar PR rascunho como pronto para revisão",
+  "thread.headerActions.openNewPrTooltip":
+    "Abrir um novo PR com os últimos commits",
+  "thread.headerActions.openPrForBranchTooltip":
+    "Abrir um PR para {branch} → {base}",
+  "thread.headerActions.prMergedTooltip": "PR #{prNumber} mesclado em {base}",
   "thread.headerActions.publish": "Publicar",
   "thread.headerActions.publishDirectlySkipReview":
     "Publicar diretamente, pulando a revisão",
   "thread.headerActions.publishedPr": "PR #{prNumber} publicado",
+  "thread.headerActions.published": "Publicado",
+  "thread.headerActions.publishToProduction": "Publicar em produção",
+  "thread.headerActions.pushAndOpenPrTooltip":
+    "Enviar e abrir um PR para {branch} → {base}",
+  "thread.headerActions.pushLocalCommitsTooltip":
+    "Enviar commits locais para o PR #{prNumber}",
   "thread.headerActions.reconnectGithub": "Reconectar GitHub",
+  "thread.headerActions.reopen": "Reabrir",
+  "thread.headerActions.reopenPrTooltip": "Reabrir PR #{prNumber}",
+  "thread.headerActions.resolveConflictsTooltip":
+    "Resolver conflitos com {base} antes de mesclar",
+  "thread.headerActions.runningTests": "Executando testes…",
+  "thread.headerActions.startingSandbox": "Iniciando sandbox…",
+  "thread.headerActions.submitForReview": "Enviar para revisão",
+  "thread.headerActions.switchingTo": "Mudando para {branch}…",
+  "thread.headerActions.syncWith": "Sincronizar com {base}",
+  "thread.headerActions.unresolvedConversationsTooltip":
+    "{count} conversa(s) não resolvida(s)",
+  "thread.headerActions.upToDate": "Atualizado",
+  "thread.headerActions.waitingForApprovalsTooltip":
+    "Aguardando aprovações obrigatórias",
+  "thread.headerActions.waitingForBranchTooltip":
+    "Aguardando metadados da branch do daemon da sandbox",
+  "thread.headerActions.waitingForDaemonTooltip":
+    "Aguardando o daemon da sandbox ficar online",
+  "thread.headerActions.waitingForSandboxBranchTooltip":
+    "Aguardando branch da sandbox",
+  "thread.headerActions.waitingOnChecksTooltip":
+    "Aguardando {count} verificação(ões) terminar",
   "thread.mergeSplitButton.moreActionsAriaLabel": "Mais ações",
   "thread.mergeSplitButton.review": "Revisar",
   "thread.openInBoardButton.openTaskAriaLabel": "Abrir tarefa no quadro",


### PR DESCRIPTION
## Summary

- Sandbox header buttons (Up to date, Sync with main, Publish, Submit for review, Running tests, etc.) were hardcoded in English inside `selectHeaderButton` and `publishToBaseLabel`, bypassing the i18n system
- Pass `TFunction` into `selectHeaderButton` and `publishToBaseLabel` so all labels and tooltips are routed through `t()`
- Add 28 new keys to `en/thread.ts` and matching Portuguese translations to `pt-br/thread.ts`

## Test plan

- [ ] `bun test apps/mesh/src/web/components/thread/github/panel-state.test.ts` — 40 tests pass with `mockT` resolving against the EN dictionary
- [ ] `bun test apps/mesh/src/web/components/thread/github/publish-label.test.ts` — 4 tests pass
- [ ] `bun run check` — no TypeScript errors
- [ ] Switch UI language to Português (Brasil) and verify header buttons show translated labels ("Atualizado", "Sincronizar com main", "Publicar", "Enviar para revisão", etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized sandbox header action buttons and tooltips by routing all labels through the i18n layer, with full pt-br support. Removes hardcoded English strings so Portuguese users see correct translations.

- **Bug Fixes**
  - Passed `t: TFunction` into `selectHeaderButton` and `publishToBaseLabel`.
  - Replaced hardcoded labels/tooltips with `t()` across header actions.
  - Added 28 new keys to `en/thread.ts` with matching `pt-br/thread.ts` translations.
  - Updated tests to inject a `mockT`; all tests pass.

- **Migration**
  - `selectHeaderButton` now requires `{ ..., t }`.
  - `publishToBaseLabel(base, t)` replaces `publishToBaseLabel(base)`.

<sup>Written for commit 26ccf0a2d6c69b88c8457c290149017b370ea4f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

