### PR TITLE
fix(registry): distinguish an unreachable QA connection from a missing token

### DIFF
--- a/apps/mesh/src/web/i18n/en/registry.ts
+++ b/apps/mesh/src/web/i18n/en/registry.ts
@@ -118,6 +118,8 @@ export const registry = {
     '"{title}" is reachable. You can re-authenticate if needed.',
   "registry.monitorConnectionsPanel.connectionsSynced":
     "Connections synced (store + pending requests)",
+  "registry.monitorConnectionsPanel.connectionUnreachable":
+    '"{title}" could not be reached: {error}',
   "registry.monitorConnectionsPanel.couldNotReachConnection":
     'Could not reach "{title}". The remote MCP may be down.',
   "registry.monitorConnectionsPanel.description1":
@@ -191,6 +193,7 @@ export const registry = {
   "registry.monitorConnectionsPanel.tokenManualAuth": "Token/manual auth",
   "registry.monitorConnectionsPanel.tokenSaved": 'Token saved for "{title}"!',
   "registry.monitorConnectionsPanel.unknownError": "Unknown error",
+  "registry.monitorConnectionsPanel.unreachable": "Unreachable",
   "registry.monitorConnectionsPanel.visibilityOnlyForStore":
     "Visibility controls are available only for store items.",
   "registry.monitorConnectionsPanel.visibilityUpdated": "Visibility updated",

--- a/apps/mesh/src/web/i18n/pt-br/registry.ts
+++ b/apps/mesh/src/web/i18n/pt-br/registry.ts
@@ -126,6 +126,8 @@ export const registry = {
     '"{title}" está acessível. Você pode autenticar novamente se necessário.',
   "registry.monitorConnectionsPanel.connectionsSynced":
     "Conexões sincronizadas (loja + solicitações pendentes)",
+  "registry.monitorConnectionsPanel.connectionUnreachable":
+    'Não foi possível alcançar "{title}": {error}',
   "registry.monitorConnectionsPanel.couldNotReachConnection":
     'Não foi possível alcançar "{title}". O MCP remoto pode estar inativo.',
   "registry.monitorConnectionsPanel.description1":
@@ -201,6 +203,7 @@ export const registry = {
     "Token/autenticação manual",
   "registry.monitorConnectionsPanel.tokenSaved": 'Token salvo para "{title}"!',
   "registry.monitorConnectionsPanel.unknownError": "Erro desconhecido",
+  "registry.monitorConnectionsPanel.unreachable": "Inacessível",
   "registry.monitorConnectionsPanel.visibilityOnlyForStore":
     "Os controles de visibilidade estão disponíveis apenas para itens da loja.",
   "registry.monitorConnectionsPanel.visibilityUpdated":

--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -137,19 +137,25 @@ function ConnectionRow({
   const hasOAuthToken = probeResult?.hasOAuthToken ?? false;
   const isServerError = probeResult?.isServerError ?? false;
   const probeIsAuthenticated = probeResult?.isAuthenticated ?? false;
+  // A non-server-error `error` means the probe request itself failed (network,
+  // DNS, CORS) — distinct from "not authenticated yet", which otherwise falls
+  // through to the misleading "token required" flavor below.
+  const probeError = !isServerError ? probeResult?.error : undefined;
   const authFlavor = isProbeLoading
     ? "checking"
     : isServerError
       ? "server_error"
-      : supportsOAuth
-        ? probeIsAuthenticated
-          ? hasOAuthToken
-            ? "oauth_connected"
-            : "connected"
-          : "oauth_available"
-        : probeIsAuthenticated
-          ? "connected"
-          : "token_required";
+      : probeError
+        ? "unreachable"
+        : supportsOAuth
+          ? probeIsAuthenticated
+            ? hasOAuthToken
+              ? "oauth_connected"
+              : "connected"
+            : "oauth_available"
+          : probeIsAuthenticated
+            ? "connected"
+            : "token_required";
 
   const markAuthenticated = () => {
     updateAuth.mutate(
@@ -204,6 +210,16 @@ function ConnectionRow({
         toast.error(
           t("registry.monitorConnectionsPanel.serverErrorConnection", {
             title,
+          }),
+        );
+        return;
+      }
+
+      if (status.error) {
+        toast.error(
+          t("registry.monitorConnectionsPanel.connectionUnreachable", {
+            title,
+            error: status.error,
           }),
         );
         return;
@@ -403,7 +419,7 @@ function ConnectionRow({
                 variant="outline"
                 className={cn(
                   "text-[10px]",
-                  authFlavor === "server_error"
+                  authFlavor === "server_error" || authFlavor === "unreachable"
                     ? "border-destructive/40 text-destructive"
                     : authFlavor === "oauth_connected"
                       ? "border-success/30 text-success"
@@ -418,6 +434,8 @@ function ConnectionRow({
                   t("registry.monitorConnectionsPanel.checkingAuth")}
                 {authFlavor === "server_error" &&
                   t("registry.monitorConnectionsPanel.serverError")}
+                {authFlavor === "unreachable" &&
+                  t("registry.monitorConnectionsPanel.unreachable")}
                 {authFlavor === "oauth_connected" &&
                   t("registry.monitorConnectionsPanel.oauthConnected")}
                 {authFlavor === "oauth_available" &&


### PR DESCRIPTION
Bug found while auditing `monitor-connections-panel.tsx` for missing error handling in the live connection-probe flow (no linked issue).

`isConnectionAuthenticated()` (packages/mesh-sdk/src/lib/mcp-oauth.ts) sets a plain `error` string when the probe request itself fails (network error, DNS, CORS) inside its `catch` block — distinct from `isServerError`, which is only set for a 5xx HTTP response. The panel read `isServerError` but never read `error`, so a total probe failure silently fell through to the same "token required" badge and the same "noOAuthSupport" toast used for a perfectly reachable server that simply lacks OAuth — telling the user to paste an API token for a connection that's actually unreachable.

**Fix**: read `probeResult.error` (when not a server error) as a new `unreachable` auth flavor, surfaced as its own destructive-styled badge (`registry.monitorConnectionsPanel.unreachable`) in the row, and as its own toast (`connectionUnreachable`) in the Authenticate button's flow, checked before the generic "no OAuth support" branch. Added the new en/pt-br i18n keys per the repo's i18n convention.

Behavior-preserving for every other path: `isServerError`, `supportsOAuth`, and `isAuthenticated` branches are untouched; only the previously-uncovered "fetch itself threw" case gets its own label instead of masquerading as "needs a token."

**To verify**: force `isConnectionAuthenticated` to hit its `catch` block (e.g. point a connection's MCP proxy at an unreachable host) and confirm the row shows an "Unreachable" badge and the Authenticate button reports a reachability error instead of prompting for a token.

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` in `apps/mesh` (both clean). No existing test covers this UI path; full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Distinguishes an unreachable connection from a missing token in the Monitor Connections panel, showing a clear “Unreachable” state instead of prompting for a token. Prevents misleading auth prompts when the probe request fails (network/DNS/CORS).

- **Bug Fixes**
  - Read `probeResult.error` (when not `isServerError`) and map to a new `unreachable` auth flavor.
  - Show a destructive-styled “Unreachable” badge and an Authenticate toast (`connectionUnreachable`) before the “no OAuth support” path.
  - Added i18n keys for en and pt-br.
  - No changes to other auth states (`isServerError`, `supportsOAuth`, `isAuthenticated`).

<sup>Written for commit 5d83d584c8024e983b162753eec6d863d2d587ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

