### PR TITLE
fix(chat): translate the user-ask question pagination count

### DIFF
--- a/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
+++ b/apps/mesh/src/web/components/chat/highlight/user-ask-question.tsx
@@ -474,7 +474,10 @@ function UserAskPrompt({ parts, isStreaming, onSubmit }: UserAskPromptProps) {
         <CollapsibleHighlight
           icon={<MessageQuestionCircle size={14} />}
           label={t("chat.userAskQuestion.questionPending")}
-          count={`${decisionForm.currentIndex + 1} of ${parts.length}`}
+          count={t("chat.userAskQuestion.questionCount", {
+            current: decisionForm.currentIndex + 1,
+            total: parts.length,
+          })}
           title={current?.input?.prompt ?? t("chat.userAskQuestion.question")}
           defaultExpanded={true}
           footerLeft={footerLeft}

--- a/apps/mesh/src/web/i18n/en/chat.ts
+++ b/apps/mesh/src/web/i18n/en/chat.ts
@@ -428,6 +428,7 @@ export const chat = {
   "chat.userAskQuestion.customChoiceInputAriaLabel": "Custom choice input",
   "chat.userAskQuestion.preparingQuestion": "Preparing question...",
   "chat.userAskQuestion.question": "Question",
+  "chat.userAskQuestion.questionCount": "{current} of {total}",
   "chat.userAskQuestion.questionPending": "Question pending",
   "chat.userAskQuestion.selectOption": "Select {option}",
   "chat.userAskQuestion.skip": "Skip",

--- a/apps/mesh/src/web/i18n/pt-br/chat.ts
+++ b/apps/mesh/src/web/i18n/pt-br/chat.ts
@@ -441,6 +441,7 @@ export const chat = {
     "Entrada de escolha customizada",
   "chat.userAskQuestion.preparingQuestion": "Preparando pergunta...",
   "chat.userAskQuestion.question": "Pergunta",
+  "chat.userAskQuestion.questionCount": "{current} de {total}",
   "chat.userAskQuestion.questionPending": "Pergunta pendente",
   "chat.userAskQuestion.selectOption": "Selecione {option}",
   "chat.userAskQuestion.skip": "Pular",


### PR DESCRIPTION
The "N of M" pagination count on the multi-question ask-question highlight card (`user-ask-question.tsx`) was built with a raw template literal (`` `${current} of ${total}` ``) instead of going through `t()`, so it stayed in English for pt-BR users while every other label on the same card (skip, submit, aria-labels, etc.) is already translated via `chat.userAskQuestion.*` keys. This is a straightforward completeness gap in the i18n coverage of this component, per the repo's "never hardcode user-facing strings in apps/mesh/src/web" rule.

**Fix**: added `chat.userAskQuestion.questionCount` ("{current} of {total}" / "{current} de {total}") to both `en/chat.ts` and `pt-br/chat.ts`, and swapped the raw template string in `user-ask-question.tsx` for `t("chat.userAskQuestion.questionCount", { current, total })`. Pure string swap, no behavior change to the pagination logic itself.

**To verify**: switch language to Portuguese (BR) in preferences, trigger a multi-part user-ask question (2+ pending questions in one turn), and confirm the count badge reads "1 de 2" instead of "1 of 2".

**Checks run locally**: `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/mesh` (no new errors — the only errors present are in a pre-existing unrelated untracked test file I did not touch). No existing test covers this component's rendered text directly; `bun run check`/i18n key-completeness typecheck (which enforces `en`/`pt-br` key parity) validates the new key pair. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the "N of M" question count on the user ask card so it matches the selected language. Adds an i18n key and swaps the hardcoded string; no behavior changes.

- **Bug Fixes**
  - Added `chat.userAskQuestion.questionCount` to `en/chat.ts` and `pt-br/chat.ts` ("{current} of {total}" / "{current} de {total}").
  - Replaced the inline template in `user-ask-question.tsx` with `t("chat.userAskQuestion.questionCount", { current, total })`.

<sup>Written for commit b57bd0cc2acd682d385f954f4fab76fcfece9e51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

