### PR TITLE
refactor(chat): replace render-time ref-current writes with useEffectEvent in mention hooks

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/mention-at.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention-at.tsx
@@ -15,7 +15,7 @@ import {
 import type { ListResourcesResult } from "@modelcontextprotocol/sdk/types.js";
 import { useQueryClient } from "@tanstack/react-query";
 import type { Editor } from "@tiptap/react";
-import { useRef, useState } from "react";
+import { useEffectEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 import { BaseItem, insertMention, OnSelectProps, Suggestion } from "./mention";
 import { track } from "@/web/lib/posthog-client";
@@ -59,9 +59,9 @@ export const AtMention = ({
   const resourcesQueryKey = KEYS.virtualMcpResources(virtualMcpId, org.id);
 
   const [mode, setMode] = useState<AtMode>("categories");
-  const modeRef = useRef(mode);
-  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
-  modeRef.current = mode;
+  // Always reads the latest `mode` from fetchItems, which react-query calls
+  // outside of render (so a plain closure over `mode` would go stale).
+  const getMode = useEffectEvent(() => mode);
 
   // Track picker open → close outcome so we can measure abandonment.
   const pickerOpenedAtRef = useRef<number | null>(null);
@@ -139,7 +139,7 @@ export const AtMention = ({
 
   const fetchItems = async (props: { query: string }): Promise<AtItem[]> => {
     const { query } = props;
-    const currentMode = modeRef.current;
+    const currentMode = getMode();
 
     if (currentMode === "categories") {
       if (!query.trim()) return categoryItems;

--- a/apps/mesh/src/web/components/chat/tiptap/mention/hooks.ts
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/hooks.ts
@@ -12,6 +12,7 @@ import {
   useContext,
   useDeferredValue,
   useEffect,
+  useEffectEvent,
   useReducer,
   useRef,
   useState,
@@ -365,10 +366,12 @@ export function useMentionState({
     selectedItem: null,
   });
 
-  // Ref for onOpenChange to avoid stale closures in the plugin
-  const onOpenChangeRef = useRef(onOpenChange);
-  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
-  onOpenChangeRef.current = onOpenChange;
+  // Always calls the latest onOpenChange, without needing the plugin
+  // registration effect below to re-run (and tear down/rebuild the plugin)
+  // whenever the caller passes a new function identity.
+  const notifyOpenChange = useEffectEvent((open: boolean) => {
+    onOpenChange?.(open);
+  });
 
   // Register the suggestion plugin here at the top level
   // This ensures it's always active even when the menu is closed
@@ -426,7 +429,7 @@ export function useMentionState({
               range: props.range,
             },
           });
-          onOpenChangeRef.current?.(true);
+          notifyOpenChange(true);
         },
 
         onUpdate: (props: SuggestionProps<BaseItem>) => {
@@ -450,7 +453,7 @@ export function useMentionState({
 
         onExit: () => {
           dispatch({ type: "ON_EXIT" });
-          onOpenChangeRef.current?.(false);
+          notifyOpenChange(false);
         },
       }),
 


### PR DESCRIPTION
Removes two suppressed lint warnings (each carrying a `// oxlint-disable-next-line ban-ref-current-assignment ... TODO: refactor render-time .current access` comment) in the chat tiptap mention machinery, by fixing the underlying pattern instead of leaving it suppressed.

`apps/mesh/src/web/components/chat/tiptap/mention/hooks.ts`'s `useMentionState` and `apps/mesh/src/web/components/chat/tiptap/mention-at.tsx`'s `AtMention` each wrote to a ref's `.current` directly in the render body, to keep a callback/value fresh for code that runs outside React's render (a ProseMirror plugin callback, and react-query's `queryFn`) without re-triggering an expensive effect (plugin re-registration) on every render. That's exactly the case React 19.2's `useEffectEvent` exists for, and the codebase already uses it elsewhere (`auth-entry.tsx`, `signal-deck.tsx`). Swapping the ref-write for `useEffectEvent` removes the anti-pattern the lint rule flags, with no ref indirection and no suppression comment needed.

Behavior is unchanged: `notifyOpenChange`/`getMode` are called at exactly the same call sites the old `.current` reads were, just via a React-managed stable function instead of a manually-synced ref.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit`, and `bun test apps/mesh/src/web/components/chat/tiptap/input.test.tsx apps/mesh/src/web/components/chat/tiptap/mention/node.test.tsx` (both exercise the suggestion-dropdown open/close and mention-insertion flows these hooks drive).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace, clean), and the two targeted test files above (9/9 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced render-time `ref.current` writes in chat mention components with React 19.2 `useEffectEvent` to keep callbacks fresh without re-registering plugins. Removes suppressed lint warnings; behavior is unchanged.

- **Refactors**
  - `AtMention`: added `getMode` via `useEffectEvent` so `@tanstack/react-query` fetcher always reads the latest mode.
  - `useMentionState`: wrapped `onOpenChange` with `useEffectEvent` for the ProseMirror suggestion plugin callbacks.

<sup>Written for commit 7bd5f09f5dc707dab4f4ab936409e20f2a9b0e00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

