### PR TITLE
fix(worker): protect decopilot workers from Karpenter consolidation + survive sandbox reap

### DIFF
--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/cluster-sandbox-fs.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/cluster-sandbox-fs.ts
@@ -148,12 +148,16 @@ export async function buildClusterSandboxFs(
   // reap + respawn rather than surface a sticky failure.
   const canAutoRestart =
     vm.branch === "ephemeral" || providerKind === "user-desktop";
-  const invalidateHandle = async () => {
+  const invalidateHandle = async (opts?: { force?: boolean }) => {
     // Capture before clearing — we need the dead handle to flush the captured
     // runner's cache below.
     const lastHandlePromise = cached;
     cached = null;
-    if (!canAutoRestart) return;
+    // `force` (set by the retry layer when the daemon reported the sandbox is
+    // provably GONE — 404) reaps + respawns even for non-auto-restart branches:
+    // a reaped sandbox has no working tree left to preserve, so recovering an
+    // in-flight run beats surfacing a sticky failure after infra dropped it.
+    if (!canAutoRestart && !opts?.force) return;
     // Reap the vmMap entry so the next `ensureSandbox` provisions fresh rather
     // than returning the dead vmId from the fast path.
     try {

--- a/deploy/helm/studio/templates/worker-deployment.yaml
+++ b/deploy/helm/studio/templates/worker-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      {{- if or .Values.metrics.scrape .Values.podAnnotations }}
+      {{- if or .Values.metrics.scrape .Values.podAnnotations .Values.worker.doNotDisrupt }}
       annotations:
         {{- if .Values.metrics.scrape }}
         # Worker runs the stream pump (encode/publish) and the run executors, so
@@ -43,6 +43,17 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.configMap.meshConfig.PORT | default "3000" | quote }}
         prometheus.io/path: {{ .Values.metrics.path | quote }}
+        {{- end }}
+        {{- if .Values.worker.doNotDisrupt }}
+        # Workers execute in-flight agent-loop runs (DBOS workflows, concurrency=1
+        # per thread). Workers are I/O-bound on LLM/sandbox calls, so their nodes
+        # look CPU-idle and Karpenter consolidates them ("Evicted: Underutilized")
+        # mid-run — graceful shutdown then blocks on pending workflows while the
+        # replacement pod re-recovers ~20 workflows and the interrupted run's
+        # sandbox is reaped, so decopilot chats stall. Block Karpenter VOLUNTARY
+        # disruption (consolidation/drift/expiration); deploys still roll pods
+        # normally and land them on fresh nodes, so drift is resolved each release.
+        karpenter.sh/do-not-disrupt: "true"
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -87,6 +87,12 @@ worker:
     minReplicas: 2
     maxReplicas: 30
     targetCPUUtilizationPercentage: 65
+  # Stamp `karpenter.sh/do-not-disrupt: "true"` on worker pods so Karpenter does
+  # not consolidate/drift-evict a worker mid-run (see worker-deployment.yaml).
+  # Default on; set false where Karpenter isn't the node provisioner. (A
+  # PodDisruptionBudget for forced/involuntary eviction is deployed alongside,
+  # in the deco-apps-cd wrapper chart, next to the existing mesh PDB.)
+  doNotDisrupt: true
   # Extra env for worker pods only (merged after the shared envFrom).
   env: []
 

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
@@ -229,4 +229,65 @@ describe("createSandboxFsHooks", () => {
     expect(attempts).toBe(2);
     expect(invalidated).toBe(1);
   });
+
+  test("respawns on 404 sandbox-not-found even when canAutoRestart is false", async () => {
+    // A reaped sandbox (worker eviction / housekeeper GC dropped it mid-run) is
+    // provably gone — never a user pause — so even a persistent branch recovers
+    // instead of surfacing a sticky failure. `force` must reach invalidateHandle
+    // so the map entry is reaped, not just the memoised handle cleared.
+    let attempts = 0;
+    let forced: boolean | undefined;
+    const provider = {
+      kind: "agent-sandbox",
+      proxyDaemonRequest: async () => {
+        attempts++;
+        if (attempts === 1) {
+          return new Response(JSON.stringify({ error: "sandbox not found" }), {
+            status: 404,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({ kind: "text", content: "recovered", lineCount: 1 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      },
+    } as unknown as SandboxProvider;
+    const hooks = createSandboxFsHooks(provider, {
+      ensureHandle: async () => "h",
+      invalidateHandle: async (opts) => {
+        forced = opts?.force;
+      },
+      canAutoRestart: false,
+    });
+    const out = await hooks.onRead("/app/x.ts");
+    expect(out).toBe("recovered");
+    expect(attempts).toBe(2);
+    expect(forced).toBe(true);
+  });
+
+  test("does NOT respawn on an ambiguous connect failure when canAutoRestart is false", async () => {
+    // A transport throw (not a 404) could be a transient blip on a still-live
+    // persistent sandbox — reaping would abandon its working tree — so the
+    // conservative branch surfaces the sticky failure without a retry.
+    let attempts = 0;
+    let invalidated = 0;
+    const provider = {
+      kind: "agent-sandbox",
+      proxyDaemonRequest: async () => {
+        attempts++;
+        throw new Error("connection refused");
+      },
+    } as unknown as SandboxProvider;
+    const hooks = createSandboxFsHooks(provider, {
+      ensureHandle: async () => "h",
+      invalidateHandle: async () => {
+        invalidated++;
+      },
+      canAutoRestart: false,
+    });
+    await expect(hooks.onRead("/app/x.ts")).rejects.toThrow(/not running/);
+    expect(attempts).toBe(1);
+    expect(invalidated).toBe(0);
+  });
 });

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.ts
@@ -97,8 +97,13 @@ export interface SandboxFsHooksLifecycle {
    * underlying sandbox map entry) so the next `ensureHandle` provisions a fresh
    * sandbox. Used by the retry layer when the daemon proxy reports the sandbox
    * is unreachable.
+   *
+   * `force: true` reaps the map entry even for non-auto-restart branches — the
+   * retry layer sets it when the sandbox is provably GONE (404), where there is
+   * no live working tree to preserve, so an in-flight run can survive infra
+   * reaping (e.g. a worker eviction that dropped the sandbox).
    */
-  invalidateHandle(): Promise<void>;
+  invalidateHandle(opts?: { force?: boolean }): Promise<void>;
   /**
    * When true, the call wrapper retries once on `DaemonUnreachableError` (after
    * invalidating the handle). Enabled for ephemeral agents (no server-button UI
@@ -167,8 +172,20 @@ function abortable<T>(signal: AbortSignal, promise: Promise<T>): Promise<T> {
  */
 class DaemonUnreachableError extends Error {
   readonly code = "DAEMON_UNREACHABLE" as const;
-  constructor(cause: unknown) {
+  /**
+   * True when the daemon definitively reported the sandbox is GONE — a 404
+   * `sandbox not found`, i.e. the record was reaped (housekeeper GC, or a worker
+   * eviction that dropped the sandbox mid-run). A reaped sandbox has no working
+   * tree left to preserve, so respawning is always safe — the retry layer honors
+   * this even when `canAutoRestart` is false. Left false for AMBIGUOUS failures
+   * (transport threw / 5xx): those can be a transient blip on a still-live
+   * sandbox, where a respawn would abandon its working tree, so they stay gated
+   * behind `canAutoRestart`.
+   */
+  readonly gone: boolean;
+  constructor(cause: unknown, gone = false) {
     super(cause instanceof Error ? cause.message : "Daemon proxy failed");
+    this.gone = gone;
     if (cause instanceof Error) {
       this.cause = cause;
     }
@@ -262,7 +279,9 @@ async function daemonRequest(
       (json as { error?: string }).error ??
       `Daemon ${path} failed (${res.status})`;
     if (res.status === 404 && errorMessage === "sandbox not found") {
-      throw new DaemonUnreachableError(new Error(errorMessage));
+      // `gone: true` — the sandbox is provably reaped (never a user pause), so
+      // the retry layer respawns even for persistent branches.
+      throw new DaemonUnreachableError(new Error(errorMessage), true);
     }
     throw new Error(errorMessage);
   }
@@ -332,18 +351,20 @@ export function createSandboxFsHooks(
       // Only retry on daemon-unreachable (sandbox dead). HTTP-level errors
       // from a live daemon (4xx/5xx) are surfaced as-is — a retry would
       // just repeat the same failure.
-      if (!(firstErr instanceof DaemonUnreachableError) || !canAutoRestart) {
-        if (firstErr instanceof DaemonUnreachableError) {
-          throw new Error(formatUnreachableMessage(firstErr.cause ?? firstErr));
-        }
-        throw firstErr;
+      if (!(firstErr instanceof DaemonUnreachableError)) throw firstErr;
+      // Respawn when the branch opts into auto-restart, OR when the sandbox is
+      // provably GONE (404) — a reaped sandbox has nothing to preserve, so even
+      // persistent branches recover instead of surfacing a sticky failure when
+      // infra (a worker eviction / housekeeper GC) drops the sandbox mid-run.
+      if (!canAutoRestart && !firstErr.gone) {
+        throw new Error(formatUnreachableMessage(firstErr.cause ?? firstErr));
       }
       console.warn(
         `[sandbox-fs-hooks] daemon ${daemonPath} unreachable — reaping sandbox and retrying once`,
         firstErr.cause ?? firstErr,
       );
       try {
-        await invalidateHandle();
+        await invalidateHandle({ force: firstErr.gone });
       } catch (reapErr) {
         console.warn("[sandbox-fs-hooks] invalidateHandle failed", reapErr);
       }


### PR DESCRIPTION
## Problem

Decopilot chats were **pending/slow** in prod (eks-serverless). Diagnosed via kubectl + Grafana:

- Karpenter kept evicting `deco-studio-worker` pods as **`Evicted: Underutilized`** (workers are I/O-bound on LLM/sandbox calls, so their nodes look CPU-idle). The worker had **no `karpenter.sh/do-not-disrupt`** and **no PDB**.
- Each eviction killed in-flight DBOS runs mid-step. Graceful shutdown then logged `Waiting for pending workflows to finish`, and the replacement pod logged `Recovering 20 workflows`.
- The interrupted run's **sandbox was reaped**, so its tool calls failed with `404 sandbox not found` / `502 Unable to connect` (`[sandbox-fs-hooks] daemon unreachable`), holding the **`decopilot-hosted-harness` concurrency=1** per-thread slot → the chat stalls. DBOS even self-throttled: `Contention detected … Increasing polling interval … to 2.00s`.

This was **churn, not backlog** — the queue was ~empty and KEDA correctly showed queue-depth 0 (it's ENQUEUED-only; parked/in-flight runs are invisible to it, as the code already documents).

## Fix

1. **Consolidation protection** — stamp `karpenter.sh/do-not-disrupt: "true"` on worker pods (gated by `worker.doNotDisrupt`, default on). Karpenter no longer voluntarily consolidates/drift-evicts a worker mid-run. Deploys still roll pods normally, so drift is resolved each release.

2. **Survive sandbox reap** — a `404 sandbox not found` now marks `DaemonUnreachableError` as `gone`; the fs-hooks retry layer reaps + respawns the sandbox on `gone` **even for persistent (non-auto-restart) branches**. A reaped sandbox has no working tree to preserve, so an in-flight hosted run recovers instead of failing. Ambiguous connect failures (5xx / transport throw) stay gated behind `canAutoRestart` to avoid abandoning a still-live sandbox on a transient blip.

## Companion

The **worker PDB** (forced/involuntary eviction) is added in the deco-apps-cd wrapper chart (next to the existing mesh PDB), which is where PDBs and the KEDA ScaledObject already live: decocms/deco-apps-cd#167. `do-not-disrupt` reaches prod once that repo bumps the `chart-deco-studio` dependency to include this change.

## Testing

- `bun test packages/sandbox/server/provider/sandbox-fs-hooks.test.ts` — 12 pass, including two new cases: respawn-on-404 even when `canAutoRestart=false`, and no-respawn on ambiguous connect failure.
- `bun run check` clean for changed files; `bun run fmt` clean.
- `helm template` verified: annotation lands on the worker pod template only.