### PR TITLE
fix(monitoring): translate log row status badge into pt-br

### DIFF
--- a/apps/mesh/src/web/components/monitoring/log-row.tsx
+++ b/apps/mesh/src/web/components/monitoring/log-row.tsx
@@ -10,6 +10,7 @@ import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Container } from "@untitledui/icons";
 import type { EnrichedMonitoringLog } from "./types.tsx";
 import { TableCell, TableRow } from "@deco/ui/components/table.tsx";
+import { useT } from "@/web/i18n/use-t";
 
 // ============================================================================
 // Types
@@ -42,6 +43,7 @@ export function LogRow({
   onClick,
   lastLogRef,
 }: LogRowProps) {
+  const t = useT();
   const timestamp = new Date(log.timestamp);
   const dateStr = timestamp.toLocaleDateString("en-US", {
     month: "short",
@@ -131,7 +133,9 @@ export function LogRow({
             variant={log.isError ? "destructive" : "success"}
             className="px-1.5 md:px-2 py-0.5 md:py-1"
           >
-            {log.isError ? "Error" : "OK"}
+            {log.isError
+              ? t("monitoring.logRow.statusError")
+              : t("monitoring.logRow.statusOk")}
           </Badge>
         </div>
       </TableCell>

--- a/apps/mesh/src/web/i18n/en/monitoring.ts
+++ b/apps/mesh/src/web/i18n/en/monitoring.ts
@@ -26,6 +26,8 @@ export const monitoring = {
   "monitoring.types.timestamp": "Timestamp",
   "monitoring.types.truncated": "truncated",
   "monitoring.types.user": "User",
+  "monitoring.logRow.statusError": "Error",
+  "monitoring.logRow.statusOk": "OK",
   "monitoring.timeRangePicker.absoluteTimeRange": "Absolute time range",
   "monitoring.timeRangePicker.from": "From",
   "monitoring.timeRangePicker.to": "To",

--- a/apps/mesh/src/web/i18n/pt-br/monitoring.ts
+++ b/apps/mesh/src/web/i18n/pt-br/monitoring.ts
@@ -32,6 +32,8 @@ export const monitoring = {
   "monitoring.types.timestamp": "Data e hora",
   "monitoring.types.truncated": "truncado",
   "monitoring.types.user": "Usu\u00e1rio",
+  "monitoring.logRow.statusError": "Erro",
+  "monitoring.logRow.statusOk": "OK",
   "monitoring.timeRangePicker.absoluteTimeRange": "Intervalo de tempo absoluto",
   "monitoring.timeRangePicker.from": "De",
   "monitoring.timeRangePicker.to": "Para",


### PR DESCRIPTION
The monitoring log table's per-row status badge (`LogRow`) hardcoded "Error"/"OK" as English string literals instead of going through the i18n dictionary, so a pt-br user sees English text next to every other translated label in the monitoring UI (repo rule: no hardcoded user-facing strings in apps/mesh/src/web — see CLAUDE.md i18n section).

Change:
- Added `monitoring.logRow.statusError` / `monitoring.logRow.statusOk` keys to `i18n/en/monitoring.ts` and `i18n/pt-br/monitoring.ts` (Erro/OK).
- `log-row.tsx` now calls `useT()` and renders the badge text via `t(...)` instead of the raw literals.

Net diff: +9/-1 across 3 files, one concern (i18n only), no behavior change to English users.

How to verify: switch language to Português (Brasil) in preferences, open the monitoring log table — the status badge on a row now reads "Erro"/"OK" instead of "Error"/"OK".

Local checks run: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (passes, and since `pt-br/monitoring.ts` uses `satisfies Record<keyof typeof monitoringEn, string>`, a missing pt-br key would have been a compile error). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translated the monitoring log row status badge by replacing hardcoded "Error"/"OK" with i18n keys. Added `monitoring.logRow.statusError` and `monitoring.logRow.statusOk` to `i18n/en/monitoring.ts` and `i18n/pt-br/monitoring.ts`, so pt-br shows "Erro"/"OK" with no change for English users.

<sup>Written for commit b750a0725863602fc64980be038fac416e291eef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

