### PR TITLE
fix(thread): show the correct tooltip on the squash-merge action button

### DIFF
--- a/apps/mesh/src/web/components/thread/github/panel-state.test.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.test.ts
@@ -353,6 +353,7 @@ describe("selectHeaderButton", () => {
     expect(r.label).toBe("Publish to production");
     expect(r.action).toBe("merge-split");
     expect(r.variant).toBe("success");
+    expect(r.tooltip).toBe("Squash-merge PR #42 into main");
   });
 
   test("ahead of base + closed non-merged PR → Reopen PR", () => {

--- a/apps/mesh/src/web/components/thread/github/panel-state.ts
+++ b/apps/mesh/src/web/components/thread/github/panel-state.ts
@@ -367,7 +367,7 @@ export function selectHeaderButton(
       label: publishToBaseLabel(pr.base, t),
       action: "merge-split",
       variant: "success",
-      tooltip: t("thread.headerActions.prMergedTooltip", {
+      tooltip: t("thread.headerActions.squashMergeTooltip", {
         prNumber: String(pr.number),
         base: pr.base,
       }),

--- a/apps/mesh/src/web/i18n/en/thread.ts
+++ b/apps/mesh/src/web/i18n/en/thread.ts
@@ -87,6 +87,8 @@ export const thread = {
   "thread.headerActions.resolveConflictsTooltip":
     "Resolve conflicts with {base} before merging",
   "thread.headerActions.runningTests": "Running tests…",
+  "thread.headerActions.squashMergeTooltip":
+    "Squash-merge PR #{prNumber} into {base}",
   "thread.headerActions.startingSandbox": "Starting sandbox…",
   "thread.headerActions.submitForReview": "Submit for review",
   "thread.headerActions.switchingTo": "Switching to {branch}…",

--- a/apps/mesh/src/web/i18n/pt-br/thread.ts
+++ b/apps/mesh/src/web/i18n/pt-br/thread.ts
@@ -91,6 +91,8 @@ export const thread = {
   "thread.headerActions.resolveConflictsTooltip":
     "Resolver conflitos com {base} antes de mesclar",
   "thread.headerActions.runningTests": "Executando testes…",
+  "thread.headerActions.squashMergeTooltip":
+    "Squash-merge do PR #{prNumber} em {base}",
   "thread.headerActions.startingSandbox": "Iniciando sandbox…",
   "thread.headerActions.submitForReview": "Enviar para revisão",
   "thread.headerActions.switchingTo": "Mudando para {branch}…",


### PR DESCRIPTION
Follows #5064's i18n pass — a regression introduced by that PR, not a pre-existing bug.

**Why a maintainer wants this:** `panel-state.ts`'s `merge-split` branch is the clickable squash-merge CTA shown while a PR is still open and mergeable (`variant: "success"`). Before #5064 it had its own tooltip string, `Squash-merge PR #${pr.number} into ${pr.base}`. The i18n extraction in #5064 accidentally pointed it at `thread.headerActions.prMergedTooltip` ("PR #{prNumber} merged into {base}") instead — the same key used by the *already-merged, disabled* `Published` state a few branches above. The button now tells the user their PR is already merged while its entire purpose is to merge it.

**Fix:** added a distinct key `thread.headerActions.squashMergeTooltip` ("Squash-merge PR #{prNumber} into {base}", plus pt-br) and pointed the merge-split branch at it instead of reusing `prMergedTooltip`.

**Regression test:** extended the existing `panel-state.test.ts` case `"false-positive unpushed (headSha matches PR) → falls through to merge"` (the case that exercises the merge-split branch) with `expect(r.tooltip).toBe("Squash-merge PR #42 into main")` — this fails against the pre-fix code (which resolves to "PR #42 merged into main").

**To verify:** `bun test apps/mesh/src/web/components/thread/github/panel-state.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file above (39 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the wrong tooltip on the squash-merge action button by restoring the correct, present-tense copy. Adds a dedicated i18n key and a test to prevent regressions.

- **Bug Fixes**
  - Use `thread.headerActions.squashMergeTooltip` for the `merge-split` CTA instead of `prMergedTooltip`.
  - Add EN and PT-BR strings for the new key.
  - Extend `panel-state.test.ts` to assert the expected tooltip.

<sup>Written for commit 6063f4a0fa526bcd59204fceda970003499a9ecd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

