### PR TITLE
fix(connection-details): add aria-label to icon-only controls in connection detail views

### DIFF
--- a/apps/mesh/src/web/components/details/connection/connection-instances-panel.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-instances-panel.tsx
@@ -107,6 +107,7 @@ function InstanceItem({
             className="h-7 w-7 text-muted-foreground"
             onClick={() => onToggleStatus(instance, "inactive")}
             title={t("details.connectionInstancesPanel.disable")}
+            aria-label={t("details.connectionInstancesPanel.disable")}
           >
             <SlashCircle01 size={13} />
           </Button>
@@ -117,6 +118,7 @@ function InstanceItem({
           className="h-7 w-7"
           onClick={() => onConfigure(instance)}
           title={t("details.connectionInstancesPanel.configure")}
+          aria-label={t("details.connectionInstancesPanel.configure")}
         >
           <Settings02 size={13} />
         </Button>
@@ -126,6 +128,7 @@ function InstanceItem({
           className="h-7 w-7 text-muted-foreground hover:text-destructive"
           onClick={() => onDelete(instance)}
           title={t("details.connectionInstancesPanel.delete")}
+          aria-label={t("details.connectionInstancesPanel.delete")}
         >
           <Trash01 size={13} />
         </Button>
@@ -160,6 +163,7 @@ function InstanceItemFallback({
           className="h-7 w-7"
           onClick={() => onConfigure(instance)}
           title={t("details.connectionInstancesPanel.configure")}
+          aria-label={t("details.connectionInstancesPanel.configure")}
         >
           <Settings02 size={13} />
         </Button>

--- a/apps/mesh/src/web/components/details/connection/connection-sidebar.tsx
+++ b/apps/mesh/src/web/components/details/connection/connection-sidebar.tsx
@@ -406,6 +406,9 @@ export function ConnectionFields({
                     onClick={() => field.onChange("")}
                     className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded hover:bg-muted opacity-0 group-hover:opacity-100 transition-opacity"
                     title={t("details.connectionSidebar.clearAndReplaceToken")}
+                    aria-label={t(
+                      "details.connectionSidebar.clearAndReplaceToken",
+                    )}
                   >
                     <XClose size={14} className="text-muted-foreground" />
                   </button>


### PR DESCRIPTION
Source: accessibility gap found while auditing `apps/mesh/src/web/components/details/connection/*` for consistency/a11y — no linked issue.

Why: five icon-only controls (disable/configure/delete instance buttons in the connections panel, plus the clear-token button in the connection sidebar) only set a `title` attribute. `title` is a tooltip, not an accessible name — screen readers announce these buttons with no label, so a screen-reader user browsing a connection's instances or editing its token can't tell what each icon button does.

Fix: added `aria-label` to each, reusing the existing translated string already used for `title` (`t("details.connectionInstancesPanel.disable/configure/delete")` and `t("details.connectionSidebar.clearAndReplaceToken")`), so no new i18n keys were needed and behavior/visuals are unchanged.

Reviewer check: open a connection's detail page, add a second instance, and inspect the disable/configure/delete icon buttons and the token clear (X) button in dev tools — each now has a matching `aria-label`.

Local checks run: `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/mesh` (no new errors — the only errors reported are pre-existing in an unrelated untracked file, `src/storage/types.test.ts`, from a different in-flight change). No test file needed: this is a static-markup a11y attribute addition, not a logic change. Full CI will run lint/type/tests on the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added aria-labels to icon-only controls in connection details so screen readers announce clear button names. Applies to disable/configure/delete buttons in the instances panel and the clear-token button in the sidebar; reuses existing i18n strings with no UI or behavior changes.

<sup>Written for commit 7c18b263987b0b39011b20ab6fafab24e6c2ae6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

