### PR TITLE
fix(blog): call useT unconditionally in product blocks (React #300)

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-blocks.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/product-blocks.tsx
@@ -163,6 +163,7 @@ function SortableProductCard({
   loading: boolean;
   onRemove: () => void;
 }) {
+  const t = useT();
   const {
     attributes,
     listeners,
@@ -189,7 +190,7 @@ function SortableProductCard({
         />
         <button
           type="button"
-          aria-label={useT()("sandbox.productBlocks.dragToReorderLabel")}
+          aria-label={t("sandbox.productBlocks.dragToReorderLabel")}
           {...attributes}
           {...listeners}
           className="absolute left-1 top-1 flex h-6 w-6 cursor-grab items-center justify-center rounded bg-background/80 text-muted-foreground opacity-0 backdrop-blur-sm transition-opacity hover:text-foreground active:cursor-grabbing group-hover/card:opacity-100"
@@ -198,7 +199,7 @@ function SortableProductCard({
         </button>
         <button
           type="button"
-          aria-label={useT()("sandbox.productBlocks.removeProductLabel")}
+          aria-label={t("sandbox.productBlocks.removeProductLabel")}
           onClick={onRemove}
           className="absolute right-1 top-1 flex h-6 w-6 items-center justify-center rounded bg-background/80 text-muted-foreground opacity-0 backdrop-blur-sm transition-opacity hover:text-destructive group-hover/card:opacity-100 cursor-pointer"
         >
@@ -209,11 +210,11 @@ function SortableProductCard({
         <p className="line-clamp-2 text-xs leading-tight text-foreground">
           {option?.label ??
             (loading
-              ? useT()("sandbox.productBlocks.loadingEllipsis")
-              : useT()("sandbox.productBlocks.productWithId", { id }))}
+              ? t("sandbox.productBlocks.loadingEllipsis")
+              : t("sandbox.productBlocks.productWithId", { id }))}
         </p>
         <p className="text-[11px] text-muted-foreground">
-          {useT()("sandbox.productBlocks.idLabel", { id })}
+          {t("sandbox.productBlocks.idLabel", { id })}
         </p>
       </div>
     </div>
@@ -348,6 +349,7 @@ export function ProductShelfBlock({
   onChange: (next: Record<string, unknown>) => void;
   sandboxRef?: RunBlockSandboxRef | null;
 }) {
+  const t = useT();
   const rawIds = readProductListIds(block.products);
   const ids = [...new Set(rawIds.filter(Boolean))];
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -372,14 +374,14 @@ export function ProductShelfBlock({
             <div className="flex items-center justify-between">
               <span className="text-xs font-medium text-muted-foreground">
                 {ids.length}{" "}
-                {useT()(
+                {t(
                   ids.length === 1
                     ? "sandbox.productBlocks.productSingular"
                     : "sandbox.productBlocks.productPlural",
                 )}
               </span>
               <BrowseButton
-                label={useT()("sandbox.productBlocks.browseProductsButton")}
+                label={t("sandbox.productBlocks.browseProductsButton")}
                 onClick={() => setPickerOpen(true)}
               />
             </div>


### PR DESCRIPTION
## Summary

Fixes a **Minified React error #300** (*"Rendered fewer hooks than expected"*) that crashed the blog **post editor → Content tab** — showing the "Algo deu errado / Something went wrong" error boundary — every time a product block's lookup resolved.

`useT()` (`apps/mesh/src/web/i18n/use-t.ts`) is a React hook (it calls `usePreferences()` → `useQuery`). In `product-blocks.tsx` two components called it inside **conditional JSX**, so the number of hooks changed between renders:

- **`SortableProductCard`** — the product-name fallback:
  ```jsx
  {option?.label ?? (loading ? useT()(…) : useT()(…))}
  ```
  While products load, `option?.label` is `undefined` so the `useT()` runs; once the lookup resolves and `option.label` exists, the `??` short-circuits and that `useT()` is skipped → fewer hooks than the previous render → crash.
- **`ProductShelfBlock`** — two `useT()` calls inside `{ids.length > 0 && …}`, same class of bug when the first product is added/removed.

## Fix

Hoist to a single top-level `const t = useT()` per component and use `t(...)` in the JSX — the pattern the other blocks in this file already follow (`ProductCardBlock`, `SelectedProductRow`, `ShelfTitle`, …). No behavior or copy changes; only the hook call site moves.

## Testing

- `bun run fmt` ✅
- `bun run --cwd=apps/mesh check` (tsc) ✅

## Affected areas

Blog post editor Content tab, ProductShelf / ProductCard blocks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a React hooks ordering crash in the blog post editor Content tab by calling useT() unconditionally in product blocks. Moves the hook to a single top-level const t = useT() in SortableProductCard and ProductShelfBlock, preventing "Rendered fewer hooks than expected" and keeping the editor stable while products load.

<sup>Written for commit 29af9a99c6c4322a908cbc55ba80f3f149ab0715. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

