### PR TITLE
fix(registry): cancel pending remote-URL auto-discover before it can clobber manual tool edits

### DIFF
--- a/apps/mesh/src/web/views/registry/registry-item-dialog.tsx
+++ b/apps/mesh/src/web/views/registry/registry-item-dialog.tsx
@@ -605,6 +605,10 @@ export function RegistryItemDialog({
   const handleDiscoverTools = async () => {
     const url = normalizeRemoteUrl(remoteHost);
     if (!url) return;
+    if (discoverTimerRef.current) {
+      clearTimeout(discoverTimerRef.current);
+      discoverTimerRef.current = null;
+    }
     lastDiscoveredUrlRef.current = url;
     const discovered = await discover(url, remoteTypeRef.current);
     if (discovered) {
@@ -743,6 +747,12 @@ export function RegistryItemDialog({
 
   const handleNext = () => {
     if (!validateStep(step)) return;
+    if (step === 1 && discoverTimerRef.current) {
+      // Leaving step 1 cancels any pending auto-discover so it can't
+      // overwrite tools the user edits by hand later, on step 3.
+      clearTimeout(discoverTimerRef.current);
+      discoverTimerRef.current = null;
+    }
     if (step < 3) setStep((step + 1) as WizardStep);
   };
 


### PR DESCRIPTION
**Source:** bug found while reading `registry-item-dialog.tsx` (registry item dialog is this tick's focus area).

**Payoff:** without this fix, a user can silently lose tool edits they just made.

**Failure scenario:** on step 1, typing a remote URL schedules an 800ms debounced auto-discover (`scheduleAutoDiscover`) that eventually calls `setTools(discovered)`. That `setTimeout` is tied to the dialog's lifetime, not to the current wizard step. If the user advances to step 3 and manually edits the tools list (via `ToolsEditor`) before the 800ms elapses, the stale timer still fires and overwrites their manual edits with the originally-discovered list — a silent data-loss bug that gets worse the faster the user moves through the wizard. The same problem exists if the user clicks "Discover tools" manually right after typing: the pending debounce timer isn't cancelled, so it can fire a second time later and stomp whatever the user changed in between.

**Fix:** cancel the pending debounce timer (1) when the user manually triggers discovery via the button, and (2) when the user advances past step 1 via "Next" — auto-discover is only relevant while the user is on the remote-URL step, so leaving it should retire any in-flight timer.

**Command to confirm:** `cd apps/mesh && bunx tsc --noEmit` (green). To see it manually: open the registry "Add MCP server" dialog, type a remote URL on step 1, immediately click Next before the auto-discover fires, edit the tools list on step 3, and wait — before the fix the list reverts to the auto-discovered tools; after the fix it doesn't.

**Checks run locally:** `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (clean). No existing test file covers this component; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale auto-discover from overwriting manual tool edits in the Registry Item dialog. We now clear any pending remote-URL auto-discover when the user clicks Discover or leaves step 1.

- **Bug Fixes**
  - Cancel the pending debounce timer before running manual discovery.
  - Cancel the pending debounce timer when advancing from step 1.

<sup>Written for commit eb0ff2e281eaca2f0b14418a2fd07ceb0bb8257a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

