### PR TITLE
refactor(chat): tighten mention node type safety for optional kind attribute

### DIFF
--- a/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
+++ b/apps/mesh/src/web/components/chat/tiptap/mention/node.tsx
@@ -120,7 +120,7 @@ function MentionNodeView(props: NodeViewProps) {
   // prompt or a legacy chip without `kind` (we'll re-verify in the handler).
   // Resources and skills have no edit dialog — their chip is inert.
   const isClickable =
-    view.editable && char === "/" && (kind === "prompt" || kind == null);
+    view.editable && char === "/" && (kind === "prompt" || kind === undefined);
 
   const triggerEdit = () => {
     const storage = getMentionStorage(editor);
@@ -253,8 +253,8 @@ export const MentionNode = Node.create({
         },
       },
       kind: {
-        default: null,
-        parseHTML: (element) => element.getAttribute("data-kind") || null,
+        default: undefined,
+        parseHTML: (element) => element.getAttribute("data-kind") || undefined,
         renderHTML: (attributes) => {
           if (!attributes.kind) return {};
           return { "data-kind": attributes.kind };


### PR DESCRIPTION
## Summary
Aligns the `kind` attribute's Tiptap default and HTML parser to use `undefined` instead of `null`, matching the TypeScript type definition (`kind?: "prompt" | "resource" | "skill" | "task"`). Replaces the loose equality check (`==`) with strict equality (`===`) to enforce type safety.

## Motivation
The mention node component had a type inconsistency: the TypeScript interface declared `kind` as optional (which in TypeScript means `undefined` for missing values), but the Tiptap attribute parser returned `null`. This required loose equality checking (`kind == null`) to handle both cases, which can hide subtle type mismatches. Making the types consistent allows strict comparisons and improves compile-time safety.

## Behavior
Behavior is fully preserved — missing kind still evaluates to falsy in the isClickable check — but the type system now accurately reflects runtime values. Legacy chips without a kind attribute (backward compatibility) still render and behave identically.

## Verification
- `bun run fmt` ✓
- `cd apps/mesh && bunx tsc --noEmit` ✓
- `bun test ./apps/mesh/src/web/components/chat/tiptap/mention/node.test.tsx` ✓ (3 tests pass)

CI will run the full suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened type safety for the chat mention node by treating the optional `kind` as `undefined` (not `null`) and using strict `===` checks. Behavior is unchanged; legacy chips without `kind` still render, and prompt chip clickability works as before.

<sup>Written for commit b0e2540a134357676cb4fa3e666788c0609048ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

