### PR TITLE
fix(web): fix 7 conditional hook calls (React #300)

### DIFF
--- a/apps/mesh/src/web/components/chat/markdown.tsx
+++ b/apps/mesh/src/web/components/chat/markdown.tsx
@@ -139,6 +139,22 @@ function Table(props: React.HTMLAttributes<HTMLTableElement>) {
   );
 }
 
+function MarkdownImage(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+  const t = useT();
+  const { src, alt, ...rest } = props;
+  if (!src) return <img {...props} />;
+  return (
+    <ImageLightbox src={src} alt={alt ?? t("chat.markdown.image")}>
+      <img
+        {...rest}
+        src={src}
+        alt={alt}
+        className="max-w-full rounded-lg border border-border hover:border-foreground/20 transition-colors"
+      />
+    </ImageLightbox>
+  );
+}
+
 // Memoize the plugins arrays to prevent re-creating them on every render
 const remarkPluginsMemo = [remarkGfm];
 const rehypePluginsMemo = [rehypeRaw];
@@ -152,21 +168,9 @@ const markdownComponents = {
   table: (props: React.HTMLAttributes<HTMLTableElement>) => (
     <Table {...props} />
   ),
-  img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
-    const { src, alt, ...rest } = props;
-    if (!src) return <img {...props} />;
-    const t = useT();
-    return (
-      <ImageLightbox src={src} alt={alt ?? t("chat.markdown.image")}>
-        <img
-          {...rest}
-          src={src}
-          alt={alt}
-          className="max-w-full rounded-lg border border-border hover:border-foreground/20 transition-colors"
-        />
-      </ImageLightbox>
-    );
-  },
+  img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <MarkdownImage {...props} />
+  ),
 } as typeof sharedMarkdownComponents;
 
 // ── Streaming word fade-in ───────────────────────────────────────────────────

--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -635,6 +635,7 @@ function AgentToolList({
   connectionIds: string[];
   pinnedTiles: VirtualMcpHomeTile[];
 }) {
+  const t = useT();
   const studio = useStudioTools();
 
   const { data, isLoading } = useQuery({
@@ -720,8 +721,6 @@ function AgentToolList({
   };
 
   const hasPinned = pinnedTiles.some((tile) => !!resolveToolForTile(tile));
-
-  const t = useT();
 
   return (
     <div className="flex flex-col gap-2">

--- a/apps/mesh/src/web/components/home/native-tiles.tsx
+++ b/apps/mesh/src/web/components/home/native-tiles.tsx
@@ -400,9 +400,9 @@ function CommerceMetricTile({
   metricKey: keyof typeof METRIC_CONFIG;
 }) {
   const t = useT();
-  const connected =
-    useConnections({ slug: "vtex" }).length > 0 ||
-    useConnections({ slug: "shopify" }).length > 0;
+  const vtexConnections = useConnections({ slug: "vtex" });
+  const shopifyConnections = useConnections({ slug: "shopify" });
+  const connected = vtexConnections.length > 0 || shopifyConnections.length > 0;
   const [open, setOpen] = useState(false);
   const cfg = METRIC_CONFIG[metricKey];
   if (connected || !cfg) return <ConnectedSoon label="Commerce" />;

--- a/apps/mesh/src/web/components/sandbox/content/blog/blocks/list-blocks.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/blog/blocks/list-blocks.tsx
@@ -284,7 +284,6 @@ export function ComparisonBlock({
     });
 
   const renderCol = (side: "left" | "right", col: Col, accent: string) => {
-    const t = useT();
     const itemsList = col.items ?? [];
     return (
       <div className="space-y-2 rounded-lg border p-4">

--- a/apps/mesh/src/web/routes/commerce-onboarding.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding.tsx
@@ -643,6 +643,7 @@ function CommerceSetup({
   org: CommerceOrganization;
   initialSiteUrl?: string;
 }) {
+  const t = useT();
   const { data: session } = authClient.useSession();
   const [preferences] = usePreferences();
   const meetingUrl = buildScheduleMeetingUrl({
@@ -666,7 +667,7 @@ function CommerceSetup({
                 message={
                   error instanceof Error
                     ? error.message
-                    : useT()(
+                    : t(
                         "routes.commerceOnboarding.couldNotVerifyCommerceSetting",
                       )
                 }

--- a/apps/mesh/src/web/routes/orgs/collection-detail.tsx
+++ b/apps/mesh/src/web/routes/orgs/collection-detail.tsx
@@ -85,6 +85,7 @@ function CollectionDetailsContent() {
     from: "/shell/$org/settings/connections/$appSlug/$collectionName/$itemId",
   });
 
+  const t = useT();
   const collectionName = decodeURIComponent(params.collectionName);
   const itemId = decodeURIComponent(params.itemId);
 
@@ -170,7 +171,6 @@ function CollectionDetailsContent() {
     );
   }
 
-  const t = useT();
   return (
     <ViewLayout breadcrumb={breadcrumb}>
       <EmptyState

--- a/apps/mesh/src/web/views/settings/org-role-detail.tsx
+++ b/apps/mesh/src/web/views/settings/org-role-detail.tsx
@@ -54,7 +54,7 @@ import { z } from "zod";
 import { SearchInput } from "@deco/ui/components/search-input.tsx";
 import { Page } from "@/web/components/page";
 import { IntegrationIcon } from "@/web/components/integration-icon";
-import { useT } from "@/web/i18n/use-t.ts";
+import { type TFunction, useT } from "@/web/i18n/use-t.ts";
 import {
   SettingsCard,
   SettingsCardItem,
@@ -112,8 +112,12 @@ interface OrgPermissionsTabProps {
   searchQuery: string;
 }
 
-function makeToggle(checked: boolean, readOnly: boolean, onToggle: () => void) {
-  const t = useT();
+function makeToggle(
+  t: TFunction,
+  checked: boolean,
+  readOnly: boolean,
+  onToggle: () => void,
+) {
   const sw = (
     <Switch checked={checked} disabled={readOnly} onCheckedChange={onToggle} />
   );
@@ -187,7 +191,7 @@ function OrgPermissionsTab({
               description={t(
                 "settings.orgRoleDetail.grantFullAccessToAllFeaturesBelow",
               )}
-              action={makeToggle(allowAllStaticPermissions, readOnly, () => {
+              action={makeToggle(t, allowAllStaticPermissions, readOnly, () => {
                 onAllowAllChange(!allowAllStaticPermissions);
                 onPermissionsChange([]);
               })}
@@ -232,7 +236,7 @@ function OrgPermissionsTab({
                         </span>
                       }
                       description={cap.description}
-                      action={makeToggle(enabled, readOnly, () =>
+                      action={makeToggle(t, enabled, readOnly, () =>
                         toggleCapability(cap, enabled),
                       )}
                       onClick={


### PR DESCRIPTION
## Summary

Follow-up to #5074. That PR fixed the blog Content-tab crash in `product-blocks.tsx`; this one fixes **7 more instances of the same class of bug** across the web app, found by running the authoritative `react/rules-of-hooks` check (the repo's oxlint config enables `plugins: ["react"]` but does **not** turn on `react/rules-of-hooks`, which is why these shipped).

Each is a React hook called conditionally, so the hook count varies between renders → **"Rendered fewer hooks than expected" (React error #300)**.

### Fixes (ranked by likelihood of firing)

**High — crashes under ordinary interaction**
- **`home/native-tiles.tsx`** (`CommerceMetricTile`): `useConnections("vtex") || useConnections("shopify")` — the `||` short-circuited the second hook as soon as VTEX had a connection. Now both are called unconditionally.
- **`home/add-tile-drawer.tsx`** (`AgentToolList`): `useT()` sat *after* the `isLoading` / empty-data early returns → count went 0→1 on every load. Hoisted to the top.
- **`views/settings/org-role-detail.tsx`** (`makeToggle`): a plain helper called `useT()` and is invoked inside a search-filtered `.map` → count changed on every search keystroke. Now takes `t: TFunction` as a param.
- **`routes/orgs/collection-detail.tsx`** (`CollectionDetailsContent`): `useT()` after `if (ViewComponent) return …`. Hoisted above the early return.

**Medium / low — genuine violations, usually stable per instance**
- **`components/chat/markdown.tsx`**: the `img` renderer called `useT()` after a `!src` early return; extracted into a named `MarkdownImage` component (matching the sibling `MarkdownCode` / `MarkdownAnchor`).
- **`routes/commerce-onboarding.tsx`** (`CommerceSetup`): `useT()` inside an `ErrorBoundary` `fallback` render prop; hoisted to the component body.
- **`components/sandbox/content/blog/blocks/list-blocks.tsx`** (`ComparisonBlock`): dropped a redundant `useT()` inside the `renderCol` closure (reuses the outer `t`).

## Testing
- `bunx oxlint --react-plugin -D react/rules-of-hooks apps/mesh/src/web packages/ui/src` → **0** violations (was 7).
- `bun run --cwd=apps/mesh check` (tsc) ✅
- `bun run fmt` ✅

## Follow-up suggestion
Consider adding `"react/rules-of-hooks": "error"` to `.oxlintrc.json` so this whole class of bug is caught in CI. (One caveat: it currently false-positives on Playwright's `use()` fixture in `packages/e2e/fixtures/test.ts`, which would need a scoped override.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes seven conditional React hook calls that caused “Rendered fewer hooks than expected” (React #300) crashes and inconsistent renders. Hooks are now called unconditionally or moved to safe locations to stabilize the UI.

- **Bug Fixes**
  - Call both `useConnections({ slug: "vtex" })` and `useConnections({ slug: "shopify" })` unconditionally in CommerceMetricTile.
  - Hoist `useT()` above early returns in add-tile-drawer, collection-detail, and commerce-onboarding (ErrorBoundary fallback).
  - Extract `MarkdownImage` for the chat markdown `img` renderer so `useT()` runs before any early return; remove redundant `useT()` in list-blocks.
  - Pass `t` into `makeToggle` in org-role-detail to avoid calling `useT()` inside a mapped helper.

<sup>Written for commit 028cbada720b8ec8ee87edc964845e44f0ba9bc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

