### PR TITLE
fix(home): make the on-home remove button's aria-label actually name the agent

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -475,10 +475,12 @@ function HomeAgentRow({
               .removeAgent(agent.id)
               .catch(() => toast.error(t("home.addTileDrawer.removeError")))
           }
-          aria-label={t("home.addTileDrawer.removeFromHome", {
+          aria-label={t("home.addTileDrawer.removeAgentFromHome", {
             name: agent.title ?? agent.id,
           })}
-          title={t("home.addTileDrawer.removeFromHomeTitle")}
+          title={t("home.addTileDrawer.removeAgentFromHome", {
+            name: agent.title ?? agent.id,
+          })}
           className="shrink-0 inline-flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
         >
           <X size={14} />

--- a/apps/mesh/src/web/i18n/en/home.ts
+++ b/apps/mesh/src/web/i18n/en/home.ts
@@ -22,10 +22,10 @@ export const home = {
   "home.addTileDrawer.promptCountLabel": "{count} prompt(s)",
   "home.addTileDrawer.promptsOffLabel": "prompts off",
   "home.addTileDrawer.quickAccess": "Quick access",
+  "home.addTileDrawer.removeAgentFromHome": "Remove {name} from home",
   "home.addTileDrawer.removeError":
     "Couldn't remove from home \u2014 please try again.",
   "home.addTileDrawer.removeFromHome": "Remove from home",
-  "home.addTileDrawer.removeFromHomeTitle": "Remove from home",
   "home.addTileDrawer.reorderError":
     "Couldn't reorder home \u2014 please try again.",
   "home.addTileDrawer.save": "Save",

--- a/apps/mesh/src/web/i18n/pt-br/home.ts
+++ b/apps/mesh/src/web/i18n/pt-br/home.ts
@@ -24,10 +24,10 @@ export const home = {
   "home.addTileDrawer.promptCountLabel": "{count} prompt(s)",
   "home.addTileDrawer.promptsOffLabel": "prompts desativados",
   "home.addTileDrawer.quickAccess": "Acesso r\u00e1pido",
+  "home.addTileDrawer.removeAgentFromHome": "Remover {name} do home",
   "home.addTileDrawer.removeError":
     "N\u00e3o foi poss\u00edvel remover do home \u2014 por favor, tente novamente.",
   "home.addTileDrawer.removeFromHome": "Remover do home",
-  "home.addTileDrawer.removeFromHomeTitle": "Remover do home",
   "home.addTileDrawer.reorderError":
     "N\u00e3o foi poss\u00edvel reordenar o home \u2014 por favor, tente novamente.",
   "home.addTileDrawer.save": "Salvar",


### PR DESCRIPTION
**Source:** bug found while auditing `add-tile-drawer.tsx` (home drawer ergonomics/accessibility area).

**Payoff:** with several agents pinned to home, every row's remove button currently announces the identical generic "Remove from home" to screen readers, so keyboard/screen-reader users tabbing through the list can't tell which agent's remove button they're on — the drawer grows less usable exactly as more tiles are added to home.

**Failure scenario / root cause:** `HomeAgentRow`'s remove button called `t("home.addTileDrawer.removeFromHome", { name: agent.title })`, but the `removeFromHome` translation string is a plain `"Remove from home"` with no `{name}` placeholder. Studio's `interpolate()` (`apps/mesh/src/web/i18n/interpolate.ts`) only substitutes placeholders that exist in the template and silently drops unknown vars otherwise — so the `name` var was always a no-op and the aria-label (and title) rendered identically for every agent, despite the code visibly intending per-agent text (mirroring the working `dragToReorder: "Drag to reorder {name}"` pattern right next to it).

**Fix:** added a dedicated `home.addTileDrawer.removeAgentFromHome` key (en: `"Remove {name} from home"`, pt-br: `"Remover {name} do home"`) and pointed both the button's `aria-label` and `title` at it. Left the shared `removeFromHome` key (used without a name elsewhere, e.g. the pinned-tile remove button) untouched, and removed the now-dead `removeFromHomeTitle` key that this button's `title` had been using.

**How a reviewer confirms:** open the "Manage home" drawer with 2+ agents pinned, inspect the remove (X) button's accessible name per row (e.g. via browser a11y tree) — each should now read "Remove <Agent Name> from home" instead of the same generic string.

**Checks run locally:** `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (no errors in touched files — the tsc run reports pre-existing errors only in an unrelated untracked test file). No new test added since this is a one-line string/prop fix with no branching logic; full CI covers formatting/typecheck/i18n-completeness (the `satisfies Record<keyof typeof homeEn, string>` on the pt-br file already enforces key parity).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the remove button in the Manage home drawer to include the agent name (e.g., “Remove Alice from home”), improving screen reader clarity and navigation.

- **Bug Fixes**
  - Added `home.addTileDrawer.removeAgentFromHome` ("Remove {name} from home") and used it for both `aria-label` and `title` with `agent.title ?? agent.id`.
  - Kept `removeFromHome` for generic uses; removed unused `removeFromHomeTitle`.

<sup>Written for commit 998ede4b0c53c64535b12144e2ffea32b34ead39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

