### PR TITLE
chore(studio): bump chart-deco-studio to 0.12.3

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
-version: 0.12.2
+version: 0.12.3
 appVersion: "latest"
 
 dependencies:


### PR DESCRIPTION
Bumps the Helm chart version `0.12.2 → 0.12.3` to **publish** the worker consolidation-protection change from #5069.

## Why this is needed
`.github/workflows/publish-chart.yml` fires **only on pushes to `main` that change `deploy/helm/studio/Chart.yaml`**. #5069 changed `worker-deployment.yaml` + `values.yaml` (the `karpenter.sh/do-not-disrupt` annotation + `worker.doNotDisrupt` default) but **not** `Chart.yaml` — so merging it did not publish a new chart. The registry is still at `0.12.2`, which does not contain the annotation.

## What merging this does
1. `publish-chart.yml` packages + pushes `chart-deco-studio-0.12.3` to `oci://ghcr.io/decocms`.
2. Its `bump-deco-apps-cd` job fires a `studio-chart-bump` repository_dispatch → deco-apps-cd's `bump-studio-chart.yml` self-commits the dependency bump to `0.12.3` (stg + prod) and regenerates `Chart.lock` + the vendored tgz.

After that, `worker.doNotDisrupt` (default-on in the chart) renders on the worker pods, activating consolidation protection in prod (prod is manual-sync, so it still gates on the Argo promotion).

## Companion
- decocms/studio#5069 (merged) — the annotation + sandbox-reap-survival.
- decocms/deco-apps-cd#167 — worker PDB + parked-runs KEDA trigger (ship on merge, chart-version-independent) + declares `studio.worker.doNotDisrupt=true`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `chart-deco-studio` Helm chart from 0.12.2 to 0.12.3 to trigger a chart publish. This releases the worker `karpenter.sh/do-not-disrupt` annotation so consolidation protection reaches the worker pods.

<sup>Written for commit 0fbc43f8d73e158f360994894ceb8aa5dd435d94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

