### PR TITLE
fix(sections-editor): support deco icon-select fields with SVG previews

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeOptions } from "./dynamic-options-field";
+import {
+  filterOptions,
+  normalizeOptions,
+  svgPreviewDataUri,
+} from "./dynamic-options-field";
 
 describe("normalizeOptions", () => {
   test("returns empty array for non-array input", () => {
@@ -27,14 +31,33 @@ describe("normalizeOptions", () => {
       { value: "y", label: "Option Y", image: "https://img.test/y.png" },
     ];
     expect(normalizeOptions(input)).toEqual([
-      { value: "x", label: "Option X", image: undefined },
-      { value: "y", label: "Option Y", image: "https://img.test/y.png" },
+      { value: "x", label: "Option X", image: undefined, icon: undefined },
+      {
+        value: "y",
+        label: "Option Y",
+        image: "https://img.test/y.png",
+        icon: undefined,
+      },
+    ]);
+  });
+
+  test("keeps inline SVG icon from icon-select loaders", () => {
+    // Real shape returned by e.g. odin-ui/loaders/icons.ts (deco icon-select).
+    const svg = '<svg viewBox="0 0 24 24"><path d="M0 0h24v24H0z"/></svg>';
+    expect(normalizeOptions([{ value: "activity", icon: svg }])).toEqual([
+      { value: "activity", label: "activity", image: undefined, icon: svg },
+    ]);
+  });
+
+  test("ignores non-string icon values", () => {
+    expect(normalizeOptions([{ value: "v", icon: 42 }])).toEqual([
+      { value: "v", label: "v", image: undefined, icon: undefined },
     ]);
   });
 
   test("uses String(value) as label when label is missing", () => {
     expect(normalizeOptions([{ value: 123 }])).toEqual([
-      { value: "123", label: "123", image: undefined },
+      { value: "123", label: "123", image: undefined, icon: undefined },
     ]);
   });
 
@@ -49,13 +72,75 @@ describe("normalizeOptions", () => {
     ]);
     expect(result).toEqual([
       { value: "plain", label: "plain" },
-      { value: "obj", label: "Object", image: undefined },
+      { value: "obj", label: "Object", image: undefined, icon: undefined },
     ]);
   });
 
   test("ignores non-string image values", () => {
     expect(normalizeOptions([{ value: "v", image: 123 }])).toEqual([
-      { value: "v", label: "v", image: undefined },
+      { value: "v", label: "v", image: undefined, icon: undefined },
     ]);
+  });
+});
+
+describe("filterOptions", () => {
+  const options = [
+    { value: "#00db00", label: "brand" },
+    { value: "#eef1f0", label: "body" },
+    { value: "activity", label: "activity" },
+  ];
+
+  test("returns all options for empty or whitespace search", () => {
+    expect(filterOptions(options, "")).toEqual(options);
+    expect(filterOptions(options, "   ")).toEqual(options);
+  });
+
+  test("matches on label, case-insensitively", () => {
+    expect(filterOptions(options, "BRAND")).toEqual([options[0]!]);
+  });
+
+  test("matches on value (e.g. color hex)", () => {
+    expect(filterOptions(options, "#eef")).toEqual([options[1]!]);
+  });
+
+  test("returns empty when nothing matches", () => {
+    expect(filterOptions(options, "zzz")).toEqual([]);
+  });
+
+  test("options without label still match by value", () => {
+    expect(filterOptions([{ value: "plain" }], "pla")).toEqual([
+      { value: "plain" },
+    ]);
+  });
+});
+
+describe("svgPreviewDataUri", () => {
+  test("injects the current-color shim inside the root svg tag", () => {
+    // odin-ui color-swatch shape: fill-current class + color on the root.
+    const svg =
+      '<svg viewBox="0 0 8 8" style="color: #00db00;" xmlns="http://www.w3.org/2000/svg"><circle class="fill-current" cx="4" cy="4" r="4" /></svg>';
+    const uri = svgPreviewDataUri(svg);
+    expect(uri.startsWith("data:image/svg+xml;utf8,")).toBe(true);
+    const decoded = decodeURIComponent(
+      uri.slice("data:image/svg+xml;utf8,".length),
+    );
+    expect(decoded).toContain(
+      '<svg viewBox="0 0 8 8" style="color: #00db00;" xmlns="http://www.w3.org/2000/svg"><style>.fill-current{fill:currentColor}',
+    );
+    expect(decoded).toContain('<circle class="fill-current"');
+  });
+
+  test("injects a theme fallback color that inline style still overrides", () => {
+    // Monochrome icon sets (fill="currentColor") default to black inside an
+    // isolated <img> SVG document — the fallback rule makes them theme-colored.
+    const svg = '<svg viewBox="0 0 24 24"><path fill="currentColor"/></svg>';
+    const uri = svgPreviewDataUri(svg, "rgb(250, 250, 250)");
+    const decoded = decodeURIComponent(uri.split(",")[1]!);
+    expect(decoded).toContain("<style>svg{color:rgb(250, 250, 250)}");
+  });
+
+  test("leaves markup without an svg tag unchanged (besides encoding)", () => {
+    const uri = svgPreviewDataUri("<div>not svg</div>");
+    expect(decodeURIComponent(uri.split(",")[1]!)).toBe("<div>not svg</div>");
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
@@ -26,6 +26,8 @@ export interface DynamicOption {
   value: string;
   label?: string;
   image?: string;
+  /** Inline SVG markup for the option preview (deco `icon-select` loaders). */
+  icon?: string;
 }
 
 export function normalizeOptions(data: unknown): DynamicOption[] {
@@ -40,10 +42,64 @@ export function normalizeOptions(data: unknown): DynamicOption[] {
         value: String(obj.value),
         label: typeof obj.label === "string" ? obj.label : String(obj.value),
         image: typeof obj.image === "string" ? obj.image : undefined,
+        icon: typeof obj.icon === "string" ? obj.icon : undefined,
       });
     }
   }
   return result;
+}
+
+/**
+ * Client-side narrowing of the fetched options. The loader already receives
+ * the search as `term`, but many real-world options loaders ignore it and
+ * always return the full list (e.g. odin-ui's icons loader) — without this
+ * the combobox search would do nothing.
+ */
+export function filterOptions(
+  options: DynamicOption[],
+  search: string,
+): DynamicOption[] {
+  const term = search.trim().toLowerCase();
+  if (!term) return options;
+  return options.filter(
+    (opt) =>
+      opt.value.toLowerCase().includes(term) ||
+      (opt.label ?? "").toLowerCase().includes(term),
+  );
+}
+
+/**
+ * Data URI for an option's inline-SVG preview. Rendered through an `img` so
+ * loader-controlled markup is never injected into the document. Loader SVGs
+ * rely on Tailwind's current-color utilities (e.g. odin-ui color swatches are
+ * `<circle class="fill-current"/>` with `style="color: #hex"` on the root);
+ * inside an isolated SVG document those classes have no CSS, so the shim
+ * defines them — without it every swatch falls back to a black fill.
+ *
+ * `color` is the fallback `currentColor` for the SVG document: isolated SVG
+ * documents default `currentColor` to black, which makes monochrome icon
+ * sets (e.g. odin-ui icons with `fill="currentColor"`) invisible on a dark
+ * theme. A stylesheet rule loses to an inline `style` attribute, so swatches
+ * that set their own `style="color: #hex"` on the root are unaffected.
+ */
+export function svgPreviewDataUri(svg: string, color?: string): string {
+  const colorRule = color ? `svg{color:${color}}` : "";
+  const shim = `<style>${colorRule}.fill-current{fill:currentColor}.stroke-current{stroke:currentColor}.text-current{color:currentColor}</style>`;
+  const shimmed = svg.replace(/(<svg[^>]*>)/i, `$1${shim}`);
+  return `data:image/svg+xml;utf8,${encodeURIComponent(shimmed)}`;
+}
+
+/** The app's current foreground color, so icon previews match the theme. */
+function themeForegroundColor(): string | undefined {
+  const color = getComputedStyle(document.documentElement).color;
+  return color || undefined;
+}
+
+/** Preview image source for an option: `image` is a URL, `icon` inline SVG. */
+function optionPreviewSrc(opt: DynamicOption): string | undefined {
+  if (opt.image) return opt.image;
+  if (opt.icon) return svgPreviewDataUri(opt.icon, themeForegroundColor());
+  return undefined;
 }
 
 async function fetchDynamicOptions(
@@ -67,6 +123,29 @@ async function fetchDynamicOptions(
   }
   const data = await res.json();
   return normalizeOptions(data);
+}
+
+function OptionPreview({
+  option,
+  className,
+}: {
+  option: DynamicOption;
+  className?: string;
+}) {
+  const src = optionPreviewSrc(option);
+  if (!src) return null;
+  return (
+    <img
+      src={src}
+      alt=""
+      referrerPolicy="no-referrer"
+      className={cn(
+        "shrink-0",
+        option.image ? "rounded object-cover" : "object-contain",
+        className,
+      )}
+    />
+  );
 }
 
 function FieldHeader({
@@ -118,6 +197,8 @@ export function DynamicOptionsField({
     ? `${sandbox.orgSlug}/${sandbox.virtualMcpId}/${sandbox.branch}`
     : "";
 
+  const currentValue = typeof value === "string" ? value : "";
+
   const query = useQuery({
     queryKey: KEYS.sandboxInvoke(
       sandboxKey,
@@ -129,13 +210,15 @@ export function DynamicOptionsField({
         loaderPath!,
         debouncedSearch || undefined,
       ),
-    enabled: !!previewUrl && !!loaderPath && open,
+    // Fetch eagerly when a value is already selected so its preview (icon /
+    // swatch / label) shows on the closed trigger, not only after opening.
+    enabled: !!previewUrl && !!loaderPath && (open || !!currentValue),
     staleTime: 60_000,
     retry: 1,
   });
 
   const options = query.data ?? [];
-  const currentValue = typeof value === "string" ? value : "";
+  const visibleOptions = filterOptions(options, search);
   const selectedOption = options.find((opt) => opt.value === currentValue);
 
   // Fallback to text input when preview is not available
@@ -170,14 +253,7 @@ export function DynamicOptionsField({
           >
             {selectedOption ? (
               <span className="flex min-w-0 items-center gap-2">
-                {selectedOption.image && (
-                  <img
-                    src={selectedOption.image}
-                    alt=""
-                    referrerPolicy="no-referrer"
-                    className="h-6 w-6 shrink-0 rounded object-cover"
-                  />
-                )}
+                <OptionPreview option={selectedOption} className="h-6 w-6" />
                 <span className="truncate">
                   {selectedOption.label ?? selectedOption.value}
                 </span>
@@ -212,7 +288,7 @@ export function DynamicOptionsField({
                   : t("sectionsEditor.dynamicOptionsField.noResults")}
               </CommandEmpty>
               <CommandGroup>
-                {options.map((opt) => (
+                {visibleOptions.map((opt) => (
                   <CommandItem
                     key={opt.value}
                     value={opt.value}
@@ -222,14 +298,10 @@ export function DynamicOptionsField({
                     }}
                   >
                     <span className="flex min-w-0 items-center gap-2">
-                      {opt.image && (
-                        <img
-                          src={opt.image}
-                          alt=""
-                          referrerPolicy="no-referrer"
-                          className="h-9 w-9 shrink-0 rounded object-cover"
-                        />
-                      )}
+                      <OptionPreview
+                        option={opt}
+                        className={cn(opt.image ? "h-9 w-9" : "h-6 w-6")}
+                      />
                       <span className="truncate">{opt.label ?? opt.value}</span>
                     </span>
                     <Check

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.test.ts
@@ -151,6 +151,51 @@ describe("resolveSchema – nullable unions inherit leaf metadata", () => {
     expect(collection?.format).toBe("dynamic-options");
     expect(collection?.options).toBe("vtex/loaders/collections/list.ts");
   });
+
+  test("preserves format/options as siblings of a $ref (real deco shape)", () => {
+    // deco emits `@format icon-select` annotations on the property node while
+    // the type itself lives behind a $ref (e.g. stone ButtonCtaAttendenceProps.icon).
+    const meta = metaWithSchema({
+      type: "object",
+      properties: {
+        color: {
+          $ref: "#/definitions/BackgroundColor",
+          format: "icon-select",
+          options: "odin-ui/loaders/background-colors.ts",
+        },
+      },
+    });
+    (meta.schema as { definitions?: Record<string, unknown> }).definitions = {
+      BackgroundColor: { type: "string" },
+    };
+
+    const color = resolveSchema("site/sections/Test.tsx", meta)?.properties
+      ?.color;
+    expect(color?.format).toBe("icon-select");
+    expect(color?.options).toBe("odin-ui/loaders/background-colors.ts");
+  });
+
+  test("preserves format/options on a union of const literals", () => {
+    // TS union of icon names (`"user" | "chat" | ...`) with @format icon-select:
+    // the enum-from-consts path must keep the widget annotations, otherwise the
+    // field demotes to a static select without icon previews.
+    const meta = metaWithSchema({
+      type: "object",
+      properties: {
+        icon: {
+          anyOf: [{ const: "user" }, { const: "chat" }, { const: "earth" }],
+          format: "icon-select",
+          options: "site/loaders/icons.ts",
+        },
+      },
+    });
+
+    const icon = resolveSchema("site/sections/Test.tsx", meta)?.properties
+      ?.icon;
+    expect(icon?.enum).toEqual(["user", "chat", "earth"]);
+    expect(icon?.format).toBe("icon-select");
+    expect(icon?.options).toBe("site/loaders/icons.ts");
+  });
 });
 
 describe("resolveSchema – app resolveType aliases", () => {

--- a/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
+++ b/apps/mesh/src/web/components/sections-editor/resolve-schema.ts
@@ -509,6 +509,15 @@ export function resolveSchema(
       } else {
         // const-only branches: TypeScript string/number enum
         if (enumFromConsts) {
+          // A union of literals can still carry widget annotations
+          // (`@format icon-select` / `@options loader.ts` on the prop) —
+          // dropping them here would demote the field to a static select.
+          const annotation = (key: "format" | "options"): string | undefined =>
+            typeof v[key] === "string"
+              ? (v[key] as string)
+              : typeof resolved[key] === "string"
+                ? (resolved[key] as string)
+                : undefined;
           return {
             type: "string",
             title:
@@ -518,6 +527,8 @@ export function resolveSchema(
                 ? resolved.description
                 : undefined,
             enum: enumFromConsts,
+            format: annotation("format"),
+            options: annotation("options"),
           };
         }
 
@@ -1009,9 +1020,11 @@ export function resolveSchema(
         ? resolved.enum
         : (enumFromConsts ?? undefined),
       format:
-        typeof resolved.format === "string"
-          ? resolved.format
-          : fromLeaf<string>("format"),
+        typeof v.format === "string"
+          ? v.format
+          : typeof resolved.format === "string"
+            ? resolved.format
+            : fromLeaf<string>("format"),
       properties: nestedProperties,
       items: itemsSchema,
       hidden: isSchemaHidden(resolved) || isSchemaHidden(v) ? true : undefined,
@@ -1024,9 +1037,11 @@ export function resolveSchema(
           ? resolved.image
           : fromLeaf<string>("image"),
       options:
-        typeof resolved.options === "string"
-          ? resolved.options
-          : fromLeaf<string>("options"),
+        typeof v.options === "string"
+          ? v.options
+          : typeof resolved.options === "string"
+            ? resolved.options
+            : fromLeaf<string>("options"),
     };
   };
 

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -244,8 +244,12 @@ export function renderField(props: FieldProps) {
     return <MapField key={props.path} {...props} />;
   }
 
-  // dynamic-options → DynamicOptionsField (select with options from a loader)
-  if (schema.format === "dynamic-options" && schema.options) {
+  // dynamic-options / icon-select → DynamicOptionsField (select with options
+  // from a loader; icon-select options carry an inline-SVG preview)
+  if (
+    (schema.format === "dynamic-options" || schema.format === "icon-select") &&
+    schema.options
+  ) {
     return <DynamicOptionsField key={props.path} {...props} />;
   }
 


### PR DESCRIPTION
## What is this contribution about?

Fixes DECO-5745 — the "dynamic options" widget for v1 sites in the visual editor. The real culprit was the deco `@format icon-select` widget (used by e.g. odin-ui's `SvgIcon` name/color fields), which the Studio didn't support at all — those fields fell back to a raw text input or a static enum select.

Changes:

- **Routing** (`schema-form.tsx`): `format: "icon-select"` with an `@options` loader now renders the `DynamicOptionsField` combobox, same as `dynamic-options`.
- **SVG previews** (`dynamic-options-field.tsx`): icon-select loaders return options with an inline-SVG `icon` field. It's rendered through `<img src="data:image/svg+xml,...">` so loader-controlled markup never touches the DOM. A `<style>` shim defines `fill-current`/`stroke-current` (odin-ui color swatches depend on those Tailwind classes) and injects the theme foreground as the fallback `currentColor` — isolated SVG documents default it to black, making monochrome icons invisible on the dark theme.
- **Schema resolution** (`resolve-schema.ts`): `format`/`options` annotations were dropped in two real-world shapes — (1) as siblings of a `$ref` (only `title` had that fallback) and (2) on a union of const literals (the `enumFromConsts` early-return discarded them, demoting the field to a static select). Both are preserved now.
- **UX**: client-side option filtering (real loaders often ignore the `term` param and return the full list) and eager fetch when a value is already selected so the closed trigger shows its icon preview.

## Screenshots/Demonstration

Validated against real production icon-select loaders (`odin-ui/loaders/icons.ts` / `background-colors.ts` on stone.com.br): icon names render with their SVG preview and color options with their swatch, matching the legacy deco admin.

## How to Test

1. Open the sections editor for a v1 site whose schema uses `@format icon-select` + `@options <loader>.ts` (e.g. odin-ui `SvgIcon`: Header → Logo → Icon).
2. The "Nome"/icon field renders a searchable combobox instead of a text input; each option shows its icon preview, theme-colored on dark mode.
3. The color field shows color swatches per option.
4. Select a value and close the popover — the trigger shows the selected option's icon without needing to open the list first.
5. Typing in the search narrows the list even when the loader ignores the `term` param.
6. `bun test apps/mesh/src/web/components/sections-editor/` — 477 pass (includes new tests for the resolver gaps, `normalizeOptions` icon handling, `filterOptions`, and `svgPreviewDataUri`).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for deco `@format icon-select` fields with SVG previews in the sections editor, fixing dynamic options for v1 sites. Fixes DECO-5745 by rendering loader-provided options with icons and keeping schema metadata intact.

- **Bug Fixes**
  - Route `icon-select` with `@options` to `DynamicOptionsField` so v1 dynamic options render as a searchable combobox.
  - Render inline SVG icons via `img` data URIs with a current-color shim and theme fallback; loader markup never touches the DOM.
  - Preserve `format`/`options` metadata when next to `$ref` or on unions of const literals to prevent demotion to static selects.
  - Improve UX with client-side filtering and eager fetch so selected values show previews on the closed trigger.

<sup>Written for commit dfc686b101934075681db972608788a8f355d835. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

