### PR TITLE
fix(blocks): open Blocks editor from committed snapshot during sandbox boot

### DIFF
--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
@@ -19,11 +19,32 @@ function input(
 }
 
 describe("resolveBlocksTabState", () => {
-  test("loads while the sandbox is progressing", () => {
-    expect(
-      resolveBlocksTabState(input({ lifecyclePhase: "installing" })),
-    ).toEqual({ kind: "loading" });
-  });
+  test.each(["idle", "cloning"] as const)(
+    "loads while the daemon is not yet serving the snapshot (%s)",
+    (lifecyclePhase) => {
+      // Pre-daemon / pre-clone: the committed `.deco/*.gen.json` isn't readable
+      // yet, so show loading regardless of the (necessarily stale) query state.
+      expect(
+        resolveBlocksTabState(
+          input({ lifecyclePhase, hasEditableContent: true }),
+        ),
+      ).toEqual({ kind: "loading" });
+    },
+  );
+
+  test.each(["checking-out", "installing", "starting"] as const)(
+    "renders editable content from the committed snapshot while booting (%s)",
+    (lifecyclePhase) => {
+      // Repo is cloned and the daemon is up, so the snapshot is readable and the
+      // Blocks editor opens before the dev server reaches `running` — matching
+      // Content, which renders as soon as the sandbox handle exists.
+      expect(
+        resolveBlocksTabState(
+          input({ lifecyclePhase, hasEditableContent: true }),
+        ),
+      ).toEqual({ kind: "content" });
+    },
+  );
 
   test("loads while initial Deco data is pending", () => {
     expect(

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts
@@ -46,6 +46,53 @@ describe("resolveBlocksTabState", () => {
     },
   );
 
+  test.each(["checking-out", "installing", "starting"] as const)(
+    "keeps loading (not a data error) when the snapshot is absent while booting (%s)",
+    (lifecyclePhase) => {
+      // An absent committed snapshot surfaces as a synthetic 502 from the read
+      // fallback, not a 404. Before the dev server settles we must not flash a
+      // red data-error card — the `→running` transition will resolve it.
+      expect(
+        resolveBlocksTabState(
+          input({
+            lifecyclePhase,
+            decofile: { status: "error", hasData: false, errorStatus: 502 },
+            meta: { status: "error", hasData: false, errorStatus: 502 },
+          }),
+        ),
+      ).toEqual({ kind: "loading" });
+    },
+  );
+
+  test("surfaces a data error once the dev server has settled (running)", () => {
+    expect(
+      resolveBlocksTabState(
+        input({
+          lifecyclePhase: "running",
+          meta: { status: "error", hasData: false, errorStatus: 502 },
+        }),
+      ),
+    ).toEqual({ kind: "error", source: "data" });
+  });
+
+  test("loads while the snapshot is still pending during boot (starting)", () => {
+    expect(
+      resolveBlocksTabState(
+        input({
+          lifecyclePhase: "starting",
+          decofile: { status: "pending", hasData: false },
+          meta: { status: "pending", hasData: false },
+        }),
+      ),
+    ).toEqual({ kind: "loading" });
+  });
+
+  test("renders empty when the booting snapshot has no editable content (installing)", () => {
+    expect(
+      resolveBlocksTabState(input({ lifecyclePhase: "installing" })),
+    ).toEqual({ kind: "empty" });
+  });
+
   test("loads while initial Deco data is pending", () => {
     expect(
       resolveBlocksTabState(

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
@@ -28,24 +28,37 @@ const TERMINAL_LIFECYCLE_PHASES = new Set<LifecycleState["phase"]>([
   "crashed",
 ]);
 
+// Phases where the daemon is reachable AND the repo is already cloned, so the
+// committed `.deco/*.gen.json` snapshot is readable even before the dev server
+// is up. Blocks edits persist to the FS, so the editor stays usable throughout
+// boot — mirroring Content, which renders as soon as the sandbox handle exists
+// rather than waiting for the dev server to reach `running`. `crashed` (dev
+// server died but daemon alive) is included for the same reason. `idle` and
+// `cloning` are excluded: the daemon isn't serving the snapshot yet, so we show
+// loading rather than a false "empty" from a 404 on a not-yet-cloned file.
+const SNAPSHOT_READABLE_PHASES = new Set<LifecycleState["phase"]>([
+  "checking-out",
+  "installing",
+  "starting",
+  "running",
+  "crashed",
+]);
+
 export function resolveBlocksTabState(
   input: BlocksTabStateInput,
 ): BlocksTabState {
-  // `crashed` = the dev server was running and stopped responding (paused or
-  // died). The committed `.deco/*.gen.json` is still readable from the daemon,
-  // so treat it like `running` here and let the data drive the state: the user
-  // can still edit blocks (writes persist to the FS), only the live preview is
-  // broken until the dev server is back. Genuine setup failures stay terminal.
-  const devUpOrRecoverable =
-    input.lifecyclePhase === "running" || input.lifecyclePhase === "crashed";
-
+  // Genuine setup failures stay terminal. `crashed` is recoverable (see
+  // SNAPSHOT_READABLE_PHASES) — the committed snapshot is still editable, only
+  // the live preview is broken until the dev server is back.
   if (
     TERMINAL_LIFECYCLE_PHASES.has(input.lifecyclePhase) &&
     input.lifecyclePhase !== "crashed"
   ) {
     return { kind: "error", source: "sandbox" };
   }
-  if (!devUpOrRecoverable) return { kind: "loading" };
+  if (!SNAPSHOT_READABLE_PHASES.has(input.lifecyclePhase)) {
+    return { kind: "loading" };
+  }
 
   const blocksFrameworkMissing = [input.decofile, input.meta].some(
     (query) =>

--- a/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
+++ b/apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts
@@ -21,44 +21,49 @@ export type BlocksTabState =
   | { kind: "empty" }
   | { kind: "error"; source: "sandbox" | "data" };
 
-const TERMINAL_LIFECYCLE_PHASES = new Set<LifecycleState["phase"]>([
-  "clone-failed",
-  "install-failed",
-  "start-failed",
-  "crashed",
-]);
+type PhaseClass =
+  /** Setup failed for good — surface a sandbox error card. */
+  | "terminal-error"
+  /** Daemon not serving reads yet (no clone / no daemon) — show loading. */
+  | "booting"
+  /**
+   * Daemon reachable AND repo cloned, so the committed `.deco/*.gen.json`
+   * snapshot is readable — even before the dev server reaches `running`. This
+   * is what lets Blocks open during boot (mirroring Content, which renders as
+   * soon as the sandbox handle exists). `crashed` (dev server died, daemon
+   * alive) is here too: the snapshot stays editable, only the live preview is
+   * broken until the dev server is back.
+   */
+  | "snapshot-readable";
 
-// Phases where the daemon is reachable AND the repo is already cloned, so the
-// committed `.deco/*.gen.json` snapshot is readable even before the dev server
-// is up. Blocks edits persist to the FS, so the editor stays usable throughout
-// boot — mirroring Content, which renders as soon as the sandbox handle exists
-// rather than waiting for the dev server to reach `running`. `crashed` (dev
-// server died but daemon alive) is included for the same reason. `idle` and
-// `cloning` are excluded: the daemon isn't serving the snapshot yet, so we show
-// loading rather than a false "empty" from a 404 on a not-yet-cloned file.
-const SNAPSHOT_READABLE_PHASES = new Set<LifecycleState["phase"]>([
-  "checking-out",
-  "installing",
-  "starting",
-  "running",
-  "crashed",
-]);
+// Exhaustive over `LifecycleState["phase"]`: the switch has no `default`, so
+// adding a phase to the union is a compile error here rather than a silent
+// fall-through to the wrong state.
+function classifyPhase(phase: LifecycleState["phase"]): PhaseClass {
+  switch (phase) {
+    case "clone-failed":
+    case "install-failed":
+    case "start-failed":
+      return "terminal-error";
+    case "idle":
+    case "cloning":
+      return "booting";
+    case "checking-out":
+    case "installing":
+    case "starting":
+    case "running":
+    case "crashed":
+      return "snapshot-readable";
+  }
+}
 
 export function resolveBlocksTabState(
   input: BlocksTabStateInput,
 ): BlocksTabState {
-  // Genuine setup failures stay terminal. `crashed` is recoverable (see
-  // SNAPSHOT_READABLE_PHASES) — the committed snapshot is still editable, only
-  // the live preview is broken until the dev server is back.
-  if (
-    TERMINAL_LIFECYCLE_PHASES.has(input.lifecyclePhase) &&
-    input.lifecyclePhase !== "crashed"
-  ) {
+  const phaseClass = classifyPhase(input.lifecyclePhase);
+  if (phaseClass === "terminal-error")
     return { kind: "error", source: "sandbox" };
-  }
-  if (!SNAPSHOT_READABLE_PHASES.has(input.lifecyclePhase)) {
-    return { kind: "loading" };
-  }
+  if (phaseClass === "booting") return { kind: "loading" };
 
   const blocksFrameworkMissing = [input.decofile, input.meta].some(
     (query) =>
@@ -69,7 +74,18 @@ export function resolveBlocksTabState(
   const initialDataFailed =
     (input.decofile.status === "error" && !input.decofile.hasData) ||
     (input.meta.status === "error" && !input.meta.hasData);
-  if (initialDataFailed) return { kind: "error", source: "data" };
+  if (initialDataFailed) {
+    // While booting, the committed snapshot may not be written yet, and an
+    // absent file surfaces as a synthetic 502 from the read fallback (see
+    // `use-decofile`), NOT a 404 — so it can't be classified as "framework
+    // missing" above. Treat it as loading instead of a hard data error: the
+    // `→running` lifecycle transition re-invalidates both queries and resolves
+    // content/empty authoritatively. Only surface the error once the dev
+    // server has settled (running/crashed), where the failure is real.
+    const devSettled =
+      input.lifecyclePhase === "running" || input.lifecyclePhase === "crashed";
+    return devSettled ? { kind: "error", source: "data" } : { kind: "loading" };
+  }
 
   if (!input.decofile.hasData || !input.meta.hasData) {
     return { kind: "loading" };


### PR DESCRIPTION
## Summary

The **Blocks** editor (the "Blocos" toggle inside the Preview tab) stayed stuck on a loading spinner while the sandbox was booting ("Starting your preview…"), even though the **Content** tab worked fine in the same state. Since Blocks and Content read the same committed `.deco/blocks.gen.json` / `.deco/meta.gen.json` snapshot, Blocks should be editable during boot too.

**Root cause:** `resolveBlocksTabState` gated on the dev server reaching `running`/`crashed`, returning `{ kind: "loading" }` for every other phase — including the boot phases (`checking-out`/`installing`/`starting`) where the daemon is already up and the repo is cloned, so the snapshot is readable. Content has no such gate: it renders as soon as a `previewUrl` exists and lets the query state drive loading/empty/error.

**Fix:** replace the `running`/`crashed`-only gate with a `SNAPSHOT_READABLE_PHASES` set (`checking-out`, `installing`, `starting`, `running`, `crashed`) — the phases where the daemon is reachable and the repo is cloned. `idle`/`cloning` stay in `loading` (daemon/repo not ready yet, avoids a false "empty" from a 404 on a not-yet-cloned file). Terminal setup failures still surface the sandbox error.

Result: clicking **Blocos** during boot now opens the editor reading from the committed snapshot, matching Content. The Blocks panel lives in the left resizable panel; the booting overlay only covers the preview canvas on the right, so the two coexist.

## Testing
- `blocks-tab-state.test.ts` — inverted the test that encoded the old behavior (`installing` → `loading`) and added coverage for the new phases (`idle`/`cloning` → loading; `checking-out`/`installing`/`starting` → content). **16 pass / 0 fail.**
- `bun run --cwd=apps/mesh check` (tsc) ✅
- `bun run lint` — 0 errors (pre-existing warnings only)
- `bun run fmt` ✅

## Affected areas
- `apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.ts`
- `apps/mesh/src/web/layouts/main-panel-tabs/blocks-tab-state.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Blocks editor spinner during sandbox boot and avoids false data errors when the snapshot is missing. The editor now opens from the committed snapshot as soon as the daemon is reachable, matching the Content tab.

- **Bug Fixes**
  - Allow editing in checking-out/installing/starting/running/crashed; keep idle/cloning in loading.
  - During boot, treat absent snapshot (synthetic 502) and pending reads as loading; only show data errors once the dev server is running/crashed.
  - Terminal setup errors still surface from the sandbox.
  - Replaced phase sets with an exhaustive phase classifier; tests cover boot, missing/pending snapshot, empty, and settled error paths.

<sup>Written for commit b17623b0cd30a2ab5153846e9f1b944c45967bf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

