### PR TITLE
feat(sandbox): configurable publish policy for code agents (AI smart review)

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -792,6 +792,7 @@ export const createSandboxRoutes = () => {
         const body = (await c.req.json().catch(() => ({}))) as {
           status?: GitStatusLike;
           diff?: GitDiffLike;
+          language?: string;
         };
 
         const clientStatus = body.status;
@@ -820,7 +821,12 @@ export const createSandboxRoutes = () => {
                   { userId, projectRef },
                 ),
               ]);
-        const verdict = await judgeRequiresReviewWithLlm(ctx, status, diff);
+        const verdict = await judgeRequiresReviewWithLlm(
+          ctx,
+          status,
+          diff,
+          typeof body.language === "string" ? body.language : undefined,
+        );
         return c.json(verdict, 200, SANDBOX_PROXY_CACHE_HEADERS);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -36,6 +36,7 @@ import {
   isGitStatusLike,
   suggestCommitMessageWithLlm,
 } from "../../lib/suggest-commit-message";
+import { judgeRequiresReviewWithLlm } from "../../lib/judge-requires-review";
 import {
   buildLoaderInvokeUrl,
   parseLoaderInvokeRequest,
@@ -747,6 +748,80 @@ export const createSandboxRoutes = () => {
               ]);
         const suggestion = await suggestCommitMessageWithLlm(ctx, status, diff);
         return c.json(suggestion, 200, SANDBOX_PROXY_CACHE_HEADERS);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message === "SANDBOX_GONE") {
+          return c.json(
+            {
+              error:
+                "Sandbox handle is gone. The sandbox needs to be re-provisioned.",
+            },
+            410,
+            SANDBOX_PROXY_CACHE_HEADERS,
+          );
+        }
+        return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
+      }
+    },
+  );
+
+  // Smart-review judge: the client sends the full publish payload (status +
+  // combined diff) and the cheap "fast" model tier decides whether the changes
+  // need PR review. Backfills status/diff from the daemon when omitted, mirrors
+  // the suggest-commit handler. On any failure the lib returns a permissive
+  // verdict (requiresReview: false) so the AI's absence never blocks publish.
+  app.post(
+    "/:virtualMcpId/:branch/git/judge-review",
+    bodyLimit({
+      maxSize: SUGGEST_COMMIT_MAX_BODY_BYTES,
+      onError: (c) =>
+        c.json(
+          { error: "Payload too large" },
+          413,
+          SANDBOX_PROXY_CACHE_HEADERS,
+        ),
+    }),
+    async (c) => {
+      const runner = requireRunner(c);
+      if (runner instanceof Response) return runner;
+
+      const { claimName, userId, projectRef } = c.get("vmClaim");
+      const ctx = c.var.studioContext;
+
+      try {
+        const body = (await c.req.json().catch(() => ({}))) as {
+          status?: GitStatusLike;
+          diff?: GitDiffLike;
+        };
+
+        const clientStatus = body.status;
+        const clientDiff = body.diff;
+        const hasClientDiff =
+          clientDiff != null &&
+          typeof clientDiff.diffs === "object" &&
+          clientDiff.diffs !== null;
+
+        const [status, diff] =
+          isGitStatusLike(clientStatus) && hasClientDiff
+            ? [clientStatus, clientDiff]
+            : await Promise.all([
+                fetchDaemonJson<GitStatusLike>(
+                  runner,
+                  claimName,
+                  "/_sandbox/git/status",
+                  "GET",
+                  { userId, projectRef },
+                ),
+                fetchDaemonJson<GitDiffLike>(
+                  runner,
+                  claimName,
+                  "/_sandbox/git/diff",
+                  "GET",
+                  { userId, projectRef },
+                ),
+              ]);
+        const verdict = await judgeRequiresReviewWithLlm(ctx, status, diff);
+        return c.json(verdict, 200, SANDBOX_PROXY_CACHE_HEADERS);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         if (message === "SANDBOX_GONE") {

--- a/apps/mesh/src/lib/judge-requires-review.ts
+++ b/apps/mesh/src/lib/judge-requires-review.ts
@@ -1,0 +1,89 @@
+import { generateObject } from "ai";
+import { z } from "zod";
+import type { StudioContext } from "../core/studio-context";
+import { resolveTier } from "../core/resolve-tier";
+import {
+  buildCommitContextSummary,
+  type GitDiffLike,
+  type GitStatusLike,
+} from "./suggest-commit-message";
+
+/** Whether a set of code changes needs human review before a direct publish. */
+export interface ReviewVerdict {
+  requiresReview: boolean;
+  reason: string;
+}
+
+const ReviewVerdictSchema = z.object({
+  requiresReview: z
+    .boolean()
+    .describe("true if the changes should go through pull-request review"),
+  reason: z
+    .string()
+    .describe("One short sentence explaining the decision (max ~120 chars)"),
+});
+
+const REVIEW_JUDGE_SYSTEM = `You decide whether a set of changes to a web project must go through human pull-request review before being published directly to production.
+
+Require review (requiresReview = true) when the changes:
+- add or modify backend/server logic, API routes, or HTTP endpoints
+- touch authentication, authorization, permissions, or security
+- change the database, migrations, environment variables, or secrets
+- add or change server-side integrations, jobs, or webhooks
+- are large or sweeping: many files changed, or large/complex code edits
+
+Do NOT require review (requiresReview = false) when the changes are low-risk, such as:
+- frontend-only presentation: UI components, styling/CSS, layout, copy/text
+- content or design edits
+- small, localized, obviously-safe tweaks
+
+When unsure between the two, lean toward NOT requiring review for small frontend-only diffs, and toward requiring it for anything backend or large.
+
+Respond with the structured verdict and a short reason.`;
+
+/**
+ * Permissive fallback: when we can't run the judge (no org, no model provider,
+ * or an error), do NOT block the user — allow the direct publish. This matches
+ * the product decision that the AI's absence must never gate publishing.
+ */
+const ALLOW_FALLBACK: ReviewVerdict = { requiresReview: false, reason: "" };
+
+/**
+ * Ask the org's cheap "fast" model tier whether a publish payload needs review.
+ * Mirrors `suggestCommitMessageWithLlm` (same tier + context-summary plumbing)
+ * but returns a typed verdict via `generateObject`.
+ */
+export async function judgeRequiresReviewWithLlm(
+  ctx: StudioContext,
+  status: GitStatusLike,
+  diff: GitDiffLike,
+): Promise<ReviewVerdict> {
+  const orgId = ctx.organization?.id;
+  if (!orgId) return ALLOW_FALLBACK;
+
+  try {
+    const tier = await resolveTier(ctx, "fast");
+    const provider = await ctx.aiProviders.activate(tier.credentialId, orgId);
+    const model = provider.aiSdk.languageModel(tier.modelId);
+    const summary = buildCommitContextSummary(status, diff);
+
+    const { object } = await generateObject({
+      model,
+      schema: ReviewVerdictSchema,
+      system: REVIEW_JUDGE_SYSTEM,
+      prompt: summary,
+      temperature: 0,
+    });
+
+    return {
+      requiresReview: object.requiresReview,
+      reason: object.reason.trim().slice(0, 200),
+    };
+  } catch (err) {
+    console.warn(
+      "[judge-requires-review] LLM failed, allowing direct publish",
+      err,
+    );
+    return ALLOW_FALLBACK;
+  }
+}

--- a/apps/mesh/src/lib/judge-requires-review.ts
+++ b/apps/mesh/src/lib/judge-requires-review.ts
@@ -42,6 +42,20 @@ When unsure between the two, lean toward NOT requiring review for small frontend
 Respond with the structured verdict and a short reason.`;
 
 /**
+ * Map a UI locale to a language name for the model. The `reason` is shown to
+ * the user, so it should be written in their language. Unknown locales fall
+ * back to English.
+ */
+function languageInstruction(language: string | undefined): string {
+  switch (language) {
+    case "pt-BR":
+      return "Write the `reason` in Brazilian Portuguese (pt-BR).";
+    default:
+      return "Write the `reason` in English.";
+  }
+}
+
+/**
  * Permissive fallback: when we can't run the judge (no org, no model provider,
  * or an error), do NOT block the user — allow the direct publish. This matches
  * the product decision that the AI's absence must never gate publishing.
@@ -57,6 +71,7 @@ export async function judgeRequiresReviewWithLlm(
   ctx: StudioContext,
   status: GitStatusLike,
   diff: GitDiffLike,
+  language?: string,
 ): Promise<ReviewVerdict> {
   const orgId = ctx.organization?.id;
   if (!orgId) return ALLOW_FALLBACK;
@@ -70,7 +85,7 @@ export async function judgeRequiresReviewWithLlm(
     const { object } = await generateObject({
       model,
       schema: ReviewVerdictSchema,
-      system: REVIEW_JUDGE_SYSTEM,
+      system: `${REVIEW_JUDGE_SYSTEM}\n\n${languageInstruction(language)}`,
       prompt: summary,
       temperature: 0,
     });

--- a/apps/mesh/src/lib/judge-requires-review.ts
+++ b/apps/mesh/src/lib/judge-requires-review.ts
@@ -31,6 +31,7 @@ Require review (requiresReview = true) when the changes:
 - change the database, migrations, environment variables, or secrets
 - add or change server-side integrations, jobs, or webhooks
 - are large or sweeping: many files changed, or large/complex code edits
+- look OBVIOUSLY broken or incomplete in the shown diff — e.g. a removed closing bracket/parenthesis/brace, an unterminated string or comment, a dangling/unbalanced expression, or a deletion that clearly leaves the code syntactically invalid. You only see diff snippets, not whole files, so flag this ONLY when the breakage is plainly visible in the changed lines; do NOT guess about code you can't see.
 
 Do NOT require review (requiresReview = false) when the changes are low-risk, such as:
 - frontend-only presentation: UI components, styling/CSS, layout, copy/text

--- a/apps/mesh/src/web/components/sandbox/hooks/use-publish-gate.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-publish-gate.ts
@@ -92,9 +92,43 @@ export function usePublishGate(args: {
     retry: (count, error) => !isSandboxUnreachable(error) && count < 2,
   });
 
-  const status = query.data?.status ?? null;
-  const diff = query.data?.diff ?? null;
-  const needsJudge = needsSmartReviewJudgment(diff, policy);
+  return useResolvedPublishGate({
+    orgSlug,
+    virtualMcpId,
+    branch,
+    status: query.data?.status ?? null,
+    diff: query.data?.diff ?? null,
+    policy,
+  });
+}
+
+/**
+ * Combine an already-loaded diff + policy (+ the smart AI verdict) into the
+ * final publish gate. Single source of truth for the "does this publish need
+ * review?" decision, shared by the header's self-fetching `usePublishGate` and
+ * the publish dialog (which supplies its own loaded diff). `judgeEnabled` lets
+ * the dialog restrict the AI call to its publish-only intent.
+ */
+export function useResolvedPublishGate(args: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  status: GitStatus | null;
+  diff: GitDiffResult | null;
+  policy: PublishPolicy;
+  judgeEnabled?: boolean;
+}): { gate: PublishGate; ready: boolean } {
+  const {
+    orgSlug,
+    virtualMcpId,
+    branch,
+    status,
+    diff,
+    policy,
+    judgeEnabled = true,
+  } = args;
+
+  const needsJudge = judgeEnabled && needsSmartReviewJudgment(diff, policy);
 
   // In `smart` policy with code in the diff, defer to the cheap AI judge (cached
   // per diff content, no polling). Deco-only / non-smart cases skip it entirely.
@@ -110,8 +144,7 @@ export function usePublishGate(args: {
   // While the diff is still loading (or the sandbox is unreachable) don't gate
   // the button — let the click fall through to the dialog, which does its own
   // loading + gating. Only enforce the gate once we actually have the diff.
-  if (!query.data)
-    return { gate: { allowed: true, reason: null }, ready: false };
+  if (!diff) return { gate: { allowed: true, reason: null }, ready: false };
   if (!needsJudge)
     return { gate: canPublishDirectly(diff, policy), ready: true };
   return { gate: smartReviewGate(verdict, loading), ready: !loading };

--- a/apps/mesh/src/web/components/sandbox/hooks/use-publish-gate.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-publish-gate.ts
@@ -6,9 +6,14 @@ import {
   fetchGitStatus,
   hasGitLocalWork,
   isSandboxUnreachable,
+  needsSmartReviewJudgment,
+  smartReviewGate,
   type GitDiffResult,
+  type GitStatus,
   type PublishGate,
+  type PublishPolicy,
 } from "../../thread/github/sandbox-git-api.ts";
+import { useSmartReviewVerdict } from "./use-smart-review-verdict.ts";
 
 function publishGateQueryKey(
   orgSlug: string,
@@ -45,6 +50,7 @@ export function usePublishGate(args: {
   base: string;
   headSha?: string | null;
   signature: string;
+  policy: PublishPolicy;
   enabled?: boolean;
 }): { gate: PublishGate; ready: boolean } {
   const {
@@ -54,10 +60,11 @@ export function usePublishGate(args: {
     base,
     headSha,
     signature,
+    policy,
     enabled = true,
   } = args;
 
-  const query = useQuery<GitDiffResult>({
+  const query = useQuery<{ status: GitStatus; diff: GitDiffResult }>({
     queryKey: publishGateQueryKey(
       orgSlug,
       virtualMcpId,
@@ -77,7 +84,7 @@ export function usePublishGate(args: {
       const workingDiff = hasGitLocalWork(status)
         ? await fetchGitDiff(orgSlug, virtualMcpId, branch)
         : null;
-      return combinePublishDiffs(baseDiff, workingDiff);
+      return { status, diff: combinePublishDiffs(baseDiff, workingDiff) };
     },
     enabled: enabled && !!branch,
     refetchInterval: 10_000,
@@ -85,10 +92,27 @@ export function usePublishGate(args: {
     retry: (count, error) => !isSandboxUnreachable(error) && count < 2,
   });
 
+  const status = query.data?.status ?? null;
+  const diff = query.data?.diff ?? null;
+  const needsJudge = needsSmartReviewJudgment(diff, policy);
+
+  // In `smart` policy with code in the diff, defer to the cheap AI judge (cached
+  // per diff content, no polling). Deco-only / non-smart cases skip it entirely.
+  const { verdict, loading } = useSmartReviewVerdict({
+    orgSlug,
+    virtualMcpId,
+    branch,
+    status,
+    diff,
+    enabled: needsJudge,
+  });
+
   // While the diff is still loading (or the sandbox is unreachable) don't gate
   // the button — let the click fall through to the dialog, which does its own
   // loading + gating. Only enforce the gate once we actually have the diff.
   if (!query.data)
     return { gate: { allowed: true, reason: null }, ready: false };
-  return { gate: canPublishDirectly(query.data), ready: true };
+  if (!needsJudge)
+    return { gate: canPublishDirectly(diff, policy), ready: true };
+  return { gate: smartReviewGate(verdict, loading), ready: !loading };
 }

--- a/apps/mesh/src/web/components/sandbox/hooks/use-smart-review-verdict.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-smart-review-verdict.ts
@@ -1,0 +1,85 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchReviewVerdict,
+  isSandboxUnreachable,
+  type GitDiffResult,
+  type GitStatus,
+  type ReviewVerdict,
+} from "../../thread/github/sandbox-git-api.ts";
+
+/**
+ * Cheap, stable fingerprint of a diff's content so the verdict is cached per
+ * distinct set of changes (path + content length + a content prefix). Avoids
+ * hashing megabytes of file bodies on every render while still changing on
+ * virtually every meaningful edit — a rare collision only means a slightly
+ * stale verdict, which the permissive gate errs safe on anyway.
+ */
+function smartReviewVerdictQueryKey(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+  signature: string,
+) {
+  return [
+    "smart-review-verdict",
+    orgSlug,
+    virtualMcpId,
+    branch,
+    signature,
+  ] as const;
+}
+
+function reviewDiffSignature(diff: GitDiffResult): string {
+  return Object.keys(diff.diffs)
+    .sort()
+    .map((path) => {
+      const entry = diff.diffs[path];
+      const from = entry?.from ?? "";
+      const to = entry?.to ?? "";
+      return `${path}:${from.length}:${to.length}:${to.slice(0, 48)}`;
+    })
+    .join("|");
+}
+
+/**
+ * Ask the cheap-model judge whether a `smart`-policy code diff needs review.
+ * Keyed by the diff content so the AI is called at most once per distinct diff
+ * (no `refetchInterval` — the verdict is stable for a given diff). `enabled`
+ * should be `needsSmartReviewJudgment(diff, policy)` so we never spend a model
+ * call on deco-only diffs or non-smart policies.
+ */
+export function useSmartReviewVerdict(args: {
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  status: GitStatus | null;
+  diff: GitDiffResult | null;
+  enabled: boolean;
+}): { verdict: ReviewVerdict | null; loading: boolean } {
+  const { orgSlug, virtualMcpId, branch, status, diff, enabled } = args;
+  const signature = diff ? reviewDiffSignature(diff) : "";
+  const canRun = enabled && !!branch && !!status && !!diff && signature !== "";
+
+  const query = useQuery<ReviewVerdict>({
+    queryKey: smartReviewVerdictQueryKey(
+      orgSlug,
+      virtualMcpId,
+      branch,
+      signature,
+    ),
+    queryFn: () =>
+      fetchReviewVerdict(orgSlug, virtualMcpId, branch, {
+        status: status!,
+        diff: diff!,
+      }),
+    enabled: canRun,
+    staleTime: Infinity,
+    gcTime: 10 * 60_000,
+    retry: (count, error) => !isSandboxUnreachable(error) && count < 1,
+  });
+
+  return {
+    verdict: query.data ?? null,
+    loading: canRun && query.isFetching && !query.data,
+  };
+}

--- a/apps/mesh/src/web/components/sandbox/hooks/use-smart-review-verdict.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-smart-review-verdict.ts
@@ -3,18 +3,12 @@ import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import {
   fetchReviewVerdict,
   isSandboxUnreachable,
+  reviewDiffSignature,
   type GitDiffResult,
   type GitStatus,
   type ReviewVerdict,
 } from "../../thread/github/sandbox-git-api.ts";
 
-/**
- * Cheap, stable fingerprint of a diff's content so the verdict is cached per
- * distinct set of changes (path + content length + a content prefix). Avoids
- * hashing megabytes of file bodies on every render while still changing on
- * virtually every meaningful edit — a rare collision only means a slightly
- * stale verdict, which the permissive gate errs safe on anyway.
- */
 function smartReviewVerdictQueryKey(
   orgSlug: string,
   virtualMcpId: string,
@@ -30,18 +24,6 @@ function smartReviewVerdictQueryKey(
     signature,
     language,
   ] as const;
-}
-
-function reviewDiffSignature(diff: GitDiffResult): string {
-  return Object.keys(diff.diffs)
-    .sort()
-    .map((path) => {
-      const entry = diff.diffs[path];
-      const from = entry?.from ?? "";
-      const to = entry?.to ?? "";
-      return `${path}:${from.length}:${to.length}:${to.slice(0, 48)}`;
-    })
-    .join("|");
 }
 
 /**

--- a/apps/mesh/src/web/components/sandbox/hooks/use-smart-review-verdict.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-smart-review-verdict.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import {
   fetchReviewVerdict,
   isSandboxUnreachable,
@@ -19,6 +20,7 @@ function smartReviewVerdictQueryKey(
   virtualMcpId: string,
   branch: string,
   signature: string,
+  language: string,
 ) {
   return [
     "smart-review-verdict",
@@ -26,6 +28,7 @@ function smartReviewVerdictQueryKey(
     virtualMcpId,
     branch,
     signature,
+    language,
   ] as const;
 }
 
@@ -57,6 +60,7 @@ export function useSmartReviewVerdict(args: {
   enabled: boolean;
 }): { verdict: ReviewVerdict | null; loading: boolean } {
   const { orgSlug, virtualMcpId, branch, status, diff, enabled } = args;
+  const [{ language }] = usePreferences();
   const signature = diff ? reviewDiffSignature(diff) : "";
   const canRun = enabled && !!branch && !!status && !!diff && signature !== "";
 
@@ -66,11 +70,13 @@ export function useSmartReviewVerdict(args: {
       virtualMcpId,
       branch,
       signature,
+      language,
     ),
     queryFn: () =>
       fetchReviewVerdict(orgSlug, virtualMcpId, branch, {
         status: status!,
         diff: diff!,
+        language,
       }),
     enabled: canRun,
     staleTime: Infinity,

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -478,8 +478,9 @@ function HeaderButtonRenderer(props: {
           label={
             props.publishGate.pending
               ? t("thread.headerActions.reviewingChanges")
-              : (props.publishGate.reason ??
-                t("thread.headerActions.publishDirectlySkipReview"))
+              : props.publishGate.allowed
+                ? t("thread.headerActions.publishDirectlySkipReview")
+                : t("thread.headerActions.publishNeedsReview")
           }
         >
           <Button

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -476,8 +476,10 @@ function HeaderButtonRenderer(props: {
       {props.showPublishSide ? (
         <WithTooltip
           label={
-            props.publishGate.reason ??
-            t("thread.headerActions.publishDirectlySkipReview")
+            props.publishGate.pending
+              ? t("thread.headerActions.reviewingChanges")
+              : (props.publishGate.reason ??
+                t("thread.headerActions.publishDirectlySkipReview"))
           }
         >
           <Button
@@ -486,6 +488,9 @@ function HeaderButtonRenderer(props: {
             disabled={props.githubActionPending || !props.publishGate.allowed}
             onClick={props.onPublishSide}
           >
+            {props.publishGate.pending ? (
+              <Spinner size="xs" variant="default" />
+            ) : null}
             {t("thread.headerActions.publish")}
           </Button>
         </WithTooltip>

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -35,7 +35,7 @@ import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-eve
 import { usePublishGate } from "@/web/components/sandbox/hooks/use-publish-gate.ts";
 import { useChecks, usePrByBranch } from "./use-pr-data.ts";
 import { usePrReviews } from "./use-pr-reviews.ts";
-import type { PublishGate } from "./sandbox-git-api.ts";
+import { normalizePublishPolicy, type PublishGate } from "./sandbox-git-api.ts";
 import { useT, type TFunction } from "@/web/i18n/use-t";
 
 interface Props {
@@ -162,6 +162,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
     effectiveBranchMeta.kind === "ready"
       ? `${effectiveBranchMeta.headSha}:${effectiveBranchMeta.workingTreeDirty}:${effectiveBranchMeta.unpushed}:${effectiveBranchMeta.aheadOfBase}`
       : "unknown";
+  const publishPolicy = normalizePublishPolicy(vm?.metadata?.publishPolicy);
   const { gate: publishGate } = usePublishGate({
     orgSlug: org.slug,
     virtualMcpId,
@@ -170,6 +171,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
     headSha:
       effectiveBranchMeta.kind === "ready" ? effectiveBranchMeta.headSha : null,
     signature: publishGateSignature,
+    policy: publishPolicy,
     enabled: publishGateEnabled,
   });
 
@@ -386,6 +388,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
           owner={githubRepo.owner}
           repo={githubRepo.name}
           previewUrl={previewUrl}
+          publishPolicy={publishPolicy}
           dialogIntent={publishDialogIntent}
           headSha={
             effectiveBranchMeta.kind === "ready"

--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -480,7 +480,8 @@ function HeaderButtonRenderer(props: {
               ? t("thread.headerActions.reviewingChanges")
               : props.publishGate.allowed
                 ? t("thread.headerActions.publishDirectlySkipReview")
-                : t("thread.headerActions.publishNeedsReview")
+                : (props.publishGate.reason ??
+                  t("thread.headerActions.publishNeedsReview"))
           }
         >
           <Button

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -36,9 +36,8 @@ import {
 import type { PrSummary } from "./use-pr-data.ts";
 import { useSandboxStart } from "@/web/components/sandbox/hooks/use-sandbox-start";
 import { publishToBaseLabel } from "./publish-label.ts";
-import { useSmartReviewVerdict } from "@/web/components/sandbox/hooks/use-smart-review-verdict.ts";
+import { useResolvedPublishGate } from "@/web/components/sandbox/hooks/use-publish-gate.ts";
 import {
-  canPublishDirectly,
   combinePublishDiffs,
   countGitChanges,
   discardGitFiles,
@@ -49,12 +48,10 @@ import {
   hasLocalWorkToPush,
   hasUnpublishedWork,
   isSandboxUnreachable,
-  needsSmartReviewJudgment,
   publishGitChanges,
   readGitHeadBranch,
   rebaseGitBranch,
   shouldUseBaseDiff,
-  smartReviewGate,
   type GitDiffResult,
   type GitStatus,
   type PublishPolicy,
@@ -299,17 +296,16 @@ function PublishDialogBody({
   const changesCount = countGitChanges(gitStatus);
   const diffCount = gitDiff ? Object.keys(gitDiff.diffs).length : changesCount;
 
-  // The direct Publish button is only shown in publish-only intent; only judge
-  // (spend an AI call) there, and only for a smart-policy diff that has code.
-  const needsJudge =
-    isPublishOnly && needsSmartReviewJudgment(gitDiff, publishPolicy);
-  const { verdict, loading: judging } = useSmartReviewVerdict({
+  // The direct Publish button is only shown in publish-only intent, so only
+  // spend an AI judge call there (`judgeEnabled`). Shared with the header gate.
+  const { gate: publishGate } = useResolvedPublishGate({
     orgSlug,
     virtualMcpId,
     branch,
     status: gitStatus,
     diff: gitDiff,
-    enabled: needsJudge,
+    policy: publishPolicy,
+    judgeEnabled: isPublishOnly,
   });
 
   const hasLocalUnpublished = openPrFromCommits
@@ -317,9 +313,6 @@ function PublishDialogBody({
     : hasUnpublishedWork(gitStatus, gitDiff);
   const canSubmit =
     !isLoadingGitDiff && (hasLocalUnpublished || openPrFromCommits);
-  const publishGate = needsJudge
-    ? smartReviewGate(verdict, judging)
-    : canPublishDirectly(gitDiff, publishPolicy);
   const canPublish = canSubmit && publishGate.allowed;
   // The gate's `reason` is the AI judge's explanation, written in the UI
   // language (see useSmartReviewVerdict); show it when present, else a

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -321,7 +321,11 @@ function PublishDialogBody({
     ? smartReviewGate(verdict, judging)
     : canPublishDirectly(gitDiff, publishPolicy);
   const canPublish = canSubmit && publishGate.allowed;
-  const publishDisabledReason = canSubmit ? publishGate.reason : null;
+  const publishDisabledReason = !canSubmit
+    ? null
+    : publishGate.pending
+      ? t("thread.publishDialog.reviewingChanges")
+      : publishGate.reason;
 
   /** There is committed or uncommitted local work that can be pushed + PR'd. */
   const showSubmitForReviewButton =

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -36,6 +36,7 @@ import {
 import type { PrSummary } from "./use-pr-data.ts";
 import { useSandboxStart } from "@/web/components/sandbox/hooks/use-sandbox-start";
 import { publishToBaseLabel } from "./publish-label.ts";
+import { useSmartReviewVerdict } from "@/web/components/sandbox/hooks/use-smart-review-verdict.ts";
 import {
   canPublishDirectly,
   combinePublishDiffs,
@@ -48,12 +49,15 @@ import {
   hasLocalWorkToPush,
   hasUnpublishedWork,
   isSandboxUnreachable,
+  needsSmartReviewJudgment,
   publishGitChanges,
   readGitHeadBranch,
   rebaseGitBranch,
   shouldUseBaseDiff,
+  smartReviewGate,
   type GitDiffResult,
   type GitStatus,
+  type PublishPolicy,
 } from "./sandbox-git-api.ts";
 
 class PublishFlowError extends Error {
@@ -81,6 +85,8 @@ export interface PublishDialogProps {
   owner: string;
   repo: string;
   previewUrl?: string | null;
+  /** The code agent's publish policy — gates the direct Publish button. */
+  publishPolicy: PublishPolicy;
   /**
    * `open-pr` — push local work and open a PR for review (default).
    * `publish-only` — direct publish to base; single green Publish button.
@@ -128,6 +134,7 @@ function PublishDialogBody({
   owner,
   repo,
   previewUrl,
+  publishPolicy,
   dialogIntent = "open-pr",
   headSha = null,
   openPullRequest = null,
@@ -292,12 +299,27 @@ function PublishDialogBody({
   const changesCount = countGitChanges(gitStatus);
   const diffCount = gitDiff ? Object.keys(gitDiff.diffs).length : changesCount;
 
+  // The direct Publish button is only shown in publish-only intent; only judge
+  // (spend an AI call) there, and only for a smart-policy diff that has code.
+  const needsJudge =
+    isPublishOnly && needsSmartReviewJudgment(gitDiff, publishPolicy);
+  const { verdict, loading: judging } = useSmartReviewVerdict({
+    orgSlug,
+    virtualMcpId,
+    branch,
+    status: gitStatus,
+    diff: gitDiff,
+    enabled: needsJudge,
+  });
+
   const hasLocalUnpublished = openPrFromCommits
     ? hasLocalWorkToPush(gitStatus)
     : hasUnpublishedWork(gitStatus, gitDiff);
   const canSubmit =
     !isLoadingGitDiff && (hasLocalUnpublished || openPrFromCommits);
-  const publishGate = canPublishDirectly(gitDiff);
+  const publishGate = needsJudge
+    ? smartReviewGate(verdict, judging)
+    : canPublishDirectly(gitDiff, publishPolicy);
   const canPublish = canSubmit && publishGate.allowed;
   const publishDisabledReason = canSubmit ? publishGate.reason : null;
 

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -321,14 +321,15 @@ function PublishDialogBody({
     ? smartReviewGate(verdict, judging)
     : canPublishDirectly(gitDiff, publishPolicy);
   const canPublish = canSubmit && publishGate.allowed;
-  // The gate's `reason` carries the server/AI-generated (English) explanation;
-  // we don't render it directly so the tooltip stays in the user's language.
+  // The gate's `reason` is the AI judge's explanation, written in the UI
+  // language (see useSmartReviewVerdict); show it when present, else a
+  // localized generic message.
   const publishDisabledReason =
     !canSubmit || publishGate.allowed
       ? null
       : publishGate.pending
         ? t("thread.publishDialog.reviewingChanges")
-        : t("thread.publishDialog.publishNeedsReview");
+        : (publishGate.reason ?? t("thread.publishDialog.publishNeedsReview"));
 
   /** There is committed or uncommitted local work that can be pushed + PR'd. */
   const showSubmitForReviewButton =

--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -321,11 +321,14 @@ function PublishDialogBody({
     ? smartReviewGate(verdict, judging)
     : canPublishDirectly(gitDiff, publishPolicy);
   const canPublish = canSubmit && publishGate.allowed;
-  const publishDisabledReason = !canSubmit
-    ? null
-    : publishGate.pending
-      ? t("thread.publishDialog.reviewingChanges")
-      : publishGate.reason;
+  // The gate's `reason` carries the server/AI-generated (English) explanation;
+  // we don't render it directly so the tooltip stays in the user's language.
+  const publishDisabledReason =
+    !canSubmit || publishGate.allowed
+      ? null
+      : publishGate.pending
+        ? t("thread.publishDialog.reviewingChanges")
+        : t("thread.publishDialog.publishNeedsReview");
 
   /** There is committed or uncommitted local work that can be pushed + PR'd. */
   const showSubmitForReviewButton =

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, test } from "bun:test";
 import {
   canPublishDirectly,
   combinePublishDiffs,
+  DEFAULT_PUBLISH_POLICY,
   hasGitLocalWork,
   hasLocalWorkToPush,
   hasUnpublishedWork,
   isDecoOnlyDiff,
+  needsSmartReviewJudgment,
+  normalizePublishPolicy,
   PUBLISH_REQUIRES_SUBMIT_TOOLTIP,
   shouldUseBaseDiff,
+  smartReviewGate,
   stripGeneratedFilesFromDiff,
   type GitDiffResult,
   type GitStatus,
@@ -297,6 +301,88 @@ describe("canPublishDirectly", () => {
 
   test("blocks an empty diff", () => {
     expect(canPublishDirectly({ diffs: {} }).allowed).toBe(false);
+  });
+
+  test("defaults to code-review behavior (deco allowed, code blocked)", () => {
+    expect(canPublishDirectly(decoDiff, "code-review").allowed).toBe(true);
+    expect(canPublishDirectly(codeDiff, "code-review").allowed).toBe(false);
+  });
+
+  test("open policy allows code directly", () => {
+    const gate = canPublishDirectly(codeDiff, "open");
+    expect(gate.allowed).toBe(true);
+    expect(gate.reason).toBeNull();
+  });
+
+  test("smart policy allows a deco-only payload without the judge", () => {
+    expect(canPublishDirectly(decoDiff, "smart").allowed).toBe(true);
+  });
+});
+
+describe("normalizePublishPolicy", () => {
+  test("defaults unknown/absent values to smart", () => {
+    expect(DEFAULT_PUBLISH_POLICY).toBe("smart");
+    expect(normalizePublishPolicy(undefined)).toBe("smart");
+    expect(normalizePublishPolicy(null)).toBe("smart");
+    expect(normalizePublishPolicy("bogus")).toBe("smart");
+  });
+
+  test("passes through valid values", () => {
+    expect(normalizePublishPolicy("smart")).toBe("smart");
+    expect(normalizePublishPolicy("code-review")).toBe("code-review");
+    expect(normalizePublishPolicy("open")).toBe("open");
+  });
+});
+
+describe("needsSmartReviewJudgment", () => {
+  const decoDiff: GitDiffResult = {
+    diffs: { ".deco/blocks/home.json": { from: "{}", to: "{}" } },
+  };
+  const codeDiff: GitDiffResult = {
+    diffs: { "routes/index.tsx": { from: "a", to: "b" } },
+  };
+
+  test("only smart policy with code needs the judge", () => {
+    expect(needsSmartReviewJudgment(codeDiff, "smart")).toBe(true);
+    expect(needsSmartReviewJudgment(decoDiff, "smart")).toBe(false);
+    expect(needsSmartReviewJudgment(codeDiff, "code-review")).toBe(false);
+    expect(needsSmartReviewJudgment(codeDiff, "open")).toBe(false);
+  });
+
+  test("empty/null diffs never need the judge", () => {
+    expect(needsSmartReviewJudgment(null, "smart")).toBe(false);
+    expect(needsSmartReviewJudgment({ diffs: {} }, "smart")).toBe(false);
+  });
+});
+
+describe("smartReviewGate", () => {
+  test("permissive while judging (no block on absence)", () => {
+    expect(smartReviewGate(null, true).allowed).toBe(true);
+  });
+
+  test("permissive when the judge is unavailable (no verdict)", () => {
+    expect(smartReviewGate(null, false).allowed).toBe(true);
+  });
+
+  test("allows when the verdict says no review needed", () => {
+    const gate = smartReviewGate({ requiresReview: false, reason: "" }, false);
+    expect(gate.allowed).toBe(true);
+    expect(gate.reason).toBeNull();
+  });
+
+  test("blocks with the AI reason when review is required", () => {
+    const gate = smartReviewGate(
+      { requiresReview: true, reason: "New API endpoint added" },
+      false,
+    );
+    expect(gate.allowed).toBe(false);
+    expect(gate.reason).toBe("New API endpoint added");
+  });
+
+  test("falls back to the default tooltip when the AI gives no reason", () => {
+    const gate = smartReviewGate({ requiresReview: true, reason: "" }, false);
+    expect(gate.allowed).toBe(false);
+    expect(gate.reason).toBe(PUBLISH_REQUIRES_SUBMIT_TOOLTIP);
   });
 });
 

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -356,12 +356,18 @@ describe("needsSmartReviewJudgment", () => {
 });
 
 describe("smartReviewGate", () => {
-  test("permissive while judging (no block on absence)", () => {
-    expect(smartReviewGate(null, true).allowed).toBe(true);
+  test("blocks (pending) while the judge is still running", () => {
+    const gate = smartReviewGate(null, true);
+    expect(gate.allowed).toBe(false);
+    expect(gate.pending).toBe(true);
+    // Copy is i18n'd at the component level, so no inline reason here.
+    expect(gate.reason).toBeNull();
   });
 
   test("permissive when the judge is unavailable (no verdict)", () => {
-    expect(smartReviewGate(null, false).allowed).toBe(true);
+    const gate = smartReviewGate(null, false);
+    expect(gate.allowed).toBe(true);
+    expect(gate.pending).toBeUndefined();
   });
 
   test("allows when the verdict says no review needed", () => {

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -9,6 +9,7 @@ import {
   isDecoOnlyDiff,
   needsSmartReviewJudgment,
   normalizePublishPolicy,
+  reviewDiffSignature,
   shouldUseBaseDiff,
   smartReviewGate,
   stripGeneratedFilesFromDiff,
@@ -317,6 +318,62 @@ describe("canPublishDirectly", () => {
 
   test("smart policy allows a deco-only payload without the judge", () => {
     expect(canPublishDirectly(decoDiff, "smart").allowed).toBe(true);
+  });
+});
+
+describe("reviewDiffSignature", () => {
+  test("is stable for the same diff", () => {
+    const diff: GitDiffResult = {
+      diffs: { "routes/a.tsx": { from: "a", to: "b" } },
+    };
+    expect(reviewDiffSignature(diff)).toBe(reviewDiffSignature(diff));
+  });
+
+  test("is order-independent across paths", () => {
+    const a: GitDiffResult = {
+      diffs: {
+        "a.tsx": { from: "1", to: "2" },
+        "b.tsx": { from: "3", to: "4" },
+      },
+    };
+    const b: GitDiffResult = {
+      diffs: {
+        "b.tsx": { from: "3", to: "4" },
+        "a.tsx": { from: "1", to: "2" },
+      },
+    };
+    expect(reviewDiffSignature(a)).toBe(reviewDiffSignature(b));
+  });
+
+  // The safety case: a length-preserving edit deep in a file (past a short
+  // prefix) must still change the signature, or a stale "allowed" verdict would
+  // be reused for code that now needs review (fail-open).
+  test("changes for a length-preserving deep edit", () => {
+    const prefix = "x".repeat(80);
+    const before: GitDiffResult = {
+      diffs: { "routes/api.tsx": { from: "", to: `${prefix}LIMIT=1000` } },
+    };
+    const after: GitDiffResult = {
+      diffs: { "routes/api.tsx": { from: "", to: `${prefix}LIMIT=5000` } },
+    };
+    expect(reviewDiffSignature(before)).not.toBe(reviewDiffSignature(after));
+  });
+
+  test("changes when a path is added or removed", () => {
+    const one: GitDiffResult = { diffs: { "a.tsx": { from: "1", to: "2" } } };
+    const two: GitDiffResult = {
+      diffs: {
+        "a.tsx": { from: "1", to: "2" },
+        "b.tsx": { from: null, to: "3" },
+      },
+    };
+    expect(reviewDiffSignature(one)).not.toBe(reviewDiffSignature(two));
+  });
+
+  test("distinguishes a from/to swap of equal-length content", () => {
+    const a: GitDiffResult = { diffs: { "a.tsx": { from: "ab", to: "cd" } } };
+    const b: GitDiffResult = { diffs: { "a.tsx": { from: "cd", to: "ab" } } };
+    expect(reviewDiffSignature(a)).not.toBe(reviewDiffSignature(b));
   });
 });
 

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.test.ts
@@ -9,7 +9,6 @@ import {
   isDecoOnlyDiff,
   needsSmartReviewJudgment,
   normalizePublishPolicy,
-  PUBLISH_REQUIRES_SUBMIT_TOOLTIP,
   shouldUseBaseDiff,
   smartReviewGate,
   stripGeneratedFilesFromDiff,
@@ -293,10 +292,12 @@ describe("canPublishDirectly", () => {
     expect(gate.reason).toBeNull();
   });
 
-  test("blocks a payload containing code", () => {
+  test("blocks a payload containing code (reason localized in UI)", () => {
     const gate = canPublishDirectly(codeDiff);
     expect(gate.allowed).toBe(false);
-    expect(gate.reason).toBe(PUBLISH_REQUIRES_SUBMIT_TOOLTIP);
+    // No inline reason: the deterministic code-review block is rendered as a
+    // localized generic tooltip at the component level.
+    expect(gate.reason).toBeNull();
   });
 
   test("blocks an empty diff", () => {
@@ -385,10 +386,10 @@ describe("smartReviewGate", () => {
     expect(gate.reason).toBe("New API endpoint added");
   });
 
-  test("falls back to the default tooltip when the AI gives no reason", () => {
+  test("blocks with a null reason when the AI gives no reason (UI localizes)", () => {
     const gate = smartReviewGate({ requiresReview: true, reason: "" }, false);
     expect(gate.allowed).toBe(false);
-    expect(gate.reason).toBe(PUBLISH_REQUIRES_SUBMIT_TOOLTIP);
+    expect(gate.reason).toBeNull();
   });
 });
 
@@ -433,6 +434,6 @@ describe("combinePublishDiffs (full publish payload = committed ∪ working)", (
       combinePublishDiffs(committedCode, workingDeco),
     );
     expect(gate.allowed).toBe(false);
-    expect(gate.reason).toBe(PUBLISH_REQUIRES_SUBMIT_TOOLTIP);
+    expect(gate.reason).toBeNull();
   });
 });

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -245,6 +245,57 @@ export function isDecoOnlyDiff(
 export const PUBLISH_REQUIRES_SUBMIT_TOOLTIP =
   "Code changes can't be published directly — use Submit for review";
 
+/**
+ * Per-code-agent policy controlling when a direct publish is allowed:
+ * - `smart` (default): a cheap AI judges whether the code needs review.
+ * - `code-review`: any code change requires review (only deco/design publishes).
+ * - `open`: everything publishes directly.
+ * Mirrors `PublishPolicy` in `@decocms/mesh-sdk` (kept local to avoid pulling
+ * the SDK into this browser module).
+ */
+export type PublishPolicy = "smart" | "code-review" | "open";
+
+export const DEFAULT_PUBLISH_POLICY: PublishPolicy = "smart";
+
+/** Coerce an untrusted `metadata.publishPolicy` value into a valid policy. */
+export function normalizePublishPolicy(value: unknown): PublishPolicy {
+  return value === "code-review" || value === "open" || value === "smart"
+    ? value
+    : DEFAULT_PUBLISH_POLICY;
+}
+
+/** Verdict from the cheap AI judge on whether a code diff needs human review. */
+export interface ReviewVerdict {
+  requiresReview: boolean;
+  reason: string;
+}
+
+/**
+ * Ask the server-side cheap-model judge whether this publish payload needs
+ * review. Only meaningful for `smart` policy on a diff that contains code
+ * (see `needsSmartReviewJudgment`). Generated files are stripped to keep the
+ * payload under the endpoint's body limit.
+ */
+export async function fetchReviewVerdict(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+  payload: { status: GitStatus; diff: GitDiffResult },
+): Promise<ReviewVerdict> {
+  const res = await sandboxFetch(
+    buildSandboxGitUrl(orgSlug, virtualMcpId, branch, "judge-review"),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        status: payload.status,
+        diff: stripGeneratedFilesFromDiff(payload.diff),
+      }),
+    },
+  );
+  return parseJson<ReviewVerdict>(res);
+}
+
 export async function discardGitFiles(
   orgSlug: string,
   virtualMcpId: string,
@@ -373,15 +424,57 @@ export function combinePublishDiffs(
 }
 
 /**
- * Whether the changes may be squash-merged straight to base, bypassing review.
- * `diff` must be the full publish payload (see `combinePublishDiffs`) so the
- * gate sees every file — committed and uncommitted. Only deco-only payloads
- * publish directly; anything with code must go through Submit for review.
+ * Whether the changes may be squash-merged straight to base, bypassing review,
+ * for the given publish policy. `diff` must be the full publish payload (see
+ * `combinePublishDiffs`) so the gate sees every file — committed and
+ * uncommitted.
+ *
+ * This is the SYNCHRONOUS decision and covers every case except `smart` with
+ * code in the diff — that one needs the async AI verdict, so callers must first
+ * check `needsSmartReviewJudgment` and use `smartReviewGate` when it's true.
+ * (Calling this for that case falls back to the safe `code-review` behavior.)
  */
 export function canPublishDirectly(
   diff: GitDiffResult | null | undefined,
+  policy: PublishPolicy = "code-review",
 ): PublishGate {
+  if (policy === "open") return { allowed: true, reason: null };
+  // `smart` deco-only diffs (and all `code-review`) fall through to the
+  // deco-only rule: content/design publishes, code is blocked.
   return isDecoOnlyDiff(diff)
     ? { allowed: true, reason: null }
     : { allowed: false, reason: PUBLISH_REQUIRES_SUBMIT_TOOLTIP };
+}
+
+/**
+ * True when deciding the gate requires the async AI judge: `smart` policy on a
+ * non-empty diff that contains code. Deco-only diffs never need the judge
+ * (they always publish), and `code-review`/`open` are fully synchronous.
+ */
+export function needsSmartReviewJudgment(
+  diff: GitDiffResult | null | undefined,
+  policy: PublishPolicy,
+): boolean {
+  if (policy !== "smart") return false;
+  if (!diff || Object.keys(diff.diffs).length === 0) return false;
+  return !isDecoOnlyDiff(diff);
+}
+
+/**
+ * Resolve the gate for `smart` policy from the AI verdict. Deliberately
+ * permissive: while the judge is still running, or when it's unavailable
+ * (no model provider, error), we DON'T block — only an explicit
+ * `requiresReview` verdict disables direct publish.
+ */
+export function smartReviewGate(
+  verdict: ReviewVerdict | null | undefined,
+  loading: boolean,
+): PublishGate {
+  if (loading || !verdict) return { allowed: true, reason: null };
+  if (!verdict.requiresReview) return { allowed: true, reason: null };
+  const reason = verdict.reason?.trim();
+  return {
+    allowed: false,
+    reason: reason ? reason : PUBLISH_REQUIRES_SUBMIT_TOOLTIP,
+  };
 }

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -242,9 +242,6 @@ export function isDecoOnlyDiff(
   );
 }
 
-export const PUBLISH_REQUIRES_SUBMIT_TOOLTIP =
-  "Code changes can't be published directly — use Submit for review";
-
 /**
  * Per-code-agent policy controlling when a direct publish is allowed:
  * - `smart` (default): a cheap AI judges whether the code needs review.
@@ -280,7 +277,7 @@ export async function fetchReviewVerdict(
   orgSlug: string,
   virtualMcpId: string,
   branch: string,
-  payload: { status: GitStatus; diff: GitDiffResult },
+  payload: { status: GitStatus; diff: GitDiffResult; language?: string },
 ): Promise<ReviewVerdict> {
   const res = await sandboxFetch(
     buildSandboxGitUrl(orgSlug, virtualMcpId, branch, "judge-review"),
@@ -290,6 +287,10 @@ export async function fetchReviewVerdict(
       body: JSON.stringify({
         status: payload.status,
         diff: stripGeneratedFilesFromDiff(payload.diff),
+        // The `reason` is shown to the user, so ask the model to write it in
+        // the UI language. This is a deliberate exception to "don't thread
+        // locale to the server" — it applies only to this displayed AI text.
+        ...(payload.language ? { language: payload.language } : {}),
       }),
     },
   );
@@ -447,10 +448,11 @@ export function canPublishDirectly(
 ): PublishGate {
   if (policy === "open") return { allowed: true, reason: null };
   // `smart` deco-only diffs (and all `code-review`) fall through to the
-  // deco-only rule: content/design publishes, code is blocked.
+  // deco-only rule: content/design publishes, code is blocked. Reason is left
+  // null — the component renders a localized generic tooltip for this case.
   return isDecoOnlyDiff(diff)
     ? { allowed: true, reason: null }
-    : { allowed: false, reason: PUBLISH_REQUIRES_SUBMIT_TOOLTIP };
+    : { allowed: false, reason: null };
 }
 
 /**
@@ -483,9 +485,9 @@ export function smartReviewGate(
   if (loading) return { allowed: false, reason: null, pending: true };
   if (!verdict) return { allowed: true, reason: null };
   if (!verdict.requiresReview) return { allowed: true, reason: null };
+  // The AI reason is localized (the judge is asked to write in the UI
+  // language); show it. Fall back to null so the component renders its own
+  // localized generic message when the model returned no reason.
   const reason = verdict.reason?.trim();
-  return {
-    allowed: false,
-    reason: reason ? reason : PUBLISH_REQUIRES_SUBMIT_TOOLTIP,
-  };
+  return { allowed: false, reason: reason ? reason : null };
 }

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -268,6 +268,36 @@ export interface ReviewVerdict {
 }
 
 /**
+ * Stable content fingerprint of a diff, used to cache the AI review verdict per
+ * distinct set of changes. Hashes every path plus its FULL from/to content, so
+ * any change to the diff yields a different signature. This matters for safety:
+ * the verdict is cached with `staleTime: Infinity`, so a fingerprint that
+ * collided on two different diffs could reuse a stale "publish allowed" verdict
+ * for code that actually needs review — failing open. A full-content djb2 hash
+ * avoids that (unlike a length+prefix fingerprint, which a length-preserving
+ * edit deep in a file can collide). Cheap: O(diff size), memoized by the React
+ * compiler on the stable diff reference.
+ */
+export function reviewDiffSignature(diff: GitDiffResult): string {
+  let hash = 5381;
+  const mix = (s: string) => {
+    for (let i = 0; i < s.length; i++) {
+      hash = ((hash << 5) + hash + s.charCodeAt(i)) | 0;
+    }
+  };
+  for (const path of Object.keys(diff.diffs).sort()) {
+    const entry = diff.diffs[path];
+    mix(path);
+    mix(" from:");
+    mix(entry?.from ?? "");
+    mix(" to:");
+    mix(entry?.to ?? "");
+    mix("  ");
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/**
  * Ask the server-side cheap-model judge whether this publish payload needs
  * review. Only meaningful for `smart` policy on a diff that contains code
  * (see `needsSmartReviewJudgment`). Generated files are stripped to keep the

--- a/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
+++ b/apps/mesh/src/web/components/thread/github/sandbox-git-api.ts
@@ -403,6 +403,13 @@ export function shouldUseBaseDiff(
 export interface PublishGate {
   allowed: boolean;
   reason: string | null;
+  /**
+   * `smart` policy only: the AI judge is still running, so the decision isn't
+   * known yet. The button should be disabled (not optimistically enabled) with
+   * a "reviewing" tooltip until the verdict arrives. `reason` is null here
+   * because the tooltip copy is i18n'd at the component level.
+   */
+  pending?: boolean;
 }
 
 /**
@@ -461,16 +468,20 @@ export function needsSmartReviewJudgment(
 }
 
 /**
- * Resolve the gate for `smart` policy from the AI verdict. Deliberately
- * permissive: while the judge is still running, or when it's unavailable
- * (no model provider, error), we DON'T block — only an explicit
- * `requiresReview` verdict disables direct publish.
+ * Resolve the gate for `smart` policy from the AI verdict.
+ * - While the judge is still running: block (`pending`) so the button can't be
+ *   clicked before the decision is known — the component shows a "reviewing"
+ *   tooltip.
+ * - When the judge is unavailable (no model provider, error → no verdict):
+ *   permissive, allow the direct publish rather than blocking on the AI.
+ * - Otherwise honour the verdict.
  */
 export function smartReviewGate(
   verdict: ReviewVerdict | null | undefined,
   loading: boolean,
 ): PublishGate {
-  if (loading || !verdict) return { allowed: true, reason: null };
+  if (loading) return { allowed: false, reason: null, pending: true };
+  if (!verdict) return { allowed: true, reason: null };
   if (!verdict.requiresReview) return { allowed: true, reason: null };
   const reason = verdict.reason?.trim();
   return {

--- a/apps/mesh/src/web/i18n/en/thread.ts
+++ b/apps/mesh/src/web/i18n/en/thread.ts
@@ -82,6 +82,7 @@ export const thread = {
   "thread.headerActions.pushLocalCommitsTooltip":
     "Push local commits to PR #{prNumber}",
   "thread.headerActions.reconnectGithub": "Reconnect GitHub",
+  "thread.headerActions.reviewingChanges": "Reviewing changes…",
   "thread.headerActions.reopen": "Reopen",
   "thread.headerActions.reopenPrTooltip": "Reopen PR #{prNumber}",
   "thread.headerActions.resolveConflictsTooltip":
@@ -146,6 +147,7 @@ export const thread = {
   "thread.publishDialog.publishedTo": "Published to {baseBranch}",
   "thread.publishDialog.pullRequest": "Pull request",
   "thread.publishDialog.regenerate": "Regenerate",
+  "thread.publishDialog.reviewingChanges": "Reviewing changes…",
   "thread.publishDialog.squashMergesInto":
     "{publishLabel} squash-merges into {baseBranch}.",
   "thread.publishDialog.submitForReview": "Submit for review",

--- a/apps/mesh/src/web/i18n/en/thread.ts
+++ b/apps/mesh/src/web/i18n/en/thread.ts
@@ -76,6 +76,8 @@ export const thread = {
     "Publish directly, skipping review",
   "thread.headerActions.publishedPr": "Published PR #{prNumber}",
   "thread.headerActions.published": "Published",
+  "thread.headerActions.publishNeedsReview":
+    "This change needs review before publishing.",
   "thread.headerActions.publishToProduction": "Publish to production",
   "thread.headerActions.pushAndOpenPrTooltip":
     "Push and open a PR for {branch} → {base}",
@@ -145,6 +147,8 @@ export const thread = {
   "thread.publishDialog.opensPullRequestInto":
     "Opens a pull request into {baseBranch} for review.",
   "thread.publishDialog.publishedTo": "Published to {baseBranch}",
+  "thread.publishDialog.publishNeedsReview":
+    "This change needs review before publishing.",
   "thread.publishDialog.pullRequest": "Pull request",
   "thread.publishDialog.regenerate": "Regenerate",
   "thread.publishDialog.reviewingChanges": "Reviewing changes…",

--- a/apps/mesh/src/web/i18n/en/virtual-mcp.ts
+++ b/apps/mesh/src/web/i18n/en/virtual-mcp.ts
@@ -162,6 +162,18 @@ export const virtualMcp = {
     "No connections yet. Add one to get started.",
   "virtualMcp.virtualMcp.openFullscreenEditor": "Open fullscreen editor",
   "virtualMcp.virtualMcp.promptTemplate": "+ Prompt template",
+  "virtualMcp.virtualMcp.publishing": "Publishing",
+  "virtualMcp.virtualMcp.publishingDescription":
+    "Control when this agent's changes can be published directly, skipping pull-request review.",
+  "virtualMcp.virtualMcp.publishPolicySmart": "Smart review",
+  "virtualMcp.virtualMcp.publishPolicySmartDescription":
+    "AI checks each change and only asks for review when the code looks risky (new endpoints, large or backend changes). Content and design edits publish directly.",
+  "virtualMcp.virtualMcp.publishPolicyCodeReview": "Require review for code",
+  "virtualMcp.virtualMcp.publishPolicyCodeReviewDescription":
+    "Any code change must go through pull-request review before publishing. Only content and design changes publish directly.",
+  "virtualMcp.virtualMcp.publishPolicyOpen": "Publish freely",
+  "virtualMcp.virtualMcp.publishPolicyOpenDescription":
+    "Publish any change directly, without review.",
   "virtualMcp.virtualMcp.sandbox": "Sandbox",
   "virtualMcp.virtualMcp.settings": "Settings",
   "virtualMcp.virtualMcp.spaceNotFound": "Space not found",

--- a/apps/mesh/src/web/i18n/pt-br/thread.ts
+++ b/apps/mesh/src/web/i18n/pt-br/thread.ts
@@ -86,6 +86,7 @@ export const thread = {
   "thread.headerActions.pushLocalCommitsTooltip":
     "Enviar commits locais para o PR #{prNumber}",
   "thread.headerActions.reconnectGithub": "Reconectar GitHub",
+  "thread.headerActions.reviewingChanges": "Revisando alterações…",
   "thread.headerActions.reopen": "Reabrir",
   "thread.headerActions.reopenPrTooltip": "Reabrir PR #{prNumber}",
   "thread.headerActions.resolveConflictsTooltip":
@@ -153,6 +154,7 @@ export const thread = {
   "thread.publishDialog.publishedTo": "Publicado em {baseBranch}",
   "thread.publishDialog.pullRequest": "Pull request",
   "thread.publishDialog.regenerate": "Regenerar",
+  "thread.publishDialog.reviewingChanges": "Revisando alterações…",
   "thread.publishDialog.squashMergesInto":
     "{publishLabel} faz squash-merge para {baseBranch}.",
   "thread.publishDialog.submitForReview": "Enviar para revisão",

--- a/apps/mesh/src/web/i18n/pt-br/thread.ts
+++ b/apps/mesh/src/web/i18n/pt-br/thread.ts
@@ -80,6 +80,8 @@ export const thread = {
     "Publicar diretamente, pulando a revisão",
   "thread.headerActions.publishedPr": "PR #{prNumber} publicado",
   "thread.headerActions.published": "Publicado",
+  "thread.headerActions.publishNeedsReview":
+    "Esta alteração precisa de revisão antes de publicar.",
   "thread.headerActions.publishToProduction": "Publicar em produção",
   "thread.headerActions.pushAndOpenPrTooltip":
     "Enviar e abrir um PR para {branch} → {base}",
@@ -152,6 +154,8 @@ export const thread = {
   "thread.publishDialog.opensPullRequestInto":
     "Abre um pull request para {baseBranch} para revisão.",
   "thread.publishDialog.publishedTo": "Publicado em {baseBranch}",
+  "thread.publishDialog.publishNeedsReview":
+    "Esta alteração precisa de revisão antes de publicar.",
   "thread.publishDialog.pullRequest": "Pull request",
   "thread.publishDialog.regenerate": "Regenerar",
   "thread.publishDialog.reviewingChanges": "Revisando alterações…",

--- a/apps/mesh/src/web/i18n/pt-br/virtual-mcp.ts
+++ b/apps/mesh/src/web/i18n/pt-br/virtual-mcp.ts
@@ -165,6 +165,18 @@ export const virtualMcp = {
     "Nenhuma conexão ainda. Adicione uma para começar.",
   "virtualMcp.virtualMcp.openFullscreenEditor": "Abrir editor em tela cheia",
   "virtualMcp.virtualMcp.promptTemplate": "+ Modelo de prompt",
+  "virtualMcp.virtualMcp.publishing": "Publicação",
+  "virtualMcp.virtualMcp.publishingDescription":
+    "Controle quando as alterações deste agente podem ser publicadas diretamente, sem revisão por pull request.",
+  "virtualMcp.virtualMcp.publishPolicySmart": "Revisão inteligente",
+  "virtualMcp.virtualMcp.publishPolicySmartDescription":
+    "A IA analisa cada alteração e só pede revisão quando o código parece arriscado (novos endpoints, mudanças grandes ou de backend). Ajustes de conteúdo e design são publicados diretamente.",
+  "virtualMcp.virtualMcp.publishPolicyCodeReview": "Exigir revisão de código",
+  "virtualMcp.virtualMcp.publishPolicyCodeReviewDescription":
+    "Qualquer alteração de código precisa passar por revisão via pull request antes de publicar. Só mudanças de conteúdo e design são publicadas diretamente.",
+  "virtualMcp.virtualMcp.publishPolicyOpen": "Publicar sem revisão",
+  "virtualMcp.virtualMcp.publishPolicyOpenDescription":
+    "Publica qualquer alteração diretamente, sem revisão.",
   "virtualMcp.virtualMcp.sandbox": "Sandbox",
   "virtualMcp.virtualMcp.settings": "Configurações",
   "virtualMcp.virtualMcp.spaceNotFound": "Espaço não encontrado",

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -35,6 +35,10 @@ import {
 } from "@deco/ui/components/dialog.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Card, CardContent } from "@deco/ui/components/card.tsx";
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@deco/ui/components/radio-group.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import {
   Tooltip,
@@ -1039,6 +1043,90 @@ Define step-by-step how the agent should handle requests.
 
             {/* Development agent section (link a dev counterpart) */}
             <DevAgentSetup virtualMcp={virtualMcp} />
+
+            {/* Publishing section (code agents only) */}
+            {hasGithubRepo && (
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-1">
+                  <h2 className="text-sm font-medium text-foreground">
+                    {t("virtualMcp.virtualMcp.publishing")}
+                  </h2>
+                  <p className="text-sm text-muted-foreground">
+                    {t("virtualMcp.virtualMcp.publishingDescription")}
+                  </p>
+                </div>
+                <Card className="p-6">
+                  <CardContent className="p-0">
+                    <Controller
+                      name="metadata.publishPolicy"
+                      control={form.control}
+                      render={({ field }) => (
+                        <RadioGroup
+                          value={field.value ?? "smart"}
+                          onValueChange={(value) => {
+                            field.onChange(value);
+                            flushAndSave();
+                          }}
+                          className="gap-4"
+                        >
+                          {(
+                            [
+                              {
+                                value: "smart",
+                                label: t(
+                                  "virtualMcp.virtualMcp.publishPolicySmart",
+                                ),
+                                description: t(
+                                  "virtualMcp.virtualMcp.publishPolicySmartDescription",
+                                ),
+                              },
+                              {
+                                value: "code-review",
+                                label: t(
+                                  "virtualMcp.virtualMcp.publishPolicyCodeReview",
+                                ),
+                                description: t(
+                                  "virtualMcp.virtualMcp.publishPolicyCodeReviewDescription",
+                                ),
+                              },
+                              {
+                                value: "open",
+                                label: t(
+                                  "virtualMcp.virtualMcp.publishPolicyOpen",
+                                ),
+                                description: t(
+                                  "virtualMcp.virtualMcp.publishPolicyOpenDescription",
+                                ),
+                              },
+                            ] as const
+                          ).map((option) => (
+                            <label
+                              key={option.value}
+                              htmlFor={`publish-policy-${option.value}`}
+                              className="flex cursor-pointer items-start gap-3"
+                            >
+                              <RadioGroupItem
+                                id={`publish-policy-${option.value}`}
+                                value={option.value}
+                                className="mt-0.5"
+                              />
+                              <div className="flex flex-col gap-0.5">
+                                <span className="text-sm font-medium text-foreground">
+                                  {option.label}
+                                </span>
+                                <span className="text-sm text-muted-foreground">
+                                  {option.description}
+                                </span>
+                              </div>
+                            </label>
+                          ))}
+                        </RadioGroup>
+                      )}
+                    />
+                  </CardContent>
+                </Card>
+              </div>
+            )}
 
             {/* Sandbox section */}
             <div className="flex flex-col gap-3">

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -551,7 +551,7 @@ const knowledgeMetadataField = z
  *   publish directly.
  * - `open`: every change publishes directly, no review required.
  */
-export const PublishPolicySchema = z.enum(["smart", "code-review", "open"]);
+const PublishPolicySchema = z.enum(["smart", "code-review", "open"]);
 export type PublishPolicy = z.infer<typeof PublishPolicySchema>;
 
 const publishPolicyMetadataField = PublishPolicySchema.nullable()

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -542,6 +542,25 @@ const knowledgeMetadataField = z
   );
 
 /**
+ * Controls when a code agent's changes may be published directly (squash-merged
+ * to base) instead of going through pull-request review.
+ * - `smart` (default): a cheap AI judges each change — code that looks risky
+ *   (new endpoints, large or backend changes) needs review; content/design and
+ *   small frontend edits publish directly.
+ * - `code-review`: any code change requires review; only CMS/design changes
+ *   publish directly.
+ * - `open`: every change publishes directly, no review required.
+ */
+export const PublishPolicySchema = z.enum(["smart", "code-review", "open"]);
+export type PublishPolicy = z.infer<typeof PublishPolicySchema>;
+
+const publishPolicyMetadataField = PublishPolicySchema.nullable()
+  .optional()
+  .describe(
+    "Controls when this code agent's changes may be published directly vs. requiring PR review. 'smart' (default) uses AI to judge per change; 'code-review' requires review for any code; 'open' allows direct publish always.",
+  );
+
+/**
  * Virtual MCP entity schema - single source of truth
  * Compliant with collections binding pattern
  */
@@ -610,6 +629,7 @@ export const VirtualMCPEntitySchema = z.object({
         .nullable()
         .optional()
         .describe("Linked asset site slug (managed storage tenancy)"),
+      publishPolicy: publishPolicyMetadataField,
     })
     .loose()
     .describe("Metadata"),
@@ -708,6 +728,7 @@ export const VirtualMCPCreateDataSchema = z.object({
         .nullable()
         .optional()
         .describe("Linked asset site slug (managed storage tenancy)"),
+      publishPolicy: publishPolicyMetadataField,
     })
     .loose()
     .nullable()
@@ -787,6 +808,7 @@ export const VirtualMCPUpdateDataSchema = z.object({
         .nullable()
         .optional()
         .describe("Linked asset site slug (managed storage tenancy)"),
+      publishPolicy: publishPolicyMetadataField,
     })
     .loose()
     .nullable()


### PR DESCRIPTION
## Summary

Clients complained that Publish is disabled whenever a branch has code changes. This moves that gate out of hardcoded logic and into a **per-code-agent setting** (`metadata.publishPolicy`) with three modes, defaulting to an AI-judged mode:

| Mode (`publishPolicy`) | en / pt-br | Behavior |
|---|---|---|
| `smart` **(default)** | Smart review / Revisão inteligente | Deco/design-only diffs publish directly. When there's code, a cheap **"fast"-tier** model judges `{requiresReview, reason}` — review for endpoints/backend/large changes, direct publish for frontend/content/design. |
| `code-review` | Require review for code / Exigir revisão de código | Previous behavior: any code change requires review. |
| `open` | Publish freely / Publicar sem revisão | Publish anything directly. |

## How it works
- **Schema**: `publishPolicy` added to the three metadata schemas in `packages/mesh-sdk`; the existing shallow-merge in `COLLECTION_VIRTUAL_MCP_UPDATE` persists it.
- **Backend**: new `apps/mesh/src/lib/judge-requires-review.ts` (mirrors `suggest-commit-message.ts`: `resolveTier(ctx, "fast")` + `generateObject` + zod) and a `POST .../git/judge-review` proxy route next to `suggest-commit`.
- **Frontend**: `canPublishDirectly(diff, policy)` + new `needsSmartReviewJudgment` / `smartReviewGate` helpers; new `useSmartReviewVerdict` hook **caches the verdict per diff-content hash** (no `refetchInterval`), so the model is called at most once per distinct diff rather than on every 10s poll. Both the header side-Publish button (`usePublishGate`) and the publish dialog share the logic.
- **UI**: a new **Publishing** section in the agent Settings tab (shown only for code agents with a repo).
- **i18n**: full en + pt-br.

## ⚠️ Behavior change to be aware of
Per product decision, the smart-mode fallback is **permissive**: when the model is unavailable (org has no AI provider configured, or the call errors) the judge never blocks publishing. Since the default is now `smart` for every agent, an org with no AI provider will be able to publish code directly (the opposite of the old always-block behavior). Users who want the strict old behavior can pick **Require review for code**. Flipping the fallback to fail-safe is a one-line change if we'd rather err toward blocking.

## Testing
- `bun test` — 15 new unit cases for `canPublishDirectly` (per-policy), `needsSmartReviewJudgment`, `smartReviewGate`, `normalizePublishPolicy`.
- `bun run check` (all workspaces), `bun run lint` (0 errors), `bun run fmt` all pass.
- No e2e references the old gate, so nothing to invert there.

The AI judge itself (LLM call) is not unit-testable per the two-tier rule; its pure input builder (`buildCommitContextSummary`) is reused from the existing, tested suggest-commit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make publishing configurable per code agent with a new `metadata.publishPolicy` (`smart`, `code-review`, `open`). In smart mode, Publish is disabled while the review check runs, falls back to allow when the judge is unavailable, shows a localized “needs review” reason, and now also flags obviously broken diffs.

- **New Features**
  - Added `publishPolicy` to `packages/mesh-sdk` metadata; defaults to `smart` (schema kept internal).
  - New `POST /:virtualMcpId/:branch/git/judge-review` uses a fast-tier model to decide if a diff needs review; returns a short, localized reason; permissive fallback on failure.
  - Smart review: judge also flags obviously broken/incomplete diffs; verdict cached per diff signature + language; `reviewDiffSignature` switched to a full-content, order-independent hash.
  - Frontend gating: `normalizePublishPolicy`, `needsSmartReviewJudgment`, `smartReviewGate` (with `pending` state), `useSmartReviewVerdict`, and `useResolvedPublishGate` shared by header and dialog. While judging, Publish shows a spinner and “Reviewing changes…”.
  - UI: new “Publishing” section in agent Settings for code agents with a repo (en + pt-br). Tests cover policy normalization, judgment gating, pending state, and diff-signature hashing.

- **Migration**
  - Behavior change: `smart` is now the default and is permissive when the judge is unavailable (publishing won’t be blocked).
  - To keep the previous strict behavior, set “Require review for code” in the agent’s Settings.

<sup>Written for commit 20889dfc5db0f8b354129f79f91d445f16377b8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---
## Review note: the publish policy is advisory (UX/workflow), not a server-enforced boundary

The gate is computed client-side; `POST /git/publish` does **not** check `publishPolicy` or the AI verdict, so any authorized org member can publish directly regardless of policy. This is **not a regression** — the prior deco-only gate was equally client-only, and direct publish has always been authorized for org members. It's a governance/workflow affordance, not an access-control guarantee: `code-review` does not guarantee unreviewed code can't reach production. If we ever need that guarantee, it requires server-side enforcement in `/git/publish` against the daemon's authoritative working tree (out of scope here). The permissive fallback (LLM unavailable → allow) and the fact that the judged diff is client-supplied both follow from this advisory design and are intentional.