### PR TITLE
feat(harness): WAF bypass header for browser tools on deco-owned hosts

### DIFF
--- a/packages/harness/src/decopilot/built-in-tools/inspect-page.ts
+++ b/packages/harness/src/decopilot/built-in-tools/inspect-page.ts
@@ -19,6 +19,7 @@ import type { ObjectStorageHooks } from "../../harness-deps";
 import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toStudioStorageUri } from "../studio-storage-uri";
 import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
+import { wafBypassHeaders } from "./waf-bypass";
 
 const InspectPageInputSchema = z.object({
   url: z.string().url().describe("The URL of the web page to inspect."),
@@ -66,6 +67,12 @@ function buildFunctionCode(
       page.on("pageerror", (err) => {
         errors.push(err.message || String(err));
       });
+
+      // Deco-zone targets get the WAF bypass header (see waf-bypass.ts).
+      const bypassHeaders = ${JSON.stringify(wafBypassHeaders(url))};
+      if (Object.keys(bypassHeaders).length) {
+        await page.setExtraHTTPHeaders(bypassHeaders);
+      }
 
       await page.goto(${JSON.stringify(url)}, {
         waitUntil: ${JSON.stringify(waitUntil)},

--- a/packages/harness/src/decopilot/built-in-tools/portable-media-tools.ts
+++ b/packages/harness/src/decopilot/built-in-tools/portable-media-tools.ts
@@ -7,6 +7,7 @@ import {
 } from "../studio-storage-uri";
 import type { PendingImage } from "./vm-tools/types";
 import { BROWSERLESS_BASE_URL } from "./constants";
+import { wafBypassHeaders } from "./waf-bypass";
 
 const FILES_URL_PATTERN = /\/api\/[^/]+\/files\/([^?#]+)/;
 const MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024;
@@ -345,6 +346,11 @@ export function createPortableTakeScreenshotTool(
                 quality: JPEG_QUALITY,
               },
               viewport: DEFAULT_VIEWPORT,
+              // Deco-zone targets get the WAF bypass header (see waf-bypass.ts)
+              // so bot management doesn't block the render.
+              ...(Object.keys(wafBypassHeaders(input.url)).length
+                ? { setExtraHTTPHeaders: wafBypassHeaders(input.url) }
+                : {}),
             }),
           },
         );

--- a/packages/harness/src/decopilot/built-in-tools/scrape-url.ts
+++ b/packages/harness/src/decopilot/built-in-tools/scrape-url.ts
@@ -16,6 +16,7 @@ import type { ObjectStorageHooks } from "../../harness-deps";
 import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toStudioStorageUri } from "../studio-storage-uri";
 import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
+import { wafBypassHeaders } from "./waf-bypass";
 
 const ScrapeUrlInputSchema = z.object({
   url: z.string().url().describe("The URL of the web page to scrape."),
@@ -55,6 +56,10 @@ export function createScrapeUrlTool(
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
               url: input.url,
+              // Deco-zone targets get the WAF bypass header (see waf-bypass.ts).
+              ...(Object.keys(wafBypassHeaders(input.url)).length
+                ? { setExtraHTTPHeaders: wafBypassHeaders(input.url) }
+                : {}),
             }),
           },
         );

--- a/packages/harness/src/decopilot/built-in-tools/waf-bypass.ts
+++ b/packages/harness/src/decopilot/built-in-tools/waf-bypass.ts
@@ -1,0 +1,34 @@
+/**
+ * WAF bypass header for deco-owned hosts.
+ *
+ * The browser tools (take_screenshot / scrape_url / inspect_page) run on
+ * Browserless — headless Chrome from datacenter egress — which Cloudflare
+ * bot management on deco's own zones scores as a bot and blocks. That breaks
+ * agent QA/verification of deco previews (envs-*.decocdn.com) and
+ * storefronts. Both zones carry a shared-secret skip rule matching the
+ * `x-deco-probe-bypass` header; sending it gives Studio's tooling trusted
+ * passage without loosening bot protection for anyone else.
+ *
+ * SECURITY: the header is attached ONLY when the target host is a deco zone
+ * (*.decocdn.com / *.deco.site). Browser tools can target arbitrary URLs —
+ * sending the secret to third-party origins would leak it.
+ */
+export function wafBypassHeaders(targetUrl: string): Record<string, string> {
+  const token =
+    typeof process !== "undefined"
+      ? process.env?.DECO_WAF_BYPASS_TOKEN
+      : undefined;
+  if (!token) return {};
+  try {
+    const host = new URL(targetUrl).hostname;
+    const decoHost =
+      host === "decocdn.com" ||
+      host === "deco.site" ||
+      host.endsWith(".decocdn.com") ||
+      host.endsWith(".deco.site");
+    if (decoHost) return { "x-deco-probe-bypass": token };
+  } catch {
+    // Malformed URL — the Browserless call will fail on its own terms.
+  }
+  return {};
+}


### PR DESCRIPTION
## Why

`take_screenshot` / `scrape_url` / `inspect_page` run on Browserless (headless Chrome, datacenter egress). Cloudflare bot management on deco's own zones scores that as a bot and blocks it — so agents doing QA/verification of deco previews (`envs-*.decocdn.com`) and storefronts consistently get 403 "Sorry, you have been blocked". Observed live on the osklen AI-Services flow: QA runs honest-blocked twice purely on the WAF.

## What

Both production zones already carry a shared-secret skip rule matching the `x-deco-probe-bypass` header (same mechanism as the commerce-discovery probe bypass). When `DECO_WAF_BYPASS_TOKEN` is set in the environment, the three browser tools now send that header.

**Security scoping:** the header is attached **only when the target host is a deco zone** (`*.decocdn.com` / `*.deco.site`) — browser tools can be pointed at arbitrary third-party URLs, and sending the secret there would leak it. See `waf-bypass.ts`.

- `/screenshot` and `/content` payloads gain `setExtraHTTPHeaders`
- the `/function` (inspect_page) puppeteer template calls `page.setExtraHTTPHeaders` before `goto`

## Deploy note

Requires `DECO_WAF_BYPASS_TOKEN` in the cluster env — value is the existing `x-deco-probe-bypass` rule secret on the decocdn.com custom firewall ruleset (rule `[SKIP] commerce-discovery probe bypass`).

## Verification

`packages/harness` `tsc --noEmit` clean · `bun test packages/harness/src/decopilot/built-in-tools` 75/75 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a WAF bypass for browser tools hitting deco-owned hosts to prevent Cloudflare 403s. Sends the `x-deco-probe-bypass` header using `DECO_WAF_BYPASS_TOKEN`, but only for `*.decocdn.com` and `*.deco.site`.

- **New Features**
  - Added `waf-bypass.ts` to generate bypass headers when the target host is a deco zone.
  - Attached headers in `take_screenshot`, `scrape_url`, and `inspect_page` via `setExtraHTTPHeaders`.
  - Never sends the header to third-party hosts.

- **Migration**
  - Set `DECO_WAF_BYPASS_TOKEN` in the cluster environment to the existing secret used by the Cloudflare rule.

<sup>Written for commit 31efea28d69dc74b2722d2d91a31430d55c8d7ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

