### PR TITLE
feat(sandbox): show production site while the preview dev server wakes

### DIFF
--- a/apps/mesh/src/shared/deco-site-production-url.test.ts
+++ b/apps/mesh/src/shared/deco-site-production-url.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import {
+  productionUrlFromDomain,
+  sanitizeProductionUrl,
+} from "./deco-site-production-url";
+
+describe("sanitizeProductionUrl", () => {
+  it("returns the canonical href for a valid http(s) URL", () => {
+    expect(sanitizeProductionUrl("https://acme.com")).toBe("https://acme.com/");
+    expect(sanitizeProductionUrl("http://acme.com/path")).toBe(
+      "http://acme.com/path",
+    );
+  });
+
+  it("trims whitespace", () => {
+    expect(sanitizeProductionUrl("  https://acme.com  ")).toBe(
+      "https://acme.com/",
+    );
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    expect(sanitizeProductionUrl("javascript:alert(1)")).toBeNull();
+    expect(sanitizeProductionUrl("ftp://acme.com")).toBeNull();
+  });
+
+  it("rejects garbage / empty / nullish", () => {
+    expect(sanitizeProductionUrl("not a url")).toBeNull();
+    expect(sanitizeProductionUrl("")).toBeNull();
+    expect(sanitizeProductionUrl("   ")).toBeNull();
+    expect(sanitizeProductionUrl(null)).toBeNull();
+    expect(sanitizeProductionUrl(undefined)).toBeNull();
+  });
+});
+
+describe("productionUrlFromDomain", () => {
+  it("prepends https:// to a bare host", () => {
+    expect(productionUrlFromDomain("acme.com")).toBe("https://acme.com/");
+    expect(productionUrlFromDomain("acme.deco.site")).toBe(
+      "https://acme.deco.site/",
+    );
+  });
+
+  it("preserves an existing scheme", () => {
+    expect(productionUrlFromDomain("http://acme.com")).toBe("http://acme.com/");
+  });
+
+  it("trims whitespace", () => {
+    expect(productionUrlFromDomain("  acme.com ")).toBe("https://acme.com/");
+  });
+
+  it("returns null for empty / whitespace / nullish", () => {
+    expect(productionUrlFromDomain("")).toBeNull();
+    expect(productionUrlFromDomain("   ")).toBeNull();
+    expect(productionUrlFromDomain(null)).toBeNull();
+    expect(productionUrlFromDomain(undefined)).toBeNull();
+  });
+});

--- a/apps/mesh/src/shared/deco-site-production-url.test.ts
+++ b/apps/mesh/src/shared/deco-site-production-url.test.ts
@@ -1,8 +1,35 @@
 import { describe, expect, it } from "bun:test";
 import {
+  pickProductionDomain,
   productionUrlFromDomain,
   sanitizeProductionUrl,
 } from "./deco-site-production-url";
+
+describe("pickProductionDomain", () => {
+  it("prefers the domain flagged production", () => {
+    expect(
+      pickProductionDomain([
+        { domain: "staging.example.com", production: false },
+        { domain: "example.com", production: true },
+      ]),
+    ).toBe("example.com");
+  });
+
+  it("falls back to the first domain when none is flagged production", () => {
+    expect(
+      pickProductionDomain([
+        { domain: "a.example.com", production: false },
+        { domain: "b.example.com", production: false },
+      ]),
+    ).toBe("a.example.com");
+  });
+
+  it("returns undefined for empty / nullish", () => {
+    expect(pickProductionDomain([])).toBeUndefined();
+    expect(pickProductionDomain(null)).toBeUndefined();
+    expect(pickProductionDomain(undefined)).toBeUndefined();
+  });
+});
 
 describe("sanitizeProductionUrl", () => {
   it("returns the canonical href for a valid http(s) URL", () => {

--- a/apps/mesh/src/shared/deco-site-production-url.ts
+++ b/apps/mesh/src/shared/deco-site-production-url.ts
@@ -1,0 +1,38 @@
+/**
+ * Production-URL helpers for linked deco.cx sites.
+ *
+ * The live production URL is persisted on the agent's `metadata.productionUrl`
+ * at import time and painted in the preview iframe while the sandbox dev server
+ * wakes (Lovable-style). We deliberately do NOT derive it from `siteSlug` (the
+ * `{slug}.deco.site` guess) — a site's real production URL can be a custom
+ * domain, so we persist what deco.cx actually reports.
+ */
+
+/** Validate/normalize a stored production URL. Returns the canonical href or `null`. */
+export function sanitizeProductionUrl(
+  value: string | null | undefined,
+): string | null {
+  const raw = value?.trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a production URL from a deco.cx domain. Domains come back as bare hosts
+ * (e.g. `acme.com`, `acme.deco.site`), so we prepend `https://` when no scheme
+ * is present, then validate. Returns `null` for empty/whitespace/invalid input.
+ */
+export function productionUrlFromDomain(
+  domain: string | null | undefined,
+): string | null {
+  const raw = domain?.trim();
+  if (!raw) return null;
+  const withProtocol = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  return sanitizeProductionUrl(withProtocol);
+}

--- a/apps/mesh/src/shared/deco-site-production-url.ts
+++ b/apps/mesh/src/shared/deco-site-production-url.ts
@@ -24,6 +24,16 @@ export function sanitizeProductionUrl(
 }
 
 /**
+ * Pick the site's production domain from the deco.cx `domains` list: the one
+ * flagged `production`, else the first. Returns `undefined` when there are none.
+ */
+export function pickProductionDomain(
+  domains: { domain: string; production: boolean }[] | null | undefined,
+): string | undefined {
+  return domains?.find((d) => d.production)?.domain ?? domains?.[0]?.domain;
+}
+
+/**
  * Build a production URL from a deco.cx domain. Domains come back as bare hosts
  * (e.g. `acme.com`, `acme.deco.site`), so we prepend `https://` when no scheme
  * is present, then validate. Returns `null` for empty/whitespace/invalid input.

--- a/apps/mesh/src/web/components/import-from-deco-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-deco-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { useAutoInstallGitHub } from "@/web/hooks/use-auto-install-github";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { resolveDecoSiteGithubRepo } from "@/shared/deco-sites-github";
+import { productionUrlFromDomain } from "@/shared/deco-site-production-url";
 import { getOrgGithubConnections } from "@/shared/github-repo-scope";
 import {
   fetchGithubInstallations,
@@ -267,6 +268,13 @@ export function ImportFromDecoDialog({
         const projectIcon = connBody.icon ?? null;
         const slug = generateSlug(siteName);
         const siteSlug = siteName.toLowerCase();
+        // Persist the site's real production URL (custom domain when present,
+        // else the deco.site host) so the preview can paint it while the
+        // sandbox dev server wakes. `null` when the site has no domains.
+        const productionUrl = productionUrlFromDomain(
+          site.domains?.find((d) => d.production)?.domain ??
+            site.domains?.[0]?.domain,
+        );
 
         // 2. Create a space (virtual MCP) wired to both admin-mcp and GitHub.
         const result = (await client.callTool({
@@ -284,6 +292,7 @@ export function ImportFromDecoDialog({
                 // Link the agent to its asset site so the CMS resolves uploads
                 // to the managed storage for this slug.
                 siteSlug,
+                productionUrl,
                 githubRepo: {
                   owner: githubRepo.owner,
                   name: githubRepo.name,

--- a/apps/mesh/src/web/components/import-from-deco-dialog.tsx
+++ b/apps/mesh/src/web/components/import-from-deco-dialog.tsx
@@ -11,7 +11,10 @@ import {
 import { useAutoInstallGitHub } from "@/web/hooks/use-auto-install-github";
 import { useNavigateToAgent } from "@/web/hooks/use-navigate-to-agent";
 import { resolveDecoSiteGithubRepo } from "@/shared/deco-sites-github";
-import { productionUrlFromDomain } from "@/shared/deco-site-production-url";
+import {
+  pickProductionDomain,
+  productionUrlFromDomain,
+} from "@/shared/deco-site-production-url";
 import { getOrgGithubConnections } from "@/shared/github-repo-scope";
 import {
   fetchGithubInstallations,
@@ -272,8 +275,7 @@ export function ImportFromDecoDialog({
         // else the deco.site host) so the preview can paint it while the
         // sandbox dev server wakes. `null` when the site has no domains.
         const productionUrl = productionUrlFromDomain(
-          site.domains?.find((d) => d.production)?.domain ??
-            site.domains?.[0]?.domain,
+          pickProductionDomain(site.domains),
         );
 
         // 2. Create a space (virtual MCP) wired to both admin-mcp and GitHub.
@@ -518,9 +520,7 @@ export function ImportFromDecoDialog({
                   </p>
                 )}
                 {filteredSites.map((site) => {
-                  const domain =
-                    site.domains?.find((d) => d.production)?.domain ??
-                    site.domains?.[0]?.domain;
+                  const domain = pickProductionDomain(site.domains);
                   const isSelected = selectedSite === site.name;
                   return (
                     <button

--- a/apps/mesh/src/web/components/sandbox/preview/preview-display.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-display.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-  productionUrlFromSiteSlug,
-  resolvePreviewDisplay,
-} from "./preview-display";
+import { resolvePreviewDisplay } from "./preview-display";
 import type { PreviewState } from "./preview-state";
 
 const IFRAME: PreviewState = {
@@ -16,26 +13,7 @@ const ERRORED: PreviewState = {
   error: { code: null, message: "boom" },
 };
 
-const PROD = "https://acme.deco.site";
-
-describe("productionUrlFromSiteSlug", () => {
-  it("derives the deco.site URL from a slug", () => {
-    expect(productionUrlFromSiteSlug("acme")).toBe("https://acme.deco.site");
-  });
-
-  it("trims surrounding whitespace", () => {
-    expect(productionUrlFromSiteSlug("  acme  ")).toBe(
-      "https://acme.deco.site",
-    );
-  });
-
-  it("returns null for empty / whitespace / nullish", () => {
-    expect(productionUrlFromSiteSlug(null)).toBeNull();
-    expect(productionUrlFromSiteSlug(undefined)).toBeNull();
-    expect(productionUrlFromSiteSlug("")).toBeNull();
-    expect(productionUrlFromSiteSlug("   ")).toBeNull();
-  });
-});
+const PROD = "https://acme.com";
 
 describe("resolvePreviewDisplay", () => {
   it("shows the sandbox iframe once boot is done (running)", () => {

--- a/apps/mesh/src/web/components/sandbox/preview/preview-display.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-display.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test";
+import {
+  productionUrlFromSiteSlug,
+  resolvePreviewDisplay,
+} from "./preview-display";
+import type { PreviewState } from "./preview-state";
+
+const IFRAME: PreviewState = {
+  kind: "iframe",
+  previewUrl: "https://sandbox.example.deco.host",
+};
+const STARTING: PreviewState = { kind: "starting" };
+const SUSPENDED: PreviewState = { kind: "suspended" };
+const ERRORED: PreviewState = {
+  kind: "errored",
+  error: { code: null, message: "boom" },
+};
+
+const PROD = "https://acme.deco.site";
+
+describe("productionUrlFromSiteSlug", () => {
+  it("derives the deco.site URL from a slug", () => {
+    expect(productionUrlFromSiteSlug("acme")).toBe("https://acme.deco.site");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(productionUrlFromSiteSlug("  acme  ")).toBe(
+      "https://acme.deco.site",
+    );
+  });
+
+  it("returns null for empty / whitespace / nullish", () => {
+    expect(productionUrlFromSiteSlug(null)).toBeNull();
+    expect(productionUrlFromSiteSlug(undefined)).toBeNull();
+    expect(productionUrlFromSiteSlug("")).toBeNull();
+    expect(productionUrlFromSiteSlug("   ")).toBeNull();
+  });
+});
+
+describe("resolvePreviewDisplay", () => {
+  it("shows the sandbox iframe once boot is done (running)", () => {
+    expect(
+      resolvePreviewDisplay({
+        previewState: IFRAME,
+        progressStatus: "done",
+        productionUrl: PROD,
+      }),
+    ).toEqual({
+      mode: "sandbox",
+      iframeBase: IFRAME.kind === "iframe" ? IFRAME.previewUrl : null,
+      showBlockingOverlay: false,
+      showWakingPill: false,
+    });
+  });
+
+  it("shows the sandbox iframe (crash page) on a failed boot, not production", () => {
+    const result = resolvePreviewDisplay({
+      previewState: IFRAME,
+      progressStatus: "failed",
+      productionUrl: PROD,
+    });
+    expect(result.mode).toBe("sandbox");
+    expect(result.showWakingPill).toBe(false);
+  });
+
+  it("falls back to production + pill while a fresh boot is in progress", () => {
+    expect(
+      resolvePreviewDisplay({
+        previewState: STARTING,
+        progressStatus: "doing",
+        productionUrl: PROD,
+      }),
+    ).toEqual({
+      mode: "production",
+      iframeBase: PROD,
+      showBlockingOverlay: false,
+      showWakingPill: true,
+    });
+  });
+
+  it("falls back to production + pill while the sandbox iframe is still warming", () => {
+    // previewUrl exists (kind === "iframe") but the dev server isn't up yet.
+    const result = resolvePreviewDisplay({
+      previewState: IFRAME,
+      progressStatus: "doing",
+      productionUrl: PROD,
+    });
+    expect(result.mode).toBe("production");
+    expect(result.iframeBase).toBe(PROD);
+    expect(result.showWakingPill).toBe(true);
+  });
+
+  it("keeps the blocking overlay while booting when there is no production URL", () => {
+    expect(
+      resolvePreviewDisplay({
+        previewState: STARTING,
+        progressStatus: "doing",
+        productionUrl: null,
+      }),
+    ).toEqual({
+      mode: "none",
+      iframeBase: null,
+      showBlockingOverlay: true,
+      showWakingPill: false,
+    });
+  });
+
+  it("keeps the blocking overlay for a warming iframe with no production URL", () => {
+    const result = resolvePreviewDisplay({
+      previewState: IFRAME,
+      progressStatus: "doing",
+      productionUrl: null,
+    });
+    expect(result.mode).toBe("none");
+    expect(result.showBlockingOverlay).toBe(true);
+  });
+
+  it("yields the canvas to the suspended card (no overlay, no pill)", () => {
+    expect(
+      resolvePreviewDisplay({
+        previewState: SUSPENDED,
+        progressStatus: "doing",
+        productionUrl: PROD,
+      }),
+    ).toEqual({
+      mode: "none",
+      iframeBase: null,
+      showBlockingOverlay: false,
+      showWakingPill: false,
+    });
+  });
+
+  it("yields the canvas to the errored card (no overlay, no pill)", () => {
+    expect(
+      resolvePreviewDisplay({
+        previewState: ERRORED,
+        progressStatus: "failed",
+        productionUrl: PROD,
+      }),
+    ).toEqual({
+      mode: "none",
+      iframeBase: null,
+      showBlockingOverlay: false,
+      showWakingPill: false,
+    });
+  });
+});

--- a/apps/mesh/src/web/components/sandbox/preview/preview-display.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-display.test.ts
@@ -12,6 +12,7 @@ const ERRORED: PreviewState = {
   kind: "errored",
   error: { code: null, message: "boom" },
 };
+const OTHERS_THREAD: PreviewState = { kind: "othersThread", label: "Alice" };
 
 const PROD = "https://acme.com";
 
@@ -113,6 +114,23 @@ describe("resolvePreviewDisplay", () => {
       resolvePreviewDisplay({
         previewState: ERRORED,
         progressStatus: "failed",
+        productionUrl: PROD,
+      }),
+    ).toEqual({
+      mode: "none",
+      iframeBase: null,
+      showBlockingOverlay: false,
+      showWakingPill: false,
+    });
+  });
+
+  it("yields the canvas to the othersThread gate — no production leak", () => {
+    // A teammate's branch: even with a productionUrl set, don't paint a toolbar
+    // or load the production iframe behind the confirmation card.
+    expect(
+      resolvePreviewDisplay({
+        previewState: OTHERS_THREAD,
+        progressStatus: "doing",
         productionUrl: PROD,
       }),
     ).toEqual({

--- a/apps/mesh/src/web/components/sandbox/preview/preview-display.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-display.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure preview-display decision — layered on top of `computePreviewState`.
+ *
+ * `computePreviewState` decides *what the sandbox is doing* (starting /
+ * suspended / errored / iframe). This layer decides *what to paint in the
+ * canvas while it boots*: instead of a blocking overlay, a deco.cx project can
+ * show its live production site (Lovable-style) plus a non-blocking "waking"
+ * pill, then swap the iframe to the sandbox preview once the dev server is up.
+ *
+ * The sandbox preview base (`previewState.previewUrl`) flips to `iframe` as soon
+ * as the sandbox handle exists — well before the dev server is routable — so we
+ * gate the sandbox surface on `progressStatus` (boot no longer in progress),
+ * NOT on the mere existence of `previewUrl`.
+ */
+
+import type { PreviewState } from "./preview-state";
+import type { PhaseStatus } from "./derive-phase-progress";
+
+/** Which surface the preview canvas should render. */
+export type PreviewDisplayMode =
+  /** Sandbox dev-server iframe (or the daemon's crash/status page). */
+  | "sandbox"
+  /** Live production site while the sandbox is still waking. */
+  | "production"
+  /** No iframe — a dedicated overlay (booting/suspended/errored) owns the canvas. */
+  | "none";
+
+export interface PreviewDisplay {
+  mode: PreviewDisplayMode;
+  /** Base URL for the iframe, or `null` when `mode === "none"`. */
+  iframeBase: string | null;
+  /** The full-canvas booting card (today's behavior when there's no fallback). */
+  showBlockingOverlay: boolean;
+  /** Non-blocking "server waking — showing published site" pill. */
+  showWakingPill: boolean;
+}
+
+export interface PreviewDisplayInput {
+  previewState: PreviewState;
+  /** Current boot step status (`derivePhaseProgress(...).status`). */
+  progressStatus: PhaseStatus;
+  /** Live production URL to fall back to while waking, or `null` if unknown. */
+  productionUrl: string | null;
+}
+
+const NONE: PreviewDisplay = {
+  mode: "none",
+  iframeBase: null,
+  showBlockingOverlay: false,
+  showWakingPill: false,
+};
+
+export function resolvePreviewDisplay(
+  input: PreviewDisplayInput,
+): PreviewDisplay {
+  const { previewState, progressStatus, productionUrl } = input;
+
+  // Suspended / errored have their own dedicated cards — hand the canvas over.
+  if (previewState.kind === "suspended" || previewState.kind === "errored") {
+    return NONE;
+  }
+
+  // The sandbox surface is showable once a previewUrl exists AND boot is no
+  // longer in progress: `done` (running) serves the live app, `failed`/`crashed`
+  // serves the daemon's auto-reloading status page — both belong in the iframe,
+  // not behind a "waking" pill.
+  if (previewState.kind === "iframe" && progressStatus !== "doing") {
+    return {
+      mode: "sandbox",
+      iframeBase: previewState.previewUrl,
+      showBlockingOverlay: false,
+      showWakingPill: false,
+    };
+  }
+
+  // Still booting (fresh boot with no previewUrl yet, or a warming iframe).
+  // Prefer the live production site so the user sees their site immediately.
+  if (productionUrl) {
+    return {
+      mode: "production",
+      iframeBase: productionUrl,
+      showBlockingOverlay: false,
+      showWakingPill: true,
+    };
+  }
+
+  // No fallback available (e.g. a GitHub-only project with no deco.cx site):
+  // keep the original blocking booting overlay.
+  return {
+    mode: "none",
+    iframeBase: null,
+    showBlockingOverlay: true,
+    showWakingPill: false,
+  };
+}
+
+/** deco.cx public convention: every imported site is served at `{slug}.deco.site`. */
+export function productionUrlFromSiteSlug(
+  siteSlug: string | null | undefined,
+): string | null {
+  const slug = siteSlug?.trim();
+  if (!slug) return null;
+  return `https://${slug}.deco.site`;
+}

--- a/apps/mesh/src/web/components/sandbox/preview/preview-display.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-display.ts
@@ -84,21 +84,12 @@ export function resolvePreviewDisplay(
     };
   }
 
-  // No fallback available (e.g. a GitHub-only project with no deco.cx site):
-  // keep the original blocking booting overlay.
+  // No fallback available (e.g. a GitHub-only project, or a site imported
+  // before productionUrl was persisted): keep the original blocking overlay.
   return {
     mode: "none",
     iframeBase: null,
     showBlockingOverlay: true,
     showWakingPill: false,
   };
-}
-
-/** deco.cx public convention: every imported site is served at `{slug}.deco.site`. */
-export function productionUrlFromSiteSlug(
-  siteSlug: string | null | undefined,
-): string | null {
-  const slug = siteSlug?.trim();
-  if (!slug) return null;
-  return `https://${slug}.deco.site`;
 }

--- a/apps/mesh/src/web/components/sandbox/preview/preview-display.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-display.ts
@@ -55,8 +55,15 @@ export function resolvePreviewDisplay(
 ): PreviewDisplay {
   const { previewState, progressStatus, productionUrl } = input;
 
-  // Suspended / errored have their own dedicated cards — hand the canvas over.
-  if (previewState.kind === "suspended" || previewState.kind === "errored") {
+  // Suspended / errored / othersThread all render their own dedicated card
+  // (the last one is a confirmation gate on a teammate's branch) — hand the
+  // canvas over so we don't paint a toolbar or load the production iframe
+  // behind/around it.
+  if (
+    previewState.kind === "suspended" ||
+    previewState.kind === "errored" ||
+    previewState.kind === "othersThread"
+  ) {
     return NONE;
   }
 

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -949,395 +949,409 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             />
           ) : null,
         )}
-      {daemonReady && previewSurfaceActive && (
-        <div className="relative flex h-12 shrink-0 items-center gap-4 border-b border-border/60 px-3 md:px-4">
-          {previewSurfaceActive && (
-            <div className="flex h-full w-full items-center justify-between gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                data-testid="preview-blocks-toggle"
-                onClick={() => toggleEditingMode("blocks")}
-                aria-pressed={editingMode === "blocks"}
-                aria-label={t("sandbox.preview.blocksEditor")}
-              >
-                <TextInput size={14} />
-                {t("sandbox.preview.blocks")}
-              </Button>
-
-              <div className="flex w-full min-w-0 max-w-[500px] items-center gap-0.5">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={handleRefresh}
-                      aria-label={t("sandbox.preview.refresh")}
-                    >
-                      <RefreshCw01 size={14} />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {t("sandbox.preview.refresh")}
-                  </TooltipContent>
-                </Tooltip>
-
-                <div
-                  ref={pagesContainerRef}
-                  className="relative min-w-0 flex-1"
+      {/* Show the preview toolbar (URL bar, device toggles, Blocks) whenever an
+          iframe surface is visible. The sandbox surface still waits for the
+          daemon; the production fallback shows it right away so the boot state
+          isn't a bare canvas — page/Blocks controls fill in once the daemon is
+          up (they read the committed snapshot, empty until then). */}
+      {previewSurfaceActive &&
+        (daemonReady || display.mode === "production") && (
+          <div className="relative flex h-12 shrink-0 items-center gap-4 border-b border-border/60 px-3 md:px-4">
+            {previewSurfaceActive && (
+              <div className="flex h-full w-full items-center justify-between gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  data-testid="preview-blocks-toggle"
+                  onClick={() => toggleEditingMode("blocks")}
+                  aria-pressed={editingMode === "blocks"}
+                  aria-label={t("sandbox.preview.blocksEditor")}
                 >
-                  <div className="flex h-8 w-full min-w-0 items-center rounded-md border border-border bg-background transition-colors duration-200 hover:bg-accent">
-                    {/* Not a <button>: path-template pages render `:param`
+                  <TextInput size={14} />
+                  {t("sandbox.preview.blocks")}
+                </Button>
+
+                <div className="flex w-full min-w-0 max-w-[500px] items-center gap-0.5">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={handleRefresh}
+                        aria-label={t("sandbox.preview.refresh")}
+                      >
+                        <RefreshCw01 size={14} />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {t("sandbox.preview.refresh")}
+                    </TooltipContent>
+                  </Tooltip>
+
+                  <div
+                    ref={pagesContainerRef}
+                    className="relative min-w-0 flex-1"
+                  >
+                    <div className="flex h-8 w-full min-w-0 items-center rounded-md border border-border bg-background transition-colors duration-200 hover:bg-accent">
+                      {/* Not a <button>: path-template pages render `:param`
                         inputs inline, and inputs can't nest inside a button.
                         Keyboard toggling stays on the chevron button. */}
-                    <div
-                      className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-1 pl-2 pr-1"
-                      onClick={() => setPagesOpen((prev) => !prev)}
-                    >
-                      {activeGlobalSection && (
-                        <span className="shrink-0 inline-flex items-center gap-1 rounded bg-global-section/14 px-1.5 py-0.5 text-[11px] font-medium text-global-section-fg dark:text-global-section-fg-dark">
-                          <Globe02 size={11} />
-                          Global
-                        </span>
-                      )}
-                      {/* Page name in focus, followed by the route path.
+                      <div
+                        className="flex h-full min-w-0 flex-1 cursor-pointer items-center gap-1 pl-2 pr-1"
+                        onClick={() => setPagesOpen((prev) => !prev)}
+                      >
+                        {activeGlobalSection && (
+                          <span className="shrink-0 inline-flex items-center gap-1 rounded bg-global-section/14 px-1.5 py-0.5 text-[11px] font-medium text-global-section-fg dark:text-global-section-fg-dark">
+                            <Globe02 size={11} />
+                            Global
+                          </span>
+                        )}
+                        {/* Page name in focus, followed by the route path.
                             Path-template segments (`:param`/`*`) stay editable
                             inputs; plain paths render as muted text. */}
-                      <span
-                        className={cn(
-                          "text-[13px] font-medium text-foreground",
-                          // A real page name stays fully visible (the route
-                          // path truncates instead); the host fallback has no
-                          // path segment to shed, so it must truncate itself.
-                          currentPageName == null
-                            ? "min-w-0 flex-1 truncate"
-                            : "shrink-0",
-                        )}
-                      >
-                        {currentPageName ?? previewLabel}
-                      </span>
-                      {!activeGlobalSection &&
-                        currentPageName != null &&
-                        currentPath && (
-                          <span className="flex min-w-0 flex-1 items-center overflow-hidden whitespace-nowrap text-[12px] text-muted-foreground">
-                            {splitPathTemplate(currentPath).map((token, i) => {
-                              if (token.type === "text") {
-                                return (
-                                  <span
-                                    key={`text-${i}`}
-                                    className={cn(
-                                      i === 0 ? "min-w-0 truncate" : "shrink-0",
-                                    )}
-                                  >
-                                    {token.text}
-                                  </span>
-                                );
-                              }
-                              const sources = pathParamSources[token.name];
-                              // Params with option sources render as a chip that
-                              // opens the modal (search or free-form value);
-                              // the rest keep the inline input.
-                              if (sources && pickerSandboxRef) {
-                                return (
-                                  <PathParamPickerChip
-                                    key={`${currentPageKey}:${token.name}`}
-                                    sources={sources}
-                                    template={currentPath}
-                                    paramName={token.name}
-                                    value={pathParamValues[token.name] ?? ""}
-                                    sandboxRef={pickerSandboxRef}
-                                    onCommit={(value) =>
-                                      setPathParamValue(token.name, value)
-                                    }
-                                  />
-                                );
-                              }
-                              return (
-                                <PathParamInput
-                                  key={`${currentPageKey}:${token.name}`}
-                                  name={token.name}
-                                  value={pathParamValues[token.name] ?? ""}
-                                  onCommit={(value) =>
-                                    setPathParamValue(token.name, value)
-                                  }
-                                />
-                              );
-                            })}
-                          </span>
-                        )}
-                    </div>
-                    <button
-                      type="button"
-                      className="flex h-full shrink-0 items-center pl-1 pr-2"
-                      onClick={() => setPagesOpen((prev) => !prev)}
-                      aria-label={t("sandbox.preview.choosePage")}
-                    >
-                      <ChevronDown
-                        size={12}
-                        className={cn(
-                          "shrink-0 text-muted-foreground transition-transform",
-                          pagesOpen && "rotate-180",
-                        )}
-                      />
-                    </button>
-                  </div>
-
-                  {pagesOpen && (
-                    <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-lg border bg-popover shadow-lg">
-                      <div className="px-2 h-10 flex items-center gap-2 border-b">
-                        <SearchLg
-                          size={14}
-                          className="shrink-0 text-muted-foreground"
-                          aria-hidden
-                        />
-                        <input
-                          type="text"
-                          value={pagesSearch}
-                          onChange={(e) => setPagesSearch(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key !== "Enter") return;
-                            const query = pagesSearch.trim();
-                            if (!query) return;
-                            // Enter only navigates when the typed path matches an
-                            // existing page exactly; otherwise it does nothing.
-                            const target = filteredPages.find(
-                              (p) => normPath(p.path) === normPath(query),
-                            );
-                            if (!target) return;
-                            e.preventDefault();
-                            setPagesOpen(false);
-                            setPagesSearch("");
-                            navigatePreviewToPage(target);
-                          }}
-                          placeholder={t(
-                            "sandbox.preview.searchPagesAndComponents",
+                        <span
+                          className={cn(
+                            "text-[13px] font-medium text-foreground",
+                            // A real page name stays fully visible (the route
+                            // path truncates instead); the host fallback has no
+                            // path segment to shed, so it must truncate itself.
+                            currentPageName == null
+                              ? "min-w-0 flex-1 truncate"
+                              : "shrink-0",
                           )}
-                          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-                          autoFocus
-                        />
-                      </div>
-                      <div className="p-1.5 border-b">
-                        <button
-                          type="button"
-                          className="flex w-full items-center gap-2.5 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-                          onMouseDown={(e) => {
-                            e.preventDefault();
-                            setPagesOpen(false);
-                            setPagesSearch("");
-                            setCreatePageError(undefined);
-                            setCreatePageDialogOpen(true);
-                          }}
                         >
-                          <Plus
-                            size={16}
-                            className="shrink-0 text-muted-foreground"
-                          />
-                          <span className="flex-1 font-medium">
-                            {t("sandbox.preview.createNewPage")}
-                          </span>
-                        </button>
-                      </div>
-                      {filteredPages.length === 0 &&
-                      filteredGlobalSections.length === 0 ? (
-                        <div className="px-4 py-5 text-center text-xs text-muted-foreground">
-                          {pages.length === 0 && globalSections.length === 0
-                            ? t("sandbox.preview.noPagesFound")
-                            : t("sandbox.preview.noSearchResults")}
-                        </div>
-                      ) : (
-                        <div className="max-h-80 overflow-y-auto overscroll-contain">
-                          {filteredPages.length > 0 && (
-                            <div className="p-1.5">
-                              {filteredPages.map((page) => (
-                                <button
-                                  key={page.key}
-                                  type="button"
-                                  className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-                                  onMouseDown={(e) => {
-                                    e.preventDefault();
-                                    setPagesOpen(false);
-                                    setPagesSearch("");
-                                    navigatePreviewToPage(page);
-                                  }}
-                                >
-                                  <LayoutAlt01
-                                    size={16}
-                                    className="shrink-0 text-muted-foreground"
-                                  />
-                                  <span className="min-w-0 flex-1 truncate font-medium">
-                                    {page.name}
-                                  </span>
-                                  <span className="shrink-0 text-xs text-muted-foreground">
-                                    {page.path}
-                                  </span>
-                                </button>
-                              ))}
-                            </div>
-                          )}
-                          {filteredGlobalSections.length > 0 && (
-                            <div
-                              className={cn(
-                                "p-1.5",
-                                filteredPages.length > 0 && "border-t",
+                          {currentPageName ?? previewLabel}
+                        </span>
+                        {!activeGlobalSection &&
+                          currentPageName != null &&
+                          currentPath && (
+                            <span className="flex min-w-0 flex-1 items-center overflow-hidden whitespace-nowrap text-[12px] text-muted-foreground">
+                              {splitPathTemplate(currentPath).map(
+                                (token, i) => {
+                                  if (token.type === "text") {
+                                    return (
+                                      <span
+                                        key={`text-${i}`}
+                                        className={cn(
+                                          i === 0
+                                            ? "min-w-0 truncate"
+                                            : "shrink-0",
+                                        )}
+                                      >
+                                        {token.text}
+                                      </span>
+                                    );
+                                  }
+                                  const sources = pathParamSources[token.name];
+                                  // Params with option sources render as a chip that
+                                  // opens the modal (search or free-form value);
+                                  // the rest keep the inline input.
+                                  if (sources && pickerSandboxRef) {
+                                    return (
+                                      <PathParamPickerChip
+                                        key={`${currentPageKey}:${token.name}`}
+                                        sources={sources}
+                                        template={currentPath}
+                                        paramName={token.name}
+                                        value={
+                                          pathParamValues[token.name] ?? ""
+                                        }
+                                        sandboxRef={pickerSandboxRef}
+                                        onCommit={(value) =>
+                                          setPathParamValue(token.name, value)
+                                        }
+                                      />
+                                    );
+                                  }
+                                  return (
+                                    <PathParamInput
+                                      key={`${currentPageKey}:${token.name}`}
+                                      name={token.name}
+                                      value={pathParamValues[token.name] ?? ""}
+                                      onCommit={(value) =>
+                                        setPathParamValue(token.name, value)
+                                      }
+                                    />
+                                  );
+                                },
                               )}
-                            >
-                              <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
-                                {t("sandbox.preview.globalComponents")}
-                              </div>
-                              {filteredGlobalSections.map((section) => (
-                                <button
-                                  key={section.key}
-                                  type="button"
-                                  className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-                                  onMouseDown={(e) => {
-                                    e.preventDefault();
-                                    setPagesOpen(false);
-                                    setPagesSearch("");
-                                    navigatePreviewToGlobalSection(section);
-                                  }}
-                                >
-                                  <Globe02
-                                    size={16}
-                                    className="shrink-0 text-muted-foreground"
-                                  />
-                                  <span className="min-w-0 flex-1 truncate font-medium">
-                                    {section.name}
-                                  </span>
-                                  <span className="shrink-0 text-xs text-muted-foreground">
-                                    {section.resolveType
-                                      .split("/")
-                                      .pop()
-                                      ?.replace(/\.tsx?$/, "")}
-                                  </span>
-                                </button>
-                              ))}
-                            </div>
+                            </span>
                           )}
-                        </div>
-                      )}
+                      </div>
+                      <button
+                        type="button"
+                        className="flex h-full shrink-0 items-center pl-1 pr-2"
+                        onClick={() => setPagesOpen((prev) => !prev)}
+                        aria-label={t("sandbox.preview.choosePage")}
+                      >
+                        <ChevronDown
+                          size={12}
+                          className={cn(
+                            "shrink-0 text-muted-foreground transition-transform",
+                            pagesOpen && "rotate-180",
+                          )}
+                        />
+                      </button>
                     </div>
-                  )}
-                </div>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const url = iframeSrc ?? display.iframeBase;
-                        if (url) window.open(url, "_blank", "noopener");
-                      }}
-                      aria-label={t("sandbox.preview.openInNewTab")}
-                    >
-                      <LinkExternal01 size={14} />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {t("sandbox.preview.openInNewTab")}
-                  </TooltipContent>
-                </Tooltip>
-              </div>
 
-              <div className="flex shrink-0 items-center">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      aria-label={t("sandbox.preview.moreOptions")}
-                    >
-                      <DotsHorizontal size={14} />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-44">
-                    <DropdownMenuItem onClick={handleHardReload}>
-                      {t("sandbox.preview.hardReload")}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={handleCopyUrl}>
-                      {t("sandbox.preview.copyCurrentUrl")}
-                    </DropdownMenuItem>
-                    {decofile && meta && (
-                      <>
-                        <DropdownMenuSeparator />
-                        {currentPageKey && (
-                          <DropdownMenuItem
-                            onClick={() => {
-                              workspace.editSeo({
-                                kind: "page",
-                                key: currentPageKey,
-                                path: currentPath,
-                              });
-                              activateEditingMode("blocks");
+                    {pagesOpen && (
+                      <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-lg border bg-popover shadow-lg">
+                        <div className="px-2 h-10 flex items-center gap-2 border-b">
+                          <SearchLg
+                            size={14}
+                            className="shrink-0 text-muted-foreground"
+                            aria-hidden
+                          />
+                          <input
+                            type="text"
+                            value={pagesSearch}
+                            onChange={(e) => setPagesSearch(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key !== "Enter") return;
+                              const query = pagesSearch.trim();
+                              if (!query) return;
+                              // Enter only navigates when the typed path matches an
+                              // existing page exactly; otherwise it does nothing.
+                              const target = filteredPages.find(
+                                (p) => normPath(p.path) === normPath(query),
+                              );
+                              if (!target) return;
+                              e.preventDefault();
+                              setPagesOpen(false);
+                              setPagesSearch("");
+                              navigatePreviewToPage(target);
                             }}
+                            placeholder={t(
+                              "sandbox.preview.searchPagesAndComponents",
+                            )}
+                            className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                            autoFocus
+                          />
+                        </div>
+                        <div className="p-1.5 border-b">
+                          <button
+                            type="button"
+                            className="flex w-full items-center gap-2.5 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              setPagesOpen(false);
+                              setPagesSearch("");
+                              setCreatePageError(undefined);
+                              setCreatePageDialogOpen(true);
+                            }}
+                          >
+                            <Plus
+                              size={16}
+                              className="shrink-0 text-muted-foreground"
+                            />
+                            <span className="flex-1 font-medium">
+                              {t("sandbox.preview.createNewPage")}
+                            </span>
+                          </button>
+                        </div>
+                        {filteredPages.length === 0 &&
+                        filteredGlobalSections.length === 0 ? (
+                          <div className="px-4 py-5 text-center text-xs text-muted-foreground">
+                            {pages.length === 0 && globalSections.length === 0
+                              ? t("sandbox.preview.noPagesFound")
+                              : t("sandbox.preview.noSearchResults")}
+                          </div>
+                        ) : (
+                          <div className="max-h-80 overflow-y-auto overscroll-contain">
+                            {filteredPages.length > 0 && (
+                              <div className="p-1.5">
+                                {filteredPages.map((page) => (
+                                  <button
+                                    key={page.key}
+                                    type="button"
+                                    className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                                    onMouseDown={(e) => {
+                                      e.preventDefault();
+                                      setPagesOpen(false);
+                                      setPagesSearch("");
+                                      navigatePreviewToPage(page);
+                                    }}
+                                  >
+                                    <LayoutAlt01
+                                      size={16}
+                                      className="shrink-0 text-muted-foreground"
+                                    />
+                                    <span className="min-w-0 flex-1 truncate font-medium">
+                                      {page.name}
+                                    </span>
+                                    <span className="shrink-0 text-xs text-muted-foreground">
+                                      {page.path}
+                                    </span>
+                                  </button>
+                                ))}
+                              </div>
+                            )}
+                            {filteredGlobalSections.length > 0 && (
+                              <div
+                                className={cn(
+                                  "p-1.5",
+                                  filteredPages.length > 0 && "border-t",
+                                )}
+                              >
+                                <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
+                                  {t("sandbox.preview.globalComponents")}
+                                </div>
+                                {filteredGlobalSections.map((section) => (
+                                  <button
+                                    key={section.key}
+                                    type="button"
+                                    className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                                    onMouseDown={(e) => {
+                                      e.preventDefault();
+                                      setPagesOpen(false);
+                                      setPagesSearch("");
+                                      navigatePreviewToGlobalSection(section);
+                                    }}
+                                  >
+                                    <Globe02
+                                      size={16}
+                                      className="shrink-0 text-muted-foreground"
+                                    />
+                                    <span className="min-w-0 flex-1 truncate font-medium">
+                                      {section.name}
+                                    </span>
+                                    <span className="shrink-0 text-xs text-muted-foreground">
+                                      {section.resolveType
+                                        .split("/")
+                                        .pop()
+                                        ?.replace(/\.tsx?$/, "")}
+                                    </span>
+                                  </button>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => {
+                          const url = iframeSrc ?? display.iframeBase;
+                          if (url) window.open(url, "_blank", "noopener");
+                        }}
+                        aria-label={t("sandbox.preview.openInNewTab")}
+                      >
+                        <LinkExternal01 size={14} />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {t("sandbox.preview.openInNewTab")}
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+
+                <div className="flex shrink-0 items-center">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label={t("sandbox.preview.moreOptions")}
+                      >
+                        <DotsHorizontal size={14} />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-44">
+                      <DropdownMenuItem onClick={handleHardReload}>
+                        {t("sandbox.preview.hardReload")}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={handleCopyUrl}>
+                        {t("sandbox.preview.copyCurrentUrl")}
+                      </DropdownMenuItem>
+                      {decofile && meta && (
+                        <>
+                          <DropdownMenuSeparator />
+                          {currentPageKey && (
+                            <DropdownMenuItem
+                              onClick={() => {
+                                workspace.editSeo({
+                                  kind: "page",
+                                  key: currentPageKey,
+                                  path: currentPath,
+                                });
+                                activateEditingMode("blocks");
+                              }}
+                            >
+                              <CreditCardSearch size={14} />
+                              {t("sandbox.preview.editSeo")}
+                            </DropdownMenuItem>
+                          )}
+                          {currentPageKey && (
+                            <DropdownMenuItem
+                              onClick={() => {
+                                try {
+                                  goToTab(
+                                    formatCodeTabId(
+                                      decoBlockFileViewPath(currentPageKey),
+                                    ),
+                                  );
+                                } catch {
+                                  toast.error(
+                                    t("sandbox.preview.invalidPageBlockKey"),
+                                  );
+                                }
+                              }}
+                            >
+                              <Code01 size={14} />
+                              {t("sandbox.preview.viewJson")}
+                            </DropdownMenuItem>
+                          )}
+                          <DropdownMenuItem
+                            onClick={() => setSiteSeoOpen(true)}
                           >
                             <CreditCardSearch size={14} />
-                            {t("sandbox.preview.editSeo")}
+                            {t("sandbox.preview.siteSeo")}
                           </DropdownMenuItem>
-                        )}
-                        {currentPageKey && (
+                        </>
+                      )}
+                      {repoDir && (
+                        <>
+                          <DropdownMenuSeparator />
                           <DropdownMenuItem
-                            onClick={() => {
-                              try {
-                                goToTab(
-                                  formatCodeTabId(
-                                    decoBlockFileViewPath(currentPageKey),
-                                  ),
-                                );
-                              } catch {
-                                toast.error(
-                                  t("sandbox.preview.invalidPageBlockKey"),
-                                );
-                              }
-                            }}
+                            onClick={() =>
+                              window.open(ideDeepLink("vscode", repoDir))
+                            }
                           >
-                            <Code01 size={14} />
-                            {t("sandbox.preview.viewJson")}
+                            <img
+                              src={VSCODE_ICON_URL}
+                              alt="VSCode"
+                              width={14}
+                              height={14}
+                            />
+                            {t("sandbox.preview.openInVscode")}
                           </DropdownMenuItem>
-                        )}
-                        <DropdownMenuItem onClick={() => setSiteSeoOpen(true)}>
-                          <CreditCardSearch size={14} />
-                          {t("sandbox.preview.siteSeo")}
-                        </DropdownMenuItem>
-                      </>
-                    )}
-                    {repoDir && (
-                      <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                          onClick={() =>
-                            window.open(ideDeepLink("vscode", repoDir))
-                          }
-                        >
-                          <img
-                            src={VSCODE_ICON_URL}
-                            alt="VSCode"
-                            width={14}
-                            height={14}
-                          />
-                          {t("sandbox.preview.openInVscode")}
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() =>
-                            window.open(ideDeepLink("cursor", repoDir))
-                          }
-                        >
-                          <img
-                            src={CURSOR_ICON_URL}
-                            alt="Cursor"
-                            width={14}
-                            height={14}
-                          />
-                          {t("sandbox.preview.openInCursor")}
-                        </DropdownMenuItem>
-                      </>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                          <DropdownMenuItem
+                            onClick={() =>
+                              window.open(ideDeepLink("cursor", repoDir))
+                            }
+                          >
+                            <img
+                              src={CURSOR_ICON_URL}
+                              alt="Cursor"
+                              width={14}
+                              height={14}
+                            />
+                            {t("sandbox.preview.openInCursor")}
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
               </div>
-            </div>
-          )}
-        </div>
-      )}
+            )}
+          </div>
+        )}
 
       <div className="flex-1 overflow-hidden">
         {isMobile && effectiveEditingMode === "blocks" ? (

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -1460,9 +1460,19 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                 )}
 
                 {display.showWakingPill && (
-                  <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2.5 rounded-full border border-border bg-background/95 px-5 py-3 text-sm font-medium text-foreground shadow-lg backdrop-blur-sm pointer-events-none select-none">
-                    <Loading01 size={18} className="animate-spin" />
-                    {t("sandbox.preview.startingPreview")}
+                  <div className="absolute top-4 left-1/2 z-20 flex max-w-md -translate-x-1/2 items-start gap-3 rounded-xl border border-border bg-muted px-4 py-3 shadow-lg pointer-events-none select-none">
+                    <Loading01
+                      size={18}
+                      className="mt-0.5 shrink-0 animate-spin text-muted-foreground"
+                    />
+                    <div className="flex flex-col gap-0.5">
+                      <span className="text-sm font-medium text-foreground">
+                        {t("sandbox.preview.startingPreview")}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {t("sandbox.preview.startingPreviewHint")}
+                      </span>
+                    </div>
                   </div>
                 )}
 

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -5,6 +5,11 @@ import { formatCodeTabId } from "@/web/layouts/main-panel-tabs/tab-id";
 import { useChatTask } from "@/web/components/chat/context";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
+import { useInsetContext } from "@/web/layouts/agent-shell-layout";
+import {
+  productionUrlFromSiteSlug,
+  resolvePreviewDisplay,
+} from "./preview-display";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { useT } from "@/web/i18n/use-t.ts";
 import type { TranslationKey } from "@/web/i18n/use-t.ts";
@@ -17,6 +22,7 @@ import {
   Globe02,
   LayoutAlt01,
   LinkExternal01,
+  Loading01,
   Plus,
   SearchLg,
   CreditCardSearch,
@@ -398,30 +404,50 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const previewState = lifecycle.previewState;
   const userStopped = lifecycle.userStopped;
 
+  // Live production URL of the linked deco.cx site, derived from the agent's
+  // `metadata.siteSlug` (public convention: `{slug}.deco.site`). Used as a
+  // Lovable-style fallback: while the sandbox dev server is still waking, paint
+  // the published site in the iframe (non-blocking) instead of a blank overlay,
+  // then swap to the sandbox preview once it's up. `null` for GitHub-only
+  // projects with no linked site → the original blocking overlay is kept.
+  const inset = useInsetContext();
+  const productionUrl =
+    inset?.entity?.id === virtualMcpId
+      ? productionUrlFromSiteSlug(inset.entity.metadata?.siteSlug)
+      : null;
+
   // The recorded previewUrl flips previewState to "iframe" as soon as the
-  // sandbox handle exists — well before the public preview proxy is routable
-  // and actually serving, so the iframe renders blank during the initial boot.
-  // Keep the booting visual overlaid (absolute, z-30, above the warming iframe)
-  // until the dev server has come up. `progress.status === "doing"` is true for
-  // exactly the forward boot phases (provision → clone → install → starting);
-  // it flips to "done" at `running` and "failed" on a terminal error, so both
-  // the live app and the daemon's auto-reloading status/crash page still fall
-  // through to the iframe unobscured.
-  const showBootingOverlay =
-    previewState.kind === "starting" ||
-    (previewState.kind === "iframe" && progress.status === "doing");
+  // sandbox handle exists — well before the public preview proxy is routable —
+  // so the sandbox surface is gated on `progress.status` (boot no longer in
+  // progress), not on `previewUrl` alone. `resolvePreviewDisplay` decides what
+  // to paint: the sandbox iframe, the production fallback + a waking pill, or
+  // (no production URL) today's blocking booting overlay.
+  const display = resolvePreviewDisplay({
+    previewState,
+    progressStatus: progress.status,
+    productionUrl,
+  });
+  const previewSurfaceActive = display.mode !== "none";
+  const showBootingOverlay = display.showBlockingOverlay;
 
   const iframeSrc =
-    previewState.kind === "iframe"
+    display.mode === "sandbox"
       ? withVariantMatcherOverride(
           withDeviceHint(
-            directPreviewUrl ??
-              new URL(resolvedPath, previewState.previewUrl).href,
+            directPreviewUrl ?? new URL(resolvedPath, display.iframeBase!).href,
             previewDeviceSize,
           ),
           workspace.state.variantOverride ?? [],
         )
-      : null;
+      : display.mode === "production"
+        ? // Production is a different origin: no sandbox-only overrides
+          // (directPreviewUrl / variant matcher) apply. Load the current path
+          // best-effort; the published site serves its own committed pages.
+          withDeviceHint(
+            new URL(resolvedPath, display.iframeBase!).href,
+            previewDeviceSize,
+          )
+        : null;
 
   // Last visited page (incl. `:param` values), persisted per project+branch.
   const previewStorageKey =
@@ -537,10 +563,12 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     !appPaused &&
     (claimPhase?.kind === "ready" || lifecyclePhase !== "idle");
 
-  // Visual mode requires a live iframe. Blocks can stay open while the
-  // sandbox restarts so its loading/error state remains actionable.
+  // Visual mode requires the live sandbox iframe — the production fallback is a
+  // different origin we can't inject into. Blocks can stay open while the
+  // sandbox restarts (or wakes) so its loading/error state remains actionable
+  // and the panel keeps reading the committed snapshot.
   const effectiveEditingMode: PreviewEditingMode =
-    previewState.kind !== "iframe" && editingMode === "visual"
+    display.mode !== "sandbox" && editingMode === "visual"
       ? "preview"
       : editingMode;
 
@@ -858,7 +886,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     }
   };
 
-  const canVisualEdit = previewState.kind === "iframe";
+  const canVisualEdit = display.mode === "sandbox";
   const floatingPreviewControls = canVisualEdit ? (
     <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2">
       <div className="flex items-center gap-0.5 rounded-full border bg-background/90 p-1 shadow-lg backdrop-blur-sm">
@@ -922,9 +950,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             />
           ) : null,
         )}
-      {daemonReady && previewState.kind === "iframe" && (
+      {daemonReady && previewSurfaceActive && (
         <div className="relative flex h-12 shrink-0 items-center gap-4 border-b border-border/60 px-3 md:px-4">
-          {previewState.kind === "iframe" && (
+          {previewSurfaceActive && (
             <div className="flex h-full w-full items-center justify-between gap-2">
               <Button
                 variant="outline"
@@ -1197,7 +1225,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                       variant="ghost"
                       size="icon"
                       onClick={() => {
-                        const url = iframeSrc ?? previewState.previewUrl;
+                        const url = iframeSrc ?? display.iframeBase;
                         if (url) window.open(url, "_blank", "noopener");
                       }}
                       aria-label={t("sandbox.preview.openInNewTab")}
@@ -1355,11 +1383,11 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                 className={cn(
                   "h-full relative overflow-hidden",
                   previewDeviceSize !== "desktop" &&
-                    previewState.kind === "iframe" &&
+                    previewSurfaceActive &&
                     "flex justify-center bg-muted/30",
                 )}
               >
-                {navigating && previewState.kind === "iframe" && (
+                {navigating && previewSurfaceActive && (
                   <div className="absolute inset-x-0 top-0 z-40 h-0.5 overflow-hidden bg-primary/15">
                     <div className="absolute inset-y-0 w-2/5 rounded-full bg-primary animate-preview-nav" />
                   </div>
@@ -1418,6 +1446,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                   </div>
                 )}
 
+                {display.showWakingPill && (
+                  <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 rounded-full border border-border bg-background/90 px-3 py-1 text-xs font-medium text-muted-foreground shadow-md backdrop-blur-sm pointer-events-none select-none">
+                    <Loading01 size={12} className="animate-spin" />
+                    {t("sandbox.preview.wakingShowingProduction")}
+                  </div>
+                )}
+
                 {effectiveEditingMode === "visual" && !visualElement && (
                   <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 rounded-full border border-violet-400/40 bg-violet-500/90 px-3 py-1 text-xs font-medium text-white shadow-md backdrop-blur-sm pointer-events-none select-none">
                     <CursorClick01 size={12} />
@@ -1433,7 +1468,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
                 {floatingPreviewControls}
 
-                {previewState.kind === "iframe" && iframeSrc && (
+                {previewSurfaceActive && iframeSrc && (
                   <div
                     className={cn(
                       "h-full transition-[width] duration-250 [transition-timing-function:var(--ease-in-out-cubic)]",
@@ -1448,9 +1483,10 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                     }}
                   >
                     <iframe
-                      // Key on previewUrl: remount when the VM base URL changes (branch
-                      // switch). Path navigation is driven by `iframeSrc` state.
-                      key={previewState.previewUrl}
+                      // Key on the iframe base: remount when the base URL changes
+                      // (branch switch, or the production→sandbox swap once the dev
+                      // server is up). Path navigation is driven by `iframeSrc`.
+                      key={display.iframeBase}
                       ref={previewIframeRef}
                       src={iframeSrc}
                       className="w-full h-full border-0"
@@ -1459,6 +1495,10 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                         // The page finished loading — always clear the navigation
                         // indicator first, before any of the early returns below.
                         endNavigation();
+                        // The production fallback is a view-only, cross-origin frame:
+                        // skip the sandbox-only load handling (analytics, path sync,
+                        // editor injection) — none of it applies to it.
+                        if (display.mode !== "sandbox") return;
                         // This is the VM dev-server preview (sandboxed running app),
                         // NOT an MCP app. MCP apps render via <MCPAppRenderer/>.
                         track("vm_preview_loaded", {

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -1446,9 +1446,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                 )}
 
                 {display.showWakingPill && (
-                  <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 rounded-full border border-border bg-background/90 px-3 py-1 text-xs font-medium text-muted-foreground shadow-md backdrop-blur-sm pointer-events-none select-none">
-                    <Loading01 size={12} className="animate-spin" />
-                    {t("sandbox.preview.wakingShowingProduction")}
+                  <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2.5 rounded-full border border-border bg-background/95 px-5 py-3 text-sm font-medium text-foreground shadow-lg backdrop-blur-sm pointer-events-none select-none">
+                    <Loading01 size={18} className="animate-spin" />
+                    {t("sandbox.preview.startingPreview")}
                   </div>
                 )}
 

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -6,10 +6,8 @@ import { useChatTask } from "@/web/components/chat/context";
 import { useProjectContext } from "@decocms/mesh-sdk";
 import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
 import { useInsetContext } from "@/web/layouts/agent-shell-layout";
-import {
-  productionUrlFromSiteSlug,
-  resolvePreviewDisplay,
-} from "./preview-display";
+import { resolvePreviewDisplay } from "./preview-display";
+import { sanitizeProductionUrl } from "@/shared/deco-site-production-url";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { useT } from "@/web/i18n/use-t.ts";
 import type { TranslationKey } from "@/web/i18n/use-t.ts";
@@ -404,16 +402,17 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const previewState = lifecycle.previewState;
   const userStopped = lifecycle.userStopped;
 
-  // Live production URL of the linked deco.cx site, derived from the agent's
-  // `metadata.siteSlug` (public convention: `{slug}.deco.site`). Used as a
+  // Live production URL of the linked site, persisted on the agent's
+  // `metadata.productionUrl` at import time (deco.cx reports the real domain,
+  // which can be a custom one — so we store it rather than guess it). Used as a
   // Lovable-style fallback: while the sandbox dev server is still waking, paint
   // the published site in the iframe (non-blocking) instead of a blank overlay,
-  // then swap to the sandbox preview once it's up. `null` for GitHub-only
-  // projects with no linked site → the original blocking overlay is kept.
+  // then swap to the sandbox preview once it's up. `null` (no field, or a site
+  // imported before this was persisted) → the original blocking overlay is kept.
   const inset = useInsetContext();
   const productionUrl =
     inset?.entity?.id === virtualMcpId
-      ? productionUrlFromSiteSlug(inset.entity.metadata?.siteSlug)
+      ? sanitizeProductionUrl(inset.entity.metadata?.productionUrl)
       : null;
 
   // The recorded previewUrl flips previewState to "iframe" as soon as the

--- a/apps/mesh/src/web/components/sandbox/runtime-card/production-url-field.tsx
+++ b/apps/mesh/src/web/components/sandbox/runtime-card/production-url-field.tsx
@@ -1,0 +1,59 @@
+import {
+  Controller,
+  type Control,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form";
+import { Input } from "@deco/ui/components/input.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import { useT } from "@/web/i18n/use-t.ts";
+import { productionUrlFromDomain } from "@/shared/deco-site-production-url";
+
+// Generic over the parent form schema so callers pass `form.control` without
+// casting — mirrors RuntimeFields. Bound to `metadata.productionUrl`; the field
+// path is a literal contract asserted via `FieldPath<T>`, kept to this leaf.
+export interface ProductionUrlFieldProps<T extends FieldValues> {
+  control: Control<T>;
+}
+
+export function ProductionUrlField<T extends FieldValues>({
+  control,
+}: ProductionUrlFieldProps<T>) {
+  const t = useT();
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="production-url">
+        {t("sandbox.productionUrlField.label")}
+      </Label>
+      <Controller
+        control={control}
+        name={"metadata.productionUrl" as FieldPath<T>}
+        render={({ field }) => {
+          const value = (field.value as string | null | undefined) ?? "";
+          return (
+            <Input
+              id="production-url"
+              type="url"
+              inputMode="url"
+              placeholder={t("sandbox.productionUrlField.placeholder")}
+              value={value}
+              // Keep raw while typing (empty → null); the preview sanitizes on
+              // read, so an in-progress value can't break anything.
+              onChange={(e) =>
+                field.onChange(e.target.value === "" ? null : e.target.value)
+              }
+              // Normalize on blur: bare host → https URL, invalid/empty → null.
+              onBlur={() => {
+                field.onChange(productionUrlFromDomain(value));
+                field.onBlur();
+              }}
+            />
+          );
+        }}
+      />
+      <p className="text-xs text-muted-foreground">
+        {t("sandbox.productionUrlField.description")}
+      </p>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/components/sandbox/runtime-card/production-url-field.tsx
+++ b/apps/mesh/src/web/components/sandbox/runtime-card/production-url-field.tsx
@@ -9,6 +9,12 @@ import { Label } from "@deco/ui/components/label.tsx";
 import { useT } from "@/web/i18n/use-t.ts";
 import { productionUrlFromDomain } from "@/shared/deco-site-production-url";
 
+// NOTE: manual entry is a stopgap. Ideally `metadata.productionUrl` is not set
+// by hand — it's auto-populated at deco.cx import from the site's production
+// domain, and once we ship the domain-setup capability it should be sourced
+// from the site's `domains` array (the domain flagged `production`) instead of
+// this free-text field.
+//
 // Generic over the parent form schema so callers pass `form.control` without
 // casting — mirrors RuntimeFields. Bound to `metadata.productionUrl`; the field
 // path is a literal contract asserted via `FieldPath<T>`, kept to this leaf.

--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -21,10 +21,13 @@ export function useDecofile(
     ? `${params.orgSlug}/${params.virtualMcpId}/${params.branch}`
     : "";
   // `fetchEnabled` means the dev server is up, so the live `/.decofile` route is
-  // worth hitting. When it's down we read the committed `.deco/blocks.gen.json`
-  // straight from the working tree — a single source of truth for KEYS.decofile,
-  // so optimistic block writes (which persist to the FS) operate on a full base
-  // and the CMS stays editable even if the preview never comes up.
+  // worth hitting. When it's down we read `.deco/blocks.gen.json` straight from
+  // the working tree — and if that artifact is absent (it's commonly gitignored)
+  // the daemon regenerates it from the `.deco/blocks/*.json` sources, so the CMS
+  // is readable as soon as the FS is up, before the dev server boots. Single
+  // source of truth for KEYS.decofile, so optimistic block writes (which persist
+  // to the FS) operate on a full base and the CMS stays editable even if the
+  // preview never comes up.
   const fetchEnabled = options?.fetchEnabled ?? true;
   // Committed snapshot lives under the project's package path
   // (`metadata.runtime.path`) when the project isn't at the repo root — the

--- a/apps/mesh/src/web/components/sections-editor/use-decofile.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-decofile.ts
@@ -28,6 +28,12 @@ export function useDecofile(
   // source of truth for KEYS.decofile, so optimistic block writes (which persist
   // to the FS) operate on a full base and the CMS stays editable even if the
   // preview never comes up.
+  //
+  // Unlike `useLiveMeta`, there is deliberately NO production `/.decofile`
+  // fallback: content must stay branch-accurate (the FS/daemon path reflects
+  // THIS branch), whereas production would serve deployed content and desync
+  // optimistic edits. `useLiveMeta` can safely fall back to production because
+  // the schema is branch-independent — see its `metaSourceOrder`.
   const fetchEnabled = options?.fetchEnabled ?? true;
   // Committed snapshot lives under the project's package path
   // (`metadata.runtime.path`) when the project isn't at the repo root — the

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { metaSourceOrder } from "./use-live-meta";
+
+const PREVIEW = "https://sandbox.example.deco.host";
+const PROD = "https://www.example.com";
+
+describe("metaSourceOrder", () => {
+  it("dev up: live → committed → production", () => {
+    expect(
+      metaSourceOrder({
+        fetchEnabled: true,
+        previewUrl: PREVIEW,
+        productionUrl: PROD,
+      }),
+    ).toEqual([
+      { kind: "live", baseUrl: PREVIEW },
+      { kind: "committed" },
+      { kind: "production", baseUrl: PROD },
+    ]);
+  });
+
+  it("dev down: committed → production (no live attempt)", () => {
+    expect(
+      metaSourceOrder({
+        fetchEnabled: false,
+        previewUrl: PREVIEW,
+        productionUrl: PROD,
+      }),
+    ).toEqual([{ kind: "committed" }, { kind: "production", baseUrl: PROD }]);
+  });
+
+  it("no previewUrl yet: skips live even when fetchEnabled", () => {
+    expect(
+      metaSourceOrder({
+        fetchEnabled: true,
+        previewUrl: null,
+        productionUrl: PROD,
+      }),
+    ).toEqual([{ kind: "committed" }, { kind: "production", baseUrl: PROD }]);
+  });
+
+  it("no production configured: committed is the only fallback", () => {
+    expect(
+      metaSourceOrder({
+        fetchEnabled: false,
+        previewUrl: PREVIEW,
+        productionUrl: null,
+      }),
+    ).toEqual([{ kind: "committed" }]);
+  });
+
+  it("committed always precedes production (branch-accurate wins)", () => {
+    const order = metaSourceOrder({
+      fetchEnabled: true,
+      previewUrl: PREVIEW,
+      productionUrl: PROD,
+    });
+    const committedIdx = order.findIndex((s) => s.kind === "committed");
+    const productionIdx = order.findIndex((s) => s.kind === "production");
+    expect(committedIdx).toBeLessThan(productionIdx);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.test.ts
@@ -39,6 +39,16 @@ describe("metaSourceOrder", () => {
     ).toEqual([{ kind: "committed" }, { kind: "production", baseUrl: PROD }]);
   });
 
+  it("dev up, no production: live → committed (no production tier)", () => {
+    expect(
+      metaSourceOrder({
+        fetchEnabled: true,
+        previewUrl: PREVIEW,
+        productionUrl: null,
+      }),
+    ).toEqual([{ kind: "live", baseUrl: PREVIEW }, { kind: "committed" }]);
+  });
+
   it("no production configured: committed is the only fallback", () => {
     expect(
       metaSourceOrder({

--- a/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
+++ b/apps/mesh/src/web/components/sections-editor/use-live-meta.ts
@@ -4,6 +4,7 @@ import { exponentialBackoffWithJitter } from "@decocms/std";
 import { KEYS } from "@/web/lib/query-keys";
 import { decoRepoPath } from "./deco-repo-path";
 import { readCommittedJson } from "./read-committed-file";
+import { sanitizeProductionUrl } from "@/shared/deco-site-production-url";
 import type { LiveMeta } from "./resolve-schema";
 
 interface UseLiveMetaParams {
@@ -11,6 +12,41 @@ interface UseLiveMetaParams {
   virtualMcpId: string;
   branch: string;
   previewUrl?: string | null;
+}
+
+/** Where to look for the CMS schema, in priority order. */
+export type MetaSource =
+  /** Sandbox dev server's `/live/_meta` (branch, live). */
+  | { kind: "live"; baseUrl: string }
+  /** Committed `.deco/meta.gen.json` snapshot — branch-accurate. */
+  | { kind: "committed" }
+  /** Linked production site's `/live/_meta` — a live deco runtime that serves
+   *  the same route, so Fresh/Deno sites (which never persist meta to the FS)
+   *  still get a schema before the sandbox dev server is up. */
+  | { kind: "production"; baseUrl: string };
+
+/**
+ * Ordered schema sources. Pure so the priority is unit-tested without mocks.
+ *
+ * The committed snapshot always beats production: it reflects THIS branch's
+ * schema, whereas production reflects whatever is deployed. Production is the
+ * last resort — it only matters for sites with no committed `meta.gen.json`
+ * (e.g. Fresh/Deco sites), unblocking the CMS before the runtime boots.
+ */
+export function metaSourceOrder(input: {
+  fetchEnabled: boolean;
+  previewUrl: string | null | undefined;
+  productionUrl: string | null;
+}): MetaSource[] {
+  const sources: MetaSource[] = [];
+  if (input.fetchEnabled && input.previewUrl) {
+    sources.push({ kind: "live", baseUrl: input.previewUrl });
+  }
+  sources.push({ kind: "committed" });
+  if (input.productionUrl) {
+    sources.push({ kind: "production", baseUrl: input.productionUrl });
+  }
+  return sources;
 }
 
 export function useLiveMeta(
@@ -28,42 +64,54 @@ export function useLiveMeta(
   // Committed snapshot lives under the project's package path
   // (`metadata.runtime.path`) when the project isn't at the repo root; the live
   // `/live/_meta` route already resolves relative to the dev-server cwd.
-  const packagePath =
-    useVirtualMCP(params?.virtualMcpId)?.metadata?.runtime?.path ?? null;
+  const virtualMcp = useVirtualMCP(params?.virtualMcpId);
+  const packagePath = virtualMcp?.metadata?.runtime?.path ?? null;
+  const productionUrl = sanitizeProductionUrl(
+    virtualMcp?.metadata?.productionUrl,
+  );
   return useQuery({
+    // productionUrl is appended so a settings edit re-fetches; invalidators key
+    // on the (org, vm, branch) prefix, which still matches (variadic key).
     queryKey: params
       ? KEYS.liveMeta(
           params.orgSlug,
           params.virtualMcpId,
           params.branch,
           previewUrl ?? "",
+          productionUrl ?? "",
         )
       : KEYS.liveMeta(""),
     queryFn: async () => {
+      const fetchMeta = async (baseUrl: string): Promise<LiveMeta | null> => {
+        const url = new URL("/live/_meta", baseUrl).href;
+        const res = await fetch(url, { cache: "no-store" }).catch(() => null);
+        return res?.ok ? ((await res.json()) as LiveMeta) : null;
+      };
       const readCommitted = () =>
         readCommittedJson<LiveMeta>(
           params!,
           decoRepoPath(packagePath, ".deco/meta.gen.json"),
         );
-      // Prefer the live `/live/_meta` when the dev server is up; otherwise (or on
-      // failure) read the committed `.deco/meta.gen.json` snapshot so the CMS
-      // schema is available even without a working preview.
-      if (fetchEnabled && previewUrl) {
-        const url = new URL("/live/_meta", previewUrl).href;
-        const res = await fetch(url, { cache: "no-store" }).catch(() => null);
-        if (res?.ok) return (await res.json()) as LiveMeta;
-        const committed = await readCommitted();
-        if (committed) return committed;
-        const err = new Error(
-          `Failed to fetch live meta: ${res?.status ?? "network error"}`,
-        );
-        (err as { status?: number }).status = res?.status ?? 502;
-        throw err;
+
+      // Walk the sources in priority order; first hit wins. Falling all the way
+      // through means neither a live/production runtime nor a committed snapshot
+      // is reachable yet — surface 502 so the query waits for the sandbox
+      // lifecycle to re-invalidate (see sandbox-events-context) instead of
+      // hammering a known-down endpoint.
+      const sources = metaSourceOrder({
+        fetchEnabled,
+        previewUrl,
+        productionUrl,
+      });
+      for (const source of sources) {
+        const meta =
+          source.kind === "committed"
+            ? await readCommitted()
+            : await fetchMeta(source.baseUrl);
+        if (meta) return meta;
       }
-      const committed = await readCommitted();
-      if (committed) return committed;
       const err = new Error(
-        "live meta unavailable (preview down, no committed snapshot)",
+        "live meta unavailable (dev server down, no committed snapshot, no production fallback)",
       );
       (err as { status?: number }).status = 502;
       throw err;
@@ -72,9 +120,9 @@ export function useLiveMeta(
     refetchInterval: options?.refetchInterval,
     refetchIntervalInBackground: false,
     staleTime: 300_000,
-    // 502 = preview unreachable / nothing available yet. The sandbox lifecycle
-    // re-invalidates this query when the dev server comes up (see
-    // sandbox-events-context), so retrying just hammers a known-down endpoint.
+    // 502 = nothing reachable yet. The sandbox lifecycle re-invalidates this
+    // query when the dev server comes up (see sandbox-events-context), so
+    // retrying just hammers a known-down endpoint.
     retry: (failureCount, error) =>
       (error as { status?: number }).status !== 502 && failureCount < 3,
     retryDelay: (attempt) =>

--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -395,8 +395,6 @@ export const sandbox = {
   "sandbox.preview.valueForParam": "Value for {label}",
   "sandbox.preview.viewJson": "View JSON",
   "sandbox.preview.visualEditor": "Visual editor",
-  "sandbox.preview.wakingShowingProduction":
-    "Starting your preview — showing the published site",
   "sandbox.productBlocks.addProductIdButton": "Add product ID",
   "sandbox.productBlocks.addProductsButton": "Add products",
   "sandbox.productBlocks.addProductsDescription":

--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -388,6 +388,7 @@ export const sandbox = {
   "sandbox.preview.refresh": "Refresh",
   "sandbox.preview.searchPagesAndComponents": "Search pages and components...",
   "sandbox.preview.siteSeo": "Site SEO",
+  "sandbox.preview.startingPreview": "Starting your preview",
   "sandbox.preview.templateNoLongerExists":
     "Selected template no longer exists.",
   "sandbox.preview.urlCopiedToClipboard": "URL copied to clipboard",

--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -389,6 +389,8 @@ export const sandbox = {
   "sandbox.preview.searchPagesAndComponents": "Search pages and components...",
   "sandbox.preview.siteSeo": "Site SEO",
   "sandbox.preview.startingPreview": "Starting your preview",
+  "sandbox.preview.startingPreviewHint":
+    "You can make changes now — they'll appear once the preview is ready.",
   "sandbox.preview.templateNoLongerExists":
     "Selected template no longer exists.",
   "sandbox.preview.urlCopiedToClipboard": "URL copied to clipboard",

--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -394,6 +394,8 @@ export const sandbox = {
   "sandbox.preview.valueForParam": "Value for {label}",
   "sandbox.preview.viewJson": "View JSON",
   "sandbox.preview.visualEditor": "Visual editor",
+  "sandbox.preview.wakingShowingProduction":
+    "Starting your preview — showing the published site",
   "sandbox.productBlocks.addProductIdButton": "Add product ID",
   "sandbox.productBlocks.addProductsButton": "Add products",
   "sandbox.productBlocks.addProductsDescription":

--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -480,6 +480,10 @@ export const sandbox = {
   "sandbox.redirectEditor.typePermanent": "Permanent ({status})",
   "sandbox.redirectEditor.typePlaceholder": "Type",
   "sandbox.redirectEditor.typeTemporary": "Temporary ({status})",
+  "sandbox.productionUrlField.description":
+    "Shown in the preview while the dev server is starting, so you can view and edit right away.",
+  "sandbox.productionUrlField.label": "Production URL",
+  "sandbox.productionUrlField.placeholder": "https://example.com",
   "sandbox.repoRow.label": "Repository",
   "sandbox.repoRow.noRepositoryConnected": "No repository connected",
   "sandbox.repoRow.tooltipContent":

--- a/apps/mesh/src/web/i18n/pt-br/sandbox.ts
+++ b/apps/mesh/src/web/i18n/pt-br/sandbox.ts
@@ -406,6 +406,7 @@ export const sandbox = {
   "sandbox.preview.searchPagesAndComponents":
     "Procurar páginas e componentes...",
   "sandbox.preview.siteSeo": "SEO do site",
+  "sandbox.preview.startingPreview": "Iniciando seu preview",
   "sandbox.preview.templateNoLongerExists":
     "O modelo selecionado não existe mais.",
   "sandbox.preview.urlCopiedToClipboard":
@@ -413,8 +414,6 @@ export const sandbox = {
   "sandbox.preview.valueForParam": "Valor de {label}",
   "sandbox.preview.viewJson": "Visualizar JSON",
   "sandbox.preview.visualEditor": "Editor visual",
-  "sandbox.preview.wakingShowingProduction":
-    "Iniciando seu preview — exibindo o site publicado",
   "sandbox.productBlocks.addProductIdButton": "Adicionar ID do produto",
   "sandbox.productBlocks.addProductsButton": "Adicionar produtos",
   "sandbox.productBlocks.addProductsDescription":

--- a/apps/mesh/src/web/i18n/pt-br/sandbox.ts
+++ b/apps/mesh/src/web/i18n/pt-br/sandbox.ts
@@ -407,6 +407,8 @@ export const sandbox = {
     "Procurar páginas e componentes...",
   "sandbox.preview.siteSeo": "SEO do site",
   "sandbox.preview.startingPreview": "Iniciando seu preview",
+  "sandbox.preview.startingPreviewHint":
+    "Você já pode fazer alterações — elas aparecem quando o preview estiver pronto.",
   "sandbox.preview.templateNoLongerExists":
     "O modelo selecionado não existe mais.",
   "sandbox.preview.urlCopiedToClipboard":

--- a/apps/mesh/src/web/i18n/pt-br/sandbox.ts
+++ b/apps/mesh/src/web/i18n/pt-br/sandbox.ts
@@ -413,6 +413,8 @@ export const sandbox = {
   "sandbox.preview.valueForParam": "Valor de {label}",
   "sandbox.preview.viewJson": "Visualizar JSON",
   "sandbox.preview.visualEditor": "Editor visual",
+  "sandbox.preview.wakingShowingProduction":
+    "Iniciando seu preview — exibindo o site publicado",
   "sandbox.productBlocks.addProductIdButton": "Adicionar ID do produto",
   "sandbox.productBlocks.addProductsButton": "Adicionar produtos",
   "sandbox.productBlocks.addProductsDescription":

--- a/apps/mesh/src/web/i18n/pt-br/sandbox.ts
+++ b/apps/mesh/src/web/i18n/pt-br/sandbox.ts
@@ -501,6 +501,10 @@ export const sandbox = {
   "sandbox.redirectEditor.typePermanent": "Permanente ({status})",
   "sandbox.redirectEditor.typePlaceholder": "Tipo",
   "sandbox.redirectEditor.typeTemporary": "Temporário ({status})",
+  "sandbox.productionUrlField.description":
+    "Exibida no preview enquanto o servidor de desenvolvimento inicia, para você já visualizar e editar.",
+  "sandbox.productionUrlField.label": "URL de produção",
+  "sandbox.productionUrlField.placeholder": "https://exemplo.com",
   "sandbox.repoRow.label": "Repositório",
   "sandbox.repoRow.noRepositoryConnected": "Nenhum repositório conectado",
   "sandbox.repoRow.tooltipContent":

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -80,6 +80,7 @@ import { DevAgentSetup } from "@/web/components/dev-agent/dev-agent-setup.tsx";
 import { EnvVarsField } from "@/web/components/sandbox/runtime-card/env-vars-field";
 import { RepoRow } from "@/web/components/sandbox/runtime-card/repo-row";
 import { RuntimeFields } from "@/web/components/sandbox/runtime-card/runtime-fields";
+import { ProductionUrlField } from "@/web/components/sandbox/runtime-card/production-url-field";
 
 type DialogState = {
   shareDialogOpen: boolean;
@@ -1138,6 +1139,7 @@ Define step-by-step how the agent should handle requests.
               <Card className="p-6 gap-5">
                 <CardContent className="p-0 space-y-5">
                   <RepoRow repo={runtimeCardRepo} />
+                  <ProductionUrlField control={form.control} />
                   <RuntimeFields control={form.control} />
                   <EnvVarsField
                     control={form.control}

--- a/packages/mesh-sdk/src/types/virtual-mcp.ts
+++ b/packages/mesh-sdk/src/types/virtual-mcp.ts
@@ -630,6 +630,13 @@ export const VirtualMCPEntitySchema = z.object({
         .optional()
         .describe("Linked asset site slug (managed storage tenancy)"),
       publishPolicy: publishPolicyMetadataField,
+      productionUrl: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "Live production URL of the linked site (e.g. https://acme.com). Painted in the preview iframe while the sandbox dev server is waking.",
+        ),
     })
     .loose()
     .describe("Metadata"),
@@ -729,6 +736,13 @@ export const VirtualMCPCreateDataSchema = z.object({
         .optional()
         .describe("Linked asset site slug (managed storage tenancy)"),
       publishPolicy: publishPolicyMetadataField,
+      productionUrl: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "Live production URL of the linked site (e.g. https://acme.com). Painted in the preview iframe while the sandbox dev server is waking.",
+        ),
     })
     .loose()
     .nullable()
@@ -809,6 +823,13 @@ export const VirtualMCPUpdateDataSchema = z.object({
         .optional()
         .describe("Linked asset site slug (managed storage tenancy)"),
       publishPolicy: publishPolicyMetadataField,
+      productionUrl: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "Live production URL of the linked site (e.g. https://acme.com). Painted in the preview iframe while the sandbox dev server is waking.",
+        ),
     })
     .loose()
     .nullable()

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -20,6 +20,7 @@ import {
   makeGrepHandler,
   makeGlobHandler,
   generateDecofileFromBlocks,
+  generateDecofileFromBlocksDeduped,
   collectEmptyDirectories,
   pathSegmentDepth,
   registerGlobAncestorDirectories,
@@ -838,6 +839,24 @@ describe("decofile fallback (blocks.gen.json generation)", () => {
       post("/_sandbox/read", { path: ".deco/blocks.gen.json", full: true }),
     );
     expect(res.status).toBe(400);
+  });
+
+  it("deduped: concurrent rebuilds share one in-flight promise, then reset", async () => {
+    writeBlock("Section%20One", { title: "one" });
+    const dir = join(appRoot, ".deco", "blocks");
+    // Concurrent callers coalesce onto the same build (no per-call re-merge).
+    const p1 = generateDecofileFromBlocksDeduped(dir);
+    const p2 = generateDecofileFromBlocksDeduped(dir);
+    expect(p1).toBe(p2);
+    const [a, b] = await Promise.all([p1, p2]);
+    expect(a).toBe(b);
+    expect(JSON.parse(a!)).toEqual({ "Section One": { title: "one" } });
+    // After settling it's a coalescer, not a cache: a fresh call rebuilds.
+    const p3 = generateDecofileFromBlocksDeduped(dir);
+    expect(p3).not.toBe(p1);
+    expect(JSON.parse((await p3)!)).toEqual({
+      "Section One": { title: "one" },
+    });
   });
 });
 

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -19,6 +19,7 @@ import {
   makeEditHandler,
   makeGrepHandler,
   makeGlobHandler,
+  generateDecofileFromBlocks,
   collectEmptyDirectories,
   pathSegmentDepth,
   registerGlobAncestorDirectories,
@@ -745,3 +746,105 @@ describe("fs handlers", () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe("decofile fallback (blocks.gen.json generation)", () => {
+  let appRoot = "";
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "decofile-gen-"));
+  });
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true });
+  });
+
+  const writeBlock = (stem: string, value: unknown) => {
+    const dir = join(appRoot, ".deco", "blocks");
+    mkdirSync(dir, { recursive: true });
+    // Pretty-printed, like the runtime writes them.
+    writeFileSync(join(dir, `${stem}.json`), JSON.stringify(value, null, 2));
+  };
+
+  it("generateDecofileFromBlocks: merges files keyed by decoded stem", async () => {
+    // %20 in the stem decodes to a space in the block id.
+    writeBlock("Banner%20Home", { banners: [{ alt: "a" }] });
+    writeBlock("pages%2FHome", { __resolveType: "page" });
+    const merged = await generateDecofileFromBlocks(
+      join(appRoot, ".deco", "blocks"),
+    );
+    expect(merged).not.toBeNull();
+    const parsed = JSON.parse(merged!) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      "Banner Home": { banners: [{ alt: "a" }] },
+      "pages/Home": { __resolveType: "page" },
+    });
+  });
+
+  it("generateDecofileFromBlocks: returns null with no blocks dir", async () => {
+    expect(await generateDecofileFromBlocks(join(appRoot, "nope"))).toBeNull();
+  });
+
+  it("generateDecofileFromBlocks: returns null for an empty blocks dir", async () => {
+    mkdirSync(join(appRoot, ".deco", "blocks"), { recursive: true });
+    expect(
+      await generateDecofileFromBlocks(join(appRoot, ".deco", "blocks")),
+    ).toBeNull();
+  });
+
+  it("generateDecofileFromBlocks: ignores non-.json and empty files", async () => {
+    writeBlock("Real", { ok: true });
+    const dir = join(appRoot, ".deco", "blocks");
+    writeFileSync(join(dir, "README.md"), "not a block");
+    writeFileSync(join(dir, "Empty.json"), "   ");
+    const merged = await generateDecofileFromBlocks(dir);
+    expect(JSON.parse(merged!)).toEqual({ Real: { ok: true } });
+  });
+
+  it("read: generates blocks.gen.json on the fly when it is absent", async () => {
+    writeBlock("Section%20One", { title: "one" });
+    const h = makeReadHandler({ appRoot, repoDir: appRoot });
+    const res = await h(
+      post("/_sandbox/read", { path: ".deco/blocks.gen.json", full: true }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { kind: string; content: string };
+    expect(body.kind).toBe("text");
+    // Un-numbered: the client's stripLineNumbers (which strips `^\d+\t`) is a
+    // no-op on pretty JSON, so the raw content JSON.parses directly.
+    expect(JSON.parse(body.content)).toEqual({
+      "Section One": { title: "one" },
+    });
+  });
+
+  it("read: prefers the committed blocks.gen.json when it exists", async () => {
+    writeBlock("Section%20One", { title: "from-blocks-dir" });
+    // A committed artifact that intentionally disagrees with the sources.
+    writeFileSync(
+      join(appRoot, ".deco", "blocks.gen.json"),
+      JSON.stringify({ "Section One": { title: "committed" } }),
+    );
+    const h = makeReadHandler({ appRoot, repoDir: appRoot });
+    const res = await h(
+      post("/_sandbox/read", { path: ".deco/blocks.gen.json", full: true }),
+    );
+    const body = (await res.json()) as { content: string };
+    expect(JSON.parse(stripLineNumbers(body.content))).toEqual({
+      "Section One": { title: "committed" },
+    });
+  });
+
+  it("read: still 400s for blocks.gen.json when there is no blocks dir", async () => {
+    mkdirSync(join(appRoot, ".deco"), { recursive: true });
+    const h = makeReadHandler({ appRoot, repoDir: appRoot });
+    const res = await h(
+      post("/_sandbox/read", { path: ".deco/blocks.gen.json", full: true }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+/** Mirrors the frontend's stripLineNumbers so the test asserts the same contract. */
+function stripLineNumbers(content: string): string {
+  return content
+    .split("\n")
+    .map((line) => line.replace(/^\d+\t/, ""))
+    .join("\n");
+}

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -125,15 +125,23 @@ const DECOFILE_BLOCKS_DIRNAME = "blocks";
  * to `{ [decodeURIComponent(stem)]: <file contents> }` — exactly what the deco
  * runtime emits (the filename stem is the `encodeURIComponent` of the block id).
  *
- * Non-blocking on purpose (daemon runs a single-threaded event loop): reads are
- * async and the file contents are concatenated as raw text — no per-value
- * `JSON.parse`/`JSON.stringify` (that would parse/serialize the full multi-MB
- * payload on the loop). Only the small keys are JSON-encoded. A malformed block
- * therefore isn't caught here; the client's `JSON.parse` fails and falls back to
- * "no snapshot", same as today — the write/edit handlers already gate validity.
+ * Kept off the critical path of the single-threaded event loop (daemon health
+ * probe has a ~500ms budget): reads are async, and the file contents are
+ * concatenated as raw text — no per-value `JSON.parse`/`JSON.stringify` over the
+ * merge (only the small keys are JSON-encoded). The unavoidable full-payload
+ * serialization happens once, downstream, when `jsonResponse` stringifies the
+ * result — the same ~multi-MB cost the existing committed-file read path already
+ * pays via `readFileSync` + `jsonResponse`, so this is no worse. A malformed
+ * block isn't caught here; the client's `JSON.parse` fails and falls back to "no
+ * snapshot", same as today — the write/edit handlers already gate validity.
  *
  * Returns `null` when there's no `blocks` dir (nothing to merge) so the caller
  * falls through to its normal "file not found" path.
+ *
+ * Prefer `generateDecofileFromBlocksDeduped` from request handlers: concurrent
+ * cold reads (multiple tabs/users on a shared sandbox during boot) would each
+ * rebuild the whole payload and their serialization bursts would serialize on
+ * the loop, risking a missed health probe.
  */
 export async function generateDecofileFromBlocks(
   blocksDir: string,
@@ -170,6 +178,27 @@ export async function generateDecofileFromBlocks(
   return `{${parts.join(",")}}`;
 }
 
+/**
+ * Single-flight guard around {@link generateDecofileFromBlocks}: concurrent
+ * reads for the same `blocksDir` share one in-flight rebuild instead of each
+ * doing a full multi-MB merge. Keyed by absolute dir; the entry is cleared when
+ * the build settles (resolve or reject). This is a boot-window coalescer, not a
+ * cache — the next read after settle rebuilds, so it never serves stale content.
+ */
+const decofileBuildsInFlight = new Map<string, Promise<string | null>>();
+
+export function generateDecofileFromBlocksDeduped(
+  blocksDir: string,
+): Promise<string | null> {
+  const existing = decofileBuildsInFlight.get(blocksDir);
+  if (existing) return existing;
+  const build = generateDecofileFromBlocks(blocksDir).finally(() => {
+    decofileBuildsInFlight.delete(blocksDir);
+  });
+  decofileBuildsInFlight.set(blocksDir, build);
+  return build;
+}
+
 export function makeReadHandler(deps: FsDeps) {
   return async (req: Request): Promise<Response> => {
     let body: {
@@ -201,7 +230,7 @@ export function makeReadHandler(deps: FsDeps) {
       // un-numbered (pretty JSON never matches the `^\d+\t` line-number prefix,
       // so the client's stripLineNumbers is a no-op and JSON.parse still works).
       if (path.basename(filePath) === DECOFILE_GEN_BASENAME) {
-        const merged = await generateDecofileFromBlocks(
+        const merged = await generateDecofileFromBlocksDeduped(
           path.join(path.dirname(filePath), DECOFILE_BLOCKS_DIRNAME),
         );
         if (merged !== null) {

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -108,6 +109,67 @@ function resolveReadPath(
   return safePath(appRoot, repoDir, userPath);
 }
 
+/**
+ * On-disk name of the merged decofile artifact and its source directory.
+ * `.deco/blocks.gen.json` is the runtime's merge of every `.deco/blocks/*.json`;
+ * many repos gitignore it (it's a multi-MB single line that conflicts on every
+ * content PR and is regenerated on dev cold-start), so a fresh sandbox has the
+ * block sources but not the merged file.
+ */
+const DECOFILE_GEN_BASENAME = "blocks.gen.json";
+const DECOFILE_BLOCKS_DIRNAME = "blocks";
+
+/**
+ * Rebuild `.deco/blocks.gen.json` from the sibling `.deco/blocks/*.json` files
+ * so the CMS is readable before the dev server is up. The merge maps each file
+ * to `{ [decodeURIComponent(stem)]: <file contents> }` — exactly what the deco
+ * runtime emits (the filename stem is the `encodeURIComponent` of the block id).
+ *
+ * Non-blocking on purpose (daemon runs a single-threaded event loop): reads are
+ * async and the file contents are concatenated as raw text — no per-value
+ * `JSON.parse`/`JSON.stringify` (that would parse/serialize the full multi-MB
+ * payload on the loop). Only the small keys are JSON-encoded. A malformed block
+ * therefore isn't caught here; the client's `JSON.parse` fails and falls back to
+ * "no snapshot", same as today — the write/edit handlers already gate validity.
+ *
+ * Returns `null` when there's no `blocks` dir (nothing to merge) so the caller
+ * falls through to its normal "file not found" path.
+ */
+export async function generateDecofileFromBlocks(
+  blocksDir: string,
+): Promise<string | null> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await readdir(blocksDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const names = entries
+    .filter((e) => e.isFile() && e.name.toLowerCase().endsWith(".json"))
+    .map((e) => e.name)
+    // Stable output order so byte-for-byte the artifact is deterministic.
+    .sort();
+  if (names.length === 0) return null;
+
+  const parts: string[] = [];
+  for (const name of names) {
+    const stem = name.slice(0, -".json".length);
+    let key: string;
+    try {
+      key = decodeURIComponent(stem);
+    } catch {
+      // A stem that isn't valid percent-encoding keeps its literal form,
+      // mirroring the frontend's decoBlockKeyFromFileStem fallback.
+      key = stem;
+    }
+    const raw = (await readFile(path.join(blocksDir, name), "utf-8")).trim();
+    // Skip empty files — `"key":` with no value would break the merged JSON.
+    if (!raw) continue;
+    parts.push(`${JSON.stringify(key)}:${raw}`);
+  }
+  return `{${parts.join(",")}}`;
+}
+
 export function makeReadHandler(deps: FsDeps) {
   return async (req: Request): Promise<Response> => {
     let body: {
@@ -133,6 +195,20 @@ export function makeReadHandler(deps: FsDeps) {
     try {
       stat = fs.statSync(filePath);
     } catch {
+      // Decofile fallback: when `.deco/blocks.gen.json` is absent (commonly
+      // gitignored), regenerate it on the fly from the sibling `.deco/blocks/`
+      // sources so the CMS is readable before the dev server boots. Returned
+      // un-numbered (pretty JSON never matches the `^\d+\t` line-number prefix,
+      // so the client's stripLineNumbers is a no-op and JSON.parse still works).
+      if (path.basename(filePath) === DECOFILE_GEN_BASENAME) {
+        const merged = await generateDecofileFromBlocks(
+          path.join(path.dirname(filePath), DECOFILE_BLOCKS_DIRNAME),
+        );
+        if (merged !== null) {
+          // lineCount is advisory here; the decofile is consumed as one blob.
+          return jsonResponse({ kind: "text", content: merged, lineCount: 1 });
+        }
+      }
       return jsonResponse({ error: `File not found: ${body.path}` }, 400);
     }
     if (stat.isDirectory()) {


### PR DESCRIPTION
## Summary

Lovable-style boot for projects linked to a live site. While the sandbox dev server is still waking, the preview canvas paints the linked site's **live production URL** inside the iframe with a **non-blocking "waking" pill**, instead of the full blocking booting overlay. The user sees their site immediately and can open **Blocks** / edit the CMS right away; the iframe swaps to the sandbox preview the moment the dev server is up.

### Product decisions (confirmed with @guitavano)
1. **Source of the production URL: persisted, not guessed.** We do **not** assume `{siteSlug}.deco.site` — a site's real production URL can be a custom domain. The actual URL deco.cx reports is stored on the agent's `metadata.productionUrl`.
2. **Where:** agent `metadata` (branch-independent), alongside `siteSlug`/`githubRepo`. No DB migration (metadata is JSON).
3. **Editable, not just import-time.** Set automatically at deco.cx import, and editable afterwards via a "Production URL" field in the agent settings' Sandbox card — so users can set it for projects imported before the field existed, or when a custom domain changes.

### What changed
- **Schema:** `productionUrl` added to the virtual-mcp metadata (entity / create / update) in `packages/mesh-sdk`.
- **Shared helper** (`shared/deco-site-production-url.ts`): `productionUrlFromDomain` (bare host → `https://…`, validated) and `sanitizeProductionUrl` (validate stored value to a canonical http(s) href — rejects `javascript:`/garbage).
- **Import:** `import-from-deco-dialog.tsx` computes the production URL from the site's domains (`d.production` first, else the first domain) and persists it on create.
- **Editable field:** `ProductionUrlField` in the settings Sandbox card, bound to `metadata.productionUrl`, autosaved via the existing form; normalizes on blur.
- **Preview:** reads `metadata.productionUrl` (sanitized) — no siteSlug derivation. New pure, unit-tested `resolvePreviewDisplay` decides the canvas surface: `sandbox` iframe, `production` fallback + waking pill, or (no productionUrl) today's blocking overlay. Gated on `progress.status` (boot no longer in progress), so a *failed* boot correctly shows the sandbox crash page, not a false "waking" pill.
- The production frame is **view-only**: visual/CMS editor injection, path sync, and `vm_preview_loaded` analytics are skipped for the cross-origin fallback (injection already targets the sandbox origin, so it's a no-op there anyway). The Blocks panel keeps working from the committed `.deco/*.gen.json` snapshot.
- Unified the toolbar/Blocks-button gate on a derived `previewSurfaceActive` (the deferred follow-up from #1) so Blocks is reachable during the production fallback. iframe `key` tracks the base URL so it remounts cleanly on the production→sandbox swap.

### Behavior when there's no `productionUrl`
GitHub-only projects, or sites imported before this field existed and never set → `productionUrl` is `null` → **exact current behavior** (blocking `SandboxStateCard` until the dev server is ready). Suspended/errored states are untouched.

## Testing
- `bun test shared/deco-site-production-url.test.ts` — URL normalization/validation (bare host, existing scheme, whitespace, `javascript:`/garbage/empty/nullish).
- `bun test .../preview-display.test.ts` — every display-mode branch (running → sandbox; failed → sandbox crash page, no pill; fresh/warming boot → production + pill; no productionUrl → blocking overlay; suspended/errored passthrough).
- Full workspace `bun run check` clean; `bun run lint` 0 errors on changed files; `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR: daemon regenerates `blocks.gen.json` when absent

Related, but independent of the production-preview fallback above — both make the editing surface usable earlier in the boot.

**Problem:** Many repos gitignore `.deco/blocks.gen.json` (a multi-MB single-line merge of `.deco/blocks/*.json`, regenerated on dev cold-start — see casaevideo-tanstack). So a fresh sandbox has the block *sources* but not the merged artifact, and the CMS/Blocks panel (which reads the committed snapshot via the daemon when the dev server is down) couldn't render until the runtime came up — **even with the FS ready**.

**Fix:** The daemon's `/read` handler regenerates it on the fly when absent — merging each `.deco/blocks/<stem>.json` into `{ [decodeURIComponent(stem)]: <contents> }`, exactly what the runtime emits (the stem is the `encodeURIComponent` of the block id).

- **Non-blocking** (daemon = single-threaded event loop): async `readdir`/`readFile` + raw-text concatenation — **no** per-value `JSON.parse`/`JSON.stringify` of the multi-MB payload; only the small keys are JSON-encoded.
- **No client change:** returned un-numbered. Pretty JSON never matches the `^\d+\t` line-number prefix, so the existing `stripLineNumbers` is a no-op and `readCommittedJson`'s `JSON.parse` works as-is.
- **Inert otherwise:** when the file exists the normal read wins; when there's no `blocks` dir it falls through to the existing 404. A malformed block isn't caught here (parsing would block the loop) — the client `JSON.parse` fails → 'no snapshot', same as today; write/edit handlers already gate block validity.

Tests: 7 new cases in `routes/fs.test.ts` (decoded-key merge incl. `%2F`→`/`; no-dir / empty-dir → null; ignores non-json + empty files; on-the-fly generation via the handler; committed file preferred; still-404 with no blocks dir). Full `bun run check` clean.