### PR TITLE
fix(thread): capitalize "Changes" tab label in publish dialog

### DIFF
--- a/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
+++ b/apps/mesh/src/web/components/thread/github/publish-dialog.tsx
@@ -575,7 +575,7 @@ function PublishDialogBody({
                   {t("thread.publishDialog.description")}
                 </TabsTrigger>
                 <TabsTrigger value="changes" className="px-3 text-xs">
-                  {t("thread.publishDialog.changes")}
+                  {t("thread.publishDialog.changesTab")}
                 </TabsTrigger>
               </TabsList>
               {diffCount > 0 && !openPrFromCommits && (

--- a/apps/mesh/src/web/i18n/en/thread.ts
+++ b/apps/mesh/src/web/i18n/en/thread.ts
@@ -116,6 +116,7 @@ export const thread = {
   "thread.publishDialog.change": "change",
   "thread.publishDialog.changes": "changes",
   "thread.publishDialog.changesFrom": "Changes from {branch}",
+  "thread.publishDialog.changesTab": "Changes",
   "thread.publishDialog.commitMessage": "Commit message",
   "thread.publishDialog.commitTitlePlaceholder": "Commit title…",
   "thread.publishDialog.description": "Description",

--- a/apps/mesh/src/web/i18n/pt-br/thread.ts
+++ b/apps/mesh/src/web/i18n/pt-br/thread.ts
@@ -121,6 +121,7 @@ export const thread = {
   "thread.publishDialog.change": "alteração",
   "thread.publishDialog.changes": "alterações",
   "thread.publishDialog.changesFrom": "Alterações de {branch}",
+  "thread.publishDialog.changesTab": "Alterações",
   "thread.publishDialog.commitMessage": "Mensagem de commit",
   "thread.publishDialog.commitTitlePlaceholder": "Título do commit…",
   "thread.publishDialog.description": "Descrição",


### PR DESCRIPTION
## Summary
The publish dialog's tab label rendered lowercase ("alterações") while the sibling "Descrição" tab was capitalized. Root cause: the `thread.publishDialog.changes` key was reused for both mid-sentence count text ("3 alterações a publicar" — lowercase correct) and the tab label.

Added a dedicated `thread.publishDialog.changesTab` key so the tab reads "Alterações" / "Changes" without affecting the mid-sentence usage. The English dictionary had the same inconsistency ("Description" tab vs lowercase "changes" tab), now fixed too.

## Changes
- `i18n/en/thread.ts` + `i18n/pt-br/thread.ts`: new `changesTab` key
- `publish-dialog.tsx`: tab trigger now uses `changesTab`

## Testing
- `bun run fmt` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capitalized the Changes tab label in the publish dialog by adding a dedicated i18n key `thread.publishDialog.changesTab`, avoiding the lowercase used for mid-sentence text.
Updated the English and pt-BR dictionaries and switched the tab trigger to use the new key.

<sup>Written for commit 26727fd4c51eb6bf9c28da6e104289c66016fb9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

