### PR TITLE
feat(sandbox): confirm before auto-starting on another member's thread

### DIFF
--- a/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
+++ b/apps/mesh/src/web/components/sandbox/content/content-browser.tsx
@@ -308,6 +308,11 @@ export function ContentBrowser({ mode = "content" }: ContentBrowserProps) {
         : null,
   });
 
+  // The others-thread gate only applies on the Preview surface (which owns
+  // auto-start); Content is gated behind lifecycle.phase === "running" and
+  // never passes `othersThreadGate`, so this state is unreachable here.
+  if (sandboxState.kind === "othersThread") return null;
+
   if (sandboxState.kind !== "iframe") {
     return (
       <SandboxStateRenderer

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -5,6 +5,8 @@ import {
   shouldSelfHeal,
   computeDrawerStatus,
   buildSandboxStartArgs,
+  deriveOthersThreadLabel,
+  computeOthersThreadGate,
   type BranchMapEntryLike,
 } from "./sandbox-lifecycle-context";
 
@@ -109,10 +111,15 @@ describe("shouldSelfHeal", () => {
     lastDeadVmId: null as string | null,
     isPending: false,
     userStopped: false,
+    autoStartBlocked: false,
   };
 
   test("fresh dead vm → true", () => {
     expect(shouldSelfHeal(base)).toBe(true);
+  });
+
+  test("blocked on another member's thread → false (no silent reprovision)", () => {
+    expect(shouldSelfHeal({ ...base, autoStartBlocked: true })).toBe(false);
   });
 
   test("not notFound → false", () => {
@@ -184,5 +191,126 @@ describe("computeDrawerStatus", () => {
     expect(computeDrawerStatus({ kind: "othersThread", label: "main" })).toBe(
       "idle",
     );
+  });
+});
+
+describe("deriveOthersThreadLabel", () => {
+  test("own thread (created_by === userId) → null", () => {
+    expect(
+      deriveOthersThreadLabel({
+        userId: "u1",
+        createdBy: "u1",
+        branch: "main",
+        title: "New chat",
+      }),
+    ).toBeNull();
+  });
+
+  test("no userId → null (unauthenticated, don't gate)", () => {
+    expect(
+      deriveOthersThreadLabel({
+        userId: null,
+        createdBy: "u2",
+        branch: "main",
+        title: "New chat",
+      }),
+    ).toBeNull();
+  });
+
+  test("no created_by → null (own/new unsaved thread)", () => {
+    expect(
+      deriveOthersThreadLabel({
+        userId: "u1",
+        createdBy: null,
+        branch: "main",
+        title: "New chat",
+      }),
+    ).toBeNull();
+  });
+
+  test("others thread with a branch → branch (encodes owner)", () => {
+    expect(
+      deriveOthersThreadLabel({
+        userId: "u1",
+        createdBy: "u2",
+        branch: "tavano-321312",
+        title: "New chat",
+      }),
+    ).toBe("tavano-321312");
+  });
+
+  test("others thread with no branch → title fallback", () => {
+    expect(
+      deriveOthersThreadLabel({
+        userId: "u1",
+        createdBy: "u2",
+        branch: null,
+        title: "Fix the banner",
+      }),
+    ).toBe("Fix the banner");
+  });
+
+  test("others thread with neither branch nor title → null", () => {
+    expect(
+      deriveOthersThreadLabel({
+        userId: "u1",
+        createdBy: "u2",
+        branch: null,
+        title: null,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("computeOthersThreadGate", () => {
+  test("own thread (no label) → not blocked regardless of ack", () => {
+    expect(
+      computeOthersThreadGate({
+        othersThreadLabel: null,
+        acknowledgedThreadId: null,
+        threadId: "t1",
+      }).autoStartBlocked,
+    ).toBe(false);
+  });
+
+  test("others thread, never acknowledged → blocked", () => {
+    expect(
+      computeOthersThreadGate({
+        othersThreadLabel: "main",
+        acknowledgedThreadId: null,
+        threadId: "t1",
+      }).autoStartBlocked,
+    ).toBe(true);
+  });
+
+  test("others thread, acknowledged this thread → not blocked", () => {
+    expect(
+      computeOthersThreadGate({
+        othersThreadLabel: "main",
+        acknowledgedThreadId: "t1",
+        threadId: "t1",
+      }).autoStartBlocked,
+    ).toBe(false);
+  });
+
+  test("acknowledged a DIFFERENT thread → blocked (re-arms per thread)", () => {
+    expect(
+      computeOthersThreadGate({
+        othersThreadLabel: "main",
+        acknowledgedThreadId: "t1",
+        threadId: "t2",
+      }).autoStartBlocked,
+    ).toBe(true);
+  });
+
+  test("acknowledgement survives a null → assigned branch on the same thread", () => {
+    // Same thread id, so acknowledging while branch was null stays valid once
+    // the server assigns a branch — no re-prompt, no double SANDBOX_START.
+    const acked = computeOthersThreadGate({
+      othersThreadLabel: "New chat", // title fallback (branch was null)
+      acknowledgedThreadId: "t1",
+      threadId: "t1",
+    });
+    expect(acked.autoStartBlocked).toBe(false);
   });
 });

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -55,10 +55,15 @@ describe("shouldAutoStart", () => {
     userStopped: false,
     isPending: false,
     attempted: false,
+    autoStartBlocked: false,
   };
 
   test("all conditions met → true", () => {
     expect(shouldAutoStart(base)).toBe(true);
+  });
+
+  test("blocked on another member's thread → false", () => {
+    expect(shouldAutoStart({ ...base, autoStartBlocked: true })).toBe(false);
   });
 
   test("no github repo → false", () => {
@@ -173,5 +178,11 @@ describe("computeDrawerStatus", () => {
         error: { code: null, message: "boom" },
       }),
     ).toBe("errored");
+  });
+
+  test("othersThread → idle", () => {
+    expect(computeDrawerStatus({ kind: "othersThread", label: "main" })).toBe(
+      "idle",
+    );
   });
 });

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -61,6 +61,9 @@ export interface ShouldSelfHealArgs {
   lastDeadVmId: string | null;
   isPending: boolean;
   userStopped: boolean;
+  /** Same gate as auto-start: never silently reprovision a sandbox on another
+   *  member's branch while the confirmation gate is up. */
+  autoStartBlocked: boolean;
 }
 
 export function shouldSelfHeal(args: ShouldSelfHealArgs): boolean {
@@ -69,8 +72,41 @@ export function shouldSelfHeal(args: ShouldSelfHealArgs): boolean {
     !!args.deadVmId &&
     !args.isPending &&
     !args.userStopped &&
+    !args.autoStartBlocked &&
     args.deadVmId !== args.lastDeadVmId
   );
+}
+
+/** The gate label for an active thread: non-null iff the thread belongs to
+ *  another member (its branch — which encodes the owner — or title as a
+ *  fallback). Extracted from the layout so the ownership rule is unit-testable:
+ *  an inverted comparison here would silently gate the user's own thread. */
+export function deriveOthersThreadLabel(args: {
+  userId: string | null;
+  createdBy: string | null | undefined;
+  branch: string | null | undefined;
+  title: string | null | undefined;
+}): string | null {
+  const isOthers =
+    !!args.userId && !!args.createdBy && args.createdBy !== args.userId;
+  if (!isOthers) return null;
+  return args.branch ?? args.title ?? null;
+}
+
+/** Whether auto-start (and self-heal) must be held back pending confirmation.
+ *  Keyed by thread id, not branch: acknowledging a null-branch thread survives
+ *  the server later assigning it a branch (no re-prompt / double-start), and
+ *  two different members' threads that collide on a branch name don't share an
+ *  acknowledgement. Re-arms when the active thread id changes. */
+export function computeOthersThreadGate(args: {
+  othersThreadLabel: string | null;
+  acknowledgedThreadId: string | null;
+  threadId: string | null;
+}): { autoStartBlocked: boolean } {
+  const acknowledged =
+    args.acknowledgedThreadId !== null &&
+    args.acknowledgedThreadId === args.threadId;
+  return { autoStartBlocked: !!args.othersThreadLabel && !acknowledged };
 }
 
 /** Shared SANDBOX_START arg-builder so every call site (auto-start,
@@ -181,6 +217,7 @@ export function SandboxLifecycleProvider({
   sandboxMap,
   sandboxProviderKind,
   othersThreadLabel,
+  othersThreadId,
   children,
 }: {
   virtualMcpId: string | null;
@@ -197,6 +234,8 @@ export function SandboxLifecycleProvider({
    *  acknowledged, auto-start is held back so we never silently boot a sandbox
    *  on someone else's branch. Null on the user's own thread. */
   othersThreadLabel: string | null;
+  /** Active thread id — the acknowledgement key (see computeOthersThreadGate). */
+  othersThreadId: string | null;
   children: ReactNode;
 }) {
   const { org } = useProjectContext();
@@ -204,16 +243,15 @@ export function SandboxLifecycleProvider({
   const events = useSandboxEvents();
   const queryClient = useQueryClient();
 
-  // Confirmation gate for another member's thread. Keyed by branch (normalize
-  // null → "") so switching threads re-arms the gate rather than carrying a
-  // stale acknowledgement. `false` = never acknowledged (distinct from the
-  // null-branch key "").
-  const [acknowledgedBranch, setAcknowledgedBranch] = useState<string | false>(
-    false,
-  );
-  const acknowledged =
-    acknowledgedBranch !== false && acknowledgedBranch === (branch ?? "");
-  const autoStartBlocked = !!othersThreadLabel && !acknowledged;
+  // Confirmation gate for another member's thread (see computeOthersThreadGate).
+  const [acknowledgedThreadId, setAcknowledgedThreadId] = useState<
+    string | null
+  >(null);
+  const { autoStartBlocked } = computeOthersThreadGate({
+    othersThreadLabel,
+    acknowledgedThreadId,
+    threadId: othersThreadId,
+  });
 
   const mcpClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
@@ -327,6 +365,7 @@ export function SandboxLifecycleProvider({
     lastDeadVmId: reprovisionedForVmIdRef.current,
     isPending: startVm.isPending,
     userStopped,
+    autoStartBlocked,
   });
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- one-shot reprovision trigger gated on notFound→deadVmId
   useEffect(() => {
@@ -414,7 +453,7 @@ export function SandboxLifecycleProvider({
 
   // Confirm opening another member's thread → release the gate. Auto-start
   // becomes eligible on the next render and fires SANDBOX_START for this branch.
-  const acknowledgeOthersThread = () => setAcknowledgedBranch(branch ?? "");
+  const acknowledgeOthersThread = () => setAcknowledgedThreadId(othersThreadId);
 
   // Value is recomputed each render; React 19 Compiler handles memoization.
   const value: SandboxLifecycleValue = {

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -37,6 +37,10 @@ export interface ShouldAutoStartArgs {
   userStopped: boolean;
   isPending: boolean;
   attempted: boolean;
+  /** Held back until the user confirms opening another member's thread — see
+   *  `othersThreadLabel` on the provider. Prevents silently booting a sandbox
+   *  on someone else's branch. */
+  autoStartBlocked: boolean;
 }
 
 export function shouldAutoStart(args: ShouldAutoStartArgs): boolean {
@@ -46,7 +50,8 @@ export function shouldAutoStart(args: ShouldAutoStartArgs): boolean {
     !args.vmEntry &&
     !args.userStopped &&
     !args.isPending &&
-    !args.attempted
+    !args.attempted &&
+    !args.autoStartBlocked
   );
 }
 
@@ -93,6 +98,8 @@ export function computeDrawerStatus(state: PreviewState): DrawerStatus {
       return "starting";
     case "errored":
       return "errored";
+    case "othersThread":
+      return "idle";
   }
 }
 
@@ -100,7 +107,14 @@ export function computeDrawerStatus(state: PreviewState): DrawerStatus {
 // Provider + hook
 // ---------------------------------------------------------------------------
 
-import { createContext, use, useEffect, useRef, type ReactNode } from "react";
+import {
+  createContext,
+  use,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   parseBranchMap,
   SELF_MCP_ALIAS_ID,
@@ -132,6 +146,9 @@ export interface SandboxLifecycleValue {
   restart: () => Promise<void>;
   retry: () => void;
   resume: () => void;
+  /** Confirm opening another member's thread: releases the auto-start gate so
+   *  the sandbox boots on that thread's branch. See `othersThreadLabel`. */
+  acknowledgeOthersThread: () => void;
 }
 
 const DEFAULT_VALUE: SandboxLifecycleValue = {
@@ -146,6 +163,7 @@ const DEFAULT_VALUE: SandboxLifecycleValue = {
   restart: async () => {},
   retry: () => {},
   resume: () => {},
+  acknowledgeOthersThread: () => {},
 };
 
 const SandboxLifecycleContext =
@@ -162,6 +180,7 @@ export function SandboxLifecycleProvider({
   hasActiveGithubRepo,
   sandboxMap,
   sandboxProviderKind,
+  othersThreadLabel,
   children,
 }: {
   virtualMcpId: string | null;
@@ -173,12 +192,28 @@ export function SandboxLifecycleProvider({
    *  (unlocked). When non-null, entry selection and SANDBOX_START are scoped to
    *  this kind so the preview never silently shows a different-provider sibling. */
   sandboxProviderKind: SandboxProviderKind | null;
+  /** Non-null when the active thread belongs to another member: label to show
+   *  in the confirmation gate (its branch, or title). While set and not yet
+   *  acknowledged, auto-start is held back so we never silently boot a sandbox
+   *  on someone else's branch. Null on the user's own thread. */
+  othersThreadLabel: string | null;
   children: ReactNode;
 }) {
   const { org } = useProjectContext();
   const { setCurrentTaskBranch } = useChatTask();
   const events = useSandboxEvents();
   const queryClient = useQueryClient();
+
+  // Confirmation gate for another member's thread. Keyed by branch (normalize
+  // null → "") so switching threads re-arms the gate rather than carrying a
+  // stale acknowledgement. `false` = never acknowledged (distinct from the
+  // null-branch key "").
+  const [acknowledgedBranch, setAcknowledgedBranch] = useState<string | false>(
+    false,
+  );
+  const acknowledged =
+    acknowledgedBranch !== false && acknowledgedBranch === (branch ?? "");
+  const autoStartBlocked = !!othersThreadLabel && !acknowledged;
 
   const mcpClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
@@ -228,6 +263,10 @@ export function SandboxLifecycleProvider({
     appPaused,
     userStopped,
     startError,
+    othersThreadGate:
+      autoStartBlocked && othersThreadLabel
+        ? { label: othersThreadLabel }
+        : null,
   });
   const status = computeDrawerStatus(previewState);
 
@@ -249,6 +288,7 @@ export function SandboxLifecycleProvider({
     userStopped,
     isPending: startVm.isPending,
     attempted,
+    autoStartBlocked,
   });
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- bridges external state into a one-shot mutation; no render-time equivalent
   useEffect(() => {
@@ -372,6 +412,10 @@ export function SandboxLifecycleProvider({
   };
   const resume = retry;
 
+  // Confirm opening another member's thread → release the gate. Auto-start
+  // becomes eligible on the next render and fires SANDBOX_START for this branch.
+  const acknowledgeOthersThread = () => setAcknowledgedBranch(branch ?? "");
+
   // Value is recomputed each render; React 19 Compiler handles memoization.
   const value: SandboxLifecycleValue = {
     branch,
@@ -385,6 +429,7 @@ export function SandboxLifecycleProvider({
     restart,
     retry,
     resume,
+    acknowledgeOthersThread,
   };
 
   return (

--- a/apps/mesh/src/web/components/sandbox/preview/preview-state.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-state.test.ts
@@ -64,4 +64,23 @@ describe("computePreviewState", () => {
       }),
     ).toEqual({ kind: "suspended" });
   });
+
+  test("othersThreadGate with no previewUrl → othersThread (before starting)", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        previewUrl: null,
+        othersThreadGate: { label: "tavano-321312" },
+      }),
+    ).toEqual({ kind: "othersThread", label: "tavano-321312" });
+  });
+
+  test("othersThreadGate but a live previewUrl → iframe (acknowledged, VM is running)", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        othersThreadGate: { label: "tavano-321312" },
+      }),
+    ).toEqual({ kind: "iframe", previewUrl: "http://localhost:5173" });
+  });
 });

--- a/apps/mesh/src/web/components/sandbox/preview/preview-state.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-state.test.ts
@@ -83,4 +83,26 @@ describe("computePreviewState", () => {
       }),
     ).toEqual({ kind: "iframe", previewUrl: "http://localhost:5173" });
   });
+
+  test("gate beats userStopped when no previewUrl (never boot someone else's branch)", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        previewUrl: null,
+        userStopped: true,
+        othersThreadGate: { label: "tavano-321312" },
+      }),
+    ).toEqual({ kind: "othersThread", label: "tavano-321312" });
+  });
+
+  test("gate beats startError when no previewUrl", () => {
+    expect(
+      computePreviewState({
+        ...base,
+        previewUrl: null,
+        startError: { code: null, message: "boom" },
+        othersThreadGate: { label: "tavano-321312" },
+      }),
+    ).toEqual({ kind: "othersThread", label: "tavano-321312" });
+  });
 });

--- a/apps/mesh/src/web/components/sandbox/preview/preview-state.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/preview-state.ts
@@ -25,15 +25,31 @@ export interface PreviewStateInput {
   userStopped: boolean;
   /** SANDBOX_START rejected (e.g. GitHub not authenticated) with no VM yet. */
   startError: SandboxStartError | null;
+  /**
+   * The active thread belongs to another member and the current user hasn't
+   * acknowledged opening it yet. While set, auto-start is held back and the
+   * preview shows a confirmation gate instead of silently booting a sandbox on
+   * the other member's branch. `label` identifies the thread (its branch, or
+   * title as a fallback). Null once acknowledged, or on the user's own thread.
+   */
+  othersThreadGate?: { label: string } | null;
 }
 
 export type PreviewState =
   | { kind: "starting" }
   | { kind: "suspended" }
   | { kind: "errored"; error: SandboxStartError }
+  | { kind: "othersThread"; label: string }
   | { kind: "iframe"; previewUrl: string };
 
 export function computePreviewState(input: PreviewStateInput): PreviewState {
+  // Gate wins before we ever spin the booting overlay: don't birth a sandbox on
+  // another member's branch until the user confirms. Once a previewUrl exists
+  // the user already acknowledged and the VM is theirs, so the running preview
+  // wins over a stale gate.
+  if (input.othersThreadGate && !input.previewUrl) {
+    return { kind: "othersThread", label: input.othersThreadGate.label };
+  }
   if (input.appPaused || input.userStopped) return { kind: "suspended" };
   // A start error with no live VM is terminal: show it instead of spinning
   // on the booting overlay forever. Once a previewUrl exists the running

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -1375,6 +1375,29 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                   </div>
                 )}
 
+                {previewState.kind === "othersThread" && (
+                  <div className="absolute inset-0 z-30">
+                    <SandboxStateCard
+                      kind="othersThread"
+                      label={previewState.label}
+                      onContinue={lifecycle.acknowledgeOthersThread}
+                      onStartNewChat={() =>
+                        navigate({
+                          to: "/$org/$taskId",
+                          params: {
+                            org: org.slug,
+                            taskId: crypto.randomUUID(),
+                          },
+                          search: (prev) => ({
+                            ...prev,
+                            sidepanel: "chat" as const,
+                          }),
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
                 {previewState.kind === "suspended" && (
                   <div className="absolute inset-0 z-30">
                     <SandboxStateCard

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -1381,7 +1381,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                       kind="othersThread"
                       label={previewState.label}
                       onContinue={lifecycle.acknowledgeOthersThread}
-                      onStartNewChat={() =>
+                      onStartNewThread={() =>
                         navigate({
                           to: "/$org/$taskId",
                           params: {

--- a/apps/mesh/src/web/components/sandbox/preview/state-card.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/state-card.tsx
@@ -35,7 +35,7 @@ export type SandboxStateCardProps =
       /** Identifies the other member's thread (its branch, or title). */
       label: string;
       onContinue: () => void;
-      onStartNewChat: () => void;
+      onStartNewThread: () => void;
     };
 
 export function SandboxStateCard(props: SandboxStateCardProps) {
@@ -57,7 +57,7 @@ export function SandboxStateCard(props: SandboxStateCardProps) {
               <Eye className="size-4" />{" "}
               {t("sandbox.stateCard.othersThreadContinue")}
             </Button>
-            <Button onClick={props.onStartNewChat}>
+            <Button onClick={props.onStartNewThread}>
               <Plus className="size-4" />{" "}
               {t("sandbox.stateCard.othersThreadNewChat")}
             </Button>

--- a/apps/mesh/src/web/components/sandbox/preview/state-card.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/state-card.tsx
@@ -1,9 +1,12 @@
 import { Button } from "@deco/ui/components/button.tsx";
 import {
   AlertTriangle,
+  Eye,
   PauseCircle,
   Play,
+  Plus,
   RefreshCw01,
+  Users01,
 } from "@untitledui/icons";
 import { SANDBOX_START_ERROR_CODES } from "@/shared/sandbox-start-errors";
 import { BootingVisual } from "./booting-visual";
@@ -26,10 +29,43 @@ export type SandboxStateCardProps =
       onRetry: () => void;
       /** Link to the org's Connections page, for the GitHub-auth case. */
       connectionsHref?: string;
+    }
+  | {
+      kind: "othersThread";
+      /** Identifies the other member's thread (its branch, or title). */
+      label: string;
+      onContinue: () => void;
+      onStartNewChat: () => void;
     };
 
 export function SandboxStateCard(props: SandboxStateCardProps) {
   const t = useT();
+
+  if (props.kind === "othersThread") {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-background p-6">
+        <div className="flex w-full max-w-md flex-col items-center gap-4 text-center">
+          <Users01 className="size-12 text-muted-foreground" />
+          <h3 className="text-lg font-medium">
+            {t("sandbox.stateCard.othersThreadTitle")}
+          </h3>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            {t("sandbox.stateCard.othersThreadMessage", { label: props.label })}
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <Button variant="outline" onClick={props.onContinue}>
+              <Eye className="size-4" />{" "}
+              {t("sandbox.stateCard.othersThreadContinue")}
+            </Button>
+            <Button onClick={props.onStartNewChat}>
+              <Plus className="size-4" />{" "}
+              {t("sandbox.stateCard.othersThreadNewChat")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (props.kind === "starting") {
     return (

--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -562,6 +562,11 @@ export const sandbox = {
   "sandbox.sectionsRightPane.selectSectionTitle": "Select a section to edit",
   "sandbox.stateCard.githubNotAuthenticatedMessage":
     "This agent's GitHub repo isn't authenticated. Reconnect it in Connections, then retry.",
+  "sandbox.stateCard.othersThreadTitle": "You're in someone else's chat",
+  "sandbox.stateCard.othersThreadMessage":
+    "This conversation ({label}) belongs to another member. Continuing will start a sandbox on their branch — start a new chat to work on your own instead.",
+  "sandbox.stateCard.othersThreadContinue": "Continue anyway",
+  "sandbox.stateCard.othersThreadNewChat": "Start new chat",
   "sandbox.stateCard.reconnectGithub": "Reconnect GitHub",
   "sandbox.stateCard.resume": "Resume",
   "sandbox.stateCard.resumeToContinue": "Resume to continue.",

--- a/apps/mesh/src/web/i18n/pt-br/sandbox.ts
+++ b/apps/mesh/src/web/i18n/pt-br/sandbox.ts
@@ -587,6 +587,11 @@ export const sandbox = {
     "Selecione uma seção para editar",
   "sandbox.stateCard.githubNotAuthenticatedMessage":
     "O repositório GitHub deste agente não está autenticado. Reconecte em Conexões e tente novamente.",
+  "sandbox.stateCard.othersThreadTitle": "Você está no chat de outra pessoa",
+  "sandbox.stateCard.othersThreadMessage":
+    "Esta conversa ({label}) é de outro membro. Continuar vai iniciar um sandbox na branch dela — comece um novo chat para trabalhar no seu.",
+  "sandbox.stateCard.othersThreadContinue": "Continuar mesmo assim",
+  "sandbox.stateCard.othersThreadNewChat": "Começar novo chat",
   "sandbox.stateCard.reconnectGithub": "Reconectar GitHub",
   "sandbox.stateCard.resume": "Retomar",
   "sandbox.stateCard.resumeToContinue": "Retome para continuar.",

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -175,6 +175,16 @@ function VmEventsBridge({
   const effectiveHasGithubRepo =
     hasActiveGithubRepo || agentHasClonableSource(activeTask?.metadata);
 
+  // Someone else's thread: hold auto-start behind a confirmation gate so the
+  // sandbox doesn't silently boot on the creator's branch (mirrors the chat
+  // composer's read-only banner). Label it by branch (encodes the owner), or
+  // title as a fallback. Own thread → null (no gate).
+  const isOthersThread =
+    !!userId && !!activeTask?.created_by && activeTask.created_by !== userId;
+  const othersThreadLabel = isOthersThread
+    ? (activeTask?.branch ?? activeTask?.title ?? null)
+    : null;
+
   // Open the events stream only when a sandbox actually exists or a start is
   // in flight — NOT merely because the agent has a GitHub repo configured.
   // Gate instead on a registered sandboxMap entry, or an in-flight
@@ -216,6 +226,7 @@ function VmEventsBridge({
         hasActiveGithubRepo={effectiveHasGithubRepo}
         sandboxMap={effectiveSandboxMap}
         sandboxProviderKind={pendingSandboxProviderKind}
+        othersThreadLabel={othersThreadLabel}
       >
         <BlocksPreviewWorkspaceProvider
           key={`${virtualMcpId}:${currentBranch ?? "no-branch"}`}

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -70,6 +70,7 @@ import { SandboxEventsProvider } from "@/web/components/sandbox/hooks/sandbox-ev
 import {
   SandboxLifecycleProvider,
   selectVmEntry,
+  deriveOthersThreadLabel,
   type BranchMapEntryLike,
 } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context";
 import { useEnsureTask } from "@/web/hooks/use-ensure-task";
@@ -177,13 +178,14 @@ function VmEventsBridge({
 
   // Someone else's thread: hold auto-start behind a confirmation gate so the
   // sandbox doesn't silently boot on the creator's branch (mirrors the chat
-  // composer's read-only banner). Label it by branch (encodes the owner), or
-  // title as a fallback. Own thread → null (no gate).
-  const isOthersThread =
-    !!userId && !!activeTask?.created_by && activeTask.created_by !== userId;
-  const othersThreadLabel = isOthersThread
-    ? (activeTask?.branch ?? activeTask?.title ?? null)
-    : null;
+  // composer's read-only banner). Ownership rule lives in the pure, tested
+  // deriveOthersThreadLabel; own thread → null (no gate).
+  const othersThreadLabel = deriveOthersThreadLabel({
+    userId: userId ?? null,
+    createdBy: activeTask?.created_by,
+    branch: activeTask?.branch,
+    title: activeTask?.title,
+  });
 
   // Open the events stream only when a sandbox actually exists or a start is
   // in flight — NOT merely because the agent has a GitHub repo configured.
@@ -227,6 +229,7 @@ function VmEventsBridge({
         sandboxMap={effectiveSandboxMap}
         sandboxProviderKind={pendingSandboxProviderKind}
         othersThreadLabel={othersThreadLabel}
+        othersThreadId={activeTask?.id ?? null}
       >
         <BlocksPreviewWorkspaceProvider
           key={`${virtualMcpId}:${currentBranch ?? "no-branch"}`}


### PR DESCRIPTION
## Summary

Opening another org member's thread by URL (`/<org>/<threadId>`) silently **auto-started a sandbox on the creator's branch**. The existing "read-only" guard only replaced the chat composer — the sandbox/CMS preview kept booting and stayed fully editable, so a user could edit (and commit to) someone else's branch without ever choosing to.

This adds a confirmation gate: when the active thread belongs to someone else, the sandbox does **not** auto-start. The preview shows a card identifying the thread with two actions:

- **Continue anyway** → releases the gate and boots the sandbox on that branch (the old behavior, now deliberate).
- **Start new chat** → navigates to a fresh thread with **no branch**, so the server scopes it to the user's own warm branch (or a new one) — never the creator's.

On your own thread nothing changes.

## How it works

- `shouldAutoStart` gains an `autoStartBlocked` flag.
- `computePreviewState` gains an `othersThread` state that wins before `starting` (but yields to a live `previewUrl`, i.e. once acknowledged).
- `SandboxLifecycleProvider` takes an `othersThreadLabel` prop (branch, or title fallback) and an `acknowledgeOthersThread()` action; the acknowledgement is keyed by branch so switching threads re-arms the gate.
- `VmEventsBridge` computes `othersThreadLabel` from `activeTask.created_by !== userId` — the same signal the chat composer's read-only banner already uses.
- `content-browser` narrows out the new state (the Content tab is gated behind `phase === "running"` and never passes the gate).

## Scope

This is a **client-side** mitigation, matching the existing read-only banner. The authoritative fixes are follow-ups:
- `COLLECTION_THREADS_GET` (`storage/threads.ts`) scopes only by org, not owner — any member can open any thread id by URL.
- "Continue anyway" still yields an editable sandbox on the creator's branch.

## Testing

- `bun run --cwd=apps/mesh check` ✅
- `bun test apps/mesh/src/web/components/sandbox/` → 385 pass ✅ (added cases for `shouldAutoStart` blocked, `computeDrawerStatus` othersThread→idle, and `computePreviewState` gate precedence)
- `bun run lint` — no new warnings ✅
- `bun run fmt` applied ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a confirmation gate before auto-starting the sandbox when opening another member’s thread to prevent silent boot/edits on their branch. Users can continue on that branch or start a new thread on their own.

- **New Features**
  - Block auto-start on others’ threads via `autoStartBlocked`; Preview shows a card with the thread label and actions: “Continue anyway” or “Start new chat”.
  - Preview adds an `othersThread` gate that wins before `starting`; Content remains gated by `phase === "running"`.
  - `SandboxLifecycleProvider` now takes `othersThreadLabel` + `othersThreadId` and exposes `acknowledgeOthersThread()`; `VmEventsBridge` derives the label with `deriveOthersThreadLabel`.
  - Added en/pt-br strings and tests. Client-side mitigation; server scoping follow-up remains.

- **Bug Fixes**
  - Self-heal also honors the gate (`shouldSelfHeal`), preventing silent reprovision on another member’s branch.
  - Acknowledgement keyed by thread id (not branch), fixing the null-branch re-prompt/double-start and avoiding cross-thread collisions on identical branch names.

<sup>Written for commit 52f9507017f3567a90fbd912142090f3688b24ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

