### PR TITLE
fix(sections-editor): fall back to schema enum when icon-select loader is empty

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  enumFallbackOptions,
   filterOptions,
   normalizeOptions,
+  resolveOptions,
   svgPreviewDataUri,
 } from "./dynamic-options-field";
 
@@ -142,5 +144,44 @@ describe("svgPreviewDataUri", () => {
   test("leaves markup without an svg tag unchanged (besides encoding)", () => {
     const uri = svgPreviewDataUri("<div>not svg</div>");
     expect(decodeURIComponent(uri.split(",")[1]!)).toBe("<div>not svg</div>");
+  });
+});
+
+describe("enumFallbackOptions", () => {
+  test("maps string enum literals to value/label options", () => {
+    expect(enumFallbackOptions(["user", "chat", "earth"])).toEqual([
+      { value: "user", label: "user" },
+      { value: "chat", label: "chat" },
+      { value: "earth", label: "earth" },
+    ]);
+  });
+
+  test("ignores non-string enum entries", () => {
+    expect(enumFallbackOptions(["a", 1, null, { x: 1 }, "b"])).toEqual([
+      { value: "a", label: "a" },
+      { value: "b", label: "b" },
+    ]);
+  });
+
+  test("returns empty array for undefined or non-array input", () => {
+    expect(enumFallbackOptions(undefined)).toEqual([]);
+    expect(enumFallbackOptions([])).toEqual([]);
+  });
+});
+
+describe("resolveOptions", () => {
+  const loader = [{ value: "activity", icon: "<svg/>" }];
+  const fallback = [{ value: "user", label: "user" }];
+
+  test("prefers loader options when the loader returned any", () => {
+    expect(resolveOptions(loader, fallback)).toBe(loader);
+  });
+
+  test("falls back to enum options when the loader returned nothing", () => {
+    expect(resolveOptions([], fallback)).toBe(fallback);
+  });
+
+  test("returns empty when neither source has options", () => {
+    expect(resolveOptions([], [])).toEqual([]);
   });
 });

--- a/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
@@ -50,6 +50,36 @@ export function normalizeOptions(data: unknown): DynamicOption[] {
 }
 
 /**
+ * Options derived from the schema's own `enum` (icon-name literals). Used as a
+ * fallback when the `@options` loader yields nothing — e.g. a deco `icon-select`
+ * field whose options loader (`availableIcons.ts`) was dropped during the
+ * TanStack migration, so `/deco/invoke/<loader>` 404s. Without this the combobox
+ * would render empty; with it the field degrades to the pre-#5080 text list.
+ */
+export function enumFallbackOptions(
+  enumValues: unknown[] | undefined,
+): DynamicOption[] {
+  if (!Array.isArray(enumValues)) return [];
+  const result: DynamicOption[] = [];
+  for (const item of enumValues) {
+    if (typeof item === "string") result.push({ value: item, label: item });
+  }
+  return result;
+}
+
+/**
+ * Pick the option source: loader results when it returned any, otherwise the
+ * schema-enum fallback. Loader options carry icon/image previews; the fallback
+ * is plain text — so a working loader always wins.
+ */
+export function resolveOptions(
+  loaderOptions: DynamicOption[],
+  fallback: DynamicOption[],
+): DynamicOption[] {
+  return loaderOptions.length > 0 ? loaderOptions : fallback;
+}
+
+/**
  * Client-side narrowing of the fetched options. The loader already receives
  * the search as `term`, but many real-world options loaders ignore it and
  * always return the full list (e.g. odin-ui's icons loader) — without this
@@ -217,12 +247,14 @@ export function DynamicOptionsField({
     retry: 1,
   });
 
-  const options = query.data ?? [];
+  const enumFallback = enumFallbackOptions(schema.enum);
+  const options = resolveOptions(query.data ?? [], enumFallback);
   const visibleOptions = filterOptions(options, search);
   const selectedOption = options.find((opt) => opt.value === currentValue);
 
-  // Fallback to text input when preview is not available
-  if (!previewUrl || !loaderPath) {
+  // Fallback to text input only when there's no option source at all: no
+  // loader/preview to fetch from AND no schema enum to list.
+  if ((!previewUrl || !loaderPath) && enumFallback.length === 0) {
     return (
       <div className="space-y-2">
         <FieldHeader


### PR DESCRIPTION
## Summary

The Granado client's block editor stopped listing any icons in the "Ícone" (icon-select) field — the dropdown renders **empty** where it previously showed the icon names as text.

Root cause is two-fold:

1. **This repo (mesh):** PR #5080 (`2313bb83e`) routes `icon-select` fields to `DynamicOptionsField`, which fetches options from the `@options` loader and **ignores the schema's own `enum`**. When the loader returns nothing, the list is empty.
2. **Framework (`@decocms/blocks`):** the site schemas reference `@options deco-sites/storefront/loaders/availableIcons.ts`, but the blocks-cli migration **deletes** that loader (and skips its `adminIcons.ts` SVG map), so `/deco/invoke/.../availableIcons.ts` 404s on migrated TanStack sites like Granado. (Tracked separately — a fix to restore the loader in `@decocms/apps-website` + the migration script is coming.)

This PR fixes **(1)** — the client-side resilience:

- Fall back to the schema `enum` (icon-name literals) when the `@options` loader yields no options. A working loader still wins (icon/SVG previews preserved); a missing/empty loader now degrades to the **text list** (pre-#5080 behavior) instead of an empty dropdown.
- Only drop to a free-text `<Input>` when there's **neither** a loader/preview **nor** an enum.
- Extracts pure helpers `enumFallbackOptions` and `resolveOptions`.

## Testing

- `bun test .../dynamic-options-field.test.ts` — 24 pass (added `enumFallbackOptions` + `resolveOptions` cases).
- `bun run check` (tsc) clean; `bun run fmt` clean; `bun run lint` — no new warnings.

## Behavior by scenario
- loader OK → icons (unchanged)
- loader empty/404 → enum text list (restored)
- no preview/loader but enum present → enum text list (combobox)
- nothing → text input (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty icon dropdowns in the sections editor by falling back to schema enums when the `@options` loader returns nothing, restoring a text list instead of a blank combobox. Keeps SVG previews when the loader works, and only falls back to free-text input if neither a loader nor an enum is available.

- **Bug Fixes**
  - Use schema `enum` to build options when the loader yields no results; loader still wins when present (preserves icon previews).
  - Only render a free-text input when there’s no loader/preview and no enum.
  - Added `enumFallbackOptions` and `resolveOptions` helpers with unit tests.

<sup>Written for commit 90b5ab64da6858f9652856d57e2b1067724e0376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

