### PR TITLE
feat(sections-editor): render icon-select previews from the site's sprite

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -845,17 +845,23 @@ export const createSandboxRoutes = () => {
     },
   );
 
-  // -- Preview fetch (CORS proxy for /.decofile) ----------------------------
+  // -- Preview fetch (CORS proxy for whitelisted public preview assets) -------
   // /live/_meta is fetched directly from the preview URL by the client
-  // (the deco dev server allows CORS `*` for it). /.decofile must go through
-  // this proxy because cloud previews don't expose it cross-origin.
+  // (the deco dev server allows CORS `*` for it). These paths must go through
+  // this proxy because cloud previews don't expose them cross-origin:
+  //   - /.decofile   — the committed decofile snapshot
+  //   - /sprites.svg — the site's icon sprite sheet, served by the CF Assets
+  //     binding with no CORS header, so the icon-select picker reads it here.
+  // The preview URL is derived server-side from the authed claim (never a
+  // client param), so this stays SSRF-safe.
+  const PREVIEW_FETCH_ALLOWED_PATHS = new Set(["/.decofile", "/sprites.svg"]);
   app.get("/:virtualMcpId/:branch/preview-fetch", async (c) => {
     const runner = requireRunner(c);
     if (runner instanceof Response) return runner;
 
     const { claimName } = c.get("vmClaim");
     const path = c.req.query("path");
-    if (path !== "/.decofile") {
+    if (!path || !PREVIEW_FETCH_ALLOWED_PATHS.has(path)) {
       return c.json({ error: "Path not allowed" }, 403);
     }
 

--- a/apps/mesh/src/observability/instrumentations/fetch.test.ts
+++ b/apps/mesh/src/observability/instrumentations/fetch.test.ts
@@ -42,6 +42,8 @@ describe("benignPreview404", () => {
   it("treats a 404 on the deco-site probe paths as not-a-deco-site", () => {
     expect(benignPreview404(404, "/.decofile")).toBe("not_a_deco_site");
     expect(benignPreview404(404, "/live/_meta")).toBe("not_a_deco_site");
+    // A site with no icon sprite is fine — previews fall back to text.
+    expect(benignPreview404(404, "/sprites.svg")).toBe("not_a_deco_site");
   });
 
   it("does not suppress non-404 statuses on those paths", () => {

--- a/apps/mesh/src/observability/instrumentations/fetch.ts
+++ b/apps/mesh/src/observability/instrumentations/fetch.ts
@@ -59,7 +59,10 @@ function benignSandbox4xx(status: number, pathname: string): string | null {
 function benignPreview404(status: number, pathname: string): string | null {
   if (
     status === 404 &&
-    (pathname === "/.decofile" || pathname === "/live/_meta")
+    (pathname === "/.decofile" ||
+      pathname === "/live/_meta" ||
+      // A site with no icon sprite (icon-select previews just fall back to text).
+      pathname === "/sprites.svg")
   ) {
     return "not_a_deco_site";
   }

--- a/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
@@ -121,10 +121,19 @@ export function svgPreviewDataUri(svg: string, color?: string): string {
   return `data:image/svg+xml;utf8,${encodeURIComponent(shimmed)}`;
 }
 
-/** The app's current foreground color, so icon previews match the theme. */
+/**
+ * The app's foreground token, so monochrome `currentColor` icon previews match
+ * the theme (white on the dark theme). Reads the `--foreground` design-system
+ * variable, which flips with the `.dark` class on `<html>`. Reading the raw
+ * `color` of `<html>` instead is wrong — the theme sets its foreground via this
+ * variable, not the element's `color`, so `<html>.color` stays the default black
+ * and would render every icon black (invisible on the dark theme).
+ */
 function themeForegroundColor(): string | undefined {
-  const color = getComputedStyle(document.documentElement).color;
-  return color || undefined;
+  const fg = getComputedStyle(document.documentElement)
+    .getPropertyValue("--foreground")
+    .trim();
+  return fg || undefined;
 }
 
 /** Preview image source for an option: `image` is a URL, `icon` inline SVG. */

--- a/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
@@ -30,6 +30,12 @@ export interface DynamicOption {
   image?: string;
   /** Inline SVG markup for the option preview (deco `icon-select` loaders). */
   icon?: string;
+  /**
+   * Pre-rendered preview `src` (URL or data-URI). Set by callers that can encode
+   * it once up front (e.g. sprite icons) so the render path doesn't re-encode
+   * per option; falls back to deriving from `image`/`icon` when absent.
+   */
+  previewSrc?: string;
 }
 
 export function normalizeOptions(data: unknown): DynamicOption[] {
@@ -136,10 +142,17 @@ function themeForegroundColor(): string | undefined {
   return fg || undefined;
 }
 
-/** Preview image source for an option: `image` is a URL, `icon` inline SVG. */
-function optionPreviewSrc(opt: DynamicOption): string | undefined {
+/**
+ * Preview image source for an option: a pre-rendered `previewSrc`, else an
+ * `image` URL, else an inline `icon` SVG encoded with the theme `fg` color.
+ */
+function optionPreviewSrc(
+  opt: DynamicOption,
+  fg: string | undefined,
+): string | undefined {
+  if (opt.previewSrc) return opt.previewSrc;
   if (opt.image) return opt.image;
-  if (opt.icon) return svgPreviewDataUri(opt.icon, themeForegroundColor());
+  if (opt.icon) return svgPreviewDataUri(opt.icon, fg);
   return undefined;
 }
 
@@ -169,11 +182,13 @@ async function fetchDynamicOptions(
 function OptionPreview({
   option,
   className,
+  fg,
 }: {
   option: DynamicOption;
   className?: string;
+  fg: string | undefined;
 }) {
-  const src = optionPreviewSrc(option);
+  const src = optionPreviewSrc(option, fg);
   if (!src) return null;
   return (
     <img
@@ -267,9 +282,11 @@ export function DynamicOptionsField({
 
   const loaderOptions = query.data ?? [];
 
-  // Only reach for the sprite when the loader didn't already supply icons
-  // (i.e. TanStack sites with the deleted loader) — avoids a wasted request on
-  // sites whose loader works.
+  // Reach for the site sprite only when the loader can't supply icons: either
+  // there's no `@options` loader (TanStack, where it's deleted) or the loader
+  // has settled with nothing. Gating on `query.isFetched` (not just an empty
+  // `loaderOptions`, which is also empty while the loader is in flight) is what
+  // keeps a working-loader site from fetching the sprite concurrently.
   const spriteQuery = useQuery({
     queryKey: KEYS.sandboxSprite(sandboxKey),
     queryFn: () =>
@@ -288,18 +305,34 @@ export function DynamicOptionsField({
       isIconSelect &&
       !!sandbox &&
       (open || !!currentValue) &&
-      loaderOptions.length === 0,
+      (!loaderPath || (query.isFetched && loaderOptions.length === 0)),
     staleTime: 300_000,
     retry: 1,
   });
 
   const enumFallback = enumFallbackOptions(schema.enum);
   const spriteIcons = spriteQuery.data ?? {};
-  // Enum is the fallback list; on icon-select each name is enriched with its
-  // sprite SVG so the picker shows the icon, not just the label.
+  // Read the theme foreground once per render (a getComputedStyle style read)
+  // instead of once per option inside OptionPreview.
+  const fg = themeForegroundColor();
+  // Encode each sprite icon to a data-URI exactly once. Both inputs are stable
+  // across renders (react-query's data ref + the fg string value), so the React
+  // Compiler memoizes this — without it a 100+ icon list would re-encode every
+  // SVG on every keystroke.
+  const spriteSrcByValue = Object.fromEntries(
+    Object.entries(spriteIcons).map(([name, svg]) => [
+      name,
+      svgPreviewDataUri(svg, fg),
+    ]),
+  );
+  // Enum is the fallback list; on icon-select each name carries its already
+  // encoded sprite preview so the picker shows the icon, not just the label.
   const enumOptions =
-    isIconSelect && Object.keys(spriteIcons).length > 0
-      ? enumFallback.map((opt) => ({ ...opt, icon: spriteIcons[opt.value] }))
+    isIconSelect && Object.keys(spriteSrcByValue).length > 0
+      ? enumFallback.map((opt) => ({
+          ...opt,
+          previewSrc: spriteSrcByValue[opt.value],
+        }))
       : enumFallback;
   // Loader wins when it returns anything (Fresh/Deno); otherwise the enum
   // (+ sprite previews for icon-select).
@@ -342,7 +375,11 @@ export function DynamicOptionsField({
           >
             {selectedOption ? (
               <span className="flex min-w-0 items-center gap-2">
-                <OptionPreview option={selectedOption} className="h-6 w-6" />
+                <OptionPreview
+                  option={selectedOption}
+                  className="h-6 w-6"
+                  fg={fg}
+                />
                 <span className="truncate">
                   {selectedOption.label ?? selectedOption.value}
                 </span>
@@ -390,6 +427,7 @@ export function DynamicOptionsField({
                       <OptionPreview
                         option={opt}
                         className={cn(opt.image ? "h-9 w-9" : "h-6 w-6")}
+                        fg={fg}
                       />
                       <span className="truncate">{opt.label ?? opt.value}</span>
                     </span>

--- a/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/dynamic-options-field.tsx
@@ -21,6 +21,8 @@ import { Label } from "@deco/ui/components/label.tsx";
 import { KEYS } from "@/web/lib/query-keys";
 import { useT } from "@/web/i18n/use-t.ts";
 import type { FieldProps } from "./field-props";
+import { buildPreviewFetchUrl } from "../preview-fetch-url";
+import { fetchSpriteIcons } from "./icon-sprite";
 
 export interface DynamicOption {
   value: string;
@@ -229,6 +231,13 @@ export function DynamicOptionsField({
 
   const currentValue = typeof value === "string" ? value : "";
 
+  // icon-select works across runtimes: Deno/Fresh (and other sites that still
+  // ship the `availableIcons` loader) resolve icons through the `@options`
+  // loader as usual; on TanStack sites that loader is deleted during migration
+  // (its resolveType 404s), so we fall back to the schema `enum` for the list
+  // and the site's own `/sprites.svg` (see icon-sprite.ts) for the previews.
+  const isIconSelect = schema.format === "icon-select";
+
   const query = useQuery({
     queryKey: KEYS.sandboxInvoke(
       sandboxKey,
@@ -247,14 +256,53 @@ export function DynamicOptionsField({
     retry: 1,
   });
 
+  const loaderOptions = query.data ?? [];
+
+  // Only reach for the sprite when the loader didn't already supply icons
+  // (i.e. TanStack sites with the deleted loader) — avoids a wasted request on
+  // sites whose loader works.
+  const spriteQuery = useQuery({
+    queryKey: KEYS.sandboxSprite(sandboxKey),
+    queryFn: () =>
+      fetchSpriteIcons(
+        buildPreviewFetchUrl(
+          {
+            orgSlug: sandbox!.orgSlug,
+            virtualMcpId: sandbox!.virtualMcpId,
+            branch: sandbox!.branch,
+            previewUrl,
+          },
+          "/sprites.svg",
+        ),
+      ),
+    enabled:
+      isIconSelect &&
+      !!sandbox &&
+      (open || !!currentValue) &&
+      loaderOptions.length === 0,
+    staleTime: 300_000,
+    retry: 1,
+  });
+
   const enumFallback = enumFallbackOptions(schema.enum);
-  const options = resolveOptions(query.data ?? [], enumFallback);
+  const spriteIcons = spriteQuery.data ?? {};
+  // Enum is the fallback list; on icon-select each name is enriched with its
+  // sprite SVG so the picker shows the icon, not just the label.
+  const enumOptions =
+    isIconSelect && Object.keys(spriteIcons).length > 0
+      ? enumFallback.map((opt) => ({ ...opt, icon: spriteIcons[opt.value] }))
+      : enumFallback;
+  // Loader wins when it returns anything (Fresh/Deno); otherwise the enum
+  // (+ sprite previews for icon-select).
+  const options = resolveOptions(loaderOptions, enumOptions);
   const visibleOptions = filterOptions(options, search);
   const selectedOption = options.find((opt) => opt.value === currentValue);
 
   // Fallback to text input only when there's no option source at all: no
   // loader/preview to fetch from AND no schema enum to list.
-  if ((!previewUrl || !loaderPath) && enumFallback.length === 0) {
+  const noOptionSource =
+    (!previewUrl || !loaderPath) && enumFallback.length === 0;
+  if (noOptionSource) {
     return (
       <div className="space-y-2">
         <FieldHeader

--- a/apps/mesh/src/web/components/sections-editor/fields/icon-sprite.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/icon-sprite.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { parseSpriteSymbols } from "./icon-sprite";
+
+const SPRITE = `<svg style="display:none" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<symbol id="Close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M5 5L19 19" />
+</symbol>
+<symbol id="Granado" viewBox="0 0 72 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1 16" fill="currentColor" />
+</symbol>
+</svg>`;
+
+describe("parseSpriteSymbols", () => {
+  test("maps each symbol id to a standalone svg preserving its viewBox/fill", () => {
+    const map = parseSpriteSymbols(SPRITE);
+    expect(Object.keys(map).sort()).toEqual(["Close", "Granado"]);
+    expect(map.Close).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">\n  <path d="M5 5L19 19" />\n</svg>',
+    );
+    // viewBox may appear after fill/xmlns in the source — still captured.
+    expect(map.Granado).toContain('viewBox="0 0 72 32"');
+    expect(map.Granado).toContain('fill="none"');
+    expect(map.Granado).toContain('<path d="M1 16" fill="currentColor" />');
+  });
+
+  test("omits fill when the symbol has none", () => {
+    const map = parseSpriteSymbols(
+      '<svg><symbol id="X" viewBox="0 0 8 8"><circle /></symbol></svg>',
+    );
+    expect(map.X).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle /></svg>',
+    );
+  });
+
+  test("skips symbols without an id", () => {
+    const map = parseSpriteSymbols(
+      '<svg><symbol viewBox="0 0 8 8"><circle /></symbol></svg>',
+    );
+    expect(map).toEqual({});
+  });
+
+  test("returns empty object for non-string / empty input", () => {
+    expect(parseSpriteSymbols(null)).toEqual({});
+    expect(parseSpriteSymbols(undefined)).toEqual({});
+    expect(parseSpriteSymbols("")).toEqual({});
+    expect(parseSpriteSymbols("<svg></svg>")).toEqual({});
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/fields/icon-sprite.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/icon-sprite.test.ts
@@ -32,6 +32,15 @@ describe("parseSpriteSymbols", () => {
     );
   });
 
+  test("tolerates a literal > inside a quoted attribute value", () => {
+    const map = parseSpriteSymbols(
+      '<svg><symbol id="X" data-label="a>b" viewBox="0 0 8 8"><circle /></symbol></svg>',
+    );
+    expect(map.X).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle /></svg>',
+    );
+  });
+
   test("skips symbols without an id", () => {
     const map = parseSpriteSymbols(
       '<svg><symbol viewBox="0 0 8 8"><circle /></symbol></svg>',

--- a/apps/mesh/src/web/components/sections-editor/fields/icon-sprite.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/icon-sprite.ts
@@ -1,0 +1,57 @@
+/**
+ * Icon-select previews from a site's SVG sprite sheet.
+ *
+ * Migrated deco sites ship their icon set as `public/sprites.svg` — a hidden
+ * `<svg>` of `<symbol id="…" viewBox="…">…</symbol>` elements, rendered at
+ * runtime via `<use href="/sprites.svg#id">`. The block-editor icon-select
+ * field reuses that same set for its previews: it fetches the sprite (through
+ * the same-origin preview proxy) and converts each `<symbol>` into a standalone
+ * `<svg>` string, which the combobox renders as a data-URI `<img>`.
+ *
+ * Each icon is rendered in isolation (its own data-URI document), so `clipPath`
+ * / gradient ids inside a symbol can't collide with another icon's — no id
+ * namespacing is needed.
+ */
+
+const attr = (attrs: string, name: string): string | undefined =>
+  attrs.match(new RegExp(`\\b${name}\\s*=\\s*"([^"]*)"`, "i"))?.[1];
+
+/**
+ * Parse a sprite sheet into a map of `symbol id → standalone <svg> markup`.
+ * Each `<symbol id="X" viewBox="V" fill="F">INNER</symbol>` becomes
+ * `<svg xmlns=… viewBox="V" fill="F">INNER</svg>`, preserving the symbol's own
+ * viewBox/fill (they vary per icon).
+ */
+export function parseSpriteSymbols(svgText: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (typeof svgText !== "string") return out;
+  const symbolRe = /<symbol\b([^>]*)>([\s\S]*?)<\/symbol>/gi;
+  for (const match of svgText.matchAll(symbolRe)) {
+    const attrs = match[1] ?? "";
+    const inner = match[2] ?? "";
+    const id = attr(attrs, "id");
+    if (!id) continue;
+    const viewBox = attr(attrs, "viewBox");
+    const fill = attr(attrs, "fill");
+    const svgAttrs = [
+      'xmlns="http://www.w3.org/2000/svg"',
+      viewBox ? `viewBox="${viewBox}"` : "",
+      fill ? `fill="${fill}"` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    out[id] = `<svg ${svgAttrs}>${inner}</svg>`;
+  }
+  return out;
+}
+
+/** Fetch a site's sprite sheet (via the preview proxy) and parse its symbols. */
+export async function fetchSpriteIcons(
+  url: string,
+): Promise<Record<string, string>> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch sprite sheet: ${res.status}`);
+  }
+  return parseSpriteSymbols(await res.text());
+}

--- a/apps/mesh/src/web/components/sections-editor/fields/icon-sprite.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/icon-sprite.ts
@@ -25,7 +25,11 @@ const attr = (attrs: string, name: string): string | undefined =>
 export function parseSpriteSymbols(svgText: unknown): Record<string, string> {
   const out: Record<string, string> = {};
   if (typeof svgText !== "string") return out;
-  const symbolRe = /<symbol\b([^>]*)>([\s\S]*?)<\/symbol>/gi;
+  // The attribute-list group tolerates a literal `>` inside a quoted attribute
+  // value (`"..."`/`'...'`) instead of stopping at the first `>`. The three
+  // alternatives are disjoint on their first char, so there's no backtracking.
+  const symbolRe =
+    /<symbol\b((?:[^>"']|"[^"]*"|'[^']*')*)>([\s\S]*?)<\/symbol>/gi;
   for (const match of svgText.matchAll(symbolRe)) {
     const attrs = match[1] ?? "";
     const inner = match[2] ?? "";

--- a/apps/mesh/src/web/components/sections-editor/preview-fetch-url.ts
+++ b/apps/mesh/src/web/components/sections-editor/preview-fetch-url.ts
@@ -30,15 +30,28 @@ function readPreviewUrlFromDocument(): string | null {
   return null;
 }
 
-export function buildDecofileFetchUrl(input: DecofileFetchInput): string {
+/**
+ * URL for a whitelisted public preview asset. Browser-reachable local previews
+ * are hit directly (they allow CORS `*`); cloud previews go through the
+ * same-origin `preview-fetch` proxy (which allows `/.decofile` and
+ * `/sprites.svg`). `assetPath` must be one the proxy whitelists.
+ */
+export function buildPreviewFetchUrl(
+  input: DecofileFetchInput,
+  assetPath: string,
+): string {
   const browserPreviewUrl =
     input.previewUrl ??
     input.getFallbackPreviewUrl?.() ??
     readPreviewUrlFromDocument();
   if (browserPreviewUrl && isBrowserReachableLocalPreview(browserPreviewUrl)) {
-    return new URL("/.decofile", browserPreviewUrl).toString();
+    return new URL(assetPath, browserPreviewUrl).toString();
   }
 
-  const search = new URLSearchParams({ path: "/.decofile" });
+  const search = new URLSearchParams({ path: assetPath });
   return `/api/${input.orgSlug}/sandbox/${encodeURIComponent(input.virtualMcpId)}/${encodeURIComponent(input.branch)}/preview-fetch?${search.toString()}`;
+}
+
+export function buildDecofileFetchUrl(input: DecofileFetchInput): string {
+  return buildPreviewFetchUrl(input, "/.decofile");
 }

--- a/apps/mesh/src/web/components/sections-editor/schema-form.tsx
+++ b/apps/mesh/src/web/components/sections-editor/schema-form.tsx
@@ -244,11 +244,13 @@ export function renderField(props: FieldProps) {
     return <MapField key={props.path} {...props} />;
   }
 
-  // dynamic-options / icon-select → DynamicOptionsField (select with options
-  // from a loader; icon-select options carry an inline-SVG preview)
+  // dynamic-options / icon-select → DynamicOptionsField.
+  // dynamic-options needs an `@options` loader; icon-select draws its list from
+  // the schema enum and its previews from the site's `/sprites.svg`, so it
+  // routes here even when the (now-deleted) `availableIcons` loader is absent.
   if (
-    (schema.format === "dynamic-options" || schema.format === "icon-select") &&
-    schema.options
+    schema.format === "icon-select" ||
+    (schema.format === "dynamic-options" && schema.options)
   ) {
     return <DynamicOptionsField key={props.path} {...props} />;
   }

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -523,6 +523,9 @@ export const KEYS = {
     ["sandbox-invoke", sandboxKey, loaderKey] as const,
   sandboxRepoDir: (orgSlug: string, virtualMcpId: string, branch: string) =>
     ["sandbox-repo-dir", orgSlug, virtualMcpId, branch] as const,
+  // icon-select previews: the site's /sprites.svg, fetched via the preview proxy
+  sandboxSprite: (sandboxKey: string) =>
+    ["sandbox-sprite", sandboxKey] as const,
 
   // Link daemon status (user-scoped; the cluster derives the userSub
   // from the bearer session, so we don't include it in the key).


### PR DESCRIPTION
## Summary

Follow-up to #5087. The block-editor **icon-select** picker showed only icon **names as text** — the `availableIcons` options loader is deleted during the TanStack migration, so its hard-coded `@options` resolveType 404s, and #5087 fell back to the schema `enum` as text.

This restores the **SVG previews**, per-site, with **no vendored icon set** and **no client-repo/migration changes** — by reusing each site's own `public/sprites.svg` (the sprite the migration already ships and renders at runtime via `Icon.tsx`).

## How

The sprite is public but served by the Cloudflare Assets binding **without a CORS header**, so the admin browser can't read it cross-origin. We fetch it **server-side** instead (the sprite is public → no auth needed):

- **Server:** the existing `preview-fetch` proxy now whitelists `/sprites.svg` (alongside `/.decofile`). The preview URL is still **derived server-side from the authed claim** (never a client param) → SSRF-safe.
- **Client (`icon-select`):** fetch the sprite through that proxy (same-origin), parse each `<symbol id viewBox fill>…</symbol>` into a standalone `<svg>` (`icon-sprite.ts`), and attach it to the enum-derived options. Rendered via the **existing data-URI `<img>`** path (each icon is its own document, so `clipPath`/gradient ids can't collide). Falls back to the text list when there's no sprite/preview.
- Route `format: "icon-select"` to `DynamicOptionsField` even without an `@options` loader (list = enum, previews = sprite); the dead loader is no longer fetched for icon-select.
- `/sprites.svg` 404 is treated as a benign preview probe (no error noise).

## Why this shape

Earlier I explored putting the loader back in `@decocms/apps-website` — that leaked a client's private icon set into a public repo and was unnecessary. This approach uses each site's **own** assets, works for **any** migrated site immediately, and touches only the Studio.

## Testing

- Unit: `icon-sprite.test.ts` (sprite → standalone-svg parsing, edge cases) + `fetch.test.ts` (benign `/sprites.svg` 404).
- `bun run check` clean; `bun run lint` no new warnings; `bun test` sections-editor suite 514 pass.
- Behavior: loader-less icon-select now shows SVG previews from the site sprite; no sprite/preview → text list (unchanged from #5087).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore SVG previews in the sections-editor `icon-select` by reading each site’s `public/sprites.svg` through a secure server proxy, keeping loader-based sites working and falling back to text when no sprite is present. Adds theme-aware previews with minimal extra network work and supports both runtimes.

- New Features
  - Show per-site icon previews by fetching `/sprites.svg` via `preview-fetch`, parsing `<symbol>` into standalone `<svg>`, and rendering via data-URI.
  - Cross-runtime: `@options` loader → use it; else schema `enum` + sprite previews; else enum-only text. Route `icon-select` to `DynamicOptionsField` even without a loader. Added `buildPreviewFetchUrl` and `sandboxSprite` query key.
  - Perf: fetch the sprite only after the loader settles empty; pre-encode sprite icons once; read `--foreground` once per render.

- Bug Fixes
  - Whitelist `/.decofile` and `/sprites.svg` in `preview-fetch`; server-derived preview URL avoids CORS and stays SSRF-safe.
  - Treat `/sprites.svg` 404 as a benign probe; render `currentColor` icons using the `--foreground` token for dark mode; make sprite parsing robust to a literal `>` inside quoted attributes.

<sup>Written for commit 20c2007a261d74ba7bdc8691f44a7fcb45afd1bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

