### PR TITLE
feat(sandbox): resilient path-param picker with homepage-link discovery

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -774,7 +774,17 @@ export const createSandboxRoutes = () => {
 
     const { claimName } = c.get("vmClaim");
     const path = c.req.query("path");
-    if (path !== "/.decofile") {
+    // Only same-origin sandbox paths (the iframe already loads this origin):
+    // `/.decofile` (block state) and any storefront page (`/`, `/granado/...`)
+    // whose SSR HTML the path-param picker scrapes for category/product links.
+    // Reject anything that could escape the origin (protocol-relative, traversal).
+    if (
+      !path ||
+      !path.startsWith("/") ||
+      path.startsWith("//") ||
+      path.includes("..") ||
+      path.includes("\\")
+    ) {
       return c.json({ error: "Path not allowed" }, 403);
     }
 

--- a/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
+++ b/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
@@ -32,9 +32,10 @@ export function buildPreviewInvokePath(ref: RunBlockSandboxRef): string {
 /**
  * Studio proxy path for a preview GET fetch:
  * `GET /api/:org/sandbox/:virtualMcpId/:branch/preview-fetch?path=<path>`.
- * The proxy fetches `<preview><path>` server-side (only an allowlisted set of
- * paths — `/.decofile`, `/`) so the browser stays out of CORS. Used to read the
- * site's homepage HTML for link-based entity discovery.
+ * The proxy fetches `<preview><path>` server-side so the browser stays out of
+ * CORS. `path` may be any same-origin path that can't escape the origin (the
+ * proxy rejects protocol-relative / traversal); used to read the site's
+ * homepage and listing HTML for link-based entity discovery.
  */
 export function buildPreviewFetchPath(
   ref: RunBlockSandboxRef,

--- a/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
+++ b/apps/mesh/src/web/components/sandbox/content/use-run-block.ts
@@ -30,6 +30,21 @@ export function buildPreviewInvokePath(ref: RunBlockSandboxRef): string {
 }
 
 /**
+ * Studio proxy path for a preview GET fetch:
+ * `GET /api/:org/sandbox/:virtualMcpId/:branch/preview-fetch?path=<path>`.
+ * The proxy fetches `<preview><path>` server-side (only an allowlisted set of
+ * paths — `/.decofile`, `/`) so the browser stays out of CORS. Used to read the
+ * site's homepage HTML for link-based entity discovery.
+ */
+export function buildPreviewFetchPath(
+  ref: RunBlockSandboxRef,
+  path: string,
+): string {
+  const base = `/api/${ref.orgSlug}/sandbox/${encodeURIComponent(ref.virtualMcpId)}/${encodeURIComponent(ref.branch)}/preview-fetch`;
+  return `${base}?path=${encodeURIComponent(path)}`;
+}
+
+/**
  * Build the invoke URL for "Open result in new tab": a top-level GET
  * navigation to `<preview>/deco/invoke/<resolveType>` with the resolveType RAW
  * in the path (slashes intact). A navigation can't POST, so props ride in the

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-input.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-input.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import { CornerDownLeft } from "@untitledui/icons";
+import { stripSurroundingSlashes } from "@/web/components/sections-editor/page-path-utils";
 import { useT } from "@/web/i18n/use-t.ts";
 
 /**
@@ -57,8 +58,10 @@ export function PathParamInput({
               return;
             }
             // Blank values are not accepted: clearing the input reverts to the
-            // bare `:param` token (placeholder) and the template URL.
-            const next = draft.trim();
+            // bare `:param` token (placeholder) and the template URL. Surrounding
+            // slashes are stripped (the template supplies the leading `/`), so a
+            // pasted `/perfumaasdria/colonia` commits as `perfumaasdria/colonia`.
+            const next = stripSurroundingSlashes(draft);
             setDraft(next);
             if (next !== value) onCommit(next);
           }}

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
@@ -105,7 +105,10 @@ async function fetchSiteLinkOptions(
   ctx: OptionPayloadContext,
 ): Promise<PathParamOption[]> {
   const home = source.optionsFromPayload(await fetchPreviewPage(ref, "/"), ctx);
-  const firstListing = home[0];
+  // Drill into the first CATEGORY (a listing page whose SSR embeds shelf
+  // products) — not home[0], which is a product when the homepage embeds shelves
+  // (products are emitted before categories), and a PDP has no shelf to scrape.
+  const firstListing = home.find((o) => o.kind === "category");
   if (!firstListing) return home;
   const listingPath = fillPathTemplate(ctx.template, {
     [ctx.paramName]: firstListing.value,
@@ -288,35 +291,54 @@ export function PathParamPickerChip({
   });
 
   const ctx: OptionPayloadContext = { template, paramName };
-  // All sources queried at chip level so we can decide which to render; every
-  // group shares its cache key with PathParamAutoFill (no duplicate fetch).
-  const queries = useQueries({
-    queries: sources.map((source) =>
+  const toState = (
+    source: OptionSource,
+    query: { data?: PathParamOption[]; isLoading: boolean; isError: boolean },
+  ) => ({
+    source,
+    query,
+    options: source.clientFilter
+      ? filterPickerOptions(query.data ?? [], search)
+      : (query.data ?? []),
+  });
+
+  // Primaries are queried on open; fallbacks (the homepage-links source) are
+  // only queried once the primaries have settled with no options — so opening
+  // the picker on a healthy loader-backed page never fires the homepage fetch.
+  const primarySources = sources.filter((s) => !s.isFallback);
+  const fallbackSources = sources.filter((s) => s.isFallback);
+  const primaryQueries = useQueries({
+    queries: primarySources.map((source) =>
       pickerQuery(sandboxRef, source, debouncedSearch, ctx, open),
     ),
   });
-  const states = sources.map((source, i) => {
-    const query = queries[i]!;
-    const options = source.clientFilter
-      ? filterPickerOptions(query.data ?? [], search)
-      : (query.data ?? []);
-    return { source, query, options };
-  });
-
-  // Fallbacks (e.g. the homepage-links source) REPLACE the primaries once every
-  // primary has settled with no options (or there are none) — so a loader's
-  // "couldn't load" / empty result quietly gives way to the fallback instead of
-  // rendering alongside it. While primaries have options (or are still loading),
-  // only they show.
-  const primaries = states.filter((s) => !s.source.isFallback);
+  const primaryStates = primarySources.map((source, i) =>
+    toState(source, primaryQueries[i]!),
+  );
   const primariesExhausted =
-    primaries.length === 0 ||
-    primaries.every(
+    primaryStates.length === 0 ||
+    primaryStates.every(
       (s) => !s.query.isLoading && (s.query.isError || s.options.length === 0),
     );
-  const visible = states.filter((s) =>
-    s.source.isFallback ? primariesExhausted : !primariesExhausted,
+  const fallbackQueries = useQueries({
+    queries: fallbackSources.map((source) =>
+      pickerQuery(
+        sandboxRef,
+        source,
+        debouncedSearch,
+        ctx,
+        open && primariesExhausted,
+      ),
+    ),
+  });
+  const fallbackStates = fallbackSources.map((source, i) =>
+    toState(source, fallbackQueries[i]!),
   );
+
+  // Fallbacks REPLACE the primaries once every primary has settled with no
+  // options (or there are none) — a loader's "couldn't load" / empty result
+  // quietly gives way to the fallback instead of rendering alongside it.
+  const visible = primariesExhausted ? fallbackStates : primaryStates;
 
   // The homepage-links source carries both categories and products. When it's
   // the sole view and both are present, lay them out side by side (Categorias |

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
@@ -1,5 +1,5 @@
-import { useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { Fragment, useRef, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
 import { ArrowRight, SearchSm } from "@untitledui/icons";
 import {
   Command,
@@ -15,10 +15,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
-import { fillPathTemplate } from "@/web/components/sections-editor/page-path-utils";
+import {
+  fillPathTemplate,
+  stripSurroundingSlashes,
+} from "@/web/components/sections-editor/page-path-utils";
 import { KEYS } from "@/web/lib/query-keys";
 import { useT } from "@/web/i18n/use-t.ts";
 import {
+  buildPreviewFetchPath,
   buildPreviewInvokePath,
   type RunBlockSandboxRef,
 } from "@/web/components/sandbox/content/use-run-block";
@@ -72,6 +76,54 @@ async function invokeLoader(
 }
 
 /**
+ * Fetch a storefront page's SSR HTML through the preview-fetch proxy
+ * (same-origin, server-side — the preview origin isn't CORS-reachable). Used by
+ * the homepage-links fallback source to discover real category/product URLs.
+ */
+async function fetchPreviewPage(
+  ref: RunBlockSandboxRef,
+  path: string,
+): Promise<string> {
+  const res = await fetch(buildPreviewFetchPath(ref, path), {
+    signal: AbortSignal.timeout(PICKER_FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch page: ${res.status}`);
+  }
+  return res.text();
+}
+
+/**
+ * Discover options for the homepage-links source. The homepage yields the nav
+ * categories, but its (cookie-less) SSR often omits shelf products — so we drill
+ * into the first discovered listing, whose SSR embeds the product JSON, and
+ * merge. Two fetches at most; a failed drill-in still returns the categories.
+ */
+async function fetchSiteLinkOptions(
+  ref: RunBlockSandboxRef,
+  source: OptionSource,
+  ctx: OptionPayloadContext,
+): Promise<PathParamOption[]> {
+  const home = source.optionsFromPayload(await fetchPreviewPage(ref, "/"), ctx);
+  const firstListing = home[0];
+  if (!firstListing) return home;
+  const listingPath = fillPathTemplate(ctx.template, {
+    [ctx.paramName]: firstListing.value,
+  });
+  if (listingPath === "/") return home;
+  try {
+    // The listing page contributes PRODUCTS only — categories stay the clean
+    // homepage nav, not the drilled page's (much longer) subcategory list.
+    const products = source
+      .optionsFromPayload(await fetchPreviewPage(ref, listingPath), ctx)
+      .filter((o) => o.kind === "product");
+    return mergePickerOptions([home, products]);
+  } catch {
+    return home;
+  }
+}
+
+/**
  * react-query key for a source + term. clientFilter sources fetch once (whole
  * tree, filtered locally) so their key ignores the term; both the chip's modal
  * query and preview.tsx's auto-fill query use this, sharing one cache entry.
@@ -89,8 +141,9 @@ function pickerInvokeKey(
 
 /**
  * Fetch and map options for one source. A term can fan out to several loader
- * calls (e.g. product ids + name query); they run in parallel and merge in
- * order, deduped. Partial failures are tolerated as long as one call succeeds.
+ * calls (e.g. product ids + name query, or the generic-seed variants); they run
+ * in parallel and merge in order, deduped. Partial failures are tolerated as
+ * long as one call succeeds.
  */
 async function fetchOptions(
   ref: RunBlockSandboxRef,
@@ -98,7 +151,10 @@ async function fetchOptions(
   term: string,
   ctx: OptionPayloadContext,
 ): Promise<PathParamOption[]> {
-  const requests = source.buildRequests(term);
+  if (source.homepageLinks) {
+    return fetchSiteLinkOptions(ref, source, ctx);
+  }
+  const requests = source.buildRequests?.(term) ?? [];
   if (requests.length === 0) return [];
   const settled = await Promise.allSettled(
     requests.map((request) => invokeLoader(ref, request)),
@@ -119,91 +175,80 @@ async function fetchOptions(
   );
 }
 
-/** One source's fetched options rendered as a labelled command group. */
-function PickerSourceGroup({
-  source,
-  sandboxRef,
-  template,
-  paramName,
-  open,
-  search,
-  debouncedSearch,
-  showHeading,
-  onSelect,
-}: {
-  source: OptionSource;
-  sandboxRef: RunBlockSandboxRef;
-  template: string;
-  paramName: string;
-  open: boolean;
-  search: string;
-  debouncedSearch: string;
-  showHeading: boolean;
-  onSelect: (value: string) => void;
-}) {
-  const t = useT();
-  const query = useQuery({
-    queryKey: pickerInvokeKey(sandboxRef, source, debouncedSearch),
-    queryFn: () =>
-      fetchOptions(sandboxRef, source, debouncedSearch, {
-        template,
-        paramName,
-      }),
-    enabled: open,
+/** query options shared by the chip's modal and the headless auto-fill. */
+function pickerQuery(
+  ref: RunBlockSandboxRef,
+  source: OptionSource,
+  term: string,
+  ctx: OptionPayloadContext,
+  enabled: boolean,
+) {
+  return {
+    queryKey: pickerInvokeKey(ref, source, term),
+    queryFn: () => fetchOptions(ref, source, term, ctx),
+    enabled,
     staleTime: 60_000,
     retry: 1,
-  });
+  };
+}
 
-  const { noun, heading } = kindLabels(t)[source.kind];
-  const options = source.clientFilter
-    ? filterPickerOptions(query.data ?? [], search)
-    : (query.data ?? []);
-
-  const status = query.isLoading
-    ? t("sandbox.pathParamPickerChip.loading", { noun })
-    : query.isError
-      ? t("sandbox.pathParamPickerChip.couldNotLoad")
-      : null;
-
-  if (!status && options.length === 0) return null;
-
+/** A labelled list of options (presentational). Renders nothing when empty. */
+function OptionGroup({
+  heading,
+  iconKind,
+  options,
+  template,
+  paramName,
+  keyPrefix,
+  onSelect,
+}: {
+  heading?: string;
+  iconKind: PathParamKind;
+  options: PathParamOption[];
+  template: string;
+  paramName: string;
+  keyPrefix: string;
+  onSelect: (value: string) => void;
+}) {
+  if (options.length === 0) return null;
   return (
-    <CommandGroup heading={showHeading ? heading : undefined}>
-      {status ? (
-        <div className="px-2 py-2 text-xs text-muted-foreground">{status}</div>
-      ) : (
-        options.map((opt) => (
-          <CommandItem
-            key={`${source.id}:${opt.value}`}
-            value={`${source.id}:${opt.value}`}
-            className="gap-3 py-2"
-            onSelect={() => onSelect(opt.value)}
-          >
-            {source.kind === "product" && (
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-muted">
-                {opt.image ? (
-                  <img
-                    src={opt.image}
-                    alt=""
-                    referrerPolicy="no-referrer"
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <SearchSm size={14} className="text-muted-foreground" />
-                )}
-              </span>
-            )}
-            <span className="min-w-0 flex-1">
-              <span className="block truncate text-sm">{opt.label}</span>
-              <span className="block truncate text-xs text-muted-foreground">
-                {fillPathTemplate(template, { [paramName]: opt.value })}
-              </span>
+    <CommandGroup heading={heading}>
+      {options.map((opt) => (
+        <CommandItem
+          key={`${keyPrefix}:${opt.value}`}
+          value={`${keyPrefix}:${opt.value}`}
+          className="gap-3 py-2"
+          onSelect={() => onSelect(opt.value)}
+        >
+          {iconKind === "product" && (
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border bg-muted">
+              {opt.image ? (
+                <img
+                  src={opt.image}
+                  alt=""
+                  referrerPolicy="no-referrer"
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <SearchSm size={14} className="text-muted-foreground" />
+              )}
             </span>
-          </CommandItem>
-        ))
-      )}
+          )}
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-sm">{opt.label}</span>
+            <span className="block truncate text-xs text-muted-foreground">
+              {fillPathTemplate(template, { [paramName]: opt.value })}
+            </span>
+          </span>
+        </CommandItem>
+      ))}
     </CommandGroup>
   );
+}
+
+/** Loading / error status line for a source's query. */
+function StatusRow({ text }: { text: string }) {
+  return <div className="px-2 py-2 text-xs text-muted-foreground">{text}</div>;
 }
 
 /**
@@ -242,6 +287,57 @@ export function PathParamPickerChip({
     options: nouns.join(" or "),
   });
 
+  const ctx: OptionPayloadContext = { template, paramName };
+  // All sources queried at chip level so we can decide which to render; every
+  // group shares its cache key with PathParamAutoFill (no duplicate fetch).
+  const queries = useQueries({
+    queries: sources.map((source) =>
+      pickerQuery(sandboxRef, source, debouncedSearch, ctx, open),
+    ),
+  });
+  const states = sources.map((source, i) => {
+    const query = queries[i]!;
+    const options = source.clientFilter
+      ? filterPickerOptions(query.data ?? [], search)
+      : (query.data ?? []);
+    return { source, query, options };
+  });
+
+  // Fallbacks (e.g. the homepage-links source) REPLACE the primaries once every
+  // primary has settled with no options (or there are none) — so a loader's
+  // "couldn't load" / empty result quietly gives way to the fallback instead of
+  // rendering alongside it. While primaries have options (or are still loading),
+  // only they show.
+  const primaries = states.filter((s) => !s.source.isFallback);
+  const primariesExhausted =
+    primaries.length === 0 ||
+    primaries.every(
+      (s) => !s.query.isLoading && (s.query.isError || s.options.length === 0),
+    );
+  const visible = states.filter((s) =>
+    s.source.isFallback ? primariesExhausted : !primariesExhausted,
+  );
+
+  // The homepage-links source carries both categories and products. When it's
+  // the sole view and both are present, lay them out side by side (Categorias |
+  // Produtos); otherwise fall back to the stacked single-column rendering.
+  const siteState =
+    visible.length === 1 && visible[0]?.source.homepageLinks
+      ? visible[0]
+      : null;
+  const siteReady =
+    siteState && !siteState.query.isLoading && !siteState.query.isError;
+  const siteData = siteReady ? (siteState?.query.data ?? []) : [];
+  const siteCats = filterPickerOptions(
+    siteData.filter((o) => o.kind !== "product"),
+    search,
+  );
+  const siteProds = filterPickerOptions(
+    siteData.filter((o) => o.kind === "product"),
+    search,
+  );
+  const twoColumn = siteCats.length > 0 && siteProds.length > 0;
+
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -266,7 +362,7 @@ export function PathParamPickerChip({
 
   // Strip surrounding slashes so a typed `/sabonetes/x` fills as `sabonetes/x`
   // (the template supplies the leading slash; a `*` value keeps inner slashes).
-  const rawTerm = search.trim().replace(/^\/+|\/+$/g, "");
+  const rawTerm = stripSurroundingSlashes(search);
   const rawPath = fillPathTemplate(template, { [paramName]: rawTerm });
 
   return (
@@ -317,12 +413,12 @@ export function PathParamPickerChip({
               value={search}
               onValueChange={handleSearchChange}
             />
-            <CommandList className="max-h-none flex-1">
+            <CommandList className="flex max-h-none min-h-0 flex-1 flex-col overflow-hidden">
               <CommandEmpty>
                 {t("sandbox.pathParamPickerChip.noResults")}
               </CommandEmpty>
               {rawTerm && (
-                <CommandGroup>
+                <CommandGroup className="shrink-0">
                   <CommandItem
                     value={`__raw__:${rawTerm}`}
                     className="gap-3 py-2"
@@ -345,20 +441,104 @@ export function PathParamPickerChip({
                   </CommandItem>
                 </CommandGroup>
               )}
-              {sources.map((source) => (
-                <PickerSourceGroup
-                  key={source.id}
-                  source={source}
-                  sandboxRef={sandboxRef}
-                  template={template}
-                  paramName={paramName}
-                  open={open}
-                  search={search}
-                  debouncedSearch={debouncedSearch}
-                  showHeading={sources.length > 1}
-                  onSelect={commit}
-                />
-              ))}
+              {twoColumn ? (
+                // Categories | Products, side by side, each scrolling on its own.
+                <div className="flex min-h-0 flex-1">
+                  <div className="min-w-0 flex-1 overflow-y-auto border-r border-border">
+                    <OptionGroup
+                      heading={labels.category.heading}
+                      iconKind="category"
+                      options={siteCats}
+                      template={template}
+                      paramName={paramName}
+                      keyPrefix={`${siteState?.source.id}:cat`}
+                      onSelect={commit}
+                    />
+                  </div>
+                  <div className="min-w-0 flex-1 overflow-y-auto">
+                    <OptionGroup
+                      heading={labels.product.heading}
+                      iconKind="product"
+                      options={siteProds}
+                      template={template}
+                      paramName={paramName}
+                      keyPrefix={`${siteState?.source.id}:prod`}
+                      onSelect={commit}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  {visible.map(({ source, query, options }) => {
+                    const { noun } = labels[source.kind];
+                    if (query.isLoading)
+                      return (
+                        <StatusRow
+                          key={source.id}
+                          text={t("sandbox.pathParamPickerChip.loading", {
+                            noun,
+                          })}
+                        />
+                      );
+                    if (query.isError)
+                      return (
+                        <StatusRow
+                          key={source.id}
+                          text={t("sandbox.pathParamPickerChip.couldNotLoad")}
+                        />
+                      );
+                    // Homepage-links source with only one kind present: render
+                    // the non-empty group single-column (two-column handled above).
+                    if (source.homepageLinks) {
+                      const all = query.data ?? [];
+                      return (
+                        <Fragment key={source.id}>
+                          <OptionGroup
+                            heading={labels.category.heading}
+                            iconKind="category"
+                            options={filterPickerOptions(
+                              all.filter((o) => o.kind !== "product"),
+                              search,
+                            )}
+                            template={template}
+                            paramName={paramName}
+                            keyPrefix={`${source.id}:cat`}
+                            onSelect={commit}
+                          />
+                          <OptionGroup
+                            heading={labels.product.heading}
+                            iconKind="product"
+                            options={filterPickerOptions(
+                              all.filter((o) => o.kind === "product"),
+                              search,
+                            )}
+                            template={template}
+                            paramName={paramName}
+                            keyPrefix={`${source.id}:prod`}
+                            onSelect={commit}
+                          />
+                        </Fragment>
+                      );
+                    }
+                    return (
+                      <OptionGroup
+                        key={source.id}
+                        heading={
+                          visible.length > 1
+                            ? labels[source.kind].heading
+                            : undefined
+                        }
+                        iconKind={source.kind}
+                        options={options}
+                        template={template}
+                        paramName={paramName}
+                        keyPrefix={source.id}
+                        onSelect={commit}
+                      />
+                    );
+                  })}
+                </div>
+              )}
             </CommandList>
           </Command>
         </DialogContent>
@@ -370,39 +550,51 @@ export function PathParamPickerChip({
 /**
  * Renders nothing; fetches the first option for a picker param that has no
  * value yet and commits it, so navigating to a bare dynamic-route template
- * lands on a real entity instead of an empty page. Mounted by preview.tsx only
- * while the param is empty (unmounts the instant the value is filled), so it
- * never overwrites a user/restored value and can't loop. Shares the chip's
- * react-query cache (same key/fetch).
+ * lands on a real entity instead of an empty page. Tries the ordered sources
+ * in priority order (waiting for a higher-priority source before falling to a
+ * lower one), so a failing category tree gives way to product search. Mounted
+ * by preview.tsx only while the param is empty (unmounts the instant the value
+ * is filled), so it never overwrites a user/restored value and can't loop.
+ * Shares the chip's react-query cache (same key/fetch).
  */
 export function PathParamAutoFill({
-  source,
+  sources,
   template,
   paramName,
   sandboxRef,
   onFill,
 }: {
-  source: OptionSource;
+  sources: OptionSource[];
   template: string;
   paramName: string;
   sandboxRef: RunBlockSandboxRef;
   onFill: (value: string) => void;
 }) {
-  const query = useQuery({
-    queryKey: pickerInvokeKey(sandboxRef, source, ""),
-    queryFn: () =>
-      fetchOptions(sandboxRef, source, "", { template, paramName }),
-    staleTime: 60_000,
-    retry: 1,
+  const ctx: OptionPayloadContext = { template, paramName };
+  // Only PRIMARY sources auto-fill: a fallback (e.g. product search standing in
+  // for a category param) must never silently commit — that would drop a product
+  // slug into a Category param and land on the wrong page. A fallback only
+  // surfaces when the user opens the modal and the primaries came up empty.
+  const primarySources = sources.filter((source) => !source.isFallback);
+  const queries = useQueries({
+    queries: primarySources.map((source) =>
+      pickerQuery(sandboxRef, source, "", ctx, true),
+    ),
   });
   // Render-time guard (the codebase's run-once pattern). Setting own state
   // during render is allowed; the parent commit is deferred to a microtask so
   // it doesn't update a different component mid-render.
   const [filled, setFilled] = useState(false);
-  if (!filled && query.data && query.data.length > 0) {
-    setFilled(true);
-    const value = query.data[0]!.value;
-    queueMicrotask(() => onFill(value));
+  if (!filled) {
+    for (const query of queries) {
+      if (query.isLoading) break; // wait for a higher-priority source
+      const first = query.data?.[0];
+      if (first) {
+        setFilled(true);
+        queueMicrotask(() => onFill(first.value));
+        break;
+      }
+    }
   }
   return null;
 }

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker.test.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, test } from "bun:test";
+import { stripSurroundingSlashes } from "@/web/components/sections-editor/page-path-utils";
 import {
   categoryOptionsFromPayload,
   classifyParamKinds,
   collectPageLoaderResolveTypes,
   commercePlatformsFromLoaders,
   filterPickerOptions,
+  GENERIC_SEED_TERMS,
+  linkOptionsFromHtml,
   mergePickerOptions,
+  parseEmbeddedProducts,
+  parseHomepageAnchors,
   productOptionsFromPayload,
   resolveOptionSources,
+  SITE_LINKS_SOURCE_ID,
   valueFromEntityUrl,
   type PathParamKind,
 } from "./path-param-picker";
@@ -104,11 +110,11 @@ describe("resolveOptionSources", () => {
       kinds("product"),
       new Set([VTEX_PRODUCT]),
     );
-    expect(source?.buildRequests("123")).toEqual([
+    expect(source?.buildRequests?.("123")).toEqual([
       { resolveType: VTEX_PRODUCT, props: { ids: ["123"] } },
       { resolveType: VTEX_PRODUCT, props: { query: "123", count: 10 } },
     ]);
-    expect(source?.buildRequests("torrada-multigraos")).toEqual([
+    expect(source?.buildRequests?.("torrada-multigraos")).toEqual([
       {
         resolveType: VTEX_PRODUCT,
         props: { query: "torrada multigraos", count: 10 },
@@ -122,7 +128,7 @@ describe("resolveOptionSources", () => {
       new Set([ALGOLIA_LIST]),
     );
     expect(source?.resolveType).toBe(ALGOLIA_LIST);
-    expect(source?.buildRequests("torrada")).toEqual([
+    expect(source?.buildRequests?.("torrada")).toEqual([
       {
         resolveType: ALGOLIA_LIST,
         props: { term: "torrada", hitsPerPage: 10 },
@@ -145,7 +151,7 @@ describe("resolveOptionSources", () => {
     );
     expect(source?.kind).toBe("category");
     expect(source?.clientFilter).toBe(true);
-    expect(source?.buildRequests("anything")).toEqual([
+    expect(source?.buildRequests?.("anything")).toEqual([
       { resolveType: VTEX_TREE, props: {} },
     ]);
   });
@@ -160,7 +166,7 @@ describe("resolveOptionSources", () => {
       new Set(["magento"]),
     );
     expect(product?.resolveType).toBe(magentoList);
-    expect(product?.buildRequests("sabonete")).toEqual([
+    expect(product?.buildRequests?.("sabonete")).toEqual([
       {
         resolveType: magentoList,
         props: { props: { search: "sabonete", pageSize: 10, currentPage: 1 } },
@@ -170,8 +176,8 @@ describe("resolveOptionSources", () => {
 
   test("skips a competing vendor's loader for the page's platform", () => {
     // Magento store that also has the VTEX app installed: product must resolve
-    // to the neutral Algolia loader, NOT vtex; category must NOT invoke a vtex
-    // category-tree loader that merely exists in the manifest.
+    // to the neutral Algolia loader, NOT vtex; a competing vtex category-tree
+    // loader must NOT bind — leaving only the universal homepage-links fallback.
     const magento = new Set(["magento"]);
     const [product] = resolveOptionSources(
       kinds("product"),
@@ -179,13 +185,12 @@ describe("resolveOptionSources", () => {
       magento,
     );
     expect(product?.resolveType).toBe(ALGOLIA_LIST);
-    expect(
-      resolveOptionSources(
-        kinds("category"),
-        new Set(["vtex/loaders/catalog/getCategoryTree"]),
-        magento,
-      ),
-    ).toEqual([]);
+    const category = resolveOptionSources(
+      kinds("category"),
+      new Set(["vtex/loaders/catalog/getCategoryTree"]),
+      magento,
+    );
+    expect(category.map((s) => s.id)).toEqual([SITE_LINKS_SOURCE_ID]);
   });
 
   test("commercePlatformsFromLoaders picks vendor namespaces only", () => {
@@ -199,14 +204,239 @@ describe("resolveOptionSources", () => {
     ).toEqual(new Set(["magento"]));
   });
 
-  test("a kind with no available loader yields no source", () => {
-    // Granado: product (Algolia) resolves, category has no tree loader.
+  test("every classified param gets a homepage-links fallback appended", () => {
     const sources = resolveOptionSources(
-      kinds("product", "category"),
-      new Set([ALGOLIA_LIST]),
+      kinds("product"),
+      new Set([VTEX_PRODUCT]),
     );
-    expect(sources.map((s) => s.kind)).toEqual(["product"]);
-    expect(resolveOptionSources(kinds("product"), new Set())).toEqual([]);
+    expect(sources.map((s) => [s.kind, s.isFallback])).toEqual([
+      ["product", false],
+      ["product", true],
+    ]);
+    const links = sources[1]!;
+    expect(links.id).toBe(SITE_LINKS_SOURCE_ID);
+    expect(links.homepageLinks).toBe(true);
+    expect(links.clientFilter).toBe(true);
+  });
+
+  test("category with a tree loader keeps it primary; homepage-links is fallback", () => {
+    // Bagaggio: the tree binds; homepage links ride along, rendered only if the
+    // tree comes up empty/errored (decided in the chip).
+    const sources = resolveOptionSources(
+      kinds("category"),
+      new Set([VTEX_TREE]),
+    );
+    expect(
+      sources.map((s) => [s.kind, s.isFallback, Boolean(s.homepageLinks)]),
+    ).toEqual([
+      ["category", false, false],
+      ["category", true, true],
+    ]);
+    expect(sources[0]?.clientFilter).toBe(true);
+  });
+
+  test("category with no tree loader → only the homepage-links fallback", () => {
+    // Granado catch-all classified `category`, no tree loader available: the
+    // modal still appears, backed by homepage-link discovery.
+    const sources = resolveOptionSources(kinds("category"), new Set());
+    expect(sources.map((s) => s.id)).toEqual([SITE_LINKS_SOURCE_ID]);
+    expect(sources[0]?.kind).toBe("category");
+  });
+
+  test("a param with no matching loader still gets the fallback (never empty)", () => {
+    expect(
+      resolveOptionSources(kinds("product"), new Set()).map((s) => s.id),
+    ).toEqual([SITE_LINKS_SOURCE_ID]);
+    // An unclassified param gets nothing (keeps the plain free-text input).
+    expect(resolveOptionSources(new Set(), new Set([VTEX_PRODUCT]))).toEqual(
+      [],
+    );
+  });
+
+  test("empty term seeds product search with generic color terms", () => {
+    const [source] = resolveOptionSources(
+      kinds("product"),
+      new Set([VTEX_PRODUCT]),
+    );
+    const requests = source!.buildRequests!("");
+    expect(requests).toHaveLength(GENERIC_SEED_TERMS.length);
+    expect(requests.map((r) => r.props.query)).toEqual(GENERIC_SEED_TERMS);
+    // A real user term is used verbatim (no seeding).
+    expect(source!.buildRequests!("mochila")).toEqual([
+      { resolveType: VTEX_PRODUCT, props: { query: "mochila", count: 10 } },
+    ]);
+  });
+
+  test("empty term seeds the Magento search loader too", () => {
+    const magentoList = "magento/loaders/product/list.ts";
+    const [source] = resolveOptionSources(
+      kinds("product"),
+      new Set([magentoList]),
+      new Set(["magento"]),
+    );
+    const requests = source!.buildRequests!("");
+    expect(requests).toHaveLength(GENERIC_SEED_TERMS.length);
+    expect(requests[0]).toEqual({
+      resolveType: magentoList,
+      props: { props: { search: "rosa", pageSize: 10, currentPage: 1 } },
+    });
+  });
+});
+
+describe("linkOptionsFromHtml (homepage-links fallback)", () => {
+  const html = `
+    <nav>
+      <a href="/granado/perfumaria">Perfumaria</a>
+      <a href="/granado/sabonetes"><span>Sabonetes</span></a>
+      <a href="/granado/casa/vela">Vela</a>
+      <a href="/granado/perfumaria">Perfumaria dup</a>
+      <a href="https://instagram.com/granado">Instagram</a>
+      <a href="/mala-detroit/p">Mala Detroit</a>
+    </nav>`;
+
+  test("extracts internal template-matching links, deduped, text label", () => {
+    const opts = linkOptionsFromHtml(html, {
+      template: "/granado/*",
+      paramName: "*",
+    });
+    expect(opts).toEqual([
+      { value: "perfumaria", label: "Perfumaria", kind: "category" },
+      { value: "sabonetes", label: "Sabonetes", kind: "category" },
+      { value: "casa/vela", label: "Vela", kind: "category" },
+    ]);
+  });
+
+  test("drops product-detail (…/p) links from a catch-all category picker", () => {
+    const opts = linkOptionsFromHtml(
+      '<a href="/malas">Malas</a><a href="/mochila-x/p">Mochila</a>',
+      { template: "/*", paramName: "*" },
+    );
+    expect(opts.map((o) => o.value)).toEqual(["malas"]);
+  });
+
+  test("keeps /p links for a product (/p) template, slug extracted", () => {
+    const opts = linkOptionsFromHtml(
+      '<a href="/mochila-x/p">Mochila X</a><a href="/malas">Malas</a>',
+      { template: "/:slug/p", paramName: "slug" },
+    );
+    expect(opts).toEqual([
+      { value: "mochila-x", label: "Mochila X", kind: "category" },
+    ]);
+  });
+
+  test("falls back to a humanized slug when the link has no text", () => {
+    const opts = linkOptionsFromHtml(
+      '<a href="/granado/corpo-e-banho"><img src="x"/></a>',
+      { template: "/granado/*", paramName: "*" },
+    );
+    expect(opts).toEqual([
+      { value: "corpo-e-banho", label: "Corpo E Banho", kind: "category" },
+    ]);
+  });
+
+  test("parseHomepageAnchors strips inner tags from link text", () => {
+    expect(parseHomepageAnchors('<a href="/x"><b>Hi</b> there</a>')).toEqual([
+      { href: "/x", text: "Hi there" },
+    ]);
+    expect(parseHomepageAnchors(null)).toEqual([]);
+  });
+
+  test("parseEmbeddedProducts reads quoted JSON and RSC unquoted-key formats", () => {
+    // Quoted JSON (preview-origin URL) + RSC-streamed (unquoted keys,
+    // production-domain URL, escaped slashes) — both yield url + name.
+    const html = `
+      {"@type":"Product","productID":"1","sku":"x","url":"http://127.0.0.1:50153/granado/perfume-figo-75ml","name":"Perfume Figo 75ml"}
+      $R[9]={"@type":"Product",productID:"2",sku:"y",url:"https:\\/\\/loja.granado.com.br\\/granado\\/eau-suede-100ml",name:"Eau Suede 100ml"}`;
+    expect(parseEmbeddedProducts(html)).toEqual([
+      {
+        url: "http://127.0.0.1:50153/granado/perfume-figo-75ml",
+        name: "Perfume Figo 75ml",
+      },
+      {
+        url: "https://loja.granado.com.br/granado/eau-suede-100ml",
+        name: "Eau Suede 100ml",
+      },
+    ]);
+    expect(parseEmbeddedProducts(null)).toEqual([]);
+  });
+
+  test("parseEmbeddedProducts captures the first image url when present", () => {
+    const html = `{"@type":"Product","url":"/granado/perfume-x","name":"Perfume X","image":[{"@type":"ImageObject","alternateName":"x","url":"https://cdn.granado.com.br/perfume-x.jpg"}]}`;
+    expect(parseEmbeddedProducts(html)).toEqual([
+      {
+        url: "/granado/perfume-x",
+        name: "Perfume X",
+        image: "https://cdn.granado.com.br/perfume-x.jpg",
+      },
+    ]);
+  });
+
+  test("merges nav categories AND embedded products, tagged by kind", () => {
+    // Granado: nav links (categories) + shelf products, both under /granado/*.
+    const html = `
+      <a href="/granado/perfumaria">Perfumaria</a>
+      <a href="/granado/sabonetes">Sabonetes</a>
+      {"@type":"Product","url":"https://loja.granado.com.br/granado/perfume-figo-75ml","name":"Perfume Figo 75ml"}`;
+    const opts = linkOptionsFromHtml(html, {
+      template: "/granado/*",
+      paramName: "*",
+    });
+    // Embedded products are emitted before nav categories (products claim their
+    // URLs first so listing-page product anchors aren't mislabeled as categories).
+    expect(opts).toEqual([
+      {
+        value: "perfume-figo-75ml",
+        label: "Perfume Figo 75ml",
+        kind: "product",
+      },
+      { value: "perfumaria", label: "Perfumaria", kind: "category" },
+      { value: "sabonetes", label: "Sabonetes", kind: "category" },
+    ]);
+  });
+
+  test("a product's <a href> on a listing page is tagged product, not category", () => {
+    // The product card is BOTH an embedded Product and an <a href> anchor —
+    // the embedded signal wins so it lands under Products.
+    const html = `
+      <a href="/granado/perfume-figo-75ml">Perfume Figo</a>
+      <a href="/granado/perfumaria">Perfumaria</a>
+      {"@type":"Product","url":"/granado/perfume-figo-75ml","name":"Perfume Figo 75ml"}`;
+    const opts = linkOptionsFromHtml(html, {
+      template: "/granado/*",
+      paramName: "*",
+    });
+    expect(opts).toEqual([
+      {
+        value: "perfume-figo-75ml",
+        label: "Perfume Figo 75ml",
+        kind: "product",
+      },
+      { value: "perfumaria", label: "Perfumaria", kind: "category" },
+    ]);
+  });
+
+  test("filters utility (non-category) nav links from the category signal", () => {
+    // Bagaggio nav: real categories stay, login/account/checkout are dropped.
+    const html = `
+      <a href="/malas">Malas</a>
+      <a href="/outlet">Outlet</a>
+      <a href="/login">Entrar</a>
+      <a href="/myaccount">Minha conta</a>
+      <a href="/checkout">Checkout</a>`;
+    const opts = linkOptionsFromHtml(html, { template: "/*", paramName: "*" });
+    expect(opts.map((o) => o.value)).toEqual(["malas", "outlet"]);
+  });
+});
+
+describe("stripSurroundingSlashes", () => {
+  test("strips leading and trailing slashes, keeps inner ones", () => {
+    expect(stripSurroundingSlashes("/perfumaasdria/colonia")).toBe(
+      "perfumaasdria/colonia",
+    );
+    expect(stripSurroundingSlashes("//x//")).toBe("x");
+    expect(stripSurroundingSlashes("  /a/b/  ")).toBe("a/b");
+    expect(stripSurroundingSlashes("sabonete")).toBe("sabonete");
+    expect(stripSurroundingSlashes("")).toBe("");
   });
 });
 

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker.ts
@@ -123,16 +123,7 @@ export function classifyParamKinds(
  * color words — present in essentially every catalog (clothing, perfume,
  * luggage, soap). PT + EN, since stores serve both markets.
  */
-export const GENERIC_SEED_TERMS = [
-  "rosa",
-  "preto",
-  "azul",
-  "branco",
-  "pink",
-  "black",
-  "blue",
-  "white",
-];
+export const GENERIC_SEED_TERMS = ["rosa", "preto", "pink", "black"];
 
 /**
  * Expand a single-term request builder over the generic seeds when the user
@@ -391,7 +382,7 @@ export function resolveOptionSources(
  * via the preview-fetch proxy (not a loader invoke), fetched once and filtered
  * client-side. `kind` only drives the label/icon.
  */
-export function siteLinksSource(kind: PathParamKind): OptionSource {
+function siteLinksSource(kind: PathParamKind): OptionSource {
   return {
     kind,
     id: SITE_LINKS_SOURCE_ID,
@@ -669,7 +660,6 @@ const NON_CATEGORY_SEGMENTS = new Set([
   "catalogsearch",
   "search",
   "busca",
-  "checkout",
   "privacy-policy-cookie-restriction-mode",
 ]);
 

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker.ts
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker.ts
@@ -12,6 +12,8 @@ export interface PathParamOption {
   value: string;
   label: string;
   image?: string;
+  /** What the option represents — drives grouping/icon in the picker. */
+  kind?: PathParamKind;
 }
 
 export interface PickerLoaderRequest {
@@ -38,12 +40,30 @@ export interface OptionSource {
   resolveType: string;
   /** Options fetched once (term-independent) and filtered client-side. */
   clientFilter: boolean;
-  buildRequests: (term: string) => PickerLoaderRequest[];
+  /**
+   * A safety net rendered only when every non-fallback source came up empty or
+   * errored (or there are no primary sources at all) — e.g. the homepage-links
+   * source standing in for a category tree/search that returned nothing.
+   * Primary sources always render.
+   */
+  isFallback: boolean;
+  /**
+   * Universal, loader-independent source: options are scraped from the site's
+   * homepage HTML (internal `<a href>` matched against the route template),
+   * fetched via the preview-fetch proxy rather than a loader invoke. When set,
+   * `buildRequests` is unused and `optionsFromPayload` receives the HTML string.
+   */
+  homepageLinks?: boolean;
+  /** Loader requests to enumerate options; absent for homepage-link sources. */
+  buildRequests?: (term: string) => PickerLoaderRequest[];
   optionsFromPayload: (
     payload: unknown,
     ctx: OptionPayloadContext,
   ) => PathParamOption[];
 }
+
+/** Stable id / cache discriminator for the homepage-links fallback source. */
+export const SITE_LINKS_SOURCE_ID = "site-links";
 
 /**
  * Loaders whose presence on a page classify its dynamic param. Matched against
@@ -95,6 +115,38 @@ export function classifyParamKinds(
     kinds.add("category");
   }
   return kinds;
+}
+
+/**
+ * Universal seed terms for a product search with no term yet (initial open /
+ * autofill): most engines return nothing for an empty query, so we seed with
+ * color words — present in essentially every catalog (clothing, perfume,
+ * luggage, soap). PT + EN, since stores serve both markets.
+ */
+export const GENERIC_SEED_TERMS = [
+  "rosa",
+  "preto",
+  "azul",
+  "branco",
+  "pink",
+  "black",
+  "blue",
+  "white",
+];
+
+/**
+ * Expand a single-term request builder over the generic seeds when the user
+ * hasn't typed anything, so the picker lands on real products in any store;
+ * a non-empty term is used verbatim (one builder call). The fanned-out seed
+ * requests run in parallel and merge/dedupe downstream (see `fetchOptions`).
+ */
+function withGenericSeeds(
+  build: (term: string) => PickerLoaderRequest[],
+  term: string,
+): PickerLoaderRequest[] {
+  const trimmed = term.trim();
+  if (trimmed) return build(trimmed);
+  return GENERIC_SEED_TERMS.flatMap((seed) => build(seed));
 }
 
 /**
@@ -196,7 +248,8 @@ const OPTION_SOURCE_CANDIDATES: OptionSourceCandidate[] = [
     kind: "product",
     test: (rt) => rt === "vtex/loaders/intelligentSearch/productList.ts",
     clientFilter: false,
-    buildRequests: vtexProductRequests,
+    buildRequests: (resolveType, term) =>
+      withGenericSeeds((t) => vtexProductRequests(resolveType, t), term),
     optionsFromPayload: productOptionsFromPayload,
   },
   {
@@ -208,12 +261,16 @@ const OPTION_SOURCE_CANDIDATES: OptionSourceCandidate[] = [
     kind: "product",
     test: (rt) => /magento\/.*products?\/list(\.tsx?)?$/i.test(rt),
     clientFilter: false,
-    buildRequests: (resolveType, term) => [
-      {
-        resolveType,
-        props: { props: { search: term.trim(), pageSize: 10, currentPage: 1 } },
-      },
-    ],
+    buildRequests: (resolveType, term) =>
+      withGenericSeeds(
+        (t) => [
+          {
+            resolveType,
+            props: { props: { search: t, pageSize: 10, currentPage: 1 } },
+          },
+        ],
+        term,
+      ),
     optionsFromPayload: productOptionsFromPayload,
   },
   {
@@ -222,9 +279,11 @@ const OPTION_SOURCE_CANDIDATES: OptionSourceCandidate[] = [
     test: (rt) =>
       /algolia\/.*products?\/(list|suggestions)(\.tsx?)?$/i.test(rt),
     clientFilter: false,
-    buildRequests: (resolveType, term) => [
-      { resolveType, props: { term: term.trim(), hitsPerPage: 10 } },
-    ],
+    buildRequests: (resolveType, term) =>
+      withGenericSeeds(
+        (t) => [{ resolveType, props: { term: t, hitsPerPage: 10 } }],
+        term,
+      ),
     optionsFromPayload: productOptionsFromPayload,
   },
   {
@@ -233,17 +292,16 @@ const OPTION_SOURCE_CANDIDATES: OptionSourceCandidate[] = [
     kind: "product",
     test: (rt) => /products?\/list(\.tsx?)?$/i.test(rt),
     clientFilter: false,
-    buildRequests: (resolveType, term) => [
-      {
-        resolveType,
-        props: {
-          query: term.trim(),
-          term: term.trim(),
-          count: 10,
-          hitsPerPage: 10,
-        },
-      },
-    ],
+    buildRequests: (resolveType, term) =>
+      withGenericSeeds(
+        (t) => [
+          {
+            resolveType,
+            props: { query: t, term: t, count: 10, hitsPerPage: 10 },
+          },
+        ],
+        term,
+      ),
     optionsFromPayload: productOptionsFromPayload,
   },
   // Category — a term-independent tree, filtered client-side.
@@ -263,6 +321,13 @@ const OPTION_SOURCE_CANDIDATES: OptionSourceCandidate[] = [
  * manifest into a concrete {@link OptionSource}. Kinds with no available loader
  * are dropped (the free-text "Use …" row and the plain inline input still let
  * the user type a value). Preserves candidate order = priority.
+ *
+ * Any classified param also gets a universal **homepage-links fallback**
+ * ({@link siteLinksSource}): options scraped from the site's homepage HTML,
+ * matched against the route template. It's app-agnostic (no loader/index
+ * config) and is rendered only when the loader-based primary sources come up
+ * empty/errored — so Granado (empty Algolia) and Bagaggio (failing category
+ * tree) still surface real categories/products to pick from.
  */
 export function resolveOptionSources(
   kinds: ReadonlySet<PathParamKind>,
@@ -270,12 +335,11 @@ export function resolveOptionSources(
   platforms: ReadonlySet<string> = new Set(),
 ): OptionSource[] {
   const loaders = [...manifestLoaders];
-  const sources: OptionSource[] = [];
-  for (const kind of ["product", "category"] as const) {
-    if (!kinds.has(kind)) continue;
-    // Collect every candidate that resolves to an allowed loader, in candidate
-    // order, then prefer one from the page's own platform (Magento's native
-    // search over a neutral Algolia index) — otherwise take the first.
+
+  // Best allowed candidate for a kind: collect every candidate resolving to an
+  // allowed loader in candidate order, then prefer one from the page's own
+  // platform (Magento's native search over a neutral Algolia index).
+  const chooseCandidate = (kind: PathParamKind) => {
     const matches: { cand: OptionSourceCandidate; resolveType: string }[] = [];
     for (const cand of OPTION_SOURCE_CANDIDATES) {
       if (cand.kind !== kind) continue;
@@ -284,21 +348,59 @@ export function resolveOptionSources(
       );
       if (resolveType) matches.push({ cand, resolveType });
     }
-    const chosen =
+    return (
       matches.find((m) => platforms.has(loaderVendor(m.resolveType))) ??
-      matches[0];
-    if (!chosen) continue;
-    const { cand, resolveType } = chosen;
-    sources.push({
-      kind,
-      id: `${kind}:${resolveType}`,
-      resolveType,
-      clientFilter: cand.clientFilter,
-      buildRequests: (term) => cand.buildRequests(resolveType, term),
-      optionsFromPayload: cand.optionsFromPayload,
-    });
+      matches[0]
+    );
+  };
+
+  const bind = (
+    cand: OptionSourceCandidate,
+    resolveType: string,
+    isFallback: boolean,
+  ): OptionSource => ({
+    kind: cand.kind,
+    id: `${cand.kind}:${resolveType}${isFallback ? ":fallback" : ""}`,
+    resolveType,
+    clientFilter: cand.clientFilter,
+    isFallback,
+    buildRequests: (term) => cand.buildRequests(resolveType, term),
+    optionsFromPayload: cand.optionsFromPayload,
+  });
+
+  const sources: OptionSource[] = [];
+  for (const kind of ["product", "category"] as const) {
+    if (!kinds.has(kind)) continue;
+    const chosen = chooseCandidate(kind);
+    if (chosen) sources.push(bind(chosen.cand, chosen.resolveType, false));
   }
+
+  // Universal homepage-links fallback for any classified param (see doc above).
+  if (kinds.size > 0) {
+    sources.push(
+      siteLinksSource(kinds.has("category") ? "category" : "product"),
+    );
+  }
+
   return sources;
+}
+
+/**
+ * The homepage-links fallback source: enumerates entities by scraping the
+ * site's homepage HTML for internal links that match the route template. Fetched
+ * via the preview-fetch proxy (not a loader invoke), fetched once and filtered
+ * client-side. `kind` only drives the label/icon.
+ */
+export function siteLinksSource(kind: PathParamKind): OptionSource {
+  return {
+    kind,
+    id: SITE_LINKS_SOURCE_ID,
+    resolveType: SITE_LINKS_SOURCE_ID,
+    clientFilter: true,
+    isFallback: true,
+    homepageLinks: true,
+    optionsFromPayload: (payload, ctx) => linkOptionsFromHtml(payload, ctx),
+  };
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -524,6 +626,171 @@ export function categoryOptionsFromPayload(data: unknown): PathParamOption[] {
   };
   if (Array.isArray(data)) {
     for (const node of data) walk(node, []);
+  }
+  return options;
+}
+
+/**
+ * First path segments that are storefront utility pages, never product
+ * categories — filtered out of the category signal so a category picker isn't
+ * polluted with login/account/checkout/help links from the site nav & footer.
+ */
+const NON_CATEGORY_SEGMENTS = new Set([
+  "login",
+  "logout",
+  "signin",
+  "sign-in",
+  "signup",
+  "sign-up",
+  "register",
+  "account",
+  "myaccount",
+  "my-account",
+  "minha-conta",
+  "conta",
+  "cart",
+  "carrinho",
+  "checkout",
+  "wishlist",
+  "favoritos",
+  "favorites",
+  "orders",
+  "pedidos",
+  "help",
+  "hc",
+  "sac",
+  "atendimento",
+  "contato",
+  "contact",
+  "institucional",
+  "newsletter",
+  "customer",
+  "sales",
+  "catalogsearch",
+  "search",
+  "busca",
+  "checkout",
+  "privacy-policy-cookie-restriction-mode",
+]);
+
+/** Humanize a value's last path segment for a link label ("casa/vela" → "Vela"). */
+function deslugLabel(value: string): string {
+  const last = value.split("/").filter(Boolean).pop() ?? value;
+  return last
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Internal `<a href>` links with their visible text, parsed from raw HTML. */
+export function parseHomepageAnchors(
+  html: unknown,
+): { href: string; text: string }[] {
+  if (typeof html !== "string" || !html) return [];
+  const anchors: { href: string; text: string }[] = [];
+  const re = /<a\b[^>]*?\bhref="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+  let m: RegExpExecArray | null;
+  let guard = 0;
+  while ((m = re.exec(html)) !== null && guard++ < 5000) {
+    const href = m[1] ?? "";
+    const text = (m[2] ?? "")
+      .replace(/<[^>]*>/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    anchors.push({ href, text });
+  }
+  return anchors;
+}
+
+/**
+ * Products embedded as schema.org JSON in a page's SSR HTML (shelves / listing
+ * data), so a homepage with no product `<a href>` still yields real PDPs. Each
+ * Product marker is anchored to its nearest `url` + `name`, handling both quoted
+ * JSON (`"url":"…","name":"…"`) and the RSC-streamed unquoted-key form
+ * (`url:"…",name:"…"`) deco/TanStack pages emit. URLs may be absolute
+ * production-domain — {@link valueFromEntityUrl} matches on the pathname anyway.
+ */
+export function parseEmbeddedProducts(
+  html: unknown,
+): { url: string; name: string; image?: string }[] {
+  if (typeof html !== "string" || !html) return [];
+  const out: { url: string; name: string; image?: string }[] = [];
+  const seen = new Set<string>();
+  const re =
+    /"@type":"Product"[\s\S]{0,600}?(?:"url"|\burl):"([^"]+)"[\s\S]{0,300}?(?:"name"|\bname):"([^"]+)"/g;
+  // First image URL inside the product's `image` array, searched in a bounded
+  // window after the match (optional — a product without one still resolves).
+  const imgRe =
+    /(?:"image"|\bimage):\s*\[\s*\{[\s\S]{0,400}?(?:"url"|\burl):"([^"]+)"/;
+  let m: RegExpExecArray | null;
+  let guard = 0;
+  while ((m = re.exec(html)) !== null && guard++ < 3000) {
+    const url = (m[1] ?? "").replace(/\\\//g, "/");
+    if (!url || seen.has(url)) continue;
+    seen.add(url);
+    const image = html
+      .slice(m.index, m.index + 900)
+      .match(imgRe)?.[1]
+      ?.replace(/\\\//g, "/");
+    out.push({ url, name: m[2] ?? "", image: image || undefined });
+  }
+  return out;
+}
+
+/**
+ * Options from the site's homepage HTML — the universal, loader-independent
+ * source. Two signals, matched against the route template
+ * ({@link valueFromEntityUrl}): internal `<a href>` links (the nav → categories)
+ * and embedded schema.org products (shelves → PDPs). So a catch-all page that
+ * serves both PLP and PDP surfaces both. For a catch-all (`*`) param,
+ * product-detail links (VTEX `…/p`) are dropped so a category picker isn't
+ * polluted with PDPs, and utility pages (login/account/…) are filtered from the
+ * category signal. Each option is tagged `kind` so the picker groups them into
+ * Categories / Products. Label prefers the link/product text, else a humanized
+ * slug. Capped to bound the list.
+ */
+export function linkOptionsFromHtml(
+  html: unknown,
+  ctx: OptionPayloadContext,
+): PathParamOption[] {
+  const options: PathParamOption[] = [];
+  const seen = new Set<string>();
+  const add = (
+    rawUrl: string,
+    label: string,
+    kind: PathParamKind,
+    image?: string,
+  ) => {
+    if (options.length >= 200) return;
+    const value = valueFromEntityUrl(rawUrl, ctx.template, ctx.paramName);
+    if (!value || seen.has(value)) return;
+    // Catch-all category picker: drop product-detail links (…/p) so the list is
+    // categories, not PDPs (the /p is only ambiguous for the `*` template).
+    if (ctx.paramName === "*" && /(^|\/)p$/.test(value)) return;
+    // Nav links: keep only category-like paths, not utility pages.
+    if (
+      kind === "category" &&
+      NON_CATEGORY_SEGMENTS.has(value.split("/")[0] ?? "")
+    )
+      return;
+    seen.add(value);
+    options.push({
+      value,
+      label: label && label.length <= 80 ? label : deslugLabel(value),
+      kind,
+      image,
+    });
+  };
+  // Embedded products FIRST: on a listing page the product cards are also
+  // `<a href>` anchors, so if nav links were processed first they'd claim the
+  // product URLs as "category". Products claim their URLs here; duplicate nav
+  // anchors are then skipped, leaving only genuine category links.
+  for (const { url, name, image } of parseEmbeddedProducts(html))
+    add(url, name, "product", image);
+  for (const { href, text } of parseHomepageAnchors(html)) {
+    if (href.startsWith("/") && !href.startsWith("//"))
+      add(href, text, "category");
   }
   return options;
 }

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -914,7 +914,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           (pathParamValues[name] ?? "") === "" ? (
             <PathParamAutoFill
               key={`${currentPageKey}:${name}`}
-              source={sources[0]!}
+              sources={sources}
               template={currentPath}
               paramName={name}
               sandboxRef={pickerSandboxRef}

--- a/apps/mesh/src/web/components/sections-editor/page-path-utils.ts
+++ b/apps/mesh/src/web/components/sections-editor/page-path-utils.ts
@@ -3,6 +3,15 @@ export function normalizePagePath(path: string): string {
   return path.replace(/\/+$/, "") || "/";
 }
 
+/**
+ * Trim surrounding slashes from a path-param value: the template supplies the
+ * leading `/`, so a typed `/sabonetes/x` fills as `sabonetes/x`. Internal
+ * slashes are kept (a catch-all value can be multi-segment).
+ */
+export function stripSurroundingSlashes(value: string): string {
+  return value.trim().replace(/^\/+|\/+$/g, "");
+}
+
 /** Reject protocol-relative paths, parent segments, and non-path values. */
 export function isValidPagePath(path: string): boolean {
   const trimmed = path.trim();


### PR DESCRIPTION
## What is this contribution about?
The sandbox preview URL path-param picker only worked for VTEX PDPs; on other stores it showed an empty/dead modal or degraded to a bare text input. This makes it app-agnostic: params are classified (product/category), and when the site's configured loaders (VTEX category tree, Algolia/Magento product search) come up empty or absent, it falls back to scraping the site's own homepage — and drilling one listing page — for real category and product URLs via the existing `preview-fetch` proxy (allowlist widened to same-origin GETs). Results render side by side as **Categorias | Produtos** with product thumbnails; empty product searches are seeded with generic color terms, free-text entry strips surrounding slashes, and auto-fill only commits from primary sources (never a fallback), fixing a bug where a Category param auto-filled a PDP.

## Screenshots/Demonstration
Granado (Magento, no working search loader) now lists real categories on the left and products with thumbnails on the right; clicking navigates to a valid PLP/PDP. Verified live in the studio dev sandbox.

## How to Test
1. `bun run dev`, open the studio and a sandbox whose page uses a dynamic route (e.g. Granado `/{granado/}?*`, or a VTEX store's category `*` / PDP `:slug/p`).
2. Click the violet path chip in the preview URL bar — the modal opens with Categorias | Produtos (or the loader-driven results where configured).
3. Pick an entity (or type a value) → the preview navigates to the real page; leading slashes are stripped. `bun test apps/mesh/src/web/components/sandbox/preview/path-param-picker.test.ts` (56 pass).

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the sandbox preview URL path-param picker app-agnostic and resilient. It now prefers loader results and only falls back to homepage-link discovery, drilling a category listing to find real categories and products.

- **New Features**
  - Gates the homepage-links fallback; queried only after primary loaders return no options or error.
  - Drills into the first category listing during homepage discovery to collect embedded products; categories come from the homepage nav.
  - Seeds empty product searches with four generic color terms to show results with fewer requests.

- **Bug Fixes**
  - Auto-fill now tries primary sources in priority order and never commits from fallbacks; prevents wrong-kind fills.
  - Strips surrounding slashes on free-text entry.
  - Hardens the `preview-fetch` allowlist to same-origin paths only (rejects missing/invalid paths, `//`, `..`, `\`); tests cover fallback gating, homepage parsing, embedded products, and input normalization.

<sup>Written for commit 68ca75a488f98c02db98703f8a07771f47861eed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

