### PR TITLE
feat(github): add repository setup empty state

### DIFF
--- a/apps/mesh/src/web/components/github-repo-picker.tsx
+++ b/apps/mesh/src/web/components/github-repo-picker.tsx
@@ -33,6 +33,7 @@ import { KEYS } from "@/web/lib/query-keys";
 import { toast } from "sonner";
 import {
   ArrowLeft,
+  LinkExternal01,
   Loading01,
   Lock01,
   LockUnlocked01,
@@ -623,6 +624,72 @@ function InstallationPicker({
   const data = installationsQuery.data;
   if (!data) return null;
 
+  const installUrl = data.appSlug
+    ? `https://github.com/apps/${data.appSlug}/installations/new`
+    : "https://github.com/settings/installations";
+
+  if (data.installations.length === 0) {
+    return (
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {showBackButton && (
+          <div className="flex items-center gap-1 px-4 pt-3 pb-1 shrink-0">
+            <button
+              type="button"
+              onClick={onBack}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ArrowLeft size={12} />
+              {t("common.githubRepoPicker.changeConnection")}
+            </button>
+          </div>
+        )}
+
+        <div className="flex-1 flex flex-col items-center justify-center px-8 py-6 text-center">
+          <div className="size-16 rounded-2xl bg-muted flex items-center justify-center">
+            <GitHubIcon className="size-8 text-foreground" />
+          </div>
+
+          <div className="mt-4 flex items-center gap-1.5 text-xs font-medium text-success">
+            <span className="size-1.5 rounded-full bg-success" />
+            {t("common.githubRepoPicker.githubConnected")}
+          </div>
+
+          <h2 className="mt-2 text-base font-semibold text-foreground">
+            {t("common.githubRepoPicker.setupRepositoriesTitle")}
+          </h2>
+          <p className="mt-1.5 max-w-[360px] text-xs leading-relaxed text-muted-foreground">
+            {t("common.githubRepoPicker.noRepositoriesShared")}
+          </p>
+
+          <div className="mt-5 flex items-center gap-2">
+            <Button asChild size="sm">
+              <a href={installUrl} target="_blank" rel="noopener noreferrer">
+                {t("common.githubRepoPicker.chooseRepositories")}
+                <LinkExternal01 size={14} />
+              </a>
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void installationsQuery.refetch()}
+              disabled={installationsQuery.isFetching}
+            >
+              {installationsQuery.isFetching && (
+                <Loading01 size={14} className="animate-spin" />
+              )}
+              {t("common.githubRepoPicker.checkAgain")}
+            </Button>
+          </div>
+
+          <p className="mt-4 max-w-[360px] rounded-lg bg-muted/50 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+            {t("common.githubRepoPicker.repositoryAccessNote")}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {showBackButton && (
@@ -670,11 +737,7 @@ function InstallationPicker({
 
       <div className="px-4 py-3 border-t border-border shrink-0">
         <a
-          href={
-            data.appSlug
-              ? `https://github.com/apps/${data.appSlug}/installations/new`
-              : "https://github.com/settings/installations"
-          }
+          href={installUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="text-xs text-muted-foreground hover:text-foreground transition-colors"

--- a/apps/mesh/src/web/i18n/en/common.ts
+++ b/apps/mesh/src/web/i18n/en/common.ts
@@ -85,6 +85,8 @@ export const common = {
   "common.githubRepoPicker.authenticatingGitHub": "Authenticating with GitHub",
   "common.githubRepoPicker.backToAccounts": "Back to accounts",
   "common.githubRepoPicker.changeConnection": "Change connection",
+  "common.githubRepoPicker.checkAgain": "Check again",
+  "common.githubRepoPicker.chooseRepositories": "Choose repositories",
   "common.githubRepoPicker.completeOAuthFlow":
     "Complete the OAuth flow in your browser",
   "common.githubRepoPicker.connectionExpiredMessage":
@@ -95,20 +97,27 @@ export const common = {
     "Failed to load GitHub accounts",
   "common.githubRepoPicker.failedReconnect":
     "Failed to reconnect GitHub: {error}",
+  "common.githubRepoPicker.githubConnected": "GitHub connected",
   "common.githubRepoPicker.importFromGitHub": "Import from GitHub",
   "common.githubRepoPicker.importedRepo": "Imported {name} from GitHub",
   "common.githubRepoPicker.installGitHubApp": "Install the GitHub App",
   "common.githubRepoPicker.installingGitHubConnection":
     "Installing the GitHub connection...",
   "common.githubRepoPicker.noRepositoriesFound": "No repositories found",
+  "common.githubRepoPicker.noRepositoriesShared":
+    "No repositories are shared with Deco yet. Choose what to share on GitHub, then return here to continue.",
   "common.githubRepoPicker.personalAccount": "Personal account",
   "common.githubRepoPicker.private": "Private",
   "common.githubRepoPicker.public": "Public",
   "common.githubRepoPicker.reconnectGitHub": "Reconnect GitHub",
+  "common.githubRepoPicker.repositoryAccessNote":
+    "You decide exactly what Deco can access. Choosing “all repositories” is optional.",
   "common.githubRepoPicker.searchRepositories": "Search repositories...",
   "common.githubRepoPicker.select": "Select",
   "common.githubRepoPicker.selectConnection": "Select a connection",
   "common.githubRepoPicker.settingUpGitHub": "Setting up GitHub",
+  "common.githubRepoPicker.setupRepositoriesTitle":
+    "Let Deco see your repositories",
   "common.githubRepoPicker.somethingWentWrong":
     "Something went wrong while connecting to GitHub.",
   "common.githubRepoPicker.tryAgain": "Try again",

--- a/apps/mesh/src/web/i18n/pt-br/common.ts
+++ b/apps/mesh/src/web/i18n/pt-br/common.ts
@@ -89,6 +89,8 @@ export const common = {
   "common.githubRepoPicker.authenticatingGitHub": "Autenticando com GitHub",
   "common.githubRepoPicker.backToAccounts": "Voltar às contas",
   "common.githubRepoPicker.changeConnection": "Alterar conexão",
+  "common.githubRepoPicker.checkAgain": "Verificar novamente",
+  "common.githubRepoPicker.chooseRepositories": "Escolher repositórios",
   "common.githubRepoPicker.completeOAuthFlow":
     "Complete o fluxo OAuth no seu navegador",
   "common.githubRepoPicker.connectionExpiredMessage":
@@ -100,6 +102,7 @@ export const common = {
     "Falha ao carregar contas do GitHub",
   "common.githubRepoPicker.failedReconnect":
     "Falha ao reconectar GitHub: {error}",
+  "common.githubRepoPicker.githubConnected": "GitHub conectado",
   "common.githubRepoPicker.importFromGitHub": "Importar do GitHub",
   "common.githubRepoPicker.importedRepo": "Importado {name} do GitHub",
   "common.githubRepoPicker.installGitHubApp": "Instalar o aplicativo GitHub",
@@ -107,14 +110,20 @@ export const common = {
     "Instalando a conexão com GitHub...",
   "common.githubRepoPicker.noRepositoriesFound":
     "Nenhum repositório encontrado",
+  "common.githubRepoPicker.noRepositoriesShared":
+    "Ainda não há repositórios compartilhados com a Deco. Escolha no GitHub o que deseja compartilhar e volte aqui para continuar.",
   "common.githubRepoPicker.personalAccount": "Conta pessoal",
   "common.githubRepoPicker.private": "Privado",
   "common.githubRepoPicker.public": "Público",
   "common.githubRepoPicker.reconnectGitHub": "Reconectar GitHub",
+  "common.githubRepoPicker.repositoryAccessNote":
+    "Você decide exatamente o que a Deco pode acessar. Escolher “todos os repositórios” é opcional.",
   "common.githubRepoPicker.searchRepositories": "Pesquisar repositórios...",
   "common.githubRepoPicker.select": "Selecionar",
   "common.githubRepoPicker.selectConnection": "Selecione uma conexão",
   "common.githubRepoPicker.settingUpGitHub": "Configurando GitHub",
+  "common.githubRepoPicker.setupRepositoriesTitle":
+    "Permita que a Deco veja seus repositórios",
   "common.githubRepoPicker.somethingWentWrong":
     "Algo deu errado ao conectar ao GitHub.",
   "common.githubRepoPicker.tryAgain": "Tentar novamente",


### PR DESCRIPTION
## Summary

- show a dedicated setup empty state when the connected GitHub account has no app installations
- provide a primary action to choose repositories and a refresh action with loading feedback
- add matching English and Brazilian Portuguese copy

## Testing

- bun run fmt
- bun run check
- bun run lint (0 errors; repository warnings remain in unrelated files)
- bun run knip
- git diff --check
- bun run test: 5,633 passed; 325 failed and 49 errored because this local environment has no Postgres/browser integration services. No failure referenced the changed picker or translation files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a setup empty state in the GitHub repo picker when the connected account has no app installations. It shows clear actions to choose repositories on GitHub or check again, and adds EN/PT-BR copy.

- New empty state with a GitHub-connected badge, guidance text, and an external link to the app installation page (built from `appSlug`, fallback to GitHub settings).
- Primary “Choose repositories” opens GitHub in a new tab; “Check again” refetches with a loading spinner.
- Added matching i18n strings in English and Brazilian Portuguese.

<sup>Written for commit 4010f4bea13d4812c3285b784b29547037ba823a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

