### PR TITLE
fix(i18n): make others-thread state card copy business-friendly

### DIFF
--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -571,7 +571,7 @@ export const sandbox = {
     "This agent's GitHub repo isn't authenticated. Reconnect it in Connections, then retry.",
   "sandbox.stateCard.othersThreadTitle": "You're in someone else's chat",
   "sandbox.stateCard.othersThreadMessage":
-    "This conversation ({label}) belongs to another member. Continuing will start a sandbox on their branch — start a new chat to work on your own instead.",
+    "This conversation ({label}) belongs to another member. Continuing here means picking up their work — start a new chat to work on your own instead.",
   "sandbox.stateCard.othersThreadContinue": "Continue anyway",
   "sandbox.stateCard.othersThreadNewChat": "Start new chat",
   "sandbox.stateCard.reconnectGithub": "Reconnect GitHub",

--- a/apps/mesh/src/web/i18n/pt-br/sandbox.ts
+++ b/apps/mesh/src/web/i18n/pt-br/sandbox.ts
@@ -596,7 +596,7 @@ export const sandbox = {
     "O repositório GitHub deste agente não está autenticado. Reconecte em Conexões e tente novamente.",
   "sandbox.stateCard.othersThreadTitle": "Você está no chat de outra pessoa",
   "sandbox.stateCard.othersThreadMessage":
-    "Esta conversa ({label}) é de outro membro. Continuar vai iniciar um sandbox na branch dela — comece um novo chat para trabalhar no seu.",
+    "Esta conversa ({label}) é de outro membro. Continuar aqui significa dar sequência ao trabalho dela — comece um novo chat para trabalhar no seu.",
   "sandbox.stateCard.othersThreadContinue": "Continuar mesmo assim",
   "sandbox.stateCard.othersThreadNewChat": "Começar novo chat",
   "sandbox.stateCard.reconnectGithub": "Reconectar GitHub",


### PR DESCRIPTION
## Summary
The "you're in someone else's chat" state card used developer jargon ("start a sandbox on their branch" / "iniciar um sandbox na branch dela"). Reworded to be business-friendly in both the English source and the pt-br translation.

**Before (en):** "Continuing will start a sandbox on their branch — start a new chat to work on your own instead."
**After (en):** "Continuing here means picking up their work — start a new chat to work on your own instead."

**Before (pt-br):** "Continuar vai iniciar um sandbox na branch dela — …"
**After (pt-br):** "Continuar aqui significa dar sequência ao trabalho dela — …"

## Affected areas
- `apps/mesh/src/web/i18n/en/sandbox.ts` — `sandbox.stateCard.othersThreadMessage`
- `apps/mesh/src/web/i18n/pt-br/sandbox.ts` — same key, kept in sync

Copy-only change; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the “You’re in someone else’s chat” state card message to use business-friendly wording in English and pt-br, replacing developer jargon with plain language. Copy-only change; no logic touched.

<sup>Written for commit f63f34da5152ad69ca92f04cec027cdfc2e85021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

