### PR TITLE
fix(github): surface PR check-run tool errors instead of showing "no checks"

### DIFF
--- a/apps/api/src/oauth/github-mint.ts
+++ b/apps/api/src/oauth/github-mint.ts
@@ -84,10 +84,13 @@ async function mintRepoToken(
         },
       }) as Promise<MintResult>;
 
-    // Fall back to a checks-less mint when the deployed github-mcp predates the
-    // `checks` allowlist and hard-rejects it — keeps existing tokens refreshing
-    // until that deploy lands.
-    let res = await mintWith(recipe.permissions);
+    // Self-heal legacy connections on their ~1h re-mint: always request
+    // checks:read (even if the stored recipe predates it) so the token gains
+    // check-run access without a re-install. Fall back to the checks-less recipe
+    // when checks isn't available yet (github-mcp allowlist skew, or the
+    // installation hasn't granted Checks → 422).
+    const desiredPermissions = { ...recipe.permissions, checks: "read" };
+    let res = await mintWith(desiredPermissions);
     if (
       res.isError &&
       isChecksPermissionRejected(

--- a/apps/api/src/oauth/github-mint.ts
+++ b/apps/api/src/oauth/github-mint.ts
@@ -19,8 +19,7 @@ import {
 } from "@/oauth/token-refresh";
 import {
   getRepoScope,
-  isChecksPermissionRejected,
-  permissionsWithoutChecks,
+  mintRepoTokenWithChecksFallback,
   type RepoScopeRecipe,
 } from "@decocms/shared/github-repo-scope";
 import { DownstreamTokenStorage } from "@/storage/downstream-token";
@@ -73,32 +72,24 @@ async function mintRepoToken(
       structuredContent?: { token?: string; expiresAt?: string };
       content?: Array<{ type?: string; text?: string }>;
     };
-    const mintWith = (permissions: Record<string, string>) =>
-      client.callTool({
-        name: "MINT_REPO_TOKEN",
-        arguments: {
-          installationId: recipe.installationId,
-          owner: recipe.owner,
-          repo: recipe.repo,
-          permissions,
-        },
-      }) as Promise<MintResult>;
 
-    // Self-heal legacy connections on their ~1h re-mint: always request
-    // checks:read (even if the stored recipe predates it) so the token gains
-    // check-run access without a re-install. Fall back to the checks-less recipe
-    // when checks isn't available yet (github-mcp allowlist skew, or the
-    // installation hasn't granted Checks → 422).
-    const desiredPermissions = { ...recipe.permissions, checks: "read" };
-    let res = await mintWith(desiredPermissions);
-    if (
-      res.isError &&
-      isChecksPermissionRejected(
-        res.content?.find((c) => c.type === "text")?.text,
-      )
-    ) {
-      res = await mintWith(permissionsWithoutChecks(recipe.permissions));
-    }
+    // Self-heal legacy connections on their ~1h re-mint: request checks:read on
+    // top of the stored recipe so the token gains check-run access without a
+    // re-install, falling back to the checks-less recipe when checks isn't
+    // available yet. (Re-probes each cycle — see the helper's note.)
+    const { result: res } = await mintRepoTokenWithChecksFallback<MintResult>(
+      (permissions) =>
+        client.callTool({
+          name: "MINT_REPO_TOKEN",
+          arguments: {
+            installationId: recipe.installationId,
+            owner: recipe.owner,
+            repo: recipe.repo,
+            permissions,
+          },
+        }) as Promise<MintResult>,
+      recipe.permissions,
+    );
 
     const token = res.structuredContent?.token;
     if (res.isError || !token) {

--- a/apps/api/src/oauth/github-mint.ts
+++ b/apps/api/src/oauth/github-mint.ts
@@ -19,6 +19,8 @@ import {
 } from "@/oauth/token-refresh";
 import {
   getRepoScope,
+  isChecksPermissionRejected,
+  permissionsWithoutChecks,
   type RepoScopeRecipe,
 } from "@decocms/shared/github-repo-scope";
 import { DownstreamTokenStorage } from "@/storage/downstream-token";
@@ -66,18 +68,34 @@ async function mintRepoToken(
   // injected as the bearer either way (the gate needs the user-to-server token).
   const client = await clientFromConnection(orgConn, ctx, true);
   try {
-    const res = (await client.callTool({
-      name: "MINT_REPO_TOKEN",
-      arguments: {
-        installationId: recipe.installationId,
-        owner: recipe.owner,
-        repo: recipe.repo,
-        permissions: recipe.permissions,
-      },
-    })) as {
+    type MintResult = {
       isError?: boolean;
       structuredContent?: { token?: string; expiresAt?: string };
+      content?: Array<{ type?: string; text?: string }>;
     };
+    const mintWith = (permissions: Record<string, string>) =>
+      client.callTool({
+        name: "MINT_REPO_TOKEN",
+        arguments: {
+          installationId: recipe.installationId,
+          owner: recipe.owner,
+          repo: recipe.repo,
+          permissions,
+        },
+      }) as Promise<MintResult>;
+
+    // Fall back to a checks-less mint when the deployed github-mcp predates the
+    // `checks` allowlist and hard-rejects it — keeps existing tokens refreshing
+    // until that deploy lands.
+    let res = await mintWith(recipe.permissions);
+    if (
+      res.isError &&
+      isChecksPermissionRejected(
+        res.content?.find((c) => c.type === "text")?.text,
+      )
+    ) {
+      res = await mintWith(permissionsWithoutChecks(recipe.permissions));
+    }
 
     const token = res.structuredContent?.token;
     if (res.isError || !token) {

--- a/apps/web/src/components/thread/github/check-run-output.test.ts
+++ b/apps/web/src/components/thread/github/check-run-output.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { joinCheckOutput } from "./check-run-output";
+
+describe("joinCheckOutput", () => {
+  test("joins summary and text with a blank line", () => {
+    expect(
+      joinCheckOutput({
+        summary: "**Verdict:** pass",
+        text: "| step |\n|---|",
+      }),
+    ).toBe("**Verdict:** pass\n\n| step |\n|---|");
+  });
+
+  test("returns summary alone when text is empty", () => {
+    expect(joinCheckOutput({ summary: "only summary", text: null })).toBe(
+      "only summary",
+    );
+  });
+
+  test("returns text alone when summary is empty", () => {
+    expect(joinCheckOutput({ summary: "   ", text: "only text" })).toBe(
+      "only text",
+    );
+  });
+
+  test("returns empty string when both are missing/whitespace", () => {
+    expect(joinCheckOutput({ summary: "  ", text: "" })).toBe("");
+    expect(joinCheckOutput({})).toBe("");
+    expect(joinCheckOutput(null)).toBe("");
+    expect(joinCheckOutput(undefined)).toBe("");
+  });
+});

--- a/apps/web/src/components/thread/github/check-run-output.ts
+++ b/apps/web/src/components/thread/github/check-run-output.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure helpers for a check run's `output`. GitHub splits the detail into
+ * `summary` (e.g. URL/verdict) and `text` (e.g. the step table) and renders
+ * BOTH; joining them keeps the detailed section from being dropped when a
+ * summary is present.
+ */
+
+export interface CheckRunOutput {
+  title: string | null;
+  summary: string | null;
+  text: string | null;
+}
+
+/** Trimmed `summary` + `text`, joined with a blank line; "" when both empty. */
+export function joinCheckOutput(
+  output: { summary?: string | null; text?: string | null } | null | undefined,
+): string {
+  return [output?.summary?.trim(), output?.text?.trim()]
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/apps/web/src/components/thread/github/checks-tab.tsx
+++ b/apps/web/src/components/thread/github/checks-tab.tsx
@@ -52,8 +52,13 @@ export function ChecksTab({ pr, connectionId, owner, repo }: Props) {
 
   if (checksQuery.isError) {
     return (
-      <div className="text-sm text-destructive">
-        {t("thread.checksTab.couldntLoadCheckRuns")}
+      <div className="flex flex-col gap-1 text-sm text-destructive">
+        <span>{t("thread.checksTab.couldntLoadCheckRuns")}</span>
+        {checksQuery.error?.message && (
+          <span className="text-xs text-muted-foreground">
+            {checksQuery.error.message}
+          </span>
+        )}
       </div>
     );
   }

--- a/apps/web/src/components/thread/github/checks-tab.tsx
+++ b/apps/web/src/components/thread/github/checks-tab.tsx
@@ -1,9 +1,9 @@
 import { useProjectContext } from "@/sdk";
 import { Button } from "@deco/ui/components/button.tsx";
+import { Markdown } from "@deco/ui/components/markdown.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { ChevronRight, LinkExternal01 } from "@untitledui/icons";
 import { useState } from "react";
-import { MemoizedMarkdown } from "@/components/chat/markdown.tsx";
 import { useT } from "@/i18n/use-t.ts";
 import { useChatStream } from "../../chat/chat-context.tsx";
 import * as tpl from "./message-templates.ts";
@@ -214,7 +214,10 @@ function CheckRunDetail({ checkRunId, ...repo }: CheckRunDetailProps) {
           {output.title}
         </div>
       )}
-      <MemoizedMarkdown id={`check-${checkRunId}`} text={body} />
+      {/* Check output is attacker-influenceable (any app with checks:write can
+          set it), so render through the sanitizing Markdown — NOT the chat
+          renderer, which enables rehype-raw (raw HTML → XSS). */}
+      <Markdown className="max-w-none text-sm">{body}</Markdown>
     </div>
   );
 }

--- a/apps/web/src/components/thread/github/checks-tab.tsx
+++ b/apps/web/src/components/thread/github/checks-tab.tsx
@@ -1,10 +1,18 @@
 import { useProjectContext } from "@/sdk";
 import { Button } from "@deco/ui/components/button.tsx";
-import { LinkExternal01 } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { ChevronRight, LinkExternal01 } from "@untitledui/icons";
+import { useState } from "react";
+import { MemoizedMarkdown } from "@/components/chat/markdown.tsx";
 import { useT } from "@/i18n/use-t.ts";
 import { useChatStream } from "../../chat/chat-context.tsx";
 import * as tpl from "./message-templates.ts";
-import { useChecks, type CheckRun, type PrSummary } from "./use-pr-data.ts";
+import {
+  useCheckRunDetail,
+  useChecks,
+  type CheckRun,
+  type PrSummary,
+} from "./use-pr-data.ts";
 
 interface Props {
   pr: PrSummary;
@@ -17,11 +25,14 @@ interface Props {
  * Checks sub-tab: list of CI runs for the PR head SHA. Each row shows
  * the run name, status/conclusion, duration, a link to the provider's
  * run page, and a Re-run button that sends a templated chat message.
+ * Rows expand to render the check run's `output` (e.g. the QA journey's
+ * step-by-step table) inline, lazily fetched via GET_CHECK_RUN.
  */
 export function ChecksTab({ pr, connectionId, owner, repo }: Props) {
   const { org } = useProjectContext();
   const chat = useChatStream();
   const t = useT();
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
   const checksQuery = useChecks({
     orgId: org.id,
@@ -40,6 +51,14 @@ export function ChecksTab({ pr, connectionId, owner, repo }: Props) {
           text: tpl.rerunCheck({ prNumber: pr.number, checkName: name }),
         },
       ],
+    });
+
+  const toggle = (id: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
     });
 
   if (checksQuery.isLoading) {
@@ -75,46 +94,128 @@ export function ChecksTab({ pr, connectionId, owner, repo }: Props) {
 
   return (
     <ul className="flex flex-col gap-0.5">
-      {checks.map((c) => (
-        <li
-          key={c.id}
-          className="flex items-center justify-between gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
-        >
-          <span className="flex min-w-0 items-center gap-2">
-            <StatusIcon check={c} />
-            <span className="truncate">{c.name}</span>
-            {c.durationMs != null && (
-              <span className="text-xs text-muted-foreground">
-                {formatDuration(c.durationMs)}
+      {checks.map((c) => {
+        const isOpen = expanded.has(c.id);
+        const checkRunId = Number(c.id);
+        return (
+          <li key={c.id} className="flex flex-col">
+            <div className="flex items-center justify-between gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted">
+              <button
+                type="button"
+                onClick={() => toggle(c.id)}
+                aria-expanded={isOpen}
+                className="flex min-w-0 flex-1 items-center gap-2 text-left"
+              >
+                <ChevronRight
+                  className={cn(
+                    "h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform",
+                    isOpen && "rotate-90",
+                  )}
+                />
+                <StatusIcon check={c} />
+                <span className="truncate">{c.name}</span>
+                {c.durationMs != null && (
+                  <span className="text-xs text-muted-foreground">
+                    {formatDuration(c.durationMs)}
+                  </span>
+                )}
+              </button>
+              <span className="flex shrink-0 items-center gap-1">
+                {c.htmlUrl && (
+                  <a
+                    href={c.htmlUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex h-7 items-center justify-center rounded px-2 text-xs text-muted-foreground hover:bg-background"
+                    title={t("thread.checksTab.viewRun")}
+                  >
+                    <LinkExternal01 className="h-3.5 w-3.5" />
+                  </a>
+                )}
+                {c.conclusion === "failure" && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={chat.isStreaming}
+                    onClick={() => rerun(c.name)}
+                  >
+                    {t("thread.checksTab.rerun")}
+                  </Button>
+                )}
               </span>
+            </div>
+            {isOpen && (
+              <CheckRunDetail
+                orgId={org.id}
+                orgSlug={org.slug}
+                connectionId={connectionId}
+                owner={owner}
+                repo={repo}
+                checkRunId={Number.isFinite(checkRunId) ? checkRunId : null}
+              />
             )}
-          </span>
-          <span className="flex shrink-0 items-center gap-1">
-            {c.htmlUrl && (
-              <a
-                href={c.htmlUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex h-7 items-center justify-center rounded px-2 text-xs text-muted-foreground hover:bg-background"
-                title={t("thread.checksTab.viewRun")}
-              >
-                <LinkExternal01 className="h-3.5 w-3.5" />
-              </a>
-            )}
-            {c.conclusion === "failure" && (
-              <Button
-                size="sm"
-                variant="ghost"
-                disabled={chat.isStreaming}
-                onClick={() => rerun(c.name)}
-              >
-                {t("thread.checksTab.rerun")}
-              </Button>
-            )}
-          </span>
-        </li>
-      ))}
+          </li>
+        );
+      })}
     </ul>
+  );
+}
+
+interface CheckRunDetailProps {
+  orgId: string;
+  orgSlug: string;
+  connectionId: string;
+  owner: string;
+  repo: string;
+  checkRunId: number | null;
+}
+
+/** Lazily-loaded detail rendered under an expanded check row. */
+function CheckRunDetail({ checkRunId, ...repo }: CheckRunDetailProps) {
+  const t = useT();
+  const detailQuery = useCheckRunDetail({ ...repo, checkRunId, enabled: true });
+
+  if (detailQuery.isLoading) {
+    return (
+      <div className="px-7 py-2 text-xs text-muted-foreground">
+        {t("thread.checksTab.loadingCheckDetail")}
+      </div>
+    );
+  }
+
+  if (detailQuery.isError) {
+    return (
+      <div className="flex flex-col gap-1 px-7 py-2 text-xs text-destructive">
+        <span>{t("thread.checksTab.couldntLoadCheckDetail")}</span>
+        {detailQuery.error?.message && (
+          <span className="text-muted-foreground">
+            {detailQuery.error.message}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  const output = detailQuery.data;
+  const body = output?.summary?.trim() || output?.text?.trim();
+
+  if (!body) {
+    return (
+      <div className="px-7 py-2 text-xs text-muted-foreground">
+        {t("thread.checksTab.noCheckDetail")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-7 pb-3 pt-1 text-sm">
+      {output?.title && (
+        <div className="mb-1 text-xs font-medium text-muted-foreground">
+          {output.title}
+        </div>
+      )}
+      <MemoizedMarkdown id={`check-${checkRunId}`} text={body} />
+    </div>
   );
 }
 

--- a/apps/web/src/components/thread/github/checks-tab.tsx
+++ b/apps/web/src/components/thread/github/checks-tab.tsx
@@ -197,7 +197,12 @@ function CheckRunDetail({ checkRunId, ...repo }: CheckRunDetailProps) {
   }
 
   const output = detailQuery.data;
-  const body = output?.summary?.trim() || output?.text?.trim();
+  // GitHub splits a check's output into `summary` (e.g. URL/verdict) and `text`
+  // (e.g. the step table) and renders BOTH — join them so the detailed section
+  // isn't dropped when a summary is present.
+  const body = [output?.summary?.trim(), output?.text?.trim()]
+    .filter(Boolean)
+    .join("\n\n");
 
   if (!body) {
     return (

--- a/apps/web/src/components/thread/github/checks-tab.tsx
+++ b/apps/web/src/components/thread/github/checks-tab.tsx
@@ -5,6 +5,7 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { ChevronRight, LinkExternal01 } from "@untitledui/icons";
 import { useState } from "react";
 import { useT } from "@/i18n/use-t.ts";
+import { joinCheckOutput } from "./check-run-output.ts";
 import { useChatStream } from "../../chat/chat-context.tsx";
 import * as tpl from "./message-templates.ts";
 import {
@@ -197,14 +198,9 @@ function CheckRunDetail({ checkRunId, ...repo }: CheckRunDetailProps) {
   }
 
   const output = detailQuery.data;
-  // GitHub splits a check's output into `summary` (e.g. URL/verdict) and `text`
-  // (e.g. the step table) and renders BOTH — join them so the detailed section
-  // isn't dropped when a summary is present.
-  const body = [output?.summary?.trim(), output?.text?.trim()]
-    .filter(Boolean)
-    .join("\n\n");
+  const body = joinCheckOutput(output);
 
-  if (!body) {
+  if (!body && !output?.title) {
     return (
       <div className="px-7 py-2 text-xs text-muted-foreground">
         {t("thread.checksTab.noCheckDetail")}
@@ -222,7 +218,7 @@ function CheckRunDetail({ checkRunId, ...repo }: CheckRunDetailProps) {
       {/* Check output is attacker-influenceable (any app with checks:write can
           set it), so render through the sanitizing Markdown — NOT the chat
           renderer, which enables rehype-raw (raw HTML → XSS). */}
-      <Markdown className="max-w-none text-sm">{body}</Markdown>
+      {body && <Markdown className="max-w-none text-sm">{body}</Markdown>}
     </div>
   );
 }

--- a/apps/web/src/components/thread/github/extract-tool-json.test.ts
+++ b/apps/web/src/components/thread/github/extract-tool-json.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { extractToolJson } from "./extract-tool-json";
+import {
+  assertToolOk,
+  extractToolJson,
+  toolErrorMessage,
+} from "./extract-tool-json";
 
 describe("extractToolJson", () => {
   test("returns null for null/undefined input", () => {
@@ -34,5 +38,43 @@ describe("extractToolJson", () => {
     expect(extractToolJson<{ from: string }>(r)).toEqual({
       from: "structured",
     });
+  });
+});
+
+describe("toolErrorMessage / assertToolOk", () => {
+  test("returns null for a successful result", () => {
+    expect(
+      toolErrorMessage({ content: [{ type: "text", text: "{}" }] }),
+    ).toBeNull();
+    expect(toolErrorMessage(null)).toBeNull();
+  });
+
+  test("returns the text payload of an isError result", () => {
+    const r = {
+      isError: true,
+      content: [{ type: "text", text: "unknown method: get_check_runs" }],
+    };
+    expect(toolErrorMessage(r)).toBe("unknown method: get_check_runs");
+  });
+
+  test("falls back to a generic message when isError has no text", () => {
+    expect(toolErrorMessage({ isError: true })).toBe(
+      "GitHub MCP tool returned an error",
+    );
+  });
+
+  test("assertToolOk throws on an isError result (so select surfaces it)", () => {
+    expect(() =>
+      assertToolOk({
+        isError: true,
+        content: [{ type: "text", text: "403 checks:read required" }],
+      }),
+    ).toThrow("403 checks:read required");
+  });
+
+  test("assertToolOk does not throw on a successful result", () => {
+    expect(() =>
+      assertToolOk({ content: [{ type: "text", text: '{"check_runs":[]}' }] }),
+    ).not.toThrow();
   });
 });

--- a/apps/web/src/components/thread/github/extract-tool-json.ts
+++ b/apps/web/src/components/thread/github/extract-tool-json.ts
@@ -8,9 +8,34 @@
  * we still read the text payload.
  */
 type ToolResultLike = {
+  isError?: boolean;
   structuredContent?: unknown;
   content?: Array<{ type?: string; text?: string }>;
 };
+
+/**
+ * Returns the error text of a tool result flagged `isError`, or null when the
+ * call succeeded. github-mcp-server signals failures (bad token scope,
+ * unsupported method, GitHub API errors) via `isError: true` with the message
+ * in the text content — NOT by rejecting the call.
+ */
+export function toolErrorMessage(r: unknown): string | null {
+  if (!r || typeof r !== "object") return null;
+  const result = r as ToolResultLike;
+  if (!result.isError) return null;
+  const text = result.content?.find((c) => c.type === "text")?.text?.trim();
+  return text || "GitHub MCP tool returned an error";
+}
+
+/**
+ * Throws when a tool result is flagged `isError`. Call at the top of a query
+ * `select` so a swallowed tool failure surfaces as the query's error state
+ * instead of being silently mapped to an empty/`null` payload.
+ */
+export function assertToolOk(r: unknown): void {
+  const message = toolErrorMessage(r);
+  if (message) throw new Error(message);
+}
 
 function parseTextJson(text: string): unknown | null {
   try {

--- a/apps/web/src/components/thread/github/github-pr-api.ts
+++ b/apps/web/src/components/thread/github/github-pr-api.ts
@@ -2,6 +2,7 @@ import {
   extractToolJson,
   pullNumberFromUrl,
   pullRequestFromToolText,
+  toolErrorMessage,
 } from "./extract-tool-json.ts";
 import {
   appendCoAuthorToPullRequestBody,
@@ -15,11 +16,6 @@ type GithubMcpClient = {
     name: string;
     arguments: Record<string, unknown>;
   }) => Promise<unknown>;
-};
-
-type ToolResultLike = {
-  isError?: boolean;
-  content?: Array<{ type?: string; text?: string }>;
 };
 
 export interface CreatedPullRequest {
@@ -40,14 +36,6 @@ export interface OpenPullRequestArgs {
   body?: string;
   base: string;
   coAuthor?: CoAuthorIdentity;
-}
-
-function toolErrorMessage(result: unknown): string | null {
-  if (!result || typeof result !== "object") return null;
-  const r = result as ToolResultLike;
-  if (!r.isError) return null;
-  const text = r.content?.find((c) => c.type === "text")?.text?.trim();
-  return text || "GitHub MCP tool returned an error";
 }
 
 function assertGithubToolSuccess(result: unknown): void {

--- a/apps/web/src/components/thread/github/use-pr-data.ts
+++ b/apps/web/src/components/thread/github/use-pr-data.ts
@@ -16,7 +16,7 @@
 import { useMCPClient, useMCPToolCallQuery } from "@/sdk";
 
 import { extractPullRequestList } from "./github-pr-api.ts";
-import { extractToolJson } from "./extract-tool-json.ts";
+import { assertToolOk, extractToolJson } from "./extract-tool-json.ts";
 
 export interface PrSummary {
   number: number;
@@ -141,6 +141,7 @@ export function usePrByBranch(args: RepoArgs & { branch: string | null }) {
     refetchIntervalInBackground: false,
     staleTime: STALE,
     select: (r) => {
+      assertToolOk(r);
       const arr = extractPullRequestList(r);
       if (arr.length === 0) return null;
       return mapRawPr(arr[0]!);
@@ -180,7 +181,10 @@ export function useOpenPrs(args: RepoArgs & { enabled?: boolean }) {
       !!args.owner &&
       !!args.repo,
     staleTime: STALE,
-    select: (r) => extractPullRequestList(r).map(mapRawPr),
+    select: (r) => {
+      assertToolOk(r);
+      return extractPullRequestList(r).map(mapRawPr);
+    },
   });
 }
 
@@ -211,6 +215,7 @@ export function useChecks(
     refetchIntervalInBackground: false,
     staleTime: STALE,
     select: (r) => {
+      assertToolOk(r);
       // Accept both `{ check_runs: [...] }` envelopes and raw arrays.
       const raw = extractToolJson<
         { check_runs?: Record<string, unknown>[] } | Record<string, unknown>[]
@@ -269,6 +274,7 @@ export function usePrComments(
     refetchIntervalInBackground: false,
     staleTime: STALE,
     select: (r) => {
+      assertToolOk(r);
       const arr = extractToolJson<Record<string, unknown>[]>(r);
       if (!Array.isArray(arr)) return [];
       return arr.map((c): PrComment => {

--- a/apps/web/src/components/thread/github/use-pr-data.ts
+++ b/apps/web/src/components/thread/github/use-pr-data.ts
@@ -17,6 +17,7 @@ import { useMCPClient, useMCPToolCallQuery } from "@/sdk";
 
 import { extractPullRequestList } from "./github-pr-api.ts";
 import { assertToolOk, extractToolJson } from "./extract-tool-json.ts";
+import type { CheckRunOutput } from "./check-run-output.ts";
 
 export interface PrSummary {
   number: number;
@@ -244,12 +245,6 @@ export function useChecks(
       });
     },
   });
-}
-
-export interface CheckRunOutput {
-  title: string | null;
-  summary: string | null;
-  text: string | null;
 }
 
 /**

--- a/apps/web/src/components/thread/github/use-pr-data.ts
+++ b/apps/web/src/components/thread/github/use-pr-data.ts
@@ -246,6 +246,49 @@ export function useChecks(
   });
 }
 
+export interface CheckRunOutput {
+  title: string | null;
+  summary: string | null;
+  text: string | null;
+}
+
+/**
+ * Fetches a single check run's full `output` (title/summary/text markdown) via
+ * the github-mcp first-party GET_CHECK_RUN tool. The list tool
+ * (pull_request_read get_check_runs) returns a minimal shape without `output`,
+ * so the Checks tab lazily loads this when a row is expanded.
+ */
+export function useCheckRunDetail(
+  args: RepoArgs & { checkRunId: number | null; enabled: boolean },
+) {
+  const client = useMCPClient({
+    connectionId: args.connectionId,
+    orgId: args.orgId,
+    orgSlug: args.orgSlug,
+  });
+
+  return useMCPToolCallQuery<CheckRunOutput>({
+    client,
+    toolName: "GET_CHECK_RUN",
+    toolArguments: {
+      owner: args.owner,
+      repo: args.repo,
+      checkRunId: args.checkRunId ?? 0,
+    },
+    enabled: args.enabled && !!args.checkRunId,
+    staleTime: STALE,
+    select: (r) => {
+      assertToolOk(r);
+      const d = extractToolJson<{ output?: Partial<CheckRunOutput> }>(r);
+      return {
+        title: d?.output?.title ?? null,
+        summary: d?.output?.summary ?? null,
+        text: d?.output?.text ?? null,
+      };
+    },
+  });
+}
+
 /**
  * Issue-level comments on a PR via pull_request_read(get_comments).
  * Does NOT return review comments tied to a file + line — those belong

--- a/apps/web/src/components/thread/github/use-pr-reviews.ts
+++ b/apps/web/src/components/thread/github/use-pr-reviews.ts
@@ -13,7 +13,7 @@
 
 import { useMCPClient, useMCPToolCallQuery } from "@/sdk";
 
-import { extractToolJson } from "./extract-tool-json.ts";
+import { assertToolOk, extractToolJson } from "./extract-tool-json.ts";
 
 export type MergeableState =
   | "clean"
@@ -63,6 +63,7 @@ export function usePrReviews(args: Args) {
     refetchIntervalInBackground: false,
     staleTime: STALE,
     select: (r) => {
+      assertToolOk(r);
       const p = extractToolJson<Record<string, unknown>>(r);
       if (!p) return null;
       const ms = (p.mergeable_state as MergeableState | undefined) ?? "unknown";

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -16,10 +16,14 @@ export const thread = {
   "thread.changesTab.loadingChanges": "Loading changes…",
   "thread.changesTab.noCommittedChanges":
     "No committed changes in this pull request",
+  "thread.checksTab.couldntLoadCheckDetail":
+    "Couldn't load this check's detail.",
   "thread.checksTab.couldntLoadCheckRuns": "Couldn't load check runs.",
   "thread.checksTab.failure": "Failure",
   "thread.checksTab.inProgress": "In progress",
+  "thread.checksTab.loadingCheckDetail": "Loading detail…",
   "thread.checksTab.loadingChecks": "Loading checks…",
+  "thread.checksTab.noCheckDetail": "This check has no detailed output.",
   "thread.checksTab.noCheckRunsOnPrHeadCommit":
     "No check runs on the PR head commit.",
   "thread.checksTab.rerun": "Re-run",

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -18,11 +18,15 @@ export const thread = {
   "thread.changesTab.loadingChanges": "Carregando mudanças…",
   "thread.changesTab.noCommittedChanges":
     "Nenhuma mudança confirmada neste pull request",
+  "thread.checksTab.couldntLoadCheckDetail":
+    "Não foi possível carregar o detalhe desta verificação.",
   "thread.checksTab.couldntLoadCheckRuns":
     "Não foi possível carregar as verificações.",
   "thread.checksTab.failure": "Falha",
   "thread.checksTab.inProgress": "Em progresso",
+  "thread.checksTab.loadingCheckDetail": "Carregando detalhe…",
   "thread.checksTab.loadingChecks": "Carregando verificações…",
+  "thread.checksTab.noCheckDetail": "Esta verificação não tem detalhe.",
   "thread.checksTab.noCheckRunsOnPrHeadCommit":
     "Nenhuma verificação no commit principal do PR.",
   "thread.checksTab.rerun": "Executar novamente",

--- a/apps/web/src/lib/provision-repo-scoped-github-connection.ts
+++ b/apps/web/src/lib/provision-repo-scoped-github-connection.ts
@@ -1,8 +1,7 @@
 import type { ConnectionEntity } from "@/sdk";
 import {
   GITHUB_SCOPED_PERMISSIONS,
-  isChecksPermissionRejected,
-  permissionsWithoutChecks,
+  mintRepoTokenWithChecksFallback,
 } from "@decocms/shared/github-repo-scope";
 
 type McpCallTool = (req: {
@@ -79,27 +78,19 @@ export async function provisionRepoScopedGithubConnection(params: {
     };
     content?: Array<{ type?: string; text?: string }>;
   };
-  const mintWith = (permissions: Record<string, string>) =>
-    githubCallTool({
-      name: "MINT_REPO_TOKEN",
-      arguments: { installationId, owner, repo, permissions },
-    }) as Promise<MintResult>;
-
-  // Try the full set (incl. checks:read for the PR Checks tab). If the deployed
-  // github-mcp still predates the `checks` allowlist it hard-rejects the mint;
-  // fall back to a checks-less token so importing the repo keeps working until
-  // that deploy lands. The stored recipe records whichever set was granted.
-  let grantedPermissions: Record<string, string> = GITHUB_SCOPED_PERMISSIONS;
-  let mintRes = await mintWith(grantedPermissions);
-  if (
-    mintRes.isError &&
-    isChecksPermissionRejected(
-      mintRes.content?.find((c) => c.type === "text")?.text,
-    )
-  ) {
-    grantedPermissions = permissionsWithoutChecks(GITHUB_SCOPED_PERMISSIONS);
-    mintRes = await mintWith(grantedPermissions);
-  }
+  // Request checks:read for the PR Checks tab, falling back to a checks-less
+  // token when the deployed github-mcp/installation doesn't grant it yet — so
+  // importing the repo keeps working. The stored recipe records whichever set
+  // was granted.
+  const { result: mintRes, grantedPermissions } =
+    await mintRepoTokenWithChecksFallback<MintResult>(
+      (permissions) =>
+        githubCallTool({
+          name: "MINT_REPO_TOKEN",
+          arguments: { installationId, owner, repo, permissions },
+        }) as Promise<MintResult>,
+      GITHUB_SCOPED_PERMISSIONS,
+    );
   const minted = mintRes.structuredContent;
   if (mintRes.isError || !minted?.token) {
     const detail = mintRes.content?.find((c) => c.type === "text")?.text;

--- a/apps/web/src/lib/provision-repo-scoped-github-connection.ts
+++ b/apps/web/src/lib/provision-repo-scoped-github-connection.ts
@@ -1,5 +1,9 @@
 import type { ConnectionEntity } from "@/sdk";
-import { GITHUB_SCOPED_PERMISSIONS } from "@decocms/shared/github-repo-scope";
+import {
+  GITHUB_SCOPED_PERMISSIONS,
+  isChecksPermissionRejected,
+  permissionsWithoutChecks,
+} from "@decocms/shared/github-repo-scope";
 
 type McpCallTool = (req: {
   name: string;
@@ -61,15 +65,7 @@ export async function provisionRepoScopedGithubConnection(params: {
     orgShared,
   } = params;
 
-  const mintRes = (await githubCallTool({
-    name: "MINT_REPO_TOKEN",
-    arguments: {
-      installationId,
-      owner,
-      repo,
-      permissions: GITHUB_SCOPED_PERMISSIONS,
-    },
-  })) as {
+  type MintResult = {
     isError?: boolean;
     structuredContent?: {
       token?: string;
@@ -83,6 +79,27 @@ export async function provisionRepoScopedGithubConnection(params: {
     };
     content?: Array<{ type?: string; text?: string }>;
   };
+  const mintWith = (permissions: Record<string, string>) =>
+    githubCallTool({
+      name: "MINT_REPO_TOKEN",
+      arguments: { installationId, owner, repo, permissions },
+    }) as Promise<MintResult>;
+
+  // Try the full set (incl. checks:read for the PR Checks tab). If the deployed
+  // github-mcp still predates the `checks` allowlist it hard-rejects the mint;
+  // fall back to a checks-less token so importing the repo keeps working until
+  // that deploy lands. The stored recipe records whichever set was granted.
+  let grantedPermissions: Record<string, string> = GITHUB_SCOPED_PERMISSIONS;
+  let mintRes = await mintWith(grantedPermissions);
+  if (
+    mintRes.isError &&
+    isChecksPermissionRejected(
+      mintRes.content?.find((c) => c.type === "text")?.text,
+    )
+  ) {
+    grantedPermissions = permissionsWithoutChecks(GITHUB_SCOPED_PERMISSIONS);
+    mintRes = await mintWith(grantedPermissions);
+  }
   const minted = mintRes.structuredContent;
   if (mintRes.isError || !minted?.token) {
     const detail = mintRes.content?.find((c) => c.type === "text")?.text;
@@ -149,7 +166,7 @@ export async function provisionRepoScopedGithubConnection(params: {
             repositoryId,
             owner,
             repo,
-            permissions: GITHUB_SCOPED_PERMISSIONS,
+            permissions: grantedPermissions,
             grantProvider: "github-mcp",
           },
         },

--- a/packages/shared/src/github-repo-scope.test.ts
+++ b/packages/shared/src/github-repo-scope.test.ts
@@ -3,7 +3,9 @@ import {
   getOrgGithubConnections,
   getRepoScope,
   GITHUB_SCOPED_PERMISSIONS,
+  isChecksPermissionRejected,
   isOrgSharedConnection,
+  permissionsWithoutChecks,
   type RepoScopeRecipe,
 } from "./github-repo-scope";
 
@@ -21,6 +23,45 @@ describe("GITHUB_SCOPED_PERMISSIONS", () => {
       metadata: "read",
       pull_requests: "write",
       issues: "write",
+    });
+  });
+});
+
+describe("isChecksPermissionRejected", () => {
+  it("matches the deco/mcp-github checks-not-allowed mint error", () => {
+    expect(
+      isChecksPermissionRejected(
+        'Permission "checks" is not allowed. This tool only mints repo-scoped ' +
+          "code access (contents, metadata, pull_requests, issues).",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated errors or empty input", () => {
+    expect(
+      isChecksPermissionRejected('Permission "issues" is not allowed.'),
+    ).toBe(false);
+    expect(isChecksPermissionRejected("Repository is not accessible.")).toBe(
+      false,
+    );
+    expect(isChecksPermissionRejected(null)).toBe(false);
+    expect(isChecksPermissionRejected(undefined)).toBe(false);
+  });
+});
+
+describe("permissionsWithoutChecks", () => {
+  it("drops only the checks key and leaves the rest intact", () => {
+    expect(permissionsWithoutChecks(GITHUB_SCOPED_PERMISSIONS)).toEqual({
+      contents: "write",
+      metadata: "read",
+      pull_requests: "write",
+      issues: "write",
+    });
+  });
+
+  it("is a no-op when checks is absent", () => {
+    expect(permissionsWithoutChecks({ contents: "write" })).toEqual({
+      contents: "write",
     });
   });
 });

--- a/packages/shared/src/github-repo-scope.test.ts
+++ b/packages/shared/src/github-repo-scope.test.ts
@@ -28,11 +28,20 @@ describe("GITHUB_SCOPED_PERMISSIONS", () => {
 });
 
 describe("isChecksPermissionRejected", () => {
-  it("matches the deco/mcp-github checks-not-allowed mint error", () => {
+  it("matches the github-mcp allowlist rejection", () => {
     expect(
       isChecksPermissionRejected(
         'Permission "checks" is not allowed. This tool only mints repo-scoped ' +
           "code access (contents, metadata, pull_requests, issues).",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the GitHub 422 raised when the installation lacks Checks", () => {
+    expect(
+      isChecksPermissionRejected(
+        "Repository is not in this installation, or the requested permissions " +
+          "exceed what the GitHub App was granted.",
       ),
     ).toBe(true);
   });

--- a/packages/shared/src/github-repo-scope.test.ts
+++ b/packages/shared/src/github-repo-scope.test.ts
@@ -5,6 +5,7 @@ import {
   GITHUB_SCOPED_PERMISSIONS,
   isChecksPermissionRejected,
   isOrgSharedConnection,
+  mintRepoTokenWithChecksFallback,
   permissionsWithoutChecks,
   type RepoScopeRecipe,
 } from "./github-repo-scope";
@@ -72,6 +73,58 @@ describe("permissionsWithoutChecks", () => {
     expect(permissionsWithoutChecks({ contents: "write" })).toEqual({
       contents: "write",
     });
+  });
+});
+
+describe("mintRepoTokenWithChecksFallback", () => {
+  type MintResult = {
+    isError?: boolean;
+    content?: Array<{ type?: string; text?: string }>;
+    structuredContent?: { token?: string };
+  };
+  const ok: MintResult = { structuredContent: { token: "ghs_x" } };
+  const base = { contents: "write", metadata: "read" };
+
+  it("requests checks:read and returns it as granted on success", async () => {
+    const calls: Record<string, string>[] = [];
+    const { result, grantedPermissions } =
+      await mintRepoTokenWithChecksFallback((permissions) => {
+        calls.push(permissions);
+        return Promise.resolve(ok);
+      }, base);
+    expect(calls).toEqual([{ ...base, checks: "read" }]);
+    expect(grantedPermissions).toEqual({ ...base, checks: "read" });
+    expect(result).toBe(ok);
+  });
+
+  it("retries without checks when the mint is rejected for checks", async () => {
+    const calls: Record<string, string>[] = [];
+    const rejected: MintResult = {
+      isError: true,
+      content: [{ type: "text", text: 'Permission "checks" is not allowed.' }],
+    };
+    const { result, grantedPermissions } =
+      await mintRepoTokenWithChecksFallback((permissions) => {
+        calls.push(permissions);
+        return Promise.resolve(calls.length === 1 ? rejected : ok);
+      }, base);
+    expect(calls).toEqual([{ ...base, checks: "read" }, base]);
+    expect(grantedPermissions).toEqual(base);
+    expect(result).toBe(ok);
+  });
+
+  it("does NOT retry on an unrelated error (surfaces it once)", async () => {
+    const calls: Record<string, string>[] = [];
+    const err: MintResult = {
+      isError: true,
+      content: [{ type: "text", text: "GitHub is temporarily unavailable." }],
+    };
+    const { result } = await mintRepoTokenWithChecksFallback((permissions) => {
+      calls.push(permissions);
+      return Promise.resolve(err);
+    }, base);
+    expect(calls).toHaveLength(1);
+    expect(result).toBe(err);
   });
 });
 

--- a/packages/shared/src/github-repo-scope.test.ts
+++ b/packages/shared/src/github-repo-scope.test.ts
@@ -7,6 +7,24 @@ import {
   type RepoScopeRecipe,
 } from "./github-repo-scope";
 
+describe("GITHUB_SCOPED_PERMISSIONS", () => {
+  it("includes checks:read so the PR panel can read CI check runs", () => {
+    // Without this, the minted GitHub App installation token gets
+    // `403 Resource not accessible by integration` on
+    // GET /commits/{sha}/check-runs. See github-repo-scope.ts.
+    expect(GITHUB_SCOPED_PERMISSIONS.checks).toBe("read");
+  });
+
+  it("keeps the write scopes the PR/sandbox flows depend on", () => {
+    expect(GITHUB_SCOPED_PERMISSIONS).toMatchObject({
+      contents: "write",
+      metadata: "read",
+      pull_requests: "write",
+      issues: "write",
+    });
+  });
+});
+
 describe("getRepoScope", () => {
   it("returns the grant metadata for a refreshable repoScope without sourceConnectionId", () => {
     const recipe = {

--- a/packages/shared/src/github-repo-scope.ts
+++ b/packages/shared/src/github-repo-scope.ts
@@ -31,17 +31,24 @@ export const GITHUB_SCOPED_PERMISSIONS: Record<string, string> = {
 };
 
 /**
- * Detects the deco/mcp-github mint error raised when the deployed server's
- * permission allowlist predates `checks` (it hard-rejects any permission
- * outside contents/metadata/pull_requests/issues). Lets callers fall back to a
- * checks-less mint so provisioning keeps working until the github-mcp deploy
- * that allowlists `checks` lands — the two repos deploy independently.
+ * Detects a mint failure caused specifically by requesting `checks`, so callers
+ * can retry without it. Two distinct upstreams produce this:
+ *   1. github-mcp's own allowlist predating `checks` — it hard-rejects with
+ *      `Permission "checks" is not allowed` (deploy-window skew).
+ *   2. GitHub itself, when the App installation hasn't granted Checks — the
+ *      mint 422s, surfaced as `...the requested permissions exceed what the
+ *      GitHub App was granted`.
+ * Either way the safe move is a checks-less retry; if the real problem were
+ * unrelated (e.g. repo not in the installation), that retry fails identically.
  */
 export function isChecksPermissionRejected(
   message: string | null | undefined,
 ): boolean {
   if (!message) return false;
-  return /permission\s+"?checks"?\s+is not allowed/i.test(message);
+  return (
+    /permission\s+"?checks"?\s+is not allowed/i.test(message) ||
+    /permissions exceed what the github app/i.test(message)
+  );
 }
 
 /** A copy of a permission map with the `checks` key removed. */

--- a/packages/shared/src/github-repo-scope.ts
+++ b/packages/shared/src/github-repo-scope.ts
@@ -14,12 +14,20 @@
  * (oauth/github-mint) and the web import flow (github-repo-picker) can import it.
  */
 
-/** Least-privilege permission set minted for an imported agent's repo token. */
+/**
+ * Least-privilege permission set minted for an imported agent's repo token.
+ *
+ * `checks: read` lets the PR panel's Checks tab read CI check runs
+ * (`GET /commits/{sha}/check-runs`); without it the GitHub App installation
+ * token gets `403 Resource not accessible by integration`. The backing GitHub
+ * App must also grant Checks (read) or the mint fails with 422.
+ */
 export const GITHUB_SCOPED_PERMISSIONS: Record<string, string> = {
   contents: "write",
   metadata: "read",
   pull_requests: "write",
   issues: "write",
+  checks: "read",
 };
 
 /** The repo grant metadata stored at `connection.metadata.repoScope`. */

--- a/packages/shared/src/github-repo-scope.ts
+++ b/packages/shared/src/github-repo-scope.ts
@@ -30,6 +30,28 @@ export const GITHUB_SCOPED_PERMISSIONS: Record<string, string> = {
   checks: "read",
 };
 
+/**
+ * Detects the deco/mcp-github mint error raised when the deployed server's
+ * permission allowlist predates `checks` (it hard-rejects any permission
+ * outside contents/metadata/pull_requests/issues). Lets callers fall back to a
+ * checks-less mint so provisioning keeps working until the github-mcp deploy
+ * that allowlists `checks` lands — the two repos deploy independently.
+ */
+export function isChecksPermissionRejected(
+  message: string | null | undefined,
+): boolean {
+  if (!message) return false;
+  return /permission\s+"?checks"?\s+is not allowed/i.test(message);
+}
+
+/** A copy of a permission map with the `checks` key removed. */
+export function permissionsWithoutChecks(
+  permissions: Record<string, string>,
+): Record<string, string> {
+  const { checks: _checks, ...rest } = permissions;
+  return rest;
+}
+
 /** The repo grant metadata stored at `connection.metadata.repoScope`. */
 export interface RepoScopeRecipe {
   /** Legacy org mcp-github connection used to mint before refreshable grants. */

--- a/packages/shared/src/github-repo-scope.ts
+++ b/packages/shared/src/github-repo-scope.ts
@@ -59,6 +59,49 @@ export function permissionsWithoutChecks(
   return rest;
 }
 
+/** Minimal shape of a github-mcp MINT_REPO_TOKEN result the fallback inspects. */
+export interface MintToolResultLike {
+  isError?: boolean;
+  content?: Array<{ type?: string; text?: string }>;
+}
+
+/**
+ * Mint a repo token requesting `checks:read` on top of `basePermissions`, and
+ * transparently retry WITHOUT `checks` when the mint is rejected specifically
+ * for it (github-mcp allowlist skew, or an installation that hasn't granted
+ * Checks → 422). Single-sources the retry decision shared by the web provision
+ * flow and the server re-mint path.
+ *
+ * `callTool` performs the actual MINT_REPO_TOKEN call with a given permission
+ * map; the returned `grantedPermissions` is whichever set was ultimately
+ * requested (with or without `checks`) so callers can persist the truth.
+ *
+ * Note: callers that re-mint on a timer (github-mint) always re-add `checks`
+ * here, so a connection whose installation will never grant Checks pays a
+ * second mint each cycle. That's the deliberate cost of picking up a
+ * later-granted Checks without a re-import; provision persists the granted set
+ * and does not re-probe.
+ */
+export async function mintRepoTokenWithChecksFallback<
+  R extends MintToolResultLike,
+>(
+  callTool: (permissions: Record<string, string>) => Promise<R>,
+  basePermissions: Record<string, string>,
+): Promise<{ result: R; grantedPermissions: Record<string, string> }> {
+  const desiredPermissions = { ...basePermissions, checks: "read" };
+  const result = await callTool(desiredPermissions);
+  if (
+    result.isError &&
+    isChecksPermissionRejected(
+      result.content?.find((c) => c.type === "text")?.text,
+    )
+  ) {
+    const grantedPermissions = permissionsWithoutChecks(basePermissions);
+    return { result: await callTool(grantedPermissions), grantedPermissions };
+  }
+  return { result, grantedPermissions: desiredPermissions };
+}
+
 /** The repo grant metadata stored at `connection.metadata.repoScope`. */
 export interface RepoScopeRecipe {
   /** Legacy org mcp-github connection used to mint before refreshable grants. */


### PR DESCRIPTION
## Summary

The **Review Changes → Checks** tab was showing *"Nenhuma verificação no commit principal do PR."* for PRs that actually have check runs (e.g. `deco-sites/casaevideo-tanstack#460`, whose head commit has `Deco / QA / Purchase journey` and `Workers Builds` runs).

Root cause: `useChecks` calls `pull_request_read(get_check_runs)`, but `useMCPToolCallQuery` **never rejects on an `isError` tool result** — it returns the error payload as query data. The `select` then ran `extractToolJson`, got `null` for the non-JSON error text, and fell through to the empty state. So a failing fetch was indistinguishable from a PR with genuinely no checks. Likely triggers: the connected GitHub token/app missing `checks:read`, an older `github-mcp-server` without the `get_check_runs` method, or a transient API/rate-limit error.

The same latent bug affected the PR comments, reviews, and PR-list read hooks.

## Changes

- Add shared `toolErrorMessage()` / `assertToolOk()` helpers to `extract-tool-json.ts` and dedup the copy that already lived in `github-pr-api.ts`.
- Call `assertToolOk(r)` at the top of every PR read-hook `select` (`useChecks`, `usePrComments`, `usePrByBranch`, `useOpenPrs`, `usePrReviews`). A throw inside `select` surfaces as the query's `error` state in TanStack Query v5, so the tab renders its error state instead of a false empty state.
- `ChecksTab` now renders the underlying tool error message beneath the generic error line, so the real cause is diagnosable.

## Testing

- Added unit tests for `toolErrorMessage` / `assertToolOk`.
- `bun test` on `apps/mesh/src/web/components/thread/github/` — 152 pass.
- `bun run --cwd=apps/mesh check`, `bun run lint` (0 errors), `bun run fmt:check` all clean.

## Notes

Once deployed, the Checks tab will now show *why* the fetch failed rather than a misleading empty state — most likely the linked GitHub connection is missing `checks:read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Checks tab showing “no checks” on tool failures, adds an inline, sanitized check output viewer (joins summary + text), and ensures repo tokens can read check runs via `checks:read` with a shared, graceful fallback.

- New Features
  - Rows expand to show a run’s `output` rendered with sanitized `@deco/ui` `Markdown`; details are fetched lazily via `GET_CHECK_RUN`. Renders both `summary` and `text` together, and shows the title even when the body is empty.

- Bug Fixes
  - PR read hooks throw on `isError` tool results via `assertToolOk`; the Checks tab now shows the tool error message.
  - Added `checks:read` to `GITHUB_SCOPED_PERMISSIONS`. Mint/provision and periodic re-mint request it; if rejected by older `github-mcp` allowlists or installs without Checks, a shared `@decocms/shared` fallback retries without `checks` and persists the granted set. Legacy tokens self-heal on re-mint.

<sup>Written for commit a61c60b5a4476d25eb0d9b8751801ba0748bcd02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

