### PR TITLE
fix(helm): add missing CPU limits to nginx and worker containers

### DIFF
--- a/deploy/helm/studio/README.md
+++ b/deploy/helm/studio/README.md
@@ -63,8 +63,9 @@ worker:
 ```
 
 The main pod requests 2 CPU cores total by default: 500m for nginx and 750m for
-each Bun API container. The chart requires PostgreSQL for this split topology so
-API and worker pods share the DBOS run queue.
+each Bun API container, with limits matching requests + headroom (1 CPU per
+container). The chart requires PostgreSQL for this split topology so API and
+worker pods share the DBOS run queue.
 
 ## Prerequisites
 

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -82,6 +82,9 @@ worker:
     requests:
       cpu: "1"
       memory: 1Gi
+    limits:
+      cpu: "1.5"
+      memory: 1Gi
   autoscaling:
     enabled: true
     minReplicas: 2
@@ -106,6 +109,7 @@ nginx:
       cpu: "500m"
       memory: "128Mi"
     limits:
+      cpu: "1"
       memory: "256Mi"
   securityContext:
     runAsNonRoot: true


### PR DESCRIPTION
## Summary

Nginx and worker containers in the Studio Helm chart had requests but no CPU limits, allowing unbounded CPU usage that can starve other workloads on shared nodes. This fix adds CPU limits aligned with the pattern established in #e2d71dc25:
- Nginx: 1 CPU limit (requests 500m)
- Worker: 1.5 CPU limit (requests 1 CPU)

Worker pods now match the resource pattern of the main API deployment: both requests and limits are explicitly set, preventing uncontrolled CPU consumption during autoscaling up to 30 replicas.

## Why this matters

Workers are CPU-bound on LLM streams and autoscale up to 30 replicas. Without CPU limits, a worker burst (or a fleet of them) can starve other workloads on the node, causing application latency and cascading failures. This fix limits CPU per container to slightly above requests (1:1.5 ratio for workers), providing headroom for stream encoding bursts while preventing resource hogging.

## Verification

- `helm lint deploy/helm/studio` ✓ (1 chart(s) linted, 0 chart(s) failed)
- YAML syntax valid ✓
- Pattern matches recent CPU limit fixes (e2d71dc25) ✓
- Diff: +7 / -2 (tight, one concern) ✓

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CPU limits to the Studio Helm chart for the `nginx` and worker containers to prevent unbounded CPU bursts on shared nodes. Caps `nginx` at 1 CPU and workers at 1.5 CPUs while keeping worker requests at 1 CPU for headroom.

- **Bug Fixes**
  - Add limits in `values.yaml`: workers `cpu: "1.5"`, `memory: 1Gi`; `nginx` `cpu: "1"`.
  - Update README to document the requests + headroom limits pattern.

<sup>Written for commit 7413066d7293044ba5510088202f46df26221711. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

