### PR TITLE
fix(sandbox): show original content in the diff for a renamed file

### DIFF
--- a/packages/sandbox/daemon/git/porcelain.test.ts
+++ b/packages/sandbox/daemon/git/porcelain.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { parsePorcelainEntry, parsePorcelainZ } from "./porcelain";
+import {
+  parsePorcelainEntry,
+  parsePorcelainFiles,
+  parsePorcelainZ,
+} from "./porcelain";
 
 describe("parsePorcelainEntry", () => {
   it("parses standard spaced format", () => {
@@ -23,5 +27,21 @@ describe("parsePorcelainZ", () => {
   it("collects paths from multiple entries", () => {
     const out = " M a.ts\0?? b.ts\0";
     expect(parsePorcelainZ(out)).toEqual(new Set(["a.ts", "b.ts"]));
+  });
+});
+
+describe("parsePorcelainFiles", () => {
+  it("captures the pre-rename path for R entries", () => {
+    const out = "R  b.txt\0a.txt\0";
+    expect(parsePorcelainFiles(out)).toEqual([
+      { path: "b.txt", index: "R", working_dir: " ", origPath: "a.txt" },
+    ]);
+  });
+
+  it("omits origPath for a plain modification", () => {
+    const out = " M a.ts\0";
+    expect(parsePorcelainFiles(out)).toEqual([
+      { path: "a.ts", index: " ", working_dir: "M" },
+    ]);
   });
 });

--- a/packages/sandbox/daemon/git/porcelain.ts
+++ b/packages/sandbox/daemon/git/porcelain.ts
@@ -16,6 +16,8 @@ export interface PorcelainFileStatus {
   path: string;
   index: string;
   working_dir: string;
+  /** Pre-rename path, present only for R/C entries (`-z` emits it as the next null-separated field). */
+  origPath?: string;
 }
 
 /** Parse full `-z` porcelain output into per-file index/worktree status. */
@@ -27,14 +29,17 @@ export function parsePorcelainFiles(out: string): PorcelainFileStatus[] {
     if (!entry) continue;
     const parsed = parsePorcelainEntry(entry);
     if (!parsed) continue;
-    files.push({
+    const file: PorcelainFileStatus = {
       path: parsed.path,
       index: parsed.index,
       working_dir: parsed.working,
-    });
+    };
     if (parsed.index === "R" || parsed.index === "C") {
       i++;
+      const origPath = parts[i];
+      if (origPath) file.origPath = origPath;
     }
+    files.push(file);
   }
   return files;
 }

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -217,6 +217,19 @@ describe("git routes", () => {
     expect(body.diffs["README.md"]?.to).toContain("hello world");
   });
 
+  it("diff shows the original content for a renamed file, not null", async () => {
+    const { appRoot, repoDir } = initRepo();
+    gitSync(["mv", "README.md", "GUIDE.md"], { cwd: repoDir, asUser: false });
+    const handler = makeGitDiffHandler({ appRoot, repoDir });
+    const res = await handler(new Request("http://x/git/diff"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      diffs: Record<string, { from: string | null; to: string | null }>;
+    };
+    expect(body.diffs["GUIDE.md"]?.from).toContain("hello");
+    expect(body.diffs["GUIDE.md"]?.to).toContain("hello");
+  });
+
   it("diff against base returns committed branch changes", async () => {
     const { appRoot, repoDir } = initRepo();
     gitSync(["checkout", "-b", "feature"], { cwd: repoDir, asUser: false });

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -116,6 +116,8 @@ export interface GitStatusFile {
   path: string;
   index: string;
   working_dir: string;
+  /** Pre-rename path, present only for R/C entries. */
+  origPath?: string;
 }
 
 export interface GitStatusResult {
@@ -274,7 +276,14 @@ async function computeDiff(repoDir: string): Promise<GitDiffResult> {
       const index = file?.index ?? " ";
       const working = file?.working_dir ?? " ";
       const isDeleted = index === "D" || working === "D";
-      const head = await readRefFileAsync(repoDir, "HEAD", filePath);
+      // A renamed file's HEAD content lives under its pre-rename path — reading
+      // HEAD:filePath would 404 (the new name never existed at HEAD) and the
+      // rename would render as a brand-new file with no "from" content.
+      const head = await readRefFileAsync(
+        repoDir,
+        "HEAD",
+        file?.origPath ?? filePath,
+      );
       const isNew =
         (index === "?" && working === "?") ||
         index === "A" ||


### PR DESCRIPTION
**Bug**: `git status --porcelain=v1 -z` emits a renamed file's pre-rename path as a second null-separated field right after the new path (verified: `R  b.txt\0a.txt\0`). `parsePorcelainFiles` (packages/sandbox/daemon/git/porcelain.ts) skipped that field with `i++` instead of capturing it, so the old path was silently dropped everywhere downstream. `computeDiff` (packages/sandbox/daemon/routes/git.ts) then tried to read the renamed file's HEAD content at its *new* path, which never existed there, fell back to `isNew = true`, and rendered the rename as a brand-new file with `from: null` — losing all visibility that the content carried over from the old file.

**Payoff**: renaming a tracked file in the sandbox (`git mv`, or an agent's rename tool) is a common editing action; the Changes/diff panel silently showed it as a new file with no prior content, hiding the actual (often empty) diff and making a pure rename look like a full addition.

**Fix**: `parsePorcelainFiles` now captures the pre-rename path into a new optional `origPath` field on each R/C status entry. `computeDiff` reads `HEAD:<origPath>` when present instead of `HEAD:<newPath>`, so the diff correctly shows the original content as `from` and the new path's working-tree content as `to`.

**Regression tests**:
- `porcelain.test.ts`: `parsePorcelainFiles` captures `origPath` for an `R` entry and omits it for a plain modification.
- `git.test.ts`: new end-to-end test — `git mv README.md GUIDE.md`, then GET `/git/diff` — asserts `diffs["GUIDE.md"].from` contains the original content instead of being `null`.

**Reviewer check**: `bun test packages/sandbox/daemon/git/porcelain.test.ts packages/sandbox/daemon/routes/git.test.ts`

**Verified locally**: `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox`, and both targeted test files above (34 tests, all green). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the diff view for renamed files in the sandbox so the “from” side shows the original content instead of rendering the file as a brand-new addition. This makes the Changes panel accurately reflect pure renames.

- **Bug Fixes**
  - `parsePorcelainFiles` now captures the pre-rename path (`origPath`) for `R`/`C` entries from `git status --porcelain=v1 -z`.
  - `computeDiff` reads `HEAD:<origPath>` when present, so renamed files show correct “from” content.
  - Added tests covering rename parsing and end-to-end diff behavior.

<sup>Written for commit 4e5cd8a4522d6738fd67d158eaa4e1e2fad62102. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

