### PR TITLE
fix(registry): add aria-label to the cancel-replace-token button in the QA monitor panel

### DIFF
--- a/apps/mesh/src/web/i18n/en/registry.ts
+++ b/apps/mesh/src/web/i18n/en/registry.ts
@@ -109,6 +109,8 @@ export const registry = {
   "registry.monitorConnectionsPanel.actionsFor": "Actions for {title}",
   "registry.monitorConnectionsPanel.authError": "Error: {error}",
   "registry.monitorConnectionsPanel.authenticated": "Authenticated",
+  "registry.monitorConnectionsPanel.cancelReplaceToken":
+    "Cancel replacing token",
   "registry.monitorConnectionsPanel.checking": "Checking...",
   "registry.monitorConnectionsPanel.checkingAuth": "Checking auth...",
   "registry.monitorConnectionsPanel.connected": "Connected",

--- a/apps/mesh/src/web/i18n/pt-br/registry.ts
+++ b/apps/mesh/src/web/i18n/pt-br/registry.ts
@@ -116,6 +116,8 @@ export const registry = {
   "registry.monitorConnectionsPanel.actionsFor": "Ações para {title}",
   "registry.monitorConnectionsPanel.authError": "Erro: {error}",
   "registry.monitorConnectionsPanel.authenticated": "Autenticado",
+  "registry.monitorConnectionsPanel.cancelReplaceToken":
+    "Cancelar substituição do token",
   "registry.monitorConnectionsPanel.checking": "Verificando...",
   "registry.monitorConnectionsPanel.checkingAuth":
     "Verificando autenticação...",

--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -578,6 +578,9 @@ function ConnectionRow({
               size="sm"
               variant="ghost"
               className="h-8 text-xs"
+              aria-label={t(
+                "registry.monitorConnectionsPanel.cancelReplaceToken",
+              )}
               onClick={() => {
                 setIsReplacingToken(false);
                 setTokenValue("");


### PR DESCRIPTION
**Source:** bug found while auditing `monitor-connections-panel.tsx` for error-handling/i18n/a11y gaps (this session's assigned focus area). Not tied to an open issue.

**Why a maintainer wants this:** every other icon-only control in this file (the row's actions-menu trigger, added in #4904) already carries an `aria-label`, but the "✕" button that cancels replacing a saved token was missed — a screen reader has no meaningful name to announce for a bare `✕` glyph, so users of assistive tech can't tell what the button does.

**Fix:** add `aria-label` (new `registry.monitorConnectionsPanel.cancelReplaceToken` i18n key, en + pt-br) to that button, matching the pattern already used by the DropdownMenu trigger a few lines above.

**Reviewer check:** open a QA connection card whose auth is `authenticated` via a plain token (not OAuth), click "Edit" to reveal the token input, and inspect the "✕" button — it now exposes an accessible name.

**Verified locally:** `bun run fmt` (clean), `cd apps/mesh && bunx tsc --noEmit` (no new errors — the only errors reported are pre-existing in an untracked `types.test.ts`/`create-sse-subscription.test.ts` unrelated to this change). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an aria-label to the cancel “replace token” button in the Registry Monitor Connections panel. This gives the icon-only ✕ an accessible name so screen readers announce it correctly.

- **Bug Fixes**
  - Added `aria-label` using `registry.monitorConnectionsPanel.cancelReplaceToken`.
  - Added i18n strings in `en` and `pt-br`.

<sup>Written for commit 3a515b86847565c6fc377cd81c4f9f15f58944d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

