### PR TITLE
fix(i18n): add i18n to commerce report banner

### DIFF
--- a/apps/mesh/src/web/components/home/commerce-report-banner.tsx
+++ b/apps/mesh/src/web/components/home/commerce-report-banner.tsx
@@ -28,6 +28,7 @@ import {
   type CommerceReportBannerStatus,
   deriveCommerceReportBannerStatus,
 } from "@/web/hooks/commerce-diagnostic-status";
+import { useT } from "@/web/i18n/use-t";
 
 /** The tilted miniature report page bleeding out of the banner's bottom
  *  edge. Pure decoration (aria-hidden); `generating` swaps the score ring
@@ -129,8 +130,9 @@ function BannerShell({
   host: string | null;
   onOpen: () => void;
 }) {
+  const t = useT();
   const generating = status === "generating";
-  const store = host ?? "sua loja";
+  const store = host ?? t("reports.commerceBanner.storeDefault");
 
   return (
     <button
@@ -156,13 +158,13 @@ function BannerShell({
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <span className="text-base font-medium leading-6 text-foreground sm:text-lg">
             {generating
-              ? "Gerando seu diagnóstico"
-              : "Seu relatório está pronto"}
+              ? t("reports.commerceBanner.generatingTitle")
+              : t("reports.commerceBanner.readyTitle")}
           </span>
           <span className="truncate text-sm text-muted-foreground">
             {generating
-              ? `Analisando ${store}. Isso leva alguns minutos.`
-              : `Veja a análise completa de ${store}.`}
+              ? t("reports.commerceBanner.generatingSubtitle", { store })
+              : t("reports.commerceBanner.readySubtitle", { store })}
           </span>
         </div>
         <div

--- a/apps/mesh/src/web/i18n/en/reports.ts
+++ b/apps/mesh/src/web/i18n/en/reports.ts
@@ -130,4 +130,10 @@ export const reports = {
   "reports.signalDeck.shareOnLinkedIn": "Compartilhar no LinkedIn",
   "reports.signalDeck.shareOnX": "Compartilhar no X",
   "reports.signalDeck.viewFullDiagnostic": "Ver diagnóstico completo",
+  "reports.commerceBanner.storeDefault": "your store",
+  "reports.commerceBanner.generatingTitle": "Generating your diagnostic",
+  "reports.commerceBanner.readyTitle": "Your report is ready",
+  "reports.commerceBanner.generatingSubtitle":
+    "Analyzing {store}. This takes a few minutes.",
+  "reports.commerceBanner.readySubtitle": "See the full analysis of {store}.",
 } as const;

--- a/apps/mesh/src/web/i18n/pt-br/reports.ts
+++ b/apps/mesh/src/web/i18n/pt-br/reports.ts
@@ -132,4 +132,10 @@ export const reports = {
   "reports.signalDeck.shareOnLinkedIn": "Compartilhar no LinkedIn",
   "reports.signalDeck.shareOnX": "Compartilhar no X",
   "reports.signalDeck.viewFullDiagnostic": "Ver diagnóstico completo",
+  "reports.commerceBanner.storeDefault": "sua loja",
+  "reports.commerceBanner.generatingTitle": "Gerando seu diagnóstico",
+  "reports.commerceBanner.readyTitle": "Seu relatório está pronto",
+  "reports.commerceBanner.generatingSubtitle":
+    "Analisando {store}. Isso leva alguns minutos.",
+  "reports.commerceBanner.readySubtitle": "Veja a análise completa de {store}.",
 } satisfies Record<keyof typeof reportsEn, string>;

--- a/packages/e2e/tests/commerce-report-banner.spec.ts
+++ b/packages/e2e/tests/commerce-report-banner.spec.ts
@@ -30,8 +30,8 @@ import { expect, test } from "../fixtures/test";
 const cdConnectionId = (orgId: string) => `${orgId}_commerce-discovery`;
 const REPORT_TOOL = "get_my_diagnostic";
 
-const READY_TITLE = "Seu relatório está pronto";
-const GENERATING_TITLE = "Gerando seu diagnóstico";
+const READY_TITLE = "Your report is ready";
+const GENERATING_TITLE = "Generating your diagnostic";
 
 const SITE_URL = "https://minha-loja.example";
 


### PR DESCRIPTION
## What is this contribution about?

The commerce report banner (`commerce-report-banner.tsx`) had four hardcoded Portuguese strings — the title and subtitle for both the "generating" and "ready" states, plus the "sua loja" fallback when no host is known. This PR moves all of them through the i18n system using `useT()`, with English keys added to `en/reports.ts` and Portuguese translations in `pt-br/reports.ts`.

## Screenshots/Demonstration

No visual change — the banner renders identically in pt-br. English users will now see properly translated copy ("Your report is ready", "Generating your diagnostic", etc.).

## How to Test

1. Open the home page for an org with Commerce Discovery connected.
2. Switch language to English (settings → preferences).
3. Confirm the banner reads "Your report is ready" / "See the full analysis of {store}." (or the generating variants).
4. Switch back to Portuguese and confirm the original copy still appears.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internationalized the Commerce Report banner using `useT()` and new `reports.commerceBanner.*` keys in `en/reports.ts` and `pt-br/reports.ts`. Localized titles, subtitles, and the store fallback (EN/PT-BR) with no visual changes; updated e2e tests to expect English strings to match CI.

<sup>Written for commit e360251f85fe71b2e355fc46ff5d568d65f57024. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

