### PR TITLE
feat(i18n): translate the agent instructions prompt-template insert

### DIFF
--- a/apps/mesh/src/web/i18n/en/virtual-mcp.ts
+++ b/apps/mesh/src/web/i18n/en/virtual-mcp.ts
@@ -162,6 +162,32 @@ export const virtualMcp = {
     "No connections yet. Add one to get started.",
   "virtualMcp.virtualMcp.openFullscreenEditor": "Open fullscreen editor",
   "virtualMcp.virtualMcp.promptTemplate": "+ Prompt template",
+  "virtualMcp.virtualMcp.promptTemplateContent": `<role>
+Define who this agent is and what it specializes in.
+Example: You are a support triage agent for B2B merchants.
+</role>
+
+<capabilities>
+List what this agent can do using its connected tools.
+- Investigate issues using connected data sources.
+- Summarize findings and recommend next steps.
+</capabilities>
+
+<constraints>
+Set clear boundaries on what the agent must not do.
+- Do not perform destructive actions without confirmation.
+- Escalate to a human when the request is outside your expertise.
+</constraints>
+
+<workflows>
+Define step-by-step how the agent should handle requests.
+
+## Default workflow
+1. Read the user's request and gather context.
+2. Use the appropriate tools to investigate or act.
+3. Summarize the result and propose next steps.
+4. Ask for confirmation before making any changes.
+</workflows>`,
   "virtualMcp.virtualMcp.publishing": "Publishing",
   "virtualMcp.virtualMcp.publishingDescription":
     "Control when this agent's changes can be published directly, skipping pull-request review.",

--- a/apps/mesh/src/web/i18n/pt-br/virtual-mcp.ts
+++ b/apps/mesh/src/web/i18n/pt-br/virtual-mcp.ts
@@ -165,6 +165,32 @@ export const virtualMcp = {
     "Nenhuma conexão ainda. Adicione uma para começar.",
   "virtualMcp.virtualMcp.openFullscreenEditor": "Abrir editor em tela cheia",
   "virtualMcp.virtualMcp.promptTemplate": "+ Modelo de prompt",
+  "virtualMcp.virtualMcp.promptTemplateContent": `<role>
+Defina quem é este agente e em que ele é especializado.
+Exemplo: Você é um agente de triagem de suporte para comerciantes B2B.
+</role>
+
+<capabilities>
+Liste o que este agente pode fazer usando suas ferramentas conectadas.
+- Investigar problemas usando as fontes de dados conectadas.
+- Resumir descobertas e recomendar próximos passos.
+</capabilities>
+
+<constraints>
+Defina limites claros sobre o que o agente não deve fazer.
+- Não realizar ações destrutivas sem confirmação.
+- Escalar para um humano quando a solicitação estiver fora da sua especialidade.
+</constraints>
+
+<workflows>
+Defina passo a passo como o agente deve tratar as solicitações.
+
+## Fluxo padrão
+1. Ler a solicitação do usuário e reunir contexto.
+2. Usar as ferramentas apropriadas para investigar ou agir.
+3. Resumir o resultado e propor próximos passos.
+4. Pedir confirmação antes de fazer qualquer alteração.
+</workflows>`,
   "virtualMcp.virtualMcp.publishing": "Publicação",
   "virtualMcp.virtualMcp.publishingDescription":
     "Controle quando as alterações deste agente podem ser publicadas diretamente, sem revisão por pull request.",

--- a/apps/mesh/src/web/views/virtual-mcp/index.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/index.tsx
@@ -694,32 +694,7 @@ function VirtualMcpDetailViewWithData({
 
   const handleInsertTemplate = () => {
     const current = form.getValues("metadata.instructions") ?? "";
-    const template = `<role>
-Define who this agent is and what it specializes in.
-Example: You are a support triage agent for B2B merchants.
-</role>
-
-<capabilities>
-List what this agent can do using its connected tools.
-- Investigate issues using connected data sources.
-- Summarize findings and recommend next steps.
-</capabilities>
-
-<constraints>
-Set clear boundaries on what the agent must not do.
-- Do not perform destructive actions without confirmation.
-- Escalate to a human when the request is outside your expertise.
-</constraints>
-
-<workflows>
-Define step-by-step how the agent should handle requests.
-
-## Default workflow
-1. Read the user's request and gather context.
-2. Use the appropriate tools to investigate or act.
-3. Summarize the result and propose next steps.
-4. Ask for confirmation before making any changes.
-</workflows>`;
+    const template = t("virtualMcp.virtualMcp.promptTemplateContent");
     const next = current.trim() ? `${current}\n\n${template}` : template;
     form.setValue("metadata.instructions", next, { shouldDirty: true });
   };


### PR DESCRIPTION
The `+ Prompt template` button in the agent (virtual MCP) Instructions editor inserted a hardcoded English `<role>/<capabilities>/<constraints>/<workflows>` scaffold directly into the textarea, violating the repo rule that every user-facing string in `apps/mesh/src/web` goes through `t()` (see CLAUDE.md i18n section) — every other string on this same view is already localized (`instructionsPlaceholder`, `promptTemplate` label itself, etc.), so this one template body was the odd one out.

A Portuguese-speaking org member clicking that button gets English boilerplate seeded straight into their agent's instructions with no path to a localized version, unlike every other string on the page.

Changes:
- Added `virtualMcp.virtualMcp.promptTemplateContent` to `apps/mesh/src/web/i18n/en/virtual-mcp.ts` (identical text, moved verbatim) and its pt-br translation in `apps/mesh/src/web/i18n/pt-br/virtual-mcp.ts`.
- `apps/mesh/src/web/views/virtual-mcp/index.tsx`'s `handleInsertTemplate` now reads the template via `t("virtualMcp.virtualMcp.promptTemplateContent")` instead of a literal template string. No behavior change for English users; pt-br users now get a translated scaffold.

Net diff: -26 / +53 (pure string relocation + one new translation), no logic change.

How to verify: switch the UI language to Português (Brasil) in preferences, open an agent with empty Instructions, click "+ Modelo de prompt", and confirm the inserted scaffold is in Portuguese.

Locally ran: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (green, includes the `en`/`pt-br` `satisfies` completeness check for the new key). Full CI runs lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the "+ Prompt template" insert in the agent Instructions editor by moving the scaffold into i18n. PT-BR users get a translated template; English behavior is unchanged.

- **Bug Fixes**
  - Added `virtualMcp.virtualMcp.promptTemplateContent` to `en` and `pt-br` dictionaries.
  - Updated `handleInsertTemplate` to use `t("virtualMcp.virtualMcp.promptTemplateContent")` instead of a hardcoded string.

<sup>Written for commit d47b2ba22afd5a54235f9d88e05a3cee387ecd9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

