### PR TITLE
fix(sandbox-preview): translate the file explorer delete confirmation dialog

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer-delete-dialog.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer-delete-dialog.tsx
@@ -8,6 +8,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@deco/ui/components/alert-dialog.tsx";
+import { useT } from "@/web/i18n/use-t.ts";
 import type { TreeNode } from "./types";
 
 export function FileExplorerDeleteDialog({
@@ -23,32 +24,40 @@ export function FileExplorerDeleteDialog({
   onOpenChange: (open: boolean) => void;
   onConfirm: (node: TreeNode) => void;
 }) {
+  const t = useT();
+  const isFolder = deleteTarget?.kind === "directory";
   return (
     <AlertDialog open={deleteTarget !== null} onOpenChange={onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>
-            Delete {deleteTarget?.kind === "directory" ? "folder" : "file"}?
+            {t(
+              isFolder
+                ? "sandbox.fileExplorerDeleteDialog.titleFolder"
+                : "sandbox.fileExplorerDeleteDialog.titleFile",
+            )}
           </AlertDialogTitle>
           <AlertDialogDescription>
-            This will permanently delete{" "}
+            {t("sandbox.fileExplorerDeleteDialog.description")}{" "}
             <span className="font-mono">{deleteTarget?.name}</span>
-            {deleteTarget?.kind === "directory"
-              ? " and everything inside it."
+            {isFolder
+              ? t("sandbox.fileExplorerDeleteDialog.folderSuffix")
               : "."}
             {deleteDirtyPaths.length > 0 && (
               <>
                 {" "}
                 {deleteDirtyPaths.length === 1
-                  ? "One open file has unsaved changes that will be lost."
-                  : `${deleteDirtyPaths.length} open files have unsaved changes that will be lost.`}
+                  ? t("sandbox.fileExplorerDeleteDialog.unsavedChangesOne")
+                  : t("sandbox.fileExplorerDeleteDialog.unsavedChangesMany", {
+                      count: deleteDirtyPaths.length,
+                    })}
               </>
             )}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel disabled={fsActionPending}>
-            Cancel
+            {t("sandbox.fileExplorerDeleteDialog.cancel")}
           </AlertDialogCancel>
           <AlertDialogAction
             disabled={fsActionPending || !deleteTarget}
@@ -57,7 +66,7 @@ export function FileExplorerDeleteDialog({
               if (deleteTarget) onConfirm(deleteTarget);
             }}
           >
-            Delete
+            {t("sandbox.fileExplorerDeleteDialog.delete")}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -194,6 +194,17 @@ export const sandbox = {
   "sandbox.fileExplorer.selectFileToEdit": "Select a file to edit",
   "sandbox.fileExplorer.send": "Send",
   "sandbox.fileExplorer.textCopied": "{label} copied",
+  "sandbox.fileExplorerDeleteDialog.cancel": "Cancel",
+  "sandbox.fileExplorerDeleteDialog.delete": "Delete",
+  "sandbox.fileExplorerDeleteDialog.description":
+    "This will permanently delete",
+  "sandbox.fileExplorerDeleteDialog.folderSuffix": " and everything inside it.",
+  "sandbox.fileExplorerDeleteDialog.titleFile": "Delete file?",
+  "sandbox.fileExplorerDeleteDialog.titleFolder": "Delete folder?",
+  "sandbox.fileExplorerDeleteDialog.unsavedChangesMany":
+    "{count} open files have unsaved changes that will be lost.",
+  "sandbox.fileExplorerDeleteDialog.unsavedChangesOne":
+    "One open file has unsaved changes that will be lost.",
   "sandbox.fileExplorerNameDialog.cancel": "Cancel",
   "sandbox.fileExplorerNameDialog.location": "Location",
   "sandbox.fileExplorerNameDialog.name": "Name",

--- a/apps/mesh/src/web/i18n/pt-br/sandbox.ts
+++ b/apps/mesh/src/web/i18n/pt-br/sandbox.ts
@@ -203,6 +203,17 @@ export const sandbox = {
   "sandbox.fileExplorer.selectFileToEdit": "Selecione um arquivo para editar",
   "sandbox.fileExplorer.send": "Enviar",
   "sandbox.fileExplorer.textCopied": "{label} copiado",
+  "sandbox.fileExplorerDeleteDialog.cancel": "Cancelar",
+  "sandbox.fileExplorerDeleteDialog.delete": "Excluir",
+  "sandbox.fileExplorerDeleteDialog.description":
+    "Isso excluirá permanentemente",
+  "sandbox.fileExplorerDeleteDialog.folderSuffix": " e tudo dentro dela.",
+  "sandbox.fileExplorerDeleteDialog.titleFile": "Excluir arquivo?",
+  "sandbox.fileExplorerDeleteDialog.titleFolder": "Excluir pasta?",
+  "sandbox.fileExplorerDeleteDialog.unsavedChangesMany":
+    "{count} arquivos abertos têm alterações não salvas que serão perdidas.",
+  "sandbox.fileExplorerDeleteDialog.unsavedChangesOne":
+    "Um arquivo aberto tem alterações não salvas que serão perdidas.",
   "sandbox.fileExplorerNameDialog.cancel": "Cancelar",
   "sandbox.fileExplorerNameDialog.location": "Local",
   "sandbox.fileExplorerNameDialog.name": "Nome",


### PR DESCRIPTION
The sandbox file explorer's delete confirmation dialog (`file-explorer-delete-dialog.tsx`) was entirely hardcoded in English — title, description, the "unsaved changes will be lost" warning, and the Cancel/Delete buttons — missed by the sandbox i18n sweep (#4971). Every other dialog in this same folder (`file-explorer-name-dialog.tsx`) already goes through `useT()`, so this was a straggler.

A maintainer wants this because a pt-br user deleting a file today sees a dialog that's a mix of translated surrounding UI and raw English text, which is exactly the class of bug #4971 set out to close.

No logic changed — this is a pure string-to-`t()` wiring following the existing codebase convention (see `delete-connection-dialogs.tsx`) of a translated prefix + an untranslated inline `<span>` for the filename, so the interpolation never has to embed JSX. Added `sandbox.fileExplorerDeleteDialog.*` keys to both `en/sandbox.ts` and `pt-br/sandbox.ts`.

To confirm: open the sandbox file explorer, switch language to Portuguese in preferences, right-click a file/folder → Delete, and confirm the dialog is fully translated (including the unsaved-changes warning when an open file has edits).

Locally verified: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (green — this also proves pt-br key completeness since pt-br `satisfies Record<keyof typeof sandboxEn, string>`). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate the sandbox file explorer delete confirmation dialog to use i18n, fixing the last English-only dialog from the sweep (#4971). Users now see localized title, description, unsaved-changes warning, and buttons.

- **Bug Fixes**
  - Routed all dialog strings through `useT()` with file/folder variants and count-based unsaved changes.
  - Added `sandbox.fileExplorerDeleteDialog.*` keys to `en/sandbox.ts` and `pt-br/sandbox.ts`.

<sup>Written for commit 998246ef35892fd3f8025ae2b05b7b6195f45182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

