### PR TITLE
fix(sandbox-env): raise sandbox memory request 1Gi → 2Gi to stop node-pressure evictions

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,11 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.9.14: sandbox pod memory request 1Gi -> 2Gi (= measured p95 of per-pod peak
+# working-set; 7d). At 1Gi the scheduler bin-packed on less than half of real
+# usage and prod nodes hit memory-pressure eviction (0 per-pod OOMs — the 4Gi
+# limit was never reached). Sizes the request to real usage; trades packing
+# density for the elimination of node-pressure evictions. Limit unchanged.
 # 0.9.6: default studio-sandbox image tag bumped to 1.17.8 — catches the chart
 # up to the current sandbox image (the tag lockstep had drifted from 1.12.0,
 # missing 5 minors of image changes, incl. the slides deck-as-theme CSS fix
@@ -40,7 +45,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.13
+version: 0.9.14
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.20.1"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -46,10 +46,16 @@ image:
 
 # ── sandbox pod resources (per SandboxClaim) ───────────────────────────
 # Prod ceilings. Adjust per measured workload.
+# memory request = observed p95 of per-pod peak working-set (~2Gi over 7d;
+# 2d raw p90 2.2Gi, p95 2.4Gi). It was 1Gi — but busy pods spend ~100% of
+# their life above 1Gi, so the scheduler bin-packed on a request less than
+# half of real usage and prod nodes hit memory-pressure eviction (never
+# per-pod OOM: 0 pods reach the 4Gi limit). Sizing the request to real p95
+# stops the node-pressure evictions at the cost of lower packing density.
 resources:
   requests:
     cpu: 500m
-    memory: 1Gi
+    memory: 2Gi
   limits:
     cpu: "2"
     memory: 4Gi


### PR DESCRIPTION
## Summary

Prod `studio-sandbox` pods were being **evicted** (`Reason: Evicted`, `The node was low on resource: memory`) and then getting stuck re-initializing — surfacing as pods "restarting" and "stuck terminating". Root cause: the sandbox container's memory **request** is set well below real usage, so the scheduler over-packs nodes.

## Evidence (Prometheus, `grafana.infra.deco.cx`)

Per-pod **peak** working-set memory:

| window | p50 | p90 | p95 | p99 | max |
|---|---|---|---|---|---|
| 7d (10m step) | 731Mi | 1.7Gi | **2.0Gi** | 2.6Gi | 3.8Gi |
| 2d (raw) | 831Mi | 2.2Gi | 2.4Gi | 2.9Gi | 3.6Gi |

- Request was **1Gi**; busy pods spend **~100% of their life above 1Gi**.
- Sandbox nodes are **8Gi** (7.6Gi allocatable); at a 1Gi request the scheduler packed ~7 pods/node (observed max **30 concurrent** across 4 nodes). When several hit p90 (2.2Gi) together, they blow past node capacity → kubelet crosses the 100Mi eviction threshold → evicts whichever pod is furthest over its request.
- The **4Gi limit is never the constraint**: 0 pods reach it, 0 per-pod OOMKills. Every kill was node-level memory pressure.

## Change

Raise the sandbox memory **request** `1Gi → 2Gi` (≈ observed p95). Limit unchanged at 4Gi. Chart bumped `0.9.13 → 0.9.14` so the publish workflow ships it.

The scheduler now reserves what pods actually use, so Karpenter provisions enough nodes and node-pressure evictions stop.

## Trade-off

Packing density drops ~7 → ~3 pods per 8Gi node, so Karpenter runs roughly 2× the nodes for the same load. If node count matters more than bin-packing overhead, a follow-up can move the pool to larger instances (request stays 2Gi, per-node system-reserve amortizes over more pods).

## Testing notes

- Config-only change to `deploy/helm/sandbox-env` (values default + chart version + changelog). No code paths touched.
- Confidence caveat: sizing is from a 7d window (30d scans time out on this Prometheus). p95 ≈ 2Gi is stable across 2d/7d; re-check if the workload mix (heavier Vite builds) shifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase sandbox memory request from 1Gi to 2Gi to stop node-pressure evictions and stuck restarts in prod. Limit stays 4Gi; bumps `deploy/helm/sandbox-env` chart to `0.9.14`.

- **Bug Fixes**
  - Root cause: memory request was below real usage (p95 ≈ 2Gi), which over-packed nodes and triggered kubelet evictions.
  - Effect: scheduler now reserves realistic memory; Karpenter adds capacity; evictions stop.
  - Trade-off: fewer pods per 8Gi node (~3 vs ~7). Consider larger instances if node count becomes a concern.

<sup>Written for commit 5e9fc78430a723302da216990628b44ee5b9d539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

