### PR TITLE
fix(docs): repair broken legacy-admin quickstart links in deco-chat docs

### DIFF
--- a/apps/docs/client/src/content/deco-chat/en/getting-started/developers.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/getting-started/developers.mdx
@@ -108,6 +108,6 @@ deco project import --from ./my-project --org <org>
 
 **Get Help:** [Discord](https://decocms.com/discord)
 
-**Non-developer?** See [For AI Builders](/latest/en/getting-started/ai-builders) for no-code workflow.
+**Non-developer?** See [For AI Builders](/deco-chat/en/getting-started/ai-builders) for no-code workflow.
 
 

--- a/apps/docs/client/src/content/deco-chat/en/introduction.mdx
+++ b/apps/docs/client/src/content/deco-chat/en/introduction.mdx
@@ -152,5 +152,5 @@ MCP gives you a standard interface. deco CMS provides the **control plane** arou
 
 If you’re using the current SaaS admin at `admin.decocms.com` (still supported, deprecated soon), start here:
 
-- **[For AI Builders](/latest/en/getting-started/ai-builders)**
-- **[For Developers](/latest/en/getting-started/developers)**
+- **[For AI Builders](/deco-chat/en/getting-started/ai-builders)**
+- **[For Developers](/deco-chat/en/getting-started/developers)**

--- a/apps/docs/client/src/content/deco-chat/pt-br/getting-started/developers.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/getting-started/developers.mdx
@@ -109,6 +109,6 @@ deco project import --from ./my-project --org <org>
 
 **Obter Ajuda:** [Discord](https://decocms.com/discord)
 
-**Não é desenvolvedor?** Veja [Para AI Builders](/pt-br/getting-started/ai-builders) para workflow sem código.
+**Não é desenvolvedor?** Veja [Para AI Builders](/deco-chat/pt-br/getting-started/ai-builders) para workflow sem código.
 
 

--- a/apps/docs/client/src/content/deco-chat/pt-br/introduction.mdx
+++ b/apps/docs/client/src/content/deco-chat/pt-br/introduction.mdx
@@ -153,5 +153,5 @@ MCP te dá uma interface padrão. O deco CMS fornece o **control plane** ao redo
 
 Se você usa o admin SaaS atual em `admin.decocms.com` (ainda suportado, em breve descontinuado), comece por aqui:
 
-- **[Para AI Builders](/pt-br/getting-started/ai-builders)**
-- **[Para Desenvolvedores](/pt-br/getting-started/developers)**
+- **[Para AI Builders](/deco-chat/pt-br/getting-started/ai-builders)**
+- **[Para Desenvolvedores](/deco-chat/pt-br/getting-started/developers)**


### PR DESCRIPTION
Doc navigation bug found while auditing `apps/docs/client/src/content` for broken links.

The "Legacy Admin quick start" section in the legacy `deco-chat` docs (`introduction.mdx` and `getting-started/developers.mdx`, both `en` and `pt-br`) links to "For AI Builders" / "For Developers" pages that only exist inside the `deco-chat` version tree, but the links pointed elsewhere:

- `en` links used `/latest/en/getting-started/ai-builders` and `/latest/en/getting-started/developers`. Per the routing logic in `apps/docs/client/src/pages/[version]/[locale]/[...slug].astro`, a `/latest/...` URL only resolves to that slug if it exists in the *latest* version (`deco-studio`); since `getting-started/ai-builders` and `getting-started/developers` don't exist there, these silently redirect to the `deco-studio` quickstart root instead of the intended page — a reader clicking "For AI Builders" lands on an unrelated quickstart page.
- `pt-br` links were worse: `/pt-br/getting-started/ai-builders` and `/pt-br/getting-started/developers` are missing the required version segment entirely (every other internal link in the same files correctly uses `/deco-chat/pt-br/...`), so these don't match any static route and 404.

Fix: point all 6 links at the pages' actual location, `/deco-chat/<locale>/getting-started/<slug>`, matching the pattern already used by every other internal link in these same files.

How to confirm: `find apps/docs/client/src/content/deco-chat -iname 'ai-builders.mdx' -o -iname 'developers.mdx'` shows both pages live under `deco-chat/{en,pt-br}/getting-started/`, confirming the corrected paths resolve; `grep -rn 'getting-started/ai-builders\|getting-started/developers' apps/docs/client/src/content/deco-chat` shows all links now consistently use the `/deco-chat/<locale>/...` prefix.

Local checks: `bun run fmt` (clean, no changes needed beyond the edit) — this is docs-content only (MDX), no TypeScript touched, so no targeted typecheck/test applies. Full CI validates the docs build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "For AI Builders" and "For Developers" links in the legacy `deco-chat` quickstart so they resolve under /deco-chat/<locale>/getting-started. This prevents redirects to unrelated `deco-studio` pages and fixes pt-br 404s.

- **Bug Fixes**
  - Updated en links from /latest/en/getting-started/... to /deco-chat/en/getting-started/... in introduction and developers pages.
  - Updated pt-br links from /pt-br/getting-started/... to /deco-chat/pt-br/getting-started/... in introduction and developers pages.
  - 6 links corrected across 4 MDX files.

<sup>Written for commit be678b7af2622287658f374e5176ebd39be084b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

