### PR TITLE
fix(sandbox-preview): translate the catch-all path-param placeholder

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/path-param-input.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-input.tsx
@@ -20,7 +20,8 @@ export function PathParamInput({
   const [draft, setDraft] = useState(value);
   const [focused, setFocused] = useState(false);
   const cancelledRef = useRef(false);
-  const label = name === "*" ? "path" : `:${name}`;
+  const label =
+    name === "*" ? t("sandbox.preview.catchAllParamLabel") : `:${name}`;
   const sizer = draft || label;
   return (
     <>

--- a/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/path-param-picker-chip.tsx
@@ -283,7 +283,10 @@ export function PathParamPickerChip({
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // The `*` catch-all reads badly in the URL bar; show a friendly word instead.
-  const paramLabel = paramName === "*" ? "path" : `:${paramName}`;
+  const paramLabel =
+    paramName === "*"
+      ? t("sandbox.preview.catchAllParamLabel")
+      : `:${paramName}`;
   const labels = kindLabels(t);
   const nouns = [...new Set(sources.map((s) => labels[s.kind].noun))];
   const placeholder = t("sandbox.pathParamPickerChip.searchPlaceholder", {

--- a/apps/mesh/src/web/i18n/en/sandbox.ts
+++ b/apps/mesh/src/web/i18n/en/sandbox.ts
@@ -370,6 +370,7 @@ export const sandbox = {
   "sandbox.postToolbar.sortZA": "Z–A",
   "sandbox.preview.blocks": "Blocks",
   "sandbox.preview.blocksEditor": "Blocks editor",
+  "sandbox.preview.catchAllParamLabel": "path",
   "sandbox.preview.choosePage": "Choose page",
   "sandbox.preview.clickElementToAsk": "Click any element to ask the AI",
   "sandbox.preview.copyCurrentUrl": "Copy Current URL",

--- a/apps/mesh/src/web/i18n/pt-br/sandbox.ts
+++ b/apps/mesh/src/web/i18n/pt-br/sandbox.ts
@@ -383,6 +383,7 @@ export const sandbox = {
   "sandbox.postToolbar.sortZA": "Z–A",
   "sandbox.preview.blocks": "Blocos",
   "sandbox.preview.blocksEditor": "Editor de blocos",
+  "sandbox.preview.catchAllParamLabel": "caminho",
   "sandbox.preview.choosePage": "Escolher página",
   "sandbox.preview.clickElementToAsk":
     "Clique em qualquer elemento para perguntar à IA",


### PR DESCRIPTION
Follows #4971/#5089 i18n hardening — the `*` catch-all path param's friendly label ("path") was hardcoded in English in both `path-param-input.tsx` (inline URL-bar editor) and `path-param-picker-chip.tsx` (the entity picker chip added in #5089), so pt-br users see an untranslated English word in the URL bar and picker dialog while every other string on the same UI is translated.

Adds `sandbox.preview.catchAllParamLabel` ("path" / "caminho") to the en/pt-br sandbox dictionaries and swaps both hardcoded literals for `t("sandbox.preview.catchAllParamLabel")`.

Net change: +8/-2 across 4 files (2 dictionary entries, 2 one-line call-site swaps). No behavior change for English users; pt-br now shows "caminho" instead of the raw literal "path".

To confirm: switch the UI language preference to pt-br, open a page whose route is a catch-all (`*`) template in the sandbox preview, and check the URL-bar param editor and the path-param picker dialog — both should show "caminho" instead of "path".

Locally verified: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean, exit 0). No dedicated test added — this is a pure string-literal → `t()` call swap with no logic branch to regress; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate the `*` catch-all path param label in the sandbox preview so pt-br users see “caminho” instead of the hardcoded “path” in the URL bar and the picker dialog.

- **Bug Fixes**
  - Added `sandbox.preview.catchAllParamLabel` to `en` and `pt-br` dictionaries.
  - Replaced the hardcoded label in `path-param-input.tsx` and `path-param-picker-chip.tsx` with `t("sandbox.preview.catchAllParamLabel")`.

<sup>Written for commit b89ff61faa85199b65e1be16132f1282cfa7124a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

