### PR TITLE
fix(organization): fail closed on unresolved org in ORGANIZATION_SETTINGS_UPDATE

### DIFF
--- a/apps/mesh/src/tools/organization/settings-update.test.ts
+++ b/apps/mesh/src/tools/organization/settings-update.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, mock } from "bun:test";
+import { ORGANIZATION_SETTINGS_UPDATE } from "./settings-update";
+
+function makeCtx(organization: { id: string } | undefined) {
+  return {
+    auth: { user: { id: "user-1" } },
+    organization,
+    access: { check: mock(async () => {}) },
+    storage: {
+      organizationSettings: {
+        upsert: mock(async (organizationId: string) => ({
+          organizationId,
+          createdAt: new Date("2026-01-01T00:00:00Z"),
+          updatedAt: new Date("2026-01-01T00:00:00Z"),
+        })),
+      },
+    },
+  } as unknown as Parameters<typeof ORGANIZATION_SETTINGS_UPDATE.handler>[1];
+}
+
+describe("ORGANIZATION_SETTINGS_UPDATE", () => {
+  it("rejects a write scoped to a different organization than the context", async () => {
+    const ctx = makeCtx({ id: "org-a" });
+
+    await expect(
+      ORGANIZATION_SETTINGS_UPDATE.handler({ organizationId: "org-b" }, ctx),
+    ).rejects.toThrow(/different organization/i);
+  });
+
+  it("fails closed instead of writing an unscoped organizationId when ctx.organization is unresolved", async () => {
+    // Regression: `if (ctx.organization && ctx.organization.id !== input.organizationId)`
+    // skipped the mismatch check entirely when ctx.organization was undefined,
+    // letting the client-supplied organizationId through unvalidated.
+    const ctx = makeCtx(undefined);
+
+    await expect(
+      ORGANIZATION_SETTINGS_UPDATE.handler({ organizationId: "org-b" }, ctx),
+    ).rejects.toThrow(/organization scope/i);
+
+    expect(
+      (
+        ctx as unknown as {
+          storage: {
+            organizationSettings: { upsert: ReturnType<typeof mock> };
+          };
+        }
+      ).storage.organizationSettings.upsert,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("allows a write matching the context's organization", async () => {
+    const ctx = makeCtx({ id: "org-a" });
+
+    const result = await ORGANIZATION_SETTINGS_UPDATE.handler(
+      { organizationId: "org-a" },
+      ctx,
+    );
+
+    expect(result.organizationId).toBe("org-a");
+  });
+});

--- a/apps/mesh/src/tools/organization/settings-update.ts
+++ b/apps/mesh/src/tools/organization/settings-update.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/studio-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
   SidebarItemSchema,
   RegistryConfigSchema,
@@ -45,7 +45,12 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
     requireAuth(ctx);
     await ctx.access.check();
 
-    if (ctx.organization && ctx.organization.id !== input.organizationId) {
+    // `requireOrganization` throws when no org is resolved on this context —
+    // the previous `ctx.organization && ...` guard skipped the mismatch check
+    // entirely in that case, letting `input.organizationId` (client-supplied)
+    // through unvalidated instead of failing closed.
+    const organization = requireOrganization(ctx);
+    if (organization.id !== input.organizationId) {
       throw new Error("Cannot update settings for a different organization");
     }
 


### PR DESCRIPTION
**Source:** bug found while auditing `apps/mesh/src/tools/organization` for auth-scoping issues (core services / tier-resolution focus area).

**Why a maintainer wants this:** the cross-org guard in `ORGANIZATION_SETTINGS_UPDATE` was `if (ctx.organization && ctx.organization.id !== input.organizationId) throw`. That only rejects a mismatch when `ctx.organization` is already resolved. Every sibling org-scoped write tool (e.g. `member-add.ts`'s `if (organizationId !== ctx.organization?.id)`, `settings-get.ts` deriving the id itself) either checks unconditionally or never trusts client input for the org id — this tool was the one outlier.

**Failure scenario:** if `ctx.organization` ends up unresolved on a request that still passes `ctx.access.check()` (e.g. an org-id/slug hint mismatch upstream in `context-factory.ts`, which explicitly leaves `ctx.organization` undefined to "fail closed" for other tools), the guard here is skipped entirely and the handler upserts organization settings straight into whatever `input.organizationId` the client supplied, with zero validation that the caller belongs to that org.

**Fix:** replaced the conditional guard with `requireOrganization(ctx)` (throws "requires organization scope" when unresolved) followed by an unconditional equality check against `input.organizationId` — matching the pattern already used elsewhere in this file's sibling tools.

**Regression test:** `settings-update.test.ts` (new file) — asserts (1) a mismatched `organizationId` is rejected, (2) when `ctx.organization` is `undefined` the handler throws "organization scope" and never calls `storage.organizationSettings.upsert`, and (3) a matching id still succeeds.

**To verify:** `bun test apps/mesh/src/tools/organization/settings-update.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test file above (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an auth-scoping bug in `ORGANIZATION_SETTINGS_UPDATE` by requiring a resolved organization and rejecting mismatched `organizationId`. This blocks unscoped updates when `ctx.organization` is undefined and adds tests to prevent regressions.

- **Bug Fixes**
  - Use `requireOrganization(ctx)` and compare `organization.id` to `input.organizationId`.
  - Fail closed when no org is resolved; throw on cross-org mismatch.
  - Add `settings-update.test.ts` covering mismatch, unresolved context (no write), and success.

<sup>Written for commit 958ec0a678b8a291787413a517c8c9833440026e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

