### PR TITLE
fix(sandbox): return 400 for path-traversal in git discard

### DIFF
--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -659,7 +659,7 @@ describe("git routes", () => {
       }),
     );
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
     expect(await res.json()).toEqual({
       error: "Invalid path: ../outside-secret.txt",
     });

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -460,14 +460,22 @@ function changedPathsFromStatus(status: { files: GitStatusFile[] }): string[] {
   ];
 }
 
+/** A discard request path that escapes the repo — a client/data condition, not a server fault. */
+class InvalidDiscardPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidDiscardPathError";
+  }
+}
+
 function resolveRepoRelativePath(deps: GitDeps, userPath: string): string {
   const abs = safePath(deps.appRoot, deps.repoDir, userPath);
   if (!abs) {
-    throw new Error(`Invalid path: ${userPath}`);
+    throw new InvalidDiscardPathError(`Invalid path: ${userPath}`);
   }
   const rel = path.relative(deps.repoDir, abs);
   if (rel.startsWith("..") || path.isAbsolute(rel)) {
-    throw new Error(`Invalid path: ${userPath}`);
+    throw new InvalidDiscardPathError(`Invalid path: ${userPath}`);
   }
   return rel;
 }
@@ -752,6 +760,9 @@ export function makeGitDiscardHandler(deps: GitDeps) {
       discard(deps, filepaths);
       return jsonResponse({ success: true });
     } catch (err) {
+      if (err instanceof InvalidDiscardPathError) {
+        return jsonResponse({ error: err.message }, 400);
+      }
       return jsonResponse(
         { error: err instanceof Error ? err.message : String(err) },
         500,


### PR DESCRIPTION
**Source**: a bug found while auditing `packages/sandbox/daemon/routes/git.ts` for missing/incorrect status codes.

**Why a maintainer wants it**: `makeGitDiscardHandler` returned a 500 for a `filepaths` entry that escapes the repo (e.g. `"../outside-secret.txt"`), even though that's a client input-validation condition, not a server fault — every sibling handler (`fs.ts`'s `safePath` checks, and this same file's `makeGitRebaseHandler` for an invalid branch name) already responds 400 for the equivalent case. A 500 tells callers/monitoring "the daemon is broken" when the request was simply invalid, which is misleading for alerting and client retry logic.

**Failure scenario + fix**: POST `/git/discard` with `filepaths: ["../outside-secret.txt"]` returned HTTP 500 with `{"error": "Invalid path: ../outside-secret.txt"}`. Fixed by introducing `InvalidDiscardPathError` (thrown from `resolveRepoRelativePath`) and mapping it to 400 in the handler, mirroring the existing `InvalidRemoteBranchNameError` -> 400 pattern used by `makeGitDiffHandler`/`makeGitRebaseHandler` in the same file. The existing test `discard rejects path traversal` asserted the old (wrong) 500 status — inverted it to assert 400.

**Reviewer command**: `bun test packages/sandbox/daemon/routes/git.test.ts`

**Local checks run**: `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit` (clean), and the targeted test file above (29 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 400 for repo-escaping filepaths in the git discard route instead of 500. This correctly treats path traversal as client input and avoids false server-error alarms.

- **Bug Fixes**
  - Added `InvalidDiscardPathError`, thrown by `resolveRepoRelativePath` and mapped to 400 in `makeGitDiscardHandler` (`packages/sandbox/daemon/routes/git.ts`).
  - Updated test to expect 400 for path traversal (`packages/sandbox/daemon/routes/git.test.ts`).

<sup>Written for commit 6efec22f06fed6b080afe70915642fc5bcc485c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

