### PR TITLE
fix(auth): require organizationId to match the authenticated org in ORGANIZATION_MEMBER_REMOVE

### DIFF
--- a/apps/mesh/src/tools/organization/member-remove.test.ts
+++ b/apps/mesh/src/tools/organization/member-remove.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, mock } from "bun:test";
+import { ORGANIZATION_MEMBER_REMOVE } from "./member-remove";
+
+function makeCtx(organization: { id: string } | undefined) {
+  const removeMember = mock(async () => {});
+  const ctx = {
+    auth: { user: { id: "user-1" } },
+    organization,
+    access: { check: mock(async () => {}) },
+    boundAuth: { organization: { removeMember } },
+  } as unknown as Parameters<typeof ORGANIZATION_MEMBER_REMOVE.handler>[1];
+  return { ctx, removeMember };
+}
+
+describe("ORGANIZATION_MEMBER_REMOVE", () => {
+  it("rejects a removal scoped to a different organization than the context", async () => {
+    // Regression: `input.organizationId` was used to call
+    // `boundAuth.organization.removeMember` without ever checking it matched
+    // `ctx.organization` — `ctx.access.check()` only verifies the caller's
+    // permissions in `ctx.organization`, so a caller could remove a member
+    // from an unrelated org they have no membership in at all.
+    const { ctx, removeMember } = makeCtx({ id: "org-a" });
+
+    await expect(
+      ORGANIZATION_MEMBER_REMOVE.handler(
+        { organizationId: "org-b", memberIdOrEmail: "victim@example.com" },
+        ctx,
+      ),
+    ).rejects.toThrow(/does not match/i);
+
+    expect(removeMember).not.toHaveBeenCalled();
+  });
+
+  it("allows a removal matching the context's organization", async () => {
+    const { ctx, removeMember } = makeCtx({ id: "org-a" });
+
+    const result = await ORGANIZATION_MEMBER_REMOVE.handler(
+      { organizationId: "org-a", memberIdOrEmail: "member@example.com" },
+      ctx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(removeMember).toHaveBeenCalledWith({
+      organizationId: "org-a",
+      memberIdOrEmail: "member@example.com",
+    });
+  });
+});

--- a/apps/mesh/src/tools/organization/member-remove.ts
+++ b/apps/mesh/src/tools/organization/member-remove.ts
@@ -45,6 +45,16 @@ export const ORGANIZATION_MEMBER_REMOVE = defineTool({
       );
     }
 
+    // `ctx.access.check()` above only verified the caller can remove members
+    // in `ctx.organization` (the path-resolved org). Without this check, a
+    // caller could pass a *different* `input.organizationId` and remove a
+    // member from an org they have no membership in at all.
+    if (organizationId !== ctx.organization?.id) {
+      throw new Error(
+        "Organization ID does not match authenticated organization",
+      );
+    }
+
     // Remove member via Better Auth
     await ctx.boundAuth.organization.removeMember({
       organizationId,


### PR DESCRIPTION
**Source:** bug — a cross-tenant authorization gap found while auditing the org-scoping pattern from #5104 (fail-closed org resolution). `ORGANIZATION_MEMBER_REMOVE` is the sibling of `ORGANIZATION_MEMBER_ADD` and `ORGANIZATION_MEMBER_UPDATE_ROLE`; both of those validate the target `organizationId` against the caller's real authorization before acting (an explicit equality check in member-add, a target-org DB membership lookup in member-update-role), but member-remove never had either check.

**Why a maintainer wants it:** `ctx.access.check()` only verifies the caller's permission in `ctx.organization` (the path-resolved org). Since `input.organizationId` is optional and falls back to `ctx.organization?.id` but was never validated against it, any authenticated caller with remove-member permission in *their own* org could pass an arbitrary `organizationId` and remove a member from a completely unrelated org they have no membership in at all.

**Failure scenario + fix:** Caller is a member of `org-a` with `ORGANIZATION_MEMBER_REMOVE` permission there. They call the tool with `{ organizationId: "org-b", memberIdOrEmail: "victim@example.com" }`. `ctx.access.check()` passes (checked against `org-a`), and the handler calls `boundAuth.organization.removeMember({ organizationId: "org-b", ... })` unchecked — removing a member from `org-b` despite the caller having zero relationship to it. The fix adds the same `organizationId !== ctx.organization?.id` guard already used in `member-add.ts`, failing closed with an error instead of proceeding. Added `member-remove.test.ts` covering both the rejected-mismatch and the legitimate same-org path.

**Reviewer command:** `bun test apps/mesh/src/tools/organization/member-remove.test.ts`

**Local checks run:** `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/mesh` (clean), targeted test file above (2 pass). Full CI suite (lint, e2e) not run locally per repo guidance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a cross-tenant auth gap by requiring `organizationId` to match the authenticated org in `ORGANIZATION_MEMBER_REMOVE`. Mismatches now fail with an error; tests cover both rejection and valid paths.

- **Bug Fixes**
  - Add equality check: reject when `input.organizationId !== ctx.organization?.id`.
  - Prevents users authorized in one org from removing members in another.
  - Add `member-remove.test.ts` for mismatch rejection and same-org success.

<sup>Written for commit 972502a0d6e2825f70d17677186465277c1c02ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

