### PR TITLE
fix(chat): guard mention-metadata parsing against malformed/non-object shapes

### DIFF
--- a/apps/mesh/src/web/components/chat/derive-parts.test.ts
+++ b/apps/mesh/src/web/components/chat/derive-parts.test.ts
@@ -204,3 +204,32 @@ describe("derivePartsFromTiptapDoc — task ref mention", () => {
     expect(texts.some((t) => t.includes("Broken on Safari."))).toBe(true);
   });
 });
+
+describe("derivePartsFromTiptapDoc — malformed mention metadata", () => {
+  // A doc's tiptapDoc is persisted JSON and can be created/edited outside the
+  // slash/agent-mention UI (e.g. via the thread API), so `metadata` can't be
+  // trusted to always hold the object shape the UI would have produced.
+  test("does not throw when a '/' mention's metadata array holds a non-object", () => {
+    expect(() =>
+      joinText(skillDoc({ name: "foo", metadata: [null] })),
+    ).not.toThrow();
+  });
+
+  test("does not throw when an '@' mention's metadata is a bare primitive", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "mention",
+              attrs: { char: "@", name: "bot", metadata: "oops" },
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => joinText(doc)).not.toThrow();
+  });
+});

--- a/apps/mesh/src/web/components/chat/derive-parts.ts
+++ b/apps/mesh/src/web/components/chat/derive-parts.ts
@@ -61,6 +61,7 @@ function resourcesToParts(
   const parts: ChatMessage["parts"] = [];
 
   for (const content of contents) {
+    if (!content || typeof content !== "object") continue;
     if ("text" in content && content.text) {
       parts.push({
         type: "text",
@@ -267,7 +268,12 @@ export function derivePartsFromTiptapDoc(
           | Record<string, unknown>
           | unknown[]
           | null;
-        if (meta && !Array.isArray(meta) && "agentId" in meta) {
+        if (
+          meta &&
+          typeof meta === "object" &&
+          !Array.isArray(meta) &&
+          "agentId" in meta
+        ) {
           // Agent mention: instruct the AI to delegate via subtask
           parts.push({
             type: "text",
@@ -305,6 +311,8 @@ export function derivePartsFromTiptapDoc(
         if (
           Array.isArray(metadata) &&
           metadata.length > 0 &&
+          typeof metadata[0] === "object" &&
+          metadata[0] !== null &&
           "role" in metadata[0]
         ) {
           // Prompt messages


### PR DESCRIPTION
A `tiptapDoc` is persisted JSON that can be created or edited outside the mention-insertion UI (the thread API, older drafts, hand-edited content), so a mention's `metadata` attribute can't be trusted to always hold the object shape the UI would produce.

**Failure scenario**: `derivePartsFromTiptapDoc` used the `in` operator directly on array/metadata values without first checking they were objects. If a mention chip's `metadata` is a primitive or contains a non-object element (e.g. `[null]`, or a bare string), `"role" in metadata[0]`, `"agentId" in meta`, and `"text" in content` all throw `TypeError: ... is not an Object`. This function runs on every message send (`chat-context.tsx:1255`) and on every automation-detail render (`automation-detail.tsx:181`), so a single malformed mention chip crashes that flow entirely.

**Fix**: add a `typeof`/non-null guard before each `in` check, matching the defensive style already used elsewhere in this file (e.g. `fileAttrsToParts`' base64-decode try/catch). Pure guard clauses — no behavior change for well-formed docs (all 11 existing tests still pass).

**Regression tests** (`derive-parts.test.ts`): two new cases reproduce the crash directly — a "/" mention with `metadata: [null]` and an "@" mention with `metadata: "oops"` — both now resolve without throwing instead of crashing.

**Reviewer check**: `bun test apps/mesh/src/web/components/chat/derive-parts.test.ts` (13 pass).

**Verified locally**: `bun run fmt`, `bun test apps/mesh/src/web/components/chat/derive-parts.test.ts` (13/13 pass), and `bunx tsc --noEmit` in `apps/mesh` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented chat crashes caused by malformed mention `metadata` in `tiptapDoc` by guarding parsing with non-null and object checks. This stops TypeErrors and keeps message send and automation detail views from breaking.

- **Bug Fixes**
  - Validate `content` and `metadata` before using `in` checks; ignore non-object entries when reading `text`, `agentId`, or `role`.
  - Added tests for a "/" mention with `metadata: [null]` and an "@" mention with a primitive `metadata`, ensuring no throw.

<sup>Written for commit ba7c8bb4d73b2aa0ba0d0448c423770706fb77f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

