### PR TITLE
fix(sandbox-preview): surface a toast when opening a file in the explorer fails

### DIFF
--- a/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx
@@ -366,7 +366,7 @@ export function FileExplorer({
     await fetchFileTree();
     await refreshGitStatus();
     setNameDialog(null);
-    handleFileClick(filePath);
+    openFileGuarded(filePath);
   }
 
   async function handleCreateFolder(t: ReturnType<typeof useT>, name: string) {
@@ -502,13 +502,7 @@ export function FileExplorer({
     const pathToOpen = openPath;
     queueMicrotask(() => {
       if (isSafeExplorerOpenPath(pathToOpen)) {
-        void handleFileClick(pathToOpen).catch((err) => {
-          toast.error(
-            err instanceof Error
-              ? err.message
-              : t("sandbox.fileExplorer.failedToOpenFile"),
-          );
-        });
+        openFileGuarded(pathToOpen);
       }
     });
   }
@@ -794,7 +788,7 @@ export function FileExplorer({
     pendingRevealRef.current = { path: match.path, line: match.line };
     const alreadyOpen =
       selectedFile === match.path && buffers.get(match.path)?.loaded;
-    void handleFileClick(match.path);
+    openFileGuarded(match.path);
     // Same file already mounted → no remount fires, so reveal immediately.
     if (alreadyOpen && editorRef.current) applyPendingReveal(editorRef.current);
   }
@@ -908,6 +902,21 @@ export function FileExplorer({
       return next;
     });
     openFile(path);
+  }
+
+  /**
+   * Fire-and-forget `handleFileClick`, surfacing a toast if it rejects (e.g.
+   * `ensureAncestorsLoaded` throwing on a truncated folder listing) instead of
+   * leaving an unhandled rejection with no user-facing feedback.
+   */
+  function openFileGuarded(path: string) {
+    void handleFileClick(path).catch((err) => {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : t("sandbox.fileExplorer.failedToOpenFile"),
+      );
+    });
   }
 
   function getCreateParentDir(): string {
@@ -1094,7 +1103,7 @@ export function FileExplorer({
                       if (isDir) {
                         void handleDirectoryOpen(node.path, isExpanded);
                       } else {
-                        void handleFileClick(node.path);
+                        openFileGuarded(node.path);
                       }
                     }}
                     onNewFile={() =>
@@ -1160,7 +1169,7 @@ export function FileExplorer({
                     <button
                       key={path}
                       type="button"
-                      onClick={() => void handleFileClick(path)}
+                      onClick={() => openFileGuarded(path)}
                       title={path}
                       className={cn(
                         "flex w-full items-center gap-1.5 px-3 py-1 text-left text-xs hover:bg-accent",


### PR DESCRIPTION
Bug found while auditing the sandbox preview file-explorer component (`apps/mesh/src/web/components/sandbox/preview/file-explorer/file-explorer.tsx`).

`handleFileClick` awaits `ensureAncestorsLoaded`, which throws when an ancestor folder's listing comes back truncated. Three of the four call sites invoked `handleFileClick` fire-and-forget with no `.catch` (tree-row click, filename-search-match click, and right after creating a new file), so that rejection became an unhandled promise rejection with zero user-facing feedback. The fourth call site — the `openPath` deep-link effect — already had the correct `.catch` that shows a toast with the error message.

**Failure scenario:** click a file in the tree (or a filename-search hit, or create a new file) whose ancestor directory hasn't been lazily loaded yet and whose listing comes back truncated (>`EXPLORER_GLOB_LIMIT` entries) — the click silently does nothing (console-only unhandled rejection) instead of telling the user the folder listing was truncated, unlike the equivalent deep-link path which does.

**Fix:** extracted the deep-link's existing catch-and-toast into a shared `openFileGuarded` helper and used it at all four call sites, so behavior is now consistent everywhere `handleFileClick` is invoked without being awaited.

Net diff: +20/-11, one file, no behavior change on the success path (same `handleFileClick` logic) — only the error path now surfaces feedback instead of failing silently.

**To confirm:** `cd apps/mesh && bunx tsc --noEmit` (clean). There's no existing component test for `file-explorer.tsx` (only `utils.ts` has unit coverage, per this repo's testing tiers — a React-hook-heavy component isn't unit-testable without mocks). Reviewer can confirm visually: open the sandbox preview file explorer, click a file in a very large/truncated repo tree, and check that a toast now appears instead of a silent no-op (previously only reproducible via `?main=code:<path>` deep link).

Locally ran: `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a toast when opening a file from the sandbox file explorer fails, instead of failing silently due to unhandled promise rejections. Introduces `openFileGuarded` so all file-open paths show consistent error feedback.

- **Bug Fixes**
  - Wrapped `handleFileClick` with `openFileGuarded` to catch errors from `ensureAncestorsLoaded` (e.g., truncated listings over `EXPLORER_GLOB_LIMIT`).
  - Applied to tree row clicks, filename search results, new file creation, and the deep-link `openPath` effect.

<sup>Written for commit cfbc49bd5dc10eec70353c2752fb7467ee1aa4cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

