### PR TITLE
fix(sandbox): return 409 instead of 500 for publish refusals on detached HEAD/protected branch

### DIFF
--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -402,6 +402,21 @@ describe("git routes", () => {
     expect(log.trim()).toBe("init");
   });
 
+  it("publish route returns 409 (not 500) for a protected-branch refusal", async () => {
+    const { appRoot, repoDir } = initRepo(); // initRepo checks out main
+    writeFileSync(join(repoDir, "README.md"), "changed\n");
+    const handler = makeGitPublishHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/publish", {
+        method: "POST",
+        body: JSON.stringify({ message: "from main" }),
+      }),
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/protected branch "main"/);
+  });
+
   it("publish() does not commit org-fs mount content excluded via .git/info/exclude", () => {
     const { appRoot, repoDir } = initRepo();
     onFeatureBranch(repoDir); // publish() refuses the protected default branch

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -468,6 +468,18 @@ class InvalidDiscardPathError extends Error {
   }
 }
 
+/**
+ * publish() refused because of the sandbox's current git state (detached HEAD,
+ * or the checked-out branch is protected) — a conflict with the request, not a
+ * server fault, so the route maps it to 409 like repoNotReadyResponse().
+ */
+class PublishBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PublishBlockedError";
+  }
+}
+
 function resolveRepoRelativePath(deps: GitDeps, userPath: string): string {
   const abs = safePath(deps.appRoot, deps.repoDir, userPath);
   if (!abs) {
@@ -535,14 +547,14 @@ export function publish(
   }
   const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (!branch || branch === "HEAD") {
-    throw new Error("Cannot publish from a detached HEAD");
+    throw new PublishBlockedError("Cannot publish from a detached HEAD");
   }
   // The pre-push hook (protect-branch.ts) also guards this, but the push below
   // runs with --no-verify and skips it — so the block MUST live in code too.
   // Refuse before committing so we never leave a stray commit on a protected
   // branch either. Changes reach the default branch via PR, never a direct push.
   if (protectedBranches(repoDir).has(branch)) {
-    throw new Error(
+    throw new PublishBlockedError(
       `Refusing to push to protected branch "${branch}" from a sandbox. Work on a feature branch; changes reach the default branch via PR.`,
     );
   }
@@ -735,6 +747,11 @@ export function makeGitPublishHandler(deps: GitDeps) {
       // An invalid-block refusal is a client/data condition, not a server fault.
       if (err instanceof InvalidDecofileBlockError) {
         return jsonResponse({ error: err.message }, 400);
+      }
+      // A detached HEAD / protected-branch refusal is a conflict with the
+      // sandbox's current state, not a server fault.
+      if (err instanceof PublishBlockedError) {
+        return jsonResponse({ error: err.message }, 409);
       }
       return jsonResponse({ error: formatGitError(err) }, 500);
     }


### PR DESCRIPTION
**Source**: a bug found while auditing `packages/sandbox/daemon/routes/git.ts` for missing/incorrect status codes, the same file (and same audit angle) as the just-merged #5105 ("return 400 for path-traversal in git discard").

**Why a maintainer wants it**: `makeGitPublishHandler` returns a generic 500 when `publish()` throws because the sandbox is on a detached HEAD or the checked-out branch is protected (e.g. `main`) — but that's a conflict with the current git state, not a server crash, exactly the same class of condition `repoNotReadyResponse()` already maps to 409 elsewhere in this file. A 500 here misleads alerting/monitoring into treating a normal "you're on main, publish to a feature branch instead" refusal as a daemon fault.

**Failure scenario + fix**: POST `/git/publish` while checked out on `main` (or in a detached HEAD) throws `Refusing to push to protected branch "main"...` / `Cannot publish from a detached HEAD`, which the handler previously caught with the catch-all branch and returned as HTTP 500. Fixed by introducing `PublishBlockedError`, thrown from both refusal sites in `publish()`, and mapped to 409 in `makeGitPublishHandler` — mirroring the existing `InvalidDecofileBlockError` -> 400 and `InvalidRemoteBranchNameError` -> 400 patterns in the same file. Added a new handler-level test (`publish route returns 409 (not 500) for a protected-branch refusal`) asserting the status code; the existing function-level test for the protected-branch throw message is untouched (still passes, message unchanged).

**Reviewer command**: `bun test packages/sandbox/daemon/routes/git.test.ts`

**Local checks run**: `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit` (clean), and the targeted test file above (30 pass, up from 29). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 409 Conflict (not 500) when POST `/git/publish` is refused due to detached HEAD or a protected branch, so monitoring doesn’t treat it as a server error. Adds `PublishBlockedError` and maps it in `makeGitPublishHandler`; includes a new route test.

- **Bug Fixes**
  - `publish()` now throws `PublishBlockedError` for detached HEAD or protected branches, and the handler returns `409` instead of `500` (mirrors existing error-to-status mappings).
  - Added `git.test.ts` test to assert the 409 response and error message.

<sup>Written for commit 34b354607b1e0528b39a8a24968681de0d7f870c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

