### PR TITLE
fix(i18n): translate not-supported-tab fallback strings in dependency selection dialog

### DIFF
--- a/apps/mesh/src/web/i18n/en/virtual-mcp.ts
+++ b/apps/mesh/src/web/i18n/en/virtual-mcp.ts
@@ -69,6 +69,10 @@ export const virtualMcp = {
   "virtualMcp.dependencySelectionDialog.noResourcesAvailable":
     "No resources available",
   "virtualMcp.dependencySelectionDialog.noToolsAvailable": "No tools available",
+  "virtualMcp.dependencySelectionDialog.promptsNotSupported":
+    "Prompts not supported by this server",
+  "virtualMcp.dependencySelectionDialog.resourcesNotSupported":
+    "Resources not supported by this server",
   "virtualMcp.dependencySelectionDialog.selectAll": "Select all",
   "virtualMcp.dependencySelectionDialog.somethingWentWrong":
     "Something went wrong",
@@ -76,6 +80,8 @@ export const virtualMcp = {
   "virtualMcp.dependencySelectionDialog.tabPrompts": "Prompts",
   "virtualMcp.dependencySelectionDialog.tabResources": "Resources",
   "virtualMcp.dependencySelectionDialog.tabTools": "Tools",
+  "virtualMcp.dependencySelectionDialog.toolsNotSupported":
+    "Tools not supported by this server",
   "virtualMcp.dependencySelectionDialog.unexpectedError":
     "An unexpected error occurred",
   "virtualMcp.filesSection.add": "Add",

--- a/apps/mesh/src/web/i18n/pt-br/virtual-mcp.ts
+++ b/apps/mesh/src/web/i18n/pt-br/virtual-mcp.ts
@@ -74,12 +74,18 @@ export const virtualMcp = {
     "Nenhum recurso disponível",
   "virtualMcp.dependencySelectionDialog.noToolsAvailable":
     "Nenhuma ferramenta disponível",
+  "virtualMcp.dependencySelectionDialog.promptsNotSupported":
+    "Prompts não são suportados por este servidor",
+  "virtualMcp.dependencySelectionDialog.resourcesNotSupported":
+    "Recursos não são suportados por este servidor",
   "virtualMcp.dependencySelectionDialog.selectAll": "Selecionar tudo",
   "virtualMcp.dependencySelectionDialog.somethingWentWrong": "Algo deu errado",
   "virtualMcp.dependencySelectionDialog.tabActive": "Ativas",
   "virtualMcp.dependencySelectionDialog.tabPrompts": "Prompts",
   "virtualMcp.dependencySelectionDialog.tabResources": "Recursos",
   "virtualMcp.dependencySelectionDialog.tabTools": "Ferramentas",
+  "virtualMcp.dependencySelectionDialog.toolsNotSupported":
+    "Ferramentas não são suportadas por este servidor",
   "virtualMcp.dependencySelectionDialog.unexpectedError": "Erro inesperado",
   "virtualMcp.filesSection.add": "Adicionar",
   "virtualMcp.filesSection.description":

--- a/apps/mesh/src/web/views/virtual-mcp/dependency-selection-dialog.tsx
+++ b/apps/mesh/src/web/views/virtual-mcp/dependency-selection-dialog.tsx
@@ -522,7 +522,7 @@ function ConnectionDetailsContent({
         {activeTab === "active" && (
           <ErrorBoundary
             fallback={createMethodNotFoundFallback(
-              "Tools not supported by this server",
+              t("virtualMcp.dependencySelectionDialog.toolsNotSupported"),
               t,
             )}
           >
@@ -542,7 +542,7 @@ function ConnectionDetailsContent({
         {activeTab === "tools" && (
           <ErrorBoundary
             fallback={createMethodNotFoundFallback(
-              "Tools not supported by this server",
+              t("virtualMcp.dependencySelectionDialog.toolsNotSupported"),
               t,
             )}
           >
@@ -564,7 +564,7 @@ function ConnectionDetailsContent({
         {activeTab === "resources" && (
           <ErrorBoundary
             fallback={createMethodNotFoundFallback(
-              "Resources not supported by this server",
+              t("virtualMcp.dependencySelectionDialog.resourcesNotSupported"),
               t,
             )}
           >
@@ -584,7 +584,7 @@ function ConnectionDetailsContent({
         {activeTab === "prompts" && (
           <ErrorBoundary
             fallback={createMethodNotFoundFallback(
-              "Prompts not supported by this server",
+              t("virtualMcp.dependencySelectionDialog.promptsNotSupported"),
               t,
             )}
           >


### PR DESCRIPTION
Follows the repo's i18n convention (CLAUDE.md) that requires every user-facing string in `apps/mesh/src/web` to go through `t()`.

The Tools/Resources/Prompts tabs in the virtual MCP's dependency selection dialog (`dependency-selection-dialog.tsx`) render a fallback message when the connected MCP server doesn't implement `list_tools`/`list_resources`/`list_prompts` (caught as a "Method not found" JSON-RPC error by the tab's `ErrorBoundary`). All three fallback strings ("Tools not supported by this server", "Resources not supported by this server", "Prompts not supported by this server") were hardcoded in English and passed directly into `createMethodNotFoundFallback(...)`, even though every other string in the same dialog already goes through `t("virtualMcp.dependencySelectionDialog....")`. A pt-br user hitting this fallback (e.g. connecting a tools-only MCP server and viewing its Resources tab) would see English text mid-dialog.

Changes:
- Added `virtualMcp.dependencySelectionDialog.{toolsNotSupported,resourcesNotSupported,promptsNotSupported}` keys to both `en/virtual-mcp.ts` and `pt-br/virtual-mcp.ts`.
- Replaced the three hardcoded string literals in `dependency-selection-dialog.tsx` with `t(...)` calls (the enclosing component already has `const t = useT()` in scope).

How to confirm: open a virtual MCP's dependency selection dialog for a connection that returns "Method not found" for `resources/list` or `prompts/list`, with the org's language preference set to Portuguese, and check the fallback text is now translated.

Local verification: `bun run fmt` and `cd apps/mesh && bunx tsc --noEmit` both pass (the `pt-br` dictionary's `satisfies Record<keyof typeof enDomain, string>` check would fail to compile if a key were missing, so this also proves translation completeness). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the “not supported” fallback text in the virtual MCP dependency selection dialog for Tools, Resources, and Prompts tabs. Replaces hardcoded English with i18n keys so users see translated messages (e.g., pt‑BR).

- **Bug Fixes**
  - Replaced hardcoded tab fallback strings with `t("virtualMcp.dependencySelectionDialog.*NotSupported")` in `dependency-selection-dialog.tsx`.
  - Added `toolsNotSupported`, `resourcesNotSupported`, and `promptsNotSupported` keys to `en/virtual-mcp.ts` and `pt-br/virtual-mcp.ts`.

<sup>Written for commit a47efcabb7853e1f25b8517b19f7ff6293c7ffd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

