### PR TITLE
fix(mcp-clients): log the actual error when configuration token issuance fails

### DIFF
--- a/apps/mesh/src/mcp-clients/outbound/headers.ts
+++ b/apps/mesh/src/mcp-clients/outbound/headers.ts
@@ -133,7 +133,7 @@ async function _buildRequestHeaders(
     : [null, new Error("User ID required to issue configuration token")];
 
   if (error) {
-    console.error("Failed to issue configuration token:", configurationToken);
+    console.error("Failed to issue configuration token:", error);
   }
 
   const callerConnectionId = ctx.auth.user?.connectionId;


### PR DESCRIPTION
Found while hardening the outbound MCP auth transport (`apps/mesh/src/mcp-clients/outbound/headers.ts`), reviewed as part of the OAuth-proxy/outbound-auth focus area.

The failure branch for issuing the per-request configuration JWT logs the wrong variable:

```ts
const [configurationToken, error] = userId
  ? await issueMeshToken(...).then(...).catch((error) => [null, error])
  : [null, new Error("User ID required to issue configuration token")];

if (error) {
  console.error("Failed to issue configuration token:", configurationToken);
}
```

**Failure scenario:** whenever JWT issuance fails (bad signing key, DB hiccup during permission lookup, missing user id, etc.), `configurationToken` is always `null` in that branch — so the log line prints `Failed to issue configuration token: null` and the actual `Error` object (message + stack) is discarded. This is on the outbound path used for every proxied MCP tool call, so a real issuance failure is currently unobservable in logs — you can't tell whether the JWT signer is misconfigured, a permission lookup threw, or something else.

**Fix:** log `error` instead of `configurationToken`. One-line, behavior-preserving — the token issuance/fallback logic itself is unchanged, only what gets logged in the already-existing error branch.

No new test: this is a one-line swap in a `console.error` argument inside a function that composes JWT issuance, DB token storage, and StudioContext — exercising it meaningfully requires the mocks/DB that unit tests in this repo aren't supposed to use (see TESTING.md), so there's no cheap unit-testable surface to cover.

**To verify:** read `apps/mesh/src/mcp-clients/outbound/headers.ts:135-137` — confirm `error` (not `configurationToken`) is now the logged value.

**Checks run locally:** `bun run fmt` (clean), `cd apps/mesh && bunx tsc --noEmit` (clean, no type changes). Full CI suite covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log the actual error when per-request configuration JWT issuance fails in outbound MCP auth. Replaces logging of `configurationToken` (null on failure) with the caught `error`, making failures visible with message and stack.

<sup>Written for commit 65dbbc90e680b0e0934ff8eaa2cdf50f4bdd576c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

