### PR TITLE
feat(sandbox): share agent sandboxes by branch

### DIFF
--- a/apps/mesh/migrations/137-agent-sandbox-runner-state.ts
+++ b/apps/mesh/migrations/137-agent-sandbox-runner-state.ts
@@ -1,0 +1,36 @@
+/**
+ * Runner-private persistence for shared hosted sandboxes.
+ *
+ * The existing sandbox_runner_state remains user-scoped for user-desktop and
+ * legacy hosted claims. New shared agent-sandbox claims are keyed only by the
+ * project ref (which already includes org, virtual MCP, and branch).
+ */
+
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("agent_sandbox_runner_state")
+    .addColumn("project_ref", "text", (col) => col.notNull())
+    .addColumn("sandbox_provider_kind", "text", (col) => col.notNull())
+    .addColumn("handle", "text", (col) => col.notNull())
+    .addColumn("state", "jsonb", (col) => col.notNull())
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .addPrimaryKeyConstraint("agent_sandbox_runner_state_pkey", [
+      "project_ref",
+      "sandbox_provider_kind",
+    ])
+    .execute();
+
+  await db.schema
+    .createIndex("agent_sandbox_runner_state_handle_idx")
+    .on("agent_sandbox_runner_state")
+    .column("handle")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("agent_sandbox_runner_state").execute();
+}

--- a/apps/mesh/migrations/138-agent-sandbox-sessions.ts
+++ b/apps/mesh/migrations/138-agent-sandbox-sessions.ts
@@ -1,0 +1,69 @@
+/**
+ * First-class lifecycle registry for shared hosted sandboxes.
+ *
+ * virtual_mcp_id intentionally has no foreign key: the well-known Decopilot
+ * virtual MCP is synthetic and still owns thread-scoped sandboxes.
+ */
+
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("agent_sandbox_sessions")
+    .addColumn("organization_id", "text", (col) =>
+      col.notNull().references("organization.id").onDelete("cascade"),
+    )
+    .addColumn("virtual_mcp_id", "text", (col) => col.notNull())
+    .addColumn("branch", "text", (col) => col.notNull())
+    .addColumn("thread_id", "text")
+    .addColumn("sandbox_handle", "text")
+    .addColumn("preview_url", "text")
+    .addColumn("sandbox_api_url", "text")
+    .addColumn("desired_state", "text", (col) =>
+      col.notNull().defaultTo("running"),
+    )
+    .addColumn("status", "text", (col) =>
+      col.notNull().defaultTo("provisioning"),
+    )
+    .addColumn("generation", "integer", (col) => col.notNull().defaultTo(1))
+    .addColumn("started_with", "jsonb")
+    .addColumn("failure_reason", "text")
+    .addColumn("created_by", "text", (col) => col.notNull())
+    .addColumn("last_started_by", "text", (col) => col.notNull())
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn("updated_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .addPrimaryKeyConstraint("agent_sandbox_sessions_pkey", [
+      "organization_id",
+      "virtual_mcp_id",
+      "branch",
+    ])
+    .addCheckConstraint(
+      "agent_sandbox_sessions_desired_state_check",
+      sql`desired_state in ('running', 'stopped')`,
+    )
+    .addCheckConstraint(
+      "agent_sandbox_sessions_status_check",
+      sql`status in ('provisioning', 'ready', 'missing', 'failed', 'stopping', 'reaping', 'deleting', 'stopped')`,
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("agent_sandbox_sessions_vm_updated_idx")
+    .on("agent_sandbox_sessions")
+    .columns(["organization_id", "virtual_mcp_id", "updated_at"])
+    .execute();
+
+  await db.schema
+    .createIndex("agent_sandbox_sessions_thread_idx")
+    .on("agent_sandbox_sessions")
+    .columns(["organization_id", "thread_id"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("agent_sandbox_sessions").execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -135,6 +135,8 @@ import * as migration133dedupeduplicatemembers from "./133-dedupe-duplicate-memb
 import * as migration134droptaskboardenabled from "./134-drop-task-board-enabled.ts";
 import * as migration135taskboarditemfkcascade from "./135-task-board-item-fk-cascade.ts";
 import * as migration136taskboardimportidempotency from "./136-task-board-import-idempotency.ts";
+import * as migration137agentsandboxrunnerstate from "./137-agent-sandbox-runner-state.ts";
+import * as migration138agentsandboxsessions from "./138-agent-sandbox-sessions.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -295,6 +297,8 @@ const migrations: Record<string, Migration> = {
   "134-drop-task-board-enabled": migration134droptaskboardenabled,
   "135-task-board-item-fk-cascade": migration135taskboarditemfkcascade,
   "136-task-board-import-idempotency": migration136taskboardimportidempotency,
+  "137-agent-sandbox-runner-state": migration137agentsandboxrunnerstate,
+  "138-agent-sandbox-sessions": migration138agentsandboxsessions,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/routes/agent-sandbox-sessions.ts
+++ b/apps/mesh/src/api/routes/agent-sandbox-sessions.ts
@@ -1,0 +1,98 @@
+import { Hono } from "hono";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
+import { getSettings } from "../../settings";
+import type { Env } from "../hono-env";
+
+interface SessionCursor {
+  updatedAt: string;
+  branch: string;
+}
+
+function decodeCursor(value: string | undefined): SessionCursor | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(value, "base64url").toString("utf8"),
+    ) as Partial<SessionCursor>;
+    if (
+      typeof parsed.updatedAt !== "string" ||
+      !Number.isFinite(Date.parse(parsed.updatedAt)) ||
+      typeof parsed.branch !== "string" ||
+      !parsed.branch
+    ) {
+      return undefined;
+    }
+    return { updatedAt: parsed.updatedAt, branch: parsed.branch };
+  } catch {
+    return undefined;
+  }
+}
+
+function encodeCursor(cursor: SessionCursor): string {
+  return Buffer.from(JSON.stringify(cursor)).toString("base64url");
+}
+
+export function createAgentSandboxSessionRoutes() {
+  const app = new Hono<Env>();
+
+  app.get("/:virtualMcpId", async (c) => {
+    const ctx = c.var.studioContext;
+    try {
+      requireAuth(ctx);
+    } catch {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    const organization = requireOrganization(ctx);
+    const virtualMcpId = c.req.param("virtualMcpId");
+    const virtualMcp = await ctx.storage.virtualMcps.findById(virtualMcpId);
+    if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+      return c.json({ error: "Virtual MCP not found" }, 404);
+    }
+
+    if (!getSettings().sharedAgentSandboxesEnabled) {
+      return c.json({ items: [], nextCursor: null });
+    }
+
+    const branch = c.req.query("branch");
+    if (branch) {
+      const session = await ctx.storage.agentSandboxSessions.find({
+        organizationId: organization.id,
+        virtualMcpId,
+        branch,
+      });
+      return c.json({ items: session ? [session] : [], nextCursor: null });
+    }
+
+    const requestedLimit = Number(c.req.query("limit") ?? 100);
+    const limit = Number.isFinite(requestedLimit)
+      ? Math.min(Math.max(Math.trunc(requestedLimit), 1), 200)
+      : 100;
+    const rawBefore = c.req.query("before");
+    const before = decodeCursor(rawBefore);
+    if (rawBefore && !before) {
+      return c.json({ error: "Invalid pagination cursor" }, 400);
+    }
+    const items = await ctx.storage.agentSandboxSessions.listByVirtualMcp(
+      organization.id,
+      virtualMcpId,
+      {
+        limit: limit + 1,
+        before,
+      },
+    );
+    const hasMore = items.length > limit;
+    const page = hasMore ? items.slice(0, limit) : items;
+    return c.json({
+      items: page,
+      nextCursor:
+        hasMore && page.at(-1)
+          ? encodeCursor({
+              updatedAt: page.at(-1)!.updatedAt,
+              branch: page.at(-1)!.branch,
+            })
+          : null,
+    });
+  });
+
+  return app;
+}

--- a/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/mesh/src/api/routes/decopilot/dispatch-run.ts
@@ -2008,7 +2008,7 @@ export async function prepareLinkWorkDispatch(
  *
  * Mirrors the formula used by `ensureSandbox` / `provisionSandbox`:
  *   projectRef = composeSandboxRef({ orgId, virtualMcpId: agentId, branch })
- *   handle     = computeClaimHandle({ userId, projectRef }, branch)
+ *   handle     = computeClaimHandle(userSandboxId(userId, projectRef), branch)
  *
  * This is the SAME handle the daemon receives in `WorkItem.sandbox.handle`
  * (set by `resolveLinkSandboxConfig`) and that the daemon derives via
@@ -2032,5 +2032,8 @@ export function computeDesktopSandboxHandle(input: {
     virtualMcpId: input.agentId,
     branch: input.branch,
   });
-  return computeClaimHandle({ userId: input.userId, projectRef }, input.branch);
+  return computeClaimHandle(
+    { scope: "user", userId: input.userId, projectRef },
+    input.branch,
+  );
 }

--- a/apps/mesh/src/api/routes/dev-connection.ts
+++ b/apps/mesh/src/api/routes/dev-connection.ts
@@ -2,15 +2,13 @@
  * Ephemeral dev-server connection resolver.
  *
  * Materializes an in-memory `ConnectionEntity` for the synthetic id
- * `dev_<virtualMcpId>`, pointing at the acting user's running sandbox dev
+ * `dev_<virtualMcpId>`, pointing at the running sandbox dev
  * server (`${previewUrl}/api/mcp`, authless by default). Never persisted — the
  * proxy chokepoints call this instead of `connections.findById` when they see a
  * `dev_` id (mirrors the `_self` synthetic-id bypass).
  *
- * Per-acting-user by construction: the previewUrl is read from
- * `sandboxMap[actingUserId]`, so each member only ever reaches their own
- * sandbox — there is no shared row to leak across users. No sandbox running for
- * the user → `null` (callers render a "start dev server" state).
+ * Shared hosted sessions resolve from the org registry; user-desktop sessions
+ * continue to resolve from `sandboxMap[actingUserId]`.
  *
  * Returns `null` unless the agent is the dev side of a dev/live pair (the
  * MCP-app signal — see the gate below), so plain website/Hydrogen sandbox
@@ -36,6 +34,7 @@ import {
 } from "../../storage/secrets";
 import { readValidatedRuntimeEnv } from "../../tools/sandbox/helpers";
 import { readSandboxMap } from "../../tools/sandbox/sandbox-map";
+import { getSettings } from "../../settings";
 import {
   type BranchMapEntryLike,
   selectVmEntry,
@@ -117,11 +116,38 @@ export async function resolveDevConnection(
 
   const metadata = (vm.metadata ?? {}) as Record<string, unknown>;
   const userMap = readSandboxMap(metadata)[actingUserId];
-  if (!userMap) return null;
-
-  const picked = branch
-    ? pickEntryForBranch(userMap, branch)
-    : pickMostRecentEntry(userMap);
+  const sharedSession = getSettings().sharedAgentSandboxesEnabled
+    ? branch
+      ? await ctx.storage.agentSandboxSessions.find({
+          organizationId: orgId,
+          virtualMcpId: agentId,
+          branch,
+        })
+      : await ctx.storage.agentSandboxSessions.findLatestReadyByVirtualMcp(
+          orgId,
+          agentId,
+        )
+    : null;
+  const sharedEntry =
+    sharedSession?.desiredState === "running" &&
+    sharedSession.status === "ready" &&
+    sharedSession.sandboxHandle &&
+    sharedSession.previewUrl
+      ? {
+          sandboxHandle: sharedSession.sandboxHandle,
+          previewUrl: sharedSession.previewUrl,
+          sandboxProviderKind: "agent-sandbox" as const,
+        }
+      : null;
+  const picked = sharedEntry
+    ? {
+        entry: sharedEntry,
+      }
+    : userMap
+      ? branch
+        ? pickEntryForBranch(userMap, branch)
+        : pickMostRecentEntry(userMap)
+      : null;
   if (!picked?.entry.previewUrl) return null;
 
   // Authless by default — most dev servers run open. If the app gates /mcp
@@ -164,7 +190,12 @@ export async function resolveDevConnection(
     metadata: {
       isDevConnection: true,
       virtualMcpId: agentId,
-      branch: picked.branch,
+      branch:
+        sharedEntry && sharedSession
+          ? sharedSession.branch
+          : "branch" in picked
+            ? picked.branch
+            : branch,
     },
     // null forces live tool/resource discovery (the dev server hot-reloads).
     tools: null,

--- a/apps/mesh/src/api/routes/org-scoped.ts
+++ b/apps/mesh/src/api/routes/org-scoped.ts
@@ -32,6 +32,7 @@ import { createToolsRestRoutes } from "./tools-rest";
 import { createTriggerCallbackRoutes } from "./trigger-callback";
 import { createVirtualMcpRoutes } from "./virtual-mcp";
 import { createSandboxRoutes } from "./sandbox-proxy";
+import { createAgentSandboxSessionRoutes } from "./agent-sandbox-sessions";
 
 interface OrgScopedDeps {
   kvStorage: KVStorage;
@@ -99,6 +100,7 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
     createOrgFsRoutes({ getConnection: deps.getNatsConnection }),
   ); // /api/:org/fs/:volume/...
   app.route("/sandbox", createSandboxRoutes()); // /api/:org/sandbox/:virtualMcpId/:branch/*
+  app.route("/agent-sandbox-sessions", createAgentSandboxSessionRoutes());
   app.route("/", createHomeNextActionsRoutes());
   app.route("/deco-sites", createDecoSitesOrgRoutes()); // /api/:org/deco-sites
   app.route("/sso", createSsoRoutes()); // /api/:org/sso/* (renamed from /api/org-sso)

--- a/apps/mesh/src/api/routes/sandbox-events-handler.ts
+++ b/apps/mesh/src/api/routes/sandbox-events-handler.ts
@@ -10,14 +10,13 @@
 import type { Context } from "hono";
 import { streamSSE } from "hono/streaming";
 import {
-  resolveSandboxProviderKindFromEnv,
+  type SandboxId,
   type SandboxProviderKind,
   type SandboxProvider,
 } from "@decocms/sandbox/provider";
 import { delay, exponentialBackoffWithJitter } from "@decocms/std";
 import { subscribeLifecycle } from "../../sandbox/lifecycle";
 import type { StudioContext } from "../../core/studio-context";
-import { KyselySandboxProviderStateStore } from "../../storage/sandbox-runner-state";
 import {
   readSandboxMap,
   removeSandboxMapEntry,
@@ -29,6 +28,7 @@ import {
   threadIdFromBranch,
 } from "../../tools/sandbox/thread-repo";
 import type { Env } from "../hono-env";
+import { requireOrganization } from "../../core/studio-context";
 
 /**
  * Cap on how long we keep the SSE open if a claim never materializes (e.g.
@@ -61,10 +61,11 @@ export interface VmEventsHandlerArgs {
   ctx: StudioContext;
   claimName: string;
   runner: SandboxProvider;
+  sandboxId: SandboxId;
+  providerKind: SandboxProviderKind;
   virtualMcpId: string;
   branch: string;
   userId: string;
-  projectRef: string;
   virtualMcpMetadata: Record<string, unknown> | null;
 }
 
@@ -73,14 +74,13 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
     ctx,
     claimName,
     runner,
+    sandboxId,
+    providerKind,
     virtualMcpId,
     branch,
     userId,
-    projectRef,
     virtualMcpMetadata,
   } = args;
-  const providerKind = resolveSandboxProviderKindFromEnv();
-
   // The agent row is a no-op sandbox store for the synthetic Decopilot agent —
   // its records live on the THREAD (see `setThreadSandboxMapEntry`). Resolve the
   // thread id from the branch so the stale-handle check below covers thread-
@@ -104,23 +104,93 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
     });
 
     try {
-      // Prefer the agent entry; fall back to the thread entry (thread-scoped
-      // branches). `fromThread` steers cleanup to the right store.
-      let vmEntry = resolveVm(
-        readSandboxMap(virtualMcpMetadata),
-        userId,
-        branch,
-        providerKind,
-      );
+      let vmEntry;
       let fromThread = false;
-      if (!vmEntry && threadId) {
+      if (sandboxId.scope === "shared") {
+        const organization = requireOrganization(ctx);
+        const session = await ctx.storage.agentSandboxSessions.find({
+          organizationId: organization.id,
+          virtualMcpId,
+          branch,
+        });
+        if (session?.desiredState === "stopped") {
+          if (session.status === "stopping" || session.status === "deleting") {
+            const transition = session.status;
+            let deleteSucceeded = true;
+            try {
+              const handle =
+                session.sandboxHandle ??
+                (transition === "deleting" ? claimName : null);
+              if (handle) {
+                await runner.delete(handle, sandboxId);
+              }
+            } catch (error) {
+              deleteSucceeded = false;
+              console.warn(
+                `[vm-events] failed to resume shared stop for ${virtualMcpId}/${branch}: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              );
+            } finally {
+              if (transition !== "deleting" || deleteSucceeded) {
+                const locator = {
+                  organizationId: organization.id,
+                  virtualMcpId,
+                  branch,
+                };
+                await ctx.storage.agentSandboxSessions.withLock(
+                  locator,
+                  (sessions) =>
+                    transition === "deleting"
+                      ? sessions.completeDelete(locator, session.generation)
+                      : sessions.completeStop(locator, session.generation),
+                );
+              }
+            }
+          }
+          await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
+          return;
+        }
+        if (session?.status === "reaping" && session.sandboxHandle) {
+          await cleanupStaleEntry({
+            ctx,
+            runner,
+            claimName: session.sandboxHandle,
+            virtualMcpId,
+            branch,
+            userId,
+            sandboxId,
+            sandboxProviderKind: providerKind,
+            threadId: null,
+          });
+          await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
+          return;
+        }
+        vmEntry =
+          session?.sandboxHandle && session.status === "ready"
+            ? {
+                sandboxHandle: session.sandboxHandle,
+                sandboxProviderKind: "agent-sandbox" as const,
+              }
+            : null;
+      } else {
+        // Prefer the agent entry; fall back to the thread entry (thread-scoped
+        // branches). `fromThread` steers cleanup to the right store.
         vmEntry = resolveVm(
-          await getThreadSandboxMap(ctx, threadId),
+          readSandboxMap(virtualMcpMetadata),
           userId,
           branch,
           providerKind,
         );
-        fromThread = !!vmEntry;
+        if (!vmEntry && threadId) {
+          vmEntry = resolveVm(
+            await getThreadSandboxMap(ctx, threadId),
+            userId,
+            branch,
+            providerKind,
+          );
+          fromThread = !!vmEntry;
+        }
       }
       const existingProviderKind: SandboxProviderKind | null =
         vmEntry?.sandboxProviderKind ?? null;
@@ -135,7 +205,7 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
             virtualMcpId,
             branch,
             userId,
-            projectRef,
+            sandboxId,
             sandboxProviderKind: existingProviderKind ?? providerKind,
             threadId: fromThread ? threadId : null,
           });
@@ -190,7 +260,7 @@ async function cleanupStaleEntry(args: {
   virtualMcpId: string;
   branch: string;
   userId: string;
-  projectRef: string;
+  sandboxId: SandboxId;
   sandboxProviderKind: SandboxProviderKind;
   /** Set when the stale entry was found on the thread (synthetic agent) — clear
    *  it there instead of / in addition to the agent row. */
@@ -203,10 +273,39 @@ async function cleanupStaleEntry(args: {
     virtualMcpId,
     branch,
     userId,
-    projectRef,
+    sandboxId,
     sandboxProviderKind,
     threadId,
   } = args;
+  if (sandboxId.scope === "shared") {
+    const organization = requireOrganization(ctx);
+    const locator = {
+      organizationId: organization.id,
+      virtualMcpId,
+      branch,
+    };
+    try {
+      const reaping = await ctx.storage.agentSandboxSessions.withLock(
+        locator,
+        (sessions) => sessions.beginReap(locator, claimName),
+      );
+      if (!reaping) return;
+      try {
+        await runner.delete(claimName, sandboxId);
+      } finally {
+        await ctx.storage.agentSandboxSessions.withLock(locator, (sessions) =>
+          sessions.completeReap(locator, reaping.generation, claimName),
+        );
+      }
+    } catch (err) {
+      console.warn(
+        `[vm-events] shared session cleanup failed for ${virtualMcpId}/${branch}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    return;
+  }
   // Drop the sandboxMap entry first. Without this the dangling `sandboxHandle`
   // stays in metadata, so every client SSE reconnect re-enters this stale path
   // and re-issues a DELETE against the already-gone claim — a 404 flood that
@@ -239,20 +338,10 @@ async function cleanupStaleEntry(args: {
     );
   }
   try {
-    await runner.delete(claimName);
+    await runner.delete(claimName, sandboxId);
   } catch (err) {
     console.warn(
       `[vm-events] runner.delete failed for ${claimName}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
-  try {
-    const stateStore = new KyselySandboxProviderStateStore(ctx.db);
-    await stateStore.delete({ userId, projectRef }, sandboxProviderKind);
-  } catch (err) {
-    console.warn(
-      `[vm-events] sandbox_runner_state delete failed for ${userId}/${projectRef}/${sandboxProviderKind}: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -15,8 +15,14 @@ import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { streamSSE } from "hono/streaming";
 import { createMiddleware } from "hono/factory";
-import { composeSandboxRef } from "@decocms/sandbox/provider";
-import type { SandboxProvider } from "@decocms/sandbox/provider";
+import {
+  composeSandboxRef,
+  sharedSandboxId,
+  userSandboxId,
+  type SandboxId,
+  type SandboxProvider,
+  type SandboxProviderKind,
+} from "@decocms/sandbox/provider";
 import type { ClaimPhase } from "@decocms/sandbox/provider/agent-sandbox";
 import { computeClaimHandle } from "../../sandbox/claim-handle";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
@@ -47,11 +53,14 @@ import {
   parseGithubRepoFromMetadata,
   refreshSandboxGitCredentials,
 } from "../../tools/sandbox/sync-git-credentials";
+import { getSettings } from "../../settings";
 
 // ---- Middleware types -------------------------------------------------------
 
 interface VmClaim {
   claimName: string;
+  sandboxId: SandboxId;
+  providerKind: SandboxProviderKind;
   /** Null when no sandbox runner is configured on this studio instance. */
   runner: SandboxProvider | null;
   virtualMcpId: string;
@@ -163,7 +172,6 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
     virtualMcpId,
     branch,
   });
-  const claimName = computeClaimHandle({ userId, projectRef }, branch);
   const virtualMcpMetadata =
     (virtualMcp.metadata as Record<string, unknown>) ?? null;
 
@@ -180,23 +188,35 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
   // to a sandbox that doesn't host this VM. The events handler streams a
   // `failed` phase from null; other handlers 503 via `requireRunner`.
   let runner: SandboxProvider | null;
+  let providerKind: SandboxProviderKind | null = null;
   try {
     const resolved = await resolveSandboxProvider(ctx, {
       userId,
       branch,
+      virtualMcpId,
       virtualMcpMetadata,
     });
     runner = resolved.provider;
+    providerKind = resolved.kind;
   } catch {
     runner = null;
   }
 
-  if (!runner) {
+  if (!runner || !providerKind) {
     return c.json({ error: "No sandbox runner found" }, 404);
   }
 
+  const sandboxId =
+    providerKind === "agent-sandbox" &&
+    getSettings().sharedAgentSandboxesEnabled
+      ? sharedSandboxId(projectRef)
+      : userSandboxId(userId, projectRef);
+  const claimName = computeClaimHandle(sandboxId, branch);
+
   c.set("vmClaim", {
     claimName,
+    sandboxId,
+    providerKind,
     runner,
     virtualMcpId,
     branch,
@@ -252,7 +272,7 @@ async function proxyDaemon(
   const runner = requireRunner(c);
   if (runner instanceof Response) return runner;
 
-  const { claimName, userId, projectRef } = c.get("vmClaim");
+  const { claimName, sandboxId } = c.get("vmClaim");
   const method = opts?.method ?? "POST";
   let body: string | null = null;
   const headers = new Headers();
@@ -294,10 +314,7 @@ async function proxyDaemon(
       } catch {
         /* ignore */
       }
-      const adopted = await runner.adoptLiveClaim?.(
-        { userId, projectRef },
-        claimName,
-      );
+      const adopted = await runner.adoptLiveClaim?.(sandboxId, claimName);
       if (adopted) {
         upstream = await runner.proxyDaemonRequest(
           claimName,
@@ -398,7 +415,7 @@ async function fetchDaemonJson<T>(
   claimName: string,
   daemonPath: string,
   method: "GET" | "POST" = "GET",
-  sandboxId?: { userId: string; projectRef: string },
+  sandboxId?: SandboxId,
 ): Promise<T> {
   let upstream = await runner.proxyDaemonRequest(claimName, daemonPath, {
     method,
@@ -569,6 +586,9 @@ export const createSandboxRoutes = () => {
             orgId: organization.id,
             userId: claim.userId,
             entries,
+            organizationSecretsOnly:
+              claim.providerKind === "agent-sandbox" &&
+              claim.sandboxId.scope === "shared",
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
@@ -608,10 +628,11 @@ export const createSandboxRoutes = () => {
       ctx: c.var.studioContext,
       claimName: claim.claimName,
       runner: claim.runner,
+      sandboxId: claim.sandboxId,
+      providerKind: claim.providerKind,
       virtualMcpId: claim.virtualMcpId,
       branch: claim.branch,
       userId: claim.userId,
-      projectRef: claim.projectRef,
       virtualMcpMetadata: claim.virtualMcpMetadata,
     });
   });
@@ -711,7 +732,7 @@ export const createSandboxRoutes = () => {
       const runner = requireRunner(c);
       if (runner instanceof Response) return runner;
 
-      const { claimName, userId, projectRef } = c.get("vmClaim");
+      const { claimName, sandboxId } = c.get("vmClaim");
       const ctx = c.var.studioContext;
 
       try {
@@ -736,14 +757,14 @@ export const createSandboxRoutes = () => {
                   claimName,
                   "/_sandbox/git/status",
                   "GET",
-                  { userId, projectRef },
+                  sandboxId,
                 ),
                 fetchDaemonJson<GitDiffLike>(
                   runner,
                   claimName,
                   "/_sandbox/git/diff",
                   "GET",
-                  { userId, projectRef },
+                  sandboxId,
                 ),
               ]);
         const suggestion = await suggestCommitMessageWithLlm(ctx, status, diff);
@@ -785,7 +806,7 @@ export const createSandboxRoutes = () => {
       const runner = requireRunner(c);
       if (runner instanceof Response) return runner;
 
-      const { claimName, userId, projectRef } = c.get("vmClaim");
+      const { claimName, sandboxId } = c.get("vmClaim");
       const ctx = c.var.studioContext;
 
       try {
@@ -811,14 +832,14 @@ export const createSandboxRoutes = () => {
                   claimName,
                   "/_sandbox/git/status",
                   "GET",
-                  { userId, projectRef },
+                  sandboxId,
                 ),
                 fetchDaemonJson<GitDiffLike>(
                   runner,
                   claimName,
                   "/_sandbox/git/diff",
                   "GET",
-                  { userId, projectRef },
+                  sandboxId,
                 ),
               ]);
         const verdict = await judgeRequiresReviewWithLlm(

--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -26,6 +26,7 @@ import { readSandboxMap } from "../../tools/sandbox/sandbox-map";
 import type { ConnectionEntity } from "../../tools/connection/schema";
 import type { Env } from "../hono-env";
 import { serveMcpRequest } from "../utils/serve-mcp";
+import { getSettings } from "../../settings";
 
 // ============================================================================
 // Route Handler (shared between /gateway and /virtual-mcp endpoints for backward compat)
@@ -159,7 +160,8 @@ export async function handleVirtualMcpRequest(
     if (
       virtualMcp.id &&
       actingUserId &&
-      readSandboxMap(virtualMcp.metadata)[actingUserId]
+      (getSettings().sharedAgentSandboxesEnabled ||
+        readSandboxMap(virtualMcp.metadata)[actingUserId])
     ) {
       devConnection = await resolveDevConnection(
         ctx,

--- a/apps/mesh/src/api/routes/vm-events.ts
+++ b/apps/mesh/src/api/routes/vm-events.ts
@@ -2,7 +2,7 @@
  * Unified VM events SSE.
  *
  * Single browser-facing stream for everything happening to a sandbox keyed
- * on (virtualMcpId, branch, callerUserId):
+ * on (virtualMcpId, branch), plus callerUserId only for user-desktop:
  *
  *   1. Pre-Ready lifecycle phases (`event: phase`) — surfaces the gap between
  *      SANDBOX_START posting a SandboxClaim and the daemon coming online.
@@ -21,10 +21,8 @@
  * Auth model:
  *   - Caller must be authenticated.
  *   - Caller's organization must own the requested virtualMcp.
- *   - Claim name is derived deterministically from
- *     (orgId, virtualMcpId, branch, callerUserId), so a caller only sees
- *     events for *their own* sandbox; another user in the same org would
- *     compute a different handle.
+ *   - Hosted claim names omit callerUserId so authorized collaborators on the
+ *     same branch share a stream. Desktop claim names remain user-scoped.
  *
  * Why one stream instead of two: prior design had the browser open
  * `/api/vm-lifecycle` (studio) plus a direct EventSource to the daemon's public
@@ -36,7 +34,12 @@
 
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import { composeSandboxRef } from "@decocms/sandbox/provider";
+import {
+  composeSandboxRef,
+  sharedSandboxId,
+  userSandboxId,
+  type SandboxId,
+} from "@decocms/sandbox/provider";
 import { delay } from "@decocms/std";
 import type {
   ClaimPhase,
@@ -52,9 +55,9 @@ import {
   requireOrganization,
   type StudioContext,
 } from "../../core/studio-context";
-import { KyselySandboxProviderStateStore } from "../../storage/sandbox-runner-state";
 import { readSandboxMap, resolveVm } from "../../tools/sandbox/sandbox-map";
 import type { Env } from "../hono-env";
+import { getSettings } from "../../settings";
 
 /**
  * Cap on how long we keep the SSE open if a claim never materializes (e.g.
@@ -110,7 +113,6 @@ export const createVmEventsRoutes = () => {
       virtualMcpId,
       branch,
     });
-    const claimName = computeClaimHandle({ userId, projectRef }, branch);
     const virtualMcpMetadata =
       (virtualMcp.metadata as Record<string, unknown> | null) ?? null;
 
@@ -128,6 +130,7 @@ export const createVmEventsRoutes = () => {
       const resolved = await resolveSandboxProvider(ctx, {
         userId,
         branch,
+        virtualMcpId,
         virtualMcpMetadata,
       });
       runner = resolved.provider;
@@ -137,6 +140,13 @@ export const createVmEventsRoutes = () => {
       runner = null;
     }
 
+    const sandboxId: SandboxId =
+      providerKind === "agent-sandbox" &&
+      getSettings().sharedAgentSandboxesEnabled
+        ? sharedSandboxId(projectRef)
+        : userSandboxId(userId, projectRef);
+    const claimName = computeClaimHandle(sandboxId, branch);
+
     // Snapshot sandboxMap from the same metadata read used for the org-ownership
     // check. Used below to gate the stale-handle probe: we only run it when
     // this user already had a sandboxMap entry pointing at *this exact* claim.
@@ -145,14 +155,29 @@ export const createVmEventsRoutes = () => {
     // similar window for user-desktop between `provider.ensure` returning and
     // `setSandboxMapEntry` writing the row). Without it, an SSE that opens during
     // that window would observe alive=false and emit a spurious `gone`.
+    const sharedSession =
+      sandboxId.scope === "shared"
+        ? await ctx.storage.agentSandboxSessions.find({
+            organizationId: organization.id,
+            virtualMcpId,
+            branch,
+          })
+        : null;
     const existingVmEntry =
-      providerKind &&
-      resolveVm(
-        readSandboxMap(virtualMcpMetadata),
-        userId,
-        branch,
-        providerKind,
-      );
+      sandboxId.scope === "shared"
+        ? sharedSession?.sandboxHandle && sharedSession.status === "ready"
+          ? {
+              sandboxHandle: sharedSession.sandboxHandle,
+              sandboxProviderKind: "agent-sandbox" as const,
+            }
+          : null
+        : providerKind &&
+          resolveVm(
+            readSandboxMap(virtualMcpMetadata),
+            userId,
+            branch,
+            providerKind,
+          );
     const expectingHandle =
       !!existingVmEntry && existingVmEntry.sandboxHandle === claimName;
 
@@ -187,6 +212,74 @@ export const createVmEventsRoutes = () => {
       });
 
       try {
+        if (
+          sandboxId.scope === "shared" &&
+          sharedSession?.desiredState === "stopped"
+        ) {
+          if (
+            sharedSession.status === "stopping" ||
+            sharedSession.status === "deleting"
+          ) {
+            const transition = sharedSession.status;
+            let deleteSucceeded = true;
+            try {
+              const handle =
+                sharedSession.sandboxHandle ??
+                (transition === "deleting" ? claimName : null);
+              if (handle) {
+                await runner.delete(handle, sandboxId);
+              }
+            } catch (error) {
+              deleteSucceeded = false;
+              console.warn(
+                `[vm-events] failed to resume shared stop for ${virtualMcpId}/${branch}: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              );
+            } finally {
+              if (transition !== "deleting" || deleteSucceeded) {
+                const locator = {
+                  organizationId: organization.id,
+                  virtualMcpId,
+                  branch,
+                };
+                await ctx.storage.agentSandboxSessions.withLock(
+                  locator,
+                  (sessions) =>
+                    transition === "deleting"
+                      ? sessions.completeDelete(
+                          locator,
+                          sharedSession.generation,
+                        )
+                      : sessions.completeStop(
+                          locator,
+                          sharedSession.generation,
+                        ),
+                );
+              }
+            }
+          }
+          await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
+          return;
+        }
+        if (
+          sandboxId.scope === "shared" &&
+          sharedSession?.status === "reaping" &&
+          sharedSession.sandboxHandle
+        ) {
+          await cleanupStaleEntry({
+            ctx,
+            runner,
+            claimName: sharedSession.sandboxHandle,
+            sandboxId,
+            organizationId: organization.id,
+            virtualMcpId,
+            branch,
+          });
+          await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
+          return;
+        }
+
         // Same probe for every provider. `runner.alive` is honest across both
         // providers: each queries its source-of-truth (the K8s API for
         // agent-sandbox, the link daemon for user-desktop). When the prior
@@ -200,9 +293,10 @@ export const createVmEventsRoutes = () => {
               ctx,
               runner,
               claimName,
-              userId,
-              projectRef,
-              sandboxProviderKind: providerKind,
+              sandboxId,
+              organizationId: organization.id,
+              virtualMcpId,
+              branch,
             });
             await stream.writeSSE({ event: "gone", data: "" }).catch(() => {});
             return;
@@ -285,33 +379,49 @@ async function cleanupStaleEntry(args: {
   ctx: StudioContext;
   runner: SandboxProvider;
   claimName: string;
-  userId: string;
-  projectRef: string;
-  sandboxProviderKind: SandboxProviderKind;
+  sandboxId: SandboxId;
+  organizationId: string;
+  virtualMcpId: string;
+  branch: string;
 }): Promise<void> {
   const {
     ctx,
     runner,
     claimName,
-    userId,
-    projectRef,
-    sandboxProviderKind: providerKind,
+    sandboxId,
+    organizationId,
+    virtualMcpId,
+    branch,
   } = args;
+  if (sandboxId.scope === "shared") {
+    const locator = { organizationId, virtualMcpId, branch };
+    try {
+      const reaping = await ctx.storage.agentSandboxSessions.withLock(
+        locator,
+        (sessions) => sessions.beginReap(locator, claimName),
+      );
+      if (!reaping) return;
+      try {
+        await runner.delete(claimName, sandboxId);
+      } finally {
+        await ctx.storage.agentSandboxSessions.withLock(locator, (sessions) =>
+          sessions.completeReap(locator, reaping.generation, claimName),
+        );
+      }
+    } catch (err) {
+      console.warn(
+        `[vm-events] shared cleanup failed for ${virtualMcpId}/${branch}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    return;
+  }
   try {
-    await runner.delete(claimName);
+    await runner.delete(claimName, sandboxId);
   } catch (err) {
     console.warn(
       `[vm-events] runner.delete failed for ${claimName}: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
-  try {
-    const stateStore = new KyselySandboxProviderStateStore(ctx.db);
-    await stateStore.delete({ userId, projectRef }, providerKind);
-  } catch (err) {
-    console.warn(
-      `[vm-events] sandbox_runner_state delete failed for ${userId}/${projectRef}/${providerKind}: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -60,6 +60,7 @@ import type { PrivateRegistryDatabase } from "../storage/registry/types";
 import { TagStorage } from "../storage/tags";
 import type { Database, Permission } from "../storage/types";
 import { UserStorage } from "../storage/user";
+import { AgentSandboxSessionStorage } from "../storage/agent-sandbox-sessions";
 import { AccessControl } from "./access-control";
 import { buildWildcardPermission } from "./permission-wildcard";
 import { isOrgArchived } from "./org-archived";
@@ -1336,6 +1337,7 @@ export async function createStudioContextFactory(
       metricsFromLogs,
     ),
     virtualMcps: new VirtualMCPStorage(config.db),
+    agentSandboxSessions: new AgentSandboxSessionStorage(config.db),
     users: new UserStorage(config.db),
     tags: new TagStorage(config.db),
     virtualMcpPluginConfigs: new VirtualMcpPluginConfigsStorage(config.db),

--- a/apps/mesh/src/core/studio-context.test.ts
+++ b/apps/mesh/src/core/studio-context.test.ts
@@ -45,6 +45,7 @@ const createMockContext = (
     organizationJoinRequests: null as never,
     kv: null as never,
     interests: null as never,
+    agentSandboxSessions: null as never,
   },
   vault: null as never,
   authInstance: null as never,

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -311,6 +311,7 @@ import type { OAuthPkceStateStorage } from "@/storage/oauth-pkce-states";
 import { AIProviderFactory } from "@/ai-providers/factory";
 import type { FireAutomationOutcome } from "../automations/dbos-workflow";
 import type { BoundObjectStorage } from "../object-storage/bound-object-storage";
+import type { AgentSandboxSessionStorage } from "../storage/agent-sandbox-sessions";
 
 // Better Auth instance type - flexible for testing
 // In production, this is the actual Better Auth instance
@@ -353,6 +354,7 @@ export interface MeshStorage {
   organizationJoinRequests: OrganizationJoinRequestStorage;
   kv: KVStorage;
   interests: InterestsStorage;
+  agentSandboxSessions: AgentSandboxSessionStorage;
 }
 
 // ============================================================================

--- a/apps/mesh/src/file-storage/mount/provisioning.ts
+++ b/apps/mesh/src/file-storage/mount/provisioning.ts
@@ -121,10 +121,11 @@ export async function mintOrgFsConfigJson(
   try {
     const apiKey = await ctx.boundAuth.apiKey.create({
       name: `orgfs-${opts.orgSlug}`,
-      // The mount only needs management/self tools; the actual file ops
-      // (ORG_FS_READ/WRITE) are granted to every member via basic-usage. With
-      // no implicit default (auth/index.ts), the scope must be explicit.
-      permissions: { self: ["*"] },
+      // This credential is baked into the sandbox mount and may be read by
+      // every collaborator in a shared hosted workspace. Keep it restricted
+      // to the two org-fs operations instead of carrying the creator's full
+      // management permissions.
+      permissions: { self: ["ORG_FS_READ", "ORG_FS_WRITE"] },
       expiresIn: ORG_FS_KEY_TTL_SECONDS,
       metadata: { organization: { id: opts.orgId, slug: opts.orgSlug } },
     });

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/cluster-sandbox-fs.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/cluster-sandbox-fs.ts
@@ -23,6 +23,7 @@ import { mintMcpEndpoint } from "@/mcp-clients/virtual-mcp/mint-endpoint";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import { ensureSandbox } from "@/tools/sandbox/start";
 import { removeSandboxMapEntry } from "@/tools/sandbox/sandbox-map";
+import { getSettings } from "@/settings";
 import type { SandboxFsHooks } from "@decocms/harness/decopilot/built-in-tools/vm-tools/sandbox-fs-hooks-types";
 
 /**
@@ -42,6 +43,16 @@ async function syncToolsCatalog(
   handle: string,
   vm: { virtualMcpId: string; providerKind: SandboxProviderKind },
 ): Promise<void> {
+  // A tool-scripting endpoint is a user-bound API key. Persisting it inside a
+  // shared workspace would let another collaborator act as the user who
+  // happened to sync last. Shared hosted sandboxes therefore keep tool calls
+  // in the outer harness and do not materialize user credentials on disk.
+  if (
+    vm.providerKind === "agent-sandbox" &&
+    getSettings().sharedAgentSandboxesEnabled
+  ) {
+    return;
+  }
   try {
     const organization = ctx.organization;
     if (!organization) return;
@@ -105,6 +116,7 @@ export async function buildClusterSandboxFs(
     {
       userId: vm.userId,
       branch: vm.branch,
+      virtualMcpId: vm.virtualMcpId,
       virtualMcpMetadata: null,
     },
   );
@@ -179,6 +191,40 @@ export async function buildClusterSandboxFs(
     if (lastHandlePromise && typeof runner.forgetHandle === "function") {
       try {
         const lastHandle = await lastHandlePromise;
+        if (
+          providerKind === "agent-sandbox" &&
+          getSettings().sharedAgentSandboxesEnabled
+        ) {
+          const virtualMcp = await ctx.storage.virtualMcps.findById(
+            vm.virtualMcpId,
+          );
+          if (virtualMcp) {
+            const locator = {
+              organizationId: virtualMcp.organization_id,
+              virtualMcpId: vm.virtualMcpId,
+              branch: vm.branch,
+            };
+            const reaping = await ctx.storage.agentSandboxSessions.withLock(
+              locator,
+              (sessions) => sessions.beginReap(locator, lastHandle),
+            );
+            if (!reaping) return;
+            try {
+              await runner.forgetHandle(lastHandle);
+            } finally {
+              await ctx.storage.agentSandboxSessions.withLock(
+                locator,
+                (sessions) =>
+                  sessions.completeReap(
+                    locator,
+                    reaping.generation,
+                    lastHandle,
+                  ),
+              );
+            }
+            return;
+          }
+        }
         await runner.forgetHandle(lastHandle);
       } catch (err) {
         console.warn("[cluster-sandbox-fs] forgetHandle failed", err);

--- a/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/mesh/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -205,6 +205,7 @@ export async function createLoadRepoTool(opts: {
       const { kind } = await resolveSandboxProvider(ctx, {
         userId,
         branch,
+        virtualMcpId,
         virtualMcpMetadata: null,
       });
       const entry = await ensureSandbox(

--- a/apps/mesh/src/sandbox/claim-handle.test.ts
+++ b/apps/mesh/src/sandbox/claim-handle.test.ts
@@ -7,7 +7,10 @@ describe("computeClaimHandle", () => {
     // public hostnames, so the handle hash must be long enough to resist
     // guessing at an unrate-limited gateway. The hashLen no longer varies by
     // kind, so the handle is env-agnostic.
-    const h = computeClaimHandle({ userId: "u", projectRef: "p" }, "main");
+    const h = computeClaimHandle(
+      { scope: "user", userId: "u", projectRef: "p" },
+      "main",
+    );
     // computeHandle output: "<slug>-<hash>"; assert the hash segment length.
     const hash = h.split("-").pop()!;
     expect(hash.length).toBe(16);

--- a/apps/mesh/src/sandbox/lifecycle.ts
+++ b/apps/mesh/src/sandbox/lifecycle.ts
@@ -19,6 +19,7 @@ import type { Kysely } from "kysely";
 import { meter } from "@/observability";
 import type { Database as DatabaseSchema } from "@/storage/types";
 import { KyselySandboxProviderStateStore } from "@/storage/sandbox-runner-state";
+import { KyselyAgentSandboxRunnerStateStore } from "@/storage/agent-sandbox-runner-state";
 import { buildCloneInfo } from "@/shared/github-clone-info";
 import { CredentialVault } from "@/encryption/credential-vault";
 import { getSettings } from "@/settings";
@@ -33,11 +34,19 @@ import { parseGithubOwnerRepo } from "@/sandbox/parse-github-clone-url";
 // Symbol.for keeps the same key across module instances.
 const RUNNERS_KEY = Symbol.for("decocms.sandbox.lifecycle.runners");
 const INFLIGHT_KEY = Symbol.for("decocms.sandbox.lifecycle.inflight");
+const SHARED_AGENT_RUNNER_KEY = Symbol.for(
+  "decocms.sandbox.lifecycle.shared-agent-runner",
+);
+const SHARED_AGENT_INFLIGHT_KEY = Symbol.for(
+  "decocms.sandbox.lifecycle.shared-agent-inflight",
+);
 type LifecycleGlobal = {
   [RUNNERS_KEY]?: Partial<Record<SandboxProviderKind, SandboxProvider>>;
   [INFLIGHT_KEY]?: Partial<
     Record<SandboxProviderKind, Promise<SandboxProvider>>
   >;
+  [SHARED_AGENT_RUNNER_KEY]?: SandboxProvider;
+  [SHARED_AGENT_INFLIGHT_KEY]?: Promise<SandboxProvider>;
 };
 const lifecycleGlobal = globalThis as unknown as LifecycleGlobal;
 
@@ -139,11 +148,16 @@ function readPreviewGateway(): { name: string; namespace: string } | undefined {
 async function instantiate(
   kind: SandboxProviderKind,
   db: Kysely<DatabaseSchema>,
+  agentStateScope: "configured" | "shared" = "configured",
 ): Promise<SandboxProvider> {
-  const stateStore = new KyselySandboxProviderStateStore(db);
   const previewUrlPattern = readPreviewUrlPattern();
   switch (kind) {
     case "agent-sandbox": {
+      const stateStore =
+        agentStateScope === "shared" ||
+        getSettings().sharedAgentSandboxesEnabled
+          ? new KyselyAgentSandboxRunnerStateStore(db)
+          : new KyselySandboxProviderStateStore(db);
       // Dynamic import — @kubernetes/client-node is heavy and only needed
       // when STUDIO_SANDBOX_PROVIDER=agent-sandbox. Deploys that never select
       // the hosted provider don't load it.
@@ -241,6 +255,33 @@ export function getSandboxProviderByKind(
   kind: SandboxProviderKind,
 ): Promise<SandboxProvider> {
   return resolveOnce(kind, () => instantiate(kind, ctx.db));
+}
+
+/**
+ * Resolve the shared-identity hosted runner even after the rollout flag is
+ * switched off. Session cleanup must remain available during a rollback so
+ * previously-created claims and shared runner-state rows are not orphaned.
+ */
+export function getSharedAgentSandboxProvider(
+  ctx: StudioContext,
+): Promise<SandboxProvider> {
+  if (getSettings().sharedAgentSandboxesEnabled) {
+    return getSandboxProviderByKind(ctx, "agent-sandbox");
+  }
+  const cached = lifecycleGlobal[SHARED_AGENT_RUNNER_KEY];
+  if (cached) return Promise.resolve(cached);
+  const pending = lifecycleGlobal[SHARED_AGENT_INFLIGHT_KEY];
+  if (pending) return pending;
+  const promise = instantiate("agent-sandbox", ctx.db, "shared")
+    .then((runner) => {
+      lifecycleGlobal[SHARED_AGENT_RUNNER_KEY] = runner;
+      return runner;
+    })
+    .finally(() => {
+      delete lifecycleGlobal[SHARED_AGENT_INFLIGHT_KEY];
+    });
+  lifecycleGlobal[SHARED_AGENT_INFLIGHT_KEY] = promise;
+  return promise;
 }
 
 /**

--- a/apps/mesh/src/sandbox/resolve-provider.ts
+++ b/apps/mesh/src/sandbox/resolve-provider.ts
@@ -37,11 +37,14 @@ import {
 import type { StudioContext } from "../core/studio-context";
 import { readSandboxMap } from "../tools/sandbox/sandbox-map";
 import { buildDesktopProvider, getSandboxProviderByKind } from "./lifecycle";
+import { getSettings } from "../settings";
 
 export interface ResolveSandboxProviderArgs {
   /** User whose sandboxMap cell to read and (for `desktop`) whose link to bind. */
   userId: string;
   branch: string;
+  /** Required to discover a first-class shared agent-sandbox session. */
+  virtualMcpId?: string;
   /** Raw `virtualmcp.metadata` JSON column. May be null. */
   virtualMcpMetadata: Record<string, unknown> | null;
   /**
@@ -63,7 +66,8 @@ export async function resolveSandboxProvider(
   ctx: StudioContext,
   args: ResolveSandboxProviderArgs,
 ): Promise<ResolvedSandboxProvider> {
-  const { userId, branch, virtualMcpMetadata, explicitKind } = args;
+  const { userId, branch, virtualMcpId, virtualMcpMetadata, explicitKind } =
+    args;
 
   // 1. Caller override.
   if (explicitKind) {
@@ -102,11 +106,12 @@ export async function resolveSandboxProvider(
   //    path consistently picks the one matching current intent
   //    (link online → `desktop`, else env kind) instead of whatever
   //    `Object.keys` happens to enumerate first.
-  const [firstRecorded, ...restRecorded] = readRecordedKinds(
+  const [firstRecorded, ...restRecorded] = await readRecordedKinds(ctx, {
     virtualMcpMetadata,
+    virtualMcpId,
     userId,
     branch,
-  );
+  });
   if (firstRecorded) {
     const preferred =
       restRecorded.length === 0
@@ -128,15 +133,38 @@ export async function resolveSandboxProvider(
  * `setSandboxMapEntry` preserves siblings. Callers that need exactly one kind
  * (`readRecordedKind`) tiebreak against the default policy.
  */
-function readRecordedKinds(
-  metadata: Record<string, unknown> | null,
-  userId: string,
-  branch: string,
-): SandboxProviderKind[] {
-  const cell = readSandboxMap(metadata)[userId]?.[branch];
-  if (!cell) return [];
-  const parsed = parseBranchMap(cell);
-  return Object.keys(parsed) as SandboxProviderKind[];
+async function readRecordedKinds(
+  ctx: StudioContext,
+  args: {
+    virtualMcpMetadata: Record<string, unknown> | null;
+    virtualMcpId?: string;
+    userId: string;
+    branch: string;
+  },
+): Promise<SandboxProviderKind[]> {
+  const cell = readSandboxMap(args.virtualMcpMetadata)[args.userId]?.[
+    args.branch
+  ];
+  const parsed = cell ? parseBranchMap(cell) : {};
+  const recorded = Object.keys(parsed) as SandboxProviderKind[];
+
+  if (!getSettings().sharedAgentSandboxesEnabled) return recorded;
+
+  // Legacy hosted metadata is deliberately ignored while shared mode is on.
+  // Keep user-desktop entries intact and add hosted presence from the
+  // first-class org-scoped session registry.
+  const kinds: SandboxProviderKind[] = recorded.filter(
+    (kind) => kind !== "agent-sandbox",
+  );
+  const organizationId = ctx.organization?.id;
+  if (!organizationId || !args.virtualMcpId) return kinds;
+  const session = await ctx.storage.agentSandboxSessions.find({
+    organizationId,
+    virtualMcpId: args.virtualMcpId,
+    branch: args.branch,
+  });
+  if (session) kinds.unshift("agent-sandbox");
+  return kinds;
 }
 
 /**

--- a/apps/mesh/src/settings/resolve-config.test.ts
+++ b/apps/mesh/src/settings/resolve-config.test.ts
@@ -10,6 +10,20 @@ const flags: CliFlags = {
 };
 
 describe("resolveConfig sandbox provider kind", () => {
+  it("keeps shared agent sandboxes off by default", () => {
+    expect(resolveConfig(flags, {}).settings.sharedAgentSandboxesEnabled).toBe(
+      false,
+    );
+  });
+
+  it("enables shared agent sandboxes independently", () => {
+    expect(
+      resolveConfig(flags, {
+        SHARED_AGENT_SANDBOXES_ENABLED: "true",
+      }).settings.sharedAgentSandboxesEnabled,
+    ).toBe(true);
+  });
+
   it("accepts canonical agent-sandbox", () => {
     const result = resolveConfig(flags, {
       STUDIO_SANDBOX_PROVIDER: "agent-sandbox",

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -191,6 +191,7 @@ export function resolveConfig(
     ),
     orgFsPublicSetsJson: envVars.ORGFS_PUBLIC_SETS,
     orgFsMountsDisabled: toBool(envVars.DISABLE_ORGFS_MOUNTS),
+    sharedAgentSandboxesEnabled: toBool(envVars.SHARED_AGENT_SANDBOXES_ENABLED),
 
     // Object Storage (S3-compatible)
     s3Endpoint: envVars.S3_ENDPOINT,

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -82,6 +82,11 @@ export interface Settings {
    *  (DISABLE_ORGFS_MOUNTS). org-fs is otherwise always mounted; this is
    *  for low-level mount debugging, not a supported org-fs-off mode. */
   orgFsMountsDisabled: boolean;
+  /**
+   * Route agent-sandbox identities through the shared (org, virtual MCP,
+   * branch) registry. Default-off for a reversible rollout.
+   */
+  sharedAgentSandboxesEnabled: boolean;
 
   // Object Storage (S3-compatible)
   s3Endpoint: string | undefined;

--- a/apps/mesh/src/storage/agent-sandbox-runner-state.ts
+++ b/apps/mesh/src/storage/agent-sandbox-runner-state.ts
@@ -1,0 +1,207 @@
+/**
+ * Kysely-backed runner state for shared agent-sandbox claims.
+ *
+ * Unlike sandbox-runner-state.ts, this store deliberately has no user column:
+ * projectRef already encodes organization, virtual MCP, and branch.
+ */
+
+import { createHash } from "node:crypto";
+import { sql, type Kysely } from "kysely";
+import type {
+  RunnerStatePut,
+  RunnerStateRecord,
+  RunnerStateRecordWithId,
+  RunnerStateStore,
+  RunnerStateStoreOps,
+  SandboxId,
+} from "@decocms/sandbox/provider";
+import type { Database } from "./types";
+
+type Executor = Kysely<Database>;
+
+function requireSharedId(
+  id: SandboxId,
+): Extract<SandboxId, { scope: "shared" }> {
+  if (id.scope !== "shared") {
+    throw new Error(
+      "KyselyAgentSandboxRunnerStateStore only accepts shared sandbox ids",
+    );
+  }
+  return id;
+}
+
+function lockKey(id: SandboxId, kind: string): bigint {
+  const shared = requireSharedId(id);
+  const hash = createHash("sha256")
+    .update(shared.projectRef)
+    .update("\x00")
+    .update(kind)
+    .digest();
+  return hash.readBigInt64BE(0);
+}
+
+async function getRow(
+  exec: Executor,
+  id: SandboxId,
+  kind: string,
+): Promise<RunnerStateRecord | null> {
+  const shared = requireSharedId(id);
+  const row = await exec
+    .selectFrom("agent_sandbox_runner_state")
+    .select(["handle", "state", "updated_at"])
+    .where("project_ref", "=", shared.projectRef)
+    .where("sandbox_provider_kind", "=", kind)
+    .executeTakeFirst();
+  if (!row) return null;
+  return {
+    handle: row.handle,
+    state: row.state,
+    updatedAt: row.updated_at,
+  };
+}
+
+async function getByHandleRow(
+  exec: Executor,
+  kind: string,
+  handle: string,
+): Promise<RunnerStateRecordWithId | null> {
+  const row = await exec
+    .selectFrom("agent_sandbox_runner_state")
+    .select(["project_ref", "handle", "state", "updated_at"])
+    .where("sandbox_provider_kind", "=", kind)
+    .where("handle", "=", handle)
+    .executeTakeFirst();
+  if (!row) return null;
+  return {
+    id: { scope: "shared", projectRef: row.project_ref },
+    handle: row.handle,
+    state: row.state,
+    updatedAt: row.updated_at,
+  };
+}
+
+async function putRow(
+  exec: Executor,
+  id: SandboxId,
+  kind: string,
+  entry: RunnerStatePut,
+): Promise<void> {
+  const shared = requireSharedId(id);
+  const stateJson = JSON.stringify(entry.state);
+  const now = new Date().toISOString();
+  await exec
+    .insertInto("agent_sandbox_runner_state")
+    .values({
+      project_ref: shared.projectRef,
+      sandbox_provider_kind: kind,
+      handle: entry.handle,
+      state: stateJson,
+      updated_at: now,
+    })
+    .onConflict((conflict) =>
+      conflict.columns(["project_ref", "sandbox_provider_kind"]).doUpdateSet({
+        handle: entry.handle,
+        state: stateJson,
+        updated_at: now,
+      }),
+    )
+    .execute();
+}
+
+async function deleteRow(
+  exec: Executor,
+  id: SandboxId,
+  kind: string,
+): Promise<void> {
+  const shared = requireSharedId(id);
+  await exec
+    .deleteFrom("agent_sandbox_runner_state")
+    .where("project_ref", "=", shared.projectRef)
+    .where("sandbox_provider_kind", "=", kind)
+    .execute();
+}
+
+async function deleteByHandleRow(
+  exec: Executor,
+  kind: string,
+  handle: string,
+): Promise<void> {
+  await exec
+    .deleteFrom("agent_sandbox_runner_state")
+    .where("sandbox_provider_kind", "=", kind)
+    .where("handle", "=", handle)
+    .execute();
+}
+
+function scopedStore(exec: Executor): RunnerStateStoreOps {
+  return {
+    get: (id, kind) => getRow(exec, id, kind),
+    getByHandle: (kind, handle) => getByHandleRow(exec, kind, handle),
+    put: (id, kind, entry) => putRow(exec, id, kind, entry),
+    delete: (id, kind) => deleteRow(exec, id, kind),
+    deleteByHandle: (kind, handle) => deleteByHandleRow(exec, kind, handle),
+  };
+}
+
+export class KyselyAgentSandboxRunnerStateStore implements RunnerStateStore {
+  constructor(private db: Kysely<Database>) {}
+
+  get(id: SandboxId, kind: string): Promise<RunnerStateRecord | null> {
+    return getRow(this.db, id, kind);
+  }
+
+  getByHandle(
+    kind: string,
+    handle: string,
+  ): Promise<RunnerStateRecordWithId | null> {
+    return getByHandleRow(this.db, kind, handle);
+  }
+
+  put(id: SandboxId, kind: string, entry: RunnerStatePut): Promise<void> {
+    return putRow(this.db, id, kind, entry);
+  }
+
+  delete(id: SandboxId, kind: string): Promise<void> {
+    return deleteRow(this.db, id, kind);
+  }
+
+  deleteByHandle(kind: string, handle: string): Promise<void> {
+    return deleteByHandleRow(this.db, kind, handle);
+  }
+
+  async withLock<T>(
+    id: SandboxId,
+    kind: string,
+    fn: (store: RunnerStateStoreOps) => Promise<T>,
+  ): Promise<T> {
+    const shared = requireSharedId(id);
+    const key = lockKey(id, kind);
+    return this.db.transaction().execute(async (transaction) => {
+      try {
+        await sql`set local statement_timeout = ${sql.lit(LOCK_WAIT_MS)}`.execute(
+          transaction,
+        );
+        await sql`select pg_advisory_xact_lock(${key}::bigint)`.execute(
+          transaction,
+        );
+      } catch (error) {
+        if (isStatementTimeoutError(error)) {
+          throw new Error(
+            `agent sandbox advisory lock busy >${LOCK_WAIT_MS}ms for projectRef=${shared.projectRef} kind=${kind} — provisioner is slow or stuck; retry shortly`,
+          );
+        }
+        throw error;
+      }
+      await sql`set local statement_timeout = 0`.execute(transaction);
+      return fn(scopedStore(transaction));
+    });
+  }
+}
+
+const LOCK_WAIT_MS = 90_000;
+
+function isStatementTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === "57014" || /statement timeout/i.test(error.message);
+}

--- a/apps/mesh/src/storage/agent-sandbox-sessions.integration.test.ts
+++ b/apps/mesh/src/storage/agent-sandbox-sessions.integration.test.ts
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sharedSandboxId, userSandboxId } from "@decocms/sandbox/provider";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import type { StudioDatabase } from "../database";
+import { KyselyAgentSandboxRunnerStateStore } from "./agent-sandbox-runner-state";
+import { AgentSandboxSessionStorage } from "./agent-sandbox-sessions";
+
+describe("shared agent sandbox storage", () => {
+  let database: StudioDatabase;
+  let sessions: AgentSandboxSessionStorage;
+  let runnerState: KyselyAgentSandboxRunnerStateStore;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: "org_shared_sandbox",
+        name: "Shared Sandbox Org",
+        slug: "shared-sandbox-org",
+        createdAt: new Date().toISOString(),
+      })
+      .execute();
+    sessions = new AgentSandboxSessionStorage(database.db);
+    runnerState = new KyselyAgentSandboxRunnerStateStore(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("stores runner state once per project regardless of acting user", async () => {
+    const id = sharedSandboxId("org:vm:branch");
+    await runnerState.put(id, "agent-sandbox", {
+      handle: "shared-handle",
+      state: { phase: "ready" },
+    });
+
+    expect(await runnerState.get(id, "agent-sandbox")).toMatchObject({
+      handle: "shared-handle",
+      state: { phase: "ready" },
+    });
+    expect(
+      await runnerState.getByHandle("agent-sandbox", "shared-handle"),
+    ).toMatchObject({ id });
+    await expect(
+      runnerState.get(
+        userSandboxId("user_2", "org:vm:branch"),
+        "agent-sandbox",
+      ),
+    ).rejects.toThrow("only accepts shared sandbox ids");
+  });
+
+  it("coalesces concurrent starts and fences a completion after stop", async () => {
+    const locator = {
+      organizationId: "org_shared_sandbox",
+      virtualMcpId: "vm_shared",
+      branch: "feature/shared",
+    };
+    const [first, second] = await Promise.all([
+      sessions.beginStart(locator, "user_1", null),
+      sessions.beginStart(locator, "user_2", null),
+    ]);
+    expect(first.generation).toBe(second.generation);
+    expect(first.desiredState).toBe("running");
+    expect(second.desiredState).toBe("running");
+
+    const stopping = await sessions.withLock(locator, (locked) =>
+      locked.beginStop(locator, "user_2"),
+    );
+    expect(stopping).toMatchObject({
+      desiredState: "stopped",
+      status: "stopping",
+    });
+    if (!stopping) throw new Error("expected stopping session");
+    expect(
+      await sessions.completeStart(locator, first.generation, {
+        sandboxHandle: "too-late",
+        previewUrl: "https://too-late.example",
+        sandboxProviderKind: "agent-sandbox",
+      }),
+    ).toBeNull();
+    await sessions.withLock(locator, (locked) =>
+      locked.completeStop(locator, stopping.generation),
+    );
+    const stopped = await sessions.find(locator);
+    expect(stopped).toMatchObject({
+      desiredState: "stopped",
+      status: "stopped",
+    });
+    if (!stopped) throw new Error("expected stopped session");
+
+    const restarted = await sessions.beginStart(locator, "user_1", null);
+    expect(restarted.generation).toBeGreaterThan(stopped.generation);
+    const ready = await sessions.completeStart(locator, restarted.generation, {
+      sandboxHandle: "shared-ready",
+      previewUrl: "https://shared.example",
+      sandboxProviderKind: "agent-sandbox",
+    });
+    expect(ready).toMatchObject({
+      sandboxHandle: "shared-ready",
+      previewUrl: "https://shared.example",
+      desiredState: "running",
+      status: "ready",
+      lastStartedBy: "user_1",
+    });
+  });
+
+  it("commits failed provisioning state and its cleanup handle under the lifecycle lock", async () => {
+    const locator = {
+      organizationId: "org_shared_sandbox",
+      virtualMcpId: "vm_failed",
+      branch: "feature/failed",
+    };
+    await sessions.withLock(locator, async (locked) => {
+      const started = await locked.beginStart(locator, "user_1", null);
+      await locked.recordProvisioningHandle(
+        locator,
+        started.generation,
+        "failed-handle",
+      );
+      await locked.failStart(locator, started.generation, "clone failed");
+    });
+
+    expect(await sessions.find(locator)).toMatchObject({
+      sandboxHandle: "failed-handle",
+      desiredState: "running",
+      status: "failed",
+      failureReason: "clone failed",
+    });
+  });
+
+  it("fences starts while parent cleanup owns the session", async () => {
+    const locator = {
+      organizationId: "org_shared_sandbox",
+      virtualMcpId: "vm_deleting",
+      branch: "feature/deleting",
+    };
+    await sessions.beginStart(locator, "user_1", null);
+    const deleting = await sessions.withLock(locator, (locked) =>
+      locked.beginDelete(locator, "user_1"),
+    );
+    expect(deleting).toMatchObject({
+      desiredState: "stopped",
+      status: "deleting",
+    });
+    if (!deleting) throw new Error("expected deleting session");
+    await expect(
+      sessions.withLock(locator, (locked) =>
+        locked.beginStart(locator, "user_2", null),
+      ),
+    ).rejects.toThrow("lifecycle transition in progress");
+
+    await sessions.withLock(locator, (locked) =>
+      locked.completeDelete(locator, deleting.generation),
+    );
+    expect(await sessions.find(locator)).toBeNull();
+  });
+});

--- a/apps/mesh/src/storage/agent-sandbox-sessions.ts
+++ b/apps/mesh/src/storage/agent-sandbox-sessions.ts
@@ -1,0 +1,504 @@
+import { createHash } from "node:crypto";
+import { type Kysely, sql, type Selectable } from "kysely";
+import type { SandboxRecord } from "@decocms/mesh-sdk";
+import type { AgentSandboxSessionTable, Database } from "./types";
+
+export type AgentSandboxDesiredState = "running" | "stopped";
+export type AgentSandboxSessionStatus =
+  | "provisioning"
+  | "ready"
+  | "missing"
+  | "failed"
+  | "stopping"
+  | "reaping"
+  | "deleting"
+  | "stopped";
+
+export interface AgentSandboxSessionLocator {
+  organizationId: string;
+  virtualMcpId: string;
+  branch: string;
+}
+
+export interface AgentSandboxSession {
+  organizationId: string;
+  virtualMcpId: string;
+  branch: string;
+  threadId: string | null;
+  sandboxHandle: string | null;
+  previewUrl: string | null;
+  sandboxApiUrl: string | null;
+  desiredState: AgentSandboxDesiredState;
+  status: AgentSandboxSessionStatus;
+  generation: number;
+  startedWith: Record<string, unknown> | null;
+  failureReason: string | null;
+  createdBy: string;
+  lastStartedBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function toIsoString(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : String(value);
+}
+
+function toSession(
+  row: Selectable<AgentSandboxSessionTable>,
+): AgentSandboxSession {
+  return {
+    organizationId: row.organization_id,
+    virtualMcpId: row.virtual_mcp_id,
+    branch: row.branch,
+    threadId: row.thread_id,
+    sandboxHandle: row.sandbox_handle,
+    previewUrl: row.preview_url,
+    sandboxApiUrl: row.sandbox_api_url,
+    desiredState: row.desired_state,
+    status: row.status,
+    generation: row.generation,
+    startedWith: row.started_with,
+    failureReason: row.failure_reason,
+    createdBy: row.created_by,
+    lastStartedBy: row.last_started_by,
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
+  };
+}
+
+export class AgentSandboxSessionStorage {
+  constructor(private db: Kysely<Database>) {}
+
+  /**
+   * Serialize a short lifecycle state transition for one shared branch.
+   *
+   * Do not call the runner inside this callback: the runner owns a separate
+   * claim lock. Holding both would consume two pool connections per branch and
+   * can starve the pool under a multi-branch burst.
+   */
+  async withLock<T>(
+    locator: AgentSandboxSessionLocator,
+    fn: (storage: AgentSandboxSessionStorage) => Promise<T>,
+  ): Promise<T> {
+    const key = sessionLockKey(locator);
+    return this.db.transaction().execute(async (transaction) => {
+      try {
+        await sql`set local statement_timeout = ${sql.lit(SESSION_LOCK_WAIT_MS)}`.execute(
+          transaction,
+        );
+        await sql`select pg_advisory_xact_lock(${key}::bigint)`.execute(
+          transaction,
+        );
+      } catch (error) {
+        if (isStatementTimeoutError(error)) {
+          throw new Error(
+            `agent sandbox lifecycle lock busy >${SESSION_LOCK_WAIT_MS}ms for ${locator.virtualMcpId}/${locator.branch}; retry shortly`,
+          );
+        }
+        throw error;
+      }
+      await sql`set local statement_timeout = 0`.execute(transaction);
+      return fn(new AgentSandboxSessionStorage(transaction));
+    });
+  }
+
+  async find(
+    locator: AgentSandboxSessionLocator,
+  ): Promise<AgentSandboxSession | null> {
+    const row = await this.db
+      .selectFrom("agent_sandbox_sessions")
+      .selectAll()
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .executeTakeFirst();
+    return row ? toSession(row) : null;
+  }
+
+  /**
+   * Request a running sandbox generation.
+   *
+   * Concurrent starts join the same generation. A start after stop/missing/
+   * failure advances the fence so stale completions cannot overwrite it.
+   */
+  async beginStart(
+    locator: AgentSandboxSessionLocator,
+    actorUserId: string,
+    threadId: string | null,
+  ): Promise<AgentSandboxSession> {
+    const now = new Date().toISOString();
+    await this.db
+      .insertInto("agent_sandbox_sessions")
+      .values({
+        organization_id: locator.organizationId,
+        virtual_mcp_id: locator.virtualMcpId,
+        branch: locator.branch,
+        thread_id: threadId,
+        sandbox_handle: null,
+        preview_url: null,
+        sandbox_api_url: null,
+        desired_state: "running",
+        status: "provisioning",
+        generation: 1,
+        started_with: null,
+        failure_reason: null,
+        created_by: actorUserId,
+        last_started_by: actorUserId,
+        created_at: now,
+        updated_at: now,
+      })
+      .onConflict((conflict) =>
+        conflict
+          .columns(["organization_id", "virtual_mcp_id", "branch"])
+          .doNothing(),
+      )
+      .execute();
+
+    const row = await this.db
+      .updateTable("agent_sandbox_sessions")
+      .set((expression) => ({
+        desired_state: "running",
+        generation: sql<number>`case
+          when ${expression.ref("desired_state")} = 'stopped'
+            or ${expression.ref("status")} in ('missing', 'failed')
+          then ${expression.ref("generation")} + 1
+          else ${expression.ref("generation")}
+        end`,
+        status: sql<AgentSandboxSessionStatus>`case
+          when ${expression.ref("desired_state")} = 'stopped'
+            or ${expression.ref("status")} in ('missing', 'failed')
+          then 'provisioning'
+          else ${expression.ref("status")}
+        end`,
+        sandbox_handle: sql<string | null>`case
+          when ${expression.ref("desired_state")} = 'stopped'
+            or ${expression.ref("status")} in ('missing', 'failed')
+          then null
+          else ${expression.ref("sandbox_handle")}
+        end`,
+        preview_url: sql<string | null>`case
+          when ${expression.ref("desired_state")} = 'stopped'
+            or ${expression.ref("status")} in ('missing', 'failed')
+          then null
+          else ${expression.ref("preview_url")}
+        end`,
+        sandbox_api_url: sql<string | null>`case
+          when ${expression.ref("desired_state")} = 'stopped'
+            or ${expression.ref("status")} in ('missing', 'failed')
+          then null
+          else ${expression.ref("sandbox_api_url")}
+        end`,
+        failure_reason: null,
+        thread_id: threadId,
+        last_started_by: actorUserId,
+        updated_at: now,
+      }))
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .where("status", "not in", ["stopping", "reaping", "deleting"])
+      .returningAll()
+      .executeTakeFirst();
+    if (!row) {
+      throw new Error(
+        `agent sandbox lifecycle transition in progress for ${locator.virtualMcpId}/${locator.branch}; retry shortly`,
+      );
+    }
+    return toSession(row);
+  }
+
+  async recordProvisioningHandle(
+    locator: AgentSandboxSessionLocator,
+    generation: number,
+    sandboxHandle: string,
+  ): Promise<void> {
+    await this.db
+      .updateTable("agent_sandbox_sessions")
+      .set({
+        sandbox_handle: sandboxHandle,
+        updated_at: new Date().toISOString(),
+      })
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .where("generation", "=", generation)
+      .where("desired_state", "=", "running")
+      .where("status", "=", "provisioning")
+      .execute();
+  }
+
+  async completeStart(
+    locator: AgentSandboxSessionLocator,
+    generation: number,
+    entry: SandboxRecord,
+  ): Promise<AgentSandboxSession | null> {
+    const row = await this.db
+      .updateTable("agent_sandbox_sessions")
+      .set({
+        sandbox_handle: entry.sandboxHandle,
+        preview_url: entry.previewUrl,
+        sandbox_api_url: entry.sandboxApiUrl ?? entry.previewUrl,
+        desired_state: "running",
+        status: "ready",
+        started_with: entry.startedWith
+          ? JSON.stringify(entry.startedWith)
+          : null,
+        failure_reason: null,
+        updated_at: new Date().toISOString(),
+      })
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .where("generation", "=", generation)
+      .where("desired_state", "=", "running")
+      .returningAll()
+      .executeTakeFirst();
+    return row ? toSession(row) : null;
+  }
+
+  async failStart(
+    locator: AgentSandboxSessionLocator,
+    generation: number,
+    reason: string,
+  ): Promise<void> {
+    await this.db
+      .updateTable("agent_sandbox_sessions")
+      .set({
+        status: "failed",
+        failure_reason: reason,
+        updated_at: new Date().toISOString(),
+      })
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .where("generation", "=", generation)
+      .where("desired_state", "=", "running")
+      .where("status", "=", "provisioning")
+      .execute();
+  }
+
+  async beginReap(
+    locator: AgentSandboxSessionLocator,
+    expectedHandle: string,
+  ): Promise<AgentSandboxSession | null> {
+    const row = await this.db
+      .updateTable("agent_sandbox_sessions")
+      .set((expression) => ({
+        status: "reaping",
+        generation: sql<number>`case
+          when ${expression.ref("status")} = 'reaping'
+          then ${expression.ref("generation")}
+          else ${expression.ref("generation")} + 1
+        end`,
+        updated_at: new Date().toISOString(),
+      }))
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .where("sandbox_handle", "=", expectedHandle)
+      .where("desired_state", "=", "running")
+      .where("status", "not in", ["stopping", "deleting", "stopped"])
+      .returningAll()
+      .executeTakeFirst();
+    return row ? toSession(row) : null;
+  }
+
+  async completeReap(
+    locator: AgentSandboxSessionLocator,
+    generation: number,
+    expectedHandle: string,
+  ): Promise<void> {
+    await this.db
+      .updateTable("agent_sandbox_sessions")
+      .set({
+        status: "missing",
+        sandbox_handle: null,
+        preview_url: null,
+        sandbox_api_url: null,
+        updated_at: new Date().toISOString(),
+      })
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .where("generation", "=", generation)
+      .where("sandbox_handle", "=", expectedHandle)
+      .where("desired_state", "=", "running")
+      .where("status", "=", "reaping")
+      .execute();
+  }
+
+  async beginStop(
+    locator: AgentSandboxSessionLocator,
+    actorUserId: string,
+  ): Promise<AgentSandboxSession | null> {
+    const row = await this.db
+      .updateTable("agent_sandbox_sessions")
+      .set((expression) => ({
+        desired_state: "stopped",
+        status: sql<AgentSandboxSessionStatus>`case
+          when ${expression.ref("desired_state")} = 'stopped'
+          then ${expression.ref("status")}
+          else 'stopping'
+        end`,
+        generation: sql<number>`case
+          when ${expression.ref("desired_state")} = 'stopped'
+          then ${expression.ref("generation")}
+          else ${expression.ref("generation")} + 1
+        end`,
+        last_started_by: actorUserId,
+        failure_reason: null,
+        updated_at: new Date().toISOString(),
+      }))
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .returningAll()
+      .executeTakeFirst();
+    return row ? toSession(row) : null;
+  }
+
+  async completeStop(
+    locator: AgentSandboxSessionLocator,
+    generation: number,
+  ): Promise<void> {
+    await this.db
+      .updateTable("agent_sandbox_sessions")
+      .set({
+        status: "stopped",
+        sandbox_handle: null,
+        preview_url: null,
+        sandbox_api_url: null,
+        updated_at: new Date().toISOString(),
+      })
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .where("generation", "=", generation)
+      .where("desired_state", "=", "stopped")
+      .where("status", "=", "stopping")
+      .execute();
+  }
+
+  async beginDelete(
+    locator: AgentSandboxSessionLocator,
+    actorUserId: string,
+  ): Promise<AgentSandboxSession | null> {
+    const row = await this.db
+      .updateTable("agent_sandbox_sessions")
+      .set((expression) => ({
+        desired_state: "stopped",
+        status: "deleting",
+        generation: sql<number>`case
+          when ${expression.ref("status")} = 'deleting'
+          then ${expression.ref("generation")}
+          else ${expression.ref("generation")} + 1
+        end`,
+        last_started_by: actorUserId,
+        failure_reason: null,
+        updated_at: new Date().toISOString(),
+      }))
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .returningAll()
+      .executeTakeFirst();
+    return row ? toSession(row) : null;
+  }
+
+  async completeDelete(
+    locator: AgentSandboxSessionLocator,
+    generation: number,
+  ): Promise<void> {
+    await this.db
+      .deleteFrom("agent_sandbox_sessions")
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .where("generation", "=", generation)
+      .where("status", "=", "deleting")
+      .execute();
+  }
+
+  async listByVirtualMcp(
+    organizationId: string,
+    virtualMcpId: string,
+    options: {
+      limit?: number;
+      before?: { updatedAt: string; branch: string };
+    } = {},
+  ): Promise<AgentSandboxSession[]> {
+    let query = this.db
+      .selectFrom("agent_sandbox_sessions")
+      .selectAll()
+      .where("organization_id", "=", organizationId)
+      .where("virtual_mcp_id", "=", virtualMcpId);
+    if (options.before) {
+      const beforeDate = new Date(options.before.updatedAt);
+      query = query.where((expression) =>
+        expression.or([
+          expression("updated_at", "<", beforeDate),
+          expression.and([
+            expression("updated_at", "=", beforeDate),
+            expression("branch", "<", options.before!.branch),
+          ]),
+        ]),
+      );
+    }
+    const rows = await query
+      .orderBy("updated_at", "desc")
+      .orderBy("branch", "desc")
+      .limit(Math.min(Math.max(options.limit ?? 100, 1), 200))
+      .execute();
+    return rows.map(toSession);
+  }
+
+  async findLatestReadyByVirtualMcp(
+    organizationId: string,
+    virtualMcpId: string,
+  ): Promise<AgentSandboxSession | null> {
+    const row = await this.db
+      .selectFrom("agent_sandbox_sessions")
+      .selectAll()
+      .where("organization_id", "=", organizationId)
+      .where("virtual_mcp_id", "=", virtualMcpId)
+      .where("desired_state", "=", "running")
+      .where("status", "=", "ready")
+      .where("sandbox_handle", "is not", null)
+      .orderBy("updated_at", "desc")
+      .orderBy("branch", "desc")
+      .executeTakeFirst();
+    return row ? toSession(row) : null;
+  }
+
+  async listByThread(
+    organizationId: string,
+    threadId: string,
+  ): Promise<AgentSandboxSession[]> {
+    const rows = await this.db
+      .selectFrom("agent_sandbox_sessions")
+      .selectAll()
+      .where("organization_id", "=", organizationId)
+      .where("thread_id", "=", threadId)
+      .execute();
+    return rows.map(toSession);
+  }
+}
+
+const SESSION_LOCK_WAIT_MS = 30_000;
+
+function sessionLockKey(locator: AgentSandboxSessionLocator): bigint {
+  const hash = createHash("sha256")
+    .update(locator.organizationId)
+    .update("\x00")
+    .update(locator.virtualMcpId)
+    .update("\x00")
+    .update(locator.branch)
+    .digest();
+  return hash.readBigInt64BE(0);
+}
+
+function isStatementTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === "57014" || /statement timeout/i.test(error.message);
+}

--- a/apps/mesh/src/storage/sandbox-runner-state.integration.test.ts
+++ b/apps/mesh/src/storage/sandbox-runner-state.integration.test.ts
@@ -24,6 +24,7 @@ describe("KyselySandboxProviderStateStore", () => {
 
   // Each test uses a unique id to avoid cross-test pollution.
   const mkId = (tag: string): SandboxId => ({
+    scope: "user",
     userId: `user-${tag}`,
     projectRef: `proj-${tag}`,
   });
@@ -70,7 +71,7 @@ describe("KyselySandboxProviderStateStore", () => {
     const { rows } = await database.pool.query<{ count: string }>(
       `SELECT COUNT(*)::text AS count FROM sandbox_runner_state
          WHERE user_id = $1 AND project_ref = $2 AND sandbox_provider_kind = $3`,
-      [id.userId, id.projectRef, "agent-sandbox"],
+      [id.scope === "user" ? id.userId : "", id.projectRef, "agent-sandbox"],
     );
     expect(rows[0]!.count).toBe("1");
   });

--- a/apps/mesh/src/storage/sandbox-runner-state.ts
+++ b/apps/mesh/src/storage/sandbox-runner-state.ts
@@ -24,13 +24,25 @@ import type { Database } from "./types";
 
 type Executor = Kysely<Database>;
 
+function requireUserScopedId(
+  id: SandboxId,
+): Extract<SandboxId, { scope: "user" }> {
+  if (id.scope !== "user") {
+    throw new Error(
+      "KyselySandboxProviderStateStore only accepts user-scoped sandbox ids",
+    );
+  }
+  return id;
+}
+
 /**
  * Hash `(userId, projectRef, kind)` to a signed int64 for
  * `pg_advisory_xact_lock` — cast so the range fits pg's `bigint`.
  */
 function lockKey(id: SandboxId, kind: string): bigint {
+  const userId = requireUserScopedId(id).userId;
   const h = createHash("sha256")
-    .update(id.userId)
+    .update(userId)
     .update("\x00")
     .update(id.projectRef)
     .update("\x00")
@@ -44,10 +56,11 @@ async function getRow(
   id: SandboxId,
   kind: string,
 ): Promise<RunnerStateRecord | null> {
+  const userId = requireUserScopedId(id).userId;
   const row = await exec
     .selectFrom("sandbox_runner_state")
     .select(["handle", "state", "updated_at"])
-    .where("user_id", "=", id.userId)
+    .where("user_id", "=", userId)
     .where("project_ref", "=", id.projectRef)
     .where("sandbox_provider_kind", "=", kind)
     .executeTakeFirst();
@@ -72,7 +85,11 @@ async function getByHandleRow(
     .executeTakeFirst();
   if (!row) return null;
   return {
-    id: { userId: row.user_id, projectRef: row.project_ref },
+    id: {
+      scope: "user",
+      userId: row.user_id,
+      projectRef: row.project_ref,
+    },
     handle: row.handle,
     state: row.state as Record<string, unknown>,
     updatedAt: row.updated_at as Date,
@@ -85,12 +102,13 @@ async function putRow(
   kind: string,
   entry: RunnerStatePut,
 ): Promise<void> {
+  const userId = requireUserScopedId(id).userId;
   const stateJson = JSON.stringify(entry.state);
   const now = new Date().toISOString();
   await exec
     .insertInto("sandbox_runner_state")
     .values({
-      user_id: id.userId,
+      user_id: userId,
       project_ref: id.projectRef,
       sandbox_provider_kind: kind,
       handle: entry.handle,
@@ -114,9 +132,10 @@ async function deleteRow(
   id: SandboxId,
   kind: string,
 ): Promise<void> {
+  const userId = requireUserScopedId(id).userId;
   await exec
     .deleteFrom("sandbox_runner_state")
-    .where("user_id", "=", id.userId)
+    .where("user_id", "=", userId)
     .where("project_ref", "=", id.projectRef)
     .where("sandbox_provider_kind", "=", kind)
     .execute();
@@ -188,6 +207,7 @@ export class KyselySandboxProviderStateStore implements RunnerStateStore {
     kind: string,
     fn: (store: RunnerStateStoreOps) => Promise<T>,
   ): Promise<T> {
+    const userId = requireUserScopedId(id).userId;
     const key = lockKey(id, kind);
     return this.db.transaction().execute(async (trx) => {
       try {
@@ -198,7 +218,7 @@ export class KyselySandboxProviderStateStore implements RunnerStateStore {
       } catch (err) {
         if (isStatementTimeoutError(err)) {
           throw new Error(
-            `sandbox advisory lock busy >${LOCK_WAIT_MS}ms for user=${id.userId} projectRef=${id.projectRef} kind=${kind} — provisioner is slow or stuck; retry shortly`,
+            `sandbox advisory lock busy >${LOCK_WAIT_MS}ms for user=${userId} projectRef=${id.projectRef} kind=${kind} — provisioner is slow or stuck; retry shortly`,
           );
         }
         throw err;

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -1397,6 +1397,45 @@ export interface SandboxProviderStateTable {
   updated_at: ColumnType<Date, Date | string, Date | string>;
 }
 
+export interface AgentSandboxRunnerStateTable {
+  project_ref: string;
+  sandbox_provider_kind: string;
+  handle: string;
+  state: ColumnType<Record<string, unknown>, string, string>;
+  updated_at: ColumnType<Date, Date | string, Date | string>;
+}
+
+export interface AgentSandboxSessionTable {
+  organization_id: string;
+  virtual_mcp_id: string;
+  branch: string;
+  thread_id: string | null;
+  sandbox_handle: string | null;
+  preview_url: string | null;
+  sandbox_api_url: string | null;
+  desired_state: "running" | "stopped";
+  status:
+    | "provisioning"
+    | "ready"
+    | "missing"
+    | "failed"
+    | "stopping"
+    | "reaping"
+    | "deleting"
+    | "stopped";
+  generation: number;
+  started_with: ColumnType<
+    Record<string, unknown> | null,
+    string | null,
+    string | null
+  >;
+  failure_reason: string | null;
+  created_by: string;
+  last_started_by: string;
+  created_at: ColumnType<Date, Date | string, never>;
+  updated_at: ColumnType<Date, Date | string, Date | string>;
+}
+
 // ============================================================================
 // Organization Domain Table Definition
 // ============================================================================
@@ -1765,4 +1804,6 @@ export interface Database extends PrivateRegistryDatabase {
   task_board_import_runs: TaskBoardImportRunTable;
 
   sandbox_runner_state: SandboxProviderStateTable;
+  agent_sandbox_runner_state: AgentSandboxRunnerStateTable;
+  agent_sandbox_sessions: AgentSandboxSessionTable;
 }

--- a/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
+++ b/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
@@ -100,6 +100,7 @@ describe("Connection Tools", () => {
             updatedAt: new Date().toISOString(),
           }),
         } as never,
+        agentSandboxSessions: null as never,
         monitoring: null as never,
         threads: null as never,
         asyncResearchJobs: null as never,

--- a/apps/mesh/src/tools/sandbox/delete-agent-sessions.ts
+++ b/apps/mesh/src/tools/sandbox/delete-agent-sessions.ts
@@ -1,0 +1,63 @@
+import { composeSandboxRef, sharedSandboxId } from "@decocms/sandbox/provider";
+import type { StudioContext } from "../../core/studio-context";
+import type { AgentSandboxSession } from "../../storage/agent-sandbox-sessions";
+import { getSharedAgentSandboxProvider } from "../../sandbox/lifecycle";
+import { computeClaimHandle } from "../../sandbox/claim-handle";
+
+const DELETE_CONCURRENCY = 20;
+
+export async function deleteAgentSandboxSessions(
+  ctx: StudioContext,
+  sessions: AgentSandboxSession[],
+): Promise<void> {
+  if (sessions.length === 0) return;
+
+  const runner = await getSharedAgentSandboxProvider(ctx);
+  for (let offset = 0; offset < sessions.length; offset += DELETE_CONCURRENCY) {
+    const batch = sessions.slice(offset, offset + DELETE_CONCURRENCY);
+    await Promise.all(
+      batch.map(async (session) => {
+        const projectRef = composeSandboxRef({
+          orgId: session.organizationId,
+          virtualMcpId: session.virtualMcpId,
+          branch: session.branch,
+        });
+        const sandboxId = sharedSandboxId(projectRef);
+        const locator = {
+          organizationId: session.organizationId,
+          virtualMcpId: session.virtualMcpId,
+          branch: session.branch,
+        };
+        const current = await ctx.storage.agentSandboxSessions.withLock(
+          locator,
+          (storage) => storage.beginDelete(locator, session.lastStartedBy),
+        );
+        if (!current) return;
+        await runner.delete(
+          current.sandboxHandle ??
+            computeClaimHandle(sandboxId, session.branch),
+          sandboxId,
+        );
+        await ctx.storage.agentSandboxSessions.withLock(locator, (storage) =>
+          storage.completeDelete(locator, current.generation),
+        );
+      }),
+    );
+  }
+}
+
+export async function deleteAllAgentSandboxSessionsForVirtualMcp(
+  ctx: StudioContext,
+  organizationId: string,
+  virtualMcpId: string,
+): Promise<void> {
+  while (true) {
+    const sessions = await ctx.storage.agentSandboxSessions.listByVirtualMcp(
+      organizationId,
+      virtualMcpId,
+      { limit: 200 },
+    );
+    if (sessions.length === 0) return;
+    await deleteAgentSandboxSessions(ctx, sessions);
+  }
+}

--- a/apps/mesh/src/tools/sandbox/delete.test.ts
+++ b/apps/mesh/src/tools/sandbox/delete.test.ts
@@ -35,6 +35,7 @@ mock.module("../../sandbox/lifecycle", () => ({
     lastRequestedKind.value = kind;
     return makeMockRunner(kind);
   },
+  getSharedAgentSandboxProvider: () => makeMockRunner("agent-sandbox"),
   buildDesktopProvider: async () => {
     lastRequestedKind.value = "user-desktop";
     return makeMockRunner("user-desktop");

--- a/apps/mesh/src/tools/sandbox/delete.ts
+++ b/apps/mesh/src/tools/sandbox/delete.ts
@@ -5,11 +5,21 @@
  */
 
 import { z } from "zod";
-import { normalizeSandboxProviderKind } from "@decocms/sandbox/provider";
+import {
+  composeSandboxRef,
+  normalizeSandboxProviderKind,
+  sharedSandboxId,
+} from "@decocms/sandbox/provider";
 import { defineTool } from "../../core/define-tool";
 import { requireVmEntry } from "./helpers";
 import { removeSandboxMapEntry } from "./sandbox-map";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
+import {
+  getUserId,
+  requireAuth,
+  requireOrganization,
+} from "../../core/studio-context";
+import { getSettings } from "../../settings";
 
 const sandboxProviderKindInputSchema = z.enum([
   "agent-sandbox",
@@ -48,6 +58,61 @@ export const SANDBOX_DELETE = defineTool({
     // Normalize here too because direct unit tests call handler() without
     // going through schema parsing.
     const kind = normalizeSandboxProviderKind(input.sandboxProviderKind);
+
+    if (kind === "agent-sandbox" && getSettings().sharedAgentSandboxesEnabled) {
+      requireAuth(ctx);
+      const organization = requireOrganization(ctx);
+      await ctx.access.check();
+      const userId = getUserId(ctx);
+      if (!userId) throw new Error("User ID required");
+      const virtualMcp = await ctx.storage.virtualMcps.findById(
+        input.virtualMcpId,
+      );
+      if (!virtualMcp || virtualMcp.organization_id !== organization.id) {
+        return { success: true };
+      }
+
+      const locator = {
+        organizationId: organization.id,
+        virtualMcpId: input.virtualMcpId,
+        branch: input.branch,
+      };
+      const { provider: runner } = await resolveSandboxProvider(ctx, {
+        userId,
+        branch: input.branch,
+        virtualMcpMetadata:
+          (virtualMcp.metadata as Record<string, unknown> | null) ?? null,
+        explicitKind: "agent-sandbox",
+      });
+      const projectRef = composeSandboxRef({
+        orgId: organization.id,
+        virtualMcpId: input.virtualMcpId,
+        branch: input.branch,
+      });
+      const entry = await ctx.storage.agentSandboxSessions.withLock(
+        locator,
+        (sessions) => sessions.beginStop(locator, userId),
+      );
+      if (!entry) return { success: true };
+      try {
+        if (entry.sandboxHandle) {
+          await runner
+            .delete(entry.sandboxHandle, sharedSandboxId(projectRef))
+            .catch((error) =>
+              console.error(
+                `[SANDBOX_DELETE] agent-sandbox ${entry.sandboxHandle}: ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              ),
+            );
+        }
+      } finally {
+        await ctx.storage.agentSandboxSessions.withLock(locator, (sessions) =>
+          sessions.completeStop(locator, entry.generation),
+        );
+      }
+      return { success: true };
+    }
 
     let vmEntry: Awaited<ReturnType<typeof requireVmEntry>>;
     try {

--- a/apps/mesh/src/tools/sandbox/resolve-env.ts
+++ b/apps/mesh/src/tools/sandbox/resolve-env.ts
@@ -13,6 +13,7 @@ interface ResolveAndPushParams {
   orgId: string;
   userId: string;
   entries: RuntimeEnvEntry[] | null | undefined;
+  organizationSecretsOnly?: boolean;
 }
 
 /**
@@ -32,6 +33,7 @@ export async function resolveAndPushEnv({
   orgId,
   userId,
   entries,
+  organizationSecretsOnly = false,
 }: ResolveAndPushParams): Promise<void> {
   if (!entries || entries.length === 0) return;
 
@@ -42,11 +44,16 @@ export async function resolveAndPushEnv({
       continue;
     }
     try {
-      const { value } = await ctx.storage.secrets.resolveById(
+      const { info, value } = await ctx.storage.secrets.resolveById(
         entry.secretId,
         orgId,
         userId,
       );
+      if (organizationSecretsOnly && info.scope !== "organization") {
+        throw new Error(
+          `Shared agent sandboxes require organization-scoped secrets (${entry.key})`,
+        );
+      }
       env[entry.key] = value;
     } catch (err) {
       if (

--- a/apps/mesh/src/tools/sandbox/resolve-submodule-creds.ts
+++ b/apps/mesh/src/tools/sandbox/resolve-submodule-creds.ts
@@ -10,6 +10,7 @@ interface ResolveParams {
   orgId: string;
   userId: string;
   entries: SubmoduleCredential[] | null | undefined;
+  organizationSecretsOnly?: boolean;
 }
 
 /**
@@ -28,17 +29,23 @@ export async function resolveSubmoduleCredentials({
   orgId,
   userId,
   entries,
+  organizationSecretsOnly = false,
 }: ResolveParams): Promise<{ host: string; token: string }[]> {
   if (!entries || entries.length === 0) return [];
 
   const resolved: { host: string; token: string }[] = [];
   for (const entry of entries) {
     try {
-      const { value } = await ctx.storage.secrets.resolveById(
+      const { info, value } = await ctx.storage.secrets.resolveById(
         entry.secretId,
         orgId,
         userId,
       );
+      if (organizationSecretsOnly && info.scope !== "organization") {
+        throw new Error(
+          `Shared agent sandboxes require organization-scoped submodule credentials (${entry.host})`,
+        );
+      }
       resolved.push({ host: entry.host, token: value });
     } catch (err) {
       if (

--- a/apps/mesh/src/tools/sandbox/start.test.ts
+++ b/apps/mesh/src/tools/sandbox/start.test.ts
@@ -7,7 +7,8 @@ import type {
   SandboxId,
   SandboxProvider,
 } from "@decocms/sandbox/provider";
-import { composeSandboxRef } from "@decocms/sandbox/provider";
+import { composeSandboxRef, sharedSandboxId } from "@decocms/sandbox/provider";
+import { computeClaimHandle } from "../../sandbox/claim-handle";
 
 // Pin provider kind — the dev env flips STUDIO_SANDBOX_PROVIDER and SANDBOX_START
 // reads it at handler time.
@@ -65,6 +66,7 @@ mock.module("../../sandbox/lifecycle", () => ({
   // runner under test.
   buildDesktopProvider: async () => mockDesktopRunner,
   getOrInitSharedRunner: async () => mockClusterRunner,
+  getSharedAgentSandboxProvider: async () => mockClusterRunner,
   // Bun's mock.module persists across test files in the same shard. Other
   // tests in the shard (e.g. oauth-proxy.e2e.test.ts) load app.ts which
   // imports subscribeLifecycle from this module — keep the export shape
@@ -73,8 +75,12 @@ mock.module("../../sandbox/lifecycle", () => ({
   __resetSharedLifecyclesForTesting: () => {},
 }));
 
+let sharedAgentSandboxesEnabled = false;
 mock.module("../../settings", () => ({
-  getSettings: () => ({ nodeEnv: "test" }),
+  getSettings: () => ({
+    nodeEnv: "test",
+    sharedAgentSandboxesEnabled,
+  }),
 }));
 
 const { DownstreamTokenStorage: RealDownstreamTokenStorage } = await import(
@@ -214,6 +220,30 @@ function makeCtx(overrides: {
   } = overrides;
 
   const findById = mock(async (_id: string) => virtualMcp ?? null);
+  let agentSandboxSessions: StudioContext["storage"]["agentSandboxSessions"];
+  agentSandboxSessions = {
+    find: mock(async () => null),
+    beginStart: mock(async () => ({
+      generation: 1,
+      desiredState: "running",
+      status: "provisioning",
+    })),
+    recordProvisioningHandle: mock(async () => {}),
+    completeStart: mock(async () => ({
+      generation: 1,
+      desiredState: "running",
+      status: "ready",
+    })),
+    failStart: mock(async () => {}),
+    withLock: mock(
+      async (
+        _locator: unknown,
+        fn: (
+          storage: StudioContext["storage"]["agentSandboxSessions"],
+        ) => Promise<unknown>,
+      ) => fn(agentSandboxSessions),
+    ),
+  } as never;
 
   return {
     auth: {
@@ -246,6 +276,7 @@ function makeCtx(overrides: {
         get: mock(async (_id: string) => null),
         update: mock(async () => {}),
       },
+      agentSandboxSessions,
     } as never,
     timings: {
       measure: async <T>(_name: string, cb: () => Promise<T>) => await cb(),
@@ -283,6 +314,7 @@ function makeCtx(overrides: {
 
 describe("SANDBOX_START", () => {
   beforeEach(() => {
+    sharedAgentSandboxesEnabled = false;
     globalThis.fetch = mock(
       async () => new Response("{}", { status: 404 }),
     ) as unknown as typeof fetch;
@@ -337,7 +369,11 @@ describe("SANDBOX_START", () => {
     expect(mockTokenGet).toHaveBeenCalledWith("conn_github_1");
     expect(mockEnsure).toHaveBeenCalledTimes(1);
     const [id, opts] = mockEnsure.mock.calls[0]! as [SandboxId, EnsureOptions];
-    expect(id).toEqual({ userId: USER_ID, projectRef: EXPECTED_REF });
+    expect(id).toEqual({
+      scope: "user",
+      userId: USER_ID,
+      projectRef: EXPECTED_REF,
+    });
     expect(opts.repo?.cloneUrl).toContain("acme/app");
     expect(opts.repo?.branch).toBe(BRANCH);
     expect(opts.repo?.displayName).toBe("acme/app");
@@ -346,6 +382,38 @@ describe("SANDBOX_START", () => {
       packageManager: "npm",
       devPort: 3000,
     });
+  });
+
+  it("uses a user-independent id and skips sandboxMap in shared agent mode", async () => {
+    sharedAgentSandboxesEnabled = true;
+    const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
+    const updateSpy = mock(async () => {});
+    const ctx = makeCtx({ virtualMcp, updateSpy });
+
+    await SANDBOX_START.handler(
+      {
+        virtualMcpId: VMCP_ID,
+        branch: BRANCH,
+        sandboxProviderKind: "agent-sandbox",
+      },
+      ctx,
+    );
+
+    const [id] = mockEnsure.mock.calls[0]! as [SandboxId];
+    const expectedId = sharedSandboxId(EXPECTED_REF);
+    expect(id).toEqual(expectedId);
+    expect(
+      ctx.storage.agentSandboxSessions.recordProvisioningHandle,
+    ).toHaveBeenCalledWith(
+      {
+        organizationId: ORG_ID,
+        virtualMcpId: VMCP_ID,
+        branch: BRANCH,
+      },
+      1,
+      computeClaimHandle(expectedId, BRANCH),
+    );
+    expect(updateSpy).not.toHaveBeenCalled();
   });
 
   it("sends a real git branch for a synthetic thread branch, keeping the ref synthetic", async () => {

--- a/apps/mesh/src/tools/sandbox/start.ts
+++ b/apps/mesh/src/tools/sandbox/start.ts
@@ -1,11 +1,10 @@
 /**
- * SANDBOX_START. Keyed by (userId, branch, sandboxProviderKind) in the Virtual MCP's `sandboxMap`.
- * Provider-agnostic — dispatches through the active `SandboxProvider`; this
- * handler only does `sandboxMap` bookkeeping. Branch defaults to a Bayer-style
- * `<greek-letter>-<constellation>` name (e.g. `alpha-centauri`) when omitted.
+ * SANDBOX_START. Hosted agent sandboxes are keyed by (organization, virtual
+ * MCP, branch) in agent_sandbox_sessions. User-desktop remains keyed by
+ * (user, branch, kind) in the Virtual MCP's sandboxMap.
  *
- * Different sandbox provider kinds coexist as siblings under the same
- * (user, branch) key — no stale-sandbox teardown is needed on kind change.
+ * Different provider kinds can coexist for a branch without changing the
+ * user-desktop persistence contract.
  */
 
 import { z } from "zod";
@@ -13,8 +12,10 @@ import type { SandboxRecord } from "@decocms/mesh-sdk";
 import {
   composeSandboxRef,
   normalizeSandboxProviderKind,
+  sharedSandboxId,
   type SandboxProvider,
   type SandboxProviderKind,
+  userSandboxId,
   type Workload,
 } from "@decocms/sandbox/provider";
 import { defineTool } from "../../core/define-tool";
@@ -25,6 +26,7 @@ import {
   type StudioContext,
 } from "../../core/studio-context";
 import {
+  readValidatedRuntimeEnv,
   readValidatedSubmoduleCredentials,
   resolveRuntimeConfig,
   type RuntimeConfigMeta,
@@ -48,6 +50,7 @@ import {
 import { generateBranchName } from "../../shared/branch-name";
 import { PACKAGE_MANAGER_CONFIG } from "../../shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
+import { computeClaimHandle } from "../../sandbox/claim-handle";
 import {
   getThreadGithubRepo,
   setThreadSandboxMapEntry,
@@ -60,6 +63,7 @@ import { getPublicUrl } from "../../core/server-constants";
 import { mintOrgFsConfigJson } from "../../file-storage/mount/provisioning";
 import { setSandboxMapEntry } from "./sandbox-map";
 import type { VirtualMCPUpdateData } from "../virtual/schema";
+import type { AgentSandboxSessionStorage } from "../../storage/agent-sandbox-sessions";
 
 type GithubRepo = {
   owner: string;
@@ -70,6 +74,33 @@ type GithubRepo = {
 type GithubRepoMeta = {
   githubRepo?: GithubRepo | null;
 };
+
+function usesSharedAgentSession(kind: SandboxProviderKind): boolean {
+  return kind === "agent-sandbox" && getSettings().sharedAgentSandboxesEnabled;
+}
+
+function sessionToSandboxRecord(
+  session: Awaited<
+    ReturnType<StudioContext["storage"]["agentSandboxSessions"]["find"]>
+  > | null,
+): SandboxRecord | null {
+  if (
+    !session ||
+    session.desiredState !== "running" ||
+    session.status !== "ready" ||
+    !session.sandboxHandle
+  ) {
+    return null;
+  }
+  return {
+    sandboxHandle: session.sandboxHandle,
+    previewUrl: session.previewUrl,
+    sandboxApiUrl: session.sandboxApiUrl,
+    sandboxProviderKind: "agent-sandbox",
+    createdAt: Date.parse(session.createdAt),
+    startedWith: session.startedWith as SandboxRecord["startedWith"],
+  };
+}
 
 const sandboxProviderKindInputSchema = z.enum([
   "agent-sandbox",
@@ -147,16 +178,25 @@ export const SANDBOX_START = defineTool({
       await resolveSandboxProvider(ctx, {
         userId,
         branch: resolvedBranch,
+        virtualMcpId: input.virtualMcpId,
         virtualMcpMetadata: metadata,
         explicitKind,
       });
 
-    const existing: SandboxRecord | null = resolveVm(
-      readSandboxMap(metadata),
-      userId,
-      resolvedBranch,
-      providerKind,
-    );
+    const existing: SandboxRecord | null = usesSharedAgentSession(providerKind)
+      ? sessionToSandboxRecord(
+          await ctx.storage.agentSandboxSessions.find({
+            organizationId: organization.id,
+            virtualMcpId: input.virtualMcpId,
+            branch: resolvedBranch,
+          }),
+        )
+      : resolveVm(
+          readSandboxMap(metadata),
+          userId,
+          resolvedBranch,
+          providerKind,
+        );
 
     // Thread-scoped repo (bound by `load_repo`) wins over the agent's repo — the
     // same rule as `ensureSandbox`. Without this the frontend's auto-start
@@ -224,14 +264,16 @@ export async function ensureSandbox(
     throw new Error("Virtual MCP not found");
   }
   const metadata = (virtualMcp.metadata ?? {}) as Record<string, unknown>;
-  const existing: SandboxRecord | null = resolveVm(
-    readSandboxMap(metadata),
-    userId,
-    input.branch,
-    input.sandboxProviderKind,
-  );
-
   const providerKind = input.sandboxProviderKind;
+  const existing: SandboxRecord | null = usesSharedAgentSession(providerKind)
+    ? sessionToSandboxRecord(
+        await ctx.storage.agentSandboxSessions.find({
+          organizationId: organization.id,
+          virtualMcpId: input.virtualMcpId,
+          branch: input.branch,
+        }),
+      )
+    : resolveVm(readSandboxMap(metadata), userId, input.branch, providerKind);
 
   // Resolve the runner up front: for user-desktop we must verify the cached
   // entry against the live daemon before trusting it (the daemon may have
@@ -240,6 +282,7 @@ export async function ensureSandbox(
   const { provider: runner } = await resolveSandboxProvider(ctx, {
     userId,
     branch: input.branch,
+    virtualMcpId: input.virtualMcpId,
     virtualMcpMetadata: metadata,
     explicitKind: providerKind,
   });
@@ -248,7 +291,7 @@ export async function ensureSandbox(
   // daemon first — a relinked daemon has an empty sandbox map and answers the
   // liveness probe with 404, which means we must reap the stale entry and
   // re-provision (runner.ensure spawns a fresh sandbox on the new daemon).
-  if (existing) {
+  if (existing && !usesSharedAgentSession(providerKind)) {
     if (providerKind !== "user-desktop") return existing;
     const alive = await runner.alive(existing.sandboxHandle).catch(() => false);
     if (alive) return existing;
@@ -310,6 +353,102 @@ type StartParams = {
 async function provisionSandbox(
   params: StartParams,
 ): Promise<{ entry: SandboxRecord; isNewVm: boolean }> {
+  if (!usesSharedAgentSession(params.providerKind)) {
+    return provisionSandboxInner(params, null);
+  }
+
+  const locator = {
+    organizationId: params.orgId,
+    virtualMcpId: params.virtualMcpId,
+    branch: params.branch,
+  };
+  await finishInterruptedSharedTransition(params, locator);
+  const started = await params.ctx.storage.agentSandboxSessions.withLock(
+    locator,
+    (sessions) =>
+      sessions.beginStart(
+        locator,
+        params.userId,
+        threadIdFromBranch(params.branch),
+      ),
+  );
+  try {
+    return await provisionSandboxInner(params, {
+      locator,
+      generation: started.generation,
+      sessions: params.ctx.storage.agentSandboxSessions,
+    });
+  } catch (error) {
+    await params.ctx.storage.agentSandboxSessions
+      .failStart(
+        locator,
+        started.generation,
+        error instanceof Error ? error.message : String(error),
+      )
+      .catch(() => {});
+    throw error;
+  }
+}
+
+async function finishInterruptedSharedTransition(
+  params: StartParams,
+  locator: {
+    organizationId: string;
+    virtualMcpId: string;
+    branch: string;
+  },
+): Promise<void> {
+  const pending = await params.ctx.storage.agentSandboxSessions.withLock(
+    locator,
+    (sessions) => sessions.find(locator),
+  );
+  if (
+    !pending ||
+    (pending.status !== "stopping" && pending.status !== "reaping")
+  ) {
+    return;
+  }
+
+  const sandboxId = sharedSandboxId(
+    composeSandboxRef({
+      orgId: params.orgId,
+      virtualMcpId: params.virtualMcpId,
+      branch: params.branch,
+    }),
+  );
+  if (pending.sandboxHandle) {
+    await params.runner.delete(pending.sandboxHandle, sandboxId);
+  }
+  await params.ctx.storage.agentSandboxSessions.withLock(
+    locator,
+    (sessions) => {
+      if (pending.status === "stopping") {
+        return sessions.completeStop(locator, pending.generation);
+      }
+      if (!pending.sandboxHandle) {
+        throw new Error("Reaping agent sandbox session is missing its handle");
+      }
+      return sessions.completeReap(
+        locator,
+        pending.generation,
+        pending.sandboxHandle,
+      );
+    },
+  );
+}
+
+async function provisionSandboxInner(
+  params: StartParams,
+  sharedStart: {
+    locator: {
+      organizationId: string;
+      virtualMcpId: string;
+      branch: string;
+    };
+    generation: number;
+    sessions: AgentSandboxSessionStorage;
+  } | null,
+): Promise<{ entry: SandboxRecord; isNewVm: boolean }> {
   const {
     ctx,
     userId,
@@ -321,6 +460,14 @@ async function provisionSandbox(
     existing,
     runner,
   } = params;
+
+  if (sharedStart) {
+    await assertSharedSandboxSecrets(ctx, {
+      orgId,
+      userId,
+      metadata,
+    });
+  }
 
   let { runtime, packageManager, port, packageManagerPath } =
     resolveRuntimeConfig(metadata);
@@ -425,6 +572,7 @@ async function provisionSandbox(
       orgId,
       userId,
       entries: readValidatedSubmoduleCredentials(metadata),
+      organizationSecretsOnly: !!sharedStart,
     });
 
     repoOpts = {
@@ -512,34 +660,45 @@ async function provisionSandbox(
     }
   }
 
-  const sandbox = await runner.ensure(
-    { userId, projectRef },
-    {
-      // Pass branch explicitly so the runner-side `computeHandle` agrees with
-      // the sandbox-proxy's `computeClaimHandle`. Without it, a repo-less
-      // VM falls back to `s-<hash>` while the proxy looks up `<branch>-<hash>`
-      // and every proxy call 404s with `unknown handle` (see resilience
-      // scenarios `link-dispatch-ws-partition` / `link-dispatch-log-replay`).
-      branch,
-      repo: repoOpts,
-      workload,
-      tenant: {
-        orgId,
-        userId,
-        ...(ctx.organization?.slug ? { orgSlug: ctx.organization.slug } : {}),
-        ...(ctx.organization?.name ? { orgName: ctx.organization.name } : {}),
-        ...(ctx.auth.user?.email ? { userEmail: ctx.auth.user.email } : {}),
-        ...(ctx.auth.user?.name ? { userName: ctx.auth.user.name } : {}),
-      },
-      ...(offload
-        ? {
-            offloadAllowedHosts: offload.hosts,
-            offloadAllowSameHostDev: offload.allowSameHostDev,
-          }
+  const sandboxId = sharedStart
+    ? sharedSandboxId(projectRef)
+    : userSandboxId(userId, projectRef);
+  if (sharedStart) {
+    await sharedStart.sessions.recordProvisioningHandle(
+      sharedStart.locator,
+      sharedStart.generation,
+      computeClaimHandle(sandboxId, branch),
+    );
+  }
+  const sandbox = await runner.ensure(sandboxId, {
+    // Pass branch explicitly so the runner-side `computeHandle` agrees with
+    // the sandbox-proxy's `computeClaimHandle`. Without it, a repo-less
+    // VM falls back to `s-<hash>` while the proxy looks up `<branch>-<hash>`
+    // and every proxy call 404s with `unknown handle` (see resilience
+    // scenarios `link-dispatch-ws-partition` / `link-dispatch-log-replay`).
+    branch,
+    repo: repoOpts,
+    workload,
+    tenant: {
+      orgId,
+      ...(sharedStart ? {} : { userId }),
+      ...(ctx.organization?.slug ? { orgSlug: ctx.organization.slug } : {}),
+      ...(ctx.organization?.name ? { orgName: ctx.organization.name } : {}),
+      ...(!sharedStart && ctx.auth.user?.email
+        ? { userEmail: ctx.auth.user.email }
         : {}),
-      ...(orgFsConfigJson ? { orgFsConfigJson } : {}),
+      ...(!sharedStart && ctx.auth.user?.name
+        ? { userName: ctx.auth.user.name }
+        : {}),
     },
-  );
+    ...(offload
+      ? {
+          offloadAllowedHosts: offload.hosts,
+          offloadAllowSameHostDev: offload.allowSameHostDev,
+        }
+      : {}),
+    ...(orgFsConfigJson ? { orgFsConfigJson } : {}),
+  });
 
   // Resolve declared env (literals + secret refs) and push to the daemon
   // *before* it can start install/dev. Daemon deep-merges, so resuming an
@@ -552,6 +711,7 @@ async function provisionSandbox(
     orgId,
     userId,
     entries: envEntries,
+    organizationSecretsOnly: !!sharedStart,
   });
 
   // Preserve `createdAt` across resumes so the booting overlay's elapsed
@@ -578,34 +738,78 @@ async function provisionSandbox(
     },
   };
 
-  await setSandboxMapEntry(
-    ctx.storage.virtualMcps,
-    virtualMcpId,
-    userId,
-    userId,
-    branch,
-    params.providerKind,
-    entry,
-  );
-  // Thread-scoped branch: the agent write above is a no-op for the synthetic
-  // Decopilot agent, so also persist the record on the thread — the only place
-  // the frontend reads previewUrl/handle from for these sandboxes. Applies to
-  // EVERY provisioning path (load_repo, SANDBOX_START auto-start, fs tools).
-  const threadId = threadIdFromBranch(branch);
-  if (threadId) {
-    await setThreadSandboxMapEntry(
-      ctx,
-      threadId,
+  if (sharedStart) {
+    const completed = await sharedStart.sessions.completeStart(
+      sharedStart.locator,
+      sharedStart.generation,
+      entry,
+    );
+    if (!completed) {
+      await runner.delete(entry.sandboxHandle, sandboxId).catch(() => {});
+      throw new Error("Sandbox start was superseded by a stop");
+    }
+  } else {
+    await setSandboxMapEntry(
+      ctx.storage.virtualMcps,
+      virtualMcpId,
+      userId,
       userId,
       branch,
       params.providerKind,
       entry,
     );
+    // Legacy/desktop thread-scoped entries remain user-specific.
+    const threadId = threadIdFromBranch(branch);
+    if (threadId) {
+      await setThreadSandboxMapEntry(
+        ctx,
+        threadId,
+        userId,
+        branch,
+        params.providerKind,
+        entry,
+      );
+    }
   }
 
   // Different handle = new sandbox (stale entry / orphan recovery / state miss).
   const isNewVm = !existing || existing.sandboxHandle !== sandbox.handle;
   return { entry, isNewVm };
+}
+
+async function assertSharedSandboxSecrets(
+  ctx: StudioContext,
+  args: {
+    orgId: string;
+    userId: string;
+    metadata: Record<string, unknown>;
+  },
+): Promise<void> {
+  const references = [
+    ...(readValidatedRuntimeEnv(args.metadata) ?? []).flatMap((entry) =>
+      entry.kind === "secret"
+        ? [{ id: entry.secretId, label: `environment variable ${entry.key}` }]
+        : [],
+    ),
+    ...(readValidatedSubmoduleCredentials(args.metadata) ?? []).map(
+      (entry) => ({
+        id: entry.secretId,
+        label: `submodule credential ${entry.host}`,
+      }),
+    ),
+  ];
+  for (const reference of references) {
+    const info = await ctx.storage.secrets.findById(
+      reference.id,
+      args.orgId,
+      args.userId,
+    );
+    if (info.scope !== "organization") {
+      throw new Error(
+        `Shared agent sandboxes require organization-scoped secrets (${reference.label})`,
+      );
+    }
+  }
 }
 
 /**

--- a/apps/mesh/src/tools/thread/create.ts
+++ b/apps/mesh/src/tools/thread/create.ts
@@ -5,8 +5,8 @@
  *
  * Branch resolution (only meaningful when the vMCP has a githubRepo):
  *   1. Honor `data.branch` when provided.
- *   2. Otherwise pick the most-recently-touched branch from the user's
- *      `sandboxMap[userId]` so a new task lands on a warm sandbox.
+ *   2. Otherwise pick the most-recent shared hosted branch, then the user's
+ *      most-recent user-desktop branch.
  *   3. Fall back to a freshly generated Bayer-style `<greek>-<constellation>`
  *      name (e.g. `alpha-centauri`) when the user has no sandboxMap entries
  *      for this vMCP.
@@ -28,6 +28,7 @@ import { normalizeThreadForResponse } from "./helpers";
 import { ThreadCreateDataSchema, ThreadEntitySchema } from "./schema";
 import { generatePrefixedId } from "@/shared/utils/generate-id";
 import { generateBranchName } from "@/shared/branch-name";
+import { getSettings } from "../../settings";
 
 const CreateInputSchema = z.object({
   data: ThreadCreateDataSchema.describe(
@@ -124,8 +125,17 @@ export const COLLECTION_THREADS_CREATE = defineTool({
     const githubRepo = metadata?.githubRepo;
     let branch: string | null = null;
     if (githubRepo) {
+      const sharedWarmBranch = getSettings().sharedAgentSandboxesEnabled
+        ? (
+            await ctx.storage.agentSandboxSessions.findLatestReadyByVirtualMcp(
+              organization.id,
+              data.virtual_mcp_id,
+            )
+          )?.branch
+        : undefined;
       branch =
         data.branch ??
+        sharedWarmBranch ??
         pickWarmBranchFromSandboxMap(metadata?.sandboxMap, userId) ??
         generateBranchName(
           ctx.auth.user?.name ?? ctx.auth.user?.email?.split("@")[0],

--- a/apps/mesh/src/tools/thread/delete.ts
+++ b/apps/mesh/src/tools/thread/delete.ts
@@ -17,6 +17,7 @@ import {
 } from "../../core/studio-context";
 import { normalizeThreadForResponse } from "./helpers";
 import { ThreadEntitySchema } from "./schema";
+import { deleteAgentSandboxSessions } from "../sandbox/delete-agent-sessions";
 
 export const COLLECTION_THREADS_DELETE = defineTool({
   name: "COLLECTION_THREADS_DELETE",
@@ -42,6 +43,13 @@ export const COLLECTION_THREADS_DELETE = defineTool({
       throw new Error(`Thread not found: ${input.id}`);
     }
 
+    await deleteAgentSandboxSessions(
+      ctx,
+      await ctx.storage.agentSandboxSessions.listByThread(
+        organization.id,
+        input.id,
+      ),
+    );
     await ctx.storage.threads.delete(input.id);
 
     const userId = getUserId(ctx);

--- a/apps/mesh/src/tools/virtual/delete.ts
+++ b/apps/mesh/src/tools/virtual/delete.ts
@@ -15,6 +15,7 @@ import {
 } from "../../core/studio-context";
 import { deleteAgentPrompts } from "../../file-storage/agent-prompts";
 import { VirtualMCPEntitySchema } from "./schema";
+import { deleteAllAgentSandboxSessionsForVirtualMcp } from "../sandbox/delete-agent-sessions";
 
 /**
  * Input schema for deleting a virtual MCP
@@ -59,6 +60,12 @@ export const COLLECTION_VIRTUAL_MCP_DELETE = defineTool({
     if (existing.organization_id !== organization.id) {
       throw new Error(`Virtual MCP not found: ${input.id}`);
     }
+
+    await deleteAllAgentSandboxSessionsForVirtualMcp(
+      ctx,
+      organization.id,
+      input.id,
+    );
 
     // Delete the agent first. virtualMcps.delete() removes (in its transaction)
     // the connection_aggregations rows that reference the per-agent child

--- a/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/mesh/src/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -159,7 +159,7 @@ import {
 } from "@decocms/mesh-sdk";
 import type { SandboxMap } from "@decocms/mesh-sdk/types";
 import { useQueryClient } from "@tanstack/react-query";
-import { invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
+import { KEYS, invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
 import { useChatTask } from "@/web/components/chat/context";
 import {
   sandboxUserStop,
@@ -216,6 +216,8 @@ export function SandboxLifecycleProvider({
   hasActiveGithubRepo,
   sandboxMap,
   sandboxProviderKind,
+  sharedDesiredState,
+  sharedLifecyclePending,
   othersThreadLabel,
   othersThreadId,
   children,
@@ -229,6 +231,8 @@ export function SandboxLifecycleProvider({
    *  (unlocked). When non-null, entry selection and SANDBOX_START are scoped to
    *  this kind so the preview never silently shows a different-provider sibling. */
   sandboxProviderKind: SandboxProviderKind | null;
+  sharedDesiredState: "running" | "stopped" | null;
+  sharedLifecyclePending: boolean;
   /** Non-null when the active thread belongs to another member: label to show
    *  in the confirmation gate (its branch, or title). While set and not yet
    *  acknowledged, auto-start is held back so we never silently boot a sandbox
@@ -288,9 +292,10 @@ export function SandboxLifecycleProvider({
     : selectVmEntry(branchMap);
   const previewUrl = vmEntry?.previewUrl ?? null;
   const userStopped =
-    !!virtualMcpId &&
-    !!branch &&
-    sandboxUserStop.isStopped(virtualMcpId, branch);
+    sharedDesiredState === "stopped" ||
+    (!!virtualMcpId &&
+      !!branch &&
+      sandboxUserStop.isStopped(virtualMcpId, branch));
   const appPaused = events.status.state === "paused";
   const startError =
     startVm.isError && startVm.error
@@ -324,7 +329,7 @@ export function SandboxLifecycleProvider({
     branch,
     vmEntry,
     userStopped,
-    isPending: startVm.isPending,
+    isPending: startVm.isPending || sharedLifecyclePending,
     attempted,
     autoStartBlocked,
   });
@@ -363,7 +368,7 @@ export function SandboxLifecycleProvider({
     deadVmId,
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; recorded inside effect after firing
     lastDeadVmId: reprovisionedForVmIdRef.current,
-    isPending: startVm.isPending,
+    isPending: startVm.isPending || sharedLifecyclePending,
     userStopped,
     autoStartBlocked,
   });
@@ -431,6 +436,11 @@ export function SandboxLifecycleProvider({
       // Best effort
     }
     invalidateVirtualMcpQueries(queryClient);
+    if (branch) {
+      queryClient.invalidateQueries({
+        queryKey: KEYS.agentSandboxSession(org.slug, virtualMcpId, branch),
+      });
+    }
   };
 
   const restart = async () => {

--- a/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-start.ts
+++ b/apps/mesh/src/web/components/sandbox/hooks/use-sandbox-start.ts
@@ -12,7 +12,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
-import { invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
+import { KEYS, invalidateVirtualMcpQueries } from "@/web/lib/query-keys";
 import { callSandboxTool } from "./call-sandbox-tool";
 
 const SANDBOX_START_MUTATION_KEY = ["SANDBOX_START"] as const;
@@ -46,7 +46,7 @@ export interface SandboxStartResult {
 
 const inflightStarts = new Map<string, Promise<SandboxStartResult>>();
 const startKey = (args: SandboxStartArgs) =>
-  `${args.virtualMcpId}::${args.branch ?? ""}`;
+  `${args.virtualMcpId}::${args.branch ?? ""}::${args.sandboxProviderKind ?? ""}`;
 
 // Tracks (virtualMcpId, branch) pairs explicitly stopped by the user.
 // Prevents self-heal from restarting a sandbox the user just stopped: the SSE
@@ -92,6 +92,9 @@ export function useSandboxStart(client: MinimalMcpClient) {
     // Per-call onSuccess (via `mutate(args, { onSuccess })`) runs AFTER this.
     onSuccess: () => {
       invalidateVirtualMcpQueries(queryClient);
+      queryClient.invalidateQueries({
+        queryKey: KEYS.agentSandboxSessionsPrefix(),
+      });
     },
   });
 }

--- a/apps/mesh/src/web/components/sandbox/runtime-card/env-vars-field.tsx
+++ b/apps/mesh/src/web/components/sandbox/runtime-card/env-vars-field.tsx
@@ -60,6 +60,7 @@ import {
   useCreateSecret,
   useSecrets,
 } from "@/web/hooks/use-secrets";
+import { useAgentSandboxSessions } from "@/web/hooks/use-agent-sandbox-session";
 
 export interface EnvVarsFieldProps<T extends FieldValues> {
   control: Control<T>;
@@ -148,6 +149,10 @@ function RunningSandboxNotice<T extends FieldValues>({
   const t = useT();
   const session = authClient.useSession();
   const userId = session.data?.user?.id;
+  const { data: sharedSessions = [] } = useAgentSandboxSessions(
+    orgSlug,
+    virtualMcpId,
+  );
 
   const fieldPath = "metadata.runtime.env" as FieldPath<T>;
   const sandboxMapPath = "metadata.sandboxMap" as FieldPath<T>;
@@ -162,8 +167,20 @@ function RunningSandboxNotice<T extends FieldValues>({
   const sandboxMap = form.getValues(sandboxMapPath) as
     | Record<string, Record<string, unknown>>
     | undefined;
-  const userBranches = userId ? Object.keys(sandboxMap?.[userId] ?? {}) : [];
-  const hasActiveSandbox = userBranches.length > 0;
+  const branches = [
+    ...new Set([
+      ...(userId ? Object.keys(sandboxMap?.[userId] ?? {}) : []),
+      ...sharedSessions
+        .filter(
+          (sandbox) =>
+            sandbox.desiredState === "running" &&
+            sandbox.status === "ready" &&
+            !!sandbox.sandboxHandle,
+        )
+        .map((sandbox) => sandbox.branch),
+    ]),
+  ];
+  const hasActiveSandbox = branches.length > 0;
 
   const [isRestarting, setRestarting] = useState(false);
 
@@ -172,7 +189,7 @@ function RunningSandboxNotice<T extends FieldValues>({
   const handleRestart = async () => {
     setRestarting(true);
     const results = await Promise.allSettled(
-      userBranches.map(async (branch) => {
+      branches.map(async (branch) => {
         const url = `/api/${encodeURIComponent(orgSlug)}/sandbox/${encodeURIComponent(virtualMcpId)}/${encodeURIComponent(branch)}/setup/start`;
         const res = await fetch(url, { method: "POST" });
         if (!res.ok) {
@@ -186,17 +203,17 @@ function RunningSandboxNotice<T extends FieldValues>({
     if (failed === 0) {
       setBaseline(currentStr);
       toast.success(
-        userBranches.length === 1
+        branches.length === 1
           ? t("sandbox.envVarsField.restartedSingle")
           : t("sandbox.envVarsField.restartedMultiple", {
-              count: userBranches.length,
+              count: branches.length,
             }),
       );
     } else {
       toast.error(
         t("sandbox.envVarsField.restartFailed", {
           failed,
-          total: userBranches.length,
+          total: branches.length,
         }),
       );
     }

--- a/apps/mesh/src/web/components/thread/github/branch-picker.tsx
+++ b/apps/mesh/src/web/components/thread/github/branch-picker.tsx
@@ -62,10 +62,7 @@ export function BranchPicker({
   orgSlug,
   userId,
   userLabel,
-  // virtualMcpId is consumed by callers via Props (e.g. BranchPill);
-  // BranchPicker itself doesn't use it directly. Kept on the Props
-  // contract so the pill container can pass it down uniformly.
-  virtualMcpId: _virtualMcpId,
+  virtualMcpId,
   connectionId,
   owner,
   repo,
@@ -96,6 +93,7 @@ export function BranchPicker({
   } = useBranches({
     orgId,
     orgSlug,
+    virtualMcpId,
     userId,
     connectionId,
     sandboxMap,

--- a/apps/mesh/src/web/components/thread/github/use-branches.ts
+++ b/apps/mesh/src/web/components/thread/github/use-branches.ts
@@ -1,6 +1,7 @@
 import { KEYS, type SandboxMap, useMCPClient } from "@decocms/mesh-sdk";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { groupBranches } from "./group-branches";
+import { useAgentSandboxSessions } from "@/web/hooks/use-agent-sandbox-session";
 
 export interface Branch {
   name: string;
@@ -35,6 +36,7 @@ export interface UseBranchesResult {
 interface UseBranchesArgs {
   orgId: string;
   orgSlug: string;
+  virtualMcpId: string;
   userId: string;
   connectionId: string | null | undefined;
   sandboxMap: SandboxMap | undefined;
@@ -132,6 +134,7 @@ function extractBranches(r: unknown): RawBranchesResponse {
 export function useBranches({
   orgId,
   orgSlug,
+  virtualMcpId,
   userId,
   connectionId,
   sandboxMap,
@@ -139,6 +142,11 @@ export function useBranches({
   repo,
   enabled = true,
 }: UseBranchesArgs): UseBranchesResult {
+  const { data: sharedSessions = [] } = useAgentSandboxSessions(
+    orgSlug,
+    virtualMcpId,
+    enabled,
+  );
   const client = useMCPClient({
     connectionId: connectionId ?? null,
     orgId,
@@ -209,8 +217,35 @@ export function useBranches({
           : (b.commit?.author?.login ?? null),
     }));
 
+  let effectiveSandboxMap = sandboxMap;
+  for (const session of sharedSessions) {
+    if (
+      session.desiredState !== "running" ||
+      session.status !== "ready" ||
+      !session.sandboxHandle
+    ) {
+      continue;
+    }
+    effectiveSandboxMap = {
+      ...(effectiveSandboxMap ?? {}),
+      [userId]: {
+        ...(effectiveSandboxMap?.[userId] ?? {}),
+        [session.branch]: {
+          ...(effectiveSandboxMap?.[userId]?.[session.branch] ?? {}),
+          "agent-sandbox": {
+            sandboxHandle: session.sandboxHandle,
+            previewUrl: session.previewUrl,
+            sandboxApiUrl: session.sandboxApiUrl,
+            sandboxProviderKind: "agent-sandbox",
+            createdAt: Date.parse(session.updatedAt),
+          },
+        },
+      },
+    };
+  }
+
   const { recent, yours, others } = groupBranches({
-    sandboxMap,
+    sandboxMap: effectiveSandboxMap,
     userId,
     rawBranches,
     now: Date.now(),

--- a/apps/mesh/src/web/hooks/use-agent-sandbox-session.ts
+++ b/apps/mesh/src/web/hooks/use-agent-sandbox-session.ts
@@ -1,0 +1,73 @@
+import { useQuery } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+
+export interface AgentSandboxSession {
+  virtualMcpId: string;
+  branch: string;
+  sandboxHandle: string | null;
+  previewUrl: string | null;
+  sandboxApiUrl: string | null;
+  desiredState: "running" | "stopped";
+  status:
+    | "provisioning"
+    | "ready"
+    | "missing"
+    | "failed"
+    | "stopping"
+    | "reaping"
+    | "deleting"
+    | "stopped";
+  startedWith: Record<string, unknown> | null;
+  failureReason: string | null;
+  updatedAt: string;
+}
+
+interface AgentSandboxSessionsResponse {
+  items: AgentSandboxSession[];
+}
+
+async function fetchAgentSandboxSessions(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch?: string,
+): Promise<AgentSandboxSession[]> {
+  const query = branch ? `?branch=${encodeURIComponent(branch)}` : "";
+  const response = await fetch(
+    `/api/${orgSlug}/agent-sandbox-sessions/${virtualMcpId}${query}`,
+    { cache: "no-store" },
+  );
+  if (!response.ok) throw new Error("Failed to load sandbox sessions");
+  const body = (await response.json()) as AgentSandboxSessionsResponse;
+  return body.items;
+}
+
+export function useAgentSandboxSession(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string | null,
+) {
+  return useQuery({
+    queryKey: KEYS.agentSandboxSession(orgSlug, virtualMcpId, branch ?? ""),
+    queryFn: async (): Promise<AgentSandboxSession | null> => {
+      if (!branch) return null;
+      return (
+        (await fetchAgentSandboxSessions(orgSlug, virtualMcpId, branch))[0] ??
+        null
+      );
+    },
+    enabled: !!branch,
+    refetchInterval: 5_000,
+  });
+}
+
+export function useAgentSandboxSessions(
+  orgSlug: string,
+  virtualMcpId: string,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: KEYS.agentSandboxSessions(orgSlug, virtualMcpId),
+    queryFn: () => fetchAgentSandboxSessions(orgSlug, virtualMcpId),
+    enabled,
+  });
+}

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -79,6 +79,7 @@ import { OrgFilePreviewMount } from "./org-file-preview";
 import { OrgFileOpenProvider } from "@/web/components/chat/org-file-open-context";
 import { BlocksPreviewWorkspaceProvider } from "@/web/components/sandbox/blocks/blocks-preview-workspace-context";
 import { SidePanel } from "./side-panel";
+import { useAgentSandboxSession } from "@/web/hooks/use-agent-sandbox-session";
 
 // ---------------------------------------------------------------------------
 // Types & Context
@@ -152,9 +153,15 @@ function VmEventsBridge({
   children: ReactNode;
 }) {
   const { currentBranch, activeTask } = useChatTask();
+  const { org } = useProjectContext();
   const { pendingSandboxProviderKind } = useChatPrefs();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
+  const { data: agentSandboxSession } = useAgentSandboxSession(
+    org.slug,
+    virtualMcpId,
+    currentBranch,
+  );
 
   // Overlay the thread's own sandbox record for the current branch. `load_repo`
   // binds a repo to the thread and persists its sandbox there (the ephemeral
@@ -163,7 +170,7 @@ function VmEventsBridge({
   const threadSandboxMap = activeTask?.metadata?.sandboxMap as
     | SandboxMap
     | undefined;
-  const effectiveSandboxMap: SandboxMap | undefined =
+  const threadEffectiveSandboxMap: SandboxMap | undefined =
     userId && currentBranch && threadSandboxMap?.[userId]?.[currentBranch]
       ? {
           ...(sandboxMap ?? {}),
@@ -173,6 +180,31 @@ function VmEventsBridge({
           },
         }
       : sandboxMap;
+  const effectiveSandboxMap: SandboxMap | undefined =
+    userId &&
+    currentBranch &&
+    agentSandboxSession?.desiredState === "running" &&
+    agentSandboxSession.status === "ready" &&
+    agentSandboxSession.sandboxHandle
+      ? {
+          ...(threadEffectiveSandboxMap ?? {}),
+          [userId]: {
+            ...(threadEffectiveSandboxMap?.[userId] ?? {}),
+            [currentBranch]: {
+              ...parseBranchMap(
+                threadEffectiveSandboxMap?.[userId]?.[currentBranch],
+              ),
+              "agent-sandbox": {
+                sandboxHandle: agentSandboxSession.sandboxHandle,
+                previewUrl: agentSandboxSession.previewUrl,
+                sandboxApiUrl: agentSandboxSession.sandboxApiUrl,
+                sandboxProviderKind: "agent-sandbox",
+                startedWith: agentSandboxSession.startedWith ?? undefined,
+              },
+            },
+          },
+        }
+      : threadEffectiveSandboxMap;
   const effectiveHasGithubRepo =
     hasActiveGithubRepo || agentHasClonableSource(activeTask?.metadata);
 
@@ -212,7 +244,11 @@ function VmEventsBridge({
         | undefined) ?? null)
     : selectVmEntry(branchMap);
   const previewUrl = vmEntry?.previewUrl ?? null;
-  const shouldConnect = Object.keys(branchMap).length > 0 || isStartPending;
+  const shouldConnect =
+    Object.keys(branchMap).length > 0 ||
+    isStartPending ||
+    agentSandboxSession?.status === "provisioning" ||
+    agentSandboxSession?.status === "reaping";
 
   return (
     <SandboxEventsProvider
@@ -228,6 +264,11 @@ function VmEventsBridge({
         hasActiveGithubRepo={effectiveHasGithubRepo}
         sandboxMap={effectiveSandboxMap}
         sandboxProviderKind={pendingSandboxProviderKind}
+        sharedDesiredState={agentSandboxSession?.desiredState ?? null}
+        sharedLifecyclePending={
+          agentSandboxSession?.status === "provisioning" ||
+          agentSandboxSession?.status === "reaping"
+        }
         othersThreadLabel={othersThreadLabel}
         othersThreadId={activeTask?.id ?? null}
       >

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -523,6 +523,14 @@ export const KEYS = {
     ["sandbox-invoke", sandboxKey, loaderKey] as const,
   sandboxRepoDir: (orgSlug: string, virtualMcpId: string, branch: string) =>
     ["sandbox-repo-dir", orgSlug, virtualMcpId, branch] as const,
+  agentSandboxSession: (
+    orgSlug: string,
+    virtualMcpId: string,
+    branch: string,
+  ) => ["agent-sandbox-session", orgSlug, virtualMcpId, branch] as const,
+  agentSandboxSessionsPrefix: () => ["agent-sandbox-session"] as const,
+  agentSandboxSessions: (orgSlug: string, virtualMcpId: string) =>
+    ["agent-sandbox-session", orgSlug, virtualMcpId] as const,
   // icon-select previews: the site's /sprites.svg, fetched via the preview proxy
   sandboxSprite: (sandboxKey: string) =>
     ["sandbox-sprite", sandboxKey] as const,

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -118,6 +118,7 @@ serviceAccount:
 configMap:
   meshConfig:
     STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
+    SHARED_AGENT_SANDBOXES_ENABLED: "true"
     STUDIO_ENV: "staging"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-staging"
     # The next three values are required only when previewGateway.enabled=true.

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -1,9 +1,11 @@
 # @decocms/sandbox
 
-Isolated per-user sandboxes for MCP tool execution.
+Isolated sandboxes for MCP tool execution.
 
-One sandbox per `(userId, projectRef)`: a container (or VM) holding a checked-out
-repo plus an in-pod daemon that proxies exec, file ops, and the dev server.
+Hosted agent sandboxes use one workspace per `projectRef`; user-desktop keeps
+one workspace per `(userId, projectRef)`. A sandbox is a container (or VM)
+holding a checked-out repo plus an in-pod daemon that proxies exec, file ops,
+and the dev server.
 Callers go through a single `SandboxProvider` interface; the provider decides how
 the sandbox is provisioned and reached.
 
@@ -47,9 +49,10 @@ Preconditions:
 - **user-desktop**: previews are served by the user's link daemon at its own
   reachable URL.
 
-Handles are `<branch-slug>-<hash5>` (or a bare 5-char hash when no branch is
-set), DNS-label safe (RFC 1035 caps labels at 63). The hash portion is a
-truncated SHA256 of `userId:projectRef`; collisions are bounded per-project.
+Handles are `<branch-slug>-<hash>` (or a bare hash when no branch is set),
+DNS-label safe (RFC 1035 caps labels at 63). The hash portion is a truncated
+SHA256 of `projectRef` for shared hosted sandboxes and `userId:projectRef` for
+user-desktop.
 The URL itself is the routing key, not a capability — daemon endpoints
 require a bearer token.
 
@@ -58,6 +61,12 @@ require a bearer token.
 - `STUDIO_SANDBOX_PROVIDER` — pin the provider: `agent-sandbox` or `user-desktop`.
   Defaults to `user-desktop`. Setting it explicitly is required for production
   deploys.
+- `SHARED_AGENT_SANDBOXES_ENABLED` — default-off rollout flag. When `true`,
+  agent-sandbox uses the org-scoped session registry and shares a branch across
+  authorized collaborators. It does not change user-desktop identity. Enabling
+  it does not migrate a running per-user hosted workspace, so drain those
+  sandboxes (and commit any working-tree changes) before rollout. Shared claims
+  remain cleanup-capable if the flag is later disabled.
 - `SANDBOX_ROOT_URL` — production template for the pod URL. Either a bare
   base (`https://sandboxes.example.com` → handle becomes leading subdomain)
   or a `{handle}` template (`https://{handle}.sandboxes.example.com`).

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -226,7 +226,7 @@ interface PortForwarder {
 
 interface RunnerTenant {
   orgId: string;
-  userId: string;
+  userId?: string;
   orgSlug?: string;
   orgName?: string;
   userEmail?: string;
@@ -514,8 +514,22 @@ export class AgentSandboxProvider implements SandboxProvider {
     );
   }
 
-  async delete(handle: string): Promise<void> {
-    const rec = await this.getRecord(handle);
+  async delete(handle: string, id?: SandboxId): Promise<void> {
+    if (id && this.stateStore) {
+      await withSandboxLock(this.stateStore, id, RUNNER_KIND, (ops) =>
+        this.deleteLocked(handle, id, ops),
+      );
+      return;
+    }
+    await this.deleteLocked(handle, id, this.stateStore);
+  }
+
+  private async deleteLocked(
+    handle: string,
+    id: SandboxId | undefined,
+    stateStore: RunnerStateStoreOps | null,
+  ): Promise<void> {
+    const rec = this.records.get(handle) ?? null;
     this.records.delete(handle);
     if (rec) {
       this.closeForwarder(rec.daemonForward);
@@ -537,9 +551,10 @@ export class AgentSandboxProvider implements SandboxProvider {
       );
     });
     await deleteSandboxClaim(this.kubeConfig, this.namespace, handle);
-    if (this.stateStore) {
-      if (rec) await this.stateStore.delete(rec.id, RUNNER_KIND);
-      else await this.stateStore.deleteByHandle(RUNNER_KIND, handle);
+    if (stateStore) {
+      if (id) await stateStore.delete(id, RUNNER_KIND);
+      else if (rec) await stateStore.delete(rec.id, RUNNER_KIND);
+      else await stateStore.deleteByHandle(RUNNER_KIND, handle);
     }
   }
 
@@ -2279,7 +2294,7 @@ function buildTenantLabels(
   const labels: Record<string, string> = { ...extra };
   if (tenant) {
     const orgId = sanitizeLabelValue(tenant.orgId);
-    const userId = sanitizeLabelValue(tenant.userId);
+    const userId = tenant.userId ? sanitizeLabelValue(tenant.userId) : "";
     if (orgId) labels[LABEL_KEYS.orgId] = orgId;
     if (userId) labels[LABEL_KEYS.userId] = userId;
   }
@@ -2369,11 +2384,11 @@ function readClaimTenant(claim: SandboxResource): RunnerTenant | null {
   if (!labels) return null;
   const orgId = labels[LABEL_KEYS.orgId];
   const userId = labels[LABEL_KEYS.userId];
-  if (!orgId || !userId) return null;
+  if (!orgId) return null;
   const annotations = claim.metadata?.annotations ?? {};
   return {
     orgId,
-    userId,
+    ...(userId ? { userId } : {}),
     orgSlug: annotations[ANNOTATION_KEYS.orgSlug],
     orgName: annotations[ANNOTATION_KEYS.orgName],
     userEmail: annotations[ANNOTATION_KEYS.userEmail],

--- a/packages/sandbox/server/provider/desktop/runner.test.ts
+++ b/packages/sandbox/server/provider/desktop/runner.test.ts
@@ -79,7 +79,7 @@ function makeStateStore(): RunnerStateStoreOps & {
         handle: row.handle,
         state: row.state,
         updatedAt: new Date(),
-        id: { userId: "u1", projectRef: "ref" },
+        id: { scope: "user", userId: "u1", projectRef: "ref" },
       };
     },
     async put(
@@ -103,6 +103,7 @@ function makeStateStore(): RunnerStateStoreOps & {
 // ---- Tests ------------------------------------------------------------------
 
 const SANDBOX_ID: SandboxId = {
+  scope: "user",
   userId: "u1",
   projectRef: "agent:org:vmcp:deco/test-branch",
 };

--- a/packages/sandbox/server/provider/index.ts
+++ b/packages/sandbox/server/provider/index.ts
@@ -25,6 +25,8 @@ export {
   normalizeSandboxProviderKind,
   sandboxIdKey,
   sandboxProviderKindSchema,
+  sharedSandboxId,
+  userSandboxId,
 } from "./types";
 // Needed by studio callers (decopilot dispatch-run) that compute handles
 // directly. Re-exported here so consumers don't dig into shared/.

--- a/packages/sandbox/server/provider/shared/handle.test.ts
+++ b/packages/sandbox/server/provider/shared/handle.test.ts
@@ -3,11 +3,48 @@ import { computeHandle, hashSandboxId } from "./handle";
 import type { SandboxId } from "../types";
 
 const ID: SandboxId = {
+  scope: "user",
   userId: "u_1",
   projectRef: "agent:org:vmcp:deco/mellow-flint",
 };
 
 describe("computeHandle", () => {
+  it("shares hosted handles for the same project ref", () => {
+    const first: SandboxId = {
+      scope: "shared",
+      projectRef: "agent:org:vmcp:deco/shared",
+    };
+    const second: SandboxId = {
+      scope: "shared",
+      projectRef: "agent:org:vmcp:deco/shared",
+    };
+    expect(computeHandle(first, "deco/shared")).toBe(
+      computeHandle(second, "deco/shared"),
+    );
+  });
+
+  it("keeps user-scoped desktop handles isolated", () => {
+    expect(
+      computeHandle(
+        {
+          scope: "user",
+          userId: "u_1",
+          projectRef: "agent:org:vmcp:deco/shared",
+        },
+        "deco/shared",
+      ),
+    ).not.toBe(
+      computeHandle(
+        {
+          scope: "user",
+          userId: "u_2",
+          projectRef: "agent:org:vmcp:deco/shared",
+        },
+        "deco/shared",
+      ),
+    );
+  });
+
   it("strips the prefix before the last `/` from the branch slug", () => {
     const handle = computeHandle(ID, "deco/mellow-flint");
     expect(handle).toMatch(/^mellow-flint-[0-9a-f]{16}$/);
@@ -73,7 +110,11 @@ describe("computeHandle", () => {
   it("uses the SandboxId for the hash, so different ids with the same slug differ", () => {
     const handleA = computeHandle(ID, "deco/foo");
     const handleB = computeHandle(
-      { userId: "u_2", projectRef: "agent:org:vmcp:deco/foo" },
+      {
+        scope: "user",
+        userId: "u_2",
+        projectRef: "agent:org:vmcp:deco/foo",
+      },
       "deco/foo",
     );
     expect(handleA).not.toBe(handleB);

--- a/packages/sandbox/server/provider/shared/handle.ts
+++ b/packages/sandbox/server/provider/shared/handle.ts
@@ -14,8 +14,10 @@ export function hashSandboxId(id: SandboxId, length = 16): string {
 /**
  * Human-readable URL handle for a sandbox: `<slug>-<hash16>`, where `slug` is
  * derived from the last `/`-segment of the branch and `hash16` is the first
- * 16 hex chars (~64 bits) of `SHA256(userId:projectRef)`. Falls back to a
- * bare hash when the branch is missing or sanitizes to empty.
+ * 16 hex chars (~64 bits) of the identity key. Shared hosted identities hash
+ * `projectRef`; user-scoped desktop identities preserve the historical
+ * `userId:projectRef` input. Falls back to a bare hash when the branch is
+ * missing or sanitizes to empty.
  *
  * Both live runners expose the handle as a public hostname (agent-sandbox
  * preview URLs; the user-desktop `<handle>.localhost` ingress), so the handle

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -6,10 +6,32 @@
 import { z } from "zod";
 import type { ClaimPhase } from "./lifecycle-types";
 
-export interface SandboxId {
-  userId: string;
-  /** Opaque routing key; compose via `composeSandboxRef()`. */
-  projectRef: string;
+/**
+ * Stable sandbox identity.
+ *
+ * Hosted agent sandboxes are shared by every authorized user working on the
+ * same project ref. Desktop sandboxes remain bound to one user's link daemon.
+ * The discriminator makes choosing the wrong identity scope a compile error.
+ */
+export type SandboxId =
+  | {
+      scope: "shared";
+      /** Opaque routing key; compose via `composeSandboxRef()`. */
+      projectRef: string;
+    }
+  | {
+      scope: "user";
+      userId: string;
+      /** Opaque routing key; compose via `composeSandboxRef()`. */
+      projectRef: string;
+    };
+
+export function sharedSandboxId(projectRef: string): SandboxId {
+  return { scope: "shared", projectRef };
+}
+
+export function userSandboxId(userId: string, projectRef: string): SandboxId {
+  return { scope: "user", userId, projectRef };
 }
 
 /** Opaque handle; transport (HTTP/kube-exec/ssh) stays inside the runner. */
@@ -100,8 +122,8 @@ export interface EnsureOptions {
    * org/user. Optional — callers without an org context (smoke tests, internal
    * tool sandboxes) leave it unset and pods get only platform-level labels.
    *
-   * `orgId`/`userId` are the stable IDs surfaced as k8s labels (label values
-   * are charset-restricted, so UUIDs only). The remaining fields are
+   * `orgId` and optional `userId` are the stable IDs surfaced as k8s labels
+   * (label values are charset-restricted, so UUIDs only). The remaining fields are
    * human-readable identity surfaced as k8s *annotations* (no charset limit) so
    * `kubectl describe sandboxclaim` and dashboards can show who owns a sandbox
    * without a join back to the DB. All optional — runners drop any that are
@@ -109,7 +131,8 @@ export interface EnsureOptions {
    */
   tenant?: {
     orgId: string;
-    userId: string;
+    /** Omitted for org-shared hosted sandboxes. */
+    userId?: string;
     orgSlug?: string;
     orgName?: string;
     userEmail?: string;
@@ -170,7 +193,11 @@ export interface SandboxProvider {
   readonly kind: SandboxProviderKind;
 
   ensure(id: SandboxId, opts?: EnsureOptions): Promise<Sandbox>;
-  delete(handle: string): Promise<void>;
+  /**
+   * Delete a sandbox. Callers deleting a shared hosted sandbox pass its id so
+   * ensure/delete serialize on the same cross-pod lock.
+   */
+  delete(handle: string, id?: SandboxId): Promise<void>;
   alive(handle: string): Promise<boolean>;
 
   /**
@@ -226,5 +253,9 @@ export interface SandboxProvider {
 }
 
 export function sandboxIdKey(id: SandboxId): string {
-  return `${id.userId}:${id.projectRef}`;
+  // Preserve the historical desktop hash input byte-for-byte. Hosted shared
+  // identities deliberately contain no acting-user component.
+  return id.scope === "shared"
+    ? id.projectRef
+    : `${id.userId}:${id.projectRef}`;
 }


### PR DESCRIPTION
## Summary

- share agent sandboxes by organization, virtual MCP, and branch while keeping user desktops user-scoped
- add persistent session and runner-state storage with generation fencing, transition tombstones, recovery, and lifecycle cleanup
- route agent traffic and UI lifecycle state through the shared session registry
- prevent user-specific credentials and tool catalogs from being persisted into shared workspaces
- add a default-off SHARED_AGENT_SANDBOXES_ENABLED rollout flag

## Rollout

Existing per-user agent workspaces are not migrated. Drain or commit active work before enabling SHARED_AGENT_SANDBOXES_ENABLED. Cleanup of shared claims remains available if the flag is later disabled.

## Validation

- bun run check
- bun run lint (0 errors)
- bun run knip
- 83 focused unit and lifecycle tests
- 4 real-PostgreSQL concurrency and lifecycle tests
- bun run fmt
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable shared hosted agent sandboxes per organization, virtual MCP, and branch, while keeping user-desktop sandboxes user-scoped. Adds a session registry, durable runner state, and UI/API to manage shared sessions, gated by SHARED_AGENT_SANDBOXES_ENABLED (default off).

- New Features
  - Shared identities and handles via `sharedSandboxId`/`userSandboxId`; updated `computeClaimHandle` in `@decocms/sandbox`.
  - Persistent storage: new DB tables `agent_sandbox_sessions` and `agent_sandbox_runner_state` with generation fencing, tombstones, recovery, and cleanup.
  - API/UI: `/api/:org/agent-sandbox-sessions` routes; `vm-events` streams shared hosted lifecycle; `sandbox-proxy` and `dev-connection` route through the shared registry; React hooks `useAgentSandboxSession(s)` and query keys added.
  - Lifecycle/provider: shared agent runner and runner-state store; `resolveSandboxProvider` discovers shared sessions; `SANDBOX_START/DELETE` handle shared sessions; thread and vMCP deletes clean up sessions.
  - Safety: prevent persisting user-bound tool catalogs/credentials into shared workspaces; env vars and submodule creds for shared sandboxes must be organization-scoped.
  - Config: new setting `sharedAgentSandboxesEnabled` (from `SHARED_AGENT_SANDBOXES_ENABLED`); Helm example updated.

- Migration
  - No automatic migration of existing per-user workspaces. Drain or commit active work before enabling the flag.
  - To roll out: set `SHARED_AGENT_SANDBOXES_ENABLED=true`, ensure org-scoped secrets/submodule tokens are configured, then start shared sessions. Disabling the flag later keeps cleanup tools available.

<sup>Written for commit 0d9351fbd36271a6708207493219aa6f03fc9326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

