### PR TITLE
fix(sections-editor): scope multivariate rule-schema cache per site meta

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/fields/multivariate-field-wrapper.tsx
+++ b/apps/mesh/src/web/components/sections-editor/fields/multivariate-field-wrapper.tsx
@@ -18,36 +18,21 @@ import {
   type MatcherEntry,
 } from "../matcher-picker";
 import { formatMatcher } from "../format-matcher";
-import {
-  resolveSchema,
-  type SchemaProperty,
-  type LiveMeta,
-} from "../resolve-schema";
+import type { LiveMeta } from "../resolve-schema";
 import { SchemaForm } from "../schema-form";
 import { ALWAYS_MATCHER_RESOLVE_TYPE } from "../section-types";
+import { cachedResolveSchema } from "./resolved-schema-cache";
 
-// Cache expensive computations that depend on stable inputs.
-// `meta` changes only on page load; `resolveType` changes only on rule picker selection.
+// `meta` changes only on page load; `resolveType` changes only on rule picker
+// selection — cache the matcher list per meta instance (WeakMap, so a stale
+// meta's entries GC with it).
 const matchersCache = new WeakMap<LiveMeta, MatcherEntry[]>();
-const schemaCache = new Map<string, SchemaProperty | null>();
 
 function cachedExtractMatchers(meta: LiveMeta): MatcherEntry[] {
   let result = matchersCache.get(meta);
   if (!result) {
     result = extractMatchers(meta);
     matchersCache.set(meta, result);
-  }
-  return result;
-}
-
-function cachedResolveSchema(
-  resolveType: string,
-  meta: LiveMeta,
-): SchemaProperty | null {
-  let result = schemaCache.get(resolveType);
-  if (result === undefined) {
-    result = resolveSchema(resolveType, meta);
-    schemaCache.set(resolveType, result);
   }
   return result;
 }

--- a/apps/mesh/src/web/components/sections-editor/fields/resolved-schema-cache.test.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/resolved-schema-cache.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { cachedResolveSchema } from "./resolved-schema-cache";
+import type { LiveMeta } from "../resolve-schema";
+
+describe("cachedResolveSchema", () => {
+  it("does not leak a resolveType's schema across different meta (site) instances", () => {
+    // Built-in matcher resolveTypes are identical strings across every deco
+    // site — only `meta` (site A vs. site B) tells them apart.
+    const resolveType = "website/matchers/MatchDevice.ts";
+    const metaA: LiveMeta = {
+      manifest: {
+        blocks: { matchers: { [resolveType]: { $ref: "#/definitions/A" } } },
+      },
+      schema: {
+        $defs: {
+          A: {
+            type: "object",
+            title: "A",
+            properties: { a: { type: "string" } },
+          },
+        },
+      },
+    };
+    const metaB: LiveMeta = {
+      manifest: {
+        blocks: { matchers: { [resolveType]: { $ref: "#/definitions/B" } } },
+      },
+      schema: {
+        $defs: {
+          B: {
+            type: "object",
+            title: "B",
+            properties: { b: { type: "number" } },
+          },
+        },
+      },
+    };
+
+    const resultA = cachedResolveSchema(resolveType, metaA);
+    const resultB = cachedResolveSchema(resolveType, metaB);
+
+    expect(Object.keys(resultA?.properties ?? {})).toEqual(["a"]);
+    expect(Object.keys(resultB?.properties ?? {})).toEqual(["b"]);
+  });
+});

--- a/apps/mesh/src/web/components/sections-editor/fields/resolved-schema-cache.ts
+++ b/apps/mesh/src/web/components/sections-editor/fields/resolved-schema-cache.ts
@@ -1,0 +1,33 @@
+import {
+  resolveSchema,
+  type LiveMeta,
+  type SchemaProperty,
+} from "../resolve-schema";
+
+/**
+ * Cache resolveSchema() results per (meta, resolveType) pair. Keyed on the
+ * `meta` instance (WeakMap, so a stale meta's entries GC with it) rather than
+ * on `resolveType` alone — built-in matcher/loader resolveType strings (e.g.
+ * the standard device/user matchers) are shared verbatim across every deco
+ * site, so a resolveType-only cache would return one site's schema for
+ * another site's block the moment the user switches virtual MCPs without a
+ * full page reload.
+ */
+const schemaCache = new WeakMap<LiveMeta, Map<string, SchemaProperty | null>>();
+
+export function cachedResolveSchema(
+  resolveType: string,
+  meta: LiveMeta,
+): SchemaProperty | null {
+  let byResolveType = schemaCache.get(meta);
+  if (!byResolveType) {
+    byResolveType = new Map();
+    schemaCache.set(meta, byResolveType);
+  }
+  let result = byResolveType.get(resolveType);
+  if (result === undefined) {
+    result = resolveSchema(resolveType, meta);
+    byResolveType.set(resolveType, result);
+  }
+  return result;
+}


### PR DESCRIPTION
**Source:** bug found while auditing schema-handling/stale-state code in `apps/mesh/src/web/components/sections-editor/fields/multivariate-field-wrapper.tsx`.

**Why a maintainer wants it:** `cachedResolveSchema` cached `resolveSchema()` results in a module-level `Map` keyed only on `resolveType`, ignoring which site's `meta` produced the schema. Built-in matcher/loader resolveType strings (e.g. the standard device/user matchers) are identical across every deco site, so switching virtual MCPs in the same browser session (no full page reload) returns a stale schema from a *previously visited site* for a rule that shares the same resolveType — wrong fields render, or the form can break, in the multivariate rule editor. The sibling `matchersCache` in the same file already avoids this by keying on the `meta` instance (`WeakMap<LiveMeta, ...>`); `schemaCache` didn't follow the same pattern.

**Fix:** extracted the cache into its own pure module (`fields/resolved-schema-cache.ts`, no JSX deps) and re-keyed it as `WeakMap<LiveMeta, Map<string, SchemaProperty | null>>` — one map per site instance, cleared automatically via GC when that site's `meta` is dropped. `multivariate-field-wrapper.tsx` now imports `cachedResolveSchema` from there; no behavior change to the matcher list cache.

**Regression test:** `fields/resolved-schema-cache.test.ts` resolves the same resolveType against two different `meta` instances (mirroring two different sites) with different underlying schemas ($defs `A` vs `B`) and asserts each call gets its own site's shape back. Verified the test fails against the old resolveType-only cache (returns site A's shape for both calls) and passes with the fix.

**Reviewer command:** `cd apps/mesh && bun test src/web/components/sections-editor/fields/resolved-schema-cache.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/mesh && bunx tsc --noEmit` (clean), and the targeted test above (1 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the multivariate rule schema cache by site `meta` to prevent cross-site schema reuse when switching sites without a full reload. Fixes wrong fields or broken forms when different sites share the same `resolveType`.

- **Bug Fixes**
  - Cache `resolveSchema` per `(meta, resolveType)` using `WeakMap<LiveMeta, Map<string, SchemaProperty | null>>`.
  - Extracted cache to `fields/resolved-schema-cache.ts` and updated `multivariate-field-wrapper.tsx` to use it.
  - Added `resolved-schema-cache.test.ts` to ensure schemas don’t leak across sites.

<sup>Written for commit 135935a37813b885197680959ac6edfe78718c14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

