### PR TITLE
fix(sandbox): serialize publish/rebase per claim to stop shared-sandbox races

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.test.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { redactRepoDir } from "./sandbox-proxy";
+import { delay } from "@decocms/std";
+import { redactRepoDir, withClaimGitLock } from "./sandbox-proxy";
 
 describe("redactRepoDir", () => {
   it("nulls a container-internal repoDir while preserving other fields", () => {
@@ -30,5 +31,46 @@ describe("redactRepoDir", () => {
   it("passes through JSON that is not an object", () => {
     expect(redactRepoDir("[1,2,3]")).toBe("[1,2,3]");
     expect(redactRepoDir('"repoDir"')).toBe('"repoDir"');
+  });
+});
+
+describe("withClaimGitLock", () => {
+  it("serializes concurrent calls for the same claim", async () => {
+    const order: string[] = [];
+    const first = withClaimGitLock("claim-1", async () => {
+      order.push("first-start");
+      await delay(5);
+      order.push("first-end");
+    });
+    const second = withClaimGitLock("claim-1", async () => {
+      order.push("second-start");
+    });
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first-start", "first-end", "second-start"]);
+  });
+
+  it("does not serialize calls for different claims", async () => {
+    let firstDone = false;
+    let secondSawFirstDone: boolean | undefined;
+    const first = withClaimGitLock("claim-a", async () => {
+      await delay(5);
+      firstDone = true;
+    });
+    const second = withClaimGitLock("claim-b", async () => {
+      secondSawFirstDone = firstDone;
+    });
+    await Promise.all([first, second]);
+    expect(secondSawFirstDone).toBe(false);
+  });
+
+  it("does not let a rejection block later calls for the same claim", async () => {
+    await expect(
+      withClaimGitLock("claim-err", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    const after = await withClaimGitLock("claim-err", async () => "ok");
+    expect(after).toBe("ok");
   });
 });

--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -238,6 +238,36 @@ function requireRunner(c: Context<VmEnv>): SandboxProvider | Response {
   return runner;
 }
 
+/**
+ * Publish/rebase first PUT an `operator` identity into the daemon's persisted
+ * tenant config, then trigger the commit/push against the single working
+ * tree the daemon reads that config back from. On a sandbox shared by
+ * multiple users (see `sharedSandboxId`), two concurrent publish/rebase
+ * calls for the same claim can otherwise interleave: one request's operator
+ * PUT gets read back by the other's commit, and two `git commit`/`push`
+ * sequences race the same working tree. Serializing per claim closes that
+ * window for this mesh process. Entries are removed once idle so this never
+ * grows unbounded — it only ever holds one promise per claim currently in
+ * flight.
+ */
+const claimGitLocks = new Map<string, Promise<unknown>>();
+
+export function withClaimGitLock<T>(
+  claimName: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prior = claimGitLocks.get(claimName) ?? Promise.resolve();
+  const next = prior.catch(() => {}).then(fn);
+  const settled = next.catch(() => {});
+  claimGitLocks.set(claimName, settled);
+  settled.finally(() => {
+    if (claimGitLocks.get(claimName) === settled) {
+      claimGitLocks.delete(claimName);
+    }
+  });
+  return next;
+}
+
 // ---- Proxy helpers ----------------------------------------------------------
 
 /** Sandbox runtime responses must never be cached — 410 Gone was getting stuck in disk cache. */
@@ -670,26 +700,37 @@ export const createSandboxRoutes = () => {
     const { claimName, virtualMcpMetadata, connectionIds } = c.get("vmClaim");
     const ctx = c.var.studioContext;
 
-    try {
-      await patchSandboxOperator(ctx, runner, claimName);
-      const githubRepo = parseGithubRepoFromMetadata(
-        virtualMcpMetadata,
-        connectionIds,
-      );
-      if (githubRepo) {
-        await refreshSandboxGitCredentials(ctx, runner, claimName, githubRepo);
+    return withClaimGitLock(claimName, async () => {
+      try {
+        await patchSandboxOperator(ctx, runner, claimName);
+        const githubRepo = parseGithubRepoFromMetadata(
+          virtualMcpMetadata,
+          connectionIds,
+        );
+        if (githubRepo) {
+          await refreshSandboxGitCredentials(
+            ctx,
+            runner,
+            claimName,
+            githubRepo,
+          );
+        }
+      } catch (err) {
+        if (err instanceof GitPushAuthError) {
+          return c.json(
+            { error: err.message },
+            403,
+            SANDBOX_PROXY_CACHE_HEADERS,
+          );
+        }
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
       }
-    } catch (err) {
-      if (err instanceof GitPushAuthError) {
-        return c.json({ error: err.message }, 403, SANDBOX_PROXY_CACHE_HEADERS);
-      }
-      const message = err instanceof Error ? err.message : String(err);
-      return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
-    }
 
-    return proxyDaemon(c, "/_sandbox/git/publish", {
-      forwardJsonBody: true,
-      map404to410: true,
+      return proxyDaemon(c, "/_sandbox/git/publish", {
+        forwardJsonBody: true,
+        map404to410: true,
+      });
     });
   });
   app.post("/:virtualMcpId/:branch/git/discard", (c) =>
@@ -705,16 +746,18 @@ export const createSandboxRoutes = () => {
     const { claimName } = c.get("vmClaim");
     const ctx = c.var.studioContext;
 
-    try {
-      await patchSandboxOperator(ctx, runner, claimName);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
-    }
+    return withClaimGitLock(claimName, async () => {
+      try {
+        await patchSandboxOperator(ctx, runner, claimName);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
+      }
 
-    return proxyDaemon(c, "/_sandbox/git/rebase", {
-      forwardJsonBody: true,
-      map404to410: true,
+      return proxyDaemon(c, "/_sandbox/git/rebase", {
+        forwardJsonBody: true,
+        map404to410: true,
+      });
     });
   });
   app.post(


### PR DESCRIPTION
Follows #5112 (share agent sandboxes by branch) hardening.

**Bug**: `git/publish` and `git/rebase` each PUT an `operator` identity into the daemon's persisted tenant config (`patchSandboxOperator`), then trigger a commit/push that reads that config back (`deps.getOperator()` in the daemon, used for the co-author trailer). Before #5112, a sandbox only ever had one active user, so this two-step "set then act" sequence was safe. Now that a sandbox can be shared by branch across teammates, two people can hit publish (or one publish + one rebase) for the *same claim* concurrently:

1. Request A PUTs operator=A.
2. Request B PUTs operator=B (overwrites).
3. Request A's commit runs — reads operator=B, misattributing A's change as co-authored by B.
4. Both requests' `git add`/`commit`/`push` can also interleave against the single shared working tree, which git operations were never designed to run concurrently against.

**Fix**: added `withClaimGitLock(claimName, fn)` in `sandbox-proxy.ts` — a small per-claim promise chain (no new dependency) that serializes the whole patch-operator-then-publish (or patch-operator-then-rebase) sequence per claim. Entries are removed once idle, so the map never grows past the number of claims currently mid-publish/rebase. This closes the race for concurrent requests hitting the same mesh process; other read-only git routes (status/diff/discard) are untouched since they don't touch the operator or commit/push.

**Verification**:
- Added 3 unit tests to `sandbox-proxy.test.ts` covering: same-claim calls run in strict order, different-claim calls don't block each other, and a rejection doesn't wedge the lock for later calls on that claim.
- `cd apps/mesh && bunx tsc --noEmit` — clean (pre-existing unrelated errors in an untracked `link-daemon/ensure-rclone.test.ts` file are not from this change).
- `bun test apps/mesh/src/api/routes/sandbox-proxy.test.ts` — 8 pass, 0 fail.
- `bun run fmt` — no changes needed.

A reviewer can confirm with `bun test apps/mesh/src/api/routes/sandbox-proxy.test.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize `git/publish` and `git/rebase` per claim to stop operator misattribution and concurrent git races in shared sandboxes. Adds a per-claim lock so only one publish/rebase runs at a time for a claim.

- **Bug Fixes**
  - Introduced `withClaimGitLock(claimName, fn)` in `sandbox-proxy.ts` to serialize the operator patch + commit/push flow for `git/publish` and `git/rebase`.
  - Wrapped publish/rebase handlers with the lock to prevent overwriting `operator` and interleaving `git commit/push` on the same working tree.
  - Lock is per-claim, promise-chained, and cleans up when idle; different claims run in parallel.
  - Added 3 unit tests validating same-claim ordering, cross-claim parallelism, and recovery after rejection.
  - Preserves existing error handling, including `GitPushAuthError` responses and 404→410 mapping.

<sup>Written for commit 3f092dc9a2f694ff92faeba3b69125c0ca819711. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

