### PR TITLE
fix(sandbox): serialize git/discard on the same claim lock as publish/rebase

### DIFF
--- a/apps/mesh/src/api/routes/sandbox-proxy.ts
+++ b/apps/mesh/src/api/routes/sandbox-proxy.ts
@@ -731,12 +731,15 @@ export const createSandboxRoutes = () => {
       });
     });
   });
-  app.post("/:virtualMcpId/:branch/git/discard", (c) =>
-    proxyDaemon(c, "/_sandbox/git/discard", {
-      forwardJsonBody: true,
-      map404to410: true,
-    }),
-  );
+  app.post("/:virtualMcpId/:branch/git/discard", (c) => {
+    const { claimName } = c.get("vmClaim");
+    return withClaimGitLock(claimName, () =>
+      proxyDaemon(c, "/_sandbox/git/discard", {
+        forwardJsonBody: true,
+        map404to410: true,
+      }),
+    );
+  });
   app.post("/:virtualMcpId/:branch/git/rebase", async (c) => {
     const runner = requireRunner(c);
     if (runner instanceof Response) return runner;


### PR DESCRIPTION
Follows #5114, which added `withClaimGitLock` to serialize `publish`/`rebase` per claim on shared agent sandboxes so concurrent requests can't interleave `git commit`/`push` against the same working tree. `discard` was left unwrapped even though it also mutates the same working tree (`git checkout --` to restore tracked files, plus unlinking untracked ones) — so on a sandbox shared by two teammates (#5112), a `discard` racing a concurrent `publish` can still interleave: `discard`'s `git checkout` can revert files mid-way through `publish`'s `git add`/`commit`, or a discard-driven `unlink` can delete a file `publish` just staged, either silently dropping a teammate's in-flight change or corrupting the commit.

Fix: wrap the `git/discard` route in the same `withClaimGitLock(claimName, ...)` used by `publish`/`rebase`, so only one of publish/rebase/discard runs against a given claim's working tree at a time.

No new test added — `withClaimGitLock` itself is already exhaustively unit-tested (serializes same-claim calls, doesn't block different claims, rejections don't wedge the queue) in `sandbox-proxy.test.ts`; this change is pure wiring of the existing, already-verified lock into one more route, not new locking logic.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` and `bun test apps/mesh/src/api/routes/sandbox-proxy.test.ts` (both pass locally). Full CI validates the rest.

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in apps/mesh, and the single test file above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap the `git/discard` route with `withClaimGitLock` to serialize per-claim operations, matching `publish`/`rebase`. This prevents discard from racing with add/commit/push on shared sandboxes and avoids dropped files or corrupt commits.

<sup>Written for commit 52712cffafc4ce7fbcdd31c2b412c867bce1bc80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

