### PR TITLE
fix(runtime): validate redirect_uri on OAuth /authorize requests

### DIFF
--- a/packages/runtime/src/oauth.test.ts
+++ b/packages/runtime/src/oauth.test.ts
@@ -94,3 +94,36 @@ describe("OAuth /token refresh handler", () => {
     expect(body.refresh_token).toBe("rt2");
   });
 });
+
+describe("OAuth /authorize handler", () => {
+  it("rejects a redirect_uri with a non-https, non-local scheme", async () => {
+    const handlers = createOAuthHandlers(baseConfig());
+
+    const response = await handlers.handleAuthorize(
+      new Request(
+        "https://mcp.example.com/authorize?response_type=code&redirect_uri=" +
+          encodeURIComponent("http://attacker.example.com/callback"),
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("invalid_request");
+  });
+
+  it("accepts an https redirect_uri and redirects to the upstream authorization URL", async () => {
+    const handlers = createOAuthHandlers(baseConfig());
+
+    const response = await handlers.handleAuthorize(
+      new Request(
+        "https://mcp.example.com/authorize?response_type=code&redirect_uri=" +
+          encodeURIComponent("https://client.example.com/callback"),
+      ),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://upstream.example.com/authorize",
+    );
+  });
+});

--- a/packages/runtime/src/oauth.ts
+++ b/packages/runtime/src/oauth.ts
@@ -175,6 +175,16 @@ export function createOAuthHandlers(oauth: OAuthConfig) {
       );
     }
 
+    if (!isValidRedirectUri(redirectUri)) {
+      return Response.json(
+        {
+          error: "invalid_request",
+          error_description: `Invalid redirect_uri: ${redirectUri}`,
+        },
+        { status: 400 },
+      );
+    }
+
     if (responseType !== "code") {
       return Response.json(
         {


### PR DESCRIPTION
**Source:** bug found while auditing `packages/runtime/src/oauth.ts` for missing validation on untrusted input (this tick's runtime-utilities focus area).

**Why a maintainer wants this:** `createOAuthHandlers()` implements a stateless OAuth 2.1 authorization-server proxy for MCP servers. It already defines `isValidRedirectUri()` (only allows `https:`, `localhost`/`127.0.0.1`, or a non-http custom scheme) and calls it during dynamic client registration (RFC 7591), but `handleAuthorize()` — the actual `/authorize` endpoint — never called it; it only checked that `redirect_uri` was non-empty. That means any client can point `redirect_uri` at an arbitrary `http://` URL, which the server happily stores in its stateless encoded `state` param and later redirects the user's browser to (with the OAuth authorization `code` attached) once the upstream provider completes the exchange — a classic OAuth open-redirect / code-leak vector (RFC 6749 §10.6).

**Failure scenario:** `GET /authorize?response_type=code&redirect_uri=http://attacker.example.com/callback` was accepted and, after the user approved access upstream, the flow redirected to `http://attacker.example.com/callback?code=...`, handing the attacker a valid authorization code exchangeable for an access token. The fix applies the existing `isValidRedirectUri()` check to `handleAuthorize()`, returning `400 invalid_request` for a rejected URI, matching the check already enforced for client registration.

**Regression test:** `packages/runtime/src/oauth.test.ts` — new `describe("OAuth /authorize handler")` block asserts a plain-`http://` external redirect_uri is rejected with 400, and a valid `https://` redirect_uri still proceeds to the upstream authorization redirect (302).

**Reviewer command:** `bun test packages/runtime/src/oauth.test.ts`

**Checks run locally:** `bun run fmt` (clean), `cd packages/runtime && bunx tsc --noEmit` (clean), `bun test packages/runtime/src/oauth.test.ts` (5→7 tests, all pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an OAuth open-redirect/code leak by validating `redirect_uri` on `/authorize` using `isValidRedirectUri()`. Insecure or external `http://` URIs now return 400 to prevent redirects to attacker-controlled sites.

- **Bug Fixes**
  - Apply `isValidRedirectUri()` in `handleAuthorize()` within `packages/runtime/src/oauth.ts` to allow only `https`, `localhost`/`127.0.0.1`, or custom schemes.
  - Add tests in `packages/runtime/src/oauth.test.ts` to reject `http://` and allow `https://` redirect URIs.

<sup>Written for commit 3fde859d6a06d446ff374a1f39e0cfced8fccd10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

