### PR TITLE
fix(settings): validate DATABASE_POOL_MAX instead of silently defaulting

### DIFF
--- a/apps/mesh/src/settings/resolve-config.test.ts
+++ b/apps/mesh/src/settings/resolve-config.test.ts
@@ -80,6 +80,29 @@ describe("resolveConfig NATS tunnel settings", () => {
   );
 });
 
+describe("resolveConfig database pool max", () => {
+  it("defaults to 5 when unset", () => {
+    const result = resolveConfig(flags, {});
+
+    expect(result.settings.databasePoolMax).toBe(5);
+  });
+
+  it("uses DATABASE_POOL_MAX when set", () => {
+    const result = resolveConfig(flags, { DATABASE_POOL_MAX: "20" });
+
+    expect(result.settings.databasePoolMax).toBe(20);
+  });
+
+  it.each(["abc", "0", "-1", "1.5", "Infinity"])(
+    "throws for invalid pool max %p",
+    (value) => {
+      expect(() => resolveConfig(flags, { DATABASE_POOL_MAX: value })).toThrow(
+        "DATABASE_POOL_MAX must be a positive integer",
+      );
+    },
+  );
+});
+
 describe("resolveConfig deployment admin emails", () => {
   it("defaults to an empty list when unset", () => {
     const result = resolveConfig(flags, {});

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -140,7 +140,11 @@ export function resolveConfig(
 
     // Database (url resolved after services start)
     databasePgSsl: toBool(envVars.DATABASE_PG_SSL),
-    databasePoolMax: Number(envVars.DATABASE_POOL_MAX) || 5,
+    databasePoolMax: toPositiveIntegerOrDefault(
+      "DATABASE_POOL_MAX",
+      envVars.DATABASE_POOL_MAX,
+      5,
+    ),
 
     // Auth & Secrets
     betterAuthSecret: envVars.BETTER_AUTH_SECRET || "",


### PR DESCRIPTION
Found while reviewing env-fallback robustness in `apps/mesh/src/settings/resolve-config.ts`.

`databasePoolMax` was computed as `Number(envVars.DATABASE_POOL_MAX) || 5` — any non-numeric or invalid value (e.g. a typo like `"5invalid"`, or `"-1"`, `"1.5"`) silently coerced to `NaN`/falsy and fell back to the default of 5, masking a real operator misconfiguration instead of surfacing it. The file already has a `toPositiveIntegerOrDefault` helper doing exactly this validation for `NATS_TUNNEL_SESSION_TTL_SECONDS` (throws `"<NAME> must be a positive integer"`); this reuses that same helper for `DATABASE_POOL_MAX` instead of duplicating the fragile `Number(...) || default` pattern.

Behavior for valid input is unchanged (still defaults to 5 when unset, still accepts a positive integer). Only the previously-silent invalid-value path now throws a clear startup error instead of quietly running with the wrong pool size.

Regression test added mirroring the existing TTL validation tests: defaults to 5 when unset, accepts a valid value, and throws for `"abc"`, `"0"`, `"-1"`, `"1.5"`, `"Infinity"`.

To verify: `cd apps/mesh && bun test src/settings/resolve-config.test.ts` (24 pass).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (in `apps/mesh`), and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `DATABASE_POOL_MAX` as a positive integer so misconfigurations fail fast instead of silently defaulting to 5. Added tests for defaulting, valid values, and clear errors on invalid input.

<sup>Written for commit 697ae66214059e8cb7a48174313f00e7bcc9349f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

