### PR TITLE
fix(sandbox): stop discard from deleting renamed files with no recovery

### DIFF
--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -1,7 +1,9 @@
 import {
   chmodSync,
+  existsSync,
   mkdtempSync,
   mkdirSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -678,6 +680,35 @@ describe("git routes", () => {
     expect(await res.json()).toEqual({
       error: "Invalid path: ../outside-secret.txt",
     });
+  });
+
+  it("discard on a renamed file restores the original instead of deleting both", async () => {
+    const { appRoot, repoDir } = initRepo();
+    writeFileSync(join(repoDir, "old.txt"), "important content\n");
+    gitSync(["add", "old.txt"], { cwd: repoDir, asUser: false });
+    gitSync(["commit", "-m", "add old.txt"], { cwd: repoDir, asUser: false });
+    gitSync(["mv", "old.txt", "new.txt"], { cwd: repoDir, asUser: false });
+
+    const handler = makeGitDiscardHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/discard", {
+        method: "POST",
+        body: JSON.stringify({ filepaths: ["new.txt"] }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(existsSync(join(repoDir, "new.txt"))).toBe(false);
+    expect(existsSync(join(repoDir, "old.txt"))).toBe(true);
+    expect(readFileSync(join(repoDir, "old.txt"), "utf8")).toBe(
+      "important content\n",
+    );
+    expect(
+      gitSync(["status", "--porcelain=v1"], {
+        cwd: repoDir,
+        asUser: false,
+      }).trim(),
+    ).toBe("");
   });
 
   it("rebase rejects invalid base branch names", async () => {

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -649,8 +649,22 @@ function discard(deps: GitDeps, filepaths: string[]): void {
   const status = computeWorkingTreeStatus(repoDir);
   const toRestore: string[] = [];
   const toDelete: string[] = [];
+  // A renamed file's new path never existed at HEAD, so the isNew check below
+  // would treat it as untracked and unlink it outright — losing the content
+  // entirely, since the original path is already gone from the working tree
+  // too. Discarding a rename must instead restore the original file from HEAD
+  // and unstage + drop the new path.
+  const toRestoreFromHead: string[] = [];
+  const renamedNewPaths: string[] = [];
 
   for (const fp of validated) {
+    const origPath = status.files.find((f) => f.path === fp)?.origPath;
+    if (origPath) {
+      toRestoreFromHead.push(origPath);
+      renamedNewPaths.push(fp);
+      toDelete.push(fp);
+      continue;
+    }
     const isNew =
       status.not_added.includes(fp) ||
       status.created.includes(fp) ||
@@ -659,6 +673,13 @@ function discard(deps: GitDeps, filepaths: string[]): void {
     else toRestore.push(fp);
   }
 
+  if (toRestoreFromHead.length > 0) {
+    // Unstage the rename's "new path added" side before restoring the
+    // original — otherwise it survives in the index even after the working
+    // tree file below is deleted.
+    runGit(repoDir, ["reset", "--", ...renamedNewPaths]);
+    runGit(repoDir, ["checkout", "HEAD", "--", ...toRestoreFromHead]);
+  }
   if (toRestore.length > 0) {
     runGit(repoDir, ["checkout", "--", ...toRestore]);
   }


### PR DESCRIPTION
Found by reading `packages/sandbox/daemon/routes/git.ts` for race/edge-case bugs in the sandbox daemon git route.

**The bug:** `discard()` in `git.ts` decides whether a requested file is "new" (delete it) or "modified" (restore it from HEAD/index) by checking `readRefFile(repoDir, "HEAD", fp) === null`. For a renamed file, `fp` is the *new* path — which never existed at HEAD under that name — so the check always resolves to "new" and the code just `unlinkSync`s the working-tree file. Since the original path is already gone from disk (it was renamed away), this deletes the file's content completely, with no way to recover it, and leaves `git status` in a broken `RD` (renamed+deleted) state.

**Repro (before the fix):**
```
git mv old.txt new.txt
# call POST /git/discard { filepaths: ["new.txt"] }
# both old.txt and new.txt are now gone; git status shows "RD old.txt -> new.txt"
```

**The fix:** when the requested path corresponds to a rename (has an `origPath` in the parsed status), discard now unstages the rename and restores the original file from HEAD at its original path, then deletes the new path — actually undoing the rename instead of just deleting the renamed-to file.

Added a regression test (`discard on a renamed file restores the original instead of deleting both`) that reproduces the exact repro above and asserts the original file survives with its content intact and `git status` is clean afterward.

**To verify:** `bun test packages/sandbox/daemon/routes/git.test.ts` (31 pass). Also ran `bunx tsc --noEmit` in `packages/sandbox` (clean) and `bun run fmt`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox git discard to undo renames instead of deleting the renamed file and losing content. Discarding a renamed path now restores the original from HEAD, unstages the rename, deletes the new path, and leaves git status clean.

- Bug Fixes
  - Updated `discard()` in `packages/sandbox/daemon/routes/git.ts` to detect renames via status, reset the new path, checkout the original from `HEAD`, then remove the new path.
  - Added a regression test in `packages/sandbox/daemon/routes/git.test.ts` to ensure the original file is restored and the working tree is clean.

<sup>Written for commit 02f45cbcfecbe9213a72e25eff3954f547cc76c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

