### PR TITLE
fix(virtual-mcp): require org context for id-scoped legacy MCP requests

### DIFF
--- a/apps/mesh/src/api/routes/virtual-mcp.ts
+++ b/apps/mesh/src/api/routes/virtual-mcp.ts
@@ -77,6 +77,17 @@ export async function handleVirtualMcpRequest(
       return c.json({ error: "Agent ID or organization ID is required" }, 400);
     }
 
+    // A specific virtual MCP id was requested but no organization context
+    // could be resolved (legacy /mcp/gateway|virtual-mcp route hit without
+    // x-org-id/x-org-slug headers and no path-resolved org — e.g. a
+    // multi-org member whose session has no deterministic active org). The
+    // ownership checks below only run when organizationId is truthy, so
+    // without this guard the lookup falls through with no org scoping at
+    // all and would serve whichever org happens to own that id.
+    if (virtualMcpId && !organizationId) {
+      return c.json({ error: "Organization context is required" }, 400);
+    }
+
     const virtualMcp = await ctx.tracer.startActiveSpan(
       "studio.virtual_mcp.lookup",
       { attributes: { "virtual_mcp.id": virtualId } },


### PR DESCRIPTION
**Source**: bug found while auditing `apps/mesh/src/api/routes/virtual-mcp.ts` (the shared handler behind both `/mcp/gateway/:virtualMcpId` and `/mcp/virtual-mcp/:virtualMcpId`, and their org-scoped `/api/:org/mcp/...` counterparts).

**Why a maintainer wants this**: `handleVirtualMcpRequest` only enforces that the requested virtual MCP belongs to the caller's organization when `organizationId` (resolved from `x-org-id`/`x-org-slug` headers, or from `ctx.organization` set by `resolveOrgFromPath`) is truthy — both ownership checks (`organizationId && virtualMcp.organization_id !== organizationId` and `ctx.organization?.id && virtualMcp.organization_id !== ctx.organization.id`) are skipped entirely when it's null. On the org-scoped route this never happens (`resolveOrgFromPath` always sets `ctx.organization`). But on the legacy unscoped route (`/mcp/gateway/:virtualMcpId`, still mounted and documented as accepting either header), `context-factory.ts` deliberately returns no organization when a multi-org member's session has no deterministic active org and no header is sent (see the `auth_query_membership` comment: "return undefined ... instead of a non-deterministic pick"). In that combination — multi-org user, legacy route, no org headers, explicit `virtualMcpId` — `organizationId` stays `null`, both guards are skipped, and `ctx.storage.virtualMcps.findById(virtualId, undefined)` fetches the target virtual MCP with zero org scoping, regardless of which org it actually belongs to.

**Failure scenario**: a member of two or more orgs calls `/mcp/gateway/<virtualMcpId>` directly (no `x-org-id`/`x-org-slug` headers) with a virtual-MCP id belonging to an organization they're not a member of. The existing 404/403 ownership checks never trigger because they're gated on a resolved `organizationId`, so the request proceeds to build a live MCP server/session bound to that other org's agent (server info, instructions, tool listing) instead of failing closed.

**Fix**: when a specific `virtualMcpId` is requested but no organization context could be resolved, return `400 { error: "Organization context is required" }` before the lookup, instead of silently falling through with no ownership check. This only affects the narrow legacy-route-without-headers case; the org-scoped route is unaffected since `organizationId` is always resolved there.

**Verify**: `cd apps/mesh && bunx tsc --noEmit` (clean). No existing test file covers this route (`apps/mesh/src/api/routes/virtual-mcp.ts` has no `.test.ts`), so this is a pure typecheck-verified guard-clause addition — CI's full suite validates the rest.

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace). No targeted unit test exists for this file to run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require organization context for id-scoped legacy Virtual MCP requests to close a cross-org access gap. If a specific virtual MCP id is requested on legacy routes without org headers, the API now returns 400 instead of performing an unscoped lookup.

- **Bug Fixes**
  - Added a guard in `handleVirtualMcpRequest` to return 400 when `virtualMcpId` is provided and no organization is resolved.
  - Prevents unscoped lookups for multi-org users on `/mcp/gateway/:virtualMcpId` and `/mcp/virtual-mcp/:virtualMcpId`; org-scoped `/api/:org/...` routes are unchanged.

<sup>Written for commit 4b001357a888b7225013c9340cef73c837f59fdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

