### PR TITLE
fix(auth): stop reflecting arbitrary origins in credentialed CORS

### DIFF
--- a/apps/mesh/src/api/app.test.ts
+++ b/apps/mesh/src/api/app.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isSsoExemptPath } from "./app";
+import { isSsoExemptPath, resolveCorsOrigin } from "./app";
 
 describe("isSsoExemptPath", () => {
   test("exempts the legacy unscoped oauth-proxy mount", () => {
@@ -25,5 +25,50 @@ describe("isSsoExemptPath", () => {
   test("does not exempt other org-scoped routes", () => {
     expect(isSsoExemptPath("/api/acme-corp/connections")).toBe(false);
     expect(isSsoExemptPath("/api/acme-corp/mcp/conn_123")).toBe(false);
+  });
+});
+
+describe("resolveCorsOrigin", () => {
+  const ctx = {
+    baseUrl: "https://studio.example.com",
+    requestOrigin: "https://studio.example.com",
+  };
+
+  test("reflects localhost and 127.0.0.1 regardless of port", () => {
+    expect(resolveCorsOrigin("http://localhost:4000", ctx)).toBe(
+      "http://localhost:4000",
+    );
+    expect(resolveCorsOrigin("http://127.0.0.1:4000", ctx)).toBe(
+      "http://127.0.0.1:4000",
+    );
+  });
+
+  test("rejects a hostname that merely contains 'localhost'", () => {
+    expect(resolveCorsOrigin("http://localhost.evil.com", ctx)).toBeNull();
+    expect(resolveCorsOrigin("http://evil-127.0.0.1.com", ctx)).toBeNull();
+  });
+
+  test("reflects the configured baseUrl's origin", () => {
+    expect(resolveCorsOrigin("https://studio.example.com", ctx)).toBe(
+      "https://studio.example.com",
+    );
+  });
+
+  test("falls back to the request's own origin when baseUrl is unset", () => {
+    const noBaseUrl = {
+      baseUrl: undefined,
+      requestOrigin: "https://self-hosted.internal",
+    };
+    expect(resolveCorsOrigin("https://self-hosted.internal", noBaseUrl)).toBe(
+      "https://self-hosted.internal",
+    );
+  });
+
+  test("rejects an arbitrary cross-site origin", () => {
+    expect(resolveCorsOrigin("https://evil.example", ctx)).toBeNull();
+  });
+
+  test("rejects a malformed origin", () => {
+    expect(resolveCorsOrigin("not-a-url", ctx)).toBeNull();
   });
 });

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -336,6 +336,45 @@ export function isSsoExemptPath(path: string): boolean {
 }
 
 /**
+ * Decide the `Access-Control-Allow-Origin` value for a request's `Origin`
+ * header. The CORS middleware below sets `credentials: true`, so reflecting
+ * every origin (the previous behavior) let any external site issue a
+ * cookie-authenticated cross-site request against this API and read the
+ * response — a permissive-CORS-with-credentials hole. Only reflect
+ * localhost/127.0.0.1 (the Vite dev server, on a different port than the
+ * API) and the deployment's own origin, falling back to the request's own
+ * origin when `baseUrl` isn't configured (same fallback already used for
+ * redirect_uri validation above).
+ */
+export function resolveCorsOrigin(
+  origin: string,
+  {
+    baseUrl,
+    requestOrigin,
+  }: { baseUrl: string | undefined; requestOrigin: string },
+): string | null {
+  let originHost: string;
+  try {
+    originHost = new URL(origin).hostname;
+  } catch {
+    return null;
+  }
+  if (originHost === "localhost" || originHost === "127.0.0.1") {
+    return origin;
+  }
+
+  const allowedOrigin = baseUrl ?? requestOrigin;
+  try {
+    if (new URL(allowedOrigin).origin === origin) {
+      return origin;
+    }
+  } catch {
+    // malformed baseUrl config — fall through to reject
+  }
+  return null;
+}
+
+/**
  * Handle OAuth-proxy requests for an MCP connection.
  *
  * On the org-scoped mount (`/api/:org/oauth-proxy/...`) `resolveOrgFromPath`
@@ -1154,14 +1193,11 @@ export async function createApp(options: CreateAppOptions = {}) {
   app.use(
     "/*",
     cors({
-      origin: (origin) => {
-        // Allow localhost and configured origins
-        if (origin.includes("localhost") || origin.includes("127.0.0.1")) {
-          return origin;
-        }
-        // TODO: Configure allowed origins from environment
-        return origin;
-      },
+      origin: (origin, c) =>
+        resolveCorsOrigin(origin, {
+          baseUrl: getSettings().baseUrl,
+          requestOrigin: new URL(c.req.url).origin,
+        }),
       credentials: true,
       allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
       allowHeaders: ["Content-Type", "Authorization", "mcp-protocol-version"],


### PR DESCRIPTION
Closes #3757 ("Gateway CORS reflects any origin with credentials enabled").

The global CORS middleware in `apps/mesh/src/api/app.ts` reflected the incoming `Origin` header for *every* request (the `origin` callback had a literal `// TODO: Configure allowed origins from environment` and then returned the origin unconditionally), while `credentials: true` was set. That combination lets any external website issue a cookie-authenticated cross-site `fetch(..., {credentials: 'include'})` against the API and read the JSON response for a logged-in victim — a classic permissive-CORS-with-credentials hole (CWE-942). The existing `localhost`/`127.0.0.1` allowance was also a loose substring check (`origin.includes("localhost")`), bypassable by a hostname like `http://localhost.evil.com`.

A maintainer wants this fixed because it's a real, currently-exploitable cross-tenant data-leak vector on every session-authenticated API route (chat, connections, org settings, etc.) — not just OAuth-proxy, but the same middleware also guards the OAuth/auth-adjacent routes I was auditing.

The fix extracts the origin decision into a small pure function, `resolveCorsOrigin(origin, { baseUrl, requestOrigin })`, unit-tested the same way `isSsoExemptPath` already is in this file:
- Reflects `localhost`/`127.0.0.1` only on an exact hostname match (not substring).
- Reflects the deployment's configured `baseUrl` origin, falling back to the request's own origin when `baseUrl` isn't configured — mirroring the exact fallback pattern (`getSettings().baseUrl ?? reqUrl.origin`) already used a few dozen lines above for `redirect_uri` validation in the same file.
- Otherwise returns `null` (no `Access-Control-Allow-Origin` header), which only blocks genuinely cross-origin browser reads — same-origin app traffic (the normal case, since the Studio client and API are served from the same origin in production) is unaffected because browsers don't gate same-origin requests on CORS headers at all.

Net change: `apps/mesh/src/api/app.ts` (+~40/-9), `apps/mesh/src/api/app.test.ts` (+6 test cases covering the localhost exact-match, the substring bypass, baseUrl reflection, the no-baseUrl fallback, and rejection of an arbitrary origin).

To verify: `bun test apps/mesh/src/api/app.test.ts` (10/10 pass, including the 6 new `resolveCorsOrigin` cases).

Locally ran: `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (no errors introduced by this change — the only errors present are pre-existing, in an unrelated untracked file). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops reflecting arbitrary origins when CORS uses credentials, closing a data leak where any site could read cookie-authenticated API responses. Only trusted origins are allowed; same-origin production traffic is unaffected.

- **Bug Fixes**
  - Added `resolveCorsOrigin` to gate CORS `origin` when `credentials: true`.
  - Allow only exact `localhost`/`127.0.0.1` (any port) and the deployment origin from `getSettings().baseUrl` (fallback to the request’s origin if unset).
  - Removed substring checks; reject `localhost.evil.com`, arbitrary sites, and malformed origins.
  - Wired the global CORS middleware to `resolveCorsOrigin` and added targeted tests in `apps/mesh/src/api/app.test.ts`.

<sup>Written for commit 92e3d99cd6c3017b4564db6c6b1987522b1b1601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

