### PR TITLE
feat(billing): seat management tools + change-log (invoiced orgs)

### DIFF
--- a/apps/mesh/migrations/140-seat-change-log.ts
+++ b/apps/mesh/migrations/140-seat-change-log.ts
@@ -1,0 +1,36 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Append-only log of seat transitions (paid <-> free), written in the same
+ * transaction as the organization_paid_seat change. For `invoiced`
+ * (contract) orgs this IS the billing source: end-of-cycle invoicing reads
+ * who held a paid seat when, so rows are only appended for ACTUAL
+ * transitions (a no-op "set paid on already-paid" writes nothing).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("seat_change_log")
+    .addColumn("id", "uuid", (col) =>
+      col.primaryKey().defaultTo(sql`gen_random_uuid()`),
+    )
+    .addColumn("organization_id", "text", (col) =>
+      col.notNull().references("organization.id").onDelete("cascade"),
+    )
+    .addColumn("user_id", "text", (col) => col.notNull())
+    .addColumn("seat", "text", (col) => col.notNull())
+    .addColumn("changed_by", "text", (col) => col.notNull())
+    .addColumn("created_at", "timestamptz", (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex("idx_seat_change_log_org_created")
+    .on("seat_change_log")
+    .columns(["organization_id", "created_at"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("seat_change_log").execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -138,6 +138,7 @@ import * as migration136taskboardimportidempotency from "./136-task-board-import
 import * as migration137agentsandboxrunnerstate from "./137-agent-sandbox-runner-state.ts";
 import * as migration138agentsandboxsessions from "./138-agent-sandbox-sessions.ts";
 import * as migration139organizationbilling from "./139-organization-billing.ts";
+import * as migration140seatchangelog from "./140-seat-change-log.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -301,6 +302,7 @@ const migrations: Record<string, Migration> = {
   "137-agent-sandbox-runner-state": migration137agentsandboxrunnerstate,
   "138-agent-sandbox-sessions": migration138agentsandboxsessions,
   "139-organization-billing": migration139organizationbilling,
+  "140-seat-change-log": migration140seatchangelog,
 };
 
 export default migrations;

--- a/apps/mesh/src/auth/index.ts
+++ b/apps/mesh/src/auth/index.ts
@@ -40,7 +40,7 @@ import { createEmailOtpConfig } from "./email-otp";
 import { createEmailSender, findEmailProvider } from "./email-providers";
 import { emailButton, emailParagraph, emailTemplate } from "./email-template";
 import { createMagicLinkConfig } from "./magic-link";
-import { seedOrgDb } from "./org";
+import { releaseSeat, seedOrgDb } from "./org";
 import { hoistOrgLogo } from "./hoist-org-logo";
 import { identifyAuthenticatedUser } from "./posthog-identify";
 import { ADMIN_ROLES } from "./roles";
@@ -244,6 +244,40 @@ const plugins = [
       // and MCP tool wrappers.
       beforeCreateOrganization: async ({ organization }) => {
         rejectReservedOrganizationSlug(organization.slug);
+      },
+      // Seat lifecycle (per-seat billing) at the canonical membership
+      // boundaries — these hooks cover EVERY add/remove path (tools, direct
+      // Better Auth endpoints, invitation accepts, join-request approvals),
+      // and both are fail-soft: seats must never break membership itself.
+      //
+      // afterAddMember: invites always land FREE — dropping any stale
+      // paid-seat row here means a crash between a removal and its seat
+      // release can't resurrect the seat when the user rejoins. (Between
+      // those two moments the stale row is harmless: every seat count joins
+      // against `member`, so a non-member row never bills.)
+      afterAddMember: async ({ member }) => {
+        try {
+          await releaseSeat(
+            member.organizationId,
+            member.userId,
+            "system:join",
+          );
+        } catch (err) {
+          console.error("Failed to reset seat on member join:", err);
+        }
+      },
+      // afterRemoveMember: a removed member stops counting toward the org's
+      // bill and gateway allowance.
+      afterRemoveMember: async ({ member }) => {
+        try {
+          await releaseSeat(
+            member.organizationId,
+            member.userId,
+            "system:member-removed",
+          );
+        } catch (err) {
+          console.error("Failed to release seat on member removal:", err);
+        }
       },
       // Keep base64 logos out of the org row (they bloat every
       // organization.list response). Mirrors `backfill-assets

--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -9,6 +9,7 @@ import { getDb } from "@/database";
 import { CredentialVault } from "@/encryption/credential-vault";
 import { AIProviderKeyStorage } from "@/storage/ai-provider-keys";
 import { ConnectionStorage } from "@/storage/connection";
+import { OrganizationBillingStorage } from "@/storage/organization-billing";
 import { Permission } from "@/storage/types";
 import { fetchToolsFromMCP } from "@/tools/connection/fetch-tools";
 import {
@@ -80,6 +81,24 @@ function getDefaultOrgMcps(organizationId: string): MCPCreationSpec[] {
       data: getWellKnownRegistryConnection(organizationId),
     },
   ];
+}
+
+/**
+ * Drop a user's paid seat (if any) + log the transition. Called from the
+ * afterAddMember / afterRemoveMember organization hooks — see
+ * OrganizationBillingStorage.releaseSeat for the invariant this maintains.
+ */
+export async function releaseSeat(
+  organizationId: string,
+  userId: string,
+  changedBy: string,
+): Promise<void> {
+  const database = getDb();
+  await new OrganizationBillingStorage(database.db).releaseSeat(
+    organizationId,
+    userId,
+    changedBy,
+  );
 }
 
 /**

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -392,9 +392,7 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
       },
 
       removeMember: async (data) => {
-        // Return Better Auth's result: it carries the removed member's userId,
-        // which the tool needs to release the member's paid seat.
-        return auth.api.removeMember({
+        await auth.api.removeMember({
           headers,
           body: data,
         });

--- a/apps/mesh/src/core/context-factory.ts
+++ b/apps/mesh/src/core/context-factory.ts
@@ -58,6 +58,7 @@ import {
 } from "../storage/registry";
 import type { PrivateRegistryDatabase } from "../storage/registry/types";
 import { TagStorage } from "../storage/tags";
+import { OrganizationBillingStorage } from "../storage/organization-billing";
 import type { Database, Permission } from "../storage/types";
 import { UserStorage } from "../storage/user";
 import { AgentSandboxSessionStorage } from "../storage/agent-sandbox-sessions";
@@ -391,7 +392,9 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
       },
 
       removeMember: async (data) => {
-        await auth.api.removeMember({
+        // Return Better Auth's result: it carries the removed member's userId,
+        // which the tool needs to release the member's paid seat.
+        return auth.api.removeMember({
           headers,
           body: data,
         });
@@ -1340,6 +1343,7 @@ export async function createStudioContextFactory(
     agentSandboxSessions: new AgentSandboxSessionStorage(config.db),
     users: new UserStorage(config.db),
     tags: new TagStorage(config.db),
+    organizationBilling: new OrganizationBillingStorage(config.db),
     virtualMcpPluginConfigs: new VirtualMcpPluginConfigsStorage(config.db),
     aiProviderKeys: new AIProviderKeyStorage(
       config.db,

--- a/apps/mesh/src/core/studio-context.test.ts
+++ b/apps/mesh/src/core/studio-context.test.ts
@@ -20,6 +20,7 @@ const createMockContext = (
   storage: {
     connections: null as never,
     connectionCredentialVault: null as never,
+    organizationBilling: null as never,
     organizationSettings: null as never,
     monitoring: null as never,
     virtualMcps: null as never,

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -47,9 +47,6 @@ export type ListOrganizationsResult = Awaited<
   ReturnType<BetterAuthApi["listOrganizations"]>
 >;
 export type AddMemberResult = Awaited<ReturnType<BetterAuthApi["addMember"]>>;
-export type RemoveMemberResult = Awaited<
-  ReturnType<BetterAuthApi["removeMember"]>
->;
 export type ListMembersResult = Awaited<
   ReturnType<BetterAuthApi["listMembers"]>
 >;
@@ -139,7 +136,7 @@ export interface BoundAuthClient {
     removeMember(data: {
       memberIdOrEmail: string;
       organizationId?: string;
-    }): Promise<RemoveMemberResult>;
+    }): Promise<void>;
 
     listMembers(options?: {
       organizationId?: string;

--- a/apps/mesh/src/core/studio-context.ts
+++ b/apps/mesh/src/core/studio-context.ts
@@ -47,6 +47,9 @@ export type ListOrganizationsResult = Awaited<
   ReturnType<BetterAuthApi["listOrganizations"]>
 >;
 export type AddMemberResult = Awaited<ReturnType<BetterAuthApi["addMember"]>>;
+export type RemoveMemberResult = Awaited<
+  ReturnType<BetterAuthApi["removeMember"]>
+>;
 export type ListMembersResult = Awaited<
   ReturnType<BetterAuthApi["listMembers"]>
 >;
@@ -136,7 +139,7 @@ export interface BoundAuthClient {
     removeMember(data: {
       memberIdOrEmail: string;
       organizationId?: string;
-    }): Promise<void>;
+    }): Promise<RemoveMemberResult>;
 
     listMembers(options?: {
       organizationId?: string;
@@ -312,6 +315,7 @@ import { AIProviderFactory } from "@/ai-providers/factory";
 import type { FireAutomationOutcome } from "../automations/dbos-workflow";
 import type { BoundObjectStorage } from "../object-storage/bound-object-storage";
 import type { AgentSandboxSessionStorage } from "../storage/agent-sandbox-sessions";
+import type { OrganizationBillingStorage } from "../storage/organization-billing";
 
 // Better Auth instance type - flexible for testing
 // In production, this is the actual Better Auth instance
@@ -355,6 +359,7 @@ export interface MeshStorage {
   kv: KVStorage;
   interests: InterestsStorage;
   agentSandboxSessions: AgentSandboxSessionStorage;
+  organizationBilling: OrganizationBillingStorage;
 }
 
 // ============================================================================

--- a/apps/mesh/src/storage/organization-billing.integration.test.ts
+++ b/apps/mesh/src/storage/organization-billing.integration.test.ts
@@ -107,28 +107,32 @@ describe("OrganizationBillingStorage", () => {
     expect(await storage.listPaidSeatUserIds(ORG)).toEqual(["user_a"]);
   });
 
-  it("releases the seat on member removal and logs the transition", async () => {
-    // Simulate the member row already being gone (removal completed).
+  it("a stale seat row (member gone, release never ran) never counts", async () => {
+    // Simulate the crash window: member removed, releaseSeat never ran.
     await database.db
       .deleteFrom("member")
       .where("userId", "=", "user_a")
       .where("organizationId", "=", ORG)
       .execute();
 
-    const released = await storage.releaseSeatOnMemberRemoval(
-      ORG,
-      "user_a",
-      "admin_1",
-    );
+    // The orphan row still exists…
+    const raw = await database.db
+      .selectFrom("organization_paid_seat")
+      .select(["user_id"])
+      .where("organization_id", "=", ORG)
+      .execute();
+    expect(raw.map((r) => r.user_id)).toEqual(["user_a"]);
+    // …but the member JOIN keeps it out of every count.
+    expect(await storage.listPaidSeatUserIds(ORG)).toEqual([]);
+  });
+
+  it("releases the seat (hooks boundary) and logs the transition", async () => {
+    const released = await storage.releaseSeat(ORG, "user_a", "admin_1");
     expect(released).toBe(true);
     expect(await storage.listPaidSeatUserIds(ORG)).toEqual([]);
 
     // Releasing again is a no-op — nothing new logged.
-    const again = await storage.releaseSeatOnMemberRemoval(
-      ORG,
-      "user_a",
-      "admin_1",
-    );
+    const again = await storage.releaseSeat(ORG, "user_a", "admin_1");
     expect(again).toBe(false);
 
     const frees = await database.db

--- a/apps/mesh/src/storage/organization-billing.integration.test.ts
+++ b/apps/mesh/src/storage/organization-billing.integration.test.ts
@@ -1,0 +1,150 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import {
+  OrganizationBillingStorage,
+  SeatTargetNotMemberError,
+} from "./organization-billing";
+
+// Real-Postgres coverage for the seat transaction: paid-seat rows and their
+// change-log entries must commit together (the log is the invoiced orgs'
+// billing source), no-ops must not log, and unknown users must reject the
+// whole batch.
+const ORG = "org_billing_1";
+
+describe("OrganizationBillingStorage", () => {
+  let database: StudioDatabase;
+  let storage: OrganizationBillingStorage;
+
+  // Raw SQL like seedCommonTestPgFixtures: real Postgres has BOOLEAN
+  // emailVerified, which the (PGlite-era) typed table shape disagrees with.
+  const addMember = async (userId: string) => {
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${userId}, ${`${userId}@billing.test`}, false, ${userId}, ${now}, ${now})
+    `.execute(database.db);
+    await sql`
+      INSERT INTO "member" (id, "userId", "organizationId", role, "createdAt")
+      VALUES (${`mem_${userId}`}, ${userId}, ${ORG}, 'user', ${now})
+    `.execute(database.db);
+  };
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: ORG,
+        name: "Billing Org",
+        slug: "billing-org",
+        createdAt: new Date().toISOString(),
+      })
+      .execute();
+    await database.db
+      .insertInto("organization_billing")
+      .values({ organization_id: ORG, legacy: false })
+      .execute();
+    await addMember("user_a");
+    await addMember("user_b");
+    storage = new OrganizationBillingStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("applies transitions and logs exactly the ones that changed state", async () => {
+    const first = await storage.setSeats(
+      ORG,
+      [
+        { userId: "user_a", seat: "paid" },
+        { userId: "user_b", seat: "free" }, // already free — no-op
+      ],
+      "admin_1",
+    );
+    expect(first.applied).toEqual([{ userId: "user_a", seat: "paid" }]);
+    expect(first.paidSeatCount).toBe(1);
+
+    // Replaying the same state applies (and logs) nothing.
+    const replay = await storage.setSeats(
+      ORG,
+      [{ userId: "user_a", seat: "paid" }],
+      "admin_1",
+    );
+    expect(replay.applied).toEqual([]);
+    expect(replay.paidSeatCount).toBe(1);
+
+    const log = await database.db
+      .selectFrom("seat_change_log")
+      .select(["user_id", "seat", "changed_by"])
+      .where("organization_id", "=", ORG)
+      .execute();
+    expect(log).toEqual([
+      { user_id: "user_a", seat: "paid", changed_by: "admin_1" },
+    ]);
+  });
+
+  it("rejects the whole batch when any target is not a member", async () => {
+    await expect(
+      storage.setSeats(
+        ORG,
+        [
+          { userId: "user_b", seat: "paid" },
+          { userId: "ghost", seat: "paid" },
+        ],
+        "admin_1",
+      ),
+    ).rejects.toThrow(SeatTargetNotMemberError);
+
+    // Atomicity: the valid half of the batch must NOT have been applied.
+    expect(await storage.listPaidSeatUserIds(ORG)).toEqual(["user_a"]);
+  });
+
+  it("releases the seat on member removal and logs the transition", async () => {
+    // Simulate the member row already being gone (removal completed).
+    await database.db
+      .deleteFrom("member")
+      .where("userId", "=", "user_a")
+      .where("organizationId", "=", ORG)
+      .execute();
+
+    const released = await storage.releaseSeatOnMemberRemoval(
+      ORG,
+      "user_a",
+      "admin_1",
+    );
+    expect(released).toBe(true);
+    expect(await storage.listPaidSeatUserIds(ORG)).toEqual([]);
+
+    // Releasing again is a no-op — nothing new logged.
+    const again = await storage.releaseSeatOnMemberRemoval(
+      ORG,
+      "user_a",
+      "admin_1",
+    );
+    expect(again).toBe(false);
+
+    const frees = await database.db
+      .selectFrom("seat_change_log")
+      .select(["seat"])
+      .where("organization_id", "=", ORG)
+      .where("user_id", "=", "user_a")
+      .execute();
+    expect(frees.map((r) => r.seat)).toEqual(["paid", "free"]);
+  });
+
+  it("getBilling maps the row; missing row is null (fail-open upstream)", async () => {
+    const billing = await storage.getBilling(ORG);
+    expect(billing?.legacy).toBe(false);
+    expect(billing?.billingMode).toBe("self_serve");
+    expect(billing?.status).toBe("none");
+    expect(await storage.getBilling("org_without_billing")).toBeNull();
+  });
+});

--- a/apps/mesh/src/storage/organization-billing.ts
+++ b/apps/mesh/src/storage/organization-billing.ts
@@ -67,11 +67,27 @@ export class OrganizationBillingStorage {
     };
   }
 
+  /**
+   * Paid seats of CURRENT members only — joined against `member` so a stale
+   * row (member removed but the release hook never ran: crash mid-request)
+   * can never count toward billing or the gateway allowance. Orphan rows are
+   * harmless dust, cleared by the afterAddMember hook if the user ever
+   * rejoins (invites always land free).
+   */
   async listPaidSeatUserIds(organizationId: string): Promise<string[]> {
     const rows = await this.db
       .selectFrom("organization_paid_seat")
-      .select(["user_id"])
-      .where("organization_id", "=", organizationId)
+      .innerJoin("member", (join) =>
+        join
+          .onRef("member.userId", "=", "organization_paid_seat.user_id")
+          .onRef(
+            "member.organizationId",
+            "=",
+            "organization_paid_seat.organization_id",
+          ),
+      )
+      .select(["organization_paid_seat.user_id"])
+      .where("organization_paid_seat.organization_id", "=", organizationId)
       .execute();
     return rows.map((r) => r.user_id);
   }
@@ -147,10 +163,20 @@ export class OrganizationBillingStorage {
           .execute();
       }
 
+      // Same member JOIN as listPaidSeatUserIds: never count a stale row.
       const paidSeats = await trx
         .selectFrom("organization_paid_seat")
+        .innerJoin("member", (join) =>
+          join
+            .onRef("member.userId", "=", "organization_paid_seat.user_id")
+            .onRef(
+              "member.organizationId",
+              "=",
+              "organization_paid_seat.organization_id",
+            ),
+        )
         .select((eb) => eb.fn.countAll().as("count"))
-        .where("organization_id", "=", organizationId)
+        .where("organization_paid_seat.organization_id", "=", organizationId)
         .executeTakeFirst();
 
       return { applied, paidSeatCount: Number(paidSeats?.count ?? 0) };
@@ -158,12 +184,15 @@ export class OrganizationBillingStorage {
   }
 
   /**
-   * Member left/was removed: release their paid seat (if any) and log the
-   * transition — otherwise a removed member's seat keeps counting toward the
-   * org's bill forever. Direct ops (not setSeats): the member row is already
-   * gone at this point, so setSeats' membership validation would reject it.
+   * Drop a user's paid-seat row (if any) and log the transition. Called from
+   * BOTH membership boundaries (auth/index.ts organizationHooks):
+   *   - afterRemoveMember — a removed member must stop counting;
+   *   - afterAddMember — invites always land FREE, so a stale row from a
+   *     crashed removal can't resurrect as paid when the user rejoins.
+   * Direct ops (not setSeats): at removal time the member row is already
+   * gone, so setSeats' membership validation would reject it. Idempotent.
    */
-  async releaseSeatOnMemberRemoval(
+  async releaseSeat(
     organizationId: string,
     userId: string,
     changedBy: string,

--- a/apps/mesh/src/storage/organization-billing.ts
+++ b/apps/mesh/src/storage/organization-billing.ts
@@ -1,0 +1,191 @@
+/**
+ * Organization Billing Storage
+ *
+ * Per-seat billing state: the org's billing identity (organization_billing),
+ * paid-seat membership (organization_paid_seat, presence = paid) and the
+ * append-only seat_change_log. Platform-written only — no org-member-facing
+ * write goes anywhere near organization_billing except through the seat
+ * tools, which gate on billing_mode.
+ */
+
+import type { Kysely } from "kysely";
+import type { Database } from "./types";
+
+export interface OrganizationBillingRow {
+  organizationId: string;
+  legacy: boolean;
+  billingMode: string;
+  status: string;
+  stripeCustomerId: string | null;
+  stripeSubscriptionId: string | null;
+  currentPeriodEnd: Date | null;
+  includedReportUrl: string | null;
+}
+
+export type SeatKind = "paid" | "free";
+
+export interface SeatChange {
+  userId: string;
+  seat: SeatKind;
+}
+
+export interface SetSeatsResult {
+  /** Transitions actually applied (no-ops — already in the target state —
+   *  are skipped and NOT logged, so the invoiced change-log stays clean). */
+  applied: SeatChange[];
+  paidSeatCount: number;
+}
+
+export class SeatTargetNotMemberError extends Error {
+  constructor(userIds: string[]) {
+    super(`not members of this organization: ${userIds.join(", ")}`);
+    this.name = "SeatTargetNotMemberError";
+  }
+}
+
+export class OrganizationBillingStorage {
+  constructor(private db: Kysely<Database>) {}
+
+  async getBilling(
+    organizationId: string,
+  ): Promise<OrganizationBillingRow | null> {
+    const row = await this.db
+      .selectFrom("organization_billing")
+      .selectAll()
+      .where("organization_id", "=", organizationId)
+      .executeTakeFirst();
+    if (!row) return null;
+    return {
+      organizationId: row.organization_id,
+      legacy: row.legacy,
+      billingMode: row.billing_mode,
+      status: row.status,
+      stripeCustomerId: row.stripe_customer_id,
+      stripeSubscriptionId: row.stripe_subscription_id,
+      currentPeriodEnd: row.current_period_end,
+      includedReportUrl: row.included_report_url,
+    };
+  }
+
+  async listPaidSeatUserIds(organizationId: string): Promise<string[]> {
+    const rows = await this.db
+      .selectFrom("organization_paid_seat")
+      .select(["user_id"])
+      .where("organization_id", "=", organizationId)
+      .execute();
+    return rows.map((r) => r.user_id);
+  }
+
+  /**
+   * Apply seat transitions atomically: paid-seat rows and their change-log
+   * entries commit together (the log is the invoiced orgs' billing source —
+   * they must never diverge). Every target must be a CURRENT org member;
+   * unknown users reject the whole batch (SeatTargetNotMemberError) so a
+   * stale UI can't silently bill a ghost. Idempotent per state: setting a
+   * seat to the state it's already in applies nothing and logs nothing.
+   */
+  async setSeats(
+    organizationId: string,
+    changes: SeatChange[],
+    changedBy: string,
+  ): Promise<SetSeatsResult> {
+    return await this.db.transaction().execute(async (trx) => {
+      const userIds = [...new Set(changes.map((c) => c.userId))];
+      if (userIds.length !== changes.length) {
+        throw new Error("duplicate userId in seat changes");
+      }
+      if (userIds.length > 0) {
+        const members = await trx
+          .selectFrom("member")
+          .select(["userId"])
+          .where("organizationId", "=", organizationId)
+          .where("userId", "in", userIds)
+          .execute();
+        const memberIds = new Set(members.map((m) => m.userId));
+        const unknown = userIds.filter((id) => !memberIds.has(id));
+        if (unknown.length > 0) throw new SeatTargetNotMemberError(unknown);
+      }
+
+      const applied: SeatChange[] = [];
+      for (const change of changes) {
+        if (change.seat === "paid") {
+          // ON CONFLICT DO NOTHING → zero rows returned when already paid.
+          const inserted = await trx
+            .insertInto("organization_paid_seat")
+            .values({
+              organization_id: organizationId,
+              user_id: change.userId,
+            })
+            .onConflict((oc) =>
+              oc.columns(["organization_id", "user_id"]).doNothing(),
+            )
+            .returning("user_id")
+            .executeTakeFirst();
+          if (inserted) applied.push(change);
+        } else {
+          const deleted = await trx
+            .deleteFrom("organization_paid_seat")
+            .where("organization_id", "=", organizationId)
+            .where("user_id", "=", change.userId)
+            .returning("user_id")
+            .executeTakeFirst();
+          if (deleted) applied.push(change);
+        }
+      }
+
+      if (applied.length > 0) {
+        await trx
+          .insertInto("seat_change_log")
+          .values(
+            applied.map((c) => ({
+              organization_id: organizationId,
+              user_id: c.userId,
+              seat: c.seat,
+              changed_by: changedBy,
+            })),
+          )
+          .execute();
+      }
+
+      const paidSeats = await trx
+        .selectFrom("organization_paid_seat")
+        .select((eb) => eb.fn.countAll().as("count"))
+        .where("organization_id", "=", organizationId)
+        .executeTakeFirst();
+
+      return { applied, paidSeatCount: Number(paidSeats?.count ?? 0) };
+    });
+  }
+
+  /**
+   * Member left/was removed: release their paid seat (if any) and log the
+   * transition — otherwise a removed member's seat keeps counting toward the
+   * org's bill forever. Direct ops (not setSeats): the member row is already
+   * gone at this point, so setSeats' membership validation would reject it.
+   */
+  async releaseSeatOnMemberRemoval(
+    organizationId: string,
+    userId: string,
+    changedBy: string,
+  ): Promise<boolean> {
+    return await this.db.transaction().execute(async (trx) => {
+      const deleted = await trx
+        .deleteFrom("organization_paid_seat")
+        .where("organization_id", "=", organizationId)
+        .where("user_id", "=", userId)
+        .returning("user_id")
+        .executeTakeFirst();
+      if (!deleted) return false;
+      await trx
+        .insertInto("seat_change_log")
+        .values({
+          organization_id: organizationId,
+          user_id: userId,
+          seat: "free",
+          changed_by: changedBy,
+        })
+        .execute();
+      return true;
+    });
+  }
+}

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -1271,6 +1271,22 @@ export interface OrganizationPaidSeatTable {
 }
 
 /**
+ * Append-only seat-transition log, written in the same transaction as the
+ * organization_paid_seat change. For `invoiced` orgs this is the billing
+ * source (end-of-cycle invoicing reads who held a paid seat when); rows are
+ * appended only for ACTUAL transitions.
+ */
+export interface SeatChangeLogTable {
+  id: ColumnType<string, string | undefined, never>;
+  organization_id: string;
+  user_id: string;
+  /** "paid" | "free" — the state the seat transitioned TO. */
+  seat: string;
+  changed_by: string;
+  created_at: ColumnType<Date, Date | string | undefined, never>;
+}
+
+/**
  * Organization tag table definition
  * Stores normalized tag definitions per organization
  */
@@ -1809,6 +1825,7 @@ export interface Database extends PrivateRegistryDatabase {
   // Per-seat billing (dormant behind STUDIO_BILLING_ENFORCED)
   organization_billing: OrganizationBillingTable;
   organization_paid_seat: OrganizationPaidSeatTable;
+  seat_change_log: SeatChangeLogTable;
 
   // Virtual MCP plugin configs
   virtual_mcp_plugin_configs: VirtualMcpPluginConfigTable;

--- a/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
+++ b/apps/mesh/src/tools/connection/connection-tools.integration.test.ts
@@ -101,6 +101,7 @@ describe("Connection Tools", () => {
           }),
         } as never,
         agentSandboxSessions: null as never,
+        organizationBilling: null as never,
         monitoring: null as never,
         threads: null as never,
         asyncResearchJobs: null as never,

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -75,6 +75,8 @@ export const CORE_TOOLS = [
   OrganizationTools.ORGANIZATION_MEMBER_REMOVE,
   OrganizationTools.ORGANIZATION_MEMBER_LIST,
   OrganizationTools.ORGANIZATION_MEMBER_UPDATE_ROLE,
+  OrganizationTools.ORGANIZATION_SEATS_GET,
+  OrganizationTools.ORGANIZATION_SEATS_SET,
 
   // Connection collection tools
   ConnectionTools.COLLECTION_CONNECTIONS_CREATE,

--- a/apps/mesh/src/tools/organization/index.ts
+++ b/apps/mesh/src/tools/organization/index.ts
@@ -41,3 +41,6 @@ export { ORGANIZATION_MEMBER_ADD } from "./member-add";
 export { ORGANIZATION_MEMBER_REMOVE } from "./member-remove";
 export { ORGANIZATION_MEMBER_LIST } from "./member-list";
 export { ORGANIZATION_MEMBER_UPDATE_ROLE } from "./member-update-role";
+
+// Seats (per-seat billing)
+export { ORGANIZATION_SEATS_GET, ORGANIZATION_SEATS_SET } from "./seats";

--- a/apps/mesh/src/tools/organization/member-remove.ts
+++ b/apps/mesh/src/tools/organization/member-remove.ts
@@ -56,7 +56,7 @@ export const ORGANIZATION_MEMBER_REMOVE = defineTool({
     }
 
     // Remove member via Better Auth
-    await ctx.boundAuth.organization.removeMember({
+    const removed = await ctx.boundAuth.organization.removeMember({
       organizationId,
       memberIdOrEmail: input.memberIdOrEmail,
     });
@@ -66,6 +66,23 @@ export const ORGANIZATION_MEMBER_REMOVE = defineTool({
     // for removed members since the DB row is gone.
 
     const actorId = getUserId(ctx);
+
+    // Release the member's paid seat (lifecycle pairing with membership):
+    // without this, a removed member's seat keeps counting toward the org's
+    // bill and gateway allowance forever. Fail-soft: seat release must never
+    // make the (already completed) removal report failure.
+    const removedUserId = removed?.member?.userId;
+    if (removedUserId) {
+      try {
+        await ctx.storage.organizationBilling.releaseSeatOnMemberRemoval(
+          organizationId,
+          removedUserId,
+          actorId ?? "system",
+        );
+      } catch (err) {
+        console.error("Failed to release paid seat on member removal:", err);
+      }
+    }
     if (actorId) {
       posthog.capture({
         distinctId: actorId,

--- a/apps/mesh/src/tools/organization/member-remove.ts
+++ b/apps/mesh/src/tools/organization/member-remove.ts
@@ -55,8 +55,10 @@ export const ORGANIZATION_MEMBER_REMOVE = defineTool({
       );
     }
 
-    // Remove member via Better Auth
-    const removed = await ctx.boundAuth.organization.removeMember({
+    // Remove member via Better Auth. The paid-seat release happens in the
+    // afterRemoveMember organization hook (auth/index.ts) — the canonical
+    // removal boundary, covering every path, not just this tool.
+    await ctx.boundAuth.organization.removeMember({
       organizationId,
       memberIdOrEmail: input.memberIdOrEmail,
     });
@@ -66,23 +68,6 @@ export const ORGANIZATION_MEMBER_REMOVE = defineTool({
     // for removed members since the DB row is gone.
 
     const actorId = getUserId(ctx);
-
-    // Release the member's paid seat (lifecycle pairing with membership):
-    // without this, a removed member's seat keeps counting toward the org's
-    // bill and gateway allowance forever. Fail-soft: seat release must never
-    // make the (already completed) removal report failure.
-    const removedUserId = removed?.member?.userId;
-    if (removedUserId) {
-      try {
-        await ctx.storage.organizationBilling.releaseSeatOnMemberRemoval(
-          organizationId,
-          removedUserId,
-          actorId ?? "system",
-        );
-      } catch (err) {
-        console.error("Failed to release paid seat on member removal:", err);
-      }
-    }
     if (actorId) {
       posthog.capture({
         distinctId: actorId,

--- a/apps/mesh/src/tools/organization/seats.ts
+++ b/apps/mesh/src/tools/organization/seats.ts
@@ -1,0 +1,145 @@
+/**
+ * ORGANIZATION_SEATS_GET / ORGANIZATION_SEATS_SET
+ *
+ * Per-seat billing management. Seats are monetization, orthogonal to Better
+ * Auth roles: a paid seat unlocks mutations + AI spend when the deployment
+ * enforces billing (STUDIO_BILLING_ENFORCED); a free seat is readonly. GET is
+ * readOnlyHint so even free-seat members can render the members/billing page.
+ *
+ * SET currently applies only to `invoiced` (contract) orgs — their admins
+ * toggle seats freely and the seat_change_log is the end-of-cycle invoicing
+ * source. `self_serve` orgs get their SET path with the Stripe integration
+ * (checkout/proration), and legacy orgs have no seats to manage.
+ */
+
+import { z } from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, getUserId } from "../../core/studio-context";
+import { SeatTargetNotMemberError } from "../../storage/organization-billing";
+
+const BillingSchema = z.object({
+  legacy: z.boolean(),
+  billingMode: z.string(),
+  status: z.string(),
+  includedReportUrl: z.string().nullable(),
+});
+
+export const ORGANIZATION_SEATS_GET = defineTool({
+  name: "ORGANIZATION_SEATS_GET",
+  description:
+    "Get the organization's billing identity and which members hold paid seats.",
+  annotations: {
+    title: "Get Organization Seats",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    /** null = org predates billing entirely (no row — treated as legacy). */
+    billing: BillingSchema.nullable(),
+    paidSeatUserIds: z.array(z.string()),
+  }),
+
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const organizationId = ctx.organization?.id;
+    if (!organizationId) {
+      throw new Error("Organization context required");
+    }
+
+    const [billing, paidSeatUserIds] = await Promise.all([
+      ctx.storage.organizationBilling.getBilling(organizationId),
+      ctx.storage.organizationBilling.listPaidSeatUserIds(organizationId),
+    ]);
+
+    return {
+      billing: billing
+        ? {
+            legacy: billing.legacy,
+            billingMode: billing.billingMode,
+            status: billing.status,
+            includedReportUrl: billing.includedReportUrl,
+          }
+        : null,
+      paidSeatUserIds,
+    };
+  },
+});
+
+export const ORGANIZATION_SEATS_SET = defineTool({
+  name: "ORGANIZATION_SEATS_SET",
+  description:
+    "Set members' seats (paid/free). Currently available for invoiced (contract) organizations only; self-serve organizations change seats through checkout.",
+  annotations: {
+    title: "Set Organization Seats",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: z.object({
+    seats: z
+      .array(
+        z.object({
+          userId: z.string().min(1),
+          seat: z.enum(["paid", "free"]),
+        }),
+      )
+      .min(1)
+      .max(200),
+  }),
+  outputSchema: z.object({
+    /** Transitions actually applied — no-ops are skipped and not logged. */
+    applied: z.array(
+      z.object({ userId: z.string(), seat: z.enum(["paid", "free"]) }),
+    ),
+    paidSeatCount: z.number(),
+  }),
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const organizationId = ctx.organization?.id;
+    if (!organizationId) {
+      throw new Error("Organization context required");
+    }
+    const changedBy = getUserId(ctx);
+    if (!changedBy) {
+      throw new Error("User ID required");
+    }
+
+    const billing =
+      await ctx.storage.organizationBilling.getBilling(organizationId);
+    if (!billing || billing.legacy) {
+      throw new Error(
+        "This organization is on the legacy plan — seats do not apply.",
+      );
+    }
+    if (billing.billingMode !== "invoiced") {
+      // TODO(billing/phase-3): self_serve seat changes go through Stripe
+      // preview + prorated charge before they land here.
+      throw new Error(
+        "Self-serve seat changes require checkout, which is not available yet.",
+      );
+    }
+
+    try {
+      const result = await ctx.storage.organizationBilling.setSeats(
+        organizationId,
+        input.seats,
+        changedBy,
+      );
+      // TODO(billing/2.8): syncOrgBenefits(organizationId) — gateway
+      // allowance (paid_seats × $5) + reports weekly-run schedule.
+      return result;
+    } catch (err) {
+      if (err instanceof SeatTargetNotMemberError) {
+        throw new Error(err.message);
+      }
+      throw err;
+    }
+  },
+});

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -72,6 +72,8 @@ const ALL_TOOL_NAMES = [
   "ORGANIZATION_MEMBER_REMOVE",
   "ORGANIZATION_MEMBER_LIST",
   "ORGANIZATION_MEMBER_UPDATE_ROLE",
+  "ORGANIZATION_SEATS_GET",
+  "ORGANIZATION_SEATS_SET",
   // Connection tools
   "COLLECTION_CONNECTIONS_CREATE",
   "COLLECTION_CONNECTIONS_LIST",
@@ -405,6 +407,17 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     name: "ORGANIZATION_MEMBER_UPDATE_ROLE",
     description: "Update member roles",
     category: "Organizations",
+  },
+  {
+    name: "ORGANIZATION_SEATS_GET",
+    description: "Get billing identity and paid seats",
+    category: "Organizations",
+  },
+  {
+    name: "ORGANIZATION_SEATS_SET",
+    description: "Set members' seats (paid/free)",
+    category: "Organizations",
+    dangerous: true,
   },
   // Connection tools
   {
@@ -1185,6 +1198,10 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "ORGANIZATION_MEMBER_ADD",
       "ORGANIZATION_MEMBER_REMOVE",
       "ORGANIZATION_MEMBER_UPDATE_ROLE",
+      // Seats live on the members page and change who the org pays for —
+      // same trust tier as adding/removing the member itself.
+      "ORGANIZATION_SEATS_GET",
+      "ORGANIZATION_SEATS_SET",
       // Approving/denying join requests adds members, and the UI lives on the
       // members page — keep it under members:manage.
       "ORGANIZATION_JOIN_REQUEST_LIST",


### PR DESCRIPTION
## Summary

Task 2.5 of the per-seat plan (builds on #5117). Backend for seat management — the piece that unlocks managing contract (`invoiced`) orgs in-product; UI (2.6) and gateway benefits sync (2.8) come next.

- **Migration 140** `seat_change_log`: append-only seat transitions, written in the same transaction as the `organization_paid_seat` change. For `invoiced` orgs this IS the billing source (end-of-cycle boleto reads who held a paid seat when), so rows are appended **only for actual transitions** — a no-op "set paid on already-paid" writes nothing.
- **`OrganizationBillingStorage`** (`ctx.storage.organizationBilling`): `getBilling`, `listPaidSeatUserIds`, `setSeats` (transactional; validates every target is a current member — any unknown user rejects the whole batch, so a stale UI can't bill a ghost), `releaseSeatOnMemberRemoval`.
- **`ORGANIZATION_SEATS_GET`** — `readOnlyHint: true`, so free-seat members can render the members/billing page through the seat gate. **`ORGANIZATION_SEATS_SET`** — `members:manage` capability (seats change who the org pays for; same trust tier as removing the member). SET gates on `billing_mode`: `invoiced` applies directly; `self_serve` errors until the Stripe checkout path (phase 3); `legacy` errors (no seats).
- **Lifecycle pairing**: `ORGANIZATION_MEMBER_REMOVE` now releases the removed member's paid seat + logs it (fail-soft — release failure never fails the completed removal). `boundAuth.removeMember` now returns Better Auth's result (it carries the removed `userId`).

## Testing

- New real-Postgres integration suite (`organization-billing.integration.test.ts`, `Storage Integration` workflow): transition-exact logging, replay idempotency (nothing applied/logged), batch atomicity on unknown members, seat release on removal, `getBilling` mapping + missing-row null. 4/4 green locally against a migrated Postgres 16.
- Registry/core suites green (89), full-workspace `bun run check` green, `knip` clean, `bun run fmt` applied. The 8 pre-existing env-dependent tool-test failures are identical on main (verified via stash).
- Still dormant end to end: without `STUDIO_BILLING_ENFORCED` nothing consults seats, and no org has `billing_mode = invoiced` until flipped manually for the pilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backend seat management for invoiced orgs with transactional seat changes and an append-only change log. Seat lifecycle now runs at Better Auth membership hooks to auto-release/reset seats and make orphan rows harmless; enforcement stays behind `STUDIO_BILLING_ENFORCED`; UI and self-serve checkout come later.

- New Features
  - `OrganizationBillingStorage`: `getBilling`, `listPaidSeatUserIds` (JOINs `member` so stale rows never count), `setSeats` (atomic, member-validated; logs only real transitions), `releaseSeat`.
  - Tools: `ORGANIZATION_SEATS_GET` (readOnlyHint) and `ORGANIZATION_SEATS_SET` (under `members:manage`, applies only to `invoiced`; `self_serve` errors, `legacy` has no seats).
  - Membership hooks: `afterRemoveMember` releases any paid seat; `afterAddMember` drops stale rows on rejoin. Both fail-soft.

- Migration
  - New table: `seat_change_log` (append-only) + index on `organization_id, created_at`.
  - Registered as migration `140`; no behavior change until the flag is enabled.

<sup>Written for commit fa0eb12baf953f0b2e0f8d965c39637c6b7473c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

