### PR TITLE
fix(settings): validate PORT instead of silently defaulting to 3000

### DIFF
--- a/apps/mesh/src/settings/resolve-config.test.ts
+++ b/apps/mesh/src/settings/resolve-config.test.ts
@@ -103,6 +103,35 @@ describe("resolveConfig database pool max", () => {
   );
 });
 
+describe("resolveConfig port", () => {
+  it("defaults to 3000 when unset", () => {
+    const result = resolveConfig(flags, {});
+
+    expect(result.settings.port).toBe(3000);
+  });
+
+  it("uses PORT when set", () => {
+    const result = resolveConfig(flags, { PORT: "8080" });
+
+    expect(result.settings.port).toBe(8080);
+  });
+
+  it("prefers the --port flag over PORT", () => {
+    const result = resolveConfig({ ...flags, port: "9000" }, { PORT: "8080" });
+
+    expect(result.settings.port).toBe(9000);
+  });
+
+  it.each(["abc", "0", "-1", "1.5", "Infinity"])(
+    "throws for invalid PORT %p",
+    (value) => {
+      expect(() => resolveConfig(flags, { PORT: value })).toThrow(
+        "PORT must be a positive integer",
+      );
+    },
+  );
+});
+
 describe("resolveConfig deployment admin emails", () => {
   it("defaults to an empty list when unset", () => {
     const result = resolveConfig(flags, {});

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -134,7 +134,7 @@ export function resolveConfig(
   const settings: Omit<Settings, "databaseUrl" | "natsUrls"> = {
     // Core
     nodeEnv,
-    port: Number(flags.port) || Number(envVars.PORT) || 3000,
+    port: toPositiveIntegerOrDefault("PORT", flags.port || envVars.PORT, 3000),
     baseUrl: flags.baseUrl || envVars.BASE_URL,
     dataDir,
 


### PR DESCRIPTION
Follows #5123, which hardened `DATABASE_POOL_MAX` to reject malformed values via a new `toPositiveIntegerOrDefault` helper instead of silently defaulting. `port` in the same `resolveConfig` function still had the old pattern: `Number(flags.port) || Number(envVars.PORT) || 3000`.

**Payoff:** a typo'd or malformed `PORT` (e.g. `PORT=abc`, `PORT=-1`, `PORT=0`) currently falls back to 3000 with zero warning, so a deploy silently binds to the wrong port instead of failing fast at startup — exactly the class of bug #5123 just fixed for the pool-size setting.

**Fix:** reuse the existing `toPositiveIntegerOrDefault` helper for `port`, keeping the `--port` flag > `PORT` env var precedence, defaulting to 3000 only when neither is set, and throwing `PORT must be a positive integer` otherwise.

**Reviewer check:** `cd apps/mesh && bun test src/settings/resolve-config.test.ts`

**Verified locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace), and the targeted test file above (32 pass). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `PORT` in mesh config and fail fast on invalid values instead of silently defaulting to 3000. Keeps `--port` > `PORT` precedence and only defaults to 3000 when both are unset.

- **Bug Fixes**
  - Use `toPositiveIntegerOrDefault("PORT", flags.port || envVars.PORT, 3000)` in `resolveConfig`.
  - Throw a clear error for invalid values (e.g., "abc", "0", "-1", "1.5", "Infinity").
  - Add tests for defaulting, env/flag precedence, and invalid inputs.

<sup>Written for commit ce6fcc36ec95de7a72a5d8037e5a5c15cd17415d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

