### PR TITLE
fix(cms-tour): only anchor the submit step on the create-PR state

### DIFF
--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -466,7 +466,13 @@ function HeaderButtonRenderer(props: {
           size="sm"
           variant={button.variant}
           disabled={disabled}
-          data-tour={TOUR_ANCHORS.submit}
+          // Only anchor the tour's "submit for review" step when the button is
+          // actually in that state. In neutral states (e.g. "Up to date", which
+          // is disabled and has no action) the step would point at an unrelated
+          // button; leaving the anchor off lets the tour skip the step.
+          data-tour={
+            button.action === "create-pr" ? TOUR_ANCHORS.submit : undefined
+          }
           onClick={() => {
             if (button.action) props.onActivate(button.action);
           }}


### PR DESCRIPTION
## Summary

Follow-up fix for the CMS visual tour (shipped in #5055).

The "submit for review" step anchored `tour-submit` on the header's **primary action button unconditionally**. In neutral states — notably **"Up to date"** (disabled, no `action`) — the step highlighted that button, so the spotlight landed on a control whose label ("Atualizado") contradicts the step copy ("Enviar para revisão").

## Fix

Gate the anchor on the button actually being in the submit state:

```tsx
data-tour={button.action === "create-pr" ? TOUR_ANCHORS.submit : undefined}
```

When the branch is up-to-date (or in any non-submit state), the anchor is absent and driver.js skips the step via `skipMissingElement`. `tour-publish` was already state-gated (green Publish side button / merge-split only render when there's something to publish), so no change needed there.

## Testing

- `bunx tsc` — 0 errors
- `bun run lint` — clean
- Verified `create-pr` is the submit-for-review action in `panel-state.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CMS visual tour so the “Submit for review” step only shows when the primary action is actually submit (create PR). Prevents highlighting the disabled “Up to date” button.

- **Bug Fixes**
  - Set `data-tour` only when `button.action === "create-pr"`; otherwise omit the anchor so the tour skips the step.

<sup>Written for commit bedbc9c5bcc43d67f7c126c4c267eddf29c741df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

