### PR TITLE
fix(sandbox): return 409 instead of 500 for a blocked rebase

### DIFF
--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -21,6 +21,18 @@ export interface RebaseOntoBaseOptions {
   operator?: OperatorIdentity;
 }
 
+/**
+ * rebaseOntoBase() refused because of the sandbox's current git state (detached
+ * HEAD, or the checked-out branch is protected) — a conflict with the request,
+ * not a server fault, so the route maps it to 409 like PublishBlockedError.
+ */
+export class RebaseBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RebaseBlockedError";
+  }
+}
+
 function gitEnv(repoDir: string): Record<string, string> {
   return { ...process.env, GIT_CEILING_DIRECTORIES: repoDir };
 }
@@ -326,13 +338,13 @@ function rebaseOntoBaseInner(
 
   const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (!branch || branch === "HEAD") {
-    throw new Error("Cannot rebase from a detached HEAD");
+    throw new RebaseBlockedError("Cannot rebase from a detached HEAD");
   }
   // Same guard as publish() (protect-branch.ts): this ends in a force-push,
   // which is even more destructive than a normal push, so a sandbox sitting
   // on main/master/default must never reach it.
   if (protectedBranches(repoDir).has(branch)) {
-    throw new Error(
+    throw new RebaseBlockedError(
       `Refusing to rebase and force-push protected branch "${branch}" from a sandbox. Work on a feature branch; changes reach the default branch via PR.`,
     );
   }

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -726,4 +726,19 @@ describe("git routes", () => {
       error: "Invalid base branch name: --upload-pack=evil",
     });
   });
+
+  it("rebase route returns 409 (not 500) for a protected-branch refusal", async () => {
+    const { appRoot, repoDir } = initRepo(); // initRepo checks out main
+    const handler = makeGitRebaseHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/rebase", {
+        method: "POST",
+        body: JSON.stringify({ base: "main" }),
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/protected branch "main"/);
+  });
 });

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -5,7 +5,7 @@ import { appendCoAuthorTrailer } from "../../git-co-author";
 import { computeBranchDivergence } from "../git/branch-divergence";
 import { parsePorcelainFiles } from "../git/porcelain";
 import { protectedBranches } from "../git/protect-branch";
-import { rebaseOntoBase } from "../git/rebase-onto-base";
+import { RebaseBlockedError, rebaseOntoBase } from "../git/rebase-onto-base";
 import {
   cloneUrlHasCredentials,
   syncOriginRemote,
@@ -833,6 +833,11 @@ export function makeGitRebaseHandler(deps: GitDeps) {
     } catch (err) {
       if (err instanceof InvalidRemoteBranchNameError) {
         return jsonResponse({ error: err.message }, 400);
+      }
+      // A detached HEAD / protected-branch refusal is a conflict with the
+      // sandbox's current state, not a server fault (mirrors publish() above).
+      if (err instanceof RebaseBlockedError) {
+        return jsonResponse({ error: err.message }, 409);
       }
       return jsonResponse({ error: formatGitError(err) }, 500);
     }


### PR DESCRIPTION
**Source:** bug found while auditing `packages/sandbox/daemon/routes/git.ts` for error-propagation gaps in the sandbox git rebase flow.

**Payoff:** `publish()` already distinguishes a client/data conflict (detached HEAD, protected branch) from a real server fault via `PublishBlockedError` → 409, so the UI can show a clear "can't publish from here" message instead of a generic error. `rebaseOntoBase()` has the exact same two guards (detached HEAD, protected branch — it's even more destructive since it force-pushes) but threw a plain `Error`, which `makeGitRebaseHandler` fell through to a generic 500. A sandbox sitting on `main` and hitting "sync with base" got an opaque server-error toast instead of the same clear conflict message publish gets.

**Fix:** added `RebaseBlockedError` in `rebase-onto-base.ts` (mirrors `PublishBlockedError`), thrown for the detached-HEAD and protected-branch cases, and mapped to 409 in `makeGitRebaseHandler`. Added a regression test (`rebase route returns 409 (not 500) for a protected-branch refusal`) mirroring the existing publish-route test of the same shape.

**Verify:** `bun test packages/sandbox/daemon/routes/git.test.ts` and `bun test packages/sandbox/daemon/git/rebase-onto-base.test.ts`.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox`, and the two targeted test files above (32 + 2 tests, all green). Full CI validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 409 (Conflict) instead of 500 when a rebase is blocked by a detached HEAD or a protected branch, so the UI shows a clear “can’t rebase from here” message. Aligns `/git/rebase` with `publish()` behavior.

- **Bug Fixes**
  - Added `RebaseBlockedError` in `packages/sandbox/daemon/git/rebase-onto-base.ts` for detached HEAD and protected-branch checks.
  - Mapped `RebaseBlockedError` to 409 in `makeGitRebaseHandler` for the `/git/rebase` route.
  - Added a regression test to assert 409 on protected-branch refusal.

<sup>Written for commit c9fac51dd46832bcb2514eef39a014006172d7e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

