### PR TITLE
fix(settings): validate CLICKHOUSE_MAX_MEMORY_USAGE instead of silently ignoring invalid values

### DIFF
--- a/apps/mesh/src/settings/resolve-config.test.ts
+++ b/apps/mesh/src/settings/resolve-config.test.ts
@@ -132,6 +132,31 @@ describe("resolveConfig port", () => {
   );
 });
 
+describe("resolveConfig clickhouse max memory usage", () => {
+  it("defaults to undefined when unset", () => {
+    const result = resolveConfig(flags, {});
+
+    expect(result.settings.clickhouseMaxMemoryUsage).toBeUndefined();
+  });
+
+  it("uses CLICKHOUSE_MAX_MEMORY_USAGE when set", () => {
+    const result = resolveConfig(flags, {
+      CLICKHOUSE_MAX_MEMORY_USAGE: "1000000000",
+    });
+
+    expect(result.settings.clickhouseMaxMemoryUsage).toBe(1000000000);
+  });
+
+  it.each(["abc", "0", "-1", "1.5", "Infinity"])(
+    "throws for invalid value %p",
+    (value) => {
+      expect(() =>
+        resolveConfig(flags, { CLICKHOUSE_MAX_MEMORY_USAGE: value }),
+      ).toThrow("CLICKHOUSE_MAX_MEMORY_USAGE must be a positive integer");
+    },
+  );
+});
+
 describe("resolveConfig deployment admin emails", () => {
   it("defaults to an empty list when unset", () => {
     const result = resolveConfig(flags, {});

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -57,6 +57,19 @@ function toPositiveIntegerOrDefault(
   return numberValue;
 }
 
+function toPositiveIntegerOrUndefined(
+  name: string,
+  value: string | undefined,
+): number | undefined {
+  if (value === undefined || value === "") return undefined;
+
+  const numberValue = Number(value);
+  if (!Number.isSafeInteger(numberValue) || numberValue <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return numberValue;
+}
+
 /** Tri-state flag: unset/empty → `fallback`, otherwise parse as boolean. */
 function toBoolWithDefault(
   value: string | undefined,
@@ -160,8 +173,10 @@ export function resolveConfig(
 
     // Observability
     clickhouseUrl: envVars.CLICKHOUSE_URL,
-    clickhouseMaxMemoryUsage:
-      Number(envVars.CLICKHOUSE_MAX_MEMORY_USAGE) || undefined,
+    clickhouseMaxMemoryUsage: toPositiveIntegerOrUndefined(
+      "CLICKHOUSE_MAX_MEMORY_USAGE",
+      envVars.CLICKHOUSE_MAX_MEMORY_USAGE,
+    ),
     monitoringOtlpEndpoint: envVars.MONITORING_OTLP_ENDPOINT,
     otelServiceName: envVars.OTEL_SERVICE_NAME || "studio",
 


### PR DESCRIPTION
Follows #5129 (PORT validation) and the same pattern applied to DUCKDB_THREADS in #5130 — `resolve-config.ts` has more than one env var that silently swallows a bad value instead of failing loudly.

`clickhouseMaxMemoryUsage` was computed as `Number(envVars.CLICKHOUSE_MAX_MEMORY_USAGE) || undefined`. Any non-numeric or invalid value (`"abc"`, `"-1"`, `"1.5"`) silently produces `NaN` which then falls through `|| undefined`, so a typo in this env var quietly disables the ClickHouse memory-limit engine option in production instead of failing startup — the same failure mode PORT and DUCKDB_THREADS just got fixed for.

**Fix:** added a `toPositiveIntegerOrUndefined` helper (same shape as the existing `toPositiveIntegerOrDefault` used for PORT/DATABASE_POOL_MAX) and use it for `CLICKHOUSE_MAX_MEMORY_USAGE`. Unset/empty still resolves to `undefined` (unchanged default behavior — `context-factory.ts`'s `settings.clickhouseMaxMemoryUsage ? {...} : ...` check is unaffected), but an invalid value now throws `"CLICKHOUSE_MAX_MEMORY_USAGE must be a positive integer"` at startup instead of being silently dropped.

**To verify:** `bun test apps/mesh/src/settings/resolve-config.test.ts`

**Locally ran:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace), and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `CLICKHOUSE_MAX_MEMORY_USAGE` as a positive integer and fail fast on invalid values. This prevents silently disabling the ClickHouse memory limit.

- **Bug Fixes**
  - Added `toPositiveIntegerOrUndefined` and used it for `CLICKHOUSE_MAX_MEMORY_USAGE`.
  - Unset/empty stays `undefined`; invalid values now throw "CLICKHOUSE_MAX_MEMORY_USAGE must be a positive integer" at startup.
  - Added tests for default, valid, and invalid values in `resolve-config.test.ts`.

<sup>Written for commit 02050425bba31de1e904719d097c9968d3983030. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

