### PR TITLE
fix(chat): only show copied checkmark after clipboard write succeeds

### DIFF
--- a/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
+++ b/apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx
@@ -96,9 +96,10 @@ export function ConnectDesktopDialog({
               variant="ghost"
               size="icon-sm"
               onClick={() => {
-                navigator.clipboard.writeText(INSTALL_SNIPPET);
-                setCopied(true);
-                setTimeout(() => setCopied(false), 1500);
+                navigator.clipboard.writeText(INSTALL_SNIPPET).then(() => {
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 1500);
+                });
               }}
             >
               {copied ? <Check size={14} /> : <Copy01 size={14} />}


### PR DESCRIPTION
**Source:** bug found while auditing desktop-linking UI (`apps/mesh/src/web/components/chat/connect-desktop-dialog.tsx`) for the desktop-launcher-resilience focus area. Note: the area hint pointed at `apps/mesh/src/web/desktop/` (the Tauri launcher), but that directory doesn't exist on `main` yet — it's only introduced by the still-open PR #4178 — so I audited the existing desktop-linking surface that does live on main instead.

**The bug:** the install-snippet copy button called `navigator.clipboard.writeText(...)` and then immediately, synchronously, set `copied = true` (showing a checkmark) without waiting for the write to resolve. If the write rejects — document not focused, clipboard permission denied, etc. — the UI still claims success and the rejected promise is left unhandled (console warning). Every other clipboard-copy call site in `apps/mesh/src/web` (`account-popover.tsx`, `markdown.tsx`, `preview.tsx`, `webhook-secret-dialog.tsx`, ...) awaits or chains `.then()`/`.catch()` before touching UI state — this one didn't.

**Fix:** chain the state update inside `.then()` so the checkmark only appears once the write actually succeeds, matching the pattern used everywhere else in the codebase (e.g. `account-popover.tsx`).

**Failure scenario:** user clicks copy while the tab/window isn't focused (a plausible state right after switching to read the `bunx decocms@latest link` snippet) → `writeText` rejects → checkmark still shows, clipboard is actually empty, and the user pastes nothing into their terminal.

**To confirm:** `cd apps/mesh && bunx tsc --noEmit` (green); read the diff — it's a 1-line control-flow change with no type/behavior surface beyond the click handler.

**Verified locally:** `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (no new errors introduced by this change — a pre-existing unrelated error in an untracked `backfill-assets.test.ts` file in this worktree is unaffected). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix copy button feedback in ConnectDesktopDialog: show the checkmark only after navigator.clipboard.writeText succeeds. Prevents false success when clipboard write fails (e.g., tab not focused or permission denied) and avoids unhandled promise rejections.

<sup>Written for commit 801a7002f15531350a28dcdf4ab459f36e1f3823. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

