### PR TITLE
fix(registry): guard Enter-key token save against duplicate submission

### DIFF
--- a/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
+++ b/apps/mesh/src/web/views/registry/monitor-connections-panel.tsx
@@ -561,7 +561,7 @@ function ConnectionRow({
               onChange={(e) => setTokenValue(e.target.value)}
               className="h-8 text-xs flex-1"
               onKeyDown={(e) => {
-                if (e.key === "Enter") {
+                if (e.key === "Enter" && !busy && tokenValue.trim()) {
                   handleSaveToken();
                 }
               }}


### PR DESCRIPTION
Bug: in the registry connection monitor's manual API-token field (`monitor-connections-panel.tsx`), the Save *button* correctly disables while a save is in flight (`disabled={busy || !tokenValue.trim()}`), but the Input's `onKeyDown` handler called `handleSaveToken()` on Enter with no such guard. A held-down or repeated Enter keypress while a prior save (which awaits `saveTokenInternal` + `markAuthenticated` + `probeQuery.refetch()`) is still pending fires `COLLECTION_CONNECTIONS_UPDATE` concurrently again, racing the in-flight save/probe cycle.

Why a maintainer wants this: it's a one-line concurrency fix that closes a duplicate-submission path a reviewer would otherwise flag — and the codebase already has an established convention for exactly this class of guard: `apps/mesh/src/web/views/settings/brand-form-sections.tsx:101` guards its own Enter handler with `e.key === "Enter" && domain.trim() && !isExtracting`. This PR brings the token-save Enter handler in line with that same pattern (`!busy && tokenValue.trim()`), matching the Save button's own disabled condition.

Failure scenario: user pastes a token, presses Enter, and (via key-repeat or a fast double-press) presses Enter again before `busy` re-renders false — a second `handleSaveToken()` fires and issues a second concurrent `COLLECTION_CONNECTIONS_UPDATE` call for the same connection.

No new test added: `ConnectionRow` isn't exported and exercising this requires mocking `useProjectContext`/`useMCPClient`/multiple react-query hooks that no existing test in this file sets up — disproportionate scaffolding for a one-line guard. Verified instead via typecheck and the existing component test.

Reviewer check: `cd apps/mesh && bunx tsc --noEmit` (clean on this file), and `bun test apps/mesh/src/web/views/registry/monitor-connections-panel.test.tsx` (passes, 1/1).

Locally ran: `bun run fmt` (no changes), targeted `bunx tsc --noEmit` in apps/mesh (no errors on this file), and the single existing test file for this component (passes). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard the Enter key in the registry connection monitor’s token input to prevent duplicate submissions. In `monitor-connections-panel.tsx`, the input now saves only when `!busy && tokenValue.trim()`, matching the Save button and avoiding concurrent updates.

<sup>Written for commit 720087cc1afed7c62d1b7fed6b859a8f616d6eb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

