### PR TITLE
fix(home): enforce HOME_LIMIT inside the writer transform, not a stale pre-check

### DIFF
--- a/apps/mesh/src/web/components/home/add-tile-drawer.test.ts
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { HOME_LIMIT, nextHomeIdsWithAdd } from "./add-tile-drawer";
+
+describe("nextHomeIdsWithAdd", () => {
+  test("appends when under the limit", () => {
+    expect(nextHomeIdsWithAdd(["a"], "b")).toEqual(["a", "b"]);
+  });
+
+  test("is a no-op when the id is already present", () => {
+    expect(nextHomeIdsWithAdd(["a", "b"], "a")).toBeNull();
+  });
+
+  test("is a no-op once the live count reaches HOME_LIMIT", () => {
+    const ids = Array.from({ length: HOME_LIMIT }, (_, i) => `agent-${i}`);
+    expect(nextHomeIdsWithAdd(ids, "new-agent")).toBeNull();
+  });
+
+  test("ignores dead (unresolvable) ids when checking capacity", () => {
+    const ids = [
+      ...Array.from({ length: HOME_LIMIT }, (_, i) => `live-${i}`),
+      "dead-1",
+      "dead-2",
+    ];
+    const validIds = new Set(ids.filter((id) => id.startsWith("live-")));
+    // Every slot is already taken by a *live* agent, so still blocked...
+    expect(nextHomeIdsWithAdd(ids, "new-agent", validIds)).toBeNull();
+
+    // ...but freeing a live slot (simulating a concurrent remove that already
+    // landed in the cache) lets the add through even with dead ids present.
+    const withRoom = ids.filter((id) => id !== "live-0");
+    expect(nextHomeIdsWithAdd(withRoom, "new-agent", validIds)).toEqual([
+      ...withRoom,
+      "new-agent",
+    ]);
+  });
+
+  test("two concurrent adds against the same live snapshot both resolve at the limit, but applying them in sequence against fresh ids only lets the first one through", () => {
+    const ids = Array.from({ length: HOME_LIMIT - 1 }, (_, i) => `agent-${i}`);
+    // Simulates the writer's serialized chain: each call sees the ids left by
+    // the previous one, not a stale render-time snapshot.
+    const afterFirst = nextHomeIdsWithAdd(ids, "agent-x");
+    expect(afterFirst).not.toBeNull();
+    const afterSecond = nextHomeIdsWithAdd(afterFirst as string[], "agent-y");
+    expect(afterSecond).toBeNull();
+  });
+});

--- a/apps/mesh/src/web/components/home/add-tile-drawer.tsx
+++ b/apps/mesh/src/web/components/home/add-tile-drawer.tsx
@@ -90,6 +90,26 @@ import { useT } from "@/web/i18n/use-t.ts";
  * blocked so the user never pins something that silently won't show. */
 export const HOME_LIMIT = 8;
 
+/** Adds `id` to the ordered home-agent list if there's room, or returns
+ * `null` (no-op) if it's already there or the live (non-dead) count is
+ * already at HOME_LIMIT. Must run *inside* the writer's transform — it's
+ * given the ids live at write time, not a render-time snapshot — so two
+ * adds started concurrently (e.g. two pins whose mutations are both still
+ * in flight) can't both pass a stale under-limit check and push the count
+ * past HOME_LIMIT. */
+export function nextHomeIdsWithAdd(
+  ids: string[],
+  id: string,
+  validIds?: ReadonlySet<string>,
+): string[] | null {
+  if (ids.includes(id)) return null;
+  const liveCount = validIds
+    ? ids.filter((x) => validIds.has(x)).length
+    : ids.length;
+  if (liveCount >= HOME_LIMIT) return null;
+  return [...ids, id];
+}
+
 interface AddTileDrawerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -189,10 +209,8 @@ function useHomeBoard(validIds?: ReadonlySet<string>) {
     : homeIds.length;
   const atLimit = liveCount >= HOME_LIMIT;
 
-  const addAgent = (id: string) => {
-    if (isOnHome(id) || atLimit) return Promise.resolve();
-    return writer.apply((ids) => (ids.includes(id) ? null : [...ids, id]));
-  };
+  const addAgent = (id: string) =>
+    writer.apply((ids) => nextHomeIdsWithAdd(ids, id, validIds));
   const removeAgent = (id: string) =>
     writer.apply((ids) => ids.filter((x) => x !== id));
   const reorder = (next: string[]) => writer.apply(() => next);
@@ -207,11 +225,7 @@ function useHomeBoard(validIds?: ReadonlySet<string>) {
       id: agent.id,
       data: { metadata: nextMetadata },
     });
-    if (!isOnHome(agent.id) && !atLimit) {
-      await writer.apply((ids) =>
-        ids.includes(agent.id) ? null : [...ids, agent.id],
-      );
-    }
+    await writer.apply((ids) => nextHomeIdsWithAdd(ids, agent.id, validIds));
     await refetchHome();
   };
 


### PR DESCRIPTION
Bug found while auditing `apps/mesh/src/web/components/home/add-tile-drawer.tsx` for stale-state/concurrency issues in the home board.

**Failure scenario:** `useHomeBoard`'s `addAgent` and `saveAgentMetadata` gated the `HOME_LIMIT` (8) check on `atLimit`, a boolean captured from the *render-time* home-agent count, then only applied the actual add to the ordered id list afterwards via the serialized `writer.apply`. If two adds are kicked off before either resolves — e.g. the user expands two different agents in the drawer and pins a UI tile on each while the first pin's `PATCH` is still in flight — both closures see the same pre-mutation `atLimit=false`, both pass the check, and both then call `writer.apply` to append themselves to `default_home_agents.ids`. The writer's transform only dedupes by membership, not capacity, so both appends land and the board silently exceeds `HOME_LIMIT` — which the file's own doc comment says should never happen ("adding past this is blocked so the user never pins something that silently won't show"). The extra agent gets added to the stored list but the home view (capped at 8 tiles) never renders it, so the pin the user just made appears to succeed but silently doesn't show.

**Fix:** extracted the capacity check into `nextHomeIdsWithAdd(ids, id, validIds)`, a pure function that takes the *live* `ids` argument the writer's transform receives at write time (per `useHomeAgentsWriter`'s own contract: each write derives its next list from the live cache, never a render-time snapshot). `addAgent` and `saveAgentMetadata` now call it *inside* `writer.apply`, so the check runs against whatever the previous write in the serialized chain actually landed — the second concurrent add correctly sees the board already full and no-ops instead of exceeding the limit. `atLimit`/`isOnHome` are kept as-is for their existing UI-hint uses (disabling the "+" button, the full-board toast, the `x/8` counter) — only the actual enforcement moved.

Net diff: little logic moved into one small pure helper, no behavior change for the non-concurrent path (verified by the new test's first two cases matching the old dedupe/limit checks).

**Regression test:** `apps/mesh/src/web/components/home/add-tile-drawer.test.ts` — covers append-under-limit, no-op-if-present, no-op-at-limit, dead-id-exclusion from the capacity count, and the concurrent-adds-in-sequence case that reproduces the old bug (second add now correctly blocked once applied against the fresh post-first-add ids).

**Reviewer check:** `bun test apps/mesh/src/web/components/home/add-tile-drawer.test.ts`

**Locally run:** `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace, clean), and the targeted test file above (5/5 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the home board limit by enforcing `HOME_LIMIT` inside the writer transform so concurrent adds can’t exceed 8. UI hints stay the same; only enforcement moved to use live ids.

- **Bug Fixes**
  - Added `nextHomeIdsWithAdd(ids, id, validIds)` and call it inside `writer.apply` in `addAgent` and `saveAgentMetadata`.
  - Checks capacity against live ids (and ignores dead ids) to prevent over-limit on concurrent adds; second add now no-ops.
  - Added tests covering under-limit append, no-op if present/at limit, dead-id handling, and the concurrent-adds sequence.

<sup>Written for commit 318a973de80620a48fee0afe7bd24c254360c55d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

