### PR TITLE
fix(cms-tour): only tour visible anchors; gate start on the toolbar

### DIFF
--- a/apps/mesh/src/web/components/cms-tour/anchors.ts
+++ b/apps/mesh/src/web/components/cms-tour/anchors.ts
@@ -8,8 +8,6 @@
 export const TOUR_ANCHORS = {
   /** The Preview tab in the header (produced generically as `tour-tab-preview`). */
   previewTab: "tour-tab-preview",
-  /** The preview content root — readiness signal that the Preview view is live. */
-  previewRoot: "tour-preview-root",
   dropdown: "tour-dropdown",
   edit: "tour-edit",
   visualEditor: "tour-visual-editor",

--- a/apps/mesh/src/web/components/cms-tour/cms-tour.tsx
+++ b/apps/mesh/src/web/components/cms-tour/cms-tour.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useState } from "react";
-import type { Config, Driver } from "driver.js";
+import type { Config, Driver, DriveStep } from "driver.js";
 import "driver.js/dist/driver.css";
 import "./cms-tour.css";
 import { authClient } from "@/web/lib/auth-client";
@@ -31,16 +31,39 @@ import { tourAnchorSelector } from "./anchors";
 import { buildSteps } from "./steps";
 
 /**
- * The tour only starts once the Preview *content* is mounted (not merely the
- * Preview tab, which is always in the header). This keeps the auto-run from
- * firing a mostly-empty tour when another main view (e.g. Code) is active.
+ * The tour only starts once the preview toolbar is actually on screen. The CMS
+ * toggle anchors an early step and only exists when the Preview view is open
+ * with its toolbar rendered (dev server up), so gating on it — not merely the
+ * Preview root, which can be mounted-but-hidden behind another tab — keeps the
+ * tour from launching in a context where its controls are missing.
  */
-const READY_SELECTOR = tourAnchorSelector("previewRoot");
+const READY_SELECTOR = tourAnchorSelector("edit");
 
 const seenFlag = (userId: string) =>
   makeSeenFlag(LOCALSTORAGE_KEYS.cmsTourSeen(userId));
 
-function buildConfig(t: TFunction): Config {
+/** An anchor counts only when it's in the DOM *and* actually visible (not
+ *  display:none behind an inactive tab, not a zero-box collapsed control). */
+function isAnchorOnScreen(selector: string): boolean {
+  const el = document.querySelector(selector);
+  return el instanceof HTMLElement && el.offsetParent !== null;
+}
+
+/**
+ * Build the step list from only the anchors that are present AND visible right
+ * now. This is what keeps a step from floating over an unrelated spot or
+ * mis-highlighting a hidden control: absent controls (e.g. the branch pill on a
+ * template with no connected repo) simply aren't steps, so the progress count
+ * has no gaps either.
+ */
+function visibleSteps(t: TFunction): DriveStep[] {
+  return buildSteps(t).filter(
+    (step) =>
+      typeof step.element === "string" && isAnchorOnScreen(step.element),
+  );
+}
+
+function buildConfig(t: TFunction, steps: DriveStep[]): Config {
   return {
     showProgress: true,
     progressText: t("cmsTour.progress"),
@@ -54,9 +77,9 @@ function buildConfig(t: TFunction): Config {
     allowClose: true,
     stagePadding: 6,
     stageRadius: 8,
-    // Anchors live across two panels and some appear only once the preview is
-    // live; wait briefly for each and skip any that never show.
-    waitForElement: 2000,
+    // Steps are pre-filtered to currently-visible anchors, so don't wait/float
+    // for an element to appear; skip immediately if one vanishes mid-tour.
+    waitForElement: 0,
     skipMissingElement: true,
     popoverClass: "cms-tour-popover",
     onPopoverRender: (popover, { driver: instance }) => {
@@ -79,7 +102,7 @@ function buildConfig(t: TFunction): Config {
     onDestroyed: () => {
       tourStarted = false;
     },
-    steps: buildSteps(t),
+    steps,
   };
 }
 
@@ -100,21 +123,27 @@ async function loadDriver(): Promise<(config?: Config) => Driver> {
 }
 
 /**
- * Poll (bounded, via rAF) until the Preview content is mounted, then drive the
- * tour. `onStart` fires the moment we commit to driving (used to mark the
- * auto-run seen). If the content never appears — or driver.js fails to load /
- * throws — we release the guard so a later attempt (or the ⋯ re-run) can retry.
+ * Poll (bounded, via rAF) until the preview toolbar is on screen, then drive the
+ * tour over the currently-visible anchors. `onStart` fires the moment we commit
+ * to driving (used to mark the auto-run seen). If the toolbar never appears, no
+ * anchor is visible, or driver.js fails to load / throws, we release the guard
+ * so a later attempt (or the ⋯ re-run) can retry.
  */
 function driveTour(t: TFunction, onStart?: () => void) {
   if (tourStarted) return;
   tourStarted = true;
   let frames = 0;
   const tryStart = () => {
-    if (document.querySelector(READY_SELECTOR)) {
+    if (isAnchorOnScreen(READY_SELECTOR)) {
+      const steps = visibleSteps(t);
+      if (steps.length === 0) {
+        tourStarted = false;
+        return;
+      }
       onStart?.();
       loadDriver()
         .then((driver) => {
-          driver(buildConfig(t)).drive();
+          driver(buildConfig(t, steps)).drive();
         })
         .catch(() => {
           tourStarted = false;

--- a/apps/mesh/src/web/components/cms-tour/cms-tour.tsx
+++ b/apps/mesh/src/web/components/cms-tour/cms-tour.tsx
@@ -75,6 +75,10 @@ function buildConfig(t: TFunction, steps: DriveStep[]): Config {
     showButtons: ["next", "previous"],
     smoothScroll: true,
     allowClose: true,
+    // Look-but-don't-touch: the highlighted control stays non-interactive so a
+    // user can't click e.g. the Preview tab mid-tour, close the view, and strand
+    // the remaining steps with no anchors. Navigation is Next / Back / Skip only.
+    disableActiveInteraction: true,
     stagePadding: 6,
     stageRadius: 8,
     // Steps are pre-filtered to currently-visible anchors, so don't wait/float

--- a/apps/mesh/src/web/components/sandbox/preview/preview.tsx
+++ b/apps/mesh/src/web/components/sandbox/preview/preview.tsx
@@ -1382,10 +1382,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   ) : null;
 
   return (
-    <div
-      className="flex flex-col w-full h-full"
-      data-tour={TOUR_ANCHORS.previewRoot}
-    >
+    <div className="flex flex-col w-full h-full">
       {/* Auto-select the first entity for a picker param with no value yet, so
           navigating to a bare dynamic-route template lands on a real page.
           Each helper renders nothing and unmounts once its param is filled. */}


### PR DESCRIPTION
## Summary

Follow-up polish for the CMS visual tour (shipped in #5055, after the submit-step fix in #5133).

The tour could start with the **Preview view not actually open** — its root can be mounted-but-hidden behind another tab — so steps whose controls live in the preview toolbar had no on-screen anchor. driver.js then floated the popover over an unrelated corner while `waitForElement` counted down, and skipped steps left **gaps in the progress count** (e.g. `5/8 → 7/8` when the branch pill is absent).

## Fix

- **Gate the start on the CMS toggle being visible** (`tour-edit`) — proof the toolbar is really rendered — instead of just the Preview root.
- **Build the step list from only the anchors present AND visible right now** (`offsetParent !== null`), so a step never floats / mis-highlights, and the progress count has no gaps (absent controls simply aren't steps).
- **`waitForElement: 0`** — steps are pre-filtered, so skip instantly if one vanishes mid-tour instead of floating.
- Drop the now-unused `tour-preview-root` anchor.

## Testing

- `bunx tsc` — 0 errors
- `bun test` (cms-tour steps) — pass
- `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CMS visual tour to start only when the preview toolbar is visible, target only visible anchors, and disable clicks on highlighted controls to keep the tour stable.

- **Bug Fixes**
  - Gate auto-start on the CMS toggle (`tour-edit`) being visible instead of the hidden preview root.
  - Build steps from anchors that exist and are visible to avoid mis-highlighting and progress gaps.
  - Disable interaction with highlighted controls (`disableActiveInteraction: true` in `driver.js`) so users can’t close the view mid-tour; use Next/Back/Skip.
  - Set `waitForElement: 0` in `driver.js` to skip instantly if a step disappears.
  - Remove the unused `tour-preview-root` anchor and its markup.

<sup>Written for commit fce4c578328a70f4eb95896636c7ab225b959e03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

