### PR TITLE
fix(task-board): prompt to connect GitHub on every Super Agent assignment

### DIFF
--- a/apps/mesh/src/web/layouts/task-board/index.tsx
+++ b/apps/mesh/src/web/layouts/task-board/index.tsx
@@ -248,12 +248,24 @@ export function TaskBoardPage() {
   const { items, isLoading } = useTaskBoardItems();
   const actions = useTaskBoardItemActions();
   const reportsOnly = useReportsOnly();
-  // Auto-fix hands the task to the Super Agent, which opens a PR — so it needs
-  // an org-level GitHub connection. If the org has none, prompt to connect
+  // Handing a task to the Super Agent makes it open a PR — so it needs an
+  // org-level GitHub connection. Every path that assigns to the Super Agent
+  // (Auto-fix, the lane assignee picker, the task dialog) prompts to connect
   // instead of enqueueing a run that can't push.
   const hasGithub =
     getOrgGithubConnections(useConnections({ slug: "mcp-github" })).length > 0;
   const [connectGithubOpen, setConnectGithubOpen] = useState(false);
+  // Returns true if the assignment was blocked (connect prompt opened) so the
+  // caller stops before dispatching.
+  const blockSuperAgentWithoutGithub = (
+    assigneeId: string | null | undefined,
+  ) => {
+    if (assigneeId === SUPER_AGENT_ASSIGNEE_ID && !hasGithub) {
+      setConnectGithubOpen(true);
+      return true;
+    }
+    return false;
+  };
   const { data: membersData } = useMembers();
   const members = (membersData?.data?.members ?? []) as Member[];
   const memberByUserId = new Map(members.map((m) => [m.userId, m]));
@@ -477,16 +489,15 @@ export function TaskBoardPage() {
           onOpen={openTask}
           onCreate={openCreateInLane}
           onMove={(id, status) => actions.update.mutate({ id, status })}
-          onAssign={(id, userId) =>
-            actions.update.mutate({ id, assigneeId: userId ?? undefined })
-          }
+          onAssign={(id, userId) => {
+            if (blockSuperAgentWithoutGithub(userId)) return;
+            actions.update.mutate({ id, assigneeId: userId ?? undefined });
+          }}
           onAutoFix={
             reportsOnly
               ? (item) => {
-                  if (!hasGithub) {
-                    setConnectGithubOpen(true);
+                  if (blockSuperAgentWithoutGithub(SUPER_AGENT_ASSIGNEE_ID))
                     return;
-                  }
                   actions.update.mutate({
                     id: item.id,
                     assigneeId: SUPER_AGENT_ASSIGNEE_ID,
@@ -531,6 +542,10 @@ export function TaskBoardPage() {
         defaultStatus={createStatus ?? undefined}
         isSaving={actions.create.isPending || actions.update.isPending}
         onSubmit={(input) => {
+          if (blockSuperAgentWithoutGithub(input.assigneeId)) {
+            closeDialog();
+            return;
+          }
           if (activeItem) {
             actions.update.mutate({ id: activeItem.id, ...input });
           } else {


### PR DESCRIPTION
## Summary

If a user hasn't connected GitHub and hands a task to the Super Agent, they now get the existing "connect GitHub" prompt instead of a silently-failing run.

The GitHub gate already existed — but only on the reports-only **Auto-fix** button. Assigning a task to the Super Agent (which opens a PR and needs an org-level GitHub connection) is also reachable ungated via:
- the **lane assignee picker** (`onAssign`)
- the **task dialog** (`onSubmit`)

This centralizes the check in a `blockSuperAgentWithoutGithub()` helper so all three paths reuse the same `ConnectGitHubDialog` and `hasGithub` check. No new component, no new dependency.

## Testing notes
- `bun run fmt` clean; `tsc` shows only pre-existing unrelated errors (missing `satori`/`driver.js` optional deps), none from the task-board file.
- Affected area: task board only (`apps/mesh/src/web/layouts/task-board/index.tsx`).

## Follow-ups
- The assignee picker may still show "Super Agent" selected while the mutation is skipped — worth a UX pass on whether the connect prompt alone is clear enough.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prompt users to connect GitHub when assigning tasks to the Super Agent, preventing silently failing runs. This applies to Auto-fix, the lane assignee picker, and the task dialog.

- **Bug Fixes**
  - Centralized gate in `blockSuperAgentWithoutGithub()` to reuse `hasGithub` and show `ConnectGitHubDialog`, blocking mutations when needed.
  - Wired into `onAssign`, `onAutoFix`, and `onSubmit`; closes the task dialog when blocked. Changes limited to `apps/mesh/src/web/layouts/task-board/index.tsx`.

<sup>Written for commit 86839167bd891b7bc1cf2f26ba02e786acb0c315. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

