### PR TITLE
feat(i18n): translate hardcoded question/answer strings in UserAskPart

### DIFF
--- a/apps/mesh/src/web/components/chat/message/parts/tool-call-part/user-ask.tsx
+++ b/apps/mesh/src/web/components/chat/message/parts/tool-call-part/user-ask.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@deco/ui/lib/utils.ts";
 import { MessageQuestionCircle } from "@untitledui/icons";
+import { useT } from "@/web/i18n/use-t.ts";
 import type { UserAskToolPart } from "../../../types.ts";
 import { getToolPartErrorText } from "../utils.ts";
 
@@ -12,20 +13,22 @@ interface UserAskPartProps {
 }
 
 export function UserAskPart({ part }: UserAskPartProps) {
+  const t = useT();
   // Only render after user has responded
   if (!part.state.startsWith("output-")) {
     return null;
   }
 
-  const question = part.input?.prompt?.trim() || "Question";
+  const question =
+    part.input?.prompt?.trim() || t("chat.userAskQuestion.question");
   const isError =
     part.state === "output-error" || part.state === "output-denied";
   const isDenied = part.state === "output-denied";
 
   const answer: string = isDenied
-    ? "Skipped"
+    ? t("chat.userAskQuestion.skippedAnswer")
     : part.state === "output-error"
-      ? (getToolPartErrorText(part) ?? "Error")
+      ? (getToolPartErrorText(part) ?? t("chat.subtask.errorLabel"))
       : (part.output?.response ?? "");
 
   return (

--- a/apps/mesh/src/web/i18n/en/chat.ts
+++ b/apps/mesh/src/web/i18n/en/chat.ts
@@ -425,6 +425,7 @@ export const chat = {
   "chat.userAskQuestion.selectOption": "Select {option}",
   "chat.userAskQuestion.skip": "Skip",
   "chat.userAskQuestion.skipMessage": "user has skip this question",
+  "chat.userAskQuestion.skippedAnswer": "Skipped",
   "chat.userAskQuestion.somethingElsePlaceholder": "Something else...",
   "chat.userAskQuestion.textResponseInputAriaLabel": "Text response input",
   "chat.userAskQuestion.typeResponse": "Type your response...",

--- a/apps/mesh/src/web/i18n/pt-br/chat.ts
+++ b/apps/mesh/src/web/i18n/pt-br/chat.ts
@@ -438,6 +438,7 @@ export const chat = {
   "chat.userAskQuestion.selectOption": "Selecione {option}",
   "chat.userAskQuestion.skip": "Pular",
   "chat.userAskQuestion.skipMessage": "usuário pulou esta pergunta",
+  "chat.userAskQuestion.skippedAnswer": "Pulado",
   "chat.userAskQuestion.somethingElsePlaceholder": "Algo mais...",
   "chat.userAskQuestion.textResponseInputAriaLabel":
     "Entrada de resposta em texto",


### PR DESCRIPTION
**Source:** i18n debt in the chat tool-call UI — a bounded, self-contained gap in `apps/mesh/src/web/components/chat/message/parts/tool-call-part/user-ask.tsx`. This is a proven merge lane (see #5048, #5062, #5070, #5099, #5100, #5110); this file was simply not yet covered.

**Why a maintainer wants this:** `UserAskPart` renders the fallback question text ("Question"), the denied-answer text ("Skipped"), and the error fallback ("Error") as raw English literals, bypassing the i18n dictionary every other chat surface goes through — this repo's CLAUDE.md requires all user-facing strings in `apps/mesh/src/web` to go through `t()`. A pt-br user who declines a Claude Code `AskUserQuestion` prompt currently sees English leak into an otherwise fully-localized chat transcript.

**What changed:**
- `user-ask.tsx`: call `useT()` and route the three literals through it — reusing the existing `chat.userAskQuestion.question` and `chat.subtask.errorLabel` keys (already used elsewhere for the same meaning), and adding one new key `chat.userAskQuestion.skippedAnswer` ("Skipped" / "Pulado") since no existing key covered the denied-answer case.
- `i18n/en/chat.ts` + `i18n/pt-br/chat.ts`: add the new key pair.

No logic/behavior change — same rendering, just localized strings. Net diff: +8/-3 across 3 files.

**Command a reviewer runs to confirm:** switch language to Português (Brasil) in preferences, trigger an agent `AskUserQuestion` prompt, and skip/deny it — the answer row should read "Pulado" instead of "Skipped".

**Verified locally:**
- `bun run fmt` — clean
- `cd apps/mesh && bunx tsc --noEmit` — clean (no new type errors)
- `pt-br/chat.ts` mirrors `en/chat.ts` exactly for the new key, satisfying the `satisfies Record<keyof typeof enChat, string>` compile-time completeness check, so `bun run check` will pass

Full CI (lint, full typecheck, test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the fallback question, denied answer, and error labels in `UserAskPart` by routing them through `useT()` to prevent English text from leaking in localized chats. Adds `chat.userAskQuestion.skippedAnswer` and reuses existing keys; no behavior change—PT‑BR now shows "Pulado" when a prompt is denied.

<sup>Written for commit 17932dc929249f8a435f8089e381e13541189572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

