### PR TITLE
fix(sandbox): return 400 instead of 500 when the diff base branch isn't on origin

### DIFF
--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -330,6 +330,22 @@ describe("git routes", () => {
     });
   });
 
+  it("diff POST returns 400 (not 500) when the base branch isn't on origin", async () => {
+    const { appRoot, repoDir } = initRepo();
+    const handler = makeGitDiffHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/diff", {
+        method: "POST",
+        body: JSON.stringify({ base: "does-not-exist" }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "Base branch 'does-not-exist' not found on origin",
+    });
+  });
+
   it("publish appends operator co-author trailer", async () => {
     const { appRoot, repoDir } = initRepo();
     onFeatureBranch(repoDir);

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -146,6 +146,18 @@ export interface GitStatusResult {
   unpushed: number;
 }
 
+/**
+ * The requested base branch doesn't exist on origin (typo, deleted branch) —
+ * a client/data condition, not a server fault, so the route maps it to 400
+ * instead of a raw 500.
+ */
+class BaseBranchNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BaseBranchNotFoundError";
+  }
+}
+
 export interface GitDiffEntry {
   from: string | null;
   to: string | null;
@@ -364,7 +376,9 @@ export async function computeDiffAgainstBase(
     }
 
     if (!resolveLocally(upstream)) {
-      throw new Error(`Base branch '${base}' not found on origin`);
+      throw new BaseBranchNotFoundError(
+        `Base branch '${base}' not found on origin`,
+      );
     }
 
     if (hasValidHeadSha && resolveLocally(`${headSha}^{commit}`)) {
@@ -739,6 +753,9 @@ export function makeGitDiffHandler(deps: GitDeps) {
       return jsonResponse(result);
     } catch (err) {
       if (err instanceof InvalidRemoteBranchNameError) {
+        return jsonResponse({ error: err.message }, 400);
+      }
+      if (err instanceof BaseBranchNotFoundError) {
         return jsonResponse({ error: err.message }, 400);
       }
       return jsonResponse(


### PR DESCRIPTION
Bug found while auditing `packages/sandbox/daemon/routes/git.ts`: `computeDiffAgainstBase()` (used by `POST /git/diff` when a `base` is supplied) threw a plain `Error` when the requested base branch doesn't exist on `origin` (typo, deleted branch). That fell through the handler's generic `catch` and surfaced as an opaque 500, the same class of bug already fixed elsewhere in this file for `InvalidRemoteBranchNameError` (400) and `PublishBlockedError`/`RebaseBlockedError` (409) — this one case was missed.

A maintainer wants this because a bad/stale base branch is a client input problem, not a server fault; the UI can distinguish and retry/report accordingly instead of treating it as a crash.

Failure scenario: client POSTs `/git/diff` with a syntactically-valid `base` (e.g. a deleted or mistyped branch name) that has no matching ref on `origin` — previously a 500 with a generic error body; now a 400 with the same descriptive message ("Base branch '<name>' not found on origin"). Added a regression test (`diff POST returns 400 (not 500) when the base branch isn't on origin`) asserting the new status/body.

Reviewer check: `bun test packages/sandbox/daemon/routes/git.test.ts` (33 pass, includes the new test).

Locally verified: `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit` (clean), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 400 (Bad Request) instead of 500 when `POST /git/diff` is called with a base branch that isn’t on origin. This clarifies client input errors so the UI can handle them.

- **Bug Fixes**
  - Added `BaseBranchNotFoundError` and mapped it to 400 in `packages/sandbox/daemon/routes/git.ts`.
  - Error message is "Base branch '<name>' not found on origin".
  - Added a regression test in `packages/sandbox/daemon/routes/git.test.ts`.

<sup>Written for commit 97b20919a12436a02b536975fedd4011b09de7ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

