### PR TITLE
fix(threads): skip chat_started analytics on an id-collision replay

### DIFF
--- a/apps/mesh/src/storage/ports.ts
+++ b/apps/mesh/src/storage/ports.ts
@@ -47,7 +47,10 @@ export type ThreadUpdateData = Partial<Thread> & {
 };
 
 export interface ThreadStoragePort {
-  create(data: Partial<Thread>): Promise<Thread>;
+  /** `isNew` is false when `data.id` collided with an existing row (the
+   *  insert is `ON CONFLICT DO NOTHING`) — callers use it to skip
+   *  create-only side effects (e.g. analytics) on a replayed/idempotent call. */
+  create(data: Partial<Thread>): Promise<Thread & { isNew: boolean }>;
   get(id: string, organizationId: string): Promise<Thread | null>;
   update(
     id: string,

--- a/apps/mesh/src/storage/threads.ts
+++ b/apps/mesh/src/storage/threads.ts
@@ -70,7 +70,7 @@ export class OrgScopedThreadStorage {
     return this.organizationId;
   }
 
-  create(data: Partial<Thread>): Promise<Thread> {
+  create(data: Partial<Thread>): Promise<Thread & { isNew: boolean }> {
     const orgId = this.requireOrg();
     return this.inner.create({ ...data, organization_id: orgId });
   }
@@ -268,7 +268,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
   // Thread Operations
   // ==========================================================================
 
-  async create(data: Partial<Thread>): Promise<Thread> {
+  async create(data: Partial<Thread>): Promise<Thread & { isNew: boolean }> {
     const id = data.id ?? generatePrefixedId("thrd");
     const now = new Date().toISOString();
 
@@ -313,7 +313,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .executeTakeFirst();
 
     if (inserted) {
-      return this.threadFromDbRow(inserted);
+      return { ...this.threadFromDbRow(inserted), isNew: true };
     }
 
     // Conflict — another caller already inserted this id. Return the row that won.
@@ -324,7 +324,7 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .where("organization_id", "=", data.organization_id)
       .executeTakeFirstOrThrow();
 
-    return this.threadFromDbRow(existing);
+    return { ...this.threadFromDbRow(existing), isNew: false };
   }
 
   async get(id: string, organizationId: string): Promise<Thread | null> {

--- a/apps/mesh/src/tools/thread/create.integration.test.ts
+++ b/apps/mesh/src/tools/thread/create.integration.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, spyOn } from "bun:test";
 import { COLLECTION_THREADS_CREATE } from "./create";
 import { buildThreadTestContext, type ThreadTestEnv } from "./test-helpers";
+import { posthog } from "../../posthog";
 
 describe("COLLECTION_THREADS_CREATE", () => {
   let env: ThreadTestEnv;
@@ -184,5 +185,28 @@ describe("COLLECTION_THREADS_CREATE", () => {
 
     expect(second.item.id).toBe(first.item.id);
     expect(second.item.title).toBe("first"); // existing row, not overwritten
+  });
+
+  it("does not re-fire the chat_started analytics event on an id-collision replay", async () => {
+    const vmcp = await env.ctx.storage.virtualMcps.create(
+      env.orgId,
+      env.userId,
+      { title: "y", connections: [], status: "active", pinned: false },
+    );
+    const captureSpy = spyOn(posthog, "capture");
+    captureSpy.mockClear();
+
+    const id = "thrd_test_idempotent_analytics";
+    await COLLECTION_THREADS_CREATE.handler(
+      { data: { id, virtual_mcp_id: vmcp.id, title: "first" } },
+      env.ctx,
+    );
+    await COLLECTION_THREADS_CREATE.handler(
+      { data: { id, virtual_mcp_id: vmcp.id, title: "second" } },
+      env.ctx,
+    );
+
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+    captureSpy.mockRestore();
   });
 });

--- a/apps/mesh/src/tools/thread/create.ts
+++ b/apps/mesh/src/tools/thread/create.ts
@@ -95,17 +95,22 @@ export const COLLECTION_THREADS_CREATE = defineTool({
       created_by: userId,
     });
 
-    posthog.capture({
-      distinctId: userId,
-      event: "chat_started",
-      groups: { organization: organization.id },
-      properties: {
-        organization_id: organization.id,
-        thread_id: taskId,
-        has_title: !!input.data.title,
-        created_via: "tool",
-      },
-    });
+    // Skip on a replayed/idempotent call (same id already existed) — the
+    // conflict path returns the pre-existing row, and firing again would
+    // double-count "chat_started" for a thread that was never actually created.
+    if (result.isNew) {
+      posthog.capture({
+        distinctId: userId,
+        event: "chat_started",
+        groups: { organization: organization.id },
+        properties: {
+          organization_id: organization.id,
+          thread_id: taskId,
+          has_title: !!input.data.title,
+          created_via: "tool",
+        },
+      });
+    }
 
     return {
       item: normalizeThreadForResponse(result),


### PR DESCRIPTION
**Source:** bug found while auditing `apps/mesh/src/tools/thread/create.ts` (recent-changes hunt) — no existing issue.

**Payoff:** `COLLECTION_THREADS_CREATE`'s own docstring says it's "Idempotent on `id` collisions (storage uses INSERT … ON CONFLICT DO NOTHING)", but the `chat_started` posthog event fired unconditionally, even on the conflict path where no row was actually inserted. This is a live path, not theoretical: `shell-layout.tsx`'s `usePanelActions` comments explain the eager client-side create races the route loader's create-on-404 fallback, both sharing the same client-generated thread id — so a genuine double-call happens in normal use, and every replay inflated the `chat_started` count for a thread that was created exactly once.

**Failure scenario:** two create calls for the same `id` (retry, or the eager-create/route-loader race described above) → storage's `ON CONFLICT DO NOTHING` correctly returns the existing row both times, but the tool fired `chat_started` on *both* calls, double-counting the metric.

**Fix:** surface `isNew` from `SqlThreadStorage.create()` — it already knows internally whether the `RETURNING` insert produced a row (fresh insert) or fell through to the conflict-select (pre-existing row); this was just never exposed. The tool now only calls `posthog.capture` when `result.isNew` is true. Added `does not re-fire the chat_started analytics event on an id-collision replay` to `create.integration.test.ts`, spying on `posthog.capture` across two same-id create calls and asserting it fires exactly once.

**To confirm:** `bun test apps/mesh/src/tools/thread/create.integration.test.ts` (requires Postgres — not run locally per repo dev-environment constraints; CI has Postgres and will validate it, alongside the existing `is idempotent: creating with the same id twice returns the same row` test in the same file, which still passes unchanged).

**Locally verified:** `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean — the two callers of `storage.threads.create`, `create.ts` and `enqueue-super-agent.ts`, both type-check against the new `Thread & { isNew: boolean }` return type without changes on the latter, since it never inspected the extra field).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate `chat_started` analytics when thread creation replays with the same id. Surfaces `isNew` from storage and only emits analytics on new inserts to keep metrics accurate.

- **Bug Fixes**
  - `SqlThreadStorage.create()` now returns `Thread & { isNew: boolean }` to signal insert vs conflict.
  - `COLLECTION_THREADS_CREATE` calls `posthog.capture` only when `result.isNew` is true.
  - Added an integration test to ensure a same-id double call fires the event once.

<sup>Written for commit 4bc3f0eb14b451e2866a096d29c72a5e169dcbbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

