### PR TITLE
fix(sandbox): return 400 instead of 500 when the rebase base branch isn't on origin

### DIFF
--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -9,7 +9,10 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { rebaseOntoBase } from "./rebase-onto-base";
+import {
+  RebaseBaseBranchNotFoundError,
+  rebaseOntoBase,
+} from "./rebase-onto-base";
 
 function setupConflictingRepo(): {
   repoDir: string;
@@ -120,6 +123,20 @@ describe("rebaseOntoBase", () => {
         .toString()
         .trim();
       expect(mainAfter).toBe(mainBefore);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("throws RebaseBaseBranchNotFoundError for a base branch missing on origin", () => {
+    const { repoDir, cleanup } = setupConflictingRepo();
+    try {
+      expect(() =>
+        rebaseOntoBase(repoDir, "does-not-exist", { asUser: false }),
+      ).toThrow(RebaseBaseBranchNotFoundError);
+      expect(() =>
+        rebaseOntoBase(repoDir, "does-not-exist", { asUser: false }),
+      ).toThrow(/Base branch 'does-not-exist' not found on origin/);
     } finally {
       cleanup();
     }

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -33,6 +33,18 @@ export class RebaseBlockedError extends Error {
   }
 }
 
+/**
+ * The requested base branch doesn't exist on origin (typo, deleted branch) —
+ * a client/data condition, not a server fault, mirroring
+ * BaseBranchNotFoundError in routes/git.ts's diff-against-base path.
+ */
+export class RebaseBaseBranchNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RebaseBaseBranchNotFoundError";
+  }
+}
+
 function gitEnv(repoDir: string): Record<string, string> {
   return { ...process.env, GIT_CEILING_DIRECTORIES: repoDir };
 }
@@ -349,7 +361,13 @@ function rebaseOntoBaseInner(
     );
   }
 
-  runGit(repoDir, ["fetch", "-p", "origin", base, branch]);
+  // Fetch base and branch as separate requests: `git fetch <a> <b>` fails the
+  // whole command if either ref is missing on origin, which would otherwise
+  // turn a bad `base` (typo, deleted branch) into a raw fetch error before we
+  // get a chance to report it as RebaseBaseBranchNotFoundError below, and would
+  // also skip fetching `branch` (needed for the force-push lease).
+  tryGit(repoDir, ["fetch", "-p", "origin", base]);
+  runGit(repoDir, ["fetch", "-p", "origin", branch]);
   const leaseSha = remoteBranchSha(repoDir, branch);
 
   tryGit(repoDir, [
@@ -363,7 +381,9 @@ function rebaseOntoBaseInner(
 
   const upstream = `origin/${base}`;
   if (tryGit(repoDir, ["rev-parse", "--verify", upstream]) === null) {
-    throw new Error(`Base branch '${base}' not found on origin`);
+    throw new RebaseBaseBranchNotFoundError(
+      `Base branch '${base}' not found on origin`,
+    );
   }
 
   commitBeforeRebase(repoDir, operator);

--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -743,6 +743,34 @@ describe("git routes", () => {
     });
   });
 
+  it("rebase route returns 400 (not 500) when the base branch isn't on origin", async () => {
+    const { appRoot, repoDir } = initRepo();
+    onFeatureBranch(repoDir);
+    const bareOrigin = mkdtempSync(join(tmpdir(), "git-route-origin-"));
+    gitSync(["init", "--bare", bareOrigin], { cwd: bareOrigin, asUser: false });
+    gitSync(["remote", "add", "origin", bareOrigin], {
+      cwd: repoDir,
+      asUser: false,
+    });
+    gitSync(["push", "-u", "origin", "feature/x"], {
+      cwd: repoDir,
+      asUser: false,
+    });
+
+    const handler = makeGitRebaseHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/rebase", {
+        method: "POST",
+        body: JSON.stringify({ base: "does-not-exist" }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "Base branch 'does-not-exist' not found on origin",
+    });
+  });
+
   it("rebase route returns 409 (not 500) for a protected-branch refusal", async () => {
     const { appRoot, repoDir } = initRepo(); // initRepo checks out main
     const handler = makeGitRebaseHandler({ appRoot, repoDir });

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -5,7 +5,11 @@ import { appendCoAuthorTrailer } from "../../git-co-author";
 import { computeBranchDivergence } from "../git/branch-divergence";
 import { parsePorcelainFiles } from "../git/porcelain";
 import { protectedBranches } from "../git/protect-branch";
-import { RebaseBlockedError, rebaseOntoBase } from "../git/rebase-onto-base";
+import {
+  RebaseBaseBranchNotFoundError,
+  RebaseBlockedError,
+  rebaseOntoBase,
+} from "../git/rebase-onto-base";
 import {
   cloneUrlHasCredentials,
   syncOriginRemote,
@@ -849,6 +853,12 @@ export function makeGitRebaseHandler(deps: GitDeps) {
       );
     } catch (err) {
       if (err instanceof InvalidRemoteBranchNameError) {
+        return jsonResponse({ error: err.message }, 400);
+      }
+      // The requested base branch doesn't exist on origin — a client/data
+      // condition, not a server fault (mirrors BaseBranchNotFoundError in the
+      // diff-against-base path above).
+      if (err instanceof RebaseBaseBranchNotFoundError) {
         return jsonResponse({ error: err.message }, 400);
       }
       // A detached HEAD / protected-branch refusal is a conflict with the


### PR DESCRIPTION
Follows #5142 and #5134's hardening of the sandbox git routes' error-status mapping.

`rebaseOntoBase()` threw a plain `Error` when the requested base branch didn't exist on origin (typo, deleted branch), which `/git/rebase` mapped to a generic 500 — the exact client/data condition that `computeDiffAgainstBase` already maps to 400 via `BaseBranchNotFoundError` (#5142), and the same class of "conflict with current state, not a server fault" that `RebaseBlockedError` already gets a 409 for on this same route (#5134). Added a matching `RebaseBaseBranchNotFoundError`, mapped to 400 in `makeGitRebaseHandler`.

While reproducing this I found the check was actually unreachable in the common case: `git fetch -p origin <base> <branch>` fails the *whole* fetch if `base` doesn't exist on origin, so the code threw a raw fetch error (128, "couldn't find remote ref") before ever reaching the `BaseBranchNotFoundError` check below it — and skipped fetching `branch`, which the force-push lease relies on. Fetching base and branch as separate requests fixes both: a missing base no longer blocks fetching the branch, and the existing post-fetch check now actually runs and throws the typed error.

Failure scenario: client calls `POST /git/rebase` with a `base` that was renamed/deleted upstream (or typo'd) — daemon returned 500 (crash-looking) instead of a clean, retryable 400 the UI can show as "branch not found."

Regression tests added:
- `packages/sandbox/daemon/git/rebase-onto-base.test.ts`: `rebaseOntoBase()` throws `RebaseBaseBranchNotFoundError` for a base branch missing on origin (real bare-repo fixture, mirrors the existing conflict-resolution/protected-branch tests in this file).
- `packages/sandbox/daemon/routes/git.test.ts`: `/git/rebase` route returns 400 (not 500) for the same condition, mirroring the existing diff-route test for the identical scenario.

Reviewer command: `bun test packages/sandbox/daemon/git/rebase-onto-base.test.ts packages/sandbox/daemon/routes/git.test.ts`

Locally ran: `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit` (clean), and the targeted test file above (37 pass / 0 fail). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 400 (not 500) from the sandbox rebase route when the base branch is missing on origin. Also fix fetch behavior so a missing base doesn’t prevent fetching the working branch.

- **Bug Fixes**
  - Added `RebaseBaseBranchNotFoundError` and map it to 400 in `makeGitRebaseHandler` for `/git/rebase`.
  - Fetch base and branch separately to avoid whole-command failure and preserve the force-push lease.
  - Route now mirrors the diff path’s 400 semantics; 409 for `RebaseBlockedError` remains.
  - Added regression tests for the error and route behavior.

<sup>Written for commit 5581d632f4de9e60e543153bb2719465c81f83b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

