### PR TITLE
fix(web): open EventSource for first subscriber without crossTab leader

### DIFF
--- a/apps/mesh/src/web/hooks/create-sse-subscription.test.ts
+++ b/apps/mesh/src/web/hooks/create-sse-subscription.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createSSESubscription } from "./create-sse-subscription";
+
+class FakeEventSource {
+  static CLOSED = 2;
+  static instances: FakeEventSource[] = [];
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public url: string) {
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(): void {}
+  close(): void {}
+}
+
+describe("createSSESubscription", () => {
+  const originalEventSource = globalThis.EventSource;
+
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    (globalThis as unknown as { EventSource: unknown }).EventSource =
+      FakeEventSource;
+  });
+
+  afterEach(() => {
+    (globalThis as unknown as { EventSource: unknown }).EventSource =
+      originalEventSource;
+  });
+
+  it("opens an EventSource for the first subscriber on a key without crossTab", () => {
+    // Regression: leadership used to be requested before refCount was
+    // incremented, so the synchronous (non-crossTab) leader path always saw
+    // refCount === 0 and bailed out — no EventSource was ever created.
+    const sub = createSSESubscription({
+      buildUrl: (key) => `/watch/${key}`,
+      eventTypes: ["foo"],
+    });
+
+    const unsubscribe = sub.subscribe("org1", () => {});
+
+    expect(FakeEventSource.instances.length).toBe(1);
+    expect(FakeEventSource.instances[0]?.url).toBe("/watch/org1");
+
+    unsubscribe();
+  });
+});

--- a/apps/mesh/src/web/hooks/create-sse-subscription.ts
+++ b/apps/mesh/src/web/hooks/create-sse-subscription.ts
@@ -222,7 +222,6 @@ export function createSSESubscription(
       conn.channel = channel;
     }
 
-    requestLeadership(conn);
     return conn;
   }
 
@@ -254,10 +253,15 @@ export function createSSESubscription(
 
   return {
     subscribe(key, handler, onReconnect) {
+      const isNew = !connections.has(key);
       const conn = getOrCreate(key);
       conn.refCount++;
       conn.handlers.add(handler);
       if (onReconnect) conn.reconnectHandlers.add(onReconnect);
+      // Leadership is requested only after refCount reflects this subscriber —
+      // the non-crossTab path elects synchronously, and becomeLeader bails
+      // when refCount is still 0.
+      if (isNew) requestLeadership(conn);
 
       let unsubscribed = false;
       return () => {


### PR DESCRIPTION
Bug found during a reactive smoke-test sweep of surrounding SSE/watch flows — not tied to a specific issue.

**Failure scenario:** in `createSSESubscription` (`apps/mesh/src/web/hooks/create-sse-subscription.ts`), `getOrCreate` called `requestLeadership(conn)` while `conn.refCount` was still `0` — `subscribe()` only increments `refCount` *after* `getOrCreate` returns. For the non-crossTab path (and the crossTab path falling back when `BroadcastChannel`/`navigator.locks` are unavailable, e.g. Safari < 15.4), `requestLeadership` calls `becomeLeader` synchronously, which bails out on `refCount <= 0` — so no `EventSource` is ever opened for the first subscriber. The one production caller (`watch-sse-pool.ts`) uses `crossTab: true` on modern browsers, which masked this: `navigator.locks.request`'s grant callback runs asynchronously, by which time `refCount` had already been incremented — so real-time SSE updates (thread status, workflow events) silently never connect on any browser without the Web Locks API.

**Fix:** move the `requestLeadership` call from `getOrCreate` into `subscribe()`, after `refCount++`, gated on whether the connection was newly created.

**Regression test:** `apps/mesh/src/web/hooks/create-sse-subscription.test.ts` — asserts an `EventSource` is opened for the first subscriber on a non-crossTab connection; failed against the old code (`Expected: 1, Received: 0`), passes now.

Reviewer command: `bun test apps/mesh/src/web/hooks/create-sse-subscription.test.ts`

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/mesh workspace, clean aside from an unrelated pre-existing untracked file), and the targeted test above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSE subscriptions so the first subscriber opens an EventSource when cross-tab leadership is unavailable or falls back. Restores real-time updates on browsers without Web Locks (e.g., older Safari).

- **Bug Fixes**
  - Request leadership in subscribe() after refCount++ only when a new connection is created, ensuring the first subscriber opens an EventSource in non-crossTab paths.
  - Add a regression test that verifies an EventSource is opened for the first subscriber without crossTab.

<sup>Written for commit aa44a3b178c7a20df3259705bfc8bd0ba6fd6d28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

