### PR TITLE
fix(sections-editor): cancel pending autosave timers before restructuring sections

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -633,6 +633,19 @@ export function SectionsEditor({
     options?: { onSuccess?: () => void },
   ) => {
     if (!activePageKey) return;
+    // Cancel pending field/rule autosave timers — they capture a section index
+    // at schedule time and write into `rawSections[index]` (read fresh via
+    // latestRef) when they fire. Restructuring the array here (delete,
+    // duplicate, reorder, hide/show, ...) shifts what's at that index, so a
+    // still-pending timer would land its stale write on the wrong section.
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    if (sectionRuleDebounceRef.current) {
+      clearTimeout(sectionRuleDebounceRef.current);
+      sectionRuleDebounceRef.current = null;
+    }
     const fullPageData = buildPageDataWithSections(
       decofile,
       activePageKey,


### PR DESCRIPTION
A bug, follow-up hardening on #4917 — found while reading `sections-editor.tsx`'s debounce refs for other structural mutation call sites.

**Failure scenario:** `scheduleAutoSave` (field autosave) and `scheduleSectionRuleSave` (section-rule autosave) are hand-rolled `setTimeout` debounces (`debounceRef` / `sectionRuleDebounceRef`) that capture a section index at schedule time and, when they fire up to `AUTOSAVE_DELAY` (700ms) later, read the *current* render's `rawSections` via `latestRef` and write into `rawSections[index]`. #4917 already cancelled these same timers on page/global-block switch, but every structural rewrite of the sections array — delete, duplicate, reorder, hide, show, toggle-lazy, make-reusable — routes through `savePageSections` without cancelling them. So: start editing a field on section A, then within the debounce window delete/reorder/duplicate an earlier section (shifting indices), and the pending timer fires with the *old* index against the *new* array — silently corrupting whatever section now sits at that index while A's real edit is lost.

**Fix:** cancel `debounceRef` and `sectionRuleDebounceRef` at the top of `savePageSections`, the single choke point all 12 structural-mutation call sites already route through — mirrors the cancellation `#4917` added for the page-switch case.

**Verify:** read the top of `savePageSections` in `apps/mesh/src/web/components/sections-editor/sections-editor.tsx` — the two timers are cleared before `buildPageDataWithSections` runs.

**Local checks:** `bun run fmt` and `bunx tsc --noEmit` in `apps/mesh` are green (an unrelated pre-existing untracked file in this worktree, `src/cli/commands/backfill-assets.test.ts`, was set aside during the check and is not part of this diff). No regression test added — same as #4917, reproducing this needs the full `SectionsEditor` rendered with its network hooks mocked, which is outside this repo's unit-test tier and outside this environment's e2e infra (no Postgres/Docker). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel pending autosave timers before restructuring sections to prevent stale index writes and accidental edits to the wrong section. Fixes a race where field/section-rule autosave could fire after delete/duplicate/reorder/hide/show.

- **Bug Fixes**
  - Clear `debounceRef` and `sectionRuleDebounceRef` at the start of `savePageSections`, the shared path for all structural changes.
  - Prevent autosave from writing to the wrong `rawSections[index]` when indices shift.

<sup>Written for commit 3dbf2f4c6d42ade2c4016f892b9f889bb10e0e5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

