### PR TITLE
feat(billing): seat toggle + staged apply on the members page

### DIFF
--- a/apps/mesh/src/web/hooks/use-organization-seats.ts
+++ b/apps/mesh/src/web/hooks/use-organization-seats.ts
@@ -1,0 +1,64 @@
+/**
+ * Per-seat billing hooks: the org's billing identity + who holds paid seats
+ * (ORGANIZATION_SEATS_GET), and the staged-changes apply
+ * (ORGANIZATION_SEATS_SET — invoiced orgs only until the Stripe checkout
+ * path lands). Seats are monetization, orthogonal to roles.
+ */
+
+import { useProjectContext } from "@decocms/mesh-sdk";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { KEYS } from "@/web/lib/query-keys";
+import { callStudioTool } from "@/web/lib/studio-tools";
+
+export type SeatKind = "paid" | "free";
+
+export interface OrganizationSeats {
+  /** null = org predates billing entirely (treated as legacy — no seats). */
+  billing: {
+    legacy: boolean;
+    billingMode: string;
+    status: string;
+    includedReportUrl: string | null;
+  } | null;
+  paidSeatUserIds: string[];
+}
+
+export function useOrganizationSeats() {
+  const { org } = useProjectContext();
+
+  return useQuery({
+    queryKey: KEYS.organizationSeats(org.id),
+    queryFn: async (): Promise<OrganizationSeats> => {
+      // Best-effort: a failed read renders the members page without the seat
+      // column instead of erroring it (same posture as org-settings).
+      try {
+        return (await callStudioTool(
+          org.slug,
+          "ORGANIZATION_SEATS_GET",
+          {},
+        )) as OrganizationSeats;
+      } catch {
+        return { billing: null, paidSeatUserIds: [] };
+      }
+    },
+    staleTime: 60_000,
+  });
+}
+
+export function useSetSeats() {
+  const { org } = useProjectContext();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (seats: Array<{ userId: string; seat: SeatKind }>) => {
+      return (await callStudioTool(org.slug, "ORGANIZATION_SEATS_SET", {
+        seats,
+      })) as { applied: Array<{ userId: string; seat: SeatKind }> };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: KEYS.organizationSeats(org.id),
+      });
+    },
+  });
+}

--- a/apps/mesh/src/web/i18n/en/orgs.ts
+++ b/apps/mesh/src/web/i18n/en/orgs.ts
@@ -167,6 +167,18 @@ export const orgs = {
   "orgs.members.sortJoined": "Joined",
   "orgs.members.sortName": "Name",
   "orgs.members.sortRole": "Role",
+  "orgs.seats.apply": "Apply",
+  "orgs.seats.applyError": "Failed to update seats",
+  "orgs.seats.applySuccess": "Seats updated",
+  "orgs.seats.applying": "Applying...",
+  "orgs.seats.column": "Seat",
+  "orgs.seats.discard": "Discard",
+  "orgs.seats.free": "Free",
+  "orgs.seats.paid": "Paid",
+  "orgs.seats.pendingChanges":
+    "{count} pending seat change(s) — {paid} paid seat(s) after applying",
+  "orgs.seats.selfServeSoon":
+    "Seat changes for self-serve plans are coming soon",
   "orgs.members.title": "Members",
   "orgs.members.toolCount": "{count} tool{plural}",
   "orgs.members.unknown": "Unknown",

--- a/apps/mesh/src/web/i18n/en/orgs.ts
+++ b/apps/mesh/src/web/i18n/en/orgs.ts
@@ -177,8 +177,6 @@ export const orgs = {
   "orgs.seats.paid": "Paid",
   "orgs.seats.pendingChanges":
     "{count} pending seat change(s) — {paid} paid seat(s) after applying",
-  "orgs.seats.selfServeSoon":
-    "Seat changes for self-serve plans are coming soon",
   "orgs.members.title": "Members",
   "orgs.members.toolCount": "{count} tool{plural}",
   "orgs.members.unknown": "Unknown",

--- a/apps/mesh/src/web/i18n/pt-br/orgs.ts
+++ b/apps/mesh/src/web/i18n/pt-br/orgs.ts
@@ -175,6 +175,18 @@ export const orgs = {
   "orgs.members.title": "Membros",
   "orgs.members.toolCount": "{count} ferramenta(s)",
   "orgs.members.unknown": "Desconhecido",
+  "orgs.seats.apply": "Aplicar",
+  "orgs.seats.applyError": "Falha ao atualizar os seats",
+  "orgs.seats.applySuccess": "Seats atualizados",
+  "orgs.seats.applying": "Aplicando...",
+  "orgs.seats.column": "Seat",
+  "orgs.seats.discard": "Descartar",
+  "orgs.seats.free": "Gratuito",
+  "orgs.seats.paid": "Pago",
+  "orgs.seats.pendingChanges":
+    "{count} mudança(s) de seat pendente(s) — {paid} seat(s) pago(s) após aplicar",
+  "orgs.seats.selfServeSoon":
+    "Mudanças de seat para planos self-serve chegam em breve",
   "orgs.monitoring.addFilter": "Adicionar filtro",
   "orgs.monitoring.agents": "Agentes",
   "orgs.monitoring.allAgents": "Todos os agentes",

--- a/apps/mesh/src/web/i18n/pt-br/orgs.ts
+++ b/apps/mesh/src/web/i18n/pt-br/orgs.ts
@@ -185,8 +185,6 @@ export const orgs = {
   "orgs.seats.paid": "Pago",
   "orgs.seats.pendingChanges":
     "{count} mudança(s) de seat pendente(s) — {paid} seat(s) pago(s) após aplicar",
-  "orgs.seats.selfServeSoon":
-    "Mudanças de seat para planos self-serve chegam em breve",
   "orgs.monitoring.addFilter": "Adicionar filtro",
   "orgs.monitoring.agents": "Agentes",
   "orgs.monitoring.allAgents": "Todos os agentes",

--- a/apps/mesh/src/web/lib/query-keys.ts
+++ b/apps/mesh/src/web/lib/query-keys.ts
@@ -155,6 +155,10 @@ export const KEYS = {
   organizationSettings: (organizationId: string) =>
     ["organization-settings", organizationId] as const,
 
+  // Per-seat billing: billing identity + paid-seat membership
+  organizationSeats: (organizationId: string) =>
+    ["organization-seats", organizationId] as const,
+
   // API keys (scoped by organization; the LIST tool filters by org server-side)
   apiKeysList: (organizationId: string) =>
     ["api-keys", organizationId] as const,

--- a/apps/mesh/src/web/routes/orgs/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/members.tsx
@@ -12,6 +12,11 @@ import { getInitials } from "@/web/lib/get-initials";
 import { useT } from "@/web/i18n/use-t.ts";
 import { useMembers } from "@/web/hooks/use-members";
 import {
+  useOrganizationSeats,
+  useSetSeats,
+  type SeatKind,
+} from "@/web/hooks/use-organization-seats";
+import {
   useInvitations,
   useInvitationActions,
 } from "@/web/hooks/use-invitations";
@@ -411,6 +416,54 @@ function OrgMembersContent() {
 
   const members = data?.data?.members;
 
+  // Per-seat billing: staged toggles applied in one batch. The column only
+  // renders when the org actually has seats (billing row exists and is not
+  // legacy); toggling is enabled for invoiced (contract) orgs — self-serve
+  // waits for the Stripe checkout flow.
+  const { data: seatState } = useOrganizationSeats();
+  const setSeatsMutation = useSetSeats();
+  const [stagedSeats, setStagedSeats] = useState<Record<string, SeatKind>>({});
+  const seatsApply = !!seatState?.billing && !seatState.billing.legacy;
+  const seatsEditable = seatState?.billing?.billingMode === "invoiced";
+  const paidSeatSet = new Set(seatState?.paidSeatUserIds ?? []);
+  const baseSeat = (userId: string): SeatKind =>
+    paidSeatSet.has(userId) ? "paid" : "free";
+  const effectiveSeat = (userId: string): SeatKind =>
+    stagedSeats[userId] ?? baseSeat(userId);
+  const toggleSeat = (userId: string) => {
+    const next: SeatKind = effectiveSeat(userId) === "paid" ? "free" : "paid";
+    setStagedSeats((prev) => {
+      const copy = { ...prev };
+      if (next === baseSeat(userId)) delete copy[userId];
+      else copy[userId] = next;
+      return copy;
+    });
+  };
+  const stagedCount = Object.keys(stagedSeats).length;
+  const stagedPaidCount =
+    (seatState?.paidSeatUserIds.length ?? 0) +
+    Object.entries(stagedSeats).reduce(
+      (sum, [, seat]) => sum + (seat === "paid" ? 1 : -1),
+      0,
+    );
+  const applySeats = () => {
+    setSeatsMutation.mutate(
+      Object.entries(stagedSeats).map(([userId, seat]) => ({ userId, seat })),
+      {
+        onSuccess: () => {
+          track("seats_updated", { changes: stagedCount });
+          setStagedSeats({});
+          toast.success(t("orgs.seats.applySuccess"));
+        },
+        onError: (error) => {
+          toast.error(
+            error instanceof Error ? error.message : t("orgs.seats.applyError"),
+          );
+        },
+      },
+    );
+  };
+
   const handleSort = (key: string) => {
     if (sortKey === key) {
       setSortDirection((prev) =>
@@ -692,6 +745,49 @@ function OrgMembersContent() {
       cellClassName: "w-36 shrink-0",
       sortable: true,
     },
+    ...(seatsApply
+      ? ([
+          {
+            id: "seat",
+            header: t("orgs.seats.column"),
+            render: (row) => {
+              if (row.type !== "member") {
+                return <span className="text-xs text-muted-foreground">-</span>;
+              }
+              const userId = row.data.userId;
+              const seat = effectiveSeat(userId);
+              const isStaged = userId in stagedSeats;
+              const button = (
+                <Button
+                  variant={seat === "paid" ? "secondary" : "outline"}
+                  size="xs"
+                  disabled={!seatsEditable}
+                  onClick={() => toggleSeat(userId)}
+                  className={cn(isStaged && "ring-2 ring-primary/60")}
+                >
+                  {seat === "paid"
+                    ? t("orgs.seats.paid")
+                    : t("orgs.seats.free")}
+                </Button>
+              );
+              if (seatsEditable) return button;
+              return (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>{button}</span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {t("orgs.seats.selfServeSoon")}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              );
+            },
+            cellClassName: "w-24 shrink-0",
+          },
+        ] satisfies TableColumn<MemberRow>[])
+      : []),
     {
       id: "tags",
       header: t("orgs.members.columnTags"),
@@ -872,6 +968,35 @@ function OrgMembersContent() {
               </div>
               {ctaButton}
             </div>
+            {stagedCount > 0 && (
+              <Card className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+                <span className="text-sm text-foreground">
+                  {t("orgs.seats.pendingChanges", {
+                    count: stagedCount,
+                    paid: stagedPaidCount,
+                  })}
+                </span>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setStagedSeats({})}
+                    disabled={setSeatsMutation.isPending}
+                  >
+                    {t("orgs.seats.discard")}
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={applySeats}
+                    disabled={setSeatsMutation.isPending}
+                  >
+                    {setSeatsMutation.isPending
+                      ? t("orgs.seats.applying")
+                      : t("orgs.seats.apply")}
+                  </Button>
+                </div>
+              </Card>
+            )}
             {viewMode === "cards" ? (
               <div>
                 {allRows.length === 0 ? (

--- a/apps/mesh/src/web/routes/orgs/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/members.tsx
@@ -423,8 +423,15 @@ function OrgMembersContent() {
   const { data: seatState } = useOrganizationSeats();
   const setSeatsMutation = useSetSeats();
   const [stagedSeats, setStagedSeats] = useState<Record<string, SeatKind>>({});
-  const seatsApply = !!seatState?.billing && !seatState.billing.legacy;
-  const seatsEditable = seatState?.billing?.billingMode === "invoiced";
+  // Column only for orgs EXPLICITLY put on invoiced (contract) billing — the
+  // per-org opt-in is the rollout switch. Without this, any org created after
+  // the billing migration (legacy=false, self_serve by default) would grow a
+  // disabled Seat column before checkout/paywall exist. self_serve gets the
+  // column with the Stripe flow (phase 3).
+  const seatsApply =
+    !!seatState?.billing &&
+    !seatState.billing.legacy &&
+    seatState.billing.billingMode === "invoiced";
   const paidSeatSet = new Set(seatState?.paidSeatUserIds ?? []);
   const baseSeat = (userId: string): SeatKind =>
     paidSeatSet.has(userId) ? "paid" : "free";
@@ -757,11 +764,10 @@ function OrgMembersContent() {
               const userId = row.data.userId;
               const seat = effectiveSeat(userId);
               const isStaged = userId in stagedSeats;
-              const button = (
+              return (
                 <Button
                   variant={seat === "paid" ? "secondary" : "outline"}
                   size="xs"
-                  disabled={!seatsEditable}
                   onClick={() => toggleSeat(userId)}
                   className={cn(isStaged && "ring-2 ring-primary/60")}
                 >
@@ -769,19 +775,6 @@ function OrgMembersContent() {
                     ? t("orgs.seats.paid")
                     : t("orgs.seats.free")}
                 </Button>
-              );
-              if (seatsEditable) return button;
-              return (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span>{button}</span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {t("orgs.seats.selfServeSoon")}
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
               );
             },
             cellClassName: "w-24 shrink-0",


### PR DESCRIPTION
## Summary

Task 2.6 of the per-seat plan (builds on #5128). The members page grows a **Seat** column with staged toggles and a batch apply — the UI that makes the invoiced-org pilot usable end to end.

- **Rendering is conditional on seats actually applying**: `ORGANIZATION_SEATS_GET` feeds a best-effort query (`use-organization-seats.ts`); no billing row or `legacy` → no column, page byte-identical to today. Every legacy org and every deployment without billing sees zero change.
- **Staged apply**: toggling Paid/Free stages locally (ring highlight on staged cells; re-toggling back to the base state un-stages). An apply bar appears with "{count} pending seat change(s) — {paid} paid seat(s) after applying" + Discard/Apply. Apply commits the whole batch via `ORGANIZATION_SEATS_SET` (server validates membership + billing_mode) and invalidates the seats query.
- **invoiced orgs**: toggles enabled. **self_serve**: disabled with a "coming soon" tooltip — the Stripe preview/prorated-charge flow (phase 3) will slot into this exact staged-apply surface, per the plan (`invoices.createPreview` rendering in the apply bar).
- i18n: new `orgs.seats.*` keys in `en` + `pt-br` (compile-checked mirror).

## Testing

- `bun run check` (all workspaces, includes pt-br dictionary completeness) green; `bun run lint`, `bun run fmt` clean.
- Behavior surface is UI-only over the already-tested tools from #5128 (batch atomicity, membership validation, change-log exactness are server-enforced and integration-tested there).
- Manual path for the pilot: mark an org `billing_mode = 'invoiced'` → members page shows the column → toggle + apply → `seat_change_log` records transitions.

Screenshot note: column and apply bar only render for orgs with a non-legacy billing row, so a plain dev org shows no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Seat column with staged, batch-apply changes on the Members page, now rendered only for invoiced orgs as the rollout switch. Keeps all other orgs unchanged and enables the invoiced-org pilot end to end.

- New Features
  - Conditional rendering: shows only for invoiced orgs; hidden for legacy, self-serve, or failed reads.
  - Hooks: `useOrganizationSeats` reads billing + paid-seat users via `ORGANIZATION_SEATS_GET` (best-effort, 60s stale). `useSetSeats` applies changes and invalidates `organization-seats`.
  - Staged apply: toggle Paid/Free per member, staged cells get a ring, and a Discard/Apply bar shows pending count and resulting paid-seat total. Batch commits via `ORGANIZATION_SEATS_SET` with success/error toasts.
  - Access: column appears only for invoiced orgs; removed the disabled self-serve toggle/tooltip path.
  - i18n: added `orgs.seats.*` strings in `en` and `pt-br`.

<sup>Written for commit e318dbd8097c462749628b8e1bc8e7879d59dbf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

