### PR TITLE
fix(sections-editor): cancel pending rule autosave before page-variant restructuring

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -1829,6 +1829,12 @@ export function SectionsEditor({
       : editingBreadcrumbs;
   const handleAddPageVariant = () => {
     if (!activePageKey) return;
+    // Cancel a pending rule-autosave timer — it writes into
+    // `variants[latestVariantIndex]` (read fresh via latestRef) when it fires,
+    // and appending a variant here doesn't change that index, but a stale save
+    // firing after this mutation would clobber the newly-saved data with an
+    // outdated variants array.
+    cancelPendingRuleSaves();
     const fullPageData = decofile[activePageKey] as Record<string, unknown>;
     const updatedSections = appendPageVariantSections(
       fullPageData.sections,
@@ -1874,6 +1880,11 @@ export function SectionsEditor({
     orphanMatcherBlockKey?: string | null,
   ) => {
     if (!activePageKey) return;
+    // Cancel a pending rule-autosave timer — it writes into
+    // `variants[latestVariantIndex]` (read fresh via latestRef) when it fires,
+    // so reordering/deleting/duplicating variants here would land that stale
+    // write on the wrong (or now-missing) variant.
+    cancelPendingRuleSaves();
     const fullPageData = decofile[activePageKey] as Record<string, unknown>;
     const current = fullPageData.sections;
     if (!current || typeof current !== "object" || Array.isArray(current))


### PR DESCRIPTION
Follows #5146, which cancelled pending field/section-rule autosave timers before *section* restructuring (delete/duplicate/reorder) because those timers write into `rawSections[index]` read fresh at fire time, and restructuring shifts what's at that index. The same debounce, `ruleDebounceRef` (the *page-variant* matcher-rule autosave, `scheduleRuleSave`), has the identical race but for the sibling `variants` array — and none of `handleReorderPageVariants`, `handleDeletePageVariant`, `handleDuplicatePageVariant`, or `handleAddPageVariant` cancelled it.

Failure scenario: a user edits a page variant's matcher rule (schedules a debounced save keyed by the *current* `variantIndex`, read fresh via `latestRef` when the timer fires), then within the ~500ms debounce window reorders, deletes, duplicates, or adds a page variant. When the timer fires afterward, it writes the stale rule into whatever now sits at that index — silently corrupting a different variant's matcher rule, or resurrecting one that was just deleted.

Fix mirrors #5146's approach: cancel the pending timer (`cancelPendingRuleSaves()`) in `mutatePageVariants` (shared by reorder/delete/duplicate) and in `handleAddPageVariant`, before the restructuring mutation runs.

Verification: `cd apps/mesh && bunx tsc --noEmit` passes. No new test — `sections-editor.tsx` has no direct unit-test target (same as #5146, which also shipped without one; the component requires full rendering context, covered instead by manual/e2e paths). A reviewer can confirm by reading the diff: `cancelPendingRuleSaves()` is now called at the top of `mutatePageVariants` and `handleAddPageVariant`, alongside its existing call sites (`handlePageVariantSelectGlobal`, `handleRenamePageVariant`, etc). Full CI (typecheck, lint, e2e) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel any pending page-variant matcher rule autosave before variants are changed (reorder, delete, duplicate, add) to prevent stale writes to the wrong entry in `variants` or restoring a deleted rule. Added `cancelPendingRuleSaves()` at the start of `mutatePageVariants` and `handleAddPageVariant`, mirroring the earlier sections-rule fix.

<sup>Written for commit 82f98d14e7c0ef80328901e80343f9fb7b2285d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

