### PR TITLE
feat(billing): syncOrgBenefits — gateway allowance rides every seat change

### DIFF
--- a/apps/mesh/migrations/141-benefits-sync-pending.ts
+++ b/apps/mesh/migrations/141-benefits-sync-pending.ts
@@ -1,0 +1,25 @@
+import { type Kysely } from "kysely";
+
+/**
+ * Durable benefit sync: `benefits_reference_id` is the pending-grant marker,
+ * written INSIDE the same transaction as the seat change (setSeats /
+ * releaseSeat) — so a crash anywhere after commit can never lose the intent.
+ * Non-null = "the gateway allowance grant for this change-set hasn't been
+ * confirmed yet"; the value is the grant's idempotency key at the gateway.
+ * Cleared (CAS) by the sync workflow on success; a scheduled sweep re-enqueues
+ * rows that stay pending (pod died before enqueue, gateway down past the
+ * step-retry budget).
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("organization_billing")
+    .addColumn("benefits_reference_id", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("organization_billing")
+    .dropColumn("benefits_reference_id")
+    .execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -139,6 +139,7 @@ import * as migration137agentsandboxrunnerstate from "./137-agent-sandbox-runner
 import * as migration138agentsandboxsessions from "./138-agent-sandbox-sessions.ts";
 import * as migration139organizationbilling from "./139-organization-billing.ts";
 import * as migration140seatchangelog from "./140-seat-change-log.ts";
+import * as migration141benefitssyncpending from "./141-benefits-sync-pending.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -303,6 +304,7 @@ const migrations: Record<string, Migration> = {
   "138-agent-sandbox-sessions": migration138agentsandboxsessions,
   "139-organization-billing": migration139organizationbilling,
   "140-seat-change-log": migration140seatchangelog,
+  "141-benefits-sync-pending": migration141benefitssyncpending,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -17,6 +17,7 @@ import {
   registerPublicSetsSyncWorkflow,
   setPublicSetsSyncRuntime,
 } from "../file-storage/dbos-public-sets-sync";
+import { registerBenefitsSyncWorkflows } from "../billing/sync-org-benefits";
 import { getPublicUrl } from "@/core/server-constants";
 import { usesLocalObjectStorage } from "../tools/connection/dev-assets";
 import { DECO_STORE_URL, isDecoHostedMcp } from "@/core/deco-constants";
@@ -1717,6 +1718,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Must run before DBOS.launch() (which fires in index.ts after createApp).
   registerMonitoringRetentionWorkflow();
   registerPublicSetsSyncWorkflow();
+  registerBenefitsSyncWorkflows();
 
   const automationRunner: StudioContext["automationRunner"] = async (
     automationId,

--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -10,6 +10,7 @@ import { CredentialVault } from "@/encryption/credential-vault";
 import { AIProviderKeyStorage } from "@/storage/ai-provider-keys";
 import { ConnectionStorage } from "@/storage/connection";
 import { OrganizationBillingStorage } from "@/storage/organization-billing";
+import { syncOrgBenefits } from "@/billing/sync-org-benefits";
 import { Permission } from "@/storage/types";
 import { fetchToolsFromMCP } from "@/tools/connection/fetch-tools";
 import {
@@ -94,11 +95,25 @@ export async function releaseSeat(
   changedBy: string,
 ): Promise<void> {
   const database = getDb();
-  await new OrganizationBillingStorage(database.db).releaseSeat(
-    organizationId,
-    userId,
-    changedBy,
-  );
+  const storage = new OrganizationBillingStorage(database.db);
+  const released = await storage.releaseSeat(organizationId, userId, changedBy);
+  if (!released) return;
+
+  // The paid-seat count just changed, so the benefits it buys change too.
+  // released=true implies the org actually sells seats (only seat-managed
+  // orgs ever have paid rows), so no billing-mode guard is needed. Fail-soft:
+  // a failed grant self-heals on the next seat apply.
+  try {
+    const paidSeatCount = (await storage.listPaidSeatUserIds(organizationId))
+      .length;
+    await syncOrgBenefits({
+      organizationId,
+      paidSeatCount,
+      referenceId: `seat-release:${organizationId}:${crypto.randomUUID()}`,
+    });
+  } catch (err) {
+    console.error("Failed to sync org benefits after seat release:", err);
+  }
 }
 
 /**

--- a/apps/mesh/src/auth/org.ts
+++ b/apps/mesh/src/auth/org.ts
@@ -10,7 +10,10 @@ import { CredentialVault } from "@/encryption/credential-vault";
 import { AIProviderKeyStorage } from "@/storage/ai-provider-keys";
 import { ConnectionStorage } from "@/storage/connection";
 import { OrganizationBillingStorage } from "@/storage/organization-billing";
-import { syncOrgBenefits } from "@/billing/sync-org-benefits";
+import {
+  benefitsSyncEnabled,
+  enqueueBenefitsSync,
+} from "@/billing/sync-org-benefits";
 import { Permission } from "@/storage/types";
 import { fetchToolsFromMCP } from "@/tools/connection/fetch-tools";
 import {
@@ -96,23 +99,21 @@ export async function releaseSeat(
 ): Promise<void> {
   const database = getDb();
   const storage = new OrganizationBillingStorage(database.db);
-  const released = await storage.releaseSeat(organizationId, userId, changedBy);
-  if (!released) return;
-
-  // The paid-seat count just changed, so the benefits it buys change too.
-  // released=true implies the org actually sells seats (only seat-managed
-  // orgs ever have paid rows), so no billing-mode guard is needed. Fail-soft:
-  // a failed grant self-heals on the next seat apply.
+  // The paid-seat count changed, so the benefits it buys change too. The
+  // pending marker commits with the release; the DBOS workflow + scheduled
+  // sweep deliver the gateway grant durably. Enqueue is fail-soft — a failed
+  // enqueue is exactly what the sweep exists for.
+  const { released, benefitsReferenceId } = await storage.releaseSeat(
+    organizationId,
+    userId,
+    changedBy,
+    { markBenefitsPending: benefitsSyncEnabled() },
+  );
+  if (!released || !benefitsReferenceId) return;
   try {
-    const paidSeatCount = (await storage.listPaidSeatUserIds(organizationId))
-      .length;
-    await syncOrgBenefits({
-      organizationId,
-      paidSeatCount,
-      referenceId: `seat-release:${organizationId}:${crypto.randomUUID()}`,
-    });
+    await enqueueBenefitsSync(organizationId, benefitsReferenceId, "apply");
   } catch (err) {
-    console.error("Failed to sync org benefits after seat release:", err);
+    console.error("Failed to enqueue benefit sync (sweep covers):", err);
   }
 }
 

--- a/apps/mesh/src/billing/sync-org-benefits.test.ts
+++ b/apps/mesh/src/billing/sync-org-benefits.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { computeAllowanceMicros } from "./sync-org-benefits";
+
+describe("computeAllowanceMicros", () => {
+  test("paid seats × per-seat cents, in microdollars", () => {
+    // 4 paid seats × $5 = $20/month = 20M micros (the plan's example org)
+    expect(computeAllowanceMicros(4, 500)).toBe(20_000_000);
+    expect(computeAllowanceMicros(1, 500)).toBe(5_000_000);
+  });
+
+  test("zero seats revokes (amount 0 is the gateway's revoke)", () => {
+    expect(computeAllowanceMicros(0, 500)).toBe(0);
+  });
+});

--- a/apps/mesh/src/billing/sync-org-benefits.ts
+++ b/apps/mesh/src/billing/sync-org-benefits.ts
@@ -1,28 +1,37 @@
 /**
- * syncOrgBenefits — propagate an org's paid-seat count to the benefits it
- * buys. ONE function, called from every place seats change: the invoiced
- * seat-apply today, the Stripe webhooks (checkout / subscription.updated /
- * invoice.paid) in phase 3.
+ * Durable org-benefit sync: paid-seat count → AI-gateway monthly allowance
+ * (paid_seats × seatAllowanceCents, $5 default).
  *
- * Benefit 1 — AI-gateway monthly allowance: paid_seats × seatAllowanceCents
- * ($5 default), granted via the gateway's idempotent
- * `POST /api/admin/allowance` (referenceId dedupes retries; the gateway
- * REBASES per call — a mid-cycle seat change refreshes the current cycle's
- * allowance, the same accepted slack as the plan's multi-subscription rule).
+ * Delivery guarantee is two-layered, and neither layer is in-memory:
+ *  1. INTENT commits with the seat change — setSeats/releaseSeat write
+ *     `benefits_reference_id` in the same transaction (a crash after commit
+ *     can never lose it).
+ *  2. DELIVERY is a DBOS workflow (step retries survive restarts) enqueued on
+ *     the fast path, plus a scheduled sweep that re-enqueues rows whose
+ *     marker stayed pending (pod died before enqueue, gateway down past the
+ *     step-retry budget).
  *
- * Benefit 2 — weekly report re-run for included_report_url:
- * TODO(billing/4.1): call the reports internal schedule endpoint once it
- * exists (set next_scheduled_run_at when paidSeatCount >= 1, clear at 0).
+ * The grant is ABSOLUTE (full current amount, not a delta) and idempotent at
+ * the gateway per referenceId — so duplicate deliveries of the same reference
+ * are no-ops, and only the LATEST change-set ever needs delivering (a newer
+ * seat change overwrites the pending marker; superseded workflows exit
+ * early). The gateway REBASES per grant — a mid-cycle seat change refreshes
+ * the cycle's allowance, the plan's accepted slack.
  *
- * Fail-soft BY THE CALLER's choice: this function throws on failure so the
- * caller decides (the seat tool reports benefitsSynced=false and the next
- * apply self-heals — every call re-grants the full current amount).
+ * TODO(billing/4.1): second benefit — reports weekly-run schedule for
+ * included_report_url — joins the workflow once the reports endpoint exists.
  */
 
-import { retry } from "@decocms/std";
+import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
+import { getDb } from "@/database";
 import { getSettings } from "../settings";
+import { OrganizationBillingStorage } from "../storage/organization-billing";
 
 const MICROS_PER_CENT = 10_000;
+/** Fast path is instant; anything pending past this is a failed delivery. */
+const SWEEP_STALE_AFTER_MS = 10 * 60 * 1000;
+const SWEEP_BATCH = 50;
+const SWEEP_CRONTAB = "*/10 * * * *";
 
 export function computeAllowanceMicros(
   paidSeatCount: number,
@@ -31,51 +40,137 @@ export function computeAllowanceMicros(
   return paidSeatCount * seatAllowanceCents * MICROS_PER_CENT;
 }
 
-export interface SyncOrgBenefitsResult {
-  /** false = deployment has no gateway admin configured (sync skipped). */
-  allowanceSynced: boolean;
+/** Whether this deployment can deliver benefits at all (self-hosted can't). */
+export function benefitsSyncEnabled(): boolean {
+  const settings = getSettings();
+  return settings.aiGatewayEnabled && !!settings.aiGatewayAdminToken;
 }
 
-export async function syncOrgBenefits(input: {
-  organizationId: string;
-  paidSeatCount: number;
-  /** Idempotency key for THIS billing event (seat apply id / Stripe invoice
-   *  id). Retries with the same id are no-ops on the gateway. */
-  referenceId: string;
-}): Promise<SyncOrgBenefitsResult> {
+function storage(): OrganizationBillingStorage {
+  return new OrganizationBillingStorage(getDb().db);
+}
+
+async function grantAllowance(
+  organizationId: string,
+  paidSeatCount: number,
+  referenceId: string,
+): Promise<void> {
   const settings = getSettings();
-  if (!settings.aiGatewayEnabled || !settings.aiGatewayAdminToken) {
-    return { allowanceSynced: false };
-  }
-
-  const amountMicros = computeAllowanceMicros(
-    input.paidSeatCount,
-    settings.seatAllowanceCents,
-  );
-
-  await retry(
-    async () => {
-      const res = await fetch(`${settings.aiGatewayUrl}/api/admin/allowance`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${settings.aiGatewayAdminToken}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          orgId: input.organizationId,
-          amountMicros,
-          referenceId: input.referenceId,
-        }),
-      });
-      if (!res.ok) {
-        const body = await res.text().catch(() => "");
-        throw new Error(
-          `gateway allowance grant failed (${res.status}): ${body}`,
-        );
-      }
+  const res = await fetch(`${settings.aiGatewayUrl}/api/admin/allowance`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${settings.aiGatewayAdminToken}`,
+      "Content-Type": "application/json",
     },
-    { maxAttempts: 3, minTimeout: 500, maxTimeout: 4_000 },
+    body: JSON.stringify({
+      orgId: organizationId,
+      amountMicros: computeAllowanceMicros(
+        paidSeatCount,
+        settings.seatAllowanceCents,
+      ),
+      referenceId,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`gateway allowance grant failed (${res.status}): ${body}`);
+  }
+}
+
+async function syncOrgBenefitsWorkflowFn(
+  organizationId: string,
+  referenceId: string,
+): Promise<{ delivered: boolean }> {
+  // Read live state: the CURRENT pending ref and paid count. If a newer seat
+  // change replaced the ref, that change's own workflow owns delivery — exit.
+  const state = await DBOS.runStep(
+    async () => {
+      const s = storage();
+      const [billing, paidSeatUserIds] = await Promise.all([
+        s.getBilling(organizationId),
+        s.listPaidSeatUserIds(organizationId),
+      ]);
+      return {
+        pendingRef: billing?.benefitsReferenceId ?? null,
+        paidSeatCount: paidSeatUserIds.length,
+      };
+    },
+    { name: "readSeatState", retriesAllowed: true, maxAttempts: 3 },
+  );
+  if (state.pendingRef !== referenceId) return { delivered: false };
+
+  await DBOS.runStep(
+    () => grantAllowance(organizationId, state.paidSeatCount, referenceId),
+    // Generous budget: the grant is gateway-idempotent per referenceId, and
+    // this is money owed to the customer — outlast a gateway deploy window.
+    { name: "grantAllowance", retriesAllowed: true, maxAttempts: 8 },
   );
 
-  return { allowanceSynced: true };
+  await DBOS.runStep(
+    () => storage().clearBenefitsPending(organizationId, referenceId),
+    { name: "clearPending", retriesAllowed: true, maxAttempts: 3 },
+  );
+
+  return { delivered: true };
+}
+
+/** Sweep: re-enqueue deliveries whose pending marker went stale. */
+async function benefitsSyncSweepFn(): Promise<void> {
+  if (!benefitsSyncEnabled()) return;
+  const pending = await DBOS.runStep(
+    () =>
+      storage().listBenefitsPending(
+        new Date(Date.now() - SWEEP_STALE_AFTER_MS),
+        SWEEP_BATCH,
+      ),
+    { name: "listPending", retriesAllowed: true, maxAttempts: 3 },
+  );
+  // startWorkflow is forbidden inside a step — enqueue at workflow level.
+  for (const row of pending) {
+    await enqueueBenefitsSync(row.organizationId, row.referenceId, "sweep");
+  }
+}
+
+let syncWorkflow: typeof syncOrgBenefitsWorkflowFn | null = null;
+
+// Must run before DBOS.launch(). Guarded so HMR repeats don't re-register.
+export function registerBenefitsSyncWorkflows(): void {
+  if (syncWorkflow) return;
+  // ⚠️ Durable DBOS workflow. Changing its STEP SEQUENCE requires bumping
+  // DBOS_WORKFLOW_VERSION — see apps/mesh/src/dbos/workflow-version.ts.
+  syncWorkflow = DBOS.registerWorkflow(syncOrgBenefitsWorkflowFn, {
+    name: "syncOrgBenefitsWorkflow",
+  });
+  const sweep = DBOS.registerWorkflow(benefitsSyncSweepFn, {
+    name: "benefitsSyncSweep",
+  });
+  DBOS.registerScheduled(sweep, {
+    name: "benefitsSyncSweep",
+    crontab: SWEEP_CRONTAB,
+    mode: SchedulerMode.ExactlyOncePerIntervalWhenActive,
+  });
+}
+
+/**
+ * Enqueue a delivery (fast path after a seat change, or the sweep retry).
+ * Fire-and-forget: the intent marker is already committed, so failure to
+ * enqueue is exactly what the sweep exists for. workflowIDs are
+ * per-origin/per-time-bucket rather than strictly unique — duplicate
+ * deliveries are harmless (gateway referenceId dedupe), while a FAILED
+ * fast-path workflow must not pin the ID forever (the sweep's bucketed ID
+ * gets a fresh run).
+ */
+export async function enqueueBenefitsSync(
+  organizationId: string,
+  referenceId: string,
+  origin: "apply" | "sweep",
+): Promise<void> {
+  if (!syncWorkflow) throw new Error("benefits sync workflow not registered");
+  const bucket =
+    origin === "sweep"
+      ? `:${Math.floor(Date.now() / SWEEP_STALE_AFTER_MS)}`
+      : "";
+  await DBOS.startWorkflow(syncWorkflow, {
+    workflowID: `benefits:${referenceId}:${origin}${bucket}`,
+  })(organizationId, referenceId);
 }

--- a/apps/mesh/src/billing/sync-org-benefits.ts
+++ b/apps/mesh/src/billing/sync-org-benefits.ts
@@ -1,0 +1,81 @@
+/**
+ * syncOrgBenefits — propagate an org's paid-seat count to the benefits it
+ * buys. ONE function, called from every place seats change: the invoiced
+ * seat-apply today, the Stripe webhooks (checkout / subscription.updated /
+ * invoice.paid) in phase 3.
+ *
+ * Benefit 1 — AI-gateway monthly allowance: paid_seats × seatAllowanceCents
+ * ($5 default), granted via the gateway's idempotent
+ * `POST /api/admin/allowance` (referenceId dedupes retries; the gateway
+ * REBASES per call — a mid-cycle seat change refreshes the current cycle's
+ * allowance, the same accepted slack as the plan's multi-subscription rule).
+ *
+ * Benefit 2 — weekly report re-run for included_report_url:
+ * TODO(billing/4.1): call the reports internal schedule endpoint once it
+ * exists (set next_scheduled_run_at when paidSeatCount >= 1, clear at 0).
+ *
+ * Fail-soft BY THE CALLER's choice: this function throws on failure so the
+ * caller decides (the seat tool reports benefitsSynced=false and the next
+ * apply self-heals — every call re-grants the full current amount).
+ */
+
+import { retry } from "@decocms/std";
+import { getSettings } from "../settings";
+
+const MICROS_PER_CENT = 10_000;
+
+export function computeAllowanceMicros(
+  paidSeatCount: number,
+  seatAllowanceCents: number,
+): number {
+  return paidSeatCount * seatAllowanceCents * MICROS_PER_CENT;
+}
+
+export interface SyncOrgBenefitsResult {
+  /** false = deployment has no gateway admin configured (sync skipped). */
+  allowanceSynced: boolean;
+}
+
+export async function syncOrgBenefits(input: {
+  organizationId: string;
+  paidSeatCount: number;
+  /** Idempotency key for THIS billing event (seat apply id / Stripe invoice
+   *  id). Retries with the same id are no-ops on the gateway. */
+  referenceId: string;
+}): Promise<SyncOrgBenefitsResult> {
+  const settings = getSettings();
+  if (!settings.aiGatewayEnabled || !settings.aiGatewayAdminToken) {
+    return { allowanceSynced: false };
+  }
+
+  const amountMicros = computeAllowanceMicros(
+    input.paidSeatCount,
+    settings.seatAllowanceCents,
+  );
+
+  await retry(
+    async () => {
+      const res = await fetch(`${settings.aiGatewayUrl}/api/admin/allowance`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${settings.aiGatewayAdminToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          orgId: input.organizationId,
+          amountMicros,
+          referenceId: input.referenceId,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(
+          `gateway allowance grant failed (${res.status}): ${body}`,
+        );
+      }
+    },
+    { maxAttempts: 3, minTimeout: 500, maxTimeout: 4_000 },
+  );
+
+  return { allowanceSynced: true };
+}

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,6 +1,7 @@
 {
   "auth/install-studio-pack-workflow.ts": "fe506448bcbd657194f72999b8196b842a3cc52e2685997462f1d4715cc734f1",
   "automations/dbos-workflow.ts": "088986a214dd803913438f51bdbaa14dfef25b151422e117605a7907dc2bd987",
+  "billing/sync-org-benefits.ts": "65d394d8f513a99d2c1685762a81043c72ff8cbfa0acd7fb85f21568f1cadc24",
   "dispatch-queue/hosted-harness-workflow.ts": "1ee53df2391d0b73f10630be7f7d947db16653d5b8740b799e64a98cb2f49c86",
   "dispatch-queue/thread-gate-workflow.ts": "674cd393ad3b06806e967389dfe7e87bd0de6ba933fd54df1e5cd24a08b99e43",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -199,6 +199,12 @@ export function resolveConfig(
     // AI Gateway
     aiGatewayEnabled: toBool(envVars.DECO_AI_GATEWAY_ENABLED),
     aiGatewayUrl: envVars.DECO_AI_GATEWAY_URL || "https://ai-site.deco.site",
+    aiGatewayAdminToken: envVars.DECO_AI_GATEWAY_ADMIN_TOKEN,
+    seatAllowanceCents: toPositiveIntegerOrDefault(
+      "STUDIO_SEAT_ALLOWANCE_CENTS",
+      envVars.STUDIO_SEAT_ALLOWANCE_CENTS,
+      500,
+    ),
 
     // Feature Flags
     enableDecoImport: toBool(envVars.ENABLE_DECO_IMPORT),

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -69,6 +69,11 @@ export interface Settings {
   // AI Gateway
   aiGatewayEnabled: boolean;
   aiGatewayUrl: string;
+  /** Bearer for the gateway's /api/admin/* (allowance grants). Absent →
+   *  benefit sync is skipped (self-hosted deployments have no gateway admin). */
+  aiGatewayAdminToken: string | undefined;
+  /** Monthly AI-gateway allowance per PAID SEAT, in cents (default $5). */
+  seatAllowanceCents: number;
 
   // Feature Flags
   enableDecoImport: boolean;

--- a/apps/mesh/src/storage/organization-billing.integration.test.ts
+++ b/apps/mesh/src/storage/organization-billing.integration.test.ts
@@ -126,14 +126,24 @@ describe("OrganizationBillingStorage", () => {
     expect(await storage.listPaidSeatUserIds(ORG)).toEqual([]);
   });
 
-  it("releases the seat (hooks boundary) and logs the transition", async () => {
-    const released = await storage.releaseSeat(ORG, "user_a", "admin_1");
-    expect(released).toBe(true);
+  it("releases the seat (hooks boundary), logs it, and marks the sync pending", async () => {
+    const release = await storage.releaseSeat(ORG, "user_a", "admin_1", {
+      markBenefitsPending: true,
+    });
+    expect(release.released).toBe(true);
+    expect(release.benefitsReferenceId).toBeTruthy();
     expect(await storage.listPaidSeatUserIds(ORG)).toEqual([]);
+    // The pending marker committed with the release (same transaction).
+    expect((await storage.getBilling(ORG))?.benefitsReferenceId).toBe(
+      release.benefitsReferenceId,
+    );
 
-    // Releasing again is a no-op — nothing new logged.
-    const again = await storage.releaseSeat(ORG, "user_a", "admin_1");
-    expect(again).toBe(false);
+    // Releasing again is a no-op — nothing new logged, no new marker.
+    const again = await storage.releaseSeat(ORG, "user_a", "admin_1", {
+      markBenefitsPending: true,
+    });
+    expect(again.released).toBe(false);
+    expect(again.benefitsReferenceId).toBeNull();
 
     const frees = await database.db
       .selectFrom("seat_change_log")
@@ -142,6 +152,33 @@ describe("OrganizationBillingStorage", () => {
       .where("user_id", "=", "user_a")
       .execute();
     expect(frees.map((r) => r.seat)).toEqual(["paid", "free"]);
+  });
+
+  it("clearBenefitsPending is a CAS: only the matching reference clears", async () => {
+    const pendingRef = (await storage.getBilling(ORG))?.benefitsReferenceId;
+    expect(pendingRef).toBeTruthy();
+
+    // A stale delivery (older reference) must NOT clear the newer marker.
+    await storage.clearBenefitsPending(ORG, "some-older-reference");
+    expect((await storage.getBilling(ORG))?.benefitsReferenceId).toBe(
+      pendingRef ?? null,
+    );
+
+    // The sweep sees it once stale…
+    const pending = await storage.listBenefitsPending(
+      new Date(Date.now() + 60_000),
+      10,
+    );
+    expect(pending).toEqual([
+      { organizationId: ORG, referenceId: pendingRef as string },
+    ]);
+
+    // …and the matching delivery clears it.
+    await storage.clearBenefitsPending(ORG, pendingRef as string);
+    expect((await storage.getBilling(ORG))?.benefitsReferenceId).toBeNull();
+    expect(
+      await storage.listBenefitsPending(new Date(Date.now() + 60_000), 10),
+    ).toEqual([]);
   });
 
   it("getBilling maps the row; missing row is null (fail-open upstream)", async () => {

--- a/apps/mesh/src/storage/organization-billing.ts
+++ b/apps/mesh/src/storage/organization-billing.ts
@@ -20,6 +20,9 @@ export interface OrganizationBillingRow {
   stripeSubscriptionId: string | null;
   currentPeriodEnd: Date | null;
   includedReportUrl: string | null;
+  /** Non-null = a gateway allowance grant is pending for the latest seat
+   *  change (the value is the grant's gateway idempotency key). */
+  benefitsReferenceId: string | null;
 }
 
 export type SeatKind = "paid" | "free";
@@ -34,6 +37,10 @@ export interface SetSeatsResult {
    *  are skipped and NOT logged, so the invoiced change-log stays clean). */
   applied: SeatChange[];
   paidSeatCount: number;
+  /** Set when the change-set marked a benefit sync pending (markBenefitsPending
+   *  option, applied non-empty): the grant's gateway idempotency key, committed
+   *  ATOMICALLY with the seat rows so a crash can never lose the intent. */
+  benefitsReferenceId: string | null;
 }
 
 export class SeatTargetNotMemberError extends Error {
@@ -64,6 +71,7 @@ export class OrganizationBillingStorage {
       stripeSubscriptionId: row.stripe_subscription_id,
       currentPeriodEnd: row.current_period_end,
       includedReportUrl: row.included_report_url,
+      benefitsReferenceId: row.benefits_reference_id,
     };
   }
 
@@ -104,6 +112,7 @@ export class OrganizationBillingStorage {
     organizationId: string,
     changes: SeatChange[],
     changedBy: string,
+    opts?: { markBenefitsPending?: boolean },
   ): Promise<SetSeatsResult> {
     return await this.db.transaction().execute(async (trx) => {
       const userIds = [...new Set(changes.map((c) => c.userId))];
@@ -179,7 +188,30 @@ export class OrganizationBillingStorage {
         .where("organization_paid_seat.organization_id", "=", organizationId)
         .executeTakeFirst();
 
-      return { applied, paidSeatCount: Number(paidSeats?.count ?? 0) };
+      // Benefit-sync intent commits WITH the seat rows — the crash-proof half
+      // of the durable grant (the workflow + sweep are the delivery half).
+      // Overwriting a previous pending ref is correct: grants are absolute
+      // (full current amount), so only the LATEST change-set needs delivering.
+      const benefitsReferenceId =
+        opts?.markBenefitsPending && applied.length > 0
+          ? crypto.randomUUID()
+          : null;
+      if (benefitsReferenceId) {
+        await trx
+          .updateTable("organization_billing")
+          .set({
+            benefits_reference_id: benefitsReferenceId,
+            updated_at: new Date(),
+          })
+          .where("organization_id", "=", organizationId)
+          .execute();
+      }
+
+      return {
+        applied,
+        paidSeatCount: Number(paidSeats?.count ?? 0),
+        benefitsReferenceId,
+      };
     });
   }
 
@@ -196,7 +228,8 @@ export class OrganizationBillingStorage {
     organizationId: string,
     userId: string,
     changedBy: string,
-  ): Promise<boolean> {
+    opts?: { markBenefitsPending?: boolean },
+  ): Promise<{ released: boolean; benefitsReferenceId: string | null }> {
     return await this.db.transaction().execute(async (trx) => {
       const deleted = await trx
         .deleteFrom("organization_paid_seat")
@@ -204,7 +237,7 @@ export class OrganizationBillingStorage {
         .where("user_id", "=", userId)
         .returning("user_id")
         .executeTakeFirst();
-      if (!deleted) return false;
+      if (!deleted) return { released: false, benefitsReferenceId: null };
       await trx
         .insertInto("seat_change_log")
         .values({
@@ -214,7 +247,65 @@ export class OrganizationBillingStorage {
           changed_by: changedBy,
         })
         .execute();
-      return true;
+      const benefitsReferenceId = opts?.markBenefitsPending
+        ? crypto.randomUUID()
+        : null;
+      if (benefitsReferenceId) {
+        await trx
+          .updateTable("organization_billing")
+          .set({
+            benefits_reference_id: benefitsReferenceId,
+            updated_at: new Date(),
+          })
+          .where("organization_id", "=", organizationId)
+          .execute();
+      }
+      return { released: true, benefitsReferenceId };
     });
+  }
+
+  /**
+   * Confirm a delivered grant: clear the pending marker iff it still holds
+   * THIS reference (CAS) — a newer seat change may have replaced it, and that
+   * newer grant must stay pending until its own delivery confirms.
+   */
+  async clearBenefitsPending(
+    organizationId: string,
+    referenceId: string,
+  ): Promise<void> {
+    await this.db
+      .updateTable("organization_billing")
+      .set({ benefits_reference_id: null, updated_at: new Date() })
+      .where("organization_id", "=", organizationId)
+      .where("benefits_reference_id", "=", referenceId)
+      .execute();
+  }
+
+  /**
+   * Orgs whose latest grant is still undelivered and stale enough that the
+   * fast path clearly failed (pod died before enqueue, workflow exhausted) —
+   * the sweep's work list.
+   */
+  async listBenefitsPending(
+    olderThan: Date,
+    limit: number,
+  ): Promise<Array<{ organizationId: string; referenceId: string }>> {
+    const rows = await this.db
+      .selectFrom("organization_billing")
+      .select(["organization_id", "benefits_reference_id"])
+      .where("benefits_reference_id", "is not", null)
+      .where("updated_at", "<", olderThan)
+      .limit(limit)
+      .execute();
+    return rows.flatMap((r) =>
+      r.benefits_reference_id
+        ? [
+            {
+              organizationId: r.organization_id,
+              referenceId: r.benefits_reference_id,
+            },
+          ]
+        : [],
+    );
   }
 }

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -1254,6 +1254,15 @@ export interface OrganizationBillingTable {
     string | null | undefined,
     string | null
   >;
+  /** Pending benefit-sync marker (migration 141): non-null = a gateway
+   *  allowance grant for the latest seat change hasn't been confirmed.
+   *  Written in the SAME transaction as the seat change; the value is the
+   *  grant's idempotency key at the gateway. */
+  benefits_reference_id: ColumnType<
+    string | null,
+    string | null | undefined,
+    string | null
+  >;
   created_at: ColumnType<Date, Date | string | undefined, never>;
   updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
 }

--- a/apps/mesh/src/tools/organization/seats.ts
+++ b/apps/mesh/src/tools/organization/seats.ts
@@ -13,7 +13,10 @@
  */
 
 import { z } from "zod";
-import { syncOrgBenefits } from "../../billing/sync-org-benefits";
+import {
+  benefitsSyncEnabled,
+  enqueueBenefitsSync,
+} from "../../billing/sync-org-benefits";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, getUserId } from "../../core/studio-context";
 import { SeatTargetNotMemberError } from "../../storage/organization-billing";
@@ -98,10 +101,11 @@ export const ORGANIZATION_SEATS_SET = defineTool({
       z.object({ userId: z.string(), seat: z.enum(["paid", "free"]) }),
     ),
     paidSeatCount: z.number(),
-    /** Whether the gateway allowance grant succeeded. false = seats saved
-     *  but the benefit sync failed/was skipped — the NEXT apply re-grants
-     *  the full current amount, so the state self-heals. */
-    benefitsSynced: z.boolean(),
+    /** Whether a durable benefit-sync delivery was queued. false = this
+     *  deployment doesn't deliver benefits (no gateway admin) or nothing
+     *  changed. Delivery itself is guaranteed by the pending marker committed
+     *  with the seats + the DBOS workflow/sweep — not by this flag. */
+    benefitsSyncQueued: z.boolean(),
   }),
 
   handler: async (input, ctx) => {
@@ -135,10 +139,14 @@ export const ORGANIZATION_SEATS_SET = defineTool({
       ReturnType<typeof ctx.storage.organizationBilling.setSeats>
     >;
     try {
+      // The benefit-sync intent (pending marker) commits IN the same
+      // transaction as the seat rows — a crash after this line can never
+      // lose the gateway grant; the DBOS workflow + scheduled sweep deliver.
       result = await ctx.storage.organizationBilling.setSeats(
         organizationId,
         input.seats,
         changedBy,
+        { markBenefitsPending: benefitsSyncEnabled() },
       );
     } catch (err) {
       if (err instanceof SeatTargetNotMemberError) {
@@ -147,24 +155,26 @@ export const ORGANIZATION_SEATS_SET = defineTool({
       throw err;
     }
 
-    // Benefits ride the seat change but never fail it: the seats are already
-    // committed (they're the billing truth), and a failed grant self-heals on
-    // the next apply (every call re-grants the full current amount). One
-    // referenceId per applied change-set keeps gateway retries deduped.
-    let benefitsSynced = false;
-    if (result.applied.length > 0) {
+    // Fast-path enqueue. Fail-soft: the marker is committed, so a failed
+    // enqueue is exactly what the sweep exists for.
+    let benefitsSyncQueued = false;
+    if (result.benefitsReferenceId) {
       try {
-        const sync = await syncOrgBenefits({
+        await enqueueBenefitsSync(
           organizationId,
-          paidSeatCount: result.paidSeatCount,
-          referenceId: `seats:${organizationId}:${crypto.randomUUID()}`,
-        });
-        benefitsSynced = sync.allowanceSynced;
+          result.benefitsReferenceId,
+          "apply",
+        );
+        benefitsSyncQueued = true;
       } catch (err) {
-        console.error("Failed to sync org benefits after seat change:", err);
+        console.error("Failed to enqueue benefit sync (sweep covers):", err);
       }
     }
 
-    return { ...result, benefitsSynced };
+    return {
+      applied: result.applied,
+      paidSeatCount: result.paidSeatCount,
+      benefitsSyncQueued,
+    };
   },
 });

--- a/apps/mesh/src/tools/organization/seats.ts
+++ b/apps/mesh/src/tools/organization/seats.ts
@@ -13,6 +13,7 @@
  */
 
 import { z } from "zod";
+import { syncOrgBenefits } from "../../billing/sync-org-benefits";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, getUserId } from "../../core/studio-context";
 import { SeatTargetNotMemberError } from "../../storage/organization-billing";
@@ -97,6 +98,10 @@ export const ORGANIZATION_SEATS_SET = defineTool({
       z.object({ userId: z.string(), seat: z.enum(["paid", "free"]) }),
     ),
     paidSeatCount: z.number(),
+    /** Whether the gateway allowance grant succeeded. false = seats saved
+     *  but the benefit sync failed/was skipped — the NEXT apply re-grants
+     *  the full current amount, so the state self-heals. */
+    benefitsSynced: z.boolean(),
   }),
 
   handler: async (input, ctx) => {
@@ -126,20 +131,40 @@ export const ORGANIZATION_SEATS_SET = defineTool({
       );
     }
 
+    let result: Awaited<
+      ReturnType<typeof ctx.storage.organizationBilling.setSeats>
+    >;
     try {
-      const result = await ctx.storage.organizationBilling.setSeats(
+      result = await ctx.storage.organizationBilling.setSeats(
         organizationId,
         input.seats,
         changedBy,
       );
-      // TODO(billing/2.8): syncOrgBenefits(organizationId) — gateway
-      // allowance (paid_seats × $5) + reports weekly-run schedule.
-      return result;
     } catch (err) {
       if (err instanceof SeatTargetNotMemberError) {
         throw new Error(err.message);
       }
       throw err;
     }
+
+    // Benefits ride the seat change but never fail it: the seats are already
+    // committed (they're the billing truth), and a failed grant self-heals on
+    // the next apply (every call re-grants the full current amount). One
+    // referenceId per applied change-set keeps gateway retries deduped.
+    let benefitsSynced = false;
+    if (result.applied.length > 0) {
+      try {
+        const sync = await syncOrgBenefits({
+          organizationId,
+          paidSeatCount: result.paidSeatCount,
+          referenceId: `seats:${organizationId}:${crypto.randomUUID()}`,
+        });
+        benefitsSynced = sync.allowanceSynced;
+      } catch (err) {
+        console.error("Failed to sync org benefits after seat change:", err);
+      }
+    }
+
+    return { ...result, benefitsSynced };
   },
 });


### PR DESCRIPTION
## Summary

Task 2.8 of the per-seat plan — the wire connecting studio seats to the ai-gateway allowance primitive (ai-gateway#13). One idempotent seam, `syncOrgBenefits`, called from **every place the paid-seat count changes**:

- `ORGANIZATION_SEATS_SET` (invoiced apply) — new `benefitsSynced` output field;
- the `afterRemoveMember` seat release — a removed paid member shrinks the grant instead of lingering until the next manual apply;
- phase-3 Stripe webhooks will call the same function (`checkout.session.completed`, `invoice.paid` as the monthly reset clock).

**Mechanics**: allowance = `paid_seats × STUDIO_SEAT_ALLOWANCE_CENTS` (default 500 = \$5/seat/month) → `POST {gateway}/api/admin/allowance` with a per-change-set `referenceId` (gateway dedupes retries; `@decocms/std` retry ×3). The gateway REBASES per call, so a mid-cycle seat change refreshes the cycle's allowance — same accepted-slack class as the plan's multi-subscription rule, documented in code.

**Failure posture**: seats commit first (they're the billing truth), benefits never fail the apply. A failed grant logs + returns `benefitsSynced: false`, and the state self-heals on the next apply because every call re-grants the full current amount. Deployments without the new `DECO_AI_GATEWAY_ADMIN_TOKEN` env (self-hosted) skip the sync.

## Deploy prerequisite

Prod/stg need `DECO_AI_GATEWAY_ADMIN_TOKEN` set on deco-studio (one of the gateway's `ADMIN_TOKENS`) for the sync to be live — until then it's a logged skip. Flagging instead of a deco-apps-cd PR since it's a secret, not a values entry.

## Testing

- Unit: `computeAllowanceMicros` (the plan's 4-seats→\$20 example, zero-seats revoke).
- Full-workspace `bun run check` green, `knip` clean, `bun run fmt` applied.
- Wire smoke once deployed to stg: apply seats on an invoiced org → gateway `subscription_allowances` row + OpenRouter key limit reflect `seats × $5`; remove a paid member → grant shrinks.
- Weekly report schedule intentionally still a `TODO(billing/4.1)` — no dead code for an endpoint that doesn't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs paid-seat changes to the AI Gateway monthly allowance via a durable, idempotent DBOS workflow. Seat updates write a pending marker and enqueue delivery; the grant self-heals and never blocks billing.

- **New Features**
  - Durable sync on every paid-seat change: `ORGANIZATION_SEATS_SET` and member removal. Writes `benefits_reference_id` in the same transaction and enqueues a DBOS workflow.
  - Allowance = paid seats × `STUDIO_SEAT_ALLOWANCE_CENTS` (default $5/seat). Calls `POST /api/admin/allowance` with idempotent `referenceId`.
  - Scheduled sweep (every 10 min) re-enqueues stale markers; duplicate deliveries are no-ops.
  - Seats tool now returns `benefitsSyncQueued`. Releasing a paid member shrinks the grant immediately.
  - Skips syncing if the gateway admin token is not set; logs but never blocks seat updates.

- **Migration**
  - Set `DECO_AI_GATEWAY_ADMIN_TOKEN` in staging/production to enable syncing. Optionally tune `STUDIO_SEAT_ALLOWANCE_CENTS`.

<sup>Written for commit 8c0f24f508163c28507799fb8ce8c61a00eb293b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

