### PR TITLE
fix(sandbox): return 400 instead of 500 for non-string entries in git/discard filepaths

### DIFF
--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -698,6 +698,21 @@ describe("git routes", () => {
     });
   });
 
+  it("discard returns 400 (not 500) when filepaths contains a non-string entry", async () => {
+    const { appRoot, repoDir } = initRepo();
+
+    const handler = makeGitDiscardHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/discard", {
+        method: "POST",
+        body: JSON.stringify({ filepaths: ["README.md", 123] }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "filepaths is required" });
+  });
+
   it("discard on a renamed file restores the original instead of deleting both", async () => {
     const { appRoot, repoDir } = initRepo();
     writeFileSync(join(repoDir, "old.txt"), "important content\n");

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -812,7 +812,11 @@ export function makeGitDiscardHandler(deps: GitDeps) {
       return jsonResponse({ error: (e as Error).message }, 400);
     }
     const filepaths = body.filepaths;
-    if (!Array.isArray(filepaths) || filepaths.length === 0) {
+    if (
+      !Array.isArray(filepaths) ||
+      filepaths.length === 0 ||
+      !filepaths.every((fp) => typeof fp === "string")
+    ) {
       return jsonResponse({ error: "filepaths is required" }, 400);
     }
     try {


### PR DESCRIPTION
**Source:** bug found while auditing `packages/sandbox/daemon/routes/git.ts` (my assigned focus area: sandbox daemon git route hardening). Same lane as the repo's proven series of "return 4xx instead of 500" daemon fixes (#5008, #5105, #5106, #5109, #5124).

**Why a maintainer wants this:** the `/git/discard` route only validated that `filepaths` was a non-empty array, not that each entry was a string. A non-string entry (e.g. `123`) reaches `resolveRepoRelativePath()` -> `safePath()` -> `path.resolve(baseDir, userPath)`, and Node's `path.resolve` throws a `TypeError` for a non-string argument. That TypeError isn't one of the route's known error classes, so it falls through to the generic catch and surfaces as an opaque 500 instead of a client-input 400 — the exact bug shape this daemon has repeatedly hardened against elsewhere.

**Failure scenario:** `POST /git/discard` with body `{"filepaths": ["README.md", 123]}` throws inside `path.resolve` and returns 500. After the fix it returns 400 with `{"error": "filepaths is required"}`.

**Regression test:** added `discard returns 400 (not 500) when filepaths contains a non-string entry` to `packages/sandbox/daemon/routes/git.test.ts`, which fails against the old code (500) and passes against the fix (400).

**Reviewer verification:** `bun test packages/sandbox/daemon/routes/git.test.ts`

**Locally verified:** `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit`, and the single targeted test file above (35/35 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 400 (not 500) from `/git/discard` when `filepaths` contains a non-string entry by validating every item is a string. Adds a regression test to cover this case.

- **Bug Fixes**
  - Validate `filepaths` is a non-empty array of strings; otherwise return 400 with `{ "error": "filepaths is required" }`.
  - Added test: rejects `["README.md", 123]` with 400 in `packages/sandbox/daemon/routes/git.test.ts`.

<sup>Written for commit 96c998e2b5c7f040cca30e6b8edbbcfa6037f205. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

