### PR TITLE
fix(chat): process window-dropped files in order, not racing on a stale position

### DIFF
--- a/apps/mesh/src/web/components/chat/input.tsx
+++ b/apps/mesh/src/web/components/chat/input.tsx
@@ -135,17 +135,25 @@ function useWindowFileDrop(
       const files = e.dataTransfer?.files;
       if (!files || files.length === 0) return;
 
-      const { from } = editor.state.selection;
-      for (const file of Array.from(files)) {
-        void processFile(
-          editor,
-          selectedModel,
-          file,
-          from,
-          onUnsupportedFile,
-          t,
-        );
-      }
+      // Process files sequentially, re-reading the selection after each
+      // insert so multiple files land in order instead of racing to insert
+      // at the same stale position (see the ProseMirror-level fix for the
+      // same race in tiptap/file/uploader.tsx).
+      const fileArray = Array.from(files);
+      void (async () => {
+        let insertPos = editor.state.selection.from;
+        for (const file of fileArray) {
+          await processFile(
+            editor,
+            selectedModel,
+            file,
+            insertPos,
+            onUnsupportedFile,
+            t,
+          );
+          insertPos = editor.state.selection.to;
+        }
+      })();
     };
 
     window.addEventListener("dragenter", onDragEnter);


### PR DESCRIPTION
PR #4806 fixed the identical race in `FileUploader`'s ProseMirror `handleDrop`/`handlePaste` (tiptap/file/uploader.tsx) but missed the sibling window-level drop handler in `input.tsx`'s `useWindowFileDrop` — the one that backs the full-composer `FileDropZone` overlay you see when dragging files anywhere over the chat input, not just directly onto the editor.

**Bug**: `onDrop` captured `editor.state.selection.from` once, then looped over all dropped files firing `void processFile(...)` unawaited, every call reusing that same stale position. `processFile` does async work (`FileReader`), so with 2+ files dropped together in one gesture, each `insertFile` call resolves and inserts against whatever the live document looks like at that moment, at the *same* original position — files land in reverse order or interleaved unpredictably, exactly the bug #4806 already documented and fixed one file over.

**Fix**: process files sequentially — `await` each `processFile` call and re-read `editor.state.selection.to` after every insert as the position for the next one, mirroring the fix already merged in `tiptap/file/uploader.tsx`.

**Reviewer check**: drag 2+ files (e.g. two images) onto the chat composer (dropping anywhere over it, not just precisely on the text area) in a single gesture — they should now appear in the order dropped, matching the already-fixed in-editor drop/paste behavior.

**Verified locally**: `bun run fmt` (clean) and `cd apps/mesh && bunx tsc --noEmit` (clean). No unit-test harness in the repo instantiates a live ProseMirror editor (same constraint noted in #4806), so this is a manual/visual reviewer check; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes window-level file drop in the chat composer by processing files sequentially so they insert in the correct order at the current selection. Drops over the `FileDropZone` now match in-editor drop/paste behavior.

- **Bug Fixes**
  - Await each file’s processing and re-read `editor.state.selection.to` after every insert to avoid racing on a stale position.
  - Applies to the overlay drop handler (`useWindowFileDrop`) so multiple files land in the order they were dropped.

<sup>Written for commit 43f8d4c480213f5749586f140389138ec15b798d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

