### PR TITLE
fix(sections-editor): cancel pending page-rule autosave before section CRUD

### DIFF
--- a/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
+++ b/apps/mesh/src/web/components/sections-editor/sections-editor.tsx
@@ -646,6 +646,14 @@ export function SectionsEditor({
       clearTimeout(sectionRuleDebounceRef.current);
       sectionRuleDebounceRef.current = null;
     }
+    // Cancel a pending page-variant rule autosave too — it rebuilds the whole
+    // page's `sections` from a `decofile` snapshot read at fire time, which
+    // may still predate this save's result, so a stale timer would revert
+    // the restructuring committed here.
+    if (ruleDebounceRef.current) {
+      clearTimeout(ruleDebounceRef.current);
+      ruleDebounceRef.current = null;
+    }
     const fullPageData = buildPageDataWithSections(
       decofile,
       activePageKey,


### PR DESCRIPTION
Follows #5148/#5146 hardening of the same autosave-race class in this file.

`savePageSections()` — used by reorder/delete/duplicate/hide/lazy-toggle/detach/add-section — cancelled the field-level and section-rule autosave timers before writing, but missed the page-variant matcher-rule autosave (`ruleDebounceRef`, scheduled by `scheduleRuleSave`/`handleRuleFormChange`/`handleMatcherTypeChange`).

**Failure scenario:** user edits a page variant's matcher rule (schedules a debounced rule-autosave), then within the debounce window deletes/reorders/duplicates a section. `savePageSections` fires an immediate save with the updated sections. ~500ms later the still-pending rule-autosave timer fires — it rebuilds the *entire* page's `sections` object from a `decofile` snapshot read at fire time (via `latestRef`). If the query cache hasn't yet reflected the just-completed section-CRUD save, that stale snapshot's sections array gets written back, silently reverting the section restructuring the user just made.

**Fix:** `savePageSections` now also clears `ruleDebounceRef` (same pattern already used for `handleAddPageVariant`/`handleReorderPageVariants` etc. in the prior two PRs), so no stale rule-autosave can fire after a section-CRUD save.

No test added — matches the precedent of #5148/#5146, which fixed the identical race class in the same component with no dedicated test (component isn't unit-testable without mocking React Query/hooks, which the repo's unit-test tier disallows).

A reviewer can confirm by reading `savePageSections` (apps/mesh/src/web/components/sections-editor/sections-editor.tsx) alongside `scheduleRuleSave` and comparing against how #5148 handled the reverse direction (page-variant restructuring cancelling section/rule autosave).

Local checks: `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/mesh` (no new errors — pre-existing unrelated errors in an untracked `src/storage/types.test.ts` file, not touched by this change). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents section changes from being reverted by a stale page-variant rule autosave. `savePageSections()` now cancels the pending matcher-rule debounce before saving section CRUD operations.

- **Bug Fixes**
  - Clear `ruleDebounceRef` in `savePageSections()` so a delayed rule autosave can’t rebuild and write an outdated `sections` array after section CRUD (reorder/delete/duplicate/hide/lazy-toggle/detach/add).

<sup>Written for commit 9d27ae0bb7dd0939ef7ff87e5d71a363b2e085c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

