### PR TITLE
fix(orgs): disable seat toggle while a batch apply is in flight

### DIFF
--- a/apps/mesh/src/web/routes/orgs/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/members.tsx
@@ -769,6 +769,7 @@ function OrgMembersContent() {
                   variant={seat === "paid" ? "secondary" : "outline"}
                   size="xs"
                   onClick={() => toggleSeat(userId)}
+                  disabled={setSeatsMutation.isPending}
                   className={cn(isStaged && "ring-2 ring-primary/60")}
                 >
                   {seat === "paid"


### PR DESCRIPTION
Post-merge hardening follow-up to #5147 (billing seat toggle + staged apply on the members page).

**Bug:** the per-row seat toggle button in the members table has no guard on `setSeatsMutation.isPending`, unlike the Apply/Discard buttons which already disable while a batch is in flight. If an admin clicks Apply, then toggles another member's seat before the request resolves, the mutation's `onSuccess` handler unconditionally resets `stagedSeats` to `{}` — silently discarding the toggle made during the in-flight request. The admin sees no error and the change is simply lost, with no indication it never reached the server.

**Fix:** disable the seat toggle button while `setSeatsMutation.isPending`, exactly matching the existing pattern already used on the Apply/Discard buttons. This closes the race by preventing new staged input during an in-flight apply, rather than trying to reconcile the state diff after the fact.

**To confirm:** open the members page of an invoiced org, toggle a seat, click Apply, and (before the mutation resolves) confirm the toggle buttons in the table are disabled instead of accepting another click.

**Checks run locally:** `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/mesh` (clean, no test file exists for this component — Playwright CT covers UI interactions and isn't run locally per this repo's testing tiers). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the per-row seat toggle in the members table while `setSeatsMutation` is pending, matching the Apply/Discard buttons. This prevents a race where toggles clicked during an in-flight apply were silently discarded when `onSuccess` reset `stagedSeats`.

<sup>Written for commit 28209312ca304921a55ca5e6e643e618fe12480a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

