### PR TITLE
feat(billing): Stripe webhook intake — subscription state + monthly allowance clock

### DIFF
--- a/apps/mesh/src/api/app.ts
+++ b/apps/mesh/src/api/app.ts
@@ -96,6 +96,7 @@ import { createTriggerCallbackRoutes } from "./routes/trigger-callback";
 import publicConfigRoutes from "./routes/public-config";
 import { createReportPagesRoutes } from "./routes/report-pages";
 import reportsRoutes from "./routes/reports";
+import { stripeWebhookRoutes } from "./routes/stripe-webhook";
 import filesRoutes from "./routes/files";
 import { createThreadOutputsRoutes } from "./routes/thread-outputs";
 import { createSelfRoutes } from "./routes/self";
@@ -1342,6 +1343,10 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Report shell stays public so authentication can happen inline, while all
   // report data and scan operations behind this proxy require a user session.
   app.route("/api/_reports", reportsRoutes);
+
+  // Stripe webhook (per-seat billing): signature-authed, no session — the
+  // caller is Stripe. Instance-level namespace, before the /api/:org catch-all.
+  app.route("/api/_stripe", stripeWebhookRoutes);
 
   // Auth-gated report page + domain-derived metadata. API-only/test apps safely
   // return 404 for the HTML shell when no built client directory is supplied.

--- a/apps/mesh/src/api/routes/stripe-webhook.ts
+++ b/apps/mesh/src/api/routes/stripe-webhook.ts
@@ -1,0 +1,57 @@
+/**
+ * POST /api/_stripe/webhook — Stripe event intake (per-seat billing).
+ *
+ * Instance-level (underscore namespace, mounted before the /api/:org
+ * catch-all) and deliberately OUTSIDE any session/admin auth: the caller is
+ * Stripe, authenticated exclusively by the signature over the RAW body.
+ * 503 when the deployment has no webhook secret (self-hosted: Stripe billing
+ * simply doesn't exist there).
+ */
+
+import { Hono } from "hono";
+import { getSettings } from "../../settings";
+import {
+  processStripeEvent,
+  verifyStripeSignature,
+  type StripeEvent,
+} from "../../billing/stripe-webhook";
+
+export const stripeWebhookRoutes = new Hono();
+
+stripeWebhookRoutes.post("/webhook", async (c) => {
+  const secret = getSettings().stripeWebhookSecret;
+  if (!secret) {
+    return c.json({ error: "stripe billing not configured" }, 503);
+  }
+
+  // Raw body FIRST — the signature covers the exact bytes, any parse-then-
+  // restringify would break verification.
+  const rawBody = await c.req.text();
+  const ok = await verifyStripeSignature(
+    rawBody,
+    c.req.header("stripe-signature"),
+    secret,
+  );
+  if (!ok) {
+    return c.json({ error: "invalid signature" }, 400);
+  }
+
+  let event: StripeEvent;
+  try {
+    event = JSON.parse(rawBody) as StripeEvent;
+  } catch {
+    return c.json({ error: "invalid payload" }, 400);
+  }
+  if (
+    typeof event?.type !== "string" ||
+    typeof event?.data?.object !== "object"
+  ) {
+    return c.json({ error: "invalid payload" }, 400);
+  }
+
+  // Always 200 for verified events — handlers are idempotent and unknown
+  // orgs/events are acknowledged no-ops (a Stripe redelivery wouldn't help).
+  // A thrown handler error falls through to 500 so Stripe DOES redeliver.
+  const result = await processStripeEvent(event);
+  return c.json(result);
+});

--- a/apps/mesh/src/billing/stripe-webhook.integration.test.ts
+++ b/apps/mesh/src/billing/stripe-webhook.integration.test.ts
@@ -1,0 +1,150 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import { OrganizationBillingStorage } from "../storage/organization-billing";
+import { applyStripeEvent, type StripeEvent } from "./stripe-webhook";
+
+// Real-Postgres coverage for the webhook handlers: binding a checkout to the
+// org, mirroring subscription lifecycle, and the invoice.paid monthly clock —
+// including the deterministic reference ids that collapse Stripe redeliveries.
+const ORG = "org_stripe_1";
+
+function event(type: string, object: Record<string, unknown>): StripeEvent {
+  return { type, data: { object } };
+}
+
+describe("applyStripeEvent", () => {
+  let database: StudioDatabase;
+  let storage: OrganizationBillingStorage;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: ORG,
+        name: "Stripe Org",
+        slug: "stripe-org",
+        createdAt: new Date().toISOString(),
+      })
+      .execute();
+    await database.db
+      .insertInto("organization_billing")
+      .values({ organization_id: ORG, legacy: false })
+      .execute();
+    storage = new OrganizationBillingStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("checkout.session.completed binds the subscription and marks the grant", async () => {
+    const result = await applyStripeEvent(
+      storage,
+      event("checkout.session.completed", {
+        id: "cs_1",
+        mode: "subscription",
+        customer: "cus_1",
+        subscription: "sub_1",
+        metadata: { orgId: ORG },
+      }),
+    );
+    expect(result.handled).toBe(true);
+
+    const billing = await storage.getBilling(ORG);
+    expect(billing?.stripeCustomerId).toBe("cus_1");
+    expect(billing?.stripeSubscriptionId).toBe("sub_1");
+    expect(billing?.status).toBe("active");
+    expect(billing?.benefitsReferenceId).toBe("stripe-checkout:cs_1");
+  });
+
+  it("subscription.updated mirrors status + period end, keyed by Stripe id", async () => {
+    const periodEnd = 1_800_000_000;
+    const result = await applyStripeEvent(
+      storage,
+      event("customer.subscription.updated", {
+        id: "sub_1",
+        status: "past_due",
+        current_period_end: periodEnd,
+      }),
+    );
+    expect(result.handled).toBe(true);
+
+    const billing = await storage.getBilling(ORG);
+    expect(billing?.status).toBe("past_due");
+    expect(billing?.currentPeriodEnd?.getTime()).toBe(periodEnd * 1000);
+    // Deterministic per (sub, status, period): a redelivery re-marks the SAME
+    // reference — one gateway rebase, not two.
+    expect(billing?.benefitsReferenceId).toBe(
+      `stripe-sub:sub_1:past_due:${periodEnd * 1000}`,
+    );
+  });
+
+  it("invoice.paid is the monthly clock: reactivates and re-marks per invoice id", async () => {
+    const result = await applyStripeEvent(
+      storage,
+      event("invoice.paid", {
+        id: "in_42",
+        subscription: "sub_1",
+        period_end: 1_802_592_000,
+      }),
+    );
+    expect(result.handled).toBe(true);
+
+    const billing = await storage.getBilling(ORG);
+    expect(billing?.status).toBe("active");
+    expect(billing?.benefitsReferenceId).toBe("stripe-invoice:in_42");
+  });
+
+  it("subscription.deleted cancels service", async () => {
+    const result = await applyStripeEvent(
+      storage,
+      event("customer.subscription.deleted", {
+        id: "sub_1",
+        status: "canceled",
+      }),
+    );
+    expect(result.handled).toBe(true);
+    expect((await storage.getBilling(ORG))?.status).toBe("canceled");
+  });
+
+  it("unknown orgs/subscriptions and non-subscription checkouts are acked no-ops", async () => {
+    const unknownSub = await applyStripeEvent(
+      storage,
+      event("customer.subscription.updated", { id: "sub_ghost" }),
+    );
+    expect(unknownSub.handled).toBe(false);
+
+    const unknownOrg = await applyStripeEvent(
+      storage,
+      event("checkout.session.completed", {
+        id: "cs_2",
+        mode: "subscription",
+        metadata: { orgId: "org_ghost" },
+      }),
+    );
+    expect(unknownOrg.handled).toBe(false);
+
+    const payment = await applyStripeEvent(
+      storage,
+      event("checkout.session.completed", {
+        id: "cs_3",
+        mode: "payment",
+        metadata: { orgId: ORG },
+      }),
+    );
+    expect(payment.handled).toBe(false);
+
+    const unhandled = await applyStripeEvent(
+      storage,
+      event("charge.refunded", { id: "ch_1" }),
+    );
+    expect(unhandled.handled).toBe(false);
+  });
+});

--- a/apps/mesh/src/billing/stripe-webhook.test.ts
+++ b/apps/mesh/src/billing/stripe-webhook.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { createHmac } from "node:crypto";
+import { mapSubscriptionStatus, verifyStripeSignature } from "./stripe-webhook";
+
+const SECRET = "whsec_test_secret";
+
+function sign(body: string, secret = SECRET, t = 1_700_000_000): string {
+  const v1 = createHmac("sha256", secret).update(`${t}.${body}`).digest("hex");
+  return `t=${t},v1=${v1}`;
+}
+
+describe("verifyStripeSignature", () => {
+  test("accepts Stripe's v1 scheme over the raw body", async () => {
+    const body = '{"type":"invoice.paid"}';
+    expect(await verifyStripeSignature(body, sign(body), SECRET)).toBe(true);
+  });
+
+  test("rejects a tampered body, wrong secret, and malformed headers", async () => {
+    const body = '{"type":"invoice.paid"}';
+    const header = sign(body);
+    expect(await verifyStripeSignature(`${body} `, header, SECRET)).toBe(false);
+    expect(await verifyStripeSignature(body, sign(body, "other"), SECRET)).toBe(
+      false,
+    );
+    expect(await verifyStripeSignature(body, "garbage", SECRET)).toBe(false);
+    expect(await verifyStripeSignature(body, undefined, SECRET)).toBe(false);
+    expect(await verifyStripeSignature(body, header, undefined)).toBe(false);
+  });
+});
+
+describe("mapSubscriptionStatus", () => {
+  test("active/trialing serve, past_due is grace, everything else is out", () => {
+    expect(mapSubscriptionStatus("active")).toBe("active");
+    expect(mapSubscriptionStatus("trialing")).toBe("active");
+    expect(mapSubscriptionStatus("past_due")).toBe("past_due");
+    expect(mapSubscriptionStatus("canceled")).toBe("canceled");
+    expect(mapSubscriptionStatus("unpaid")).toBe("canceled");
+    expect(mapSubscriptionStatus(undefined)).toBe("canceled");
+  });
+});

--- a/apps/mesh/src/billing/stripe-webhook.ts
+++ b/apps/mesh/src/billing/stripe-webhook.ts
@@ -1,0 +1,190 @@
+/**
+ * Stripe webhook intake for per-seat self-serve billing (phase 3).
+ *
+ * The webhook is the SOURCE OF TRUTH writer for organization_billing's
+ * subscription state — checkout/portal flows only send users to Stripe; what
+ * comes back here is what we believe. Handlers are idempotent (state-setting
+ * writes + gateway-deduped benefit grants), so Stripe redeliveries are safe.
+ *
+ * Events:
+ *  - checkout.session.completed  → bind customer/subscription to the org
+ *    (metadata.orgId, set by our checkout creator), status active, grant.
+ *  - customer.subscription.updated → mirror status + current_period_end.
+ *  - customer.subscription.deleted → status canceled, grant recomputes to 0
+ *    (the sync workflow zeroes self_serve orgs whose status isn't good).
+ *  - invoice.paid → THE MONTHLY CLOCK: refresh period end + re-grant with
+ *    referenceId = invoice id, which is what makes the gateway allowance
+ *    reset per billing cycle (no cron anywhere).
+ *
+ * Signature: Stripe's v1 scheme (HMAC-SHA256 over `${t}.${rawBody}`),
+ * verified timing-safe — same hand-rolled approach as the reports worker; the
+ * Stripe SDK arrives with the checkout/preview API surface, not for this.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { getDb } from "@/database";
+import { OrganizationBillingStorage } from "../storage/organization-billing";
+import { enqueueBenefitsSync } from "./sync-org-benefits";
+
+export async function verifyStripeSignature(
+  rawBody: string,
+  sigHeader: string | null | undefined,
+  secret: string | undefined,
+): Promise<boolean> {
+  if (!sigHeader || !secret) return false;
+  const parts: Record<string, string> = {};
+  for (const kv of sigHeader.split(",")) {
+    const i = kv.indexOf("=");
+    if (i > 0) parts[kv.slice(0, i).trim()] = kv.slice(i + 1).trim();
+  }
+  if (!parts.t || !parts.v1) return false;
+  const expected = createHmac("sha256", secret)
+    .update(`${parts.t}.${rawBody}`)
+    .digest("hex");
+  const a = Buffer.from(expected, "hex");
+  const b = Buffer.from(parts.v1, "hex");
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+/** The slice of a Stripe event the handlers consume. */
+export interface StripeEvent {
+  type: string;
+  data: { object: Record<string, unknown> };
+}
+
+/** Map Stripe subscription statuses onto our billing.status vocabulary. */
+export function mapSubscriptionStatus(stripeStatus: unknown): string {
+  switch (stripeStatus) {
+    case "active":
+    case "trialing":
+      return "active";
+    case "past_due":
+      return "past_due";
+    default:
+      // canceled, unpaid, incomplete_expired, paused… — no service.
+      return "canceled";
+  }
+}
+
+function s(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function epochToDate(v: unknown): Date | null {
+  return typeof v === "number" ? new Date(v * 1000) : null;
+}
+
+export type HandledStripeEvent =
+  | { handled: false; reason: string }
+  | { handled: true; organizationId: string; benefitsReferenceId?: string };
+
+/**
+ * Apply one Stripe event to billing state. Pure-ish over the storage: returns
+ * what changed so the route can enqueue the benefit delivery AFTER the write
+ * committed. Unknown org / unknown event types are acknowledged no-ops —
+ * Stripe must get its 200 either way, redelivery wouldn't help.
+ */
+export async function applyStripeEvent(
+  storage: OrganizationBillingStorage,
+  event: StripeEvent,
+): Promise<HandledStripeEvent> {
+  const obj = event.data.object;
+
+  switch (event.type) {
+    case "checkout.session.completed": {
+      const organizationId = s(
+        (obj.metadata as Record<string, unknown> | undefined)?.orgId,
+      );
+      if (!organizationId) return { handled: false, reason: "no orgId" };
+      if (obj.mode !== "subscription") {
+        return { handled: false, reason: "not a subscription checkout" };
+      }
+      const updated = await storage.updateStripeState(organizationId, {
+        stripeCustomerId: s(obj.customer),
+        stripeSubscriptionId: s(obj.subscription),
+        status: "active",
+      });
+      if (!updated) return { handled: false, reason: "unknown org" };
+      const referenceId = `stripe-checkout:${s(obj.id) ?? crypto.randomUUID()}`;
+      await storage.markBenefitsPending(organizationId, referenceId);
+      return {
+        handled: true,
+        organizationId,
+        benefitsReferenceId: referenceId,
+      };
+    }
+
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted": {
+      const subscriptionId = s(obj.id);
+      if (!subscriptionId) return { handled: false, reason: "no sub id" };
+      const billing =
+        await storage.getBillingByStripeSubscriptionId(subscriptionId);
+      if (!billing) return { handled: false, reason: "unknown subscription" };
+      const status =
+        event.type === "customer.subscription.deleted"
+          ? "canceled"
+          : mapSubscriptionStatus(obj.status);
+      await storage.updateStripeState(billing.organizationId, {
+        status,
+        currentPeriodEnd: epochToDate(obj.current_period_end),
+      });
+      // Status changes move the effective grant (canceled → 0) — re-deliver.
+      // Deterministic per (sub, status, period) so redeliveries collapse.
+      const referenceId = `stripe-sub:${subscriptionId}:${status}:${
+        epochToDate(obj.current_period_end)?.getTime() ?? 0
+      }`;
+      await storage.markBenefitsPending(billing.organizationId, referenceId);
+      return {
+        handled: true,
+        organizationId: billing.organizationId,
+        benefitsReferenceId: referenceId,
+      };
+    }
+
+    case "invoice.paid": {
+      const subscriptionId = s(obj.subscription);
+      if (!subscriptionId) return { handled: false, reason: "no sub id" };
+      const billing =
+        await storage.getBillingByStripeSubscriptionId(subscriptionId);
+      if (!billing) return { handled: false, reason: "unknown subscription" };
+      await storage.updateStripeState(billing.organizationId, {
+        status: "active",
+        currentPeriodEnd: epochToDate(obj.period_end),
+      });
+      // THE monthly reset: deterministic reference (invoice id) so Stripe
+      // redeliveries collapse into one gateway rebase per cycle.
+      const referenceId = `stripe-invoice:${s(obj.id) ?? crypto.randomUUID()}`;
+      await storage.markBenefitsPending(billing.organizationId, referenceId);
+      return {
+        handled: true,
+        organizationId: billing.organizationId,
+        benefitsReferenceId: referenceId,
+      };
+    }
+
+    default:
+      return { handled: false, reason: `unhandled event ${event.type}` };
+  }
+}
+
+/** Route-facing wrapper: apply + durable benefit delivery (fail-soft — the
+ *  pending marker is committed, the scheduled sweep covers a lost enqueue). */
+export async function processStripeEvent(
+  event: StripeEvent,
+): Promise<HandledStripeEvent> {
+  const storage = new OrganizationBillingStorage(getDb().db);
+  const result = await applyStripeEvent(storage, event);
+  if (result.handled && result.benefitsReferenceId) {
+    try {
+      await enqueueBenefitsSync(
+        result.organizationId,
+        result.benefitsReferenceId,
+        "apply",
+      );
+    } catch (err) {
+      console.error("Failed to enqueue benefit sync (sweep covers):", err);
+    }
+  }
+  return result;
+}

--- a/apps/mesh/src/billing/sync-org-benefits.ts
+++ b/apps/mesh/src/billing/sync-org-benefits.ts
@@ -81,8 +81,12 @@ async function syncOrgBenefitsWorkflowFn(
   organizationId: string,
   referenceId: string,
 ): Promise<{ delivered: boolean }> {
-  // Read live state: the CURRENT pending ref and paid count. If a newer seat
-  // change replaced the ref, that change's own workflow owns delivery — exit.
+  // Read live state: the CURRENT pending ref and the EFFECTIVE paid count.
+  // If a newer seat change replaced the ref, that change's own workflow owns
+  // delivery — exit. self_serve orgs whose subscription isn't in good
+  // standing (canceled/none) grant 0 regardless of seat flags: seats describe
+  // WHO is paid-for, the subscription is whether anyone is paying at all.
+  // invoiced (contract) orgs have no Stripe status — their seats always count.
   const state = await DBOS.runStep(
     async () => {
       const s = storage();
@@ -90,9 +94,13 @@ async function syncOrgBenefitsWorkflowFn(
         s.getBilling(organizationId),
         s.listPaidSeatUserIds(organizationId),
       ]);
+      const subscriptionGood =
+        billing?.billingMode !== "self_serve" ||
+        billing.status === "active" ||
+        billing.status === "past_due";
       return {
         pendingRef: billing?.benefitsReferenceId ?? null,
-        paidSeatCount: paidSeatUserIds.length,
+        paidSeatCount: subscriptionGood ? paidSeatUserIds.length : 0,
       };
     },
     { name: "readSeatState", retriesAllowed: true, maxAttempts: 3 },

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,7 +1,7 @@
 {
   "auth/install-studio-pack-workflow.ts": "fe506448bcbd657194f72999b8196b842a3cc52e2685997462f1d4715cc734f1",
   "automations/dbos-workflow.ts": "088986a214dd803913438f51bdbaa14dfef25b151422e117605a7907dc2bd987",
-  "billing/sync-org-benefits.ts": "65d394d8f513a99d2c1685762a81043c72ff8cbfa0acd7fb85f21568f1cadc24",
+  "billing/sync-org-benefits.ts": "da13d485441279eebfbe72a6095e047aa3a783384717bcfe8d359194f8ca76ac",
   "dispatch-queue/hosted-harness-workflow.ts": "1ee53df2391d0b73f10630be7f7d947db16653d5b8740b799e64a98cb2f49c86",
   "dispatch-queue/thread-gate-workflow.ts": "674cd393ad3b06806e967389dfe7e87bd0de6ba933fd54df1e5cd24a08b99e43",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -205,6 +205,7 @@ export function resolveConfig(
       envVars.STUDIO_SEAT_ALLOWANCE_CENTS,
       500,
     ),
+    stripeWebhookSecret: envVars.STRIPE_WEBHOOK_SECRET,
 
     // Feature Flags
     enableDecoImport: toBool(envVars.ENABLE_DECO_IMPORT),

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -75,6 +75,10 @@ export interface Settings {
   /** Monthly AI-gateway allowance per PAID SEAT, in cents (default $5). */
   seatAllowanceCents: number;
 
+  // Stripe (per-seat self-serve billing). Absent → the webhook route 503s and
+  // no checkout can be created; invoiced/legacy orgs are unaffected.
+  stripeWebhookSecret: string | undefined;
+
   // Feature Flags
   enableDecoImport: boolean;
   /** Per-seat billing enforcement (STUDIO_BILLING_ENFORCED). Default OFF —

--- a/apps/mesh/src/storage/organization-billing.ts
+++ b/apps/mesh/src/storage/organization-billing.ts
@@ -264,6 +264,70 @@ export class OrganizationBillingStorage {
     });
   }
 
+  /** Resolve the org behind a Stripe subscription (webhook events carry
+   *  Stripe ids, not ours). One row per org keeps this a cheap scan. */
+  async getBillingByStripeSubscriptionId(
+    stripeSubscriptionId: string,
+  ): Promise<OrganizationBillingRow | null> {
+    const row = await this.db
+      .selectFrom("organization_billing")
+      .select(["organization_id"])
+      .where("stripe_subscription_id", "=", stripeSubscriptionId)
+      .executeTakeFirst();
+    return row ? this.getBilling(row.organization_id) : null;
+  }
+
+  /**
+   * Platform write from the Stripe webhook handlers: subscription identity /
+   * status / period end. Never touches seats or legacy — webhooks only ever
+   * narrate what Stripe already committed.
+   */
+  async updateStripeState(
+    organizationId: string,
+    patch: {
+      stripeCustomerId?: string;
+      stripeSubscriptionId?: string;
+      status?: string;
+      currentPeriodEnd?: Date | null;
+    },
+  ): Promise<boolean> {
+    const result = await this.db
+      .updateTable("organization_billing")
+      .set({
+        ...(patch.stripeCustomerId !== undefined && {
+          stripe_customer_id: patch.stripeCustomerId,
+        }),
+        ...(patch.stripeSubscriptionId !== undefined && {
+          stripe_subscription_id: patch.stripeSubscriptionId,
+        }),
+        ...(patch.status !== undefined && { status: patch.status }),
+        ...(patch.currentPeriodEnd !== undefined && {
+          current_period_end: patch.currentPeriodEnd,
+        }),
+        updated_at: new Date(),
+      })
+      .where("organization_id", "=", organizationId)
+      .executeTakeFirst();
+    return (result.numUpdatedRows ?? 0n) > 0n;
+  }
+
+  /**
+   * Mark a benefit sync pending outside a seat change (Stripe webhooks: the
+   * grant amount is recomputed from live state at delivery, so the marker is
+   * all a billing event needs to write). Pass a DETERMINISTIC referenceId for
+   * cycle events (e.g. the invoice id) so replays collapse at the gateway.
+   */
+  async markBenefitsPending(
+    organizationId: string,
+    referenceId: string,
+  ): Promise<void> {
+    await this.db
+      .updateTable("organization_billing")
+      .set({ benefits_reference_id: referenceId, updated_at: new Date() })
+      .where("organization_id", "=", organizationId)
+      .execute();
+  }
+
   /**
    * Confirm a delivered grant: clear the pending marker iff it still holds
    * THIS reference (CAS) — a newer seat change may have replaced it, and that


### PR DESCRIPTION
## Summary

Phase-3 opener (tasks 3.1 + 3.4 of the per-seat plan): the webhook spine that makes Stripe the source-of-truth writer for `organization_billing`'s subscription state. Checkout/preview/apply (3.2–3.3) come next and only *send* users to Stripe — what comes back through here is what we believe.

- **`POST /api/_stripe/webhook`** — instance-level namespace (like `/api/_reports`, wins over the `/api/:org` catch-all), deliberately outside session/admin auth: the caller is Stripe, authenticated exclusively by the **timing-safe v1 signature over the raw body** (hand-rolled like the reports worker — the Stripe SDK arrives with the API surface in the next PR, not for 20 lines of HMAC). `503` without `STRIPE_WEBHOOK_SECRET`.
- **Handlers, all idempotent/redelivery-safe**:
  - `checkout.session.completed` → binds customer+subscription to the org (`metadata.orgId`), status `active`, marks + enqueues the allowance grant;
  - `customer.subscription.updated`/`deleted` → mirrors status (`active|past_due|canceled`) + `current_period_end`, keyed by Stripe subscription id;
  - `invoice.paid` → **the monthly clock**: re-marks the grant with `referenceId = invoice id`, so the gateway allowance rebases exactly once per billing cycle — Stripe redeliveries collapse at the gateway, and there is no cron anywhere in the reset path.
- **Status-aware grants**: the benefits workflow's effective seat count now zeroes `self_serve` orgs whose subscription isn't `active`/`past_due` — seats say *who* is paid for; the subscription says whether anyone is paying. `invoiced` (contract) orgs are untouched (no Stripe status). Reference ids for lifecycle events are deterministic per (sub, status, period), so redeliveries re-mark the same reference instead of double-granting.
- Storage additions: `getBillingByStripeSubscriptionId`, `updateStripeState` (platform-write, never touches seats/legacy), standalone `markBenefitsPending`.

## Dormancy

No behavior change anywhere until `STRIPE_WEBHOOK_SECRET` is set (route 503s), and even then nothing happens for an org until a checkout binds a subscription to it — which requires the 3.2 checkout flow that doesn't exist yet.

## Testing

- Unit: signature scheme (valid / tampered body / wrong secret / malformed header) + status mapping.
- Real-Postgres integration (`Storage Integration` workflow): checkout binding, lifecycle mirroring with period end, the invoice clock, deterministic reference ids, and unknown-org/sub/payment-mode acked no-ops.
- Full-workspace `bun run check` green, workflow-source guard re-baselined (step content changed, sequence unchanged), `knip` clean, `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Stripe webhook intake at `POST /api/_stripe/webhook` to make Stripe the source of truth for `organization_billing` and to drive a cron‑free, monthly allowance reset. It binds checkouts to orgs, mirrors subscription lifecycle, and re-grants allowances per invoice.

- **New Features**
  - Signature-verified webhook (v1 HMAC over the raw body), no session/auth.
  - Idempotent handlers:
    - `checkout.session.completed` → bind `{customer, subscription}` via `metadata.orgId`, set status `active`, mark grant.
    - `customer.subscription.updated|deleted` → mirror `status` and `current_period_end`, deterministic reference for redeliveries.
    - `invoice.paid` → monthly reset via invoice id; single gateway rebase per cycle.
  - Status-aware grants: `self_serve` orgs only grant seats when `status` is `active` or `past_due`; `invoiced` orgs unchanged.
  - Storage APIs: `getBillingByStripeSubscriptionId`, `updateStripeState`, `markBenefitsPending`.

- **Migration**
  - Set `STRIPE_WEBHOOK_SECRET` and point Stripe to `/api/_stripe/webhook`.
  - No behavior change until the secret is set and a checkout binds a subscription to an org.

<sup>Written for commit cebe2ee1989381b3489a298334110ddb50d82e7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

