### PR TITLE
feat(billing): self-serve checkout + prorated seat changes (3.2/3.3 backend)

### DIFF
--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -192,6 +192,16 @@ export const resolveOrgFromPath: MiddlewareHandler<{
             .where("organization_id", "=", org.id)
             .as("billing_legacy"),
           eb
+            .selectFrom("organization_billing")
+            .select("billing_mode")
+            .where("organization_id", "=", org.id)
+            .as("billing_mode"),
+          eb
+            .selectFrom("organization_billing")
+            .select("status")
+            .where("organization_id", "=", org.id)
+            .as("billing_status"),
+          eb
             .exists(
               eb
                 .selectFrom("organization_paid_seat")
@@ -230,10 +240,20 @@ export const resolveOrgFromPath: MiddlewareHandler<{
       // AccessControl.check() BEFORE the admin/owner bypass. `billing_legacy`
       // is null when the org has NO billing row: fail OPEN (treated as
       // legacy) so an org-creation hook failure can't brick an org.
+      //
+      // A paid-seat row only UNLOCKS while someone is actually paying: for
+      // self_serve orgs the subscription must be in good standing (staged
+      // seats before the first checkout, or after cancellation, don't grant
+      // access) — same semantics as effectivePaidSeatCount on the grant side.
+      // invoiced (contract) orgs have no Stripe status; their rows count.
       if (billingEnforced) {
+        const subscriptionGood =
+          membership.billing_mode !== "self_serve" ||
+          membership.billing_status === "active" ||
+          membership.billing_status === "past_due";
         ctx.access.setSeatGated(
           membership.billing_legacy === false &&
-            membership.has_paid_seat !== true,
+            !(membership.has_paid_seat === true && subscriptionGood),
         );
       }
     }

--- a/apps/mesh/src/api/middleware/resolve-org-from-path.ts
+++ b/apps/mesh/src/api/middleware/resolve-org-from-path.ts
@@ -1,4 +1,5 @@
 import type { Context, MiddlewareHandler } from "hono";
+import { subscriptionInGoodStanding } from "../../billing/subscription-state";
 import type { StudioContext } from "../../core/studio-context";
 import { rebindOrgScope } from "../../core/context-factory";
 import { isOrgArchived } from "../../core/org-archived";
@@ -244,13 +245,19 @@ export const resolveOrgFromPath: MiddlewareHandler<{
       // A paid-seat row only UNLOCKS while someone is actually paying: for
       // self_serve orgs the subscription must be in good standing (staged
       // seats before the first checkout, or after cancellation, don't grant
-      // access) — same semantics as effectivePaidSeatCount on the grant side.
-      // invoiced (contract) orgs have no Stripe status; their rows count.
+      // access) — subscriptionInGoodStanding, the SAME predicate the grant
+      // side (effectivePaidSeatCount) keys on, so access and allowance can't
+      // drift. A null billing row passes the predicate, but billing_legacy is
+      // null then too, so the gate stays off regardless.
       if (billingEnforced) {
-        const subscriptionGood =
-          membership.billing_mode !== "self_serve" ||
-          membership.billing_status === "active" ||
-          membership.billing_status === "past_due";
+        const subscriptionGood = subscriptionInGoodStanding(
+          membership.billing_mode && membership.billing_status
+            ? {
+                billingMode: membership.billing_mode,
+                status: membership.billing_status,
+              }
+            : null,
+        );
         ctx.access.setSeatGated(
           membership.billing_legacy === false &&
             !(membership.has_paid_seat === true && subscriptionGood),

--- a/apps/mesh/src/billing/stripe-api.test.ts
+++ b/apps/mesh/src/billing/stripe-api.test.ts
@@ -27,6 +27,14 @@ describe("toStripeForm", () => {
     expect(form.get("d")).toBe("false");
   });
 
+  test("empty arrays and nested null/undefined encode to nothing", () => {
+    const form = toStripeForm({
+      items: [],
+      nested: { keep: "x", drop: undefined, gone: null },
+    });
+    expect([...form.keys()]).toEqual(["nested[keep]"]);
+  });
+
   test("encodes the seat-change preview shape (nested items in details)", () => {
     const form = toStripeForm({
       subscription: "sub_1",

--- a/apps/mesh/src/billing/stripe-api.test.ts
+++ b/apps/mesh/src/billing/stripe-api.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { toStripeForm } from "./stripe-api";
+
+describe("toStripeForm", () => {
+  test("encodes nested objects and arrays in Stripe's bracket form", () => {
+    const form = toStripeForm({
+      mode: "subscription",
+      line_items: [{ price: "price_1", quantity: 3 }],
+      subscription_data: { metadata: { orgId: "org_1" } },
+    });
+    expect(form.get("mode")).toBe("subscription");
+    expect(form.get("line_items[0][price]")).toBe("price_1");
+    expect(form.get("line_items[0][quantity]")).toBe("3");
+    expect(form.get("subscription_data[metadata][orgId]")).toBe("org_1");
+  });
+
+  test("drops null/undefined and keeps falsy scalars", () => {
+    const form = toStripeForm({
+      a: undefined,
+      b: null,
+      c: 0,
+      d: false,
+    });
+    expect(form.has("a")).toBe(false);
+    expect(form.has("b")).toBe(false);
+    expect(form.get("c")).toBe("0");
+    expect(form.get("d")).toBe("false");
+  });
+
+  test("encodes the seat-change preview shape (nested items in details)", () => {
+    const form = toStripeForm({
+      subscription: "sub_1",
+      subscription_details: {
+        items: [{ id: "si_1", quantity: 5 }],
+        proration_behavior: "always_invoice",
+      },
+    });
+    expect(form.get("subscription_details[items][0][id]")).toBe("si_1");
+    expect(form.get("subscription_details[items][0][quantity]")).toBe("5");
+    expect(form.get("subscription_details[proration_behavior]")).toBe(
+      "always_invoice",
+    );
+  });
+});

--- a/apps/mesh/src/billing/stripe-api.ts
+++ b/apps/mesh/src/billing/stripe-api.ts
@@ -1,0 +1,169 @@
+/**
+ * Minimal Stripe API client for the per-seat billing surface: first-subscribe
+ * Checkout, prorated seat-change preview, and the quantity update that
+ * charges the difference. Raw fetch + form encoding (Stripe's API is
+ * form-encoded), same no-SDK posture as the reports worker and the gateway —
+ * three endpoints don't buy a dependency.
+ *
+ * Proration model (the plan's "pay the difference now" flow):
+ *  - previewSeatChange → POST /v1/invoices/create_preview with the new
+ *    quantity: Stripe returns exactly "new total minus what this cycle
+ *    already paid", which the members-page apply bar renders.
+ *  - applySeatQuantity → POST /v1/subscriptions/:id with
+ *    proration_behavior=always_invoice: charges/credits the prorated
+ *    difference immediately on the saved card. payment_behavior=
+ *    pending_if_incomplete leaves the subscription consistent when the card
+ *    demands 3DS — the webhook narrates whatever lands.
+ */
+
+import { getSettings } from "../settings";
+
+const BASE_URL = "https://api.stripe.com/v1";
+
+export class StripeApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(`Stripe API ${status}: ${message}`);
+    this.name = "StripeApiError";
+  }
+}
+
+/** Flatten nested params into Stripe's bracket form encoding:
+ *  { line_items: [{ price: "p", quantity: 2 }] } →
+ *  line_items[0][price]=p & line_items[0][quantity]=2 */
+export function toStripeForm(
+  params: Record<string, unknown>,
+  prefix = "",
+  out: URLSearchParams = new URLSearchParams(),
+): URLSearchParams {
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    const name = prefix ? `${prefix}[${key}]` : key;
+    if (Array.isArray(value)) {
+      value.forEach((item, i) => {
+        if (typeof item === "object" && item !== null) {
+          toStripeForm(item as Record<string, unknown>, `${name}[${i}]`, out);
+        } else {
+          out.append(`${name}[${i}]`, String(item));
+        }
+      });
+    } else if (typeof value === "object") {
+      toStripeForm(value as Record<string, unknown>, name, out);
+    } else {
+      out.append(name, String(value));
+    }
+  }
+  return out;
+}
+
+async function stripeRequest<T>(
+  path: string,
+  params: Record<string, unknown>,
+): Promise<T> {
+  const key = getSettings().stripeSecretKey;
+  if (!key) throw new StripeApiError(503, "STRIPE_SECRET_KEY not configured");
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: toStripeForm(params).toString(),
+  });
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) {
+    const message =
+      ((body.error as Record<string, unknown> | undefined)?.message as
+        | string
+        | undefined) ?? `HTTP ${res.status}`;
+    throw new StripeApiError(res.status, message);
+  }
+  return body as T;
+}
+
+/** First subscribe: Checkout collects + saves the card; afterwards every
+ *  seat change is an inline prorated charge (no redirect ever again). */
+export async function createSeatCheckoutSession(input: {
+  organizationId: string;
+  quantity: number;
+  successUrl: string;
+  cancelUrl: string;
+}): Promise<{ url: string }> {
+  const priceId = getSettings().stripeSeatPriceId;
+  if (!priceId) {
+    throw new StripeApiError(503, "STRIPE_SEAT_PRICE_ID not configured");
+  }
+  const session = await stripeRequest<{ url?: string }>("/checkout/sessions", {
+    mode: "subscription",
+    line_items: [{ price: priceId, quantity: input.quantity }],
+    success_url: input.successUrl,
+    cancel_url: input.cancelUrl,
+    // orgId on BOTH the session (checkout.session.completed) and the
+    // subscription (defense in depth for subscription-keyed lookups).
+    metadata: { orgId: input.organizationId },
+    subscription_data: { metadata: { orgId: input.organizationId } },
+  });
+  if (!session.url) throw new StripeApiError(500, "checkout session lacks url");
+  return { url: session.url };
+}
+
+interface StripeSubscription {
+  id: string;
+  items: { data: Array<{ id: string; quantity?: number }> };
+}
+
+async function getSubscriptionItem(
+  subscriptionId: string,
+): Promise<{ itemId: string }> {
+  const key = getSettings().stripeSecretKey;
+  if (!key) throw new StripeApiError(503, "STRIPE_SECRET_KEY not configured");
+  const res = await fetch(`${BASE_URL}/subscriptions/${subscriptionId}`, {
+    headers: { Authorization: `Bearer ${key}` },
+  });
+  const body = (await res.json().catch(() => ({}))) as StripeSubscription &
+    Record<string, unknown>;
+  if (!res.ok) throw new StripeApiError(res.status, "subscription not found");
+  const itemId = body.items?.data?.[0]?.id;
+  if (!itemId) throw new StripeApiError(500, "subscription has no items");
+  return { itemId };
+}
+
+/** The inline recompute behind the Apply button: what the org pays NOW for
+ *  moving this cycle to `quantity` seats (negative = credit). */
+export async function previewSeatChange(input: {
+  subscriptionId: string;
+  quantity: number;
+}): Promise<{ amountDueCents: number; currency: string }> {
+  const { itemId } = await getSubscriptionItem(input.subscriptionId);
+  const preview = await stripeRequest<{
+    amount_due?: number;
+    currency?: string;
+  }>("/invoices/create_preview", {
+    subscription: input.subscriptionId,
+    subscription_details: {
+      items: [{ id: itemId, quantity: input.quantity }],
+      proration_behavior: "always_invoice",
+    },
+  });
+  return {
+    amountDueCents: preview.amount_due ?? 0,
+    currency: preview.currency ?? "usd",
+  };
+}
+
+/** Commit the seat change on Stripe: prorated difference charged immediately
+ *  on the saved card (always_invoice); pending_if_incomplete keeps the
+ *  subscription consistent if the bank demands 3DS. */
+export async function applySeatQuantity(input: {
+  subscriptionId: string;
+  quantity: number;
+}): Promise<void> {
+  const { itemId } = await getSubscriptionItem(input.subscriptionId);
+  await stripeRequest(`/subscriptions/${input.subscriptionId}`, {
+    items: [{ id: itemId, quantity: input.quantity }],
+    proration_behavior: "always_invoice",
+    payment_behavior: "pending_if_incomplete",
+  });
+}

--- a/apps/mesh/src/billing/stripe-api.ts
+++ b/apps/mesh/src/billing/stripe-api.ts
@@ -58,29 +58,41 @@ export function toStripeForm(
   return out;
 }
 
+const REQUEST_TIMEOUT_MS = 15_000;
+
 async function stripeRequest<T>(
   path: string,
-  params: Record<string, unknown>,
+  init?: {
+    method?: "GET" | "POST" | "DELETE";
+    params?: Record<string, unknown>;
+  },
 ): Promise<T> {
   const key = getSettings().stripeSecretKey;
-  if (!key) throw new StripeApiError(503, "STRIPE_SECRET_KEY not configured");
+  // Config-missing messages are deliberately generic: they surface to org
+  // admins through tool errors — actionable, without echoing env var names.
+  if (!key) throw new StripeApiError(503, "billing is not configured");
+  const body = init?.params ? toStripeForm(init.params).toString() : undefined;
   const res = await fetch(`${BASE_URL}${path}`, {
-    method: "POST",
+    method: init?.method ?? (body ? "POST" : "GET"),
     headers: {
       Authorization: `Bearer ${key}`,
-      "Content-Type": "application/x-www-form-urlencoded",
+      ...(body && { "Content-Type": "application/x-www-form-urlencoded" }),
     },
-    body: toStripeForm(params).toString(),
+    body,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
-  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  const parsed = (await res.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
   if (!res.ok) {
     const message =
-      ((body.error as Record<string, unknown> | undefined)?.message as
+      ((parsed.error as Record<string, unknown> | undefined)?.message as
         | string
         | undefined) ?? `HTTP ${res.status}`;
     throw new StripeApiError(res.status, message);
   }
-  return body as T;
+  return parsed as T;
 }
 
 /** First subscribe: Checkout collects + saves the card; afterwards every
@@ -93,17 +105,19 @@ export async function createSeatCheckoutSession(input: {
 }): Promise<{ url: string }> {
   const priceId = getSettings().stripeSeatPriceId;
   if (!priceId) {
-    throw new StripeApiError(503, "STRIPE_SEAT_PRICE_ID not configured");
+    throw new StripeApiError(503, "billing is not configured");
   }
   const session = await stripeRequest<{ url?: string }>("/checkout/sessions", {
-    mode: "subscription",
-    line_items: [{ price: priceId, quantity: input.quantity }],
-    success_url: input.successUrl,
-    cancel_url: input.cancelUrl,
-    // orgId on BOTH the session (checkout.session.completed) and the
-    // subscription (defense in depth for subscription-keyed lookups).
-    metadata: { orgId: input.organizationId },
-    subscription_data: { metadata: { orgId: input.organizationId } },
+    params: {
+      mode: "subscription",
+      line_items: [{ price: priceId, quantity: input.quantity }],
+      success_url: input.successUrl,
+      cancel_url: input.cancelUrl,
+      // orgId on BOTH the session (checkout.session.completed) and the
+      // subscription (defense in depth for subscription-keyed lookups).
+      metadata: { orgId: input.organizationId },
+      subscription_data: { metadata: { orgId: input.organizationId } },
+    },
   });
   if (!session.url) throw new StripeApiError(500, "checkout session lacks url");
   return { url: session.url };
@@ -111,23 +125,32 @@ export async function createSeatCheckoutSession(input: {
 
 interface StripeSubscription {
   id: string;
-  items: { data: Array<{ id: string; quantity?: number }> };
+  items: {
+    data: Array<{ id: string; quantity?: number; price?: { id?: string } }>;
+  };
 }
 
-async function getSubscriptionItem(
+/**
+ * The org's SEAT item on its subscription: matched by the configured seat
+ * price so a dashboard-added second item (a future addon) can never get its
+ * quantity silently rewritten by a seat change. Falls back to a sole item
+ * only when no price is configured.
+ */
+async function getSeatItem(
   subscriptionId: string,
-): Promise<{ itemId: string }> {
-  const key = getSettings().stripeSecretKey;
-  if (!key) throw new StripeApiError(503, "STRIPE_SECRET_KEY not configured");
-  const res = await fetch(`${BASE_URL}/subscriptions/${subscriptionId}`, {
-    headers: { Authorization: `Bearer ${key}` },
-  });
-  const body = (await res.json().catch(() => ({}))) as StripeSubscription &
-    Record<string, unknown>;
-  if (!res.ok) throw new StripeApiError(res.status, "subscription not found");
-  const itemId = body.items?.data?.[0]?.id;
-  if (!itemId) throw new StripeApiError(500, "subscription has no items");
-  return { itemId };
+): Promise<{ itemId: string; quantity: number }> {
+  const sub = await stripeRequest<StripeSubscription>(
+    `/subscriptions/${encodeURIComponent(subscriptionId)}`,
+  );
+  const items = sub.items?.data ?? [];
+  const priceId = getSettings().stripeSeatPriceId;
+  const item = priceId
+    ? items.find((i) => i.price?.id === priceId)
+    : items.length === 1
+      ? items[0]
+      : undefined;
+  if (!item) throw new StripeApiError(500, "subscription has no seat item");
+  return { itemId: item.id, quantity: item.quantity ?? 0 };
 }
 
 /** The inline recompute behind the Apply button: what the org pays NOW for
@@ -136,15 +159,17 @@ export async function previewSeatChange(input: {
   subscriptionId: string;
   quantity: number;
 }): Promise<{ amountDueCents: number; currency: string }> {
-  const { itemId } = await getSubscriptionItem(input.subscriptionId);
+  const { itemId } = await getSeatItem(input.subscriptionId);
   const preview = await stripeRequest<{
     amount_due?: number;
     currency?: string;
   }>("/invoices/create_preview", {
-    subscription: input.subscriptionId,
-    subscription_details: {
-      items: [{ id: itemId, quantity: input.quantity }],
-      proration_behavior: "always_invoice",
+    params: {
+      subscription: input.subscriptionId,
+      subscription_details: {
+        items: [{ id: itemId, quantity: input.quantity }],
+        proration_behavior: "always_invoice",
+      },
     },
   });
   return {
@@ -160,10 +185,53 @@ export async function applySeatQuantity(input: {
   subscriptionId: string;
   quantity: number;
 }): Promise<void> {
-  const { itemId } = await getSubscriptionItem(input.subscriptionId);
-  await stripeRequest(`/subscriptions/${input.subscriptionId}`, {
-    items: [{ id: itemId, quantity: input.quantity }],
-    proration_behavior: "always_invoice",
-    payment_behavior: "pending_if_incomplete",
+  const { itemId } = await getSeatItem(input.subscriptionId);
+  await stripeRequest(
+    `/subscriptions/${encodeURIComponent(input.subscriptionId)}`,
+    {
+      params: {
+        items: [{ id: itemId, quantity: input.quantity }],
+        proration_behavior: "always_invoice",
+        payment_behavior: "pending_if_incomplete",
+      },
+    },
+  );
+}
+
+/** Cancel a subscription outright. Used for orphans: a checkout that
+ *  completed for an org already bound to a different subscription — the
+ *  customer paid, the webhook refused the bind, nothing should keep billing. */
+export async function cancelSubscription(
+  subscriptionId: string,
+): Promise<void> {
+  await stripeRequest(`/subscriptions/${encodeURIComponent(subscriptionId)}`, {
+    method: "DELETE",
   });
+}
+
+/**
+ * Converge the subscription quantity onto the seat rows (the truth of WHO is
+ * paid-for). Called from webhook anchors that prove the card WORKS
+ * (invoice.paid, checkout completion) — never from failure paths, so a
+ * declined proration can't loop charge attempts. No-op when they already
+ * match. Returns whether a correction was pushed.
+ */
+export async function reconcileSeatQuantity(input: {
+  subscriptionId: string;
+  targetQuantity: number;
+}): Promise<boolean> {
+  if (input.targetQuantity < 1) return false; // zero-seat = cancellation flow, not a quantity
+  const { itemId, quantity } = await getSeatItem(input.subscriptionId);
+  if (quantity === input.targetQuantity) return false;
+  await stripeRequest(
+    `/subscriptions/${encodeURIComponent(input.subscriptionId)}`,
+    {
+      params: {
+        items: [{ id: itemId, quantity: input.targetQuantity }],
+        proration_behavior: "always_invoice",
+        payment_behavior: "pending_if_incomplete",
+      },
+    },
+  );
+  return true;
 }

--- a/apps/mesh/src/billing/stripe-webhook.integration.test.ts
+++ b/apps/mesh/src/billing/stripe-webhook.integration.test.ts
@@ -289,9 +289,12 @@ describe("applyStripeEvent", () => {
         metadata: { orgId: ORG_BASIL },
       }),
     );
+    // The refusal names the orphan so the route wrapper can cancel the
+    // subscription the customer just paid for.
     expect(rebind).toEqual({
       handled: false,
       reason: "org already bound to another subscription",
+      orphanSubscriptionId: "sub_evil",
     });
     expect((await storage.getBilling(ORG_BASIL))?.stripeSubscriptionId).toBe(
       "sub_b1",

--- a/apps/mesh/src/billing/stripe-webhook.ts
+++ b/apps/mesh/src/billing/stripe-webhook.ts
@@ -1,8 +1,9 @@
 /**
- * Stripe webhook intake for per-seat self-serve billing (phase 3 — the
- * checkout/portal creator that sets metadata.orgId is phase 4; until it
- * ships AND the deployment sets STRIPE_WEBHOOK_SECRET, this module is
- * dormant).
+ * Stripe webhook intake for per-seat self-serve billing. The checkout
+ * creator that sets metadata.orgId is ORGANIZATION_BILLING_CHECKOUT_START
+ * (tools/organization/billing-checkout.ts); the customer portal (cancel /
+ * card update) is still future work. On deployments without
+ * STRIPE_WEBHOOK_SECRET this module is dormant.
  *
  * The webhook is the SOURCE OF TRUTH writer for organization_billing's
  * subscription state. Stripe guarantees neither delivery order nor
@@ -22,7 +23,7 @@
  *    customer/subscription to the org (metadata.orgId, set by our checkout
  *    creator) once payment_status is "paid"; status active, grant. Refuses
  *    legacy / non-self-serve orgs and rebinding over a live different
- *    subscription.
+ *    subscription (the refused-but-paid orphan subscription is canceled).
  *  - customer.subscription.updated → mirror status + current period end.
  *  - customer.subscription.deleted → status canceled + unbind; grant
  *    recomputes to 0 (the sync workflow zeroes self_serve orgs whose
@@ -30,6 +31,12 @@
  *  - invoice.paid → THE MONTHLY CLOCK: refresh period end + re-grant with
  *    referenceId = invoice id, which is what makes the gateway allowance
  *    reset per billing cycle (no cron anywhere).
+ *
+ * Payment-success events (checkout completion, invoice.paid) additionally
+ * RECONCILE the subscription quantity onto the paid-seat rows — the
+ * self-healing loop for a SEATS_SET whose Stripe mirror failed or whose
+ * pending_if_incomplete update expired. Success anchors only: reconciling on
+ * failure events would loop charge attempts on a failing card.
  *
  * Payload compat: API version 2025-03-31 (Basil) moved invoice.subscription
  * under invoice.parent.subscription_details and the subscription's
@@ -47,6 +54,12 @@ import {
   OrganizationBillingStorage,
   type OrganizationBillingRow,
 } from "../storage/organization-billing";
+import {
+  cancelSubscription,
+  reconcileSeatQuantity,
+  StripeApiError,
+} from "./stripe-api";
+import { hasChargeableSubscription } from "./subscription-state";
 import { enqueueBenefitsSync } from "./sync-org-benefits";
 
 const SIGNATURE_TOLERANCE_SEC = 300;
@@ -199,7 +212,14 @@ function nextWatermark(
 }
 
 export type HandledStripeEvent =
-  | { handled: false; reason: string }
+  | {
+      handled: false;
+      reason: string;
+      /** A LIVE subscription the customer paid for that we refused to bind
+       *  (rebind guard) — the route wrapper cancels it so nothing keeps
+       *  charging a card that bought no service. */
+      orphanSubscriptionId?: string;
+    }
   | { handled: true; organizationId: string; benefitsReferenceId?: string };
 
 /**
@@ -257,6 +277,7 @@ export async function applyStripeEvent(
         return {
           handled: false,
           reason: "org already bound to another subscription",
+          orphanSubscriptionId: subscriptionId,
         };
       }
       if (isStale(event, billing)) {
@@ -342,6 +363,44 @@ export async function applyStripeEvent(
   }
 }
 
+/** Events that prove the customer's card WORKS — the only anchors we let
+ *  trigger a quantity reconciliation (re-applying a quantity can charge; a
+ *  failure-path anchor would loop charge attempts on a failing card). */
+const RECONCILE_EVENT_TYPES = new Set([
+  "checkout.session.completed",
+  "checkout.session.async_payment_succeeded",
+  "invoice.paid",
+]);
+
+/**
+ * Converge Stripe's subscription quantity onto the org's seat rows. This is
+ * the self-healing half of the SEATS_SET mirror: rows commit before the
+ * Stripe call there, so a failed/pending proration (declined card, expired
+ * pending_update, pod death mid-request) leaves quantity < rows — every paid
+ * invoice re-converges it, monthly at worst. Fail-soft: a miss is retried by
+ * the next cycle's event.
+ */
+async function reconcileQuantityWithRows(
+  storage: OrganizationBillingStorage,
+  organizationId: string,
+): Promise<void> {
+  const [billing, paidSeatUserIds] = await Promise.all([
+    storage.getBilling(organizationId),
+    storage.listPaidSeatUserIds(organizationId),
+  ]);
+  if (!hasChargeableSubscription(billing)) return;
+  const corrected = await reconcileSeatQuantity({
+    subscriptionId: billing.stripeSubscriptionId,
+    targetQuantity: paidSeatUserIds.length,
+  });
+  if (corrected) {
+    console.error("stripe webhook: reconciled diverged seat quantity", {
+      organizationId,
+      targetQuantity: paidSeatUserIds.length,
+    });
+  }
+}
+
 /** Route-facing wrapper: apply + durable benefit delivery (fail-soft — the
  *  pending marker is committed, the scheduled sweep covers a lost enqueue). */
 export async function processStripeEvent(
@@ -358,6 +417,32 @@ export async function processStripeEvent(
       );
     } catch (err) {
       console.error("Failed to enqueue benefit sync (sweep covers):", err);
+    }
+  }
+  if (result.handled && RECONCILE_EVENT_TYPES.has(event.type)) {
+    try {
+      await reconcileQuantityWithRows(storage, result.organizationId);
+    } catch (err) {
+      console.error("Failed to reconcile seat quantity (next cycle):", err);
+    }
+  }
+  // The customer PAID for this subscription and the org refused it — cancel
+  // so it stops charging. NOT fail-soft: the route 200-acks refusals (no
+  // Stripe redelivery), so a transient cancel failure must escape to the
+  // route's 500 to make Stripe redeliver this refusal and retry the cancel.
+  // Already-gone (400 canceled / 404 missing) is success.
+  if (!result.handled && result.orphanSubscriptionId) {
+    try {
+      await cancelSubscription(result.orphanSubscriptionId);
+      console.error("stripe webhook: canceled orphan subscription", {
+        subscriptionId: result.orphanSubscriptionId,
+        eventId: event.id,
+      });
+    } catch (err) {
+      const alreadyGone =
+        err instanceof StripeApiError &&
+        (err.status === 400 || err.status === 404);
+      if (!alreadyGone) throw err;
     }
   }
   return result;

--- a/apps/mesh/src/billing/subscription-state.test.ts
+++ b/apps/mesh/src/billing/subscription-state.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+  hasChargeableSubscription,
+  subscriptionInGoodStanding,
+} from "./subscription-state";
+
+describe("subscriptionInGoodStanding", () => {
+  test("self_serve: active and past_due (dunning grace) are good, everything else is not", () => {
+    for (const status of ["active", "past_due"]) {
+      expect(
+        subscriptionInGoodStanding({ billingMode: "self_serve", status }),
+      ).toBe(true);
+    }
+    for (const status of ["none", "canceled", "incomplete", ""]) {
+      expect(
+        subscriptionInGoodStanding({ billingMode: "self_serve", status }),
+      ).toBe(false);
+    }
+  });
+
+  test("invoiced orgs and missing billing rows are always in good standing", () => {
+    expect(
+      subscriptionInGoodStanding({ billingMode: "invoiced", status: "none" }),
+    ).toBe(true);
+    expect(subscriptionInGoodStanding(null)).toBe(true);
+  });
+});
+
+describe("hasChargeableSubscription", () => {
+  const base = {
+    billingMode: "self_serve",
+    status: "active",
+    stripeSubscriptionId: "sub_1",
+  };
+
+  test("chargeable only when self_serve + active + a bound subscription", () => {
+    expect(hasChargeableSubscription(base)).toBe(true);
+    expect(hasChargeableSubscription(null)).toBe(false);
+    expect(
+      hasChargeableSubscription({ ...base, billingMode: "invoiced" }),
+    ).toBe(false);
+    expect(
+      hasChargeableSubscription({ ...base, stripeSubscriptionId: null }),
+    ).toBe(false);
+  });
+
+  test("past_due is NOT chargeable — good standing (grace) without stacking charges on a failing card", () => {
+    const pastDue = { ...base, status: "past_due" };
+    expect(subscriptionInGoodStanding(pastDue)).toBe(true);
+    expect(hasChargeableSubscription(pastDue)).toBe(false);
+  });
+});

--- a/apps/mesh/src/billing/subscription-state.ts
+++ b/apps/mesh/src/billing/subscription-state.ts
@@ -1,0 +1,39 @@
+/**
+ * Subscription-standing predicates — the ONE source for "is anyone paying?"
+ * decisions. Two deliberately different questions:
+ *
+ *  - subscriptionInGoodStanding: does the org's payment state unlock seats
+ *    (the middleware seat gate) and grant the allowance (the benefit sync)?
+ *    `past_due` counts — Stripe dunning grace: access survives a failed card
+ *    until Stripe gives up (which arrives as a status change).
+ *
+ *  - hasChargeableSubscription: may we charge the saved card right now
+ *    (seat-change proration mirror, preview)? `past_due` is EXCLUDED —
+ *    never stack prorated charges on a card already failing its renewal.
+ *
+ * invoiced (contract) orgs have no Stripe status: always in good standing,
+ * never chargeable (their invoicing is end-of-cycle from seat_change_log).
+ * A null billing row fails open — orgs predating billing are legacy.
+ */
+
+export function subscriptionInGoodStanding(
+  billing: { billingMode: string; status: string } | null,
+): boolean {
+  if (!billing || billing.billingMode !== "self_serve") return true;
+  return billing.status === "active" || billing.status === "past_due";
+}
+
+export function hasChargeableSubscription<
+  T extends {
+    billingMode: string;
+    status: string;
+    stripeSubscriptionId: string | null;
+  },
+>(billing: T | null): billing is T & { stripeSubscriptionId: string } {
+  return (
+    !!billing &&
+    billing.billingMode === "self_serve" &&
+    billing.status === "active" &&
+    billing.stripeSubscriptionId !== null
+  );
+}

--- a/apps/mesh/src/billing/sync-org-benefits.ts
+++ b/apps/mesh/src/billing/sync-org-benefits.ts
@@ -26,6 +26,7 @@ import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
 import { getDb } from "@/database";
 import { getSettings } from "../settings";
 import { OrganizationBillingStorage } from "../storage/organization-billing";
+import { subscriptionInGoodStanding } from "./subscription-state";
 
 const MICROS_PER_CENT = 10_000;
 /** Fast path is instant; anything pending past this is a failed delivery. */
@@ -43,18 +44,14 @@ export function computeAllowanceMicros(
 /**
  * self_serve orgs grant 0 while the subscription isn't in good standing
  * (canceled/none — past_due is grace): seats describe WHO is paid-for, the
- * subscription is whether anyone is paying at all. invoiced (contract) orgs
- * have no Stripe status, and orgs predating billing rows fail open — their
- * seats always count.
+ * subscription is whether anyone is paying at all (subscriptionInGoodStanding
+ * — the same predicate the middleware seat gate uses).
  */
 export function effectivePaidSeatCount(
   billing: { billingMode: string; status: string } | null,
   paidSeatCount: number,
 ): number {
-  if (!billing || billing.billingMode !== "self_serve") return paidSeatCount;
-  return billing.status === "active" || billing.status === "past_due"
-    ? paidSeatCount
-    : 0;
+  return subscriptionInGoodStanding(billing) ? paidSeatCount : 0;
 }
 
 /** Whether this deployment can deliver benefits at all (self-hosted can't). */

--- a/apps/mesh/src/core/access-control.test.ts
+++ b/apps/mesh/src/core/access-control.test.ts
@@ -486,6 +486,51 @@ describe("AccessControl", () => {
       );
     });
 
+    it("lets billing-bootstrap tools through for a gated admin — but only past the gate, not past permissions", async () => {
+      // A fresh self-serve org gates EVERYONE (no paying subscription yet) —
+      // staging seats and starting checkout must stay reachable or nobody can
+      // ever subscribe. The permission layer still applies.
+      const ac = new AccessControl(
+        "user_1",
+        "ORGANIZATION_BILLING_CHECKOUT_START",
+        createMockBoundAuth({ self: ["ORGANIZATION_BILLING_CHECKOUT_START"] }),
+        "user",
+      );
+      ac.setSeatGated(true);
+      ac.setToolReadOnly(false);
+      await ac.check();
+      expect(ac.granted()).toBe(true);
+
+      const acSeats = new AccessControl(
+        "user_1",
+        "ORGANIZATION_SEATS_SET",
+        createMockBoundAuth({ self: ["ORGANIZATION_SEATS_SET"] }),
+        "user",
+      );
+      acSeats.setSeatGated(true);
+      acSeats.setToolReadOnly(false);
+      await acSeats.check();
+      expect(acSeats.granted()).toBe(true);
+
+      // Bypass is gate-only: without the permission, the check still 403s.
+      const acNoPerm = new AccessControl(
+        "user_1",
+        "ORGANIZATION_SEATS_SET",
+        createMockBoundAuth({}),
+        "user",
+      );
+      acNoPerm.setSeatGated(true);
+      acNoPerm.setToolReadOnly(false);
+      // Plain permission 403 — NOT the paid-seat paywall error.
+      const err = await acNoPerm.check().then(
+        () => null,
+        (e: unknown) => e,
+      );
+      expect(err).toBeInstanceOf(ForbiddenError);
+      expect(err).not.toBeInstanceOf(PaidSeatRequiredError);
+      expect(acNoPerm.granted()).toBe(false);
+    });
+
     it("changes nothing when the gate is off (flag off / legacy / paid seat)", async () => {
       const ac = new AccessControl(
         "user_1",

--- a/apps/mesh/src/core/access-control.ts
+++ b/apps/mesh/src/core/access-control.ts
@@ -78,6 +78,21 @@ export class PaidSeatRequiredError extends ForbiddenError {
  */
 const SEAT_GATE_READ_RESOURCES: ReadonlySet<string> = new Set(["ORG_FS_READ"]);
 
+/**
+ * Mutating billing-bootstrap tools a seat-gated caller must still reach: on a
+ * fresh self-serve org NOBODY holds an unlocking seat yet (staged seats don't
+ * unlock until a subscription is paying), so gating these would deadlock the
+ * subscribe flow — the admin could never stage seats or start the checkout
+ * that ends the gating. Only the seat gate is bypassed; the permission check
+ * below still applies (these live under members:manage — admins/owners only).
+ * Read-only billing tools (SEATS_GET, SEATS_PREVIEW) already pass via
+ * readOnlyHint.
+ */
+const SEAT_GATE_BOOTSTRAP_TOOLS: ReadonlySet<string> = new Set([
+  "ORGANIZATION_SEATS_SET",
+  "ORGANIZATION_BILLING_CHECKOUT_START",
+]);
+
 // ============================================================================
 // AccessControl Class
 // ============================================================================
@@ -210,6 +225,7 @@ export class AccessControl {
     if (
       this.seatGated &&
       !this.toolReadOnly &&
+      !(this.toolName && SEAT_GATE_BOOTSTRAP_TOOLS.has(this.toolName)) &&
       !(
         resourcesToCheck.length > 0 &&
         resourcesToCheck.every((r) => SEAT_GATE_READ_RESOURCES.has(r))

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,7 +1,7 @@
 {
   "auth/install-studio-pack-workflow.ts": "fe506448bcbd657194f72999b8196b842a3cc52e2685997462f1d4715cc734f1",
   "automations/dbos-workflow.ts": "088986a214dd803913438f51bdbaa14dfef25b151422e117605a7907dc2bd987",
-  "billing/sync-org-benefits.ts": "d2ed083a1b7ea79daaf309f53167800c74c15c4d1aa66c00df24731fc29795b9",
+  "billing/sync-org-benefits.ts": "1b2609809b3e3553561463d2b508903c99ef4666d29d33ffe15bb7c9afc0a05a",
   "dispatch-queue/hosted-harness-workflow.ts": "1ee53df2391d0b73f10630be7f7d947db16653d5b8740b799e64a98cb2f49c86",
   "dispatch-queue/thread-gate-workflow.ts": "674cd393ad3b06806e967389dfe7e87bd0de6ba933fd54df1e5cd24a08b99e43",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",

--- a/apps/mesh/src/settings/resolve-config.ts
+++ b/apps/mesh/src/settings/resolve-config.ts
@@ -206,6 +206,8 @@ export function resolveConfig(
       500,
     ),
     stripeWebhookSecret: envVars.STRIPE_WEBHOOK_SECRET,
+    stripeSecretKey: envVars.STRIPE_SECRET_KEY,
+    stripeSeatPriceId: envVars.STRIPE_SEAT_PRICE_ID,
 
     // Feature Flags
     enableDecoImport: toBool(envVars.ENABLE_DECO_IMPORT),

--- a/apps/mesh/src/settings/types.ts
+++ b/apps/mesh/src/settings/types.ts
@@ -78,6 +78,10 @@ export interface Settings {
   // Stripe (per-seat self-serve billing). Absent → the webhook route 503s and
   // no checkout can be created; invoiced/legacy orgs are unaffected.
   stripeWebhookSecret: string | undefined;
+  stripeSecretKey: string | undefined;
+  /** The $20/seat/month multi-currency price (created in the Stripe
+   *  dashboard); quantity = the org's paid-seat count. */
+  stripeSeatPriceId: string | undefined;
 
   // Feature Flags
   enableDecoImport: boolean;

--- a/apps/mesh/src/tools/index.ts
+++ b/apps/mesh/src/tools/index.ts
@@ -77,6 +77,8 @@ export const CORE_TOOLS = [
   OrganizationTools.ORGANIZATION_MEMBER_UPDATE_ROLE,
   OrganizationTools.ORGANIZATION_SEATS_GET,
   OrganizationTools.ORGANIZATION_SEATS_SET,
+  OrganizationTools.ORGANIZATION_BILLING_CHECKOUT_START,
+  OrganizationTools.ORGANIZATION_SEATS_PREVIEW,
 
   // Connection collection tools
   ConnectionTools.COLLECTION_CONNECTIONS_CREATE,

--- a/apps/mesh/src/tools/organization/billing-checkout.integration.test.ts
+++ b/apps/mesh/src/tools/organization/billing-checkout.integration.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Real-Postgres coverage for the money-flow guards — everything that fires
+ * BEFORE any Stripe HTTP call, so no key and no network:
+ *  - CHECKOUT_START's matrix: legacy / invoiced / already-active /
+ *    bound-but-not-active (the orphan-payment hole) / zero staged seats.
+ *  - SEATS_PREVIEW requires a chargeable subscription.
+ *  - SEATS_SET applies by mode: invoiced directly; self_serve WITHOUT a
+ *    subscription directly (staging); self_serve WITH an active subscription
+ *    attempts the Stripe mirror — including on an all-no-op replay, which is
+ *    the documented retry after a failed mirror (the rows-already-right case
+ *    MUST still reach Stripe or "apply again" would be a lie).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import type { StudioDatabase } from "../../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../../database/test-db-pg";
+import type { StudioContext } from "../../core/studio-context";
+import { OrganizationBillingStorage } from "../../storage/organization-billing";
+import {
+  ORGANIZATION_BILLING_CHECKOUT_START,
+  ORGANIZATION_SEATS_PREVIEW,
+} from "./billing-checkout";
+import { ORGANIZATION_SEATS_SET } from "./seats";
+
+const USER = "user_1";
+
+function makeCtx(
+  database: StudioDatabase,
+  organizationId: string,
+): StudioContext {
+  return {
+    timings: {
+      measure: async <T>(_name: string, cb: () => Promise<T>) => await cb(),
+    },
+    auth: { user: { id: USER, email: "user_1@test.com", name: "Test" } },
+    organization: { id: organizationId, slug: organizationId, name: "Test" },
+    storage: {
+      organizationBilling: new OrganizationBillingStorage(database.db),
+    },
+    access: {
+      granted: () => true,
+      check: async () => {},
+      grant: () => {},
+      setToolName: () => {},
+      setToolReadOnly: () => {},
+    },
+    tracer: {
+      startActiveSpan: (
+        _name: string,
+        _opts: unknown,
+        fn: (span: unknown) => unknown,
+      ) =>
+        fn({ setStatus: () => {}, recordException: () => {}, end: () => {} }),
+    },
+    meter: {
+      createHistogram: () => ({ record: () => {} }),
+      createCounter: () => ({ add: () => {} }),
+    },
+    metadata: { requestId: "req_test", timestamp: new Date() },
+  } as unknown as StudioContext;
+}
+
+describe("billing money-flow guards", () => {
+  let database: StudioDatabase;
+  let storage: OrganizationBillingStorage;
+
+  const ORG_LEGACY = "org_bg_legacy";
+  const ORG_INVOICED = "org_bg_invoiced";
+  const ORG_STAGING = "org_bg_staging"; // self_serve, no subscription yet
+  const ORG_ACTIVE = "org_bg_active"; // self_serve, active + bound
+  const ORG_DUNNING = "org_bg_dunning"; // self_serve, past_due + bound
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
+    const orgs = [
+      ORG_LEGACY,
+      ORG_INVOICED,
+      ORG_STAGING,
+      ORG_ACTIVE,
+      ORG_DUNNING,
+    ];
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values(
+        orgs.map((id) => ({
+          id,
+          name: id,
+          slug: id.replaceAll("_", "-"),
+          createdAt: now,
+        })),
+      )
+      .execute();
+    await database.db
+      .insertInto("member")
+      .values(
+        orgs.map((id) => ({
+          id: `member_${id}`,
+          organizationId: id,
+          userId: USER,
+          role: "owner",
+          createdAt: now,
+        })),
+      )
+      .execute();
+    await database.db
+      .insertInto("organization_billing")
+      .values([
+        { organization_id: ORG_LEGACY, legacy: true },
+        {
+          organization_id: ORG_INVOICED,
+          legacy: false,
+          billing_mode: "invoiced",
+        },
+        { organization_id: ORG_STAGING, legacy: false },
+        {
+          organization_id: ORG_ACTIVE,
+          legacy: false,
+          status: "active",
+          stripe_subscription_id: "sub_active_1",
+        },
+        {
+          organization_id: ORG_DUNNING,
+          legacy: false,
+          status: "past_due",
+          stripe_subscription_id: "sub_dunning_1",
+        },
+      ])
+      .execute();
+    storage = new OrganizationBillingStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  describe("ORGANIZATION_BILLING_CHECKOUT_START guards", () => {
+    it("rejects legacy and invoiced orgs", async () => {
+      await expect(
+        ORGANIZATION_BILLING_CHECKOUT_START.execute(
+          {},
+          makeCtx(database, ORG_LEGACY),
+        ),
+      ).rejects.toThrow(/legacy plan/);
+      await expect(
+        ORGANIZATION_BILLING_CHECKOUT_START.execute(
+          {},
+          makeCtx(database, ORG_INVOICED),
+        ),
+      ).rejects.toThrow(/Contract-billed/);
+    });
+
+    it("rejects an org with an active subscription", async () => {
+      await expect(
+        ORGANIZATION_BILLING_CHECKOUT_START.execute(
+          {},
+          makeCtx(database, ORG_ACTIVE),
+        ),
+      ).rejects.toThrow(/already has an active subscription/);
+    });
+
+    it("rejects a BOUND subscription even when not active — no second paid subscription", async () => {
+      // past_due (and unpaid→canceled-without-unbind) still has a live
+      // subscription on Stripe; a second checkout would strand the payment.
+      await expect(
+        ORGANIZATION_BILLING_CHECKOUT_START.execute(
+          {},
+          makeCtx(database, ORG_DUNNING),
+        ),
+      ).rejects.toThrow(/still has a subscription on file/);
+    });
+
+    it("rejects zero staged seats — a quantity-0 checkout must never exist", async () => {
+      await expect(
+        ORGANIZATION_BILLING_CHECKOUT_START.execute(
+          {},
+          makeCtx(database, ORG_STAGING),
+        ),
+      ).rejects.toThrow(/at least one member/);
+    });
+  });
+
+  describe("ORGANIZATION_SEATS_PREVIEW guard", () => {
+    it("requires a chargeable subscription (active + bound, self_serve)", async () => {
+      for (const org of [ORG_LEGACY, ORG_INVOICED, ORG_STAGING, ORG_DUNNING]) {
+        await expect(
+          ORGANIZATION_SEATS_PREVIEW.execute(
+            { quantity: 2 },
+            makeCtx(database, org),
+          ),
+        ).rejects.toThrow(/active self-serve subscription/);
+      }
+    });
+  });
+
+  describe("ORGANIZATION_SEATS_SET by billing mode", () => {
+    it("invoiced orgs apply directly, no Stripe involved", async () => {
+      const result = await ORGANIZATION_SEATS_SET.execute(
+        { seats: [{ userId: USER, seat: "paid" }] },
+        makeCtx(database, ORG_INVOICED),
+      );
+      expect(result.applied).toEqual([{ userId: USER, seat: "paid" }]);
+      expect(result.paidSeatCount).toBe(1);
+    });
+
+    it("self_serve WITHOUT a subscription stages seats directly (they charge at checkout)", async () => {
+      const result = await ORGANIZATION_SEATS_SET.execute(
+        { seats: [{ userId: USER, seat: "paid" }] },
+        makeCtx(database, ORG_STAGING),
+      );
+      expect(result.applied).toEqual([{ userId: USER, seat: "paid" }]);
+      expect(await storage.listPaidSeatUserIds(ORG_STAGING)).toEqual([USER]);
+    });
+
+    it("self_serve WITH an active subscription mirrors to Stripe — rows commit, mirror failure surfaces as retryable", async () => {
+      // No STRIPE_SECRET_KEY in the test env, so the mirror deterministically
+      // fails AFTER the rows commit — exactly the partial-failure state the
+      // error copy describes.
+      await expect(
+        ORGANIZATION_SEATS_SET.execute(
+          { seats: [{ userId: USER, seat: "paid" }] },
+          makeCtx(database, ORG_ACTIVE),
+        ),
+      ).rejects.toThrow(/Seats saved, but updating the subscription failed/);
+      expect(await storage.listPaidSeatUserIds(ORG_ACTIVE)).toEqual([USER]);
+    });
+
+    it("an all-no-op replay STILL attempts the Stripe mirror — the documented retry path", async () => {
+      // Same seats again: rows are already right (applied would be empty),
+      // but the mirror must still run or "apply again to retry the charge"
+      // could never recover a failed mirror.
+      await expect(
+        ORGANIZATION_SEATS_SET.execute(
+          { seats: [{ userId: USER, seat: "paid" }] },
+          makeCtx(database, ORG_ACTIVE),
+        ),
+      ).rejects.toThrow(/Seats saved, but updating the subscription failed/);
+    });
+
+    it("self_serve past_due applies rows but does NOT charge the failing card", async () => {
+      const result = await ORGANIZATION_SEATS_SET.execute(
+        { seats: [{ userId: USER, seat: "paid" }] },
+        makeCtx(database, ORG_DUNNING),
+      );
+      // No Stripe error — hasChargeableSubscription excludes past_due; the
+      // webhook reconciles quantity on the next PAID invoice.
+      expect(result.paidSeatCount).toBe(1);
+    });
+  });
+});

--- a/apps/mesh/src/tools/organization/billing-checkout.ts
+++ b/apps/mesh/src/tools/organization/billing-checkout.ts
@@ -1,0 +1,141 @@
+/**
+ * ORGANIZATION_BILLING_CHECKOUT_START / ORGANIZATION_SEATS_PREVIEW
+ *
+ * The self-serve money flow around seats:
+ *  - CHECKOUT_START: first subscribe. The admin stages WHO is paid via
+ *    ORGANIZATION_SEATS_SET (rows grant/unlock nothing while status != active),
+ *    then this creates the Stripe Checkout session with quantity = the staged
+ *    paid count. Completion comes back via the webhook (binds the
+ *    subscription, flips status, delivers the allowance). The ONE redirect in
+ *    the org's life — afterwards seat changes charge inline.
+ *  - SEATS_PREVIEW: the apply bar's "you pay R$X now" — Stripe's prorated
+ *    invoice preview for moving this cycle to the staged quantity.
+ */
+
+import { z } from "zod";
+import {
+  createSeatCheckoutSession,
+  previewSeatChange,
+  StripeApiError,
+} from "../../billing/stripe-api";
+import { getBaseUrl } from "../../core/server-constants";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth } from "../../core/studio-context";
+
+export const ORGANIZATION_BILLING_CHECKOUT_START = defineTool({
+  name: "ORGANIZATION_BILLING_CHECKOUT_START",
+  description:
+    "Start the organization's seat subscription: creates a Stripe Checkout session for the current paid-seat count and returns its URL.",
+  annotations: {
+    title: "Start Billing Checkout",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    url: z.string(),
+    quantity: z.number(),
+  }),
+
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const organizationId = ctx.organization?.id;
+    const orgSlug = ctx.organization?.slug;
+    if (!organizationId || !orgSlug) {
+      throw new Error("Organization context required");
+    }
+
+    const [billing, paidSeatUserIds] = await Promise.all([
+      ctx.storage.organizationBilling.getBilling(organizationId),
+      ctx.storage.organizationBilling.listPaidSeatUserIds(organizationId),
+    ]);
+    if (!billing || billing.legacy) {
+      throw new Error(
+        "This organization is on the legacy plan — no subscription needed.",
+      );
+    }
+    if (billing.billingMode !== "self_serve") {
+      throw new Error("Contract-billed organizations do not use checkout.");
+    }
+    if (billing.status === "active") {
+      throw new Error(
+        "This organization already has an active subscription — seat changes apply directly.",
+      );
+    }
+    const quantity = paidSeatUserIds.length;
+    if (quantity < 1) {
+      throw new Error(
+        "Mark at least one member as a paid seat before subscribing.",
+      );
+    }
+
+    const membersUrl = `${getBaseUrl()}/${encodeURIComponent(orgSlug)}/members`;
+    try {
+      const { url } = await createSeatCheckoutSession({
+        organizationId,
+        quantity,
+        successUrl: `${membersUrl}?checkout=success`,
+        cancelUrl: `${membersUrl}?checkout=canceled`,
+      });
+      return { url, quantity };
+    } catch (err) {
+      if (err instanceof StripeApiError) throw new Error(err.message);
+      throw err;
+    }
+  },
+});
+
+export const ORGANIZATION_SEATS_PREVIEW = defineTool({
+  name: "ORGANIZATION_SEATS_PREVIEW",
+  description:
+    "Preview what the organization pays now for changing its paid-seat count (Stripe prorated invoice preview). Read-only — nothing is charged.",
+  annotations: {
+    title: "Preview Seat Change",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({
+    /** The resulting paid-seat count the staged changes would produce. */
+    quantity: z.number().int().min(1).max(1000),
+  }),
+  outputSchema: z.object({
+    /** Prorated amount charged on apply (negative = credited). */
+    amountDueCents: z.number(),
+    currency: z.string(),
+  }),
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const organizationId = ctx.organization?.id;
+    if (!organizationId) {
+      throw new Error("Organization context required");
+    }
+
+    const billing =
+      await ctx.storage.organizationBilling.getBilling(organizationId);
+    if (
+      !billing ||
+      billing.billingMode !== "self_serve" ||
+      billing.status !== "active" ||
+      !billing.stripeSubscriptionId
+    ) {
+      throw new Error("Seat previews need an active self-serve subscription.");
+    }
+
+    try {
+      return await previewSeatChange({
+        subscriptionId: billing.stripeSubscriptionId,
+        quantity: input.quantity,
+      });
+    } catch (err) {
+      if (err instanceof StripeApiError) throw new Error(err.message);
+      throw err;
+    }
+  },
+});

--- a/apps/mesh/src/tools/organization/billing-checkout.ts
+++ b/apps/mesh/src/tools/organization/billing-checkout.ts
@@ -16,9 +16,9 @@ import { z } from "zod";
 import {
   createSeatCheckoutSession,
   previewSeatChange,
-  StripeApiError,
 } from "../../billing/stripe-api";
-import { getBaseUrl } from "../../core/server-constants";
+import { hasChargeableSubscription } from "../../billing/subscription-state";
+import { getPublicUrl } from "../../core/server-constants";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth } from "../../core/studio-context";
 
@@ -65,6 +65,18 @@ export const ORGANIZATION_BILLING_CHECKOUT_START = defineTool({
         "This organization already has an active subscription — seat changes apply directly.",
       );
     }
+    // A BOUND subscription blocks checkout even when status isn't active:
+    // past_due (dunning) and unpaid/paused (mapped to canceled WITHOUT
+    // unbinding) all mean a live subscription still exists on Stripe — a
+    // second checkout would charge the customer for a subscription the
+    // webhook then refuses to bind (orphan). Recovery is Stripe-side: settle
+    // the invoice (invoice.paid reactivates) or let Stripe delete the
+    // subscription (deleted unbinds, and checkout opens up again).
+    if (billing.stripeSubscriptionId) {
+      throw new Error(
+        "This organization still has a subscription on file — settle or cancel it before starting a new checkout.",
+      );
+    }
     const quantity = paidSeatUserIds.length;
     if (quantity < 1) {
       throw new Error(
@@ -72,19 +84,16 @@ export const ORGANIZATION_BILLING_CHECKOUT_START = defineTool({
       );
     }
 
-    const membersUrl = `${getBaseUrl()}/${encodeURIComponent(orgSlug)}/members`;
-    try {
-      const { url } = await createSeatCheckoutSession({
-        organizationId,
-        quantity,
-        successUrl: `${membersUrl}?checkout=success`,
-        cancelUrl: `${membersUrl}?checkout=canceled`,
-      });
-      return { url, quantity };
-    } catch (err) {
-      if (err instanceof StripeApiError) throw new Error(err.message);
-      throw err;
-    }
+    // getPublicUrl: the browser follows these from Stripe's domain, so they
+    // must be externally reachable, never a localhost fallback.
+    const membersUrl = `${getPublicUrl()}/${encodeURIComponent(orgSlug)}/members`;
+    const { url } = await createSeatCheckoutSession({
+      organizationId,
+      quantity,
+      successUrl: `${membersUrl}?checkout=success`,
+      cancelUrl: `${membersUrl}?checkout=canceled`,
+    });
+    return { url, quantity };
   },
 });
 
@@ -119,23 +128,13 @@ export const ORGANIZATION_SEATS_PREVIEW = defineTool({
 
     const billing =
       await ctx.storage.organizationBilling.getBilling(organizationId);
-    if (
-      !billing ||
-      billing.billingMode !== "self_serve" ||
-      billing.status !== "active" ||
-      !billing.stripeSubscriptionId
-    ) {
+    if (!hasChargeableSubscription(billing)) {
       throw new Error("Seat previews need an active self-serve subscription.");
     }
 
-    try {
-      return await previewSeatChange({
-        subscriptionId: billing.stripeSubscriptionId,
-        quantity: input.quantity,
-      });
-    } catch (err) {
-      if (err instanceof StripeApiError) throw new Error(err.message);
-      throw err;
-    }
+    return await previewSeatChange({
+      subscriptionId: billing.stripeSubscriptionId,
+      quantity: input.quantity,
+    });
   },
 });

--- a/apps/mesh/src/tools/organization/index.ts
+++ b/apps/mesh/src/tools/organization/index.ts
@@ -44,3 +44,7 @@ export { ORGANIZATION_MEMBER_UPDATE_ROLE } from "./member-update-role";
 
 // Seats (per-seat billing)
 export { ORGANIZATION_SEATS_GET, ORGANIZATION_SEATS_SET } from "./seats";
+export {
+  ORGANIZATION_BILLING_CHECKOUT_START,
+  ORGANIZATION_SEATS_PREVIEW,
+} from "./billing-checkout";

--- a/apps/mesh/src/tools/organization/seats.ts
+++ b/apps/mesh/src/tools/organization/seats.ts
@@ -6,13 +6,21 @@
  * enforces billing (STUDIO_BILLING_ENFORCED); a free seat is readonly. GET is
  * readOnlyHint so even free-seat members can render the members/billing page.
  *
- * SET currently applies only to `invoiced` (contract) orgs — their admins
- * toggle seats freely and the seat_change_log is the end-of-cycle invoicing
- * source. `self_serve` orgs get their SET path with the Stripe integration
- * (checkout/proration), and legacy orgs have no seats to manage.
+ * SET semantics by billing mode:
+ *  - `invoiced` (contract): applies directly; the seat_change_log is the
+ *    end-of-cycle invoicing source.
+ *  - `self_serve` WITHOUT an active subscription: applies directly too — seat
+ *    rows are the truth of WHO is paid-for, but grant nothing and unlock
+ *    nothing until a subscription exists (effectivePaidSeatCount and the seat
+ *    gate both zero them). Staging seats is what the first checkout charges.
+ *  - `self_serve` WITH an active subscription: applies rows, then mirrors the
+ *    new count onto the Stripe subscription quantity (prorated difference
+ *    charged immediately — the UI shows ORGANIZATION_SEATS_PREVIEW first).
+ *  - legacy orgs have no seats to manage.
  */
 
 import { z } from "zod";
+import { applySeatQuantity, StripeApiError } from "../../billing/stripe-api";
 import {
   benefitsSyncEnabled,
   enqueueBenefitsSync,
@@ -76,7 +84,7 @@ export const ORGANIZATION_SEATS_GET = defineTool({
 export const ORGANIZATION_SEATS_SET = defineTool({
   name: "ORGANIZATION_SEATS_SET",
   description:
-    "Set members' seats (paid/free). Currently available for invoiced (contract) organizations only; self-serve organizations change seats through checkout.",
+    "Set members' seats (paid/free). Invoiced organizations apply directly; self-serve organizations with an active subscription also charge the prorated difference on the saved card (preview it with ORGANIZATION_SEATS_PREVIEW first).",
   annotations: {
     title: "Set Organization Seats",
     readOnlyHint: false,
@@ -127,13 +135,10 @@ export const ORGANIZATION_SEATS_SET = defineTool({
         "This organization is on the legacy plan — seats do not apply.",
       );
     }
-    if (billing.billingMode !== "invoiced") {
-      // TODO(billing/phase-3): self_serve seat changes go through Stripe
-      // preview + prorated charge before they land here.
-      throw new Error(
-        "Self-serve seat changes require checkout, which is not available yet.",
-      );
-    }
+    const mirrorToStripe =
+      billing.billingMode === "self_serve" &&
+      billing.status === "active" &&
+      !!billing.stripeSubscriptionId;
 
     let result: Awaited<
       ReturnType<typeof ctx.storage.organizationBilling.setSeats>
@@ -153,6 +158,26 @@ export const ORGANIZATION_SEATS_SET = defineTool({
         throw new Error(err.message);
       }
       throw err;
+    }
+
+    // Mirror the new count onto the Stripe subscription (prorated difference
+    // charged on the saved card). AFTER the rows: seat rows are the truth of
+    // WHO; the quantity is derived and idempotent-absolute, so a failure here
+    // is retried by simply re-applying (same rows → same target quantity).
+    // Surfaced as an error so the UI knows the charge didn't happen.
+    if (mirrorToStripe && result.applied.length > 0) {
+      try {
+        await applySeatQuantity({
+          subscriptionId: billing.stripeSubscriptionId as string,
+          quantity: result.paidSeatCount,
+        });
+      } catch (err) {
+        const detail =
+          err instanceof StripeApiError ? err.message : "Stripe update failed";
+        throw new Error(
+          `Seats saved, but updating the subscription failed: ${detail}. Apply again to retry the charge.`,
+        );
+      }
     }
 
     // Fast-path enqueue. Fail-soft: the marker is committed, so a failed

--- a/apps/mesh/src/tools/organization/seats.ts
+++ b/apps/mesh/src/tools/organization/seats.ts
@@ -21,6 +21,7 @@
 
 import { z } from "zod";
 import { applySeatQuantity, StripeApiError } from "../../billing/stripe-api";
+import { hasChargeableSubscription } from "../../billing/subscription-state";
 import {
   benefitsSyncEnabled,
   enqueueBenefitsSync,
@@ -135,10 +136,10 @@ export const ORGANIZATION_SEATS_SET = defineTool({
         "This organization is on the legacy plan — seats do not apply.",
       );
     }
-    const mirrorToStripe =
-      billing.billingMode === "self_serve" &&
-      billing.status === "active" &&
-      !!billing.stripeSubscriptionId;
+    // Narrowed once here: the id survives past the setSeats call below.
+    const stripeSubscriptionId = hasChargeableSubscription(billing)
+      ? billing.stripeSubscriptionId
+      : null;
 
     let result: Awaited<
       ReturnType<typeof ctx.storage.organizationBilling.setSeats>
@@ -162,13 +163,17 @@ export const ORGANIZATION_SEATS_SET = defineTool({
 
     // Mirror the new count onto the Stripe subscription (prorated difference
     // charged on the saved card). AFTER the rows: seat rows are the truth of
-    // WHO; the quantity is derived and idempotent-absolute, so a failure here
-    // is retried by simply re-applying (same rows → same target quantity).
-    // Surfaced as an error so the UI knows the charge didn't happen.
-    if (mirrorToStripe && result.applied.length > 0) {
+    // WHO; the quantity is derived and idempotent-absolute. Deliberately NOT
+    // gated on `applied.length` — a re-apply whose rows are already right
+    // (all no-ops) is exactly the retry after a failed mirror, and it must
+    // still reach Stripe or "apply again to retry the charge" would be a lie.
+    // Surfaced as an error so the UI knows the charge didn't happen. The
+    // webhook additionally reconciles quantity↔rows on every paid invoice,
+    // so a divergence self-heals even if nobody retries.
+    if (stripeSubscriptionId) {
       try {
         await applySeatQuantity({
-          subscriptionId: billing.stripeSubscriptionId as string,
+          subscriptionId: stripeSubscriptionId,
           quantity: result.paidSeatCount,
         });
       } catch (err) {

--- a/apps/mesh/src/tools/registry-metadata.ts
+++ b/apps/mesh/src/tools/registry-metadata.ts
@@ -74,6 +74,8 @@ const ALL_TOOL_NAMES = [
   "ORGANIZATION_MEMBER_UPDATE_ROLE",
   "ORGANIZATION_SEATS_GET",
   "ORGANIZATION_SEATS_SET",
+  "ORGANIZATION_BILLING_CHECKOUT_START",
+  "ORGANIZATION_SEATS_PREVIEW",
   // Connection tools
   "COLLECTION_CONNECTIONS_CREATE",
   "COLLECTION_CONNECTIONS_LIST",
@@ -418,6 +420,17 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     description: "Set members' seats (paid/free)",
     category: "Organizations",
     dangerous: true,
+  },
+  {
+    name: "ORGANIZATION_BILLING_CHECKOUT_START",
+    description: "Start the seat subscription checkout",
+    category: "Organizations",
+    dangerous: true,
+  },
+  {
+    name: "ORGANIZATION_SEATS_PREVIEW",
+    description: "Preview a seat change's prorated charge",
+    category: "Organizations",
   },
   // Connection tools
   {
@@ -1199,9 +1212,12 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "ORGANIZATION_MEMBER_REMOVE",
       "ORGANIZATION_MEMBER_UPDATE_ROLE",
       // Seats live on the members page and change who the org pays for —
-      // same trust tier as adding/removing the member itself.
+      // same trust tier as adding/removing the member itself. Checkout and
+      // preview are the money half of the same surface.
       "ORGANIZATION_SEATS_GET",
       "ORGANIZATION_SEATS_SET",
+      "ORGANIZATION_BILLING_CHECKOUT_START",
+      "ORGANIZATION_SEATS_PREVIEW",
       // Approving/denying join requests adds members, and the UI lives on the
       // members page — keep it under members:manage.
       "ORGANIZATION_JOIN_REQUEST_LIST",

--- a/apps/mesh/src/web/hooks/use-organization-seats.ts
+++ b/apps/mesh/src/web/hooks/use-organization-seats.ts
@@ -1,8 +1,10 @@
 /**
  * Per-seat billing hooks: the org's billing identity + who holds paid seats
  * (ORGANIZATION_SEATS_GET), and the staged-changes apply
- * (ORGANIZATION_SEATS_SET — invoiced orgs only until the Stripe checkout
- * path lands). Seats are monetization, orthogonal to roles.
+ * (ORGANIZATION_SEATS_SET — the backend also handles self-serve orgs, but
+ * this UI still exposes the toggle to invoiced orgs only; the self-serve
+ * checkout/preview surface is the frontend follow-up). Seats are
+ * monetization, orthogonal to roles.
  */
 
 import { useProjectContext } from "@decocms/mesh-sdk";

--- a/apps/mesh/src/web/routes/orgs/members.tsx
+++ b/apps/mesh/src/web/routes/orgs/members.tsx
@@ -418,16 +418,17 @@ function OrgMembersContent() {
 
   // Per-seat billing: staged toggles applied in one batch. The column only
   // renders when the org actually has seats (billing row exists and is not
-  // legacy); toggling is enabled for invoiced (contract) orgs — self-serve
-  // waits for the Stripe checkout flow.
+  // legacy); toggling is enabled for invoiced (contract) orgs — the backend
+  // self-serve path (checkout + prorated apply) exists but its UI is the
+  // frontend follow-up.
   const { data: seatState } = useOrganizationSeats();
   const setSeatsMutation = useSetSeats();
   const [stagedSeats, setStagedSeats] = useState<Record<string, SeatKind>>({});
   // Column only for orgs EXPLICITLY put on invoiced (contract) billing — the
   // per-org opt-in is the rollout switch. Without this, any org created after
   // the billing migration (legacy=false, self_serve by default) would grow a
-  // disabled Seat column before checkout/paywall exist. self_serve gets the
-  // column with the Stripe flow (phase 3).
+  // disabled Seat column before the checkout/paywall UI exists. self_serve
+  // gets the column with the checkout UI follow-up (backend already live).
   const seatsApply =
     !!seatState?.billing &&
     !seatState.billing.legacy &&


### PR DESCRIPTION
## Summary

Tasks 3.2 + 3.3 (backend) of the per-seat plan, on top of the webhook spine (#5154). The UI wiring (apply-bar preview + checkout button for self_serve orgs) is the next PR.

**Flow** (the plan's "pay the difference now" design):
1. Admin stages WHO is paid via `ORGANIZATION_SEATS_SET` — now allowed for `self_serve` orgs pre-subscription, because rows grant/unlock **nothing** until someone pays (both the gateway grant and the seat gate are subscription-aware).
2. `ORGANIZATION_BILLING_CHECKOUT_START` creates the Checkout session: quantity = staged paid count, `metadata.orgId` on session **and** subscription (defense in depth), success/cancel back to the members page. The one redirect in the org's life — the card is saved.
3. Webhook (#5154) binds the subscription, flips status active, delivers the allowance.
4. From then on: `ORGANIZATION_SEATS_PREVIEW` (readOnly — renders "you pay R$X now" in the apply bar) and `SEATS_SET` mirrors the new count onto the subscription with `proration_behavior=always_invoice` + `payment_behavior=pending_if_incomplete` (3DS-safe; the webhook narrates what lands). Rows commit first — seats are the truth of WHO, quantity is derived and absolute, so a Stripe failure surfaces as a retryable error with the rows intact.

**Gate hardening**: a paid-seat row only unlocks access while the self_serve subscription is `active`/`past_due` — staged seats before checkout, or seats left flagged after cancellation, cannot unlock (mirrors `effectivePaidSeatCount` on the grant side; the middleware's membership query gains two scalar subqueries, same single round-trip).

**Stripe client**: raw fetch + bracket form encoding (`stripe-api.ts`), no SDK — same posture as the reports worker and the gateway; three endpoints don't buy a dependency.

## Dormancy

`STRIPE_SECRET_KEY` / `STRIPE_SEAT_PRICE_ID` absent → checkout/preview error cleanly at call time; nothing else changes. Legacy and invoiced orgs untouched. Deploy needs both secrets + the price ID of the $20 multi-currency seat price when we flip.

## Testing

- Unit: the bracket form encoder (nested `line_items`/`subscription_details` shapes — the load-bearing encoding), plus existing suites (48 green across billing/registry/access-control).
- Full-workspace `bun run check` green, `knip` clean, `bun run fmt` applied.
- Real-Stripe smoke (test mode) planned with the UI PR: stage seats → checkout with `4242…` card → webhook binds → preview shows prorated delta → apply charges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-serve per-seat billing with Stripe: Checkout to start a subscription, prorated charges for seat changes, and automatic reconciliation to keep subscription quantity in sync with seats. Also makes the seat gate subscription-aware with a safe bootstrap bypass and hardens webhook handling, including canceling orphan subscriptions.

- **New Features**
  - Minimal Stripe client (form-encoded fetch, 15s timeout) for Checkout, invoice previews, and subscription updates (`always_invoice` + `pending_if_incomplete`); matches the seat item by price id; generic config-missing errors; redirects use `getPublicUrl`.
  - New tools: `ORGANIZATION_BILLING_CHECKOUT_START` (quantity = staged paid seats; returns Checkout URL; `metadata.orgId` on session and subscription; blocks legacy/contract orgs and any already-bound subscription) and `ORGANIZATION_SEATS_PREVIEW` (requires an active self-serve subscription; shows prorated delta).
  - `ORGANIZATION_SEATS_SET`: invoiced applies directly; self-serve without a subscription stages seats; self-serve with an active subscription writes rows then mirrors quantity to Stripe (prorated charge). Stripe failures surface as retryable errors; re-applying identical rows still retries the mirror; `past_due` applies rows without charging (webhook reconciliation will converge).
  - Webhook hardening: out-of-order/replay guard, signature tolerance with secret rotation, Basil payload support, success-event reconciliation (Checkout completion/invoice.paid) to converge quantity→rows, and refusal of rebinds with cancelation of the paid-but-refused orphan subscription.
  - Seat gate: uses a shared `subscriptionInGoodStanding` predicate (matches allowance logic); gated admins can still run `ORGANIZATION_SEATS_SET` and `ORGANIZATION_BILLING_CHECKOUT_START` (permission check unchanged).

- **Migration**
  - Run migration 142 (adds `last_stripe_event_at` and a unique partial index on `stripe_subscription_id`).
  - Configure `STRIPE_WEBHOOK_SECRET`, `STRIPE_SECRET_KEY`, and `STRIPE_SEAT_PRICE_ID`. Without keys, checkout/preview return clear 503-style errors; legacy and invoiced orgs are unaffected.

<sup>Written for commit c264ad2e1db9488ed97c2c384f02322b3ccb0718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

