### PR TITLE
fix(billing): harden Stripe webhook — ordering, replay, checkout guards

### DIFF
--- a/apps/mesh/migrations/142-stripe-event-watermark.ts
+++ b/apps/mesh/migrations/142-stripe-event-watermark.ts
@@ -1,0 +1,35 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Stripe webhook ordering + integrity:
+ *
+ * 1. `last_stripe_event_at` — high-water mark of the newest applied Stripe
+ *    event's `created` time. Stripe does not guarantee delivery order and
+ *    retries for days; events older than the mark are skipped so a late
+ *    redelivery can never regress subscription state (e.g. a replayed
+ *    invoice.paid resurrecting a canceled org).
+ *
+ * 2. Unique partial index on `stripe_subscription_id` — two orgs must never
+ *    claim the same subscription; the webhook's reverse lookup assumes it.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("organization_billing")
+    .addColumn("last_stripe_event_at", "timestamptz")
+    .execute();
+  await sql`
+    create unique index organization_billing_stripe_subscription_id_uq
+    on organization_billing (stripe_subscription_id)
+    where stripe_subscription_id is not null
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`drop index organization_billing_stripe_subscription_id_uq`.execute(
+    db,
+  );
+  await db.schema
+    .alterTable("organization_billing")
+    .dropColumn("last_stripe_event_at")
+    .execute();
+}

--- a/apps/mesh/migrations/index.ts
+++ b/apps/mesh/migrations/index.ts
@@ -140,6 +140,7 @@ import * as migration138agentsandboxsessions from "./138-agent-sandbox-sessions.
 import * as migration139organizationbilling from "./139-organization-billing.ts";
 import * as migration140seatchangelog from "./140-seat-change-log.ts";
 import * as migration141benefitssyncpending from "./141-benefits-sync-pending.ts";
+import * as migration142stripeeventwatermark from "./142-stripe-event-watermark.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -305,6 +306,7 @@ const migrations: Record<string, Migration> = {
   "139-organization-billing": migration139organizationbilling,
   "140-seat-change-log": migration140seatchangelog,
   "141-benefits-sync-pending": migration141benefitssyncpending,
+  "142-stripe-event-watermark": migration142stripeeventwatermark,
 };
 
 export default migrations;

--- a/apps/mesh/src/api/routes/stripe-webhook.ts
+++ b/apps/mesh/src/api/routes/stripe-webhook.ts
@@ -9,49 +9,61 @@
  */
 
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { getSettings } from "../../settings";
 import {
+  parseStripeEvent,
   processStripeEvent,
   verifyStripeSignature,
-  type StripeEvent,
 } from "../../billing/stripe-webhook";
+
+// Stripe events are small; the route is unauthenticated, so cap the body
+// before buffering it (same pattern as trigger-callback).
+const MAX_BODY_SIZE = 1_048_576; // 1MB
 
 export const stripeWebhookRoutes = new Hono();
 
-stripeWebhookRoutes.post("/webhook", async (c) => {
-  const secret = getSettings().stripeWebhookSecret;
-  if (!secret) {
-    return c.json({ error: "stripe billing not configured" }, 503);
-  }
+stripeWebhookRoutes.post(
+  "/webhook",
+  bodyLimit({
+    maxSize: MAX_BODY_SIZE,
+    onError: (c) => c.json({ error: "payload too large" }, 413),
+  }),
+  async (c) => {
+    const secret = getSettings().stripeWebhookSecret;
+    if (!secret) {
+      return c.json({ error: "stripe billing not configured" }, 503);
+    }
 
-  // Raw body FIRST — the signature covers the exact bytes, any parse-then-
-  // restringify would break verification.
-  const rawBody = await c.req.text();
-  const ok = await verifyStripeSignature(
-    rawBody,
-    c.req.header("stripe-signature"),
-    secret,
-  );
-  if (!ok) {
-    return c.json({ error: "invalid signature" }, 400);
-  }
+    // Raw body FIRST — the signature covers the exact bytes, any parse-then-
+    // restringify would break verification.
+    const rawBody = await c.req.text();
+    const ok = verifyStripeSignature(
+      rawBody,
+      c.req.header("stripe-signature"),
+      secret,
+    );
+    if (!ok) {
+      return c.json({ error: "invalid signature" }, 400);
+    }
 
-  let event: StripeEvent;
-  try {
-    event = JSON.parse(rawBody) as StripeEvent;
-  } catch {
-    return c.json({ error: "invalid payload" }, 400);
-  }
-  if (
-    typeof event?.type !== "string" ||
-    typeof event?.data?.object !== "object"
-  ) {
-    return c.json({ error: "invalid payload" }, 400);
-  }
+    const event = parseStripeEvent(rawBody);
+    if (!event) {
+      return c.json({ error: "invalid payload" }, 400);
+    }
 
-  // Always 200 for verified events — handlers are idempotent and unknown
-  // orgs/events are acknowledged no-ops (a Stripe redelivery wouldn't help).
-  // A thrown handler error falls through to 500 so Stripe DOES redeliver.
-  const result = await processStripeEvent(event);
-  return c.json(result);
-});
+    // Always 200 for verified events — handlers are idempotent, and unknown
+    // orgs/events/stale deliveries are acknowledged no-ops (a Stripe
+    // redelivery wouldn't help). A thrown handler error falls through to 500
+    // so Stripe DOES redeliver. One log line per event — the audit trail for
+    // a source-of-truth money writer.
+    const result = await processStripeEvent(event);
+    console.log("stripe webhook", {
+      eventId: event.id,
+      type: event.type,
+      livemode: event.livemode,
+      ...result,
+    });
+    return c.json({ received: true });
+  },
+);

--- a/apps/mesh/src/billing/stripe-webhook.integration.test.ts
+++ b/apps/mesh/src/billing/stripe-webhook.integration.test.ts
@@ -9,12 +9,42 @@ import { OrganizationBillingStorage } from "../storage/organization-billing";
 import { applyStripeEvent, type StripeEvent } from "./stripe-webhook";
 
 // Real-Postgres coverage for the webhook handlers: binding a checkout to the
-// org, mirroring subscription lifecycle, and the invoice.paid monthly clock —
-// including the deterministic reference ids that collapse Stripe redeliveries.
+// org, mirroring subscription lifecycle, the invoice.paid monthly clock, and
+// the two ordering rules — the last_stripe_event_at high-water mark (stale
+// deliveries skipped) and terminal deletes (exempt + unbind), which together
+// make Stripe's unordered redeliveries unable to resurrect a canceled org.
 const ORG = "org_stripe_1";
+const ORG_LEGACY = "org_stripe_legacy";
+const ORG_INVOICED = "org_stripe_invoiced";
+const ORG_BASIL = "org_stripe_basil";
 
-function event(type: string, object: Record<string, unknown>): StripeEvent {
-  return { type, data: { object } };
+// Event-created timeline (epoch seconds).
+const T1 = 1_800_000_010;
+const T2 = 1_800_000_020;
+const T3 = 1_800_000_030;
+const T5 = 1_800_000_050;
+const T6 = 1_800_000_060;
+const PERIOD_1 = 1_800_100_000;
+const PERIOD_2 = 1_800_200_000;
+
+function event(
+  type: string,
+  object: Record<string, unknown>,
+  created?: number,
+): StripeEvent {
+  return { type, created, data: { object } };
+}
+
+function checkout(object: Record<string, unknown>, created?: number) {
+  return event(
+    "checkout.session.completed",
+    {
+      mode: "subscription",
+      payment_status: "paid",
+      ...object,
+    },
+    created,
+  );
 }
 
 describe("applyStripeEvent", () => {
@@ -24,18 +54,30 @@ describe("applyStripeEvent", () => {
   beforeAll(async () => {
     database = await connectTestPgDatabase();
     await resetTestPgDatabase(database);
+    const orgs = [ORG, ORG_LEGACY, ORG_INVOICED, ORG_BASIL];
     await database.db
       .insertInto("organization")
-      .values({
-        id: ORG,
-        name: "Stripe Org",
-        slug: "stripe-org",
-        createdAt: new Date().toISOString(),
-      })
+      .values(
+        orgs.map((id) => ({
+          id,
+          name: `Stripe ${id}`,
+          slug: id.replaceAll("_", "-"),
+          createdAt: new Date().toISOString(),
+        })),
+      )
       .execute();
     await database.db
       .insertInto("organization_billing")
-      .values({ organization_id: ORG, legacy: false })
+      .values([
+        { organization_id: ORG, legacy: false },
+        { organization_id: ORG_LEGACY, legacy: true },
+        {
+          organization_id: ORG_INVOICED,
+          legacy: false,
+          billing_mode: "invoiced",
+        },
+        { organization_id: ORG_BASIL, legacy: false },
+      ])
       .execute();
     storage = new OrganizationBillingStorage(database.db);
   });
@@ -47,13 +89,15 @@ describe("applyStripeEvent", () => {
   it("checkout.session.completed binds the subscription and marks the grant", async () => {
     const result = await applyStripeEvent(
       storage,
-      event("checkout.session.completed", {
-        id: "cs_1",
-        mode: "subscription",
-        customer: "cus_1",
-        subscription: "sub_1",
-        metadata: { orgId: ORG },
-      }),
+      checkout(
+        {
+          id: "cs_1",
+          customer: "cus_1",
+          subscription: "sub_1",
+          metadata: { orgId: ORG },
+        },
+        T1,
+      ),
     );
     expect(result.handled).toBe(true);
 
@@ -62,56 +106,232 @@ describe("applyStripeEvent", () => {
     expect(billing?.stripeSubscriptionId).toBe("sub_1");
     expect(billing?.status).toBe("active");
     expect(billing?.benefitsReferenceId).toBe("stripe-checkout:cs_1");
+    expect(billing?.lastStripeEventAt?.getTime()).toBe(T1 * 1000);
   });
 
   it("subscription.updated mirrors status + period end, keyed by Stripe id", async () => {
-    const periodEnd = 1_800_000_000;
-    const result = await applyStripeEvent(
-      storage,
-      event("customer.subscription.updated", {
-        id: "sub_1",
-        status: "past_due",
-        current_period_end: periodEnd,
-      }),
+    const updated = event(
+      "customer.subscription.updated",
+      { id: "sub_1", status: "past_due", current_period_end: PERIOD_1 },
+      T2,
     );
+    const result = await applyStripeEvent(storage, updated);
     expect(result.handled).toBe(true);
 
     const billing = await storage.getBilling(ORG);
     expect(billing?.status).toBe("past_due");
-    expect(billing?.currentPeriodEnd?.getTime()).toBe(periodEnd * 1000);
+    expect(billing?.currentPeriodEnd?.getTime()).toBe(PERIOD_1 * 1000);
     // Deterministic per (sub, status, period): a redelivery re-marks the SAME
     // reference — one gateway rebase, not two.
-    expect(billing?.benefitsReferenceId).toBe(
-      `stripe-sub:sub_1:past_due:${periodEnd * 1000}`,
+    const referenceId = `stripe-sub:sub_1:past_due:${PERIOD_1 * 1000}`;
+    expect(billing?.benefitsReferenceId).toBe(referenceId);
+
+    // Redelivery of the exact same event: same state, same reference.
+    const redelivered = await applyStripeEvent(storage, updated);
+    expect(redelivered.handled).toBe(true);
+    const after = await storage.getBilling(ORG);
+    expect(after?.status).toBe("past_due");
+    expect(after?.benefitsReferenceId).toBe(referenceId);
+  });
+
+  it("skips a stale subscription.updated (out-of-order delivery)", async () => {
+    const result = await applyStripeEvent(
+      storage,
+      event(
+        "customer.subscription.updated",
+        { id: "sub_1", status: "active" },
+        T1,
+      ),
     );
+    expect(result).toEqual({ handled: false, reason: "stale event" });
+    expect((await storage.getBilling(ORG))?.status).toBe("past_due");
   });
 
   it("invoice.paid is the monthly clock: reactivates and re-marks per invoice id", async () => {
-    const result = await applyStripeEvent(
-      storage,
-      event("invoice.paid", {
-        id: "in_42",
-        subscription: "sub_1",
-        period_end: 1_802_592_000,
-      }),
+    const paid = event(
+      "invoice.paid",
+      { id: "in_42", subscription: "sub_1", period_end: PERIOD_2 },
+      T3,
     );
+    const result = await applyStripeEvent(storage, paid);
     expect(result.handled).toBe(true);
 
     const billing = await storage.getBilling(ORG);
     expect(billing?.status).toBe("active");
+    expect(billing?.currentPeriodEnd?.getTime()).toBe(PERIOD_2 * 1000);
     expect(billing?.benefitsReferenceId).toBe("stripe-invoice:in_42");
+
+    // Stripe redelivery collapses into the same reference and state.
+    const redelivered = await applyStripeEvent(storage, paid);
+    expect(redelivered.handled).toBe(true);
+    expect((await storage.getBilling(ORG))?.benefitsReferenceId).toBe(
+      "stripe-invoice:in_42",
+    );
   });
 
-  it("subscription.deleted cancels service", async () => {
+  it("subscription.deleted cancels service and unbinds the subscription", async () => {
     const result = await applyStripeEvent(
       storage,
-      event("customer.subscription.deleted", {
-        id: "sub_1",
-        status: "canceled",
-      }),
+      event(
+        "customer.subscription.deleted",
+        { id: "sub_1", status: "canceled" },
+        T5,
+      ),
     );
     expect(result.handled).toBe(true);
+    const billing = await storage.getBilling(ORG);
+    expect(billing?.status).toBe("canceled");
+    expect(billing?.stripeSubscriptionId).toBeNull();
+  });
+
+  it("a late invoice.paid can NOT resurrect a canceled org", async () => {
+    // Stripe retries for days; the sub is unbound, so this resolves to
+    // nothing instead of flipping the org back to active forever.
+    const result = await applyStripeEvent(
+      storage,
+      event(
+        "invoice.paid",
+        { id: "in_41", subscription: "sub_1", period_end: PERIOD_1 },
+        T3,
+      ),
+    );
+    expect(result).toEqual({ handled: false, reason: "unknown subscription" });
     expect((await storage.getBilling(ORG))?.status).toBe("canceled");
+  });
+
+  it("re-subscribe binds fresh (async_payment_succeeded counts as paid)", async () => {
+    const result = await applyStripeEvent(storage, {
+      ...checkout(
+        {
+          id: "cs_2",
+          customer: "cus_1",
+          subscription: "sub_2",
+          metadata: { orgId: ORG },
+        },
+        T6,
+      ),
+      type: "checkout.session.async_payment_succeeded",
+    });
+    expect(result.handled).toBe(true);
+    const billing = await storage.getBilling(ORG);
+    expect(billing?.stripeSubscriptionId).toBe("sub_2");
+    expect(billing?.status).toBe("active");
+  });
+
+  it("subscription.deleted is terminal: applies even delivered out of order", async () => {
+    // created T5 < watermark T6 — deleted is exempt from the staleness check
+    // (a deleted subscription never comes back), and the mark never regresses.
+    const result = await applyStripeEvent(
+      storage,
+      event(
+        "customer.subscription.deleted",
+        { id: "sub_2", status: "canceled" },
+        T5,
+      ),
+    );
+    expect(result.handled).toBe(true);
+    const billing = await storage.getBilling(ORG);
+    expect(billing?.status).toBe("canceled");
+    expect(billing?.stripeSubscriptionId).toBeNull();
+    expect(billing?.lastStripeEventAt?.getTime()).toBe(T6 * 1000);
+  });
+
+  it("checkout refuses unpaid sessions and legacy/invoiced orgs", async () => {
+    const unpaid = await applyStripeEvent(
+      storage,
+      checkout({
+        id: "cs_u",
+        payment_status: "unpaid",
+        subscription: "sub_u",
+        metadata: { orgId: ORG_BASIL },
+      }),
+    );
+    expect(unpaid).toEqual({ handled: false, reason: "payment not confirmed" });
+
+    for (const orgId of [ORG_LEGACY, ORG_INVOICED]) {
+      const refused = await applyStripeEvent(
+        storage,
+        checkout({ id: "cs_x", subscription: "sub_x", metadata: { orgId } }),
+      );
+      expect(refused).toEqual({
+        handled: false,
+        reason: "org is not self-serve",
+      });
+      expect(
+        (await storage.getBilling(orgId))?.stripeSubscriptionId,
+      ).toBeNull();
+    }
+  });
+
+  it("reads Basil (2025-03-31) payload shapes; rebinds are refused", async () => {
+    // Bind normally first.
+    const bound = await applyStripeEvent(
+      storage,
+      checkout(
+        {
+          id: "cs_b1",
+          customer: "cus_b1",
+          subscription: "sub_b1",
+          metadata: { orgId: ORG_BASIL },
+        },
+        T1,
+      ),
+    );
+    expect(bound.handled).toBe(true);
+
+    // A checkout for an org still bound to a DIFFERENT live subscription is
+    // refused — metadata.orgId must not be able to hijack billing state.
+    const rebind = await applyStripeEvent(
+      storage,
+      checkout({
+        id: "cs_evil",
+        subscription: "sub_evil",
+        metadata: { orgId: ORG_BASIL },
+      }),
+    );
+    expect(rebind).toEqual({
+      handled: false,
+      reason: "org already bound to another subscription",
+    });
+    expect((await storage.getBilling(ORG_BASIL))?.stripeSubscriptionId).toBe(
+      "sub_b1",
+    );
+
+    // Basil: current_period_end lives on items.data[], not the subscription.
+    const updated = await applyStripeEvent(
+      storage,
+      event(
+        "customer.subscription.updated",
+        {
+          id: "sub_b1",
+          status: "active",
+          items: { data: [{ current_period_end: PERIOD_1 }] },
+        },
+        T2,
+      ),
+    );
+    expect(updated.handled).toBe(true);
+    expect(
+      (await storage.getBilling(ORG_BASIL))?.currentPeriodEnd?.getTime(),
+    ).toBe(PERIOD_1 * 1000);
+
+    // Basil: invoice.subscription moved under invoice.parent.
+    const paid = await applyStripeEvent(
+      storage,
+      event(
+        "invoice.paid",
+        {
+          id: "in_b1",
+          parent: { subscription_details: { subscription: "sub_b1" } },
+          period_end: PERIOD_2,
+        },
+        T3,
+      ),
+    );
+    expect(paid.handled).toBe(true);
+    const billing = await storage.getBilling(ORG_BASIL);
+    expect(billing?.status).toBe("active");
+    expect(billing?.benefitsReferenceId).toBe("stripe-invoice:in_b1");
   });
 
   it("unknown orgs/subscriptions and non-subscription checkouts are acked no-ops", async () => {
@@ -123,21 +343,13 @@ describe("applyStripeEvent", () => {
 
     const unknownOrg = await applyStripeEvent(
       storage,
-      event("checkout.session.completed", {
-        id: "cs_2",
-        mode: "subscription",
-        metadata: { orgId: "org_ghost" },
-      }),
+      checkout({ id: "cs_ghost", metadata: { orgId: "org_ghost" } }),
     );
     expect(unknownOrg.handled).toBe(false);
 
     const payment = await applyStripeEvent(
       storage,
-      event("checkout.session.completed", {
-        id: "cs_3",
-        mode: "payment",
-        metadata: { orgId: ORG },
-      }),
+      checkout({ id: "cs_pay", mode: "payment", metadata: { orgId: ORG } }),
     );
     expect(payment.handled).toBe(false);
 

--- a/apps/mesh/src/billing/stripe-webhook.test.ts
+++ b/apps/mesh/src/billing/stripe-webhook.test.ts
@@ -1,30 +1,107 @@
 import { describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
-import { mapSubscriptionStatus, verifyStripeSignature } from "./stripe-webhook";
+import {
+  mapSubscriptionStatus,
+  parseStripeEvent,
+  verifyStripeSignature,
+} from "./stripe-webhook";
 
 const SECRET = "whsec_test_secret";
+const T = 1_700_000_000;
+/** Verification clock aligned with the signing timestamp. */
+const NOW = T * 1000;
 
-function sign(body: string, secret = SECRET, t = 1_700_000_000): string {
-  const v1 = createHmac("sha256", secret).update(`${t}.${body}`).digest("hex");
-  return `t=${t},v1=${v1}`;
+function hmac(body: string, secret: string, t = T): string {
+  return createHmac("sha256", secret).update(`${t}.${body}`).digest("hex");
+}
+
+function sign(body: string, secret = SECRET, t = T): string {
+  return `t=${t},v1=${hmac(body, secret, t)}`;
 }
 
 describe("verifyStripeSignature", () => {
-  test("accepts Stripe's v1 scheme over the raw body", async () => {
+  test("accepts Stripe's v1 scheme over the raw body", () => {
     const body = '{"type":"invoice.paid"}';
-    expect(await verifyStripeSignature(body, sign(body), SECRET)).toBe(true);
+    expect(verifyStripeSignature(body, sign(body), SECRET, NOW)).toBe(true);
   });
 
-  test("rejects a tampered body, wrong secret, and malformed headers", async () => {
+  test("rejects a tampered body, wrong secret, and malformed headers", () => {
     const body = '{"type":"invoice.paid"}';
     const header = sign(body);
-    expect(await verifyStripeSignature(`${body} `, header, SECRET)).toBe(false);
-    expect(await verifyStripeSignature(body, sign(body, "other"), SECRET)).toBe(
+    expect(verifyStripeSignature(`${body} `, header, SECRET, NOW)).toBe(false);
+    expect(verifyStripeSignature(body, sign(body, "other"), SECRET, NOW)).toBe(
       false,
     );
-    expect(await verifyStripeSignature(body, "garbage", SECRET)).toBe(false);
-    expect(await verifyStripeSignature(body, undefined, SECRET)).toBe(false);
-    expect(await verifyStripeSignature(body, header, undefined)).toBe(false);
+    expect(verifyStripeSignature(body, "garbage", SECRET, NOW)).toBe(false);
+    expect(verifyStripeSignature(body, undefined, SECRET, NOW)).toBe(false);
+    expect(verifyStripeSignature(body, header, undefined, NOW)).toBe(false);
+  });
+
+  test("rejects timestamps outside the ±5 min tolerance (replay window)", () => {
+    const body = '{"type":"invoice.paid"}';
+    const header = sign(body);
+    expect(verifyStripeSignature(body, header, SECRET, (T + 299) * 1000)).toBe(
+      true,
+    );
+    expect(verifyStripeSignature(body, header, SECRET, (T + 301) * 1000)).toBe(
+      false,
+    );
+    // Future-skewed timestamps are just as invalid.
+    expect(verifyStripeSignature(body, header, SECRET, (T - 301) * 1000)).toBe(
+      false,
+    );
+    // Non-numeric timestamp must not sneak past the tolerance check.
+    const v1 = hmac(body, SECRET);
+    expect(verifyStripeSignature(body, `t=abc,v1=${v1}`, SECRET, NOW)).toBe(
+      false,
+    );
+  });
+
+  test("accepts ANY v1 entry — secret rotation sends one per active secret", () => {
+    const body = '{"type":"invoice.paid"}';
+    const good = hmac(body, SECRET);
+    const stale = hmac(body, "whsec_rotated_out");
+    expect(
+      verifyStripeSignature(body, `t=${T},v1=${stale},v1=${good}`, SECRET, NOW),
+    ).toBe(true);
+    expect(
+      verifyStripeSignature(body, `t=${T},v1=${good},v1=${stale}`, SECRET, NOW),
+    ).toBe(true);
+    expect(verifyStripeSignature(body, `t=${T},v1=${stale}`, SECRET, NOW)).toBe(
+      false,
+    );
+  });
+});
+
+describe("parseStripeEvent", () => {
+  test("extracts the handled slice", () => {
+    const event = parseStripeEvent(
+      JSON.stringify({
+        id: "evt_1",
+        type: "invoice.paid",
+        created: T,
+        livemode: false,
+        data: { object: { id: "in_1" } },
+      }),
+    );
+    expect(event).toEqual({
+      id: "evt_1",
+      type: "invoice.paid",
+      created: T,
+      livemode: false,
+      data: { object: { id: "in_1" } },
+    });
+  });
+
+  test("rejects non-JSON, wrong shapes, and data.object null", () => {
+    expect(parseStripeEvent("not json")).toBeNull();
+    expect(parseStripeEvent('"a string"')).toBeNull();
+    expect(parseStripeEvent("{}")).toBeNull();
+    expect(parseStripeEvent('{"type":"x"}')).toBeNull();
+    // typeof null === "object" — a signed-but-degenerate payload must be a
+    // 400, not a 500 that Stripe redelivers for days.
+    expect(parseStripeEvent('{"type":"x","data":{"object":null}}')).toBeNull();
+    expect(parseStripeEvent('{"type":1,"data":{"object":{}}}')).toBeNull();
   });
 });
 

--- a/apps/mesh/src/billing/stripe-webhook.ts
+++ b/apps/mesh/src/billing/stripe-webhook.ts
@@ -1,55 +1,121 @@
 /**
- * Stripe webhook intake for per-seat self-serve billing (phase 3).
+ * Stripe webhook intake for per-seat self-serve billing (phase 3 — the
+ * checkout/portal creator that sets metadata.orgId is phase 4; until it
+ * ships AND the deployment sets STRIPE_WEBHOOK_SECRET, this module is
+ * dormant).
  *
  * The webhook is the SOURCE OF TRUTH writer for organization_billing's
- * subscription state — checkout/portal flows only send users to Stripe; what
- * comes back here is what we believe. Handlers are idempotent (state-setting
- * writes + gateway-deduped benefit grants), so Stripe redeliveries are safe.
+ * subscription state. Stripe guarantees neither delivery order nor
+ * exactly-once, so safety comes from two rules rather than trust:
+ *  - `last_stripe_event_at` high-water mark: an event whose `created` is
+ *    older than the newest applied one is skipped (same-second ties apply
+ *    last-write-wins — the accepted 1s ceiling).
+ *  - customer.subscription.deleted is EXEMPT from the mark (terminal in
+ *    Stripe — a deleted subscription never comes back) and UNBINDS
+ *    stripe_subscription_id, so late events for a dead subscription resolve
+ *    to nothing and a re-subscribe binds a fresh subscription cleanly.
+ * Benefit grants are additionally deduped at the gateway by deterministic
+ * referenceIds, and state + grant intent commit in one row update.
  *
  * Events:
- *  - checkout.session.completed  → bind customer/subscription to the org
- *    (metadata.orgId, set by our checkout creator), status active, grant.
- *  - customer.subscription.updated → mirror status + current_period_end.
- *  - customer.subscription.deleted → status canceled, grant recomputes to 0
- *    (the sync workflow zeroes self_serve orgs whose status isn't good).
+ *  - checkout.session.completed / ...async_payment_succeeded → bind
+ *    customer/subscription to the org (metadata.orgId, set by our checkout
+ *    creator) once payment_status is "paid"; status active, grant. Refuses
+ *    legacy / non-self-serve orgs and rebinding over a live different
+ *    subscription.
+ *  - customer.subscription.updated → mirror status + current period end.
+ *  - customer.subscription.deleted → status canceled + unbind; grant
+ *    recomputes to 0 (the sync workflow zeroes self_serve orgs whose
+ *    subscription isn't good).
  *  - invoice.paid → THE MONTHLY CLOCK: refresh period end + re-grant with
  *    referenceId = invoice id, which is what makes the gateway allowance
  *    reset per billing cycle (no cron anywhere).
  *
+ * Payload compat: API version 2025-03-31 (Basil) moved invoice.subscription
+ * under invoice.parent.subscription_details and the subscription's
+ * current_period_end onto items.data[] — handlers read both shapes.
+ *
  * Signature: Stripe's v1 scheme (HMAC-SHA256 over `${t}.${rawBody}`),
- * verified timing-safe — same hand-rolled approach as the reports worker; the
- * Stripe SDK arrives with the checkout/preview API surface, not for this.
+ * timing-safe, ±5 min timestamp tolerance (replay window), any v1 entry may
+ * match (secret rotation sends one per active secret). Hand-rolled on
+ * purpose — the Stripe SDK isn't a dependency anywhere in this repo.
  */
 
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { getDb } from "@/database";
-import { OrganizationBillingStorage } from "../storage/organization-billing";
+import {
+  OrganizationBillingStorage,
+  type OrganizationBillingRow,
+} from "../storage/organization-billing";
 import { enqueueBenefitsSync } from "./sync-org-benefits";
 
-export async function verifyStripeSignature(
+const SIGNATURE_TOLERANCE_SEC = 300;
+
+export function verifyStripeSignature(
   rawBody: string,
   sigHeader: string | null | undefined,
   secret: string | undefined,
-): Promise<boolean> {
+  nowMs = Date.now(),
+): boolean {
   if (!sigHeader || !secret) return false;
-  const parts: Record<string, string> = {};
+  let timestamp: string | undefined;
+  const signatures: string[] = [];
   for (const kv of sigHeader.split(",")) {
     const i = kv.indexOf("=");
-    if (i > 0) parts[kv.slice(0, i).trim()] = kv.slice(i + 1).trim();
+    if (i <= 0) continue;
+    const key = kv.slice(0, i).trim();
+    const value = kv.slice(i + 1).trim();
+    if (key === "t") timestamp = value;
+    else if (key === "v1") signatures.push(value);
   }
-  if (!parts.t || !parts.v1) return false;
+  if (!timestamp || signatures.length === 0) return false;
+  // Stale timestamps are rejected outright: a captured (body, signature)
+  // pair must not be a permanent replay capability.
+  const t = Number(timestamp);
+  if (
+    !Number.isFinite(t) ||
+    Math.abs(nowMs / 1000 - t) > SIGNATURE_TOLERANCE_SEC
+  ) {
+    return false;
+  }
   const expected = createHmac("sha256", secret)
-    .update(`${parts.t}.${rawBody}`)
+    .update(`${timestamp}.${rawBody}`)
     .digest("hex");
   const a = Buffer.from(expected, "hex");
-  const b = Buffer.from(parts.v1, "hex");
-  return a.length === b.length && timingSafeEqual(a, b);
+  return signatures.some((sig) => {
+    const b = Buffer.from(sig, "hex");
+    return a.length === b.length && timingSafeEqual(a, b);
+  });
 }
 
 /** The slice of a Stripe event the handlers consume. */
 export interface StripeEvent {
+  id?: string;
   type: string;
+  /** Event creation time (epoch seconds) — feeds the high-water mark. */
+  created?: number;
+  livemode?: boolean;
   data: { object: Record<string, unknown> };
+}
+
+/** Structural gate over a verified raw body: null = not a Stripe event. */
+export function parseStripeEvent(rawBody: string): StripeEvent | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    return null;
+  }
+  const event = rec(parsed);
+  const object = rec(rec(event?.data)?.object);
+  if (!event || typeof event.type !== "string" || !object) return null;
+  return {
+    id: s(event.id),
+    type: event.type,
+    created: typeof event.created === "number" ? event.created : undefined,
+    livemode: typeof event.livemode === "boolean" ? event.livemode : undefined,
+    data: { object },
+  };
 }
 
 /** Map Stripe subscription statuses onto our billing.status vocabulary. */
@@ -61,7 +127,9 @@ export function mapSubscriptionStatus(stripeStatus: unknown): string {
     case "past_due":
       return "past_due";
     default:
-      // canceled, unpaid, incomplete_expired, paused… — no service.
+      // canceled, unpaid, incomplete_expired, paused… — no service. A later
+      // legitimate recovery (unpaid invoice settled, pause resumed) arrives
+      // as a fresh subscription.updated and passes the high-water mark.
       return "canceled";
   }
 }
@@ -70,8 +138,64 @@ function s(v: unknown): string | undefined {
   return typeof v === "string" ? v : undefined;
 }
 
+function rec(v: unknown): Record<string, unknown> | undefined {
+  return typeof v === "object" && v !== null
+    ? (v as Record<string, unknown>)
+    : undefined;
+}
+
 function epochToDate(v: unknown): Date | null {
   return typeof v === "number" ? new Date(v * 1000) : null;
+}
+
+/** Id-or-expanded-object fields (customer, subscription). */
+function idOf(v: unknown): string | undefined {
+  return s(v) ?? s(rec(v)?.id);
+}
+
+/** invoice → subscription id; Basil moved it under invoice.parent. */
+function invoiceSubscriptionId(
+  obj: Record<string, unknown>,
+): string | undefined {
+  return (
+    idOf(obj.subscription) ??
+    s(rec(rec(obj.parent)?.subscription_details)?.subscription)
+  );
+}
+
+/** subscription → current period end; Basil moved it onto items.data[]. */
+function subscriptionPeriodEnd(obj: Record<string, unknown>): Date | null {
+  const direct = epochToDate(obj.current_period_end);
+  if (direct) return direct;
+  const items = rec(obj.items)?.data;
+  if (!Array.isArray(items)) return null;
+  let max = 0;
+  for (const item of items) {
+    const end = rec(item)?.current_period_end;
+    if (typeof end === "number" && end > max) max = end;
+  }
+  return max > 0 ? new Date(max * 1000) : null;
+}
+
+function isStale(event: StripeEvent, billing: OrganizationBillingRow): boolean {
+  const created = epochToDate(event.created);
+  return (
+    !!created &&
+    !!billing.lastStripeEventAt &&
+    created < billing.lastStripeEventAt
+  );
+}
+
+/** Forward-only mark: never regress it (deleted applies out of order). */
+function nextWatermark(
+  event: StripeEvent,
+  billing: OrganizationBillingRow,
+): Date | undefined {
+  const created = epochToDate(event.created);
+  if (!created) return undefined;
+  return billing.lastStripeEventAt && billing.lastStripeEventAt > created
+    ? undefined
+    : created;
 }
 
 export type HandledStripeEvent =
@@ -81,8 +205,9 @@ export type HandledStripeEvent =
 /**
  * Apply one Stripe event to billing state. Pure-ish over the storage: returns
  * what changed so the route can enqueue the benefit delivery AFTER the write
- * committed. Unknown org / unknown event types are acknowledged no-ops —
- * Stripe must get its 200 either way, redelivery wouldn't help.
+ * committed. Unknown org / unknown event types / stale deliveries are
+ * acknowledged no-ops — Stripe must get its 200 either way, redelivery
+ * wouldn't help.
  */
 export async function applyStripeEvent(
   storage: OrganizationBillingStorage,
@@ -91,22 +216,60 @@ export async function applyStripeEvent(
   const obj = event.data.object;
 
   switch (event.type) {
-    case "checkout.session.completed": {
-      const organizationId = s(
-        (obj.metadata as Record<string, unknown> | undefined)?.orgId,
-      );
+    case "checkout.session.completed":
+    case "checkout.session.async_payment_succeeded": {
+      const organizationId = s(rec(obj.metadata)?.orgId);
       if (!organizationId) return { handled: false, reason: "no orgId" };
       if (obj.mode !== "subscription") {
         return { handled: false, reason: "not a subscription checkout" };
       }
-      const updated = await storage.updateStripeState(organizationId, {
-        stripeCustomerId: s(obj.customer),
-        stripeSubscriptionId: s(obj.subscription),
-        status: "active",
-      });
-      if (!updated) return { handled: false, reason: "unknown org" };
+      // Delayed-notification methods fire checkout.session.completed while
+      // payment_status is still "unpaid" — service starts when the payment
+      // confirms (async_payment_succeeded re-enters here with "paid").
+      if (s(obj.payment_status) !== "paid") {
+        return { handled: false, reason: "payment not confirmed" };
+      }
+      const billing = await storage.getBilling(organizationId);
+      if (!billing) return { handled: false, reason: "unknown org" };
+      // metadata.orgId comes from our checkout creator, but never let it
+      // rebind billing it must not touch: self-serve, non-legacy orgs only,
+      // and never an org still bound to a DIFFERENT subscription (deleted
+      // unbinds, so a legitimate re-subscribe passes).
+      if (billing.legacy || billing.billingMode !== "self_serve") {
+        console.error("stripe webhook: refused checkout bind", {
+          organizationId,
+          eventId: event.id,
+          legacy: billing.legacy,
+          billingMode: billing.billingMode,
+        });
+        return { handled: false, reason: "org is not self-serve" };
+      }
+      const subscriptionId = idOf(obj.subscription);
+      if (
+        billing.stripeSubscriptionId &&
+        subscriptionId &&
+        billing.stripeSubscriptionId !== subscriptionId
+      ) {
+        console.error("stripe webhook: refused checkout rebind", {
+          organizationId,
+          eventId: event.id,
+        });
+        return {
+          handled: false,
+          reason: "org already bound to another subscription",
+        };
+      }
+      if (isStale(event, billing)) {
+        return { handled: false, reason: "stale event" };
+      }
       const referenceId = `stripe-checkout:${s(obj.id) ?? crypto.randomUUID()}`;
-      await storage.markBenefitsPending(organizationId, referenceId);
+      await storage.updateStripeState(organizationId, {
+        stripeCustomerId: idOf(obj.customer),
+        stripeSubscriptionId: subscriptionId,
+        status: "active",
+        benefitsReferenceId: referenceId,
+        lastStripeEventAt: nextWatermark(event, billing),
+      });
       return {
         handled: true,
         organizationId,
@@ -121,20 +284,25 @@ export async function applyStripeEvent(
       const billing =
         await storage.getBillingByStripeSubscriptionId(subscriptionId);
       if (!billing) return { handled: false, reason: "unknown subscription" };
-      const status =
-        event.type === "customer.subscription.deleted"
-          ? "canceled"
-          : mapSubscriptionStatus(obj.status);
-      await storage.updateStripeState(billing.organizationId, {
-        status,
-        currentPeriodEnd: epochToDate(obj.current_period_end),
-      });
+      const isDeleted = event.type === "customer.subscription.deleted";
+      // deleted is terminal — always safe to apply, even delivered late.
+      if (!isDeleted && isStale(event, billing)) {
+        return { handled: false, reason: "stale event" };
+      }
+      const status = isDeleted ? "canceled" : mapSubscriptionStatus(obj.status);
+      const periodEnd = subscriptionPeriodEnd(obj);
       // Status changes move the effective grant (canceled → 0) — re-deliver.
       // Deterministic per (sub, status, period) so redeliveries collapse.
       const referenceId = `stripe-sub:${subscriptionId}:${status}:${
-        epochToDate(obj.current_period_end)?.getTime() ?? 0
+        periodEnd?.getTime() ?? 0
       }`;
-      await storage.markBenefitsPending(billing.organizationId, referenceId);
+      await storage.updateStripeState(billing.organizationId, {
+        status,
+        currentPeriodEnd: periodEnd,
+        ...(isDeleted && { stripeSubscriptionId: null }),
+        benefitsReferenceId: referenceId,
+        lastStripeEventAt: nextWatermark(event, billing),
+      });
       return {
         handled: true,
         organizationId: billing.organizationId,
@@ -143,19 +311,25 @@ export async function applyStripeEvent(
     }
 
     case "invoice.paid": {
-      const subscriptionId = s(obj.subscription);
+      const subscriptionId = invoiceSubscriptionId(obj);
       if (!subscriptionId) return { handled: false, reason: "no sub id" };
       const billing =
         await storage.getBillingByStripeSubscriptionId(subscriptionId);
       if (!billing) return { handled: false, reason: "unknown subscription" };
+      if (isStale(event, billing)) {
+        return { handled: false, reason: "stale event" };
+      }
+      // THE monthly reset: deterministic reference (invoice id) so Stripe
+      // redeliveries collapse into one gateway rebase per cycle. Setting
+      // active here is also the unpaid→paid recovery path; a truly deleted
+      // subscription can't reach this (deleted unbinds the id).
+      const referenceId = `stripe-invoice:${s(obj.id) ?? crypto.randomUUID()}`;
       await storage.updateStripeState(billing.organizationId, {
         status: "active",
         currentPeriodEnd: epochToDate(obj.period_end),
+        benefitsReferenceId: referenceId,
+        lastStripeEventAt: nextWatermark(event, billing),
       });
-      // THE monthly reset: deterministic reference (invoice id) so Stripe
-      // redeliveries collapse into one gateway rebase per cycle.
-      const referenceId = `stripe-invoice:${s(obj.id) ?? crypto.randomUUID()}`;
-      await storage.markBenefitsPending(billing.organizationId, referenceId);
       return {
         handled: true,
         organizationId: billing.organizationId,

--- a/apps/mesh/src/billing/sync-org-benefits.test.ts
+++ b/apps/mesh/src/billing/sync-org-benefits.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { computeAllowanceMicros } from "./sync-org-benefits";
+import {
+  computeAllowanceMicros,
+  effectivePaidSeatCount,
+} from "./sync-org-benefits";
 
 describe("computeAllowanceMicros", () => {
   test("paid seats × per-seat cents, in microdollars", () => {
@@ -10,5 +13,41 @@ describe("computeAllowanceMicros", () => {
 
   test("zero seats revokes (amount 0 is the gateway's revoke)", () => {
     expect(computeAllowanceMicros(0, 500)).toBe(0);
+  });
+});
+
+describe("effectivePaidSeatCount", () => {
+  test("self_serve orgs serve only in good standing (past_due is grace)", () => {
+    expect(
+      effectivePaidSeatCount(
+        { billingMode: "self_serve", status: "active" },
+        4,
+      ),
+    ).toBe(4);
+    expect(
+      effectivePaidSeatCount(
+        { billingMode: "self_serve", status: "past_due" },
+        4,
+      ),
+    ).toBe(4);
+    expect(
+      effectivePaidSeatCount({ billingMode: "self_serve", status: "none" }, 4),
+    ).toBe(0);
+    expect(
+      effectivePaidSeatCount(
+        { billingMode: "self_serve", status: "canceled" },
+        4,
+      ),
+    ).toBe(0);
+  });
+
+  test("invoiced (contract) orgs have no Stripe status — seats always count", () => {
+    expect(
+      effectivePaidSeatCount({ billingMode: "invoiced", status: "none" }, 4),
+    ).toBe(4);
+  });
+
+  test("orgs predating billing rows fail open", () => {
+    expect(effectivePaidSeatCount(null, 4)).toBe(4);
   });
 });

--- a/apps/mesh/src/billing/sync-org-benefits.ts
+++ b/apps/mesh/src/billing/sync-org-benefits.ts
@@ -40,6 +40,23 @@ export function computeAllowanceMicros(
   return paidSeatCount * seatAllowanceCents * MICROS_PER_CENT;
 }
 
+/**
+ * self_serve orgs grant 0 while the subscription isn't in good standing
+ * (canceled/none — past_due is grace): seats describe WHO is paid-for, the
+ * subscription is whether anyone is paying at all. invoiced (contract) orgs
+ * have no Stripe status, and orgs predating billing rows fail open — their
+ * seats always count.
+ */
+export function effectivePaidSeatCount(
+  billing: { billingMode: string; status: string } | null,
+  paidSeatCount: number,
+): number {
+  if (!billing || billing.billingMode !== "self_serve") return paidSeatCount;
+  return billing.status === "active" || billing.status === "past_due"
+    ? paidSeatCount
+    : 0;
+}
+
 /** Whether this deployment can deliver benefits at all (self-hosted can't). */
 export function benefitsSyncEnabled(): boolean {
   const settings = getSettings();
@@ -81,12 +98,10 @@ async function syncOrgBenefitsWorkflowFn(
   organizationId: string,
   referenceId: string,
 ): Promise<{ delivered: boolean }> {
-  // Read live state: the CURRENT pending ref and the EFFECTIVE paid count.
+  // Read live state: the CURRENT pending ref and the EFFECTIVE paid count
+  // (effectivePaidSeatCount — subscription standing gates self_serve orgs).
   // If a newer seat change replaced the ref, that change's own workflow owns
-  // delivery — exit. self_serve orgs whose subscription isn't in good
-  // standing (canceled/none) grant 0 regardless of seat flags: seats describe
-  // WHO is paid-for, the subscription is whether anyone is paying at all.
-  // invoiced (contract) orgs have no Stripe status — their seats always count.
+  // delivery — exit.
   const state = await DBOS.runStep(
     async () => {
       const s = storage();
@@ -94,13 +109,9 @@ async function syncOrgBenefitsWorkflowFn(
         s.getBilling(organizationId),
         s.listPaidSeatUserIds(organizationId),
       ]);
-      const subscriptionGood =
-        billing?.billingMode !== "self_serve" ||
-        billing.status === "active" ||
-        billing.status === "past_due";
       return {
         pendingRef: billing?.benefitsReferenceId ?? null,
-        paidSeatCount: subscriptionGood ? paidSeatUserIds.length : 0,
+        paidSeatCount: effectivePaidSeatCount(billing, paidSeatUserIds.length),
       };
     },
     { name: "readSeatState", retriesAllowed: true, maxAttempts: 3 },

--- a/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/mesh/src/dbos/workflow-source-guard.snapshot.json
@@ -1,7 +1,7 @@
 {
   "auth/install-studio-pack-workflow.ts": "fe506448bcbd657194f72999b8196b842a3cc52e2685997462f1d4715cc734f1",
   "automations/dbos-workflow.ts": "088986a214dd803913438f51bdbaa14dfef25b151422e117605a7907dc2bd987",
-  "billing/sync-org-benefits.ts": "da13d485441279eebfbe72a6095e047aa3a783384717bcfe8d359194f8ca76ac",
+  "billing/sync-org-benefits.ts": "d2ed083a1b7ea79daaf309f53167800c74c15c4d1aa66c00df24731fc29795b9",
   "dispatch-queue/hosted-harness-workflow.ts": "1ee53df2391d0b73f10630be7f7d947db16653d5b8740b799e64a98cb2f49c86",
   "dispatch-queue/thread-gate-workflow.ts": "674cd393ad3b06806e967389dfe7e87bd0de6ba933fd54df1e5cd24a08b99e43",
   "file-storage/dbos-public-sets-sync.ts": "831f6077e4094e8ce6ee337007f3b466a98355a23a11032841d0439d63395126",

--- a/apps/mesh/src/storage/organization-billing.ts
+++ b/apps/mesh/src/storage/organization-billing.ts
@@ -8,8 +8,25 @@
  * tools, which gate on billing_mode.
  */
 
-import type { Kysely } from "kysely";
+import type { Kysely, Selectable } from "kysely";
 import type { Database } from "./types";
+
+function toBillingRow(
+  row: Selectable<Database["organization_billing"]>,
+): OrganizationBillingRow {
+  return {
+    organizationId: row.organization_id,
+    legacy: row.legacy,
+    billingMode: row.billing_mode,
+    status: row.status,
+    stripeCustomerId: row.stripe_customer_id,
+    stripeSubscriptionId: row.stripe_subscription_id,
+    currentPeriodEnd: row.current_period_end,
+    includedReportUrl: row.included_report_url,
+    benefitsReferenceId: row.benefits_reference_id,
+    lastStripeEventAt: row.last_stripe_event_at,
+  };
+}
 
 export interface OrganizationBillingRow {
   organizationId: string;
@@ -23,6 +40,9 @@ export interface OrganizationBillingRow {
   /** Non-null = a gateway allowance grant is pending for the latest seat
    *  change (the value is the grant's gateway idempotency key). */
   benefitsReferenceId: string | null;
+  /** Newest applied Stripe event's `created` time — the webhook skips
+   *  deliveries older than this so out-of-order events can't regress state. */
+  lastStripeEventAt: Date | null;
 }
 
 export type SeatKind = "paid" | "free";
@@ -61,18 +81,7 @@ export class OrganizationBillingStorage {
       .selectAll()
       .where("organization_id", "=", organizationId)
       .executeTakeFirst();
-    if (!row) return null;
-    return {
-      organizationId: row.organization_id,
-      legacy: row.legacy,
-      billingMode: row.billing_mode,
-      status: row.status,
-      stripeCustomerId: row.stripe_customer_id,
-      stripeSubscriptionId: row.stripe_subscription_id,
-      currentPeriodEnd: row.current_period_end,
-      includedReportUrl: row.included_report_url,
-      benefitsReferenceId: row.benefits_reference_id,
-    };
+    return row ? toBillingRow(row) : null;
   }
 
   /**
@@ -265,30 +274,38 @@ export class OrganizationBillingStorage {
   }
 
   /** Resolve the org behind a Stripe subscription (webhook events carry
-   *  Stripe ids, not ours). One row per org keeps this a cheap scan. */
+   *  Stripe ids, not ours; migration 142's unique index guarantees at most
+   *  one org per subscription). */
   async getBillingByStripeSubscriptionId(
     stripeSubscriptionId: string,
   ): Promise<OrganizationBillingRow | null> {
     const row = await this.db
       .selectFrom("organization_billing")
-      .select(["organization_id"])
+      .selectAll()
       .where("stripe_subscription_id", "=", stripeSubscriptionId)
       .executeTakeFirst();
-    return row ? this.getBilling(row.organization_id) : null;
+    return row ? toBillingRow(row) : null;
   }
 
   /**
    * Platform write from the Stripe webhook handlers: subscription identity /
-   * status / period end. Never touches seats or legacy — webhooks only ever
-   * narrate what Stripe already committed.
+   * status / period end, plus the pending benefit marker and the event
+   * high-water mark — ONE row update, so state and grant intent commit
+   * atomically (the webhook counterpart of setSeats' in-transaction marker).
+   * Never touches seats or legacy — webhooks only ever narrate what Stripe
+   * already committed. Pass a DETERMINISTIC benefitsReferenceId for cycle
+   * events (e.g. the invoice id) so replays collapse at the gateway.
    */
   async updateStripeState(
     organizationId: string,
     patch: {
       stripeCustomerId?: string;
-      stripeSubscriptionId?: string;
+      /** null = unbind (subscription deleted). */
+      stripeSubscriptionId?: string | null;
       status?: string;
       currentPeriodEnd?: Date | null;
+      benefitsReferenceId?: string;
+      lastStripeEventAt?: Date;
     },
   ): Promise<boolean> {
     const result = await this.db
@@ -304,28 +321,17 @@ export class OrganizationBillingStorage {
         ...(patch.currentPeriodEnd !== undefined && {
           current_period_end: patch.currentPeriodEnd,
         }),
+        ...(patch.benefitsReferenceId !== undefined && {
+          benefits_reference_id: patch.benefitsReferenceId,
+        }),
+        ...(patch.lastStripeEventAt !== undefined && {
+          last_stripe_event_at: patch.lastStripeEventAt,
+        }),
         updated_at: new Date(),
       })
       .where("organization_id", "=", organizationId)
       .executeTakeFirst();
     return (result.numUpdatedRows ?? 0n) > 0n;
-  }
-
-  /**
-   * Mark a benefit sync pending outside a seat change (Stripe webhooks: the
-   * grant amount is recomputed from live state at delivery, so the marker is
-   * all a billing event needs to write). Pass a DETERMINISTIC referenceId for
-   * cycle events (e.g. the invoice id) so replays collapse at the gateway.
-   */
-  async markBenefitsPending(
-    organizationId: string,
-    referenceId: string,
-  ): Promise<void> {
-    await this.db
-      .updateTable("organization_billing")
-      .set({ benefits_reference_id: referenceId, updated_at: new Date() })
-      .where("organization_id", "=", organizationId)
-      .execute();
   }
 
   /**

--- a/apps/mesh/src/storage/types.ts
+++ b/apps/mesh/src/storage/types.ts
@@ -1263,6 +1263,14 @@ export interface OrganizationBillingTable {
     string | null | undefined,
     string | null
   >;
+  /** High-water mark of the newest applied Stripe event's `created` time
+   *  (migration 142) — older webhook deliveries are skipped, so out-of-order
+   *  redeliveries can never regress subscription state. */
+  last_stripe_event_at: ColumnType<
+    Date | null,
+    Date | string | null | undefined,
+    Date | string | null
+  >;
   created_at: ColumnType<Date, Date | string | undefined, never>;
   updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
 }


### PR DESCRIPTION
Hardening pass on the Stripe webhook intake that merged in #5154, from a multi-perspective review (correctness / security / architecture / testing critics).

## What was broken

1. **A canceled org could be resurrected forever.** Stripe guarantees neither ordering nor exactly-once, and retries for days. A late-redelivered `invoice.paid` (or stale `subscription.updated`) unconditionally set `status: "active"` after `customer.subscription.deleted` — and nothing would ever correct it.
2. **Infinite replay window.** The signature verifier never checked `t=` against the clock — any captured signed payload was a permanent "reactivate my org" capability. Stripe's reference implementation enforces 5 minutes.
3. **Secret rotation broke delivery.** During rotation Stripe sends multiple `v1=` entries; the parser kept only the last, 400-ing every event for the rotation window.
4. **The monthly clock silently never ticks on current API versions.** Basil (2025-03-31) moved `invoice.subscription` under `invoice.parent.subscription_details` and the subscription period end onto `items.data[]` — every `invoice.paid` would no-op with a 200.
5. **`metadata.orgId` could hijack billing state** — bind over an invoiced/legacy org or a different live subscription; `checkout.session.completed` also granted service before payment confirmed for delayed-notification methods.

## The fix

- **`last_stripe_event_at` high-water mark** (migration 142): events older than the newest applied one are skipped. `subscription.deleted` is exempt (terminal in Stripe — always safe) and now **unbinds** `stripe_subscription_id`, so late events for a dead subscription resolve to nothing and a re-subscribe binds fresh. Same-second ties are last-write-wins (accepted 1s ceiling).
- Verifier: ±300s tolerance, any `v1` entry may match; sync (no await inside).
- Checkout: requires `payment_status === "paid"`, handles `checkout.session.async_payment_succeeded`, refuses legacy/non-self-serve orgs and rebinds over a live different subscription (logged loudly, acked so Stripe doesn't retry).
- Both payload generations read for `invoice.subscription` / period end.
- Route: 1MB `bodyLimit` (same pattern as trigger-callback), structural `parseStripeEvent` (`data.object: null` was a 500 → poison redelivery loop), `{received: true}` response, one audit log line per event.
- Storage: pending-benefit marker folded into `updateStripeState` — state + grant intent commit in one row update; unique partial index on `stripe_subscription_id` (one org per subscription, enforced); single-query reverse lookup.
- `effectivePaidSeatCount` extracted as a pure function (the self-serve zero-grant gate is now unit-tested).

## Testing

- Unit: verifier tolerance/rotation/malformed-header cases, `parseStripeEvent` shape gate, `effectivePaidSeatCount` matrix.
- Real-Postgres integration: full lifecycle plus redelivery idempotency, out-of-order delivery (stale update skipped; late `invoice.paid` cannot resurrect; late terminal delete still applies), checkout guards (unpaid / legacy / invoiced / rebind), and Basil-shaped payloads.
- `bun run check`, `bun run lint`, `bun run fmt:check` clean; DBOS workflow-source snapshot re-baselined (step-internal change, recovery-compatible).

Still dormant in production: the route 503s until `STRIPE_WEBHOOK_SECRET` is set, and self-serve orgs can't acquire paid seats until the checkout flow ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Stripe webhook to enforce event ordering, block replays, and guard checkout binding. Prevents canceled orgs from being reactivated, stops `metadata.orgId` hijacks, and fixes the monthly clock on newer Stripe payloads.

- **Bug Fixes**
  - Ordering: added `last_stripe_event_at` watermark; skips stale events. `customer.subscription.deleted` always applies and unbinds `stripe_subscription_id`.
  - Replay: signature verifier enforces ±300s tolerance and matches any `v1` entry (supports secret rotation).
  - Checkout guards: requires `payment_status === "paid"`, handles `checkout.session.async_payment_succeeded`, and refuses legacy/invoiced orgs or rebinds to a different live subscription.
  - Payload compat: reads Basil (2025-03-31) shapes for invoice subscription and period end, restoring the monthly clock.
  - Route hardening: 1MB body limit, structural `parseStripeEvent`, `{received: true}` responses for verified events, and a single audit log line per event.
  - Storage: unique partial index on `stripe_subscription_id`; `updateStripeState` now commits state and pending grant in one update; simpler reverse lookup.
  - Tests: unit and Postgres integration coverage for ordering, idempotency, secret rotation, checkout guards, and both payload generations.

- **Migration**
  - Run migration 142 to add `last_stripe_event_at` and the unique index on `stripe_subscription_id`.
  - Ensure `STRIPE_WEBHOOK_SECRET` is set so the route is enabled.

<sup>Written for commit 7e9966574b34b58986a422f26764f8bcaa941184. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

