### PR TITLE
feat(commerce-onboarding): redesign connect step

### DIFF
--- a/apps/mesh/src/web/i18n/en/commerce-onboarding.ts
+++ b/apps/mesh/src/web/i18n/en/commerce-onboarding.ts
@@ -13,6 +13,8 @@ export const commerceOnboarding = {
   "commerceOnboarding.companionCard.disconnectedSuccess":
     "{title} desconectado",
   "commerceOnboarding.companionCard.editConfiguration": "Editar configuração",
+  "commerceOnboarding.companionCard.finishSetup": "Finish setup",
+  "commerceOnboarding.companionCard.required": "Required",
   "commerceOnboarding.companionCard.grantAccessDescription":
     "Conceda acesso ao nosso leitor e informe o identificador",
   "commerceOnboarding.githubConfigForm.cancel": "Cancel",

--- a/apps/mesh/src/web/i18n/en/routes.ts
+++ b/apps/mesh/src/web/i18n/en/routes.ts
@@ -139,8 +139,12 @@ export const routes = {
     "Something went wrong generating your report. Try again in a moment.",
   "routes.commerceOnboarding.connectModal.openingReport": "Opening report...",
   "routes.commerceOnboarding.connectModal.connectToolToContinue":
-    "Connect a tool to continue",
+    "Connect your analytics to continue",
   "routes.commerceOnboarding.connectModal.viewFullReport": "View full report",
+  "routes.commerceOnboarding.connectModal.close": "Close",
+  "routes.commerceOnboarding.connectModal.quote":
+    "I was grinning ear to ear, because we had already spotted all of it, we just didn't know what to do next... you brought a really meaningful perspective on the next steps.",
+  "routes.commerceOnboarding.connectModal.quoteAuthor": "Ágata Esteves",
   "routes.commerceOnboarding.companionSection.title":
     "Connect your tools to see the full diagnostic",
   "routes.commerceOnboarding.companionSection.loadError":

--- a/apps/mesh/src/web/i18n/pt-br/commerce-onboarding.ts
+++ b/apps/mesh/src/web/i18n/pt-br/commerce-onboarding.ts
@@ -15,6 +15,8 @@ export const commerceOnboarding = {
   "commerceOnboarding.companionCard.disconnectedSuccess":
     "{title} desconectado",
   "commerceOnboarding.companionCard.editConfiguration": "Editar configuração",
+  "commerceOnboarding.companionCard.finishSetup": "Concluir configuração",
+  "commerceOnboarding.companionCard.required": "Obrigatório",
   "commerceOnboarding.companionCard.grantAccessDescription":
     "Conceda acesso ao nosso leitor e informe o identificador",
   "commerceOnboarding.githubConfigForm.cancel": "Cancelar",

--- a/apps/mesh/src/web/i18n/pt-br/routes.ts
+++ b/apps/mesh/src/web/i18n/pt-br/routes.ts
@@ -143,9 +143,13 @@ export const routes = {
   "routes.commerceOnboarding.connectModal.openingReport":
     "Abrindo relatório...",
   "routes.commerceOnboarding.connectModal.connectToolToContinue":
-    "Conecte uma ferramenta para continuar",
+    "Conecte sua analytics para continuar",
   "routes.commerceOnboarding.connectModal.viewFullReport":
     "Ver relatório completo",
+  "routes.commerceOnboarding.connectModal.close": "Fechar",
+  "routes.commerceOnboarding.connectModal.quote":
+    "Eu tava sorrindo de orelha a orelha, porque tudo aquilo a gente já tinha identificado, mas a gente não sabia o que fazer... vocês trouxeram uma visão bem significativa para os próximos passos.",
+  "routes.commerceOnboarding.connectModal.quoteAuthor": "Ágata Esteves",
   "routes.commerceOnboarding.companionSection.title":
     "Conecte suas ferramentas para ver o diagnóstico completo",
   "routes.commerceOnboarding.companionSection.loadError":

--- a/apps/mesh/src/web/routes/commerce-onboarding/commerce-connect-modal.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/commerce-connect-modal.tsx
@@ -1,8 +1,6 @@
 import { normalizeReportsSiteUrl, siteUrlToHost } from "@/reports/site-url";
 import { ErrorBoundary } from "@/web/components/error-boundary";
-import { authClient } from "@/web/lib/auth-client";
 import { useT } from "@/web/i18n/use-t.ts";
-import { usePreferences } from "@/web/hooks/use-preferences.ts";
 import { LOCALSTORAGE_KEYS } from "@/web/lib/localstorage-keys";
 import { track } from "@/web/lib/posthog-client";
 import { KEYS } from "@/web/lib/query-keys";
@@ -31,13 +29,8 @@ import {
   CompanionMcpsSection,
   CompanionMcpsSectionSkeleton,
 } from "./companion-mcps-section.tsx";
-import {
-  buildScheduleMeetingUrl,
-  ScheduleMeetingBanner,
-  ScheduleMeetingVisual,
-} from "./schedule-meeting.tsx";
+import { ConnectFooterButton, ConnectLayout } from "./connect-layout.tsx";
 import { parseSelfToolResult } from "./self-tool-result.ts";
-import { SiteBadge } from "./site-badge.tsx";
 
 /**
  * Blocking commerce-onboarding connections step, rendered as a modal OVER the
@@ -130,9 +123,7 @@ function CommerceConnectModalContent({
   onComplete: () => void;
 }) {
   const t = useT();
-  const [preferences] = usePreferences();
   const { org } = useProjectContext();
-  const { data: session } = authClient.useSession();
   const connectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
   const selfClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
@@ -191,12 +182,6 @@ function CommerceConnectModalContent({
     retry: false,
   });
 
-  const meetingUrl = buildScheduleMeetingUrl({
-    siteUrl,
-    email: session?.user?.email,
-    locale: preferences.language,
-  });
-
   const openReport = async () => {
     setRunError(null);
     // The onboarding-completion intent: the click, not the report render.
@@ -251,60 +236,43 @@ function CommerceConnectModalContent({
     onComplete();
   };
 
+  const ready = hasConnectedSource;
+
   return (
-    // Mobile: single flex column (header → scrolling cards → pinned footer with
-    // the compact meeting banner + CTA). lg+: two columns — the connect column
-    // on the left, the full meeting card on the right (the original split), with
-    // the banner hidden since the card carries it. The left column always owns
-    // the scroll + pinned CTA so the CTA stays reachable at short window heights.
-    <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
-      {/* Left column — matches the old page's bg-sidebar content panel. The
-          companion section owns its own scroll (title pinned, cards scroll), so
-          it goes here directly as the flex-1 child; no extra scroll wrapper. */}
-      <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 lg:gap-6 lg:bg-sidebar lg:p-10">
-        {siteHost ? <SiteBadge host={siteHost} /> : null}
-        <CompanionMcpsSection
-          org={org}
-          cdConnectionId={connectionId}
-          siteUrl={siteUrl}
-          onReadinessChange={setHasConnectedSource}
-        />
-        <div className="flex shrink-0 flex-col gap-3">
-          <ScheduleMeetingBanner
-            href={meetingUrl}
-            orgId={org.id}
-            className="lg:hidden"
-          />
+    <ConnectLayout
+      siteHost={siteHost}
+      footer={
+        <>
           {runError ? (
             <p className="text-sm leading-5 text-destructive" role="alert">
               {runError}
             </p>
           ) : null}
-          <Button
-            type="button"
-            size="xl"
-            className="w-full rounded-2xl text-base font-medium whitespace-normal h-auto py-3"
+          <ConnectFooterButton
+            ready={ready}
+            pending={runMutation.isPending}
+            label={
+              runMutation.isPending
+                ? t("routes.commerceOnboarding.connectModal.openingReport")
+                : !ready
+                  ? t(
+                      "routes.commerceOnboarding.connectModal.connectToolToContinue",
+                    )
+                  : t("routes.commerceOnboarding.connectModal.viewFullReport")
+            }
             onClick={() => void openReport()}
-            disabled={runMutation.isPending || !hasConnectedSource}
           >
-            {runMutation.isPending
-              ? t("routes.commerceOnboarding.connectModal.openingReport")
-              : !hasConnectedSource
-                ? t(
-                    "routes.commerceOnboarding.connectModal.connectToolToContinue",
-                  )
-                : t("routes.commerceOnboarding.connectModal.viewFullReport")}
-            {!runMutation.isPending && hasConnectedSource ? (
-              <ArrowRight size={18} />
-            ) : null}
-          </Button>
-        </div>
-      </div>
-      {/* Right panel — the old page's right side: divider, distinct bg-muted
-          background, and the meeting card centered in the middle. Desktop only. */}
-      <aside className="hidden lg:flex lg:w-[380px] lg:shrink-0 lg:items-center lg:justify-center lg:overflow-y-auto lg:border-l lg:border-border lg:bg-muted">
-        <ScheduleMeetingVisual href={meetingUrl} orgId={org.id} />
-      </aside>
-    </div>
+            <ArrowRight size={18} />
+          </ConnectFooterButton>
+        </>
+      }
+    >
+      <CompanionMcpsSection
+        org={org}
+        cdConnectionId={connectionId}
+        siteUrl={siteUrl}
+        onReadinessChange={setHasConnectedSource}
+      />
+    </ConnectLayout>
   );
 }

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card-view.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card-view.tsx
@@ -1,0 +1,149 @@
+import { IntegrationIcon } from "@/web/components/integration-icon";
+import { useT } from "@/web/i18n/use-t.ts";
+import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { CheckCircle, Loading01, Settings01 } from "@untitledui/icons";
+import type { ReactNode } from "react";
+
+/**
+ * Presentational shell for a companion source row (Figma node 9473-8422): a
+ * horizontal card — icon + title with a benefit line below, and an action on
+ * the right. The required source carries a small "Obrigatório" pill straddling
+ * its top edge. Shared by the live {@link CompanionCard} (which wires MCP config
+ * dialogs into `action`) and the dev preview harness, so the two can't drift.
+ */
+export function CompanionCardView({
+  icon,
+  title,
+  headline,
+  required,
+  attention,
+  action,
+}: {
+  icon: string | null;
+  title: string;
+  headline?: string | null;
+  /** Shows the "Obrigatório" pill on the top edge. */
+  required?: boolean;
+  /** Amber ring — draws the eye to a linked-but-unconfigured source. */
+  attention?: boolean;
+  action: ReactNode;
+}) {
+  const t = useT();
+  return (
+    <div
+      className={cn(
+        // Compact row at every width (button inline). The benefit line is hidden
+        // on mobile so more cards fit; it returns from sm+ where there's room.
+        "relative flex items-center justify-between gap-3 rounded-lg border bg-card p-3.5 sm:gap-4 sm:p-4",
+        attention ? "border-warning/50 bg-warning/[0.04]" : "border-border",
+      )}
+    >
+      {required && (
+        <span className="absolute -top-3 right-4 rounded-full border border-input bg-background px-3 py-1 text-xs font-medium text-foreground">
+          {t("commerceOnboarding.companionCard.required")}
+        </span>
+      )}
+      <div className="flex min-w-0 flex-1 items-center gap-3 sm:items-start">
+        <IntegrationIcon
+          icon={icon}
+          name={title}
+          size="sm"
+          fit="contain"
+          className="size-[30px] shrink-0 p-1"
+        />
+        {/* Title + description stacked so the benefit line sits under the title. */}
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="text-sm font-medium text-foreground">{title}</span>
+          {headline && (
+            <p className="hidden text-sm leading-5 text-muted-foreground sm:block">
+              {headline}
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="shrink-0">{action}</div>
+    </div>
+  );
+}
+
+/** The "Connect" action. `primary` renders a solid button (the required/hero
+ *  source); everything else is a quieter outline. */
+export function ConnectAction({
+  connecting,
+  disabled,
+  title,
+  primary,
+  onConnect,
+}: {
+  connecting: boolean;
+  disabled: boolean;
+  title: string;
+  primary?: boolean;
+  onConnect: () => void;
+}) {
+  const t = useT();
+  return (
+    <Button
+      type="button"
+      variant={primary ? "default" : "outline"}
+      size="sm"
+      disabled={disabled || connecting}
+      onClick={onConnect}
+      aria-label={t("commerceOnboarding.companionCard.connectAriaLabel", {
+        title,
+      })}
+    >
+      {connecting ? (
+        <Loading01 size={16} className="animate-spin" />
+      ) : (
+        t("commerceOnboarding.companionCard.connect")
+      )}
+    </Button>
+  );
+}
+
+/** Linked but not usable yet → an amber "Finish setup" button that must be
+ *  clicked before the source counts as connected. */
+export function ConfigureAction({
+  disabled,
+  title,
+  onConfigure,
+}: {
+  disabled: boolean;
+  title: string;
+  onConfigure: () => void;
+}) {
+  const t = useT();
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="border-warning/60 text-warning hover:bg-warning/10 hover:text-warning"
+      disabled={disabled}
+      onClick={onConfigure}
+      aria-label={t("commerceOnboarding.companionCard.configureAriaLabel", {
+        title,
+      })}
+    >
+      <Settings01 size={16} />
+      {t("commerceOnboarding.companionCard.finishSetup")}
+    </Button>
+  );
+}
+
+/** The "Connected ✓" label + trailing controls (gear, unlink) passed as
+ *  `controls`. Kept presentational so the preview can render mock controls. */
+export function ConnectedAction({ controls }: { controls?: ReactNode }) {
+  const t = useT();
+  return (
+    <div className="flex items-center gap-1">
+      <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+        <CheckCircle size={16} className="text-success" />{" "}
+        {t("commerceOnboarding.companionCard.connected")}
+      </span>
+      {controls}
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-card.tsx
@@ -2,7 +2,6 @@ import { IntegrationIcon } from "@/web/components/integration-icon";
 import { KEYS } from "@/web/lib/query-keys";
 import { useT } from "@/web/i18n/use-t.ts";
 import { Button } from "@deco/ui/components/button.tsx";
-import { cn } from "@deco/ui/lib/utils.ts";
 import {
   Dialog,
   DialogContent,
@@ -18,12 +17,7 @@ import {
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { useMCPClient } from "@decocms/mesh-sdk";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  CheckCircle,
-  LinkBroken01,
-  Loading01,
-  Settings01,
-} from "@untitledui/icons";
+import { LinkBroken01, Loading01, Settings01 } from "@untitledui/icons";
 import { Suspense, useState } from "react";
 import { toast } from "sonner";
 import type { CompanionCardModel } from "./companions-core.ts";
@@ -31,6 +25,12 @@ import {
   getConfigurationSummaryEntries,
   shouldAutoOpenCompanionConfig,
 } from "./companions-core.ts";
+import {
+  CompanionCardView,
+  ConfigureAction,
+  ConnectAction,
+  ConnectedAction,
+} from "./companion-card-view.tsx";
 import { COMPANION_CONFIG_FORMS } from "./companion-forms/registry.ts";
 import { SaBindingForm } from "./companion-forms/sa-binding-form.tsx";
 import {
@@ -56,8 +56,50 @@ export function CompanionCardSkeleton() {
   );
 }
 
-const AREA_BADGE_CLASS =
-  "rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground";
+/** Ghost unlink button — reverts a linked source back to "Connect" so a wrong
+ *  or stale link can be replaced. */
+function UnlinkButton({
+  title,
+  disconnecting,
+  disabled,
+  onDisconnect,
+}: {
+  title: string;
+  disconnecting: boolean;
+  disabled: boolean;
+  onDisconnect: () => void;
+}) {
+  const t = useT();
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="shrink-0 text-muted-foreground hover:text-destructive"
+          disabled={disabled || disconnecting}
+          onClick={onDisconnect}
+          aria-label={t(
+            "commerceOnboarding.companionCard.disconnectAriaLabel",
+            {
+              title,
+            },
+          )}
+        >
+          {disconnecting ? (
+            <Loading01 size={16} className="animate-spin" />
+          ) : (
+            <LinkBroken01 size={16} />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {t("commerceOnboarding.companionCard.disconnect")}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 export function CompanionCard({
   card,
@@ -84,7 +126,6 @@ export function CompanionCard({
   autoOpenConfigFieldKey: string | null;
   onAutoOpenConfigHandled: () => void;
 }) {
-  const t = useT();
   const linkedConnectionId = card.linkedConnectionId;
   // GA4/GSC use the shared-SA lane by default; only fall back to the OAuth gear
   // when the card was actually satisfied via OAuth (has a companion connection).
@@ -92,6 +133,10 @@ export function CompanionCard({
     | BindProvider
     | undefined;
   const useSaFlow = !!saProvider && card.boundVia !== "oauth";
+  // Linked but not usable yet (no credentials / no repo / no property) — must
+  // read as "needs setup", never "Connected". Only the OAuth/config-form lane
+  // can hit this; SA bindings are configured the moment they verify.
+  const needsConfig = card.satisfied && !card.configured;
 
   const action =
     useSaFlow && saProvider ? (
@@ -104,13 +149,10 @@ export function CompanionCard({
         onOAuthInstead={onConnect}
         disabled={disabled}
         connecting={connecting}
+        primary={card.required}
       />
     ) : card.satisfied && linkedConnectionId ? (
       <div className="flex items-center justify-end gap-1 sm:justify-start">
-        <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
-          <CheckCircle size={16} className="text-success" />{" "}
-          {t("commerceOnboarding.companionCard.connected")}
-        </span>
         {/* Own Suspense boundary: CompanionConfiguration opens the companion's
             own MCP client (useMCPClient → useSuspenseQuery). Isolating it keeps
             a connecting companion from reverting the whole grid to skeletons. */}
@@ -121,95 +163,44 @@ export function CompanionCard({
             selfClient={selfClient}
             connectionId={linkedConnectionId}
             contextSiteUrl={siteUrl}
-            autoOpen={shouldAutoOpenCompanionConfig({
-              autoOpenFieldKey: autoOpenConfigFieldKey,
-              card,
-            })}
+            variant={needsConfig ? "configure" : "gear"}
+            disabled={disabled}
+            autoOpen={
+              needsConfig ||
+              shouldAutoOpenCompanionConfig({
+                autoOpenFieldKey: autoOpenConfigFieldKey,
+                card,
+              })
+            }
             onAutoOpenHandled={onAutoOpenConfigHandled}
           />
         </Suspense>
-        {/* Unlink to revalidate: reverts the card to "Conectar" so a wrong or
-            stale link (e.g. a repo-scoped GitHub connection) can be replaced. */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              className="shrink-0 text-muted-foreground hover:text-destructive"
-              disabled={disabled || disconnecting}
-              onClick={onDisconnect}
-              aria-label={t(
-                "commerceOnboarding.companionCard.disconnectAriaLabel",
-                { title: card.title },
-              )}
-            >
-              {disconnecting ? (
-                <Loading01 size={16} className="animate-spin" />
-              ) : (
-                <LinkBroken01 size={16} />
-              )}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            {t("commerceOnboarding.companionCard.disconnect")}
-          </TooltipContent>
-        </Tooltip>
+        <UnlinkButton
+          title={card.title}
+          disconnecting={disconnecting}
+          disabled={disabled}
+          onDisconnect={onDisconnect}
+        />
       </div>
     ) : (
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="sm:w-full"
-        disabled={disabled || connecting}
-        onClick={onConnect}
-        aria-label={t("commerceOnboarding.companionCard.connectAriaLabel", {
-          title: card.title,
-        })}
-      >
-        {connecting ? (
-          <Loading01 size={16} className="animate-spin" />
-        ) : (
-          t("commerceOnboarding.companionCard.connect")
-        )}
-      </Button>
+      <ConnectAction
+        connecting={connecting}
+        disabled={disabled}
+        title={card.title}
+        primary={card.required}
+        onConnect={onConnect}
+      />
     );
 
   return (
-    // Responsive: a compact horizontal row on mobile (icon · text · action),
-    // a vertical tile in the desktop grid (sm+). The old inline "Configuração"
-    // block lives in the gear's dialog so a connected card stays compact.
-    <div className="flex items-center gap-3 rounded-2xl border border-border bg-card p-3 sm:h-full sm:flex-col sm:items-stretch sm:p-4">
-      {/* Icon row: on the desktop tile the badge sits top-right, centered with
-          the icon. Mobile is a compact list row (icon · name · action) — the
-          area tag and benefit line are dropped there to keep it dense. */}
-      <div className="shrink-0 sm:flex sm:w-full sm:items-center sm:justify-between sm:gap-2">
-        <IntegrationIcon
-          icon={card.icon}
-          name={card.title}
-          size="sm"
-          fit="contain"
-          className="shrink-0 p-1.5"
-        />
-        {card.area && (
-          <span className={cn("hidden sm:inline-block", AREA_BADGE_CLASS)}>
-            {card.area}
-          </span>
-        )}
-      </div>
-
-      <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium text-foreground">{card.title}</p>
-        {card.headline && (
-          <p className="hidden text-sm leading-5 text-muted-foreground sm:mt-0.5 sm:line-clamp-2 sm:block">
-            {card.headline}
-          </p>
-        )}
-      </div>
-
-      <div className="shrink-0 sm:mt-auto sm:w-full sm:pt-1">{action}</div>
-    </div>
+    <CompanionCardView
+      icon={card.icon}
+      title={card.title}
+      headline={card.headline}
+      required={card.required && !card.satisfied}
+      attention={needsConfig}
+      action={action}
+    />
   );
 }
 
@@ -227,6 +218,7 @@ function SaConnectAction({
   onOAuthInstead,
   disabled,
   connecting,
+  primary,
 }: {
   card: CompanionCardModel;
   provider: BindProvider;
@@ -236,6 +228,7 @@ function SaConnectAction({
   onOAuthInstead: () => void;
   disabled: boolean;
   connecting: boolean;
+  primary?: boolean;
 }) {
   const t = useT();
   const [open, setOpen] = useState(false);
@@ -249,50 +242,38 @@ function SaConnectAction({
   return (
     <>
       {card.satisfied ? (
-        <div className="flex items-center justify-end gap-1 sm:justify-start">
-          <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
-            <CheckCircle size={16} className="text-success" />{" "}
-            {t("commerceOnboarding.companionCard.connected")}
-          </span>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                className="shrink-0"
-                onClick={() => setOpen(true)}
-                aria-label={t(
-                  "commerceOnboarding.companionCard.configureAriaLabel",
-                  { title: card.title },
-                )}
-              >
-                <Settings01 size={16} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              {t("commerceOnboarding.companionCard.editConfiguration")}
-            </TooltipContent>
-          </Tooltip>
-        </div>
+        <ConnectedAction
+          controls={
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="shrink-0"
+                  onClick={() => setOpen(true)}
+                  aria-label={t(
+                    "commerceOnboarding.companionCard.configureAriaLabel",
+                    { title: card.title },
+                  )}
+                >
+                  <Settings01 size={16} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {t("commerceOnboarding.companionCard.editConfiguration")}
+              </TooltipContent>
+            </Tooltip>
+          }
+        />
       ) : (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="sm:w-full"
-          disabled={disabled || connecting}
-          onClick={() => setOpen(true)}
-          aria-label={t("commerceOnboarding.companionCard.connectAriaLabel", {
-            title: card.title,
-          })}
-        >
-          {connecting ? (
-            <Loading01 size={16} className="animate-spin" />
-          ) : (
-            t("commerceOnboarding.companionCard.connect")
-          )}
-        </Button>
+        <ConnectAction
+          connecting={connecting}
+          disabled={disabled}
+          title={card.title}
+          primary={primary}
+          onConnect={() => setOpen(true)}
+        />
       )}
 
       <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -341,6 +322,10 @@ interface CompanionConfigurationProps {
   selfClient: Client;
   connectionId: string;
   contextSiteUrl?: string;
+  /** "gear" = quiet edit button for a configured source; "configure" = amber
+   *  "finish setup" button for a linked-but-unconfigured one. */
+  variant: "gear" | "configure";
+  disabled: boolean;
   autoOpen: boolean;
   onAutoOpenHandled: () => void;
 }
@@ -359,6 +344,8 @@ function CompanionConfiguration({
   selfClient,
   connectionId,
   contextSiteUrl,
+  variant,
+  disabled,
   autoOpen,
   onAutoOpenHandled,
 }: CompanionConfigurationProps) {
@@ -418,13 +405,21 @@ function CompanionConfiguration({
     },
   });
 
-  // No config form for this binding → nothing to open; skip the gear entirely.
+  // No config form for this binding → nothing to open. A "configure" variant
+  // still needs a visible trigger, so it degrades to a quiet gear-less noop
+  // only when there's genuinely nothing to configure.
   if (!FormComponent) {
     return null;
   }
 
-  return (
-    <>
+  const trigger =
+    variant === "configure" ? (
+      <ConfigureAction
+        disabled={disabled}
+        title={card.title}
+        onConfigure={() => setDialogOpen(true)}
+      />
+    ) : (
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -447,6 +442,11 @@ function CompanionConfiguration({
             : t("commerceOnboarding.companionCard.configure")}
         </TooltipContent>
       </Tooltip>
+    );
+
+  return (
+    <>
+      {trigger}
 
       <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
         <DialogContent className="sm:max-w-lg">

--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -20,14 +20,14 @@ interface CompanionOrg {
 // so the layout can't drift between the three — see CompanionMcpsSectionSkeleton
 // and CompanionMcpsSectionError.
 const SECTION_CONTAINER_CLASS =
-  "flex min-h-0 flex-1 flex-col gap-4 md:grid md:flex-none md:gap-4";
+  "flex min-h-0 flex-1 flex-col gap-6 md:grid md:flex-none md:gap-6";
 
 function SectionIntro() {
   const t = useT();
   // Matches the onboarding title scale (CommerceHeader / auth screen use the
   // same text-2xl font-medium leading-8).
   return (
-    <h1 className="text-lg font-medium leading-6 text-foreground lg:text-2xl lg:leading-8">
+    <h1 className="text-lg font-medium leading-6 text-foreground lg:text-xl lg:leading-7">
       {t("routes.commerceOnboarding.companionSection.title")}
     </h1>
   );
@@ -35,7 +35,7 @@ function SectionIntro() {
 
 function CompanionCardSkeletons() {
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+    <div className="flex flex-col gap-4">
       {[0, 1, 2, 3].map((i) => (
         <CompanionCardSkeleton key={i} />
       ))}
@@ -167,10 +167,22 @@ function CompanionMcpsSectionContent({
     string | null
   >(null);
 
-  // Nothing required, or at least one connected → the report CTA may proceed.
-  // Called during render (derived from query data, not an effect) so the
-  // parent's button re-enables the same render pass a source connects.
-  onReadinessChange?.(cards.length === 0 || cards.some((c) => c.satisfied));
+  // A source counts toward the report only when it's linked AND usable (a VTEX
+  // linked with no credentials, or GitHub with no repo, does NOT count).
+  const isReady = (c: (typeof cards)[number]) => c.satisfied && c.configured;
+  const requiredCards = cards.filter((c) => c.required);
+  const enhancedCards = cards.filter((c) => !c.required);
+
+  // Analytics (and any required source) MUST be ready before continuing. When
+  // the resolved set has no required source, fall back to "any source ready"
+  // so a config that never offers Analytics can't trap the user. Derived during
+  // render (not an effect) so the parent's button re-enables the same pass a
+  // source becomes ready.
+  const ready =
+    requiredCards.length > 0
+      ? requiredCards.every(isReady)
+      : cards.length === 0 || cards.some(isReady);
+  onReadinessChange?.(ready);
 
   // Empty: nothing to connect → render nothing (the parent footer still shows
   // the report CTA).
@@ -179,6 +191,39 @@ function CompanionMcpsSectionContent({
   }
 
   const busy = connectingFieldKey !== null || disconnectingFieldKey !== null;
+
+  const renderCard = (card: (typeof cards)[number]) => {
+    const handleConnect = async () => {
+      const connected = await connect(card);
+      if (connected) {
+        setAutoOpenConfigFieldKey(card.fieldKey);
+      }
+    };
+    return (
+      <CompanionCard
+        key={card.fieldKey}
+        card={card}
+        connecting={connectingFieldKey === card.fieldKey}
+        disconnecting={disconnectingFieldKey === card.fieldKey}
+        disabled={
+          busy &&
+          connectingFieldKey !== card.fieldKey &&
+          disconnectingFieldKey !== card.fieldKey
+        }
+        org={org}
+        selfClient={selfClient}
+        siteUrl={siteUrl}
+        autoOpenConfigFieldKey={autoOpenConfigFieldKey}
+        onAutoOpenConfigHandled={() =>
+          setAutoOpenConfigFieldKey((current) =>
+            current === card.fieldKey ? null : current,
+          )
+        }
+        onConnect={() => void handleConnect()}
+        onDisconnect={() => void disconnect(card)}
+      />
+    );
+  };
 
   return (
     // Mobile: fill the parent's remaining height — the header + intro copy stay
@@ -199,40 +244,10 @@ function CompanionMcpsSectionContent({
             {connectError}
           </p>
         )}
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          {cards.map((card) => {
-            const handleConnect = async () => {
-              const connected = await connect(card);
-              if (connected) {
-                setAutoOpenConfigFieldKey(card.fieldKey);
-              }
-            };
-
-            return (
-              <CompanionCard
-                key={card.fieldKey}
-                card={card}
-                connecting={connectingFieldKey === card.fieldKey}
-                disconnecting={disconnectingFieldKey === card.fieldKey}
-                disabled={
-                  busy &&
-                  connectingFieldKey !== card.fieldKey &&
-                  disconnectingFieldKey !== card.fieldKey
-                }
-                org={org}
-                selfClient={selfClient}
-                siteUrl={siteUrl}
-                autoOpenConfigFieldKey={autoOpenConfigFieldKey}
-                onAutoOpenConfigHandled={() =>
-                  setAutoOpenConfigFieldKey((current) =>
-                    current === card.fieldKey ? null : current,
-                  )
-                }
-                onConnect={() => void handleConnect()}
-                onDisconnect={() => void disconnect(card)}
-              />
-            );
-          })}
+        {/* Single list, required source(s) first — the "Obrigatório" pill on the
+            card carries the must-vs-optional distinction (no section headers). */}
+        <div className="flex flex-col gap-4">
+          {[...requiredCards, ...enhancedCards].map(renderCard)}
         </div>
       </ScrollReveal>
     </div>

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.test.ts
@@ -3,9 +3,11 @@ import {
   buildCompanionCards,
   buildRegistryWhere,
   getConfigurationSummaryEntries,
+  isCompanionConfigured,
   matchGscSite,
   mergeBindingValue,
   parseBindingRequirements,
+  REQUIRED_BINDING_TYPES,
   resolveCandidate,
   shouldAutoOpenCompanionConfig,
   toPropertyOptions,
@@ -205,6 +207,80 @@ describe("unwrapToolResult", () => {
   });
 });
 
+describe("isCompanionConfigured", () => {
+  it("treats an SA-verified binding as always configured", () => {
+    expect(
+      isCompanionConfigured({
+        bindingType: "google-analytics",
+        boundVia: "sa",
+        companionConfig: null,
+        cdConfig: null,
+      }),
+    ).toBe(true);
+  });
+  it("requires a VTEX account name (linked ≠ usable)", () => {
+    expect(
+      isCompanionConfigured({
+        bindingType: "vtex",
+        boundVia: "oauth",
+        companionConfig: null,
+        cdConfig: null,
+      }),
+    ).toBe(false);
+    expect(
+      isCompanionConfigured({
+        bindingType: "vtex",
+        boundVia: "oauth",
+        companionConfig: { accountName: "electrolux" },
+        cdConfig: null,
+      }),
+    ).toBe(true);
+  });
+  it("requires a picked property/site for OAuth GA4/GSC", () => {
+    expect(
+      isCompanionConfigured({
+        bindingType: "google-analytics",
+        boundVia: "oauth",
+        companionConfig: {},
+        cdConfig: null,
+      }),
+    ).toBe(false);
+    expect(
+      isCompanionConfigured({
+        bindingType: "google-search-console",
+        boundVia: "oauth",
+        companionConfig: { siteUrl: "sc-domain:loja.com" },
+        cdConfig: null,
+      }),
+    ).toBe(true);
+  });
+  it("reads GitHub's repo from the CD connection state", () => {
+    expect(
+      isCompanionConfigured({
+        bindingType: "github",
+        boundVia: "oauth",
+        companionConfig: null,
+        cdConfig: { github_repo: "deco/site" },
+      }),
+    ).toBe(true);
+    expect(
+      isCompanionConfigured({
+        bindingType: "github",
+        boundVia: "oauth",
+        companionConfig: null,
+        cdConfig: {},
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("REQUIRED_BINDING_TYPES", () => {
+  it("marks analytics as the required source and others as optional", () => {
+    expect(REQUIRED_BINDING_TYPES.has("google-analytics")).toBe(true);
+    expect(REQUIRED_BINDING_TYPES.has("vtex")).toBe(false);
+  });
+});
+
 describe("buildCompanionCards", () => {
   const item = (id: string, name: string) => ({
     id,
@@ -285,6 +361,23 @@ describe("buildCompanionCards", () => {
     expect(cards[0]!.configurationState).toEqual({
       accountName: "electrolux",
     });
+    // Linked AND has its account → usable.
+    expect(cards[0]!.configured).toBe(true);
+  });
+  it("marks a linked VTEX with no account as satisfied-but-not-configured", () => {
+    const cards = buildCompanionCards({
+      requirements: [{ fieldKey: "VTEX_STORE", bindingType: "vtex" }],
+      itemsById: { "deco/vtex": item("deco/vtex", "VTEX") },
+      itemsByName: {},
+      // Linked connection exists but carries no accountName yet.
+      connections: [{ id: "c_vtex", app_name: "vtex", status: "active" }],
+      configurationState: { VTEX_STORE: { __type: "vtex", value: "c_vtex" } },
+      curated,
+    });
+    expect(cards[0]!.satisfied).toBe(true);
+    expect(cards[0]!.configured).toBe(false);
+    // VTEX is an enhancement, not the required source.
+    expect(cards[0]!.required).toBe(false);
   });
   it("treats configuration_state links to missing org connections as connectable", () => {
     const cards = buildCompanionCards({

--- a/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companions-core.ts
@@ -49,7 +49,17 @@ export interface CompanionCardModel {
   /** Curated business-area tag (e.g. "Funil"); null for plain cards. */
   area: string | null;
   bullets: string[];
+  /** The binding is linked to a connection (or SA-verified). Note: linked does
+   *  NOT imply usable — see {@link CompanionCardModel.configured}. */
   satisfied: boolean;
+  /** The linked binding has everything it needs to produce data (credentials
+   *  entered, repo/property picked, or SA-verified). A card can be `satisfied`
+   *  but not `configured` — e.g. VTEX linked with no account yet — in which case
+   *  it must read as "needs configuration", never "connected". */
+  configured: boolean;
+  /** This source is mandatory for a useful report; the rest only enrich it.
+   *  Drives the required/optional grouping and the continue gate. */
+  required: boolean;
   candidateConnectionId: string | null;
   linkedConnectionId: string | null;
   configurationState: Record<string, unknown> | null;
@@ -65,6 +75,47 @@ export interface CompanionCardModel {
 /** Providers connected through the shared-SA lane, keyed by binding type
  *  (e.g. "google-analytics"), from the commerce-discovery status endpoint. */
 export type SaBindings = Record<string, { resource: string | null }>;
+
+/** Binding types a merchant MUST connect for the report to be worth anything —
+ *  analytics is the baseline data source, everything else only enriches it.
+ *  Cards for these render under "Required" and gate the continue button. */
+export const REQUIRED_BINDING_TYPES: ReadonlySet<string> = new Set([
+  "google-analytics",
+]);
+
+/**
+ * Whether a linked binding actually has what it needs to produce data. A
+ * binding can be "linked" (its connection id is written into the CD state) yet
+ * unusable: VTEX linked with no account/credentials, GitHub linked with no repo
+ * picked, GA/GSC linked via OAuth with no property/site chosen. A shared-SA
+ * binding is always configured — the verification IS the configuration.
+ *
+ * `companionConfig` is the linked companion connection's configuration_state;
+ * `cdConfig` is the Commerce Discovery connection's configuration_state (where
+ * the free-standing `github_repo` lives).
+ */
+export function isCompanionConfigured(args: {
+  bindingType: string;
+  boundVia: "oauth" | "sa" | null;
+  companionConfig: Record<string, unknown> | null | undefined;
+  cdConfig: Record<string, unknown> | null | undefined;
+}): boolean {
+  if (args.boundVia === "sa") return true;
+  const { companionConfig, cdConfig } = args;
+  switch (args.bindingType) {
+    case "vtex":
+      return isMeaningfulConfigValue(companionConfig?.accountName);
+    case "google-analytics":
+      return isMeaningfulConfigValue(companionConfig?.propertyId);
+    case "google-search-console":
+      return isMeaningfulConfigValue(companionConfig?.siteUrl);
+    case "github":
+      return isMeaningfulConfigValue(cdConfig?.github_repo);
+    default:
+      // Bindings with no post-link config step are usable as soon as linked.
+      return true;
+  }
+}
 
 type ComparisonWhere = { field: string[]; operator: "in"; value: string[] };
 type WhereExpr =
@@ -315,6 +366,14 @@ export function buildCompanionCards(args: {
       : saBinding
         ? "sa"
         : null;
+    const configured =
+      satisfied &&
+      isCompanionConfigured({
+        bindingType: req.bindingType,
+        boundVia,
+        companionConfig: linkedConnection?.configuration_state ?? null,
+        cdConfig: args.configurationState ?? null,
+      });
     cards.push({
       fieldKey: req.fieldKey,
       bindingType: req.bindingType,
@@ -328,6 +387,8 @@ export function buildCompanionCards(args: {
       area: curatedEntry?.area ?? null,
       bullets: curatedEntry?.bullets ?? [],
       satisfied,
+      configured,
+      required: REQUIRED_BINDING_TYPES.has(req.bindingType),
       candidateConnectionId: satisfied
         ? null
         : linkedConnectionId

--- a/apps/mesh/src/web/routes/commerce-onboarding/connect-extras.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/connect-extras.tsx
@@ -1,0 +1,43 @@
+import { useT } from "@/web/i18n/use-t.ts";
+
+/**
+ * Right-hand panel of the connect modal: a customer quote over a full-bleed
+ * brand photo (Monte Carlo). The merchant just saw their diagnostic; a real
+ * testimonial makes connecting feel expected. Rendered over the photo + a light
+ * scrim (see {@link ConnectLayout}), so all text is white.
+ *
+ * NOTE: the background photo (see {@link ConnectLayout}), the avatar and the
+ * quote copy are the shipped Monte Carlo testimonial — swap the CDN image URLs
+ * + the `connectModal.quote` / `quoteAuthor` strings to change it.
+ */
+const AVATAR_SRC =
+  "https://decoims.com/image?src=decocms%2F06b54678-5335-4671-b63a-e13d9e541155%2Fagataesteves.png&quality=original&fit=cover&width=160&height=160";
+
+export function ConnectQuotePanel() {
+  const t = useT();
+  return (
+    <div className="relative flex flex-col gap-8 text-white">
+      {/* Explicit box + object-contain: this SVG reports a 300×150 intrinsic
+          size and h-only + w-auto squishes it, so pin both dimensions. */}
+      <img
+        src="/logos/summit/monte-carlo.svg"
+        alt="Monte Carlo"
+        className="h-14 w-[112px] shrink-0 self-start object-contain object-left brightness-0 invert"
+      />
+      <blockquote className="text-lg font-medium leading-[1.45] lg:text-xl">
+        “{t("routes.commerceOnboarding.connectModal.quote")}”
+      </blockquote>
+      <figcaption className="flex items-center gap-2.5">
+        <img
+          src={AVATAR_SRC}
+          alt=""
+          className="size-10 shrink-0 rounded-full object-cover"
+          loading="lazy"
+        />
+        <span className="text-base font-medium">
+          {t("routes.commerceOnboarding.connectModal.quoteAuthor")}
+        </span>
+      </figcaption>
+    </div>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/connect-layout.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/connect-layout.tsx
@@ -1,0 +1,125 @@
+import { useT } from "@/web/i18n/use-t.ts";
+import { Button } from "@deco/ui/components/button.tsx";
+import { ChevronRight, X } from "@untitledui/icons";
+import type { ReactNode } from "react";
+import { ConnectQuotePanel } from "./connect-extras.tsx";
+
+/**
+ * Shared chrome for the commerce connect step, used by BOTH the live
+ * {@link CommerceConnectModal} and the dev preview harness so they can't drift.
+ * Matches Figma node 9473-8422: a clean left column (breadcrumb header →
+ * heading + source rows → pinned footer CTA) and a full-bleed brand-photo quote
+ * panel on the right (desktop only). A close control sits top-right.
+ */
+export function ConnectLayout({
+  siteHost,
+  footer,
+  onClose,
+  children,
+}: {
+  siteHost?: string | null;
+  /** Pinned footer (the primary CTA + any error). */
+  footer: ReactNode;
+  /** Optional close control (top-right). Omit to render a non-dismissable modal. */
+  onClose?: () => void;
+  /** Heading + source rows (own their internal scroll). */
+  children: ReactNode;
+}) {
+  const t = useT();
+  const faviconUrl = siteHost
+    ? `https://www.google.com/s2/favicons?domain=${siteHost}&sz=128`
+    : null;
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col lg:flex-row">
+      {onClose && (
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={t("routes.commerceOnboarding.connectModal.close")}
+          className="absolute right-3 top-3 z-10 flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-black/10 hover:text-foreground lg:text-white/80 lg:hover:bg-white/15 lg:hover:text-white"
+        >
+          <X size={18} />
+        </button>
+      )}
+
+      {/* Left column */}
+      <div className="flex min-h-0 flex-1 flex-col gap-8 bg-background p-6 lg:p-8">
+        {/* Breadcrumb header: deco → site */}
+        <div className="flex items-center gap-2">
+          <img
+            src="/logos/deco logo.svg"
+            alt="Deco"
+            className="size-7 shrink-0 dark:hidden"
+          />
+          <img
+            src="/logos/deco logo negative.svg"
+            alt="Deco"
+            className="hidden size-7 shrink-0 dark:block"
+          />
+          {siteHost && (
+            <>
+              <ChevronRight size={16} className="shrink-0 text-foreground/25" />
+              {faviconUrl && (
+                <span className="flex size-4 shrink-0 items-center justify-center overflow-hidden rounded bg-white">
+                  <img src={faviconUrl} alt="" className="size-full" />
+                </span>
+              )}
+              <span className="truncate text-[15px] leading-tight text-muted-foreground">
+                {siteHost}
+              </span>
+            </>
+          )}
+        </div>
+
+        {children}
+
+        <div className="flex shrink-0 flex-col gap-3">{footer}</div>
+      </div>
+
+      {/* Right: full-bleed brand-photo quote panel (desktop only). */}
+      <aside className="relative hidden shrink-0 overflow-hidden lg:flex lg:w-[440px] lg:flex-col lg:justify-center lg:p-14">
+        <img
+          src="https://decoims.com/image?src=decocms%2F8191643a-1947-4c30-afb4-36b8073c90fb%2Fbg-quote.png&quality=original&fit=cover&width=880"
+          alt=""
+          className="absolute inset-0 size-full object-cover"
+        />
+        {/* Scrim keeps the white quote legible over the brighter parts. */}
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative z-10">
+          <ConnectQuotePanel />
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+/** Shared footer CTA — solid primary, muted while the required source is
+ *  missing. Used by the modal and preview so the button reads identically. */
+export function ConnectFooterButton({
+  ready,
+  pending,
+  label,
+  onClick,
+  children,
+}: {
+  ready: boolean;
+  pending?: boolean;
+  label: string;
+  onClick?: () => void;
+  /** Optional trailing content (e.g. an arrow) when ready. */
+  children?: ReactNode;
+}) {
+  return (
+    <Button
+      type="button"
+      size="lg"
+      className="h-auto min-h-12 w-full whitespace-normal rounded-lg py-3 text-center text-base font-medium leading-tight"
+      onClick={onClick}
+      disabled={pending || !ready}
+    >
+      {label}
+      {ready && !pending ? children : null}
+    </Button>
+  );
+}

--- a/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/schedule-meeting.tsx
@@ -4,7 +4,7 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { ArrowUpRight } from "@untitledui/icons";
 
-type MeetingCtaPlacement = "visual_card" | "mobile_banner";
+type MeetingCtaPlacement = "visual_card";
 
 const SCHEDULE_MEETING_URLS: Record<string, string> = {
   "pt-BR": "https://decocms.com/agendar",
@@ -172,74 +172,5 @@ export function ScheduleMeetingVisual({
         </div>
       </div>
     </div>
-  );
-}
-
-/**
- * Mobile counterpart of {@link ScheduleMeetingVisual}. On small screens the
- * split disappears, so this is a compact, tappable banner that opens the
- * scheduling flow directly — quieter than the full card, still inviting.
- */
-export function ScheduleMeetingBanner({
-  className,
-  href,
-  orgId,
-}: {
-  className?: string;
-  href?: string;
-  orgId?: string;
-}) {
-  const t = useT();
-  const alt = t("routes.commerceOnboarding.scheduleMeeting.expertAlt");
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noreferrer"
-      onClick={() =>
-        track("commerce_onboarding_meeting_cta_clicked", {
-          placement: "mobile_banner" satisfies MeetingCtaPlacement,
-          organization_id: orgId,
-        })
-      }
-      className={cn(
-        "flex items-center gap-3 rounded-xl border border-border bg-card p-3 card-shadow transition-colors hover:bg-accent",
-        className,
-      )}
-    >
-      <span
-        className="relative flex shrink-0 items-center"
-        style={{ height: 32, width: 32 + 2 * Math.round(32 * 0.7) }}
-      >
-        {TEAM_PHOTOS.map((photo, i) => (
-          <span
-            key={photo}
-            className="absolute block h-8 w-8 overflow-hidden rounded-full border-2 border-card"
-            style={{
-              left: i * Math.round(32 * 0.7),
-              zIndex: TEAM_PHOTOS.length - i,
-            }}
-          >
-            <img
-              src={photo}
-              alt={alt}
-              className="h-full w-full object-cover"
-              loading="lazy"
-            />
-          </span>
-        ))}
-        <span
-          className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full border-2 border-card bg-success"
-          aria-hidden
-          style={{ zIndex: TEAM_PHOTOS.length + 1 }}
-        />
-      </span>
-      {/* Mobile-only banner: compact single line (the desktop
-          ScheduleMeetingVisual keeps the full headline + description). */}
-      <span className="flex-1 text-sm font-medium leading-tight text-foreground">
-        {t("routes.commerceOnboarding.scheduleMeeting.headline")}
-      </span>
-      <ArrowUpRight size={16} className="shrink-0 text-muted-foreground" />
-    </a>
   );
 }


### PR DESCRIPTION
## Summary

Redesigns the commerce-onboarding **connect step** (the blocking modal shown over the report until a data source is connected) to match the Figma design (`Product 2` → node `9473-8422`). Scoped to only the connect modal.

### What changed
- **Single-column source list.** Each source is a row: icon + title + benefit line, action on the right. The required source (**Google Analytics**) carries an "Obrigatório" pill and a solid CTA; the rest are outline.
- **Linked ≠ usable.** A source can be linked but not usable yet (VTEX with no account, GitHub with no repo, GA/GSC via OAuth with no property picked). Those now read as **"finish setup"** (amber), never "connected". Adds `configured` + `required` to the card model, with unit tests. Fixes the old bug where clicking Connect + closing showed a false "Conectado".
- **Continue gate** requires the required source to be ready; the others only enrich the report.
- **Brand quote panel.** Full-bleed Monte Carlo photo with a real customer quote (Ágata Esteves), replacing the client-logo wall. Breadcrumb header (deco → site).
- **Responsive.** Compact inline rows on mobile (benefit line hidden so all sources fit); full rows with descriptions on desktop.

The modal stays **non-dismissable** (no close button / escape / overlay-close), as before — connecting a source is the only way forward.

### Behavioral changes to note (beyond UI + i18n)
- The continue-gate now requires the **required** source (analytics) linked **and** configured, vs the old "any source linked". This is the fix for the false-"Conectado" bug.
- The "talk to a specialist / schedule a meeting" CTA was removed from the connect step (not in the Figma frame).

Untouched: the connect/disconnect/OAuth flow, config forms, and the enriching run/setup MCP flow. Unit tests (`bun test`) green.