### PR TITLE
fix(task-board): unstick Progress lane + show others' thread preview

### DIFF
--- a/apps/mesh/src/storage/task-board.test.ts
+++ b/apps/mesh/src/storage/task-board.test.ts
@@ -43,13 +43,13 @@ describe("shouldAdvanceToReview", () => {
     ).toBe(false);
   });
 
-  it("leaves repo-backed tasks alone — the PR path owns their in_review move", () => {
+  it("advances a repo-backed task on thread-finish too (backstop for missed PR detection)", () => {
     expect(
       shouldAdvanceToReview({
         status: "in_progress",
         threads: [thread("completed", true)],
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("only fires from in_progress, not from other lanes", () => {

--- a/apps/mesh/src/storage/task-board.ts
+++ b/apps/mesh/src/storage/task-board.ts
@@ -30,10 +30,14 @@ function extractPartText(payload: unknown): string | null {
 const TERMINAL_THREAD_STATUSES = new Set(["completed", "failed", "expired"]);
 
 /**
- * Should a repo-less task advance to In Review now that a thread finished? True
- * iff it's In Progress, has at least one thread, none of them loaded a repo, and
- * every thread's run has reached a terminal status. Repo-backed tasks are left
- * alone — they ride the PR-open → In Review path instead. Pure — unit-tested.
+ * Should a task advance to In Review now that a thread finished? True iff it's
+ * In Progress, has at least one thread, and every thread's run has reached a
+ * terminal status. Repo-backed tasks advance here too: the PR-open hook moves
+ * them earlier (mid-run, real-time) when it fires, but thread-finish is the
+ * backstop so a task doesn't sit in In Progress forever when PR detection misses
+ * (shell alias, script wrapper, or a PR opened by any other means). RANK keeps
+ * this from moving a card backward, and a re-prompt reopens it. Pure —
+ * unit-tested.
  */
 export function shouldAdvanceToReview(item: {
   status: TaskBoardItemStatus;
@@ -41,7 +45,6 @@ export function shouldAdvanceToReview(item: {
 }): boolean {
   if (item.status !== "in_progress") return false;
   if (item.threads.length === 0) return false;
-  if (item.threads.some((t) => t.hasPreview)) return false;
   return item.threads.every(
     (t) => t.status !== null && TERMINAL_THREAD_STATUSES.has(t.status),
   );

--- a/apps/mesh/src/tools/task-board/prs-get.ts
+++ b/apps/mesh/src/tools/task-board/prs-get.ts
@@ -6,6 +6,7 @@ import type { ConnectionEntity } from "@/tools/connection/schema";
 import { clientFromConnection } from "@/mcp-clients";
 import type { TaskBoardItemPrRef } from "@/storage/types";
 import { TaskBoardItemPrSchema } from "./schema";
+import { emitTaskBoardUpdated } from "./run-reactions";
 
 /** Cap a single live PR fetch — the modal shouldn't hang on a slow GitHub. */
 const PR_FETCH_TIMEOUT_MS = 8000;
@@ -122,7 +123,9 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
     "with live state (title, open/closed, draft, merged) fetched from GitHub.",
   annotations: {
     title: "Get Task Board Item Pull Requests",
-    readOnlyHint: true,
+    // Not read-only: as a side effect it moves a task to Done when it observes a
+    // merged PR (see the reconcile below). Idempotent — converges to Done.
+    readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: true,
     // Reaches out to GitHub for live PR state.
@@ -158,6 +161,31 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
         };
       }),
     );
+
+    // ponytail: reconcile-on-view — there's no GitHub PR webhook, so a merged PR
+    // only advances the card to Done when someone opens this modal. Upgrade path:
+    // a `pull_request` webhook calling the same forward move. Best-effort; a
+    // failure must never break the read. Forward-only (never un-does Done).
+    if (prs.some((p) => p.merged)) {
+      try {
+        const item = await ctx.storage.taskBoard.getById(
+          taskBoardItemId,
+          organizationId,
+        );
+        if (item && item.status !== "done") {
+          const updated = await ctx.storage.taskBoard.update(
+            taskBoardItemId,
+            organizationId,
+            { status: "done" },
+            item.updatedBy,
+          );
+          emitTaskBoardUpdated(organizationId, updated);
+        }
+      } catch (err) {
+        console.error("[task-board] merge→done reconcile failed", err);
+      }
+    }
+
     return { prs };
   },
 });

--- a/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
+++ b/apps/mesh/src/web/layouts/agent-shell-layout/index.tsx
@@ -161,13 +161,27 @@ function VmEventsBridge({
   const threadSandboxMap = activeTask?.metadata?.sandboxMap as
     | SandboxMap
     | undefined;
+  // The thread persists its sandbox under the thread OWNER's user id — yours for
+  // your own thread, the creator's when you're viewing someone else's (read-only).
+  // Read the owner's entry, not the viewer's: for another member's thread the
+  // viewer-keyed lookup misses, `previewUrl` stays null, and the gate's ack then
+  // fires a fresh clone on the owner's branch that never resolves ("Cloning your
+  // repo…" forever). Grafting the owner's entry under the viewer's key lets
+  // previewUrl resolve to the owner's already-running sandbox, so it renders
+  // read-only with no clone. `created_by` absent → falls back to the viewer
+  // (own-thread behavior unchanged).
+  const previewOwnerId = activeTask?.created_by ?? userId;
+  const threadOwnerBranchMap =
+    previewOwnerId && currentBranch
+      ? threadSandboxMap?.[previewOwnerId]?.[currentBranch]
+      : undefined;
   const threadEffectiveSandboxMap: SandboxMap | undefined =
-    userId && currentBranch && threadSandboxMap?.[userId]?.[currentBranch]
+    userId && currentBranch && threadOwnerBranchMap
       ? {
           ...(sandboxMap ?? {}),
           [userId]: {
             ...(sandboxMap?.[userId] ?? {}),
-            [currentBranch]: threadSandboxMap[userId]![currentBranch]!,
+            [currentBranch]: threadOwnerBranchMap,
           },
         }
       : sandboxMap;


### PR DESCRIPTION
## Summary
Two reported bugs on the task board:

1. **Tasks pile up in "In Progress" and never move on.** Repo-backed tasks were excluded from the thread-finish → In Review advance and relied solely on live PR-open detection, whose own comment admits it "misses shell aliases and script wrappers." A PR opened by any unmatched path left the card stuck in In Progress forever.
2. **Clicking a card opened by another member never opens the preview** — it spins on "Cloning your repo…" indefinitely.

## Changes
- **`storage/task-board.ts`** — `shouldAdvanceToReview` now advances a task to `in_review` once all its threads reach a terminal status, repo-backed or not. The PR-open hook still moves cards earlier in real time; thread-finish is the backstop. `RANK` keeps this forward-only; a re-prompt reopens. Unit test inverted.
- **`tools/task-board/prs-get.ts`** — reconcile-on-view: when it observes a merged PR it advances the card to `done` and emits the SSE update. `readOnlyHint` flipped to `false` (it now has a side effect). No PR webhook exists today; ceiling noted with a `ponytail:` comment — a `pull_request` webhook is the push-based upgrade path.
- **`web/layouts/agent-shell-layout/index.tsx`** — the sandbox lookup was keyed on the **viewer's** `userId`, but a thread persists its sandbox under the **owner's** id. For another member's card the lookup missed → `previewUrl` stayed null → the gate's ack fired a fresh clone on the owner's branch that never resolved. Now reads `activeTask.created_by`'s entry and grafts it under the viewer's key, so `previewUrl` resolves to the owner's running sandbox and it renders read-only with no clone. Own-thread behavior unchanged (`created_by === userId`). When the owner's sandbox is dead or absent, the viewer still gets a reboot via the existing gate→start / self-heal path.

## Testing
- `bun test apps/mesh/src/storage/task-board.test.ts` — 7 pass (includes the inverted repo-backed case).
- `tsc --noEmit` clean for all touched files.

## Notes / follow-ups
- merge→Done only fires when someone opens a card's PR modal (reconcile-on-view). A `pull_request` webhook would make it push-based.
- If the owner's thread branch is a synthetic/unpushed `thread:*` branch, a viewer's reboot can still hang — that's branch-level cloneability, orthogonal to the ownership fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cards getting stuck in In Progress and makes preview work when viewing another member’s thread. Also marks cards Done when a merged PR is detected from the PR modal.

- **Bug Fixes**
  - Advance tasks to In Review when all threads are terminal, including repo-backed tasks (backstop for missed PR-open detection).
  - Key sandbox lookup to the thread owner’s ID so others see the owner’s running preview instead of hanging on “Cloning your repo…”.
  - When viewing PRs, if any is merged, move the card to Done and emit the board update.

<sup>Written for commit 64261455a31feb4f32fa24ba0c0e04dba30b1f86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

