### PR TITLE
fix(commerce-onboarding): prevent Obrigatório pill from being clipped

### DIFF
--- a/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/mesh/src/web/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -246,7 +246,7 @@ function CompanionMcpsSectionContent({
         )}
         {/* Single list, required source(s) first — the "Obrigatório" pill on the
             card carries the must-vs-optional distinction (no section headers). */}
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 pt-3">
           {[...requiredCards, ...enhancedCards].map(renderCard)}
         </div>
       </ScrollReveal>


### PR DESCRIPTION
## What is this contribution about?

The "Obrigatório" badge on the required companion card was being cut off at the top because the card list had no top padding. The badge uses `absolute -top-3` positioning to straddle the card's top edge, so it needs `pt-3` on the container to avoid being clipped by the scroll area's overflow boundary.

## Screenshots/Demonstration

Before: the "Obrigatório" text was visibly clipped at the top of the first card.
After: the pill renders fully above the card edge.

## How to Test

1. Open the commerce onboarding flow for an org with a required companion (e.g. Google Analytics).
2. Verify the "Obrigatório" pill is fully visible above the card's top border.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `pt-3` to the companion card list in commerce onboarding so the “Obrigatório” pill renders fully above the card and isn’t clipped by the scroll container. This accounts for the pill’s `absolute -top-3` positioning.

<sup>Written for commit eb312ae1f988ab0b25325ab89e51c21f67f47528. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

