### PR TITLE
fix(thread/github): enable "Visit preview" in publish modal for hosted sandboxes

### DIFF
--- a/apps/mesh/src/web/components/thread/github/header-actions.tsx
+++ b/apps/mesh/src/web/components/thread/github/header-actions.tsx
@@ -1,5 +1,4 @@
 import {
-  parseBranchMap,
   useMCPClient,
   useProjectContext,
   useVirtualMCP,
@@ -31,6 +30,7 @@ import * as tpl from "./message-templates.ts";
 import { saveChangesDebug } from "./save-changes-debug.ts";
 import { resolveSandboxBranchFromMap } from "./resolve-sandbox-branch.ts";
 import { useSandboxEvents } from "@/web/components/sandbox/hooks/use-sandbox-events.ts";
+import { useSandboxLifecycle } from "@/web/components/sandbox/hooks/sandbox-lifecycle-context.tsx";
 import { usePublishGate } from "@/web/components/sandbox/hooks/use-publish-gate.ts";
 import { useChecks, usePrByBranch } from "./use-pr-data.ts";
 import { usePrReviews } from "./use-pr-reviews.ts";
@@ -189,15 +189,12 @@ export function HeaderActions({ virtualMcpId }: Props) {
   }
   if (!githubRepo) return null;
 
-  const branchMap =
-    userId && githubHeadBranch
-      ? parseBranchMap(vm?.metadata?.sandboxMap?.[userId]?.[githubHeadBranch])
-      : {};
-  const branchMapEntries = Object.values(branchMap);
-  const vmEntry =
-    branchMapEntries.find((e) => e.sandboxProviderKind !== "user-desktop") ??
-    branchMapEntries[0];
-  const previewUrl = vmEntry?.previewUrl ?? null;
+  // Live preview URL comes from the sandbox lifecycle, not the raw vMCP
+  // sandboxMap. Hosted (agent-sandbox / shared-staging) sandboxes persist their
+  // previewUrl in `agentSandboxSessions`, which the lifecycle overlays onto the
+  // branch map; the raw `vm.metadata.sandboxMap` never carries it, so reading it
+  // here left "Visit preview" permanently disabled for those sandboxes.
+  const { previewUrl } = useSandboxLifecycle();
 
   const button = githubHeadBranch
     ? selectHeaderButton({

--- a/apps/mesh/src/web/i18n/pt-br/thread.ts
+++ b/apps/mesh/src/web/i18n/pt-br/thread.ts
@@ -169,5 +169,5 @@ export const thread = {
   "thread.publishDialog.toPublish": "para publicar",
   "thread.publishDialog.viewOnGithub": "Ver no GitHub",
   "thread.publishDialog.viewPr": "Ver PR",
-  "thread.publishDialog.visitPreview": "Visitar o Preview",
+  "thread.publishDialog.visitPreview": "Abrir o Preview",
 } satisfies Record<keyof typeof threadEn, string>;

--- a/apps/mesh/src/web/i18n/pt-br/thread.ts
+++ b/apps/mesh/src/web/i18n/pt-br/thread.ts
@@ -169,5 +169,5 @@ export const thread = {
   "thread.publishDialog.toPublish": "para publicar",
   "thread.publishDialog.viewOnGithub": "Ver no GitHub",
   "thread.publishDialog.viewPr": "Ver PR",
-  "thread.publishDialog.visitPreview": "Visitar visualização",
+  "thread.publishDialog.visitPreview": "Visitar o Preview",
 } satisfies Record<keyof typeof threadEn, string>;


### PR DESCRIPTION
## Summary

The publish modal's **"Visit preview"** button was permanently disabled.

**Root cause:** since #5132 (`feat(sandbox): use shared staging branch`), GitHub-backed threads run on the hosted `agent-sandbox` provider. That provider persists its `previewUrl` in the `agentSandboxSessions` table (via `sharedStart.completeStart`), **not** in `vm.metadata.sandboxMap` — the `else` branch in `start.ts` that writes to the sandboxMap only runs for non-hosted providers.

`header-actions.tsx` (which feeds `previewUrl` into the publish dialog) still read from the raw `vm.metadata.sandboxMap`, so the lookup always returned `null` and the button stayed `disabled`.

The preview drawer/tab never broke because it reads from `useSandboxLifecycle()`, which overlays the `agentSandboxSession` onto the branch map (`agent-shell-layout/index.tsx`). The header didn't use that path.

## Changes

- `header-actions.tsx`: read `previewUrl` from `useSandboxLifecycle()` instead of recomputing it from the raw vMCP sandboxMap. `HeaderActions` already renders inside `SandboxLifecycleProvider` (via `VmEventsBridge → DesktopTaskWorkspace → WorkspacePanelGroup → VirtualMcpHeaderInfo`), and it returns the same URL the preview drawer uses. Removed the now-orphaned `parseBranchMap` import.
- Relabel pt-br string `thread.publishDialog.visitPreview` → "Visitar o Preview".

## Testing

- `bun run fmt` ✅
- `bun run --cwd=apps/mesh check` (tsc) ✅
- Manual: open the publish modal on a GitHub thread with a running hosted sandbox → "Visit preview" is enabled and opens the preview URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the "Visit preview" button in the publish modal for GitHub threads on hosted sandboxes by reading `previewUrl` from `useSandboxLifecycle()` instead of `vm.metadata.sandboxMap`. Aligns the header with the preview drawer and restores the button for `agent-sandbox` sessions.

- **Bug Fixes**
  - Read `previewUrl` from `useSandboxLifecycle()` in `header-actions.tsx`; remove `parseBranchMap`.
  - Update pt-br string `thread.publishDialog.visitPreview` to "Abrir o Preview".

<sup>Written for commit 74a07b9bf61eda2872738745ba5c60644fc6dc5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

