### PR TITLE
fix(task-board): recover missed PR link from thread summary text

### DIFF
--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -7,6 +7,7 @@ import { clientFromConnection } from "@/mcp-clients";
 import type { TaskBoardItemPrRef } from "@/storage/types";
 import { TaskBoardItemPrSchema } from "./schema";
 import { emitTaskBoardUpdated } from "./run-reactions";
+import { extractPrFromText } from "./pr-extract";
 
 /** Cap a single live PR fetch — the modal shouldn't hang on a slow GitHub. */
 const PR_FETCH_TIMEOUT_MS = 8000;
@@ -143,6 +144,40 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
         "Organization ID required (no active organization in context)",
       );
     }
+    const item = await ctx.storage.taskBoard.getById(
+      taskBoardItemId,
+      organizationId,
+    );
+
+    // Recover a PR the create-PR hook missed (shell alias, script wrapper, or a
+    // PR opened by any means the heuristic doesn't match) by scanning each
+    // linked thread's latest assistant message — the agent's closing summary
+    // reliably prints the URL ("Opened PR #309 https://github.com/…/pull/309").
+    // linkPr is idempotent per (task, url), so re-linking an already-tracked PR
+    // is a no-op. Best-effort; a failure must never break the read.
+    // ponytail: scans only the latest assistant message per thread (that's what
+    // getById already loads). Widen to more parts if a PR ever lands in an
+    // earlier message that the closing summary doesn't repeat.
+    for (const thread of item?.threads ?? []) {
+      const pr = thread.lastMessage
+        ? extractPrFromText(thread.lastMessage)
+        : null;
+      if (!pr) continue;
+      try {
+        await ctx.storage.taskBoard.linkPr({
+          taskBoardItemId,
+          organizationId,
+          url: pr.url,
+          prNumber: pr.number,
+          repoOwner: pr.owner,
+          repoName: pr.repo,
+          connectionId: null,
+        });
+      } catch (err) {
+        console.error("[task-board] PR recovery from thread text failed", err);
+      }
+    }
+
     const linked = await ctx.storage.taskBoard.listPrs(
       taskBoardItemId,
       organizationId,
@@ -168,10 +203,6 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
     // failure must never break the read. Forward-only (never un-does Done).
     if (prs.some((p) => p.merged)) {
       try {
-        const item = await ctx.storage.taskBoard.getById(
-          taskBoardItemId,
-          organizationId,
-        );
         if (item && item.status !== "done") {
           const updated = await ctx.storage.taskBoard.update(
             taskBoardItemId,


### PR DESCRIPTION
## Summary
A task's thread completed and its closing summary literally read *"Opened PR #309 https://github.com/…/pull/309"*, but the PR card in the task dialog stayed empty.

Root cause is the same detection gap fixed for the In Review transition (#5162): when the create-PR hook misses the PR-open (shell alias, script wrapper, or any path `isPrCreateMcpTool` / `isPrCreateBashCommand` doesn't match), nothing is written to `task_board_item_prs`, so `TASK_BOARD_ITEM_PRS_GET` has no PR to render.

## Fix
`PRS_GET` now recovers the PR from the thread's own text before listing: it scans each linked thread's latest assistant message (already loaded by `getById` → `attachThreads`) with the existing `extractPrFromText`, and `linkPr`s any PR found. `linkPr` is idempotent per `(task, url)`, so re-linking a tracked PR is a no-op. Reconcile-on-view — the same shape as the merge→Done pass.

Recovered PRs are linked with `connectionId: null`, so live-state fetch falls back to the org's shared `mcp-github` connection (`resolveGithubConnection`).

## Testing
- The exact markdown shape (`Opened PR ([#3](https://github.com/acme/site/pull/3))`) is already covered by `pr-extract.test.ts`; `linkPr` idempotency by `run-reactions.test.ts`. The recovery is thin glue over both.
- `tsc --noEmit` clean.

## Notes
- Follow-up to #5162 (merged). Independent change — only touches `prs-get.ts`.
- Ceiling (marked `ponytail:`): scans only the latest assistant message per thread. Widen to more message parts if a PR ever lands in an earlier message the closing summary doesn't repeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty PR cards on tasks when the create-PR hook misses the open event. `PRS_GET` now recovers the PR from the thread’s closing summary before listing.

- **Bug Fixes**
  - Scan each linked thread’s latest assistant message with `extractPrFromText`; `linkPr` any found PR (idempotent per task+url).
  - Use `connectionId: null` for recovered links so live state resolves via the org’s `mcp-github` connection.

<sup>Written for commit 762fc1013475c7f01aaa89cd339345be09315bb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

