### PR TITLE
fix(ci): harden release and rollout checks

### DIFF
--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -9,7 +9,9 @@ on:
       - "apps/web/**"
       - "package.json"
       - "scripts/build-studio.ts"
+      - "scripts/release-changes.ts"
       - "packages/**"
+      - ".github/workflows/release-tagging.yaml"
       # Baked into the nginx image at build time (apps/web/Dockerfile), so a change
       # here must cut a release to rebuild that image — it is not a ConfigMap.
       - "deploy/helm/studio/files/**"
@@ -47,11 +49,19 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
+          ref: main
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
 
       - name: Find the merged pull request
         id: find_pr
         env:
+          EVENT_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
@@ -59,7 +69,7 @@ jobs:
           PR_DATA=$(gh api \
             -H "Accept: application/vnd.github+json" \
             "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
-            --jq 'map(select(.merged_at != null)) | sort_by(.merged_at) | reverse | .[0] // {}')
+            --jq "map(select(.merged_at != null and .merge_commit_sha == \"${EVENT_SHA}\")) | .[0] // {}")
 
           PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number // empty')
           PR_TITLE=$(echo "$PR_DATA" | jq -r '.title // empty')
@@ -106,66 +116,27 @@ jobs:
         id: changed_workspaces
         if: steps.find_pr.outputs.pr_number != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_SHA: ${{ github.sha }}
           PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
         run: |
           set -euo pipefail
 
-          FILES=$(gh api --paginate \
-            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
-            --jq '.[].filename')
+          if ! git merge-base --is-ancestor "$MERGE_SHA" origin/main; then
+            echo "::error::Merge commit $MERGE_SHA is not on origin/main"
+            exit 1
+          fi
 
-          echo "Changed files:"
-          echo "$FILES"
+          DIFF_BASE=$(git rev-parse "${MERGE_SHA}^1")
+          CHANGED_FILES_PATH="$RUNNER_TEMP/release-tagging-${PR_NUMBER}.paths"
+          git diff --no-renames --name-only -z \
+            "$DIFF_BASE" "$MERGE_SHA" -- > "$CHANGED_FILES_PATH"
 
-          PACKAGE_MANIFESTS=$(FILES="$FILES" node <<'NODE'
-          const fs = require("fs");
-          const files = (process.env.FILES ?? "").split("\n").filter(Boolean);
-          const manifests = new Set();
+          RELEASE_CHANGES=$(bun run scripts/release-changes.ts "$CHANGED_FILES_PATH")
+          FILE_COUNT=$(jq -r '.fileCount' <<< "$RELEASE_CHANGES")
+          PACKAGE_MANIFESTS=$(jq -c '.packageManifests' <<< "$RELEASE_CHANGES")
+          SCOPE=$(jq -r '.deployScope' <<< "$RELEASE_CHANGES")
 
-          for (const file of files) {
-            if (
-              file === "package.json" ||
-              file === "scripts/build-studio.ts"
-            ) {
-              manifests.add("apps/api/package.json");
-              continue;
-            }
-
-            if (
-              file.startsWith("apps/api/") ||
-              file.startsWith("apps/web/")
-            ) {
-              manifests.add("apps/api/package.json");
-              continue;
-            }
-
-            // The nginx conf is baked into the studio-nginx image, tagged with
-            // apps/api's version — so a change here must bump that version to
-            // force a rebuild (there is no ConfigMap to reload).
-            if (file.startsWith("deploy/helm/studio/files/")) {
-              manifests.add("apps/api/package.json");
-              continue;
-            }
-
-            const match = file.match(/^packages\/([^/]+)\//);
-            if (match) {
-              manifests.add(`packages/${match[1]}/package.json`);
-            }
-          }
-
-          const existing = [...manifests]
-            .filter((manifest) => fs.existsSync(manifest))
-            .filter((manifest) => {
-              const pkg = JSON.parse(fs.readFileSync(manifest, "utf8"));
-              return typeof pkg.version === "string";
-            })
-            .sort();
-
-          console.log(JSON.stringify(existing));
-          NODE
-          )
-
+          echo "Changed files: $FILE_COUNT"
           echo "Workspace manifests to bump: $PACKAGE_MANIFESTS"
           echo "package_manifests=$PACKAGE_MANIFESTS" >> "$GITHUB_OUTPUT"
 
@@ -173,14 +144,6 @@ jobs:
           # bump-studio-image): apps/web-only changes roll only the web pods;
           # apps/api-only changes roll api+worker; mixed or no app changes roll
           # both (safe default).
-          API_FILES=$(echo "$FILES" | grep '^apps/api/' || true)
-          WEB_FILES=$(echo "$FILES" | grep '^apps/web/' || true)
-          SCOPE=both
-          if [ -n "$API_FILES" ] && [ -z "$WEB_FILES" ]; then
-            SCOPE=server
-          elif [ -n "$WEB_FILES" ] && [ -z "$API_FILES" ]; then
-            SCOPE=web
-          fi
           echo "Deploy scope: $SCOPE"
           echo "deploy_scope=$SCOPE" >> "$GITHUB_OUTPUT"
 

--- a/scripts/release-changes.test.ts
+++ b/scripts/release-changes.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import {
+  classifyReleaseChanges,
+  isVersionedManifest,
+  parseChangedFiles,
+  releaseManifestCandidates,
+} from "./release-changes";
+
+const API_MANIFEST = "apps/api/package.json";
+
+describe("release change classification", () => {
+  test.each([
+    {
+      files: ["apps/api/src/index.ts"],
+      manifests: [API_MANIFEST],
+      scope: "server",
+    },
+    {
+      files: ["apps/web/src/main.tsx"],
+      manifests: [API_MANIFEST],
+      scope: "web",
+    },
+    {
+      files: ["apps/api/src/index.ts", "apps/web/src/main.tsx"],
+      manifests: [API_MANIFEST],
+      scope: "both",
+    },
+    {
+      files: ["packages/runtime/src/index.ts"],
+      manifests: ["packages/runtime/package.json"],
+      scope: "both",
+    },
+  ] as const)(
+    "classifies $scope deploy changes",
+    ({ files, manifests, scope }) => {
+      expect(classifyReleaseChanges(files, new Set(manifests))).toMatchObject({
+        deployScope: scope,
+        packageManifests: manifests,
+      });
+    },
+  );
+
+  test("maps release inputs to sorted, deduplicated manifests", () => {
+    const files = [
+      "packages/ui/src/button.tsx",
+      "apps/web/src/main.tsx",
+      "apps/api/src/index.ts",
+      "package.json",
+      "scripts/build-studio.ts",
+      "deploy/helm/studio/files/nginx.conf",
+      "packages/runtime/src/index.ts",
+      "packages/ui/src/input.tsx",
+    ];
+
+    expect(releaseManifestCandidates(files)).toEqual([
+      API_MANIFEST,
+      "packages/runtime/package.json",
+      "packages/ui/package.json",
+    ]);
+  });
+
+  test("filters deleted and unversioned workspaces", () => {
+    const files = [
+      "packages/deleted/src/index.ts",
+      "packages/private/src/index.ts",
+      "packages/versioned/src/index.ts",
+    ];
+
+    expect(
+      classifyReleaseChanges(
+        files,
+        new Set(["packages/versioned/package.json"]),
+      ).packageManifests,
+    ).toEqual(["packages/versioned/package.json"]);
+  });
+
+  test("recognizes only string package versions", () => {
+    expect(isVersionedManifest({ version: "0.0.0" })).toBe(true);
+    expect(isVersionedManifest({ version: 1 })).toBe(false);
+    expect(isVersionedManifest({ private: true })).toBe(false);
+    expect(isVersionedManifest(null)).toBe(false);
+  });
+
+  test("handles a #5120-sized file list", () => {
+    const relevantFiles = [
+      "apps/api/src/index.ts",
+      "apps/web/src/main.tsx",
+      "packages/bindings/src/index.ts",
+      "packages/create-deco/index.ts",
+      "packages/e2e/tests/smoke.spec.ts",
+      "packages/harness/src/index.ts",
+      "packages/mcp-utils/src/index.ts",
+      "packages/runtime/src/index.ts",
+      "packages/sandbox/src/index.ts",
+      "packages/shared/src/index.ts",
+      "packages/tunnel/src/index.ts",
+      "packages/typegen/src/index.ts",
+      "packages/ui/src/index.ts",
+      "packages/mesh-sdk/src/index.ts",
+      "packages/std/src/index.ts",
+      "apps/mesh/src/index.ts",
+    ];
+    const fillerFiles = Array.from(
+      { length: 2_823 - relevantFiles.length },
+      (_, index) =>
+        `docs/generated/${index.toString().padStart(4, "0")}-${"x".repeat(40)}.md`,
+    );
+    const serialized = `${[...relevantFiles, ...fillerFiles].join("\0")}\0`;
+    const files = parseChangedFiles(serialized);
+    const expectedManifests = [
+      API_MANIFEST,
+      "packages/bindings/package.json",
+      "packages/create-deco/package.json",
+      "packages/e2e/package.json",
+      "packages/harness/package.json",
+      "packages/mcp-utils/package.json",
+      "packages/runtime/package.json",
+      "packages/sandbox/package.json",
+      "packages/shared/package.json",
+      "packages/tunnel/package.json",
+      "packages/typegen/package.json",
+      "packages/ui/package.json",
+    ];
+
+    expect(Buffer.byteLength(serialized)).toBeGreaterThan(128 * 1024);
+    expect(files).toHaveLength(2_823);
+    expect(classifyReleaseChanges(files, new Set(expectedManifests))).toEqual({
+      deployScope: "both",
+      fileCount: 2_823,
+      packageManifests: expectedManifests,
+    });
+  });
+});

--- a/scripts/release-changes.ts
+++ b/scripts/release-changes.ts
@@ -1,0 +1,134 @@
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const API_MANIFEST = "apps/api/package.json";
+
+export type DeployScope = "both" | "server" | "web";
+
+export interface ReleaseChanges {
+  deployScope: DeployScope;
+  fileCount: number;
+  packageManifests: string[];
+}
+
+export function parseChangedFiles(contents: string): string[] {
+  const separator = contents.includes("\0") ? "\0" : "\n";
+  return contents
+    .split(separator)
+    .map((file) => (separator === "\n" ? file.replace(/\r$/, "") : file))
+    .filter(Boolean);
+}
+
+export function releaseManifestCandidates(files: readonly string[]): string[] {
+  const manifests = new Set<string>();
+
+  for (const file of files) {
+    if (file === "package.json" || file === "scripts/build-studio.ts") {
+      manifests.add(API_MANIFEST);
+      continue;
+    }
+
+    if (file.startsWith("apps/api/") || file.startsWith("apps/web/")) {
+      manifests.add(API_MANIFEST);
+      continue;
+    }
+
+    // The nginx config is baked into the web image tagged with the API version.
+    if (file.startsWith("deploy/helm/studio/files/")) {
+      manifests.add(API_MANIFEST);
+      continue;
+    }
+
+    const packageMatch = /^packages\/([^/]+)\//.exec(file);
+    const packageDirectory = packageMatch?.[1];
+    if (packageDirectory) {
+      manifests.add(`packages/${packageDirectory}/package.json`);
+    }
+  }
+
+  return [...manifests].sort();
+}
+
+export function isVersionedManifest(manifest: unknown): boolean {
+  return (
+    typeof manifest === "object" &&
+    manifest !== null &&
+    "version" in manifest &&
+    typeof manifest.version === "string"
+  );
+}
+
+export function classifyReleaseChanges(
+  files: readonly string[],
+  versionedManifests: ReadonlySet<string>,
+): ReleaseChanges {
+  const hasApiChanges = files.some((file) => file.startsWith("apps/api/"));
+  const hasWebChanges = files.some((file) => file.startsWith("apps/web/"));
+  const deployScope =
+    hasApiChanges && !hasWebChanges
+      ? "server"
+      : hasWebChanges && !hasApiChanges
+        ? "web"
+        : "both";
+
+  return {
+    deployScope,
+    fileCount: files.length,
+    packageManifests: releaseManifestCandidates(files).filter((manifest) =>
+      versionedManifests.has(manifest),
+    ),
+  };
+}
+
+async function findVersionedManifests(
+  candidates: readonly string[],
+  repositoryRoot: string,
+): Promise<Set<string>> {
+  const versionedManifests = new Set<string>();
+
+  for (const manifestPath of candidates) {
+    let source: string;
+    try {
+      source = await readFile(join(repositoryRoot, manifestPath), "utf8");
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        continue;
+      }
+      throw error;
+    }
+
+    if (isVersionedManifest(JSON.parse(source))) {
+      versionedManifests.add(manifestPath);
+    }
+  }
+
+  return versionedManifests;
+}
+
+async function main(): Promise<void> {
+  const changedFilesPath = Bun.argv[2];
+  if (!changedFilesPath) {
+    throw new Error("Usage: bun scripts/release-changes.ts <changed-files>");
+  }
+
+  const files = parseChangedFiles(await readFile(changedFilesPath, "utf8"));
+  const repositoryRoot = resolve(import.meta.dir, "..");
+  const candidates = releaseManifestCandidates(files);
+  const versionedManifests = await findVersionedManifests(
+    candidates,
+    repositoryRoot,
+  );
+
+  process.stdout.write(
+    JSON.stringify(classifyReleaseChanges(files, versionedManifests)),
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -108,6 +108,8 @@ services:
       DECOCMS_LOCAL_MODE: "true"
       ENCRYPTION_KEY: test-encryption-key-32chars-long!
       DATA_DIR: /app/data
+      # Bound a silent recovered run inside rollout-churn's terminal poll.
+      RUN_IDLE_TIMEOUT_MS: "120000"
       # External S3 → ensureServices skips embedded MinIO (survives restarts).
       S3_ENDPOINT: http://minio:9000
       S3_BUCKET: studio-dev


### PR DESCRIPTION
## Summary

- classify release changes from a NUL-delimited git diff file instead of exporting the full PR file list through one environment variable
- keep queued release jobs safe by diffing the triggering merge commit while applying bumps on current main
- bound silent recovered runs inside the multi-pod rollout-churn polling window

## Testing

- bun run fmt:check
- bun run lint
- bun run check
- bun run knip
- bun test scripts/release-changes.test.ts
- bun x tsc -p scripts/tsconfig.json
- actionlint .github/workflows/release-tagging.yaml
- replayed the real #5120 first-parent diff: 5,349 NUL-delimited paths / 267,761 bytes, yielding the expected 12 manifests and deploy scope both
- full unit suite: all files before the unchanged monitoring SQL test passed; Bun 1.3.14 then reproducibly segfaulted on macOS at process startup for that test, while the same test passes 45/45 in isolation. Subsequent files were continued separately; two load-sensitive timer/process tests passed in isolation. Authoritative Linux suite runs in CI.
- multi-pod suite: not run locally because Docker is unavailable; authoritative suite runs in CI

## Impact

No runtime production behavior changes. The release workflow no longer crosses the Linux per-environment-string limit on large PRs, and the multi-pod test environment now resolves truly silent recovered runs before its terminal poll expires.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened release tagging to classify changes from a NUL-delimited git diff of the merge commit and compute deploy scope reliably. No production runtime changes.

- **Bug Fixes**
  - Use `git diff merge^1..merge` (NUL-delimited) and `scripts/release-changes.ts` to avoid env size limits and flaky file lists.
  - Verify the event SHA is the merge commit on `main` and an ancestor of `origin/main`, and apply bumps on current `main` for queued runs.
  - Derive deploy scope from paths (`server`/`web`/`both`) and only bump manifests with a string `version`.
  - In multi-pod tests, set `RUN_IDLE_TIMEOUT_MS=120000` to bound silent recovered runs within the rollout polling window.

<sup>Written for commit ff81bbf8dc9ead904b4e51928f3d6606efeba245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

