### PR TITLE
fix(chat): refresh read-only teammate thread metadata so preview finds the repo

### DIFF
--- a/apps/web/src/components/chat/store/thread-manager-store.ts
+++ b/apps/web/src/components/chat/store/thread-manager-store.ts
@@ -446,6 +446,43 @@ export class ThreadManagerStore {
   }
 
   /**
+   * Force-refresh a loaded thread's metadata from the server and merge it into
+   * the panel slot. Unlike `fetchThread` (which short-circuits on a local hit),
+   * this always issues `COLLECTION_THREADS_GET`, so a stale panel row picks up
+   * metadata bound after the snapshot — e.g. a teammate's thread whose
+   * `githubRepo` / `sandboxMap` was written by `load_repo` after the row was
+   * first loaded. A read-only viewer never receives the live `data-open-preview`
+   * chunk that patches this client-side, and the thread-status SSE carries no
+   * metadata, so without this the preview reads a pre-repo row and shows "no
+   * source". Update-only (guards on the row already being present), so it never
+   * inserts a teammate's thread into the scoped panel list. Best-effort.
+   */
+  async refreshThreadMetadata(id: string): Promise<void> {
+    if (!id || !this.client) return;
+    if (!this.threads.get().some((t) => t.id === id)) return;
+    try {
+      const result = await this.client.callTool({
+        name: "COLLECTION_THREADS_GET",
+        arguments: { id },
+      });
+      if ((result as { isError?: boolean }).isError) return;
+      const payload = ((result as { structuredContent?: unknown })
+        .structuredContent ?? result) as { item?: Task | null };
+      const item = payload.item;
+      if (!item) return;
+      this.patchThread({
+        id: item.id,
+        metadata: item.metadata,
+        virtual_mcp_id: item.virtual_mcp_id,
+        branch: item.branch,
+        updated_at: item.updated_at,
+      });
+    } catch {
+      // Best-effort refresh — a failure leaves the (stale) row untouched.
+    }
+  }
+
+  /**
    * Handle a single SSE MessageEvent from the shared decopilot pool. We only
    * care about `decopilot.thread.status` here; other decopilot event types
    * are consumed by `useDecopilotEvents` elsewhere.

--- a/apps/web/src/hooks/use-refresh-viewed-thread-metadata.ts
+++ b/apps/web/src/hooks/use-refresh-viewed-thread-metadata.ts
@@ -1,0 +1,48 @@
+/**
+ * useRefreshViewedThreadMetadata — one-shot fresh read of a read-only
+ * teammate's thread metadata.
+ *
+ * A read-only viewer's panel row can predate the thread's `load_repo` binding:
+ * the live `data-open-preview` stream chunk that patches `githubRepo` /
+ * `sandboxMap` onto the client row reaches only the user who ran the tool, and
+ * the thread-status SSE carries no metadata. That stale row makes the preview
+ * show "no source to preview" and hides the owner's already-running sandbox
+ * (the owner-keyed sandbox lookup finds nothing). Force a fresh
+ * `COLLECTION_THREADS_GET` and merge it into the store so `activeTask` picks up
+ * the current metadata.
+ *
+ * Gated to OTHERS' threads: the owner's own row is kept current by the live
+ * stream, so there's nothing to refresh.
+ *
+ * ponytail: fires once per (org, thread) — enough for the reported case (a
+ * completed thread opened read-only). A teammate's thread that binds a repo
+ * while you're already watching it won't refresh until reload; add a finite
+ * staleTime / refetch if that ever matters.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useProjectContext } from "@/sdk";
+import { authClient } from "@/lib/auth-client";
+import { useOptionalThreadManager } from "@/components/chat/store/hooks";
+import { KEYS } from "@/lib/query-keys";
+import type { Task } from "@/components/chat/task/types";
+
+export function useRefreshViewedThreadMetadata(task: Task | null): void {
+  const { org } = useProjectContext();
+  const manager = useOptionalThreadManager();
+  const { data: session } = authClient.useSession();
+  const userId = session?.user?.id;
+  const taskId = task?.id ?? null;
+  const isOthersThread =
+    !!task && !!userId && !!task.created_by && task.created_by !== userId;
+
+  useQuery({
+    queryKey: KEYS.viewedThreadMetadataRefresh(org.id, taskId ?? ""),
+    enabled: !!manager && !!taskId && isOthersThread,
+    staleTime: Number.POSITIVE_INFINITY,
+    queryFn: async () => {
+      await manager?.refreshThreadMetadata(taskId ?? "");
+      return true;
+    },
+  });
+}

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -51,6 +51,7 @@ import { authClient } from "@/lib/auth-client";
 import { Button } from "@deco/ui/components/button.tsx";
 import { EmptyState } from "@/components/empty-state";
 import { useWorkspaceLayoutState } from "@/hooks/use-layout-state";
+import { useRefreshViewedThreadMetadata } from "@/hooks/use-refresh-viewed-thread-metadata";
 import { getActiveGithubRepo } from "@/lib/github-repo";
 import { useT } from "@/i18n/use-t.ts";
 import { Toolbar } from "./toolbar";
@@ -431,6 +432,14 @@ function AgentInsetProvider() {
   // "Creating task…" state until the row is persisted. Without this the
   // chat renders with branch=null because the thread never existed.
   const ensureState = useEnsureTask(params.taskId ?? "", virtualMcpId);
+
+  // Read-only teammate threads: pull the current metadata (githubRepo /
+  // sandboxMap bound by load_repo after the panel snapshot) so the preview
+  // doesn't render "no source" / miss the owner's sandbox. No-op for own
+  // threads. Must run before the early returns (Rules of Hooks).
+  useRefreshViewedThreadMetadata(
+    ensureState.status === "ready" ? ensureState.task : null,
+  );
 
   // Fetch entity (Suspense-based — resolved before render)
   const entity = useVirtualMCP(virtualMcpId);

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -310,6 +310,10 @@ export const KEYS = {
   ensureTask: (orgId: string, id: string) =>
     ["ensure-task", orgId, id] as const,
 
+  // One-shot refresh of a viewed thread's metadata (read-only teammate threads)
+  viewedThreadMetadataRefresh: (orgId: string, id: string) =>
+    ["viewed-thread-metadata-refresh", orgId, id] as const,
+
   // Global search (server-side, scoped by org)
   globalSearch: (orgId: string, query: string) =>
     ["global-search", orgId, query] as const,


### PR DESCRIPTION
## Summary
Opening **someone else's** thread showed *"No source to preview / Connect GitHub"* even though the thread had clearly loaded a repo and opened a PR — as the user put it, "it opened directly on the Super Agent, and the Super Agent has no github."

## Root cause
`load_repo` correctly persists `githubRepo` (and `sandboxMap`) on the **thread row's** metadata. But a read-only viewer's panel row can predate that write:

- The live `data-open-preview` stream chunk that patches `githubRepo`/`sandboxMap` onto the client row reaches **only the user who ran the tool**.
- The `decopilot.thread.status` SSE carries **no `metadata`** (`thread-status-events.ts`), so `handleWatchEvent` never refreshes it.
- `useEnsureTask` prefers a cached `localHit` and `fetchThread` short-circuits on it, so the viewer's `activeTask` stays a pre-repo snapshot.

Result: `preview-tab` reads `activeTask.metadata.githubRepo` (absent) → empty state; and the owner-keyed sandbox lookup (from the read-only preview fix) finds no `sandboxMap` entry → no preview.

## Fix
On opening a read-only teammate thread, force one fresh `COLLECTION_THREADS_GET` and merge it into the store via a new `ThreadManagerStore.refreshThreadMetadata(id)` — **update-only** (guards on the row already being loaded), so it can never insert a teammate's thread into the scoped panel list. `activeTask` then carries the current `githubRepo` + `sandboxMap`, fixing **both** the preview gate and the owner-sandbox preview.

- New hook `useRefreshViewedThreadMetadata`, gated to others' threads (`created_by !== me`). No-op for your own thread (kept current by the live stream).
- Fires once per `(org, thread)` (`staleTime: Infinity`).

## Testing
- `tsc --noEmit` clean (apps/web).
- No `useEffect` (uses `useQuery`); query key is a `KEYS` constant.

## Notes / follow-ups
- Ceiling (marked `ponytail:`): a teammate's thread that binds a repo *while you're already watching it* won't refresh until reload — add a finite `staleTime`/refetch if that matters.
- Secondary gap (not fixed here): for a **repo-on-agent** thread (repo on `activeTask.virtual_mcp_id`'s agent metadata, opened read-only without `?virtualmcpid=`), the preview resolves the URL's Super Agent and never the thread's own agent. Follow-up: resolve `useVirtualMCP(activeTask.virtual_mcp_id)` in the clonable-source check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing repo preview when opening a teammate’s thread by force-refreshing thread metadata so `githubRepo` and `sandboxMap` are up to date. Prevents the “No source to preview / Connect GitHub” state and restores the owner’s sandbox preview.

- **Bug Fixes**
  - Added `ThreadManagerStore.refreshThreadMetadata(id)` to fetch and merge fresh metadata via `COLLECTION_THREADS_GET` (update-only).
  - Introduced `useRefreshViewedThreadMetadata` to trigger a one-time refresh for read-only teammate threads; no-op for your own.
  - Wired the hook into `agent-shell-layout` and added a `KEYS.viewedThreadMetadataRefresh` query key.

<sup>Written for commit 5c178c284a5da6023e8759d4f3a816a679a553b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

