### PR TITLE
refactor(file-storage): remove unused orgFsChangeSubject export

### DIFF
--- a/apps/api/src/file-storage/org-fs-notify.test.ts
+++ b/apps/api/src/file-storage/org-fs-notify.test.ts
@@ -1,15 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import {
-  notifyOrgFsChange,
-  orgFsChangeSubject,
-  orgFsChangeSubjects,
-} from "./org-fs-notify";
+import { notifyOrgFsChange, orgFsChangeSubjects } from "./org-fs-notify";
 
 describe("org-fs NATS compatibility subjects", () => {
   test("returns the canonical subject first and its legacy alias second", () => {
-    expect(orgFsChangeSubject("org-1", "home")).toBe(
-      "studio.org-fs.changes.org-1.home",
-    );
     expect(orgFsChangeSubjects("org-1", "home")).toEqual([
       "studio.org-fs.changes.org-1.home",
       "mesh.org-fs.changes.org-1.home",
@@ -17,7 +10,7 @@ describe("org-fs NATS compatibility subjects", () => {
   });
 
   test("rejects unsafe NATS subject tokens", () => {
-    expect(orgFsChangeSubject("org.with.dot", "home")).toBeNull();
+    expect(orgFsChangeSubjects("org.with.dot", "home")).toEqual([]);
     expect(orgFsChangeSubjects("org-1", "volume.*")).toEqual([]);
   });
 

--- a/apps/api/src/file-storage/org-fs-notify.ts
+++ b/apps/api/src/file-storage/org-fs-notify.ts
@@ -19,21 +19,12 @@ const SUBJECT_PREFIXES = [
 ] as const;
 
 /**
- * NATS subject for a volume's change notifications, or null if either token
- * contains a character that isn't safe in a subject (`.`, `*`, `>`, ws). Volume
- * is already validated upstream; orgId is server-controlled — the guard is
- * defensive, and a null subject just means the long-poll falls back to its
- * timeout safety net.
+ * Canonical subject plus the legacy alias used during rolling upgrades, or []
+ * if either token contains a character that isn't safe in a subject (`.`,
+ * `*`, `>`, ws). Volume is already validated upstream; orgId is
+ * server-controlled — the guard is defensive, and empty subjects just mean
+ * the long-poll falls back to its timeout safety net.
  */
-export function orgFsChangeSubject(
-  orgId: string,
-  volume: string,
-): string | null {
-  if (/[.*>\s]/.test(orgId) || /[.*>\s]/.test(volume)) return null;
-  return `${SUBJECT_PREFIXES[0]}.${orgId}.${volume}`;
-}
-
-/** Canonical subject plus the legacy alias used during rolling upgrades. */
 export function orgFsChangeSubjects(orgId: string, volume: string): string[] {
   if (/[.*>\s]/.test(orgId) || /[.*>\s]/.test(volume)) return [];
   return SUBJECT_PREFIXES.map((prefix) => `${prefix}.${orgId}.${volume}`);


### PR DESCRIPTION
Net code reduction found while auditing `apps/api/src/file-storage/` (org-fs filesystem abstraction).

`org-fs-notify.ts` exports both `orgFsChangeSubject` (singular) and `orgFsChangeSubjects` (plural, added in today's #5120 apps/mesh -> apps/api split, which also introduced the dual studio/mesh subject-alias for rolling upgrades). `rg` across the repo (`.ts`/`.tsx` and non-TS sources) shows the singular function has zero callers outside its own test file — the one real caller, `apps/api/src/api/routes/org-fs.ts`, only ever imports the plural `orgFsChangeSubjects`. This PR deletes the dead singular export and the test cases that only existed to cover it.

Net delta: -23 / +7 lines. Behavior-preserving: the plural function and `notifyOrgFsChange` (its only consumer) are untouched; only the unused function and its now-redundant assertions are removed.

Reviewer command: `bun test apps/api/src/file-storage/org-fs-notify.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), and the targeted test file above (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `orgFsChangeSubject` export and its tests to standardize on `orgFsChangeSubjects`. No behavior change; `notifyOrgFsChange` continues to use the plural subjects and invalid tokens still yield an empty list.

<sup>Written for commit 0468b52c3ca8c532faa42ba54bc44483a1dde5ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

