### PR TITLE
fix(settings): validate NODE_ENV instead of passing an unrecognized value through

### DIFF
--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -200,6 +200,26 @@ describe("resolveConfig Studio environment aliases", () => {
   });
 });
 
+describe("resolveConfig NODE_ENV", () => {
+  it("defaults to development when unset", () => {
+    const result = resolveConfig(flags, {});
+
+    expect(result.settings.nodeEnv).toBe("development");
+  });
+
+  it("accepts a valid NODE_ENV", () => {
+    const result = resolveConfig(flags, { NODE_ENV: "production" });
+
+    expect(result.settings.nodeEnv).toBe("production");
+  });
+
+  it("coerces an unrecognized NODE_ENV to development instead of passing it through", () => {
+    const result = resolveConfig(flags, { NODE_ENV: "Production" });
+
+    expect(result.settings.nodeEnv).toBe("development");
+  });
+});
+
 describe("resolveShutdownDrainMs", () => {
   const forceExitMs = 115_000;
 

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -19,6 +19,24 @@ function resolveDispatchRole(raw: string | undefined): DispatchRole {
     : "all";
 }
 
+const NODE_ENVS = new Set<Settings["nodeEnv"]>([
+  "production",
+  "development",
+  "test",
+]);
+
+/**
+ * Normalize `NODE_ENV`; anything unknown coerces to safe "development" rather
+ * than silently flowing an unvalidated string into `nodeEnv === "production"`
+ * checks that gate production-only behavior (e.g. sandbox `isProduction`).
+ */
+function resolveNodeEnv(raw: string | undefined): Settings["nodeEnv"] {
+  const value = (raw ?? "").trim();
+  return NODE_ENVS.has(value as Settings["nodeEnv"])
+    ? (value as Settings["nodeEnv"])
+    : "development";
+}
+
 // The shutdown drain only exists to outlast NLB ip-target deregistration of the
 // frontdoor HTTP listener. "worker" pods aren't frontdoor targets (no
 // `decocms.com/frontdoor` label), so draining just steals the grace budget
@@ -137,7 +155,7 @@ export function resolveConfig(
 
   const localMode = flags.localMode;
   const nodeEnv: Settings["nodeEnv"] =
-    flags.nodeEnv || (envVars.NODE_ENV as Settings["nodeEnv"]) || "development";
+    flags.nodeEnv || resolveNodeEnv(envVars.NODE_ENV);
 
   const natsRaw = envVars.NATS_URL || "nats://localhost:4222";
   const natsTunnelPublicEnabled =


### PR DESCRIPTION
Follows the settings/resolve-config.ts hardening area — `resolveConfig` already validates `STUDIO_DISPATCH_ROLE` and `STUDIO_SANDBOX_PROVIDER` against a `Set` with a safe fallback, but `NODE_ENV` was the odd one out: it was cast straight to the `nodeEnv` union (`envVars.NODE_ENV as Settings["nodeEnv"]`) with no membership check.

**Why it matters**: `getSettings().nodeEnv === "production"` gates production-only behavior in `apps/api/src/tools/sandbox/start.ts` (`isProduction`) and `apps/api/src/api/routes/decopilot/dispatch-run.ts`. A misconfigured or typo'd `NODE_ENV` (e.g. `"Production"`, `"prod"`) would silently flow through as an invalid `nodeEnv` value, and every strict `=== "production"` check would then silently take the non-production branch instead of failing loudly.

**Fix**: added `resolveNodeEnv()`, following the exact same pattern as the neighboring `resolveDispatchRole()`/`resolveSandboxProviderKind()` — validates against `["production", "development", "test"]` and coerces anything unrecognized to the existing safe default (`"development"`), same as the prior fallback behavior for an unset var.

**Verify**: `cd apps/api && bunx tsc --noEmit` (clean) and `bun test apps/api/src/settings/resolve-config.test.ts` (44 pass, includes 3 new cases: default, valid value, and an unrecognized value like `"Production"` coercing to `"development"` instead of passing through).

Ran locally: `bun run fmt`, targeted `tsc --noEmit` in `apps/api`, and the single targeted test file above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `NODE_ENV` in `resolveConfig` and coerce unknown values to `development` so production-only checks don’t silently downgrade due to typos (e.g., "Production").

- **Bug Fixes**
  - Introduced `resolveNodeEnv()` that allows `production`, `development`, `test`; falls back to `development` for anything else.
  - Wired `resolveConfig` to use this resolver instead of casting; added tests for default, valid, and invalid values.

<sup>Written for commit fc5b96a5a08bf53970814297eb96f081a722de49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

