### PR TITLE
fix(sandbox): reject empty base string in git/diff POST endpoint

### DIFF
--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -346,6 +346,23 @@ describe("git routes", () => {
     });
   });
 
+  it("diff POST rejects an empty base string as invalid input", async () => {
+    const { appRoot, repoDir } = initRepo();
+    const handler = makeGitDiffHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/diff", {
+        method: "POST",
+        body: JSON.stringify({ base: "" }),
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "base is required when provided",
+    });
+  });
+
   it("publish appends operator co-author trailer", async () => {
     const { appRoot, repoDir } = initRepo();
     onFeatureBranch(repoDir);

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -743,13 +743,24 @@ export function makeGitDiffHandler(deps: GitDeps) {
             base?: string;
             headSha?: string;
           };
-          const rawBase = typeof body.base === "string" ? body.base.trim() : "";
+          // If base is provided but empty after trim, that's a client error.
+          if ("base" in body) {
+            const rawBase =
+              typeof body.base === "string" ? body.base.trim() : "";
+            if (!rawBase) {
+              return jsonResponse(
+                { error: "base is required when provided" },
+                400,
+              );
+            }
+            base = rawBase;
+          }
           const rawHead =
             typeof body.headSha === "string" ? body.headSha.trim() : "";
-          if (rawBase) base = rawBase;
           if (rawHead) headSha = rawHead;
-        } catch {
-          // Empty body → working-tree diff.
+        } catch (e) {
+          if (e instanceof Response) throw e; // Re-throw early-exit responses
+          // Unparseable body → working-tree diff.
         }
       }
 
@@ -758,6 +769,7 @@ export function makeGitDiffHandler(deps: GitDeps) {
         : await computeDiff(deps.repoDir);
       return jsonResponse(result);
     } catch (err) {
+      if (err instanceof Response) return err; // Handle early-exit responses
       if (err instanceof InvalidRemoteBranchNameError) {
         return jsonResponse({ error: err.message }, 400);
       }


### PR DESCRIPTION
## Summary
The /git/diff handler accepted `base: ""` (empty string) in the request body but silently fell back to returning a working-tree diff instead of treating it as a validation error. An empty base is a client mistake, not a request for the default behavior — rejecting it with 400 makes the intent explicit and catches bugs earlier.

## Failure scenario
Client sends `POST /git/diff { base: "" }` → handler returns 200 with working-tree diff instead of 400 validation error → client gets unexpected result (working-tree diff when they thought they were requesting a base-branch diff).

## Regression test
Added `"diff POST rejects an empty base string as invalid input"` to verify empty base strings are rejected with 400 and a clear error message.

## Net diff
**-4 / +33**: Added validation branch in the handler + added 1 regression test.

## Verification
- `bun run fmt` ✓
- `bunx tsc --noEmit` in packages/sandbox ✓
- `bun test packages/sandbox/daemon/routes/git.test.ts` — all 36 tests pass ✓

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject empty base strings in `POST /git/diff` by returning 400 instead of silently falling back to a working-tree diff. This makes client mistakes obvious and prevents confusing results.

- **Bug Fixes**
  - Return 400 with `{ error: "base is required when provided" }` when `base: ""` is sent.
  - Keep default behavior: missing `base` or an unparseable body still yields a working-tree diff.
  - Add a regression test for the empty `base` case.

<sup>Written for commit 357fa5729c1adfa1182800589100460b8daefb33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

