### PR TITLE
fix(sections-editor): cancel pending section autosave before page-variant restructuring

### DIFF
--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -1893,6 +1893,16 @@ export function SectionsEditor({
     // so reordering/deleting/duplicating variants here would land that stale
     // write on the wrong (or now-missing) variant.
     cancelPendingRuleSaves();
+    // Also cancel a pending section-field autosave — it captures a section
+    // index at schedule time and writes into the *current* variant's
+    // `rawSections[index]` (read fresh via latestRef) when it fires.
+    // Reordering/deleting/duplicating a page variant here can shift which
+    // variant is active, so a still-pending timer would land its stale write
+    // on the wrong variant's section.
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
     const fullPageData = decofile[activePageKey] as Record<string, unknown>;
     const current = fullPageData.sections;
     if (!current || typeof current !== "object" || Array.isArray(current))


### PR DESCRIPTION
Follows #5146/#5148/#5152, which cancelled the same class of stale-debounce-timer bugs on section CRUD and page-variant rule autosave, but missed this trigger.

`mutatePageVariants` (used by reorder/delete/duplicate page variant) already cancels the pending page-rule autosave (`cancelPendingRuleSaves()`) before restructuring the `variants` array, but does not cancel the pending section-field autosave (`debounceRef`).

**Failure scenario:** a user edits a field on the currently-selected section (scheduling a 700ms debounced autosave that captures the section index at schedule time), then reorders, deletes, or duplicates a page variant before that timer fires. Since `scheduleAutoSave`'s callback reads `rawSections`/`activePageKey`/`decofile` fresh from `latestRef` at fire time — which by then reflects the *post-restructuring* state — the stale write lands on whatever section now sits at that index in the (possibly different) active variant, silently corrupting unrelated content.

Fix: cancel `debounceRef` in `mutatePageVariants` too, mirroring the same cancellation already done in `savePageSections` for the analogous section-CRUD case.

**To confirm:** select a section, start typing in its form (schedules the field autosave), then within 700ms reorder/delete/duplicate a page variant — the pending field write is now dropped instead of landing on the wrong section.

**Verification run locally:** `bun run fmt` and `cd apps/web && bunx tsc --noEmit` (both clean). No existing test covers this component (consistent with #5146/#5148/#5152, which also shipped without one) — full CI runs the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel pending section-field autosave when reordering, deleting, or duplicating page variants to prevent stale writes landing on the wrong section. Mirrors existing rule autosave cancellation to stop silent content corruption.

- **Bug Fixes**
  - In `mutatePageVariants`, clear `debounceRef` before restructuring variants, alongside `cancelPendingRuleSaves()`.
  - Drops an in-flight section autosave if a variant change happens within the debounce window.

<sup>Written for commit e64f0a8049634fd0f39b556ea75fec73dec9a8c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

