### PR TITLE
fix(settings): fall back to computed drain default on malformed SHUTDOWN_DRAIN_MS

### DIFF
--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -216,4 +216,11 @@ describe("resolveShutdownDrainMs", () => {
     expect(resolveShutdownDrainMs("worker", forceExitMs, "5000")).toBe(5_000);
     expect(resolveShutdownDrainMs("api", forceExitMs, "0")).toBe(0);
   });
+
+  it("falls back to the computed default on a malformed override instead of skipping the drain", () => {
+    expect(resolveShutdownDrainMs("api", forceExitMs, "not-a-number")).toBe(
+      69_000,
+    );
+    expect(resolveShutdownDrainMs("api", forceExitMs, "-100")).toBe(69_000);
+  });
 });

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -29,9 +29,14 @@ export function resolveShutdownDrainMs(
   forceExitMs: number,
   envOverride: string | undefined,
 ): number {
-  return Number(
-    envOverride ?? (role === "worker" ? 0 : Math.floor(forceExitMs * 0.6)),
-  );
+  const fallback = role === "worker" ? 0 : Math.floor(forceExitMs * 0.6);
+  if (envOverride === undefined || envOverride === "") return fallback;
+  // A malformed override must fall back to the computed default rather than
+  // silently becoming 0 (NaN/negative both collapse to a 0ms sleep) — that
+  // would skip the drain this function exists for and reintroduce the CF 520s
+  // described above.
+  const value = Number(envOverride);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
 }
 
 function toBool(value: string | undefined): boolean {


### PR DESCRIPTION
Follows the same config-hardening lane as #5173 (NODE_ENV) and #5130 (DUCKDB_THREADS): `resolveShutdownDrainMs` in `apps/api/src/settings/resolve-config.ts` passed `SHUTDOWN_DRAIN_MS` straight through `Number()` with no validation.

**Why this matters**: the function's own comment explains the drain exists to outlast NLB ip-target deregistration during rollout and avoid CF 520s on in-flight connections. A malformed override (typo, bad env injection, e.g. `SHUTDOWN_DRAIN_MS=abc` or a negative value) becomes `NaN`/negative, and the shared `sleep()`/`delay()` helper (`packages/shared/src/std/delay.ts`) silently collapses any `NaN` or negative delay to 0ms — silently skipping the drain instead of erroring, reintroducing the exact 520 failure mode the drain was added to prevent.

**Fix**: an invalid override now falls back to the computed per-role default (0 for `worker`, ~60% of the force-exit budget otherwise) instead of silently becoming a 0ms no-op drain.

**Regression test**: added two cases to the existing `resolveShutdownDrainMs` describe block in `resolve-config.test.ts` — a non-numeric string and a negative number both now resolve to the computed default instead of 0.

**Reviewer command**: `bun test apps/api/src/settings/resolve-config.test.ts`

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` in `apps/api`, and the targeted test file above (42 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the shutdown drain isn’t skipped when `SHUTDOWN_DRAIN_MS` is malformed by falling back to a computed default instead of passing through a bad `Number()` result. This keeps drains active during rollouts and helps avoid CF 520s.

- **Bug Fixes**
  - Validate `SHUTDOWN_DRAIN_MS` and only accept finite, non-negative values; otherwise use the per-role default (worker: 0ms, others: ~60% of force-exit).
  - Added tests for non-numeric and negative overrides in `resolveShutdownDrainMs`.

<sup>Written for commit 0d4bd8a5e80693cd9ff896235ed2a86f3672967c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

