### PR TITLE
fix(runtime): guard StudioKV.get against malformed trigger state

### DIFF
--- a/packages/runtime/src/trigger-storage.test.ts
+++ b/packages/runtime/src/trigger-storage.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { StudioKV } from "./trigger-storage.ts";
+
+describe("StudioKV.get", () => {
+  const kv = new StudioKV({ url: "https://studio.test", apiKey: "key" });
+
+  it("returns null instead of throwing on an unparseable JSON body", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("not json", { status: 200 }),
+    );
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const state = await kv.get("conn_1");
+
+    expect(state).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("returns null instead of trusting a malformed trigger state shape", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        value: { credentials: { callbackUrl: "https://x" } },
+      }),
+    );
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const state = await kv.get("conn_1");
+
+    expect(state).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("returns the state when it matches the expected shape", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        value: {
+          credentials: { callbackUrl: "https://x", callbackToken: "tok" },
+          activeTriggerTypes: ["github.push"],
+        },
+      }),
+    );
+
+    const state = await kv.get("conn_1");
+
+    expect(state).toEqual({
+      credentials: { callbackUrl: "https://x", callbackToken: "tok" },
+      activeTriggerTypes: ["github.push"],
+    });
+  });
+});

--- a/packages/runtime/src/trigger-storage.ts
+++ b/packages/runtime/src/trigger-storage.ts
@@ -7,6 +7,16 @@
 
 import type { TriggerState, TriggerStorage } from "./triggers.ts";
 
+/** Guards against malformed/partial state crossing the Studio KV HTTP boundary. */
+function isTriggerState(value: unknown): value is TriggerState {
+  if (!value || typeof value !== "object") return false;
+  const { credentials, activeTriggerTypes } = value as Record<string, unknown>;
+  if (!Array.isArray(activeTriggerTypes)) return false;
+  if (!credentials || typeof credentials !== "object") return false;
+  const { callbackUrl, callbackToken } = credentials as Record<string, unknown>;
+  return typeof callbackUrl === "string" && typeof callbackToken === "string";
+}
+
 // ============================================================================
 // StudioKV — backed by Studio's /api/kv endpoint
 // ============================================================================
@@ -67,8 +77,24 @@ export class StudioKV implements TriggerStorage {
       return null;
     }
 
-    const body = (await res.json()) as { value?: TriggerState };
-    return body.value ?? null;
+    let body: { value?: unknown };
+    try {
+      body = (await res.json()) as { value?: unknown };
+    } catch (err) {
+      console.error(`[StudioKV] GET returned unparseable JSON:`, err);
+      return null;
+    }
+
+    if (body.value == null) return null;
+
+    if (!isTriggerState(body.value)) {
+      console.error(
+        `[StudioKV] GET returned malformed trigger state for connection=${connectionId}`,
+      );
+      return null;
+    }
+
+    return body.value;
   }
 
   async set(connectionId: string, state: TriggerState): Promise<void> {


### PR DESCRIPTION
Bug found while auditing `@decocms/runtime`'s trigger-storage.ts for how it handles unexpected input from its network boundary.

`StudioKV.get()` (packages/runtime/src/trigger-storage.ts) already treats a 404 or non-ok HTTP response as "no stored state" and returns `null`. But once the response is `ok`, it called `await res.json()` with no try/catch, and cast the parsed `value` straight to `TriggerState` with no shape check. So:
- a 200 response with a non-JSON body threw uncaught out of `get()`
- a 200 response with valid-but-wrong-shaped JSON (e.g. missing `callbackToken`, or `activeTriggerTypes` not an array) was returned as if it were trusted state

Downstream, `TriggerStateManager.loadFromStorage` (triggers.ts) does `new Set(state.activeTriggerTypes)` and later `deliverCallback` calls `fetch(credentials.callbackUrl, ...)` with `Authorization: Bearer ${credentials.callbackToken}` — both crash on `undefined`/non-array input instead of degrading gracefully, the same way the existing 404/non-ok branches already do.

This is exactly the trust-boundary case call for a regression test: `StudioKV.get()` parses an untrusted network response (Studio's `/api/kv` endpoint) that directly feeds a webhook-delivery credential/URL used in a real `fetch()` call — a malformed response previously crashed trigger delivery instead of being treated as absent state.

Fix: wrap the `res.json()` parse in try/catch, and validate the parsed value against the `TriggerState` shape (`credentials.callbackUrl`/`callbackToken` strings, `activeTriggerTypes` array) before trusting it — logging and returning `null` in both malformed cases, consistent with the existing 404/non-ok handling.

Added `packages/runtime/src/trigger-storage.test.ts` covering: unparseable JSON body, well-formed-but-wrong-shape JSON, and the happy path (valid shape still round-trips correctly).

To confirm: `bun test packages/runtime/src/trigger-storage.test.ts`

Locally verified: `bun run fmt`, `cd packages/runtime && bunx tsc --noEmit`, and the targeted test file above (plus the pre-existing `packages/runtime/src/triggers.test.ts` still passes). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `StudioKV.get` in `@decocms/runtime` to treat malformed or unparseable JSON as absent trigger state, preventing crashes during trigger delivery. Aligns behavior with existing 404/non-ok handling.

- **Bug Fixes**
  - Wrap `res.json()` in try/catch; log and return `null` on parse errors.
  - Validate response against `TriggerState` shape; log and return `null` when invalid.
  - Avoids crashes in downstream `TriggerStateManager` when credentials or `activeTriggerTypes` are missing.
  - Added tests for unparseable JSON, wrong-shaped JSON, and happy path.

<sup>Written for commit 307088881891f4a98855219ed72573f78920da5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

