### PR TITLE
fix(virtual-mcp): scope plugin config get/update to the caller's organization

### DIFF
--- a/apps/api/src/tools/virtual/plugin-config-get.test.ts
+++ b/apps/api/src/tools/virtual/plugin-config-get.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, mock } from "bun:test";
+import { VIRTUAL_MCP_PLUGIN_CONFIG_GET } from "./plugin-config-get";
+
+function makeCtx(opts: {
+  organizationId: string;
+  connections: Record<string, { id: string; organization_id: string }>;
+}) {
+  const get = mock(async () => ({
+    id: "vpc_1",
+    virtualMcpId: "vmcp_a",
+    pluginId: "code-execution",
+    connectionId: null,
+    settings: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  }));
+  const ctx = {
+    auth: { user: { id: "user-1" } },
+    organization: { id: opts.organizationId },
+    access: { check: mock(async () => {}) },
+    storage: {
+      connections: {
+        findById: mock(async (id: string) => opts.connections[id] ?? null),
+      },
+      virtualMcpPluginConfigs: { get },
+    },
+  } as unknown as Parameters<typeof VIRTUAL_MCP_PLUGIN_CONFIG_GET.handler>[1];
+  return { ctx, get };
+}
+
+describe("VIRTUAL_MCP_PLUGIN_CONFIG_GET", () => {
+  it("returns null instead of leaking a config from another organization", async () => {
+    // Regression: virtualMcpId was passed straight to storage with no check
+    // against ctx.organization — access.check() only verifies the caller's
+    // permissions within their own org.
+    const { ctx, get } = makeCtx({
+      organizationId: "org-a",
+      connections: {
+        vmcp_other: { id: "vmcp_other", organization_id: "org-b" },
+      },
+    });
+
+    const result = await VIRTUAL_MCP_PLUGIN_CONFIG_GET.handler(
+      { virtualMcpId: "vmcp_other", pluginId: "code-execution" },
+      ctx,
+    );
+
+    expect(result.config).toBeNull();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("returns the config for a virtual MCP within the caller's own organization", async () => {
+    const { ctx, get } = makeCtx({
+      organizationId: "org-a",
+      connections: { vmcp_a: { id: "vmcp_a", organization_id: "org-a" } },
+    });
+
+    const result = await VIRTUAL_MCP_PLUGIN_CONFIG_GET.handler(
+      { virtualMcpId: "vmcp_a", pluginId: "code-execution" },
+      ctx,
+    );
+
+    expect(result.config?.virtualMcpId).toBe("vmcp_a");
+    expect(get).toHaveBeenCalledWith("vmcp_a", "code-execution");
+  });
+});

--- a/apps/api/src/tools/virtual/plugin-config-get.ts
+++ b/apps/api/src/tools/virtual/plugin-config-get.ts
@@ -6,7 +6,7 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { requireAuth } from "../../core/studio-context";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
 
 const serializedPluginConfigSchema = z.object({
   id: z.string(),
@@ -41,11 +41,24 @@ export const VIRTUAL_MCP_PLUGIN_CONFIG_GET = defineTool({
   handler: async (input, ctx) => {
     // Require authentication
     requireAuth(ctx);
+    const organization = requireOrganization(ctx);
 
     // Check authorization
     await ctx.access.check();
 
     const { virtualMcpId, pluginId } = input;
+
+    // `ctx.access.check()` only verifies the caller's permissions in
+    // `ctx.organization` — it doesn't know `virtualMcpId` belongs to it, so a
+    // caller could otherwise read another org's plugin config by ID.
+    const parentConnection =
+      await ctx.storage.connections.findById(virtualMcpId);
+    if (
+      !parentConnection ||
+      parentConnection.organization_id !== organization.id
+    ) {
+      return { config: null };
+    }
 
     const config = await ctx.storage.virtualMcpPluginConfigs.get(
       virtualMcpId,

--- a/apps/api/src/tools/virtual/plugin-config-update.test.ts
+++ b/apps/api/src/tools/virtual/plugin-config-update.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, mock } from "bun:test";
+import { VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE } from "./plugin-config-update";
+
+function makeCtx(opts: {
+  organizationId: string;
+  connections: Record<string, { id: string; organization_id: string }>;
+}) {
+  const upsert = mock(async () => ({
+    id: "vpc_1",
+    virtualMcpId: "vmcp_a",
+    pluginId: "code-execution",
+    connectionId: null,
+    settings: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  }));
+  const ctx = {
+    auth: { user: { id: "user-1" } },
+    organization: { id: opts.organizationId },
+    access: { check: mock(async () => {}) },
+    storage: {
+      connections: {
+        findById: mock(async (id: string) => opts.connections[id] ?? null),
+        create: mock(async () => {}),
+      },
+      virtualMcpPluginConfigs: { upsert },
+    },
+  } as unknown as Parameters<
+    typeof VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE.handler
+  >[1];
+  return { ctx, upsert };
+}
+
+describe("VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE", () => {
+  it("rejects a virtual MCP id belonging to a different organization", async () => {
+    // Regression: neither the virtual-MCP row nor the connection being bound
+    // was checked against ctx.organization — access.check() only verifies
+    // the caller's permissions within their own org, so a caller could
+    // reconfigure another org's virtual MCP plugin by guessing its ID.
+    const { ctx, upsert } = makeCtx({
+      organizationId: "org-a",
+      connections: {
+        vmcp_other: { id: "vmcp_other", organization_id: "org-b" },
+      },
+    });
+
+    await expect(
+      VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE.handler(
+        { virtualMcpId: "vmcp_other", pluginId: "code-execution" },
+        ctx,
+      ),
+    ).rejects.toThrow(/not found/i);
+
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects binding a connection owned by a different organization", async () => {
+    const { ctx, upsert } = makeCtx({
+      organizationId: "org-a",
+      connections: {
+        vmcp_a: { id: "vmcp_a", organization_id: "org-a" },
+        conn_other: { id: "conn_other", organization_id: "org-b" },
+      },
+    });
+
+    await expect(
+      VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE.handler(
+        {
+          virtualMcpId: "vmcp_a",
+          pluginId: "code-execution",
+          connectionId: "conn_other",
+        },
+        ctx,
+      ),
+    ).rejects.toThrow(/not found/i);
+
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("allows updating a plugin config within the caller's own organization", async () => {
+    const { ctx, upsert } = makeCtx({
+      organizationId: "org-a",
+      connections: {
+        vmcp_a: { id: "vmcp_a", organization_id: "org-a" },
+        conn_a: { id: "conn_a", organization_id: "org-a" },
+      },
+    });
+
+    const result = await VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE.handler(
+      {
+        virtualMcpId: "vmcp_a",
+        pluginId: "code-execution",
+        connectionId: "conn_a",
+      },
+      ctx,
+    );
+
+    expect(result.config.virtualMcpId).toBe("vmcp_a");
+    expect(upsert).toHaveBeenCalledWith("vmcp_a", "code-execution", {
+      connectionId: "conn_a",
+      settings: undefined,
+    });
+  });
+});

--- a/apps/api/src/tools/virtual/plugin-config-update.ts
+++ b/apps/api/src/tools/virtual/plugin-config-update.ts
@@ -6,7 +6,11 @@
 
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import { getUserId, requireAuth } from "../../core/studio-context";
+import {
+  getUserId,
+  requireAuth,
+  requireOrganization,
+} from "../../core/studio-context";
 import {
   createDevAssetsConnectionEntity,
   isDevAssetsConnection,
@@ -57,6 +61,7 @@ export const VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE = defineTool({
   handler: async (input, ctx) => {
     // Require authentication
     requireAuth(ctx);
+    const organization = requireOrganization(ctx);
 
     // Check authorization
     await ctx.access.check();
@@ -69,10 +74,26 @@ export const VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE = defineTool({
     if (!parentConnection) {
       throw new Error(`Connection not found: ${virtualMcpId}`);
     }
+    // `ctx.access.check()` only verifies the caller's permissions in
+    // `ctx.organization` — without this, a caller could target another org's
+    // virtual MCP by ID and bind/reconfigure its plugin.
+    if (parentConnection.organization_id !== organization.id) {
+      throw new Error(`Connection not found: ${virtualMcpId}`);
+    }
 
     const connectionExists = connectionId
       ? await ctx.storage.connections.findById(connectionId)
       : null;
+    // Same tenant boundary for the connection being bound: an existing
+    // connection from another org must not be adoptable into this org's
+    // plugin config.
+    if (
+      connectionId &&
+      connectionExists &&
+      connectionExists.organization_id !== organization.id
+    ) {
+      throw new Error(`Connection not found: ${connectionId}`);
+    }
 
     if (
       connectionId &&


### PR DESCRIPTION
**Source:** bug found while auditing the virtual-MCP client/tools surface (`apps/api/src/tools/virtual/`) for error propagation and defensive checks.

**The bug:** `VIRTUAL_MCP_PLUGIN_CONFIG_GET` and `VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE` took `virtualMcpId` (and, on update, `connectionId`) straight to storage with no ownership check. `ctx.access.check()` only verifies the caller's *permissions within their own org* — it has no idea whether the `virtualMcpId`/`connectionId` in the request actually belong to that org. Every sibling tool in this folder (`get.ts`, `update.ts`, `delete.ts` for the virtual MCP entity itself) already re-checks `existing.organization_id !== organization.id` after the lookup; these two plugin-config tools were missing that check entirely.

**Failure scenario:** any authenticated member of *any* org who learns/guesses another org's virtual-MCP ID (e.g. `vir_...`, visible in URLs/logs) could call `VIRTUAL_MCP_PLUGIN_CONFIG_GET` to read that org's plugin settings, or call `VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE` to overwrite them — including rebinding the plugin to point at a *different* connection they also don't own, since `connectionId` wasn't org-checked either.

**Fix:** both tools now call `requireOrganization(ctx)` and verify the resolved connection(s) belong to that organization before proceeding — `GET` returns `{ config: null }` (matches the existing not-found style, avoids leaking existence), `UPDATE` throws `Connection not found` (matches `delete.ts`'s style for a foreign-org row).

**Regression tests:** `apps/api/src/tools/virtual/plugin-config-get.test.ts` and `plugin-config-update.test.ts` — each has a test that reproduces the cross-org read/write with the old code (would pass with the bug present) and a happy-path same-org test.

**To verify:** `cd apps/api && bun test src/tools/virtual/plugin-config-get.test.ts src/tools/virtual/plugin-config-update.test.ts`

**Locally ran:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace, clean), and the two targeted test files above (5 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes virtual MCP plugin config get/update to the caller’s organization to prevent cross‑org reads and writes. Closes an access control gap with tenant checks and regression tests.

- **Bug Fixes**
  - Validate `virtualMcpId` and `connectionId` belong to the caller’s org using `requireOrganization` and `connections.findById` before proceeding in `VIRTUAL_MCP_PLUGIN_CONFIG_GET` and `VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE`.
  - `GET` returns `{ config: null }` for foreign/missing IDs; `UPDATE` throws `Connection not found`, matching existing patterns.
  - Added regression tests: `plugin-config-get.test.ts` and `plugin-config-update.test.ts` for cross‑org denial and same‑org success.

<sup>Written for commit 1fd48d737c6bd54ffd781c9238d72021a5e225bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

