### PR TITLE
fix(cli): validate --batch/--limit on backfill-assets instead of silently producing NaN

### DIFF
--- a/apps/api/src/cli.ts
+++ b/apps/api/src/cli.ts
@@ -16,6 +16,7 @@ import { parseArgs } from "util";
 import { homedir } from "os";
 import { join } from "path";
 import { resolveTui } from "./cli/resolve-tui";
+import { parsePositiveIntFlag } from "./cli/parse-positive-int-flag";
 
 const { values, positionals } = parseArgs({
   args: process.argv.slice(2),
@@ -226,10 +227,20 @@ if (command === "backfill-assets") {
     );
     process.exit(1);
   }
+  let batch = 500;
+  let limit: number | undefined;
+  try {
+    batch = parsePositiveIntFlag("batch", values.batch) ?? 500;
+    limit = parsePositiveIntFlag("limit", values.limit);
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+
   const code = await backfillThreadAssetsCommand({
     dryRun: values["dry-run"] === true,
-    batch: values.batch ? Number(values.batch) : 500,
-    limit: values.limit ? Number(values.limit) : undefined,
+    batch,
+    limit,
     baseUrl: values["base-url"],
     org: values.org as string | undefined,
     target: targetArg as "all" | "threads" | "connections" | "organizations",

--- a/apps/api/src/cli/parse-positive-int-flag.test.ts
+++ b/apps/api/src/cli/parse-positive-int-flag.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { parsePositiveIntFlag } from "./parse-positive-int-flag";
+
+describe("parsePositiveIntFlag", () => {
+  test("undefined when the flag wasn't passed", () => {
+    expect(parsePositiveIntFlag("batch", undefined)).toBeUndefined();
+  });
+
+  test("parses a positive integer", () => {
+    expect(parsePositiveIntFlag("batch", "500")).toBe(500);
+  });
+
+  test("rejects a non-numeric value", () => {
+    expect(() => parsePositiveIntFlag("batch", "abc")).toThrow(
+      'Invalid --batch "abc" — must be a positive integer.',
+    );
+  });
+
+  test("rejects zero and negative values", () => {
+    expect(() => parsePositiveIntFlag("limit", "0")).toThrow();
+    expect(() => parsePositiveIntFlag("limit", "-5")).toThrow();
+  });
+
+  test("rejects a non-integer value", () => {
+    expect(() => parsePositiveIntFlag("batch", "1.5")).toThrow();
+  });
+});

--- a/apps/api/src/cli/parse-positive-int-flag.ts
+++ b/apps/api/src/cli/parse-positive-int-flag.ts
@@ -1,0 +1,17 @@
+/**
+ * Parse a CLI flag as a positive integer, or `undefined` when the flag was
+ * not passed. Throws (naming the flag) on anything else — used to fail fast
+ * instead of letting `Number(raw)` produce a silent NaN that flows into a
+ * pagination limit (e.g. `LIMIT NaN` in a SQL query).
+ */
+export function parsePositiveIntFlag(
+  flag: string,
+  raw: string | undefined,
+): number | undefined {
+  if (raw === undefined) return undefined;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`Invalid --${flag} "${raw}" — must be a positive integer.`);
+  }
+  return value;
+}


### PR DESCRIPTION
Bug found by reading `apps/api/src/cli.ts` (the `backfill-assets` subcommand) — not tied to an issue.

`--batch` and `--limit` were passed straight through `Number(raw)` with no validation (`batch: values.batch ? Number(values.batch) : 500`, `limit: values.limit ? Number(values.limit) : undefined`). A malformed value (e.g. `--batch abc` or `--limit -1`) silently becomes `NaN`, which then flows into `runPaged`'s `Math.min(batch, remaining)` and Kysely's `.limit(take)` in `backfill-assets.ts` — producing a confusing SQL-level error deep in the DB layer instead of a clear CLI message at the entry point. This is the same bug class already fixed for `SHUTDOWN_DRAIN_MS` (#5177), `NODE_ENV` (#5173), and (in an open PR) `DUCKDB_THREADS` (#5130) in `resolve-config.ts` — this one just lives in the CLI flag parser instead of the settings pipeline.

Fix: extracted a small pure `parsePositiveIntFlag(flag, raw)` helper (`apps/api/src/cli/parse-positive-int-flag.ts`) that returns `undefined` when the flag is absent and throws a clear `Invalid --batch "abc" — must be a positive integer.` error otherwise. `cli.ts` now calls it for both flags before invoking `backfillThreadAssetsCommand`, catching and printing the error with `process.exit(1)` — matching the existing `--target` validation style right above it in the same command block.

Failure scenario before the fix: `deco backfill-assets --batch abc` would run past argument parsing and fail later with a raw SQL/driver error instead of telling the user their flag was invalid. Regression test: `apps/api/src/cli/parse-positive-int-flag.test.ts` covers the missing-flag, valid-value, non-numeric, zero/negative, and non-integer cases.

Reviewer check: `bun test apps/api/src/cli/parse-positive-int-flag.test.ts`

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test file above all pass. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `--batch` and `--limit` in the `backfill-assets` CLI to fail fast on invalid input, preventing silent `NaN` values and confusing SQL errors. Users now get clear, early error messages; defaults remain unchanged.

- **Bug Fixes**
  - Added `parsePositiveIntFlag` to parse positive integers or `undefined`, throwing `Invalid --<flag> "<value>" — must be a positive integer.` on bad input.
  - Applied it to `backfill-assets` and exit with code 1 on validation errors, matching existing `--target` checks.
  - Added unit tests covering missing flag, valid value, non-numeric, zero/negative, and non-integer cases.

<sup>Written for commit 565a4609579afae69d8b37b7b0cde13c2e7dcf62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

