### PR TITLE
fix(sections-editor): cancel pending section autosave before adding a page variant

### DIFF
--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -1843,6 +1843,14 @@ export function SectionsEditor({
     // firing after this mutation would clobber the newly-saved data with an
     // outdated variants array.
     cancelPendingRuleSaves();
+    // Also cancel a pending section-field autosave — it rebuilds
+    // `variants[latestVariantIndex]` from a `decofile` snapshot read at fire
+    // time, which may still predate this save's result, so a stale timer would
+    // clobber the newly-appended variant with an outdated variants array.
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
     const fullPageData = decofile[activePageKey] as Record<string, unknown>;
     const updatedSections = appendPageVariantSections(
       fullPageData.sections,


### PR DESCRIPTION
Follows #5176, which fixed `mutatePageVariants` (the delete/reorder/duplicate variant path) leaving a pending section-field autosave timer alive across a page-variant restructuring, letting a stale write land on the wrong variant. `handleAddPageVariant` (the "add page variant" path) does the exact same kind of restructuring — it already cancels the pending rule-autosave timers via `cancelPendingRuleSaves()` with a comment explicitly warning that "a stale save firing after this mutation would clobber the newly-saved data with an outdated variants array" — but it never cancelled the section-field autosave (`debounceRef`), which rebuilds `variants[latestVariantIndex]` from a `decofile` snapshot read at fire time exactly like the rule-autosave does.

Failure scenario: a user edits a section field (scheduling a debounced autosave), then within the debounce window clicks "Add page variant" before the edit's autosave has fired. If that stale timer fires after the append's optimistic cache update but before its variants array is fully settled, it overwrites `variants[latestVariantIndex]` with a decofile snapshot that predates the newly-appended variant, silently reverting the just-added variant.

Fix mirrors #5176 exactly: clear and null out `debounceRef.current` alongside `cancelPendingRuleSaves()` in `handleAddPageVariant`, with a comment explaining why (same rationale as the sibling `mutatePageVariants` fix).

Reviewer check: read `handleAddPageVariant` in apps/web/src/components/sections-editor/sections-editor.tsx and compare against `mutatePageVariants` (both cancel `cancelPendingRuleSaves()`; only `mutatePageVariants` previously also cleared `debounceRef`).

Verified locally: `bun run fmt` and `cd apps/web && bunx tsc --noEmit` both clean. This component is a large React component with no existing unit-test file (dedicated to it) — matches the precedent set by #5176, which also shipped without a new test since this class of race isn't unit-testable per TESTING.md (no mocks/DOM). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel pending section-field autosave before adding a page variant to prevent stale writes from overwriting the newly added variant. Fixes a race when a user edits a section and quickly adds a variant.

- **Bug Fixes**
  - In `handleAddPageVariant`, clear and null `debounceRef.current` alongside `cancelPendingRuleSaves()` to avoid clobbering `variants[latestVariantIndex]` with an outdated `decofile` snapshot.

<sup>Written for commit fd770f54590bd02cfc5e3b3d08af32eac11acb0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

