### PR TITLE
fix(sections-editor): make back button exit a multivariate section from its top level

### DIFF
--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -5,6 +5,7 @@ import {
   breadcrumbsForHeaderClick,
   buildArrayDrillDownBreadcrumb,
   consumedBreadcrumbPrefix,
+  headerBackTargetIndex,
   fieldDisplayLabel,
   findBreadcrumbLabelIndex,
   isArrayDrillDownField,
@@ -34,6 +35,27 @@ describe("breadcrumbsForHeaderClick", () => {
       "Global Sections",
       "Analytics",
     ]);
+  });
+});
+
+describe("headerBackTargetIndex", () => {
+  test("targets the parent of the last crumb by default", () => {
+    // [page, section] → back exits the section (index 0).
+    expect(headerBackTargetIndex(2, { isMultivariateSectionTop: false })).toBe(
+      0,
+    );
+    // [page, section, field] → back returns to the section top (index 1).
+    expect(headerBackTargetIndex(3, { isMultivariateSectionTop: false })).toBe(
+      1,
+    );
+  });
+
+  test("exits the section from a multivariate section top", () => {
+    // [page, section, variant] would resolve to index 1 (the redundant section
+    // crumb, a no-op). Back must exit the section instead.
+    expect(headerBackTargetIndex(3, { isMultivariateSectionTop: true })).toBe(
+      0,
+    );
   });
 });
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -144,6 +144,26 @@ export function fieldDisplayLabel(key: string, schema: SchemaProperty): string {
   return schema.title ?? humanize(key);
 }
 
+/**
+ * Header crumb index the top-bar back button ("<") should navigate to.
+ *
+ * Normally "back" targets the parent of the last crumb (`crumbCount - 2`). But a
+ * multivariate section renders its variant list AND the selected variant's form
+ * as one combined view, so the section-label crumb and the variant-label crumb
+ * collapse to the same navigation level (both map to `fieldBreadcrumbs = []`). At
+ * that top level `crumbCount - 2` points at the redundant section crumb, so back
+ * only clears the (already empty) field trail and appears to do nothing. Treat the
+ * variant top as a direct child of the section list instead, so back exits the
+ * section (index 0).
+ */
+export function headerBackTargetIndex(
+  crumbCount: number,
+  opts: { isMultivariateSectionTop: boolean },
+): number {
+  if (opts.isMultivariateSectionTop) return 0;
+  return crumbCount - 2;
+}
+
 /** Map a header crumb index to the breadcrumb trail (`headerCrumbs = [title, ...breadcrumbs]`). */
 export function breadcrumbsForHeaderClick(
   breadcrumbs: string[],

--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -49,6 +49,7 @@ import { MakeReusableModal } from "./make-reusable-modal";
 import { AddSectionModal } from "./add-section-modal";
 import type { SectionCatalogEntry } from "./section-catalog";
 import { SectionVariantList } from "./section-variant-list";
+import { headerBackTargetIndex } from "./schema-form-breadcrumb";
 import { ALWAYS_MATCHER_RESOLVE_TYPE, type RawSection } from "./section-types";
 import {
   buildMatcherBlockData,
@@ -1835,6 +1836,15 @@ export function SectionsEditor({
         ? editingBreadcrumbs
         : [globalBannerName]
       : editingBreadcrumbs;
+  // A multivariate section shows its variant list and the selected variant's
+  // form as one combined view, so the section-label and variant-label crumbs
+  // collapse to the same level. At that top level the back button must exit the
+  // section (not clear an already-empty field trail) — see headerBackTargetIndex.
+  const isMultivariateSectionTop =
+    !editingSeo &&
+    !isGlobalBlockMode &&
+    isEditingMultivariateSection &&
+    fieldBreadcrumbs.length === 0;
   const handleAddPageVariant = () => {
     if (!activePageKey) return;
     // Cancel a pending rule-autosave timer — it writes into
@@ -2414,7 +2424,13 @@ export function SectionsEditor({
               {headerCrumbs.length > 1 && (
                 <button
                   type="button"
-                  onClick={() => handleBreadcrumbClick(headerCrumbs.length - 2)}
+                  onClick={() =>
+                    handleBreadcrumbClick(
+                      headerBackTargetIndex(headerCrumbs.length, {
+                        isMultivariateSectionTop,
+                      }),
+                    )
+                  }
                   title={t("sectionsEditor.sectionsEditor.back")}
                   aria-label={t("sectionsEditor.sectionsEditor.back")}
                   className={cn(


### PR DESCRIPTION
## Summary

When you open a section that **has variants** (a multivariate section), the top-bar back button (`<`) did nothing.

The header breadcrumb is built differently for a multivariate section — it injects an extra crumb for the active variant:

- **Normal section:** `[page, section]`
- **Section with variants:** `[page, section, variant]`

The back button always navigated to the second-to-last crumb (`handleBreadcrumbClick(headerCrumbs.length - 2)`):

- Normal section → `handleBreadcrumbClick(0)` → `exitSectionEditing()` ✅ exits the section
- Section with variants → `handleBreadcrumbClick(1)` → just `setFieldBreadcrumbs([])`, which is already empty → **no-op** ❌

Root cause: a multivariate section renders its variant list *and* the selected variant's form as one combined view, so the section-label crumb and the variant-label crumb collapse to the same navigation level, making `length - 2` point at a redundant crumb.

## Changes

- Added pure helper `headerBackTargetIndex()` in `schema-form-breadcrumb.ts` — returns `0` (exit) at a multivariate section's top level, `crumbCount - 2` otherwise.
- Computed `isMultivariateSectionTop` in `sections-editor.tsx` and wired it into the back button's `onClick`.
- Added unit tests in `schema-form-breadcrumb.test.ts`.

Deeper field drill-down navigation inside a variant and direct crumb clicks are untouched — only the top-level back button behavior changed.

## Testing

- `bun run --cwd=apps/web check` (tsc) passes
- `bun test .../schema-form-breadcrumb.test.ts` — 42 pass
- `bun run fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the top-bar back button in multivariate sections so it exits the section from its top level instead of doing nothing. Non-variant sections and deeper field navigation are unchanged.

- **Bug Fixes**
  - Added `headerBackTargetIndex()` to compute the correct header crumb target; returns index 0 at a multivariate section’s top level.
  - Computed `isMultivariateSectionTop` in `sections-editor.tsx` and used the helper for the back button.
  - Added unit tests for `headerBackTargetIndex()`.

<sup>Written for commit bef4466cf9dbe10e93ebe6c2724330a24fe64b2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

