### PR TITLE
fix(sandbox): force-reprovision a provisioning session orphaned by a crashed start

### DIFF
--- a/apps/api/src/storage/agent-sandbox-sessions.integration.test.ts
+++ b/apps/api/src/storage/agent-sandbox-sessions.integration.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
 import { sharedSandboxId, userSandboxId } from "@decocms/sandbox/provider";
 import {
   closeTestPgDatabase,
@@ -160,5 +161,51 @@ describe("shared agent sandbox storage", () => {
       locked.completeDelete(locator, deleting.generation),
     );
     expect(await sessions.find(locator)).toBeNull();
+  });
+
+  it("force-reprovisions a provisioning row orphaned by a crashed start", async () => {
+    const locator = {
+      organizationId: "org_shared_sandbox",
+      virtualMcpId: "vm_orphaned",
+      branch: "feature/orphaned",
+    };
+    // Simulate a start that crashed after recording its handle but before
+    // completeStart/failStart: the row is stuck in `provisioning`.
+    const orphaned = await sessions.beginStart(locator, "user_1", null);
+    await sessions.recordProvisioningHandle(
+      locator,
+      orphaned.generation,
+      "zombie-handle",
+    );
+
+    // A recent provisioning row must NOT be reset — a genuine start may still
+    // be in flight, so a concurrent start coalesces onto its generation.
+    const fresh = await sessions.beginStart(locator, "user_2", null);
+    expect(fresh.generation).toBe(orphaned.generation);
+    expect(fresh.sandboxHandle).toBe("zombie-handle");
+
+    // Backdate past the 5-minute staleness threshold: now the next start must
+    // fence out the dead attempt (bump generation) and clear its handle.
+    await database.db
+      .updateTable("agent_sandbox_sessions")
+      .set({ updated_at: sql`now() - interval '10 minutes'` })
+      .where("organization_id", "=", locator.organizationId)
+      .where("virtual_mcp_id", "=", locator.virtualMcpId)
+      .where("branch", "=", locator.branch)
+      .execute();
+
+    const rebooted = await sessions.beginStart(locator, "user_2", null);
+    expect(rebooted.generation).toBeGreaterThan(orphaned.generation);
+    expect(rebooted.status).toBe("provisioning");
+    expect(rebooted.sandboxHandle).toBeNull();
+
+    // The zombie completion from the old generation is fenced out.
+    expect(
+      await sessions.completeStart(locator, orphaned.generation, {
+        sandboxHandle: "zombie-handle",
+        previewUrl: "https://zombie.example",
+        sandboxProviderKind: "agent-sandbox",
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/api/src/storage/agent-sandbox-sessions.ts
+++ b/apps/api/src/storage/agent-sandbox-sessions.ts
@@ -156,43 +156,46 @@ export class AgentSandboxSessionStorage {
 
     const row = await this.db
       .updateTable("agent_sandbox_sessions")
-      .set((expression) => ({
-        desired_state: "running",
-        generation: sql<number>`case
-          when ${expression.ref("desired_state")} = 'stopped'
-            or ${expression.ref("status")} in ('missing', 'failed')
-          then ${expression.ref("generation")} + 1
-          else ${expression.ref("generation")}
-        end`,
-        status: sql<AgentSandboxSessionStatus>`case
-          when ${expression.ref("desired_state")} = 'stopped'
-            or ${expression.ref("status")} in ('missing', 'failed')
-          then 'provisioning'
-          else ${expression.ref("status")}
-        end`,
-        sandbox_handle: sql<string | null>`case
-          when ${expression.ref("desired_state")} = 'stopped'
-            or ${expression.ref("status")} in ('missing', 'failed')
-          then null
-          else ${expression.ref("sandbox_handle")}
-        end`,
-        preview_url: sql<string | null>`case
-          when ${expression.ref("desired_state")} = 'stopped'
-            or ${expression.ref("status")} in ('missing', 'failed')
-          then null
-          else ${expression.ref("preview_url")}
-        end`,
-        sandbox_api_url: sql<string | null>`case
-          when ${expression.ref("desired_state")} = 'stopped'
-            or ${expression.ref("status")} in ('missing', 'failed')
-          then null
-          else ${expression.ref("sandbox_api_url")}
-        end`,
-        failure_reason: null,
-        thread_id: threadId,
-        last_started_by: actorUserId,
-        updated_at: now,
-      }))
+      .set((expression) => {
+        // Force a fresh provision when the row is stopped, terminal, or a
+        // `provisioning` row left orphaned by a crashed start (studio pod died
+        // between beginStart and completeStart/failStart, so nothing ever moved
+        // it off `provisioning` and it "reserves forever"). Bumping generation
+        // fences out any zombie in-flight writes from the dead attempt. 5m is
+        // safely longer than the ~180s real provision wait and matches the k8s
+        // scheduling timeout.
+        const reset = sql`${expression.ref("desired_state")} = 'stopped'
+          or ${expression.ref("status")} in ('missing', 'failed')
+          or (${expression.ref("status")} = 'provisioning'
+            and ${expression.ref("updated_at")} < now() - interval '5 minutes')`;
+        return {
+          desired_state: "running",
+          generation: sql<number>`case when ${reset}
+            then ${expression.ref("generation")} + 1
+            else ${expression.ref("generation")}
+          end`,
+          status: sql<AgentSandboxSessionStatus>`case when ${reset}
+            then 'provisioning'
+            else ${expression.ref("status")}
+          end`,
+          sandbox_handle: sql<string | null>`case when ${reset}
+            then null
+            else ${expression.ref("sandbox_handle")}
+          end`,
+          preview_url: sql<string | null>`case when ${reset}
+            then null
+            else ${expression.ref("preview_url")}
+          end`,
+          sandbox_api_url: sql<string | null>`case when ${reset}
+            then null
+            else ${expression.ref("sandbox_api_url")}
+          end`,
+          failure_reason: null,
+          thread_id: threadId,
+          last_started_by: actorUserId,
+          updated_at: now,
+        };
+      })
       .where("organization_id", "=", locator.organizationId)
       .where("virtual_mcp_id", "=", locator.virtualMcpId)
       .where("branch", "=", locator.branch)


### PR DESCRIPTION
## Problem

A shared-sandbox session for an old branch **reserves forever** and never reboots (reported: "Sandbox in Ferragens Floresta org didn't load, reserving forever" — the branch was very old).

Root cause: a per-branch session row stuck in `status='provisioning'` is never force-reprovisioned. `beginStart` (`apps/api/src/storage/agent-sandbox-sessions.ts`) only resets a row — bump generation, clear the stale handle, force a fresh provision — when `desired_state='stopped'` **or** `status IN ('missing','failed')`. A `provisioning` row with `desired_state='running'` hits every `else` branch: it re-joins its own generation and returns the existing (stale/`null`) `sandbox_handle`, so no reboot happens. Nothing times out `provisioning` either — there is no sweeper — so it hangs indefinitely.

An old branch makes this likely because its session row lingers un-GC'd long enough to have been left half-provisioned by an earlier start that crashed between `beginStart` and `completeStart`/`failStart` (e.g. the studio pod died mid-provision, or `failStart` no-op'd because its generation fence was already superseded).

## Fix

`beginStart` now also treats a `provisioning` row older than **5 minutes** on `updated_at` as stale and resets it — bumping the generation to fence out any zombie in-flight writes from the dead attempt, clearing the handle, and forcing a fresh provision on the next start. Self-healing; no sweeper/cron needed. 5m is safely longer than the ~180s real provision wait and matches the k8s scheduling timeout.

## Testing

Added a real-Postgres integration test (`agent-sandbox-sessions.integration.test.ts`) asserting:
- a **recent** provisioning row coalesces (is **not** reset) — a genuine in-flight start still wins;
- a **backdated** (>5m) provisioning row force-reprovisions with a new generation and a null handle;
- the old generation's `completeStart` is fenced out.

`bun run check` and `bun run fmt` pass. (Integration test runs in CI where the test Postgres + deps are available.)

## Notes / follow-ups (not in this PR)
- Did not extend `finishInterruptedSharedTransition` (heals `stopping`/`reaping` only) to cover `stopping`/`reaping`/`deleting` wedges, nor relax the `status==='ready'` gate in the sandbox-events self-heal. This fix alone unblocks the reported symptom; those are defense-in-depth.
- Did not add a migration to GC long-dead sessions — separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops shared sandbox sessions from “reserving forever” by force-reprovisioning a `provisioning` session that’s stale for over 5 minutes. This self-heals crashed starts so old branches can boot again.

- **Bug Fixes**
  - In `beginStart`, treat `status='provisioning'` rows with `updated_at < now() - 5m` as stale. Bump `generation`, clear handle/URLs, and restart provisioning to fence zombie writes.
  - Added Postgres integration test to confirm recent provisions coalesce, stale rows reboot, and old-generation completions are ignored.

<sup>Written for commit 70bc3e7d913df3e5abeb0bca05cf33d3b2a98c1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

