### PR TITLE
feat(loop): declarative domain loops — @decocms/loop CLI + domain-lint skill

### DIFF
--- a/.cursor/skills/domain-lint/SKILL.md
+++ b/.cursor/skills/domain-lint/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: domain-lint
+description: Semantic lint for domain declarations (domains/<name>/DOMAIN.md). Use when writing, reviewing, or tightening a domain declaration, when the user says "lint this domain", "red-team this declaration", or after rejecting a reconciler PR ("update the declaration so this doesn't happen again"). Validates that every invariant is checkable, red-teams the text for loopholes a lazy agent could exploit, and structures an owner's loose prose into declaration format.
+---
+
+# Domain Lint
+
+A domain declaration is a spec that an autonomous reconciler agent will obey
+literally, repeatedly, unsupervised. Classic lint validates form; this skill
+validates **semantics**: what behavior does this text actually authorize?
+
+Run all three passes and report findings grouped by pass, most severe first.
+For each finding, propose the concrete rewrite — never just "this is vague".
+
+## Pass 1 — Mechanical
+
+Reject the declaration if any of these fail:
+
+- Every invariant and health assert has a **check**: a command, grep, query, or
+  a heuristic with both good AND bad examples. No check → it does not go in.
+  ("The code should be clean" is wishful thinking, not a declaration.)
+- Scope lists real paths/globs that exist in the repo (verify them).
+- Subjective heuristics have good **and** bad examples — good-only examples
+  don't teach the boundary.
+- Has a limits section (what the reconciler must never do without a human).
+- Has an owner.
+- Checks are runnable as written (correct commands, existing scripts).
+
+## Pass 2 — Red-team (the heart of this skill)
+
+Simulate the reconciler in bad faith: a literal-minded, lazy agent that wants
+to look useful. Ask of every sentence:
+
+- **What useless-but-justifiable PR does this text authorize?** ("improve
+  translation quality" → a cosmetic retranslation PR every week, forever.)
+- **What infinite work does it authorize?** The loop must CONVERGE: on a
+  healthy domain, ten runs must produce zero PRs. Any line that always finds
+  something to do is a bug in the declaration.
+- **What loophole lets the agent escape scope or limits?** Ambiguous scope
+  ("the i18n code") instead of globs; limits phrased as advice ("prefer not
+  to") instead of prohibition.
+- **Where would the agent guess?** A check that can error ambiguously, a term
+  with two readings, a threshold left implicit.
+
+For each hole: quote the offending line, state the bad PR it permits, and
+propose the tightened wording or the objective check that closes it.
+
+## Pass 3 — Authoring / restructuring
+
+When given loose prose instead of (or alongside) a declaration — an owner's
+brain-dump, a PR rejection reason — structure it into the declaration format:
+
+- Separate: scope, checkable invariants, health asserts, runbook steps, tools,
+  limits, examples.
+- For each statement, either attach a concrete check or flag it as
+  "not declarable yet — needs a check or examples" with a suggestion.
+- For a PR rejection ("I rejected #123 because X"): produce the minimal edit to
+  the declaration that would have prevented that PR. Rejections MUST become
+  text — that is how the owner's judgment compounds.
+
+## Output
+
+```
+VERDICT: pass | fail
+[Pass 1] <finding> → <rewrite>
+[Pass 2] <quoted line> → authorizes: <bad PR> → tighten to: <rewrite>
+[Pass 3] <restructured sections or edits, ready to paste>
+```
+
+A declaration passes only when a bad-faith reconciler, given the text as-is,
+could not justify a single useless PR.

--- a/apps/web/src/i18n/placeholder-parity.test.ts
+++ b/apps/web/src/i18n/placeholder-parity.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { en } from "./en/index.ts";
+import { ptBR } from "./pt-br/index.ts";
+
+function placeholders(value: string): Set<string> {
+  return new Set(value.match(/\{[a-zA-Z]+\}/g) ?? []);
+}
+
+describe("placeholder parity", () => {
+  // A pt-br value may legitimately drop a placeholder (e.g. an English-only
+  // plural suffix like {plural} in "connection{plural}"), but must never
+  // reference one its en counterpart doesn't have — callers interpolate the
+  // en placeholder set, so anything extra renders as literal "{foo}".
+  it("pt-br values only use placeholders that exist in their en value", () => {
+    for (const [key, enValue] of Object.entries(en)) {
+      const enSet = placeholders(enValue);
+      const extra = [...placeholders(ptBR[key as keyof typeof ptBR])].filter(
+        (p) => !enSet.has(p),
+      );
+      expect(extra, key).toEqual([]);
+    }
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/api": {
       "name": "decocms",
-      "version": "4.122.3",
+      "version": "4.122.12",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -271,6 +271,16 @@
         "ai": ">=6.0.0",
       },
     },
+    "packages/loop": {
+      "name": "@decocms/loop",
+      "version": "0.1.0",
+      "bin": {
+        "loop": "./src/cli.ts",
+      },
+      "dependencies": {
+        "@decocms/shared": "workspace:*",
+      },
+    },
     "packages/mcp-utils": {
       "name": "@decocms/mcp-utils",
       "version": "1.1.0",
@@ -289,7 +299,7 @@
     },
     "packages/runtime": {
       "name": "@decocms/runtime",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "dependencies": {
         "@cloudflare/workers-types": "^4.20250617.0",
         "@decocms/bindings": "^1.0.7",
@@ -310,7 +320,7 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "1.22.4",
+      "version": "1.22.5",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/shared": "workspace:*",
@@ -700,6 +710,8 @@
     "@decocms/e2e": ["@decocms/e2e@workspace:packages/e2e"],
 
     "@decocms/harness": ["@decocms/harness@workspace:packages/harness"],
+
+    "@decocms/loop": ["@decocms/loop@workspace:packages/loop"],
 
     "@decocms/mcp-utils": ["@decocms/mcp-utils@workspace:packages/mcp-utils"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -275,9 +275,9 @@
       "name": "@decocms/loop",
       "version": "0.1.0",
       "bin": {
-        "loop": "./src/cli.ts",
+        "loop": "./dist/cli.js",
       },
-      "dependencies": {
+      "devDependencies": {
         "@decocms/shared": "workspace:*",
       },
     },

--- a/domains/DOMAIN.template.md
+++ b/domains/DOMAIN.template.md
@@ -1,0 +1,58 @@
+# Domain: <name>
+
+Owner: @<github-handle>
+
+One paragraph: what this domain is and what "healthy" means for it.
+
+## Scope
+
+Paths the reconciler may read and modify. Globs, exhaustive — anything outside
+is out of bounds.
+
+- `path/to/code/**`
+
+## Invariants
+
+Static drift: what must always be true of the code. **Every invariant carries
+its check** — a command, grep, or heuristic with good and bad examples. If you
+can't say how an agent would detect the violation, it isn't ready to be
+declared.
+
+### <invariant name>
+<what must be true>
+- Check: `<command that fails / produces output when violated>`
+
+## Health
+
+Runtime drift: asserts about production behavior, each with the query or
+command that measures it. Delete this section if the domain has no runtime
+surface.
+
+### <assert>
+- Query: `<how to measure>`
+- Healthy: `<threshold>`
+
+## Runbook
+
+How to debug when a check or health assert fails: where the logs are, which
+traces to look at, common hypotheses in order.
+
+## Tools
+
+Allowlist of what the reconciler may use — commands, MCP connections,
+credentials. This is a permission boundary: read-only by default, and nothing
+beyond this list.
+
+- `<command or MCP connection>`
+
+## Limits
+
+What the reconciler must NEVER do without a human. Phrase as prohibitions, not
+preferences.
+
+- Never `<...>`
+
+## Examples
+
+Good and bad examples for every subjective heuristic above. The bad examples
+teach the boundary.

--- a/domains/DOMAINS.md
+++ b/domains/DOMAINS.md
@@ -1,0 +1,14 @@
+# Domains
+
+Index of declared domains. Each domain has a declaration at
+`domains/<name>/DOMAIN.md` — the source of truth a reconciler agent enforces
+via PRs. See `domains/DOMAIN.template.md` to add one, and run
+`loop lint <name>` (from `@decocms/loop`) before the first `loop run <name>`.
+
+A merged row is a live domain: `loop tick` (typically on cron) reconciles
+every domain its runner's GitHub user owns. Activation is merging the
+declaration; deactivation is removing the row.
+
+| Domain | Paths | Owner |
+| ------ | ----- | ----- |
+| [i18n](./i18n/DOMAIN.md) | `apps/web/src/**` | @viktormarinho |

--- a/packages/loop/README.md
+++ b/packages/loop/README.md
@@ -20,7 +20,9 @@ bunx @decocms/loop tick          # reconcile every domain you own (cron target)
 bunx @decocms/loop status        # inbox: in-flight PRs per domain, what needs you
 ```
 
-Requires `claude` (Claude Code) and `gh` on PATH.
+Requires **Bun** (the CLI ships as a bun-bundled `dist/cli.js`; built via
+`bun build`, and `bun build --compile` is the future path for standalone
+binaries), plus `claude` (Claude Code) and `gh` on PATH.
 
 ## Scheduling
 
@@ -46,6 +48,20 @@ merge, deactivation is removing the row. Whether it runs "manually" or
 "on a schedule" is just who invokes `run`: you, or your cron. Your daily
 driver is `status`: review the in-flight PRs it shows, merge or
 close-and-edit-the-declaration, and let the next tick pick up the next item.
+
+## Security model
+
+The reconciler runs `claude` headless with `--permission-mode
+bypassPermissions`, authenticated as **you** (your `gh` and Claude Code
+logins). Two consequences to internalize:
+
+- **A merged `DOMAIN.md` is a capability grant.** The declaration IS the
+  agent's instructions — anyone who can merge an edit to `domains/` directs
+  an agent holding your push/PR credentials. Review declaration PRs with the
+  same rigor as code, and `loop lint` them (the red-team pass exists for
+  exactly this).
+- **`~/.loop/*.log` captures full agent output** from scheduled ticks — treat
+  it like any local log that may contain sensitive command output.
 
 ## The contract
 

--- a/packages/loop/README.md
+++ b/packages/loop/README.md
@@ -20,9 +20,9 @@ bunx @decocms/loop tick          # reconcile every domain you own (cron target)
 bunx @decocms/loop status        # inbox: in-flight PRs per domain, what needs you
 ```
 
-Requires **Bun** (the CLI ships as a bun-bundled `dist/cli.js`; built via
-`bun build`, and `bun build --compile` is the future path for standalone
-binaries), plus `claude` (Claude Code) and `gh` on PATH.
+Requires Node ≥20 (or Bun) plus `claude` (Claude Code) and `gh` on PATH.
+The published CLI is a single node-target bundle — bun is only a build-time
+tool (`bun build --compile` remains the future path for standalone binaries).
 
 ## Scheduling
 

--- a/packages/loop/README.md
+++ b/packages/loop/README.md
@@ -1,0 +1,57 @@
+# @decocms/loop
+
+Declarative domain loops. You declare how a domain of your repo should be
+(`domains/<name>/DOMAIN.md`); a reconciler agent observes the drift and opens
+PRs that close it — or does nothing when there is none. You stop prompting
+imperatively and start maintaining declarations.
+
+The reconcile protocol lives inside this package (the runner's prompt) and is
+versioned with it. The human-facing `domain-lint` skill is installed into the
+target repo's `.claude/skills/` by `init`, so a repo's declarations and
+protocol version travel together in git.
+
+## Usage
+
+```bash
+bunx @decocms/loop init          # scaffold domains/ + install the domain-lint skill
+bunx @decocms/loop lint <name>   # semantic lint: mechanical checks + red-team
+bunx @decocms/loop run <name>    # one reconcile: fix ONE violation, open a PR (or nothing)
+bunx @decocms/loop tick          # reconcile every domain you own (cron target)
+bunx @decocms/loop status        # inbox: in-flight PRs per domain, what needs you
+```
+
+Requires `claude` (Claude Code) and `gh` on PATH.
+
+## Scheduling
+
+There is no daemon — the OS scheduler runs `tick` and GitHub is the state.
+`tick` is idempotent (the open-PR lock makes repeat runs no-ops), so schedule
+it freely:
+
+```bash
+loop cron setup 30   # schedule tick every 30min (macOS launchd; survives sleep)
+loop cron            # show state, interval, log path
+loop cron off        # pause; `loop cron on` resumes
+```
+
+On other platforms (`cron setup` is macOS-only for now), add the equivalent
+crontab/systemd entry yourself:
+
+```cron
+*/30 * * * * cd ~/your-repo && bunx @decocms/loop tick >> ~/.loop-tick.log 2>&1
+```
+
+A domain is live once its `DOMAINS.md` row is merged — activation is the
+merge, deactivation is removing the row. Whether it runs "manually" or
+"on a schedule" is just who invokes `run`: you, or your cron. Your daily
+driver is `status`: review the in-flight PRs it shows, merge or
+close-and-edit-the-declaration, and let the next tick pick up the next item.
+
+## The contract
+
+- `run` produces **0 or 1 PR**. No drift → no PR: a healthy domain converges.
+- An open PR labeled `loop:<name>` is the lock — `run` skips while one exists.
+- Runs happen in a throwaway git worktree branched from the default branch.
+- Every declared invariant must carry a check; `lint` red-teams the
+  declaration for loopholes a lazy agent could exploit before you ever run it.
+- A rejected PR must become a declaration edit (the lint skill's Pass 3 helps).

--- a/packages/loop/build.ts
+++ b/packages/loop/build.ts
@@ -1,0 +1,10 @@
+// Bundles the CLI for plain Node (bun is a build tool here, not a runtime
+// requirement): --target node inlines @decocms/shared/std, and the shebang
+// is rewritten from the dev-time bun one to node.
+import { readFileSync, writeFileSync } from "node:fs";
+import { $ } from "bun";
+
+await $`bun build src/cli.ts --target node --outfile dist/cli.js`;
+const out = readFileSync("dist/cli.js", "utf8");
+writeFileSync("dist/cli.js", out.replace(/^#!.*/, "#!/usr/bin/env node"));
+console.log("dist/cli.js: node-target bundle, node shebang");

--- a/packages/loop/package.json
+++ b/packages/loop/package.json
@@ -13,7 +13,7 @@
     "templates"
   ],
   "scripts": {
-    "build": "bun build src/cli.ts --target bun --outfile dist/cli.js",
+    "build": "bun build.ts",
     "prepublishOnly": "bun run build",
     "check": "tsc --noEmit",
     "test": "bun test"
@@ -22,7 +22,7 @@
     "@decocms/shared": "workspace:*"
   },
   "engines": {
-    "bun": ">=1.1.0"
+    "node": ">=20.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/loop/package.json
+++ b/packages/loop/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@decocms/loop",
+  "version": "0.1.0",
+  "description": "Declarative domain loops: declare how a domain should be, let a reconciler agent open PRs that close the drift",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "loop": "./src/cli.ts"
+  },
+  "files": [
+    "src",
+    "skills",
+    "templates"
+  ],
+  "scripts": {
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@decocms/shared": "workspace:*"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/decocms/studio.git",
+    "directory": "packages/loop"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/loop/package.json
+++ b/packages/loop/package.json
@@ -5,21 +5,24 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "loop": "./src/cli.ts"
+    "loop": "./dist/cli.js"
   },
   "files": [
-    "src",
+    "dist",
     "skills",
     "templates"
   ],
   "scripts": {
-    "check": "tsc --noEmit"
+    "build": "bun build src/cli.ts --target bun --outfile dist/cli.js",
+    "prepublishOnly": "bun run build",
+    "check": "tsc --noEmit",
+    "test": "bun test"
   },
-  "dependencies": {
+  "devDependencies": {
     "@decocms/shared": "workspace:*"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "bun": ">=1.1.0"
   },
   "repository": {
     "type": "git",

--- a/packages/loop/skills/domain-lint/SKILL.md
+++ b/packages/loop/skills/domain-lint/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: domain-lint
+description: Semantic lint for domain declarations (domains/<name>/DOMAIN.md). Use when writing, reviewing, or tightening a domain declaration, when the user says "lint this domain", "red-team this declaration", or after rejecting a reconciler PR ("update the declaration so this doesn't happen again"). Validates that every invariant is checkable, red-teams the text for loopholes a lazy agent could exploit, and structures an owner's loose prose into declaration format.
+---
+
+# Domain Lint
+
+A domain declaration is a spec that an autonomous reconciler agent will obey
+literally, repeatedly, unsupervised. Classic lint validates form; this skill
+validates **semantics**: what behavior does this text actually authorize?
+
+Run all three passes and report findings grouped by pass, most severe first.
+For each finding, propose the concrete rewrite — never just "this is vague".
+
+## Pass 1 — Mechanical
+
+Reject the declaration if any of these fail:
+
+- Every invariant and health assert has a **check**: a command, grep, query, or
+  a heuristic with both good AND bad examples. No check → it does not go in.
+  ("The code should be clean" is wishful thinking, not a declaration.)
+- Scope lists real paths/globs that exist in the repo (verify them).
+- Subjective heuristics have good **and** bad examples — good-only examples
+  don't teach the boundary.
+- Has a limits section (what the reconciler must never do without a human).
+- Has an owner.
+- Checks are runnable as written (correct commands, existing scripts).
+
+## Pass 2 — Red-team (the heart of this skill)
+
+Simulate the reconciler in bad faith: a literal-minded, lazy agent that wants
+to look useful. Ask of every sentence:
+
+- **What useless-but-justifiable PR does this text authorize?** ("improve
+  translation quality" → a cosmetic retranslation PR every week, forever.)
+- **What infinite work does it authorize?** The loop must CONVERGE: on a
+  healthy domain, ten runs must produce zero PRs. Any line that always finds
+  something to do is a bug in the declaration.
+- **What loophole lets the agent escape scope or limits?** Ambiguous scope
+  ("the i18n code") instead of globs; limits phrased as advice ("prefer not
+  to") instead of prohibition.
+- **Where would the agent guess?** A check that can error ambiguously, a term
+  with two readings, a threshold left implicit.
+
+For each hole: quote the offending line, state the bad PR it permits, and
+propose the tightened wording or the objective check that closes it.
+
+## Pass 3 — Authoring / restructuring
+
+When given loose prose instead of (or alongside) a declaration — an owner's
+brain-dump, a PR rejection reason — structure it into the declaration format:
+
+- Separate: scope, checkable invariants, health asserts, runbook steps, tools,
+  limits, examples.
+- For each statement, either attach a concrete check or flag it as
+  "not declarable yet — needs a check or examples" with a suggestion.
+- For a PR rejection ("I rejected #123 because X"): produce the minimal edit to
+  the declaration that would have prevented that PR. Rejections MUST become
+  text — that is how the owner's judgment compounds.
+
+## Output
+
+```
+VERDICT: pass | fail
+[Pass 1] <finding> → <rewrite>
+[Pass 2] <quoted line> → authorizes: <bad PR> → tighten to: <rewrite>
+[Pass 3] <restructured sections or edits, ready to paste>
+```
+
+A declaration passes only when a bad-faith reconciler, given the text as-is,
+could not justify a single useless PR.

--- a/packages/loop/src/cli.ts
+++ b/packages/loop/src/cli.ts
@@ -1,0 +1,405 @@
+#!/usr/bin/env bun
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { sleep } from "@decocms/shared/std";
+import { reconcilePrompt } from "./reconcile-prompt";
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function sh(cmd: string, args: string[], opts: { cwd?: string } = {}): string {
+  const res = spawnSync(cmd, args, { cwd: opts.cwd, encoding: "utf8" });
+  if (res.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed:\n${res.stderr || res.stdout}`,
+    );
+  }
+  return res.stdout.trim();
+}
+
+function repoRoot(): string {
+  return sh("git", ["rev-parse", "--show-toplevel"]);
+}
+
+function readDeclaration(root: string, domain: string): string {
+  const dir = join(root, "domains", domain);
+  if (!existsSync(join(dir, "DOMAIN.md"))) {
+    console.error(`No declaration at domains/${domain}/DOMAIN.md`);
+    process.exit(1);
+  }
+  // DOMAIN.md first, then sibling .md files (quality guides, runbooks, etc.)
+  const files = [
+    "DOMAIN.md",
+    ...readdirSync(dir).filter((f) => f.endsWith(".md") && f !== "DOMAIN.md"),
+  ];
+  return files
+    .map(
+      (f) =>
+        `<file path="domains/${domain}/${f}">\n${readFileSync(join(dir, f), "utf8")}\n</file>`,
+    )
+    .join("\n\n");
+}
+
+function init(): void {
+  const root = repoRoot();
+  const domainsIndex = join(root, "domains", "DOMAINS.md");
+  if (!existsSync(domainsIndex)) {
+    cpSync(join(pkgRoot, "templates", "DOMAINS.md"), domainsIndex);
+    console.log("created domains/DOMAINS.md");
+  }
+  const template = join(root, "domains", "DOMAIN.template.md");
+  if (!existsSync(template)) {
+    cpSync(join(pkgRoot, "templates", "DOMAIN.md"), template);
+    console.log("created domains/DOMAIN.template.md");
+  }
+  const skillDest = join(root, ".claude", "skills", "domain-lint");
+  cpSync(join(pkgRoot, "skills", "domain-lint"), skillDest, {
+    recursive: true,
+  });
+  console.log("installed .claude/skills/domain-lint");
+  console.log(
+    "\nNext: copy domains/DOMAIN.template.md to domains/<name>/DOMAIN.md,",
+    "write your declaration, then run `loop lint <name>`.",
+  );
+}
+
+function lint(domain: string): void {
+  const root = repoRoot();
+  const skill = readFileSync(
+    join(pkgRoot, "skills", "domain-lint", "SKILL.md"),
+    "utf8",
+  );
+  const prompt = `${skill}\n\nLint the following domain declaration:\n\n${readDeclaration(root, domain)}`;
+  // prompt via stdin: content starting with "-" must not be parsed as a flag
+  spawnSync("claude", ["-p", "--permission-mode", "bypassPermissions"], {
+    cwd: root,
+    input: prompt,
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+}
+
+function run(domain: string): void {
+  const root = repoRoot();
+  const declaration = readDeclaration(root, domain);
+
+  // Lock: an open PR for this domain means a reconcile is already in flight.
+  const open = sh(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--label",
+      `loop:${domain}`,
+      "--json",
+      "url",
+      "--jq",
+      ".[].url",
+    ],
+    { cwd: root },
+  );
+  if (open) {
+    console.log(`skipped: open PR in flight for ${domain}\n${open}`);
+    return;
+  }
+
+  sh("git", ["fetch", "origin"], { cwd: root });
+  const defaultBranch = sh(
+    "git",
+    ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+    { cwd: root },
+  ).replace(/^origin\//, "");
+  const branch = `loop/${domain}/${Date.now().toString(36)}`;
+  const worktree = mkdtempSync(join(tmpdir(), `loop-${domain}-`));
+
+  sh(
+    "git",
+    ["worktree", "add", "-b", branch, worktree, `origin/${defaultBranch}`],
+    { cwd: root },
+  );
+  console.log(`reconciling ${domain} on ${branch} (${worktree})`);
+  try {
+    const res = spawnSync(
+      "claude",
+      ["-p", "--permission-mode", "bypassPermissions"],
+      {
+        cwd: worktree,
+        input: reconcilePrompt({ domain, declaration, branch, defaultBranch }),
+        stdio: ["pipe", "inherit", "inherit"],
+      },
+    );
+    if (res.status !== 0) process.exitCode = res.status ?? 1;
+  } finally {
+    sh("git", ["worktree", "remove", "--force", worktree], { cwd: root });
+    rmSync(worktree, { recursive: true, force: true });
+    // If the agent pushed, the branch lives on the remote; drop the local ref.
+    spawnSync("git", ["branch", "-D", branch], { cwd: root });
+  }
+}
+
+interface DomainRow {
+  name: string;
+  owner: string;
+}
+
+function domains(root: string): DomainRow[] {
+  const index = readFileSync(join(root, "domains", "DOMAINS.md"), "utf8");
+  const rows: DomainRow[] = [];
+  for (const line of index.split("\n")) {
+    const m = line.match(
+      /^\|\s*\[([^\]]+)\]\([^)]*\)\s*\|[^|]*\|\s*@?(\S+)\s*\|/,
+    );
+    const [, name, owner] = m ?? [];
+    if (name && owner) rows.push({ name, owner });
+  }
+  return rows;
+}
+
+interface OpenPr {
+  number: number;
+  title: string;
+  createdAt: string;
+  reviewDecision: string;
+  statusCheckRollup: { state?: string; status?: string; conclusion?: string }[];
+}
+
+function openPr(root: string, domain: string): OpenPr | null {
+  const out = sh(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--label",
+      `loop:${domain}`,
+      "--json",
+      "number,title,createdAt,reviewDecision,statusCheckRollup",
+      "--jq",
+      ".[0] // empty",
+    ],
+    { cwd: root },
+  );
+  return out ? JSON.parse(out) : null;
+}
+
+function prAge(pr: OpenPr): string {
+  const hours = Math.round((Date.now() - Date.parse(pr.createdAt)) / 3_600_000);
+  return hours < 48 ? `${hours}h` : `${Math.round(hours / 24)}d`;
+}
+
+function prChecks(pr: OpenPr): string {
+  const checks = pr.statusCheckRollup ?? [];
+  if (checks.length === 0) return "—";
+  const states = checks.map((c) => c.conclusion || c.state || c.status || "");
+  if (states.some((s) => /FAILURE|ERROR/i.test(s))) return "failing";
+  if (states.some((s) => /PENDING|IN_PROGRESS|QUEUED|^$/i.test(s)))
+    return "pending";
+  return "passing";
+}
+
+// A run in flight leaves its worktree at $TMPDIR/loop-<domain>-XXXXXX until
+// the finally-cleanup — the directory's existence IS the running state.
+function runningDomains(): Set<string> {
+  try {
+    return new Set(
+      readdirSync(tmpdir())
+        .filter((d) => d.startsWith("loop-"))
+        .map((d) => d.slice(5).replace(/-[^-]+$/, "")),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+// Cron target: reconcile every domain I own. Idempotent — the open-PR lock
+// inside run() makes repeated ticks no-ops.
+function tick(): void {
+  const root = repoRoot();
+  const me = sh("gh", ["api", "user", "--jq", ".login"]);
+  const mine = domains(root).filter((d) => d.owner === me);
+  if (mine.length === 0) {
+    console.log(`nothing to tick: no domains owned by @${me}`);
+    return;
+  }
+  for (const d of mine) run(d.name);
+}
+
+function domainTable(root: string): string[][] {
+  const running = runningDomains();
+  const table = [
+    ["DOMAIN", "OWNER", "RUNNING", "IN-FLIGHT", "AGE", "CHECKS", "REVIEW"],
+  ];
+  for (const d of domains(root)) {
+    const pr = openPr(root, d.name);
+    table.push([
+      d.name,
+      `@${d.owner}`,
+      running.has(d.name) ? "● yes" : "—",
+      pr ? `#${pr.number} ${pr.title}`.slice(0, 44) : "—",
+      pr ? prAge(pr) : "—",
+      pr ? prChecks(pr) : "—",
+      pr
+        ? (pr.reviewDecision || "waiting").toLowerCase().replace(/_/g, " ")
+        : "—",
+    ]);
+  }
+  return table;
+}
+
+function renderTable(table: string[][]): string {
+  const widths = table[0]!.map((_, i) =>
+    Math.max(...table.map((r) => r[i]!.length)),
+  );
+  return table
+    .map((row) => row.map((c, i) => c.padEnd(widths[i]!)).join("  "))
+    .join("\n");
+}
+
+function status(): void {
+  console.log(renderTable(domainTable(repoRoot())));
+}
+
+async function statusUi(): Promise<void> {
+  const root = repoRoot();
+  const { label, plist, log } = cronPaths(root);
+  for (;;) {
+    const schedule = existsSync(plist)
+      ? `${label}  ${cronLoaded(label) ? "enabled" : "disabled"}  log: ${log}`
+      : "none — `loop cron setup [minutes]` to schedule ticks";
+    const body = renderTable(domainTable(root));
+    const now = new Date().toLocaleTimeString();
+    // \x1b[2J\x1b[H = clear screen + home; plain ANSI, no TUI framework
+    console.log(
+      `\x1b[2J\x1b[Hloop — ${basename(root)}   refreshed ${now}   (ctrl-c to quit)\n\nSCHEDULE\n  ${schedule}\n\nDOMAINS\n${body
+        .split("\n")
+        .map((l) => `  ${l}`)
+        .join("\n")}`,
+    );
+    await sleep(15_000);
+  }
+}
+
+// Scheduling via the OS scheduler — launchd on macOS. The plist bakes in the
+// current bun path, cli path, and PATH, so the job doesn't depend on shell
+// config. ponytail: macOS only; Linux (systemd timer / crontab) when someone
+// on Linux needs it.
+function cronPaths(root: string): {
+  label: string;
+  plist: string;
+  log: string;
+} {
+  const label = `com.decocms.loop.${basename(root)}`;
+  return {
+    label,
+    plist: join(homedir(), "Library", "LaunchAgents", `${label}.plist`),
+    log: join(homedir(), ".loop", `${label}.log`),
+  };
+}
+
+function cronLoaded(label: string): boolean {
+  const res = spawnSync("launchctl", ["list", label], { encoding: "utf8" });
+  return res.status === 0;
+}
+
+function cron(sub: string | undefined, minutes: string | undefined): void {
+  if (process.platform !== "darwin") {
+    console.log(
+      `loop cron is macOS-only for now (${process.platform}): add a crontab/systemd entry running \`loop tick\` — see the README.`,
+    );
+    return;
+  }
+  const root = repoRoot();
+  const { label, plist, log } = cronPaths(root);
+
+  if (sub === "setup") {
+    const interval = (Number(minutes) || 30) * 60;
+    mkdirSync(dirname(log), { recursive: true });
+    writeFileSync(
+      plist,
+      `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>${label}</string>
+  <key>ProgramArguments</key><array>
+    <string>${process.execPath}</string>
+    <string>${fileURLToPath(import.meta.url)}</string>
+    <string>tick</string>
+  </array>
+  <key>WorkingDirectory</key><string>${root}</string>
+  <key>EnvironmentVariables</key><dict>
+    <key>PATH</key><string>${process.env.PATH ?? "/usr/bin:/bin"}</string>
+  </dict>
+  <key>StartInterval</key><integer>${interval}</integer>
+  <key>StandardOutPath</key><string>${log}</string>
+  <key>StandardErrorPath</key><string>${log}</string>
+</dict></plist>
+`,
+    );
+    if (cronLoaded(label)) sh("launchctl", ["unload", plist]);
+    sh("launchctl", ["load", plist]);
+    console.log(
+      `scheduled: ${label} every ${interval / 60}min (log: ${log})\n` +
+        `manage with \`loop cron on|off\`, inspect with \`loop cron\``,
+    );
+  } else if (sub === "on" || sub === "off") {
+    if (!existsSync(plist)) {
+      console.error(
+        `no schedule for this repo — run \`loop cron setup\` first`,
+      );
+      process.exit(1);
+    }
+    sh("launchctl", [sub === "on" ? "load" : "unload", plist]);
+    console.log(`${label}: ${sub === "on" ? "enabled" : "disabled"}`);
+  } else {
+    if (!existsSync(plist)) {
+      console.log(
+        `no schedule for this repo — run \`loop cron setup [minutes]\``,
+      );
+      return;
+    }
+    const interval = readFileSync(plist, "utf8").match(
+      /StartInterval<\/key><integer>(\d+)/,
+    )?.[1];
+    console.log(
+      `${label}\n  state:    ${cronLoaded(label) ? "enabled" : "disabled"}\n` +
+        `  interval: every ${Number(interval ?? 0) / 60 || "?"}min\n` +
+        `  log:      ${log}`,
+    );
+  }
+}
+
+const [cmd, arg, arg2] = process.argv.slice(2);
+if (cmd === "init") init();
+else if (cmd === "lint" && arg) lint(arg);
+else if (cmd === "run" && arg) run(arg);
+else if (cmd === "tick") tick();
+else if (cmd === "status" && arg === "--ui") await statusUi();
+else if (cmd === "status") status();
+else if (cmd === "cron") cron(arg, arg2);
+else {
+  console.log(`usage: loop <command>
+
+  init                  scaffold domains/ and install the domain-lint skill
+  lint <domain>         semantic-lint a declaration (mechanical checks + red-team)
+  run <domain>          one reconcile: observe drift, fix ONE violation, open a PR (or nothing)
+  tick                  reconcile every domain you own (the scheduler's target; idempotent)
+  status                inbox: per-domain in-flight PRs and what needs you
+  status --ui           live TUI: schedule state, running agents, PRs (refreshes 15s)
+  cron                  show this repo's schedule
+  cron setup [minutes]  schedule tick on the OS scheduler (default: every 30min)
+  cron on|off           enable/disable the schedule`);
+  process.exit(cmd ? 1 : 0);
+}

--- a/packages/loop/src/cli.ts
+++ b/packages/loop/src/cli.ts
@@ -14,6 +14,11 @@ import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { sleep } from "@decocms/shared/std";
+import {
+  type DomainRow,
+  isValidDomainName,
+  parseDomains,
+} from "./parse-domains";
 import { reconcilePrompt } from "./reconcile-prompt";
 
 const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -33,6 +38,10 @@ function repoRoot(): string {
 }
 
 function readDeclaration(root: string, domain: string): string {
+  if (!isValidDomainName(domain)) {
+    console.error(`invalid domain name "${domain}" (allowed: [a-z0-9_-])`);
+    process.exit(1);
+  }
   const dir = join(root, "domains", domain);
   if (!existsSync(join(dir, "DOMAIN.md"))) {
     console.error(`No declaration at domains/${domain}/DOMAIN.md`);
@@ -94,24 +103,9 @@ function run(domain: string): void {
   const declaration = readDeclaration(root, domain);
 
   // Lock: an open PR for this domain means a reconcile is already in flight.
-  const open = sh(
-    "gh",
-    [
-      "pr",
-      "list",
-      "--state",
-      "open",
-      "--label",
-      `loop:${domain}`,
-      "--json",
-      "url",
-      "--jq",
-      ".[].url",
-    ],
-    { cwd: root },
-  );
-  if (open) {
-    console.log(`skipped: open PR in flight for ${domain}\n${open}`);
+  const pr = openPrs(root).get(domain);
+  if (pr) {
+    console.log(`skipped: open PR in flight for ${domain}\n${pr.url}`);
     return;
   }
 
@@ -142,40 +136,36 @@ function run(domain: string): void {
     );
     if (res.status !== 0) process.exitCode = res.status ?? 1;
   } finally {
-    sh("git", ["worktree", "remove", "--force", worktree], { cwd: root });
+    // Cleanup must not mask the original error or abort a tick mid-batch —
+    // tolerate failures here; the tmpdir reaper gets stragglers eventually.
+    spawnSync("git", ["worktree", "remove", "--force", worktree], {
+      cwd: root,
+    });
     rmSync(worktree, { recursive: true, force: true });
     // If the agent pushed, the branch lives on the remote; drop the local ref.
     spawnSync("git", ["branch", "-D", branch], { cwd: root });
   }
 }
 
-interface DomainRow {
-  name: string;
-  owner: string;
-}
-
 function domains(root: string): DomainRow[] {
-  const index = readFileSync(join(root, "domains", "DOMAINS.md"), "utf8");
-  const rows: DomainRow[] = [];
-  for (const line of index.split("\n")) {
-    const m = line.match(
-      /^\|\s*\[([^\]]+)\]\([^)]*\)\s*\|[^|]*\|\s*@?(\S+)\s*\|/,
-    );
-    const [, name, owner] = m ?? [];
-    if (name && owner) rows.push({ name, owner });
-  }
-  return rows;
+  return parseDomains(
+    readFileSync(join(root, "domains", "DOMAINS.md"), "utf8"),
+  );
 }
 
 interface OpenPr {
   number: number;
   title: string;
+  url: string;
   createdAt: string;
   reviewDecision: string;
+  labels: { name: string }[];
   statusCheckRollup: { state?: string; status?: string; conclusion?: string }[];
 }
 
-function openPr(root: string, domain: string): OpenPr | null {
+// One gh call for ALL loop PRs (statusUi refreshes this every 15s — a call
+// per domain would eat GitHub API quota at 10+ domains).
+function openPrs(root: string): Map<string, OpenPr> {
   const out = sh(
     "gh",
     [
@@ -183,16 +173,23 @@ function openPr(root: string, domain: string): OpenPr | null {
       "list",
       "--state",
       "open",
-      "--label",
-      `loop:${domain}`,
+      "--limit",
+      "200",
       "--json",
-      "number,title,createdAt,reviewDecision,statusCheckRollup",
-      "--jq",
-      ".[0] // empty",
+      "number,title,url,createdAt,reviewDecision,labels,statusCheckRollup",
     ],
     { cwd: root },
   );
-  return out ? JSON.parse(out) : null;
+  const byDomain = new Map<string, OpenPr>();
+  for (const pr of JSON.parse(out || "[]") as OpenPr[]) {
+    for (const label of pr.labels ?? []) {
+      if (label.name.startsWith("loop:")) {
+        const domain = label.name.slice(5);
+        if (!byDomain.has(domain)) byDomain.set(domain, pr);
+      }
+    }
+  }
+  return byDomain;
 }
 
 function prAge(pr: OpenPr): string {
@@ -234,16 +231,25 @@ function tick(): void {
     console.log(`nothing to tick: no domains owned by @${me}`);
     return;
   }
-  for (const d of mine) run(d.name);
+  for (const d of mine) {
+    // One broken domain must not starve the rest of the batch.
+    try {
+      run(d.name);
+    } catch (e) {
+      console.error(`tick: ${d.name} failed: ${(e as Error).message}`);
+      process.exitCode = 1;
+    }
+  }
 }
 
 function domainTable(root: string): string[][] {
   const running = runningDomains();
+  const prs = openPrs(root);
   const table = [
     ["DOMAIN", "OWNER", "RUNNING", "IN-FLIGHT", "AGE", "CHECKS", "REVIEW"],
   ];
   for (const d of domains(root)) {
-    const pr = openPr(root, d.name);
+    const pr = prs.get(d.name);
     table.push([
       d.name,
       `@${d.owner}`,
@@ -279,7 +285,13 @@ async function statusUi(): Promise<void> {
     const schedule = existsSync(plist)
       ? `${label}  ${cronLoaded(label) ? "enabled" : "disabled"}  log: ${log}`
       : "none — `loop cron setup [minutes]` to schedule ticks";
-    const body = renderTable(domainTable(root));
+    // A flaky gh call (offline, rate limit) degrades the frame, not the TUI.
+    let body: string;
+    try {
+      body = renderTable(domainTable(root));
+    } catch (e) {
+      body = `ERROR refreshing: ${(e as Error).message.split("\n")[0]}`;
+    }
     const now = new Date().toLocaleTimeString();
     // \x1b[2J\x1b[H = clear screen + home; plain ANSI, no TUI framework
     console.log(
@@ -314,6 +326,10 @@ function cronLoaded(label: string): boolean {
   return res.status === 0;
 }
 
+function xmlEscape(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 function cron(sub: string | undefined, minutes: string | undefined): void {
   if (process.platform !== "darwin") {
     console.log(
@@ -332,19 +348,19 @@ function cron(sub: string | undefined, minutes: string | undefined): void {
       `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
-  <key>Label</key><string>${label}</string>
+  <key>Label</key><string>${xmlEscape(label)}</string>
   <key>ProgramArguments</key><array>
-    <string>${process.execPath}</string>
-    <string>${fileURLToPath(import.meta.url)}</string>
+    <string>${xmlEscape(process.execPath)}</string>
+    <string>${xmlEscape(fileURLToPath(import.meta.url))}</string>
     <string>tick</string>
   </array>
-  <key>WorkingDirectory</key><string>${root}</string>
+  <key>WorkingDirectory</key><string>${xmlEscape(root)}</string>
   <key>EnvironmentVariables</key><dict>
-    <key>PATH</key><string>${process.env.PATH ?? "/usr/bin:/bin"}</string>
+    <key>PATH</key><string>${xmlEscape(process.env.PATH ?? "/usr/bin:/bin")}</string>
   </dict>
   <key>StartInterval</key><integer>${interval}</integer>
-  <key>StandardOutPath</key><string>${log}</string>
-  <key>StandardErrorPath</key><string>${log}</string>
+  <key>StandardOutPath</key><string>${xmlEscape(log)}</string>
+  <key>StandardErrorPath</key><string>${xmlEscape(log)}</string>
 </dict></plist>
 `,
     );
@@ -361,7 +377,9 @@ function cron(sub: string | undefined, minutes: string | undefined): void {
       );
       process.exit(1);
     }
-    sh("launchctl", [sub === "on" ? "load" : "unload", plist]);
+    // Tolerate already-on/already-off: launchctl errors when the job is
+    // already in the requested state, which is a fine no-op for us.
+    spawnSync("launchctl", [sub === "on" ? "load" : "unload", plist]);
     console.log(`${label}: ${sub === "on" ? "enabled" : "disabled"}`);
   } else {
     if (!existsSync(plist)) {

--- a/packages/loop/src/parse-domains.test.ts
+++ b/packages/loop/src/parse-domains.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { parseDomains } from "./parse-domains";
+
+describe("parseDomains", () => {
+  it("parses a standard row", () => {
+    const md = "| [i18n](./i18n/DOMAIN.md) | `apps/web/src/**` | @alice |";
+    expect(parseDomains(md)).toEqual([{ name: "i18n", owner: "alice" }]);
+  });
+
+  it("owner @ prefix is optional", () => {
+    const md = "| [x](./x/DOMAIN.md) | `p/**` | bob |";
+    expect(parseDomains(md)).toEqual([{ name: "x", owner: "bob" }]);
+  });
+
+  it("pipes inside the paths cell do not shift the owner column", () => {
+    const md = "| [x](./x/DOMAIN.md) | `a/**|b/**` | @carol |";
+    expect(parseDomains(md)).toEqual([{ name: "x", owner: "carol" }]);
+  });
+
+  it("ignores header, separator, prose, and malformed rows", () => {
+    const md = [
+      "# Domains",
+      "| Domain | Paths | Owner |",
+      "| ------ | ----- | ----- |",
+      "| [ok](./ok/DOMAIN.md) | `p/**` | @dan |",
+      "| [broken](./broken/DOMAIN.md) | missing owner cell",
+      "not a table row at all",
+    ].join("\n");
+    expect(parseDomains(md)).toEqual([{ name: "ok", owner: "dan" }]);
+  });
+
+  it("skips domain names unsafe as path/branch components", () => {
+    const md = "| [../evil](./e/DOMAIN.md) | `p/**` | @eve |";
+    expect(parseDomains(md)).toEqual([]);
+  });
+
+  it("returns empty for an empty index", () => {
+    expect(parseDomains("")).toEqual([]);
+  });
+});

--- a/packages/loop/src/parse-domains.ts
+++ b/packages/loop/src/parse-domains.ts
@@ -1,0 +1,31 @@
+export interface DomainRow {
+  name: string;
+  owner: string;
+}
+
+// A domain name becomes a path component, a git branch segment, a gh label,
+// and a launchd-adjacent string — keep it to a safe charset.
+export function isValidDomainName(name: string): boolean {
+  return /^[a-z0-9_-]+$/i.test(name);
+}
+
+// Parses DOMAINS.md table rows: | [name](./name/DOMAIN.md) | `paths` | @owner |
+// Owner is anchored to the LAST cell so pipes inside the paths cell can't
+// shift columns. Rows with invalid domain names are skipped with a warning —
+// a silently-empty result would make `tick` a no-op with no signal.
+export function parseDomains(markdown: string): DomainRow[] {
+  const rows: DomainRow[] = [];
+  for (const line of markdown.split("\n")) {
+    const m = line.match(
+      /^\|\s*\[([^\]]+)\]\([^)]*\)\s*\|.*\|\s*@?([\w-]+)\s*\|\s*$/,
+    );
+    const [, name, owner] = m ?? [];
+    if (!name || !owner) continue;
+    if (!isValidDomainName(name)) {
+      console.error(`skipping invalid domain name in DOMAINS.md: "${name}"`);
+      continue;
+    }
+    rows.push({ name, owner });
+  }
+  return rows;
+}

--- a/packages/loop/src/reconcile-prompt.ts
+++ b/packages/loop/src/reconcile-prompt.ts
@@ -1,0 +1,61 @@
+/**
+ * The reconcile protocol: the fixed prompt every domain run uses.
+ * All domain-specific behavior comes from the declaration files —
+ * this prompt only encodes the loop's contract:
+ * observe → compare → fix ONE violation → PR, or exit clean.
+ */
+export function reconcilePrompt(opts: {
+  domain: string;
+  declaration: string;
+  branch: string;
+  defaultBranch: string;
+}): string {
+  const { domain, declaration, branch, defaultBranch } = opts;
+  return `You are the reconciler for the "${domain}" domain of this repository.
+
+Below is the domain DECLARATION. It is the single source of truth for what this
+domain should look like. Your job is to reduce the drift between the repository
+and the declaration — nothing else.
+
+## Protocol
+
+0. SETUP. This worktree is freshly created and has NO installed dependencies.
+   Run the repository's install step first (per its docs, e.g. \`bun install\`)
+   so formatters, typecheckers, and tests actually run. A check that fails
+   because dependencies are missing is a setup problem, not NO_DRIFT and not
+   CHECK_FAILED — fix the setup.
+1. OBSERVE. Run every check listed in the declaration (invariant checks and
+   health checks). Collect the actual output.
+2. COMPARE. List which declared invariants are violated, with evidence from the
+   check output. If NOTHING is violated, print exactly "NO_DRIFT", make no
+   changes, and stop. Do not invent work. A clean run that changes nothing is a
+   SUCCESS, not a failure.
+3. PICK ONE. Choose the single highest-value violation. Not two. A small,
+   reviewable PR beats a big one.
+4. FIX. Make the minimal change that resolves that violation. Stay strictly
+   inside the declared scope paths. Never do anything the declaration's limits
+   section forbids.
+5. VERIFY. Re-run the check that detected the violation and confirm it passes
+   now. Run the repository's standard checks for the files you touched
+   (formatting, typecheck, lint) as the declaration or repo docs instruct.
+6. SHIP. You are already on branch "${branch}". Commit using the repository's
+   commit convention, push the branch, ensure the label exists
+   (\`gh label create "loop:${domain}" --force\`), then open a PR against
+   "${defaultBranch}" with \`gh pr create --label "loop:${domain}"\`. The PR body
+   must state: which invariant was violated, the check output proving it
+   (before), and the check output proving the fix (after).
+
+## Hard rules
+
+- 0 or 1 PR per run. Never more.
+- Only touch files inside the declared scope.
+- Anything under the declaration's limits section requires a human — leave a
+  note in the PR body instead of doing it.
+- If a check command errors in a way the runbook doesn't explain, stop and
+  print "CHECK_FAILED: <command>" with the error. Do not guess around a broken
+  check.
+
+## Declaration
+
+${declaration}`;
+}

--- a/packages/loop/templates/DOMAIN.md
+++ b/packages/loop/templates/DOMAIN.md
@@ -1,0 +1,58 @@
+# Domain: <name>
+
+Owner: @<github-handle>
+
+One paragraph: what this domain is and what "healthy" means for it.
+
+## Scope
+
+Paths the reconciler may read and modify. Globs, exhaustive — anything outside
+is out of bounds.
+
+- `path/to/code/**`
+
+## Invariants
+
+Static drift: what must always be true of the code. **Every invariant carries
+its check** — a command, grep, or heuristic with good and bad examples. If you
+can't say how an agent would detect the violation, it isn't ready to be
+declared.
+
+### <invariant name>
+<what must be true>
+- Check: `<command that fails / produces output when violated>`
+
+## Health
+
+Runtime drift: asserts about production behavior, each with the query or
+command that measures it. Delete this section if the domain has no runtime
+surface.
+
+### <assert>
+- Query: `<how to measure>`
+- Healthy: `<threshold>`
+
+## Runbook
+
+How to debug when a check or health assert fails: where the logs are, which
+traces to look at, common hypotheses in order.
+
+## Tools
+
+Allowlist of what the reconciler may use — commands, MCP connections,
+credentials. This is a permission boundary: read-only by default, and nothing
+beyond this list.
+
+- `<command or MCP connection>`
+
+## Limits
+
+What the reconciler must NEVER do without a human. Phrase as prohibitions, not
+preferences.
+
+- Never `<...>`
+
+## Examples
+
+Good and bad examples for every subjective heuristic above. The bad examples
+teach the boundary.

--- a/packages/loop/templates/DOMAINS.md
+++ b/packages/loop/templates/DOMAINS.md
@@ -1,0 +1,13 @@
+# Domains
+
+Index of declared domains. Each domain has a declaration at
+`domains/<name>/DOMAIN.md` — the source of truth a reconciler agent enforces
+via PRs. See `domains/DOMAIN.template.md` to add one, and run
+`loop lint <name>` before the first `loop run <name>`.
+
+A merged row is a live domain: `loop tick` (typically on cron) reconciles
+every domain its runner's GitHub user owns. Activation is merging the
+declaration; deactivation is removing the row.
+
+| Domain | Paths | Owner |
+| ------ | ----- | ----- |

--- a/packages/loop/tsconfig.json
+++ b/packages/loop/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Bootstrap for **domain loops**: operate repo domains declaratively — each domain has a versioned declaration (`domains/<name>/DOMAIN.md`), a reconciler agent turns drift into small PRs, and a human owner reviews and refines the declaration. Kubernetes-style reconciliation applied to code: `reconcile(domain) → 0 or 1 PR`, state lives in git/GitHub, rejected PRs must become declaration edits.

### What's in the box

- **`packages/loop` (`@decocms/loop`)** — zero-dep CLI:
  - `init` — scaffold `domains/` + install the `domain-lint` skill into the target repo
  - `lint <domain>` — semantic lint of a declaration: mechanical checks + **red-team** ("what useless PR does this text authorize?")
  - `run <domain>` — one reconcile: open-PR lock (label `loop:<domain>`), throwaway worktree off main, `claude -p`, fix ONE violation, PR or nothing
  - `tick` — cron target: reconcile every domain you own (idempotent via the lock)
  - `status` / `status --ui` — inbox: in-flight PRs (checks/review state), running agents, schedule state; `--ui` is a live-refreshing TUI
  - `cron setup|on|off` — schedules `tick` on the OS scheduler (macOS launchd; survives sleep, bakes PATH into the job)
  - The reconcile **protocol** lives in `src/reconcile-prompt.ts` — versioned with the package, not installed anywhere
- **`.cursor/skills/domain-lint`** — the semantic-lint skill (3 passes: mechanical, red-team, authoring/restructuring)
- **`domains/DOMAINS.md` + template** — the index; a merged row = a live domain
- **`apps/web/src/i18n/placeholder-parity.test.ts`** — unit test encoding the placeholder contract (pt-br placeholders ⊆ en placeholders); found and encodes the real `{plural}` case in `orgs.members.connectionCount`

### Already proven in production

The pilot declaration (`domains/i18n/`, shipped in #5170) went through **8 red-team rounds** of `loop lint` — each round found real holes (TODO-marker escape hatch, non-convergent audit loops, spec self-editing, `.ts` toasts invisible to `.tsx` greps, deletable `satisfies` clauses). The first real `loop run i18n`:
1. correctly **stopped on a stale declaration** when #5120 split the workspaces under us (flagged the owner instead of guessing), and
2. after the owner path-fix, opened #5170 — a small, evidence-backed PR reusing existing dictionary keys.

## Testing

- `bun x tsc --noEmit -p packages/loop` ✓
- `bun test apps/web/src/i18n` ✓ (7 tests, incl. the new parity test at its post-refactor path)
- `bun run fmt` / `bun run lint` / `bun run knip` ✓ (no new warnings)
- Live: `status`, `status --ui`, `tick` (no-op path), `cron` (read path), `init`, 8× `lint`, 3× `run` (stale-stop, lock-skip, full reconcile → #5170)

### Notes

- `domains/i18n/` itself ships in #5170 (the reconciler's own PR) — no file overlap between the two PRs, either merge order works.
- `cron setup` is macOS-only for now (launchd); other platforms get a printed crontab suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce declarative domain loops with the `@decocms/loop` CLI and a `domain-lint` skill to declare, lint, and reconcile repo domains via small, evidence-backed PRs. The CLI now ships as a single Node-target bundle (no runtime deps; Bun is build-time only).

- **New Features**
  - `@decocms/loop` CLI: `init`, `lint`, `run`, `tick`, `status`, `status --ui`, `cron setup|on|off`.
  - Reconcile protocol (`src/reconcile-prompt.ts`): fix one violation per run; opens 0–1 PR labeled `loop:<domain>`; uses a throwaway worktree off the default branch.
  - `domain-lint` skill (installed by `init`): mechanical checks, red‑team for loopholes, and authoring/restructuring.
  - Domain scaffolding: `domains/DOMAINS.md` index and `domains/DOMAIN.template.md`.
  - Test: `apps/web/src/i18n/placeholder-parity.test.ts` enforces pt‑br placeholders ⊆ en.
  - Stability and packaging: CLI is a Node-target bundle (no runtime deps; Bun not required); batched GitHub PR listing; resilient run/tick/status behavior (cleanup no longer throws; tick/TUI survive failures); domain name validation; hardened `DOMAINS.md` parsing anchored to the last cell with unit tests; cron plist XML-escaped and on/off idempotent.

- **Migration**
  - Run `npx @decocms/loop init` (or `bunx @decocms/loop init`), copy `domains/DOMAIN.template.md` to `domains/<name>/DOMAIN.md`, and fill it in.
  - `npx @decocms/loop lint <name>` to tighten the declaration; then `npx @decocms/loop run <name>` to reconcile.
  - Optional: schedule with `loop cron setup [minutes]` (macOS only) or add your own crontab/systemd entry calling `loop tick`.

<sup>Written for commit 402348dfe71158a27855b7d2be79217052494696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

