### PR TITLE
fix(harness): don't open a PR to "finish" a change in live workspaces

### DIFF
--- a/packages/harness/src/coding-workspace-prompt.ts
+++ b/packages/harness/src/coding-workspace-prompt.ts
@@ -73,6 +73,7 @@ ${
 }Use the repository and working tree as the source of truth for code questions.
 Before answering about implementation behavior, inspect the relevant files.
 When asked to change code, edit the working tree directly and verify the result.
+The preview hot-reloads from the working tree, so your edits are immediately visible to the user — that IS how a change ships in this workspace, and it is the default "done" for a change request. Opening a pull request is a SEPARATE, explicit step that does NOT update the running preview: never open or push a PR to "finish" a change. Only open a PR when the user explicitly asks to publish, ship, or open one.
 
 Cite files as \`path:line\` when explaining code.
 Do not re-clone the repository; it is already available in the workspace.


### PR DESCRIPTION
## Summary

In a Studio sandbox with a **live preview**, a user asks the chat agent for a change, the agent applies it *and then opens a GitHub PR* as its "done" step. A non-technical/business user watching the preview gets confused: a PR was opened, but the running preview never changed.

Root cause is a **prompt gap** in the interactive coding path. `coding-workspace-prompt.ts` told the agent to "edit the working tree directly and verify" but never established that, in a live-preview workspace, **editing the working tree IS the deliverable**. Combined with:

- the `<agency>` framing (*"keep working until the user's request is fully resolved"* / *"bias to action"*), and
- the GitHub PR tools sitting in the toolset,

the model filled the gap on its own and treated "open a PR" as the natural definition of *done* — the standard software-engineering completion state.

## Fix

Make the default explicit in the shared coding-workspace prompt (used by both the cluster interactive agent and the in-sandbox CLI harness, assembled at `build-agent-system-prompt.ts:153`):

> The preview hot-reloads from the working tree, so your edits are immediately visible to the user — that IS how a change ships in this workspace, and it is the default "done" for a change request. Opening a pull request is a SEPARATE, explicit step that does NOT update the running preview: never open or push a PR to "finish" a change. Only open a PR when the user explicitly asks to publish, ship, or open one.

This aligns with the existing CMS-content rule already in the same prompt (*"Committing the `.deco/blocks/*.json` change is all that is needed"* — never a PR).

## Scope

Interactive path only. The task-board Super Agent seed prompt (`apps/api/src/tools/task-board/enqueue-super-agent.ts:73-75`) **deliberately** produces PRs — it's an async, background delegation flow whose deliverable is a PR — and is intentionally left unchanged.

## Testing notes

Prompt-text change only; no logic touched. `bun run fmt` clean. Worth a manual check in a live sandbox that a plain "change X" request now stops after the working-tree edit + hot reload, and only opens a PR when explicitly asked to publish/ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop opening PRs to “finish” changes in live-preview sandboxes by updating the shared `coding-workspace-prompt` to say working-tree edits are the deliverable and hot-reload is the default “done.”
PRs are now only opened when explicitly requested; the task-board Super Agent flow that produces PRs remains unchanged.

<sup>Written for commit 0f1b6910c783230f0dfe670bf73f7fc5808c7ca2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

