### PR TITLE
fix(ci): restore decocms npm publish by re-matching trusted-publisher filename

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -40,7 +40,7 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # GitOps: tell deco-apps-cd to bump the chart version. Mirrors the image path
-  # in release-studio.yaml — we do NOT write into that repo from here, we fire a
+  # in release-mesh.yaml — we do NOT write into that repo from here, we fire a
   # `studio-chart-bump` repository_dispatch and its own bump-studio-chart.yml
   # self-commits (rewriting Chart.yaml + regenerating Chart.lock + the vendored
   # tgz). Without this, chart bumps were manual and stranded the lock/tgz,

--- a/.github/workflows/release-mesh.yaml
+++ b/.github/workflows/release-mesh.yaml
@@ -1,3 +1,9 @@
+# FILENAME IS LOAD-BEARING: npm publishes `decocms` via OIDC trusted publishing
+# (see publish-npm below — no NODE_AUTH_TOKEN, --provenance only). npm binds the
+# trusted publisher to this exact workflow filename, so renaming this file breaks
+# publishing with a `404 PUT … no permission`. Renaming it studio→mesh in #5120
+# is what broke it. To rename, first update the decocms trusted-publisher config
+# on npmjs.org to the new filename.
 name: Release Studio
 
 on:

--- a/apps/api/scripts/smoke-tarball.ts
+++ b/apps/api/scripts/smoke-tarball.ts
@@ -4,7 +4,7 @@
  * scratch directory and invoking the `deco` bin's `--version`.
  *
  * Why this exists (and lives in scripts/ instead of inline in the
- * release-studio.yaml workflow): `bun build --target bun` emits ESM
+ * release-mesh.yaml workflow): `bun build --target bun` emits ESM
  * `from "pkg"` for every externalized node_modules import. The bundle
  * eagerly resolves those at load time, BEFORE any subcommand runs. If
  * the bundler externalized a package but @vercel/nft never traced +

--- a/deploy/nginx/README.md
+++ b/deploy/nginx/README.md
@@ -24,7 +24,7 @@ settings.
 
 ## Image release
 
-`.github/workflows/release-studio.yaml` publishes the nginx image as a first-class
+`.github/workflows/release-mesh.yaml` publishes the nginx image as a first-class
 release artifact alongside the Bun API image:
 
 ```text


### PR DESCRIPTION
## Summary

`decocms` npm publishes have been failing since **#5120** merged (12:59 UTC 2026-07-24). Every `Release Studio` run since fails in the **Publish to NPM** step with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/decocms
npm error 404  The requested resource 'decocms@4.122.x' could not be found or you do not have permission to access it.
```

### Root cause

The workflow publishes `decocms` via **npm OIDC trusted publishing** — `npm publish --provenance` with `id-token: write` and **no** `NODE_AUTH_TOKEN` (same mechanism as the sibling `publish-bindings` / `publish-runtime` workflows). npm binds a package's trusted-publisher config to the **exact workflow filename**.

#5120 renamed `.github/workflows/release-mesh.yaml` → `release-studio.yaml`. npm's trusted publisher for `decocms` still points at `release-mesh.yaml`, so the OIDC `job_workflow_ref` no longer matches and npm rejects the `PUT` with a 404/permission error. Last successful publish (`4.122.3`, 12:45) was on the old filename; the break lines up exactly with the rename. Sibling packages kept publishing because their workflow files weren't renamed.

### Fix

Rename the workflow back to `release-mesh.yaml`, re-matching the existing trusted-publisher binding. No npm-dashboard change and no new secret required — publishing works again on the next release. Added a load-bearing comment so a future rename updates npm first. The workflow's display name stays `Release Studio`, so this is invisible in the Actions UI. Stale references in `publish-chart.yml`, `deploy/nginx/README.md`, and `smoke-tarball.ts` updated to match.

### Alternative (not taken)

The other clean fix is to keep `release-studio.yaml` and update the `decocms` trusted-publisher config on npmjs.org to the new filename — but that requires npm package-owner access, not a PR.

## Testing

CI-only change; verify by watching the next `Release Studio` run's **Publish to NPM** step succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `decocms` npm publishes by renaming the release workflow back to `release-mesh.yaml` to match npm’s trusted-publisher binding. Fixes the 404/permission error in the “Publish to NPM” step of Release Studio.

- **Bug Fixes**
  - Renamed workflow to `release-mesh.yaml` (OIDC trusted publishing binds to exact filename).
  - Added a load-bearing comment; kept Actions display name as “Release Studio”.
  - Updated references in `.github/workflows/publish-chart.yml`, `apps/api/scripts/smoke-tarball.ts`, and `deploy/nginx/README.md`.

<sup>Written for commit 728ec63bac073e4e00d8f58df0afdd1334aefaff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

