### PR TITLE
fix(sandbox): show Content tab for thread-scoped repos cloned by load_repo

### DIFF
--- a/apps/web/src/components/sandbox/content/content-browser.tsx
+++ b/apps/web/src/components/sandbox/content/content-browser.tsx
@@ -32,14 +32,8 @@ import {
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
-import {
-  SELF_MCP_ALIAS_ID,
-  parseBranchMap,
-  useMCPClient,
-  useProjectContext,
-} from "@/sdk";
+import { useProjectContext } from "@/sdk";
 import { useInsetContext } from "@/layouts/agent-shell-layout";
-import { authClient } from "@/lib/auth-client";
 import { useChatTask } from "@/components/chat/context";
 import { useDecofile } from "@/components/sections-editor/use-decofile";
 import { useLiveMeta } from "@/components/sections-editor/use-live-meta";
@@ -69,13 +63,7 @@ import { listAvailableSections } from "@/components/sections-editor/section-cata
 import { createReferencedBlockSaver } from "@/components/sections-editor/save-referenced-block";
 import { CollectionsSidebar } from "./collections-sidebar";
 import { useSandboxEvents } from "@/components/sandbox/hooks/use-sandbox-events";
-import {
-  sandboxUserStop,
-  useSandboxStart,
-  type SandboxStartArgs,
-} from "@/components/sandbox/hooks/use-sandbox-start";
-import { computePreviewState } from "@/components/sandbox/preview/preview-state";
-import { decodeSandboxStartError } from "@decocms/shared/sandbox-start-errors";
+import { useSandboxLifecycle } from "@/components/sandbox/hooks/sandbox-lifecycle-context";
 import { SandboxStateRenderer } from "./sandbox-state-renderer";
 import {
   buildDuplicatePage,
@@ -258,59 +246,24 @@ export interface ContentBrowserProps {
 
 export function ContentBrowser({ mode = "content" }: ContentBrowserProps) {
   const inset = useInsetContext();
-  const { data: session } = authClient.useSession();
   const { currentBranch: branch } = useChatTask();
   const { org } = useProjectContext();
 
   const virtualMcpId = inset?.entity?.id ?? null;
-  const userId = session?.user?.id;
-  const metadata = inset?.entity?.metadata;
-  const branchMap =
-    userId && branch
-      ? parseBranchMap(metadata?.sandboxMap?.[userId]?.[branch])
-      : {};
-  const branchMapEntries = Object.values(branchMap);
-  const vmEntry =
-    branchMapEntries.find((e) => e.sandboxProviderKind !== "user-desktop") ??
-    branchMapEntries[0];
-  const previewUrl = vmEntry?.previewUrl ?? null;
 
   const vmEvents = useSandboxEvents();
+  // Resolve the sandbox from the shared lifecycle context — the same source
+  // Preview reads. A thread-scoped repo bound by `load_repo` lives on the
+  // thread (not the agent entity), and the lifecycle provider already merges
+  // that in. Reading `inset.entity.metadata.sandboxMap` directly would miss it
+  // and strand Content on "starting" for the ephemeral Decopilot agent.
+  const lifecycle = useSandboxLifecycle();
+  const previewUrl = lifecycle.previewUrl;
+  const sandboxState = lifecycle.previewState;
 
-  const mcpClient = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: inset?.entity?.organization_id ?? "",
-    orgSlug: org.slug,
-  });
-  const startVm = useSandboxStart(mcpClient);
-
-  const triggerStart = () => {
-    if (!virtualMcpId) return;
-    const args: SandboxStartArgs = { virtualMcpId };
-    if (branch) args.branch = branch;
-    startVm.mutate(args);
-  };
-
-  // Mirror Preview's state machine so both tabs agree on what the
-  // sandbox is doing. Without this Content would always show "starting"
-  // even when the sandbox is suspended.
-  const userStopped =
-    !!virtualMcpId &&
-    !!branch &&
-    sandboxUserStop.isStopped(virtualMcpId, branch);
-  const sandboxState = computePreviewState({
-    previewUrl,
-    appPaused: vmEvents.status.state === "paused",
-    userStopped,
-    startError:
-      startVm.isError && startVm.error
-        ? decodeSandboxStartError(startVm.error.message)
-        : null,
-  });
-
-  // The others-thread gate only applies on the Preview surface (which owns
-  // auto-start); Content is gated behind lifecycle.phase === "running" and
-  // never passes `othersThreadGate`, so this state is unreachable here.
+  // Another member's thread, not yet acknowledged: blank the editor rather
+  // than booting their sandbox — the confirmation gate lives on Preview. This
+  // also narrows `sandboxState` for SandboxStateRenderer below.
   if (sandboxState.kind === "othersThread") return null;
 
   if (sandboxState.kind !== "iframe") {
@@ -319,7 +272,7 @@ export function ContentBrowser({ mode = "content" }: ContentBrowserProps) {
         state={sandboxState}
         claimPhase={vmEvents.phase}
         lifecycle={vmEvents.lifecycle}
-        onStart={triggerStart}
+        onStart={lifecycle.start}
         connectionsHref={`/${org.slug}/settings/connections`}
       />
     );

--- a/apps/web/src/layouts/main-panel-tabs/content-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/content-tab.tsx
@@ -1,4 +1,5 @@
 import { ContentBrowser } from "@/components/sandbox/content/content-browser";
+import { useChatTask } from "@/components/chat/chat-context";
 import { agentHasClonableSource } from "@/lib/agent-capabilities";
 import { useVirtualMCP } from "@/sdk";
 import { AlertCircle } from "@untitledui/icons";
@@ -7,7 +8,13 @@ import { useT } from "@/i18n/use-t.ts";
 export function ContentTab({ virtualMcpId }: { virtualMcpId: string }) {
   const t = useT();
   const entity = useVirtualMCP(virtualMcpId);
-  const hasClonableSource = agentHasClonableSource(entity?.metadata);
+  const { activeTask } = useChatTask();
+  // A thread-scoped repo (bound by `load_repo`) is editable even when the agent
+  // itself has no clonable source (e.g. the ephemeral Decopilot agent) — mirror
+  // PreviewTab so Content and Preview agree on what's available.
+  const hasClonableSource =
+    agentHasClonableSource(entity?.metadata) ||
+    agentHasClonableSource(activeTask?.metadata);
 
   if (!hasClonableSource) {
     return (


### PR DESCRIPTION
## Summary

On the ephemeral **Decopilot** ("super agent") — which has no agent-level GitHub repo — cloning a repo into the thread with `load_repo` opens the **Preview** tab correctly, but the **Content** tab shows *"No content to edit. Connect a GitHub repository from the Settings tab to enable Content."*

Two Content-tab code paths predated thread-scoped repos and only ever inspected the **agent entity**, never the **thread** the repo was actually cloned into:

1. **`ContentTab` gate** (`content-tab.tsx`) checked `agentHasClonableSource(entity?.metadata)` alone. `PreviewTab` already also honored `activeTask?.metadata` (a thread-scoped repo bound by `load_repo`). Now mirrored.
2. **`ContentBrowser` sandbox resolution** (`content-browser.tsx`) read `inset.entity.metadata.sandboxMap` **directly**, bypassing the lifecycle context. A thread-scoped sandbox lives on the thread row and is merged into the shared lifecycle by `VmEventsBridge` — so `ContentBrowser` never saw it and stayed stuck on the "starting" state even if the gate had passed. Switched to `useSandboxLifecycle()`, the same source `PreviewContent` reads. This also deletes a hand-rolled duplicate of the sandbox state machine, keeping both tabs in sync by construction.

`load_repo` patches the thread row (see `chat-context.tsx` `data-open-preview`), not the agent entity — which is why Preview (thread-aware) worked and Content (entity-only) didn't.

## Why it's a bug, not intended

There's no comment or guard indicating the entity-only Content gate was deliberate. The Content tab (#3568) predates the Preview thread-scoped relaxation (#3472); its gate and `ContentBrowser`'s sandbox resolution simply weren't updated when `load_repo` / thread-scoped repos landed.

## Testing notes / affected areas

- Type-checked (the changed files compile cleanly; the repo-wide `check` failure is a pre-existing local-env issue — missing `vite/client` types + an untracked `apps/mesh/` runtime dir — unrelated to this diff).
- Affected surface: the Content tab body only. The normal agent-level-repo case is unchanged (the lifecycle context is fed that agent's sandbox map exactly as before); this only additionally covers the thread-scoped case.
- No behavior change to Preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Content tab so it works with thread-scoped repos cloned via `load_repo` (e.g., on the ephemeral Decopilot agent). Content now mirrors Preview and uses the shared sandbox lifecycle, so it no longer gets stuck on “starting.”

- **Bug Fixes**
  - Gate now also checks `activeTask?.metadata`, not just the agent’s metadata.
  - `ContentBrowser` now uses `useSandboxLifecycle()` instead of `inset.entity.metadata.sandboxMap`, removing the duplicate state machine and correctly resolving thread-scoped sandboxes.
  - No change for agent-level repositories.

<sup>Written for commit f2e8fff98bf5ffe826c592d12db2e2c4e4c19de7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

