### PR TITLE
fix(sandbox): return 400 instead of 500 for empty-string entries in git/discard filepaths

### DIFF
--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -730,6 +730,21 @@ describe("git routes", () => {
     expect(await res.json()).toEqual({ error: "filepaths is required" });
   });
 
+  it("discard returns 400 (not 500) when filepaths contains an empty string", async () => {
+    const { appRoot, repoDir } = initRepo();
+
+    const handler = makeGitDiscardHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/discard", {
+        method: "POST",
+        body: JSON.stringify({ filepaths: [""] }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "filepaths is required" });
+  });
+
   it("discard on a renamed file restores the original instead of deleting both", async () => {
     const { appRoot, repoDir } = initRepo();
     writeFileSync(join(repoDir, "old.txt"), "important content\n");

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -829,7 +829,7 @@ export function makeGitDiscardHandler(deps: GitDeps) {
     if (
       !Array.isArray(filepaths) ||
       filepaths.length === 0 ||
-      !filepaths.every((fp) => typeof fp === "string")
+      !filepaths.every((fp) => typeof fp === "string" && fp.trim().length > 0)
     ) {
       return jsonResponse({ error: "filepaths is required" }, 400);
     }


### PR DESCRIPTION
Follows the recurring "400 instead of 500 on malformed git/* request" hardening lane in this exact file (#5150, #5142, #5144, #5175).

**Bug**: `POST /git/discard` with `{"filepaths": [""]}` passed the existing `typeof fp === "string"` check (an empty string is a string) and reached `discard()`. `resolveRepoRelativePath(deps, "")` resolves to the repo root itself (`path.relative(repoDir, repoDir) === ""`), and since `git show HEAD:` (empty path) succeeds and returns the root tree listing instead of erroring, the code treats it as an existing tracked file and calls `git checkout -- ""`. Git rejects an empty pathspec with `fatal: empty string is not a valid pathspec` (exit 128), which isn't caught anywhere in `discard()`, so it bubbles up as an uncaught error and the route's catch-all returns a raw 500 with the git error text instead of a clean 4xx for what is really a malformed request body.

**Fix**: extend the existing filepaths validation to also reject empty/whitespace-only string entries, matching the same 400 (`"filepaths is required"`) already returned for non-string entries.

**Regression test**: added `discard returns 400 (not 500) when filepaths contains an empty string` in `packages/sandbox/daemon/routes/git.test.ts`, which fails against the pre-fix code (500) and passes after.

**To verify**: `bun test packages/sandbox/daemon/routes/git.test.ts`

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox`, and the single targeted test file above (37 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 400 Bad Request (not 500) when `POST /git/discard` receives empty or whitespace-only entries in `filepaths`. This hardens input validation and prevents uncaught git errors.

- **Bug Fixes**
  - Validate `filepaths` to reject empty/whitespace-only strings and respond with 400 `{ error: "filepaths is required" }`.
  - Added a regression test in `packages/sandbox/daemon/routes/git.test.ts` to cover this case.

<sup>Written for commit 003e114c5a3a323d091d6982b24681b131c0f691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

