### PR TITLE
refactor(cli): reuse resolveDataDir() instead of duplicating its logic

### DIFF
--- a/apps/api/src/cli.ts
+++ b/apps/api/src/cli.ts
@@ -201,11 +201,7 @@ if (command === "services") {
     process.exit(1);
   }
 
-  const decoHome =
-    values.home ||
-    process.env.DATA_DIR ||
-    process.env.DECOCMS_HOME ||
-    join(homedir(), "deco");
+  const decoHome = resolveDataDir();
 
   const { servicesCommand } = await import("./cli/commands/services");
   await servicesCommand({
@@ -412,11 +408,7 @@ if (
 }
 
 // ── Server mode (default) ──────────────────────────────────────────────
-const decoHome =
-  values.home ||
-  process.env.DATA_DIR ||
-  process.env.DECOCMS_HOME ||
-  join(homedir(), "deco");
+const decoHome = resolveDataDir();
 
 const serveOptions = {
   port: values.port!,


### PR DESCRIPTION
**Source:** reduction found while auditing `apps/api/src/cli.ts` for the backfill-assets argument-validation area (following up on #5180, which fixed --batch/--limit NaN handling). No further validation gaps found there, but this file had a real duplication.

**Why:** `cli.ts` already defines a `resolveDataDir()` helper (`values.home || process.env.DATA_DIR || process.env.DECOCMS_HOME || join(homedir(), "deco")`) used by the `auth` command. The exact same 4-line expression was copy-pasted verbatim in two other places: the `services` command and the default server-mode block. Three copies of the same precedence chain is a correctness risk if one is ever updated and the others aren't.

**Change:** Replaced both duplicated blocks with calls to the existing `resolveDataDir()` helper. Purely mechanical — `resolveDataDir()` is byte-identical to the inlined logic it replaces (verified by diff), so behavior for `deco services`, `deco` (default server mode), and `deco auth` is unchanged. Net: -10 / +2 lines.

**How to verify:** `cd apps/api && bunx tsc --noEmit` (clean), and manually compare `resolveDataDir()`'s body against the removed blocks — they're identical.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` in `apps/api` (both clean). No existing test covers this file's argument-routing directly (it's the CLI entrypoint script), so this relies on the identical-logic diff as verification; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor CLI to reuse `resolveDataDir()` for data directory resolution in the `services` command and default server mode. Removes duplicated precedence logic and preserves existing behavior.

<sup>Written for commit 03f60be125204d72e124b581e8331524978efeeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

