### PR TITLE
fix(settings): trim STUDIO_SANDBOX_PROVIDER before validating

### DIFF
--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -25,6 +25,20 @@ describe("resolveConfig sandbox provider kind", () => {
 
     expect(result.settings.sandboxProviderKind).toBe("agent-sandbox");
   });
+
+  it("trims surrounding whitespace/newlines instead of throwing", () => {
+    const result = resolveConfig(flags, {
+      STUDIO_SANDBOX_PROVIDER: "agent-sandbox\n",
+    });
+
+    expect(result.settings.sandboxProviderKind).toBe("agent-sandbox");
+  });
+
+  it("still throws for a genuinely unknown value", () => {
+    expect(() =>
+      resolveConfig(flags, { STUDIO_SANDBOX_PROVIDER: "bogus" }),
+    ).toThrow(/Unknown STUDIO_SANDBOX_PROVIDER/);
+  });
 });
 
 describe("resolveConfig NATS tunnel settings", () => {

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -129,7 +129,8 @@ type LegacySandboxProviderKind = SandboxProviderKind | "cluster";
 function resolveSandboxProviderKind(
   raw: string | undefined,
 ): SandboxProviderKind {
-  const kind = (raw && raw.length > 0 ? raw : "user-desktop") as
+  const trimmed = (raw ?? "").trim();
+  const kind = (trimmed.length > 0 ? trimmed : "user-desktop") as
     | LegacySandboxProviderKind
     | string;
   if (kind === "cluster") return "agent-sandbox";


### PR DESCRIPTION
Bug found while auditing edge-case handling in `resolveConfig` (settings config-validation focus area).

`resolveSandboxProviderKind` was the only env-var normalizer in `resolve-config.ts` that didn't trim its raw input before matching it against the known kinds — `resolveDispatchRole` and `resolveNodeEnv` both call `.trim()` first, but `resolveSandboxProviderKind` compared the raw string directly. A value with a trailing newline or surrounding whitespace (a common shape for env vars sourced from k8s ConfigMaps or shell exports) falls through both the `"cluster"` legacy check and the `SANDBOX_PROVIDER_KINDS` set, throwing `Unknown STUDIO_SANDBOX_PROVIDER="agent-sandbox\n"` and crashing the process at startup instead of resolving to the intended value.

A maintainer wants this because it closes a startup fail-fast gap: a whitespace-only difference in how `STUDIO_SANDBOX_PROVIDER` is supplied shouldn't take a pod down, and the fix brings this normalizer in line with the trimming convention already used by its two siblings in the same file.

Fix: trim the raw value before the default/legacy/set-membership checks in `resolveSandboxProviderKind`. Behavior for already-clean values (`"agent-sandbox"`, `"cluster"`, `"user-desktop"`, unset) is unchanged; genuinely unknown values still throw.

Regression tests added to `resolve-config.test.ts`: a value with a trailing newline now resolves instead of throwing, and a genuinely unknown value still throws.

Reviewer check: `bun test apps/api/src/settings/resolve-config.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test file above (47 pass, 0 fail). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim `STUDIO_SANDBOX_PROVIDER` before validation to prevent startup crashes when the env var includes whitespace or newlines. Brings `resolveSandboxProviderKind` in line with other env normalizers and keeps existing behavior for valid and unknown values.

- **Bug Fixes**
  - Trim input in `resolveSandboxProviderKind`; `"cluster"` still maps to `"agent-sandbox"`, and unknown values still throw.
  - Added tests to confirm whitespace values resolve correctly and bogus values throw.

<sup>Written for commit 70acf7ab4936173be4ccc0f8f27b284b61b46fd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

