### PR TITLE
fix(harness): make PR-completion a default, not an absolute ban

### DIFF
--- a/packages/harness/src/coding-workspace-prompt.ts
+++ b/packages/harness/src/coding-workspace-prompt.ts
@@ -73,7 +73,7 @@ ${
 }Use the repository and working tree as the source of truth for code questions.
 Before answering about implementation behavior, inspect the relevant files.
 When asked to change code, edit the working tree directly and verify the result.
-The preview hot-reloads from the working tree, so your edits are immediately visible to the user — that IS how a change ships in this workspace, and it is the default "done" for a change request. Opening a pull request is a SEPARATE, explicit step that does NOT update the running preview: never open or push a PR to "finish" a change. Only open a PR when the user explicitly asks to publish, ship, or open one.
+The preview hot-reloads from the working tree, so your edits are immediately visible to the user — that IS how a change ships in this workspace, and it is the default definition of "done" for a change request. Opening a pull request is a separate step that does NOT update the running preview, so by default do not open or push a PR on your own to "finish" a change. Open a PR only when this turn's instructions explicitly ask you to publish, ship, or open one.
 
 Cite files as \`path:line\` when explaining code.
 Do not re-clone the repository; it is already available in the workspace.


### PR DESCRIPTION
Follow-up to #5185.

## Problem

#5185 was squash-merged with its **first draft** wording:

> ...never open or push a PR to "finish" a change. Only open a PR when the user explicitly asks...

That's an **absolute ban**. But the same coding-workspace system prompt feeds **both** paths and they are indistinguishable at prompt-assembly time:

- `run-agent-loop.ts:161` → `buildAgentSystemPrompt({ codingWorkspace })` runs for both the interactive chat and the task-board Super Agent.
- In `run-stream.ts:449` `codingWorkspace` is derived only from `input.workspace` (cwd `/repo`) — no signal distinguishes a board run from a chat run. Only the **seeded user message** differs.

The task-board Super Agent **must** open a PR on its own at the end (`apps/api/src/tools/task-board/enqueue-super-agent.ts:74` seeds *"...commit on a new branch, push, and open a pull request"*). The absolute-ban wording fights that instruction.

## Fix

Reword so the guidance is a **default** that yields to an explicit per-turn instruction:

> ...by default do not open or push a PR on your own to "finish" a change. Open a PR only when **this turn's instructions** explicitly ask you to publish, ship, or open one.

This restores the intended system-default / user-message-override pattern:

- **Interactive chat** — no PR instruction → stops at the working-tree edit + hot reload. The business user sees the change live in the preview; no surprise PR.
- **Task-board Super Agent** — its seed message explicitly asks for a PR → satisfies the carve-out → keeps opening PRs autonomously.

The task-board seed prompt is left unchanged (it already asks explicitly).

## Testing notes

Prompt-text change only; no logic touched. `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworded the coding workspace prompt so opening a PR is opt-in per turn: by default do not open or push a PR, only when the current instructions ask to publish/ship/open one. This keeps interactive chat changes in the hot-reloaded working tree and allows the task-board Super Agent to continue opening PRs when instructed.

<sup>Written for commit e804e7a0f8b84d05050c109663b5bde26d35a3d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

