### PR TITLE
feat(sandbox): remove hard reload & edit content from preview overflow menu

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -747,12 +747,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     beginNavigation();
   });
 
-  const handleHardReload = () => {
-    if (!previewIframeRef.current || !iframeSrc) return;
-    const sep = iframeSrc.includes("?") ? "&" : "?";
-    previewIframeRef.current.src = `${iframeSrc}${sep}_r=${Date.now()}`;
-  };
-
   const handleDeviceToggle = () => {
     const idx = DEVICE_CYCLE.indexOf(previewDeviceSize);
     setPreviewDeviceSize(DEVICE_CYCLE[(idx + 1) % DEVICE_CYCLE.length]!);
@@ -1202,7 +1196,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // Overflow menu (⋯) — sits on the right, beside the publish actions. Renders
   // whenever there's at least one available action: the Terminal toggle is
   // always available (so it stays reachable during boot, before the iframe is
-  // up), while reload / copy / SEO items are gated on the preview being live.
+  // up), while copy / SEO items are gated on the preview being live.
   const moreMenu =
     showPreviewToolbar || terminal ? (
       <div className="flex shrink-0 items-center">
@@ -1217,20 +1211,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-44">
-            {/* The CMS/Blocks toggle also lives here so it stays reachable when
-                the center toolbar (its primary home) collapses at narrow widths
-                — the ⋯ menu is in the always-present end slot. */}
-            {showPreviewToolbar && (
-              <>
-                <DropdownMenuItem onClick={() => toggleEditingMode("blocks")}>
-                  <Edit05 size={14} />
-                  {blocksActive
-                    ? t("sandbox.preview.exitEditor")
-                    : t("sandbox.preview.editContent")}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-              </>
-            )}
             {terminal && (
               <DropdownMenuItem
                 onClick={() => terminal.setVisible(!terminal.visible)}
@@ -1244,9 +1224,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             {showPreviewToolbar && (
               <>
                 {terminal && <DropdownMenuSeparator />}
-                <DropdownMenuItem onClick={handleHardReload}>
-                  {t("sandbox.preview.hardReload")}
-                </DropdownMenuItem>
                 <DropdownMenuItem onClick={handleCopyUrl}>
                   {t("sandbox.preview.copyCurrentUrl")}
                 </DropdownMenuItem>

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -389,7 +389,6 @@ export const sandbox = {
   "sandbox.preview.failedToCopyUrl": "Failed to copy URL",
   "sandbox.preview.failedToCreatePage": "Failed to create page",
   "sandbox.preview.globalComponents": "Global components",
-  "sandbox.preview.hardReload": "Hard Reload",
   "sandbox.preview.invalidPageBlockKey": "Invalid page block key",
   "sandbox.preview.moreOptions": "More options",
   "sandbox.preview.noPagesFound": "No pages found in this site.",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -404,7 +404,6 @@ export const sandbox = {
   "sandbox.preview.failedToCopyUrl": "Falha ao copiar URL",
   "sandbox.preview.failedToCreatePage": "Falha ao criar página",
   "sandbox.preview.globalComponents": "Componentes globais",
-  "sandbox.preview.hardReload": "Recarregamento forçado",
   "sandbox.preview.invalidPageBlockKey": "Chave de bloco de página inválida",
   "sandbox.preview.moreOptions": "Mais opções",
   "sandbox.preview.noPagesFound": "Nenhuma página encontrada neste site.",


### PR DESCRIPTION
## Summary
Removes two items from the sandbox preview overflow (⋯) menu:
- **Hard Reload** (`Recarregamento forçado`)
- **Edit content** (`Editar conteúdo`) — still reachable from the center toolbar, so nothing is lost.

The menu now reads: **Show terminal → Copy current URL → (SEO) → Open in VSCode/Cursor → Visual tour**.

## Cleanup
- Deleted the now-orphaned `handleHardReload` helper.
- Removed the unused `sandbox.preview.hardReload` i18n key from `en` and `pt-br` dictionaries.
- Updated the stale menu comment that mentioned "reload".

## Testing
- `bun run fmt` ✅
- `bun run --cwd apps/web check` (tsc --noEmit) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed "Hard Reload" and "Edit content" from the sandbox preview overflow (⋯) menu to simplify actions. "Edit content" stays in the center toolbar; the menu now shows: Show terminal, Copy current URL, SEO, Open in VSCode/Cursor, Visual tour.

- **Refactors**
  - Deleted the orphaned handleHardReload helper.
  - Removed unused `sandbox.preview.hardReload` i18n keys from `en` and `pt-br`.
  - Updated the comment that referenced reload.

<sup>Written for commit 56b5f0ea3e23e5c63411497a32daab98e9818ee5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

