### PR TITLE
fix(task-board): only tilt cards that actually change lanes

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -818,6 +818,7 @@ function TaskCard({
       type="button"
       draggable
       data-flip-id={item.id}
+      data-flip-lane={item.status}
       onDragStart={(e) => {
         e.dataTransfer.setData("text/plain", item.id);
         e.dataTransfer.effectAllowed = "move";

--- a/apps/web/src/layouts/task-board/use-flip-lanes.ts
+++ b/apps/web/src/layouts/task-board/use-flip-lanes.ts
@@ -18,22 +18,23 @@ const DURATION = 380;
 const STAGGER = 90;
 const TILT = 5;
 const EASE = "cubic-bezier(0.22, 0.61, 0.36, 1)";
-// A move with meaningful horizontal travel = a lane change (tilt + stagger).
-const LANE_CHANGE_DX = 8;
 
 export function useFlipLanes(
   containerRef: React.RefObject<HTMLElement | null>,
   signature: string,
 ) {
-  const prevRects = useRef<Map<string, DOMRect>>(new Map());
+  // Remember each card's position AND which lane it was in, so a lane change is
+  // detected by the column it actually moved between — not by horizontal delta,
+  // which a board-wide sideways shift (scrollbar toggling, row re-centering)
+  // gives to every card at once, tilting the whole board.
+  const prev = useRef<Map<string, { rect: DOMRect; lane?: string }>>(new Map());
 
   useLayoutEffect(() => {
     const root = containerRef.current;
     if (!root) return;
 
     const nodes = root.querySelectorAll<HTMLElement>("[data-flip-id]");
-    const prev = prevRects.current;
-    const next = new Map<string, DOMRect>();
+    const next = new Map<string, { rect: DOMRect; lane?: string }>();
 
     const reduced =
       typeof window !== "undefined" &&
@@ -46,17 +47,18 @@ export function useFlipLanes(
       const id = el.dataset.flipId;
       if (!id) continue;
       const rect = el.getBoundingClientRect();
-      next.set(id, rect);
-      const old = prev.get(id);
+      const lane = el.dataset.flipLane;
+      next.set(id, { rect, lane });
+      const old = prev.current.get(id);
       if (!old) continue;
-      const dx = old.left - rect.left;
-      const dy = old.top - rect.top;
+      const dx = old.rect.left - rect.left;
+      const dy = old.rect.top - rect.top;
       if (dx || dy) {
-        moved.push({ el, dx, dy, lane: Math.abs(dx) > LANE_CHANGE_DX });
+        moved.push({ el, dx, dy, lane: old.lane !== lane });
       }
     }
 
-    prevRects.current = next;
+    prev.current = next;
     if (reduced || moved.length === 0) return;
 
     // Invert: paint every moved card at its previous position (before browser


### PR DESCRIPTION
## Summary
Fixes a Task board bug where moving one task to another column tilted **every** card, and they stayed tilted for ~1.7s.

## Root cause
`useFlipLanes` inferred a lane change from horizontal delta (`Math.abs(dx) > 8`). A board-wide sideways shift — a scrollbar appearing when a column grows, or the centered lane row re-centering — moves *every* card >8px, so all cards were flagged as lane-changers. Each got the tilt, and the `laneOrder++ * STAGGER` cascade delayed the last card's cleanup to `380 + 15×90 + 30 ≈ 1760ms`.

## Fix
Track each card's actual column via a new `data-flip-lane` attribute and detect a lane change by `old.lane !== lane` instead of by `dx`. A pure layout shift leaves the lane unchanged → no tilt, no stagger. The dx/dy delta is still used for the FLIP translate inversion.

## Testing
- `bun run check` and `bun run fmt` pass.
- Not covered by a unit test — FLIP is `getBoundingClientRect`/DOM-driven and only meaningfully verified in a browser. Follow-up: e2e assertion that sibling cards carry no `rotate` transform on a single move.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Task board animations so only cards that actually move columns tilt. Stops board-wide tilt and the ~1.7s stagger delay on layout shifts.

- **Bug Fixes**
  - Detect lane changes via `data-flip-lane` instead of horizontal delta; added the attribute to `TaskCard`.
  - In `useFlipLanes`, store each card’s previous rect and lane; use dx/dy only for FLIP translate, and apply tilt only when the lane value changes.

<sup>Written for commit c3b54222473eab3942ec5e57683a395c7d1ac1f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

