### PR TITLE
fix(sandbox): auto-retry transient SANDBOX_START failures without a refresh

### DIFF
--- a/apps/web/src/components/sandbox/hooks/use-sandbox-start.test.ts
+++ b/apps/web/src/components/sandbox/hooks/use-sandbox-start.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { isRetryableSandboxStartError } from "./use-sandbox-start";
+
+// Pins the retry predicate to the exact "retry shortly" marker the server
+// appends to transient lifecycle/lock errors (apps/api/src/storage/
+// agent-sandbox-sessions.ts + *-runner-state.ts). If that contract drifts,
+// this fails instead of silently reverting to surfacing the error.
+describe("isRetryableSandboxStartError", () => {
+  it("retries the server's transient lifecycle/lock errors", () => {
+    for (const message of [
+      "agent sandbox lifecycle transition in progress for vir_x/staging; retry shortly",
+      "agent sandbox lifecycle lock busy >90000ms for vir_x/staging; retry shortly",
+      "sandbox advisory lock busy >90000ms for user=u projectRef=p kind=agent-sandbox — provisioner is slow or stuck; retry shortly",
+    ]) {
+      expect(isRetryableSandboxStartError(new Error(message))).toBe(true);
+    }
+  });
+
+  it("does not retry real boot failures or user-driven stops", () => {
+    for (const message of [
+      "Sandbox start was superseded by a stop",
+      "Sandbox did not become ready within 180 seconds",
+      "tunnel_no_first_frame: no response frame arrived before firstFrameTimeoutMs",
+      "Virtual MCP not found",
+    ]) {
+      expect(isRetryableSandboxStartError(new Error(message))).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/components/sandbox/hooks/use-sandbox-start.ts
+++ b/apps/web/src/components/sandbox/hooks/use-sandbox-start.ts
@@ -48,6 +48,16 @@ const inflightStarts = new Map<string, Promise<SandboxStartResult>>();
 const startKey = (args: SandboxStartArgs) =>
   `${args.virtualMcpId}::${args.branch ?? ""}::${args.sandboxProviderKind ?? ""}`;
 
+// Concurrency-transient failures the server tags with a "retry shortly" marker
+// (lifecycle-transition-in-progress + advisory-lock-busy in
+// agent-sandbox-sessions.ts / *-runner-state.ts). These resolve within a beat
+// once the racing lifecycle transition finishes, so we retry them in-place
+// rather than surfacing an error the user would have to clear by hand. The
+// mutation stays `isPending` across retries, so the booting overlay holds
+// instead of flipping to the error state.
+export const isRetryableSandboxStartError = (error: Error) =>
+  error.message.includes("retry shortly");
+
 // Tracks (virtualMcpId, branch) pairs explicitly stopped by the user.
 // Prevents self-heal from restarting a sandbox the user just stopped: the SSE
 // "gone" event can race the sandboxMap query refetch and arrive while vmEntry
@@ -69,6 +79,9 @@ export function useSandboxStart(client: MinimalMcpClient) {
   const queryClient = useQueryClient();
   return useMutation<SandboxStartResult, Error, SandboxStartArgs>({
     mutationKey: SANDBOX_START_MUTATION_KEY,
+    // Auto-recover from transient lifecycle/lock contention without a refresh.
+    retry: (count, error) => isRetryableSandboxStartError(error) && count < 6,
+    retryDelay: (attempt) => Math.min(500 * 2 ** attempt, 5000),
     mutationFn: async (args) => {
       if (args.branch) sandboxUserStop.clear(args.virtualMcpId, args.branch);
       const key = startKey(args);

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -818,6 +818,7 @@ function TaskCard({
       type="button"
       draggable
       data-flip-id={item.id}
+      data-flip-lane={item.status}
       onDragStart={(e) => {
         e.dataTransfer.setData("text/plain", item.id);
         e.dataTransfer.effectAllowed = "move";

--- a/apps/web/src/layouts/task-board/use-flip-lanes.ts
+++ b/apps/web/src/layouts/task-board/use-flip-lanes.ts
@@ -18,22 +18,23 @@ const DURATION = 380;
 const STAGGER = 90;
 const TILT = 5;
 const EASE = "cubic-bezier(0.22, 0.61, 0.36, 1)";
-// A move with meaningful horizontal travel = a lane change (tilt + stagger).
-const LANE_CHANGE_DX = 8;
 
 export function useFlipLanes(
   containerRef: React.RefObject<HTMLElement | null>,
   signature: string,
 ) {
-  const prevRects = useRef<Map<string, DOMRect>>(new Map());
+  // Remember each card's position AND which lane it was in, so a lane change is
+  // detected by the column it actually moved between — not by horizontal delta,
+  // which a board-wide sideways shift (scrollbar toggling, row re-centering)
+  // gives to every card at once, tilting the whole board.
+  const prev = useRef<Map<string, { rect: DOMRect; lane?: string }>>(new Map());
 
   useLayoutEffect(() => {
     const root = containerRef.current;
     if (!root) return;
 
     const nodes = root.querySelectorAll<HTMLElement>("[data-flip-id]");
-    const prev = prevRects.current;
-    const next = new Map<string, DOMRect>();
+    const next = new Map<string, { rect: DOMRect; lane?: string }>();
 
     const reduced =
       typeof window !== "undefined" &&
@@ -46,17 +47,18 @@ export function useFlipLanes(
       const id = el.dataset.flipId;
       if (!id) continue;
       const rect = el.getBoundingClientRect();
-      next.set(id, rect);
-      const old = prev.get(id);
+      const lane = el.dataset.flipLane;
+      next.set(id, { rect, lane });
+      const old = prev.current.get(id);
       if (!old) continue;
-      const dx = old.left - rect.left;
-      const dy = old.top - rect.top;
+      const dx = old.rect.left - rect.left;
+      const dy = old.rect.top - rect.top;
       if (dx || dy) {
-        moved.push({ el, dx, dy, lane: Math.abs(dx) > LANE_CHANGE_DX });
+        moved.push({ el, dx, dy, lane: old.lane !== lane });
       }
     }
 
-    prevRects.current = next;
+    prev.current = next;
     if (reduced || moved.length === 0) return;
 
     // Invert: paint every moved card at its previous position (before browser


### PR DESCRIPTION
## Summary

Transient `SANDBOX_START` failures surfaced a 500 to the frontend that the user had to clear by **refreshing the page**. This retries them in-place so the booting overlay holds and the sandbox comes up on its own.

Found via VictoriaLogs (prod, `eks-serverless`, last 24h): of 20 `SANDBOX_START` 5xx, **6** were concurrency-transient — a racing start/stop/reap holding the per-branch lock:

- `agent sandbox lifecycle transition in progress … retry shortly` (`agent-sandbox-sessions.ts:207`)
- `… lifecycle lock busy … retry shortly` (`agent-sandbox-sessions.ts:95`)
- `sandbox advisory lock busy … retry shortly` (`*-runner-state.ts`)

The server already tags exactly these with a `retry shortly` marker. This keys off that contract and lets react-query retry the mutation (`retry`/`retryDelay`, matching the existing `use-publish-gate.ts` pattern). The mutation stays `isPending` across retries, so the UI keeps showing "Booting…" instead of flipping to the error state — no refresh.

## Scope

Retries **only** the `retry shortly` class. Deliberately excluded:
- `Sandbox start was superseded by a stop` — retrying could resurrect a sandbox the user just stopped.
- Boot timeouts (`did not become ready within 180s`, `tunnel_*`) — real failures; another ~180s retry usually fails the same way and is worth surfacing.

## Testing

- New co-located unit test pins the predicate to the real server messages (guards against the marker drifting).
- `bun test` on the new file passes; `bun run fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-retries transient SANDBOX_START errors so sandboxes recover without a page refresh, and fixes task-board tilt by detecting real lane changes only.

- **Bug Fixes**
  - Sandbox start: Retry server-marked “retry shortly” errors in-place via `@tanstack/react-query` (up to 6 attempts with backoff to 5s). The mutation stays pending so the “Booting…” overlay holds. Added a unit test to pin the retry predicate to the server messages.
  - Task board: Detect lane changes by column using `data-flip-lane`, so horizontal layout shifts don’t tilt every card. Added the attribute to task cards.

<sup>Written for commit 92b1936fe47faa48d02d98eac153b76ac484096e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

