### PR TITLE
fix(sandbox): isolate new chats on their own thread:<id> branch, never staging

### DIFF
--- a/apps/api/src/tools/sandbox/start.test.ts
+++ b/apps/api/src/tools/sandbox/start.test.ts
@@ -209,12 +209,14 @@ function makeCtx(overrides: {
   userId?: string;
   virtualMcp?: ReturnType<typeof makeVirtualMcp> | null;
   updateSpy?: ReturnType<typeof mock>;
+  threadId?: string;
 }): StudioContext {
   const {
     orgId = ORG_ID,
     userId = USER_ID,
     virtualMcp,
     updateSpy = mock(async () => {}),
+    threadId,
   } = overrides;
 
   const findById = mock(async (_id: string) => virtualMcp ?? null);
@@ -300,7 +302,7 @@ function makeCtx(overrides: {
       createCounter: () => ({ add: () => {} }),
     } as never,
     baseUrl: "https://studio.example.com",
-    metadata: { requestId: "req_1", timestamp: new Date() },
+    metadata: { requestId: "req_1", timestamp: new Date(), threadId },
     objectStorage: null as never,
     aiProviders: null as never,
     createMCPProxy: null as never,
@@ -582,20 +584,34 @@ describe("SANDBOX_START", () => {
     expect(result.isNewVm).toBe(false);
   });
 
-  it("uses staging when input.branch is omitted and threads it into the ref", async () => {
+  it("errors instead of defaulting to a shared branch when input.branch is omitted and there is no thread context", async () => {
     const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
     const updateSpy = mock(async () => {});
     const ctx = makeCtx({ virtualMcp, updateSpy });
 
+    await expect(
+      SANDBOX_START.handler({ virtualMcpId: VMCP_ID }, ctx),
+    ).rejects.toThrow(
+      "SANDBOX_START requires an explicit `branch` or a thread context",
+    );
+    // Never provisioned a sandbox on a silent shared-branch default.
+    expect(mockEnsure).not.toHaveBeenCalled();
+  });
+
+  it("derives the thread's own thread:<id> branch when input.branch is omitted but a thread is in context", async () => {
+    const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
+    const ctx = makeCtx({ virtualMcp, threadId: "t_42" });
+
     const result = await SANDBOX_START.handler({ virtualMcpId: VMCP_ID }, ctx);
 
-    expect(result.branch).toBe("staging");
+    // Per-thread isolation, never the shared `staging` branch.
+    expect(result.branch).toBe("thread:t_42");
     const [id] = mockEnsure.mock.calls[0]! as [SandboxId];
     expect(id.projectRef).toBe(
       composeSandboxRef({
         orgId: ORG_ID,
         virtualMcpId: VMCP_ID,
-        branch: result.branch,
+        branch: "thread:t_42",
       }),
     );
   });

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -47,16 +47,14 @@ import {
   detectRepoRuntime,
   detectRepoRuntimeAnonymous,
 } from "../../shared/github-runtime-detect";
-import {
-  DEFAULT_WORKSPACE_BRANCH,
-  PACKAGE_MANAGER_CONFIG,
-} from "@decocms/shared/runtime-defaults";
+import { PACKAGE_MANAGER_CONFIG } from "@decocms/shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import { computeClaimHandle } from "../../sandbox/claim-handle";
 import {
   getThreadGithubRepo,
   setThreadSandboxMapEntry,
   syntheticBranchToGitRef,
+  threadBranch,
   threadIdFromBranch,
 } from "./thread-repo";
 import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
@@ -128,7 +126,7 @@ export const SANDBOX_START = defineTool({
       .min(1)
       .optional()
       .describe(
-        "Optional git branch to check out. When omitted, the handler uses the shared `staging` branch. The resolved branch is returned in the response so callers can persist it.",
+        "Optional git branch to check out. When omitted, the handler derives the thread's own synthetic `thread:<id>` branch from the thread context; with neither a branch nor a thread it errors rather than defaulting to a shared branch. The resolved branch is returned in the response so callers can persist it.",
       ),
     sandboxProviderKind: sandboxProviderKindInputSchema
       .optional()
@@ -148,7 +146,19 @@ export const SANDBOX_START = defineTool({
     requireAuth(ctx);
     const organization = requireOrganization(ctx);
     await ctx.access.check();
-    const resolvedBranch = input.branch ?? DEFAULT_WORKSPACE_BRANCH;
+    // Prefer the caller's branch; otherwise isolate on the thread's own
+    // synthetic `thread:<id>` branch (same per-thread scheme as thread creation
+    // and `load_repo`) so a branchless start never lands on a shared working
+    // branch. There is deliberately NO default-to-`staging` fallback: a shared
+    // branch must be an explicit choice, never something we silently drift into.
+    const resolvedBranch =
+      input.branch ??
+      (ctx.metadata?.threadId ? threadBranch(ctx.metadata.threadId) : null);
+    if (!resolvedBranch) {
+      throw new Error(
+        "SANDBOX_START requires an explicit `branch` or a thread context; refusing to default to a shared branch.",
+      );
+    }
 
     // Resolve kind after loading metadata so recorded sandboxMap entries can
     // pin the provider when the caller did not pass an explicit kind.

--- a/apps/api/src/tools/thread/create.integration.test.ts
+++ b/apps/api/src/tools/thread/create.integration.test.ts
@@ -13,7 +13,7 @@ describe("COLLECTION_THREADS_CREATE", () => {
     await env.close();
   });
 
-  it("assigns staging when the vMCP has a github repo", async () => {
+  it("isolates the thread on its own thread:<id> branch when the vMCP has a github repo", async () => {
     const vmcp = await env.ctx.storage.virtualMcps.create(
       env.orgId,
       env.userId,
@@ -39,7 +39,9 @@ describe("COLLECTION_THREADS_CREATE", () => {
       env.ctx,
     );
 
-    expect(result.item.branch).toBe("staging");
+    // Per-thread synthetic branch (includes the repo connection id), never the
+    // shared `staging` branch — concurrent chats must not share a working branch.
+    expect(result.item.branch).toBe(`thread:${result.item.id}/conn_x`);
     expect(result.item.virtual_mcp_id).toBe(vmcp.id);
   });
 
@@ -119,7 +121,7 @@ describe("COLLECTION_THREADS_CREATE", () => {
     expect(result.item.branch).toBeNull();
   });
 
-  it("uses staging instead of a warm sandboxMap branch", async () => {
+  it("uses its own thread:<id> branch instead of a warm sandboxMap branch", async () => {
     const vmcp = await env.ctx.storage.virtualMcps.create(
       env.orgId,
       env.userId,
@@ -163,7 +165,7 @@ describe("COLLECTION_THREADS_CREATE", () => {
       env.ctx,
     );
 
-    expect(result.item.branch).toBe("staging");
+    expect(result.item.branch).toBe(`thread:${result.item.id}/conn_x`);
   });
 
   it("is idempotent: creating with the same id twice returns the same row", async () => {

--- a/apps/api/src/tools/thread/create.ts
+++ b/apps/api/src/tools/thread/create.ts
@@ -5,7 +5,9 @@
  *
  * Branch resolution (only meaningful when the vMCP has a githubRepo):
  *   1. Honor `data.branch` when provided.
- *   2. Otherwise use the shared `staging` branch.
+ *   2. Otherwise isolate the chat on its own synthetic `thread:<id>` branch
+ *      (the same per-thread scheme `load_repo` uses), so concurrent chats never
+ *      share a working branch.
  *
  * Threads created on a vMCP without a githubRepo always get `branch = null`.
  *
@@ -26,7 +28,7 @@ import {
   ThreadEntitySchema,
 } from "@decocms/shared/thread/schema";
 import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
-import { DEFAULT_WORKSPACE_BRANCH } from "@decocms/shared/runtime-defaults";
+import { threadBranch } from "../sandbox/thread-repo";
 
 const CreateInputSchema = z.object({
   data: ThreadCreateDataSchema.describe(
@@ -85,7 +87,7 @@ export const COLLECTION_THREADS_CREATE = defineTool({
     const metadata = vmcp.metadata as GithubRepoMeta | null | undefined;
     const githubRepo = metadata?.githubRepo;
     const branch = githubRepo
-      ? (data.branch ?? DEFAULT_WORKSPACE_BRANCH)
+      ? (data.branch ?? threadBranch(taskId, githubRepo.connectionId))
       : null;
 
     const result = await ctx.storage.threads.create({

--- a/apps/web/src/components/sandbox/hooks/use-sandbox-start.ts
+++ b/apps/web/src/components/sandbox/hooks/use-sandbox-start.ts
@@ -26,7 +26,7 @@ interface MinimalMcpClient {
 
 export interface SandboxStartArgs {
   virtualMcpId: string;
-  /** Optional — SANDBOX_START uses `staging` when omitted. */
+  /** Optional — SANDBOX_START derives the thread's own `thread:<id>` branch when omitted. */
   branch?: string;
   /**
    * Optional explicit sandbox provider kind. When omitted the server picks

--- a/packages/e2e/tests/chat-locked-thread.spec.ts
+++ b/packages/e2e/tests/chat-locked-thread.spec.ts
@@ -107,9 +107,10 @@ async function createAgentAndThread(
     },
   );
   // Pass `branch: "main"` explicitly: COLLECTION_THREADS_CREATE otherwise
-  // assigns `staging`, which would beat the body's "main" in the route
-  // handler's `existingThread?.branch ?? input.branch` resolution. Seed the
-  // row at "main" so the lock assertions can check against a stable value.
+  // isolates the thread on its own synthetic `thread:<id>` branch, which would
+  // beat the body's "main" in the route handler's
+  // `existingThread?.branch ?? input.branch` resolution. Seed the row at "main"
+  // so the lock assertions can check against a stable value.
   const thread = await callSelfMcpTool<{ item: { id: string } }>(
     api,
     orgSlug,

--- a/packages/shared/src/runtime-defaults.test.ts
+++ b/packages/shared/src/runtime-defaults.test.ts
@@ -1,14 +1,12 @@
 import { describe, it, expect } from "bun:test";
 import {
   DEFAULT_BASE_BRANCH,
-  DEFAULT_WORKSPACE_BRANCH,
   PACKAGE_MANAGER_CONFIG,
   type PackageManager,
 } from "./runtime-defaults";
 
 describe("PACKAGE_MANAGER_CONFIG", () => {
-  it("keeps shared sandbox work on staging and publishes to main", () => {
-    expect(DEFAULT_WORKSPACE_BRANCH).toBe("staging");
+  it("publishes sandbox work back to main", () => {
     expect(DEFAULT_BASE_BRANCH).toBe("main");
   });
 

--- a/packages/shared/src/runtime-defaults.ts
+++ b/packages/shared/src/runtime-defaults.ts
@@ -5,9 +5,6 @@ export type VMRuntime = "node" | "bun" | "deno";
 /** Base branch sandbox work starts from and publishes back to. */
 export const DEFAULT_BASE_BRANCH = "main";
 
-/** Shared branch used by new GitHub-backed threads and branchless sandboxes. */
-export const DEFAULT_WORKSPACE_BRANCH = "staging";
-
 export const PACKAGE_MANAGER_CONFIG: Record<
   PackageManager,
   {

--- a/packages/shared/src/thread/schema.ts
+++ b/packages/shared/src/thread/schema.ts
@@ -131,7 +131,7 @@ export const ThreadCreateDataSchema = z.object({
     .min(1)
     .optional()
     .describe(
-      "Preferred branch. Used only when the vMCP has a githubRepo; ignored otherwise. When omitted, the server uses the shared staging branch.",
+      "Preferred branch. Used only when the vMCP has a githubRepo; ignored otherwise. When omitted, the server isolates the thread on its own synthetic `thread:<id>` branch.",
     ),
 });
 


### PR DESCRIPTION
## Summary

New GitHub-backed threads (and branchless sandbox starts) used to default to a single shared `staging` branch. Since the hosted sandbox session is keyed only by `(organization_id, virtual_mcp_id, branch)` — **no `userId`** (`agent-sandbox-sessions.ts:105`) — that collapsed **every chat in an org onto one shared sandbox and one `staging` working tree**. Concurrent chats stepped on each other's files/git.

This PR makes **New Chat isolate each thread on its own synthetic `thread:<id>` branch** — the same per-thread scheme `load_repo` already uses (`load-repo.ts:183`). A shared sandbox is still fully supported, but only as an **explicit** choice: two users passing `branch: "staging"` still resolve to the same shared sandbox.

### Behavior

| Scenario | Result |
|---|---|
| New Chat (github-backed) | `thread:<id>` — its own sandbox, **never staging** |
| Two users pick `staging` explicitly | **same shared sandbox** (key `org+vMCP+staging`) ✅ |
| Neither branch nor thread context | **errors** — refuses to silently default to a shared branch |

## Changes

- **`COLLECTION_THREADS_CREATE`** — default branch is now `threadBranch(taskId, githubRepo.connectionId)` instead of `DEFAULT_WORKSPACE_BRANCH`.
- **`SANDBOX_START`** — derives `thread:<id>` from `ctx.metadata.threadId` when `branch` is omitted; throws instead of defaulting to a shared branch when there is neither.
- Removed the now-orphaned `DEFAULT_WORKSPACE_BRANCH` (`"staging"`) constant (dead after both fallbacks were dropped).
- Updated schema/JSDoc/inline docs that described the old staging default.

## Tradeoff

This intentionally reverts the sandbox-sharing consolidation from #5116 / #5132: each chat now gets its own sandbox (more isolation, more VMs). Explicit-branch sharing is preserved on purpose.

## Testing

- Inverted the tests that encoded the old `staging` default:
  - `start.test.ts`: "falls back to staging" → "**errors** instead of defaulting to a shared branch" (+ asserts the sandbox was never provisioned); kept/added a test proving `thread:t_42` is derived when a thread is in context.
  - `create.integration.test.ts`: asserts `thread:<id>/conn_x`.
  - `runtime-defaults.test.ts`: dropped the removed-constant assertion.
  - `chat-locked-thread.spec.ts`: refreshed a stale comment.
- `tsc` (api + shared) ✅ · `bun test` for the affected unit files ✅ (28 pass) · `fmt` ✅ · `lint` ✅ 0 errors · `knip` ✅ no dead code.
- `create.integration.test.ts` requires a live Postgres and was not run locally (assertion-only change); it runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolate each new GitHub-backed chat on its own `thread:<id>` branch to prevent sandbox collisions. `SANDBOX_START` no longer defaults to `staging`; it derives from thread context or errors, and shared branches remain opt-in.

- **Bug Fixes**
  - `COLLECTION_THREADS_CREATE`: default to `threadBranch(taskId, connectionId)` (same scheme as `load_repo`) instead of `staging`.
  - `SANDBOX_START`: derive `thread:<id>` from `ctx.metadata.threadId` when `branch` is omitted; error when neither is provided; explicit shared branches still work (e.g., `branch: "staging"`).
  - Removed `DEFAULT_WORKSPACE_BRANCH` and updated docs/tests.

- **Migration**
  - Ensure calls to `SANDBOX_START` include a `branch` or run within a thread so `threadId` is present.
  - To keep a shared sandbox, pass an explicit branch (e.g., `staging`).
  - Remove imports of `DEFAULT_WORKSPACE_BRANCH` from `@decocms/shared/runtime-defaults`.

<sup>Written for commit 8afe4212951c7dcc8b51d0d2859ad7a15fee95c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

