### PR TITLE
fix(preview): widen page picker dropdown to 500px, centered

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1042,7 +1042,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
         </div>
 
         {pagesOpen && (
-          <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-lg border bg-popover shadow-lg">
+          <div className="absolute left-1/2 top-full z-50 mt-1.5 w-[500px] max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-hidden rounded-lg border bg-popover shadow-lg">
             <div className="px-2 h-10 flex items-center gap-2 border-b">
               <SearchLg
                 size={14}


### PR DESCRIPTION
## Summary
The CMS page picker dropdown inherited its width from the narrow trigger container (`w-64` = 256px, shrinking further in a cramped toolbar), so page paths like `/black-friday/30-off` were truncated to `Bla...`, `Black ...`, etc.

The trigger stays compact, but the dropdown panel now renders at a fixed **500px**, **centered** on the trigger, so paths are no longer clipped.

## Changes
- `apps/web/src/components/sandbox/preview/preview.tsx`: dropdown panel switched from `left-0 right-0` (inherited width) to `left-1/2 -translate-x-1/2 w-[500px]`, with a `max-w-[calc(100vw-2rem)]` guard so it never overflows the viewport on narrow windows.

## Testing
- `bun run fmt` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened the preview page picker dropdown to 500px and centered it over the trigger to prevent truncating long paths. Added a viewport max-width so it won’t overflow on small screens.

<sup>Written for commit ea74e50209c8f9c55604adfa399bb549dec78332. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

