### PR TITLE
fix(decopilot): retry transient JetStream-API timeout in StreamBuffer.init

### DIFF
--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.test.ts
@@ -203,6 +203,64 @@ describe("NatsStreamBuffer", () => {
     expect(streamAddMock).toHaveBeenCalledTimes(1);
   });
 
+  it("init retries a transient JS-API timeout instead of wedging js=null", async () => {
+    // Regression: a single startup timeout on the JS-API handshake used to
+    // leave `this.js` null for the pod's whole life (init only re-ran on a
+    // reconnect that never came), failing every run at publishRawChunk.
+    let attempts = 0;
+    const streamInfoMock = mock(() => {
+      attempts += 1;
+      if (attempts === 1) return Promise.reject(new Error("timeout"));
+      return Promise.resolve({});
+    });
+    const mockJsm = {
+      streams: {
+        info: streamInfoMock,
+        update: mock(() => Promise.resolve({})),
+        add: mock(() => Promise.resolve({})),
+      },
+    };
+    const publishMock = mock(() => Promise.resolve({ seq: 1 }));
+
+    const buffer = new NatsStreamBuffer({
+      getConnection: () => ({}) as never,
+      getJetStream: () => ({ publish: publishMock }) as never,
+      getJetStreamManager: (() => Promise.resolve(mockJsm)) as never,
+    });
+
+    await buffer.init();
+
+    // Retried past the transient failure and then wired up a live client.
+    expect(streamInfoMock).toHaveBeenCalledTimes(2);
+    const ok = await buffer.publishRawChunk("thrd_x", {
+      type: "text",
+    } as never);
+    expect(ok).toBe(true);
+    expect(publishMock).toHaveBeenCalled();
+  });
+
+  it("init does NOT retry a non-transient (semantic) error", async () => {
+    const getJetStreamManager = mock(() =>
+      Promise.resolve({
+        streams: {
+          info: mock(() => Promise.reject(new Error("invalid stream config"))),
+          update: mock(() => Promise.resolve({})),
+          add: mock(() => Promise.resolve({})),
+        },
+      }),
+    );
+
+    const buffer = new NatsStreamBuffer({
+      getConnection: () => ({}) as never,
+      getJetStream: () => ({}) as never,
+      getJetStreamManager: getJetStreamManager as never,
+    });
+
+    await expect(buffer.init()).rejects.toThrow();
+    // Failed fast: exactly one attempt, no exponential-backoff loop.
+    expect(getJetStreamManager).toHaveBeenCalledTimes(1);
+  });
+
   describe("createTailStream", () => {
     function encodeMsg(payload: unknown): DeferredMsg {
       return { data: new TextEncoder().encode(JSON.stringify(payload)) };

--- a/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
+++ b/apps/api/src/api/routes/decopilot/nats-stream-buffer.ts
@@ -31,6 +31,7 @@ import {
   type MsgHdrs,
   type NatsConnection,
 } from "@nats-io/nats-core";
+import { retry } from "@decocms/shared/std";
 import { DECOPILOT_STREAM_NAME } from "./projector-stream-messages";
 import type { StreamBuffer } from "./stream-buffer";
 import { natsChunkSource } from "./nats-chunk-source";
@@ -214,6 +215,18 @@ export interface NatsStreamBufferOptions {
   getJetStreamManager?: () => Promise<JetStreamManager>;
 }
 
+/**
+ * A JetStream management round-trip that failed transiently (server briefly
+ * slow / mid-election / no responders yet) rather than because the request is
+ * semantically wrong. Only these are worth retrying — a bad stream config would
+ * fail identically every attempt.
+ */
+function isTransientJsApiError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === "TimeoutError") return true;
+  return /timeout|no responders|503/i.test(err.message);
+}
+
 export class NatsStreamBuffer implements StreamBuffer {
   private js: JetStreamClient | null = null;
   private jsm: JetStreamManager | null = null;
@@ -231,37 +244,54 @@ export class NatsStreamBuffer implements StreamBuffer {
       );
       return;
     }
-    const jsm = this.options.getJetStreamManager
-      ? await this.options.getJetStreamManager()
-      : await jetstreamManager(nc);
-
     const config = decopilotStreamConfig();
 
-    try {
-      await jsm.streams.info(DECOPILOT_STREAM_NAME);
-      await jsm.streams.update(DECOPILOT_STREAM_NAME, config);
-    } catch (err: unknown) {
-      const isNotFound =
-        err instanceof Error && err.message.includes("stream not found");
-      if (isNotFound) {
-        await jsm.streams.add(config);
-      } else {
-        // JetStream cannot change a stream's `storage` in place, so flipping the
-        // legacy Memory stream to File makes `update` reject. The stream is
-        // ephemeral run-scratch (it only holds in-flight chunks), so a one-time
-        // delete + add at deploy is safe: drop the old stream and recreate it
-        // file-backed. Any other error is real — rethrow.
-        const isStorageMismatch =
-          err instanceof Error &&
-          /can ?not change.*storage|storage type/i.test(err.message);
-        if (isStorageMismatch) {
-          await jsm.streams.delete(DECOPILOT_STREAM_NAME);
-          await jsm.streams.add(config);
-        } else {
-          throw err;
+    // The JS-API round-trips below (manager handshake + stream ensure) can time
+    // out transiently if JetStream is briefly slow at boot. Init only re-runs on
+    // a NATS `onReady` (reconnect); when the connection stays up, a single
+    // startup timeout would otherwise leave `this.js` null for the pod's whole
+    // life — every run then fails at `publishRawChunk`. Retry the transient
+    // failures in place instead of relying on a reconnect that may never come.
+    const jsm = await retry(
+      async () => {
+        const mgr = this.options.getJetStreamManager
+          ? await this.options.getJetStreamManager()
+          : await jetstreamManager(nc);
+        try {
+          await mgr.streams.info(DECOPILOT_STREAM_NAME);
+          await mgr.streams.update(DECOPILOT_STREAM_NAME, config);
+        } catch (err: unknown) {
+          const isNotFound =
+            err instanceof Error && err.message.includes("stream not found");
+          if (isNotFound) {
+            await mgr.streams.add(config);
+          } else {
+            // JetStream cannot change a stream's `storage` in place, so flipping
+            // the legacy Memory stream to File makes `update` reject. The stream
+            // is ephemeral run-scratch (it only holds in-flight chunks), so a
+            // one-time delete + add at deploy is safe: drop the old stream and
+            // recreate it file-backed. Any other error is real — rethrow.
+            const isStorageMismatch =
+              err instanceof Error &&
+              /can ?not change.*storage|storage type/i.test(err.message);
+            if (isStorageMismatch) {
+              await mgr.streams.delete(DECOPILOT_STREAM_NAME);
+              await mgr.streams.add(config);
+            } else {
+              throw err;
+            }
+          }
         }
-      }
-    }
+        return mgr;
+      },
+      {
+        maxAttempts: 5,
+        minTimeout: 250,
+        maxTimeout: 4000,
+        jitter: 0.5,
+        isRetriable: isTransientJsApiError,
+      },
+    );
 
     this.js = this.options.getJetStream();
     this.jsm = jsm;


### PR DESCRIPTION
## Summary

The single worker pod's `StreamBuffer.init()` timed out on a JetStream **control-plane** call at boot (`jsm.streams.info`), leaving `this.js = null`. Because `init()` only re-runs on a NATS `onReady` (reconnect) and the worker's connection never dropped, it **never retried** — the StreamBuffer stayed wedged for the pod's entire life. Every decopilot run it processed then failed at `publishRawChunk` (`ingest-run.ts:163` → run aborts → thread marked **failed**), across **all orgs**.

## Root cause (observed in prod)

- Worker booted `15:25:55`, connected to NATS.
- `15:26:01` → `[Decopilot] StreamBuffer init failed (late-join disabled): TimeoutError: timeout`.
- Worker never restarted (`restarts=0`); threads failed continuously with `JetStream client unavailable` → `publishRawChunk failed` → `The operation was aborted`.
- The other 6 API containers init'd fine against the **same** NATS, so JetStream was healthy — this was a transient boot-time hiccup.
- Not a payload/size issue: `DECOPILOT_STREAMS` was **4 MB / 5,857 msgs** (JS storage 4 MB of 75 GB max). A too-big message would fail as a publish rejection, not a `streams.info` timeout.

## Fix

Wrap the manager handshake + stream-ensure in the canonical `retry` from `@decocms/shared/std` (5 attempts, 250ms→4s backoff w/ jitter), retriable **only** on transient errors (`isTransientJsApiError`: timeout / no-responders / 503). Semantic errors (bad config) still fail fast; `not-found` and storage-mismatch handling unchanged.

A startup JS-API blip now self-heals in seconds instead of silently failing every thread until someone restarts the pod.

## Testing

- Added 2 unit tests: retry-past-timeout-then-`js`-live; no-retry-on-semantic-error.
- `bun test nats-stream-buffer.test.ts` → **28 pass**. `fmt` + typecheck clean.

## Note

Immediate prod unblock (separate from this PR) is a worker restart — JetStream is healthy, so it re-inits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient JetStream API timeouts in `StreamBuffer.init()` so the worker self-heals at boot and no longer wedges `js=null`. This prevents decopilot runs from failing on `publishRawChunk` across orgs.

- **Bug Fixes**
  - Wrapped manager handshake + stream ensure in `retry` from `@decocms/shared/std` (5 attempts, 250ms→4s backoff with jitter).
  - Retries only on transient errors (timeout / no responders / 503). Semantic errors still fail fast.
  - Keeps existing not-found and storage-mismatch handling (delete+add) unchanged.
  - Added unit tests for retry-on-timeout and no-retry-on-semantic-error.

<sup>Written for commit 518001ff4d4a4fed60322f193b3802685b66700f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

