### PR TITLE
fix(preview): add Copy01 icon to Copy Current URL menu item

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -18,6 +18,7 @@ import {
   ChevronDown,
   Code01,
   Compass01,
+  Copy01,
   CursorClick01,
   DotsHorizontal,
   Edit05,
@@ -1225,6 +1226,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
               <>
                 {terminal && <DropdownMenuSeparator />}
                 <DropdownMenuItem onClick={handleCopyUrl}>
+                  <Copy01 size={14} />
                   {t("sandbox.preview.copyCurrentUrl")}
                 </DropdownMenuItem>
               </>


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `Copy01` icon to the "Copy Current URL" item in the Preview dropdown to improve clarity and align with other menu items.

<sup>Written for commit 484a7995604562507289489c25660598e9f96172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

