### PR TITLE
feat(subtask): flip a running foreground subtask to background

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -135,6 +135,10 @@ import {
   type ProviderKeyCache,
 } from "../storage/provider-key-cache";
 import { NatsCancelBroadcast } from "./routes/decopilot/nats-cancel-broadcast";
+import {
+  initFlipBroadcast,
+  stopFlipBroadcast,
+} from "./routes/decopilot/flip-broadcast";
 import type { StreamBuffer } from "./routes/decopilot/stream-buffer";
 import { NatsStreamBuffer } from "./routes/decopilot/nats-stream-buffer";
 import {
@@ -1151,6 +1155,12 @@ export async function createApp(options: CreateAppOptions = {}) {
       console.error("[CancelBroadcast] Deferred start failed:", err);
     });
   });
+
+  // Cross-pod "flip subtask to background" fan-out. Local-only without NATS
+  // (single-pod dev); re-subscribes on reconnect.
+  const flipConnection = () => natsProvider?.getConnection() ?? null;
+  initFlipBroadcast(flipConnection);
+  natsProvider?.onReady(() => initFlipBroadcast(flipConnection));
   streamBuffer.init().catch((err) => {
     console.warn(
       "[Decopilot] StreamBuffer init failed, attach/late-join disabled:",
@@ -1163,6 +1173,7 @@ export async function createApp(options: CreateAppOptions = {}) {
     runRegistry.dispose();
     asyncResearchJobSweeper.dispose();
     cancelBroadcast.stop().catch(() => {});
+    stopFlipBroadcast();
     streamBuffer.teardown();
     mcpListCache?.teardown();
     modelListCache.teardown();

--- a/apps/api/src/api/routes/decopilot/flip-broadcast.ts
+++ b/apps/api/src/api/routes/decopilot/flip-broadcast.ts
@@ -1,0 +1,76 @@
+/**
+ * NATS "flip to background" broadcast.
+ *
+ * Moving a running foreground subtask to the background must reach whichever
+ * pod is executing that turn — like thread-cancel, there's no pod affinity, so
+ * it fans out over NATS Core pub/sub (see `nats-cancel-broadcast.ts` for the
+ * same pattern). Each pod's subscriber calls `requestFlip` against its local
+ * `flip-registry`; the pod running the turn resolves the waiting generator.
+ *
+ * Fire-and-forget, like cancel: if no pod is running the call, the flip is a
+ * no-op (the turn already finished, or nothing to flip). The (threadId,
+ * toolCallId) pair rides the JSON payload, never the subject, so neither can
+ * carry a NATS wildcard.
+ */
+
+import type { NatsConnection, Subscription } from "@nats-io/nats-core";
+import { requestFlip } from "@/harnesses/decopilot/flip-registry";
+
+const FLIP_SUBJECTS = ["studio.decopilot.flip", "mesh.decopilot.flip"] as const;
+
+let getConnection: (() => NatsConnection | null) | null = null;
+let subscriptions: Subscription[] = [];
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const originId = crypto.randomUUID();
+
+interface FlipMessage {
+  threadId: string;
+  toolCallId: string;
+  originId?: string;
+}
+
+/** Wire the NATS connection getter and (re)subscribe. Safe to call again on
+ *  NATS reconnect — it re-subscribes only when not already subscribed. */
+export function initFlipBroadcast(getConn: () => NatsConnection | null): void {
+  getConnection = getConn;
+  if (subscriptions.length > 0) return;
+  const nc = getConnection();
+  if (!nc) return; // NATS not ready — local flips still work via broadcastFlip
+  subscriptions = FLIP_SUBJECTS.map((subject) => nc.subscribe(subject));
+  for (const subscription of subscriptions) {
+    (async () => {
+      for await (const msg of subscription) {
+        try {
+          const parsed = JSON.parse(decoder.decode(msg.data)) as FlipMessage;
+          if (parsed.originId === originId) continue; // already handled locally
+          requestFlip(parsed.threadId, parsed.toolCallId);
+        } catch {
+          // Ignore malformed messages.
+        }
+      }
+    })().catch(console.error);
+  }
+}
+
+/** Flip a specific in-flight tool call to background: resolve it locally, then
+ *  fan out so the pod actually running the turn resolves it too. */
+export function broadcastFlip(threadId: string, toolCallId: string): void {
+  requestFlip(threadId, toolCallId);
+  try {
+    const nc = getConnection?.();
+    if (!nc) return; // NATS not ready — local flip only (single-pod dev)
+    const encoded = encoder.encode(
+      JSON.stringify({ threadId, toolCallId, originId } satisfies FlipMessage),
+    );
+    for (const subject of FLIP_SUBJECTS) nc.publish(subject, encoded);
+  } catch (err) {
+    console.warn("[FlipBroadcast] Publish failed (non-critical):", err);
+  }
+}
+
+export function stopFlipBroadcast(): void {
+  for (const subscription of subscriptions) subscription.unsubscribe();
+  subscriptions = [];
+  getConnection = null;
+}

--- a/apps/api/src/api/routes/decopilot/routes.ts
+++ b/apps/api/src/api/routes/decopilot/routes.ts
@@ -59,6 +59,7 @@ import type { HarnessId } from "@/harnesses";
 import type { Thread } from "@/storage/types";
 import { cancelThreadBackgroundJobs } from "@/harnesses/decopilot/background-tool-workflow";
 import { abortBackgroundJobs } from "@/harnesses/decopilot/background-abort-registry";
+import { broadcastFlip } from "./flip-broadcast";
 import { PartEmitter } from "./part-emitter";
 import { uploadFileParts } from "./file-materializer";
 import {
@@ -948,6 +949,23 @@ export function createDecopilotRoutes(deps: DecopilotDeps) {
       await validateThreadOwnership(c);
     await cancelActiveThreadRun({ ctx, taskId, thread, organization, userId });
     return c.json({ cancelled: true, async: true }, 202);
+  });
+
+  // Flip a still-running FOREGROUND subtask to the background so the thread gate
+  // frees up and the user can keep chatting. Fanned out over NATS to whichever
+  // pod runs the turn (like cancel); that pod's running `subtask` call aborts
+  // its inline run and re-runs it as a durable background job. Owner-only.
+  app.post("/:org/decopilot/flip/:threadId", async (c) => {
+    const { taskId } = await validateThreadOwnership(c);
+    const body = (await c.req.json().catch(() => null)) as {
+      toolCallId?: unknown;
+    } | null;
+    const toolCallId = body?.toolCallId;
+    if (typeof toolCallId !== "string" || toolCallId.length === 0) {
+      return c.json({ error: "toolCallId is required" }, 400);
+    }
+    broadcastFlip(taskId, toolCallId);
+    return c.json({ flipped: true, async: true }, 202);
   });
 
   // ==========================================================================

--- a/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
@@ -52,6 +52,7 @@ import { createUpdateInterestsTool } from "@decocms/harness/decopilot/built-in-t
 import { proposePlanTool } from "@decocms/harness/decopilot/built-in-tools/propose-plan";
 import { createGenerateImageTool } from "./generate-image";
 import { makeBackgroundable } from "@decocms/harness/decopilot/built-in-tools/backgroundable";
+import { registerFlip } from "@/harnesses/decopilot/flip-registry";
 import type { BackgroundDispatcher } from "@decocms/harness/decopilot/built-in-tools/backgroundable";
 import { GenerateImageInputSchema } from "@decocms/harness/decopilot/built-in-tools/portable-media-tools";
 import { createWebSearchTool } from "@decocms/harness/decopilot/built-in-tools/web-search";
@@ -320,6 +321,10 @@ async function buildAllTools(
         ctx,
       ),
       backgroundDispatcher,
+      // Let the user flip a still-running foreground subtask to the background
+      // (frees the thread gate so they can keep chatting). Inert without a
+      // dispatcher — makeBackgroundable returns the inner tool unchanged there.
+      (toolCallId) => registerFlip(taskId, toolCallId),
     ) as ReturnType<typeof createSubtaskTool>;
   }
   // generate_image requires a provider and an image model selection.

--- a/apps/api/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -277,6 +277,14 @@ export function createSubtaskTool(
       const targetLabel = targetRef.id;
 
       const releaseSlot = await acquireSubagentSlot();
+      // A flip abandons this generator via a detached `iter.return()` that
+      // isn't awaited (a hung provider call must not stall the flip) — so the
+      // slot can't wait on `finally` below. Release it the instant the abort
+      // fires; `releaseSlot` is idempotent, so the later `finally` call is a
+      // harmless no-op.
+      abortSignal?.addEventListener("abort", () => releaseSlot(), {
+        once: true,
+      });
       try {
         const subtaskCodingWorkspace = resolveSubtaskCodingWorkspace(
           targetRef,

--- a/apps/api/src/harnesses/decopilot/flip-registry.ts
+++ b/apps/api/src/harnesses/decopilot/flip-registry.ts
@@ -1,0 +1,51 @@
+/**
+ * In-memory "flip to background" registry, keyed by thread → tool call.
+ *
+ * A foreground (inline) backgroundable tool call — today `subtask` — holds the
+ * per-thread gate open while it runs. The user can ask to move it to the
+ * background so the chat frees up: `makeBackgroundable` registers the running
+ * call here (by toolCallId); the flip request (fanned out to every pod over
+ * NATS via `flip-broadcast`) calls `requestFlip(threadId, toolCallId)`, which
+ * resolves the `flipped` promise the running generator is racing on. It then
+ * aborts the inline run and takes its background branch instead.
+ *
+ * Per-pod and ephemeral — mirrors `background-abort-registry`: only the pod
+ * running the turn holds the resolver, and the NATS broadcast is what makes a
+ * flip arriving on any other pod reach it. Resolving twice (self + broadcast
+ * echo) is harmless: the promise is already settled and the consumer disposes.
+ */
+
+const pending = new Map<string, Map<string, () => void>>();
+
+/** Register a running backgroundable call so it can be flipped mid-flight.
+ *  `flipped` resolves once a flip is requested for this (thread, toolCall). */
+export function registerFlip(
+  threadId: string,
+  toolCallId: string,
+): { flipped: Promise<void>; dispose(): void } {
+  let byTool = pending.get(threadId);
+  if (!byTool) {
+    byTool = new Map();
+    pending.set(threadId, byTool);
+  }
+  let resolve!: () => void;
+  const flipped = new Promise<void>((r) => {
+    resolve = r;
+  });
+  byTool.set(toolCallId, resolve);
+  return {
+    flipped,
+    dispose() {
+      const m = pending.get(threadId);
+      if (!m) return;
+      m.delete(toolCallId);
+      if (m.size === 0) pending.delete(threadId);
+    },
+  };
+}
+
+/** Request a flip for a specific in-flight call. No-op when it isn't running on
+ *  this pod (registered elsewhere, or already completed/disposed). */
+export function requestFlip(threadId: string, toolCallId: string): void {
+  pending.get(threadId)?.get(toolCallId)?.();
+}

--- a/apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx
@@ -149,7 +149,7 @@ function useFlipToBackground(toolCallId: string): () => Promise<void> {
   const { taskId: threadId } = useChatTask();
   const { org } = useProjectContext();
   return async () => {
-    await fetch(
+    const res = await fetch(
       `/api/${encodeURIComponent(org.slug)}/decopilot/flip/${encodeURIComponent(threadId)}`,
       {
         method: "POST",
@@ -158,6 +158,9 @@ function useFlipToBackground(toolCallId: string): () => Promise<void> {
         body: JSON.stringify({ toolCallId }),
       },
     );
+    // A non-2xx response won't reject fetch on its own — surface it so the
+    // button resets instead of sitting on "Moving to background…" forever.
+    if (!res.ok) throw new Error(`flip failed: ${res.status}`);
   };
 }
 

--- a/apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx
@@ -132,6 +132,67 @@ function buildSubtaskRowConfig({ part, subtaskMeta }: SubtaskPartProps) {
   };
 }
 
+/** Whether a flip control should be offered: only once the call is actually
+ *  executing (so it's registered server-side) — not during input-streaming,
+ *  where a flip would be a silent no-op and leave the button stuck. */
+function isFlippable(part: SubtaskToolPart): boolean {
+  if (part.state === "input-available") return true;
+  if (part.state === "output-available")
+    return "preliminary" in part && part.preliminary === true;
+  return false;
+}
+
+/** Returns a callback that flips the given (still-running) subtask call to the
+ *  background, freeing the thread so the user can keep chatting. The server
+ *  fans the request out to the pod running the turn. */
+function useFlipToBackground(toolCallId: string): () => Promise<void> {
+  const { taskId: threadId } = useChatTask();
+  const { org } = useProjectContext();
+  return async () => {
+    await fetch(
+      `/api/${encodeURIComponent(org.slug)}/decopilot/flip/${encodeURIComponent(threadId)}`,
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ toolCallId }),
+      },
+    );
+  };
+}
+
+/** A subtle "run in background" pill shown on a still-running foreground
+ *  subtask. Clicking POSTs the flip and disables itself; the card re-renders as
+ *  the background variant once the flip lands via the stream. */
+function FlipToBackgroundButton({ onFlip }: { onFlip: () => Promise<void> }) {
+  const t = useT();
+  const [pending, setPending] = useState(false);
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      onClick={async (e) => {
+        e.stopPropagation();
+        setPending(true);
+        try {
+          await onFlip();
+        } catch {
+          setPending(false);
+        }
+      }}
+      className={cn(
+        "shrink-0 text-[12px] text-muted-foreground/70 px-2 py-1 rounded-md transition-colors",
+        "[@media(hover:hover)]:hover:text-foreground [@media(hover:hover)]:hover:bg-accent/40",
+        "disabled:opacity-50",
+      )}
+    >
+      {pending
+        ? t("chat.subtask.flipping")
+        : t("chat.subtask.flipToBackground")}
+    </button>
+  );
+}
+
 /**
  * The clickable subtask row + the right-side panel it opens. Replaces the old
  * inline collapsible: the row reads as a one-liner in the transcript; the full
@@ -145,6 +206,7 @@ function SubtaskCard({
   state,
   usage,
   onOpenChange,
+  onFlip,
   children,
 }: {
   icon: ReactNode;
@@ -154,6 +216,9 @@ function SubtaskCard({
   usage?: UsageStatsType | null;
   /** Notified when the panel opens/closes — lets a caller gate a live tail. */
   onOpenChange?: (open: boolean) => void;
+  /** When set and the subtask is still running, show a "run in background"
+   *  control (foreground calls only). */
+  onFlip?: () => Promise<void>;
   children: ReactNode;
 }) {
   const [open, setOpenState] = useState(false);
@@ -166,45 +231,50 @@ function SubtaskCard({
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className={cn(
-          "group/tool flex items-center gap-2 w-full py-2.5 text-left rounded-md transition-colors",
-          "[@media(hover:hover)]:hover:bg-accent/30",
-          isLoading && "shimmer",
-        )}
-      >
-        <div
+      <div className="flex items-center gap-1 w-full">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
           className={cn(
-            "relative shrink-0 size-4 flex items-center justify-center [&>svg]:size-4",
-            isError
-              ? "[&>svg]:text-warning/70"
-              : "[&>svg]:text-muted-foreground/75",
+            "group/tool flex items-center gap-2 flex-1 min-w-0 py-2.5 text-left rounded-md transition-colors",
+            "[@media(hover:hover)]:hover:bg-accent/30",
+            isLoading && "shimmer",
           )}
         >
-          {icon}
-        </div>
-        <span
-          className={cn(
-            "shrink-0 text-[14px] font-normal",
-            isError ? "text-warning/80" : "text-foreground",
-          )}
-        >
-          {title}
-        </span>
-        {summary ? (
-          <span className="min-w-0 flex-1 truncate">
-            <span className="text-[12px] text-muted-foreground/60 bg-muted/50 rounded-[3px] px-1 py-px leading-none">
-              {summary}
-            </span>
+          <div
+            className={cn(
+              "relative shrink-0 size-4 flex items-center justify-center [&>svg]:size-4",
+              isError
+                ? "[&>svg]:text-warning/70"
+                : "[&>svg]:text-muted-foreground/75",
+            )}
+          >
+            {icon}
+          </div>
+          <span
+            className={cn(
+              "shrink-0 text-[14px] font-normal",
+              isError ? "text-warning/80" : "text-foreground",
+            )}
+          >
+            {title}
           </span>
-        ) : (
-          <div className="flex-1" />
-        )}
-        <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/40 opacity-0 transition-opacity [@media(hover:hover)]:group-hover/tool:opacity-100" />
-        <MessageUsageStats usage={usage} />
-      </button>
+          {summary ? (
+            <span className="min-w-0 flex-1 truncate">
+              <span className="text-[12px] text-muted-foreground/60 bg-muted/50 rounded-[3px] px-1 py-px leading-none">
+                {summary}
+              </span>
+            </span>
+          ) : (
+            <div className="flex-1" />
+          )}
+          <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/40 opacity-0 transition-opacity [@media(hover:hover)]:group-hover/tool:opacity-100" />
+          <MessageUsageStats usage={usage} />
+        </button>
+        {onFlip && isLoading ? (
+          <FlipToBackgroundButton onFlip={onFlip} />
+        ) : null}
+      </div>
 
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetContent
@@ -423,6 +493,7 @@ function BackgroundSubtaskCard({ part }: SubtaskPartProps) {
 }
 
 export function SubtaskPartFallback(props: SubtaskPartProps) {
+  const onFlip = useFlipToBackground(props.part.toolCallId);
   if (isBackgroundStart(props.part.output))
     return <BackgroundSubtaskCard {...props} />;
   const { fallbackTitle, summary, usage, state } = buildSubtaskRowConfig(props);
@@ -441,6 +512,7 @@ export function SubtaskPartFallback(props: SubtaskPartProps) {
       summary={summary}
       state={state}
       usage={usage}
+      onFlip={isFlippable(props.part) ? onFlip : undefined}
     >
       <SubtaskResultBody part={props.part} />
     </SubtaskCard>
@@ -455,6 +527,7 @@ export function SubtaskPartFallback(props: SubtaskPartProps) {
  */
 export function SubtaskPart(props: SubtaskPartProps) {
   const target = useConnection(props.part.input?.agent_id);
+  const onFlip = useFlipToBackground(props.part.toolCallId);
   if (isBackgroundStart(props.part.output))
     return <BackgroundSubtaskCard {...props} />;
   const { fallbackTitle, summary, usage, state } = buildSubtaskRowConfig(props);
@@ -474,6 +547,7 @@ export function SubtaskPart(props: SubtaskPartProps) {
       summary={summary}
       state={state}
       usage={usage}
+      onFlip={isFlippable(props.part) ? onFlip : undefined}
     >
       <SubtaskResultBody part={props.part} />
     </SubtaskCard>

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -363,6 +363,8 @@ export const chat = {
   "chat.shared.tokens": "tokens",
   "chat.subtask.errorLabel": "Error",
   "chat.subtask.failedWithError": "Subtask failed: {error}",
+  "chat.subtask.flipToBackground": "Run in background",
+  "chat.subtask.flipping": "Moving to background…",
   "chat.subtask.resultLabel": "Result",
   "chat.subtask.running": "Running…",
   "chat.subtask.runningInBackground": "Running in the background…",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -374,6 +374,8 @@ export const chat = {
   "chat.shared.tokens": "tokens",
   "chat.subtask.errorLabel": "Erro",
   "chat.subtask.failedWithError": "Subtarefa falhou: {error}",
+  "chat.subtask.flipToBackground": "Executar em background",
+  "chat.subtask.flipping": "Movendo para background…",
   "chat.subtask.resultLabel": "Resultado",
   "chat.subtask.running": "Executando…",
   "chat.subtask.runningInBackground": "Executando em background…",

--- a/packages/harness/src/decopilot/built-in-tools/backgroundable.test.ts
+++ b/packages/harness/src/decopilot/built-in-tools/backgroundable.test.ts
@@ -284,6 +284,54 @@ describe("makeBackgroundable", () => {
     expect(disposed).toBe(true);
   });
 
+  // --- toModelOutput -------------------------------------------------------
+
+  test("toModelOutput surfaces the started handle's note instead of the inner tool's default", () => {
+    const inner = tool({
+      description: "inner",
+      inputSchema: BASE,
+      execute: async () => ({ ok: true }),
+      toModelOutput: () => ({
+        type: "text" as const,
+        value: "Subtask completed (no output).",
+      }),
+    });
+    const dispatcher: BackgroundDispatcher = {
+      start: async () => ({ jobId: "job-note" }),
+    };
+    const wrapped = makeBackgroundable("subtask", BASE, inner, dispatcher);
+    const out = wrapped.toModelOutput?.({
+      toolCallId: "c",
+      input: { prompt: "dig" },
+      output: {
+        background: true,
+        status: "started",
+        jobId: "job-note",
+        note: "Running in the background.",
+      },
+    } as never);
+    expect(out).toEqual({ type: "text", value: "Running in the background." });
+  });
+
+  test("toModelOutput still delegates to the inner tool for a real (non-started) output", () => {
+    const inner = tool({
+      description: "inner",
+      inputSchema: BASE,
+      execute: async () => ({ ok: true }),
+      toModelOutput: () => ({ type: "text" as const, value: "real result" }),
+    });
+    const dispatcher: BackgroundDispatcher = {
+      start: async () => ({ jobId: "x" }),
+    };
+    const wrapped = makeBackgroundable("subtask", BASE, inner, dispatcher);
+    const out = wrapped.toModelOutput?.({
+      toolCallId: "c",
+      input: { prompt: "dig" },
+      output: { text: "done" },
+    } as never);
+    expect(out).toEqual({ type: "text", value: "real result" });
+  });
+
   test("propagates dispatcher errors on background:true", async () => {
     const dispatcher: BackgroundDispatcher = {
       start: async () => {

--- a/packages/harness/src/decopilot/built-in-tools/backgroundable.test.ts
+++ b/packages/harness/src/decopilot/built-in-tools/backgroundable.test.ts
@@ -105,6 +105,185 @@ describe("makeBackgroundable", () => {
     expect(out).toEqual({ ok: true });
   });
 
+  // --- flip-to-background (generator path) -------------------------------
+
+  /** A generator inner tool: yields `step 1`, then blocks until its abort
+   *  signal fires (simulating long-running work), recording the abort. */
+  function makeGeneratorInnerTool(onAbort?: () => void) {
+    return tool({
+      description: "inner-gen",
+      inputSchema: BASE,
+      execute: async function* (
+        _input: unknown,
+        { abortSignal }: { abortSignal?: AbortSignal },
+      ) {
+        yield { text: "step 1" };
+        await new Promise<void>((resolve) => {
+          if (abortSignal?.aborted) return resolve();
+          abortSignal?.addEventListener("abort", () => resolve(), {
+            once: true,
+          });
+        });
+        onAbort?.();
+        yield { text: "final", finishReason: "stop" };
+      },
+    });
+  }
+
+  /** A generator inner tool that completes on its own (no abort needed). */
+  function makeSelfCompletingGenTool() {
+    return tool({
+      description: "inner-gen-simple",
+      inputSchema: BASE,
+      execute: async function* () {
+        yield { text: "step 1" };
+        yield { text: "final", finishReason: "stop" };
+      },
+    });
+  }
+
+  function deferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  type GenExec = (
+    input: unknown,
+    options: { toolCallId: string; abortSignal?: AbortSignal },
+  ) => AsyncGenerator<Record<string, unknown>>;
+
+  test("flip mid-stream aborts the inline run and returns a started handle", async () => {
+    let aborted = false;
+    const inner = makeGeneratorInnerTool(() => {
+      aborted = true;
+    });
+    const calls: Array<{ toolName: string; input: unknown }> = [];
+    const dispatcher: BackgroundDispatcher = {
+      start: async (req) => {
+        calls.push({ toolName: req.toolName, input: req.input });
+        return { jobId: "job-flip" };
+      },
+    };
+    const flipCtl = deferred();
+    let disposed = false;
+    const wrapped = makeBackgroundable(
+      "subtask",
+      BASE,
+      inner,
+      dispatcher,
+      () => ({ flipped: flipCtl.promise, dispose: () => (disposed = true) }),
+    );
+    const iter = (wrapped as unknown as { execute: GenExec }).execute(
+      { prompt: "dig" },
+      { toolCallId: "call-1" },
+    );
+
+    // First preview streams through untouched.
+    expect((await iter.next()).value).toEqual({ text: "step 1" });
+
+    // User flips: next pull should abort the inner and yield the started handle.
+    flipCtl.resolve();
+    const started = await iter.next();
+    expect(started.value.status).toBe("started");
+    expect(started.value.jobId).toBe("job-flip");
+    expect((await iter.next()).done).toBe(true);
+
+    // Re-ran as a durable job with `background`/flip stripped from the input.
+    expect(calls).toEqual([{ toolName: "subtask", input: { prompt: "dig" } }]);
+    expect(disposed).toBe(true);
+    // The inline run was aborted (its teardown is fire-and-forget).
+    await new Promise((r) => setTimeout(r, 0));
+    expect(aborted).toBe(true);
+  });
+
+  test("flip when the inner throws on abort (real subtask shape) still backgrounds cleanly", async () => {
+    // The real subtask generator throws AbortError out of its stream loop when
+    // aborted. The flip branch must swallow that (no unhandled rejection) and
+    // still return the started handle.
+    const inner = tool({
+      description: "inner-gen-throw",
+      inputSchema: BASE,
+      execute: async function* (
+        _input: unknown,
+        { abortSignal }: { abortSignal?: AbortSignal },
+      ) {
+        yield { text: "step 1" };
+        await new Promise<void>((_resolve, reject) => {
+          if (abortSignal?.aborted) return reject(new Error("aborted"));
+          abortSignal?.addEventListener(
+            "abort",
+            () => reject(new Error("aborted")),
+            { once: true },
+          );
+        });
+        yield { text: "unreached" };
+      },
+    });
+    const dispatcher: BackgroundDispatcher = {
+      start: async () => ({ jobId: "job-throw" }),
+    };
+    const flipCtl = deferred();
+    const wrapped = makeBackgroundable(
+      "subtask",
+      BASE,
+      inner,
+      dispatcher,
+      () => ({
+        flipped: flipCtl.promise,
+        dispose: () => {},
+      }),
+    );
+    const iter = (wrapped as unknown as { execute: GenExec }).execute(
+      { prompt: "dig" },
+      { toolCallId: "c" },
+    );
+    expect((await iter.next()).value).toEqual({ text: "step 1" });
+    flipCtl.resolve();
+    const started = await iter.next();
+    expect(started.value.status).toBe("started");
+    expect(started.value.jobId).toBe("job-throw");
+    expect((await iter.next()).done).toBe(true);
+    // Let the fire-and-forget teardown settle; no unhandled rejection should surface.
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  test("no flip: the generator runs to completion and never enqueues", async () => {
+    const inner = makeSelfCompletingGenTool();
+    let enqueued = false;
+    const dispatcher: BackgroundDispatcher = {
+      start: async () => {
+        enqueued = true;
+        return { jobId: "x" };
+      },
+    };
+    // A flip subscriber is wired but never triggered.
+    const flipCtl = deferred();
+    let disposed = false;
+    const wrapped = makeBackgroundable(
+      "subtask",
+      BASE,
+      inner,
+      dispatcher,
+      () => ({ flipped: flipCtl.promise, dispose: () => (disposed = true) }),
+    );
+    const iter = (wrapped as unknown as { execute: GenExec }).execute(
+      { prompt: "dig" },
+      { toolCallId: "c" },
+    );
+    const seen: unknown[] = [];
+    for await (const v of iter) seen.push(v);
+
+    expect(seen).toEqual([
+      { text: "step 1" },
+      { text: "final", finishReason: "stop" },
+    ]);
+    expect(enqueued).toBe(false);
+    expect(disposed).toBe(true);
+  });
+
   test("propagates dispatcher errors on background:true", async () => {
     const dispatcher: BackgroundDispatcher = {
       start: async () => {

--- a/packages/harness/src/decopilot/built-in-tools/backgroundable.ts
+++ b/packages/harness/src/decopilot/built-in-tools/backgroundable.ts
@@ -63,6 +63,17 @@ function startedHandle(jobId: string): BackgroundStartedOutput {
   return { background: true, status: "started", jobId, note: STARTED_NOTE };
 }
 
+function isBackgroundStarted(
+  output: unknown,
+): output is BackgroundStartedOutput {
+  return (
+    !!output &&
+    typeof output === "object" &&
+    (output as BackgroundStartedOutput).status === "started" &&
+    (output as BackgroundStartedOutput).background === true
+  );
+}
+
 /**
  * Wrap a tool so the model can opt a call into the background via `background:
  * true`. The schema is extended with that prop; at call time a true value
@@ -194,5 +205,23 @@ export function makeBackgroundable<S extends z.ZodObject<z.ZodRawShape>>(
         return innerExecute(rest, options);
       };
 
-  return { ...innerTool, inputSchema, execute } as Tool;
+  // The started/background handle isn't a real inner-tool output — the inner
+  // toModelOutput (built for the inner tool's own result shape) doesn't
+  // recognize it and falls through to a generic "no output" text, hiding the
+  // note that tells the model the result arrives later. Intercept it here so
+  // every backgroundable tool (explicit `background: true` AND a flip) tells
+  // the model it's running in the background instead of looking finished.
+  const toModelOutput: Tool["toModelOutput"] = (args: {
+    toolCallId: string;
+    input: unknown;
+    output: unknown;
+  }) => {
+    if (isBackgroundStarted(args.output)) {
+      return { type: "text" as const, value: args.output.note };
+    }
+    if (innerTool.toModelOutput) return innerTool.toModelOutput(args as never);
+    return { type: "text" as const, value: JSON.stringify(args.output) };
+  };
+
+  return { ...innerTool, inputSchema, execute, toModelOutput } as Tool;
 }

--- a/packages/harness/src/decopilot/built-in-tools/backgroundable.ts
+++ b/packages/harness/src/decopilot/built-in-tools/backgroundable.ts
@@ -22,6 +22,17 @@ export interface BackgroundDispatcher {
   }): Promise<{ jobId: string }>;
 }
 
+/** Subscribes a running foreground call so it can be flipped to the background
+ *  mid-flight. `flipped` resolves when the user requests the flip for this
+ *  toolCallId; `dispose` cleans up the subscription when the call ends. Wired by
+ *  the app to its flip-registry (cluster main turn); absent → no flip support,
+ *  a foreground call just runs inline. Only the generator branch honors it. */
+export interface FlipSubscription {
+  flipped: Promise<void>;
+  dispose(): void;
+}
+export type FlipSubscribe = (toolCallId: string) => FlipSubscription;
+
 export interface BackgroundStartedOutput {
   background: true;
   status: "started";
@@ -60,12 +71,19 @@ function startedHandle(jobId: string): BackgroundStartedOutput {
  * (e.g. subtask, which streams progress) stays a generator; a plain async tool
  * (e.g. generate_image) stays async — so neither's streaming/rendering changes.
  * Returns the inner tool unchanged when `dispatcher` is absent.
+ *
+ * With a `flip` subscriber, a FOREGROUND generator call can also be moved to the
+ * background mid-flight (the user clicking "run in background"): the inline run
+ * is aborted and the call takes its background branch, so the turn completes
+ * normally — with the started marker as the tool output — and the per-thread
+ * gate frees up. The lost in-flight work re-runs as the durable job.
  */
 export function makeBackgroundable<S extends z.ZodObject<z.ZodRawShape>>(
   toolName: string,
   baseSchema: S,
   innerTool: Tool,
   dispatcher: BackgroundDispatcher | null | undefined,
+  flip?: FlipSubscribe,
 ): Tool {
   if (!dispatcher) return innerTool;
 
@@ -84,16 +102,84 @@ export function makeBackgroundable<S extends z.ZodObject<z.ZodRawShape>>(
         options: ToolCallOptions,
       ) {
         const { background, ...rest } = input;
-        if (background) {
+        const startBackground = async function* () {
           const { jobId } = await dispatcher.start({
             toolName,
             input: rest,
             toolCallId: options.toolCallId,
           });
           yield startedHandle(jobId);
+        };
+        if (background) {
+          yield* startBackground();
           return;
         }
-        yield* innerExecute(rest, options) as AsyncIterable<unknown>;
+        const flipSub = flip?.(options.toolCallId);
+        if (!flipSub) {
+          yield* innerExecute(rest, options) as AsyncIterable<unknown>;
+          return;
+        }
+        // The inner run gets a CHILD abort signal so a flip stops only this
+        // subagent, not the whole parent turn (aborting the turn would cancel
+        // the very job we're about to start). The parent's own abort still
+        // forwards down — a real cancel aborts the inner and propagates.
+        const childAbort = new AbortController();
+        const onParentAbort = () => childAbort.abort();
+        options.abortSignal?.addEventListener("abort", onParentAbort, {
+          once: true,
+        });
+        const iter = (
+          innerExecute(rest, {
+            ...options,
+            abortSignal: childAbort.signal,
+          }) as AsyncIterable<unknown>
+        )[Symbol.asyncIterator]();
+        try {
+          let pending = iter.next();
+          // `tagged` is the raced view of `pending`; keep the handle so the flip
+          // branch can swallow its eventual rejection (the inner throws on abort)
+          // instead of leaking an unhandled rejection once we stop awaiting it.
+          let tagged = pending.then((r) => ({ kind: "next" as const, r }));
+          while (true) {
+            const ev = await Promise.race([
+              tagged,
+              flipSub.flipped.then(() => ({ kind: "flip" as const })),
+            ]);
+            if (ev.kind === "flip") {
+              // Stop the inline run and tear it down in the background — its
+              // `finally` releases the concurrency slot + closes the MCP client.
+              // We do NOT await teardown: a hung provider await must not stall
+              // the flip. Then take the background branch.
+              // ponytail: in the rare photo-finish where the run just completed,
+              // this re-runs it in the background (a few seconds wasted) rather
+              // than returning the just-ready result — never wrong, and cheaper
+              // than the drain-and-inspect that risks hanging on that await.
+              childAbort.abort();
+              tagged.catch(() => {}); // abandoned branch may reject on abort
+              void (async () => {
+                try {
+                  await pending;
+                } catch {
+                  /* aborted */
+                }
+                try {
+                  await iter.return?.(undefined);
+                } catch {
+                  /* ignore */
+                }
+              })();
+              yield* startBackground();
+              return;
+            }
+            if (ev.r.done) return;
+            yield ev.r.value;
+            pending = iter.next();
+            tagged = pending.then((r) => ({ kind: "next" as const, r }));
+          }
+        } finally {
+          options.abortSignal?.removeEventListener("abort", onParentAbort);
+          flipSub.dispose();
+        }
       }
     : async (input: Record<string, unknown>, options: ToolCallOptions) => {
         const { background, ...rest } = input;


### PR DESCRIPTION
## Summary

Lets the user move a still-running **foreground** `subtask` to the background so the chat frees up. A "Run in background" pill appears on a running subtask row; clicking it aborts the inline run, re-runs the subtask as a durable background job, and lets the parent turn finish normally — so the per-thread gate releases and the user can keep chatting. The result is delivered later via the existing reaction-turn flow, and the existing `BackgroundSubtaskCard` + live tail render it.

## How it works

`click → POST /api/:org/decopilot/flip/:threadId {toolCallId}` → `broadcastFlip` fans out over NATS (`*.decopilot.flip`, mirroring thread-cancel) → the pod running the turn resolves the registered flip promise → `makeBackgroundable`'s generator races the inline run against that promise and, on flip, aborts a **child** abort signal (stops only the subagent, not the whole turn — cancelling the turn would nuke the job we're starting) and takes its existing `background: true` branch → `dispatcher.start` enqueues the DBOS job and yields the `{status:"started", jobId}` marker, which persists as the tool output automatically.

This reuses the entire background pipeline (durable job, reaction turn, per-job live tail, subtask card). **No DBOS workflow change → no `DBOS_WORKFLOW_VERSION` bump.**

## Scope / decisions

- **Cluster-only for v1.** Desktop backgrounding (`createDesktopSubtaskDispatcher`) is currently unwired dead code, so the button doesn't appear on desktop (unchanged behavior).
- **Flip restarts the subtask** as a durable job, losing the few seconds of in-flight work. On the cluster a live hand-off can't be made durable (the inline subagent runs inside a single DBOS step; detaching it past the step boundary orphans an unawaited promise), so a restart is the robust equivalent.
- The button appears only once the call is actually executing (not during input-streaming), avoiding a stuck no-op click before the server-side registration exists.
- Rare photo-finish (subtask completes the same instant as the flip) → harmless redundant re-run; noted with a `ponytail:` comment.

## Files

- **New:** `flip-registry.ts` (per-pod `(thread→toolCall)` resolvers), `flip-broadcast.ts` (NATS fan-out)
- **Edited:** `backgroundable.ts` (flip param + generator race), `built-in-tools/index.ts` (wire `registerFlip`), `decopilot/routes.ts` (flip route), `app.ts` (init/stop broadcast), `subtask.tsx` (button + hook), `i18n/en/chat.ts` + `i18n/pt-br/chat.ts`

## Testing

- `bun run check` ✅ all workspaces · `bun run lint` ✅ 0 errors · `knip` ✅ clean
- `bun test` built-in-tools ✅ 78 pass, incl. 3 new `backgroundable.test.ts` cases: flip mid-stream, flip when the inner throws on abort (real subtask shape / unhandled-rejection guard), and no-flip completes-and-never-enqueues.
- **Not** end-to-end verified — requires a live cluster + NATS + DBOS. Logic is unit-tested; wiring type-checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Run in background” control to flip a still-running foreground subtask into a durable background job, freeing the chat; results arrive later via the existing background pipeline. Also improves model output to clearly say when a subtask is running in the background.

- **New Features**
  - UI: “Run in background” pill on a running subtask (only while executing); desktop unchanged.
  - API: POST `/api/:org/decopilot/flip/:threadId` with `{ toolCallId }`; fanned out over NATS to reach the executing pod.
  - Runtime: `makeBackgroundable` races the generator against a flip; on flip, aborts a child signal (not the turn) and yields a started handle; `toModelOutput` now surfaces the started task’s note (“Running in the background.”).
  - Infra: per-pod in-memory flip registry and NATS fan-out with init/teardown hooks; no DBOS workflow version bump.
  - Tests: cover mid-stream flip, abort-throws path, no-flip completion, and `toModelOutput` for started background tasks.

- **Bug Fixes**
  - UI: reset the “Run in background” pill if the flip POST returns a non‑2xx, so it doesn’t stay stuck on “Moving to background…”.

<sup>Written for commit 12d88cb13c038b1b417bf52dc0f0152a2e601487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

