### PR TITLE
fix(web): hide removed app views

### DIFF
--- a/apps/web/src/i18n/en/routes.ts
+++ b/apps/web/src/i18n/en/routes.ts
@@ -216,6 +216,9 @@ export const routes = {
   "routes.onboarding.step.extractingBrand": "Extracting brand context",
   "routes.onboarding.uploadOrgLogo": "Upload organization logo",
   "routes.onboarding.welcomeTitle": "Welcome to deco",
+  "routes.projectAppView.unavailableDescription":
+    "It may have been removed from the connection. Choose another view to continue.",
+  "routes.projectAppView.unavailableTitle": "This view is no longer available",
   "routes.reports.failedToLoadReportAriaLabel": "Couldn't load the report",
   "routes.reports.failedToLoadReportDescription":
     "Check your connection and try again.",

--- a/apps/web/src/i18n/pt-br/routes.ts
+++ b/apps/web/src/i18n/pt-br/routes.ts
@@ -221,6 +221,10 @@ export const routes = {
   "routes.onboarding.step.extractingBrand": "Extraindo contexto de marca",
   "routes.onboarding.uploadOrgLogo": "Fazer upload do logotipo da organização",
   "routes.onboarding.welcomeTitle": "Bem-vindo ao deco",
+  "routes.projectAppView.unavailableDescription":
+    "Ela pode ter sido removida da conexão. Escolha outra visualização para continuar.",
+  "routes.projectAppView.unavailableTitle":
+    "Esta visualização não está mais disponível",
   "routes.reports.failedToLoadReportAriaLabel":
     "Não foi possível carregar o relatório",
   "routes.reports.failedToLoadReportDescription":

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -11,7 +11,7 @@
  */
 
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQueries, useSuspenseQuery } from "@tanstack/react-query";
 import { Globe01, Monitor01 } from "@untitledui/icons";
 import { createElement, useSyncExternalStore } from "react";
 import {
@@ -19,6 +19,7 @@ import {
   COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
   getCommerceDiscoveryAgentId,
   getDevConnectionId,
+  mcpClientQueryOptions,
   useConnections,
   useMCPClientOptional,
   useMCPToolsListQuery,
@@ -55,6 +56,7 @@ import {
   parseDeckTabId,
   parseFileTabId,
   parseLibraryFileTabId,
+  parsePinnedViewTabId,
   resolveActiveTabAndOpen,
   resolveDefaultTabId,
   resolveTabClickTarget,
@@ -68,6 +70,7 @@ import {
 import { useCapability } from "@/hooks/use-capability";
 import { useReportsOnly } from "@/hooks/use-organization-settings";
 import { useT } from "@/i18n/use-t.ts";
+import { getUnavailableProjectAppViewKeys } from "@/routes/project-app-tool";
 
 export type AgentTabDef = {
   id: string;
@@ -194,7 +197,7 @@ export function useMainPanelTabs(ctx: {
     )?.ui ?? null;
 
   const entityLayout = entityUI?.layout ?? null;
-  const layoutTabs = (entityLayout?.tabs ?? []) as AgentTabDef[];
+  const configuredLayoutTabs = (entityLayout?.tabs ?? []) as AgentTabDef[];
 
   // The ephemeral dev connection (`dev_<id>`) the agent's sandbox dev server is
   // served through. Its views are auto-detected from the dev server's own MCP
@@ -259,11 +262,114 @@ export function useMainPanelTabs(ctx: {
           }))
       : [];
   const firstDevView = devViews[0];
-  const pinnedViews = firstDevView ? devViews : (entityUI?.pinnedViews ?? []);
+  const configuredPinnedViews = entityUI?.pinnedViews ?? [];
+  const configuredDefaultMainView = entityLayout?.defaultMainView ?? null;
+
+  // App views are persisted in agent/thread metadata, but the downstream MCP
+  // may remove or rename a tool later. Validate every persisted source against
+  // the connection's current tools/list response before presenting it. Pending
+  // or failed requests keep the view: a transient outage must not erase valid
+  // UI. Successful requests are authoritative and suppress removed/no-UI tools.
+  const requestedPinnedView =
+    typeof search.main === "string" ? parsePinnedViewTabId(search.main) : null;
+  const appViewCandidates = [
+    ...configuredPinnedViews.map((view) => ({
+      connectionId: view.connectionId,
+      toolName: view.toolName,
+    })),
+    ...configuredLayoutTabs.map((tab) => ({
+      connectionId: tab.view.appId,
+      toolName: tab.id,
+    })),
+    ...expandedTools.map((tool) => ({
+      connectionId: tool.appId,
+      toolName: tool.toolName,
+    })),
+    ...(configuredDefaultMainView?.type === "ext-apps" &&
+    configuredDefaultMainView.id &&
+    configuredDefaultMainView.toolName
+      ? [
+          {
+            connectionId: configuredDefaultMainView.id,
+            toolName: configuredDefaultMainView.toolName,
+          },
+        ]
+      : []),
+    ...(reportsOnly
+      ? [
+          {
+            connectionId: WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id),
+            toolName: COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
+          },
+        ]
+      : []),
+    ...(requestedPinnedView ? [requestedPinnedView] : []),
+  ];
+  const appViewConnectionIds = [
+    ...new Set(appViewCandidates.map((view) => view.connectionId)),
+  ].sort();
+  const appViewClientQueries = useQueries({
+    queries: appViewConnectionIds.map((connectionId) => ({
+      ...mcpClientQueryOptions({
+        connectionId,
+        orgId: org.id,
+        orgSlug: org.slug,
+      }),
+      enabled: !firstDevView,
+    })),
+  });
+  const appViewToolQueries = useQueries({
+    queries: appViewConnectionIds.map((connectionId, index) => {
+      const client = appViewClientQueries[index]?.data;
+      return {
+        queryKey: KEYS.mcpToolsList(client ?? `pending:${connectionId}`),
+        queryFn: async () => {
+          if (!client) throw new Error("MCP client is not ready");
+          return await client.listTools();
+        },
+        enabled: !firstDevView && !!client,
+        staleTime: 30_000,
+        retry: false,
+      };
+    }),
+  });
+  const unavailableAppViewKeys = getUnavailableProjectAppViewKeys(
+    appViewCandidates,
+    appViewConnectionIds.map((connectionId, index) => ({
+      connectionId,
+      tools: appViewToolQueries[index]?.isSuccess
+        ? appViewToolQueries[index].data.tools
+        : undefined,
+    })),
+  );
+  const isAppViewAvailable = (connectionId: string, toolName: string) =>
+    !unavailableAppViewKeys.has(`${connectionId}:${toolName}`);
+
+  const pinnedViews = firstDevView
+    ? devViews
+    : configuredPinnedViews.filter((view) =>
+        isAppViewAvailable(view.connectionId, view.toolName),
+      );
+  const layoutTabs = configuredLayoutTabs.filter((tab) =>
+    isAppViewAvailable(tab.view.appId, tab.id),
+  );
+  const availableExpandedTools = expandedTools.filter((tool) =>
+    isAppViewAvailable(tool.appId, tool.toolName),
+  );
+  const defaultAppViewUnavailable =
+    configuredDefaultMainView?.type === "ext-apps" &&
+    configuredDefaultMainView.id &&
+    configuredDefaultMainView.toolName &&
+    !isAppViewAvailable(
+      configuredDefaultMainView.id,
+      configuredDefaultMainView.toolName,
+    );
   const effectiveDefaultMainView =
     firstDevView && devConnId
       ? { type: "ext-apps", id: devConnId, toolName: firstDevView.toolName }
-      : (entityLayout?.defaultMainView ?? null);
+      : defaultAppViewUnavailable
+        ? { type: "chat" }
+        : configuredDefaultMainView;
   const decofileFetchParams =
     hasClonableSource && entity?.id && currentBranch
       ? {
@@ -307,12 +413,24 @@ export function useMainPanelTabs(ctx: {
           tabs: layoutTabs.map((t) => ({ id: t.id })),
         }
       : null;
+  const activePinnedView = parsePinnedViewTabId(rawActiveTab);
+  const activeAppViewUnavailable =
+    activePinnedView &&
+    !isAppViewAvailable(
+      activePinnedView.connectionId,
+      activePinnedView.toolName,
+    );
+  const configuredLayoutTabUnavailable =
+    configuredLayoutTabs.some((tab) => tab.id === rawActiveTab) &&
+    !layoutTabs.some((tab) => tab.id === rawActiveTab);
   const activeTab =
-    rawActiveTab === "git" && !gitTabVisible && !prQuery.isPending
+    activeAppViewUnavailable || configuredLayoutTabUnavailable
       ? resolveDefaultTabId(layoutForDefault)
-      : rawActiveTab === "content" && !showContentTab
+      : rawActiveTab === "git" && !gitTabVisible && !prQuery.isPending
         ? resolveDefaultTabId(layoutForDefault)
-        : rawActiveTab;
+        : rawActiveTab === "content" && !showContentTab
+          ? resolveDefaultTabId(layoutForDefault)
+          : rawActiveTab;
   const mainOpen =
     rawActiveTab === "git" && !gitTabVisible && !prQuery.isPending
       ? false
@@ -406,7 +524,7 @@ export function useMainPanelTabs(ctx: {
       iconUrl?: string | null;
     }
   >();
-  for (const t of expandedTools) {
+  for (const t of availableExpandedTools) {
     const id = formatPinnedViewTabId(t.appId, t.toolName);
     pinnedTabMap.set(id, {
       id,
@@ -432,8 +550,11 @@ export function useMainPanelTabs(ctx: {
   // current agent (and no agent switch) is needed. On the Report Agent itself
   // the loop above already added it with its configured label/icon, so this is
   // a no-op there (dedup by tab id).
-  if (reportsOnly) {
-    const reportConnectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
+  const reportConnectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
+  if (
+    reportsOnly &&
+    isAppViewAvailable(reportConnectionId, COMMERCE_DISCOVERY_REPORT_TOOL_NAME)
+  ) {
     const reportTabId = formatPinnedViewTabId(
       reportConnectionId,
       COMMERCE_DISCOVERY_REPORT_TOOL_NAME,
@@ -620,7 +741,7 @@ export function useMainPanelTabs(ctx: {
     setActiveTab,
     systemTabs: [...leadingSystemTabs, ...systemTabs],
     layoutTabs,
-    expandedTools,
+    expandedTools: availableExpandedTools,
     automationTabParsed,
     tabs,
     leadTabId,

--- a/apps/web/src/routes/project-app-tool.test.ts
+++ b/apps/web/src/routes/project-app-tool.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { namespaceCode } from "@decocms/mcp-utils/aggregate";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import {
+  findProjectAppTool,
+  getUnavailableProjectAppViewKeys,
+  hasProjectAppTool,
+} from "./project-app-tool";
+
+const UI_META = { ui: { resourceUri: "ui://app/view" } };
+
+function tool(name: string, meta: Record<string, unknown> = UI_META): Tool {
+  return {
+    name,
+    inputSchema: { type: "object" },
+    _meta: meta,
+  };
+}
+
+describe("findProjectAppTool", () => {
+  test("finds an exact tool name", () => {
+    const match = findProjectAppTool([tool("file_explorer")], "file_explorer");
+    expect(match?.name).toBe("file_explorer");
+  });
+
+  test("finds a gateway-namespaced tool from its stored base name", () => {
+    const clientId = "conn_admin";
+    const namespacedName = `${namespaceCode(clientId)}_fetch_assets`;
+    const match = findProjectAppTool(
+      [tool(namespacedName, { ...UI_META, gatewayClientId: clientId })],
+      "fetch_assets",
+    );
+    expect(match?.name).toBe(namespacedName);
+  });
+
+  test("finds a base-name tool from its stored gateway-namespaced name", () => {
+    const clientId = "conn_admin";
+    const requestedName = `${namespaceCode(clientId)}_fetch_assets`;
+    const match = findProjectAppTool(
+      [tool("fetch_assets", { ...UI_META, gatewayClientId: clientId })],
+      requestedName,
+    );
+    expect(match?.name).toBe("fetch_assets");
+  });
+});
+
+describe("hasProjectAppTool", () => {
+  test("requires the current tool to expose an app UI", () => {
+    expect(hasProjectAppTool([tool("fetch_assets")], "fetch_assets")).toBe(
+      true,
+    );
+    expect(
+      hasProjectAppTool(
+        [tool("fetch_assets", { gatewayClientId: "conn_admin" })],
+        "fetch_assets",
+      ),
+    ).toBe(false);
+  });
+
+  test("returns false for a removed tool", () => {
+    expect(hasProjectAppTool([tool("fetch_assets")], "file_explorer")).toBe(
+      false,
+    );
+  });
+});
+
+describe("getUnavailableProjectAppViewKeys", () => {
+  const candidates = [
+    { connectionId: "conn_admin", toolName: "file_explorer" },
+    { connectionId: "conn_admin", toolName: "fetch_assets" },
+  ];
+
+  test("reproduces a stale pin after the downstream MCP removes a tool", () => {
+    const unavailable = getUnavailableProjectAppViewKeys(candidates, [
+      {
+        connectionId: "conn_admin",
+        tools: [tool("fetch_assets")],
+      },
+    ]);
+
+    expect(unavailable).toEqual(new Set(["conn_admin:file_explorer"]));
+  });
+
+  test("preserves persisted views while tools/list is pending or failed", () => {
+    const unavailable = getUnavailableProjectAppViewKeys(candidates, [
+      { connectionId: "conn_admin" },
+    ]);
+
+    expect(unavailable.size).toBe(0);
+  });
+});

--- a/apps/web/src/routes/project-app-tool.ts
+++ b/apps/web/src/routes/project-app-tool.ts
@@ -1,0 +1,75 @@
+import {
+  getGatewayClientId,
+  stripToolNamespace,
+} from "@decocms/mcp-utils/aggregate";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { getUIResourceUri } from "@decocms/shared/mcp-apps/types";
+
+/**
+ * Resolve a stored app-view tool name against the tools currently advertised
+ * by its MCP connection. Stored names may predate gateway namespacing, while a
+ * live tools/list response may contain either the original or namespaced form.
+ */
+export function findProjectAppTool(
+  tools: Tool[],
+  requestedName: string,
+): Tool | undefined {
+  return (
+    tools.find((tool) => tool.name === requestedName) ??
+    tools.find((tool) => {
+      const clientId = getGatewayClientId(tool._meta);
+      if (!clientId) return false;
+
+      const baseName = stripToolNamespace(tool.name, clientId);
+      if (baseName === requestedName) return true;
+
+      const requestedBaseName = stripToolNamespace(requestedName, clientId);
+      return (
+        requestedBaseName !== requestedName && tool.name === requestedBaseName
+      );
+    })
+  );
+}
+
+export function hasProjectAppTool(
+  tools: Tool[],
+  requestedName: string,
+): boolean {
+  const tool = findProjectAppTool(tools, requestedName);
+  return !!tool && !!getUIResourceUri(tool._meta);
+}
+
+export interface ProjectAppViewCandidate {
+  connectionId: string;
+  toolName: string;
+}
+
+export interface ProjectAppConnectionTools {
+  connectionId: string;
+  /**
+   * A successful tools/list result. Undefined means the request is still
+   * pending or failed, so persisted views must be preserved.
+   */
+  tools?: Tool[];
+}
+
+export function getUnavailableProjectAppViewKeys(
+  candidates: ProjectAppViewCandidate[],
+  connectionTools: ProjectAppConnectionTools[],
+): Set<string> {
+  const unavailable = new Set<string>();
+
+  for (const connection of connectionTools) {
+    if (!connection.tools) continue;
+    for (const candidate of candidates) {
+      if (
+        candidate.connectionId === connection.connectionId &&
+        !hasProjectAppTool(connection.tools, candidate.toolName)
+      ) {
+        unavailable.add(`${candidate.connectionId}:${candidate.toolName}`);
+      }
+    }
+  }
+
+  return unavailable;
+}

--- a/apps/web/src/routes/project-app-view.tsx
+++ b/apps/web/src/routes/project-app-view.tsx
@@ -25,6 +25,8 @@ import {
 import { useChatStream, useChatPrefs } from "@/components/chat/context.tsx";
 import { usePanelActions } from "@/layouts/shell-layout";
 import { resolveAppNavigateTarget } from "@/routes/project-app-navigate.ts";
+import { findProjectAppTool } from "@/routes/project-app-tool";
+import { useT } from "@/i18n/use-t.ts";
 
 const EMPTY_TOOL_INPUT: Record<string, unknown> = {};
 
@@ -123,6 +125,7 @@ export function AppViewContent({
   toolName: string;
   args?: Record<string, unknown>;
 }) {
+  const t = useT();
   const { org } = useProjectContext();
   const lifecycle = useSandboxLifecycle();
   // A dev view (`dev_<id>`) against a user-desktop sandbox renders against the
@@ -146,33 +149,21 @@ export function AppViewContent({
 
   const decodedToolName = stripMcpServerPrefix(decodeURIComponent(toolName));
 
-  // Try exact match first. If that fails, the decoded name may be the original
-  // (un-namespaced) tool name while the tools list has gateway-namespaced names
-  // (e.g. "render_html" vs "conn-abc_render_html"), or vice versa. Fall back to
-  // matching by the base name with the gateway namespace stripped from both sides.
-  const tool =
-    toolsResult.tools.find((t) => t.name === decodedToolName) ??
-    toolsResult.tools.find((t) => {
-      const clientId = getGatewayClientId(t._meta);
-      if (!clientId) return false;
-      // Case 1: decoded name is the base name, tool list has namespaced names
-      const baseName = stripToolNamespace(t.name, clientId);
-      if (baseName === decodedToolName) return true;
-      // Case 2: decoded name has namespace prefix, tool list has base names
-      const decodedBase = stripToolNamespace(decodedToolName, clientId);
-      if (decodedBase !== decodedToolName && t.name === decodedBase)
-        return true;
-      return false;
-    });
+  const tool = findProjectAppTool(toolsResult.tools, decodedToolName);
 
   const resourceURI = tool?._meta ? getUIResourceUri(tool._meta) : undefined;
 
   if (!tool || !resourceURI) {
     return (
-      <div className="flex items-center justify-center h-full w-full">
-        <p className="text-sm text-muted-foreground">
-          Tool &quot;{decodedToolName}&quot; not found or has no UI
-        </p>
+      <div className="flex h-full w-full items-center justify-center px-6 text-center">
+        <div className="max-w-sm space-y-1">
+          <p className="text-sm font-medium text-foreground">
+            {t("routes.projectAppView.unavailableTitle")}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {t("routes.projectAppView.unavailableDescription")}
+          </p>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## What changed
- filter persisted app views, layout tabs, expanded tools, and default app views against the current `tools/list` response for each MCP connection
- keep persisted views visible while `tools/list` is pending or failed, so transient outages do not erase valid UI
- extract app-view tool resolution into shared helpers with unit coverage for namespaced and stale tool names
- replace the raw "tool not found" message with localized empty-state copy when an app view is no longer available

## Why
Persisted app views can outlive the downstream MCP tool that originally backed them. When that happens, Studio could keep exposing stale tabs or route the user into a broken app view.

## Impact
Users no longer see removed app views in the main panel, and stale direct links fall back to a clearer unavailable state instead of a broken tool lookup.

## Root cause
We were trusting persisted app-view metadata without validating it against the connection's current tool catalog.

## Validation
- `bun test apps/web/src/routes/project-app-tool.test.ts`
- `bun run fmt`
- `bun run check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide stale or removed app views by validating pinned views, layout tabs, and expanded tools against each MCP connection’s current tools list. If a view is unavailable, we redirect to a safe tab and show a clear, localized message instead of a broken UI.

- **Bug Fixes**
  - Validate persisted views against the latest `tools/list` per connection; keep views while requests are pending or failed.
  - Auto-fallback: replace an invalid default app view with Chat; fix the active tab when a pinned view, layout tab, URL-selected app view, or expanded tool no longer exists.
  - Only show the Commerce Discovery report tab (reports-only mode) when its tool is available.
  - Replace the “tool not found” message with a localized unavailable state (en, pt-BR).
  - Extract tool-resolution helpers for namespaced vs base tool names with unit tests.

<sup>Written for commit 97dd9c4bf836da7e075b59928b61459769680893. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

