### PR TITLE
feat(preview): capture sandbox preview iframe in PostHog session replay

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -85,6 +85,7 @@ import {
   type VisualEditorPayload,
 } from "./visual-editor-script";
 import { CMS_EDITOR_SCRIPT, CmsEditorPayloadSchema } from "./cms-editor-script";
+import { buildSessionReplayScript } from "./session-replay-script";
 import { parseSections } from "@/components/sections-editor/parse-sections";
 import { resolveSectionCandidates } from "./section-candidates";
 import { getPageVariantSectionsAt } from "@/components/sections-editor/page-variants";
@@ -117,6 +118,7 @@ import {
 import { PathParamInput } from "./path-param-input";
 import { manifestLoaderResolveTypes } from "@/components/sandbox/content/runnable-catalog";
 import { track } from "@/lib/posthog-client";
+import { usePublicConfig } from "@/hooks/use-public-config";
 import { useSandboxRepoDir } from "../hooks/use-sandbox-repo-dir";
 import { useBlocksPreviewWorkspace } from "@/components/sandbox/blocks/blocks-preview-workspace-context";
 import { BlocksPanel } from "@/components/sandbox/blocks/blocks-panel";
@@ -207,6 +209,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const workspace = useBlocksPreviewWorkspace();
   // Toggles the bottom terminal drawer (null on surfaces without the provider).
   const terminal = useTerminalVisibility();
+  // PostHog project (key/host) for cross-origin session replay in the preview
+  // iframe; null when PostHog isn't configured for this deployment.
+  const posthogConfig = usePublicConfig().posthog;
 
   const goToTab = (main: string) => {
     navigate({
@@ -668,6 +673,27 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     const origin = previewOrigin(previewUrl);
     if (!win || !origin) return;
     win.postMessage({ type: "cms-editor::deactivate" }, origin);
+  };
+
+  // Bootstrap PostHog session replay inside the sandbox preview so the
+  // cross-origin deco site is stitched into the parent's recording (rrweb
+  // skips cross-origin iframes otherwise). Reuses the `visual-editor::activate`
+  // channel the sandbox bootstrap already exposes (`new Function(script)()`) —
+  // present ONLY in sandbox previews, so this never runs against the
+  // production fallback. Re-sent on every onLoad because each in-iframe
+  // navigation is a fresh document; the script self-guards against double init.
+  const injectSessionReplay = () => {
+    if (!posthogConfig) return;
+    const win = previewIframeRef.current?.contentWindow;
+    const origin = previewOrigin(previewUrl);
+    if (!win || !origin) return;
+    win.postMessage(
+      {
+        type: "visual-editor::activate",
+        script: buildSessionReplayScript(posthogConfig.key, posthogConfig.host),
+      },
+      origin,
+    );
   };
 
   const activateEditingMode = (mode: PreviewEditingMode) => {
@@ -1566,6 +1592,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                         // skip the sandbox-only load handling (analytics, path sync,
                         // editor injection) — none of it applies to it.
                         if (display.mode !== "sandbox") return;
+                        // Stitch this deco site into the parent's session
+                        // replay (cross-origin — see session-replay-script.ts).
+                        injectSessionReplay();
                         // This is the VM dev-server preview (sandboxed running app),
                         // NOT an MCP app. MCP apps render via <MCPAppRenderer/>.
                         track("vm_preview_loaded", {

--- a/apps/web/src/components/sandbox/preview/session-replay-script.ts
+++ b/apps/web/src/components/sandbox/preview/session-replay-script.ts
@@ -1,0 +1,66 @@
+/**
+ * PostHog session-replay bootstrap for the sandbox Preview iframe.
+ *
+ * PostHog / rrweb only records SAME-origin iframes. Our Preview iframe loads a
+ * deco site on a different origin (`*.preview-studio.decocms.com`), so without
+ * help the preview canvas is a blank rectangle in replays. PostHog's fix is
+ * cross-origin iframe recording: load posthog-js inside the child too, init it
+ * with `recordCrossOriginIframes: true`, and it forwards its rrweb stream to
+ * the parent (which also sets the flag — see `lib/posthog-client.ts`) via
+ * postMessage instead of ingesting on its own. One stitched recording results.
+ *
+ * The script string below is eval'd inside the iframe by the sandbox bootstrap
+ * (`IFRAME_BOOTSTRAP_SCRIPT` in `packages/sandbox/shared.ts`), which listens
+ * for `visual-editor::activate` and runs `new Function(script)()`. That
+ * bootstrap is injected ONLY into sandbox dev-server previews (by the daemon
+ * proxy), never into the production-fallback frame — so this recording is
+ * scoped to deco sites the user is actively editing in Preview, by
+ * construction.
+ *
+ * Privacy: the child mirrors the parent's masking (`maskAllInputs`,
+ * `blockClass: "ph-no-capture"`) and disables autocapture / pageviews /
+ * pageleaves so it ONLY contributes the replay stream — no duplicate product
+ * analytics events from inside the customer's site.
+ */
+
+/** Distinct guard flag on the iframe's window so a re-injection is a no-op. */
+const REPLAY_GUARD = "__phSessionReplayActive";
+
+/**
+ * Build the self-contained bootstrap script for the given PostHog project.
+ *
+ * `key`/`host` come from `/api/config` (`usePublicConfig().posthog`) and are
+ * JSON-encoded so they can't break out of the string literal. `host` is the
+ * same first-party reverse proxy the parent uses; it must serve
+ * `/static/array.js` (the standard PostHog reverse-proxy contract).
+ */
+export function buildSessionReplayScript(key: string, host: string): string {
+  const k = JSON.stringify(key);
+  const h = JSON.stringify(host);
+  return `(function(){
+  if (window.${REPLAY_GUARD}) return;
+  window.${REPLAY_GUARD} = true;
+  try {
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    window.posthog.init(${k}, {
+      api_host: ${h},
+      // Contribute ONLY the replay stream to the parent — no analytics events.
+      autocapture: false,
+      capture_pageview: false,
+      capture_pageleave: false,
+      capture_performance: false,
+      capture_exceptions: false,
+      disable_surveys: true,
+      person_profiles: "never",
+      session_recording: {
+        maskAllInputs: true,
+        blockClass: "ph-no-capture",
+        recordCrossOriginIframes: true
+      }
+    });
+  } catch (err) {
+    window.${REPLAY_GUARD} = false;
+    console.error("[session-replay] bootstrap failed", err);
+  }
+})();`;
+}

--- a/apps/web/src/lib/posthog-client.ts
+++ b/apps/web/src/lib/posthog-client.ts
@@ -207,6 +207,14 @@ export function initPostHog(key: string, host: string) {
     session_recording: {
       maskAllInputs: true,
       blockClass: "ph-no-capture",
+      // Stitch the sandbox Preview iframe (a cross-origin deco site on
+      // *.preview-studio.decocms.com) into this document's recording. rrweb
+      // only records same-origin iframes by default, so without this the
+      // preview canvas shows up as a blank rectangle in replays. The child
+      // side is bootstrapped by buildSessionReplayScript(), injected ONLY into
+      // the sandbox preview (never the production fallback) — see
+      // components/sandbox/preview/session-replay-script.ts.
+      recordCrossOriginIframes: true,
       maskCapturedNetworkRequestFn: (request) => ({
         ...request,
         ...(typeof request.name === "string"


### PR DESCRIPTION
## Summary

PostHog session replay was showing the **Preview** canvas as a blank rectangle. The preview `<iframe>` loads a deco site on a **different origin** (`*.preview-studio.decocms.com`) than the app (`studio.decocms.com`), and rrweb only records same-origin iframes by default.

This enables PostHog's cross-origin iframe recording so the deco site being previewed is stitched into the parent's recording:

- **Parent** (`lib/posthog-client.ts`): set `session_recording.recordCrossOriginIframes: true`.
- **Child** (`components/sandbox/preview/session-replay-script.ts`, new): a lean posthog-js bootstrap injected into the preview iframe, inited with the same flag. The child detects it's embedded and **forwards its rrweb stream to the parent via postMessage** instead of ingesting on its own → one stitched recording.
- **Injection** (`preview.tsx`): on iframe `onLoad`, after the `display.mode === "sandbox"` guard, via the sandbox's existing `visual-editor::activate` channel (`new Function(script)()` in `IFRAME_BOOTSTRAP_SCRIPT`).

## Scoping — only Preview-tab iframes (deco sites)

The `visual-editor::activate` bootstrap is injected by the daemon proxy **only into sandbox dev-server previews**, never the production-fallback frame; combined with the `display.mode === "sandbox"` guard, recording is scoped to deco sites the user is actively editing. The child disables autocapture/pageviews/pageleaves and mirrors the parent's input masking (`maskAllInputs`, `blockClass: "ph-no-capture"`), so it contributes **only** the replay stream — no duplicate analytics events from inside the customer site.

## Testing notes

Local dev already serves the preview cross-origin (`<handle>.localhost`), so the path is reproducible, but this PR is meant to be validated on the **preview env**:

1. Open a VM Preview and interact with it.
2. In the preview iframe's console: `window.__phSessionReplayActive === true` and `window.posthog` exists; Network shows `/static/array.js`.
3. In the parent: `posthog.config.session_recording.recordCrossOriginIframes === true`; open `posthog.get_session_replay_url()`.
4. Confirm the replay renders the preview content instead of a blank rectangle.

Session replay is gated by project-level sampling (10%) + min duration (10s); the child inherits the parent's session, so no separate config.

### ⚠️ One thing to confirm on the deployed env
The child loads posthog-js from `${POSTHOG_HOST}/static/array.js` (the same first-party reverse proxy the parent uses). That proxy must serve `/static/*` (standard PostHog reverse-proxy contract). If `array.js` 404s inside the iframe, the recorder won't load — please confirm on the preview env.

## Checklist
- [x] `bun run fmt` / `fmt:check`
- [x] `bun run check` (tsc)
- [x] `bun run lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable cross-origin session replay for the Preview iframe so deco sites render inside PostHog recordings instead of a blank box. The parent enables cross-origin capture and the sandbox iframe injects a minimal `posthog-js` bootstrap to forward rrweb events to the parent.

- New Features
  - Parent: set `session_recording.recordCrossOriginIframes: true` and keep input masking.
  - Child: new `buildSessionReplayScript()` in the preview iframe using `posthog-js`; disables autocapture/pageviews and mirrors masking; forwards rrweb to the parent via `postMessage` for one stitched recording.
  - Injection: on iframe load in `preview.tsx` via the existing `visual-editor::activate` channel, gated by `display.mode === "sandbox"` and project config.
  - Scope: runs only in sandbox dev-server previews, never the production fallback; no duplicate analytics from the customer site.

- Migration
  - Ensure the PostHog host proxy serves `/static/array.js` (standard PostHog reverse-proxy path) so the iframe can load `posthog-js`.

<sup>Written for commit 28bd8fdf01b0f35d0529af9cda5c8ba16406c0ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

