### PR TITLE
fix(ui): prevent Select crash from browser translation DOM mutation

### DIFF
--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -63,8 +63,9 @@ function SelectContent({
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         data-slot="select-content"
+        translate="no"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border shadow-md",
+          "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,


### PR DESCRIPTION
## Summary

A user's PostHog session replay showed the app hard-crashing to the full-page "Something went wrong" error boundary, with:

```
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

thrown from inside Radix's `Select` portal (visible in the recording's Inspector → Console tab, component stack pointed at `SelectPortal`).

## Root cause

This is a known, well-documented class of bug — not specific to how Select is used here:

- [radix-ui/primitives#3795](https://github.com/radix-ui/primitives/issues/3795) and [#2578](https://github.com/radix-ui/primitives/issues/2578) — Select crashing after browser page-translation
- [facebook/react#11538](https://github.com/facebook/react/issues/11538) — the general React/Google-Translate DOM-race issue

When a browser's page-translation feature (Chrome Translate, etc.) rewrites text nodes inside a React-portaled subtree, it mutates DOM that React doesn't know about. The next time React tries to unmount or reconcile that portal (e.g. closing the dropdown), it attempts to remove a node that translation already moved/replaced, and throws — which our root `ErrorBoundary` catches and renders as a fatal, full-page crash.

Because it depends on the user having translation active, it's non-deterministic and not reproducible from a specific click path — it can happen on any Select, anywhere in the app.

## Fix

Radix's own recommendation (and what they use on their own docs site) is `translate="no"` on the portaled content, so the browser's translator skips that subtree instead of racing with React's cleanup:

- `translate="no"` attribute (checked by most translation engines)
- `notranslate` class (specifically checked by Chrome's translator)

Applied once in `packages/ui/src/components/select.tsx`'s shared `SelectContent`, which all ~43 call sites across the app route through — so this is a single fix rather than 43 individual patches.

### Why not something broader

Considered and rejected:
- **Monkey-patching `Node.prototype.removeChild`/`insertBefore`** to fail silently — this is the workaround used for pages with real prose content that must stay translatable. It trades a loud crash for a *silent* one (stale/duplicated DOM) which is harder for a user to notice or recover from. Not worth it here since Select option labels are short technical/proper-noun strings (env names, model names, plan names), not content anyone needs machine-translated.
- **Catching this error in the root `ErrorBoundary` and resetting state** — by the time an error boundary catches a failed commit-phase DOM operation, React's fiber tree can already be desynced from the real DOM. Silently swallowing it there risks masking a genuinely corrupted subtree rather than fixing anything.

### Trade-off

Dropdown option text inside `Select` will no longer be machine-translated by the browser. The rest of the page (labels, surrounding copy, buttons) is unaffected. Given option labels here are mostly short technical/proper-noun strings, this is a small, scoped cost against a full-page crash.

## Test plan

- [ ] Open any `Select` in the app (e.g. org switcher, model selector) with Chrome's "Translate this page" turned on and confirm no crash on open/close
- [ ] Confirm Select still functions normally (open, select an option, close) with translation off

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents full-page crashes caused by browser translation mutating the DOM inside `@radix-ui/react-select`. Marks the Select dropdown content as non-translatable to avoid the removeChild NotFoundError.

- **Bug Fixes**
  - Added translate="no" and the notranslate class to the shared Select content in `packages/ui/src/components/select.tsx`, covering all usages.
  - Trade-off: Select option text won’t be auto-translated; the rest of the page still translates.

<sup>Written for commit e3f2cb8a2f61e6f5228826b3d796cf723e985293. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

