### PR TITLE
fix(auth): mount Providers inside the router to fix crash on invite accept/login redirect

### DIFF
--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -28,11 +28,13 @@ migrateLegacyStorageKeys(window.localStorage);
 
 const rootRoute = createRootRoute({
   component: () => (
-    <ChunkErrorBoundary>
-      <Suspense fallback={<SplashScreen />}>
-        <Outlet />
-      </Suspense>
-    </ChunkErrorBoundary>
+    <Providers>
+      <ChunkErrorBoundary>
+        <Suspense fallback={<SplashScreen />}>
+          <Outlet />
+        </Suspense>
+      </ChunkErrorBoundary>
+    </Providers>
   ),
 });
 
@@ -728,8 +730,6 @@ const rootElement = document.getElementById("root")!;
 
 createRoot(rootElement).render(
   <StrictMode>
-    <Providers>
-      <RouterProvider router={router} />
-    </Providers>
+    <RouterProvider router={router} />
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary

Fixes the crash reported by multiple users during org invite acceptance and login:

```
TypeError: Cannot read properties of null (reading 'navigate')
```

The stack always bottoms out inside the `auth-catchall` route (`/auth/$pathname`, which serves `/auth/accept-invitation` and every other better-auth-ui view), and the error itself only fires when a flow *completes* (accept/reject invitation, an expired-invitation bounce, a successful sign-in view redirect) rather than on initial render — which is the key clue below.

## Root cause

`BetterAuthUIProvider` (`apps/web/src/providers/better-auth-ui-provider.tsx`) calls `useNavigate()` from `@tanstack/react-router` at render time and passes the result to `better-auth-ui`'s `AuthUIProvider` as its `navigate`/`replace` callbacks:

```tsx
const navigate = useNavigate();
<AuthUIProvider
  navigate={(href) => navigate({ to: href })}
  replace={(href) => navigate({ to: href, replace: true })}
  ...
```

`BetterAuthUIProvider` is rendered inside `Providers`, and `Providers` was mounted as the **parent** of `RouterProvider` in `apps/web/src/index.tsx`:

```tsx
createRoot(rootElement).render(
  <StrictMode>
    <Providers>
      <RouterProvider router={router} />
    </Providers>
  </StrictMode>,
);
```

React context only flows to *descendants* of the component that provides it. Since `BetterAuthUIProvider` sits above `RouterProvider` in the tree, its `useNavigate()` call resolves with no router in context at all. TanStack Router's `useRouter()` degrades to `null` in that situation (it only logs a dev warning, it doesn't throw), so `useNavigate()` returns a callback that permanently closes over a `null` router. Calling that callback later throws `Cannot read properties of null (reading 'navigate')`, because it internally does `router.navigate(...)`.

This explains the exact symptom pattern reported:
- `<Link>`-based navigation elsewhere in the app is unaffected, because `Link` is a *component* that better-auth-ui renders as a descendant of the real route tree — by the time it renders, it's correctly inside `RouterProvider`'s context.
- The broken `navigate`/`replace` are plain *functions*, captured once, outside the router's context, and only blow up when better-auth-ui actually **calls** them — which happens on every accept/reject-invitation success, every expired/invalid-invitation bounce, and any other `AuthView` success redirect (e.g. sign-in). That's why the bug clusters around invite acceptance and login specifically, while the rest of the app's own routing (which calls `useNavigate()` correctly from inside real route components) looks fine.

## Fix

Move `Providers` to wrap the root route's own component (a genuine descendant of `RouterProvider`) instead of wrapping `RouterProvider` itself, so every hook inside it — including `BetterAuthUIProvider`'s `useNavigate()` — resolves the router context correctly:

```tsx
const rootRoute = createRootRoute({
  component: () => (
    <Providers>
      <ChunkErrorBoundary>
        <Suspense fallback={<SplashScreen />}>
          <Outlet />
        </Suspense>
      </ChunkErrorBoundary>
    </Providers>
  ),
});
...
createRoot(rootElement).render(
  <StrictMode>
    <RouterProvider router={router} />
  </StrictMode>,
);
```

This is a pure reordering — no provider's own implementation changes, and the relative nesting between `Providers`'s internal providers (`QueryClientProvider`, `ThemeProvider`, `AuthConfigProvider`, `BetterAuthUIProvider`, etc.) and `ChunkErrorBoundary`/`Outlet` is preserved, so error-boundary and query-cache behavior is unaffected.

## Audit of the surrounding invite/login flow

Reviewed the rest of the invite → accept → navigate/redirect → login pipeline (`auth-catchall.tsx`, `pending-invite-screen.tsx`, `org-access-gate.tsx`, `required-auth-layout.tsx`, `login.tsx`, `auth-entry.tsx`/`unified-auth-form.tsx`, `use-org-access-status.ts`, `use-invitations.ts`, and the server-side `org-access-status`/invitation-email routes in `apps/api`). Everything else in that path either:
- uses `<Navigate>`/`<Link>` components (safe — resolved as real route-tree descendants), or
- uses `window.location.href`/`window.location.reload()` for hard navigation (safe — no router context involved).

No other instance of a captured `useNavigate()`/`useRouter()` result being used outside the router's own tree was found.

## Test plan
- [x] `tsc --noEmit` passes for `apps/web`
- [x] `oxlint` clean on the changed file (pre-existing, unrelated filename-casing warning only)
- [ ] Manually verify: log out, click an invite email's "Accept invitation" link, log in, click Accept — should land in the org instead of crashing
- [ ] Manually verify: already-signed-in user clicking an invite link accepts/rejects without the white-screen crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the crash during org invite acceptance and login redirects by mounting `Providers` inside the `@tanstack/react-router` tree. `better-auth-ui` now receives valid `navigate`/`replace` functions.

- **Bug Fixes**
  - Moved `Providers` to wrap the root route component (not `RouterProvider`) in `apps/web/src/index.tsx`, so `BetterAuthUIProvider`’s `useNavigate()` resolves a real router.
  - Eliminates `TypeError: Cannot read properties of null (reading 'navigate')` on accept/reject invitation, expired/invalid-invite bounces, and sign-in success.
  - Pure reordering only; provider internals, error boundaries, and query cache behavior are unchanged.

<sup>Written for commit cb52cfa75521fd0027925cad0412f884a940fde5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

