### PR TITLE
fix(chat): wrap composer placeholder text on narrow widths

### DIFF
--- a/apps/web/src/components/chat/tiptap/input.tsx
+++ b/apps/web/src/components/chat/tiptap/input.tsx
@@ -247,6 +247,8 @@ export function TiptapInput({
           "[&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left",
           "[&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none",
           "[&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0",
+          "[&_.ProseMirror_p.is-editor-empty:first-child::before]:w-full",
+          "[&_.ProseMirror_p.is-editor-empty:first-child::before]:break-words",
           disabled && "cursor-not-allowed opacity-70",
           disabled && "[&_.ProseMirror]:cursor-not-allowed",
         )}


### PR DESCRIPTION
## Summary
- The chat composer's placeholder text (e.g. "Pergunte qualquer coisa, / para prompts...") is rendered via the standard Tiptap `float-left` + `height: 0` CSS trick on an empty paragraph's `::before` pseudo-element.
- Without an explicit width, the floated box used shrink-to-fit sizing, which could compute to the full unwrapped content width instead of the input's actual available width — causing the text to overflow past the box on narrow screens.
- Since the composer's form wrapper has `overflow-hidden`, that overflow got visually clipped, making the placeholder look cut off at narrow screen sizes.
- Added `w-full` (forces the float to wrap within the input's real width) and `break-words` (safety net for very narrow widths) to `apps/web/src/components/chat/tiptap/input.tsx`.

## Test plan
- [ ] Open the chat composer at a narrow viewport width (e.g. ~300-350px) and confirm the placeholder text wraps fully within the box instead of being clipped
- [ ] Confirm placeholder still renders correctly at normal/wide viewport widths
- [ ] Confirm typing still clears the placeholder and editor behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat composer placeholder clipping on narrow screens by making the placeholder wrap to the input width and break long words.

- **Bug Fixes**
  - Added `w-full` and `break-words` to the empty-paragraph `::before` placeholder styles to prevent shrink-to-fit overflow.

<sup>Written for commit 9b3c9c68c0202f79564f679b8b8420539ed22c07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

