### PR TITLE
fix(sandbox): surface terminal claim failure so preview stops spinning forever

### DIFF
--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -7,6 +7,7 @@ import {
   buildSandboxStartArgs,
   deriveOthersThreadLabel,
   computeOthersThreadGate,
+  deriveStartError,
   type BranchMapEntryLike,
 } from "./sandbox-lifecycle-context";
 
@@ -259,6 +260,62 @@ describe("deriveOthersThreadLabel", () => {
         title: null,
       }),
     ).toBeNull();
+  });
+});
+
+describe("deriveStartError", () => {
+  const base = {
+    mutationError: null,
+    phase: null,
+    startPending: false,
+  } as const;
+
+  test("no error, no failed phase → null (still booting)", () => {
+    expect(deriveStartError(base)).toBeNull();
+  });
+
+  test("mutation rejection wins → surfaces the decoded error", () => {
+    const mutationError = { code: null, message: "boom" };
+    expect(deriveStartError({ ...base, mutationError })).toEqual(mutationError);
+  });
+
+  test("terminal claim-failed phase → errored (the infinite-loading fix)", () => {
+    // Regression: a terminal claim failure arrives on the SSE lifecycle stream,
+    // never as a SANDBOX_START rejection, so the preview used to spin on
+    // "starting" forever. It must surface as a terminal error instead.
+    expect(
+      deriveStartError({
+        ...base,
+        phase: {
+          kind: "failed",
+          reason: "scheduling-timeout",
+          message: "no capacity",
+        },
+      }),
+    ).toEqual({ code: null, message: "no capacity" });
+  });
+
+  test("failed phase while a start is in flight → null (keep booting overlay)", () => {
+    expect(
+      deriveStartError({
+        ...base,
+        phase: { kind: "failed", reason: "unknown", message: "x" },
+        startPending: true,
+      }),
+    ).toBeNull();
+  });
+
+  test("non-terminal phase (still provisioning) → null", () => {
+    expect(
+      deriveStartError({
+        ...base,
+        phase: { kind: "pulling-image", since: 0 },
+      }),
+    ).toBeNull();
+  });
+
+  test("ready phase → null", () => {
+    expect(deriveStartError({ ...base, phase: { kind: "ready" } })).toBeNull();
   });
 });
 

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -11,9 +11,13 @@
  * consolidation logic without crossing the no-mocks line.
  */
 
-import type { PreviewState } from "@/components/sandbox/preview/preview-state";
+import type {
+  PreviewState,
+  SandboxStartError,
+} from "@/components/sandbox/preview/preview-state";
 import type { DrawerStatus } from "@/components/sandbox/preview/drawer/status-pill";
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
+import type { ClaimPhase } from "./sandbox-events-context";
 import {
   selectVmEntry,
   type BranchMapEntryLike,
@@ -119,6 +123,28 @@ export function buildSandboxStartArgs(
   if (branch) args.branch = branch;
   if (sandboxProviderKind) args.sandboxProviderKind = sandboxProviderKind;
   return args;
+}
+
+/** Terminal SANDBOX_START error to surface (→ `errored` preview state), or null
+ *  while still booting. Two independent sources feed the same terminal state:
+ *   - a rejected SANDBOX_START mutation (GitHub-not-auth, non-retryable server error);
+ *   - a terminal claim-`failed` phase on the SSE lifecycle stream (K8s
+ *     scheduling/image-pull failure, or the synthetic "lifecycle watcher ended"
+ *     failure from lifecycle.ts).
+ *  The phase-failed source never rejects the mutation, so without it
+ *  computePreviewState pins to "starting" forever (the infinite-loading bug).
+ *  Gate the phase path on no start in flight so an in-progress retry/self-heal
+ *  reprovision keeps the booting overlay instead of flashing errored. */
+export function deriveStartError(args: {
+  mutationError: SandboxStartError | null;
+  phase: ClaimPhase | null;
+  startPending: boolean;
+}): SandboxStartError | null {
+  if (args.mutationError) return args.mutationError;
+  if (args.phase?.kind === "failed" && !args.startPending) {
+    return { code: null, message: args.phase.message };
+  }
+  return null;
 }
 
 export function computeDrawerStatus(state: PreviewState): DrawerStatus {
@@ -294,10 +320,14 @@ export function SandboxLifecycleProvider({
       !!branch &&
       sandboxUserStop.isStopped(virtualMcpId, branch));
   const appPaused = events.status.state === "paused";
-  const startError =
-    startVm.isError && startVm.error
-      ? decodeSandboxStartError(startVm.error.message)
-      : null;
+  const startError = deriveStartError({
+    mutationError:
+      startVm.isError && startVm.error
+        ? decodeSandboxStartError(startVm.error.message)
+        : null,
+    phase: events.phase,
+    startPending: startVm.isPending || sharedLifecyclePending,
+  });
   const previewState = computePreviewState({
     previewUrl,
     appPaused,


### PR DESCRIPTION
## Problem

Sandbox preview gets stuck **loading forever** — the full-canvas "Iniciando sandbox…" spinner never resolves, and the user is left with no way to recover (no retry, no escape) on that surface.

![reported bug: infinite sandbox loading](https://github.com/decocms/studio)

## Root cause

A terminal sandbox **claim failure** — a real K8s failure (`scheduling-timeout`, `image-pull-backoff`, `crash-loop-backoff`, …) **or** the synthetic `failed: "lifecycle watcher ended unexpectedly"` emitted by `apps/api/src/sandbox/lifecycle.ts` — arrives on the SSE lifecycle stream as a claim-`failed` phase (`events.phase.kind === "failed"`). It **never rejects the `SANDBOX_START` mutation**.

But `computePreviewState` only escaped `"starting"` via `startError`, which was populated *solely* from a rejected mutation. So a boot that failed **after** `SANDBOX_START` already returned (async provision) left the preview pinned to `"starting"` indefinitely — the infinite spinner. The `starting` card has no retry/new-chat affordance (only the `errored`/`othersThread` cards do), so the user is trapped. This gap was already flagged as a follow-up in `claim-phase-copy.ts`.

## Fix

Route the terminal claim-`failed` phase into `startError` via a small pure helper `deriveStartError()`. `computePreviewState` then returns `errored`, which renders the **existing** errored card with its **Retry** button (Retry re-fires `SANDBOX_START` — the correct recovery). `resolvePreviewDisplay` already suppresses the booting overlay for `errored`, so there's no double-render.

The phase path is gated on **no start in flight** (`!startVm.isPending && !sharedLifecyclePending`) so an in-progress retry/self-heal reprovision keeps the booting overlay instead of flashing errored.

No new UI, no new dependency — reuses the errored card + Retry.

## Verified against prod

Queried `agent_sandbox_sessions` on prod: **every** row with `desired_state='running'` + `status='missing'` (4 of them) has `preview_url IS NULL` **and** `failure_reason IS NULL` — the exact stuck signature (no URL, no recorded failure → frontend spins forever).

## Tests

Added `deriveStartError` unit tests (co-located, pure — no mocks): terminal `failed` → errored; `failed` while pending → null (keep overlay); non-terminal / `ready` → null; mutation rejection still wins. `bun test` (44 pass), `tsc --noEmit`, and `bun run fmt` all clean.

## Note

An unrelated working-tree change to `sections-editor/read-committed-file.ts` (treat 404 as transient) was present but is **not** part of this PR — it was not authored in this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the sandbox preview from spinning forever by surfacing terminal claim failures as start errors, so the UI shows the existing errored card with Retry instead of staying on “starting”.

- **Bug Fixes**
  - Introduced `deriveStartError` to map claim `failed` phases to `startError` when no start is in flight, enabling Retry.
  - Kept the booting overlay during in‑flight retries/self-heal to avoid flashing errored.
  - Added unit tests for `deriveStartError`.

<sup>Written for commit b602ec8feb10b863a16e360f4542de3291593cbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

