### PR TITLE
fix(cms): treat sandbox-not-provisioned 404 as transient in committed reads

### DIFF
--- a/apps/web/src/components/sections-editor/read-committed-file.ts
+++ b/apps/web/src/components/sections-editor/read-committed-file.ts
@@ -30,7 +30,15 @@ export async function readCommittedJson<T>(
   });
   // 400 = file not found: the repo simply doesn't commit this artifact, so
   // there is no committed source to fall back to. Don't retry.
-  if (res.status === 400) return null;
+  //
+  // 404 = the sandbox isn't provisioned yet (proxy/runner "sandbox not found";
+  // a healthy daemon returns 400, never 404, for an absent file). This is a
+  // transient startup state, not a hard error — return null so the caller falls
+  // through to its next source / 502-wait and the sandbox lifecycle re-triggers
+  // the read once the daemon is up, instead of throwing a non-502 error that
+  // gets retried in a tight loop (and, in useLiveMeta, skips the production
+  // fallback).
+  if (res.status === 400 || res.status === 404) return null;
   if (!res.ok) {
     const err = new Error(`Failed to read ${path}: ${res.status}`);
     (err as { status?: number }).status = res.status;


### PR DESCRIPTION
## Summary

Fixes the `POST /api/:org/sandbox/:vmcp/:branch/read` **404 storm** seen in the CMS console while a sandbox is still starting ("Iniciando sandbox").

**Root cause:** the CMS reads committed artifacts (`.deco/blocks.gen.json`, `.deco/meta.gen.json`) through the sandbox `/read` proxy via `readCommittedJson`. Before the daemon is provisioned, the proxy/runner returns `404 {"error":"sandbox not found"}` (`packages/sandbox/.../agent-sandbox/runner.ts`). A healthy daemon returns **400** (never 404) for a genuinely absent file (`packages/sandbox/daemon/routes/fs.ts:241`), so a 404 here unambiguously means *"sandbox not provisioned yet"* — a transient startup state.

`readCommittedJson` only special-cased **400** (→ `null`); **404** fell through to a `throw` with `status: 404`. Since `404 !== 502`:
- `useDecofile` (retry `status !== 502 && failureCount < 2`) and `useLiveMeta` (`< 3`) both **retried it in a tight loop**;
- `useLiveMeta`'s throw also **skipped its production-meta fallback** source.

Combined with sandbox-lifecycle re-invalidation on every SSE phase during the (long) startup, this produced the observed 404 spam.

## Fix

Treat `404` like `400` (→ `null`) in `readCommittedJson`, so callers fall through to their existing **502-wait** path and wait for the lifecycle to re-trigger the read once the daemon is up — instead of hammering an endpoint that is known-down by construction. Returning `null` (rather than throwing 502) is deliberate: it preserves `useLiveMeta`'s production-fallback source walk.

## Testing

- `bun run --cwd apps/web check` passes (change isolated).
- `bun test .../use-live-meta.test.ts` → 6/6 pass.
- Safe by construction: the daemon never emits 404 for a present-but-missing file, so this cannot mask a legit file-absent case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuVqpprnAGD3oDEXu1BJQD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the CMS 404 spam during sandbox startup by treating sandbox-not-provisioned 404s as transient. `readCommittedJson` now returns null on 404 (same as 400) so callers wait for provisioning instead of retrying.

- **Bug Fixes**
  - In `apps/web/src/components/sections-editor/read-committed-file.ts`, treat `404` from the sandbox `/read` proxy as transient: return `null` for both `400` and `404`.
  - Prevents tight retry loops in `useDecofile` and `useLiveMeta`, preserves the production-meta fallback, and is safe because the daemon uses `400` for missing files while `404` only means the sandbox isn’t provisioned yet.

<sup>Written for commit f60607cfa3cbce8160dce7f0c6b57aff107a2354. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

