### PR TITLE
fix(sandbox): return 409 instead of 500 for tokenless GitHub publish

### DIFF
--- a/packages/sandbox/daemon/routes/git.test.ts
+++ b/packages/sandbox/daemon/routes/git.test.ts
@@ -634,6 +634,26 @@ describe("git routes", () => {
     );
   });
 
+  it("publish route returns 409 (not 500) for a tokenless github origin", async () => {
+    const { appRoot, repoDir } = initRepo();
+    onFeatureBranch(repoDir);
+    gitSync(["remote", "add", "origin", "https://github.com/owner/repo.git"], {
+      cwd: repoDir,
+      asUser: false,
+    });
+    writeFileSync(join(repoDir, "README.md"), "changed\n");
+    const handler = makeGitPublishHandler({ appRoot, repoDir });
+    const res = await handler(
+      new Request("http://x/git/publish", {
+        method: "POST",
+        body: JSON.stringify({ message: "no creds" }),
+      }),
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/authenticated clone URL/);
+  });
+
   it("publish skips failing pre-commit hooks", async () => {
     const { appRoot, repoDir } = initRepo();
     onFeatureBranch(repoDir);

--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -654,7 +654,9 @@ export function publish(
   // through to pushBranch and fail with an opaque "Invalid username or token".
   const originUrl = tryGit(repoDir, ["remote", "get-url", "origin"]) ?? "";
   if (originUrl.includes("github.com") && !cloneUrlHasCredentials(originUrl)) {
-    throw new Error(
+    // Missing GitHub credentials is a config/state condition (mirrors the
+    // detached-HEAD/protected-branch refusals above), not a server fault.
+    throw new PublishBlockedError(
       "GitHub push requires an authenticated clone URL. Connect GitHub for this project and restart the sandbox.",
     );
   }


### PR DESCRIPTION
Bug fix in the sandbox daemon's git/publish route, in the same family as #5189/#5150/#5144/#5175 (the recurring "surface a client/data condition as 4xx instead of a raw 500" pattern in `packages/sandbox/daemon/routes/git.ts`).

`publish()` already refuses a tokenless GitHub origin (`cloneUrlHasCredentials` check) with a clear message, but threw a plain `Error`, which `makeGitPublishHandler`'s catch-all falls through to a generic 500 — the same opaque-server-error UX the prior fixes in this file eliminated for protected-branch/detached-HEAD refusals. A maintainer wants this because the daemon's own convention (see `PublishBlockedError` right above this check, used for detached HEAD / protected branch) is that a refusal caused by current repo/config state, not a server fault, should map to 409 so the UI can show an actionable message instead of a scary crash.

Failure scenario: a sandbox whose GitHub origin has no embedded credentials (project not yet connected to GitHub) calls POST /git/publish → daemon returns 500 with no structured error the UI can act on, even though the underlying condition ("connect GitHub and restart the sandbox") is entirely a client-actionable state, not a crash.

Fix: reuse the existing `PublishBlockedError` (already mapped to 409 in the handler) instead of a bare `Error` for this refusal — one-line change, no behavior change to the message or control flow. Regression test added: `publish route returns 409 (not 500) for a tokenless github origin` in git.test.ts, mirroring the existing `publish route returns 409 (not 500) for a protected-branch refusal` test right above it.

Reviewer command: `bun test packages/sandbox/daemon/routes/git.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (packages/sandbox), and the single targeted test file above (38 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 409 Conflict instead of 500 from sandbox `git/publish` when the GitHub remote has no credentials. This turns a client-actionable state into a clear UI message instead of a generic server error.

- **Bug Fixes**
  - Throw `PublishBlockedError` for tokenless GitHub origins so the route returns 409.
  - Added test to assert 409 and verify the error message.

<sup>Written for commit 559146480f213ddc2e459b57721dcba2cc5f8e25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

