### PR TITLE
feat(commerce-onboarding): add data-safety trust signals to connect modal

### DIFF
--- a/apps/web/src/i18n/en/routes.ts
+++ b/apps/web/src/i18n/en/routes.ts
@@ -145,6 +145,9 @@ export const routes = {
   "routes.commerceOnboarding.connectModal.quote":
     "I was grinning ear to ear, because we had already spotted all of it, we just didn't know what to do next... you brought a really meaningful perspective on the next steps.",
   "routes.commerceOnboarding.connectModal.quoteAuthor": "Ágata Esteves",
+  "routes.commerceOnboarding.connectModal.trustRevoke": "Revoke anytime",
+  "routes.commerceOnboarding.connectModal.trustEncrypted": "Encrypted",
+  "routes.commerceOnboarding.connectModal.trustNeverSold": "Never sold",
   "routes.commerceOnboarding.companionSection.title":
     "Connect your tools to see the full diagnostic",
   "routes.commerceOnboarding.companionSection.loadError":

--- a/apps/web/src/i18n/pt-br/routes.ts
+++ b/apps/web/src/i18n/pt-br/routes.ts
@@ -150,6 +150,9 @@ export const routes = {
   "routes.commerceOnboarding.connectModal.quote":
     "Eu tava sorrindo de orelha a orelha, porque tudo aquilo a gente já tinha identificado, mas a gente não sabia o que fazer... vocês trouxeram uma visão bem significativa para os próximos passos.",
   "routes.commerceOnboarding.connectModal.quoteAuthor": "Ágata Esteves",
+  "routes.commerceOnboarding.connectModal.trustRevoke": "Revogue quando quiser",
+  "routes.commerceOnboarding.connectModal.trustEncrypted": "Criptografado",
+  "routes.commerceOnboarding.connectModal.trustNeverSold": "Nunca vendido",
   "routes.commerceOnboarding.companionSection.title":
     "Conecte suas ferramentas para ver o diagnóstico completo",
   "routes.commerceOnboarding.companionSection.loadError":

--- a/apps/web/src/routes/commerce-onboarding/connect-extras.tsx
+++ b/apps/web/src/routes/commerce-onboarding/connect-extras.tsx
@@ -1,4 +1,5 @@
 import { useT } from "@/i18n/use-t.ts";
+import { Lock01, ReverseLeft, SlashCircle01 } from "@untitledui/icons";
 
 /**
  * Right-hand panel of the connect modal: a customer quote over a full-bleed
@@ -38,6 +39,49 @@ export function ConnectQuotePanel() {
           {t("routes.commerceOnboarding.connectModal.quoteAuthor")}
         </span>
       </figcaption>
+    </div>
+  );
+}
+
+/**
+ * Data-safety reassurances pinned to the bottom of the connect modal's right
+ * panel. Every claim here is deliberately conservative and verifiable against
+ * the Terms + Privacy Policy: connections can be revoked at any time (Privacy
+ * §7), data is encrypted in transit and tokens at rest (Privacy §11), and
+ * Customer Content is never sold (Terms/Privacy §6). We intentionally do NOT
+ * claim "read-only" — agents open PRs and take actions, so that would overstate
+ * the guarantee. Rendered over the photo + scrim, so all text is white.
+ */
+export function ConnectTrustSignals() {
+  const t = useT();
+  const items = [
+    {
+      Icon: ReverseLeft,
+      label: t("routes.commerceOnboarding.connectModal.trustRevoke"),
+    },
+    {
+      Icon: Lock01,
+      label: t("routes.commerceOnboarding.connectModal.trustEncrypted"),
+    },
+    {
+      Icon: SlashCircle01,
+      label: t("routes.commerceOnboarding.connectModal.trustNeverSold"),
+    },
+  ];
+  return (
+    <div className="relative flex flex-col gap-2.5 text-white">
+      <div className="h-px w-full bg-white/15" />
+      <ul className="mt-1 flex flex-col gap-2.5">
+        {items.map(({ Icon, label }) => (
+          <li
+            key={label}
+            className="flex items-center gap-2.5 text-[13px] leading-tight text-white/70"
+          >
+            <Icon className="size-4 shrink-0 opacity-85" />
+            {label}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/apps/web/src/routes/commerce-onboarding/connect-layout.tsx
+++ b/apps/web/src/routes/commerce-onboarding/connect-layout.tsx
@@ -2,7 +2,7 @@ import { useT } from "@/i18n/use-t.ts";
 import { Button } from "@deco/ui/components/button.tsx";
 import { ChevronRight, X } from "@untitledui/icons";
 import type { ReactNode } from "react";
-import { ConnectQuotePanel } from "./connect-extras.tsx";
+import { ConnectQuotePanel, ConnectTrustSignals } from "./connect-extras.tsx";
 
 /**
  * Shared chrome for the commerce connect step, used by BOTH the live
@@ -78,7 +78,7 @@ export function ConnectLayout({
       </div>
 
       {/* Right: full-bleed brand-photo quote panel (desktop only). */}
-      <aside className="relative hidden shrink-0 overflow-hidden lg:flex lg:w-[440px] lg:flex-col lg:justify-center lg:p-14">
+      <aside className="relative hidden shrink-0 overflow-hidden lg:flex lg:w-[440px] lg:flex-col lg:p-14">
         <img
           src="https://decoims.com/image?src=decocms%2F8191643a-1947-4c30-afb4-36b8073c90fb%2Fbg-quote.png&quality=original&fit=cover&width=880"
           alt=""
@@ -86,8 +86,13 @@ export function ConnectLayout({
         />
         {/* Scrim keeps the white quote legible over the brighter parts. */}
         <div className="absolute inset-0 bg-black/20" />
-        <div className="relative z-10">
+        {/* Quote centers in the space above the trust signals, which pin to the
+            bottom (equal flex spacers above/below the quote). */}
+        <div className="relative z-10 flex h-full flex-col">
+          <div className="flex-1" />
           <ConnectQuotePanel />
+          <div className="flex-1" />
+          <ConnectTrustSignals />
         </div>
       </aside>
     </div>


### PR DESCRIPTION
## Summary

Adds three data-safety reassurances pinned to the bottom of the commerce-onboarding **connect modal's** right panel (the testimonial side), giving merchants more confidence before they connect their tools.

The quote now centers vertically in the space above the signals, which sit flush at the bottom behind a hairline divider.

## The copy — every claim verified against Terms + Privacy Policy

| Signal | Grounded in |
|---|---|
| **Revoke anytime** | Privacy §7 — connections can be disconnected/revoked at any time |
| **Encrypted** | Privacy §11 — TLS in transit + encrypted token storage at rest |
| **Never sold** | Terms (AI §) / Privacy §6 — Customer Content is never sold, never used to train foundation models |

A "read-only access" claim was **deliberately dropped**: the platform's agents open PRs and take actions on the user's behalf (Terms AI §), so a blanket read-only promise would overstate the guarantee. "Shared" was also dropped, since Privacy §8 lists real subprocessors the data flows to.

## Changes

- `connect-extras.tsx` — new `ConnectTrustSignals` component (vertical stack, `white/70`, untitled-ui icons)
- `connect-layout.tsx` — right `<aside>` restructured so the quote centers and the signals pin to the bottom
- `i18n/en/routes.ts` + `i18n/pt-br/routes.ts` — three new keys each

## Testing

- `bun run fmt` ✅
- `tsc --noEmit` ✅
- `bun run lint` ✅ (0 errors)

## ⚠️ Reviewer note

These are effectively data-handling representations in the product UI. They're conservative and doc-backed, but worth a sign-off from whoever owns **legal@decocms.com** before this goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds data-safety trust signals to the commerce onboarding connect modal to boost merchant confidence. The testimonial now centers, with three verified claims pinned to the bottom of the right panel.

- **New Features**
  - Added `ConnectTrustSignals` in `connect-extras.tsx` with “Revoke anytime”, “Encrypted”, and “Never sold” (icons included).
  - Updated right panel layout in `connect-layout.tsx`: quote centers; trust signals fixed to bottom with a subtle divider.
  - Added i18n keys in `i18n/en/routes.ts` and `i18n/pt-br/routes.ts`; claims align with Privacy §§7, 11 and Terms/Privacy §6 (no “read-only” promise).

<sup>Written for commit 128208e625919cee551276d63eda34c167a02c25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

