### PR TITLE
fix(settings): stop logging the raw ENCRYPTION_KEY value on startup

### DIFF
--- a/apps/api/src/settings/pipeline.ts
+++ b/apps/api/src/settings/pipeline.ts
@@ -10,7 +10,7 @@
  */
 
 import type { CliFlags, Settings } from "./types";
-import { resolveConfig } from "./resolve-config";
+import { describeEncryptionKeyForLog, resolveConfig } from "./resolve-config";
 import { setGlobalSettings } from "./index";
 
 export interface BuildResult {
@@ -27,11 +27,8 @@ export async function buildSettings(flags: CliFlags): Promise<BuildResult> {
   // 2. Merge CLI flags + env vars + defaults
   const config = resolveConfig(flags, envVars);
 
-  // Log encryption key status on startup
-  const ek = config.settings.encryptionKey;
-  console.log(
-    `[settings] ENCRYPTION_KEY = ${JSON.stringify(ek)} (${ek.length} chars)`,
-  );
+  // Log encryption key status on startup (masked — never the raw secret)
+  console.log(describeEncryptionKeyForLog(config.settings.encryptionKey));
 
   // 3. Start services if needed
   const { ensureServices } = await import("../services/ensure-services");

--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { resolveConfig, resolveShutdownDrainMs } from "./resolve-config";
+import {
+  describeEncryptionKeyForLog,
+  resolveConfig,
+  resolveShutdownDrainMs,
+} from "./resolve-config";
 import type { CliFlags } from "./types";
 
 const flags: CliFlags = {
@@ -231,6 +235,32 @@ describe("resolveConfig NODE_ENV", () => {
     const result = resolveConfig(flags, { NODE_ENV: "Production" });
 
     expect(result.settings.nodeEnv).toBe("development");
+  });
+});
+
+describe("describeEncryptionKeyForLog", () => {
+  it("reports the deterministic-fallback message when unset", () => {
+    expect(describeEncryptionKeyForLog("")).toBe(
+      "[settings] ENCRYPTION_KEY is not set (using deterministic fallback, 32 chars) — set ENCRYPTION_KEY for production",
+    );
+  });
+
+  it("never includes the raw secret for a short key", () => {
+    const message = describeEncryptionKeyForLog("shortkey");
+
+    expect(message).not.toContain("shortkey");
+    expect(message).toContain("***");
+  });
+
+  it("masks the middle of a long key, keeping only its edges", () => {
+    const message = describeEncryptionKeyForLog(
+      "a-much-longer-encryption-key-value",
+    );
+
+    expect(message).not.toContain("a-much-longer-encryption-key-value");
+    expect(message).toBe(
+      "[settings] ENCRYPTION_KEY is set (a-mu..alue, 34 chars)",
+    );
   });
 });
 

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -57,6 +57,19 @@ export function resolveShutdownDrainMs(
   return Number.isFinite(value) && value >= 0 ? value : fallback;
 }
 
+/**
+ * Startup log line for `ENCRYPTION_KEY` — reports whether it's set and how
+ * long it is (useful for spotting misconfiguration) WITHOUT leaking the
+ * actual secret into stdout/log aggregators.
+ */
+export function describeEncryptionKeyForLog(ek: string): string {
+  if (!ek) {
+    return "[settings] ENCRYPTION_KEY is not set (using deterministic fallback, 32 chars) — set ENCRYPTION_KEY for production";
+  }
+  const masked = ek.length <= 8 ? "***" : `${ek.slice(0, 4)}..${ek.slice(-4)}`;
+  return `[settings] ENCRYPTION_KEY is set (${masked}, ${ek.length} chars)`;
+}
+
 function toBool(value: string | undefined): boolean {
   return value === "true" || value === "1";
 }


### PR DESCRIPTION
## What
`buildSettings()` in `apps/api/src/settings/pipeline.ts` logs `ENCRYPTION_KEY` via `JSON.stringify(ek)` on every process boot — this was an intentional debugging change in #2925, but it means the vault's master encryption key is printed in plaintext to stdout/container logs and any log aggregator or OTLP sink this same settings module feeds (ClickHouse, MONITORING_OTLP_ENDPOINT, etc.). That's a real credential-leak surface: anyone with log access gets the key that decrypts every stored credential.

## Why a maintainer wants this
The key existed pre-#2925 as a masked log (`ek.slice(0,4)..ek.slice(-4)` + length) that gave operators the same debugging signal (is it set? how long? does it look right?) without exposing the secret. This PR restores that behavior as a small pure, testable helper (`describeEncryptionKeyForLog`) instead of inlining it, so the behavior has a unit test guarding it going forward.

## Failure scenario / regression covered
Before: `ENCRYPTION_KEY=super-secret-vault-key` → log line `[settings] ENCRYPTION_KEY = "super-secret-vault-key" (23 chars)`, i.e. the raw secret in every startup log.
After: `[settings] ENCRYPTION_KEY is set (supe..-key, 23 chars)` — same debug signal, no raw secret. Covered by new tests in `resolve-config.test.ts` (`describeEncryptionKeyForLog`) asserting the raw key never appears in the output for both the empty and long-key cases.

## How to verify
`bun test apps/api/src/settings/resolve-config.test.ts`

## Checks run locally
- `bun run fmt`
- `cd apps/api && bunx tsc --noEmit` (clean)
- `bun test apps/api/src/settings/resolve-config.test.ts` (50/50 pass)
Full CI runs lint/typecheck across the rest of the monorepo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leaking the vault master key by masking `ENCRYPTION_KEY` in startup logs. Restores safe logging and adds tests to guard it.

- **Bug Fixes**
  - Replace raw `ENCRYPTION_KEY` logging with `describeEncryptionKeyForLog`, which masks the value (edges + length) and handles the unset case.
  - Add unit tests to ensure the raw key never appears in logs.

<sup>Written for commit a83d24bb704c85b44619fe0399747b08ce5c5ac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

