### PR TITLE
fix(virtual-mcp): reject a non-existent connectionId on plugin config update

### DIFF
--- a/apps/api/src/tools/virtual/plugin-config-update.test.ts
+++ b/apps/api/src/tools/virtual/plugin-config-update.test.ts
@@ -77,6 +77,31 @@ describe("VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE", () => {
     expect(upsert).not.toHaveBeenCalled();
   });
 
+  it("rejects a connectionId that does not exist instead of hitting the FK constraint", async () => {
+    // Regression: a non-existent, non-dev-assets connectionId used to fall
+    // through to virtualMcpPluginConfigs.upsert(), which would surface as a
+    // raw FK constraint-violation error rather than a clean "not found".
+    const { ctx, upsert } = makeCtx({
+      organizationId: "org-a",
+      connections: {
+        vmcp_a: { id: "vmcp_a", organization_id: "org-a" },
+      },
+    });
+
+    await expect(
+      VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE.handler(
+        {
+          virtualMcpId: "vmcp_a",
+          pluginId: "code-execution",
+          connectionId: "conn_missing",
+        },
+        ctx,
+      ),
+    ).rejects.toThrow(/not found/i);
+
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
   it("allows updating a plugin config within the caller's own organization", async () => {
     const { ctx, upsert } = makeCtx({
       organizationId: "org-a",

--- a/apps/api/src/tools/virtual/plugin-config-update.ts
+++ b/apps/api/src/tools/virtual/plugin-config-update.ts
@@ -99,24 +99,26 @@ export const VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE = defineTool({
       connectionId &&
       parentConnection.organization_id &&
       !connectionExists &&
-      usesLocalObjectStorage()
+      usesLocalObjectStorage() &&
+      isDevAssetsConnection(connectionId, parentConnection.organization_id)
     ) {
-      if (
-        isDevAssetsConnection(connectionId, parentConnection.organization_id)
-      ) {
-        if (!userId) {
-          throw new Error("User ID required to create dev-assets connection");
-        }
-        const devAssetsConnection = createDevAssetsConnectionEntity(
-          parentConnection.organization_id,
-          getBaseUrl(),
-        );
-        await ctx.storage.connections.create({
-          ...devAssetsConnection,
-          organization_id: parentConnection.organization_id,
-          created_by: userId,
-        });
+      if (!userId) {
+        throw new Error("User ID required to create dev-assets connection");
       }
+      const devAssetsConnection = createDevAssetsConnectionEntity(
+        parentConnection.organization_id,
+        getBaseUrl(),
+      );
+      await ctx.storage.connections.create({
+        ...devAssetsConnection,
+        organization_id: parentConnection.organization_id,
+        created_by: userId,
+      });
+    } else if (connectionId && !connectionExists) {
+      // Otherwise a non-existent connectionId would hit the DB's FK
+      // constraint on virtual_mcp_plugin_configs.connection_id and surface as
+      // a raw constraint-violation error instead of a clean, expected one.
+      throw new Error(`Connection not found: ${connectionId}`);
     }
 
     const config = await ctx.storage.virtualMcpPluginConfigs.upsert(


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/tools/virtual/` for input validation and error-message consistency (this tick's focus area).

**Why a maintainer wants this:** `VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE` only validated `connectionId` in two cases — when it existed but belonged to another org, or when it matched the dev-assets special case. Any other non-existent `connectionId` (e.g. a typo, a stale ID from a deleted connection) fell through unchecked into `virtualMcpPluginConfigs.upsert()`. The `connection_id` column has a `references("connections.id")` foreign key (migration `048-merge-projects-agents.ts`), so this call would throw a raw Postgres FK constraint-violation error instead of the clean `Connection not found: <id>` error the tool already uses for every other not-found case in this file.

**Failure scenario + fix:** Call `VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE` with a `connectionId` that doesn't exist and isn't the org's dev-assets pseudo-connection — the handler now throws `Connection not found: <id>` immediately instead of leaking a raw DB constraint error. Added a regression test (`plugin-config-update.test.ts`) asserting this and that `upsert` is never called in that case.

**Reviewer verification:** `bun test apps/api/src/tools/virtual/plugin-config-update.test.ts`

**Local checks run:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject non-existent `connectionId` in `VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE` to return a clear “Connection not found: <id>” instead of a raw DB FK error. Adds a regression test and avoids unnecessary `upsert` calls.

- **Bug Fixes**
  - Validate `connectionId` early; throw when it doesn't exist and isn’t the org’s dev-assets pseudo-connection.
  - Only auto-create the dev-assets connection when using local storage and the ID matches the org’s dev-assets ID.

<sup>Written for commit 58180e4a43c4696842451250f4a8543102aeae53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

