### PR TITLE
fix(settings): treat bracketed IPv6 loopback DATABASE_URL/NATS_URL as local

### DIFF
--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -218,6 +218,34 @@ describe("resolveConfig Studio environment aliases", () => {
   });
 });
 
+describe("resolveConfig external database/nats URL detection", () => {
+  it("treats a bracketed IPv6 loopback DATABASE_URL as local, not external", () => {
+    const result = resolveConfig(flags, {
+      DATABASE_URL: "postgres://[::1]:5432/postgres",
+    });
+
+    expect(result.externalDatabaseUrl).toBeNull();
+  });
+
+  it("treats a bracketed IPv6 loopback NATS_URL as local, not external", () => {
+    const result = resolveConfig(flags, {
+      NATS_URL: "nats://[::1]:4222",
+    });
+
+    expect(result.externalNatsUrl).toBeNull();
+  });
+
+  it("still treats a genuinely remote host as external", () => {
+    const result = resolveConfig(flags, {
+      DATABASE_URL: "postgres://db.example.com:5432/postgres",
+    });
+
+    expect(result.externalDatabaseUrl).toBe(
+      "postgres://db.example.com:5432/postgres",
+    );
+  });
+});
+
 describe("resolveConfig NODE_ENV", () => {
   it("defaults to development when unset", () => {
     const result = resolveConfig(flags, {});

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -123,7 +123,9 @@ function externalUrlOrNull(url: string | undefined): string | null {
   if (!url) return null;
   try {
     const parsed = new URL(url);
-    const host = parsed.hostname;
+    // `URL#hostname` keeps the brackets for a bracketed IPv6 host (e.g.
+    // "[::1]"), so strip them before comparing against the bare loopback form.
+    const host = parsed.hostname.replace(/^\[|\]$/g, "");
     if (host === "localhost" || host === "127.0.0.1" || host === "::1") {
       return null;
     }


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/settings/resolve-config.ts` fallback logic (this tick's focus area). Note: PR #5130 already covers the DUCKDB_THREADS validation gap in this file (against its pre-split `apps/mesh` path), so this PR targets a different, previously-unhandled gap in the same file.

**Payoff:** `externalUrlOrNull` decides whether `apps/api/src/services/ensure-services.ts` skips starting the embedded local Postgres/NATS (`skipPostgres`/`skipNats`). It compares `URL#hostname` against the bare loopback forms `"localhost"`, `"127.0.0.1"`, `"::1"` — but for a bracketed IPv6 URL like `postgres://[::1]:5432/postgres`, `URL#hostname` returns `"[::1]"` (brackets included), so the comparison never matches. A `DATABASE_URL`/`NATS_URL` written with an IPv6 loopback (a legitimate way to say "local") is misclassified as external, causing the app to skip booting the embedded services it actually needs and instead try to reach a service that was never started.

**Failure scenario:** set `DATABASE_URL=postgres://[::1]:5432/postgres` (or `NATS_URL=nats://[::1]:4222`) — `resolveConfig` reports `externalDatabaseUrl`/`externalNatsUrl` as non-null, `ensure-services.ts` sets `skipPostgres`/`skipNats` to true, and the embedded local Postgres/NATS never starts even though the URL points at localhost.

**Fix:** strip the brackets from `parsed.hostname` before comparing, so `[::1]` normalizes to `::1` and matches the existing loopback check. Added a regression test covering bracketed-IPv6 DATABASE_URL and NATS_URL (both now correctly resolve to `null`/local) plus a genuinely-remote-host case to confirm external detection still works.

**Verify:** `cd apps/api && bun test src/settings/resolve-config.test.ts` (53 pass, 0 fail).

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace, clean), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes local URL detection for bracketed IPv6 loopback so `[::1]` in `DATABASE_URL` or `NATS_URL` is treated as local. This prevents skipping the embedded Postgres/NATS when using IPv6 loopback.

- **Bug Fixes**
  - Strip brackets from `URL.hostname` before checking for loopback (`localhost`, `127.0.0.1`, `::1`).
  - Added tests for `[::1]` in `DATABASE_URL` and `NATS_URL`, plus a remote host case.

<sup>Written for commit ac1180326bfdff4d3e89285467a543e1e3e6ba6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

