### PR TITLE
fix(ui): mark Popover/HoverCard/Tooltip portals non-translatable

### DIFF
--- a/packages/ui/src/components/hover-card.tsx
+++ b/packages/ui/src/components/hover-card.tsx
@@ -31,8 +31,9 @@ function HoverCardContent({
         data-slot="hover-card-content"
         align={align}
         sideOffset={sideOffset}
+        translate="no"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
           className,
         )}
         {...props}

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -29,8 +29,9 @@ function PopoverContent({
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
+        translate="no"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-lg overflow-hidden border p-4 shadow-md outline-hidden",
+          "notranslate bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-lg overflow-hidden border p-4 shadow-md outline-hidden",
           className,
         )}
         {...props}

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -45,8 +45,9 @@ function TooltipContent({
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}
+        translate="no"
         className={cn(
-          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "notranslate bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className,
         )}
         {...props}


### PR DESCRIPTION
Follows #5214 (which itself followed #5204's Select fix for the browser page-translation `removeChild` crash — radix-ui/primitives#3795, facebook/react#11538). #5214 reasoned that DropdownMenu, ContextMenu, and Menubar "share the exact same Portal+Content/SubContent shape ... as Select, so they're equally exposed" and applied the `translate="no"` + `notranslate` guard to them. Popover, HoverCard, and Tooltip share that identical Portal+Content shape but were missed by both fixes, leaving them exposed to the same crash.

**Why a maintainer wants this:** Tooltip in particular is the most exposed of the three — it mounts/unmounts on every hover in/out, which is exactly the timing race (React reconciling a portal subtree the browser's translation engine just mutated) that throws `NotFoundError` on `removeChild`. Popover and HoverCard have the same exposure whenever a Chrome/Chromium-translated page closes one.

This is a markup-only change (one `translate="no"` prop + one `notranslate` class per Content, matching #5204/#5214 byte-for-byte) — no logic, no test needed, same as both prior PRs shipped with none.

**Command to confirm:** `cd packages/ui && bunx tsc --noEmit` (attribute is a standard passthrough prop on the underlying Radix primitives, already proven safe by the merged #5204/#5214 pattern).

**Local checks run:** `bun run fmt` (clean, no changes). `bunx tsc --noEmit` in `packages/ui` timed out locally (large package, unrelated to this change) — full CI will validate types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark `Popover`, `HoverCard`, and `Tooltip` portal content as non-translatable to prevent Chrome/Chromium page-translation NotFoundError removeChild crashes on mount/unmount. Adds `translate="no"` and a `notranslate` class to each Content, matching the prior Select/DropdownMenu/ContextMenu/Menubar fix.

<sup>Written for commit 126a61b4c29fe265764e8d0d52756a1ce91cd827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

