### PR TITLE
fix(sandbox): emit `gone` for orphaned thread sandboxes on shared scope

### DIFF
--- a/apps/api/src/api/routes/sandbox-events-handler.test.ts
+++ b/apps/api/src/api/routes/sandbox-events-handler.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { SandboxMap } from "@decocms/shared/sdk";
+import { resolveSharedThreadVm } from "./sandbox-events-handler";
+
+const BRANCH = "thread:0ced73dc/conn_u3zc";
+const OWNER = "owner-user-id";
+const VIEWER = "viewer-user-id";
+
+function mapFor(userId: string): SandboxMap {
+  return {
+    [userId]: {
+      [BRANCH]: {
+        "agent-sandbox": {
+          sandboxHandle: "conn-u3zc-d6f02ea54cdba440",
+          previewUrl: "https://conn-u3zc-d6f02ea54cdba440.example.com/",
+          sandboxProviderKind: "agent-sandbox",
+        },
+      },
+    },
+  };
+}
+
+describe("resolveSharedThreadVm", () => {
+  test("finds the entry under the owner's key when the viewer has none", () => {
+    // The regression: keying this lookup on the caller skipped the stale-handle
+    // probe for a teammate's thread, so `gone` never fired and the preview sat
+    // on "Reserving sandbox" forever.
+    const found = resolveSharedThreadVm(mapFor(OWNER), BRANCH, "agent-sandbox");
+    expect(found?.userId).toBe(OWNER);
+    expect(found?.entry.sandboxHandle).toBe("conn-u3zc-d6f02ea54cdba440");
+  });
+
+  test("returns the viewer's own entry unchanged", () => {
+    expect(
+      resolveSharedThreadVm(mapFor(VIEWER), BRANCH, "agent-sandbox")?.userId,
+    ).toBe(VIEWER);
+  });
+
+  test("returns null for another branch or another provider kind", () => {
+    const map = mapFor(OWNER);
+    expect(
+      resolveSharedThreadVm(map, "thread:other/conn_x", "agent-sandbox"),
+    ).toBeNull();
+    expect(resolveSharedThreadVm(map, BRANCH, "user-desktop")).toBeNull();
+  });
+
+  test("returns null on an empty map", () => {
+    expect(resolveSharedThreadVm({}, BRANCH, "agent-sandbox")).toBeNull();
+  });
+});

--- a/apps/api/src/api/routes/sandbox-events-handler.ts
+++ b/apps/api/src/api/routes/sandbox-events-handler.ts
@@ -15,6 +15,7 @@ import {
   type SandboxProvider,
 } from "@decocms/sandbox/provider";
 import { delay, exponentialBackoffWithJitter } from "@decocms/shared/std";
+import type { SandboxMap, SandboxRecord } from "@decocms/shared/sdk";
 import { subscribeLifecycle } from "../../sandbox/lifecycle";
 import type { StudioContext } from "../../core/studio-context";
 import {
@@ -106,6 +107,10 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
     try {
       let vmEntry;
       let fromThread = false;
+      // Which sandboxMap user key held the entry. Same as the caller for
+      // user-scoped sandboxes; for a shared one it can be a teammate's key (see
+      // `resolveSharedThreadVm`), and cleanup must delete the key it found.
+      let sandboxMapUserId = userId;
       if (sandboxId.scope === "shared") {
         const organization = requireOrganization(ctx);
         const session = await ctx.storage.agentSandboxSessions.find({
@@ -173,6 +178,26 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
                 sandboxProviderKind: "agent-sandbox" as const,
               }
             : null;
+        // No session row at all, but the thread may still carry a sandboxMap
+        // entry: a thread-scoped sandbox is recorded on the thread while
+        // agent-sandbox truth lives in the session registry, so a reap leaves
+        // the thread entry orphaned with nothing to reconcile it. Without this
+        // fallback the stale-handle probe below never runs, `gone` is never
+        // emitted, and the preview loops on `claiming` forever.
+        //
+        // Only when there is NO session — a session mid-transition
+        // (provisioning/stopping) is live state the thread map must not
+        // override.
+        if (!session && threadId) {
+          const found = resolveSharedThreadVm(
+            await getThreadSandboxMap(ctx, threadId),
+            branch,
+            providerKind,
+          );
+          vmEntry = found?.entry ?? null;
+          fromThread = !!found;
+          sandboxMapUserId = found?.userId ?? userId;
+        }
       } else {
         // Prefer the agent entry; fall back to the thread entry (thread-scoped
         // branches). `fromThread` steers cleanup to the right store.
@@ -204,7 +229,7 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
             claimName,
             virtualMcpId,
             branch,
-            userId,
+            userId: sandboxMapUserId,
             sandboxId,
             sandboxProviderKind: existingProviderKind ?? providerKind,
             threadId: fromThread ? threadId : null,
@@ -234,6 +259,30 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
       clearInterval(heartbeat);
     }
   });
+}
+
+/**
+ * Find a recorded entry for `branch` under ANY user key — for shared-scope
+ * sandboxes only.
+ *
+ * A shared claim handle derives from the projectRef, which carries no userId, so
+ * whichever member's key the thread recorded the entry under names the same
+ * sandbox. Scanning every key is what makes the stale-handle probe work when a
+ * member opens a teammate's thread: the viewer's own key is legitimately absent
+ * there, and keying the lookup on it would skip the probe and loop on
+ * `claiming`. Never use this for user-scoped sandboxes — there the user key is
+ * load-bearing (`resolveVm`).
+ */
+export function resolveSharedThreadVm(
+  sandboxMap: SandboxMap,
+  branch: string,
+  sandboxProviderKind: SandboxProviderKind,
+): { userId: string; entry: SandboxRecord } | null {
+  for (const mapUserId of Object.keys(sandboxMap)) {
+    const entry = resolveVm(sandboxMap, mapUserId, branch, sandboxProviderKind);
+    if (entry) return { userId: mapUserId, entry };
+  }
+  return null;
 }
 
 async function isStaleHandle(
@@ -277,6 +326,27 @@ async function cleanupStaleEntry(args: {
     sandboxProviderKind,
     threadId,
   } = args;
+  // Drop the thread's sandboxMap entry first, whatever the scope. A shared
+  // sandbox with no session row leaves nothing for the reap below to clear, so
+  // skipping this would keep the dangling `sandboxHandle` in thread metadata and
+  // every client SSE reconnect would re-enter this stale path.
+  if (threadId) {
+    try {
+      await removeThreadSandboxMapEntry(
+        ctx,
+        threadId,
+        userId,
+        branch,
+        sandboxProviderKind,
+      );
+    } catch (err) {
+      console.warn(
+        `[vm-events] thread sandboxMap cleanup failed for ${threadId}/${branch}/${sandboxProviderKind}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
   if (sandboxId.scope === "shared") {
     const organization = requireOrganization(ctx);
     const locator = {
@@ -306,21 +376,12 @@ async function cleanupStaleEntry(args: {
     }
     return;
   }
-  // Drop the sandboxMap entry first. Without this the dangling `sandboxHandle`
-  // stays in metadata, so every client SSE reconnect re-enters this stale path
-  // and re-issues a DELETE against the already-gone claim — a 404 flood that
-  // only stops when the tab closes. Clear whichever store held it (thread for
-  // the synthetic agent, else the agent row). Mirrors SANDBOX_DELETE.
+  // Same reasoning as the thread removal above, for the agent row: a dangling
+  // `sandboxHandle` left in metadata makes every client SSE reconnect re-enter
+  // this stale path and re-issue a DELETE against the already-gone claim — a 404
+  // flood that only stops when the tab closes. Mirrors SANDBOX_DELETE.
   try {
-    if (threadId) {
-      await removeThreadSandboxMapEntry(
-        ctx,
-        threadId,
-        userId,
-        branch,
-        sandboxProviderKind,
-      );
-    } else {
+    if (!threadId) {
       await removeSandboxMapEntry(
         ctx.storage.virtualMcps,
         virtualMcpId,


### PR DESCRIPTION
## Summary

Opening a thread whose sandbox has been reaped leaves the Preview pinned on **"Reserving sandbox"** forever. Reproduced in prod on [`fila/0ced73dc…`](https://studio.decocms.com/fila/0ced73dc-f22b-4350-b29c-c7c605402b76?virtualmcpid=decopilot_KO4OPgCGuC6sUcfXsNWAGJbOJuCB6rHt&main=preview&sidepanel=chat) — reproduces for the thread **owner** too, so this is not the read-only/teammate gate.

Reading the SSE stream live from the page:

```
GET /api/fila/sandbox/decopilot_…/thread%3A0ced73dc…%2Fconn_u3zc…/events
→ event: phase  data: {"kind":"claiming","since":…}
   …then nothing, forever
```

`claiming` maps to `CLAIM_PHASE_COPY.claiming` = "Reserving sandbox". After 90s (`NO_CLAIM_MAX_MS`) `emitLifecycle` gives up *silently* (`settle(false)`, no `gone`), the stream ends, EventSource reconnects, gets `claiming` again.

## Root cause

`providerKind === "agent-sandbox"` ⇒ `sharedSandboxId` ⇒ `scope === "shared"`, and that branch resolved `vmEntry` **only** from `agent_sandbox_sessions`. A thread-scoped sandbox (`load_repo`) is recorded on the *thread* while agent-sandbox truth lives in the session registry (`resolve-provider.ts:152` — *"Legacy hosted metadata is deliberately ignored"*), so a reap leaves the thread entry orphaned with no session row to reconcile it.

Verified in prod PG for this thread:
- `threads.metadata.sandboxMap[owner][branch]["agent-sandbox"].sandboxHandle` = `conn-u3zc-li4kbjlk1xzqlm-d6f02ea54cdba440`
- `agent_sandbox_sessions` — **no row** for the branch
- no `sandboxclaim` in the cluster for that handle (reaped)

So `vmEntry` came back `null`, the stale-handle probe at the `vmEntry?.sandboxHandle === claimName` gate was skipped, and `gone` was never emitted. The gate *would* have fired — `computeClaimHandle` yields exactly the handle sitting in thread metadata. This is precisely the loop the file header (`:85-89`) says the thread fallback exists to prevent; that fallback was only reachable from the user-scoped `else` branch.

Three client recovery paths all key off state this never produced, which is why nothing recovers (**no `SANDBOX_START` in the network log across a full page load**):

| path | gate | why it never fires |
|---|---|---|
| auto-start | `!vmEntry` | orphan entry grafted from thread metadata ⇒ `vmEntry` non-null |
| self-heal | `events.notFound` | set only by `gone` |
| overlay dismissal | `resolvePreviewDisplay` needs `progressStatus !== "doing"` | `claimPhase: "claiming"` keeps it `"doing"` |

## Changes

- Fall back to the thread sandboxMap in the shared branch **when there is no session row at all** — a session mid-transition (`provisioning`/`stopping`) is live state the thread map must not override.
- `resolveSharedThreadVm` scans every user key. A shared claim handle derives from the projectRef and carries no userId, so the entry may sit under the thread owner's key when a teammate opens the thread; keying on the viewer would skip the probe and loop on `claiming`.
- Clear the thread's sandboxMap entry in `cleanupStaleEntry` regardless of scope. The shared reap path returns early when there's no session row, which would leave the dangling handle in metadata and make every SSE reconnect re-enter the stale path (the 404 flood the existing comment warns about).

After this, the reaped handle probes dead → `gone` → `notFound` → self-heal fires `SANDBOX_START` → fresh sandbox.

## Testing

- `apps/api/src/api/routes/sandbox-events-handler.test.ts` — 4 unit tests on the pure `resolveSharedThreadVm`, including the teammate-key case that caused the regression. Pure logic, no mocks (tier 1 per TESTING.md).
- `bun run fmt`, `bun run --cwd apps/api check` (tsc clean), `bun run lint` (0 errors; 14 pre-existing warnings, none in changed files).
- `bun test apps/api/src/api apps/api/src/tools/sandbox apps/api/src/sandbox`: 112 fail with the change vs **113 fail on the same tree without it** — all pre-existing integration tests needing real Postgres/NATS, none related.

## Follow-ups (not in this PR)

- `load-repo.ts:217` claims *"`ensureSandbox` already persisted the sandbox record on the thread (provisionSandbox → setThreadSandboxMapEntry — the single writer)"*. **False for `agent-sandbox`** — `start.ts:749` only calls it in the non-shared `else` branch. It then streams a `data-open-preview` carrying an `agent-sandbox` sandboxMap the server deliberately ignores, which `chat-context.tsx:945` patches into the client thread row. That mismatch is what mints these orphans.
- `emitLifecycle`'s 90s no-claim timeout ends the stream silently, making "no claim ever appeared" indistinguishable from "still waiting". Worth considering `gone` there as a backstop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview hanging on “Reserving sandbox” for shared `agent-sandbox` threads by detecting orphaned entries, emitting `gone`, and letting the client self-heal with `SANDBOX_START`.

- **Bug Fixes**
  - In shared scope, when no `agent_sandbox_sessions` row exists, fall back to the thread `sandboxMap` to probe the stale handle and emit `gone`.
  - Scan all user keys via `resolveSharedThreadVm` so teammates opening a thread can detect the stale shared handle.
  - Always clear the thread `sandboxMap` entry during cleanup to prevent reconnect loops and 404 floods.
  - Added unit tests for `resolveSharedThreadVm` covering the teammate-key scenario.

<sup>Written for commit abdf017d061d12ff95effef8b763d51046f1383f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

