### PR TITLE
fix(cli): fix deco services CLI's stale duplicate of externalUrlOrNull

### DIFF
--- a/apps/api/src/cli/commands/services.ts
+++ b/apps/api/src/cli/commands/services.ts
@@ -4,19 +4,7 @@
  * Replaces scripts/dev-services-cli.ts with a proper CLI subcommand.
  * Plain console output — no Ink UI needed for these one-shot commands.
  */
-function externalUrlOrNull(url: string | undefined): string | null {
-  if (!url) return null;
-  try {
-    const parsed = new URL(url);
-    const host = parsed.hostname;
-    if (host === "localhost" || host === "127.0.0.1" || host === "::1") {
-      return null;
-    }
-    return url;
-  } catch {
-    return null;
-  }
-}
+import { externalUrlOrNull } from "../../settings/resolve-config";
 
 export interface ServicesOptions {
   subcommand: string;

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -119,7 +119,7 @@ function toBoolWithDefault(
  * Determine if a URL points to a non-local host (i.e., an external service).
  * Returns the URL string if external, null if local or not set.
  */
-function externalUrlOrNull(url: string | undefined): string | null {
+export function externalUrlOrNull(url: string | undefined): string | null {
   if (!url) return null;
   try {
     const parsed = new URL(url);


### PR DESCRIPTION
Follow-up hardening on #5217 (fix(settings): treat bracketed IPv6 loopback DATABASE_URL/NATS_URL as local).

That PR fixed `externalUrlOrNull` in `apps/api/src/settings/resolve-config.ts` to strip brackets from `URL#hostname` before comparing against the bare loopback forms (`localhost`, `127.0.0.1`, `::1`). It missed that `apps/api/src/cli/commands/services.ts` kept its own private copy of the exact same function, used by `deco services up/down`.

**Failure scenario:** running `deco services up` with `DATABASE_URL="postgres://[::1]:5432/postgres"` or `NATS_URL="nats://[::1]:4222"` — `URL#hostname` returns `"[::1]"` (brackets kept), which doesn't match the bare `"::1"` check, so the CLI's copy misclassifies a local loopback address as an external service. `ensureServices` then skips provisioning the local managed Postgres/NATS (`skipPostgres`/`skipNats` gate directly on this null-check, see `apps/api/src/services/ensure-services.ts:1507-1508`), leaving nothing listening at that address.

**Fix:** export the already-fixed, already-tested `externalUrlOrNull` from `resolve-config.ts` and import it in `services.ts` instead of keeping a second, drifted copy — net -12 lines, no behavior change to the already-correct path, only closes the gap in the duplicate.

**Verify:** `bun test apps/api/src/settings/resolve-config.test.ts` (58 pass, including the bracketed-IPv6 cases added by #5217, which now also exercise the code path `services.ts` delegates to) and `cd apps/api && bunx tsc --noEmit` (clean). No new test added — the fix removes the duplicate rather than adding parallel logic, so the existing resolve-config.test.ts coverage is now the only coverage needed for both call sites.

Ran locally: `bun run fmt`, targeted `bunx tsc --noEmit` in apps/api, and the single test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `deco services` CLI misclassifying bracketed IPv6 loopback URLs as external. Reuses the exported `externalUrlOrNull` from `resolve-config.ts` and removes the stale duplicate, so local Postgres/NATS are provisioned as expected.

<sup>Written for commit 6925643fe04fbc0da98375c14ce92d4856ba8098. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

