### PR TITLE
fix(sandbox): scope the claim auto-retry budget to the active branch

### DIFF
--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -10,6 +10,7 @@ import {
   deriveStartError,
   isRetryableClaimFailure,
   shouldAutoRetryClaim,
+  reconcileClaimRetryEpisode,
   MAX_CLAIM_AUTO_RETRIES,
   type BranchMapEntryLike,
 } from "./sandbox-lifecycle-context";
@@ -399,6 +400,34 @@ describe("shouldAutoRetryClaim", () => {
     expect(shouldAutoRetryClaim({ ...base, autoStartBlocked: true })).toBe(
       false,
     );
+  });
+});
+
+describe("reconcileClaimRetryEpisode", () => {
+  test("same branch → returns the same reference (no reset)", () => {
+    const prev = { branch: "main", count: 2, handled: true };
+    expect(reconcileClaimRetryEpisode(prev, "main")).toBe(prev);
+  });
+
+  test("different branch → fresh budget", () => {
+    // Regression: the lifecycle provider outlives a task switch, so a budget
+    // exhausted by one branch's failed boot must not carry over and silently
+    // skip auto-retry for a different branch's fresh boot.
+    const prev = { branch: "main", count: 2, handled: true };
+    expect(reconcileClaimRetryEpisode(prev, "feature-x")).toEqual({
+      branch: "feature-x",
+      count: 0,
+      handled: false,
+    });
+  });
+
+  test("null → a real branch resets too", () => {
+    const prev = { branch: null, count: 1, handled: false };
+    expect(reconcileClaimRetryEpisode(prev, "main")).toEqual({
+      branch: "main",
+      count: 0,
+      handled: false,
+    });
   });
 });
 

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -184,7 +184,7 @@ export interface ClaimRetryEpisode {
   handled: boolean;
 }
 
-export const INITIAL_CLAIM_RETRY_EPISODE: ClaimRetryEpisode = {
+const INITIAL_CLAIM_RETRY_EPISODE: ClaimRetryEpisode = {
   branch: null,
   count: 0,
   handled: false,

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -177,6 +177,34 @@ export function shouldAutoRetryClaim(args: ShouldAutoRetryClaimArgs): boolean {
   );
 }
 
+/** The bounded auto-retry budget for one boot episode (see shouldAutoRetryClaim). */
+export interface ClaimRetryEpisode {
+  branch: string | null;
+  count: number;
+  handled: boolean;
+}
+
+export const INITIAL_CLAIM_RETRY_EPISODE: ClaimRetryEpisode = {
+  branch: null,
+  count: 0,
+  handled: false,
+};
+
+/** Resets the auto-retry budget when the active branch changes. The
+ *  lifecycle provider is NOT remounted on a task switch (it lives above
+ *  Chat.ActiveTaskProvider), so without this a budget exhausted by one
+ *  branch's failed boot would carry over and silently skip auto-retry for
+ *  an unrelated branch's fresh boot. Returns `prev` unchanged (same
+ *  reference) when the branch hasn't changed, so callers can skip the
+ *  state update. */
+export function reconcileClaimRetryEpisode(
+  prev: ClaimRetryEpisode,
+  branch: string | null,
+): ClaimRetryEpisode {
+  if (prev.branch === branch) return prev;
+  return { branch, count: 0, handled: false };
+}
+
 /** Terminal SANDBOX_START error to surface (→ `errored` preview state), or null
  *  while still booting. Two independent sources feed the same terminal state:
  *   - a rejected SANDBOX_START mutation (GitHub-not-auth, non-retryable server error);
@@ -355,9 +383,19 @@ export function SandboxLifecycleProvider({
   // Bounded auto-retry of retryable terminal claim failures (see
   // shouldAutoRetryClaim). `count` is the budget for this boot; `handled`
   // fires exactly one retry per failed episode (re-armed when phase leaves
-  // `failed`). Both reset on a user-driven retry().
-  const claimRetryCountRef = useRef(0);
-  const claimFailureHandledRef = useRef(false);
+  // `failed`). Both reset on a user-driven retry(), and reconciled against
+  // the active branch below (see reconcileClaimRetryEpisode) since this
+  // provider outlives a task switch.
+  const [claimRetryEpisodeState, setClaimRetryEpisodeState] = useState(
+    INITIAL_CLAIM_RETRY_EPISODE,
+  );
+  const claimRetryEpisode = reconcileClaimRetryEpisode(
+    claimRetryEpisodeState,
+    branch,
+  );
+  if (claimRetryEpisode !== claimRetryEpisodeState) {
+    setClaimRetryEpisodeState(claimRetryEpisode);
+  }
 
   // Derived values, recomputed each render.
   // Cast: parseBranchMap returns SandboxRecord where sandboxProviderKind is
@@ -392,8 +430,7 @@ export function SandboxLifecycleProvider({
   const claimRetryExhausted =
     !failedPhase ||
     !isRetryableClaimFailure(failedPhase.reason) ||
-    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only budget probe; incremented inside the effect after firing
-    claimRetryCountRef.current >= MAX_CLAIM_AUTO_RETRIES;
+    claimRetryEpisode.count >= MAX_CLAIM_AUTO_RETRIES;
   const startError = deriveStartError({
     mutationError:
       startVm.isError && startVm.error
@@ -508,28 +545,31 @@ export function SandboxLifecycleProvider({
   // the common transient-infra failure self-heals without a user click.
   const claimRetryEligible = shouldAutoRetryClaim({
     failedReason: failedPhase?.reason ?? null,
-    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only budget probe; incremented inside the effect after firing
-    attempts: claimRetryCountRef.current,
+    attempts: claimRetryEpisode.count,
     isPending: startVm.isPending || sharedLifecyclePending,
     userStopped,
     autoStartBlocked,
-    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only episode guard; set inside the effect after firing
-    alreadyHandled: claimFailureHandledRef.current,
+    alreadyHandled: claimRetryEpisode.handled,
   });
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- bridges the SSE failed phase into a one-shot bounded reprovision
   useEffect(() => {
     if (!failedPhase) {
       // Left the failed state (new claim in progress / ready) → re-arm so the
-      // next distinct failure episode can fire its own retry.
-      // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- re-arm episode guard when phase leaves `failed`
-      claimFailureHandledRef.current = false;
+      // next distinct failure episode can fire its own retry. Bails out (same
+      // reference) when already re-armed, so this doesn't cause a render loop.
+      setClaimRetryEpisodeState((prev) =>
+        prev.handled ? { ...prev, handled: false } : prev,
+      );
       return;
     }
     if (!claimRetryEligible || !virtualMcpId) return;
-    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- mark this episode handled so it fires exactly once
-    claimFailureHandledRef.current = true;
-    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- consume one retry from the boot budget
-    claimRetryCountRef.current += 1;
+    // Mark this episode handled (fires exactly once) and consume one retry
+    // from this branch's boot budget.
+    setClaimRetryEpisodeState((prev) => ({
+      ...prev,
+      handled: true,
+      count: prev.count + 1,
+    }));
     const args = buildSandboxStartArgs(
       virtualMcpId,
       branch,
@@ -609,10 +649,8 @@ export function SandboxLifecycleProvider({
     autoStartAttemptedForBranchRef.current = new Set();
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- reset dedup so self-heal can fire on next gone
     reprovisionedForVmIdRef.current = null;
-    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- fresh auto-retry budget for the user-driven attempt
-    claimRetryCountRef.current = 0;
-    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- re-arm the failed-episode guard
-    claimFailureHandledRef.current = false;
+    // Fresh auto-retry budget for the user-driven attempt.
+    setClaimRetryEpisodeState({ branch, count: 0, handled: false });
     startVmReset();
     start();
   };


### PR DESCRIPTION
Follows #5210 (bounded claim auto-retry) hardening.

**The bug:** `SandboxLifecycleProvider` lives above `Chat.ActiveTaskProvider` in the tree (see `VmEventsBridge` in `apps/web/src/layouts/agent-shell-layout/index.tsx`) and is only remounted when `virtualMcpId` changes (`Chat.Provider key={chatVirtualMcpId}`) — NOT on a task/branch switch. Its claim auto-retry budget (`claimRetryCountRef` / `claimFailureHandledRef`, added in #5210) was tracked in plain refs scoped to the whole provider lifetime, not to the current branch's boot episode.

**Failure scenario:** open task A on branch `foo`, its sandbox claim fails with a retryable reason (e.g. `scheduling-timeout` during a capacity crunch) and both auto-retries are consumed (`claimRetryCountRef.current === MAX_CLAIM_AUTO_RETRIES`). Switch to task B on a different branch `bar` (same agent). If `bar`'s own boot also hits a transient claim failure — plausible, since `scheduling-timeout`/`reconciler-error` are cluster-wide capacity issues likely to correlate across branches around the same time — `claimRetryExhausted` reads the already-exhausted counter from `foo`'s episode and `bar` gets zero retries: the errored card shows immediately instead of self-healing, even though this is `bar`'s first attempt.

**The fix:** replaced the two refs with a small piece of React state (`claimRetryEpisodeState`) keyed by branch, reconciled each render through a new pure helper `reconcileClaimRetryEpisode(prev, branch)` — returns `prev` unchanged when the branch matches (no extra render), or a fresh `{ count: 0, handled: false }` budget when it doesn't. This mirrors the existing pattern in the same file (e.g. `computeOthersThreadGate`) of extracting the branching logic into a small tested pure function rather than reasoning about refs inline.

**Net effect:** each branch's boot episode now gets its own 2-retry budget again, regardless of which other branch's episode last ran in this provider instance.

**Regression test:** `apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts` — new `reconcileClaimRetryEpisode` describe block; asserts (1) same branch returns the identical reference (no needless reset/re-render), (2) a different branch resets to a fresh budget (the bug), (3) `null` → a real branch also resets.

**Reviewer verification:**
```
bun test apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
cd apps/web && bunx tsc --noEmit
```
Both run clean locally (58/58 tests pass, including the 3 new ones). `bun run fmt` was run with no diffs. Full CI covers lint/build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where the sandbox claim auto-retry budget leaked across branches, causing fresh boots on a different branch to skip retries. The budget is now scoped to the active branch so transient claim failures self-heal per branch.

- **Bug Fixes**
  - Replaced ref-based counters with branch-keyed state (`claimRetryEpisodeState`) reconciled via `reconcileClaimRetryEpisode`, which resets on branch change and returns the same reference for same-branch episodes to avoid extra renders.
  - Added unit tests for `reconcileClaimRetryEpisode` covering same-branch identity, cross-branch reset, and null-to-branch reset.

<sup>Written for commit c4de72b273874b349a6a840114e2ac75fb8cb33f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

