### PR TITLE
fix(virtual-mcp): reject non-virtual connections in plugin config update

### DIFF
--- a/apps/api/src/tools/virtual/plugin-config-update.test.ts
+++ b/apps/api/src/tools/virtual/plugin-config-update.test.ts
@@ -3,7 +3,10 @@ import { VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE } from "./plugin-config-update";
 
 function makeCtx(opts: {
   organizationId: string;
-  connections: Record<string, { id: string; organization_id: string }>;
+  connections: Record<
+    string,
+    { id: string; organization_id: string; connection_type?: string }
+  >;
 }) {
   const upsert = mock(async () => ({
     id: "vpc_1",
@@ -40,7 +43,11 @@ describe("VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE", () => {
     const { ctx, upsert } = makeCtx({
       organizationId: "org-a",
       connections: {
-        vmcp_other: { id: "vmcp_other", organization_id: "org-b" },
+        vmcp_other: {
+          id: "vmcp_other",
+          organization_id: "org-b",
+          connection_type: "VIRTUAL",
+        },
       },
     });
 
@@ -58,7 +65,11 @@ describe("VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE", () => {
     const { ctx, upsert } = makeCtx({
       organizationId: "org-a",
       connections: {
-        vmcp_a: { id: "vmcp_a", organization_id: "org-a" },
+        vmcp_a: {
+          id: "vmcp_a",
+          organization_id: "org-a",
+          connection_type: "VIRTUAL",
+        },
         conn_other: { id: "conn_other", organization_id: "org-b" },
       },
     });
@@ -77,6 +88,31 @@ describe("VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE", () => {
     expect(upsert).not.toHaveBeenCalled();
   });
 
+  it("rejects a virtualMcpId that points at a non-virtual connection", async () => {
+    // Regression: `virtualMcpId` was only checked for org ownership, so any
+    // regular connection the caller owns (HTTP/SSE/STDIO) could be passed in
+    // and get a nonsensical plugin config row attached to it.
+    const { ctx, upsert } = makeCtx({
+      organizationId: "org-a",
+      connections: {
+        conn_a: {
+          id: "conn_a",
+          organization_id: "org-a",
+          connection_type: "HTTP",
+        },
+      },
+    });
+
+    await expect(
+      VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE.handler(
+        { virtualMcpId: "conn_a", pluginId: "code-execution" },
+        ctx,
+      ),
+    ).rejects.toThrow(/not found/i);
+
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
   it("rejects a connectionId that does not exist instead of hitting the FK constraint", async () => {
     // Regression: a non-existent, non-dev-assets connectionId used to fall
     // through to virtualMcpPluginConfigs.upsert(), which would surface as a
@@ -84,7 +120,11 @@ describe("VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE", () => {
     const { ctx, upsert } = makeCtx({
       organizationId: "org-a",
       connections: {
-        vmcp_a: { id: "vmcp_a", organization_id: "org-a" },
+        vmcp_a: {
+          id: "vmcp_a",
+          organization_id: "org-a",
+          connection_type: "VIRTUAL",
+        },
       },
     });
 
@@ -106,7 +146,11 @@ describe("VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE", () => {
     const { ctx, upsert } = makeCtx({
       organizationId: "org-a",
       connections: {
-        vmcp_a: { id: "vmcp_a", organization_id: "org-a" },
+        vmcp_a: {
+          id: "vmcp_a",
+          organization_id: "org-a",
+          connection_type: "VIRTUAL",
+        },
         conn_a: { id: "conn_a", organization_id: "org-a" },
       },
     });

--- a/apps/api/src/tools/virtual/plugin-config-update.ts
+++ b/apps/api/src/tools/virtual/plugin-config-update.ts
@@ -80,6 +80,12 @@ export const VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE = defineTool({
     if (parentConnection.organization_id !== organization.id) {
       throw new Error(`Connection not found: ${virtualMcpId}`);
     }
+    // This tool only manages plugin config for virtual MCPs — without this,
+    // a caller could pass any regular connection ID they own as
+    // `virtualMcpId` and attach nonsensical plugin config to it.
+    if (parentConnection.connection_type !== "VIRTUAL") {
+      throw new Error(`Connection not found: ${virtualMcpId}`);
+    }
 
     const connectionExists = connectionId
       ? await ctx.storage.connections.findById(connectionId)


### PR DESCRIPTION
Bug found while auditing the virtual-plugin config update pathway (apps/api/src/tools/virtual/plugin-config-update.ts), following the recent hardening in #5179 and #5216.

`VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE` takes `virtualMcpId` and looks it up via the generic `ctx.storage.connections.findById()`, then only checks that it belongs to the caller's organization. It never checks that the connection is actually a virtual MCP (`connection_type === "VIRTUAL"`). Every other virtual-MCP tool (e.g. `COLLECTION_VIRTUAL_MCP_GET`, which reads through `ctx.storage.virtualMcps.findById()`) only recognizes rows with `connection_type = 'VIRTUAL'` as virtual MCPs — this tool was the odd one out.

**Failure scenario:** a caller passes the ID of any regular connection they own (HTTP/SSE/STDIO/Websocket) as `virtualMcpId`. The tool accepts it, and `virtualMcpPluginConfigs.upsert()` attaches a plugin-config row to a connection that was never meant to hold one — polluting `virtual_mcp_plugin_configs` with rows pointing at non-virtual connections instead of cleanly rejecting the request.

**Fix:** after the existing org-ownership check, reject when `parentConnection.connection_type !== "VIRTUAL"` with the same `Connection not found` message used by the sibling checks in this file. Added a regression test (`rejects a virtualMcpId that points at a non-virtual connection`) and updated the existing mocks to include `connection_type: "VIRTUAL"` on the virtual-MCP fixtures so they keep passing under the new check.

**Reviewer command:** `bun test apps/api/src/tools/virtual/plugin-config-update.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented plugin configs from being attached to non-virtual connections by enforcing a VIRTUAL connection_type check in the virtual MCP plugin-config update tool. This stops data pollution and aligns behavior with other virtual-MCP tools.

- **Bug Fixes**
  - Reject when virtualMcpId points to a non-virtual connection (returns “Connection not found”).
  - Added a regression test for the non-virtual case and updated virtual MCP fixtures to include connection_type: "VIRTUAL".

<sup>Written for commit 9525343c6571f6480bbc0477724455daf0eff1b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

