### PR TITLE
refactor(settings): dedupe S3_FORCE_PATH_STYLE default logic

### DIFF
--- a/apps/api/src/services/ensure-services.ts
+++ b/apps/api/src/services/ensure-services.ts
@@ -28,6 +28,7 @@ import { createConnection, createServer } from "net";
 import { arch, platform } from "os";
 import { dirname, join } from "path";
 import type { ServiceInputs, ServiceOutputs } from "../settings/types";
+import { resolveS3ForcePathStyle } from "../settings/resolve-config";
 import {
   buildNatsOperatorArtifacts,
   buildNatsServerConf,
@@ -884,16 +885,6 @@ export function minioDownloadUrl(os: string, arch: string): string {
   return `https://dl.min.io/server/minio/release/${osName}-${archName}/${artifact}`;
 }
 
-/**
- * Resolve external-S3 path-style addressing from the env. Mirrors
- * resolve-config.ts's default EXACTLY (unset/empty/"true"/"1" → true) so the
- * in-process `buildSettings` path (deco serve / deco dev) agrees with the
- * bundled-prod `initSettingsFromEnv` path. Pure (no IO) so it is unit-testable.
- */
-function externalForcePathStyleFromEnv(raw: string | undefined): boolean {
-  return raw === undefined || raw === "" || raw === "true" || raw === "1";
-}
-
 function minioBinaryPath(home: string): string {
   return join(servicesDir(home), "minio", "bin", `minio${EXE_EXT}`);
 }
@@ -1566,20 +1557,12 @@ export async function ensureServices(inputs: ServiceInputs): Promise<{
       port: portFromUrl(process.env.S3_ENDPOINT!, MINIO_DEFAULT_PORT),
       owner: "external",
     });
-    // For external S3, mirror resolve-config.ts's default so the in-process
-    // `buildSettings` path (deco serve / deco dev) agrees with the bundled-prod
-    // `initSettingsFromEnv` path: an unset/empty S3_FORCE_PATH_STYLE means
-    // path-style (true). A custom S3-compatible store (MinIO/Ceph) needs this;
-    // real AWS S3 (virtual-hosted-style) must set S3_FORCE_PATH_STYLE=false.
-    const externalForcePathStyle = externalForcePathStyleFromEnv(
-      process.env.S3_FORCE_PATH_STYLE,
-    );
     s3 = {
       endpoint: process.env.S3_ENDPOINT!,
       bucket: process.env.S3_BUCKET!,
       accessKeyId: process.env.S3_ACCESS_KEY_ID!,
       secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
-      forcePathStyle: externalForcePathStyle,
+      forcePathStyle: resolveS3ForcePathStyle(process.env.S3_FORCE_PATH_STYLE),
     };
   } else if (!skipMinio) {
     const minioInfo = await ensureMinio(inputs.home);

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -135,6 +135,17 @@ function externalUrlOrNull(url: string | undefined): string | null {
   }
 }
 
+/**
+ * Whether S3 access should force path-style addressing. Unset/empty defaults
+ * to path-style (needed by custom S3-compatible stores like MinIO/Ceph); real
+ * AWS S3 (virtual-hosted-style) must set S3_FORCE_PATH_STYLE=false. Shared
+ * with `ensure-services.ts`'s external-S3 branch so the in-process
+ * `buildSettings` path and the bundled-prod `initSettingsFromEnv` path agree.
+ */
+export function resolveS3ForcePathStyle(raw: string | undefined): boolean {
+  return raw === undefined || raw === "" || raw === "true" || raw === "1";
+}
+
 const SANDBOX_PROVIDER_KINDS = new Set<SandboxProviderKind>([
   "agent-sandbox",
   "user-desktop",
@@ -270,11 +281,7 @@ export function resolveConfig(
     s3Region: envVars.S3_REGION || "auto",
     s3AccessKeyId: envVars.S3_ACCESS_KEY_ID,
     s3SecretAccessKey: envVars.S3_SECRET_ACCESS_KEY,
-    s3ForcePathStyle:
-      envVars.S3_FORCE_PATH_STYLE === undefined ||
-      envVars.S3_FORCE_PATH_STYLE === "" ||
-      envVars.S3_FORCE_PATH_STYLE === "true" ||
-      envVars.S3_FORCE_PATH_STYLE === "1",
+    s3ForcePathStyle: resolveS3ForcePathStyle(envVars.S3_FORCE_PATH_STYLE),
 
     // Monitoring object storage (OTLP-JSON over GCS). Raw env passthrough;
     // fallback to s3* is applied at the context-factory consumption point.


### PR DESCRIPTION
**Source:** code-reduction (C1) found while hunting for hardening follow-ups in `apps/api/src/settings/resolve-config.ts` per this tick's focus area.

`ensure-services.ts` hand-rolled its own copy of `resolve-config.ts`'s `S3_FORCE_PATH_STYLE` default (`unset/empty/"true"/"1" -> true`), with a comment on both sides asking whoever edits one to mirror it in the other by hand — exactly the kind of duplication that drifts silently. Extracted the shared boolean into `resolveS3ForcePathStyle()` in `resolve-config.ts` (exported) and pointed `ensure-services.ts`'s external-S3 branch at it, deleting the local `externalForcePathStyleFromEnv` duplicate.

Net: -24 / +14 lines. Behavior is byte-identical — same four-branch boolean expression, just in one place; `rg` confirms the old `externalForcePathStyleFromEnv` name has zero remaining references.

**To verify:** `cd apps/api && bunx tsc --noEmit`, then `bun test apps/api/src/settings/resolve-config.test.ts apps/api/src/services/ensure-services.test.ts`.

**Ran locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace), and the two targeted test files above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated the `S3_FORCE_PATH_STYLE` default logic by centralizing it in `resolve-config.ts` and reusing it in `ensure-services.ts`. This removes drift risk and keeps behavior identical.

- **Refactors**
  - Added `resolveS3ForcePathStyle(raw)` in `apps/api/src/settings/resolve-config.ts` (unset/empty/"true"/"1" -> true).
  - Replaced the local duplicate in `apps/api/src/services/ensure-services.ts` and removed the helper.
  - Ensures both config paths use the same default for external S3.

<sup>Written for commit 8f072a824e22cab9735d07fd740cc49ca7d19bd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

