### PR TITLE
fix(sandbox): honor branch's deletion in rebase modify/delete conflicts

### DIFF
--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { execSync } from "node:child_process";
 import {
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -83,6 +84,83 @@ function setupConflictingRepo(): {
   };
 }
 
+function setupBranchDeletesBaseModifiesRepo(): {
+  repoDir: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "rebase-onto-base-ud-"));
+  const bare = join(root, "origin.git");
+  const seed = join(root, "seed");
+  const gitOpts = { stdio: "ignore" as const };
+  const gitcfg = `-c init.defaultBranch=main -c user.email=test@example.com -c user.name=test -c commit.gpgsign=false`;
+  const decoPath = ".deco/blocks/shipping.json";
+
+  execSync(`git ${gitcfg} init --bare ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} init ${seed}`, gitOpts);
+
+  mkdirSync(join(seed, ".deco/blocks"), { recursive: true });
+  writeFileSync(
+    join(seed, decoPath),
+    JSON.stringify({ threshold: 200 }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m initial`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} branch -M main`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} remote add origin ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push -u origin main`, gitOpts);
+
+  // Branch deletes the file...
+  execSync(
+    `git ${gitcfg} -C ${seed} checkout -b feat/remove-shipping`,
+    gitOpts,
+  );
+  execSync(`git ${gitcfg} -C ${seed} rm ${decoPath}`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${seed} commit -m "Remove shipping block"`,
+    gitOpts,
+  );
+  execSync(
+    `git ${gitcfg} -C ${seed} push -u origin feat/remove-shipping`,
+    gitOpts,
+  );
+
+  // ...while main keeps modifying it, so rebase hits a "UD" (deleted by
+  // branch, modified by base) conflict rather than the "DU" case above.
+  execSync(`git ${gitcfg} -C ${seed} checkout main`, gitOpts);
+  writeFileSync(
+    join(seed, decoPath),
+    JSON.stringify({ threshold: 250 }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${seed} commit -m "Update free shipping threshold to R$ 250"`,
+    gitOpts,
+  );
+  execSync(`git ${gitcfg} -C ${seed} push origin main`, gitOpts);
+
+  const repoDir = join(root, "workspace");
+  execSync(
+    `git ${gitcfg} clone --branch feat/remove-shipping ${bare} ${repoDir}`,
+    gitOpts,
+  );
+  execSync(
+    `git ${gitcfg} -C ${repoDir} config user.email test@example.com`,
+    gitOpts,
+  );
+  execSync(`git ${gitcfg} -C ${repoDir} config user.name test`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${repoDir} remote set-url origin ${bare}`,
+    gitOpts,
+  );
+
+  return {
+    repoDir,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
 describe("rebaseOntoBase", () => {
   it("rebases with -X theirs and resolves conflicts from branch changes", () => {
     const { repoDir, cleanup } = setupConflictingRepo();
@@ -102,6 +180,19 @@ describe("rebaseOntoBase", () => {
         .toString()
         .trim();
       expect(head).not.toBe(main);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("honors the branch's deletion when the base modified the same file", () => {
+    const { repoDir, cleanup } = setupBranchDeletesBaseModifiesRepo();
+    try {
+      rebaseOntoBase(repoDir, "main", { asUser: false });
+
+      expect(existsSync(join(repoDir, ".deco/blocks/shipping.json"))).toBe(
+        false,
+      );
     } finally {
       cleanup();
     }

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -176,17 +176,18 @@ function commitBeforeRebase(
 function resolveConflictFile(repoDir: string, summary: StatusFile): void {
   const filePath = summary.path;
   const xy = `${summary.index}${summary.working_dir}`;
-  const abs = path.join(repoDir, filePath);
 
-  // modify/delete during rebase: keep the replayed commit version when present.
-  if (
-    xy.includes("U") &&
-    (summary.index === "D" || summary.working_dir === "D")
-  ) {
-    if (fs.existsSync(abs)) {
-      runGit(repoDir, ["add", "--", filePath]);
-      return;
-    }
+  // modify/delete during rebase: the replayed commit ("theirs", the branch)
+  // must win, matching the `-X theirs` policy. "DU" = base ("ours") deleted,
+  // branch modified -> keep the branch's version. "UD" = branch deleted, base
+  // ("ours") modified -> honor the branch's deletion. Using fs.existsSync
+  // here would be wrong: git leaves whichever side survives the conflict in
+  // the tree, which for "UD" is the base's (unwanted) modified version.
+  if (xy === "DU") {
+    runGit(repoDir, ["add", "--", filePath]);
+    return;
+  }
+  if (xy === "UD") {
     runGit(repoDir, ["rm", "-f", "--", filePath]);
     return;
   }


### PR DESCRIPTION
**Source:** bug found while auditing `packages/sandbox/daemon/git/rebase-onto-base.ts` (rebase-onto-base tooling).

**The bug:** `resolveConflictFile()` handles rebase modify/delete conflicts (one side deletes a file, the other modifies it) by deciding whether to keep or remove the file based on `fs.existsSync(abs)`. That heuristic only holds for one direction: when the base (`DU`, "deleted by us") deletes and the branch modifies, git leaves the branch's (surviving) version in the tree, so `existsSync` correctly signals "keep it" — this is the only case the existing test covers. But when the *branch* deletes a file and the *base* modifies it (`UD`, "deleted by them"), git leaves the **base's** modified version in the tree instead, so `existsSync` is true there too — and the old code wrongly kept it, silently resurrecting a file the developer intentionally deleted on their branch every time they rebased onto an updated base. That's the opposite of the `-X theirs` policy (favor the branch) the rest of the function implements.

**Failure scenario:** a developer deletes a file on their sandbox branch; the base branch is later updated with an unrelated edit to that same file; the developer rebases (e.g. via publish's rebase-and-force-push flow) — the deleted file reappears in their branch after the rebase, with no error or warning.

**Fix:** switch on the exact git porcelain conflict codes (`DU` vs `UD`) instead of `fs.existsSync`, so the branch's ("theirs") side always wins regardless of which side git happens to leave on disk.

**Regression test:** added `honors the branch's deletion when the base modified the same file` to `rebase-onto-base.test.ts`, mirroring the existing conflict-resolution test's setup but with the delete/modify sides swapped. It fails on the old code (file wrongly resurrected) and passes with the fix.

**Reviewer verification:** `cd packages/sandbox && bun test daemon/git/rebase-onto-base.test.ts` (4 pass).

**Local checks run:** `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox` (clean), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes modify/delete conflict handling in the sandbox rebase flow to honor the branch’s deletion (`-X theirs`). Prevents deleted files from reappearing when the base modifies the same path.

- **Bug Fixes**
  - Use exact conflict codes: `DU` -> keep branch version (`git add`), `UD` -> honor branch delete (`git rm`), replacing the `fs.existsSync` heuristic.
  - Add regression test in `packages/sandbox/daemon/git/rebase-onto-base.test.ts` for the `UD` case.

<sup>Written for commit a3a83c236f14b823c4bb5cef63732f754e1e2d42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

