### PR TITLE
fix(sandbox): stop trusting legacy agent-sandbox entries on the agent row

### DIFF
--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/sdk";
 import type { VirtualMCPEntity, SandboxMap } from "@decocms/shared/sdk/types";
 import { agentHasClonableSource } from "@/lib/agent-capabilities";
+import { withoutLegacyAgentSandboxEntries } from "@/lib/agent-sandbox-map";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useIsSandboxStartPending } from "@/components/sandbox/hooks/use-sandbox-start";
 import { useStatusSounds } from "../../hooks/use-status-sounds";
@@ -136,7 +137,7 @@ function NewTaskBridge({
 function VmEventsBridge({
   virtualMcpId,
   hasActiveGithubRepo,
-  sandboxMap,
+  sandboxMap: agentRowSandboxMap,
   children,
 }: {
   virtualMcpId: string;
@@ -144,6 +145,10 @@ function VmEventsBridge({
   sandboxMap: SandboxMap | undefined;
   children: ReactNode;
 }) {
+  // The agent row is not authoritative for `agent-sandbox` — that kind resolves
+  // from the session registry below, and a leftover entry here would suppress
+  // auto-start while pointing at a reaped sandbox. See the helper.
+  const sandboxMap = withoutLegacyAgentSandboxEntries(agentRowSandboxMap);
   const { currentBranch, activeTask } = useChatTask();
   const { org } = useProjectContext();
   const { pendingSandboxProviderKind } = useChatPrefs();

--- a/apps/web/src/lib/agent-sandbox-map.test.ts
+++ b/apps/web/src/lib/agent-sandbox-map.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import type { SandboxMap, SandboxRecord } from "@decocms/shared/sdk/types";
+import { withoutLegacyAgentSandboxEntries } from "./agent-sandbox-map";
+
+const TAVANO = "sDGY2MbZs5Izp9FnbYOpRclDjd8MtWTB";
+const BRANCH = "tavano-vgfdyxrm";
+
+/** `cluster` is accepted for the legacy-spelling case; it normalizes to
+ *  agent-sandbox, so the stored record still carries a valid kind. */
+function record(
+  handle: string,
+  kind: "agent-sandbox" | "user-desktop" | "cluster",
+): SandboxRecord {
+  return {
+    sandboxHandle: handle,
+    previewUrl: `https://${handle}.preview-studio.decocms.com/`,
+    sandboxApiUrl: `https://${handle}.preview-studio.decocms.com/`,
+    sandboxProviderKind: kind === "cluster" ? "agent-sandbox" : kind,
+  };
+}
+
+describe("withoutLegacyAgentSandboxEntries", () => {
+  test("strips the leftover agent-sandbox entry that suppressed auto-start", () => {
+    // The regression: this entry pointed at a reaped sandbox, made `vmEntry`
+    // non-null for the one user whose key held it, and so no SANDBOX_START was
+    // ever issued for them.
+    const map = {
+      [TAVANO]: {
+        [BRANCH]: {
+          "agent-sandbox": record("tavano-vgfdyxrm-77c2", "agent-sandbox"),
+        },
+      },
+    } as unknown as SandboxMap;
+    expect(withoutLegacyAgentSandboxEntries(map)).toEqual({});
+  });
+
+  test("strips the legacy `cluster` spelling too", () => {
+    // `parseBranchMap` normalizes `cluster` to agent-sandbox, so leaving it
+    // would reintroduce the bug through the back door.
+    const map = {
+      [TAVANO]: { [BRANCH]: { cluster: record("legacy-abcd", "cluster") } },
+    } as unknown as SandboxMap;
+    expect(withoutLegacyAgentSandboxEntries(map)).toEqual({});
+  });
+
+  test("keeps user-desktop entries and drops only the agent-sandbox sibling", () => {
+    const desktop = record("desk-1234", "user-desktop");
+    const map = {
+      [TAVANO]: {
+        [BRANCH]: {
+          "agent-sandbox": record("tavano-vgfdyxrm-77c2", "agent-sandbox"),
+          "user-desktop": desktop,
+        },
+      },
+    } as unknown as SandboxMap;
+    expect(withoutLegacyAgentSandboxEntries(map)).toEqual({
+      [TAVANO]: { [BRANCH]: { "user-desktop": desktop } },
+    });
+  });
+
+  test("leaves sibling branches and other users intact", () => {
+    const desktop = record("desk-1234", "user-desktop");
+    const map = {
+      [TAVANO]: {
+        [BRANCH]: { "agent-sandbox": record("dead-77c2", "agent-sandbox") },
+        "other-branch": { "user-desktop": desktop },
+      },
+      "other-user": { [BRANCH]: { "user-desktop": desktop } },
+    } as unknown as SandboxMap;
+    expect(withoutLegacyAgentSandboxEntries(map)).toEqual({
+      [TAVANO]: { "other-branch": { "user-desktop": desktop } },
+      "other-user": { [BRANCH]: { "user-desktop": desktop } },
+    });
+  });
+
+  test("returns the same reference when there is nothing to strip", () => {
+    const map = {
+      [TAVANO]: {
+        [BRANCH]: { "user-desktop": record("desk-1", "user-desktop") },
+      },
+    } as unknown as SandboxMap;
+    expect(withoutLegacyAgentSandboxEntries(map)).toBe(map);
+  });
+
+  test("passes undefined through", () => {
+    expect(withoutLegacyAgentSandboxEntries(undefined)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/agent-sandbox-map.ts
+++ b/apps/web/src/lib/agent-sandbox-map.ts
@@ -1,0 +1,50 @@
+import type { SandboxMap } from "@decocms/shared/sdk/types";
+
+/**
+ * Raw sandboxMap keys that mean "agent-sandbox". `cluster` is the legacy
+ * spelling — `parseBranchMap` normalizes it, so filtering only `agent-sandbox`
+ * would let a legacy cell through and reintroduce the bug this guards against.
+ */
+const AGENT_SANDBOX_KEYS = new Set(["agent-sandbox", "cluster"]);
+
+/**
+ * Drop `agent-sandbox` entries from a virtual MCP's `metadata.sandboxMap`.
+ *
+ * The agent row is NOT authoritative for that kind: the server resolves
+ * agent-sandbox exclusively from the org-scoped session registry
+ * (`agent_sandbox_sessions`) and deliberately ignores what sits in sandboxMap —
+ * see `readRecordedKinds` in `apps/api/src/sandbox/resolve-provider.ts`. Nothing
+ * writes agent-sandbox there anymore either (`SANDBOX_START` only calls
+ * `setSandboxMapEntry` for non-shared kinds), so every such entry is a leftover
+ * from before the kind became org-shared.
+ *
+ * Trusting them client-side is what strands a preview: the leftover entry makes
+ * `vmEntry` non-null for whichever user key happens to hold it, `shouldAutoStart`
+ * then returns false, and no `SANDBOX_START` is ever issued — while `previewUrl`
+ * points at a reaped sandbox, so there is nothing to self-heal from either. A
+ * teammate whose key is absent from the same map sails through and provisions
+ * normally, which is why this reads as "works for me, stuck for you".
+ *
+ * Behaviour-neutral otherwise: when a session row does exist, its graft in
+ * `VmEventsBridge` already overwrites the entry this strips.
+ *
+ * Returns the input reference unchanged when there is nothing to strip.
+ */
+export function withoutLegacyAgentSandboxEntries(
+  sandboxMap: SandboxMap | undefined,
+): SandboxMap | undefined {
+  if (!sandboxMap) return sandboxMap;
+  let changed = false;
+  const next: SandboxMap = {};
+  for (const [userId, byBranch] of Object.entries(sandboxMap)) {
+    const nextByBranch: SandboxMap[string] = {};
+    for (const [branch, cell] of Object.entries(byBranch ?? {})) {
+      const kinds = Object.entries(cell ?? {});
+      const kept = kinds.filter(([kind]) => !AGENT_SANDBOX_KEYS.has(kind));
+      if (kept.length !== kinds.length) changed = true;
+      if (kept.length > 0) nextByBranch[branch] = Object.fromEntries(kept);
+    }
+    if (Object.keys(nextByBranch).length > 0) next[userId] = nextByBranch;
+  }
+  return changed ? next : sandboxMap;
+}


### PR DESCRIPTION
## Summary

A preview hangs for exactly **one** member while a teammate opening the same thread provisions normally. Reported on [`clovis/3934190e…`](https://studio.decocms.com/clovis/3934190e-6ac3-4e50-9f04-407f801bb8d1?virtualmcpid=vir_ByZRM2zsja00CzSuFa3rL&sidepanel=chat): stuck for @tavano (the thread's own author), instant for another member. Tavano's read — *"acho que o meu browser não rodou SANDBOX_START"* — was exactly right.

## Root cause

The agent row is **not** authoritative for `agent-sandbox`:

- Server resolves that kind exclusively from `agent_sandbox_sessions` and deliberately ignores `metadata.sandboxMap` — `readRecordedKinds`, `apps/api/src/sandbox/resolve-provider.ts:151-155`.
- Nothing writes it there anymore — `SANDBOX_START` only calls `setSandboxMapEntry` in the non-shared `else` branch (`start.ts:749`).

Every such entry is a leftover from before the kind became org-shared. The client still read them (`agent-shell-layout/index.tsx` passed `entity?.metadata?.sandboxMap` straight into `parseBranchMap(sandboxMap[userId][branch])`).

Evidence from prod for branch `tavano-vgfdyxrm`:

| source | handle | live? |
|---|---|---|
| `connections.metadata.sandboxMap[tavano][tavano-vgfdyxrm]["agent-sandbox"]` | `tavano-vgfdyxrm-77c242b4e71f6488` | **404 — reaped** |
| `agent_sandbox_sessions` | `tavano-vgfdyxrm-5e9d9abaf97aabe0` | 200 — live |

The session row's `created_at` is the moment the *other* member opened the thread, with their id as `created_by` — it did not exist while Tavano was stuck.

A leftover entry makes `vmEntry` non-null for whichever user key holds it, so `shouldAutoStart` returns false (`!args.vmEntry`) and **no `SANDBOX_START` is ever issued** for that member. Meanwhile `previewUrl` points at the reaped sandbox and there is nothing to self-heal from: the direct-daemon probe only treats HTTP 404 as `gone` (`isDirectDaemonEventsGoneStatus`), and a dead *hostname* throws and is swallowed to `false`. A member whose key is simply absent from the map gets `vmEntry === null`, hits the ownership gate, acknowledges, and provisions. The asymmetry is decided purely by which user key the leftover happens to sit under.

## Changes

- `withoutLegacyAgentSandboxEntries` — strips `agent-sandbox` from the agent-row sandboxMap in `VmEventsBridge`, leaving the session registry as the only source for that kind. Mirrors the server rule.
- Also strips the legacy `cluster` spelling, which `parseBranchMap` normalizes to agent-sandbox and would otherwise reintroduce the bug through the back door. (0 rows in prod today, and storage normalizes on read — cheap guard against a row slipping through.)
- Returns the input reference unchanged when there's nothing to strip.

Behaviour-neutral otherwise: when a session row exists, its graft in `VmEventsBridge` already overwrites the stripped entry. With no session row, `vmEntry` goes null → auto-start fires → sandbox provisions, which is what should have happened for Tavano.

The **thread**-map graft is deliberately left alone — that one is a live feature (read-only view of a teammate's running sandbox), not legacy.

## Scale

```
agent-sandbox sandboxMap entries with no matching session row:
  1789 entries · 320 agents · 112 users
```

Each was a latent "preview never starts, for one member, on one branch." This makes them inert — no data migration needed.

## Relationship to #5219

Same root disease (a client trusting agent-sandbox state the server declared dead), **different store**. #5219 covers a leftover on the *thread* row and is gated on `threadIdFromBranch(branch)`, which needs a `thread:` prefix. `"tavano-vgfdyxrm"` returns `null`, so #5219 does not help here. The two are independent and can merge in either order.

## Testing

- `apps/web/src/lib/agent-sandbox-map.test.ts` — 6 unit tests: the exact regression, the `cluster` spelling, `user-desktop` siblings preserved, sibling branches/users untouched, reference identity, `undefined` passthrough. Pure logic, no mocks (tier 1 per TESTING.md).
- `bun run fmt`, `bun run --cwd apps/web check` (tsc clean), `bun run lint` (0 errors; 14 pre-existing warnings, none in changed files).
- `bun test apps/web/src/components/sandbox apps/web/src/lib`: 574 pass / 6 fail — the same 6 fail on the same tree without this change (`clearPersistedQueryCache`, `readCachedOrg/writeCachedOrg`; localStorage readonly-property issues in the bun env).

## Note

This particular thread already healed itself: the other member's open created the session row, whose graft now overwrites the stale entry. It will not reproduce there anymore — the 1789 other entries are where the remaining risk is.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops trusting legacy agent-row `agent-sandbox` entries so previews start reliably for everyone. The client now resolves `agent-sandbox` only from the session registry, preventing stale map entries from blocking auto-start or pointing to reaped sandboxes.

- **Bug Fixes**
  - Filter `agent-sandbox` and legacy `cluster` keys out of the agent-row `sandboxMap` via `withoutLegacyAgentSandboxEntries` in `VmEventsBridge`.
  - Keep the thread sandbox map unchanged (it’s a live read-only view).
  - Behavior: if no session row exists, auto-start fires; if a session exists, its graft stays authoritative.
  - Makes 1,789 stale entries inert; no migration needed.

<sup>Written for commit 30f440d040d7719c704f7b83ffcdd696eca39ae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

