### PR TITLE
fix(ui): add aria-label to view-mode-toggle icon-only buttons

### DIFF
--- a/packages/ui/src/components/view-mode-toggle.tsx
+++ b/packages/ui/src/components/view-mode-toggle.tsx
@@ -84,6 +84,7 @@ export function ViewModeToggle<T extends string = string>({
             key={option.value}
             type="button"
             onClick={() => onValueChange(option.value)}
+            aria-label={option.label}
             className={cn(
               "relative z-10 flex items-center justify-center gap-2 rounded-lg transition-colors [transition-timing-function:var(--ease-out-cubic)] duration-200",
               fullWidth


### PR DESCRIPTION
## Summary

Adds `aria-label` attribute to buttons in ViewModeToggle component to ensure icon-only buttons have accessible names for screen readers.

## Why

Icon-only buttons without accessible text are a WCAG 2.1 Level A failure. When ViewModeToggle is used with icon-only options (no label text), screen readers have no way to announce the button's purpose. The tooltip alone is not sufficient accessibility coverage since it only appears on hover/focus.

## Change

Added `aria-label={option.label}` to the button element. When a visible label exists, it provides the same text; when icon-only, it supplies the necessary accessible name.

**Line delta:** +1 / +0

## Verification

Behavior unchanged—the button accepts and uses the aria-label attribute without affecting rendering or interaction. The change is syntax-valid and uses the existing option.label data already in scope.

## Test command

```bash
bunx tsc --noEmit
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `aria-label={option.label}` to ViewModeToggle buttons so icon-only options have accessible names for screen readers. Fixes a WCAG 2.1 Level A issue with icon-only buttons; no visual or interaction changes.

<sup>Written for commit 1a14f3eae49e3b4fe8715f75c76ac25bf54ec3f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

