### PR TITLE
fix(decopilot): bound the client-supplied memory.windowSize

### DIFF
--- a/apps/api/src/api/routes/decopilot/schemas.test.ts
+++ b/apps/api/src/api/routes/decopilot/schemas.test.ts
@@ -21,4 +21,25 @@ describe("StreamRequestSchema", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("rejects an out-of-range memory.windowSize", () => {
+    // windowSize flows straight into a DB query LIMIT (Memory.loadHistory) —
+    // an unbounded or negative value must be rejected at the boundary rather
+    // than reaching the query.
+    for (const windowSize of [0, -1, 1.5, 100_000]) {
+      const result = StreamRequestSchema.safeParse({
+        ...baseRequest,
+        memory: { windowSize, thread_id: "thread-1" },
+      });
+      expect(result.success).toBe(false);
+    }
+  });
+
+  it("accepts a valid memory.windowSize", () => {
+    const result = StreamRequestSchema.safeParse({
+      ...baseRequest,
+      memory: { windowSize: 100, thread_id: "thread-1" },
+    });
+    expect(result.success).toBe(true);
+  });
 });

--- a/apps/api/src/api/routes/decopilot/schemas.ts
+++ b/apps/api/src/api/routes/decopilot/schemas.ts
@@ -16,7 +16,11 @@ const UIMessageSchema = z.looseObject({
 });
 
 const MemoryConfigSchema = z.object({
-  windowSize: z.number().default(DEFAULT_WINDOW_SIZE),
+  // Flows straight into a DB query LIMIT (`Memory.loadHistory` →
+  // `listMessages`/`loadWindow`) with no other bound — an unvalidated huge or
+  // negative value would either force-load a thread's entire history on every
+  // turn or blow up the query at the DB layer.
+  windowSize: z.number().int().min(1).max(500).default(DEFAULT_WINDOW_SIZE),
   thread_id: z.string(),
 });
 


### PR DESCRIPTION
**Source:** bug found while auditing the decopilot API routes (dispatch-run.ts / thread-status-events.ts / nats-stream-buffer.ts area) for missing input validation at a trust boundary.

**Why:** `POST /:org/decopilot/threads/:threadId` accepts a `memory.windowSize` field (`schemas.ts`) that was validated only as `z.number()` — no min/max/int constraint. That value flows unvalidated all the way into a DB query LIMIT via `routes.ts`'s `memoryConfig?.windowSize` -> `DispatchRunInput.windowSize` -> `Memory.loadHistory(windowSize)` -> `storage.listMessages({ limit })` / `messageParts().loadWindow(threadId, { limit })` (`apps/api/src/api/routes/decopilot/memory.ts`, `apps/api/src/storage/threads.ts`). A client sending a negative/zero/fractional value can make the query fail unexpectedly at the DB layer instead of getting a clean 400, and an oversized value (e.g. `1e8`) forces the server to attempt loading a thread's *entire* message history on every turn — real resource strain with no cap anywhere downstream.

**Fix:** bound the schema field to `z.number().int().min(1).max(500)` (default unchanged, 50), so an out-of-range value is rejected at the HTTP boundary with a normal 400 instead of reaching the query.

**Regression test:** `schemas.test.ts` now asserts `windowSize` values of `0`, `-1`, `1.5`, and `100000` are rejected, while a normal value (`100`) still parses successfully.

**To verify:** `bun test apps/api/src/api/routes/decopilot/schemas.test.ts`

**Checks run locally:** `bun run fmt` (clean diff), `bunx tsc --noEmit` in `apps/api` (clean), and the single targeted test file above (3 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the client-supplied `memory.windowSize` in decopilot to prevent invalid DB LIMITs and unbounded history loads. It must be an integer 1–500 (default 50); out-of-range values now return 400.

- **Bug Fixes**
  - Added regression tests rejecting 0, -1, 1.5, 100000 and accepting 100.

<sup>Written for commit 77c190614b01781ee1cbb9dfb8d8c43501845606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

