### PR TITLE
fix(sections-editor): cancel pending section autosave before renaming a variant

### DIFF
--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -2062,6 +2062,15 @@ export function SectionsEditor({
     nextName: string,
   ) => {
     cancelPendingRuleSaves();
+    // Also cancel a pending section-field autosave — it reads the current
+    // variant's sections fresh via latestRef when it fires and writes the
+    // whole page block. This function itself persists a `sections` snapshot
+    // taken now, so a still-pending timer firing during the awaits below
+    // would have its write clobbered by this stale snapshot.
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
 
     const pageKey = latestRef.current.activePageKey;
     const latestDecofile: Record<string, unknown> = latestRef.current.decofile;
@@ -2201,6 +2210,15 @@ export function SectionsEditor({
     nextName: string,
   ) => {
     cancelPendingRuleSaves();
+    // Also cancel a pending section-field autosave — it targets the same
+    // section's `rawSections[index]` and this function persists a
+    // `latestRawSections` snapshot taken now, so a still-pending timer firing
+    // during the awaits below would have its write clobbered by this stale
+    // snapshot.
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
 
     const {
       selectedSectionIndex: sectionIndex,


### PR DESCRIPTION
**Source:** bug found while auditing `sections-editor.tsx` for stale-state/race issues in the sections-editor stability focus area, the same class of bug fixed three times already this week (#5176, #5181, #5182).

**Payoff:** every other page/section-variant restructuring path (`savePageSections`, `handleAddPageVariant`, `mutatePageVariants` — used by reorder/delete/duplicate) clears the pending section-field autosave timer (`debounceRef`) before persisting its own snapshot, with a comment explaining why: the timer resolves `latestRef.current` fresh at fire time and writes the whole page block, so a still-pending timer firing after a restructuring write lands a stale snapshot on top of it. `handleRenamePageVariant` and `handleRenameSectionVariant` were the two remaining mutators that call `cancelPendingRuleSaves()` (which only clears the *rule* debounce timers) but never clear `debounceRef` — both persist a `sections`/`rawSections` snapshot captured once at call time, then `await` one or two network round-trips (creating a promoted matcher block, in the rename-to-name path) before writing it. If the section-field autosave (700ms debounce) fires during that window, its write is silently overwritten by the rename's stale snapshot, dropping whatever field edit the user just made.

**Failure scenario:** edit a field on the active section/section-variant, then within ~1s rename the page variant (or section variant) you're viewing before the field's 700ms autosave has fired. The rename's async save (which can itself take a network round trip) lands after the field autosave and reverts it to the pre-edit value — the field edit is silently lost with no error.

**Fix:** clear `debounceRef` (same pattern as the three prior fixes) at the top of both rename handlers, right alongside the existing `cancelPendingRuleSaves()` call.

**Verify:** `cd apps/web && bunx tsc --noEmit` (green). No existing unit test covers `sections-editor.tsx` (the three prior fixes in this exact file were also shipped without one, e.g. #5176/#5181 — pure in-file timer-ordering logic, not independently unit-testable without extracting significant scaffolding).

**Checks run locally:** `bun run fmt` (clean, no changes needed) and `cd apps/web && bunx tsc --noEmit` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent field edits from being reverted when renaming a page or section variant by avoiding races between rename saves and pending autosaves.

- **Bug Fixes**
  - Clear `debounceRef` at the start of `handleRenamePageVariant` and `handleRenameSectionVariant` (next to `cancelPendingRuleSaves()`).
  - Aligns rename flow with other mutators that already cancel pending section autosaves to avoid stale snapshot writes.

<sup>Written for commit 69b640abfd8c0cd59d6303da5f403205405ac60e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

