### PR TITLE
fix(ui): add allow-downloads to sandboxed iframes

### DIFF
--- a/apps/web/src/components/deck/html-preview-panel.tsx
+++ b/apps/web/src/components/deck/html-preview-panel.tsx
@@ -69,7 +69,7 @@ export function HtmlPreviewPanel({
           ref={editor.iframeRef}
           src={src}
           onLoad={() => setReadySrc(src)}
-          sandbox="allow-scripts"
+          sandbox="allow-scripts allow-downloads"
           className={cn(
             "absolute inset-0 block h-full w-full bg-white",
             "transition-opacity ease-out",

--- a/apps/web/src/components/file-preview.tsx
+++ b/apps/web/src/components/file-preview.tsx
@@ -199,7 +199,7 @@ export function FilePreview({ file }: { file: PreviewableFile }) {
         <iframe
           src={file.downloadUrl}
           title={file.filename}
-          sandbox="allow-scripts"
+          sandbox="allow-scripts allow-downloads"
           className="block h-full w-full bg-white"
         />
       );

--- a/apps/web/src/mcp-apps/mcp-app-renderer.tsx
+++ b/apps/web/src/mcp-apps/mcp-app-renderer.tsx
@@ -164,7 +164,7 @@ function MCPAppFrame({
       <iframe
         ref={iframeRef}
         srcDoc={html}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
         className={cn("w-full h-full border-0", isLoading && "invisible")}
         title={`MCP App: ${toolName ?? uri}`}
       />


### PR DESCRIPTION
Allow HTML previews, deck renders, and MCP apps to initiate downloads from within their sandboxed iframes. Fixes browser error: 'Download is disallowed. The frame initiating the download is sandboxed, but the flag allow-downloads is not set.'

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable downloads from sandboxed iframes in HTML previews, deck renders, and MCP apps by adding the `allow-downloads` sandbox flag. This removes the “Download is disallowed…” browser error and allows files to be saved from within those frames.

<sup>Written for commit a33e899d5a9bbd21c837a118fa1e5f0e5b4b3fab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

