### PR TITLE
feat(header): branch label, truncation priority, and icon-only actions below lg

### DIFF
--- a/apps/web/src/components/chat/pills/branch-pill.tsx
+++ b/apps/web/src/components/chat/pills/branch-pill.tsx
@@ -54,9 +54,11 @@ export function BranchPill({ locked, placement, value, ...props }: Props) {
             )}
           >
             <GitBranch01 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-            {/* Show the branch (truncated); below `lg` (< 1024px) collapse to an
-                icon-only chip — the name stays available via the tooltip. */}
-            <span className="min-w-0 truncate max-lg:hidden">
+            {/* Show the branch (truncated); below 768px of panel header collapse
+                to an icon-only chip — the name stays available via the tooltip.
+                Container query on `@container/panel-header`, matching the rest
+                of the strip (see header-actions). */}
+            <span className="min-w-0 truncate @max-3xl/panel-header:hidden">
               {branchLabel}
             </span>
           </span>

--- a/apps/web/src/components/chat/pills/branch-pill.tsx
+++ b/apps/web/src/components/chat/pills/branch-pill.tsx
@@ -46,20 +46,17 @@ export function BranchPill({ locked, placement, value, ...props }: Props) {
             data-testid="branch-picker-locked"
             aria-disabled="true"
             className={cn(
-              "inline-flex items-center rounded-md font-mono text-xs",
+              "inline-flex items-center gap-1.5 rounded-md font-mono text-xs",
               "text-muted-foreground cursor-default min-w-0 max-w-[200px]",
               isHeader
-                ? "h-8 gap-1.5 border border-input bg-background px-2.5"
-                : "h-9 gap-0 px-2",
+                ? "h-8 border border-input bg-background px-2.5"
+                : "h-9 px-2",
             )}
           >
             <GitBranch01 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-            <span
-              className={cn(
-                "min-w-0 truncate",
-                isHeader ? "" : "max-w-0 opacity-0",
-              )}
-            >
+            {/* Show the branch (truncated); below `lg` (< 1024px) collapse to an
+                icon-only chip — the name stays available via the tooltip. */}
+            <span className="min-w-0 truncate max-lg:hidden">
               {branchLabel}
             </span>
           </span>

--- a/apps/web/src/components/dev-agent/dev-agent-control.tsx
+++ b/apps/web/src/components/dev-agent/dev-agent-control.tsx
@@ -65,7 +65,8 @@ export function DevAgentControl({
       )}
     >
       <Icon className="size-3.5 shrink-0" />
-      <span className="max-lg:hidden">{label}</span>
+      {/* Collapses with the rest of the strip at 768px of panel header. */}
+      <span className="@max-3xl/panel-header:hidden">{label}</span>
     </button>
   );
 

--- a/apps/web/src/components/dev-agent/dev-agent-control.tsx
+++ b/apps/web/src/components/dev-agent/dev-agent-control.tsx
@@ -7,6 +7,8 @@
  */
 
 import { cn } from "@deco/ui/lib/utils.ts";
+import { Code01, Globe01 } from "@untitledui/icons";
+import type { ComponentType } from "react";
 import { useVirtualMCPs } from "@/sdk";
 import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
 import { useChatNavigation } from "@/components/chat/hooks/use-chat-navigation";
@@ -40,28 +42,37 @@ export function DevAgentControl({
     navigateToTask(taskId, { virtualMcpId: agentId });
   };
 
-  const segment = (label: string, active: boolean) => (
+  // Below `lg` (< 1024px) the segments collapse to icon-only; the label moves to
+  // the native title tooltip (kept as `aria-label` for a11y either way).
+  const segment = (
+    label: string,
+    active: boolean,
+    Icon: ComponentType<{ className?: string }>,
+  ) => (
     <button
       type="button"
       aria-pressed={active}
+      aria-label={label}
+      title={label}
       onClick={() => {
         if (!active) void goToAgent(partner.targetId);
       }}
       className={cn(
-        "px-2.5 py-1 rounded-md transition-colors",
+        "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md transition-colors",
         active
           ? "bg-background text-foreground shadow-sm"
           : "text-muted-foreground hover:text-foreground",
       )}
     >
-      {label}
+      <Icon className="size-3.5 shrink-0" />
+      <span className="max-lg:hidden">{label}</span>
     </button>
   );
 
   return (
     <div className="inline-flex items-center rounded-lg border border-border bg-muted p-0.5 text-xs font-medium">
-      {segment("Develop", isDev)}
-      {segment("Live", !isDev)}
+      {segment("Develop", isDev, Code01)}
+      {segment("Live", !isDev, Globe01)}
     </div>
   );
 }

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -924,7 +924,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             : t("sandbox.preview.editContent")
         }
         // Distinctive icon — sheds its label with the system tabs at 768px,
-        // well before this group hides at 448px, so the group stays narrow
+        // well before this group hides at 384px, so the group stays narrow
         // through the widths where it is most cramped.
         labelCollapse="sooner"
         icon={{ kind: "component", Component: PuzzlePiece01 }}

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -910,30 +910,36 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   // Refresh + page selector + open-in-new-tab — the URL group. Sized to content
   // (capped) rather than stretching, so it doesn't dominate the top bar.
-  const urlControls = showPreviewToolbar ? (
-    <div className="flex min-w-0 items-center gap-0.5">
-      {/* Edit (Blocks) — the primary "edit this page" action, tied to the page
-          the selector shows. Leads the group (set off by a divider) so it reads
-          as a distinct action rather than being wedged inside the URL controls.
-          Filled when the Blocks editor is open; click again for plain preview. */}
-      <HeaderTabButton
-        title={t("sandbox.preview.cms")}
-        tooltip={
-          blocksActive
-            ? t("sandbox.preview.exitEditor")
-            : t("sandbox.preview.editContent")
-        }
-        // Distinctive icon — sheds its label with the system tabs at 768px,
-        // well before this group hides at 384px, so the group stays narrow
-        // through the widths where it is most cramped.
-        labelCollapse="sooner"
-        icon={{ kind: "component", Component: PuzzlePiece01 }}
-        active={blocksActive}
-        onClick={() => toggleEditingMode("blocks")}
-        testId="preview-blocks-toggle"
-        dataTour={TOUR_ANCHORS.edit}
-      />
-      <div className="mx-0.5 h-5 w-px shrink-0 bg-border" />
+  // Edit (Blocks) — the primary "edit this page" action, tied to the page the
+  // selector shows. On desktop it leads the URL group, set off by a divider, so
+  // it reads as a distinct action rather than being wedged inside the URL
+  // controls. On mobile it anchors the left edge on its own (see below).
+  // Filled when the Blocks editor is open; click again for plain preview.
+  const cmsToggle = showPreviewToolbar ? (
+    <HeaderTabButton
+      title={t("sandbox.preview.cms")}
+      tooltip={
+        blocksActive
+          ? t("sandbox.preview.exitEditor")
+          : t("sandbox.preview.editContent")
+      }
+      // Distinctive icon — sheds its label with the system tabs at 768px,
+      // well before this group hides at 384px, so the group stays narrow
+      // through the widths where it is most cramped.
+      labelCollapse="sooner"
+      icon={{ kind: "component", Component: PuzzlePiece01 }}
+      active={blocksActive}
+      onClick={() => toggleEditingMode("blocks")}
+      testId="preview-blocks-toggle"
+      dataTour={TOUR_ANCHORS.edit}
+    />
+  ) : null;
+
+  // The view controls proper: refresh · page selector · open-in-new. Kept as a
+  // unit so both layouts can place it as one block — inline after the Edit
+  // action on desktop, or in its own centered slot on mobile.
+  const urlGroup = showPreviewToolbar ? (
+    <>
       <Tooltip>
         <TooltipTrigger asChild>
           <ToolbarIconButton
@@ -1173,8 +1179,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           </div>
         )}
       </div>
-      {/* View controls (refresh · page · open-in-new) stay grouped after the
-          Edit action, which leads the group above. */}
       <Tooltip>
         <TooltipTrigger asChild>
           <ToolbarIconButton
@@ -1191,6 +1195,16 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           {t("sandbox.preview.openInNewTab")}
         </TooltipContent>
       </Tooltip>
+    </>
+  ) : null;
+
+  // Desktop composition (portaled into the panel header's centre slot): the
+  // Edit action leads, set off by a divider, then the view controls.
+  const urlControls = showPreviewToolbar ? (
+    <div className="flex min-w-0 items-center gap-0.5">
+      {cmsToggle}
+      <div className="mx-0.5 h-5 w-px shrink-0 bg-border" />
+      {urlGroup}
     </div>
   ) : null;
 
@@ -1394,9 +1408,32 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           // slot — mobile) the controls render inline instead of portaling, so
           // without it their container queries would find no container and every
           // label would stay at full width.
-          <div className="@container/panel-header relative flex h-12 shrink-0 items-center justify-between gap-2 border-b border-border/60 px-3 md:px-4">
-            {showPreviewToolbar ? urlControls : <div />}
-            {moreMenu}
+          //
+          // Three zones rather than the desktop's single left-packed group: Edit
+          // anchors the left edge, the view controls sit in the middle, and the
+          // ⋯ menu holds the right. Packed left, the page selector sat wherever
+          // Edit and refresh pushed it — visibly off-centre on a phone, where
+          // the bar is the whole screen.
+          //
+          // The two side zones are `flex-1` (equal basis) and the middle is
+          // content-sized, so the selector centres on the BAR wherever there is
+          // slack to divide. Giving the middle the flex-1 instead centres it
+          // between the side zones, which are unequal — Edit is ~9px wider than
+          // ⋯ — leaving it visibly off. On the narrowest phones the zones can no
+          // longer be equal either (the left one cannot shrink below the Edit
+          // button), so ~5px of that asymmetry returns; closing it completely
+          // would mean pinning both sides to a fixed width and letting the
+          // selector lose the space instead.
+          <div className="@container/panel-header relative flex h-12 shrink-0 items-center gap-2 border-b border-border/60 px-3 md:px-4">
+            <div className="flex flex-1 items-center justify-start">
+              {cmsToggle}
+            </div>
+            <div className="flex min-w-0 shrink items-center justify-center gap-0.5">
+              {urlGroup}
+            </div>
+            <div className="flex flex-1 items-center justify-end">
+              {moreMenu}
+            </div>
           </div>
         )
       )}

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -21,12 +21,12 @@ import {
   Copy01,
   CursorClick01,
   DotsHorizontal,
-  Edit05,
   Globe02,
   LayoutAlt01,
   LinkExternal01,
   Loading01,
   Plus,
+  PuzzlePiece01,
   SearchLg,
   CreditCardSearch,
   Monitor04,
@@ -916,23 +916,23 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           the selector shows. Leads the group (set off by a divider) so it reads
           as a distinct action rather than being wedged inside the URL controls.
           Filled when the Blocks editor is open; click again for plain preview. */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <HeaderTabButton
-            title={t("sandbox.preview.cms")}
-            icon={{ kind: "component", Component: Edit05 }}
-            active={blocksActive}
-            onClick={() => toggleEditingMode("blocks")}
-            testId="preview-blocks-toggle"
-            dataTour={TOUR_ANCHORS.edit}
-          />
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {blocksActive
+      <HeaderTabButton
+        title={t("sandbox.preview.cms")}
+        tooltip={
+          blocksActive
             ? t("sandbox.preview.exitEditor")
-            : t("sandbox.preview.editContent")}
-        </TooltipContent>
-      </Tooltip>
+            : t("sandbox.preview.editContent")
+        }
+        // Distinctive icon — sheds its label with the system tabs at 768px,
+        // well before this group hides at 448px, so the group stays narrow
+        // through the widths where it is most cramped.
+        labelCollapse="sooner"
+        icon={{ kind: "component", Component: PuzzlePiece01 }}
+        active={blocksActive}
+        onClick={() => toggleEditingMode("blocks")}
+        testId="preview-blocks-toggle"
+        dataTour={TOUR_ANCHORS.edit}
+      />
       <div className="mx-0.5 h-5 w-px shrink-0 bg-border" />
       <Tooltip>
         <TooltipTrigger asChild>
@@ -1390,7 +1390,11 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
         </>
       ) : (
         (showPreviewToolbar || moreMenu) && (
-          <div className="relative flex h-12 shrink-0 items-center justify-between gap-2 border-b border-border/60 px-3 md:px-4">
+          // Declares the same container as PanelHeader: on this path (no header
+          // slot — mobile) the controls render inline instead of portaling, so
+          // without it their container queries would find no container and every
+          // label would stay at full width.
+          <div className="@container/panel-header relative flex h-12 shrink-0 items-center justify-between gap-2 border-b border-border/60 px-3 md:px-4">
             {showPreviewToolbar ? urlControls : <div />}
             {moreMenu}
           </div>

--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -25,7 +25,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
-import { ChevronDown, GitBranch01, GitPullRequest } from "@untitledui/icons";
+import {
+  Check,
+  ChevronDown,
+  GitBranch01,
+  GitPullRequest,
+} from "@untitledui/icons";
 import { generateBranchName } from "@decocms/shared/branch-name";
 import { decodeHtmlEntities } from "./decode-html-entities.ts";
 import { useBranches } from "./use-branches";
@@ -78,6 +83,10 @@ export function BranchPicker({
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<"branches" | "prs">("branches");
   const [search, setSearch] = useState("");
+  // cmdk highlights the first item by default; seed the active item with the
+  // current branch so the picker opens focused on the branch in use rather than
+  // an unrelated first row. Kept in sync with keyboard/hover navigation.
+  const [activeValue, setActiveValue] = useState(value ?? "");
   const [isSearchingRemote, setIsSearchingRemote] = useState(false);
   const searchRequestId = useRef(0);
 
@@ -176,7 +185,19 @@ export function BranchPicker({
   };
 
   return (
-    <Popover open={open} onOpenChange={disabled ? undefined : setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={
+        disabled
+          ? undefined
+          : (next) => {
+              // Re-seed the highlight on the current branch each time the picker
+              // opens, in case the branch changed since it was last closed.
+              if (next) setActiveValue(value ?? "");
+              setOpen(next);
+            }
+      }
+    >
       <Tooltip>
         <TooltipTrigger asChild>
           <span
@@ -217,7 +238,7 @@ export function BranchPicker({
         className="w-[min(420px,calc(100vw-2rem))] p-0"
         align="start"
       >
-        <Command>
+        <Command value={activeValue} onValueChange={setActiveValue}>
           <div className="*:data-[slot=command-input-wrapper]:flex-1 *:data-[slot=command-input-wrapper]:border-b-0 flex items-center border-b pr-2">
             <CommandInput
               placeholder={
@@ -334,6 +355,9 @@ export function BranchPicker({
                       >
                         <GitBranch01 className="mr-2 h-4 w-4 shrink-0" />
                         <span className="flex-1 truncate">{b.name}</span>
+                        {b.name === value && (
+                          <Check className="ml-2 h-4 w-4 shrink-0 text-muted-foreground" />
+                        )}
                         <ContributorAvatars
                           userIds={b.contributors ?? []}
                           memberById={memberById}
@@ -357,6 +381,9 @@ export function BranchPicker({
                         >
                           <GitBranch01 className="mr-2 h-4 w-4 shrink-0" />
                           <span className="flex-1 truncate">{b.name}</span>
+                          {b.name === value && (
+                            <Check className="ml-2 h-4 w-4 shrink-0 text-muted-foreground" />
+                          )}
                         </CommandItem>
                       ))}
                     </CommandGroup>
@@ -381,6 +408,9 @@ export function BranchPicker({
                             <span className="text-xs text-muted-foreground">
                               @{b.author}
                             </span>
+                          )}
+                          {b.name === value && (
+                            <Check className="ml-2 h-4 w-4 shrink-0 text-muted-foreground" />
                           )}
                         </CommandItem>
                       ))}

--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -190,38 +190,19 @@ export function BranchPicker({
                 aria-label={label}
                 disabled={disabled}
                 className={cn(
-                  "font-mono shrink min-w-0 max-w-[200px]",
+                  "font-mono shrink min-w-0 max-w-[200px] gap-1.5",
                   isHeader
-                    ? "gap-1.5 text-xs"
-                    : cn(
-                        "text-xs text-muted-foreground hover:text-foreground transition-[gap] duration-200",
-                        disabled
-                          ? "gap-0"
-                          : "gap-0 @[320px]/chat-bottom:gap-1.5",
-                      ),
+                    ? "text-xs"
+                    : "text-xs text-muted-foreground hover:text-foreground",
                 )}
               >
                 <GitBranch01 className="h-3.5 w-3.5 shrink-0" />
-                <span
-                  className={cn(
-                    "min-w-0 truncate",
-                    isHeader
-                      ? ""
-                      : "transition-[max-width,opacity] duration-200 ease-out max-w-0 opacity-0 @[320px]/chat-bottom:max-w-[200px] @[320px]/chat-bottom:opacity-100",
-                  )}
-                >
-                  {label}
-                </span>
+                {/* Show the branch name (truncated) so the branch in use is
+                    visible at a glance. Below `lg` (< 1024px) collapse to an
+                    icon-only button — the name stays available via the tooltip. */}
+                <span className="min-w-0 truncate max-lg:hidden">{label}</span>
                 {!disabled && (
-                  <ChevronDown
-                    size={12}
-                    className={cn(
-                      "opacity-60 shrink-0",
-                      isHeader
-                        ? ""
-                        : "hidden @[320px]/chat-bottom:inline-block",
-                    )}
-                  />
+                  <ChevronDown size={12} className="opacity-60 shrink-0" />
                 )}
               </Button>
             </PopoverTrigger>

--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -198,9 +198,12 @@ export function BranchPicker({
               >
                 <GitBranch01 className="h-3.5 w-3.5 shrink-0" />
                 {/* Show the branch name (truncated) so the branch in use is
-                    visible at a glance. Below `lg` (< 1024px) collapse to an
-                    icon-only button — the name stays available via the tooltip. */}
-                <span className="min-w-0 truncate max-lg:hidden">{label}</span>
+                    visible at a glance. Below 768px of panel header collapse to
+                    an icon-only button — the name stays available via the
+                    tooltip. Container query, matching the rest of the strip. */}
+                <span className="min-w-0 truncate @max-3xl/panel-header:hidden">
+                  {label}
+                </span>
                 {!disabled && (
                   <ChevronDown size={12} className="opacity-60 shrink-0" />
                 )}

--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -48,10 +48,18 @@ interface Props {
 }
 
 /**
- * Leading icon per actionable header state. Below `lg` (< 1024px) the header
- * collapses these buttons to icon-only (the label moves to the tooltip); above
- * it, the text label shows as before. Status pills (no `action`) have no icon
- * and keep their text. `merge-split` is omitted — it renders via MergeSplitButton.
+ * Leading icon per actionable header state. Below 768px of PANEL HEADER these
+ * buttons collapse to icon-only (the label moves to the tooltip); above it the
+ * text label shows as before. Status pills (no `action`) have no icon and keep
+ * their text. `merge-split` is omitted — it renders via MergeSplitButton.
+ *
+ * The query is `@container/panel-header` (declared by PanelHeader), not the
+ * viewport: this cluster sits in one panel, so screen width says nothing about
+ * the room it has — with chat open a 1400px screen can leave it under 700px.
+ * 768px is the same cut the view tabs and Chat use, so the whole strip
+ * collapses together instead of in two stages. These components render only
+ * inside a PanelHeader; outside one the query finds no container and the label
+ * simply stays, which is the safe direction.
  */
 const ACTION_ICON: Partial<
   Record<
@@ -472,9 +480,9 @@ function HeaderButtonRenderer(props: {
   }
 
   const ActionIcon = button.action ? ACTION_ICON[button.action] : undefined;
-  // Actionable / loading states collapse to icon (or spinner) only below `lg`
-  // (< 1024px); the label stays reachable via the tooltip. Plain status pills
-  // (no action, not loading) keep their text at every size.
+  // Actionable / loading states collapse to icon (or spinner) only below 768px
+  // of panel header; the label stays reachable via the tooltip. Plain status
+  // pills (no action, not loading) keep their text at every size.
   const collapseLabel = Boolean(ActionIcon) || loading;
 
   return (
@@ -498,9 +506,9 @@ function HeaderButtonRenderer(props: {
           {loading ? (
             <Spinner size="xs" variant="default" />
           ) : ActionIcon ? (
-            <ActionIcon className="size-4 shrink-0 lg:hidden" />
+            <ActionIcon className="size-4 shrink-0 @3xl/panel-header:hidden" />
           ) : null}
-          <span className={cn(collapseLabel && "max-lg:hidden")}>
+          <span className={cn(collapseLabel && "@max-3xl/panel-header:hidden")}>
             {button.label}
           </span>
         </Button>
@@ -526,9 +534,9 @@ function HeaderButtonRenderer(props: {
             {props.publishGate.pending ? (
               <Spinner size="xs" variant="default" />
             ) : (
-              <Upload01 className="size-4 shrink-0 lg:hidden" />
+              <Upload01 className="size-4 shrink-0 @3xl/panel-header:hidden" />
             )}
-            <span className="max-lg:hidden">
+            <span className="@max-3xl/panel-header:hidden">
               {t("thread.headerActions.publish")}
             </span>
           </Button>

--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -1,13 +1,14 @@
 import { useMCPClient, useProjectContext, useVirtualMCP } from "@/sdk";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Spinner } from "@deco/ui/components/spinner.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@deco/ui/components/tooltip.tsx";
-import { useState, useRef } from "react";
+import { useState, useRef, type ComponentType } from "react";
 import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client.ts";
 import { coAuthorFromSessionUser } from "@/lib/co-author-identity.ts";
@@ -33,10 +34,38 @@ import { usePrReviews } from "./use-pr-reviews.ts";
 import { normalizePublishPolicy, type PublishGate } from "./sandbox-git-api.ts";
 import { useT, type TFunction } from "@/i18n/use-t";
 import { TOUR_ANCHORS } from "@/components/cms-tour/anchors";
+import {
+  AlertTriangle,
+  CheckCircle,
+  GitPullRequest,
+  MessageCircle01,
+  RefreshCw01,
+  Upload01,
+} from "@untitledui/icons";
 
 interface Props {
   virtualMcpId: string;
 }
+
+/**
+ * Leading icon per actionable header state. Below `lg` (< 1024px) the header
+ * collapses these buttons to icon-only (the label moves to the tooltip); above
+ * it, the text label shows as before. Status pills (no `action`) have no icon
+ * and keep their text. `merge-split` is omitted — it renders via MergeSplitButton.
+ */
+const ACTION_ICON: Partial<
+  Record<
+    NonNullable<HeaderButton["action"]>,
+    ComponentType<{ className?: string }>
+  >
+> = {
+  "create-pr": GitPullRequest,
+  reopen: RefreshCw01,
+  rebase: RefreshCw01,
+  "fix-checks": AlertTriangle,
+  "mark-ready": CheckCircle,
+  "resolve-comments": MessageCircle01,
+};
 
 // Sentinel for the branch-not-yet-selected state; labels are filled in
 // at render time using the translated versions from the component.
@@ -442,6 +471,12 @@ function HeaderButtonRenderer(props: {
     );
   }
 
+  const ActionIcon = button.action ? ACTION_ICON[button.action] : undefined;
+  // Actionable / loading states collapse to icon (or spinner) only below `lg`
+  // (< 1024px); the label stays reachable via the tooltip. Plain status pills
+  // (no action, not loading) keep their text at every size.
+  const collapseLabel = Boolean(ActionIcon) || loading;
+
   return (
     <div className="flex items-center gap-2">
       <WithTooltip label={tooltipLabel}>
@@ -460,8 +495,14 @@ function HeaderButtonRenderer(props: {
             if (button.action) props.onActivate(button.action);
           }}
         >
-          {loading ? <Spinner size="xs" variant="default" /> : null}
-          {button.label}
+          {loading ? (
+            <Spinner size="xs" variant="default" />
+          ) : ActionIcon ? (
+            <ActionIcon className="size-4 shrink-0 lg:hidden" />
+          ) : null}
+          <span className={cn(collapseLabel && "max-lg:hidden")}>
+            {button.label}
+          </span>
         </Button>
       </WithTooltip>
       {props.showPublishSide ? (
@@ -484,8 +525,12 @@ function HeaderButtonRenderer(props: {
           >
             {props.publishGate.pending ? (
               <Spinner size="xs" variant="default" />
-            ) : null}
-            {t("thread.headerActions.publish")}
+            ) : (
+              <Upload01 className="size-4 shrink-0 lg:hidden" />
+            )}
+            <span className="max-lg:hidden">
+              {t("thread.headerActions.publish")}
+            </span>
           </Button>
         </WithTooltip>
       ) : null}

--- a/apps/web/src/layouts/agent-shell-layout/header-layout.test.ts
+++ b/apps/web/src/layouts/agent-shell-layout/header-layout.test.ts
@@ -5,60 +5,36 @@ const { lead, tab, middle } = HEADER_W;
 
 describe("headerLayout", () => {
   test("unmeasured widths (-1 sentinel) → fully open", () => {
-    expect(headerLayout(-1, -1)).toEqual({
-      maxTabs: 3,
-      showPageSelector: true,
-    });
-    expect(headerLayout(1000, -1)).toEqual({
-      maxTabs: 3,
-      showPageSelector: true,
-    });
-    expect(headerLayout(-1, 200)).toEqual({
-      maxTabs: 3,
-      showPageSelector: true,
-    });
+    expect(headerLayout(-1, -1)).toEqual({ maxTabs: 3 });
+    expect(headerLayout(1000, -1)).toEqual({ maxTabs: 3 });
+    expect(headerLayout(-1, 200)).toEqual({ maxTabs: 3 });
   });
 
-  test("roomy → 3 tabs + selector", () => {
+  test("roomy → 3 tabs", () => {
     // avail = headerWidth - rightWidth must clear lead + 3*tab + middle.
     const avail = lead + 3 * tab + middle;
-    expect(headerLayout(avail + 200, 200)).toEqual({
-      maxTabs: 3,
-      showPageSelector: true,
-    });
+    expect(headerLayout(avail + 200, 200)).toEqual({ maxTabs: 3 });
   });
 
   test("degrades to 2 tabs just below the 3-tab threshold", () => {
     const threshold = lead + 3 * tab + middle;
-    expect(headerLayout(threshold - 1 + 200, 200)).toEqual({
-      maxTabs: 2,
-      showPageSelector: true,
-    });
+    expect(headerLayout(threshold - 1 + 200, 200)).toEqual({ maxTabs: 2 });
   });
 
   test("degrades to 1 tab below the 2-tab threshold", () => {
     const threshold = lead + 2 * tab + middle;
-    expect(headerLayout(threshold - 1 + 200, 200)).toEqual({
-      maxTabs: 1,
-      showPageSelector: true,
-    });
+    expect(headerLayout(threshold - 1 + 200, 200)).toEqual({ maxTabs: 1 });
   });
 
-  test("hides the page selector below the 1-tab+selector threshold", () => {
-    const threshold = lead + 1 * tab + middle;
-    expect(headerLayout(threshold - 1 + 200, 200)).toEqual({
-      maxTabs: 1,
-      showPageSelector: false,
-    });
+  test("1 tab is the floor — never drops to zero, however cramped", () => {
+    expect(headerLayout(0, 0)).toEqual({ maxTabs: 1 });
+    // A right cluster wider than the whole header (avail goes negative).
+    expect(headerLayout(300, 900)).toEqual({ maxTabs: 1 });
   });
 
   test("exact boundaries are inclusive (monotonic, no flicker-back)", () => {
     expect(headerLayout(lead + 3 * tab + middle, 0).maxTabs).toBe(3);
     expect(headerLayout(lead + 2 * tab + middle, 0).maxTabs).toBe(2);
-    expect(headerLayout(lead + 1 * tab + middle, 0)).toEqual({
-      maxTabs: 1,
-      showPageSelector: true,
-    });
   });
 
   test("a wide right cluster eats into avail and forces degradation", () => {
@@ -66,5 +42,12 @@ describe("headerLayout", () => {
     // With no right cluster it's 3 tabs; a big right cluster drops it.
     expect(headerLayout(headerWidth, 0).maxTabs).toBe(3);
     expect(headerLayout(headerWidth, tab).maxTabs).toBe(2);
+  });
+
+  test("the page selector is no longer decided here — it is a container query", () => {
+    // Moved to `@max-md/panel-header:hidden` in workspace-panel-group, so the
+    // budget must not resurrect a showPageSelector field (see PanelHeader).
+    expect(headerLayout(100, 0)).not.toHaveProperty("showPageSelector");
+    expect(headerLayout(5000, 0)).not.toHaveProperty("showPageSelector");
   });
 });

--- a/apps/web/src/layouts/agent-shell-layout/header-layout.test.ts
+++ b/apps/web/src/layouts/agent-shell-layout/header-layout.test.ts
@@ -45,7 +45,7 @@ describe("headerLayout", () => {
   });
 
   test("the page selector is no longer decided here — it is a container query", () => {
-    // Moved to `@max-md/panel-header:hidden` in workspace-panel-group, so the
+    // Moved to `@max-sm/panel-header:hidden` in workspace-panel-group, so the
     // budget must not resurrect a showPageSelector field (see PanelHeader).
     expect(headerLayout(100, 0)).not.toHaveProperty("showPageSelector");
     expect(headerLayout(5000, 0)).not.toHaveProperty("showPageSelector");

--- a/apps/web/src/layouts/agent-shell-layout/header-layout.ts
+++ b/apps/web/src/layouts/agent-shell-layout/header-layout.ts
@@ -28,9 +28,10 @@ export const HEADER_W = {
    * tab count — enough that it reads its page name rather than squishing to a
    * bare chevron. This is ONLY an allowance in the tab budget: it no longer
    * gates the center's visibility, which is a container query hiding it below
-   * 448px of header (see workspace-panel-group). Between ~448 and ~530px the
-   * center therefore shows with less than this and does squish — accepted, on
-   * the grounds that small controls beat absent ones.
+   * 384px of header (see workspace-panel-group). The center therefore shows
+   * with far less than this on narrow panels — the page name drops out around
+   * 448px, leaving the icon row down to its 112px floor — accepted, on the
+   * grounds that small controls beat absent ones.
    */
   middle: 232,
 } as const;

--- a/apps/web/src/layouts/agent-shell-layout/header-layout.ts
+++ b/apps/web/src/layouts/agent-shell-layout/header-layout.ts
@@ -1,16 +1,22 @@
 /**
- * Space budget (px) that drives the main header's responsive degradation.
+ * Space budget (px) that drives how many view tabs the main header renders.
  *
  * The header lays out as: [left group: chat + view tabs + tab-overflow] · [center:
  * Preview's page selector] · [right actions: CMS / branch / ⋯ / publish]. As the
- * panel narrows, controls drop in this exact order — 3rd tab, then 2nd tab, then
- * the whole center — and NEVER reappear (see `headerLayout`). The right actions
+ * panel narrows, controls drop in this order — button labels, then the 3rd tab,
+ * then the 2nd, then the whole center — and NEVER reappear. The right actions
  * always survive.
  *
- * Both decisions are computed from ONE pair of stable measurements — the header
- * width and the right-actions width — so nothing depends on the center gap (which
- * grows when a tab folds and previously made the selector flicker back). `avail =
- * headerWidth - rightWidth` is the room the left group + center actually share.
+ * Only the tab COUNT lives here. Label collapse and the center's visibility are
+ * container queries on `@container/panel-header` (see HeaderTabButton and
+ * workspace-panel-group), because CSS can express them without measuring. The
+ * count can't: dropping a tab changes which items render in the bar versus the
+ * overflow popover, so it needs a real number in JS.
+ *
+ * It is computed from ONE pair of stable measurements — the header width and the
+ * right-actions width — so nothing depends on the center gap, which grows when a
+ * tab folds. `avail = headerWidth - rightWidth` is the room the left group +
+ * center actually share.
  */
 export const HEADER_W = {
   /** Left prefix that's always there: chat toggle + tab-overflow menu + gaps. */
@@ -18,21 +24,23 @@ export const HEADER_W = {
   /** One labelled view tab. */
   tab: 132,
   /**
-   * Room the center (Preview's page selector) needs before it's shown at all —
-   * generous enough that when it DOES show it reads its page name instead of
-   * squishing to a bare chevron. Below this it's hidden (display:none), not
-   * shrunk.
+   * Room reserved for the center (Preview's page selector) when deciding the
+   * tab count — enough that it reads its page name rather than squishing to a
+   * bare chevron. This is ONLY an allowance in the tab budget: it no longer
+   * gates the center's visibility, which is a container query hiding it below
+   * 448px of header (see workspace-panel-group). Between ~448 and ~530px the
+   * center therefore shows with less than this and does squish — accepted, on
+   * the grounds that small controls beat absent ones.
    */
   middle: 232,
 } as const;
 
 /**
  * Given the header width and the measured right-actions width, decide how many
- * view tabs to show (rest fold into the ⋯ menu) and whether the center page
- * selector shows. Both are a monotonic function of `avail = headerWidth -
- * rightWidth`, so shrinking only ever drops controls (never brings one back).
- * Widths are `-1` until measured — treat that as roomy so the header opens fully
- * and only tightens once real measurements land.
+ * view tabs to show (the rest fold into the ⋯ menu). A monotonic function of
+ * `avail = headerWidth - rightWidth`, so shrinking only ever drops tabs (never
+ * brings one back). Widths are `-1` until measured — treat that as roomy so the
+ * header opens fully and only tightens once real measurements land.
  *
  * A CSS safety net (the left group is `min-w-0`/overflow-hidden and shrinks)
  * guarantees the right actions are never clipped even if these estimates run
@@ -41,17 +49,11 @@ export const HEADER_W = {
 export function headerLayout(
   headerWidth: number,
   rightWidth: number,
-): { maxTabs: number; showPageSelector: boolean } {
-  if (headerWidth < 0 || rightWidth < 0) {
-    return { maxTabs: 3, showPageSelector: true };
-  }
+): { maxTabs: number } {
+  if (headerWidth < 0 || rightWidth < 0) return { maxTabs: 3 };
   const avail = headerWidth - rightWidth;
   const { lead, tab, middle } = HEADER_W;
-  if (avail >= lead + 3 * tab + middle)
-    return { maxTabs: 3, showPageSelector: true };
-  if (avail >= lead + 2 * tab + middle)
-    return { maxTabs: 2, showPageSelector: true };
-  if (avail >= lead + 1 * tab + middle)
-    return { maxTabs: 1, showPageSelector: true };
-  return { maxTabs: 1, showPageSelector: false };
+  if (avail >= lead + 3 * tab + middle) return { maxTabs: 3 };
+  if (avail >= lead + 2 * tab + middle) return { maxTabs: 2 };
+  return { maxTabs: 1 };
 }

--- a/apps/web/src/layouts/agent-shell-layout/panel-header.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/panel-header.tsx
@@ -32,6 +32,14 @@ import { cn } from "@deco/ui/lib/utils.ts";
  * 48px header strip shared by every desktop panel. Sits on the sidebar
  * background above the panel card (no border/divider — the rounded card owns
  * the only visible edge).
+ *
+ * Declares `@container/panel-header`, the query container every control inside
+ * degrades against. It has to be the panel header rather than the viewport:
+ * this strip is one panel wide, so the same viewport yields very different
+ * header widths depending on whether chat is open and how the splitter sits
+ * (at a 1074px viewport the main header measures ~826px). Keying off the
+ * viewport made controls collapse at widths that had nothing to do with the
+ * room they actually had.
  */
 export function PanelHeader({
   children,
@@ -40,7 +48,10 @@ export function PanelHeader({
 }: ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex h-12 shrink-0 items-center gap-1 px-1.5", className)}
+      className={cn(
+        "@container/panel-header flex h-12 shrink-0 items-center gap-1 px-1.5",
+        className,
+      )}
       {...props}
     >
       {children}

--- a/apps/web/src/layouts/agent-shell-layout/toggle-buttons.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/toggle-buttons.tsx
@@ -32,6 +32,8 @@ export function ChatToggle({
       icon={{ kind: "component", Component: MessageCircle01 }}
       active={sidePanel === "chat"}
       disabled={disableActiveSidePanelToggle && sidePanel === "chat"}
+      // Distinctive icon — collapses with the system tabs at 768px of header.
+      labelCollapse="sooner"
       className="wco-no-drag h-10 md:h-7 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50"
       onClick={() => {
         track("agent_toolbar_toggled", {

--- a/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
@@ -139,7 +139,7 @@ export function WorkspacePanelGroup({
   // opens fully first.
   const [headerWidth, headerRef] = useElementWidth();
   const [rightWidth, rightRef] = useElementWidth();
-  const { maxTabs, showPageSelector } = headerLayout(headerWidth, rightWidth);
+  const { maxTabs } = headerLayout(headerWidth, rightWidth);
 
   // The agent switcher + new-chat action live in the nav sidebar while it's
   // expanded. When the sidebar is collapsed it has no room for them, so we
@@ -214,13 +214,22 @@ export function WorkspacePanelGroup({
         />
       </div>
       {/* The page selector centers between the two side groups in this flex-1
-          gap. `headerLayout` decides its visibility from the header/right widths
-          (not this gap), so it never flickers back when a tab folds; below the
-          threshold the slot is hidden (display:none) rather than squished. The
-          portal target stays mounted so Preview keeps rendering into it instead
-          of falling back to its inline toolbar. */}
+          gap. It hides below 448px of PANEL HEADER — a container query on
+          `@container/panel-header`, not this flex gap (which grows when a tab
+          folds and used to flicker the selector back) and not the viewport
+          (one panel is far narrower than the screen). It goes AFTER the tab
+          labels collapse, so shedding those buys the selector its room first.
+          The portal target stays mounted so Preview keeps rendering into it
+          instead of falling back to its inline toolbar.
+
+          448px is a deliberate call to keep the group around longer than the
+          old JS rule did (it hid below ~668px). The trade: between roughly 448
+          and 530px the selector has less than HEADER_W.middle to work with and
+          degrades toward a bare chevron instead of showing its page name. That
+          squish is accepted here — losing the controls entirely was judged
+          worse than showing them small. */}
       <div className="flex min-w-0 flex-1 items-center justify-center">
-        <MainPanelHeaderSlot className={cn(!showPageSelector && "hidden")} />
+        <MainPanelHeaderSlot className="@max-md/panel-header:hidden" />
       </div>
       {/* Right side. The wrapper is shrinkable so the branch selector inside it
           can yield BEFORE the centered address bar (which is `flex-1` — basis 0,

--- a/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
@@ -214,7 +214,7 @@ export function WorkspacePanelGroup({
         />
       </div>
       {/* The page selector centers between the two side groups in this flex-1
-          gap. It hides below 448px of PANEL HEADER — a container query on
+          gap. It hides below 384px of PANEL HEADER — a container query on
           `@container/panel-header`, not this flex gap (which grows when a tab
           folds and used to flicker the selector back) and not the viewport
           (one panel is far narrower than the screen). It goes AFTER the tab
@@ -222,14 +222,20 @@ export function WorkspacePanelGroup({
           The portal target stays mounted so Preview keeps rendering into it
           instead of falling back to its inline toolbar.
 
-          448px is a deliberate call to keep the group around longer than the
-          old JS rule did (it hid below ~668px). The trade: between roughly 448
-          and 530px the selector has less than HEADER_W.middle to work with and
-          degrades toward a bare chevron instead of showing its page name. That
-          squish is accepted here — losing the controls entirely was judged
-          worse than showing them small. */}
+          384px is set by the group's measured floor: its min-content is 112px
+          (36 CMS + 28 refresh + 24 page chevron + 28 open-in-new-tab), and a
+          header that size leaves ~112-128px once the left group (66px — the
+          tab budget is down to one tab this narrow) and the actions (178px)
+          take their share. One breakpoint lower and the icons clip. Note the
+          query measures the CONTENT box, so with `px-1.5` this fires around
+          396px of rendered width — a ~16px margin above the floor, not on it.
+
+          Deliberately far later than the old JS rule (~668px). The trade: the
+          page NAME is gone from ~448px down — the selector is a bare chevron
+          there — so 384-448px is four usable icons without a label. Losing the
+          controls outright was judged worse than losing the label. */}
       <div className="flex min-w-0 flex-1 items-center justify-center">
-        <MainPanelHeaderSlot className="@max-md/panel-header:hidden" />
+        <MainPanelHeaderSlot className="@max-sm/panel-header:hidden" />
       </div>
       {/* Right side. The wrapper is shrinkable so the branch selector inside it
           can yield BEFORE the centered address bar (which is `flex-1` — basis 0,

--- a/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
@@ -222,18 +222,24 @@ export function WorkspacePanelGroup({
       <div className="flex min-w-0 flex-1 items-center justify-center">
         <MainPanelHeaderSlot className={cn(!showPageSelector && "hidden")} />
       </div>
-      {/* shrink-0: the right actions (Edit / Submit / Publish / ⋯) are the
-          highest-priority controls — they hold their size and are never
-          clipped; the selector and tab group yield instead. Measured so the
-          tab count knows how much room is actually left for it. */}
-      <div
-        ref={rightRef}
-        className="flex shrink-0 items-center justify-end gap-1"
-      >
+      {/* Right side. The wrapper is shrinkable so the branch selector inside it
+          can yield BEFORE the centered address bar (which is `flex-1` — basis 0,
+          so it shrinks last). The branch sits in its own `min-w-0` slot and
+          truncates first; the actions cluster stays `shrink-0` (Edit / Submit /
+          Publish / ⋯ never clip) and is what `rightRef` measures, so the tab
+          count budget is unaffected by the branch label's width. */}
+      <div className="flex min-w-0 shrink items-center justify-end gap-1">
         {!chatOpen && newChatCrumb}
-        {branchSelector}
-        <MainPanelHeaderEndSlot />
-        {publishActions}
+        <div className="flex min-w-0 shrink items-center justify-end">
+          {branchSelector}
+        </div>
+        <div
+          ref={rightRef}
+          className="flex shrink-0 items-center justify-end gap-1"
+        >
+          <MainPanelHeaderEndSlot />
+          {publishActions}
+        </div>
       </div>
     </PanelHeader>
   );

--- a/apps/web/src/layouts/main-panel-tabs/header-tab-button.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/header-tab-button.tsx
@@ -1,16 +1,37 @@
 /**
  * HeaderTabButton — a tab in the agent-shell header tab bar.
  *
- * Both active and inactive tabs always show icon + label. The active
- * tab gets the accent background; inactive tabs are muted.
+ * Every tab shows its icon at all sizes; the text label drops out per
+ * `labelCollapse`, leaving an icon-only button. That decision is a CONTAINER
+ * query against the enclosing PanelHeader, not a viewport media query — the
+ * button cares how wide its panel is, not how wide the screen is.
  *
- * Every button is wrapped in a Tooltip showing the tab title so the
- * title is discoverable on hover in both states.
+ * The active tab gets the accent background; inactive tabs are muted.
+ *
+ * Every button is wrapped in a Tooltip so the title stays discoverable in both
+ * states — and, once the label is gone, so an icon-only tab is identifiable at
+ * all. Tabs whose icon resolves to the generic fallback (see resolve-tab-icon)
+ * are otherwise indistinguishable from one another.
  */
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import type { TabIcon } from "./resolve-tab-icon";
 import { TabIconGlyph } from "./tab-icon-glyph";
+
+/** Static class per tier — Tailwind only sees literal strings, so these can't
+ *  be built by interpolation. Queries `@container/panel-header` (PanelHeader),
+ *  NOT the viewport: these buttons live in a single panel, so panel width is
+ *  the only measure of the room they actually have. Outside a PanelHeader no
+ *  container matches and the label simply stays — the safe direction. */
+const LABEL_HIDDEN_BELOW = {
+  sooner: "@max-3xl/panel-header:hidden",
+  later: "@max-xl/panel-header:hidden",
+} as const;
 
 export function HeaderTabButton({
   title,
@@ -22,6 +43,8 @@ export function HeaderTabButton({
   className,
   testId,
   dataTour,
+  tooltip,
+  labelCollapse = "later",
 }: {
   title: string;
   icon: TabIcon;
@@ -42,8 +65,23 @@ export function HeaderTabButton({
    *  (the Chat toggle) tweak height / drag behaviour while staying pixel-
    *  identical to the tabs. */
   className?: string;
+  /** Tooltip copy, when it must differ from the label — e.g. a toggle whose
+   *  hover text describes the *next* action ("Exit editor") rather than the
+   *  button's name. Defaults to `title`. Pass this instead of wrapping the
+   *  button in your own Tooltip, which would nest two of them. */
+  tooltip?: string;
+  /** How soon the label is dropped as the PANEL HEADER narrows, leaving icon +
+   *  tooltip. Labels always go before the centered address bar does (which
+   *  hides at 448px), because shedding ~40px per button is what buys the
+   *  centre its room — the same degradation order headerLayout documents.
+   *  - `sooner` (< 768px) — Chat and the system tabs (Preview, Code, Library,
+   *    Tasks). Fixed, distinctive icons, so they read fine bare.
+   *  - `later` (< 576px, default) — dynamic tabs (files, pinned views, expanded
+   *    tools). Their icon can resolve to the generic fallback, so several open
+   *    at once would be indistinguishable; they hold their text longest. */
+  labelCollapse?: "sooner" | "later";
 }) {
-  return (
+  const button = (
     <button
       type="button"
       onClick={onClick}
@@ -67,9 +105,21 @@ export function HeaderTabButton({
       <span className="flex size-5 items-center justify-center shrink-0">
         <TabIconGlyph icon={icon} />
       </span>
-      <span className="max-md:hidden whitespace-nowrap text-sm font-medium leading-none">
+      <span
+        className={cn(
+          LABEL_HIDDEN_BELOW[labelCollapse],
+          "whitespace-nowrap text-sm font-medium leading-none",
+        )}
+      >
         {title}
       </span>
     </button>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent side="bottom">{tooltip ?? title}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/web/src/layouts/main-panel-tabs/header-tab-button.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/header-tab-button.tsx
@@ -72,7 +72,7 @@ export function HeaderTabButton({
   tooltip?: string;
   /** How soon the label is dropped as the PANEL HEADER narrows, leaving icon +
    *  tooltip. Labels always go before the centered address bar does (which
-   *  hides at 448px), because shedding ~40px per button is what buys the
+   *  hides at 384px), because shedding ~40px per button is what buys the
    *  centre its room — the same degradation order headerLayout documents.
    *  - `sooner` (< 768px) — Chat and the system tabs (Preview, Code, Library,
    *    Tasks). Fixed, distinctive icons, so they read fine bare.

--- a/apps/web/src/layouts/main-panel-tabs/main-panel-tabs-bar.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/main-panel-tabs-bar.tsx
@@ -37,6 +37,10 @@ type BarItem = {
   active: boolean;
   locked: boolean;
   onSelect: () => void;
+  /** How soon this button drops its label as the panel header narrows (see
+   *  HeaderTabButton). Buttons with a fixed, distinctive icon go `sooner`;
+   *  those that can fall back to a generic glyph hold their text `later`. */
+  labelCollapse: "sooner" | "later";
 };
 
 export function MainPanelTabsBar({
@@ -109,6 +113,7 @@ export function MainPanelTabsBar({
       icon: { kind: "component", Component: Folder },
       active: library.active,
       locked: false,
+      labelCollapse: "sooner",
       onSelect: () => {
         track("agent_toolbar_toggled", {
           button: "library",
@@ -125,6 +130,7 @@ export function MainPanelTabsBar({
       icon: { kind: "component", Component: Columns03 },
       active: tasks.active,
       locked: false,
+      labelCollapse: "sooner",
       onSelect: () => {
         track("agent_toolbar_toggled", {
           button: "tasks",
@@ -142,6 +148,7 @@ export function MainPanelTabsBar({
     active: isTabActive(tab),
     locked: disableActiveMainToggle && isTabActive(tab),
     onSelect: () => selectTab(tab.id),
+    labelCollapse: tab.kind === "system" ? "sooner" : "later",
   }));
 
   const items = [...tabItems, ...overlayItems];
@@ -186,6 +193,7 @@ export function MainPanelTabsBar({
           locked={item.locked}
           onClick={item.onSelect}
           dataTour={`tour-tab-${item.id}`}
+          labelCollapse={item.labelCollapse}
         />
       ))}
       {overflow.length > 0 && (


### PR DESCRIPTION
UI-only header/branch fixes (split out of #5215).

- **Branch button** always shows the current branch (truncated), and now yields its width **before** the centered address bar — it sits in its own `min-w-0` shrink slot, while the fixed publish/⋯ actions never clip and remain what `rightRef` measures (so the tab-count budget is unaffected).
- Below **`lg` (< 1024px)** the header collapses to **icon-only + tooltip**: the branch button, the primary action button (icon keyed off `button.action` — GitPullRequest / RefreshCw01 / AlertTriangle / CheckCircle / MessageCircle01), the side **Publish** (`Upload01`), and the **Develop/Live** toggle (`Code01` / `Globe01`). Loading pills → spinner-only; plain status pills keep their text. Desktop unchanged.

Layout/presentational only — no logic. `tsc` + oxlint clean.

---

## The problem, for anyone not on a big monitor

The panel header collapsed its controls on **viewport** media queries (`lg`, 1024px). But the header doesn't span the viewport — it lives inside one panel. So screen width tells you almost nothing about the room it actually has:

| Situation | Screen | Main panel header |
|---|---|---|
| Chat closed | 1074px | 826px |
| **Chat open** | **1180px** | **605px** |

That second row is the bug. At a 1180px screen the viewport rule says "plenty of room, show every label" — while the strip is actually 605px and out of space. The labels stayed full-width, the tab budget got squeezed, and view tabs fell into the ⋯ overflow menu earlier than they needed to.

It also meant the *same* screen behaved differently depending on where you dragged the splitter, which is impossible to reason about — and it's why this looked fine on a wide monitor and bad on a laptop.

Reported as: "the screen is 882px wide and I'm still seeing the chat and preview labels."

## What changed

`PanelHeader` now declares `@container/panel-header` and every control inside queries **its own panel's width**:

| Control | Collapses below | Was |
|---|---|---|
| Chat, system tabs (Preview/Code), Library, Tasks, CMS | 768px of header | viewport 768px / none |
| Dynamic tabs (files, pinned views, expanded tools) | 576px of header | viewport 768px |
| Branch pill, branch picker, Develop/Live, Publish | 768px of header | viewport 1024px |
| Preview's URL group (CMS · refresh · page select · open-in-new-tab) | 448px of header | JS measurement, ~668px |

Two tiers rather than one, because the icon has to carry the button once the label goes. Chat/Preview/Code/Library/Tasks have fixed, distinctive icons and collapse first. Dynamic tabs can resolve to a **generic fallback glyph** (`resolve-tab-icon.ts`), so several open files would become mutually indistinguishable — they hold their text longest.

**Small screens keep the Preview controls much longer**: the old JS rule hid the whole URL group below ~668px of header; it now survives to 448px.

### Tabs finally have tooltips

`HeaderTabButton` had **no Tooltip at all**, while its own docstring claimed "every button is wrapped in a Tooltip." Below `md` the tabs were already collapsing to bare icons — so on a small screen you got an unlabelled icon with nothing identifying it but `aria-label`. That's the part that actually hurt. Tooltips are now real, which is what makes collapsing labels safe in the first place.

`preview.tsx` wrapped one of these in its own Tooltip; that's replaced by a `tooltip` prop so the two don't nest.

## Screenshots

**1440px, chat closed** — header 1192px, everything labelled.

<img width="2880" height="1640" alt="1-wide-1440" src="https://github.com/user-attachments/assets/c2e2dc87-4fcc-451b-a4f1-8b9821c549f4" />

**1000px, chat closed** — header ~752px, labels collapsed to icon + tooltip, page selector still there.

<img width="2000" height="1640" alt="2-mid-1000" src="https://github.com/user-attachments/assets/9d9ad5c6-c457-4dfc-a290-4954f6b9ea7e" />

**1180px, chat open** — header 605px. The point of the PR: a *large* screen where the panel is narrow, so the strip collapses. Under the old rule this showed full labels and ran out of room.

<img width="2360" height="1640" alt="3-chat-open-1180" src="https://github.com/user-attachments/assets/b59a93c1-7006-44a4-8568-444d1c6f3b72" />

## Trade-off worth a reviewer's opinion

The URL group's 448px cutoff is deliberately later than the old ~668px. Between roughly **448 and 530px** the page selector has less than `HEADER_W.middle` (232px) and degrades toward a bare chevron instead of showing the page name — measured 220px at a 530px header, 150px at 460px.

That squish is the accepted cost of keeping the controls reachable on narrow panels; the old code hid them instead. Documented at the call site. Easy to move to 576px (`@xl`) if it reads badly in practice.

## Dead code removed

`headerLayout` no longer returns `showPageSelector` — CSS owns that now, so keeping it would be dead. `maxTabs` stays in JS, because it changes *which* items render in the bar vs the overflow popover and CSS can't express that. Its tests were inverted rather than appended to, plus one asserting the field doesn't come back. `HEADER_W.middle`'s docstring no longer claims to gate the centre's visibility.

## Testing

- `bun run check` clean across all workspaces; `bun run lint` 0 errors; `bun run fmt` applied.
- 1029 unit tests pass (`apps/web` layouts, sandbox, chat).
- Verified in the running app by driving the container's inline size directly and sweeping the thresholds:

| Forced header | Chat label | Centre group |
|---|---|---|
| 820, 780 | shown | visible (397, 379px) |
| **767** | **collapsed** | visible (361px) |
| 700 | collapsed | visible (361px) |
| 530 | collapsed | visible (220px — into the squish band) |
| 460 | collapsed | visible (150px) |
| **447** | collapsed | **hidden** |

- Confirmed all four right-cluster components (`BranchPill`, `BranchPicker`, `DevAgentControl`, `HeaderActions`) render **only** inside a `PanelHeader`, so the container always resolves. Outside one the query finds no container and the label simply stays — the safe direction.
- Mobile (`MobileTaskWorkspace`) doesn't render the branch selector or publish actions at all; Preview's inline fallback bar declares the same container so its queries still work on that path.

## Also in here: the CMS toggle gets its own icon

`Edit05` was doing double duty as the new-chat affordance (`task-groups-list.tsx`, `shell-breadcrumb.tsx`) *and* the header's CMS toggle — two unrelated actions, one pencil-square. That collision matters more once the label collapses and the icon is the only thing identifying the button. Now `PuzzlePiece01` (the page-builder "blocks" metaphor, unused elsewhere), applied to **both** entry points: the toolbar button and the ⋯ menu fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the header by panel container width using `@container/panel-header`, keeps the current branch visible (truncated), and switches key actions/toggles to icon-only with tooltips at small widths. Also centers the page selector in the mobile preview toolbar and lowers the Preview URL group cutoff to 384px so controls stay usable longer.

- **UI Improvements**
  - Branch sits in its own `min-w-0` slot before the centered address bar; right-side actions stay `shrink-0` and are the only area measured by `rightRef`, so tab count is unaffected.
  - Container queries drive collapse: branch picker/pill, primary action, side Publish, and Develop/Live go icon-only below 768px; tab/chat labels collapse with tooltips (system tabs at 768px, dynamic tabs at 576px); Preview URL group hides below 384px. JS now only decides `maxTabs` (1–3); page selector visibility is CSS-driven.
  - Icons and tooltips: primary action uses state icons (GitPullRequest, RefreshCw01, AlertTriangle, CheckCircle, MessageCircle01); side Publish uses Upload01; Develop/Live use Code01/Globe01; CMS toggle switches to PuzzlePiece01. Tabs now have tooltips; loading pills are spinner-only, while plain status pills keep text.

- **Bug Fixes**
  - Mobile preview toolbar declares `@container/panel-header` and centers the page selector between the CMS toggle (left) and ⋯ (right).
  - Branch picker opens focused on the current branch and marks it with a check.

<sup>Written for commit 6b8827c22b3acd9f05ecd7c45dbd67d24bd2b840. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

