### PR TITLE
fix(chat): New chat always creates, on the current branch

### DIFF
--- a/apps/web/src/components/header/shell-breadcrumb.tsx
+++ b/apps/web/src/components/header/shell-breadcrumb.tsx
@@ -227,25 +227,24 @@ export function NewChatCrumb() {
   const params = useParams({ strict: false }) as { taskId?: string };
   const search = useSearch({ strict: false }) as { virtualmcpid?: string };
   const { threads } = useThreads();
-  const { data: session } = authClient.useSession();
-  const { setTaskId, createNewTask } = usePanelActions();
+  const { createNewTask } = usePanelActions();
 
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
   const activeAgentId = params.taskId
     ? (search.virtualmcpid ?? decopilotId)
     : decopilotId;
 
+  // A new chat inherits the branch of the thread being viewed, so it lands on
+  // the same sandbox/branch. `null` on the home/agentless route (no active
+  // thread) → server default.
+  const currentBranch =
+    (params.taskId
+      ? threads.find((t) => t.id === params.taskId)?.branch
+      : null) ?? null;
+
+  // ALWAYS create a fresh chat — never reuse/refocus an existing empty one.
   const handleNewChat = () => {
-    const existing = findReusableNewChat(
-      threads,
-      activeAgentId,
-      session?.user?.id,
-    );
-    if (existing) {
-      setTaskId(existing.id, activeAgentId);
-    } else {
-      void createNewTask(activeAgentId);
-    }
+    void createNewTask(activeAgentId, currentBranch);
   };
 
   return (

--- a/apps/web/src/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/web/src/components/sidebar/task-groups/task-groups-list.tsx
@@ -34,8 +34,6 @@ import {
 } from "@deco/ui/components/sidebar.tsx";
 import {
   getWellKnownDecopilotVirtualMCP,
-  SELF_MCP_ALIAS_ID,
-  useMCPClient,
   useProjectContext,
   useVirtualMCPs,
 } from "@/sdk";
@@ -144,11 +142,6 @@ export function TaskGroupsList({
   const { data: session } = authClient.useSession();
   const currentUserId = session?.user?.id;
   const { org } = useProjectContext();
-  const client = useMCPClient({
-    connectionId: SELF_MCP_ALIAS_ID,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
   // Agent entities (for the collapsed rail's per-thread avatars).
   const agents = useVirtualMCPs();
@@ -275,39 +268,17 @@ export function TaskGroupsList({
     setTaskId(t.id, t.virtual_mcp_id);
   };
 
-  // Verify a thread has no messages (an unsent "New chat"), so we can reuse it
-  // instead of spawning another empty one. Failure → treat as non-empty.
-  const isThreadEmpty = async (threadId: string): Promise<boolean> => {
-    try {
-      const res = await client.callTool({
-        name: "COLLECTION_THREAD_MESSAGES_LIST",
-        arguments: { thread_id: threadId, limit: 1, offset: 0 },
-      });
-      const payload = ((res as { structuredContent?: unknown })
-        .structuredContent ?? res) as { items?: unknown[] };
-      return (payload.items?.length ?? 0) === 0;
-    } catch {
-      return false;
-    }
-  };
-
-  // New thread: always target the currently selected agent (the active
-  // thread's agent, else decopilot). To avoid piling up empties, focus an
-  // existing empty "New chat" for that agent (verified to have no messages)
-  // instead of spawning another.
-  const handleNewThread = async () => {
+  // New thread: ALWAYS create a fresh chat on the currently selected agent (the
+  // active thread's agent, else decopilot), inheriting the active thread's
+  // branch so it lands on the same sandbox/branch. Every click creates — we do
+  // not reuse/refocus an existing empty "New chat".
+  const handleNewThread = () => {
     const currentAgentId = activeAgentId ?? decopilotId;
+    const currentBranch =
+      allThreads.find((t) => t.id === activeTaskId)?.branch ?? null;
     track("sidebar_new_thread_clicked", { virtual_mcp_id: currentAgentId });
-    const candidate = myThreadsAll.find(
-      (t) => t.virtual_mcp_id === currentAgentId && t.title === "New chat",
-    );
-    if (candidate && (await isThreadEmpty(candidate.id))) {
-      closeAfterNavigation();
-      setTaskId(candidate.id, currentAgentId);
-      return;
-    }
     closeAfterNavigation();
-    createNewTask(currentAgentId);
+    createNewTask(currentAgentId, currentBranch);
   };
 
   const { state: sidebarState, isMobile, toggleSidebar } = useSidebar();

--- a/apps/web/src/hooks/use-layout-state.ts
+++ b/apps/web/src/hooks/use-layout-state.ts
@@ -15,7 +15,7 @@
 import { useRef } from "react";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { resolveDefaultTabId } from "@/layouts/main-panel-tabs/tab-id";
-import { useThreadActions } from "@/components/chat/store/hooks";
+import { useThreadActions, useThreads } from "@/components/chat/store/hooks";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -193,6 +193,7 @@ export function useWorkspaceLayoutState(
     taskId?: string;
   };
   const { create } = useThreadActions();
+  const { threads } = useThreads();
 
   const { virtualMcpId, orgSlug, isAgentRoute } = routeCtx;
   const mainParam = search.main === 0 ? "0" : search.main;
@@ -276,13 +277,17 @@ export function useWorkspaceLayoutState(
     if (update) navigateSearch(update, { replace: true });
   };
 
-  // The server assigns the default branch for the new thread.
+  // Inherit the branch of the thread the user is currently viewing, so a new
+  // chat lands on the same sandbox/branch (not the shared default). Branchless /
+  // unknown → omit and let the server assign the default.
   const createNewTask = async () => {
     const newTaskId = crypto.randomUUID();
+    const branch = threads.find((t) => t.id === taskId)?.branch ?? null;
     try {
       await create({
         id: newTaskId,
         virtual_mcp_id: virtualMcpId,
+        ...(branch ? { branch } : {}),
       });
     } catch {
       // Toast already fired by useCollectionActions; navigate anyway so the

--- a/apps/web/src/layouts/shell-layout.tsx
+++ b/apps/web/src/layouts/shell-layout.tsx
@@ -154,13 +154,21 @@ export function usePanelActions() {
   };
 
   // Create the row before navigating so the route loader does not race its
-  // create-on-404 fallback. The server assigns the default branch.
+  // create-on-404 fallback.
   //
   // `virtualMcpId` lets callers (e.g. the per-group "+" in the sidebar) pin
   // the thread to a specific agent regardless of the current URL. When
   // omitted, falls back to the URL's `virtualmcpid`, then to the well-known
   // Decopilot agent.
-  const createNewTask = async (virtualMcpId?: string) => {
+  //
+  // `branch` lets a "New chat on the branch I'm viewing" caller inherit the
+  // current thread's branch. When omitted/null (e.g. a branchless agent, or an
+  // "open agent X" flow), the server assigns the default branch. The schema
+  // only accepts a non-empty branch string, so null/empty is dropped.
+  const createNewTask = async (
+    virtualMcpId?: string,
+    branch?: string | null,
+  ) => {
     const newId = crypto.randomUUID();
     const targetVmcp =
       virtualMcpId ??
@@ -172,6 +180,7 @@ export function usePanelActions() {
       await manager?.create({
         id: newId,
         virtual_mcp_id: targetVmcp,
+        ...(branch ? { branch } : {}),
       });
     } catch {
       // Toast already fired by useCollectionActions; navigate anyway so the


### PR DESCRIPTION
https://github.com/user-attachments/assets/5f3c64df-dfde-4114-b7f0-1da00c73e2a8

New-chat behavior fixes (split out of #5215).

- **Always creates.** The New chat button now creates a fresh thread every click — removed the empty-chat reuse short-circuit from both entry points (header `NewChatCrumb` + sidebar `handleNewThread`); it no longer navigates to / reuses an existing empty "New chat". Dropped the now-dead `isThreadEmpty` helper + its MCP client.
- **Inherits the current branch.** The new thread lands on the branch/sandbox you're viewing instead of the hardcoded `staging` default — `createNewTask` threads the branch through (panel-actions + keyboard-shortcut paths). No backend change (the wire schema already accepts `branch`). "Open agent X" flows are untouched.

`tsc` + oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New Chat now always creates a new thread and inherits the branch you're viewing, so it opens in the same sandbox.

- **Bug Fixes**
  - Removed empty-chat reuse in header and sidebar; every click creates a new thread.
  - Threaded `branch` into `createNewTask` (panel actions + keyboard path); server default applies when absent.
  - Deleted `isThreadEmpty` and its MCP client.
  - "Open agent X" flows unchanged; no backend changes.

<sup>Written for commit 5cfd180f79def4fc44440f20e342565a3939a58b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

