### PR TITLE
refactor(storage): remove dead OrgFsEntryStorage.move

### DIFF
--- a/apps/api/src/storage/org-fs.ts
+++ b/apps/api/src/storage/org-fs.ts
@@ -633,39 +633,6 @@ export class OrgFsEntryStorage {
       .executeTakeFirst();
     return row?.seq ?? "0";
   }
-
-  /**
-   * Move/rename a file or directory within the same volume.
-   * The destination path must not already exist (move fails if it does).
-   * Updates the path, parent, and seq fields.
-   */
-  async move(
-    organizationId: string,
-    volume: string,
-    fromPath: string,
-    toPath: string,
-    actor: string,
-  ): Promise<void> {
-    const now = new Date();
-    // Extract parent directory from toPath
-    const lastSlash = toPath.lastIndexOf("/");
-    const toParent = lastSlash === -1 ? "" : toPath.slice(0, lastSlash);
-
-    await this.db
-      .updateTable("org_fs_entry")
-      .set({
-        path: toPath,
-        parent: toParent,
-        updated_by: actor,
-        updated_at: now,
-        seq: NEXT_SEQ,
-      })
-      .where("organization_id", "=", organizationId)
-      .where("volume", "=", volume)
-      .where("path", "=", fromPath)
-      .where("deleted_at", "is", null)
-      .execute();
-  }
 }
 
 /** Escape LIKE wildcards in a literal path prefix. */


### PR DESCRIPTION
**Source:** dead-code reduction found while auditing `apps/api/src/storage/org-fs.ts` (org-fs storage layer focus area).

**Why:** `OrgFsEntryStorage.move()` (apps/api/src/storage/org-fs.ts) has zero callers anywhere in the codebase. Confirmed via `rg "\.move\(" apps/ packages/" and `rg "orgFsEntries\."` — the only `.move(` call site is `apps/api/src/api/routes/org-fs.ts:802`, which calls `r.fs.move(...)`, a *different* class: `OrgFs.move` in `apps/api/src/file-storage/org-fs.ts`. That service implements move/rename itself (copy each file/dir via `putFile`/`putDir` then tombstone the source subtree — see `file-storage/org-fs.ts` around line 524) and never delegates to the storage manifest's `move()`. The manifest method is also missing its own test file, so it wasn't exercised anywhere.

**Net line delta:** -33 / +0. Behavior-preserving: the removed method was unreachable dead code, so no runtime path changes.

**How I confirmed:** grepped the whole repo (`apps/`, `packages/`) for any call to `.move(` or `orgFsEntries.move` — the only real caller uses the unrelated `OrgFs.move` service, not this manifest method.

**Command a reviewer runs to confirm:**
```
rg "orgFsEntries\.move|manifest\.move\(" apps/ packages/
cd apps/api && bunx tsc --noEmit
```

**Checks run locally:** `bun run fmt` (clean), `cd apps/api && bunx tsc --noEmit` (clean, no test file existed for this method so no targeted test was skipped). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead code by deleting OrgFsEntryStorage.move from the org-fs storage layer. No behavior changes; move/rename is handled by OrgFs.move in file storage.

- **Refactors**
  - Deleted unused method in apps/api/src/storage/org-fs.ts (-33 LOC).
  - Verified no call sites; org-fs routes use file-storage OrgFs.move instead.

<sup>Written for commit 572ab2324dc8d3e68cf397035237dae111dc1a9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

