### PR TITLE
fix(virtual-mcp): reject non-virtual connections in plugin config get

### DIFF
--- a/apps/api/src/tools/virtual/plugin-config-get.test.ts
+++ b/apps/api/src/tools/virtual/plugin-config-get.test.ts
@@ -3,7 +3,10 @@ import { VIRTUAL_MCP_PLUGIN_CONFIG_GET } from "./plugin-config-get";
 
 function makeCtx(opts: {
   organizationId: string;
-  connections: Record<string, { id: string; organization_id: string }>;
+  connections: Record<
+    string,
+    { id: string; organization_id: string; connection_type?: string }
+  >;
 }) {
   const get = mock(async () => ({
     id: "vpc_1",
@@ -52,7 +55,13 @@ describe("VIRTUAL_MCP_PLUGIN_CONFIG_GET", () => {
   it("returns the config for a virtual MCP within the caller's own organization", async () => {
     const { ctx, get } = makeCtx({
       organizationId: "org-a",
-      connections: { vmcp_a: { id: "vmcp_a", organization_id: "org-a" } },
+      connections: {
+        vmcp_a: {
+          id: "vmcp_a",
+          organization_id: "org-a",
+          connection_type: "VIRTUAL",
+        },
+      },
     });
 
     const result = await VIRTUAL_MCP_PLUGIN_CONFIG_GET.handler(
@@ -62,5 +71,29 @@ describe("VIRTUAL_MCP_PLUGIN_CONFIG_GET", () => {
 
     expect(result.config?.virtualMcpId).toBe("vmcp_a");
     expect(get).toHaveBeenCalledWith("vmcp_a", "code-execution");
+  });
+
+  it("returns null for a virtualMcpId that points at a non-virtual connection", async () => {
+    // Regression: leftover plugin config rows keyed by a non-virtual
+    // connection (data written before VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE
+    // started rejecting non-virtual connections) must not be surfaced here.
+    const { ctx, get } = makeCtx({
+      organizationId: "org-a",
+      connections: {
+        conn_a: {
+          id: "conn_a",
+          organization_id: "org-a",
+          connection_type: "HTTP",
+        },
+      },
+    });
+
+    const result = await VIRTUAL_MCP_PLUGIN_CONFIG_GET.handler(
+      { virtualMcpId: "conn_a", pluginId: "code-execution" },
+      ctx,
+    );
+
+    expect(result.config).toBeNull();
+    expect(get).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/tools/virtual/plugin-config-get.ts
+++ b/apps/api/src/tools/virtual/plugin-config-get.ts
@@ -59,6 +59,13 @@ export const VIRTUAL_MCP_PLUGIN_CONFIG_GET = defineTool({
     ) {
       return { config: null };
     }
+    // This tool only manages plugin config for virtual MCPs — a plugin
+    // config row keyed by a non-virtual connection can only exist as leftover
+    // data from before VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE started rejecting
+    // non-virtual connections (see plugin-config-update.ts), so don't surface it.
+    if (parentConnection.connection_type !== "VIRTUAL") {
+      return { config: null };
+    }
 
     const config = await ctx.storage.virtualMcpPluginConfigs.get(
       virtualMcpId,


### PR DESCRIPTION
Follows #5222 (VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE started rejecting a `virtualMcpId` that resolves to a non-virtual connection). Its read counterpart, `VIRTUAL_MCP_PLUGIN_CONFIG_GET`, was never given the same guard — it only checked org ownership of `virtualMcpId`, not `connection_type`.

A maintainer wants this because it's the exact same tenant/data-integrity class the sibling tool was just hardened for: any plugin config row keyed by a non-virtual connection (only possible as leftover data from before #5222's fix) would still be readable through GET, when it should be treated as not-found just like UPDATE now treats it as unwritable.

Failure scenario before this fix: a plugin config row exists for `connectionId` that is an HTTP/SSE/STDIO connection (created before #5222 shipped, or by any other legacy path) — `VIRTUAL_MCP_PLUGIN_CONFIG_GET` would happily return it instead of `null`.

Added a regression test (`plugin-config-get.test.ts`: "returns null for a virtualMcpId that points at a non-virtual connection") mirroring the existing test on the UPDATE tool.

Reviewer command: `bun test apps/api/src/tools/virtual/plugin-config-get.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject non-virtual connections in `VIRTUAL_MCP_PLUGIN_CONFIG_GET`. Aligns with `VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE` (#5222) and prevents reads of legacy non-virtual configs.

- **Bug Fixes**
  - Add `connection_type === "VIRTUAL"` check; return `{ config: null }` otherwise.
  - Add regression test ensuring non-virtual IDs return null and storage is not called.

<sup>Written for commit e6ec8c36c5aedac0eed5801ce9c44eb23dd5f72f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

