### PR TITLE
fix(settings): fall back to local default when DATABASE_URL is empty

### DIFF
--- a/apps/api/src/settings/index.test.ts
+++ b/apps/api/src/settings/index.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+
+describe("getSettings auto-init database URL fallback", () => {
+  it("falls back to the local default when DATABASE_URL is set but empty", async () => {
+    const original = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "";
+    try {
+      const { getSettings } = await import("./index");
+      expect(getSettings().databaseUrl).toBe(
+        "postgresql://postgres:postgres@localhost:5432/postgres",
+      );
+    } finally {
+      if (original === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = original;
+    }
+  });
+});

--- a/apps/api/src/settings/index.ts
+++ b/apps/api/src/settings/index.ts
@@ -54,7 +54,7 @@ function initSettingsFromEnv(): void {
   _settings = Object.freeze({
     ...config.settings,
     databaseUrl:
-      envVars.DATABASE_URL ??
+      envVars.DATABASE_URL ||
       "postgresql://postgres:postgres@localhost:5432/postgres",
     natsUrls: (envVars.NATS_URL || "nats://localhost:4222")
       .split(",")


### PR DESCRIPTION
Bug found while auditing `apps/api/src/settings/` for environment-fallback edge cases (a lot of similar `??`-vs-`||` bugs in this area were fixed in recent PRs like #5173, #5177, #5191, #5213, #5217).

**Failure scenario:** `getSettings()`'s child-process auto-init path (`apps/api/src/settings/index.ts`, `initSettingsFromEnv`) resolves `databaseUrl` with `envVars.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres"`. `??` only falls back on `null`/`undefined` — if `DATABASE_URL` is explicitly set but empty (e.g. a templated deploy env var left unfilled), the empty string flows straight through as the connection string instead of falling back to the documented local default. The very next field in the same object (`natsUrls`) already uses `||` for this exact reason, and every field in the sibling `resolve-config.ts` follows the same `|| default` convention — this one line was the odd one out.

**Fix:** change `??` to `||`, matching the established convention.

**Regression test:** `apps/api/src/settings/index.test.ts` sets `DATABASE_URL=""` and asserts `getSettings().databaseUrl` resolves to the local default. Verified this test fails on the old code (`Received: ""`) and passes with the fix.

**To verify:** `bun test apps/api/src/settings/index.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test file above (plus the full `resolve-config.test.ts` suite, still 58/58 green). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes settings init to fall back to the local default database URL when `DATABASE_URL` is set to an empty string. Switched `??` to `||` in `apps/api/src/settings/index.ts` and added a regression test to lock this behavior.

<sup>Written for commit d5b9d35b89992f6c081fadcbf53e9830915a7537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

