### PR TITLE
fix(sandbox): resolve AA/DD rebase conflicts instead of silently dropping them

### DIFF
--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -161,6 +161,76 @@ function setupBranchDeletesBaseModifiesRepo(): {
   };
 }
 
+function setupBothSidesAddSameFileRepo(): {
+  repoDir: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "rebase-onto-base-aa-"));
+  const bare = join(root, "origin.git");
+  const seed = join(root, "seed");
+  const gitOpts = { stdio: "ignore" as const };
+  const gitcfg = `-c init.defaultBranch=main -c user.email=test@example.com -c user.name=test -c commit.gpgsign=false`;
+  const newPath = ".deco/blocks/new-block.json";
+
+  execSync(`git ${gitcfg} init --bare ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} init ${seed}`, gitOpts);
+
+  mkdirSync(join(seed, ".deco/blocks"), { recursive: true });
+  writeFileSync(join(seed, "readme.txt"), "seed\n", "utf-8");
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m initial`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} branch -M main`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} remote add origin ${bare}`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push -u origin main`, gitOpts);
+
+  // Branch adds the file with its own content...
+  execSync(`git ${gitcfg} -C ${seed} checkout -b feat/new-block`, gitOpts);
+  writeFileSync(
+    join(seed, newPath),
+    JSON.stringify({ from: "branch" }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} commit -m "Add new block"`, gitOpts);
+  execSync(`git ${gitcfg} -C ${seed} push -u origin feat/new-block`, gitOpts);
+
+  // ...while main independently adds the same path with different content,
+  // so rebase hits an "AA" (both added) conflict rather than a modify/delete.
+  execSync(`git ${gitcfg} -C ${seed} checkout main`, gitOpts);
+  mkdirSync(join(seed, ".deco/blocks"), { recursive: true });
+  writeFileSync(
+    join(seed, newPath),
+    JSON.stringify({ from: "main" }, null, 2),
+    "utf-8",
+  );
+  execSync(`git ${gitcfg} -C ${seed} add .`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${seed} commit -m "Add new block from main"`,
+    gitOpts,
+  );
+  execSync(`git ${gitcfg} -C ${seed} push origin main`, gitOpts);
+
+  const repoDir = join(root, "workspace");
+  execSync(
+    `git ${gitcfg} clone --branch feat/new-block ${bare} ${repoDir}`,
+    gitOpts,
+  );
+  execSync(
+    `git ${gitcfg} -C ${repoDir} config user.email test@example.com`,
+    gitOpts,
+  );
+  execSync(`git ${gitcfg} -C ${repoDir} config user.name test`, gitOpts);
+  execSync(
+    `git ${gitcfg} -C ${repoDir} remote set-url origin ${bare}`,
+    gitOpts,
+  );
+
+  return {
+    repoDir,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
 describe("rebaseOntoBase", () => {
   it("rebases with -X theirs and resolves conflicts from branch changes", () => {
     const { repoDir, cleanup } = setupConflictingRepo();
@@ -193,6 +263,21 @@ describe("rebaseOntoBase", () => {
       expect(existsSync(join(repoDir, ".deco/blocks/shipping.json"))).toBe(
         false,
       );
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("resolves an 'AA' conflict (both sides added the same path) favoring the branch", () => {
+    const { repoDir, cleanup } = setupBothSidesAddSameFileRepo();
+    try {
+      rebaseOntoBase(repoDir, "main", { asUser: false });
+
+      const content = readFileSync(
+        join(repoDir, ".deco/blocks/new-block.json"),
+        "utf-8",
+      );
+      expect(JSON.parse(content)).toEqual({ from: "branch" });
     } finally {
       cleanup();
     }

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -117,9 +117,19 @@ function readStatusFiles(repoDir: string): StatusFile[] {
   return files;
 }
 
+// git's fixed set of unmerged-path codes from `git status --porcelain`. "AA"
+// (both sides added the same path) and "DD" (both sides deleted it) contain
+// no "U" — a plain `.includes("U")` check silently drops them, leaving the
+// conflict unresolved and unnoticed until `rebase --continue` rejects it.
+const UNMERGED_STATUSES = new Set(["DD", "AU", "UD", "UA", "DU", "AA", "UU"]);
+
+function isUnmerged(f: StatusFile): boolean {
+  return UNMERGED_STATUSES.has(`${f.index}${f.working_dir}`);
+}
+
 function getConflictedFiles(repoDir: string): string[] {
   return readStatusFiles(repoDir)
-    .filter((f) => `${f.index}${f.working_dir}`.includes("U"))
+    .filter(isUnmerged)
     .map((f) => f.path);
 }
 
@@ -187,7 +197,7 @@ function resolveConflictFile(repoDir: string, summary: StatusFile): void {
     runGit(repoDir, ["add", "--", filePath]);
     return;
   }
-  if (xy === "UD") {
+  if (xy === "UD" || xy === "DD") {
     runGit(repoDir, ["rm", "-f", "--", filePath]);
     return;
   }
@@ -242,9 +252,7 @@ function resolveConflictsRecursively(
   }
 
   const files = readStatusFiles(repoDir);
-  const conflicted = files.filter((f) =>
-    `${f.index}${f.working_dir}`.includes("U"),
-  );
+  const conflicted = files.filter(isUnmerged);
 
   for (const summary of conflicted) {
     resolveConflictFile(repoDir, summary);


### PR DESCRIPTION
Follows #5224/#5221 (recent rebase-onto-base hardening) — while auditing that file's conflict-detection filter for other gaps in the same class of bug, found this one.

`getConflictedFiles`/`resolveConflictsRecursively` picked out conflicted paths with `` `${index}${working}`.includes("U") ``. That misses two of git's real unmerged-path codes: `AA` (both branch and base independently add the same path with different content) and `DD` (both sides delete it) — neither status string contains a `U`.

**Failure scenario:** two sandbox branches each add a new `.deco` block file at the same path with different content (a common shape — e.g. two agents both scaffolding a new block). Rebasing one onto the other hits an `AA` conflict. Because the filter drops it, the file is never staged during conflict resolution, `getConflictedFiles().length` reports 0 (falsely looking resolved), and `git rebase --continue` is invoked while the path is still unmerged. Verified locally: git rejects that continue with `"<path>: needs merge"`, so the whole rebase throws an opaque git error instead of resolving in favor of the branch per the function's documented `-X theirs` policy.

Fix: introduced `UNMERGED_STATUSES`, the full fixed set of git's 7 unmerged-path codes (`DD, AU, UD, UA, DU, AA, UU`), and used it everywhere conflicts are detected. Added explicit `DD` handling (`git rm -f`, mirroring `UD`) — `AA` already resolves correctly via the existing `checkout --theirs` fallback once it's no longer filtered out.

Added a regression test (`resolves an 'AA' conflict ... favoring the branch`) that reproduces the both-sides-add-same-path scenario end-to-end through `rebaseOntoBase` against a real git repo, mirroring the existing UD/DU test style in this file.

To confirm: `bun test packages/sandbox/daemon/git/rebase-onto-base.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox` (clean), and the targeted test file above (5/5 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rebase conflict handling to include `AA` and `DD` so conflicts aren’t silently dropped and rebases don’t fail with “needs merge.” Rebases now finish with the intended `-X theirs` behavior.

- **Bug Fixes**
  - Detect all unmerged statuses with `UNMERGED_STATUSES` (`DD, AU, UD, UA, DU, AA, UU`) across conflict checks.
  - Resolve `DD` via `git rm -f`; `AA` already resolves via the existing `checkout --theirs` path.
  - Add end-to-end test for an `AA` scenario (both sides add the same file), asserting the branch version wins.

<sup>Written for commit 3b84080a5b911a2e238ed5f820b678f35ef5fd5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

