### PR TITLE
fix(org-fs): add allow-downloads to CSP sandbox for file downloads

### DIFF
--- a/apps/api/src/api/routes/org-fs.ts
+++ b/apps/api/src/api/routes/org-fs.ts
@@ -111,7 +111,7 @@ function byteResponse(
     // origin so nested frame-ancestors checks pass — but re-enables
     // credentialed same-origin API calls from member HTML.
     headers["Content-Security-Policy"] =
-      "sandbox allow-scripts allow-modals allow-same-origin";
+      "sandbox allow-scripts allow-modals allow-same-origin allow-downloads";
   }
   return c.body(Buffer.from(bytes), 200, headers);
 }


### PR DESCRIPTION
## Summary
- Added `allow-downloads` directive to CSP sandbox header for HTML files served through org-fs public shares
- Fixes browser error when downloading Excel/PDF files from shared data rooms with password protection

## Test plan
- ✅ Shared data room with password protection
- ✅ Download Excel files (XLSX)
- ✅ Download PDF files
- ✅ Verify cookies persist across sibling file downloads

Related: Beatriz Ramos data room restoration & link fixes

🤖 Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add allow-downloads to the CSP sandbox for HTML served by org-fs public shares. This fixes download failures (XLSX, PDF) in password-protected data rooms.

<sup>Written for commit 2f9e7e5900b3558283450128df8e7decf9d39cbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

