### PR TITLE
feat(admin): copy an agent between orgs with its connections and credentials

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -1365,7 +1365,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   app.route("/api/auth/desktop", desktopSessionBridgeRoutes);
 
   // Fence off the raw Better Auth admin plugin (/api/auth/admin/*) from
-  // external callers — see fenceRawAdminSurface's doc in routes/admin.ts for
+  // external callers — see fenceRawAdminSurface's doc in routes/admin/index.ts for
   // why this must exist whenever deploymentAdminUserIds does.
   app.all("/api/auth/admin/*", fenceRawAdminSurface);
 

--- a/apps/api/src/api/routes/admin/copy-agent.ts
+++ b/apps/api/src/api/routes/admin/copy-agent.ts
@@ -1,0 +1,476 @@
+/**
+ * Copy an agent (Virtual MCP) from one organization to another, credentials
+ * included — a deployment-admin operation.
+ *
+ * The motivating case: an agent was built and tuned in one org (usually deco's
+ * own) and needs to exist, working, in a customer's org. Doing that by hand
+ * means re-creating every connection, re-doing every OAuth dance, and
+ * re-typing the system prompt — with no way to tell whether the result
+ * actually matches.
+ *
+ * What travels:
+ *  - the agent row: title, description, icon, system prompt (`metadata.instructions`)
+ *    and the rest of its metadata, rewritten for the target org (see
+ *    ./remap-agent-metadata)
+ *  - every connection it aggregates, WITH its credentials — access token, OAuth
+ *    config, configuration state, STDIO env vars. Storage decrypts on read and
+ *    re-encrypts on write, so the plaintext only exists in memory here.
+ *  - the vault secrets its sandbox env bag references
+ *  - its kickstart prompts (org-fs) and per-plugin configs
+ *
+ * What does not, and why it is REPORTED rather than silently dropped: nested
+ * agents, knowledge files, and everything listed in `DROPPED_KEYS`. The caller
+ * surfaces `skipped` to the operator so a partial copy is never mistaken for a
+ * complete one.
+ *
+ * Not transactional: connections and secrets are separate writes and a failure
+ * midway leaves them behind as orphans in the target org. Deliberate — an admin
+ * can delete them, and the alternative (threading one Kysely transaction
+ * through five storage classes and two object stores) buys little for a
+ * hand-triggered operation.
+ */
+
+import {
+  isStudioPackAgent,
+  WellKnownOrgMCPId,
+  VirtualMCPCreateDataSchema,
+} from "@decocms/shared/sdk";
+import { sql } from "kysely";
+import type { StudioContext } from "@/core/studio-context";
+import type { ConnectionEntity } from "@/tools/connection/schema";
+import { buildOrgFs } from "@/file-storage/build-org-fs";
+import {
+  readAgentPrompts,
+  writeAgentPrompts,
+} from "@/file-storage/agent-prompts";
+import { remapAgentMetadata, type RemapTargets } from "./remap-agent-metadata";
+
+/**
+ * Connections every org gets on bootstrap, whose id embeds the org id. These
+ * are remapped to the target org's own instance instead of copied — copying
+ * would give the target a second, stale pointer at the SOURCE org's management
+ * surface (and `<org>_self` in particular is that org's full admin API).
+ */
+const WELL_KNOWN_CONNECTION_MINTERS = [
+  WellKnownOrgMCPId.SELF,
+  WellKnownOrgMCPId.REGISTRY,
+  WellKnownOrgMCPId.COMMUNITY_REGISTRY,
+  WellKnownOrgMCPId.DEV_ASSETS,
+  WellKnownOrgMCPId.SITE_DIAGNOSTICS,
+  WellKnownOrgMCPId.COMMERCE_DISCOVERY,
+];
+
+function remapWellKnownConnection(
+  id: string,
+  sourceOrgId: string,
+  targetOrgId: string,
+): string | null {
+  for (const mint of WELL_KNOWN_CONNECTION_MINTERS) {
+    if (id === mint(sourceOrgId)) return mint(targetOrgId);
+  }
+  return null;
+}
+
+export class CopyAgentError extends Error {
+  constructor(
+    message: string,
+    readonly status: 400 | 404,
+  ) {
+    super(message);
+    this.name = "CopyAgentError";
+  }
+}
+
+export interface CopyAgentInput {
+  agentId: string;
+  targetOrgId: string;
+  /** Deployment admin performing the copy; recorded as creator in the target org. */
+  actorUserId: string;
+}
+
+export interface CopyAgentResult {
+  agentId: string;
+  title: string;
+  sourceOrgId: string;
+  targetOrgId: string;
+  /** Connections newly created in the target org. */
+  copiedConnections: { sourceId: string; targetId: string; title: string }[];
+  /** Well-known connections pointed at the target org's own instance. */
+  remappedConnections: { sourceId: string; targetId: string }[];
+  copiedSecrets: number;
+  copiedPrompts: number;
+  /** Everything that could not travel. Show this to the operator. */
+  skipped: string[];
+}
+
+export async function copyAgentToOrg(
+  ctx: StudioContext,
+  input: CopyAgentInput,
+): Promise<CopyAgentResult> {
+  const { agentId, targetOrgId, actorUserId } = input;
+  const skipped: string[] = [];
+
+  const agent = await ctx.storage.virtualMcps.findById(agentId);
+  if (!agent) {
+    throw new CopyAgentError(`Agent ${agentId} not found`, 404);
+  }
+  const sourceOrgId = agent.organization_id;
+
+  if (sourceOrgId === targetOrgId) {
+    throw new CopyAgentError(
+      "Source and target organization are the same",
+      400,
+    );
+  }
+  // Studio Pack agents are provisioned per-org by the platform and their ids
+  // embed the org id; every org already has its own.
+  if (isStudioPackAgent(agent.id)) {
+    throw new CopyAgentError(
+      "Studio Pack agents are system-managed — every org already has its own",
+      400,
+    );
+  }
+
+  const targetOrg = await ctx.db
+    .selectFrom("organization")
+    .select("id")
+    .where("id", "=", targetOrgId)
+    .executeTakeFirst();
+  if (!targetOrg) {
+    throw new CopyAgentError(`Organization ${targetOrgId} not found`, 404);
+  }
+
+  // ---- Connections -------------------------------------------------------
+  const connectionMap = new Map<string, string>();
+  const copiedConnections: CopyAgentResult["copiedConnections"] = [];
+  const remappedConnections: CopyAgentResult["remappedConnections"] = [];
+
+  for (const ref of agent.connections) {
+    const sourceId = ref.connection_id;
+
+    const wellKnown = remapWellKnownConnection(
+      sourceId,
+      sourceOrgId,
+      targetOrgId,
+    );
+    if (wellKnown) {
+      const exists = await ctx.storage.connections.findById(wellKnown);
+      if (!exists) {
+        skipped.push(
+          `Built-in connection "${sourceId}" has no counterpart in the target org (expected "${wellKnown}") — the copy will not see its tools.`,
+        );
+        continue;
+      }
+      connectionMap.set(sourceId, wellKnown);
+      remappedConnections.push({ sourceId, targetId: wellKnown });
+      continue;
+    }
+
+    const source = await ctx.storage.connections.findById(sourceId);
+    if (!source || source.organization_id !== sourceOrgId) {
+      skipped.push(
+        `Connection "${sourceId}" was skipped — it no longer exists in the source org.`,
+      );
+      continue;
+    }
+    if (source.connection_type === "VIRTUAL") {
+      skipped.push(
+        `Connection "${source.title}" is another agent — nested agents are not copied. Copy it separately and add it to this one.`,
+      );
+      continue;
+    }
+
+    const created = await copyConnection(
+      ctx,
+      source,
+      targetOrgId,
+      actorUserId,
+      skipped,
+    );
+    connectionMap.set(sourceId, created.id);
+    copiedConnections.push({
+      sourceId,
+      targetId: created.id,
+      title: created.title,
+    });
+  }
+
+  // ---- Secrets referenced by the sandbox runtime config -------------------
+  const secretMap = new Map<string, string>();
+  for (const secretId of collectSecretIds(agent.metadata)) {
+    const targetId = await copySecret(
+      ctx,
+      secretId,
+      sourceOrgId,
+      targetOrgId,
+      actorUserId,
+      skipped,
+    );
+    if (targetId) secretMap.set(secretId, targetId);
+  }
+
+  // ---- Metadata ----------------------------------------------------------
+  const targets: RemapTargets = {
+    connections: connectionMap,
+    secrets: secretMap,
+  };
+  const remapped = remapAgentMetadata(agent.metadata, targets);
+  skipped.push(...remapped.skipped);
+
+  if (agent.pinned) {
+    skipped.push(
+      "The copy is not pinned to the target org's sidebar — pinning is an org-admin choice.",
+    );
+  }
+
+  // Parse instead of casting: this is the boundary where source-org JSON
+  // becomes a write into another org, and a schema violation should fail loudly
+  // here rather than land a malformed row.
+  const createData = VirtualMCPCreateDataSchema.parse({
+    title: agent.title,
+    description: agent.description,
+    icon: agent.icon,
+    status: agent.status,
+    pinned: false,
+    metadata: remapped.metadata,
+    connections: agent.connections
+      .filter((ref) => connectionMap.has(ref.connection_id))
+      .map((ref) => ({
+        connection_id: connectionMap.get(ref.connection_id)!,
+        selected_tools: ref.selected_tools,
+        selected_resources: ref.selected_resources,
+        selected_prompts: ref.selected_prompts,
+      })),
+  });
+
+  const copy = await ctx.storage.virtualMcps.create(
+    targetOrgId,
+    actorUserId,
+    createData,
+  );
+
+  // ---- Kickstart prompts (org-fs, not on the row) -------------------------
+  const copiedPrompts = await copyPrompts(
+    ctx,
+    { sourceOrgId, targetOrgId },
+    agent.id,
+    copy.id,
+    actorUserId,
+    skipped,
+  );
+
+  // ---- Per-plugin configuration ------------------------------------------
+  await copyPluginConfigs(ctx, agent.id, copy.id, connectionMap, skipped);
+
+  return {
+    agentId: copy.id,
+    title: copy.title,
+    sourceOrgId,
+    targetOrgId,
+    copiedConnections,
+    remappedConnections,
+    copiedSecrets: secretMap.size,
+    copiedPrompts,
+    skipped,
+  };
+}
+
+/**
+ * Recreate a connection under the target org with a fresh id.
+ *
+ * `findById` already decrypted the credentials and `createNew` re-encrypts
+ * them, so passing the entity through copies the secrets without this module
+ * ever touching the vault. `id` is omitted so a new one is minted — reusing the
+ * source id would make the two orgs' rows collide on the shared primary key.
+ */
+async function copyConnection(
+  ctx: StudioContext,
+  source: ConnectionEntity,
+  targetOrgId: string,
+  actorUserId: string,
+  skipped: string[],
+): Promise<ConnectionEntity> {
+  const { id: _id, created_at: _c, updated_at: _u, ...rest } = source;
+
+  if (source.connection_type === "STDIO") {
+    skipped.push(
+      `Connection "${source.title}" is a local STDIO server — its command must be runnable wherever the target org's sandboxes run.`,
+    );
+  }
+
+  return ctx.storage.connections.createNew({
+    ...rest,
+    organization_id: targetOrgId,
+    created_by: actorUserId,
+    updated_by: undefined,
+  });
+}
+
+/** Every vault secret id the agent's runtime config depends on. */
+function collectSecretIds(metadata: unknown): string[] {
+  const ids = new Set<string>();
+  if (typeof metadata !== "object" || metadata === null) return [];
+  const runtime = (metadata as { runtime?: unknown }).runtime;
+  if (typeof runtime !== "object" || runtime === null) return [];
+
+  const lists = [
+    (runtime as { env?: unknown }).env,
+    (runtime as { submoduleCredentials?: unknown }).submoduleCredentials,
+  ];
+  for (const list of lists) {
+    if (!Array.isArray(list)) continue;
+    for (const entry of list) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const secretId = (entry as { secretId?: unknown }).secretId;
+      if (typeof secretId === "string" && secretId) ids.add(secretId);
+    }
+  }
+  return [...ids];
+}
+
+/**
+ * Copy one vault secret into the target org, or reuse the target's existing
+ * secret of the same name.
+ *
+ * Reading the row directly bypasses `SecretStorage`'s per-caller visibility
+ * check, which would reject a user-scoped secret owned by someone other than
+ * the admin running the copy. That is the intended privilege of this surface —
+ * it also grants org membership and impersonates users — but it means a
+ * user-scoped secret becomes ORG-scoped in the target (the admin is typically
+ * not a member there, so a user-scoped copy would be invisible to the people
+ * who need it, and the agent would not boot). Reported, never silent.
+ *
+ * An existing same-name secret in the target is reused rather than
+ * overwritten: `secrets` is uniquely indexed on (org, lower(name)) for org
+ * scope, and clobbering a customer's live credential to make a copy tidy is
+ * not a trade worth making.
+ */
+async function copySecret(
+  ctx: StudioContext,
+  secretId: string,
+  sourceOrgId: string,
+  targetOrgId: string,
+  actorUserId: string,
+  skipped: string[],
+): Promise<string | null> {
+  const row = await ctx.db
+    .selectFrom("secrets")
+    .selectAll()
+    .where("id", "=", secretId)
+    .where("organization_id", "=", sourceOrgId)
+    .executeTakeFirst();
+
+  if (!row) {
+    skipped.push(
+      `Secret "${secretId}" was skipped — it no longer exists in the source org.`,
+    );
+    return null;
+  }
+
+  const existing = await ctx.db
+    .selectFrom("secrets")
+    .select(["id"])
+    .where("organization_id", "=", targetOrgId)
+    .where("scope", "=", "organization")
+    .where(sql<boolean>`lower(name) = lower(${row.name})`)
+    .executeTakeFirst();
+
+  if (existing) {
+    skipped.push(
+      `Secret "${row.name}" already exists in the target org — the copy reuses it instead of overwriting its value.`,
+    );
+    return existing.id;
+  }
+
+  if (row.scope === "user") {
+    skipped.push(
+      `Secret "${row.name}" was personal to one user in the source org and is now shared with the whole target org.`,
+    );
+  }
+
+  try {
+    const value = await ctx.vault.decrypt(row.encrypted_value);
+    const created = await ctx.storage.secrets.create({
+      organizationId: targetOrgId,
+      scope: { kind: "organization" },
+      name: row.name,
+      value,
+      description: row.description,
+      createdBy: actorUserId,
+    });
+    return created.id;
+  } catch (error) {
+    skipped.push(
+      `Secret "${row.name}" could not be copied: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Copy the agent's kickstart prompts between the two orgs' filesystems. The
+ * stored local `name` is intentionally dropped — `writeAgentPrompts` derives it
+ * from the title and index, so the copy gets names consistent with its own set.
+ */
+async function copyPrompts(
+  ctx: StudioContext,
+  orgs: { sourceOrgId: string; targetOrgId: string },
+  sourceAgentId: string,
+  targetAgentId: string,
+  actorUserId: string,
+  skipped: string[],
+): Promise<number> {
+  try {
+    const stored = await readAgentPrompts(
+      buildOrgFs(ctx, orgs.sourceOrgId),
+      sourceAgentId,
+    );
+    if (stored.length === 0) return 0;
+
+    await writeAgentPrompts(
+      buildOrgFs(ctx, orgs.targetOrgId),
+      targetAgentId,
+      actorUserId,
+      stored.map(({ title, description, text }) => ({
+        title,
+        description,
+        text,
+      })),
+    );
+    return stored.length;
+  } catch (error) {
+    skipped.push(
+      `Kickstart prompts were not copied: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return 0;
+  }
+}
+
+/** Per-plugin settings, with any bound connection pointed at its copy. */
+async function copyPluginConfigs(
+  ctx: StudioContext,
+  sourceAgentId: string,
+  targetAgentId: string,
+  connectionMap: Map<string, string>,
+  skipped: string[],
+): Promise<void> {
+  const configs = await ctx.storage.virtualMcpPluginConfigs.list(sourceAgentId);
+
+  for (const config of configs) {
+    let connectionId = config.connectionId;
+    if (connectionId) {
+      const mapped = connectionMap.get(connectionId);
+      if (!mapped) {
+        skipped.push(
+          `Plugin "${config.pluginId}" lost its bound connection — "${connectionId}" was not copied.`,
+        );
+      }
+      connectionId = mapped ?? null;
+    }
+    await ctx.storage.virtualMcpPluginConfigs.upsert(
+      targetAgentId,
+      config.pluginId,
+      { connectionId, settings: config.settings },
+    );
+  }
+}

--- a/apps/api/src/api/routes/admin/index.ts
+++ b/apps/api/src/api/routes/admin/index.ts
@@ -27,6 +27,8 @@ import { getDb } from "@/database";
 import { posthog } from "@/posthog";
 import { getSettings } from "@/settings";
 import type { Env } from "@/api/hono-env";
+import { isStudioPackAgent } from "@decocms/shared/sdk";
+import { CopyAgentError, copyAgentToOrg } from "./copy-agent";
 
 /**
  * Mount path for the deployment-admin surface. Single source of truth: app.ts
@@ -376,6 +378,100 @@ export function createAdminRoutes(): Hono<Env> {
     });
 
     return c.json({ ok: true });
+  });
+
+  /**
+   * The agents an org owns, for the copy picker. Studio Pack agents are
+   * excluded: they are provisioned per-org by the platform, so the target
+   * already has its own and `copyAgentToOrg` rejects them.
+   */
+  app.get("/orgs/:orgId/agents", async (c) => {
+    const ctx = c.get("studioContext");
+    const agents = await ctx.storage.virtualMcps.list(c.req.param("orgId"));
+
+    return c.json({
+      agents: agents
+        .filter((agent) => !isStudioPackAgent(agent.id))
+        .map((agent) => ({
+          id: agent.id,
+          title: agent.title,
+          description: agent.description,
+          icon: agent.icon,
+          updatedAt: agent.updated_at,
+          connectionCount: agent.connections.length,
+          // The picker shows whether an agent has a prompt at all; the prompt
+          // itself can be long and this list is not the place to ship it.
+          hasInstructions: Boolean(agent.metadata?.instructions?.trim()),
+        })),
+    });
+  });
+
+  app.post("/agents/:agentId/copy", async (c) => {
+    const agentId = c.req.param("agentId");
+    const body = (await c.req.json().catch(() => ({}))) as {
+      targetOrgId?: unknown;
+    };
+    const targetOrgId =
+      typeof body.targetOrgId === "string" ? body.targetOrgId.trim() : "";
+    if (!targetOrgId) {
+      return c.json({ error: "targetOrgId is required" }, 400);
+    }
+
+    const ctx = c.get("studioContext");
+    const { actorId: effectiveActorId, impersonatedBy } =
+      await getAuditActor(c);
+    const actorId = impersonatedBy ?? effectiveActorId;
+    if (!actorId) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    let result: Awaited<ReturnType<typeof copyAgentToOrg>>;
+    try {
+      result = await copyAgentToOrg(ctx, {
+        agentId,
+        targetOrgId,
+        // Attribute the new rows to the REAL admin, not an impersonated
+        // identity — same reasoning as the audit trail below.
+        actorUserId: actorId,
+      });
+    } catch (error) {
+      if (error instanceof CopyAgentError) {
+        return c.json({ error: error.message }, error.status);
+      }
+      throw error;
+    }
+
+    // Copying credentials into another tenant is the highest-blast-radius
+    // action on this surface after impersonation — it gets the same durable
+    // stdout trail plus a PostHog event.
+    auditAdminAction("agent_copy", {
+      actor_user_id: actorId,
+      ...(impersonatedBy ? { impersonated_user_id: effectiveActorId } : {}),
+      source_agent_id: agentId,
+      source_organization_id: result.sourceOrgId,
+      target_organization_id: result.targetOrgId,
+      copied_agent_id: result.agentId,
+      copied_connection_ids: result.copiedConnections.map((x) => x.targetId),
+      copied_secret_count: result.copiedSecrets,
+      skipped_count: result.skipped.length,
+    });
+    posthog.capture({
+      distinctId: actorId,
+      event: "deployment_admin_agent_copied",
+      groups: { organization: result.targetOrgId },
+      properties: {
+        actor_user_id: actorId,
+        source_agent_id: agentId,
+        source_organization_id: result.sourceOrgId,
+        target_organization_id: result.targetOrgId,
+        copied_agent_id: result.agentId,
+        copied_connection_count: result.copiedConnections.length,
+        copied_secret_count: result.copiedSecrets,
+        skipped_count: result.skipped.length,
+      },
+    });
+
+    return c.json(result);
   });
 
   return app;

--- a/apps/api/src/api/routes/admin/remap-agent-metadata.test.ts
+++ b/apps/api/src/api/routes/admin/remap-agent-metadata.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from "bun:test";
+import { remapAgentMetadata } from "./remap-agent-metadata";
+
+const targets = (
+  connections: Record<string, string> = {},
+  secrets: Record<string, string> = {},
+) => ({
+  connections: new Map(Object.entries(connections)),
+  secrets: new Map(Object.entries(secrets)),
+});
+
+describe("remapAgentMetadata", () => {
+  test("keeps the system prompt and unknown keys untouched", () => {
+    const { metadata } = remapAgentMetadata(
+      {
+        instructions: "<role>You are a helper</role>",
+        enabled_plugins: ["p1"],
+        somethingAddedLater: { nested: true },
+      },
+      targets(),
+    );
+
+    expect(metadata.instructions).toBe("<role>You are a helper</role>");
+    expect(metadata.enabled_plugins).toEqual(["p1"]);
+    expect(metadata.somethingAddedLater).toEqual({ nested: true });
+  });
+
+  test("drops org-bound keys and reports each one", () => {
+    const { metadata, skipped } = remapAgentMetadata(
+      {
+        instructions: "keep me",
+        sandboxMap: { user_1: { main: {} } },
+        liveAgentId: "vir_live",
+        siteSlug: "acme",
+        productionUrl: "https://acme.com",
+        knowledge: [{ id: "k1" }],
+      },
+      targets(),
+    );
+
+    for (const key of [
+      "sandboxMap",
+      "liveAgentId",
+      "siteSlug",
+      "productionUrl",
+      "knowledge",
+    ]) {
+      expect(key in metadata).toBe(false);
+      expect(skipped.some((s) => s.includes(key))).toBe(true);
+    }
+    expect(metadata.instructions).toBe("keep me");
+  });
+
+  test("does not report keys that were absent or already null", () => {
+    const { skipped } = remapAgentMetadata(
+      { instructions: null, siteSlug: null },
+      targets(),
+    );
+    expect(skipped).toEqual([]);
+  });
+
+  test("remaps connection ids across pinned views, tiles, tabs and github", () => {
+    const { metadata } = remapAgentMetadata(
+      {
+        githubRepo: {
+          url: "https://github.com/a/b",
+          owner: "a",
+          name: "b",
+          connectionId: "conn_old",
+          installationId: 42,
+        },
+        ui: {
+          pinnedViews: [
+            { connectionId: "conn_old", toolName: "T", label: "View" },
+          ],
+          homeTile: { connectionId: "conn_old", resourceUri: "ui://x" },
+          homeTiles: [{ connectionId: "conn_old", resourceUri: "ui://y" }],
+          layout: {
+            tabs: [
+              {
+                id: "t1",
+                title: "Tab",
+                view: { type: "ext-app", appId: "conn_old" },
+              },
+            ],
+          },
+        },
+      },
+      targets({ conn_old: "conn_new" }),
+    );
+
+    const ui = metadata.ui as Record<string, unknown>;
+    const layout = ui.layout as Record<string, unknown>;
+    expect((metadata.githubRepo as Record<string, unknown>).connectionId).toBe(
+      "conn_new",
+    );
+    expect(
+      (metadata.githubRepo as Record<string, unknown>).installationId,
+    ).toBe(42);
+    expect(
+      (ui.pinnedViews as { connectionId: string }[])[0]!.connectionId,
+    ).toBe("conn_new");
+    expect((ui.homeTile as { connectionId: string }).connectionId).toBe(
+      "conn_new",
+    );
+    expect((ui.homeTiles as { connectionId: string }[])[0]!.connectionId).toBe(
+      "conn_new",
+    );
+    expect((layout.tabs as { view: { appId: string } }[])[0]!.view.appId).toBe(
+      "conn_new",
+    );
+  });
+
+  test("drops unresolvable ui entries instead of pointing them at nothing", () => {
+    const { metadata, skipped } = remapAgentMetadata(
+      {
+        ui: {
+          pinnedViews: [{ connectionId: "gone", toolName: "T", label: "View" }],
+          homeTile: { connectionId: "gone", resourceUri: "ui://x" },
+          homeTiles: [{ connectionId: "gone", resourceUri: "ui://y" }],
+          layout: {
+            tabs: [{ id: "t1", view: { type: "ext-app", appId: "gone" } }],
+          },
+        },
+      },
+      targets(),
+    );
+
+    const ui = metadata.ui as Record<string, unknown>;
+    expect(ui.pinnedViews).toEqual([]);
+    expect(ui.homeTile).toBeNull();
+    expect(ui.homeTiles).toEqual([]);
+    expect((ui.layout as Record<string, unknown>).tabs).toEqual([]);
+    expect(skipped).toHaveLength(4);
+  });
+
+  test("strips github credentials when the connection did not travel", () => {
+    const { metadata, skipped } = remapAgentMetadata(
+      {
+        githubRepo: {
+          url: "https://github.com/a/b",
+          owner: "a",
+          name: "b",
+          connectionId: "gone",
+          installationId: 42,
+        },
+      },
+      targets(),
+    );
+
+    const repo = metadata.githubRepo as Record<string, unknown>;
+    expect(repo).toEqual({
+      url: "https://github.com/a/b",
+      owner: "a",
+      name: "b",
+    });
+    expect(skipped.some((s) => s.includes("githubRepo"))).toBe(true);
+  });
+
+  test("remaps secret-backed env vars and keeps literal ones", () => {
+    const { metadata, skipped } = remapAgentMetadata(
+      {
+        runtime: {
+          selected: "bun",
+          env: [
+            { key: "PUBLIC", kind: "literal", value: "v" },
+            { key: "TOKEN", kind: "secret", secretId: "sec_old" },
+            { key: "ORPHAN", kind: "secret", secretId: "sec_gone" },
+          ],
+          submoduleCredentials: [
+            { host: "github.com", secretId: "sec_old" },
+            { host: "gitlab.com", secretId: "sec_gone" },
+          ],
+        },
+      },
+      targets({}, { sec_old: "sec_new" }),
+    );
+
+    const runtime = metadata.runtime as Record<string, unknown>;
+    expect(runtime.selected).toBe("bun");
+    expect(runtime.env).toEqual([
+      { key: "PUBLIC", kind: "literal", value: "v" },
+      { key: "TOKEN", kind: "secret", secretId: "sec_new" },
+    ]);
+    expect(runtime.submoduleCredentials).toEqual([
+      { host: "github.com", secretId: "sec_new" },
+    ]);
+    expect(skipped).toHaveLength(2);
+  });
+
+  test("remaps a pinned-view default but leaves a tab-id default alone", () => {
+    const pinned = remapAgentMetadata(
+      {
+        ui: {
+          layout: {
+            defaultMainView: {
+              type: "ext-apps",
+              id: "conn_old",
+              toolName: "T",
+            },
+          },
+        },
+      },
+      targets({ conn_old: "conn_new" }),
+    );
+    expect(
+      (
+        (pinned.metadata.ui as Record<string, unknown>).layout as Record<
+          string,
+          unknown
+        >
+      ).defaultMainView,
+    ).toEqual({ type: "ext-apps", id: "conn_new", toolName: "T" });
+
+    // No toolName: `id` names a declared tab, not a connection — must not be touched.
+    const tabDefault = remapAgentMetadata(
+      {
+        ui: {
+          layout: {
+            defaultMainView: { type: "ext-app", id: "analytics" },
+            tabs: [{ id: "analytics", view: { type: "ext-app" } }],
+          },
+        },
+      },
+      targets(),
+    );
+    expect(
+      (
+        (tabDefault.metadata.ui as Record<string, unknown>).layout as Record<
+          string,
+          unknown
+        >
+      ).defaultMainView,
+    ).toEqual({ type: "ext-app", id: "analytics" });
+    expect(tabDefault.skipped).toEqual([]);
+
+    // A system tab default must survive untouched too.
+    const preview = remapAgentMetadata(
+      { ui: { layout: { defaultMainView: { type: "preview" } } } },
+      targets(),
+    );
+    expect(
+      (
+        (preview.metadata.ui as Record<string, unknown>).layout as Record<
+          string,
+          unknown
+        >
+      ).defaultMainView,
+    ).toEqual({ type: "preview" });
+  });
+
+  test("resets a pinned-view default whose connection did not travel", () => {
+    const { metadata, skipped } = remapAgentMetadata(
+      {
+        ui: {
+          layout: {
+            defaultMainView: { type: "ext-apps", id: "gone", toolName: "T" },
+          },
+        },
+      },
+      targets(),
+    );
+    expect(
+      (
+        (metadata.ui as Record<string, unknown>).layout as Record<
+          string,
+          unknown
+        >
+      ).defaultMainView,
+    ).toBeNull();
+    expect(skipped.some((s) => s.includes("defaultMainView"))).toBe(true);
+  });
+
+  test("narrows subAgents to what travelled and warns when nothing did", () => {
+    const partial = remapAgentMetadata(
+      { subAgents: ["conn_old", "vir_source_agent"] },
+      targets({ conn_old: "conn_new" }),
+    );
+    expect(partial.metadata.subAgents).toEqual(["conn_new"]);
+    expect(partial.skipped).toHaveLength(1);
+
+    // Empty is preserved: dropping the field would mean "all org targets",
+    // silently widening what the copy can delegate to.
+    const none = remapAgentMetadata({ subAgents: ["vir_a"] }, targets());
+    expect(none.metadata.subAgents).toEqual([]);
+    expect(
+      none.skipped.some((s) => s.includes("only delegate to itself")),
+    ).toBe(true);
+  });
+
+  test("null metadata yields an empty object", () => {
+    expect(remapAgentMetadata(null, targets())).toEqual({
+      metadata: {},
+      skipped: [],
+    });
+  });
+});

--- a/apps/api/src/api/routes/admin/remap-agent-metadata.ts
+++ b/apps/api/src/api/routes/admin/remap-agent-metadata.ts
@@ -1,0 +1,310 @@
+/**
+ * Rewrite an agent's `metadata` for a different organization.
+ *
+ * An agent's metadata is full of ids that only mean something inside its own
+ * org: connection ids on pinned views / home tiles / layout tabs, vault secret
+ * ids on the sandbox env bag, sandbox handles, a linked site's storage
+ * tenancy. Copying the JSON verbatim into another org produces an agent that
+ * looks configured and is quietly broken — every one of those ids resolves to
+ * nothing (or, worse, to an unrelated row that happens to share the id).
+ *
+ * So this module does two things, and reports both:
+ *  - REMAP what has a counterpart in the target org (the connections and
+ *    secrets the copy just created).
+ *  - DROP what cannot travel at all, plus any single entry whose id had no
+ *    counterpart.
+ *
+ * Everything dropped comes back in `skipped` and is surfaced to the operator.
+ * The whole point of a copy tool is fidelity, so silence here would be the
+ * bug: unknown metadata keys pass through untouched (`metadata` is a `.loose()`
+ * schema and new fields get added to it regularly), and the ones we know are
+ * org-bound are named explicitly below.
+ *
+ * Pure: no DB, no ctx. The caller creates the connections/secrets first and
+ * passes the resulting id maps in.
+ */
+
+/** Maps built by the copy before metadata is rewritten. */
+export interface RemapTargets {
+  /** source connection id -> target connection id. Missing = cannot travel. */
+  connections: Map<string, string>;
+  /** source secret id -> target secret id. Missing = cannot travel. */
+  secrets: Map<string, string>;
+}
+
+/**
+ * Metadata keys that are meaningless outside their own org, with the reason
+ * shown to the operator. Dropped wholesale — there is nothing to remap them to.
+ */
+const DROPPED_KEYS: Record<string, string> = {
+  sandboxMap:
+    "sandbox handles and preview URLs belong to the source org's running sandboxes",
+  liveAgentId: "the dev/live agent pair only exists in the source org",
+  siteSlug: "the linked site's storage tenancy belongs to the source org",
+  productionUrl: "the production URL belongs to the source org's site",
+  knowledge:
+    "knowledge files live in the source org's Library (files are not copied)",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Drop `key` from `obj` only if present, so we never invent explicit nulls. */
+function omit(
+  obj: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  if (!(key in obj)) return obj;
+  const { [key]: _dropped, ...rest } = obj;
+  return rest;
+}
+
+export interface RemapResult {
+  metadata: Record<string, unknown>;
+  /** Human-readable lines describing everything dropped. */
+  skipped: string[];
+}
+
+export function remapAgentMetadata(
+  source: Record<string, unknown> | null | undefined,
+  targets: RemapTargets,
+): RemapResult {
+  const skipped: string[] = [];
+  if (!source) return { metadata: {}, skipped };
+
+  let metadata: Record<string, unknown> = { ...source };
+
+  for (const [key, reason] of Object.entries(DROPPED_KEYS)) {
+    if (key in metadata && metadata[key] != null) {
+      skipped.push(`metadata.${key} dropped — ${reason}.`);
+    }
+    metadata = omit(metadata, key);
+  }
+
+  if (Array.isArray(metadata.subAgents)) {
+    metadata.subAgents = remapSubAgents(metadata.subAgents, targets, skipped);
+  }
+  if (isRecord(metadata.githubRepo)) {
+    metadata.githubRepo = remapGithubRepo(
+      metadata.githubRepo,
+      targets,
+      skipped,
+    );
+  }
+  if (isRecord(metadata.runtime)) {
+    metadata.runtime = remapRuntime(metadata.runtime, targets, skipped);
+  }
+  if (isRecord(metadata.ui)) {
+    metadata.ui = remapUi(metadata.ui, targets, skipped);
+  }
+
+  return { metadata, skipped };
+}
+
+/**
+ * A delegation allowlist mixing agent ids and connection ids. Only the copied
+ * connections have a counterpart; source-org agents do not.
+ *
+ * An empty result is preserved rather than deleted: `[]` means "itself only"
+ * and `null`/absent means "every active target in the org", so deleting the
+ * field to be helpful would silently WIDEN what the copy may delegate to. A
+ * broken-and-reported allowlist is the safer failure.
+ */
+function remapSubAgents(
+  subAgents: unknown[],
+  targets: RemapTargets,
+  skipped: string[],
+): string[] {
+  const out: string[] = [];
+  for (const entry of subAgents) {
+    if (typeof entry !== "string") continue;
+    const mapped = targets.connections.get(entry);
+    if (mapped) {
+      out.push(mapped);
+    } else {
+      skipped.push(
+        `metadata.subAgents entry "${entry}" dropped — no counterpart in the target org.`,
+      );
+    }
+  }
+  if (out.length === 0 && subAgents.length > 0) {
+    skipped.push(
+      "metadata.subAgents is now empty, so the copy may only delegate to itself — re-pick its subagents in the target org.",
+    );
+  }
+  return out;
+}
+
+/**
+ * The GitHub App credentials for a repo. `connectionId` names the mcp-github
+ * connection that holds the token and `installationId` the App install it came
+ * from; without the connection the install id can't authenticate anything, so
+ * both go and the repo falls back to public-clone mode.
+ */
+function remapGithubRepo(
+  repo: Record<string, unknown>,
+  targets: RemapTargets,
+  skipped: string[],
+): Record<string, unknown> {
+  const sourceId = repo.connectionId;
+  if (typeof sourceId !== "string") return repo;
+
+  const mapped = targets.connections.get(sourceId);
+  if (mapped) return { ...repo, connectionId: mapped };
+
+  skipped.push(
+    `metadata.githubRepo credentials dropped (connection "${sourceId}" was not copied) — the repo stays linked in public-clone mode.`,
+  );
+  return omit(omit(repo, "connectionId"), "installationId");
+}
+
+/** Sandbox runtime config: the secret-backed entries need the new vault ids. */
+function remapRuntime(
+  runtime: Record<string, unknown>,
+  targets: RemapTargets,
+  skipped: string[],
+): Record<string, unknown> {
+  const out = { ...runtime };
+
+  if (Array.isArray(out.env)) {
+    out.env = out.env.flatMap((entry) => {
+      if (!isRecord(entry) || entry.kind !== "secret") return [entry];
+      const sourceId = entry.secretId;
+      if (typeof sourceId !== "string") return [entry];
+      const mapped = targets.secrets.get(sourceId);
+      if (mapped) return [{ ...entry, secretId: mapped }];
+      skipped.push(
+        `metadata.runtime.env "${String(entry.key)}" dropped — its secret could not be copied.`,
+      );
+      return [];
+    });
+  }
+
+  if (Array.isArray(out.submoduleCredentials)) {
+    out.submoduleCredentials = out.submoduleCredentials.flatMap((entry) => {
+      if (!isRecord(entry)) return [];
+      const sourceId = entry.secretId;
+      if (typeof sourceId !== "string") return [entry];
+      const mapped = targets.secrets.get(sourceId);
+      if (mapped) return [{ ...entry, secretId: mapped }];
+      skipped.push(
+        `metadata.runtime.submoduleCredentials for "${String(entry.host)}" dropped — its secret could not be copied.`,
+      );
+      return [];
+    });
+  }
+
+  return out;
+}
+
+/** UI customization: pinned views, home tiles and layout tabs are all keyed by connection. */
+function remapUi(
+  ui: Record<string, unknown>,
+  targets: RemapTargets,
+  skipped: string[],
+): Record<string, unknown> {
+  const out = { ...ui };
+
+  if (Array.isArray(out.pinnedViews)) {
+    out.pinnedViews = out.pinnedViews.flatMap((view) => {
+      if (!isRecord(view)) return [];
+      const sourceId = view.connectionId;
+      if (typeof sourceId !== "string") return [];
+      const mapped = targets.connections.get(sourceId);
+      if (mapped) return [{ ...view, connectionId: mapped }];
+      skipped.push(
+        `metadata.ui.pinnedViews entry "${String(view.label ?? view.toolName)}" dropped — connection "${sourceId}" was not copied.`,
+      );
+      return [];
+    });
+  }
+
+  // Legacy single slot and the current array are both honored by the home board.
+  if (isRecord(out.homeTile)) {
+    out.homeTile = remapHomeTile(out.homeTile, targets, skipped);
+  }
+  if (Array.isArray(out.homeTiles)) {
+    out.homeTiles = out.homeTiles.flatMap((tile) => {
+      if (!isRecord(tile)) return [];
+      const remapped = remapHomeTile(tile, targets, skipped);
+      return remapped ? [remapped] : [];
+    });
+  }
+
+  if (isRecord(out.layout)) {
+    out.layout = remapLayout(out.layout, targets, skipped);
+  }
+
+  return out;
+}
+
+/**
+ * A home tile renders a `ui://` resource from a specific connection. A tile
+ * saved before `connectionId` existed has none — the home API already drops
+ * those, so pass it through untouched rather than inventing a mapping.
+ */
+function remapHomeTile(
+  tile: Record<string, unknown>,
+  targets: RemapTargets,
+  skipped: string[],
+): Record<string, unknown> | null {
+  const sourceId = tile.connectionId;
+  if (typeof sourceId !== "string") return tile;
+  const mapped = targets.connections.get(sourceId);
+  if (mapped) return { ...tile, connectionId: mapped };
+  skipped.push(
+    `metadata.ui home tile "${String(tile.resourceUri)}" dropped — connection "${sourceId}" was not copied.`,
+  );
+  return null;
+}
+
+function remapLayout(
+  layout: Record<string, unknown>,
+  targets: RemapTargets,
+  skipped: string[],
+): Record<string, unknown> {
+  const out = { ...layout };
+
+  // `tabs[].view.appId` IS a connection id (the tab renders that connection's
+  // MCP UI), despite the name.
+  if (Array.isArray(out.tabs)) {
+    out.tabs = out.tabs.flatMap((tab) => {
+      if (!isRecord(tab) || !isRecord(tab.view)) return [];
+      const sourceId = tab.view.appId;
+      if (typeof sourceId !== "string") return [tab];
+      const mapped = targets.connections.get(sourceId);
+      if (mapped) {
+        return [{ ...tab, view: { ...tab.view, appId: mapped } }];
+      }
+      skipped.push(
+        `metadata.ui.layout tab "${String(tab.title ?? tab.id)}" dropped — connection "${sourceId}" was not copied.`,
+      );
+      return [];
+    });
+  }
+
+  // `defaultMainView.id` is a connection id ONLY for a pinned-view default
+  // (`ext-app`/`ext-apps` WITH a toolName). For every other type it names a
+  // declared tab or a fixed system tab, so it must be left alone.
+  const view = out.defaultMainView;
+  if (isRecord(view)) {
+    const isPinnedViewDefault =
+      (view.type === "ext-app" || view.type === "ext-apps") &&
+      typeof view.toolName === "string" &&
+      typeof view.id === "string";
+    if (isPinnedViewDefault && typeof view.id === "string") {
+      const mapped = targets.connections.get(view.id);
+      if (mapped) {
+        out.defaultMainView = { ...view, id: mapped };
+      } else {
+        skipped.push(
+          `metadata.ui.layout.defaultMainView reset — connection "${view.id}" was not copied.`,
+        );
+        out.defaultMainView = null;
+      }
+    }
+  }
+
+  return out;
+}

--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -115,7 +115,7 @@ const scopes = Object.values(getToolsByCategory())
 
 /**
  * Deployment admin user IDs, resolved lazily from `deploymentAdminEmails` by
- * the `/api/_admin/*` middleware (apps/api/src/api/routes/admin.ts) on each
+ * the `/api/_admin/*` middleware (apps/api/src/api/routes/admin/index.ts) on each
  * verified admin's first request. Better Auth's admin plugin shallow-spreads
  * the options object it's given at plugin-init time, so `adminUserIds` below
  * keeps a reference to THIS array — `hasPermission` (better-auth 1.4.22,

--- a/apps/api/src/file-storage/build-org-fs.ts
+++ b/apps/api/src/file-storage/build-org-fs.ts
@@ -1,0 +1,25 @@
+/**
+ * Build an `OrgFs` bound to an arbitrary org scope.
+ *
+ * `ctx.orgFs` is bound to the REQUEST's org, which is the right default for
+ * every normal code path. A few server-side flows need a different scope than
+ * the caller's: the public skill-set volumes (a system org shared by everyone)
+ * and the deployment-admin agent copy (reads the source org, writes the
+ * target). Those go through here so the "S3 when configured, dev storage
+ * otherwise" fallback lives in exactly one place — mirroring the per-request
+ * rebind in `rebindOrgScope`.
+ */
+
+import { createBoundObjectStorage } from "../object-storage/bound-object-storage";
+import { DevObjectStorage } from "../object-storage/dev-object-storage";
+import { getObjectStorageS3Service } from "../object-storage/factory";
+import type { StudioContext } from "../core/studio-context";
+import { OrgFs } from "./org-fs";
+
+export function buildOrgFs(ctx: StudioContext, organizationId: string): OrgFs {
+  const s3Service = getObjectStorageS3Service();
+  const storage = s3Service
+    ? createBoundObjectStorage(s3Service, organizationId)
+    : new DevObjectStorage(organizationId, ctx.baseUrl);
+  return new OrgFs(storage, ctx.storage.orgFsEntries, organizationId);
+}

--- a/apps/api/src/file-storage/public-sets.ts
+++ b/apps/api/src/file-storage/public-sets.ts
@@ -13,11 +13,9 @@
 
 import { z } from "zod";
 import { getSettings } from "../settings";
-import { getObjectStorageS3Service } from "../object-storage/factory";
-import { createBoundObjectStorage } from "../object-storage/bound-object-storage";
-import { DevObjectStorage } from "../object-storage/dev-object-storage";
 import type { StudioContext } from "../core/studio-context";
-import { OrgFs } from "./org-fs";
+import { buildOrgFs } from "./build-org-fs";
+import type { OrgFs } from "./org-fs";
 
 export const ORG_FS_PUBLIC_ORG_ID = "org_orgfs_public_skills";
 const PUBLIC_VOLUME_PREFIX = "public-";
@@ -121,15 +119,7 @@ export function getPublicSets(): PublicSkillSetSource[] {
   return resolvePublicSets(getSettings().orgFsPublicSetsJson);
 }
 
-/**
- * An OrgFs bound to the shared public scope (mirrors the per-org rebind in
- * resolve-org-from-path.ts — like there, missing S3 falls back to the dev
- * object storage, so this always returns a working instance).
- */
+/** An OrgFs bound to the shared public scope. */
 export function buildPublicOrgFs(ctx: StudioContext): OrgFs {
-  const s3Service = getObjectStorageS3Service();
-  const storage = s3Service
-    ? createBoundObjectStorage(s3Service, ORG_FS_PUBLIC_ORG_ID)
-    : new DevObjectStorage(ORG_FS_PUBLIC_ORG_ID, ctx.baseUrl);
-  return new OrgFs(storage, ctx.storage.orgFsEntries, ORG_FS_PUBLIC_ORG_ID);
+  return buildOrgFs(ctx, ORG_FS_PUBLIC_ORG_ID);
 }

--- a/apps/web/src/i18n/en/admin.ts
+++ b/apps/web/src/i18n/en/admin.ts
@@ -1,4 +1,28 @@
 export const admin = {
+  "admin.copyAgent.agentStep": "2. Agent to copy",
+  "admin.copyAgent.agentSummary": "{connections} connections",
+  "admin.copyAgent.connectionsCopied": "Connections created in the target org",
+  "admin.copyAgent.copiedSummary":
+    "{connections} connections copied, {reused} built-in connections reused, {secrets} secrets copied, {prompts} kickstart prompts copied.",
+  "admin.copyAgent.copiedTitle": 'Copied "{title}" into {org}',
+  "admin.copyAgent.copyAction": 'Copy "{agent}" to {org}',
+  "admin.copyAgent.copyActionIdle": "Copy agent",
+  "admin.copyAgent.copyFailed": "Failed to copy the agent",
+  "admin.copyAgent.copySucceeded": "Agent copied",
+  "admin.copyAgent.credentialWarning":
+    "Access tokens, OAuth config and secrets are copied into the target org.",
+  "admin.copyAgent.failedLoadAgents": "Failed to load agents",
+  "admin.copyAgent.intro":
+    "Copy an agent into another organization with its system prompt, the connections it uses, and their credentials. Built-in connections are pointed at the target org's own; anything that cannot travel is listed after the copy.",
+  "admin.copyAgent.noAgents": "This organization has no agents.",
+  "admin.copyAgent.noOrgs": "No organizations found.",
+  "admin.copyAgent.noPrompt": "no system prompt",
+  "admin.copyAgent.pickSourceFirst": "Pick a source organization first.",
+  "admin.copyAgent.searchOrgs": "Search by name or slug...",
+  "admin.copyAgent.skippedTitle": "{count} things did not come along",
+  "admin.copyAgent.sourceStep": "1. Source organization",
+  "admin.copyAgent.tab": "Copy agent",
+  "admin.copyAgent.targetStep": "3. Target organization",
   "admin.layout.adminDashboard": "Admin Dashboard",
   "admin.layout.adminDashboardArea": "the admin dashboard",
   "admin.layout.emailVerificationRequired":

--- a/apps/web/src/i18n/pt-br/admin.ts
+++ b/apps/web/src/i18n/pt-br/admin.ts
@@ -1,6 +1,32 @@
 import type { admin as adminEn } from "../en/admin.ts";
 
 export const admin = {
+  "admin.copyAgent.agentStep": "2. Agente a copiar",
+  "admin.copyAgent.agentSummary": "{connections} conexões",
+  "admin.copyAgent.connectionsCopied":
+    "Conexões criadas na organização destino",
+  "admin.copyAgent.copiedSummary":
+    "{connections} conexões copiadas, {reused} conexões nativas reaproveitadas, {secrets} segredos copiados, {prompts} prompts iniciais copiados.",
+  "admin.copyAgent.copiedTitle": '"{title}" copiado para {org}',
+  "admin.copyAgent.copyAction": 'Copiar "{agent}" para {org}',
+  "admin.copyAgent.copyActionIdle": "Copiar agente",
+  "admin.copyAgent.copyFailed": "Falha ao copiar o agente",
+  "admin.copyAgent.copySucceeded": "Agente copiado",
+  "admin.copyAgent.credentialWarning":
+    "Tokens de acesso, configuração OAuth e segredos são copiados para a organização destino.",
+  "admin.copyAgent.failedLoadAgents": "Falha ao carregar agentes",
+  "admin.copyAgent.intro":
+    "Copie um agente para outra organização com seu system prompt, as conexões que ele usa e as credenciais delas. Conexões nativas apontam para as da própria organização destino; tudo que não pode ser copiado é listado após a cópia.",
+  "admin.copyAgent.noAgents": "Esta organização não tem agentes.",
+  "admin.copyAgent.noOrgs": "Nenhuma organização encontrada.",
+  "admin.copyAgent.noPrompt": "sem system prompt",
+  "admin.copyAgent.pickSourceFirst":
+    "Escolha primeiro a organização de origem.",
+  "admin.copyAgent.searchOrgs": "Buscar por nome ou slug...",
+  "admin.copyAgent.skippedTitle": "{count} itens não foram copiados",
+  "admin.copyAgent.sourceStep": "1. Organização de origem",
+  "admin.copyAgent.tab": "Copiar agente",
+  "admin.copyAgent.targetStep": "3. Organização destino",
   "admin.layout.adminDashboard": "Painel de Administração",
   "admin.layout.adminDashboardArea": "o painel de administração",
   "admin.layout.emailVerificationRequired":

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -136,10 +136,17 @@ const adminOrgsRoute = createRoute({
   component: lazyRouteComponent(() => import("./routes/admin/orgs.tsx")),
 });
 
+const adminCopyAgentRoute = createRoute({
+  getParentRoute: () => adminLayout,
+  path: "/copy-agent",
+  component: lazyRouteComponent(() => import("./routes/admin/copy-agent.tsx")),
+});
+
 const adminLayoutWithChildren = adminLayout.addChildren([
   adminIndexRoute,
   adminUsersRoute,
   adminOrgsRoute,
+  adminCopyAgentRoute,
 ]);
 
 // ============================================

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -542,6 +542,8 @@ export const KEYS = {
     ["deployment-admin", "orgs", search] as const,
   // Prefix key: invalidates every orgs query regardless of the search term.
   deploymentAdminOrgsList: () => ["deployment-admin", "orgs"] as const,
+  deploymentAdminOrgAgents: (organizationId: string) =>
+    ["deployment-admin", "orgs", organizationId, "agents"] as const,
 
   // Brand context (scoped by organization)
   brandContext: (organizationId: string) =>

--- a/apps/web/src/routes/admin/copy-agent.tsx
+++ b/apps/web/src/routes/admin/copy-agent.tsx
@@ -1,0 +1,426 @@
+/**
+ * Deployment-admin agent copy: move an agent — system prompt, connections, and
+ * their credentials — from one organization to another.
+ *
+ * Three panes, left to right, because the operation genuinely has three inputs
+ * and hiding any of them behind a wizard step would cost a click without buying
+ * clarity: pick the source org, pick one of its agents, pick the target org.
+ * The report that comes back is the important part of the screen — a copy is
+ * routinely partial (nested agents, knowledge files and org-bound settings can't
+ * travel), so what did NOT come along is shown as prominently as what did.
+ */
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { AlertTriangle, ArrowRight, Check, Copy01 } from "@untitledui/icons";
+import { toast } from "sonner";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@deco/ui/components/alert.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
+import { SearchInput } from "@deco/ui/components/search-input.tsx";
+import { Spinner } from "@deco/ui/components/spinner.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { AgentAvatar } from "@/components/agent-icon";
+import { Page } from "@/components/page";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { adminFetch } from "@/lib/admin-fetch";
+import { KEYS } from "@/lib/query-keys";
+import { useT } from "@/i18n/use-t.ts";
+
+interface AdminOrg {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface AdminAgent {
+  id: string;
+  title: string;
+  description: string | null;
+  icon: string | null;
+  connectionCount: number;
+  hasInstructions: boolean;
+}
+
+interface CopyResult {
+  agentId: string;
+  title: string;
+  targetOrgId: string;
+  copiedConnections: { sourceId: string; targetId: string; title: string }[];
+  remappedConnections: { sourceId: string; targetId: string }[];
+  copiedSecrets: number;
+  copiedPrompts: number;
+  skipped: string[];
+}
+
+function useOrgSearch(search: string) {
+  const debounced = useDebouncedValue(search.trim(), 300);
+  return useQuery({
+    queryKey: KEYS.deploymentAdminOrgs(debounced),
+    queryFn: () => {
+      const params = new URLSearchParams({ limit: "100" });
+      if (debounced) params.set("search", debounced);
+      return adminFetch<{ organizations: AdminOrg[] }>(
+        `/api/_admin/orgs?${params}`,
+      );
+    },
+  });
+}
+
+/** A selectable row. Radio semantics: exactly one selection per pane. */
+function PickerRow({
+  selected,
+  onSelect,
+  children,
+}: {
+  selected: boolean;
+  onSelect: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left transition-colors",
+        selected
+          ? "border-foreground bg-muted"
+          : "border-transparent hover:bg-muted",
+      )}
+    >
+      {children}
+      {selected ? (
+        <Check size={16} className="ml-auto shrink-0 text-foreground" />
+      ) : null}
+    </button>
+  );
+}
+
+function OrgPicker({
+  label,
+  selected,
+  onSelect,
+  excludeOrgId,
+}: {
+  label: string;
+  selected: AdminOrg | null;
+  onSelect: (org: AdminOrg) => void;
+  excludeOrgId?: string;
+}) {
+  const t = useT();
+  const [search, setSearch] = useState("");
+  const { data, isLoading } = useOrgSearch(search);
+  const orgs = (data?.organizations ?? []).filter(
+    (org) => org.id !== excludeOrgId,
+  );
+
+  // Each pane is a labelled region: the two org pickers are otherwise
+  // indistinguishable to a screen reader (and to a test driver) since they
+  // render the same rows.
+  return (
+    <section aria-label={label} className="flex min-h-0 flex-col gap-3">
+      <div className="text-sm font-medium text-foreground">{label}</div>
+      <SearchInput
+        value={search}
+        onChange={setSearch}
+        placeholder={t("admin.copyAgent.searchOrgs")}
+      />
+      <ScrollArea className="min-h-0 flex-1 rounded-lg border border-border">
+        {isLoading ? (
+          <div className="flex items-center justify-center p-6">
+            <Spinner size="sm" />
+          </div>
+        ) : orgs.length === 0 ? (
+          <p className="p-4 text-sm text-muted-foreground">
+            {t("admin.copyAgent.noOrgs")}
+          </p>
+        ) : (
+          <div
+            className="flex flex-col gap-1 p-1"
+            role="radiogroup"
+            aria-label={label}
+          >
+            {orgs.map((org) => (
+              <PickerRow
+                key={org.id}
+                selected={selected?.id === org.id}
+                onSelect={() => onSelect(org)}
+              >
+                <div className="min-w-0">
+                  <div className="truncate text-sm text-foreground">
+                    {org.name}
+                  </div>
+                  <div className="truncate text-xs text-muted-foreground">
+                    {org.slug}
+                  </div>
+                </div>
+              </PickerRow>
+            ))}
+          </div>
+        )}
+      </ScrollArea>
+    </section>
+  );
+}
+
+function AgentPicker({
+  sourceOrg,
+  selected,
+  onSelect,
+}: {
+  sourceOrg: AdminOrg | null;
+  selected: AdminAgent | null;
+  onSelect: (agent: AdminAgent) => void;
+}) {
+  const t = useT();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: KEYS.deploymentAdminOrgAgents(sourceOrg?.id ?? ""),
+    queryFn: () =>
+      adminFetch<{ agents: AdminAgent[] }>(
+        `/api/_admin/orgs/${sourceOrg!.id}/agents`,
+      ),
+    enabled: Boolean(sourceOrg),
+  });
+
+  const agents = data?.agents ?? [];
+  const label = t("admin.copyAgent.agentStep");
+
+  return (
+    <section aria-label={label} className="flex min-h-0 flex-col gap-3">
+      <div className="text-sm font-medium text-foreground">{label}</div>
+      <ScrollArea className="min-h-0 flex-1 rounded-lg border border-border">
+        {!sourceOrg ? (
+          <p className="p-4 text-sm text-muted-foreground">
+            {t("admin.copyAgent.pickSourceFirst")}
+          </p>
+        ) : isLoading ? (
+          <div className="flex items-center justify-center p-6">
+            <Spinner size="sm" />
+          </div>
+        ) : isError ? (
+          <p className="p-4 text-sm text-destructive">
+            {t("admin.copyAgent.failedLoadAgents")}
+          </p>
+        ) : agents.length === 0 ? (
+          <p className="p-4 text-sm text-muted-foreground">
+            {t("admin.copyAgent.noAgents")}
+          </p>
+        ) : (
+          <div
+            className="flex flex-col gap-1 p-1"
+            role="radiogroup"
+            aria-label={label}
+          >
+            {agents.map((agent) => (
+              <PickerRow
+                key={agent.id}
+                selected={selected?.id === agent.id}
+                onSelect={() => onSelect(agent)}
+              >
+                <AgentAvatar
+                  icon={agent.icon}
+                  name={agent.title}
+                  size="sm"
+                  className="shrink-0"
+                />
+                <div className="min-w-0">
+                  <div className="truncate text-sm text-foreground">
+                    {agent.title}
+                  </div>
+                  <div className="truncate text-xs text-muted-foreground">
+                    {t("admin.copyAgent.agentSummary", {
+                      connections: String(agent.connectionCount),
+                    })}
+                    {agent.hasInstructions
+                      ? ""
+                      : ` · ${t("admin.copyAgent.noPrompt")}`}
+                  </div>
+                </div>
+              </PickerRow>
+            ))}
+          </div>
+        )}
+      </ScrollArea>
+    </section>
+  );
+}
+
+function CopyReport({
+  result,
+  targetOrg,
+}: {
+  result: CopyResult;
+  targetOrg: AdminOrg;
+}) {
+  const t = useT();
+  const copiedCount = result.copiedConnections.length;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Alert variant="success">
+        <Check />
+        <AlertTitle>
+          {t("admin.copyAgent.copiedTitle", {
+            title: result.title,
+            org: targetOrg.name,
+          })}
+        </AlertTitle>
+        <AlertDescription>
+          {t("admin.copyAgent.copiedSummary", {
+            connections: String(copiedCount),
+            reused: String(result.remappedConnections.length),
+            secrets: String(result.copiedSecrets),
+            prompts: String(result.copiedPrompts),
+          })}
+        </AlertDescription>
+      </Alert>
+
+      {copiedCount > 0 ? (
+        <div className="rounded-lg border border-border">
+          <div className="border-b border-border px-3 py-2 text-sm font-medium">
+            {t("admin.copyAgent.connectionsCopied")}
+          </div>
+          <ul className="divide-y divide-border">
+            {result.copiedConnections.map((conn) => (
+              <li
+                key={conn.targetId}
+                className="flex items-center gap-2 px-3 py-2 text-sm"
+              >
+                <span className="truncate text-foreground">{conn.title}</span>
+                <ArrowRight
+                  size={14}
+                  className="shrink-0 text-muted-foreground"
+                />
+                <code className="truncate text-xs text-muted-foreground">
+                  {conn.targetId}
+                </code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {result.skipped.length > 0 ? (
+        <Alert variant="warning">
+          <AlertTriangle />
+          <AlertTitle>
+            {t("admin.copyAgent.skippedTitle", {
+              count: String(result.skipped.length),
+            })}
+          </AlertTitle>
+          <AlertDescription>
+            <ul className="list-disc space-y-1 pl-4">
+              {result.skipped.map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+    </div>
+  );
+}
+
+export default function AdminCopyAgentPage() {
+  const t = useT();
+  const [sourceOrg, setSourceOrg] = useState<AdminOrg | null>(null);
+  const [agent, setAgent] = useState<AdminAgent | null>(null);
+  const [targetOrg, setTargetOrg] = useState<AdminOrg | null>(null);
+  const [result, setResult] = useState<CopyResult | null>(null);
+  // Held so the report keeps naming the org it copied into even if the operator
+  // starts picking a different target for the next copy.
+  const [reportOrg, setReportOrg] = useState<AdminOrg | null>(null);
+
+  const copy = useMutation({
+    mutationFn: () =>
+      adminFetch<CopyResult>(`/api/_admin/agents/${agent!.id}/copy`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetOrgId: targetOrg!.id }),
+      }),
+    onSuccess: (data) => {
+      setResult(data);
+      setReportOrg(targetOrg);
+      toast.success(t("admin.copyAgent.copySucceeded"));
+    },
+    onError: (error) => {
+      setResult(null);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t("admin.copyAgent.copyFailed"),
+      );
+    },
+  });
+
+  return (
+    <Page>
+      <Page.Content>
+        <Page.Body>
+          <div className="flex flex-col gap-6">
+            <p className="max-w-3xl text-sm text-muted-foreground">
+              {t("admin.copyAgent.intro")}
+            </p>
+
+            <div className="grid min-h-0 gap-6 lg:grid-cols-3">
+              <div className="flex h-[420px] min-h-0 flex-col">
+                <OrgPicker
+                  label={t("admin.copyAgent.sourceStep")}
+                  selected={sourceOrg}
+                  onSelect={(org) => {
+                    setSourceOrg(org);
+                    setAgent(null);
+                    if (targetOrg?.id === org.id) setTargetOrg(null);
+                  }}
+                  excludeOrgId={targetOrg?.id}
+                />
+              </div>
+              <div className="flex h-[420px] min-h-0 flex-col">
+                <AgentPicker
+                  sourceOrg={sourceOrg}
+                  selected={agent}
+                  onSelect={setAgent}
+                />
+              </div>
+              <div className="flex h-[420px] min-h-0 flex-col">
+                <OrgPicker
+                  label={t("admin.copyAgent.targetStep")}
+                  selected={targetOrg}
+                  onSelect={setTargetOrg}
+                  excludeOrgId={sourceOrg?.id}
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Button
+                onClick={() => copy.mutate()}
+                disabled={!agent || !targetOrg || copy.isPending}
+              >
+                {copy.isPending ? <Spinner size="xs" /> : <Copy01 />}
+                {agent && targetOrg
+                  ? t("admin.copyAgent.copyAction", {
+                      agent: agent.title,
+                      org: targetOrg.name,
+                    })
+                  : t("admin.copyAgent.copyActionIdle")}
+              </Button>
+              <span className="text-xs text-muted-foreground">
+                {t("admin.copyAgent.credentialWarning")}
+              </span>
+            </div>
+
+            {result && reportOrg ? (
+              <CopyReport result={result} targetOrg={reportOrg} />
+            ) : null}
+          </div>
+        </Page.Body>
+      </Page.Content>
+    </Page>
+  );
+}

--- a/apps/web/src/routes/admin/layout.tsx
+++ b/apps/web/src/routes/admin/layout.tsx
@@ -10,6 +10,7 @@ import { useT } from "@/i18n/use-t.ts";
 const TABS = [
   { to: "/_admin/users", labelKey: "admin.layout.usersTab" },
   { to: "/_admin/orgs", labelKey: "admin.layout.organizationsTab" },
+  { to: "/_admin/copy-agent", labelKey: "admin.copyAgent.tab" },
 ] as const;
 
 function AdminTabs() {

--- a/packages/e2e/tests/deployment-admin-copy-agent.spec.ts
+++ b/packages/e2e/tests/deployment-admin-copy-agent.spec.ts
@@ -1,0 +1,462 @@
+/**
+ * E2E coverage for the deployment-admin agent copy (/api/_admin/agents/:id/copy).
+ *
+ * The claim under test is specifically that CREDENTIALS travel: a connection
+ * token that only exists encrypted in the source org must come back decrypted
+ * and byte-identical when the TARGET org reads its own copy. Asserting the
+ * ciphertext in Postgres could not prove that (the vault uses a random IV, so
+ * two encryptions of the same value differ), and the suite can't import the
+ * vault — so the assertion goes through the target org's own MCP surface,
+ * which is also exactly how the copied agent will use it.
+ *
+ * Shares the reserved-admin identity mechanics with deployment-admin.spec.ts —
+ * see that file's header for why an admin-side principal can't be per-test and
+ * why the describe runs serial.
+ *
+ * The source/target orgs are minted ONCE for the whole describe rather than
+ * per-test, which is a deliberate exception to the per-test-tenant doctrine in
+ * TESTING.md: `/sign-up/email` is rate-limited, and a serial describe that
+ * signs up two fresh users per test trips the limiter and turns the suite
+ * flaky. Serial mode makes the sharing safe (no parallel writers), and every
+ * assertion below is still scoped to the specific agent/connection id the test
+ * created, never to an org-wide count.
+ */
+import type { APIRequestContext, PlaywrightWorkerArgs } from "@playwright/test";
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi, TEST_PASSWORD } from "../fixtures/auth-api";
+import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
+import {
+  startTestMcpServer,
+  type TestMcpServer,
+} from "../fixtures/test-mcp-server";
+import { expect, getE2EAppOrigin, newApiContext, test } from "../fixtures/test";
+
+const DEPLOYMENT_ADMIN_EMAIL = "deployment-admin@e2e.local";
+
+async function ensureDeploymentAdmin(
+  request: APIRequestContext,
+): Promise<{ userId: string }> {
+  const signUpRes = await request.post("/api/auth/sign-up/email", {
+    data: {
+      email: DEPLOYMENT_ADMIN_EMAIL,
+      password: TEST_PASSWORD,
+      name: "Deployment Admin",
+    },
+  });
+  const res = signUpRes.ok()
+    ? signUpRes
+    : await request.post("/api/auth/sign-in/email", {
+        data: { email: DEPLOYMENT_ADMIN_EMAIL, password: TEST_PASSWORD },
+      });
+  if (!res.ok()) {
+    throw new Error(
+      `ensureDeploymentAdmin: HTTP ${res.status()} — ${await res
+        .text()
+        .catch(() => "<unreadable>")}`,
+    );
+  }
+  const body = (await res.json()) as { user?: { id?: string } };
+  if (!body.user?.id) {
+    throw new Error("ensureDeploymentAdmin: response missing user.id");
+  }
+  return { userId: body.user.id };
+}
+
+async function orgIdForSlug(db: Client, slug: string): Promise<string> {
+  const row = await db.query<{ id: string }>(
+    `SELECT id FROM "organization" WHERE slug = $1`,
+    [slug],
+  );
+  const id = row.rows[0]?.id;
+  if (!id) throw new Error(`Org not found for slug ${slug}`);
+  return id;
+}
+
+interface CopyResponse {
+  agentId: string;
+  title: string;
+  sourceOrgId: string;
+  targetOrgId: string;
+  copiedConnections: { sourceId: string; targetId: string; title: string }[];
+  remappedConnections: { sourceId: string; targetId: string }[];
+  copiedSecrets: number;
+  copiedPrompts: number;
+  skipped: string[];
+}
+
+interface AgentEntity {
+  id: string;
+  title: string;
+  metadata: { instructions?: string | null } & Record<string, unknown>;
+  connections: { connection_id: string }[];
+}
+
+/** One tenant: an authenticated API context plus its org's slug and id. */
+interface Tenant {
+  ctx: APIRequestContext;
+  orgSlug: string;
+  orgId: string;
+  userId: string;
+}
+
+test.describe("/api/_admin/agents/:id/copy", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let db: Client;
+  let mcpServer: TestMcpServer;
+  let admin: APIRequestContext;
+  let source: Tenant;
+  let target: Tenant;
+
+  /** Re-assert the shared admin's emailVerified flag — it's mutable state that
+   *  deployment-admin.spec.ts also flips (see that file's header). */
+  async function verifyAdmin(userId: string) {
+    await db.query(`UPDATE "user" SET "emailVerified" = true WHERE id = $1`, [
+      userId,
+    ]);
+  }
+
+  async function signUpTenant(
+    playwright: PlaywrightWorkerArgs["playwright"],
+  ): Promise<Tenant> {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+    return {
+      ctx,
+      orgSlug: user.orgSlug,
+      orgId: await orgIdForSlug(db, user.orgSlug),
+      userId: user.userId,
+    };
+  }
+
+  test.beforeAll(async ({ playwright }) => {
+    db = await connectDevDb();
+    mcpServer = await startTestMcpServer();
+
+    admin = await newApiContext(playwright);
+    const adminUser = await ensureDeploymentAdmin(admin);
+    await verifyAdmin(adminUser.userId);
+    const me = await admin.get("/api/_admin/me");
+    if (me.status() === 403) {
+      throw new Error(
+        "GET /api/_admin/me → 403 for the reserved admin: the app server is " +
+          "missing DEPLOYMENT_ADMIN_EMAILS (see playwright.config.ts).",
+      );
+    }
+
+    source = await signUpTenant(playwright);
+    target = await signUpTenant(playwright);
+  });
+
+  test.afterAll(async () => {
+    await Promise.all([
+      admin?.dispose(),
+      source?.ctx.dispose(),
+      target?.ctx.dispose(),
+    ]);
+    await mcpServer?.stop();
+    await db?.end();
+  });
+
+  test("copies the prompt, the connections, and their credentials", async () => {
+    // A credential that must survive the trip verbatim. Unique per run so a
+    // stale row from a previous run can never make this pass by accident.
+    const secretToken = `tok_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+    const connection = await createHttpConnection(source.ctx, source.orgSlug, {
+      title: "Copyable Upstream",
+      url: mcpServer.url,
+      token: secretToken,
+    });
+
+    const instructions =
+      "<role>Copy me verbatim, including this exact sentence.</role>";
+    const created = await callSelfMcpTool<{ item: AgentEntity }>(
+      source.ctx,
+      source.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      {
+        data: {
+          title: "Agent Worth Copying",
+          description: "Aggregates one upstream and the org's own tools",
+          metadata: { instructions },
+          connections: [
+            { connection_id: connection.id, selected_tools: ["echo"] },
+            // A built-in, org-scoped connection: must be REMAPPED to the
+            // target org's own `_self`, never copied as a second row pointing
+            // at the source org's management surface.
+            { connection_id: `${source.orgId}_self`, selected_tools: null },
+          ],
+          prompts: [
+            { title: "Say hi", text: "Greet the user and list your tools." },
+            { title: "Echo test", text: "Call echo with 'ping'." },
+          ],
+        },
+      },
+    );
+    const sourceAgentId = created.item.id;
+
+    const res = await admin.post(`/api/_admin/agents/${sourceAgentId}/copy`, {
+      data: { targetOrgId: target.orgId },
+    });
+    expect(res.status(), await res.text().catch(() => "")).toBe(200);
+    const result = (await res.json()) as CopyResponse;
+
+    expect(result.sourceOrgId).toBe(source.orgId);
+    expect(result.targetOrgId).toBe(target.orgId);
+    expect(result.agentId).not.toBe(sourceAgentId);
+    expect(result.copiedPrompts).toBe(2);
+
+    // The upstream was copied; `_self` was remapped, not copied.
+    expect(result.copiedConnections).toHaveLength(1);
+    const copiedConn = result.copiedConnections[0]!;
+    expect(copiedConn.sourceId).toBe(connection.id);
+    expect(copiedConn.targetId).not.toBe(connection.id);
+    expect(result.remappedConnections).toEqual([
+      { sourceId: `${source.orgId}_self`, targetId: `${target.orgId}_self` },
+    ]);
+
+    // The copy is a real, readable agent in the target org, with the prompt
+    // intact and its connection list pointing at TARGET-org ids only.
+    const copied = await callSelfMcpTool<{ item: AgentEntity }>(
+      target.ctx,
+      target.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_GET",
+      { id: result.agentId },
+    );
+    expect(copied.item.metadata.instructions).toBe(instructions);
+    expect(copied.item.title).toBe("Agent Worth Copying");
+    expect(copied.item.connections.map((c) => c.connection_id).sort()).toEqual(
+      [copiedConn.targetId, `${target.orgId}_self`].sort(),
+    );
+
+    // The point of the whole feature: the target org can read the credential.
+    const targetConn = await callSelfMcpTool<{
+      item: { connection_token: string | null; organization_id: string };
+    }>(target.ctx, target.orgSlug, "COLLECTION_CONNECTIONS_GET", {
+      id: copiedConn.targetId,
+    });
+    expect(targetConn.item.connection_token).toBe(secretToken);
+    expect(targetConn.item.organization_id).toBe(target.orgId);
+
+    // Tenancy: the copy is a distinct row, and the source row is untouched.
+    const rows = await db.query<{ id: string; organization_id: string }>(
+      `SELECT id, organization_id FROM connections WHERE id = ANY($1::text[])`,
+      [[connection.id, copiedConn.targetId]],
+    );
+    expect(rows.rows.map((r) => [r.id, r.organization_id]).sort()).toEqual(
+      [
+        [connection.id, source.orgId],
+        [copiedConn.targetId, target.orgId],
+      ].sort(),
+    );
+
+    // The source org cannot see the copy (cross-org reads return null).
+    const leak = await callSelfMcpTool<{ item: unknown }>(
+      source.ctx,
+      source.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_GET",
+      { id: result.agentId },
+    );
+    expect(leak.item).toBeNull();
+  });
+
+  test("reports what could not travel instead of copying it silently", async () => {
+    const nested = await callSelfMcpTool<{ item: AgentEntity }>(
+      source.ctx,
+      source.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      { data: { title: "Nested Helper", connections: [] } },
+    );
+    const parent = await callSelfMcpTool<{ item: AgentEntity }>(
+      source.ctx,
+      source.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      {
+        data: {
+          title: "Parent With Baggage",
+          metadata: {
+            instructions: "<role>parent</role>",
+            // Org-bound: must be dropped, and the drop must be reported.
+            siteSlug: "some-source-site",
+            productionUrl: "https://source.example",
+          },
+          // A nested agent (VIRTUAL connection) is not copied.
+          connections: [{ connection_id: nested.item.id }],
+        },
+      },
+    );
+
+    const res = await admin.post(`/api/_admin/agents/${parent.item.id}/copy`, {
+      data: { targetOrgId: target.orgId },
+    });
+    expect(res.status()).toBe(200);
+    const result = (await res.json()) as CopyResponse;
+
+    expect(result.copiedConnections).toEqual([]);
+    expect(result.skipped.join("\n")).toContain("nested agents are not copied");
+    expect(result.skipped.some((s) => s.includes("siteSlug"))).toBe(true);
+    expect(result.skipped.some((s) => s.includes("productionUrl"))).toBe(true);
+
+    // Dropped, not carried over as a dangling pointer.
+    const copied = await callSelfMcpTool<{ item: AgentEntity }>(
+      target.ctx,
+      target.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_GET",
+      { id: result.agentId },
+    );
+    expect(copied.item.metadata.siteSlug).toBeUndefined();
+    expect(copied.item.metadata.productionUrl).toBeUndefined();
+    expect(copied.item.metadata.instructions).toBe("<role>parent</role>");
+    expect(copied.item.connections).toEqual([]);
+  });
+
+  test("validates input: missing target 400, unknown agent/org 404, same org 400", async () => {
+    const agent = await callSelfMcpTool<{ item: AgentEntity }>(
+      source.ctx,
+      source.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      { data: { title: "Validation Subject", connections: [] } },
+    );
+
+    const missing = await admin.post(
+      `/api/_admin/agents/${agent.item.id}/copy`,
+      { data: {} },
+    );
+    expect(missing.status()).toBe(400);
+
+    const unknownAgent = await admin.post(
+      `/api/_admin/agents/vir_nonexistent_${Date.now()}/copy`,
+      { data: { targetOrgId: target.orgId } },
+    );
+    expect(unknownAgent.status()).toBe(404);
+
+    const unknownOrg = await admin.post(
+      `/api/_admin/agents/${agent.item.id}/copy`,
+      { data: { targetOrgId: `org_nonexistent_${Date.now()}` } },
+    );
+    expect(unknownOrg.status()).toBe(404);
+
+    const sameOrg = await admin.post(
+      `/api/_admin/agents/${agent.item.id}/copy`,
+      { data: { targetOrgId: source.orgId } },
+    );
+    expect(sameOrg.status()).toBe(400);
+  });
+
+  test("refuses to copy a system-managed Studio Pack agent", async () => {
+    const packAgentId = `studio-agent-manager_${source.orgId}`;
+    const res = await admin.post(`/api/_admin/agents/${packAgentId}/copy`, {
+      data: { targetOrgId: target.orgId },
+    });
+    // 404 when the org hasn't been provisioned with the pack yet, 400 once it
+    // has — either way it must never be copied.
+    expect([400, 404]).toContain(res.status());
+
+    // And the picker never offers them.
+    const list = await admin.get(`/api/_admin/orgs/${source.orgId}/agents`);
+    expect(list.status()).toBe(200);
+    const body = (await list.json()) as { agents: { id: string }[] };
+    expect(body.agents.some((a) => a.id.startsWith("studio-"))).toBe(false);
+    // Sanity: the list is actually populated, so the assertion above isn't
+    // passing on an empty array.
+    expect(body.agents.length).toBeGreaterThan(0);
+  });
+
+  test("non-admins cannot reach the copy or agent-list routes", async () => {
+    const list = await source.ctx.get(
+      `/api/_admin/orgs/${source.orgId}/agents`,
+    );
+    expect([401, 403]).toContain(list.status());
+
+    const copy = await source.ctx.post("/api/_admin/agents/vir_whatever/copy", {
+      data: { targetOrgId: target.orgId },
+    });
+    expect([401, 403]).toContain(copy.status());
+  });
+
+  test("an admin can drive the whole copy from the browser", async ({
+    browser,
+  }) => {
+    const agentTitle = `Browser Copy ${Date.now()}`;
+    await callSelfMcpTool<{ item: AgentEntity }>(
+      source.ctx,
+      source.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      {
+        data: {
+          title: agentTitle,
+          metadata: { instructions: "<role>driven from the UI</role>" },
+          connections: [],
+        },
+      },
+    );
+
+    const baseURL = getE2EAppOrigin();
+    // Origin header so the sign-in POST clears Better Auth's CSRF guard — same
+    // reason newApiContext sets it for standalone API contexts.
+    const ctx = await browser.newContext({
+      baseURL,
+      extraHTTPHeaders: { Origin: baseURL },
+    });
+    const page = await ctx.newPage();
+    const adminUser = await ensureDeploymentAdmin(page.context().request);
+    await verifyAdmin(adminUser.userId);
+
+    await page.goto("/_admin/copy-agent");
+
+    // The three panes are labelled regions — both org pickers render the same
+    // rows, so every locator below is scoped to its own pane.
+    const sourcePane = page.getByRole("region", {
+      name: "1. Source organization",
+    });
+    const agentPane = page.getByRole("region", { name: "2. Agent to copy" });
+    const targetPane = page.getByRole("region", {
+      name: "3. Target organization",
+    });
+
+    // Step 1: the source org. Searching by slug is precise on a long-lived dev
+    // DB where the first unsearched page can't be asserted on.
+    await expect(sourcePane).toBeVisible({ timeout: 15_000 });
+    await sourcePane
+      .getByPlaceholder("Search by name or slug...")
+      .fill(source.orgSlug);
+    await sourcePane
+      .getByRole("radio", { name: new RegExp(source.orgSlug) })
+      .click();
+
+    // Step 2: the agent list loads for the picked org.
+    const agentOption = agentPane.getByRole("radio", {
+      name: new RegExp(agentTitle),
+    });
+    await expect(agentOption).toBeVisible({ timeout: 15_000 });
+    await agentOption.click();
+
+    // Step 3: the target org.
+    await targetPane
+      .getByPlaceholder("Search by name or slug...")
+      .fill(target.orgSlug);
+    await targetPane
+      .getByRole("radio", { name: new RegExp(target.orgSlug) })
+      .click();
+
+    await page
+      .getByRole("button", { name: new RegExp(`Copy "${agentTitle}"`) })
+      .click();
+
+    // The report renders, naming the agent and the org it landed in.
+    await expect(
+      page.getByText(`Copied "${agentTitle}" into`, { exact: false }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // And the copy really is in the target org, not just on screen.
+    const list = await page
+      .context()
+      .request.get(`/api/_admin/orgs/${target.orgId}/agents`);
+    expect(list.status()).toBe(200);
+    const body = (await list.json()) as { agents: { title: string }[] };
+    expect(body.agents.some((a) => a.title === agentTitle)).toBe(true);
+
+    await ctx.close();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a deployment-admin surface (**Admin Dashboard → Copy agent**) to copy an agent from one organization into another, carrying its **system prompt**, the **connections** it aggregates, and those connections' **credentials**.

Today this is a manual slog: re-create every connection, re-do every OAuth dance, re-type the system prompt — with no way to verify the result matches the original. Now it's one operation that reports exactly what landed and what didn't.

`POST /api/_admin/agents/:agentId/copy { targetOrgId }` and `GET /api/_admin/orgs/:orgId/agents` (the picker), both behind the existing `requireDeploymentAdmin` + Origin-check middleware.

## Design decisions

**Credentials ride the storage layer, not the vault.** `connections.findById` already decrypts and `createNew` re-encrypts, so passing the entity through copies the token / OAuth config / configuration state / STDIO env vars without this feature touching `ctx.vault` for connections at all. Plaintext exists only in memory for the duration of the call. New ids are minted — reusing the source id would collide on the shared primary key.

**Built-in org-scoped connections are remapped, not copied.** `<org>_self`, `_registry`, `_community-registry`, `_dev-assets`, `_commerce-discovery`, `site-diagnostics_<org>` all embed the org id. Copying `<org>_self` would hand the target org a live, stale pointer at the **source** org's full management API. They're remapped to the target's own instance, and if the target has no counterpart that's reported rather than left dangling.

**Partial copies are reported, never silent.** A copy is routinely incomplete, and an agent that *looks* configured but resolves to nothing is worse than one that's visibly missing pieces. Everything below comes back in a `skipped: string[]` rendered as a warning panel:

| Not copied | Why |
|---|---|
| `sandboxMap` | handles/preview URLs belong to the source org's running sandboxes |
| `liveAgentId` | the dev/live pair only exists in the source org |
| `siteSlug`, `productionUrl` | the linked site's storage tenancy is the source org's |
| `knowledge` | files live in the source org's Library (not copied in v1) |
| nested agents (VIRTUAL connections) | copy them separately and re-add |
| `githubRepo.connectionId` + `installationId` | a GitHub App install token is scoped to the source org's repos; the repo falls back to public-clone mode |
| any pinned view / home tile / layout tab / `subAgents` entry / env var whose connection or secret had no counterpart | the individual entry is dropped, the rest survives |

**Metadata is rewritten by an allow-through / drop-known-bad rule, not an allowlist.** `metadata` is a `.loose()` schema that gains fields regularly, so unknown keys pass through untouched (fidelity is the point) and only the org-bound ones are named explicitly. The result is `VirtualMCPCreateDataSchema.parse`d rather than cast — a schema violation fails loudly at the boundary instead of landing a malformed row.

**Two semantic traps handled deliberately:**
- `metadata.ui.layout.defaultMainView.id` is a connection id **only** for a pinned-view default (`ext-app`/`ext-apps` **with** a `toolName`); otherwise it names a declared tab. Remapping it unconditionally would corrupt every non-pinned default.
- An empty `subAgents` result is **preserved**, not deleted. `[]` means "itself only"; `null`/absent means "every active target in the org". Deleting the field to be helpful would silently *widen* what the copy may delegate to. A visibly-broken allowlist beats a silently-widened one, and the report says so.

**Secrets: reuse over overwrite; user-scope becomes org-scope.** `secrets` is uniquely indexed on `(organization_id, lower(name))` for org scope, so a name that already exists in the target is **reused** — clobbering a customer's live credential to make a copy tidy isn't a trade worth making. Reading the source row goes directly to `ctx.db`, bypassing `SecretStorage`'s per-caller visibility check (which would reject another user's user-scoped secret); that's the intended privilege of a surface that already grants org membership and impersonates users. A user-scoped secret necessarily becomes **org-scoped** in the target — the admin usually isn't a member there, so a user-scoped copy would be invisible to the people who need it and the agent wouldn't boot. Reported.

**`pinned` is forced false.** Pinning to the sidebar is gated on org-admin (`requireOrgAdminForPinnedField`); a copy shouldn't quietly plant itself in a customer's sidebar. Reported.

**Audited like impersonation.** Copying credentials across tenants is the highest-blast-radius action on this surface after impersonation, so it gets the same treatment: a durable stdout line (the one sink present in every self-host) plus a PostHog event, attributed to the **real** admin via `session.impersonatedBy`, not an impersonated identity.

**Not transactional.** Connections and secrets are separate writes; a mid-way failure leaves them as orphans in the target org for an admin to delete. Threading one Kysely transaction through five storage classes and two object stores isn't worth it for a hand-triggered operation.

## Refactors

- `routes/admin.ts` → `routes/admin/index.ts` so the surface can hold more than one module (imports use `@/`, so nothing else moved).
- Extracted `buildOrgFs(ctx, orgId)` from `buildPublicOrgFs`, which was the same four lines with a hardcoded org. The copy needs two `OrgFs` instances at once (source read, target write), so the S3-or-dev-storage fallback now lives in one place.

## Testing

**Unit** (`bun test`) — 11 cases over the metadata rewrite, the pure branch-heavy part: prompt and unknown keys survive; each org-bound key is dropped *and* reported; absent/null keys are not reported; connection ids remap across pinned views, both home-tile shapes, layout tabs and `githubRepo`; unresolvable entries are dropped rather than pointed at nothing; secret-backed env vars remap while literals are untouched; the `defaultMainView` distinction in **both** directions; `subAgents` narrowing and the empty-result warning.

**E2E** (`packages/e2e`) — 6 specs, all passing locally:
- **credentials actually arrive** — the target org reads its own copy back over MCP and gets the original token *verbatim*. Asserting the ciphertext in Postgres couldn't prove this (random IV), and the suite can't import the vault, so the assertion goes through the same path the copied agent will use.
- `_self` remapped (not copied) while the real upstream is copied; prompt intact; connection list contains target-org ids only; source org can't read the copy; both rows exist under their own org.
- skip reporting for a nested agent + org-bound metadata, and the dropped keys are really absent from the copy.
- input validation (missing target 400, unknown agent/org 404, same org 400), Studio Pack refusal + absence from the picker, non-admin rejection on both routes.
- one test drives the **whole flow in the browser** and then confirms via the API that the agent really landed in the target org.

The three panes are labelled `region`s with labelled `radiogroup`s — needed to disambiguate two identical org pickers for the test driver, and correct a11y regardless.

`bun run check`, `bun run lint` (0 errors), `bun run knip`, `bun run fmt:check` all clean.

**Note on local flakes:** `deployment-admin.spec.ts` fails locally at test 4 with a signup `429`; verified identical on a stashed clean tree, so it's a local rate-limit condition, not this branch. One `apps/api` S3 integration test fails with `ECONNREFUSED` (no local minio). My own spec mints its two tenant orgs once per describe rather than per test specifically to stay under that signup limiter — noted in the file header as a deliberate, serial-mode-safe exception to the per-test-tenant doctrine.

## Follow-ups

- Knowledge files (org-fs subtree copy across tenants).
- GitHub connections referenced only from `metadata.githubRepo` (not in the aggregation list) are currently never copied, so a copied code agent loses its repo credentials. Intentional for v1 — a GitHub App install token is scoped to the source org's repos — but worth revisiting with a provision-in-target flow.
- Nested agents (recursive copy with cycle detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin tool to copy an agent between organizations, including its system prompt, connections, and credentials, in one step. Replaces manual re-setup and shows a clear report of what was copied or skipped.

- **New Features**
  - Admin Dashboard page “Copy agent” to pick source org → agent → target org; Studio Pack agents are excluded.
  - API: `POST /api/_admin/agents/:agentId/copy { targetOrgId }` and `GET /api/_admin/orgs/:orgId/agents`, behind the existing deployment-admin + Origin checks.
  - Copies non-virtual connections with credentials (decrypt on read, re-encrypt on write). Built-in org-scoped connections are remapped to the target org (`<org>_self`, `_registry`, `_community-registry`, `_dev-assets`, `_commerce-discovery`, `site-diagnostics_<org>`).
  - Copies referenced vault secrets: reuses existing same-name secrets in the target; otherwise copies and converts user-scoped to org-scoped (reported).
  - Rewrites metadata to remap/drop org-bound fields; returns a `skipped[]` report. Forces `pinned=false`.
  - Copies kickstart prompts and per‑plugin configs. Does not copy nested agents, knowledge files, sandbox handles, dev/live linkage, or other org-bound fields (reported). Audited and tracked (stdout + PostHog). Not transactional by design.
  - Tests: unit coverage for metadata remap and E2E proving credentials arrive intact, remaps work, validation and auth enforced, and full browser flow.

- **Refactors**
  - `routes/admin.ts` moved to `routes/admin/index.ts`.
  - Extracted `buildOrgFs(ctx, orgId)` and updated public OrgFs builder to use it; added `/_admin/copy-agent` route and minimal UI/i18n plumbing.

<sup>Written for commit f7d44ab1e6e059881844dd6d65d80535eb469822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

