### PR TITLE
fix(preview): fall back to the serving sandbox when the pinned provider kind has no entry

### DIFF
--- a/apps/web/src/components/chat/chat-context.tsx
+++ b/apps/web/src/components/chat/chat-context.tsx
@@ -1157,19 +1157,27 @@ export function ActiveTaskProvider({
 
     // First message on an unlocked thread: the server pins harness_id /
     // sandbox_provider_kind on receipt, but that write never flows back through
-    // `/watch` (RowPatch carries it, the SSE event does not). Mirror it into the
-    // store now so `findReusableNewChat` stops treating the (now non-empty,
-    // often just-failed) thread as an empty "New chat" and dropping the user
-    // back onto it. When the user hasn't explicitly picked a runtime the client
-    // sends no harnessId and the server pins its default ("decopilot", per
-    // resolveHarnessId's fallback for non-CLI providers) — mirror that so this
-    // covers the common brand-new-thread case, not just explicit picks. LIST is
-    // authoritative on reload; this only keeps the live view correct meanwhile.
+    // `/watch` (RowPatch carries it, the SSE event does not). Mirror the
+    // harness into the store now so `findReusableNewChat` stops treating the
+    // (now non-empty, often just-failed) thread as an empty "New chat" and
+    // dropping the user back onto it. When the user hasn't explicitly picked a
+    // runtime the client sends no harnessId and the server pins its default
+    // ("decopilot", per resolveHarnessId's fallback for non-CLI providers) —
+    // mirror that so this covers the common brand-new-thread case, not just
+    // explicit picks. LIST/GET is authoritative; this only keeps the live view
+    // correct meanwhile.
+    //
+    // `sandbox_provider_kind` is deliberately NOT mirrored: the server resolves
+    // it from state the client doesn't own (notably whether a desktop link is
+    // live), so the picker's value is a guess that the server routinely
+    // contradicts — it pins `user-desktop` for a linked desktop while the
+    // picker says `agent-sandbox`. Writing the guess made the preview's entry
+    // lookup miss a running sandbox, blanking a working preview and booting a
+    // competing one. Leave the field null until the authoritative row lands.
     if (!activeTask?.harness_id) {
       manager.patchThread({
         id: capturedTaskId,
         harness_id: submitSettings.harnessId ?? "decopilot",
-        sandbox_provider_kind: submitSettings.sandboxProviderKind ?? null,
         updated_at: new Date().toISOString(),
       });
     }

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  resolveVmEntry,
   selectVmEntry,
   shouldAutoStart,
   shouldSelfHeal,
@@ -50,6 +51,46 @@ describe("selectVmEntry", () => {
     expect(
       selectVmEntry({ a: entry("agent-sandbox", "solo") })?.sandboxHandle,
     ).toBe("solo");
+  });
+});
+
+describe("resolveVmEntry", () => {
+  test("an exact kind match wins over the non-desktop preference", () => {
+    const result = resolveVmEntry(
+      {
+        "user-desktop": entry("user-desktop", "desk"),
+        "agent-sandbox": entry("agent-sandbox", "vm"),
+      },
+      "user-desktop",
+    );
+    expect(result?.sandboxHandle).toBe("desk");
+  });
+
+  test("falls back to the serving sandbox when the pinned kind has no entry", () => {
+    // The regression: a linked desktop is serving the branch while the thread
+    // is optimistically pinned to `agent-sandbox`. Returning null here blanked
+    // a working preview into "Starting your preview" and booted a rival VM.
+    const result = resolveVmEntry(
+      { "user-desktop": entry("user-desktop", "desk") },
+      "agent-sandbox",
+    );
+    expect(result?.sandboxHandle).toBe("desk");
+  });
+
+  test("uses the heuristic when no kind is recorded", () => {
+    const result = resolveVmEntry(
+      {
+        "user-desktop": entry("user-desktop", "desk"),
+        "agent-sandbox": entry("agent-sandbox", "vm"),
+      },
+      null,
+    );
+    expect(result?.sandboxHandle).toBe("vm");
+  });
+
+  test("returns null when the branch has no sandbox at all", () => {
+    expect(resolveVmEntry({}, "agent-sandbox")).toBeNull();
+    expect(resolveVmEntry({}, null)).toBeNull();
   });
 });
 

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -19,6 +19,7 @@ import type { DrawerStatus } from "@/components/sandbox/preview/drawer/status-pi
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
 import type { ClaimFailureReason, ClaimPhase } from "./sandbox-events-context";
 import {
+  resolveVmEntry,
   selectVmEntry,
   type BranchMapEntryLike,
 } from "@decocms/shared/sandbox/select-vm-entry";
@@ -28,7 +29,7 @@ import {
 // ---------------------------------------------------------------------------
 
 // Re-exported here for existing importers and the co-located unit tests.
-export { selectVmEntry, type BranchMapEntryLike };
+export { resolveVmEntry, selectVmEntry, type BranchMapEntryLike };
 
 export interface ShouldAutoStartArgs {
   hasActiveGithubRepo: boolean;
@@ -409,13 +410,10 @@ export function SandboxLifecycleProvider({
           BranchMapEntryLike
         >)
       : {};
-  // When a provider kind is known (locked thread or live mode pick), select the
-  // matching entry directly. Fall back to the heuristic only for legacy threads
-  // with no recorded kind (sandboxProviderKind == null).
-  const vmEntry = sandboxProviderKind
-    ? ((branchMap[sandboxProviderKind] as BranchMapEntryLike | undefined) ??
-      null)
-    : selectVmEntry(branchMap);
+  // When a provider kind is known (locked thread or live mode pick), the
+  // matching entry wins; with no entry for that kind (or no kind at all) fall
+  // back to whatever is serving the branch. See resolveVmEntry.
+  const vmEntry = resolveVmEntry(branchMap, sandboxProviderKind);
   const previewUrl = vmEntry?.previewUrl ?? null;
   const userStopped =
     sharedDesiredState === "stopped" ||

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -62,7 +62,7 @@ import { MainPanelWithDrawer } from "@/layouts/main-panel-tabs/main-panel-with-d
 import { SandboxEventsProvider } from "@/components/sandbox/hooks/sandbox-events-context.tsx";
 import {
   SandboxLifecycleProvider,
-  selectVmEntry,
+  resolveVmEntry,
   deriveOthersThreadLabel,
   type BranchMapEntryLike,
 } from "@/components/sandbox/hooks/sandbox-lifecycle-context";
@@ -246,14 +246,10 @@ function VmEventsBridge({
           effectiveSandboxMap?.[userId]?.[currentBranch],
         ) as Record<string, BranchMapEntryLike>)
       : {};
-  // Use the resolved provider kind to pick the matching entry — same logic as
-  // SandboxLifecycleProvider so the SSE previewUrl and the lifecycle vmEntry
-  // always agree on which sandbox is active.
-  const vmEntry = pendingSandboxProviderKind
-    ? ((branchMap[pendingSandboxProviderKind] as
-        | BranchMapEntryLike
-        | undefined) ?? null)
-    : selectVmEntry(branchMap);
+  // Use the resolved provider kind to pick the matching entry — the SAME
+  // helper as SandboxLifecycleProvider so the SSE previewUrl and the lifecycle
+  // vmEntry always agree on which sandbox is active.
+  const vmEntry = resolveVmEntry(branchMap, pendingSandboxProviderKind);
   const previewUrl = vmEntry?.previewUrl ?? null;
   const shouldConnect =
     Object.keys(branchMap).length > 0 ||

--- a/packages/shared/src/sandbox/select-vm-entry.ts
+++ b/packages/shared/src/sandbox/select-vm-entry.ts
@@ -22,3 +22,26 @@ export function selectVmEntry<T extends BranchMapEntryLike>(
   if (!first) return null;
   return entries.find((e) => e.sandboxProviderKind !== "user-desktop") ?? first;
 }
+
+/**
+ * The sandbox entry to show for a thread whose provider kind is `kind`.
+ *
+ * An exact match on `kind` always wins, so a thread pinned to one provider
+ * keeps showing that provider even when a sibling of another kind is live —
+ * that pinning is the whole point of recording the kind.
+ *
+ * When `kind` has NO entry, degrade to whatever is actually serving the branch
+ * rather than reporting "nothing". A missing entry for the pinned kind does not
+ * mean the branch has no sandbox: the kind can be a stale or optimistic guess
+ * (the client mirrors a runtime pin at send time before the server's own
+ * resolution comes back), while a different kind is up and serving. Returning
+ * null there blanks a working preview into the booting overlay AND makes
+ * `shouldAutoStart` boot a second, competing sandbox.
+ */
+export function resolveVmEntry<T extends BranchMapEntryLike>(
+  branchMap: Record<string, T>,
+  kind: string | null | undefined,
+): T | null {
+  if (kind) return branchMap[kind] ?? selectVmEntry(branchMap);
+  return selectVmEntry(branchMap);
+}


### PR DESCRIPTION
## Summary

Sending the **first message on a fresh thread** tears down a working preview into "Starting your preview" and boots a second, competing sandbox that then fails. It self-heals a moment later when the authoritative thread row lands, which is why it reads as a flicker rather than a hard break.

It takes two individually-reasonable commits to produce, ~4 weeks apart.

### The latent half — #4025 (`ad6bcfd10`)

Preview entry selection became an exact-key lookup:

```ts
const vmEntry = sandboxProviderKind
  ? (branchMap[sandboxProviderKind] ?? null)   // exact key, no fallback
  : selectVmEntry(branchMap);
```

That was deliberate and correct — from the commit message, *"so a codex-local thread always shows the desktop sandbox even when a cluster sibling exists."* Pinning beats the heuristic.

What it doesn't cover is the pinned kind having **no entry at all**. That collapses to `null` instead of degrading to whatever is actually serving the branch. The same commit also threads `sandboxProviderKind` into `SANDBOX_START` and drops the `!!branch` gate from `shouldAutoStart` — so a lookup miss no longer just blanks the preview, it also boots a rival VM.

### What made it reachable — #4558 (`73b15a685`)

That PR mirrors the first-message runtime pin into the thread store, so `findReusableNewChat` stops reusing a thread whose first message already ran (`harness_id` is pinned server-side on dispatch and never flows back through `/watch`). Correct, and needed.

It also mirrors `sandbox_provider_kind` — sourced from the client's picker:

```ts
manager.patchThread({
  id: capturedTaskId,
  harness_id: submitSettings.harnessId ?? "decopilot",
  sandbox_provider_kind: submitSettings.sandboxProviderKind ?? null,  // ← the client's guess
  updated_at: new Date().toISOString(),
});
```

The server resolves that field from state the client doesn't own — notably whether a desktop link is live. With a linked desktop it pins `user-desktop` while the picker says `agent-sandbox`. Mirroring the guess flips `pendingSandboxProviderKind` mid-session, the exact-key lookup misses the running desktop sandbox, and the preview drops out from under the user.

Neither commit is wrong on its own. The bug is the interaction: one made a miss fatal, the other made misses happen.

## Reproduction

Linked desktop, agent whose branch map holds exactly one entry:

```
pSozqw…/gimenes-xiwzhzrm → { "user-desktop": "http://gimenes-xiwzhzrm-d7600347fc5a12ae.localhost:49361" }
```

New chat → send first message. The client fires a start for a provider that isn't there:

```json
POST /tools/SANDBOX_START
{"branch":"gimenes-xiwzhzrm","sandboxProviderKind":"agent-sandbox"}  → 500
```

```json
{"status":"failed","previewUrl":null,
 "failureReason":"SandboxClaim gimenes-xiwzhzrm-4993c564eb23f9e7 did not record an adopted Sandbox (status.sandbox.name) within 60s"}
```

Note the handle differs from the one serving the preview (`d7600347fc5a12ae`) — it's a second sandbox racing the healthy one. Meanwhile the server had pinned the thread `sandbox_provider_kind: "user-desktop"` all along.

## Fix

**1. `resolveVmEntry(branchMap, kind)`** in `@decocms/shared`. An exact match still wins, so #4025's pinning is preserved intact; a *missing* entry falls back to the serving sandbox instead of `null`. Both call sites — `SandboxLifecycleProvider` and `VmEventsBridge` — now share it, retiring the duplicated logic whose comment already said the two "must always agree."

**2. Stop mirroring `sandbox_provider_kind` at send time.** `harness_id` is all the reuse gate needs. Never optimistically write a field the server resolves from state the client can't see; it stays null until the real row arrives.

(1) is the load-bearing one — it makes a transient wrong pin harmless rather than destructive. (2) removes the trigger.

## Testing

4 unit tests on `resolveVmEntry`, including one encoding this exact failure shape (desktop serving, thread pinned to `agent-sandbox`).

Verified in a live dev app against a linked desktop:

| | before | after |
|---|---|---|
| preview state | `IFRAME → STARTING` | `IFRAME` only |
| `SANDBOX_START` calls | 1 → **500** | **0** |
| iframe src | dropped | unchanged |

Message dispatches normally; thread ends at `harness_id: decopilot`, `sandbox_provider_kind: user-desktop`, `branch: gimenes-xiwzhzrm`.

`bun run check` clean across all 14 workspaces · `bun run lint` 0 errors · `bun run fmt` applied · sandbox + chat unit suites 853/853.

## Notes for reviewers

@pedrofrxncx — tagging you since #4558 is the half that surfaces this, and the mirror there is doing real work for `findReusableNewChat` that I don't want to regress. Please sanity-check that dropping only `sandbox_provider_kind` (keeping `harness_id`) still fully covers the reuse gate you were fixing.

Split out of #5231 — unrelated to that PR's new-chat branch-inheritance change, so it ships on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes preview flicker on the first message by falling back to the serving sandbox when the pinned `sandbox_provider_kind` has no entry, preventing a second, failing VM from starting. Also stops writing the client’s provider-kind guess to avoid mismatches mid-session.

- **Bug Fixes**
  - Added `resolveVmEntry(branchMap, kind)` in `@decocms/shared`; exact match wins, otherwise falls back to `selectVmEntry`.
  - Replaced local lookups with `resolveVmEntry` in SandboxLifecycleProvider and VmEventsBridge to keep selection consistent.
  - Stopped mirroring `sandbox_provider_kind` at send time (still mirror `harness_id`); the server remains the source of truth.
  - Added unit tests for `resolveVmEntry`, including the desktop-serving/pinned-to-agent regression case.

<sup>Written for commit c833a7ed2807d0230e2522f86e481a0f2b449d06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

