### PR TITLE
fix(header): hide "New chat" action when chat is closed

### DIFF
--- a/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
@@ -244,7 +244,6 @@ export function WorkspacePanelGroup({
           Publish / ⋯ never clip) and is what `rightRef` measures, so the tab
           count budget is unaffected by the branch label's width. */}
       <div className="flex min-w-0 shrink items-center justify-end gap-1">
-        {!chatOpen && newChatCrumb}
         <div className="flex min-w-0 shrink items-center justify-end">
           {branchSelector}
         </div>


### PR DESCRIPTION
## Summary

When the sidebar is collapsed and the chat panel is **closed** (e.g. Preview / Visualização mode), the "New chat" icon was still showing in the main panel header. It only makes sense while a chat is open, so it's now rendered only in the chat header.

## Change

- `apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx`: removed the `{!chatOpen && newChatCrumb}` render in the main header. The crumb remains in the chat header (visible only when chat is open).

## Testing

- `bun run fmt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the "New chat" action in the main panel header when the chat is closed; it now only appears in the chat header while a chat is open (e.g., not shown in Preview mode).

<sup>Written for commit 9e2691bdd38eb60250950af95618a76befca0a0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

