### PR TITLE
fix(thread): open chat panel when header actions send a message

### DIFF
--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -15,6 +15,7 @@ import { coAuthorFromSessionUser } from "@/lib/co-author-identity.ts";
 import { resolveGithubAttachment } from "@/lib/github-repo.ts";
 import { useChatStream } from "../../chat/chat-context.tsx";
 import { useChatTask } from "../../chat/index";
+import { usePanelActions } from "@/layouts/shell-layout";
 import { squashMergePullRequest } from "./github-pr-api.ts";
 import { MergeSplitButton } from "./merge-split-button.tsx";
 import { PublishDialog } from "./publish-dialog.tsx";
@@ -105,6 +106,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const vm = useVirtualMCP(virtualMcpId);
   const { currentBranch: branch } = useChatTask();
   const chat = useChatStream();
+  const { openSidePanel } = usePanelActions();
   const [publishOpen, setPublishOpen] = useState(false);
   const [publishDialogIntent, setPublishDialogIntent] = useState<
     "open-pr" | "publish-only"
@@ -281,8 +283,12 @@ export function HeaderActions({ virtualMcpId }: Props) {
     });
   }
 
-  const send = (text: string) =>
-    chat.sendMessage({ parts: [{ type: "text", text }] });
+  const send = (text: string) => {
+    // Header actions can fire while the chat side panel is closed (e.g. from the
+    // GitHub tab), so surface the chat so the user sees the message we just sent.
+    openSidePanel("chat");
+    return chat.sendMessage({ parts: [{ type: "text", text }] });
+  };
 
   const isStreaming = chat.isStreaming;
 


### PR DESCRIPTION
## Summary

GitHub header actions — **"Sync with main"** (the `rebase` action), plus fix-checks, review, reopen, etc. — sent a chat message via `chat.sendMessage(...)` **without opening the chat side panel**. When the chat was closed, the message went out with no visible feedback, so it looked like nothing happened.

This wraps `send()` in `header-actions.tsx` to call `openSidePanel("chat")` before dispatching, matching the existing pattern used by the improve-prompt flow in `views/virtual-mcp/index.tsx`.

## Testing

- `bun run --cwd=apps/web check` ✅
- `bun run fmt` ✅
- Manual: open the GitHub tab with the chat closed and click "Sync with main" — the chat panel now opens and shows the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open the chat panel when GitHub header actions send a message, so users get visible feedback. Wrap the `send()` helper in `header-actions.tsx` to call `openSidePanel("chat")` before `chat.sendMessage`.

<sup>Written for commit 5d54aba5353c7a386d5c160bd3ac7df53f2d7f85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

