### PR TITLE
feat(preview): ready-gated CMS auto-open + per-agent Layout toggle

### DIFF
--- a/apps/web/src/components/sandbox/blocks/blocks-panel.tsx
+++ b/apps/web/src/components/sandbox/blocks/blocks-panel.tsx
@@ -12,7 +12,10 @@ import {
   readLastPreviewPage,
 } from "@/components/sandbox/preview/last-preview-page";
 import { useBlocksPreviewWorkspace } from "@/components/sandbox/blocks/blocks-preview-workspace-context";
-import { resolveBlocksTabState } from "@/layouts/main-panel-tabs/blocks-tab-state";
+import {
+  resolveBlocksTabState,
+  toBlocksQueryState,
+} from "@/layouts/main-panel-tabs/blocks-tab-state";
 import {
   BlocksEmptyState,
   BlocksErrorState,
@@ -24,17 +27,6 @@ const SectionsEditor = lazy(() =>
     default: m.SectionsEditor,
   })),
 );
-
-function errorStatus(error: unknown): number | undefined {
-  if (
-    error instanceof Error &&
-    "status" in error &&
-    typeof error.status === "number"
-  ) {
-    return error.status;
-  }
-  return undefined;
-}
 
 export function BlocksPanel({
   virtualMcpId,
@@ -66,16 +58,8 @@ export function BlocksPanel({
   const meta = useLiveMeta(fetchParams, { fetchEnabled: devServerReady });
   const state = resolveBlocksTabState({
     lifecyclePhase: sandboxEvents.lifecycle.phase,
-    decofile: {
-      status: decofile.status,
-      hasData: decofile.data !== undefined,
-      errorStatus: errorStatus(decofile.error),
-    },
-    meta: {
-      status: meta.status,
-      hasData: meta.data !== undefined,
-      errorStatus: errorStatus(meta.error),
-    },
+    decofile: toBlocksQueryState(decofile),
+    meta: toBlocksQueryState(meta),
     hasEditableContent: hasEditableDecoContent(decofile.data, meta.data),
   });
 

--- a/apps/web/src/components/sandbox/preview/editing-mode.test.ts
+++ b/apps/web/src/components/sandbox/preview/editing-mode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { togglePreviewEditorMode } from "./editing-mode";
+import { shouldAutoOpenCms, togglePreviewEditorMode } from "./editing-mode";
 
 describe("togglePreviewEditorMode", () => {
   test("activates an editor from the neutral preview", () => {
@@ -15,5 +15,35 @@ describe("togglePreviewEditorMode", () => {
   test("switches directly between mutually exclusive editors", () => {
     expect(togglePreviewEditorMode("visual", "blocks")).toBe("blocks");
     expect(togglePreviewEditorMode("blocks", "visual")).toBe("visual");
+  });
+});
+
+describe("shouldAutoOpenCms", () => {
+  const ready = {
+    cmsDefaultOpen: true,
+    blocksReady: true,
+    autoOpenResolved: false,
+    editingMode: "preview",
+  } as const;
+
+  test("fires only when all four conditions hold", () => {
+    expect(shouldAutoOpenCms(ready)).toBe(true);
+  });
+
+  test("off by default: never fires when the setting is disabled", () => {
+    expect(shouldAutoOpenCms({ ...ready, cmsDefaultOpen: false })).toBe(false);
+  });
+
+  test("waits until Blocks metadata is ready", () => {
+    expect(shouldAutoOpenCms({ ...ready, blocksReady: false })).toBe(false);
+  });
+
+  test("does not re-fire once resolved (user took control / already opened)", () => {
+    expect(shouldAutoOpenCms({ ...ready, autoOpenResolved: true })).toBe(false);
+  });
+
+  test("does not fire when the user is already in an editor", () => {
+    expect(shouldAutoOpenCms({ ...ready, editingMode: "blocks" })).toBe(false);
+    expect(shouldAutoOpenCms({ ...ready, editingMode: "visual" })).toBe(false);
   });
 });

--- a/apps/web/src/components/sandbox/preview/editing-mode.ts
+++ b/apps/web/src/components/sandbox/preview/editing-mode.ts
@@ -8,3 +8,26 @@ export function togglePreviewEditorMode(
 ): PreviewEditingMode {
   return current === requested ? "preview" : requested;
 }
+
+/**
+ * Whether the one-shot CMS auto-open should fire. All four must hold:
+ * - `cmsDefaultOpen`: the per-agent Layout setting is on (off by default — this
+ *   is the load-bearing safety gate),
+ * - `blocksReady`: Blocks metadata resolved to renderable content,
+ * - `!autoOpenResolved`: it hasn't already fired and the user hasn't taken
+ *   manual control of the editing mode,
+ * - `editingMode === "preview"`: the user isn't already in an editor.
+ */
+export function shouldAutoOpenCms(input: {
+  cmsDefaultOpen: boolean;
+  blocksReady: boolean;
+  autoOpenResolved: boolean;
+  editingMode: PreviewEditingMode;
+}): boolean {
+  return (
+    input.cmsDefaultOpen &&
+    input.blocksReady &&
+    !input.autoOpenResolved &&
+    input.editingMode === "preview"
+  );
+}

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -3,7 +3,7 @@ import { useState, useRef, useEffect, Suspense, lazy } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { formatCodeTabId } from "@/layouts/main-panel-tabs/tab-id";
 import { useChatTask } from "@/components/chat/context";
-import { useProjectContext } from "@/sdk";
+import { useProjectContext, useVirtualMCP } from "@/sdk";
 import { useSandboxLifecycle } from "@/components/sandbox/hooks/sandbox-lifecycle-context";
 import { startCmsTour } from "@/components/cms-tour/cms-tour";
 import { TOUR_ANCHORS } from "@/components/cms-tour/anchors";
@@ -64,9 +64,14 @@ import {
   extractGlobalSections,
   extractPages,
   findPageForPath,
+  hasEditableDecoContent,
   type GlobalSectionEntry,
   type PageEntry,
 } from "@/components/sections-editor/page-list";
+import {
+  resolveBlocksTabState,
+  toBlocksQueryState,
+} from "@/layouts/main-panel-tabs/blocks-tab-state";
 import {
   fillPathTemplate,
   normalizePagePath,
@@ -218,7 +223,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   // Editing mode is singular: Visual editor and Blocks cannot be active
   // together. Device size is independent and survives mode switches.
+  // Starts in plain "preview"; the CMS (blocks) auto-opens once its metadata is
+  // ready to render content (see `blocksAutoOpenResolved` below), so users never
+  // see the "Blocos indisponíveis"/loading card pop open on its own.
   const [editingMode, setEditingMode] = useState<PreviewEditingMode>("preview");
+  // Latches once the CMS has auto-opened (or the user has taken manual control
+  // of the editing mode), so the one-shot auto-open never fights the user.
+  const [blocksAutoOpenResolved, setBlocksAutoOpenResolved] = useState(false);
   const [previewDeviceSize, setPreviewDeviceSize] =
     useState<PreviewDeviceSize>("desktop");
   const [visualElement, setVisualElement] =
@@ -275,6 +286,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   const { org } = useProjectContext();
 
+  // Per-agent "Open CMS" Layout setting. Off by default (absent / null → false):
+  // Preview stays on the site until the user opens the CMS manually, unless an
+  // agent opts in to auto-open.
+  const virtualMcp = useVirtualMCP(virtualMcpId);
+  const cmsDefaultOpen =
+    virtualMcp?.metadata?.ui?.layout?.cmsDefaultOpen ?? false;
+
   const vmEvents = useSandboxEvents();
   const lifecycle = useSandboxLifecycle();
   const vmEntry = lifecycle.vmEntry;
@@ -303,12 +321,24 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     virtualMcpId && branch
       ? { orgSlug: org.slug, virtualMcpId, branch, previewUrl }
       : null;
-  const { data: decofile } = useDecofile(decofileParams, {
+  const decofileQuery = useDecofile(decofileParams, {
     fetchEnabled: devServerReady,
   });
-  const { data: meta } = useLiveMeta(decofileParams, {
+  const metaQuery = useLiveMeta(decofileParams, {
     fetchEnabled: devServerReady,
   });
+  const decofile = decofileQuery.data;
+  const meta = metaQuery.data;
+  // Same readiness classification the CMS panel itself uses. We only auto-open
+  // the CMS once this resolves to "content" (metadata loaded AND there is
+  // editable content) so the panel never opens onto a loading/empty/error card.
+  const blocksReady =
+    resolveBlocksTabState({
+      lifecyclePhase,
+      decofile: toBlocksQueryState(decofileQuery),
+      meta: toBlocksQueryState(metaQuery),
+      hasEditableContent: hasEditableDecoContent(decofile, meta),
+    }).kind === "content";
   const createPageParams =
     virtualMcpId && branch ? { orgSlug: org.slug, virtualMcpId, branch } : null;
   const createPage = useCreatePage(createPageParams);
@@ -686,8 +716,27 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   };
 
   const toggleEditingMode = (mode: PreviewEditorMode) => {
+    // The user is driving the editing mode now — stop the one-shot CMS
+    // auto-open from ever kicking in behind them.
+    setBlocksAutoOpenResolved(true);
     activateEditingMode(togglePreviewEditorMode(editingMode, mode));
   };
+
+  // One-shot: auto-open the CMS the first time Blocks metadata is ready to
+  // render content, so the panel never pops open onto a loading/empty/error
+  // card. Gated by the per-agent "Open CMS" Layout setting. Render-time guard
+  // is the codebase's run-once pattern (see PathParamAutoFill); the imperative
+  // open is deferred to a microtask so it runs post-commit (panel mounted)
+  // instead of mid-render.
+  if (
+    cmsDefaultOpen &&
+    blocksReady &&
+    !blocksAutoOpenResolved &&
+    editingMode === "preview"
+  ) {
+    setBlocksAutoOpenResolved(true);
+    queueMicrotask(() => activateEditingMode("blocks"));
+  }
 
   const handleRefresh = () => {
     if (!previewIframeRef.current || !iframeSrc) return;

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -3,7 +3,7 @@ import { useState, useRef, useEffect, Suspense, lazy } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { formatCodeTabId } from "@/layouts/main-panel-tabs/tab-id";
 import { useChatTask } from "@/components/chat/context";
-import { useProjectContext, useVirtualMCP } from "@/sdk";
+import { useProjectContext } from "@/sdk";
 import { useSandboxLifecycle } from "@/components/sandbox/hooks/sandbox-lifecycle-context";
 import { startCmsTour } from "@/components/cms-tour/cms-tour";
 import { TOUR_ANCHORS } from "@/components/cms-tour/anchors";
@@ -132,6 +132,7 @@ import {
   type ImperativePanelHandle,
 } from "@/components/resizable";
 import {
+  shouldAutoOpenCms,
   togglePreviewEditorMode,
   type PreviewEditingMode,
   type PreviewEditorMode,
@@ -183,6 +184,23 @@ function previewOrigin(previewUrl: string | null): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Renders nothing; fires `onOpen` exactly once when mounted to auto-open the
+ * CMS. Headless run-once helper mirroring `PathParamAutoFill`: the parent
+ * mounts it only while the auto-open should happen (see `shouldAutoOpenCms`)
+ * and latches on `onOpen`, so it unmounts the instant it fires and never
+ * re-opens behind a user who has taken manual control. `queueMicrotask` defers
+ * the imperative open to post-commit (panel mounted) instead of mid-render.
+ */
+function CmsAutoOpen({ onOpen }: { onOpen: () => void }) {
+  const [fired, setFired] = useState(false);
+  if (!fired) {
+    setFired(true);
+    queueMicrotask(onOpen);
+  }
+  return null;
 }
 
 /**
@@ -285,13 +303,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const [siteSeoOpen, setSiteSeoOpen] = useState(false);
 
   const { org } = useProjectContext();
-
-  // Per-agent "Open CMS" Layout setting. Off by default (absent / null → false):
-  // Preview stays on the site until the user opens the CMS manually, unless an
-  // agent opts in to auto-open.
-  const virtualMcp = useVirtualMCP(virtualMcpId);
-  const cmsDefaultOpen =
-    virtualMcp?.metadata?.ui?.layout?.cmsDefaultOpen ?? false;
 
   const vmEvents = useSandboxEvents();
   const lifecycle = useSandboxLifecycle();
@@ -461,6 +472,14 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     inset?.entity?.id === virtualMcpId
       ? sanitizeProductionUrl(inset.entity.metadata?.productionUrl)
       : null;
+  // Per-agent "Open CMS" Layout setting, read off the entity already in
+  // context (same source as productionUrl above). Off by default (absent /
+  // null → false): Preview stays on the site until the user opens the CMS
+  // manually, unless an agent opts in to auto-open.
+  const cmsDefaultOpen =
+    (inset?.entity?.id === virtualMcpId
+      ? inset.entity.metadata?.ui?.layout?.cmsDefaultOpen
+      : null) ?? false;
 
   // The recorded previewUrl flips previewState to "iframe" as soon as the
   // sandbox handle exists — well before the public preview proxy is routable —
@@ -717,26 +736,29 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   const toggleEditingMode = (mode: PreviewEditorMode) => {
     // The user is driving the editing mode now — stop the one-shot CMS
-    // auto-open from ever kicking in behind them.
+    // auto-open from ever kicking in behind them. This is the ONLY path back to
+    // `editingMode === "preview"` (the direct `activateEditingMode("blocks")`
+    // calls only ever leave it in "blocks"), so latching here is what keeps
+    // auto-open from re-firing after a manual close.
     setBlocksAutoOpenResolved(true);
     activateEditingMode(togglePreviewEditorMode(editingMode, mode));
   };
 
   // One-shot: auto-open the CMS the first time Blocks metadata is ready to
   // render content, so the panel never pops open onto a loading/empty/error
-  // card. Gated by the per-agent "Open CMS" Layout setting. Render-time guard
-  // is the codebase's run-once pattern (see PathParamAutoFill); the imperative
-  // open is deferred to a microtask so it runs post-commit (panel mounted)
-  // instead of mid-render.
-  if (
-    cmsDefaultOpen &&
-    blocksReady &&
-    !blocksAutoOpenResolved &&
-    editingMode === "preview"
-  ) {
+  // card. Gated by the per-agent "Open CMS" Layout setting. Handled by the
+  // headless `<CmsAutoOpen>` below, mounted only while `shouldAutoOpenCms`
+  // holds; `onOpen` latches so it fires exactly once.
+  const autoOpenCms = shouldAutoOpenCms({
+    cmsDefaultOpen,
+    blocksReady,
+    autoOpenResolved: blocksAutoOpenResolved,
+    editingMode,
+  });
+  const handleCmsAutoOpen = () => {
     setBlocksAutoOpenResolved(true);
-    queueMicrotask(() => activateEditingMode("blocks"));
-  }
+    activateEditingMode("blocks");
+  };
 
   const handleRefresh = () => {
     if (!previewIframeRef.current || !iframeSrc) return;
@@ -1425,6 +1447,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   return (
     <div className="flex flex-col w-full h-full">
+      {/* Headless: auto-opens the CMS once (renders nothing). Mounted only
+          while the per-agent setting + readiness say it should. */}
+      {autoOpenCms && <CmsAutoOpen onOpen={handleCmsAutoOpen} />}
       {/* Auto-select the first entity for a picker param with no value yet, so
           navigating to a bare dynamic-route template lands on a real page.
           Each helper renders nothing and unmounts once its param is filled. */}

--- a/apps/web/src/i18n/en/virtual-mcp.ts
+++ b/apps/web/src/i18n/en/virtual-mcp.ts
@@ -113,6 +113,9 @@ export const virtualMcp = {
     "What users see when they first open this agent.",
   "virtualMcp.layoutTabContent.noInteractiveTools":
     "None of the connected servers expose interactive tools.",
+  "virtualMcp.layoutTabContent.openCms": "Open CMS",
+  "virtualMcp.layoutTabContent.openCmsDescription":
+    "Open the CMS automatically when the preview is ready to edit content.",
   "virtualMcp.layoutTabContent.pinnedViews": "Pinned views",
   "virtualMcp.layoutTabContent.pinnedViewsDescription":
     "Surface interactive tools as top-level tabs in the agent.",

--- a/apps/web/src/i18n/pt-br/virtual-mcp.ts
+++ b/apps/web/src/i18n/pt-br/virtual-mcp.ts
@@ -116,6 +116,9 @@ export const virtualMcp = {
     "O que os usuários veem quando abrem este agente pela primeira vez.",
   "virtualMcp.layoutTabContent.noInteractiveTools":
     "Nenhum dos servidores conectados expõe ferramentas interativas.",
+  "virtualMcp.layoutTabContent.openCms": "Abrir CMS",
+  "virtualMcp.layoutTabContent.openCmsDescription":
+    "Abrir o CMS automaticamente quando a visualização estiver pronta para editar conteúdo.",
   "virtualMcp.layoutTabContent.pinnedViews": "Visualizações fixadas",
   "virtualMcp.layoutTabContent.pinnedViewsDescription":
     "Colocar ferramentas interativas como abas de nível superior no agente.",

--- a/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   resolveBlocksTabState,
+  toBlocksQueryState,
   type BlocksTabStateInput,
 } from "./blocks-tab-state";
 
@@ -17,6 +18,57 @@ function input(
     ...overrides,
   };
 }
+
+describe("toBlocksQueryState", () => {
+  test("maps a settled query: data present, no error", () => {
+    expect(
+      toBlocksQueryState({ status: "success", data: {}, error: null }),
+    ).toEqual({ status: "success", hasData: true, errorStatus: undefined });
+  });
+
+  test("hasData is false only when data is `undefined`", () => {
+    expect(
+      toBlocksQueryState({ status: "pending", data: undefined, error: null })
+        .hasData,
+    ).toBe(false);
+    // `null`, "", 0 are real data (the check is `!== undefined`).
+    for (const data of [null, "", 0]) {
+      expect(
+        toBlocksQueryState({ status: "success", data, error: null }).hasData,
+      ).toBe(true);
+    }
+  });
+
+  test("extracts a numeric `.status` off a thrown Error, else undefined", () => {
+    expect(
+      toBlocksQueryState({
+        status: "error",
+        data: undefined,
+        error: Object.assign(new Error("nope"), { status: 404 }),
+      }).errorStatus,
+    ).toBe(404);
+    // plain Error (no status), non-numeric status, and non-Error throwables
+    // all collapse to undefined.
+    expect(
+      toBlocksQueryState({
+        status: "error",
+        data: undefined,
+        error: new Error(),
+      }).errorStatus,
+    ).toBeUndefined();
+    expect(
+      toBlocksQueryState({
+        status: "error",
+        data: undefined,
+        error: Object.assign(new Error(), { status: "404" }),
+      }).errorStatus,
+    ).toBeUndefined();
+    expect(
+      toBlocksQueryState({ status: "error", data: undefined, error: "boom" })
+        .errorStatus,
+    ).toBeUndefined();
+  });
+});
 
 describe("resolveBlocksTabState", () => {
   test.each(["idle", "cloning"] as const)(

--- a/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.ts
+++ b/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.ts
@@ -8,6 +8,31 @@ export interface BlocksQueryState {
   errorStatus?: number;
 }
 
+/** Extract the numeric `.status` a read fallback tags onto its thrown Error. */
+function errorStatus(error: unknown): number | undefined {
+  if (
+    error instanceof Error &&
+    "status" in error &&
+    typeof error.status === "number"
+  ) {
+    return error.status;
+  }
+  return undefined;
+}
+
+/** Map a `useQuery` result to the shape `resolveBlocksTabState` consumes. */
+export function toBlocksQueryState(query: {
+  status: QueryStatus;
+  data: unknown;
+  error: unknown;
+}): BlocksQueryState {
+  return {
+    status: query.status,
+    hasData: query.data !== undefined,
+    errorStatus: errorStatus(query.error),
+  };
+}
+
 export interface BlocksTabStateInput {
   lifecyclePhase: LifecycleState["phase"];
   decofile: BlocksQueryState;

--- a/apps/web/src/views/virtual-mcp/layout-tab-content.tsx
+++ b/apps/web/src/views/virtual-mcp/layout-tab-content.tsx
@@ -127,6 +127,9 @@ export function LayoutTabContent({
   const layoutMeta = form.watch("metadata.ui.layout") ?? null;
   const currentDefaultMain = layoutMeta?.defaultMainView ?? null;
   const chatDefaultOpen = layoutMeta?.chatDefaultOpen ?? false;
+  // Off by default (absent / null → false): the CMS auto-opens in Preview only
+  // when an agent explicitly opts in via this toggle.
+  const cmsDefaultOpen = layoutMeta?.cmsDefaultOpen ?? false;
   // Convert the stored {type, id, toolName} object into the string composite
   // key used by the <Select> UI. Legacy tab types fold into "settings".
   const defaultMainView = (() => {
@@ -165,6 +168,7 @@ export function LayoutTabContent({
   const writeLayout = (next: {
     defaultMainView?: { type: string; id?: string; toolName?: string } | null;
     chatDefaultOpen?: boolean | null;
+    cmsDefaultOpen?: boolean | null;
   }) => {
     form.setValue(
       "metadata.ui.layout",
@@ -392,6 +396,27 @@ export function LayoutTabContent({
               )}
             </Tooltip>
           </div>
+
+          {hasClonableSource && (
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-0.5 min-w-0">
+                <Label className="font-normal text-foreground">
+                  {t("virtualMcp.layoutTabContent.openCms")}
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  {t("virtualMcp.layoutTabContent.openCmsDescription")}
+                </p>
+              </div>
+              <Switch
+                className="shrink-0"
+                checked={cmsDefaultOpen}
+                onCheckedChange={(checked) => {
+                  writeLayout({ cmsDefaultOpen: checked });
+                  flushAndSave();
+                }}
+              />
+            </div>
+          )}
         </CardContent>
 
         {hasPinnedContent && (

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -96,6 +96,13 @@ export const VirtualMcpUILayoutSchema = z.object({
    * unless the default view is Chat.
    */
   chatDefaultOpen: z.boolean().nullable().optional(),
+  /**
+   * When true, the CMS (Blocks) panel auto-opens in the Preview as soon as its
+   * metadata is ready to render content. Off by default: absent / null / false
+   * → Preview stays on the site until the user opens the CMS manually. Only
+   * relevant for agents with a preview.
+   */
+  cmsDefaultOpen: z.boolean().nullable().optional(),
   tabs: z.array(VirtualMcpUILayoutTabSchema).optional(),
 });
 

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -868,6 +868,18 @@ export interface StudioToolIO {
     input: { quantity: number };
     output: { amountDueCents: number; currency: string };
   };
+  ORGANIZATION_BILLING_PORTAL: {
+    input: { [x: string]: never };
+    output: { url: string };
+  };
+  ORGANIZATION_INCLUDED_REPORT_SET: {
+    input: { url: string | null };
+    output: { includedReportUrl: string | null; benefitsSyncQueued: boolean };
+  };
+  ORGANIZATION_REPORT_RUN_PAID: {
+    input: { url?: string | undefined };
+    output: { url: string; started: boolean };
+  };
   COLLECTION_CONNECTIONS_CREATE: {
     input: {
       data: {
@@ -1630,6 +1642,7 @@ export interface StudioToolIO {
                         | null
                         | undefined;
                       chatDefaultOpen?: boolean | null | undefined;
+                      cmsDefaultOpen?: boolean | null | undefined;
                       tabs?:
                         | {
                             id: string;
@@ -1834,6 +1847,7 @@ export interface StudioToolIO {
                             | null
                             | undefined;
                           chatDefaultOpen?: boolean | null | undefined;
+                          cmsDefaultOpen?: boolean | null | undefined;
                           tabs?:
                             | {
                                 id: string;
@@ -2008,6 +2022,7 @@ export interface StudioToolIO {
                         | null
                         | undefined;
                       chatDefaultOpen?: boolean | null | undefined;
+                      cmsDefaultOpen?: boolean | null | undefined;
                       tabs?:
                         | {
                             id: string;
@@ -2193,6 +2208,7 @@ export interface StudioToolIO {
                         | null
                         | undefined;
                       chatDefaultOpen?: boolean | null | undefined;
+                      cmsDefaultOpen?: boolean | null | undefined;
                       tabs?:
                         | {
                             id: string;
@@ -2369,6 +2385,7 @@ export interface StudioToolIO {
                         | null
                         | undefined;
                       chatDefaultOpen?: boolean | null | undefined;
+                      cmsDefaultOpen?: boolean | null | undefined;
                       tabs?:
                         | {
                             id: string;
@@ -2539,6 +2556,7 @@ export interface StudioToolIO {
                             | null
                             | undefined;
                           chatDefaultOpen?: boolean | null | undefined;
+                          cmsDefaultOpen?: boolean | null | undefined;
                           tabs?:
                             | {
                                 id: string;
@@ -2721,6 +2739,7 @@ export interface StudioToolIO {
                         | null
                         | undefined;
                       chatDefaultOpen?: boolean | null | undefined;
+                      cmsDefaultOpen?: boolean | null | undefined;
                       tabs?:
                         | {
                             id: string;
@@ -2895,6 +2914,7 @@ export interface StudioToolIO {
                         | null
                         | undefined;
                       chatDefaultOpen?: boolean | null | undefined;
+                      cmsDefaultOpen?: boolean | null | undefined;
                       tabs?:
                         | {
                             id: string;
@@ -3871,6 +3891,7 @@ export interface StudioToolIO {
                         | null
                         | undefined;
                       chatDefaultOpen?: boolean | null | undefined;
+                      cmsDefaultOpen?: boolean | null | undefined;
                       tabs?:
                         | {
                             id: string;


### PR DESCRIPTION
## Summary

The CMS (Blocks) panel in the sandbox Preview used to open tied to the editing mode with **no readiness gate** — so it could pop open onto the **"Blocos indisponíveis" / loading** card before the block metadata was actually ready.

This PR:

- **Ready-gates the CMS auto-open**: it only opens once the block metadata resolves to *renderable content* (reuses the same `resolveBlocksTabState` classification the panel itself uses), never onto a loading/empty/error card.
- **Makes it configurable per-agent**: adds an **"Open CMS"** toggle in the agent's **Layout** tab, persisted at `metadata.ui.layout.cmsDefaultOpen`. **Off by default** (opt-in) — Preview stays on the site until the user opens the CMS manually, unless an agent turns this on.
- The one-shot auto-open respects manual interaction (never fights the user) and uses the codebase's run-once render-guard + microtask pattern (like `PathParamAutoFill`), not `useEffect`.
- Extracts a shared `toBlocksQueryState` helper so the panel and the preview don't duplicate the `useQuery -> BlocksQueryState` mapping.

## Changes

- `packages/shared/src/sdk/types/virtual-mcp.ts` — new `cmsDefaultOpen` field on `VirtualMcpUILayoutSchema`.
- `packages/shared/src/tools/tool-io.ts` — regenerated contract snapshot (`generate:tool-contracts`).
- `apps/web/src/views/virtual-mcp/layout-tab-content.tsx` — "Open CMS" Switch (shown only for agents with a preview).
- `apps/web/src/i18n/{en,pt-br}/virtual-mcp.ts` — `openCms` / `openCmsDescription`.
- `apps/web/src/components/sandbox/preview/preview.tsx` — reads the setting, gates the readiness-based auto-open.
- `apps/web/src/layouts/main-panel-tabs/blocks-tab-state.ts` + `blocks-panel.tsx` — shared `toBlocksQueryState` helper.

## Testing

- `tsc --noEmit` on `packages/shared`, `apps/web`, `apps/api` — ✅
- `bun run lint` — 0 errors ✅
- `bun run fmt` — ✅
- `blocks-tab-state` unit tests — 22 pass ✅
- Not exercised in-browser (requires a live sandbox + dev server). Behavior verified by construction: auto-open fires only on `state.kind === "content"` and only when `cmsDefaultOpen` is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ready-gated the CMS (Blocks) auto-open in Preview so it only opens after metadata resolves to editable content, with a per-agent “Open CMS” toggle to opt in. The one-shot auto-open is headless, reads the setting from context, and never fights manual mode changes.

- **New Features**
  - Auto-opens CMS only when ready; never on loading/empty/error.
  - Layout tab adds “Open CMS” switch per agent; one-shot auto-open respects manual mode changes.
  - i18n keys added in `en` and `pt-br` for the new setting.

- **Refactors**
  - Extracted `toBlocksQueryState` and reused across Blocks panel and Preview; added unit tests.
  - Added pure `shouldAutoOpenCms` and headless `<CmsAutoOpen>`; read `cmsDefaultOpen` from `inset.entity` context.
  - Added `cmsDefaultOpen` to `VirtualMcpUILayoutSchema` in `packages/shared`; regenerated `packages/shared/src/tools/tool-io.ts`.

<sup>Written for commit c2b7431fcd5234126f579615b8cc45e52a2fe5d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

