### PR TITLE
fix(thread): re-point CMS view to fresh branch after publish

### DIFF
--- a/apps/web/src/components/chat/store/thread-manager-store.test.ts
+++ b/apps/web/src/components/chat/store/thread-manager-store.test.ts
@@ -952,3 +952,66 @@ describe("ThreadManagerStore.mergeThreads", () => {
     store.dispose();
   });
 });
+
+// Regression: the CMS preview/blocks editor is reached by direct link, so its
+// thread is fetched by-id and merged into the slot (see `useEnsureTask`). A
+// branch hop on publish (`setBranch`) must patch that row IN-PLACE — preserving
+// harness_id / metadata — so the active-task branch actually flips and the view
+// re-points to the fresh branch. Before the merge fix, `setBranch` on a row
+// absent from the slot upserted a LOSSY synthetic row instead, corrupting the
+// active task and stranding the user on the just-published branch.
+describe("ThreadManagerStore.setBranch on a deep-linked (by-id) thread", () => {
+  afterEach(() => {
+    __resetManagerRegistry();
+    __resetRegistry();
+  });
+
+  const richThread = {
+    id: "t-cms",
+    title: "CMS session",
+    branch: "old-branch",
+    harness_id: "harness-x",
+    sandbox_provider_kind: "agent-sandbox",
+    metadata: { sandboxMap: { u1: { "old-branch": {} } } },
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  } as unknown as Task;
+
+  it("patches the merged row in-place, preserving harness_id and metadata", async () => {
+    const sse = makeFakePool();
+    const client = makeMcpClient([]);
+    const store = new ThreadManagerStore("org", "loc", { client, sse });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // useEnsureTask merges the by-id row into the slot (it isn't hidden).
+    store.mergeThreads([richThread]);
+
+    await store.setBranch("t-cms", "fresh-branch");
+
+    const row = store.threads.get().find((t) => t.id === "t-cms");
+    expect(row?.branch).toBe("fresh-branch");
+    // The full fields survive — the update is not the lossy synthetic path.
+    expect(row?.harness_id).toBe("harness-x");
+    expect(row?.metadata).toEqual({ sandboxMap: { u1: { "old-branch": {} } } });
+    store.dispose();
+  });
+
+  it("upserts a LOSSY synthetic when the row was never merged (the pre-fix bug)", async () => {
+    const sse = makeFakePool();
+    const client = makeMcpClient([]);
+    const store = new ThreadManagerStore("org", "loc", { client, sse });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // No merge: mirrors the old behavior where the by-id row stayed out of the
+    // slot, so setBranch has nothing to patch and fabricates a bare row.
+    await store.setBranch("t-cms", "fresh-branch");
+
+    const row = store.threads.get().find((t) => t.id === "t-cms");
+    expect(row?.branch).toBe("fresh-branch");
+    // harness_id / metadata are gone — this is exactly why the active task
+    // (which reads these) breaks without the merge fix.
+    expect(row?.harness_id).toBeUndefined();
+    expect(row?.metadata).toBeUndefined();
+    store.dispose();
+  });
+});

--- a/apps/web/src/components/chat/store/thread-manager-store.test.ts
+++ b/apps/web/src/components/chat/store/thread-manager-store.test.ts
@@ -1015,3 +1015,101 @@ describe("ThreadManagerStore.setBranch on a deep-linked (by-id) thread", () => {
     store.dispose();
   });
 });
+
+// `fetchThreadIntoSlot` is the actual fix seam (called by `useEnsureTask`): it
+// resolves a thread by id and merges LIVE rows into the slot so the deep-linked
+// active view shares one source of truth with the panel. These tests guard the
+// `!hidden` decision and the win-over-lossy-synthetic race directly.
+describe("ThreadManagerStore.fetchThreadIntoSlot", () => {
+  afterEach(() => {
+    __resetManagerRegistry();
+    __resetRegistry();
+  });
+
+  const richThread = {
+    id: "t-cms",
+    title: "CMS session",
+    branch: "old-branch",
+    harness_id: "harness-x",
+    sandbox_provider_kind: "agent-sandbox",
+    metadata: { sandboxMap: { u1: { "old-branch": {} } } },
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  } as unknown as Task;
+
+  function makeGetClient(item: Task | null): MCPClient {
+    return {
+      callTool: mock(async (args: { name: string }) => {
+        if (args.name === "COLLECTION_THREADS_LIST") {
+          return { structuredContent: { items: [], hasMore: false } };
+        }
+        if (args.name === "COLLECTION_THREADS_GET") {
+          return { structuredContent: { item } };
+        }
+        return {};
+      }),
+    } as unknown as MCPClient;
+  }
+
+  it("merges a non-hidden by-id row into the slot", async () => {
+    const sse = makeFakePool();
+    const store = new ThreadManagerStore("org", "loc", {
+      client: makeGetClient(richThread),
+      sse,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const returned = await store.fetchThreadIntoSlot("t-cms");
+    expect(returned?.id).toBe("t-cms");
+    const row = store.threads.get().find((t) => t.id === "t-cms");
+    expect(row?.harness_id).toBe("harness-x");
+    store.dispose();
+  });
+
+  it("does NOT merge a hidden (archived) by-id row — panel invariant", async () => {
+    const sse = makeFakePool();
+    const store = new ThreadManagerStore("org", "loc", {
+      client: makeGetClient({ ...richThread, hidden: true } as Task),
+      sse,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const returned = await store.fetchThreadIntoSlot("t-cms");
+    // The caller still gets the row (for display), but the panel slot stays clean.
+    expect(returned?.hidden).toBe(true);
+    expect(store.threads.get().some((t) => t.id === "t-cms")).toBe(false);
+    store.dispose();
+  });
+
+  it("wins over a lossy synthetic already in the slot (the /watch race)", async () => {
+    const sse = makeFakePool();
+    const store = new ThreadManagerStore("org", "loc", {
+      client: makeGetClient(richThread),
+      sse,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Simulate a concurrent /watch event landing FIRST: a status-only synthetic
+    // with a NEWER updated_at and none of the rich fields.
+    store.mergeThreads([
+      {
+        id: "t-cms",
+        title: "New chat",
+        branch: "old-branch",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2099-01-01T00:00:00Z",
+      } as Task,
+    ]);
+    expect(
+      store.threads.get().find((t) => t.id === "t-cms")?.harness_id,
+    ).toBeUndefined();
+
+    // The authoritative full row must win despite its OLDER updated_at, so the
+    // active task regains harness_id/metadata (otherwise the bug reappears).
+    await store.fetchThreadIntoSlot("t-cms");
+    const row = store.threads.get().find((t) => t.id === "t-cms");
+    expect(row?.harness_id).toBe("harness-x");
+    expect(row?.metadata).toEqual({ sandboxMap: { u1: { "old-branch": {} } } });
+    store.dispose();
+  });
+});

--- a/apps/web/src/components/chat/store/thread-manager-store.ts
+++ b/apps/web/src/components/chat/store/thread-manager-store.ts
@@ -62,6 +62,23 @@ function applyPatch(list: Task[], patch: RowPatch): Task[] {
   return next;
 }
 
+/**
+ * Upsert a full, authoritative row: insert if missing, else overwrite fields
+ * unconditionally — NO recency guard. Used only by `fetchThreadIntoSlot` for a
+ * by-id GET result, which is the source of truth for the rich fields
+ * (`harness_id`, `sandbox_provider_kind`, `metadata`) that a concurrent
+ * `/watch` synthetic drops. `applyPatch`'s `updated_at` guard would let that
+ * newer-but-lossy synthetic win; here the full row always wins. The caller is
+ * responsible for the tombstone check.
+ */
+function upsertFullRow(list: Task[], row: Task): Task[] {
+  const idx = list.findIndex((t) => t.id === row.id);
+  if (idx === -1) return [row, ...list];
+  const next = [...list];
+  next[idx] = { ...next[idx]!, ...row };
+  return next;
+}
+
 export class ThreadManagerStore {
   readonly threads = new Store<Task[]>([]);
   readonly threadsStatus = new Store<ThreadsStatus>({ kind: "loading" });
@@ -424,13 +441,22 @@ export class ThreadManagerStore {
    * The `threads` slot represents threads loaded for the panel (filtered
    * server-side by `hidden: false`); merging arbitrary by-id GET results
    * into it would resurrect archived rows in the panel cache, so this
-   * method intentionally returns the row without inserting.
+   * method intentionally returns the row without inserting. Callers that want
+   * the resolved thread to also become the slot's source of truth (the active
+   * deep-linked view) use `fetchThreadIntoSlot`, which merges non-hidden rows.
    */
   async fetchThread(id: string): Promise<Task | null> {
     if (!id) return null;
     const local = this.threads.get().find((t) => t.id === id);
     if (local) return local;
-    if (!this.client) return null;
+    return this.getThreadRemote(id);
+  }
+
+  /** Server GET for a thread by id, no local short-circuit and no slot write.
+   *  Returns null when id is empty, no client, the row is absent server-side,
+   *  or the MCP call fails. */
+  private async getThreadRemote(id: string): Promise<Task | null> {
+    if (!id || !this.client) return null;
     try {
       const result = await this.client.callTool({
         name: "COLLECTION_THREADS_GET",
@@ -480,6 +506,39 @@ export class ThreadManagerStore {
     } catch {
       // Best-effort refresh — a failure leaves the (stale) row untouched.
     }
+  }
+
+  /**
+   * Resolve a thread by id AND, when it's a live (non-hidden) row, merge it into
+   * the `threads` slot so the active view (e.g. the CMS preview/blocks editor
+   * opened by direct link, whose thread is beyond page 0) shares a single
+   * source of truth with the panel. Once merged, optimistic mutations like
+   * `setBranch` (the publish branch-hop) patch the row IN-PLACE instead of
+   * upserting a lossy synthetic (see `applyPatch`), so `activeTask` actually
+   * re-points to the fresh branch.
+   *
+   * Reads the authoritative row via `getThreadRemote` (NOT `fetchThread`): a
+   * local row must not be trusted here, since a concurrent `/watch` event may
+   * have already upserted a lossy synthetic (status-only, no `harness_id` /
+   * `metadata`) that raced ahead of us. Merged with `upsertFullRow`, NOT
+   * `mergeThreads`, so the full row wins over that synthetic even if its
+   * `updated_at` is newer (`mergeThreads`'s recency guard would drop it and
+   * reintroduce the bug). Tombstone-checked so a just-hidden row can't be
+   * resurrected. Falls back to any local row for the return value when the
+   * remote read fails, so callers still get something to display.
+   *
+   * Hidden/archived rows are never merged (preserves the panel's `hidden:false`
+   * invariant, see `fetchThread`). Owner-scoping is intentionally NOT applied:
+   * the slot is org-wide and every owner-sensitive reader re-filters by
+   * `created_by` (`findReusableNewChat`, `readCachedLastThread`, the sidebar's
+   * `mineFiltered`).
+   */
+  async fetchThreadIntoSlot(id: string): Promise<Task | null> {
+    const remote = await this.getThreadRemote(id);
+    if (remote && !remote.hidden && !this.isTombstoned(remote.id)) {
+      this.threads.update((list) => upsertFullRow(list, remote));
+    }
+    return remote ?? this.threads.get().find((t) => t.id === id) ?? null;
   }
 
   /**

--- a/apps/web/src/hooks/use-ensure-task.ts
+++ b/apps/web/src/hooks/use-ensure-task.ts
@@ -81,6 +81,19 @@ export function useEnsureTask(id: string, virtualMcpId: string): State {
     setFetchedTask("pending");
     manager.fetchThread(id).then((row) => {
       setFetchedTask(row); // null if not found, Task if found
+      // A live thread reached by direct link (e.g. the CMS preview/blocks
+      // editor opened from a URL) isn't in the panel's paginated slot, so
+      // `fetchThread` returns it without merging. But mutations flow through the
+      // store slot: `setBranch` → `optimisticUpdate` patches the slot, which for
+      // a not-yet-present row upserts a LOSSY synthetic row (no harness_id /
+      // sandbox_provider_kind / metadata). Either way the update never reaches
+      // the `fetchedTask` object that feeds `activeTask`, so publishing (which
+      // calls `setCurrentTaskBranch` to hop onto a fresh branch) fails to
+      // re-point the view. Merge the row into the slot so it is the single
+      // source of truth and branch mutations patch it in-place. Hidden/archived
+      // rows stay out to preserve the panel's `hidden: false` invariant (see
+      // `fetchThread`).
+      if (row && !row.hidden) manager.mergeThreads([row]);
     });
   }, [id, localHit, threadsStatus.kind, fetchedTask, manager]);
 

--- a/apps/web/src/hooks/use-ensure-task.ts
+++ b/apps/web/src/hooks/use-ensure-task.ts
@@ -79,21 +79,15 @@ export function useEnsureTask(id: string, virtualMcpId: string): State {
     if (threadsStatus.kind === "loading") return;
     if (fetchedTask !== undefined) return; // already tried or in progress
     setFetchedTask("pending");
-    manager.fetchThread(id).then((row) => {
+    // `fetchThreadIntoSlot` (not a plain `fetchThread`) merges a live by-id row
+    // into the store slot, so the deep-linked active view (e.g. the CMS
+    // preview/blocks editor) shares one source of truth with the panel and
+    // optimistic `setBranch` on publish patches it in place instead of
+    // upserting a lossy synthetic — otherwise the branch-hop never re-points the
+    // view. The `!hidden` guard and the lossy-synthetic race live in the store
+    // method next to the `fetchThread` contract they uphold.
+    manager.fetchThreadIntoSlot(id).then((row) => {
       setFetchedTask(row); // null if not found, Task if found
-      // A live thread reached by direct link (e.g. the CMS preview/blocks
-      // editor opened from a URL) isn't in the panel's paginated slot, so
-      // `fetchThread` returns it without merging. But mutations flow through the
-      // store slot: `setBranch` → `optimisticUpdate` patches the slot, which for
-      // a not-yet-present row upserts a LOSSY synthetic row (no harness_id /
-      // sandbox_provider_kind / metadata). Either way the update never reaches
-      // the `fetchedTask` object that feeds `activeTask`, so publishing (which
-      // calls `setCurrentTaskBranch` to hop onto a fresh branch) fails to
-      // re-point the view. Merge the row into the slot so it is the single
-      // source of truth and branch mutations patch it in-place. Hidden/archived
-      // rows stay out to preserve the panel's `hidden: false` invariant (see
-      // `fetchThread`).
-      if (row && !row.hidden) manager.mergeThreads([row]);
     });
   }, [id, localHit, threadsStatus.kind, fetchedTask, manager]);
 


### PR DESCRIPTION
## Summary

Publishing from the CMS preview/blocks editor (reached by direct link) left the user **stranded on the just-published branch** — the header stayed on the merged PR's terminal "Published" state (`PR #NN merged into main`) instead of hopping onto a fresh branch to keep editing.

## Root cause

A **dual source of truth** for the active thread. A thread opened by direct link isn't in the panel's paginated `threads` store slot, so `useEnsureTask` resolves it via the by-id GET (`fetchThread`) and holds it in local state. But branch mutations flow through the store slot:

`switchToFreshBranch` → `setCurrentTaskBranch` → `setBranch` → `optimisticUpdate` patches the **slot**, which for a not-yet-present row upserts a **lossy synthetic row** (no `harness_id` / `sandbox_provider_kind` / `metadata`). Either way the update never reaches the object feeding `activeTask`, so `currentBranch` never flips and `SandboxLifecycleProvider` never re-points to the new branch.

## Fix

When `useEnsureTask` fetches a **live (non-hidden)** thread by id, merge it into the store slot so it's the single source of truth and branch mutations patch it **in-place**. Hidden/archived rows stay out to preserve the panel's `hidden: false` invariant (see `fetchThread`).

This repairs all three `switchToFreshBranch` call sites at once: squash-merge, publish dialog, and CMS publish.

## Tests

Adds store regression tests in `thread-manager-store.test.ts`:
- a merged row gets an **in-place** branch patch preserving `harness_id`/`metadata`;
- contrast: an unmerged row gets the **lossy synthetic** (the pre-fix bug).

`bun test` on the store file: 35 pass. `fmt` / `tsc` / `lint` clean on the changed files.

## Not in this PR (follow-up)

Reusing the *same* sandbox pod on the fresh branch (instead of a new sandbox) is blocked by the sandbox identity model — the git branch is the routing key (URL, handle, K8s claim, `agent_sandbox_sessions`, `sandboxMap` all derive from it). Warm-pool + golden-cache already make "new sandbox" cheap, and "reset-to-main not rebase" is already how a fresh branch is created (`spawnCheckoutBranch`). Pod-reuse will be scoped as its own project (decouple routing-id from git-branch) later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CMS preview/blocks editor publish flow so the view jumps to a fresh branch after publish, instead of staying on the merged PR branch.

- **Bug Fixes**
  - Added `ThreadManagerStore.fetchThreadIntoSlot(id)` to resolve a thread and merge non-hidden rows into the `threads` slot; uses `getThreadRemote` and `upsertFullRow` so the full by-id row always wins over newer lossy `/watch` synthetics and preserves `harness_id`/`metadata` (tombstone-checked).
  - Updated `useEnsureTask` to call `fetchThreadIntoSlot` so `setBranch` patches in place and the view re-points to the new branch; hidden/archived threads are not merged.
  - Added store tests for in-place branch updates, the hidden guard, and the lossy-synthetic race.

<sup>Written for commit 26835f7869681b927626728ccd80ae7f8e001f86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

