### PR TITLE
fix(chat): stop tier popover cog from showing without hover

### DIFF
--- a/apps/web/src/components/chat/tier-trigger.tsx
+++ b/apps/web/src/components/chat/tier-trigger.tsx
@@ -164,7 +164,11 @@ export function TierTriggerPure({
         </TooltipTrigger>
         <TooltipContent>{resolvedPillLabel}</TooltipContent>
       </Tooltip>
-      <PopoverContent align="end" className="p-1 w-64">
+      <PopoverContent
+        align="end"
+        className="p-1 w-64"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
         {header && (
           <div className="mb-1 border-b border-border/60 pb-1">{header}</div>
         )}


### PR DESCRIPTION
## Summary
- The per-tier model-override cog in the tier picker (Fast/Smart/Thinking) was visible on the first row even without hovering it.
- Root cause: Radix `Popover.Content` auto-focuses its first focusable descendant when it opens — the "Fast" row's select button — which tripped the `group-focus-within/tier-row` CSS rule that reveals that row's cog.
- Fix: `onOpenAutoFocus={(e) => e.preventDefault()}` on the tier popover's `PopoverContent`, so opening the popover no longer steals focus into the first row.

## Test plan
- [x] `bun test apps/web/src/components/chat/tier-trigger.test.tsx` passes (6/6)
- [x] `bun run fmt`
- [ ] Manually verify: open the tier popover — cog should not appear on any row until actually hovered/focused

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the tier picker so the per-tier override cog only appears on hover or focus. Disables auto-focus on open in Radix `PopoverContent` to avoid triggering the `group-focus-within` rule on the first row.

<sup>Written for commit ed41872e87ddd53597c2dc635518a292b57a39f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

