### PR TITLE
fix(mcp-utils): cap GatewayClient pagination so a bad upstream can't hang aggregation

### DIFF
--- a/packages/mcp-utils/src/aggregate/gateway-client.test.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.test.ts
@@ -236,6 +236,51 @@ describe("GatewayClient", () => {
     });
   });
 
+  describe("pagination", () => {
+    it("follows nextCursor across multiple pages", async () => {
+      const client = createMockClient();
+      let call = 0;
+      const tool = (name: string) => ({
+        name,
+        inputSchema: { type: "object" as const },
+      });
+      client.listTools = mock(async () => {
+        call++;
+        if (call === 1) {
+          return { tools: [tool("a")], nextCursor: "page2" };
+        }
+        return { tools: [tool("b")] };
+      }) as IClient["listTools"];
+
+      const gw = new GatewayClient({ srv: { client } });
+      const result = await gw.listTools();
+
+      expect(result.tools.map((t) => t.name)).toEqual([
+        ns("srv", "a"),
+        ns("srv", "b"),
+      ]);
+    });
+
+    it("caps pagination instead of looping forever on a server that never stops returning nextCursor", async () => {
+      const client = createMockClient();
+      let call = 0;
+      client.listTools = mock(async () => {
+        call++;
+        // A misbehaving/malicious upstream that always claims there's another page.
+        return {
+          tools: [{ name: `t${call}`, inputSchema: { type: "object" as const } }],
+          nextCursor: "always-more",
+        };
+      }) as IClient["listTools"];
+
+      const gw = new GatewayClient({ srv: { client } });
+      const result = await gw.listTools();
+
+      expect(result.tools.length).toBe(1000);
+      expect(call).toBe(1000);
+    });
+  });
+
   describe("prompt namespacing", () => {
     it("prefixes prompt names with slugified client key", async () => {
       const client = createMockClient([], [], [{ name: "greet" }]);

--- a/packages/mcp-utils/src/aggregate/gateway-client.test.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.test.ts
@@ -268,7 +268,9 @@ describe("GatewayClient", () => {
         call++;
         // A misbehaving/malicious upstream that always claims there's another page.
         return {
-          tools: [{ name: `t${call}`, inputSchema: { type: "object" as const } }],
+          tools: [
+            { name: `t${call}`, inputSchema: { type: "object" as const } },
+          ],
           nextCursor: "always-more",
         };
       }) as IClient["listTools"];

--- a/packages/mcp-utils/src/aggregate/gateway-client.ts
+++ b/packages/mcp-utils/src/aggregate/gateway-client.ts
@@ -149,6 +149,9 @@ export interface GatewayClientOptions {
 }
 
 export class GatewayClient extends Client {
+  /** Hard cap on pages fetched per client per list call — see `paginate`. */
+  private static readonly MAX_PAGES_PER_CLIENT = 1000;
+
   private readonly clients: Record<string, ClientEntry>;
   private readonly slugToKey = new Map<string, string>();
 
@@ -354,54 +357,79 @@ export class GatewayClient extends Client {
     }
   }
 
-  private async fetchAllTools(client: IClient): Promise<Tool[]> {
-    const tools: Tool[] = [];
+  /**
+   * Follow an MCP `nextCursor` pagination chain, capped at
+   * MAX_PAGES_PER_CLIENT pages. Without a cap, a misbehaving or malicious
+   * upstream MCP server that never returns a falsy `nextCursor` would hang
+   * gateway aggregation forever — this is untrusted input from a
+   * user-configured connection, not a value we control.
+   */
+  private async paginate<T>(
+    clientKey: string,
+    kind: string,
+    fetchPage: (
+      cursor?: string,
+    ) => Promise<{ items: T[]; nextCursor?: string }>,
+  ): Promise<T[]> {
+    const items: T[] = [];
     let cursor: string | undefined;
+    let pages = 0;
     do {
-      const result = await client.listTools(cursor ? { cursor } : undefined);
-      tools.push(...result.tools);
-      cursor = result.nextCursor;
-    } while (cursor);
-    return tools;
+      const page = await fetchPage(cursor);
+      items.push(...page.items);
+      cursor = page.nextCursor;
+      pages++;
+    } while (cursor && pages < GatewayClient.MAX_PAGES_PER_CLIENT);
+    if (cursor) {
+      console.warn(
+        `GatewayClient: client "${clientKey}" exceeded ${GatewayClient.MAX_PAGES_PER_CLIENT} pages listing ${kind} — truncating`,
+      );
+    }
+    return items;
   }
 
-  private async fetchAllResources(client: IClient): Promise<Resource[]> {
-    const resources: Resource[] = [];
-    let cursor: string | undefined;
-    do {
+  private fetchAllTools(client: IClient, clientKey: string): Promise<Tool[]> {
+    return this.paginate(clientKey, "tools", async (cursor) => {
+      const result = await client.listTools(cursor ? { cursor } : undefined);
+      return { items: result.tools, nextCursor: result.nextCursor };
+    });
+  }
+
+  private fetchAllResources(
+    client: IClient,
+    clientKey: string,
+  ): Promise<Resource[]> {
+    return this.paginate(clientKey, "resources", async (cursor) => {
       const result = await client.listResources(
         cursor ? { cursor } : undefined,
       );
-      resources.push(...result.resources);
-      cursor = result.nextCursor;
-    } while (cursor);
-    return resources;
+      return { items: result.resources, nextCursor: result.nextCursor };
+    });
   }
 
-  private async fetchAllResourceTemplates(
+  private fetchAllResourceTemplates(
     client: IClient,
+    clientKey: string,
   ): Promise<ResourceTemplate[]> {
-    const templates: ResourceTemplate[] = [];
-    let cursor: string | undefined;
-    do {
+    return this.paginate(clientKey, "resource templates", async (cursor) => {
       const result = await client.listResourceTemplates(
         cursor ? { cursor } : undefined,
       );
-      templates.push(...result.resourceTemplates);
-      cursor = result.nextCursor;
-    } while (cursor);
-    return templates;
+      return {
+        items: result.resourceTemplates,
+        nextCursor: result.nextCursor,
+      };
+    });
   }
 
-  private async fetchAllPrompts(client: IClient): Promise<Prompt[]> {
-    const prompts: Prompt[] = [];
-    let cursor: string | undefined;
-    do {
+  private fetchAllPrompts(
+    client: IClient,
+    clientKey: string,
+  ): Promise<Prompt[]> {
+    return this.paginate(clientKey, "prompts", async (cursor) => {
       const result = await client.listPrompts(cursor ? { cursor } : undefined);
-      prompts.push(...result.prompts);
-      cursor = result.nextCursor;
-    } while (cursor);
-    return prompts;
+      return { items: result.prompts, nextCursor: result.nextCursor };
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -424,7 +452,7 @@ export class GatewayClient extends Client {
     for (const [clientKey, entry] of Object.entries(this.clients)) {
       const clientTools = await this.listFromClient(
         clientKey,
-        (c) => this.fetchAllTools(c),
+        (c) => this.fetchAllTools(c, clientKey),
         "tools",
       );
 
@@ -466,7 +494,7 @@ export class GatewayClient extends Client {
     for (const [clientKey, entry] of Object.entries(this.clients)) {
       const clientResources = await this.listFromClient(
         clientKey,
-        (c) => this.fetchAllResources(c),
+        (c) => this.fetchAllResources(c, clientKey),
         "resources",
       );
 
@@ -521,7 +549,7 @@ export class GatewayClient extends Client {
     for (const [clientKey, _entry] of Object.entries(this.clients)) {
       const clientTemplates = await this.listFromClient(
         clientKey,
-        (c) => this.fetchAllResourceTemplates(c),
+        (c) => this.fetchAllResourceTemplates(c, clientKey),
         "resource templates",
       );
 
@@ -563,7 +591,7 @@ export class GatewayClient extends Client {
     for (const [clientKey, entry] of Object.entries(this.clients)) {
       const clientPrompts = await this.listFromClient(
         clientKey,
-        (c) => this.fetchAllPrompts(c),
+        (c) => this.fetchAllPrompts(c, clientKey),
         "prompts",
       );
 


### PR DESCRIPTION
**Source:** bug found while hardening `packages/mcp-utils/src/aggregate/gateway-client.ts` (aggregate gateway client — a core MCP integration point).

**Why:** `fetchAllTools`/`fetchAllResources`/`fetchAllResourceTemplates`/`fetchAllPrompts` each ran a `do { ... } while (cursor)` loop following an upstream MCP server's `nextCursor`, with no bound. `nextCursor` is untrusted input from a user-configured connection — a misbehaving or malicious upstream that never returns a falsy `nextCursor` would hang `listTools`/`listResources`/`listResourceTemplates`/`listPrompts` forever, taking down aggregation for that request (and, since results are cached in `toolsCache`/etc., blocking every subsequent caller waiting on the same cache promise).

**Fix:** consolidated the four near-identical pagination loops into one `paginate()` helper capped at 1000 pages per client. On exceeding the cap it logs a warning (`GatewayClient: client "<key>" exceeded 1000 pages listing <kind> — truncating`) and returns what it has, rather than looping forever — consistent with the existing pattern in this file of degrading gracefully instead of taking down the whole aggregation over one bad connection (see `listFromClient`'s handling of a throwing client).

**Failure scenario + regression test:** a mock client whose `listTools` always returns another `nextCursor` (`page1, page2, page3, ...` forever). Before the fix this loop never terminates. The new test in `gateway-client.test.ts` (`pagination > caps pagination instead of looping forever on a server that never stops returning nextCursor`) asserts the call terminates and returns exactly 1000 items. A second test covers the normal two-page happy path.

**To confirm:** `bun test packages/mcp-utils/src/aggregate/gateway-client.test.ts`

**Locally ran:** `bun run fmt`, `bunx tsc --noEmit` (in `packages/mcp-utils`), and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent infinite pagination in `GatewayClient` by capping pages at 1000 and returning partial results, keeping aggregation responsive even with bad MCP servers. Consolidates pagination into a shared `paginate()` helper.

- **Bug Fixes**
  - Cap pagination at 1000 pages for tools, resources, resource templates, and prompts.
  - On cap, log `GatewayClient: client "<key>" exceeded 1000 pages listing <kind> — truncating` and return collected items.
  - Avoids hangs that would block shared caches.

- **Refactors**
  - Replaced four near-identical loops with `paginate()`; `fetchAll*` now pass `clientKey` for better logs.
  - Added tests for multi-page happy path and the capped infinite-cursor case (returns exactly 1000 items).

<sup>Written for commit efa1d39b69554f25b60a9c905ece83b880680dd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

