### PR TITLE
refactor(ai-providers): remove dead commented-out OpenRouter model-sort code

### DIFF
--- a/apps/api/src/ai-providers/adapters/openrouter.ts
+++ b/apps/api/src/ai-providers/adapters/openrouter.ts
@@ -114,29 +114,6 @@ export const openrouterAdapter: ProviderAdapter = {
         const { data }: { data: OpenRouterAPIModel[] } = await res.json();
         const models = data.map(mapV1Model);
 
-        // Best-effort: use frontend popular order for sorting. Falls back to v1 default order.
-        // try {
-        //   const frontendRes = await fetch(
-        //     "https://openrouter.ai/api/frontend/models/find?order=most-popular",
-        //     { signal: AbortSignal.timeout(10_000) },
-        //   );
-        //   if (frontendRes.ok) {
-        //     const frontendData = await frontendRes.json();
-        //     const slugOrder = new Map<string, number>(
-        //       (frontendData.data?.models as { slug: string }[] ?? []).map(
-        //         (m, i) => [m.slug, i] as const,
-        //       ),
-        //     );
-        //     if (slugOrder.size > 0) {
-        //       models.sort(
-        //         (a, b) =>
-        //           (slugOrder.get(a.modelId) ?? Infinity) -
-        //           (slugOrder.get(b.modelId) ?? Infinity),
-        //       );
-        //     }
-        //   }
-        // } catch { /* best-effort — v1 order is fine */ }
-
         return models;
       },
     };


### PR DESCRIPTION
Source: net-code-reduction found while auditing apps/api/src/tools/ai-providers and its adjacent apps/api/src/ai-providers adapter module after the recent top-up/billing spree (PR #5157).

The OpenRouter adapter's `listModels()` has had a fully commented-out "best-effort frontend popular order" block (a `try`/`catch` with a `fetch` call, entirely inside `//` comments) sitting dead since the feature was first added in #2685 — it has never executed and has no remaining callers or references (`rg` across the repo shows the commented lines are the only occurrence).

Net line delta: -23 / +0. Behavior is unchanged since the removed code never ran (it was inert comments) — `models` is returned exactly as before, in v1 API order.

Reviewer check: `cd apps/api && bunx tsc --noEmit` (clean) — no test exercises this dead branch since it never ran.

Locally verified: `bun run fmt` (no changes needed) and `bunx tsc --noEmit` in `apps/api` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead, commented-out “popular order” sorting block from the OpenRouter adapter’s `listModels()` in `apps/api/src/ai-providers/adapters/openrouter.ts`. Behavior is unchanged (models still return in v1 API order); net -23 LOC and cleaner code.

<sup>Written for commit 7ca03e7b3e3e0756156d6fed3b5e09da001797d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

