### PR TITLE
refactor(settings): dedupe positive-integer env-var parsing

### DIFF
--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -79,20 +79,6 @@ function toBoolOrUndefined(value: string | undefined): boolean | undefined {
   return toBool(value);
 }
 
-function toPositiveIntegerOrDefault(
-  name: string,
-  value: string | undefined,
-  defaultValue: number,
-): number {
-  if (value === undefined || value === "") return defaultValue;
-
-  const numberValue = Number(value);
-  if (!Number.isSafeInteger(numberValue) || numberValue <= 0) {
-    throw new Error(`${name} must be a positive integer`);
-  }
-  return numberValue;
-}
-
 function toPositiveIntegerOrUndefined(
   name: string,
   value: string | undefined,
@@ -104,6 +90,14 @@ function toPositiveIntegerOrUndefined(
     throw new Error(`${name} must be a positive integer`);
   }
   return numberValue;
+}
+
+function toPositiveIntegerOrDefault(
+  name: string,
+  value: string | undefined,
+  defaultValue: number,
+): number {
+  return toPositiveIntegerOrUndefined(name, value) ?? defaultValue;
 }
 
 /** Tri-state flag: unset/empty → `fallback`, otherwise parse as boolean. */


### PR DESCRIPTION
Source: reduction — hunted for validation gaps in `apps/api/src/settings/resolve-config.ts` (the DUCKDB_THREADS validation gap I found there is already covered by open PR #5130, so I didn't duplicate it) and found this duplication instead while reading the file end to end.

`toPositiveIntegerOrDefault` and `toPositiveIntegerOrUndefined` had byte-identical parse-and-throw bodies (parse `Number(value)`, validate `Number.isSafeInteger(...) && > 0`, throw `"${name} must be a positive integer"`), differing only in what they return when `value` is unset/empty (a caller-supplied default vs. `undefined`). Now `toPositiveIntegerOrDefault` just delegates to `toPositiveIntegerOrUndefined(...) ?? defaultValue` — same validation, same error message, same call sites (`PORT`, `DATABASE_POOL_MAX`, `CLICKHOUSE_MAX_MEMORY_USAGE`, `NATS_TUNNEL_SESSION_TTL_SECONDS`, `STUDIO_SEAT_ALLOWANCE_CENTS`, `STUDIO_TOPUP_FEE_PERCENT`), net -6 lines.

Behavior is unchanged: all 58 existing tests in `resolve-config.test.ts` pass without modification, including the `it.each(["abc", "0", "-1", "1.5", "Infinity"])` cases that exercise both the default- and undefined-returning call sites.

To confirm: `bun test apps/api/src/settings/resolve-config.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), and the targeted test file above (58 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped positive-integer env var parsing by having `toPositiveIntegerOrDefault` call `toPositiveIntegerOrUndefined` and apply the default. Validation and error messages stay the same; behavior is unchanged.

- **Refactors**
  - Centralized parse-and-validate logic in `toPositiveIntegerOrUndefined`.
  - `toPositiveIntegerOrDefault` now returns `toPositiveIntegerOrUndefined(...) ?? defaultValue`.
  - No changes to existing env var behavior.

<sup>Written for commit d413b4c6fbf62473fb2d0ac8ccdb928117159337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

