### PR TITLE
refactor(registry-metadata): improve type safety and add missing categories

### DIFF
--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -1578,10 +1578,9 @@ export function allCapabilitiesGranted(): Record<string, boolean> {
 export function resolveCapabilities(
   permission: Record<string, string[]>,
 ): Record<string, boolean> {
-  const perm = permission as Record<string, unknown>;
   const arrayBucket = (key: string): string[] => {
-    const value = perm[key];
-    return Array.isArray(value) ? (value as string[]) : [];
+    const value = permission[key];
+    return Array.isArray(value) ? value : [];
   };
 
   // ONLY an org-wide (`*`) or full org-tool (`self`) wildcard is a GLOBAL grant
@@ -1593,7 +1592,7 @@ export function resolveCapabilities(
 
   const grantedActions = new Set<string>();
   if (!hasGlobalGrant) {
-    for (const actions of Object.values(perm)) {
+    for (const actions of Object.values(permission)) {
       if (!Array.isArray(actions)) continue;
       for (const action of actions) grantedActions.add(action);
     }
@@ -1615,8 +1614,8 @@ export function resolveCapabilities(
 /**
  * Get tools grouped by category
  */
-export function getToolsByCategory() {
-  const grouped: Record<string, ToolMetadata[]> = {
+export function getToolsByCategory(): Record<ToolCategory, ToolMetadata[]> {
+  const grouped: Record<ToolCategory, ToolMetadata[]> = {
     Organizations: [],
     Connections: [],
     "Virtual MCPs": [],
@@ -1627,6 +1626,8 @@ export function getToolsByCategory() {
     "Event Bus": [],
     Tags: [],
     "AI Providers": [],
+    Secrets: [],
+    "File Configs": [],
     Automations: [],
     "Object Storage": [],
     Registry: [],
@@ -1634,10 +1635,11 @@ export function getToolsByCategory() {
     VM: [],
     Links: [],
     Search: [],
+    "Task Board": [],
   };
 
   for (const tool of MANAGEMENT_TOOLS) {
-    grouped[tool.category]?.push(tool);
+    grouped[tool.category].push(tool);
   }
 
   return grouped;


### PR DESCRIPTION
## Summary

Fix two issues in the registry-metadata utility:
1. Unsafe type casting in `resolveCapabilities()` — removed `as Record<string, unknown>` cast
2. Missing category keys in `getToolsByCategory()` — was silently dropping tools in Secrets, File Configs, and Task Board categories

Both issues are fixed by improving type safety: the return type is now `Record<ToolCategory, ToolMetadata[]>` instead of `Record<string, ToolMetadata[]>`, enforcing completeness at compile time.

## Verification

- `bun test apps/api/src/tools/registry-metadata.test.ts` — all 12 tests pass
- `cd packages/shared && bunx tsc --noEmit` — no type errors
- `bun run fmt` — formatting passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves type safety in the registry metadata utilities and adds missing categories. Prevents dropped tools and removes an unsafe cast in capability resolution.

- **Bug Fixes**
  - Add Secrets, File Configs, and Task Board to getToolsByCategory(), preventing silent drops.

- **Refactors**
  - Remove the unsafe cast in resolveCapabilities(); read arrays directly from the input.
  - Change getToolsByCategory() return type to Record<ToolCategory, ToolMetadata[]>; all keys are now exhaustive, enabling direct .push().

<sup>Written for commit f54a27b6fda2d21391f0004419c01b1274e42b54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

