### PR TITLE
fix(org-fs): reject '.' and '..' as org-fs volume names

### DIFF
--- a/apps/api/src/file-storage/org-fs-path.test.ts
+++ b/apps/api/src/file-storage/org-fs-path.test.ts
@@ -69,4 +69,9 @@ describe("isValidVolume", () => {
     expect(isValidVolume("a/b")).toBe(false);
     expect(isValidVolume("../x")).toBe(false);
   });
+
+  test("rejects '.' and '..' — the regex alone would accept them and let fsObjectKey escape the _fs/ namespace once sanitizeKey collapses the dot segments", () => {
+    expect(isValidVolume(".")).toBe(false);
+    expect(isValidVolume("..")).toBe(false);
+  });
 });

--- a/apps/api/src/file-storage/org-fs-path.ts
+++ b/apps/api/src/file-storage/org-fs-path.ts
@@ -12,7 +12,12 @@ const VOLUME_RE = /^[A-Za-z0-9_.-]{1,128}$/;
 const FS_KEY_NAMESPACE = "_fs";
 
 export function isValidVolume(volume: string): boolean {
-  return VOLUME_RE.test(volume);
+  // The regex alone accepts "." and ".." (both are valid `[A-Za-z0-9_.-]`
+  // runs). Either would make `fsObjectKey` emit `_fs/./...` / `_fs/../...`,
+  // which `sanitizeKey`/`buildS3Key` then collapse — popping the `_fs`
+  // segment entirely and landing the write/read directly under the org's
+  // storage prefix, colliding with unrelated (non-org-fs) keys.
+  return VOLUME_RE.test(volume) && volume !== "." && volume !== "..";
 }
 
 export function assertValidVolume(volume: string): void {


### PR DESCRIPTION
A bug found while hardening the org-fs storage layer, not tied to an existing issue.

`VOLUME_RE` (`/^[A-Za-z0-9_.-]{1,128}$/`) accepts a volume string of exactly `"."` or `".."` — dots are in the allowed charset, and nothing rejected the degenerate all-dots case. `fsObjectKey` builds the storage key as `` `_fs/${volume}/${path}` ``, so `volume=".."` produces `"_fs/../path"`.

Both object-storage backends then run the *full* key through `sanitizeKey` right before touching bytes (`DevObjectStorage.filePath` locally, `S3Service` via `buildS3Key` in production) — and `sanitizeKey` resolves `".."` by popping the preceding path segment. That collapses `"_fs/../path"` down to just `"path"`, landing the write/read/delete directly under the org's bare storage prefix instead of under the intended `_fs/` namespace, where it can collide with unrelated, non-org-fs object-storage keys belonging to the same org (e.g. avatars or other uploaded assets keyed by the same literal path).

**Failure scenario:** any caller that can choose an arbitrary `volume` string for an org-fs operation (the `/api/:org/org-fs/:volume/*` routes gate on `ORG_FS_WRITE`/`ORG_FS_READ`, not on volume shape) can pass `volume=".."` and have their write/read/delete land outside the `_fs/` namespace, on a key an unrelated feature might already own.

**Fix:** `isValidVolume()` now explicitly rejects `"."` and `".."` in addition to the existing regex check. Every org-fs read/write path already funnels through `assertValidVolume`/`isValidVolume` (`apps/api/src/file-storage/org-fs.ts`, `apps/api/src/api/routes/org-fs.ts`), so this one change closes the gap everywhere — this is the trust-boundary case from the test-gate: `volume` is untrusted input that directly feeds an object-storage key.

Added a regression test to the existing pure-unit suite (`org-fs-path.test.ts`) asserting `isValidVolume(".")` / `isValidVolume("..")` are `false`.

**To verify:** `bun test apps/api/src/file-storage/org-fs-path.test.ts`

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` in `apps/api`, and the targeted test file above all pass. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects "." and ".." as org-fs volume names to prevent escaping the `_fs/` namespace and collisions with other org keys. This closes a path traversal gap in object storage by tightening validation.

- **Bug Fixes**
  - `isValidVolume` now rejects `"."` and `".."` in addition to the existing regex.
  - The check applies across all org-fs operations via `assertValidVolume`.
  - Added a unit test to lock this behavior (`org-fs-path.test.ts`).

<sup>Written for commit d817cd650cca34fa11f45ca2fd6922e4333c71a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

