### PR TITLE
fix(chat): mirror server's multi-key tier auto-pick in model-override cog

### DIFF
--- a/apps/web/src/components/chat/tier-model-override-row.tsx
+++ b/apps/web/src/components/chat/tier-model-override-row.tsx
@@ -43,6 +43,7 @@ export function TierModelOverridePicker({
   tier,
   orgSlot,
   userSlot,
+  autoSlot,
   onPick,
   onReset,
   onClose,
@@ -50,13 +51,17 @@ export function TierModelOverridePicker({
   tier: ChatTier;
   orgSlot: ModelSlot | null;
   userSlot: ModelSlot | null | undefined;
+  /** Server-mirrored auto-pick, used when neither org nor user has an
+   *  explicit slot — so the picker opens on the provider a run would
+   *  actually use instead of an arbitrary connected key. */
+  autoSlot: ModelSlot | null | undefined;
   onPick: (slot: ModelSlot) => void;
   onReset: () => void;
   onClose: () => void;
 }) {
   const t = useT();
   const allKeys = useAiProviderKeys();
-  const effective = userSlot ?? orgSlot;
+  const effective = userSlot ?? orgSlot ?? autoSlot ?? null;
   // Which provider key's catalog the picker is browsing. Seeded from the
   // effective slot; the parent remounts this component when that slot
   // changes, so it can't outlive the value it was seeded from.

--- a/apps/web/src/components/chat/tier-trigger.tsx
+++ b/apps/web/src/components/chat/tier-trigger.tsx
@@ -46,9 +46,8 @@ import {
 import { useSimpleMode } from "@/hooks/use-organization-settings";
 import {
   useAiProviderKeys,
-  useAiProviderModels,
+  useAutoSimpleModeDefaults,
 } from "@/hooks/collections/use-ai-providers";
-import { pickFallbackChatModel } from "./resolve-chat-model";
 import { TierModelOverridePicker } from "./tier-model-override-row";
 import { useAgentOptionAvailability } from "./use-agent-availability";
 import {
@@ -327,16 +326,15 @@ function tierIconFor(tier: ChatTier): ReactNode {
  * from the connected provider's catalog, so a name is still what a run uses.
  * Undefined only while the catalog is loading (caller falls back to the blurb).
  */
-function useTierModelNames(): Record<ChatTier, string | undefined> {
+function useTierModelNames(
+  autoDefaults: ReturnType<typeof useAutoSimpleModeDefaults>,
+): Record<ChatTier, string | undefined> {
   const effective = useEffectiveSimpleMode();
-  const keys = useAiProviderKeys();
-  const fallbackKeyId = keys[0]?.id ?? null;
-  const { models } = useAiProviderModels(fallbackKeyId ?? undefined);
 
   const nameFor = (tier: ChatTier) => {
     const slot = effective.tiers[tier];
     if (slot) return slot.title ?? slot.modelId;
-    return pickFallbackChatModel(tier, keys, fallbackKeyId, models)?.title;
+    return autoDefaults.chat[tier]?.title;
   };
   return {
     fast: nameFor("fast"),
@@ -471,12 +469,18 @@ export function TierTrigger() {
   const locked = taskCtx?.isThreadLocked ?? false;
   const hasLocal = availability.claudeCode || availability.codex;
   const isLocal = mode !== "cloud-decopilot";
-  // Per-tier model name (user override → org slot → auto-pick) shown as each
-  // cloud row's subtitle.
-  const tierModelNames = useTierModelNames();
   // Cloud rows only: org config + this user's overrides, wired into each
   // row's cog popover below.
   const org = useSimpleMode();
+  const keys = useAiProviderKeys();
+  // Mirrors the server's default-pick across the org's first few keys (not
+  // just the first one) so an org with more than one provider — e.g. a
+  // self-hosted/local key alongside a cloud one — shows and edits whichever
+  // key the backend would actually pick for a tier, not an arbitrary key.
+  const autoDefaults = useAutoSimpleModeDefaults(keys);
+  // Per-tier model name (user override → org slot → auto-pick) shown as each
+  // cloud row's subtitle.
+  const tierModelNames = useTierModelNames(autoDefaults);
   const { data: userModelPrefs = { tiers: {} }, error: userModelPrefsError } =
     useUserModelPreferencesQuery();
   const updateUserModelPreferences = useUpdateUserModelPreferences();
@@ -573,6 +577,7 @@ export function TierTrigger() {
                   tier={tierOption}
                   orgSlot={org.tiers[tierOption]}
                   userSlot={userSlot}
+                  autoSlot={autoDefaults.chat[tierOption]}
                   onClose={closeOverride}
                   onPick={(slot) =>
                     updateUserModelPreferences.mutate({

--- a/apps/web/src/hooks/collections/use-ai-providers.ts
+++ b/apps/web/src/hooks/collections/use-ai-providers.ts
@@ -8,9 +8,11 @@
 import type { ModelCollectionEntitySchema } from "@decocms/bindings/llm";
 import {
   useProjectContext,
+  pickSimpleModeDefaults,
   type AiProviderModel,
   type AiProviderKey,
   type AiProviderInfo,
+  type SimpleModeDefaults,
   type UseCollectionListOptions,
 } from "@/sdk";
 
@@ -80,6 +82,31 @@ export function useAiProviderModels(keyId: string | undefined) {
       })) as { models: AiProviderModel[] },
   });
   return { models: data?.models ?? [], isLoading: !!keyId && isLoading };
+}
+
+/**
+ * Mirrors the server's tier auto-pick (`pickSimpleModeDefaults`) so a UI
+ * showing "what model will this tier use" agrees with what a run actually
+ * gets. Hooks can't loop over an arbitrary key count, so this caps at the
+ * first 3 keys — same tradeoff `SimpleModeSection` already makes to prefill
+ * the settings form; picking only `keys[0]` (the previous shortcut here)
+ * showed the wrong provider's catalog whenever the org's first key wasn't
+ * the one the backend would actually select for a tier.
+ */
+export function useAutoSimpleModeDefaults(
+  keys: AiProviderKey[],
+): SimpleModeDefaults {
+  const key0 = keys[0];
+  const key1 = keys[1];
+  const key2 = keys[2];
+  const { models: models0 } = useAiProviderModels(key0?.id);
+  const { models: models1 } = useAiProviderModels(key1?.id);
+  const { models: models2 } = useAiProviderModels(key2?.id);
+  const modelsByKeyId: Record<string, AiProviderModel[]> = {};
+  if (key0?.id) modelsByKeyId[key0.id] = models0;
+  if (key1?.id) modelsByKeyId[key1.id] = models1;
+  if (key2?.id) modelsByKeyId[key2.id] = models2;
+  return pickSimpleModeDefaults(keys, modelsByKeyId);
 }
 
 export function useSuspenseAiProviderModels(keyId: string) {


### PR DESCRIPTION
## Summary
- The per-tier "customize model" cog added in #5197 fell back to `allKeys[0]` when no org/user slot was explicitly saved, instead of mirroring `resolveTier`'s `pickSimpleModeDefaults` across all connected keys.
- In a multi-key org (e.g. a self-hosted/local provider alongside OpenRouter), this made the tier subtitle and the override cog show/edit the wrong provider's catalog whenever the org's first key wasn't the one the backend would actually pick for that tier.
- Fix reuses the same "first 3 keys" auto-pick pattern `SimpleModeSection` (settings page) already uses, extracted into a shared hook `useAutoSimpleModeDefaults`, and threads it through `useTierModelNames` (subtitle) and `TierModelOverridePicker` (cog default, new `autoSlot` prop).
- No revert of #5197 — feature stays, now correctly mirrors the backend.

## Test plan
- [x] `bun run --cwd=apps/web check` (tsc clean)
- [x] `oxlint` clean on changed files
- [x] `bun test apps/web/src/components/chat/tier-trigger.test.tsx` (6 pass)
- [x] `bun test packages/shared/src/sdk/lib/default-model.test.ts` (3 pass)
- [x] `bun run fmt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the tier model override to mirror the server’s multi-key default selection, so the subtitle and cog show the provider the backend would actually use. This corrects wrong catalog browsing in orgs with multiple keys.

- **Bug Fixes**
  - Added `useAutoSimpleModeDefaults` to mirror `pickSimpleModeDefaults` across the first 3 keys.
  - Updated `useTierModelNames` to use these auto defaults for tier subtitles.
  - Passed a new `autoSlot` prop to `TierModelOverridePicker` to seed the picker when no org/user slot is set.
  - Removed the fallback to `allKeys[0]`, aligning UI with server behavior for multi-key orgs.

<sup>Written for commit 0e23d340964245d83d5b006d406b5793b3b4ab37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

