### PR TITLE
feat(chat): rooms instead of threads — multi-agent, multi-human

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -55,6 +55,10 @@ import { getSettings } from "@/settings";
 import type { WorkItemSandbox } from "@/links/link-work-item";
 import type { DispatchTarget } from "../../../links/resolve-dispatch-target";
 import type { VirtualMCPEntity } from "@decocms/shared/sdk";
+import {
+  canWriteToThread,
+  type ThreadMetadata,
+} from "@decocms/shared/entities";
 import type {
   DecopilotSecretModelSource,
   DecopilotSecretModelSources,
@@ -1024,7 +1028,16 @@ async function prepareRun(
     ctx.metadata.threadId = mem.thread.id;
     rootSpan.setAttribute("decopilot.thread.id", mem.thread.id);
 
-    if (mem.thread.created_by !== input.userId) {
+    // Personal chat: owner only. Shared room (`metadata.shared`): any member of
+    // the org — membership is already proven by the org-scoped route and the
+    // org-scoped thread fetch, so reaching this thread means belonging here.
+    if (
+      !canWriteToThread({
+        created_by: mem.thread.created_by,
+        metadata: mem.thread.metadata as ThreadMetadata | null,
+        userId: input.userId,
+      })
+    ) {
       throw new Error(
         "You are not allowed to write to this thread because you are not the owner",
       );
@@ -1321,6 +1334,7 @@ async function prepareRun(
             windowSize,
             isSubagent: input.isSubagent === true,
             systemMessages,
+            agentId: input.agent.id,
           })
         : undefined;
 

--- a/apps/api/src/api/routes/decopilot/routes.ts
+++ b/apps/api/src/api/routes/decopilot/routes.ts
@@ -68,6 +68,10 @@ import {
   listThreadGateQueue,
 } from "@/dispatch-queue/thread-gate-queue";
 import { type QueuePartRow, foldQueueHydration } from "./queue-text";
+import {
+  canWriteToThread,
+  type ThreadMetadata,
+} from "@decocms/shared/entities";
 
 // Per-connection /stream tail diagnostics. Flip to "1" in an environment where
 // the live stream intermittently delivers no chunks — logs the resolved
@@ -435,6 +439,29 @@ async function validate(
   const lockedThread = taskIdInput
     ? await ctx.storage.threads.get(taskIdInput)
     : null;
+
+  // Write guard, at the boundary: a personal chat takes messages from its
+  // owner alone; a shared room takes them from any member of the org —
+  // membership is already proven (resolveOrgFromPath rejected non-members and
+  // the thread was fetched org-scoped), so the only question left is
+  // owner-vs-room. Enforced here so an unauthorized post fails as a 403 on the
+  // POST rather than a 202 followed by a run that dies inside the workflow.
+  // `dispatch-run` re-checks the same predicate for callers that reach it by
+  // another path.
+  if (
+    lockedThread &&
+    !canWriteToThread({
+      created_by: lockedThread.created_by,
+      metadata: lockedThread.metadata as ThreadMetadata | null,
+      userId,
+    })
+  ) {
+    throw new HTTPException(403, {
+      message:
+        "You are not allowed to write to this thread because you are not the owner",
+    });
+  }
+
   const {
     harnessId: effectiveHarnessId,
     sandboxProviderKind: effectiveSandboxProviderKind,

--- a/apps/api/src/harnesses/decopilot/context-loader.ts
+++ b/apps/api/src/harnesses/decopilot/context-loader.ts
@@ -4,6 +4,7 @@ import { createMemory } from "@/api/routes/decopilot/memory";
 import type { ChatMessage } from "@/api/routes/decopilot/types";
 import type { StudioContext } from "@/core/studio-context";
 import type { ThreadMessage } from "@/storage/types";
+import { buildRoomTranscript } from "./room-transcript";
 
 function mergeHistoryWithUserMessage(
   history: ThreadMessage[] | ChatMessage[],
@@ -36,6 +37,10 @@ export async function loadDecopilotContext(input: {
   windowSize: number | undefined;
   isSubagent: boolean;
   systemMessages: ChatMessage[];
+  /** The agent answering this turn. A thread is a room — other agents may have
+   *  spoken in it, and their turns must not read as this agent's own words.
+   *  See `buildRoomTranscript`. */
+  agentId: string;
 }): Promise<ChatMessage[]> {
   const history = input.isSubagent
     ? []
@@ -49,7 +54,7 @@ export async function loadDecopilotContext(input: {
       ).loadHistory(input.windowSize ?? DEFAULT_WINDOW_SIZE);
 
   const assembled = await assembleDecopilotContextForTest({
-    history: history as ChatMessage[],
+    history: buildRoomTranscript(history as ChatMessage[], input.agentId),
     userMessage: input.userMessage,
     systemMessages: input.systemMessages,
   });

--- a/apps/api/src/harnesses/decopilot/room-transcript.test.ts
+++ b/apps/api/src/harnesses/decopilot/room-transcript.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test";
+import type { ChatMessage } from "@/api/routes/decopilot/types";
+import { buildRoomTranscript } from "./room-transcript";
+
+const MARIO = "agent_mario";
+const LUIGI = "agent_luigi";
+
+function user(
+  text: string,
+  opts: {
+    agentId?: string;
+    agentTitle?: string;
+    userName?: string;
+  } = {},
+): ChatMessage {
+  return {
+    id: crypto.randomUUID(),
+    role: "user",
+    parts: [{ type: "text", text }],
+    metadata: {
+      ...(opts.agentId
+        ? { agent: { id: opts.agentId, title: opts.agentTitle } }
+        : {}),
+      ...(opts.userName ? { user: { name: opts.userName } } : {}),
+    },
+  } as ChatMessage;
+}
+
+function assistant(text: string): ChatMessage {
+  return {
+    id: crypto.randomUUID(),
+    role: "assistant",
+    parts: [{ type: "text", text }],
+  } as ChatMessage;
+}
+
+function textOf(message: ChatMessage): string {
+  return message.parts
+    .filter((p) => (p as { type?: string }).type === "text")
+    .map((p) => (p as { text: string }).text)
+    .join("");
+}
+
+describe("buildRoomTranscript", () => {
+  it("leaves a single-agent thread untouched", () => {
+    const history = [user("hi"), assistant("hello"), user("more")];
+    expect(buildRoomTranscript(history, MARIO)).toEqual(history);
+  });
+
+  it("leaves legacy threads (no agent metadata) untouched", () => {
+    const history = [user("hi"), assistant("hello")];
+    const out = buildRoomTranscript(history, LUIGI);
+    expect(out[1]!.role).toBe("assistant");
+  });
+
+  it("keeps the answering agent's own turns as assistant", () => {
+    const history = [
+      user("diagnose", { agentId: MARIO, agentTitle: "Mario" }),
+      assistant("found a broken checkout"),
+    ];
+    const out = buildRoomTranscript(history, MARIO);
+    expect(out[1]!.role).toBe("assistant");
+    expect(textOf(out[1]!)).toBe("found a broken checkout");
+  });
+
+  it("relabels another agent's turn as a named participant message", () => {
+    const history = [
+      user("diagnose", { agentId: MARIO, agentTitle: "Mario" }),
+      assistant("found a broken checkout"),
+      user("now fix it", { agentId: LUIGI, agentTitle: "Luigi" }),
+    ];
+    const out = buildRoomTranscript(history, LUIGI);
+
+    // Mario's reply must not read as Luigi's own past words.
+    expect(out[1]!.role).toBe("user");
+    expect(textOf(out[1]!)).toBe("[Mario]: found a broken checkout");
+  });
+
+  it("drops tool parts when relabelling (invalid on a user message)", () => {
+    const withTool = {
+      id: "m1",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "ran a scan" },
+        { type: "tool-foo", toolCallId: "t1", state: "output-available" },
+      ],
+    } as unknown as ChatMessage;
+    const history = [
+      user("diagnose", { agentId: MARIO, agentTitle: "Mario" }),
+      withTool,
+      user("fix", { agentId: LUIGI, agentTitle: "Luigi" }),
+    ];
+    const out = buildRoomTranscript(history, LUIGI);
+    expect(out[1]!.parts).toHaveLength(1);
+    expect(textOf(out[1]!)).toBe("[Mario]: ran a scan");
+  });
+
+  it("describes a tool-only foreign turn instead of emitting empty text", () => {
+    const toolOnly = {
+      id: "m1",
+      role: "assistant",
+      parts: [{ type: "tool-foo", toolCallId: "t1" }],
+    } as unknown as ChatMessage;
+    const history = [
+      user("go", { agentId: MARIO, agentTitle: "Mario" }),
+      toolOnly,
+      user("now you", { agentId: LUIGI, agentTitle: "Luigi" }),
+    ];
+    const out = buildRoomTranscript(history, LUIGI);
+    expect(textOf(out[1]!)).toBe("[Mario]: (worked on this without replying)");
+  });
+
+  it("names humans only once a second human speaks", () => {
+    const solo = [user("hi", { userName: "Gui" })];
+    expect(textOf(buildRoomTranscript(solo, MARIO)[0]!)).toBe("hi");
+
+    const shared = [
+      user("hi", { userName: "Gui" }),
+      user("me too", { userName: "Ana" }),
+    ];
+    const out = buildRoomTranscript(shared, MARIO);
+    expect(textOf(out[0]!)).toBe("[Gui]: hi");
+    expect(textOf(out[1]!)).toBe("[Ana]: me too");
+  });
+
+  it("falls back to a neutral name when a foreign turn has no title", () => {
+    const history = [
+      user("go", { agentId: MARIO }),
+      assistant("did it"),
+      user("your turn", { agentId: LUIGI, agentTitle: "Luigi" }),
+    ];
+    const out = buildRoomTranscript(history, LUIGI);
+    expect(textOf(out[1]!)).toBe("[Another agent]: did it");
+  });
+
+  it("passes system messages through untouched", () => {
+    const system = {
+      id: "s1",
+      role: "system",
+      parts: [{ type: "text", text: "be nice" }],
+    } as ChatMessage;
+    const out = buildRoomTranscript([system, user("hi")], MARIO);
+    expect(out[0]).toEqual(system);
+  });
+});

--- a/apps/api/src/harnesses/decopilot/room-transcript.ts
+++ b/apps/api/src/harnesses/decopilot/room-transcript.ts
@@ -1,0 +1,108 @@
+/**
+ * Room transcript — make a shared thread readable by whichever agent is
+ * answering this turn.
+ *
+ * A thread is a room: several agents and several humans speak in it. The model
+ * context, though, only has `role` — so without this, an agent reading the
+ * history sees ANOTHER agent's replies as `assistant` and takes them for its
+ * own past words. It then contradicts itself, apologises for things it never
+ * said, or "continues" work it never started.
+ *
+ * So before the history reaches the model we rewrite it from the point of view
+ * of the agent that is about to speak:
+ *  - its OWN prior turns stay `assistant` (untouched — same shape as today);
+ *  - another agent's turns become `user` messages labelled `[Name]: …`, i.e.
+ *    what they actually are to this agent: something a participant said;
+ *  - human turns are labelled the same way, but ONLY when more than one human
+ *    has spoken — a 1:1 thread reads exactly as it does today.
+ *
+ * Who authored an assistant turn is not stored on a column: it's the agent the
+ * preceding user turn was addressed to (`metadata.agent`, set at send time).
+ * Threads written before multi-agent rooms carry no `metadata.agent`, so every
+ * turn resolves to the answering agent and nothing is rewritten.
+ */
+
+import type { ChatMessage } from "@/api/routes/decopilot/types";
+
+/** Tool calls/results can't ride on a `user` message, and a tool-result part
+ *  orphaned from its call breaks strict providers. A foreign turn is flattened
+ *  to what the room actually needs from it: what was said. */
+function flattenToText(message: ChatMessage): string {
+  return message.parts
+    .filter(
+      (part): part is { type: "text"; text: string } =>
+        (part as { type?: string }).type === "text" &&
+        typeof (part as { text?: unknown }).text === "string",
+    )
+    .map((part) => part.text.trim())
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function labelled(name: string, body: string): string {
+  return `[${name}]: ${body}`;
+}
+
+/**
+ * Rewrite a thread's history for `selfAgentId`, the agent answering this turn.
+ *
+ * `messages` is chronological and includes the current user message. System
+ * messages pass through untouched.
+ */
+export function buildRoomTranscript(
+  messages: ChatMessage[],
+  selfAgentId: string,
+): ChatMessage[] {
+  // Who is this turn addressed to? Tracks forward through the thread: an
+  // assistant message belongs to the agent the last user message named — the
+  // name rides along, since only the user message carries it.
+  let addressee = selfAgentId;
+  let addresseeTitle: string | undefined;
+
+  // Only label humans once the room actually has more than one of them —
+  // otherwise every existing 1:1 thread would gain noise.
+  const humanNames = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    const name = message.metadata?.user?.name;
+    if (name) humanNames.add(name);
+  }
+  const multiHuman = humanNames.size > 1;
+
+  return messages.map((message) => {
+    if (message.role === "system") return message;
+
+    if (message.role === "user") {
+      addressee = message.metadata?.agent?.id ?? selfAgentId;
+      addresseeTitle = message.metadata?.agent?.title;
+
+      const name = message.metadata?.user?.name;
+      if (!multiHuman || !name) return message;
+
+      const body = flattenToText(message);
+      if (!body) return message;
+      return {
+        ...message,
+        parts: [{ type: "text", text: labelled(name, body) }],
+      } as ChatMessage;
+    }
+
+    // Assistant: mine stays mine.
+    if (addressee === selfAgentId) return message;
+
+    const body = flattenToText(message);
+    const name = addresseeTitle ?? "Another agent";
+    return {
+      ...message,
+      role: "user",
+      parts: [
+        {
+          type: "text",
+          // Empty is possible: a turn that only ran tools. Say so rather than
+          // emitting an empty message, which some providers reject.
+          text: labelled(name, body || "(worked on this without replying)"),
+        },
+      ],
+    } as ChatMessage;
+  });
+}

--- a/apps/web/src/components/chat/chat-context.tsx
+++ b/apps/web/src/components/chat/chat-context.tsx
@@ -104,7 +104,10 @@ function statusToString(s: ConnStatus): ChatStreamContextValue["status"] {
 
 import { useChatNavigation } from "./hooks/use-chat-navigation";
 import { useThreadActions, useThreadManager } from "./store/hooks";
-import { derivePartsFromTiptapDoc } from "./derive-parts";
+import {
+  derivePartsFromTiptapDoc,
+  extractMentionedAgentId,
+} from "./derive-parts";
 import type { VirtualMCPInfo } from "./select-virtual-mcp";
 import type { ChatMessage, ChatMode, Metadata } from "./types";
 import type { Task } from "./task/types";
@@ -1111,7 +1114,10 @@ export function ActiveTaskProvider({
   async function dispatchUserMessage(message: ChatMessage): Promise<boolean> {
     // Capture at dispatch time (frozen in closure)
     const capturedTaskId = taskId;
-    const capturedVirtualMcpId = virtualMcpId;
+    // The message's own agent wins over the thread's current one: an "@agent"
+    // mention hands THIS turn to that agent (see sendMessageInternal), so a
+    // room can hold several agents without the user leaving the thread.
+    const capturedVirtualMcpId = message.metadata?.agent?.id ?? virtualMcpId;
 
     const appContextEntries = Object.entries(appContexts);
     const appContextSection =
@@ -1265,9 +1271,19 @@ export function ActiveTaskProvider({
     setChatError(null);
     setTiptapDoc(undefined);
 
+    // "@agent" in the draft addresses that agent: it answers this turn itself,
+    // in this thread, as itself — that's what makes a thread a room with more
+    // than one agent in it. With no mention the thread's current agent answers.
+    // Recorded on the message so every later reader (the attribution UI, and
+    // the server's history relabelling) can tell who spoke without a new column.
+    const mentioned = extractMentionedAgentId(params.tiptapDoc);
+
     const messageMetadata: Metadata = {
       tiptapDoc: params.tiptapDoc,
       created_at: new Date().toISOString(),
+      agent: mentioned
+        ? { id: mentioned.agentId, title: mentioned.title }
+        : { id: virtualMcpId },
       user: {
         avatar: user?.image ?? undefined,
         name: user?.name ?? "you",

--- a/apps/web/src/components/chat/derive-parts.ts
+++ b/apps/web/src/components/chat/derive-parts.ts
@@ -274,14 +274,12 @@ export function derivePartsFromTiptapDoc(
           !Array.isArray(meta) &&
           "agentId" in meta
         ) {
-          // Agent mention: instruct the AI to delegate via subtask
-          parts.push({
-            type: "text",
-            text:
-              `[DELEGATE TO AGENT: ${(meta as { title?: string }).title ?? node.attrs.name} (agent_id: ${(meta as { agentId: string }).agentId})]\n` +
-              `Use the subtask tool to delegate this task to the agent above. ` +
-              `Include the full relevant context from this conversation in the prompt field — the subagent has no conversation history.`,
-          });
+          // Agent mention: the mentioned agent ANSWERS THIS TURN itself (see
+          // `extractMentionedAgentId`), so nothing is injected here — the
+          // inline "@Name" already tells every reader who was addressed.
+          // (It used to emit a "[DELEGATE TO AGENT …] use the subtask tool"
+          // instruction, which made the current agent answer on the other
+          // agent's behalf instead of the room hearing the agent itself.)
         } else if (Array.isArray(meta)) {
           // Resource mention: metadata is ReadResourceResult.contents
           parts.push(
@@ -354,6 +352,57 @@ export function derivePartsFromTiptapDoc(
   }
 
   return parts;
+}
+
+/**
+ * The agent an "@" mention addresses this turn, if any — the room's way of
+ * saying "you answer this one". Multiple mentions: the LAST one wins (it reads
+ * as the addressee; earlier ones are references), and only one agent can hold a
+ * turn since a turn is one run.
+ *
+ * Returns null when the draft mentions no agent, in which case the caller keeps
+ * the thread's current agent as the responder.
+ */
+export function extractMentionedAgentId(
+  doc: Metadata["tiptapDoc"],
+): { agentId: string; title: string } | null {
+  if (!doc) return null;
+
+  let found: { agentId: string; title: string } | null = null;
+
+  const walkNode = (node: {
+    type?: string;
+    attrs?: Record<string, unknown>;
+    content?: unknown[];
+  }) => {
+    if (!node) return;
+
+    if (node.type === "mention" && node.attrs?.char === "@") {
+      const meta = node.attrs.metadata;
+      if (
+        meta &&
+        typeof meta === "object" &&
+        !Array.isArray(meta) &&
+        "agentId" in meta &&
+        typeof (meta as { agentId: unknown }).agentId === "string"
+      ) {
+        const { agentId, title } = meta as { agentId: string; title?: string };
+        found = {
+          agentId,
+          title: title ?? String(node.attrs.name ?? "Agent"),
+        };
+      }
+    }
+
+    if (Array.isArray(node.content)) {
+      for (const child of node.content) {
+        walkNode(child as typeof node);
+      }
+    }
+  };
+
+  walkNode(doc as Parameters<typeof walkNode>[0]);
+  return found;
 }
 
 /**

--- a/apps/web/src/components/chat/input.tsx
+++ b/apps/web/src/components/chat/input.tsx
@@ -11,6 +11,7 @@ import { useT } from "@/i18n/use-t.ts";
 import { Button } from "@deco/ui/components/button.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { getWellKnownDecopilotVirtualMCP, useProjectContext } from "@/sdk";
+import { canWriteToThread } from "@decocms/shared/entities";
 import { useNavigate } from "@tanstack/react-router";
 import {
   ArrowUp,
@@ -559,7 +560,18 @@ export function ChatInput({
     }
   };
 
-  if (userId && task?.created_by && task.created_by !== userId) {
+  // A teammate's personal chat stays read-only; a shared room is open to every
+  // member. Same predicate the API enforces, so the composer never offers a
+  // write the server will reject.
+  if (
+    userId &&
+    task &&
+    !canWriteToThread({
+      created_by: task.created_by,
+      metadata: task.metadata,
+      userId,
+    })
+  ) {
     return (
       <ChatInputDisabledState message={t("chat.input.readOnlyOthersChat")} />
     );

--- a/apps/web/src/components/chat/message/pair.tsx
+++ b/apps/web/src/components/chat/message/pair.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import type { ChatMessage, ChatStatus } from "../types.ts";
 import { MessageAssistant } from "./assistant.tsx";
 import { MessageUser } from "./user.tsx";
+import { AgentAvatar } from "@/components/agent-icon";
 
 export interface MessagePair {
   user: ChatMessage | null;
@@ -120,6 +121,21 @@ export function MessagePair({ pair, isLastPair, status }: MessagePairProps) {
             <MessageUser message={pair.user} onScrollToPair={scrollToPair} />
           </div>
         </>
+      )}
+      {/* Who is answering. Only rendered once a turn was handed to a named
+          agent by an "@" mention — i.e. only in a room with more than one
+          agent in it. A single-agent thread has one voice and needs no label. */}
+      {pair.user?.metadata?.agent?.title && (
+        <div className="flex items-center gap-2 pb-2 text-xs text-muted-foreground">
+          <AgentAvatar
+            icon={null}
+            name={pair.user.metadata.agent.title}
+            size="xs"
+          />
+          <span className="font-medium text-foreground">
+            {pair.user.metadata.agent.title}
+          </span>
+        </div>
       )}
       <MessageAssistant
         message={pair.assistant}

--- a/apps/web/src/components/chat/message/user.tsx
+++ b/apps/web/src/components/chat/message/user.tsx
@@ -6,6 +6,8 @@ import { useRef, useState } from "react";
 import { FileNode } from "../tiptap/file/node.tsx";
 import { MentionNode } from "../tiptap/mention/node.tsx";
 import type { Metadata } from "../types.ts";
+import { Avatar } from "@deco/ui/components/avatar.tsx";
+import { useOptionalChatTask } from "../context.tsx";
 import { MessageTextPart } from "./parts/text-part.tsx";
 import { MessageTimestamp } from "./timestamp.tsx";
 import {
@@ -65,6 +67,9 @@ export function MessageUser<T extends Metadata>({
   onScrollToPair,
 }: MessageProps<T>) {
   const { id, parts, metadata } = message;
+  // In a shared room several people speak, so each message says who sent it.
+  const isSharedRoom =
+    useOptionalChatTask()?.activeTask?.metadata?.shared === true;
   const [isFocused, setIsFocused] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const overflowChecked = useRef(false);
@@ -98,6 +103,21 @@ export function MessageUser<T extends Metadata>({
         )}
       >
         <div className="w-full min-w-0 flex flex-col">
+          {/* Who sent it. Shown only in a shared room — in a personal chat
+              every message is yours and the name would just be noise. */}
+          {isSharedRoom && metadata?.user?.name && (
+            <div className="flex items-center gap-2 self-end pb-2 text-xs">
+              <Avatar
+                shape="circle"
+                size="2xs"
+                url={metadata.user.avatar}
+                fallback={metadata.user.name}
+              />
+              <span className="font-medium text-foreground">
+                {metadata.user.name}
+              </span>
+            </div>
+          )}
           <div
             tabIndex={0}
             onClick={handleClick}

--- a/apps/web/src/components/chat/room-toggle.tsx
+++ b/apps/web/src/components/chat/room-toggle.tsx
@@ -1,0 +1,77 @@
+import { Users01, User01 } from "@untitledui/icons";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@deco/ui/components/tooltip.tsx";
+import { toast } from "sonner";
+import { ToolbarIconButton } from "@/components/toolbar-icon-button";
+import { authClient } from "@/lib/auth-client";
+import { useT } from "@/i18n/use-t.ts";
+import { track } from "@/lib/posthog-client";
+import { useOptionalChatTask } from "./context";
+import { useThreadActions } from "./store/hooks";
+
+/**
+ * Open the current thread as a shared room, or close it back to a personal
+ * chat. A shared room accepts messages from every member of the organization;
+ * a personal chat only from the person who opened it (enforced server-side —
+ * see `canWriteToThread`).
+ *
+ * Only the owner sees the control: a teammate can already read the thread, but
+ * who may write to it is the owner's call.
+ */
+export function RoomToggle() {
+  const t = useT();
+  const task = useOptionalChatTask()?.activeTask ?? null;
+  const { data: session } = authClient.useSession();
+  const userId = session?.user?.id;
+  const { setShared } = useThreadActions();
+
+  if (!task || !userId) return null;
+  // `created_by` is absent on an optimistic row that hasn't landed yet — no
+  // owner to compare against, so hold the control back until it does.
+  if (!task.created_by || task.created_by !== userId) return null;
+
+  const shared = task.metadata?.shared === true;
+  const label = shared
+    ? t("chat.roomToggle.sharedRoom")
+    : t("chat.roomToggle.personalChat");
+
+  async function toggle() {
+    const next = !shared;
+    track("chat_room_shared_toggled", { thread_id: task!.id, shared: next });
+    try {
+      await setShared(task!.id, next);
+      toast.success(
+        next
+          ? t("chat.roomToggle.nowShared")
+          : t("chat.roomToggle.nowPersonal"),
+      );
+    } catch {
+      // optimisticUpdate rolls the row back; say so rather than leaving the
+      // icon lying about the thread's state.
+      toast.error(t("chat.roomToggle.failed"));
+    }
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <ToolbarIconButton
+          aria-label={label}
+          aria-pressed={shared}
+          active={shared}
+          onClick={() => void toggle()}
+        >
+          {shared ? <Users01 size={16} /> : <User01 size={16} />}
+        </ToolbarIconButton>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {shared
+          ? t("chat.roomToggle.tooltipShared")
+          : t("chat.roomToggle.tooltipPersonal")}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/chat/store/hooks.tsx
+++ b/apps/web/src/components/chat/store/hooks.tsx
@@ -96,6 +96,7 @@ export function useThreadActions() {
     setStatus: m.setStatus.bind(m),
     setBranch: m.setBranch.bind(m),
     setAgent: m.setAgent.bind(m),
+    setShared: m.setShared.bind(m),
     setScope: m.setScope.bind(m),
     setActive: m.setActive.bind(m),
     closeActive: m.closeActive.bind(m),

--- a/apps/web/src/components/chat/store/thread-manager-store.ts
+++ b/apps/web/src/components/chat/store/thread-manager-store.ts
@@ -201,6 +201,17 @@ export class ThreadManagerStore {
     return this.optimisticUpdate(id, { virtual_mcp_id: virtualMcpId });
   }
 
+  /** Open this thread as a shared room (any org member may post) or close it
+   *  back to a personal chat — the write side is enforced by
+   *  `canWriteToThread` on the server too. Merges into the current metadata so
+   *  sibling keys (expanded_tools, …) survive. */
+  setShared(id: string, shared: boolean): Promise<void> {
+    const current = this.threads.get().find((t) => t.id === id);
+    return this.optimisticUpdate(id, {
+      metadata: { ...(current?.metadata ?? {}), shared },
+    } as Partial<ThreadUpdateData>);
+  }
+
   /**
    * Local-only patch: apply a partial Task patch in-place. No server round-trip.
    * Used for live signals that don't flow through `/watch` (e.g. titles emitted

--- a/apps/web/src/components/chat/tiptap/build-improve-prompt-doc.test.ts
+++ b/apps/web/src/components/chat/tiptap/build-improve-prompt-doc.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { buildImprovePromptDoc } from "./build-improve-prompt-doc";
-import { derivePartsFromTiptapDoc } from "../derive-parts";
+import {
+  derivePartsFromTiptapDoc,
+  extractMentionedAgentId,
+} from "../derive-parts";
 
 const baseInput = {
   managerAgentId: "agent_mgr_123",
@@ -39,7 +42,7 @@ describe("buildImprovePromptDoc", () => {
     );
   });
 
-  test("compiles through derivePartsFromTiptapDoc into a DELEGATE directive", () => {
+  test("compiles through derivePartsFromTiptapDoc addressing the manager", () => {
     const doc = buildImprovePromptDoc(baseInput);
     const parts = derivePartsFromTiptapDoc(
       doc as Parameters<typeof derivePartsFromTiptapDoc>[0],
@@ -49,11 +52,21 @@ describe("buildImprovePromptDoc", () => {
       .map((p) => p.text)
       .join("\n");
     expect(text).toContain("Use @Agent Manager to improve the instructions");
-    expect(text).toContain(
-      "[DELEGATE TO AGENT: Agent Manager (agent_id: agent_mgr_123)]",
-    );
-    expect(text).toContain("subtask tool");
     expect(text).toContain("<current_instructions>");
+    // The mention no longer expands into a "[DELEGATE TO AGENT …] use the
+    // subtask tool" directive: the mentioned agent answers the turn itself
+    // (see `extractMentionedAgentId`), so nothing is injected into the text.
+    expect(text).not.toContain("DELEGATE TO AGENT");
+    expect(text).not.toContain("subtask tool");
+  });
+
+  test("routes the turn to the manager agent", () => {
+    const doc = buildImprovePromptDoc(baseInput);
+    expect(
+      extractMentionedAgentId(
+        doc as Parameters<typeof extractMentionedAgentId>[0],
+      ),
+    ).toEqual({ agentId: "agent_mgr_123", title: "Agent Manager" });
   });
 
   test("handles automation kind", () => {

--- a/apps/web/src/components/chat/tiptap/build-improve-prompt-doc.ts
+++ b/apps/web/src/components/chat/tiptap/build-improve-prompt-doc.ts
@@ -14,9 +14,9 @@ export interface ImprovePromptDocInput {
  *   Here are its current instructions.
  *   <current_instructions>{instructions}</current_instructions>
  *
- * The mention is shaped so derivePartsFromTiptapDoc emits the standard
- * `[DELEGATE TO AGENT: ...]` directive that Decopilot's SUBTASK tool
- * picks up.
+ * The mention hands the turn to the manager agent, which answers it itself in
+ * this thread (see `extractMentionedAgentId`) rather than the current agent
+ * relaying the work through its `subtask` tool.
  */
 export function buildImprovePromptDoc(input: ImprovePromptDocInput): TiptapDoc {
   const { managerAgentId, managerName, kind, id, instructions } = input;

--- a/apps/web/src/components/sidebar/task-groups/agent-group.tsx
+++ b/apps/web/src/components/sidebar/task-groups/agent-group.tsx
@@ -1,0 +1,115 @@
+import { ChevronDown, ChevronRight } from "@untitledui/icons";
+import { TaskRow } from "@/layouts/tasks-panel/task-row";
+import type { Task } from "@/components/chat/task/types";
+import { useGroupExpanded } from "./use-group-expanded";
+import type { SidebarFilters } from "./next-page-offset";
+import { AgentAvatar } from "@/components/agent-icon";
+import { GitHubIcon } from "@/components/icons/github-icon";
+import { agentHasClonableSource } from "@/lib/agent-capabilities";
+import {
+  getWellKnownDecopilotVirtualMCP,
+  useProjectContext,
+  useVirtualMCPs,
+} from "@/sdk";
+
+/**
+ * One "room" in the room view: an agent and its threads nested one layer down.
+ * A room is the agent — a code agent is its repo, a plain agent its subject —
+ * and the threads inside are its conversations. The header is the agent
+ * (avatar + name, GitHub mark when repo-backed); the body is its threads.
+ *
+ * Groups are built by `groupThreadsByVirtualMcp`, so a threadless synthetic key
+ * (tool-call runs) can land here with no matching agent — it renders under a
+ * neutral "Other" label rather than breaking.
+ */
+export function AgentGroup({
+  virtualMcpId,
+  threads,
+  activeTaskId,
+  onSelectTask,
+  onArchiveTask,
+  canArchive,
+  filters,
+  defaultExpanded,
+}: {
+  virtualMcpId: string;
+  threads: Task[];
+  activeTaskId: string | null;
+  onSelectTask: (task: Task) => void;
+  onArchiveTask: (task: Task) => void;
+  canArchive: boolean;
+  filters: SidebarFilters;
+  defaultExpanded: boolean;
+}) {
+  const agents = useVirtualMCPs();
+  const { org } = useProjectContext();
+  const decopilot = getWellKnownDecopilotVirtualMCP(org.id);
+  const agent =
+    agents?.find((a) => a.id === virtualMcpId) ??
+    (virtualMcpId === decopilot.id ? decopilot : undefined);
+
+  const [expanded, setExpanded] = useGroupExpanded(
+    `agent-${virtualMcpId}`,
+    defaultExpanded,
+  );
+
+  const label = agent?.title ?? "Other";
+  const isCode = agent ? agentHasClonableSource(agent.metadata) : false;
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        onClick={() => setExpanded(!expanded)}
+        onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return;
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setExpanded(!expanded);
+          }
+        }}
+        className="group/group flex items-center gap-2 px-2 py-1.5 rounded-md text-sm font-medium text-foreground cursor-pointer hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 transition-colors"
+      >
+        <div className="relative size-5 shrink-0 flex items-center justify-center">
+          <span className="absolute inset-0 flex items-center justify-center transition-opacity group-hover/group:opacity-0">
+            <AgentAvatar icon={agent?.icon ?? null} name={label} size="xs" />
+          </span>
+          <span className="absolute inset-0 flex items-center justify-center text-muted-foreground opacity-0 transition-opacity group-hover/group:opacity-100">
+            {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          </span>
+        </div>
+        <span className="flex-1 truncate">{label}</span>
+        {isCode && (
+          <GitHubIcon className="size-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <div className="size-5 shrink-0 flex items-center justify-center">
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {threads.length}
+          </span>
+        </div>
+      </div>
+      {expanded && (
+        <div className="flex flex-col gap-0.5 pb-1 pl-4">
+          {threads.map((task) => (
+            <TaskRow
+              key={task.id}
+              task={task}
+              isActive={activeTaskId === task.id}
+              onClick={() => onSelectTask(task)}
+              onArchive={
+                canArchive && task.created_by === filters.currentUserId
+                  ? () => onArchiveTask(task)
+                  : undefined
+              }
+              showAutomationBadge={Boolean(task.trigger_id)}
+              hideStatusIdle
+              indented
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/sidebar/task-groups/my-threads-section.tsx
+++ b/apps/web/src/components/sidebar/task-groups/my-threads-section.tsx
@@ -1,18 +1,25 @@
 import { Inbox01 } from "@untitledui/icons";
 import { TaskRow } from "@/layouts/tasks-panel/task-row";
 import type { Task } from "@/components/chat/task/types";
-import { groupThreadsByStatus } from "./group-threads";
+import {
+  groupThreadsByStatus,
+  groupThreadsByVirtualMcp,
+} from "./group-threads";
 import { StatusGroup } from "./task-group";
+import { AgentGroup } from "./agent-group";
 import { ShowMoreButton } from "./show-more-button";
 import type { SidebarFilters } from "./next-page-offset";
+import { getWellKnownDecopilotVirtualMCP, useProjectContext } from "@/sdk";
 
 /**
- * The current user's threads, all agents mixed. Two renderings toggled by the
+ * The current user's threads, all agents mixed. Three renderings toggled by the
  * sidebar's group-by control:
+ *  - "room": collapsible groups by agent — each agent is a room, its threads
+ *    nested one layer down (the default; the product's main paradigm).
  *  - "flat": a single chronological list (each row shows its agent icon).
  *  - "status": collapsible groups by thread status.
  *
- * In flat mode, pagination piggybacks on the global thread store's
+ * In flat/room mode, pagination piggybacks on the global thread store's
  * `fetchNextPage` (the same feed the Team section reads) via the Show more
  * button. Status mode keeps its existing per-status server pagination.
  */
@@ -29,7 +36,7 @@ export function MyThreadsSection({
   filtersActive,
 }: {
   threads: Task[];
-  groupBy: "flat" | "status";
+  groupBy: "flat" | "status" | "room";
   activeTaskId: string | null;
   onSelectTask: (task: Task) => void;
   onArchiveTask: (task: Task) => void;
@@ -39,6 +46,9 @@ export function MyThreadsSection({
   onLoadMore: () => void;
   filtersActive?: boolean;
 }) {
+  const { org } = useProjectContext();
+  const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
+
   if (threads.length === 0 && !hasMore && !isFetchingMore) {
     return (
       <div className="flex flex-col items-center justify-center gap-2 px-4 py-12 text-center text-muted-foreground">
@@ -54,6 +64,33 @@ export function MyThreadsSection({
   // "New chat" to replace it. Hide the archive affordance until there's more
   // than one thread (or more waiting on the next page).
   const canArchive = threads.length > 1 || hasMore;
+
+  if (groupBy === "room") {
+    // A room is an agent; its threads nest one layer down. Decopilot pins first.
+    const rooms = groupThreadsByVirtualMcp(threads, decopilotId).filter(
+      (g) => g.threads.length > 0,
+    );
+    return (
+      <>
+        {rooms.map((room, i) => (
+          <AgentGroup
+            key={room.virtualMcpId}
+            virtualMcpId={room.virtualMcpId}
+            threads={room.threads}
+            activeTaskId={activeTaskId}
+            onSelectTask={onSelectTask}
+            onArchiveTask={onArchiveTask}
+            canArchive={canArchive}
+            filters={filters}
+            defaultExpanded={i === 0}
+          />
+        ))}
+        {(hasMore || isFetchingMore) && (
+          <ShowMoreButton onClick={onLoadMore} isFetching={isFetchingMore} />
+        )}
+      </>
+    );
+  }
 
   if (groupBy === "status") {
     return (

--- a/apps/web/src/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/web/src/components/sidebar/task-groups/task-groups-list.tsx
@@ -7,6 +7,7 @@ import {
   Activity,
   Edit05,
   FilterLines,
+  Hash02,
   LayoutLeft,
   Rows01,
   SearchSm,
@@ -54,7 +55,7 @@ import { findArchiveFallback } from "./archive-fallback";
 import { forgetThreadLayout } from "@/lib/thread-layout-memory";
 
 type TypeFilter = "all" | "manual" | "automation";
-type GroupBy = "flat" | "status";
+type GroupBy = "flat" | "status" | "room";
 
 /** Toolbar icon button with the shared dark tooltip (matches the collapsed
  * rail's SidebarMenuButton tooltip). `active` gives the pressed/highlighted look.
@@ -178,7 +179,7 @@ export function TaskGroupsList({
   );
 
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
-  const [groupBy, setGroupBy] = useState<GroupBy>("flat");
+  const [groupBy, setGroupBy] = useState<GroupBy>("room");
   const [showAll, setShowAll] = useLocalStorage<boolean>(
     "sidebar-threads-scope-all",
     false,
@@ -357,7 +358,7 @@ export function TaskGroupsList({
   }
 
   const filtersActive =
-    groupBy !== "flat" || typeFilter !== "all" || showAll === true;
+    groupBy !== "room" || typeFilter !== "all" || showAll === true;
 
   const filterPopover = (
     <Popover>
@@ -389,6 +390,11 @@ export function TaskGroupsList({
             setGroupBy(v);
           }}
           options={[
+            {
+              value: "room",
+              label: t("sidebar.taskGroupsList.viewRooms"),
+              icon: <Hash02 size={13} />,
+            },
             {
               value: "flat",
               label: t("sidebar.taskGroupsList.viewList"),

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -449,4 +449,12 @@ export const chat = {
   "chat.modelPreferences.autoPicked": "auto-picked",
   "chat.modelPreferences.loadFailed":
     "Couldn't load your model choices. What you see below may not match what your chats use.",
+  "chat.roomToggle.personalChat": "Personal chat",
+  "chat.roomToggle.sharedRoom": "Shared room",
+  "chat.roomToggle.tooltipPersonal": "Only you can post here — share the room",
+  "chat.roomToggle.tooltipShared": "Anyone in your organization can post here",
+  "chat.roomToggle.nowShared":
+    "Shared room — anyone in your organization can post",
+  "chat.roomToggle.nowPersonal": "Personal chat — only you can post",
+  "chat.roomToggle.failed": "Couldn't change who can post here",
 } as const;

--- a/apps/web/src/i18n/en/sidebar.ts
+++ b/apps/web/src/i18n/en/sidebar.ts
@@ -31,5 +31,6 @@ export const sidebar = {
   "sidebar.taskGroupsList.typeAuto": "Auto",
   "sidebar.taskGroupsList.typeChats": "Chats",
   "sidebar.taskGroupsList.viewList": "List",
+  "sidebar.taskGroupsList.viewRooms": "Rooms",
   "sidebar.taskGroupsList.viewStatus": "Status",
 } as const;

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -463,4 +463,14 @@ export const chat = {
   "chat.modelPreferences.autoPicked": "escolhido automaticamente",
   "chat.modelPreferences.loadFailed":
     "Não foi possível carregar suas escolhas de modelo. O que aparece abaixo pode não corresponder ao que seus chats usam.",
+  "chat.roomToggle.personalChat": "Chat pessoal",
+  "chat.roomToggle.sharedRoom": "Sala compartilhada",
+  "chat.roomToggle.tooltipPersonal":
+    "Só você pode escrever aqui — compartilhe a sala",
+  "chat.roomToggle.tooltipShared":
+    "Qualquer pessoa da sua organização pode escrever aqui",
+  "chat.roomToggle.nowShared":
+    "Sala compartilhada — qualquer pessoa da sua organização pode escrever",
+  "chat.roomToggle.nowPersonal": "Chat pessoal — só você pode escrever",
+  "chat.roomToggle.failed": "Não foi possível alterar quem pode escrever aqui",
 } satisfies Record<keyof typeof chatEn, string>;

--- a/apps/web/src/i18n/pt-br/sidebar.ts
+++ b/apps/web/src/i18n/pt-br/sidebar.ts
@@ -35,5 +35,6 @@ export const sidebar = {
   "sidebar.taskGroupsList.typeAuto": "Auto",
   "sidebar.taskGroupsList.typeChats": "Chats",
   "sidebar.taskGroupsList.viewList": "Lista",
+  "sidebar.taskGroupsList.viewRooms": "Salas",
   "sidebar.taskGroupsList.viewStatus": "Status",
 } satisfies Record<keyof typeof sidebarEn, string>;

--- a/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
@@ -38,6 +38,7 @@ import { headerLayout } from "./header-layout";
 import { VirtualMcpHeaderInfo } from "@/views/virtual-mcp/header-info";
 import { ChatModeRow } from "@/components/chat/pills/chat-mode-row";
 import { useOptionalChatTask } from "@/components/chat/context";
+import { RoomToggle } from "@/components/chat/room-toggle";
 import {
   AgentSwitcherCrumb,
   NewChatCrumb,
@@ -185,6 +186,7 @@ export function WorkspacePanelGroup({
       <div className="ml-auto flex shrink-0 items-center gap-1">
         {mainControlsInChat && branchSelector}
         {mainControlsInChat && publishActions}
+        <RoomToggle />
         {newChatCrumb}
       </div>
     </PanelHeader>

--- a/packages/e2e/tests/chat-room.spec.ts
+++ b/packages/e2e/tests/chat-room.spec.ts
@@ -1,0 +1,256 @@
+/**
+ * E2E: a thread is a room — several people, several agents.
+ *
+ * Two contracts, both asserted over the wire against the real
+ * `POST /api/:org/decopilot/threads/:threadId/messages` route:
+ *
+ *   1. WHO MAY POST. A personal chat takes messages from its owner alone; a
+ *      shared room (`metadata.shared`) takes them from any member of the org.
+ *      The check runs in the route's `validate()`, BEFORE model resolution and
+ *      before the user message is persisted — so a refusal is a 403 on the POST
+ *      with nothing written, not a 202 followed by a run that dies inside the
+ *      workflow. That ordering is what makes this spec model-free: no AI
+ *      provider, no harness, no link daemon is needed to prove it.
+ *
+ *   2. WHICH AGENT ANSWERS. The agent is per-request (`agent.id` in the body),
+ *      never read from `threads.virtual_mcp_id`, so a second agent can answer
+ *      in a thread another agent opened. The room keeps its primary agent — the
+ *      thread row must not follow the turn.
+ *
+ * The "accepted" cases assert 202 + a persisted user message rather than a
+ * finished run: completing a run needs a real model, and the surface under test
+ * is admission, not generation.
+ */
+
+import type { APIRequestContext, PlaywrightWorkerArgs } from "@playwright/test";
+import type { Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+function messageBody(agentId: string, text: string) {
+  return {
+    messages: [{ role: "user", parts: [{ type: "text", text }] }],
+    agent: { id: agentId },
+    temperature: 0.5,
+  };
+}
+
+function postMessage(
+  api: APIRequestContext,
+  orgSlug: string,
+  threadId: string,
+  body: unknown,
+) {
+  return api.post(`/api/${orgSlug}/decopilot/threads/${threadId}/messages`, {
+    data: body,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function createAgent(
+  api: APIRequestContext,
+  orgSlug: string,
+  title: string,
+): Promise<string> {
+  const agent = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_VIRTUAL_MCP_CREATE",
+    { data: { title, connections: [], status: "active", pinned: false } },
+  );
+  return agent.item.id;
+}
+
+async function createThread(
+  api: APIRequestContext,
+  orgSlug: string,
+  virtualMcpId: string,
+): Promise<string> {
+  const thread = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_THREADS_CREATE",
+    { data: { virtual_mcp_id: virtualMcpId, title: "E2E Room" } },
+  );
+  return thread.item.id;
+}
+
+/** Sign a second person up and pull them into `orgId` as a plain member. */
+async function inviteTeammate(
+  playwright: PlaywrightWorkerArgs["playwright"],
+  ownerApi: APIRequestContext,
+  orgId: string,
+) {
+  const teammateApi = await newApiContext(playwright);
+  const teammate = await signUpViaApi(teammateApi);
+
+  const invite = await ownerApi.post("/api/auth/organization/invite-member", {
+    data: { organizationId: orgId, email: teammate.email, role: "user" },
+  });
+  expect(
+    invite.ok(),
+    `invite-member failed: ${await invite.text().catch(() => "")}`,
+  ).toBe(true);
+  const inviteJson = (await invite.json()) as {
+    id?: string;
+    invitation?: { id?: string };
+  };
+  const invitationId = inviteJson.id ?? inviteJson.invitation?.id;
+  expect(invitationId).toBeTruthy();
+
+  const accept = await teammateApi.post(
+    "/api/auth/organization/accept-invitation",
+    { data: { invitationId } },
+  );
+  expect(
+    accept.ok(),
+    `accept-invitation failed: ${await accept.text().catch(() => "")}`,
+  ).toBe(true);
+
+  return { teammateApi, teammate };
+}
+
+/** User-message rows persisted for a thread, tenant-scoped by thread id (the
+ *  thread was minted inside this test's own org). */
+async function userMessageCount(db: Client, threadId: string) {
+  const { rows } = await db.query<{ count: string }>(
+    `SELECT COUNT(DISTINCT message_id) AS count
+       FROM thread_message_parts
+      WHERE thread_id = $1 AND role = 'user'`,
+    [threadId],
+  );
+  return Number(rows[0]?.count ?? 0);
+}
+
+test.describe("thread as a room", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    // `db` is undefined when beforeAll itself failed to connect — don't bury
+    // that error under a TypeError from the teardown.
+    await db?.end();
+  });
+
+  test("a teammate cannot post in someone's personal chat", async ({
+    authedPage,
+    playwright,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+
+    const { rows } = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [orgSlug],
+    );
+    const orgId = rows[0]?.id;
+    if (!orgId) throw new Error("org not found after signup");
+
+    const agentId = await createAgent(api, orgSlug, "E2E Room Agent");
+    const threadId = await createThread(api, orgSlug, agentId);
+
+    const { teammateApi } = await inviteTeammate(playwright, api, orgId);
+    try {
+      const res = await postMessage(
+        teammateApi,
+        orgSlug,
+        threadId,
+        messageBody(agentId, "let me in"),
+      );
+
+      expect(res.status()).toBe(403);
+      // Refused at the boundary: nothing of theirs was written.
+      expect(await userMessageCount(db, threadId)).toBe(0);
+    } finally {
+      await teammateApi.dispose();
+    }
+  });
+
+  test("a teammate can post in a shared room", async ({
+    authedPage,
+    playwright,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+
+    const { rows } = await db.query<{ id: string }>(
+      `SELECT id FROM "organization" WHERE slug = $1`,
+      [orgSlug],
+    );
+    const orgId = rows[0]?.id;
+    if (!orgId) throw new Error("org not found after signup");
+
+    const agentId = await createAgent(api, orgSlug, "E2E Room Agent");
+    const threadId = await createThread(api, orgSlug, agentId);
+
+    // Open the thread as a room — the same write the UI's "Shared room" toggle
+    // performs (thread update with `metadata.shared`).
+    await callSelfMcpTool(api, orgSlug, "COLLECTION_THREADS_UPDATE", {
+      id: threadId,
+      data: { metadata: { shared: true } },
+    });
+
+    const { teammateApi } = await inviteTeammate(playwright, api, orgId);
+    try {
+      const res = await postMessage(
+        teammateApi,
+        orgSlug,
+        threadId,
+        messageBody(agentId, "joining the room"),
+      );
+
+      expect(
+        res.status(),
+        `expected the room to admit a member, got ${await res
+          .text()
+          .catch(() => "")}`,
+      ).toBe(202);
+
+      // Admission is proven by the message landing: the route persists the user
+      // turn before handing off to the run.
+      await expect(async () => {
+        expect(await userMessageCount(db, threadId)).toBe(1);
+      }).toPass({ timeout: 10_000, intervals: [200, 500, 1000] });
+    } finally {
+      await teammateApi.dispose();
+    }
+  });
+
+  test("a second agent answers in a thread the first one opened", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+
+    const marioId = await createAgent(api, orgSlug, "E2E Mario");
+    const luigiId = await createAgent(api, orgSlug, "E2E Luigi");
+    const threadId = await createThread(api, orgSlug, marioId);
+
+    // Address the turn to the OTHER agent — what an "@Luigi" mention sends.
+    const res = await postMessage(
+      api,
+      orgSlug,
+      threadId,
+      messageBody(luigiId, "@Luigi your turn"),
+    );
+    expect(
+      res.status(),
+      `expected the room to accept a second agent, got ${await res
+        .text()
+        .catch(() => "")}`,
+    ).toBe(202);
+
+    // The room keeps its primary agent: a turn handed to another agent must not
+    // re-point the thread, or the sidebar would move the room under Luigi.
+    const { rows } = await db.query<{ virtual_mcp_id: string }>(
+      `SELECT virtual_mcp_id FROM threads WHERE id = $1`,
+      [threadId],
+    );
+    expect(rows[0]?.virtual_mcp_id).toBe(marioId);
+  });
+});

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -19,6 +19,14 @@ export type ChatMode =
 
 export interface ChatAgentConfig {
   id: string | null;
+  /**
+   * Display name of the agent this turn is addressed to. Set when an "@"
+   * mention handed the turn to an agent, so later readers (the attribution UI,
+   * the server's room-transcript relabelling) can name who spoke without a
+   * lookup. Absent on single-agent threads, where the thread's agent is the
+   * only speaker.
+   */
+  title?: string;
 }
 
 export interface ChatUserConfig {

--- a/packages/shared/src/entities.test.ts
+++ b/packages/shared/src/entities.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { canWriteToThread } from "./entities.ts";
+
+const GUI = "user_gui";
+const ANA = "user_ana";
+
+describe("canWriteToThread", () => {
+  it("lets the owner write to their own chat", () => {
+    expect(canWriteToThread({ created_by: GUI, userId: GUI })).toBe(true);
+  });
+
+  it("keeps a teammate's personal chat read-only", () => {
+    expect(canWriteToThread({ created_by: GUI, userId: ANA })).toBe(false);
+    expect(
+      canWriteToThread({ created_by: GUI, metadata: {}, userId: ANA }),
+    ).toBe(false);
+    expect(
+      canWriteToThread({
+        created_by: GUI,
+        metadata: { shared: false },
+        userId: ANA,
+      }),
+    ).toBe(false);
+  });
+
+  it("lets any member post in a shared room", () => {
+    expect(
+      canWriteToThread({
+        created_by: GUI,
+        metadata: { shared: true },
+        userId: ANA,
+      }),
+    ).toBe(true);
+  });
+
+  it("denies a write when the actor is unknown", () => {
+    expect(
+      canWriteToThread({
+        created_by: GUI,
+        metadata: { shared: true },
+        userId: null,
+      }),
+    ).toBe(false);
+    expect(canWriteToThread({ created_by: GUI, userId: undefined })).toBe(
+      false,
+    );
+  });
+
+  it("stays writable when the owner is unknown (legacy/optimistic rows)", () => {
+    expect(canWriteToThread({ created_by: null, userId: ANA })).toBe(true);
+    expect(canWriteToThread({ userId: ANA })).toBe(true);
+  });
+
+  it("ignores a non-boolean `shared` rather than trusting it", () => {
+    expect(
+      canWriteToThread({
+        created_by: GUI,
+        metadata: { shared: "yes" as unknown as boolean },
+        userId: ANA,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -18,7 +18,41 @@ export interface ThreadExpandedTool {
 
 export interface ThreadMetadata {
   expanded_tools?: ThreadExpandedTool[];
+  /**
+   * A shared room: every member of the organization may post in it, not just
+   * the person who opened it. Absent/false means a personal chat — teammates
+   * can read it (the sidebar's Team scope lists it) but not write to it.
+   *
+   * Enforced through `canWriteToThread`, which BOTH the API and the composer
+   * call so the two can't drift.
+   */
+  shared?: boolean;
   [key: string]: unknown;
+}
+
+/**
+ * May `userId` post in this thread?
+ *
+ * Org membership is verified upstream (the org-scoped route resolves the org
+ * and rejects non-members, and threads are always fetched org-scoped), so the
+ * only question left here is owner-vs-room:
+ *  - a personal chat is writable by its owner alone;
+ *  - a shared room is writable by any member who can reach it.
+ *
+ * Callers with no identity yet (`userId` null, session still loading) get
+ * `false` — never assume a write is allowed while the actor is unknown.
+ */
+export function canWriteToThread(thread: {
+  created_by?: string | null;
+  metadata?: ThreadMetadata | null;
+  userId: string | null | undefined;
+}): boolean {
+  if (!thread.userId) return false;
+  if (thread.metadata?.shared === true) return true;
+  // An unknown owner (legacy rows, optimistic local rows) stays writable by
+  // whoever is holding it — matching the pre-rooms behavior.
+  if (!thread.created_by) return true;
+  return thread.created_by === thread.userId;
 }
 
 /**


### PR DESCRIPTION
## Rooms, not threads — and more than one agent in them

Two distinctions drive this branch:

1. **The agent is the unit of improvement, not the org.** You hire a person and they *learn skills*, *remember*, hold *goals*, keep *responsibilities* on a rhythm. Memory / Skills / Loops are organs of an agent, not flat platform layers.
2. **The thread is not the paradigm — the room is.** A top-level room is a repo or a big subject. You open it and see messages from other agents *and* other people in your org, and you all collaborate there.

This PR ships the second one and the multi-participant plumbing it needs. Research behind it (Buzz) is at the bottom.

---

## How to verify (5 minutes, no AI provider needed)

```bash
bun install
bun run check && bun run lint          # 0 TS errors, 0 lint errors
bun test packages/shared/src/entities.test.ts \
         apps/api/src/harnesses/decopilot/room-transcript.test.ts   # 15 pass
```

`room-transcript.test.ts` is the one to read first — it's the whole multi-agent correctness argument in 9 cases, no mocks, no DB.

**In the app** (`bun run dev`):
1. Sidebar opens grouped by **Rooms** — one collapsible group per agent, threads nested inside.
2. Open a thread, type `@SomeOtherAgent do X` → *that* agent answers, in this thread, labelled with its avatar and name.
3. Click the person icon in the chat header → the thread becomes a **Shared room**. A teammate can now post in it; each message shows who sent it.
4. Toggle it back → the teammate's composer returns to read-only.

**E2E** (`packages/e2e/tests/chat-room.spec.ts`): three cases over the real route — teammate refused from a personal chat (403, nothing written), teammate admitted to a shared room (202, message row lands), a second agent takes a turn without the room changing its primary agent.

> **Disclosure:** I could not get a green local e2e run. The suite fails at `signUpViaApi` (`FAILED_TO_CREATE_USER`) in this workspace, and an **existing** spec (`decopilot-messages.spec.ts`) fails identically on the same box — so it's the local environment, not this spec. The file type-checks (`bun run --cwd=packages/e2e check`, 0 errors on it) and follows the pattern of the specs next to it, but it has **not** been observed passing. Please treat CI's run as the first real signal.

---

## What's here, and why it's shaped this way

### 1. Sidebar: rooms instead of a thread list
A room is an agent — a code agent is its repo, a plain agent its subject. `groupThreadsByVirtualMcp` already existed and was **unused**; this wires it up as the default view. List and Status stay in the filter popover. No schema change.

### 2. Several agents answering in one thread
`@agent` used to expand into a `[DELEGATE TO AGENT …] use the subtask tool` instruction — so the *current* agent answered on the other one's behalf and the room never heard the agent itself. Now the mention **hands the turn to that agent**.

**Why no migration:** `dispatch-run` already resolved the agent from `input.agent.id` on the request and **never** read `threads.virtual_mcp_id`. The single-agent-ness was a client convention (the `?virtualmcpid=` URL param). The mention is recorded in `metadata.agent` on the user message — `thread_messages.metadata` is free-form JSON that the history read path already preserves, so authorship needed no column. Migration 057 deliberately collapsed `agent_ids` into a singular `virtual_mcp_id`; **this does not re-add an array.** The thread keeps one primary agent (the room's), and authorship lives per message, which is where it belongs.

**The correctness core is `buildRoomTranscript`** (`apps/api/src/harnesses/decopilot/room-transcript.ts`). The model context carries only `role`. Without this, agent B reads agent A's replies as *its own past words* — it contradicts itself, apologises for things it never said, "continues" work it never began. So history is rewritten for whoever is about to speak:

- own turns stay `assistant`;
- another agent's turns become `user` messages labelled `[Mario]: …`;
- humans get named too, but only once more than one human has spoken (a 1:1 thread reads exactly as today);
- tool parts are flattened out — a tool call can't ride on a `user` message, and an orphaned tool result breaks strict providers;
- a tool-only turn becomes `(worked on this without replying)` rather than empty text, which some providers reject;
- threads with no `metadata.agent` — every thread written before this — pass through **untouched**.

Applied in `context-loader.ts`, one seam, so every decopilot run gets it.

### 3. Shared rooms (multi-human)
Threads were writable by their creator alone — right for a personal chat, wrong for a room. Opt-in `metadata.shared`.

**Why a flag and not "every thread is a room":** the owner-only rule was added deliberately (#4230 made teammates' threads read-only). Flipping it wholesale would silently undo that for everyone. A room is now something you *open*, and a personal chat still behaves exactly as it did.

**Why one predicate:** `canWriteToThread` in `packages/shared` is called by the route, by `dispatch-run`, and by the composer. Three call sites, one rule — they cannot drift, and the composer can never offer a write the server will reject. Unknown actor (session still loading) is denied rather than assumed; a non-boolean `shared` is ignored rather than trusted.

**Why the guard moved:** it lived in `dispatch-run`, inside the DBOS workflow — so an unauthorized post returned 202 and died asynchronously *after* the user message had been persisted. It now runs in the route's `validate()`, where the thread row and caller are already in hand: 403 on the POST, nothing written. `dispatch-run` keeps the check as defense in depth. Doing it before model resolution is also what lets the e2e prove the contract with no AI provider configured.

### 4. UI
- **`RoomToggle`** in the chat panel header flips personal ↔ shared. Owner-only, and hidden until the row has a `created_by` to compare against so an optimistic row can't act on the wrong thread. (There was no thread-actions menu anywhere to hang this on — `rename` exists in the store and is called from nowhere — so it's a single icon button rather than a new dropdown surface.)
- **Author on user messages**, shown only in a shared room. With the agent label from commit 2, a room now answers both halves of "who said this": which human, which agent.

---

## Trade-offs and what I deliberately did not do

- **No `room_members` table.** `metadata.shared` is a 1-bit stand-in: a room is open to the whole org or to nobody. Per-room membership, invites and scoped guests are the real model (see the Buzz notes) and a much larger change.
- **No presence.** You can't see who's in the room or which agent is working right now.
- **One agent per turn.** A turn is one run; the last `@` mention wins. No parallel replies from two agents to the same message.
- **Threads nest one level** (room → threads), not N.
- **Attribution is derived, not stored on the assistant row.** The author of an assistant message is the agent the preceding user message addressed. Cheap and correct for this flow; a real `author` column is the honest fix once agents are principals.
- **`deriveOthersThreadLabel`** (the sandbox auto-start gate) still uses raw ownership, not `canWriteToThread` — booting a sandbox on someone else's branch is a different decision from posting a message, and I didn't want to loosen it by accident.

---

# Research: what Buzz teaches us

Read alongside Buzz (`VISION.md`, `VISION_PROJECTS.md`, `VISION_AGENT.md`, `migrations/0001_initial_schema.sql`) and the Raft write-up. Buzz is a Slack-like workspace where humans and agents are members of the same channels; a branch *is* a channel and that channel *is* the PR + CI dashboard + discussion.

## Where we're already aligned

| Buzz | Studio |
|---|---|
| `events` — one signed, partitioned append-only log | `thread_message_parts` — stream-of-record with fold |
| `subscriptions` + `delivery_log`, at-least-once | event-bus, CloudEvents, at-least-once + backoff |
| `workflows`, `workflow_runs`, `scheduled_workflow_fires` | automations (cron/event/webhook) on DBOS — **our durable runtime is stronger**: fences, resume, projection |
| `community` = tenant, URL selects it | org = tenant, `/api/:org/...` |
| `thread_metadata` (parent/root/depth), N levels | threads inside a room, 1 level |

## Where we're stronger, and shouldn't copy them

MCP as the product: bindings, virtual MCPs, tool aggregation, credential vault, OAuth proxy, an AI-provider layer with tiers and credits, multiple harnesses (claude-code / codex / decopilot) with sandbox + branch + preview. Buzz uses MCP as agent plumbing, not as a control plane. That layer is our asset.

## Where we're fundamentally wrong

**1. An agent is not a principal — it's a connection.** In Buzz an agent is a row in the same `users` table as humans: its own keypair, `role='bot'` in `channel_members`, and `agent_owner_pubkey` so it *inherits* its owner's access — remove the human and every agent of theirs loses access instantly. In Studio an agent is a `connections` row of type `VIRTUAL`: a **tool**, not a **subject**. Hence it can't be a member, can't have presence, can't claim work, can't hold authority. **Most of this PR is a workaround for that missing principal model.** This is the deep fix.

**2. There is no room membership.** Our access is org-wide plus thread-owner. There is no "who is in this room" — so no participant list, no invite, no scoped guest, no per-room privacy. `metadata.shared` is a 1-bit stand-in for a `room_members` table. In Buzz, channel membership is the *only* gate, and it's the same gate for humans, agents and guests.

**3. A message has a `role`, not an author.** That's problem 1 expressed in the schema. `buildRoomTranscript` is a patch over a missing author column. In Buzz authorship is cryptographic — every event is signed by a pubkey.

**4. No presence.** Buzz shows "2s (2 agents)" working in a channel. A room without presence doesn't feel like a room; it feels like an inbox.

**5. Agents don't watch the room.** In Buzz an agent *subscribes* to a channel — that's how "an agent watching the incident channel answers on its own" happens at all. In Studio an agent acts only when a human sends a turn or a cron fires. We already have the event bus; it just isn't wired to conversation. **Cheapest gap to close, highest return.**

**6. One log, three lenses — we have N models and N screens.** Stream / Forum / Workflow are renderings of the same event log, which is *why* a Buzz channel can be the PR and the CI dashboard and the discussion at once. Our board, automations, PRs and threads are separate models: nothing to search, replay or subscribe to in one place.

**7. No attention model.** Buzz defaults to zero notifications, urgency only in DMs. A room without an attention policy becomes noise — the Raft piece reaches the same conclusion from the other direction ("what changes is what reaches you").

## Suggested order

agent-as-principal (1 + 3) → room membership (2) → agent subscribes to the room (5) → presence (4). Items 6 and 7 are strategy, not sprint. None of this needs cryptographic identity: the lesson from Buzz is the **model of subjects and belonging**, not Nostr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
