### PR TITLE
fix(chat): use short label in approval-level select trigger

### DIFF
--- a/apps/web/src/components/chat/highlight/approval.tsx
+++ b/apps/web/src/components/chat/highlight/approval.tsx
@@ -46,6 +46,11 @@ function ApprovalLevelSelect({
   const t = useT();
   const [preferences, setPreferences] = usePreferences();
 
+  const currentOption =
+    APPROVAL_LEVEL_OPTIONS.find(
+      (opt) => opt.value === preferences.toolApprovalLevel,
+    ) ?? APPROVAL_LEVEL_OPTIONS[0]!;
+
   const handleLevelChange = (value: string) => {
     const newLevel = value as ToolApprovalLevel;
     // Capture the level the pending approval was REQUESTED at before persisting
@@ -75,7 +80,7 @@ function ApprovalLevelSelect({
         className="text-xs text-muted-foreground border-border/60 bg-transparent hover:bg-accent/60 h-7 gap-1"
         onClick={(e) => e.stopPropagation()}
       >
-        <SelectValue />
+        <SelectValue>{t(currentOption.shortKey)}</SelectValue>
       </SelectTrigger>
       <SelectContent>
         {APPROVAL_LEVEL_OPTIONS.map((opt) => (


### PR DESCRIPTION
## Summary
The in-chat approval-level select (`ApprovalLevelSelect` in `apps/web/src/components/chat/highlight/approval.tsx`) rendered `<SelectValue />` in its `size="xs"` trigger, which displays the **full** selected-item label (`toolApprovalAuto`). In English that's the short "Auto approve", but in pt-br it's "Aprovar automaticamente" — too long for the small trigger, so it overflowed/clipped.

Fix: render the `shortKey` in the trigger (showing "Auto"), matching the pattern already used by the `tools-popover` trigger. The dropdown items still show the full labels.

## Testing notes
- `bun run fmt` — clean
- `bun run --cwd=apps/web check` (tsc) — passes

## Affected areas
- Chat tool-approval level selector pill (in-chat), pt-br and other longer locales.

## Screenshot (before)
Trigger clipped: "Aprovar automaticament…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the short label (`shortKey`) in the in-chat approval-level select trigger to prevent overflow in the xs trigger, especially in longer locales like pt-br. Matches `tools-popover` behavior; dropdown items still show full labels.

<sup>Written for commit d263f416f0acb2c3cf4f576fac5d25fc0e17e9dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

