### PR TITLE
feat(sections-editor): allow free-typed value when dynamic-options fetch is empty

### DIFF
--- a/apps/web/src/components/sections-editor/fields/dynamic-options-field.test.ts
+++ b/apps/web/src/components/sections-editor/fields/dynamic-options-field.test.ts
@@ -4,6 +4,7 @@ import {
   filterOptions,
   normalizeOptions,
   resolveOptions,
+  shouldOfferTypedValue,
   svgPreviewDataUri,
 } from "./dynamic-options-field";
 
@@ -183,5 +184,59 @@ describe("resolveOptions", () => {
 
   test("returns empty when neither source has options", () => {
     expect(resolveOptions([], [])).toEqual([]);
+  });
+});
+
+describe("shouldOfferTypedValue", () => {
+  const base = {
+    loaderPath: "site/loaders/collections.ts",
+    isIconSelect: false,
+    enumFallbackCount: 0,
+    trimmedSearch: "5455",
+    optionValues: [] as string[],
+    optionsSettled: true,
+  };
+
+  test("offers the typed value for a settled, empty loader result", () => {
+    expect(shouldOfferTypedValue(base)).toBe(true);
+  });
+
+  test("offers it when the loader returned options but none match", () => {
+    expect(
+      shouldOfferTypedValue({ ...base, optionValues: ["100", "200"] }),
+    ).toBe(true);
+  });
+
+  test("does not offer while the query is still settling", () => {
+    // Debounce/fetch window: options are empty only because nothing loaded yet.
+    expect(shouldOfferTypedValue({ ...base, optionsSettled: false })).toBe(
+      false,
+    );
+  });
+
+  test("does not offer when the typed value already exists as an option", () => {
+    expect(
+      shouldOfferTypedValue({ ...base, optionValues: ["5455", "200"] }),
+    ).toBe(false);
+  });
+
+  test("does not offer for an empty (or whitespace-trimmed) search", () => {
+    expect(shouldOfferTypedValue({ ...base, trimmedSearch: "" })).toBe(false);
+  });
+
+  test("does not offer without a dynamic loader", () => {
+    expect(shouldOfferTypedValue({ ...base, loaderPath: undefined })).toBe(
+      false,
+    );
+  });
+
+  test("does not offer for the constrained icon-select format", () => {
+    expect(shouldOfferTypedValue({ ...base, isIconSelect: true })).toBe(false);
+  });
+
+  test("does not offer when a schema enum makes it a closed set", () => {
+    expect(shouldOfferTypedValue({ ...base, enumFallbackCount: 3 })).toBe(
+      false,
+    );
   });
 });

--- a/apps/web/src/components/sections-editor/fields/dynamic-options-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/dynamic-options-field.tsx
@@ -107,6 +107,47 @@ export function filterOptions(
 }
 
 /**
+ * Whether to offer the typed search text as a committable free value.
+ *
+ * Only loader-backed fields treat their options as suggestions rather than a
+ * closed set: a dynamic `@options` loader, no fixed schema `enum`, and not the
+ * constrained icon-select. For those, a value the loader doesn't return (e.g. a
+ * Collection ID the search can't find, or a loader that came back empty) can
+ * still be entered by hand.
+ *
+ * Gated on `optionsSettled` so the offer never appears while the loader is
+ * still fetching — otherwise a user searching for a real option could
+ * Enter-commit the raw text over the results about to load. Suppressed when the
+ * typed value already exists as an option; dedupe against the full resolved
+ * list (`optionValues`), not the filtered view — an exact value match always
+ * survives client-side filtering, so it can never be hidden.
+ */
+export function shouldOfferTypedValue({
+  loaderPath,
+  isIconSelect,
+  enumFallbackCount,
+  trimmedSearch,
+  optionValues,
+  optionsSettled,
+}: {
+  loaderPath: string | undefined;
+  isIconSelect: boolean;
+  enumFallbackCount: number;
+  trimmedSearch: string;
+  optionValues: string[];
+  optionsSettled: boolean;
+}): boolean {
+  const allowFreeValue =
+    !!loaderPath && !isIconSelect && enumFallbackCount === 0;
+  return (
+    allowFreeValue &&
+    optionsSettled &&
+    trimmedSearch.length > 0 &&
+    !optionValues.includes(trimmedSearch)
+  );
+}
+
+/**
  * Data URI for an option's inline-SVG preview. Rendered through an `img` so
  * loader-controlled markup is never injected into the document. Loader SVGs
  * rely on Tailwind's current-color utilities (e.g. odin-ui color swatches are
@@ -340,20 +381,24 @@ export function DynamicOptionsField({
   const visibleOptions = filterOptions(options, search);
   const selectedOption = options.find((opt) => opt.value === currentValue);
 
-  // A loader-backed field (dynamic `@options`, no fixed schema `enum`, not the
-  // constrained icon-select) treats its options as suggestions, not a closed
-  // set — so a value the loader doesn't return (e.g. a Collection ID the search
-  // can't find, or a loader that came back empty) can still be entered by hand.
-  // cmdk owns the input, so we surface the typed text as a selectable "use this"
-  // item rather than a separate text box; Enter commits it when it's the only
-  // match, so an empty result set no longer traps the user.
-  const allowFreeValue =
-    !!loaderPath && !isIconSelect && enumFallback.length === 0;
+  // Offer the typed text as a committable free value on loader-backed fields
+  // (see `shouldOfferTypedValue`). cmdk owns the input, so it's surfaced as a
+  // selectable "use this" item rather than a separate text box; when it's the
+  // only item cmdk highlights it, so Enter commits it and an empty result set
+  // no longer traps the user. `optionsSettled` keeps the offer from appearing
+  // (and preempting an incoming loader result) during the debounce + fetch
+  // window: the query for a new term returns no data until it settles.
   const trimmedSearch = search.trim();
-  const canUseTypedValue =
-    allowFreeValue &&
-    trimmedSearch.length > 0 &&
-    !options.some((opt) => opt.value === trimmedSearch);
+  const optionsSettled =
+    query.isFetched && !query.isFetching && search === debouncedSearch;
+  const canUseTypedValue = shouldOfferTypedValue({
+    loaderPath,
+    isIconSelect,
+    enumFallbackCount: enumFallback.length,
+    trimmedSearch,
+    optionValues: options.map((opt) => opt.value),
+    optionsSettled,
+  });
 
   // Fallback to text input only when there's no option source at all: no
   // loader/preview to fetch from AND no schema enum to list.

--- a/apps/web/src/components/sections-editor/fields/dynamic-options-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/dynamic-options-field.tsx
@@ -340,6 +340,21 @@ export function DynamicOptionsField({
   const visibleOptions = filterOptions(options, search);
   const selectedOption = options.find((opt) => opt.value === currentValue);
 
+  // A loader-backed field (dynamic `@options`, no fixed schema `enum`, not the
+  // constrained icon-select) treats its options as suggestions, not a closed
+  // set — so a value the loader doesn't return (e.g. a Collection ID the search
+  // can't find, or a loader that came back empty) can still be entered by hand.
+  // cmdk owns the input, so we surface the typed text as a selectable "use this"
+  // item rather than a separate text box; Enter commits it when it's the only
+  // match, so an empty result set no longer traps the user.
+  const allowFreeValue =
+    !!loaderPath && !isIconSelect && enumFallback.length === 0;
+  const trimmedSearch = search.trim();
+  const canUseTypedValue =
+    allowFreeValue &&
+    trimmedSearch.length > 0 &&
+    !options.some((opt) => opt.value === trimmedSearch);
+
   // Fallback to text input only when there's no option source at all: no
   // loader/preview to fetch from AND no schema enum to list.
   const noOptionSource =
@@ -408,16 +423,19 @@ export function DynamicOptionsField({
               onValueChange={handleSearchChange}
             />
             <CommandList>
-              <CommandEmpty>
-                {query.isLoading
-                  ? t("sectionsEditor.dynamicOptionsField.loading")
-                  : t("sectionsEditor.dynamicOptionsField.noResults")}
-              </CommandEmpty>
+              {!canUseTypedValue && (
+                <CommandEmpty>
+                  {query.isLoading
+                    ? t("sectionsEditor.dynamicOptionsField.loading")
+                    : t("sectionsEditor.dynamicOptionsField.noResults")}
+                </CommandEmpty>
+              )}
               <CommandGroup>
                 {visibleOptions.map((opt) => (
                   <CommandItem
                     key={opt.value}
                     value={opt.value}
+                    className="cursor-pointer"
                     onSelect={() => {
                       onChange(opt.value === currentValue ? "" : opt.value);
                       setOpen(false);
@@ -442,6 +460,26 @@ export function DynamicOptionsField({
                   </CommandItem>
                 ))}
               </CommandGroup>
+              {canUseTypedValue && (
+                <CommandGroup>
+                  <CommandItem
+                    value={trimmedSearch}
+                    className="cursor-pointer"
+                    onSelect={() => {
+                      onChange(trimmedSearch);
+                      setSearch("");
+                      setDebouncedSearch("");
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="truncate">
+                      {t("sectionsEditor.dynamicOptionsField.useValue", {
+                        value: trimmedSearch,
+                      })}
+                    </span>
+                  </CommandItem>
+                </CommandGroup>
+              )}
             </CommandList>
           </Command>
         </PopoverContent>

--- a/apps/web/src/i18n/en/sections-editor.ts
+++ b/apps/web/src/i18n/en/sections-editor.ts
@@ -38,6 +38,7 @@ export const sectionsEditor = {
   "sectionsEditor.dynamicOptionsField.noResults": "No results found.",
   "sectionsEditor.dynamicOptionsField.searchPlaceholder": "Search...",
   "sectionsEditor.dynamicOptionsField.selectPlaceholder": "Select...",
+  "sectionsEditor.dynamicOptionsField.useValue": 'Use "{value}"',
   "sectionsEditor.enumField.selectPlaceholder": "Select...",
   "sectionsEditor.fileField.browseButton": "Browse",
   "sectionsEditor.fileField.dropFileHint": "Drop a file or click to browse",

--- a/apps/web/src/i18n/pt-br/sections-editor.ts
+++ b/apps/web/src/i18n/pt-br/sections-editor.ts
@@ -41,6 +41,7 @@ export const sectionsEditor = {
     "Nenhum resultado encontrado.",
   "sectionsEditor.dynamicOptionsField.searchPlaceholder": "Pesquisar...",
   "sectionsEditor.dynamicOptionsField.selectPlaceholder": "Selecionar...",
+  "sectionsEditor.dynamicOptionsField.useValue": 'Usar "{value}"',
   "sectionsEditor.enumField.selectPlaceholder": "Selecionar...",
   "sectionsEditor.fileField.browseButton": "Procurar",
   "sectionsEditor.fileField.dropFileHint":


### PR DESCRIPTION
## Summary
When a schema-driven **Dynamic Options** field (the combobox that fetches option values from a deco `@options` loader) returned nothing, the picker showed "No results found." with **no way to enter a value** — the search box only filtered/fetched, it never committed. So a field like `Collection ID`, where the ID you want simply isn't in the loader's list, was a dead end.

## Changes
`apps/web/src/components/sections-editor/fields/dynamic-options-field.tsx`

- For **loader-backed fields** (has a dynamic `@options` loader, no fixed schema `enum`, not the constrained `icon-select` format), options are now treated as *suggestions*, not a closed set. When you type a value no option matches, a selectable **`Use "…"`** item appears; clicking it (or pressing Enter, since it's the only item in an empty result set) commits the typed value via `onChange`.
- Enum-only and icon-select fields stay strictly constrained — no unintended free typing (gated by `allowFreeValue`).
- The "No results found." empty state is suppressed while the "Use …" item is showing, so the user sees an actionable item instead of a dead end.
- Option items (and the new "Use …" item) get a `cursor-pointer` (the shared `CommandItem` defaults to `cursor-default`); done via `className` so the shared UI primitive is untouched.

New i18n keys: `sectionsEditor.dynamicOptionsField.useValue` (`en`: `Use "{value}"`, `pt-br`: `Usar "{value}"`).

## Testing notes
- `bun run fmt` ✅
- `apps/web` `tsc --noEmit` ✅ (also proves i18n translation completeness)
- `oxlint` on the changed file: 0 warnings, 0 errors ✅
- Not driven in a live preview server against a real loader.

The committed free value is a string, consistent with the component's existing plain-text fallback branch. Numeric coercion is a separate, pre-existing concern not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows users to commit a free-typed value in loader-backed dynamic options when no fetched option matches. The “Use …” action only appears after the loader query settles to avoid accidental commits.

- **New Features**
  - Show “Use "{value}"” when typed text has no match; Enter or click commits it.
  - Hide “No results found.” while the “Use …” action is visible.
  - Keep enum-only and `icon-select` fields strict (no free typing).
  - Add pointer cursor to option items.
  - Add i18n key `sectionsEditor.dynamicOptionsField.useValue` in `en` and `pt-br`.

- **Bug Fixes**
  - Gate the “Use …” item on a settled query (`isFetched`, not `isFetching`, and `search === debouncedSearch`) to prevent preempting incoming results.
  - Extracted `shouldOfferTypedValue` helper and added unit tests.

<sup>Written for commit 9d8106c78f553dd86d51810c37ed397e9f8a19b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

