### PR TITLE
refactor(library): replace as-any cast with TranslationKey on VolumeFolderCard

### DIFF
--- a/apps/web/src/layouts/library/library-views.tsx
+++ b/apps/web/src/layouts/library/library-views.tsx
@@ -11,6 +11,7 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
 import { homeDisplayName } from "@decocms/shared/organization/home-mount";
 import { useT } from "@/i18n/use-t.ts";
+import type { TranslationKey } from "@/i18n/en/index.ts";
 import {
   type OrgFsEntry,
   type ShareMode,
@@ -176,7 +177,7 @@ function VolumeFolderCard({
   volume: string;
   /** Card label when it differs from the volume id (home shows the slug). */
   displayName?: string;
-  descriptionKey: string;
+  descriptionKey: TranslationKey;
   glyph?: ComponentType<SVGProps<SVGSVGElement>>;
   onOpen: () => void;
 }) {
@@ -190,7 +191,7 @@ function VolumeFolderCard({
           ? t("library.libraryViews.filesCount", { count: usage.data.files })
           : undefined
       }
-      subtitle={t(descriptionKey as any)}
+      subtitle={t(descriptionKey)}
       glyph={glyph}
       onOpen={onOpen}
     />


### PR DESCRIPTION
Source: C-DEBT type-safety cleanup (un-CI-enforced `no-explicit-any` debt) found while auditing `apps/web/src/layouts/library/library-views.tsx`.

Why a maintainer wants this: `VolumeFolderCard`'s `descriptionKey` prop was typed as plain `string`, which forced an `as any` cast at the `t(descriptionKey as any)` call site (bypassing `useT`'s key-validation entirely). All three real call sites (`VOLUMES` in the same file) already declare their key as an `as const` string literal, so they already satisfy the narrower `TranslationKey` type — the cast was pure debt, not a real type mismatch.

Change: typed `descriptionKey` as `TranslationKey` (imported from `@/i18n/en/index.ts`, the same type `useT()` uses) and dropped the `as any` cast. Behavior-preserving — the three existing literal keys all resolve to valid `TranslationKey` values, confirmed by `tsc` passing. A future typo/renamed translation key here is now a compile error instead of a silently-swallowed cast.

Net diff: +3/-2, one file, one concern.

Reviewer check: `cd apps/web && bunx tsc --noEmit` (green). No test file exists for this pure presentational component (single caller, no behavior change), so the type-check is the verification.

Locally ran: `bun run fmt` and `cd apps/web && bunx tsc --noEmit` (both clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed the `descriptionKey` prop as `TranslationKey` in VolumeFolderCard and removed the `as any` cast, adding compile-time validation for translation keys. No behavior changes; existing keys already match.

<sup>Written for commit ee669c7e283707290e90fe28fda86efc8373fa52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

