### PR TITLE
fix(github): surface get_files tool errors in the GitHub-fallback PR diff

### DIFF
--- a/apps/web/src/components/thread/github/github-pr-diff.test.ts
+++ b/apps/web/src/components/thread/github/github-pr-diff.test.ts
@@ -109,6 +109,33 @@ describe("github-pr-diff", () => {
     expect(fromCall?.arguments.path).toBe("old.ts");
   });
 
+  it("fetchGithubPrDiff throws instead of silently returning an empty diff when get_files errors", async () => {
+    const client = {
+      callTool: async (req: {
+        name: string;
+        arguments: Record<string, unknown>;
+      }) => {
+        if (req.name === "pull_request_read") {
+          return {
+            isError: true,
+            content: [{ type: "text", text: "403 Resource not accessible" }],
+          };
+        }
+        throw new Error("should not fetch file contents");
+      },
+    };
+
+    await expect(
+      fetchGithubPrDiff(client, {
+        owner: "acme",
+        repo: "widgets",
+        pullNumber: 1,
+        base: "main",
+        headSha: "headsha",
+      }),
+    ).rejects.toThrow("403 Resource not accessible");
+  });
+
   it("fetchGithubPrDiff paginates past the first 100 changed files", async () => {
     const totalFiles = 150;
     const client = {

--- a/apps/web/src/components/thread/github/github-pr-diff.ts
+++ b/apps/web/src/components/thread/github/github-pr-diff.ts
@@ -1,5 +1,5 @@
 import type { GitDiffResult } from "./sandbox-git-api.ts";
-import { extractToolJson } from "./extract-tool-json.ts";
+import { assertToolOk, extractToolJson } from "./extract-tool-json.ts";
 import type { PrFile } from "./use-pr-data.ts";
 
 type GithubMcpClient = {
@@ -68,6 +68,7 @@ async function getFileAtRef(
 }
 
 function parsePrFiles(result: unknown): PrFile[] {
+  assertToolOk(result);
   const arr = extractToolJson<Record<string, unknown>[]>(result);
   if (!Array.isArray(arr)) return [];
   return arr.map((f): PrFile => {


### PR DESCRIPTION
Follows #5093 ("surface PR check-run tool errors instead of showing 'no checks'") - that PR added `assertToolOk` and applied it to every PR read-hook select (useChecks, usePrComments, usePrByBranch, useOpenPrs, usePrReviews), but missed `github-pr-diff.ts`'s `parsePrFiles`, which feeds the `pull_request_read(get_files)` result straight into `extractToolJson` without checking `isError` first.

**Payoff:** on a tool error (missing checks/contents scope, an older github-mcp-server, a transient GitHub API/rate-limit error), `extractToolJson` returns `null`, `parsePrFiles` maps that to `[]`, and the pagination loop's `pageFiles.length < FILES_PER_PAGE` check (0 < 100) breaks immediately - so `fetchGithubPrDiff` silently returns `{ diffs: {} }`. This path is `usePrDiff`'s fallback (used whenever the sandbox shallow clone can't resolve the diff itself, e.g. no merge-base), so a real PR's Files tab would render "no changes" indistinguishable from a PR that genuinely has none - the exact bug class #5093 fixed everywhere else.

**Fix:** call the same `assertToolOk` helper already used by the sibling PR hooks before parsing the files page, so a tool error surfaces as the query's error state instead of a silent empty diff.

**Regression test:** added `fetchGithubPrDiff throws instead of silently returning an empty diff when get_files errors` to `github-pr-diff.test.ts`, asserting the call rejects with the tool's error message instead of resolving to `{ diffs: {} }`.

**Reviewer check:** `bun test apps/web/src/components/thread/github/github-pr-diff.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, and the targeted test file above all pass. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces GitHub get_files tool errors in the PR diff fallback so users see a clear error instead of an empty “no changes” state. Adds `assertToolOk` to prevent silent empty diffs when the GitHub MCP tool fails.

- **Bug Fixes**
  - Validate `pull_request_read(get_files)` with `assertToolOk` in `parsePrFiles`, so failures bubble up as query errors instead of `{ diffs: {} }`.
  - Add test ensuring `fetchGithubPrDiff` rejects with the tool’s error message.

<sup>Written for commit abcc8073c3900579a1f9ab4cddabeb3b7e1c3283. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

