### PR TITLE
fix(chat): stop rendering raw HTML in assistant markdown

### DIFF
--- a/apps/web/src/components/chat/markdown.tsx
+++ b/apps/web/src/components/chat/markdown.tsx
@@ -9,7 +9,6 @@ import React, {
   useState,
 } from "react";
 import ReactMarkdown from "react-markdown";
-import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -155,9 +154,11 @@ function MarkdownImage(props: React.ImgHTMLAttributes<HTMLImageElement>) {
   );
 }
 
-// Memoize the plugins arrays to prevent re-creating them on every render
+// Memoize the plugins array to prevent re-creating it on every render.
+// No rehype-raw here: assistant text can carry web-search / tool-output
+// content, and rehype-raw renders embedded raw HTML with no sanitization —
+// a real XSS vector (see the same concern noted in checks-tab.tsx).
 const remarkPluginsMemo = [remarkGfm];
-const rehypePluginsMemo = [rehypeRaw];
 
 // Extend shared markdown components with chat-specific overrides (table with CSV
 // copy, image lightbox, clickable org-file references).
@@ -344,7 +345,6 @@ const MemoizedMarkdownBlock = memo(
     return (
       <ReactMarkdown
         remarkPlugins={remarkPluginsMemo}
-        rehypePlugins={rehypePluginsMemo}
         components={animate ? animatedComponents : markdownComponents}
       >
         {content}


### PR DESCRIPTION
**Source:** a security-hardening finding, not tied to an open issue.

**Why:** the chat markdown renderer (`apps/web/src/components/chat/markdown.tsx`) pipes `rehype-raw` into `ReactMarkdown` with no sanitization pass. `rehype-raw` parses raw HTML embedded in the markdown source string and hands it to react-markdown to render as real DOM elements — the react-markdown docs themselves call this exact combination (raw HTML + no `rehype-sanitize`) an XSS risk when the markdown isn't fully trusted. Assistant messages routinely embed content pulled from web search results and tool output, so this is reachable via a prompt-injected web page or tool response that gets echoed back into the model's reply. Tellingly, another part of this same codebase already flagged this: a comment in `apps/web/src/components/thread/github/checks-tab.tsx` explicitly avoids "the chat renderer, which enables rehype-raw (raw HTML → XSS)" and routes attacker-influenceable GitHub check output through the shared `Markdown` component (`packages/ui/src/components/markdown.tsx`) instead, which has never included `rehype-raw`.

**Fix:** drop `rehype-raw` (and its now-unused import) from the chat markdown pipeline. Raw HTML tags embedded in assistant text now render as literal escaped text instead of being parsed into live DOM elements. Standard markdown syntax — bold/italic, links, images, tables, code blocks — is untouched; none of the existing component overrides (`MarkdownAnchor`, `MarkdownImage`, `MarkdownCode`, `Table`) depend on raw-HTML passthrough, they all key off standard markdown AST nodes.

No new dependency was added (`rehype-sanitize` isn't installed) — removing the risky plugin entirely is the minimal, dependency-free fix.

**Net change:** -4/+4 lines (import + plugin array + prop wiring removed; one explanatory comment added), one file.

**Command a reviewer runs to confirm:** `cd apps/web && bunx tsc --noEmit` (clean). No existing test exercises this component, so there's nothing to invert; the change is a straightforward plugin removal with a documented rationale in-line.

**Verification run locally:** `bun run fmt` (no changes needed) and `cd apps/web && bunx tsc --noEmit` (clean, no type errors). Full CI suite covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `rehype-raw` from the chat `react-markdown` pipeline to stop rendering raw HTML and close an XSS vector in assistant messages. Raw HTML is now escaped; standard markdown (bold, links, images, tables, code) and existing overrides continue to work.

<sup>Written for commit 471e8067a08ffd7e61cea2b8278ed8e46a029824. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

