### PR TITLE
fix(decopilot): reject unsafe thread IDs on POST /messages

### DIFF
--- a/apps/api/src/api/routes/decopilot/helpers.test.ts
+++ b/apps/api/src/api/routes/decopilot/helpers.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildSanitizedNameMap,
+  isUnsafeThreadId,
   sanitizeToolName,
   toolNeedsApproval,
   type ToolApprovalLevel,
@@ -179,6 +180,24 @@ describe("sanitizeToolName", () => {
       const result = sanitizeToolName(input);
       expect(isGeminiValid(result)).toBe(true);
     }
+  });
+});
+
+describe("isUnsafeThreadId", () => {
+  test("accepts a normal UUID-shaped id", () => {
+    expect(isUnsafeThreadId("a1b2c3d4-e5f6-4789-a012-3456789abcde")).toBe(
+      false,
+    );
+  });
+
+  test("rejects NATS subject metacharacters", () => {
+    // These are used verbatim as a NATS subject token (streamSubject()) —
+    // a dot/wildcard would either break subject construction or widen the
+    // subject to match other threads' subjects.
+    expect(isUnsafeThreadId("thread.other")).toBe(true);
+    expect(isUnsafeThreadId("thread*")).toBe(true);
+    expect(isUnsafeThreadId("thread>")).toBe(true);
+    expect(isUnsafeThreadId("thread id")).toBe(true);
   });
 });
 

--- a/apps/api/src/api/routes/decopilot/helpers.ts
+++ b/apps/api/src/api/routes/decopilot/helpers.ts
@@ -39,6 +39,18 @@ export function ensureOrganization(
 }
 
 /**
+ * Thread IDs are used verbatim as NATS subject tokens (e.g.
+ * `decopilot.stream.<threadId>`, see streamSubject() in
+ * packages/harness/src/run-stream-codec.ts). `.`/`*`/`>`/whitespace are
+ * subject metacharacters there, so a thread id containing one would either
+ * blow up subject construction downstream or (for `*`/`>`) silently widen
+ * the subject to match other threads. Reject it up front instead.
+ */
+export function isUnsafeThreadId(taskId: string): boolean {
+  return /[.*>\s]/.test(taskId);
+}
+
+/**
  * Validate that a thread exists and belongs to the org.
  * Does NOT enforce ownership — any authenticated org member can access.
  * Use this for read-only / observability endpoints (e.g. stream).
@@ -56,7 +68,7 @@ export async function validateThreadAccess(
   if (!taskId) {
     throw new HTTPException(400, { message: "Missing thread ID" });
   }
-  if (/[.*>\s]/.test(taskId)) {
+  if (isUnsafeThreadId(taskId)) {
     throw new HTTPException(400, { message: "Invalid thread ID" });
   }
   const thread = await ctx.storage.threads.get(taskId);

--- a/apps/api/src/api/routes/decopilot/routes.ts
+++ b/apps/api/src/api/routes/decopilot/routes.ts
@@ -27,6 +27,7 @@ import { DEFAULT_WINDOW_SIZE } from "./constants";
 import { splitRequestMessages } from "./conversation";
 import {
   ensureOrganization,
+  isUnsafeThreadId,
   validateThreadAccess,
   validateThreadOwnership,
 } from "./helpers";
@@ -418,6 +419,9 @@ async function validate(
     });
   }
   const taskIdInput = threadIdParam ?? bodyThreadId;
+  if (taskIdInput && isUnsafeThreadId(taskIdInput)) {
+    throw new HTTPException(400, { message: "Invalid thread ID" });
+  }
 
   const userId = ctx.auth?.user?.id;
   if (!userId) {


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/api/routes/decopilot/routes.ts` for validation gaps (Decopilot route robustness focus area).

**Why a maintainer wants this:** thread IDs are used verbatim as NATS subject tokens downstream (`streamSubject()` in `packages/harness/src/run-stream-codec.ts`, which itself asserts no `.`/`*`/`>`/whitespace). `validateThreadAccess`/`validateThreadOwnership` already reject such IDs for the stream/cancel/queue endpoints, but `POST /:org/decopilot/threads/:threadId/messages` — the one endpoint that actually creates/pins a thread and kicks off the durable dispatch — had no equivalent check. A thread ID slipping through here (from the URL param or a mismatched body `thread_id`) would get persisted and enqueued successfully (202 response), only to fail later as an uncaught error deep in the async publish path instead of a clean, immediate 400.

**Failure scenario:** POST `/:org/decopilot/threads/thread.evil/messages` (or a body `thread_id` containing `.`/`*`/`>`/whitespace) is accepted, persists a request message row, and enqueues a durable workflow — which only surfaces broken when something downstream tries to build/publish to that thread's NATS subject.

**Fix:** extracted the existing regex check (already used by `validateThreadAccess`) into an exported `isUnsafeThreadId()` helper in `helpers.ts`, and applied it in `validate()` (routes.ts) right after the thread ID is resolved, before it's used to look up/pin the thread row or enqueue anything.

**Regression test:** `apps/api/src/api/routes/decopilot/helpers.test.ts` — new `isUnsafeThreadId` describe block covering a normal UUID (accepted) and dot/wildcard/`>`/whitespace ids (rejected).

**Reviewer check:** `bun test apps/api/src/api/routes/decopilot/helpers.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test file above all pass. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject unsafe thread IDs in Decopilot POST /messages so invalid IDs return 400 immediately instead of failing later during NATS publish. Introduces a shared `isUnsafeThreadId` check and applies it during request validation.

- **Bug Fixes**
  - Validate `threadId` (`.` `*` `>` or whitespace) via `isUnsafeThreadId` before thread lookup/enqueue in POST `/:org/decopilot/threads/:threadId/messages`.
  - Extracted the regex into `helpers.ts` and reused it in `validateThreadAccess`.
  - Added tests for `isUnsafeThreadId` (accepts UUID-like IDs, rejects metacharacters).

<sup>Written for commit 33fd07e784a34da49eb541506d89e4342c8336a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

