### PR TITLE
fix(chat): translate the cloud tier-trigger subtitles instead of hardcoding English

### DIFF
--- a/apps/web/src/components/chat/tier-trigger.tsx
+++ b/apps/web/src/components/chat/tier-trigger.tsx
@@ -28,7 +28,7 @@ import {
   Settings01,
   Stars01,
 } from "@untitledui/icons";
-import { useT } from "@/i18n/use-t.ts";
+import { useT, type TFunction } from "@/i18n/use-t.ts";
 import type { ChatTier } from "@decocms/shared/organization/schema";
 import {
   resolveTierSubtitle,
@@ -433,6 +433,7 @@ function localGroup(params: {
   setOption: (option: AgentOption) => void;
   setTier: (tier: ChatTier) => void;
   tierLabels: Record<ChatTier, string>;
+  t: TFunction;
 }): TierGroup {
   return {
     key: params.key,
@@ -441,7 +442,7 @@ function localGroup(params: {
       key: `${params.key}-${t}`,
       icon: params.icon,
       title: params.tierLabels[t],
-      subtitle: resolveTierSubtitle(params.mode, t),
+      subtitle: resolveTierSubtitle(params.mode, t, params.t),
       active: params.isActiveRuntime && params.currentTier === t,
       onSelect: () => {
         params.setOption(params.option);
@@ -522,6 +523,7 @@ export function TierTrigger() {
           setOption: setPendingAgentOption,
           setTier,
           tierLabels,
+          t,
         }),
       );
     }
@@ -538,6 +540,7 @@ export function TierTrigger() {
           setOption: setPendingAgentOption,
           setTier,
           tierLabels,
+          t,
         }),
       );
     }
@@ -556,7 +559,8 @@ export function TierTrigger() {
             // Show the concrete model backing this tier; fall back to the
             // intent blurb before the org config has loaded.
             subtitle:
-              modelName ?? resolveTierSubtitle("cloud-decopilot", tierOption),
+              modelName ??
+              resolveTierSubtitle("cloud-decopilot", tierOption, t),
             active: tier === tierOption,
             onSelect: () => setTier(tierOption),
             // Local CLI tiers are fixed per harness, so only cloud rows get a

--- a/apps/web/src/components/chat/use-agent-mode.test.ts
+++ b/apps/web/src/components/chat/use-agent-mode.test.ts
@@ -5,6 +5,15 @@ import {
   type AgentMode,
 } from "./use-agent-mode";
 import type { AgentOption } from "./pills/agent-options";
+import { en } from "@/i18n/en/index.ts";
+import type { TFunction } from "@/i18n/use-t.ts";
+
+const t: TFunction = (key) => en[key];
+const explodingT: TFunction = () => {
+  throw new Error(
+    "local tier subtitles must not translate — they're model names",
+  );
+};
 
 describe("agentModeFromOption", () => {
   const cases: Array<[AgentOption, AgentMode]> = [
@@ -25,52 +34,56 @@ describe("agentModeFromOption", () => {
 });
 
 describe("resolveTierSubtitle", () => {
-  describe("local-claude-code: returns the versioned model label", () => {
+  describe("local-claude-code: returns the versioned model label, never translated", () => {
     it("fast → Haiku 4.5", () => {
-      expect(resolveTierSubtitle("local-claude-code", "fast")).toBe(
+      expect(resolveTierSubtitle("local-claude-code", "fast", explodingT)).toBe(
         "Haiku 4.5",
       );
     });
     it("smart → Sonnet 5", () => {
-      expect(resolveTierSubtitle("local-claude-code", "smart")).toBe(
-        "Sonnet 5",
-      );
+      expect(
+        resolveTierSubtitle("local-claude-code", "smart", explodingT),
+      ).toBe("Sonnet 5");
     });
     it("thinking → Opus 4.8 1M", () => {
-      expect(resolveTierSubtitle("local-claude-code", "thinking")).toBe(
-        "Opus 4.8 1M",
-      );
+      expect(
+        resolveTierSubtitle("local-claude-code", "thinking", explodingT),
+      ).toBe("Opus 4.8 1M");
     });
   });
 
-  describe("local-codex: returns the versioned model label", () => {
+  describe("local-codex: returns the versioned model label, never translated", () => {
     it("fast → GPT-5.6 Luna", () => {
-      expect(resolveTierSubtitle("local-codex", "fast")).toBe("GPT-5.6 Luna");
+      expect(resolveTierSubtitle("local-codex", "fast", explodingT)).toBe(
+        "GPT-5.6 Luna",
+      );
     });
     it("smart → GPT-5.6 Terra", () => {
-      expect(resolveTierSubtitle("local-codex", "smart")).toBe("GPT-5.6 Terra");
+      expect(resolveTierSubtitle("local-codex", "smart", explodingT)).toBe(
+        "GPT-5.6 Terra",
+      );
     });
     it("thinking → GPT-5.6 Sol", () => {
-      expect(resolveTierSubtitle("local-codex", "thinking")).toBe(
+      expect(resolveTierSubtitle("local-codex", "thinking", explodingT)).toBe(
         "GPT-5.6 Sol",
       );
     });
   });
 
-  describe("cloud-decopilot: returns the intent description", () => {
-    it("fast → Quicker responses", () => {
-      expect(resolveTierSubtitle("cloud-decopilot", "fast")).toBe(
-        "Quicker responses",
+  describe("cloud-decopilot: returns the translated intent description", () => {
+    it("fast → the agentModels.quickerResponses translation", () => {
+      expect(resolveTierSubtitle("cloud-decopilot", "fast", t)).toBe(
+        en["chat.agentModels.quickerResponses"],
       );
     });
-    it("smart → Balanced quality", () => {
-      expect(resolveTierSubtitle("cloud-decopilot", "smart")).toBe(
-        "Balanced quality",
+    it("smart → the agentModels.balancedQuality translation", () => {
+      expect(resolveTierSubtitle("cloud-decopilot", "smart", t)).toBe(
+        en["chat.agentModels.balancedQuality"],
       );
     });
-    it("thinking → Deeper reasoning", () => {
-      expect(resolveTierSubtitle("cloud-decopilot", "thinking")).toBe(
-        "Deeper reasoning",
+    it("thinking → the agentModels.deeperReasoning translation", () => {
+      expect(resolveTierSubtitle("cloud-decopilot", "thinking", t)).toBe(
+        en["chat.agentModels.deeperReasoning"],
       );
     });
   });

--- a/apps/web/src/components/chat/use-agent-mode.ts
+++ b/apps/web/src/components/chat/use-agent-mode.ts
@@ -1,5 +1,6 @@
 import type { ChatTier } from "@decocms/shared/organization/schema";
 import { resolveAgentTier } from "@decocms/harness/claude-code/model/agent-tiers";
+import type { TFunction } from "@/i18n/use-t.ts";
 import { useChatPrefs } from "./context";
 import type { AgentOption } from "./pills/agent-options";
 
@@ -46,29 +47,32 @@ export function useSetChatTier(): (tier: ChatTier) => void {
  * User-friendly tier descriptions shown under each tier row for the org
  * router (cloud). These users are typically non-technical and benefit from
  * intent labels ("Quicker responses") over model names — the actual model the
- * server picks depends on org settings + provider keys and would be noise here.
+ * server picks depends on org settings + provider keys and would be noise
+ * here. Reuses the same `chat.agentModels.*` keys the desktop-CLI model
+ * picker already translates through, instead of a second hardcoded copy.
  */
-const CLOUD_TIER_DESCRIPTIONS: Record<ChatTier, string> = {
-  fast: "Quicker responses",
-  smart: "Balanced quality",
-  thinking: "Deeper reasoning",
-};
+const CLOUD_TIER_DESCRIPTION_KEYS: Record<ChatTier, Parameters<TFunction>[0]> =
+  {
+    fast: "chat.agentModels.quickerResponses",
+    smart: "chat.agentModels.balancedQuality",
+    thinking: "chat.agentModels.deeperReasoning",
+  };
 
 /**
- * Per-tier subtitle shown in the TierTrigger popover. Pure — no React
- * hooks, no async I/O.
+ * Per-tier subtitle shown in the TierTrigger popover.
  *
  * - Local (Claude Code / Codex): returns the harness-mapped model name
  *   with version (e.g. "Sonnet 5", "GPT-5.5") from
  *   `@decocms/harness/claude-code/model/agent-tiers`. Desktop-CLI users are technical and
  *   want to know which model is about to run.
- * - Cloud (org router): returns a non-technical intent description from
- *   `CLOUD_TIER_DESCRIPTIONS`. The server picks the actual model via
- *   `resolveTier` at send time based on org admin config.
+ * - Cloud (org router): returns a non-technical intent description via `t`.
+ *   The server picks the actual model via `resolveTier` at send time based on
+ *   org admin config.
  */
 export function resolveTierSubtitle(
   mode: AgentMode,
   tier: ChatTier,
+  t: TFunction,
 ): string | null {
   if (mode === "local-claude-code") {
     return resolveAgentTier("claude-code", tier)?.label ?? null;
@@ -76,5 +80,5 @@ export function resolveTierSubtitle(
   if (mode === "local-codex") {
     return resolveAgentTier("codex", tier)?.label ?? null;
   }
-  return CLOUD_TIER_DESCRIPTIONS[tier];
+  return t(CLOUD_TIER_DESCRIPTION_KEYS[tier]);
 }


### PR DESCRIPTION
**Source:** bug found while auditing `tier-trigger.tsx` / `tier-model-override-row.tsx` (chat UI hardening focus area) — not tied to a specific issue.

**Payoff:** `resolveTierSubtitle`'s `CLOUD_TIER_DESCRIPTIONS` map ("Quicker responses", "Balanced quality", "Deeper reasoning") shown as the subtitle under each cloud tier row in the TierTrigger popover was hardcoded English, bypassing the app's i18n system entirely — a pt-br user sees English there regardless of their language preference. The exact same three descriptions already exist as translated keys (`chat.agentModels.quickerResponses` / `balancedQuality` / `deeperReasoning`), used correctly by the desktop-CLI model picker (`select-model/agent-models.tsx`) in both `en` and `pt-br` dictionaries. This fix removes the duplicate hardcoded copy and routes `resolveTierSubtitle` through the existing keys via a `t` parameter, so both call sites (cloud rows and local-runtime rows) go through `useT()`.

**Failure scenario (before fix):** a pt-br org member opens the tier-trigger popover in cloud mode before any per-tier model name has loaded (or once picked to a slot without a title) — the subtitle read "Quicker responses" / "Balanced quality" / "Deeper reasoning" in English instead of the already-existing pt-br translations ("Respostas mais rápidas", etc.).

**Regression test:** inverted `use-agent-mode.test.ts`'s `resolveTierSubtitle` describe block — the cloud-decopilot cases now assert against the translated dictionary value (via a stub `t`) instead of the literal English string, and the local-mode cases pass an `explodingT` stub to prove those branches never call `t` (they return the harness's own model-name labels, which aren't translated by design).

**Reviewer check:** `bun test apps/web/src/components/chat/use-agent-mode.test.ts apps/web/src/components/chat/tier-trigger.test.tsx`

**Locally verified:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), and the two targeted test files above (13 + 6 passing). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate cloud tier subtitles in the TierTrigger popover using i18n instead of hardcoded English. This fixes English-only subtitles for non-English users while keeping local runtime rows as model names.

- Bug Fixes
  - Route `resolveTierSubtitle` through `t(...)` with existing `chat.agentModels.*` keys.
  - Keep local modes returning versioned model labels (no translation).
  - Update tests to assert translations for cloud mode and enforce no `t` calls for local modes.

<sup>Written for commit 3ec80b8c89cb4aa2179aadb1d227d92c688a6323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

