### PR TITLE
refactor(sandbox): use shared exponentialBackoffWithJitter for events reconnect

### DIFF
--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
@@ -32,6 +32,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { useProjectContext } from "@/sdk";
 import { KEYS } from "@/lib/query-keys";
+import { exponentialBackoffWithJitter } from "@decocms/shared/std";
 
 import type {
   ClaimFailureReason,
@@ -570,9 +571,12 @@ export function SandboxEventsProvider({
     function scheduleReconnect(target: "studio" | "direct") {
       if (disposed || reconnectTimer) return;
 
-      const delay = Math.min(
-        BASE_RECONNECT_DELAY_MS * 2 ** reconnectAttempt,
+      const delay = exponentialBackoffWithJitter(
         MAX_RECONNECT_DELAY_MS,
+        BASE_RECONNECT_DELAY_MS,
+        reconnectAttempt,
+        2,
+        0,
       );
       reconnectAttempt++;
 


### PR DESCRIPTION
Reduction — a hand-rolled backoff formula in the sandbox-tooling area, replaced with the repo's canonical `@decocms/shared/std` helper (per CLAUDE.md: "do NOT write another `Math.min(base * 2 ** attempt, cap)` formula").

`SandboxEventsProvider.scheduleReconnect` (`apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx`) computed its SSE reconnect delay with `Math.min(BASE_RECONNECT_DELAY_MS * 2 ** reconnectAttempt, MAX_RECONNECT_DELAY_MS)` instead of the shared `exponentialBackoffWithJitter`. `apps/web/src/hooks/create-sse-subscription.ts` already solves the identical problem (SSE reconnect backoff, same constant names `MAX_RECONNECT_DELAY_MS`/`BASE_RECONNECT_DELAY_MS`) via the shared helper called with `jitter=0` — this brings the sandbox-events reconnect loop in line with that existing pattern instead of leaving a second copy of the formula to drift.

Behavior is unchanged: `exponentialBackoffWithJitter(cap, base, attempt, 2, 0)` computes `Math.min(cap, base * 2 ** attempt) * (1 - 0 * Math.random())`, i.e. exactly the old expression (jitter=0 disables randomization, matching the old code which had none).

Net: +6/-2 lines (one new import, formula call swapped for a function call).

How to verify: `cd apps/web && bunx tsc --noEmit` (clean) and `bun test apps/web/src/components/sandbox/hooks/sandbox-events-context.test.ts` (7 pass, unchanged). Ran both locally along with `bun run fmt`; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the shared `exponentialBackoffWithJitter` for sandbox events SSE reconnects to replace a custom backoff formula. Behavior is unchanged (jitter=0) and now matches `apps/web/src/hooks/create-sse-subscription.ts`.

- **Refactors**
  - Swap `Math.min(base * 2 ** attempt, cap)` for `exponentialBackoffWithJitter(MAX_RECONNECT_DELAY_MS, BASE_RECONNECT_DELAY_MS, attempt, 2, 0)` in `SandboxEventsProvider`.
  - Add import from `@decocms/shared/std`; keeps delays identical and removes duplication.

<sup>Written for commit 980523c61ad9ded2b2a7219fd7008e2c2145f548. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

