### PR TITLE
fix(chat): insert multi-selected files in order, not reversed

### DIFF
--- a/apps/web/src/components/chat/tools-popover.tsx
+++ b/apps/web/src/components/chat/tools-popover.tsx
@@ -122,18 +122,21 @@ export function ToolsPopover({
     if (!files || files.length === 0 || !editor) return;
 
     const fileArray = Array.from(files);
-    const { from } = editor.state.selection;
 
     try {
+      // Re-read the selection after each insert so multiple files land in
+      // order instead of all racing to insert at the same stale position.
+      let insertPos = editor.state.selection.from;
       for (const file of fileArray) {
         await processFile(
           editor,
           selectedModel ?? null,
           file,
-          from,
+          insertPos,
           onUnsupportedFile,
           t,
         );
+        insertPos = editor.state.selection.to;
       }
     } finally {
       if (fileInputRef.current) {


### PR DESCRIPTION
**Source:** bug found while auditing `apps/web/src/components/chat/tools-popover.tsx` (mesh chat hardening focus area). Same bug class as #4806, which fixed the drag-drop and paste file-insert paths in `uploader.tsx` but left this third entry point (the "Add file" menu item's file picker) unfixed.

**Why a maintainer wants it:** `insertContentAt()` resolves its position against the live document on every call. `handleFileSelect` captured the cursor position once before the loop and reused that same stale position for every file, so selecting 2+ files via the Add-file picker inserts them in reverse/overlapping order instead of the order the user picked them in — an easy-to-hit UX bug (multi-select is the input's default mode: `<input type="file" multiple>`).

**Fix:** re-read `editor.state.selection` after each `processFile` call and feed the updated position into the next iteration, exactly mirroring the pattern already used in the drop/paste handlers in `tiptap/file/uploader.tsx`.

**Net change:** +5/-2 in `apps/web/src/components/chat/tools-popover.tsx`. Behavior-preserving for the single-file case (position is read once, same as before); only the multi-file ordering changes, and only to fix the bug.

**To confirm:** open a chat, click the Tools menu → Add file, multi-select 2+ files (image or otherwise) in the OS file picker, and check they appear in the composer in the order selected rather than reversed.

**Verified locally:** `bun run fmt` (clean) and `cd apps/web && bunx tsc --noEmit` (clean). No existing test file covers this component (same as the precedent fix in #4806, which also shipped without one — the bug lives in an async closure over a mounted ProseMirror editor, not practical to unit test); full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-file insertion order in chat: files selected via the Add file picker now appear in the composer in the same order they were selected, not reversed. The handler re-reads the editor selection after each insert so each file lands after the previous one; single-file behavior is unchanged.

<sup>Written for commit 4af68edeb636c10f715bbae45342437da3b4b884. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

