### PR TITLE
refactor(sandbox): remove unreachable conflict-resolution branch in rebaseOntoBase

### DIFF
--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -202,11 +202,6 @@ function resolveConflictFile(repoDir: string, summary: StatusFile): void {
     return;
   }
 
-  if (summary.working_dir === "D" && !xy.includes("U")) {
-    runGit(repoDir, ["rm", "-f", filePath]);
-    return;
-  }
-
   // During rebase, `--theirs` is the commit being replayed (branch changes).
   runGit(repoDir, ["checkout", "--theirs", "--", filePath]);
   runGit(repoDir, ["add", "--", filePath]);


### PR DESCRIPTION
Dead-code reduction found while auditing recent hardening commits to `packages/sandbox/daemon/git/rebase-onto-base.ts` (#5224, #5236).

`resolveConflictFile()` is only ever invoked on files that passed `isUnmerged()` — i.e. whose `index+working_dir` pair is one of the 7 codes in `UNMERGED_STATUSES` (`DD, AU, UD, UA, DU, AA, UU`). The function already returns early for `DU` and for `UD`/`DD`. That leaves only `AU`, `UA`, `AA`, `UU` as possible inputs to the next check — none of which has a `working_dir` of `"D"`. So `if (summary.working_dir === "D" && !xy.includes("U"))` can never be true; it's unreachable code left behind once the DU/UD/DD fixes started intercepting those states earlier in the function.

Why a maintainer wants this: it's a pure deletion of code that cannot execute, so nothing about the fix (or the tests) changes — removing it just stops the file lying about a code path that matters.

Net change: -5 / +0 lines, no behavior change (confirmed by exhaustively checking the 7 possible `isUnmerged` codes against the deleted condition — none reach it).

Reviewer check: `bun test packages/sandbox/daemon/git/rebase-onto-base.test.ts` (covers DU, UD, AA conflict scenarios end-to-end).

Locally ran: `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit` (clean), and the targeted test file above (5/5 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an unreachable conflict-resolution branch in `resolveConflictFile` within `packages/sandbox/daemon/git/rebase-onto-base.ts` to simplify the code. No behavior change; rebase conflict handling stays the same.

- **Refactors**
  - Deleted the `working_dir === "D" && !xy.includes("U")` path, which can’t be reached after early returns for `DU`, `UD`, and `DD`; remaining `AU/UA/AA/UU` cases never set `working_dir` to `D`.
  - Improves readability and maintenance; existing tests (`rebase-onto-base.test.ts`) pass.

<sup>Written for commit 0f1edfd44d3adae2ae74340b63e7bfa49b27ff32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

