### PR TITLE
fix(sections-editor): translate the SEO form's "Use default" toggle label

### DIFF
--- a/apps/web/src/components/sections-editor/general-seo-form.tsx
+++ b/apps/web/src/components/sections-editor/general-seo-form.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Label } from "@deco/ui/components/label.tsx";
 import { Switch } from "@deco/ui/components/switch.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
+import { useT } from "@/i18n/use-t.ts";
 import type { SchemaProperty } from "./resolve-schema";
 import { renderField } from "./schema-form";
 import {
@@ -45,6 +46,7 @@ export function GeneralSeoForm({
   siteDefaultSeo,
   formResetKey,
 }: GeneralSeoFormProps) {
+  const t = useT();
   const filtered = filterSeoSchema(schema, DEFAULT_SEO_RESOLVE_TYPE);
   const properties = filtered.properties ?? {};
   const inheritKeys = generalSeoFieldsWithDefaultToggle();
@@ -124,7 +126,7 @@ export function GeneralSeoForm({
                   htmlFor={`seo-use-default-${key}`}
                   className="text-xs font-normal text-muted-foreground"
                 >
-                  Use default
+                  {t("sectionsEditor.generalSeoForm.useDefault")}
                 </Label>
               </div>
             )}

--- a/apps/web/src/i18n/en/sections-editor.ts
+++ b/apps/web/src/i18n/en/sections-editor.ts
@@ -55,6 +55,7 @@ export const sectionsEditor = {
   "sectionsEditor.fileField.uploading": "Uploading…",
   "sectionsEditor.fileField.videoFileError":
     "Please drop a video file (mp4, webm, …).",
+  "sectionsEditor.generalSeoForm.useDefault": "Use default",
   "sectionsEditor.imageField.browse": "Browse",
   "sectionsEditor.imageField.dropImageOrClickToBrowse":
     "Drop an image or click to browse",

--- a/apps/web/src/i18n/pt-br/sections-editor.ts
+++ b/apps/web/src/i18n/pt-br/sections-editor.ts
@@ -59,6 +59,7 @@ export const sectionsEditor = {
   "sectionsEditor.fileField.uploading": "Enviando…",
   "sectionsEditor.fileField.videoFileError":
     "Por favor, solte um arquivo de vídeo (mp4, webm, …).",
+  "sectionsEditor.generalSeoForm.useDefault": "Usar padrão",
   "sectionsEditor.imageField.browse": "Procurar",
   "sectionsEditor.imageField.dropImageOrClickToBrowse":
     "Solte uma imagem ou clique para procurar",


### PR DESCRIPTION
**Source:** i18n hardening in the sections-editor SEO form (`GeneralSeoForm`), spotted while auditing the sections-editor area for polish per the repo's i18n rule ("never hardcode user-facing strings in apps/web/src").

**Why:** `general-seo-form.tsx` renders a per-field "Use default" switch label (lets a page-level SEO field inherit the site-level default) as a raw JSX string instead of going through `useT()`, so pt-br users see English text on an otherwise-translated form — same bug class as the existing i18n-hardening lane (#5048, #5062, #5099, #5110, #5141, #5214, #5218, #5170).

**Change:** added `sectionsEditor.generalSeoForm.useDefault` to both `i18n/en/sections-editor.ts` ("Use default") and `i18n/pt-br/sections-editor.ts` ("Usar padrão"), and swapped the hardcoded string in `general-seo-form.tsx` for `t("sectionsEditor.generalSeoForm.useDefault")`. No behavior change — pure string externalization.

**Reviewer check:** switch the app language to Português (Brasil) in preferences, open a page's SEO editor for a General page with a configured site-default SEO, and confirm the "Use default" toggle label now reads "Usar padrão".

**Verified locally:** `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/web` (clean, no new errors). Both en/pt-br dictionaries satisfy the `satisfies Record<keyof typeof enDomain, string>` check so a missing/extra key would have been a compile error. Full CI (lint, tests) will validate the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the "Use default" toggle label in the sections editor SEO form by using `useT()` instead of a hardcoded string. Adds `sectionsEditor.generalSeoForm.useDefault` to `i18n/en/sections-editor.ts` and `i18n/pt-br/sections-editor.ts` so pt-br shows "Usar padrão".

<sup>Written for commit 3cd53d26c404e1a1147ac11eea4d136e8d56a027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

