### PR TITLE
fix(file-picker): make image picker modal scrollable

### DIFF
--- a/apps/web/src/components/file-picker/file-picker-dialog.tsx
+++ b/apps/web/src/components/file-picker/file-picker-dialog.tsx
@@ -161,7 +161,7 @@ function PickerBody({
         <TabsContent
           key={c.id}
           value={c.id}
-          className="min-h-0 flex-1 overflow-hidden"
+          className="min-h-0 flex-1 overflow-hidden flex flex-col"
         >
           <BucketPanel config={c} mode={mode} onSelect={onSelect} />
         </TabsContent>
@@ -280,7 +280,7 @@ function BucketPanel({
     (objectsQuery.isFetching && !objectsQuery.isFetchingNextPage);
 
   return (
-    <div className="flex flex-col gap-3 min-h-0 h-full">
+    <div className="flex flex-col gap-3 min-h-0 flex-1">
       <button
         type="button"
         onClick={() => fileInputRef.current?.click()}


### PR DESCRIPTION
## Summary

The file-picker modal ("Escolher uma imagem" / image selection dialog) had no scroll — with many assets the image grid overflowed the dialog and got clipped by `overflow-hidden`, leaving the bottom rows unreachable.

**Root cause:** `BucketPanel` used `h-full` (`height: 100%`) to fill the available height. Reproducing the real DOM in-browser confirmed the percentage-height chain didn't resolve: the panel grew to its full content height (~1943px) instead of being constrained to its container (~574px), so the inner `overflow-y-auto` region never became scrollable.

**Fix:** replace percentage height with real flex-grow, which resolves reliably in both render paths:
- `TabsContent` → add `flex flex-col` (so it's a flex column that sizes its child).
- `BucketPanel` root → `h-full` becomes `flex-1`.

## Testing

Reproduced both render paths in-browser against the running dev app using the exact component DOM + Tailwind classes:

| Path | Before | After |
|------|--------|-------|
| Multi-config (Tabs — the screenshot case) | panel 1943px overflowing, `scrollable: false` | panel clamped to container, `scrollable: true` |
| Single-config / locked bucket (BucketPanel direct child) | — | dialog fixed ~85vh, `scrollable: true` |

`bun run fmt` passing. UI-only change (2 Tailwind class tweaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the image picker modal so long image grids are scrollable instead of being clipped. Replaces percentage height with flex grow to size the panel correctly in both tabbed and single-bucket views.

- **Bug Fixes**
  - `TabsContent`: add `flex flex-col` to enable correct child sizing.
  - `BucketPanel`: replace `h-full` with `flex-1` to prevent content-sized growth.

<sup>Written for commit c49e4ee4ef84a3eb90ea2d3c8480479cfc524613. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

