### PR TITLE
refactor(storage): drop the dead shared agent-sandbox tables (R2 of #5240)

### DIFF
--- a/apps/api/migrations/147-drop-agent-sandbox-tables.ts
+++ b/apps/api/migrations/147-drop-agent-sandbox-tables.ts
@@ -1,0 +1,40 @@
+/**
+ * Migration 147: Drop the shared agent-sandbox tables (R2 of the #5240 revert).
+ *
+ * #5240 restored per-user hosted sandboxes and deleted every reader/writer of
+ * `agent_sandbox_sessions` and `agent_sandbox_runner_state` (created by 137 and
+ * 138 for the shared model). R1 deliberately left both tables in place so the
+ * rollout had a rollback window; this is the follow-up that removes them.
+ *
+ * Worth doing rather than leaving them dormant: `agent_sandbox_runner_state.state`
+ * holds plaintext credentials — an `x-access-token:ghs_…` clone URL, submodule
+ * tokens, and the resolved env bag — and the table has no organization FK, so
+ * nothing ever garbage-collects a row. Dormant rows are a standing secret leak,
+ * not merely dead weight.
+ *
+ * Must ship in a separate release from #5240: dropping in the same release lets
+ * a not-yet-rolled pod hit `relation "agent_sandbox_sessions" does not exist` on
+ * SANDBOX_START, and migrations run from the app CMD (`settings/pipeline.ts`), so
+ * there is no natural barrier between the two.
+ *
+ * `ifExists` keeps this a no-op for installs that never provisioned the shared
+ * tables, and makes a partial re-run safe.
+ */
+
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Reverse creation order. Neither table is referenced by the other (137 has
+  // no FKs; 138's only FK is to organization), so the order is tidiness, not a
+  // dependency requirement. Indexes are dropped with their table.
+  await db.schema.dropTable("agent_sandbox_sessions").ifExists().execute();
+  await db.schema.dropTable("agent_sandbox_runner_state").ifExists().execute();
+}
+
+export async function down(_db: Kysely<unknown>): Promise<void> {
+  // Intentionally irreversible, following the 084/097 precedent for retired
+  // sandbox state. Recreating the schema would restore two empty tables that no
+  // code reads — #5240 removed every consumer — while the rows themselves are
+  // unrecoverable. Duplicating 137/138's DDL here would only create a second
+  // copy to drift.
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -145,6 +145,7 @@ import * as migration143armedreporturl from "./143-armed-report-url.ts";
 import * as migration144benefitspendingindex from "./144-benefits-pending-index.ts";
 import * as migration145usermodelpreferences from "./145-user-model-preferences.ts";
 import * as migration146organizationmainagent from "./146-organization-main-agent.ts";
+import * as migration147dropagentsandboxtables from "./147-drop-agent-sandbox-tables.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -315,6 +316,7 @@ const migrations: Record<string, Migration> = {
   "144-benefits-pending-index": migration144benefitspendingindex,
   "145-user-model-preferences": migration145usermodelpreferences,
   "146-organization-main-agent": migration146organizationmainagent,
+  "147-drop-agent-sandbox-tables": migration147dropagentsandboxtables,
 };
 
 export default migrations;


### PR DESCRIPTION
## Summary

**R2 of the #5240 revert.** #5240 restored per-user hosted sandboxes and deleted every reader/writer of `agent_sandbox_sessions` and `agent_sandbox_runner_state` (created by migrations 137/138 for the shared model), but deliberately left both tables in place so the rollout had a rollback window. This drops them.

One new migration, `147-drop-agent-sandbox-tables.ts`, plus its `index.ts` registration. No other code changes — R1 already removed every reference (`grep` for either table name outside 137/138 returns nothing).

## Why not just leave them dormant

`agent_sandbox_runner_state.state` holds plaintext credentials: an `x-access-token:ghs_…` clone URL, submodule tokens, and the resolved env bag. The table has **no organization FK**, so nothing ever garbage-collects a row — not org deletion, not any sweep. Dormant rows are a standing secret leak, not merely dead weight. `agent_sandbox_sessions` is ordinary dead state.

## Deploy ordering — must not ship in the same release as #5240

#5240 is already on `main` (`5bfa8508f`, released at `0d1097643`). **This PR must go out in a later release, after that one has fully rolled out.** Dropping in the same release lets a not-yet-rolled pod hit `relation "agent_sandbox_sessions" does not exist` on `SANDBOX_START`, and migrations run from the app CMD (`apps/api/src/settings/pipeline.ts:52`), so there is no natural barrier between migrate and serve.

Merging this collapses the rollback window for #5240 — while both tables exist, rolling back is just re-promoting the previous image. Worth confirming #5240 is happy in prod first.

## Notes for review

- **`ifExists()`** on both drops: keeps this a no-op for installs that never provisioned the shared tables, and makes a partial re-run safe.
- **`down()` is intentionally a no-op**, following the 084/097 precedent for retired sandbox state. Recreating the schema would restore two empty tables no code reads, while the rows are unrecoverable; duplicating 137/138's DDL would just create a second copy to drift. Easy to change if you'd rather have a structural `down()` — say so and I'll add it.
- **Indexes** (`agent_sandbox_runner_state_handle_idx`, `agent_sandbox_sessions_vm_updated_idx`, `agent_sandbox_sessions_thread_idx`) are dropped with their tables; no explicit `dropIndex` needed.
- **No test**, matching `134-drop-task-board-enabled` — the closest precedent for a pure DDL drop. `migrations/index.test.ts` covers file↔registration parity, and `storage-integration.yml` migrates a fresh Postgres from an empty ledger in CI.

## Testing

`bun run --cwd=apps/api check` clean · `bun run lint` 0 errors · `bun run fmt` clean · `bun test apps/api/migrations/index.test.ts` 2 pass.

Not run locally: the real-Postgres integration suite — CI covers it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop the dead shared agent-sandbox tables `agent_sandbox_sessions` and `agent_sandbox_runner_state` via migration 147. This removes dormant plaintext tokens and closes a security risk.

- **Migration**
  - Add `apps/api/migrations/147-drop-agent-sandbox-tables.ts` and register in `apps/api/migrations/index.ts`.
  - Use `dropTable(...).ifExists()` for safety on fresh installs and re-runs.
  - `down()` is a no-op; tables are intentionally not recreated.
  - Release after #5240 has fully rolled out. Do not ship in the same release to avoid missing-table errors and to preserve rollback.

<sup>Written for commit 6aba45b9603915c341f6ded771648051a48b7973. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

