### PR TITLE
refactor(sandbox): use shared exponentialBackoffWithJitter for SANDBOX_START retry

### DIFF
--- a/apps/web/src/components/sandbox/hooks/use-sandbox-start.ts
+++ b/apps/web/src/components/sandbox/hooks/use-sandbox-start.ts
@@ -12,6 +12,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
+import { exponentialBackoffWithJitter } from "@decocms/shared/std";
 import { invalidateVirtualMcpQueries } from "@/lib/query-keys";
 import { callSandboxTool } from "./call-sandbox-tool";
 
@@ -81,7 +82,8 @@ export function useSandboxStart(client: MinimalMcpClient) {
     mutationKey: SANDBOX_START_MUTATION_KEY,
     // Auto-recover from transient lifecycle/lock contention without a refresh.
     retry: (count, error) => isRetryableSandboxStartError(error) && count < 6,
-    retryDelay: (attempt) => Math.min(500 * 2 ** attempt, 5000),
+    retryDelay: (attempt) =>
+      exponentialBackoffWithJitter(5000, 500, attempt, 2, 0),
     mutationFn: async (args) => {
       if (args.branch) sandboxUserStop.clear(args.virtualMcpId, args.branch);
       const key = startKey(args);


### PR DESCRIPTION
**Source:** reduction found while auditing sandbox-tooling for hand-rolled backoff formulas — the exact same lane #5264 (merged this tick) fixed in the sibling file `sandbox-events-context.tsx`.

**Why a maintainer wants this:** `useSandboxStart`'s mutation `retryDelay` computed `Math.min(500 * 2 ** attempt, 5000)` by hand instead of using the repo's canonical `@decocms/shared/std` helper (CLAUDE.md: "do NOT write another `Math.min(base * 2 ** attempt, cap)` formula"). Two other files in this exact area (`create-sse-subscription.ts`, `sandbox-events-context.tsx`) already use `exponentialBackoffWithJitter` for the identical problem shape — this closes the one remaining hand-rolled copy so the formula can't drift.

**Net line delta:** +3/-1 (one new import, one call swapped in). Behavior is unchanged: `exponentialBackoffWithJitter(5000, 500, attempt, 2, 0)` computes `Math.min(5000, 500 * 2 ** attempt) * (1 - 0 * Math.random())`, i.e. exactly the old expression — `jitter=0` disables randomization, matching the old code which had none. Confirmed via the shared helper's own test suite (`packages/shared/src/std/backoff.test.ts`) which asserts this exact `jitter=0` identity.

**Reviewer check:** `cd apps/web && bunx tsc --noEmit` and `bun test src/components/sandbox/hooks/use-sandbox-start.test.ts` (2 pass, unchanged).

**Locally verified:** `bun run fmt`, the typecheck above, and the targeted test file above all pass. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `useSandboxStart` retry backoff to use the shared `exponentialBackoffWithJitter` from `@decocms/shared/std`, matching other sandbox files and preventing formula drift. Behavior is unchanged with `jitter=0`.

- **Refactors**
  - Replaced `Math.min(500 * 2 ** attempt, 5000)` with `exponentialBackoffWithJitter(5000, 500, attempt, 2, 0)`.
  - Added import for `exponentialBackoffWithJitter`.

<sup>Written for commit cc478cc26c5a0a70633b3603837cf599ff62af1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

