### PR TITLE
fix(chat): add aria-pressed to the tier-trigger runtime toggle buttons

### DIFF
--- a/apps/web/src/components/chat/tier-trigger.tsx
+++ b/apps/web/src/components/chat/tier-trigger.tsx
@@ -367,6 +367,7 @@ function Segmented({
           key={o.key}
           type="button"
           onClick={o.onSelect}
+          aria-pressed={o.active}
           className={cn(SEG_BTN, o.active ? SEG_ACTIVE : SEG_INACTIVE)}
           title={o.active ? t("chat.tierTrigger.selected") : undefined}
         >


### PR DESCRIPTION
**Source:** bug found while auditing the tier-trigger UI (chat-tier-ui focus area) for accessibility gaps.

**Why:** `RuntimeToggle` in `tier-trigger.tsx` renders a Cloud / This-device `Segmented` control where the active option is communicated only visually (background color) plus a `title` tooltip on hover — screen reader users get no indication of which runtime is currently selected. Every other toggle button in this codebase that has an `active` boolean already sets `aria-pressed` (e.g. `chat/highlight/approval.tsx`, `sections-editor/rich-text-link-control.tsx`, `layouts/main-panel-tabs/header-tab-button.tsx`, `layouts/task-board/index.tsx`) — this one was the outlier missing it.

**Fix:** add `aria-pressed={o.active}` to the segmented-control button in `Segmented()`.

**Command a reviewer runs:** open the chat composer with a linked desktop CLI so the Cloud/This-device toggle renders, and inspect the button's accessibility tree (or just read the one-line diff) to confirm `aria-pressed` now tracks the active segment.

**Checks run locally:** `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/web` (clean, no type changes). Full CI validates lint/build/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-pressed to the Cloud/This-device runtime toggle so screen readers announce which option is selected. Aligns this segmented control with other toggles that already expose pressed state.

- **Bug Fixes**
  - Set aria-pressed={o.active} on the segmented button in `apps/web/src/components/chat/tier-trigger.tsx` (RuntimeToggle). No visual changes; improves screen reader support.

<sup>Written for commit 3d1b99584aceb76f0d617cac29d82622c0ec1109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

