### PR TITLE
fix(file-storage): zero-pad agent prompt file index so order survives listDir's lexicographic sort

### DIFF
--- a/apps/api/src/file-storage/agent-prompts.test.ts
+++ b/apps/api/src/file-storage/agent-prompts.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { localName } from "./agent-prompts";
+
+describe("agent-prompts localName", () => {
+  it("zero-pads the index so filenames sort in authored order", () => {
+    const names = [2, 9, 10, 19].map((i) => localName(i, "Prompt"));
+    const sorted = [...names].sort();
+    expect(sorted).toEqual(names);
+  });
+
+  it("falls back to a stable slug when the title has no word characters", () => {
+    expect(localName(0, "!!!")).toBe("00-prompt");
+  });
+});

--- a/apps/api/src/file-storage/agent-prompts.ts
+++ b/apps/api/src/file-storage/agent-prompts.ts
@@ -30,10 +30,17 @@ function dir(agentId: string): string {
   return slugify(agentId);
 }
 
+/**
+ * Width to zero-pad the index to, so filenames sort lexicographically
+ * (as `listDir` returns them) in the same order the prompts were authored in
+ * — e.g. `09-x` before `10-x`, not `10-x` before `2-x`.
+ */
+const INDEX_WIDTH = String(MAX_PROMPTS - 1).length;
+
 /** Local name for the Nth prompt — stable, unique, and a valid file base. */
-function localName(index: number, title: string): string {
+export function localName(index: number, title: string): string {
   const slug = slugify(title) || "prompt";
-  return `${index}-${slug}`;
+  return `${String(index).padStart(INDEX_WIDTH, "0")}-${slug}`;
 }
 
 /**


### PR DESCRIPTION
Bug found while reading `apps/api/src/file-storage/agent-prompts.ts` (the file the file-storage-abstraction focus area points at).

`writeAgentPrompts` names each seeded prompt file `${index}-${slug}.json` (e.g. `0-...json`, `9-...json`, `10-...json`). `readAgentPrompts` lists that directory via `OrgFs.listDir`, which orders rows with a plain SQL `ORDER BY path ASC` (`apps/api/src/storage/org-fs.ts`) — i.e. a lexicographic string sort, not a numeric one. For an agent with 10+ kickstart prompts (allowed up to `MAX_PROMPTS = 20`), `10-foo.json` through `19-foo.json` sort right after `1-foo.json` and before `2-foo.json`, so `readAgentPrompts` returns the prompts out of the order the user authored them in. Those prompts back the agent's MCP prompt list (icebreakers, org home, `/` mentions per the file's own header comment), so this is a real, user-visible ordering bug for any agent with a reasonably long kickstart-prompt list.

Fix: zero-pad the index to the width needed for `MAX_PROMPTS` (`String(index).padStart(INDEX_WIDTH, "0")`) so the lexicographic sort matches authoring order for every index below the cap. `localName` is now exported and covered by `apps/api/src/file-storage/agent-prompts.test.ts`, which asserts `[2, 9, 10, 19].map(localName).sort()` matches the authored order (the exact scenario that was previously broken).

Behavior preserved otherwise: filenames are still unique-per-agent-per-slug and the dir is always fully deleted-then-rewritten on each `writeAgentPrompts` call, so there's no migration concern for existing unpadded filenames — they're replaced wholesale on the next write. Did not touch the WebDAV path or any other file-storage code.

To verify: `bun test apps/api/src/file-storage/agent-prompts.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test above — all green. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes out-of-order agent prompts by zero-padding the filename index so lexicographic sorting matches the authored order. Prevents misordered prompts when agents have 10+ prompts.

- **Bug Fixes**
  - Zero-pad the index in prompt filenames via `localName(index, title)`.
  - Exported `localName` and added tests for sort order and slug fallback.
  - No migration needed; files are fully rewritten on the next write.

<sup>Written for commit 75e408e556ef8b75689f34a53adc38bb90617c7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

