### PR TITLE
fix(thread): translate the branch picker's PR-tab strings

### DIFF
--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -246,7 +246,7 @@ export function BranchPicker({
               placeholder={
                 tab === "branches"
                   ? t("thread.branchPicker.searchLoadedBranches")
-                  : "Search pull requests…"
+                  : t("thread.branchPicker.searchPullRequests")
               }
               value={search}
               onValueChange={handleSearchChange}
@@ -275,10 +275,10 @@ export function BranchPicker({
               variant="pill"
             >
               <TabsTrigger value="branches" className="h-6 px-2.5 text-xs">
-                Branches
+                {t("thread.branchPicker.branchesTab")}
               </TabsTrigger>
               <TabsTrigger value="prs" className="h-6 px-2.5 text-xs">
-                PRs
+                {t("thread.branchPicker.prsTab")}
               </TabsTrigger>
             </TabsList>
           </Tabs>
@@ -287,23 +287,25 @@ export function BranchPicker({
               <>
                 {prsError && (
                   <div className="p-3 text-xs text-muted-foreground">
-                    Couldn't load pull requests from GitHub.
+                    {t("thread.branchPicker.couldntLoadPullRequests")}
                   </div>
                 )}
                 {prsLoading && (
                   <div className="p-3 text-xs text-muted-foreground">
-                    Loading pull requests…
+                    {t("thread.branchPicker.loadingPullRequests")}
                   </div>
                 )}
                 {!prsError && !prsLoading && (
                   <CommandEmpty>
                     {search.trim()
-                      ? "No pull requests match your search."
-                      : "No open pull requests."}
+                      ? t("thread.branchPicker.noPullRequestsFound")
+                      : t("thread.branchPicker.noOpenPullRequests")}
                   </CommandEmpty>
                 )}
                 {openablePrs.length > 0 && (
-                  <CommandGroup heading="Open pull requests">
+                  <CommandGroup
+                    heading={t("thread.branchPicker.openPullRequests")}
+                  >
                     {openablePrs.map((pr) => (
                       <CommandItem
                         key={pr.number}
@@ -327,8 +329,9 @@ export function BranchPicker({
                 )}
                 {hiddenForkPrs > 0 && (
                   <div className="border-t p-2 text-center text-xs text-muted-foreground">
-                    {hiddenForkPrs} PR{hiddenForkPrs > 1 ? "s" : ""} from forks
-                    hidden — open on a branch in this repo
+                    {t("thread.branchPicker.hiddenForkPrs", {
+                      count: hiddenForkPrs,
+                    })}
                   </div>
                 )}
               </>
@@ -347,7 +350,7 @@ export function BranchPicker({
                   </CommandEmpty>
                 )}
                 {recent.length > 0 && (
-                  <CommandGroup heading="Last 7 days">
+                  <CommandGroup heading={t("thread.branchPicker.last7Days")}>
                     {recent.map((b) => (
                       <CommandItem
                         key={b.name}

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -1,15 +1,28 @@
 export const thread = {
   "thread.branchPicker.allLoaded": "All loaded",
+  "thread.branchPicker.branchesTab": "Branches",
   "thread.branchPicker.couldntLoadBranches":
     "Couldn't load branches from GitHub. You can still pick from your branches.",
+  "thread.branchPicker.couldntLoadPullRequests":
+    "Couldn't load pull requests from GitHub.",
+  "thread.branchPicker.hiddenForkPrs":
+    "{count} PR(s) from forks hidden — open on a branch in this repo",
+  "thread.branchPicker.last7Days": "Last 7 days",
   "thread.branchPicker.loadMoreBranches": "Load more branches",
   "thread.branchPicker.loadingMore": "Loading more…",
+  "thread.branchPicker.loadingPullRequests": "Loading pull requests…",
   "thread.branchPicker.lookingThroughMoreBranches":
     "Looking through more branches...",
   "thread.branchPicker.new": "New",
   "thread.branchPicker.noBranchesFound": "No branches found.",
+  "thread.branchPicker.noPullRequestsFound":
+    "No pull requests match your search.",
+  "thread.branchPicker.noOpenPullRequests": "No open pull requests.",
+  "thread.branchPicker.openPullRequests": "Open pull requests",
   "thread.branchPicker.otherBranchesInRepo": "Other branches in repo",
+  "thread.branchPicker.prsTab": "PRs",
   "thread.branchPicker.searchLoadedBranches": "Search loaded branches…",
+  "thread.branchPicker.searchPullRequests": "Search pull requests…",
   "thread.branchPicker.selectBranch": "Select branch…",
   "thread.branchPicker.yourBranches": "Your branches",
   "thread.changesTab.couldntLoadPrChanges": "Couldn't load PR changes.",

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -2,15 +2,28 @@ import type { thread as threadEn } from "../en/thread.ts";
 
 export const thread = {
   "thread.branchPicker.allLoaded": "Todas carregadas",
+  "thread.branchPicker.branchesTab": "Branches",
   "thread.branchPicker.couldntLoadBranches":
     "Não foi possível carregar branches do GitHub. Você ainda pode escolher entre suas branches.",
+  "thread.branchPicker.couldntLoadPullRequests":
+    "Não foi possível carregar pull requests do GitHub.",
+  "thread.branchPicker.hiddenForkPrs":
+    "{count} PR(s) de forks ocultado(s) — abra em uma branch deste repositório",
+  "thread.branchPicker.last7Days": "Últimos 7 dias",
   "thread.branchPicker.loadMoreBranches": "Carregar mais branches",
   "thread.branchPicker.loadingMore": "Carregando mais…",
+  "thread.branchPicker.loadingPullRequests": "Carregando pull requests…",
   "thread.branchPicker.lookingThroughMoreBranches": "Procurando mais branches…",
   "thread.branchPicker.new": "Nova",
   "thread.branchPicker.noBranchesFound": "Nenhuma branch encontrada.",
+  "thread.branchPicker.noPullRequestsFound":
+    "Nenhum pull request corresponde à sua busca.",
+  "thread.branchPicker.noOpenPullRequests": "Nenhum pull request aberto.",
+  "thread.branchPicker.openPullRequests": "Pull requests abertos",
   "thread.branchPicker.otherBranchesInRepo": "Outras branches no repositório",
+  "thread.branchPicker.prsTab": "PRs",
   "thread.branchPicker.searchLoadedBranches": "Pesquisar branches carregadas…",
+  "thread.branchPicker.searchPullRequests": "Pesquisar pull requests…",
   "thread.branchPicker.selectBranch": "Selecione uma branch…",
   "thread.branchPicker.yourBranches": "Suas branches",
   "thread.changesTab.couldntLoadPrChanges":


### PR DESCRIPTION
## Source

Repo-wide i18n rule (CLAUDE.md): "Never hardcode user-facing strings in apps/web/src". `BranchPicker`'s "Branches" tab already goes through `t()`, but its "PRs" tab — added in a later PR — hardcoded every one of its strings in English.

## Why

pt-BR users hit raw English text ("Search pull requests…", "Branches"/"PRs" tab labels, loading/error/empty states, the open-PRs group heading, the fork-hidden-count footer, and the "Last 7 days" branch group heading) inside an otherwise fully-translated picker. This is the same proven i18n-hardening lane as #5048/#5062/#5099/#5110/#5141/#5170/#5214/#5218.

## Changes

- `apps/web/src/components/thread/github/branch-picker.tsx` — replaced 9 hardcoded strings with `t("thread.branchPicker.*")` calls (tab labels, PR loading/error/empty states, open-PRs heading, hidden-fork-count message with `{count}` interpolation, and the "Last 7 days" branch group heading).
- `apps/web/src/i18n/en/thread.ts` / `apps/web/src/i18n/pt-br/thread.ts` — added the matching `thread.branchPicker.*` keys (pt-BR mirrors English exactly, following the existing pattern in this dictionary).

No logic change — pure string extraction, same behavior in English, now translated in pt-BR.

## How to verify

- `cd apps/web && bunx tsc --noEmit` — the `satisfies Record<keyof typeof enDomain, string>` constraint on `pt-br/thread.ts` fails to compile if a key is missing, so a clean typecheck proves translation completeness.
- Manually: open a repo-linked thread's branch picker, switch to the "PRs" tab with the pt-BR language preference set, confirm every label renders in Portuguese.

## Local checks run

- `bun run fmt` — clean.
- `bunx tsc --noEmit` in `apps/web` — clean (this also validates translation-key completeness, see above).
- No unit test added: this is a pure i18n string-key substitution (no branching logic touched), matching prior i18n-only PRs in this repo (e.g. #5170) which didn't add tests either. Full CI (lint, other workspaces) will run on the PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the Branch Picker PR tab by moving all user-facing strings to i18n. This fixes untranslated English text for pt-BR users and aligns with the repo i18n rule.

- **Bug Fixes**
  - Replaced 9 hardcoded PR-tab strings in `apps/web/src/components/thread/github/branch-picker.tsx` with `t("thread.branchPicker.*")` (search placeholder, tab labels, loading/error/empty states, open-PRs heading, hidden fork count with `{count}`, and "Last 7 days").
  - Added matching keys in `apps/web/src/i18n/en/thread.ts` and `apps/web/src/i18n/pt-br/thread.ts`.

<sup>Written for commit 4b74aa58f38a9b47210485e399857c6c51769b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

