### PR TITLE
fix(thread): reject empty-string branch on COLLECTION_THREADS_UPDATE

### DIFF
--- a/packages/shared/src/thread/schema.test.ts
+++ b/packages/shared/src/thread/schema.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { ThreadUpdateDataSchema } from "./schema.ts";
+
+describe("ThreadUpdateDataSchema", () => {
+  test("rejects an empty-string branch", () => {
+    const result = ThreadUpdateDataSchema.safeParse({ branch: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts null branch (clears the pin)", () => {
+    const result = ThreadUpdateDataSchema.safeParse({ branch: null });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a non-empty branch name", () => {
+    const result = ThreadUpdateDataSchema.safeParse({ branch: "feat/foo" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts omitted branch (no change)", () => {
+    const result = ThreadUpdateDataSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/shared/src/thread/schema.ts
+++ b/packages/shared/src/thread/schema.ts
@@ -150,7 +150,11 @@ export const ThreadUpdateDataSchema = z.object({
   metadata: ThreadMetadataSchema.optional().describe(
     "Full replacement of the thread's metadata object",
   ),
-  branch: z.string().nullish().describe("New git branch for this thread"),
+  branch: z
+    .string()
+    .min(1)
+    .nullish()
+    .describe("New git branch for this thread"),
   virtual_mcp_id: z
     .string()
     .optional()


### PR DESCRIPTION
**Source:** bug found while auditing the thread schema (`packages/shared/src/thread/schema.ts`) for consistency/validation gaps.

**Why a maintainer wants this:** `ThreadUpdateDataSchema.branch` had no `.min(1)` (unlike `ThreadCreateDataSchema.branch`, which already requires it), so a client could pass `branch: ""` instead of `branch: null`. The update handler's safety check (`apps/api/src/tools/thread/update.ts`) only guards `data.branch === null` — "Cannot set branch=null on a github-linked thread" — so an empty string sails right past it and silently unpins the branch on a github-linked thread. `apps/api/src/cli/link-sandbox-registry.ts:465` already treats `branch === null || branch.trim() === ""` as equivalent, confirming both should be rejected the same way at the boundary.

**Failure scenario:** call `COLLECTION_THREADS_UPDATE` with `{ data: { branch: "" } }` on a thread whose vMCP has a `githubRepo` — the null-check is bypassed and the thread's branch pin is dropped with no error, defeating the exact invariant the guard exists to enforce.

**Fix:** add `.min(1)` to the nullish branch field in `ThreadUpdateDataSchema`, so `""` fails validation up front (matching the create schema) while `null` (explicit clear) and omission (no change) keep working.

**Regression test:** `packages/shared/src/thread/schema.test.ts` — asserts `ThreadUpdateDataSchema` rejects `branch: ""`, accepts `branch: null`, a non-empty branch, and omitted branch.

**Reviewer verification:** `cd packages/shared && bunx tsc --noEmit` and `bun test packages/shared/src/thread/schema.test.ts`.

**Locally ran:** `bun run fmt`, `bunx tsc --noEmit` (packages/shared workspace), and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block empty-string branch values in thread updates to prevent silent unpinning of GitHub-linked threads. Adds input validation and tests.

- Bug Fixes
  - Require `branch` to be a non-empty string in `ThreadUpdateDataSchema` (min(1)); `null` and omission still allowed.
  - Closes the gap where `branch: ""` bypassed the null guard and unpinned the branch on GitHub-linked threads.
  - Added tests in `packages/shared/src/thread/schema.test.ts` covering rejection of `""` and acceptance of `null`, non-empty, and omitted.

<sup>Written for commit 66c1af0d13d43bcba394ce26006731119c22803d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

