### PR TITLE
fix(connection): stop re-injecting the dev-assets row on every list page

### DIFF
--- a/apps/api/src/tools/connection/dev-assets-page.test.ts
+++ b/apps/api/src/tools/connection/dev-assets-page.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+  finalizeNonBindingPage,
+  shouldConsiderDevAssetsForPage,
+} from "./dev-assets-page";
+
+describe("shouldConsiderDevAssetsForPage", () => {
+  test("considers it on the first page of a plain listing", () => {
+    expect(shouldConsiderDevAssetsForPage(false, 0)).toBe(true);
+  });
+
+  test("skips it on later pages of a plain listing", () => {
+    expect(shouldConsiderDevAssetsForPage(false, 100)).toBe(false);
+  });
+
+  test("always considers it when binding-filtering (pagination happens after)", () => {
+    expect(shouldConsiderDevAssetsForPage(true, 100)).toBe(true);
+  });
+});
+
+describe("finalizeNonBindingPage", () => {
+  test("passes through unchanged when nothing was injected", () => {
+    const connections = [1, 2, 3];
+    const result = finalizeNonBindingPage(connections, false, 100, 0, 3);
+    expect(result).toEqual({ items: [1, 2, 3], totalCount: 3, hasMore: false });
+  });
+
+  test("trims a full SQL page back to limit and counts the extra row", () => {
+    // 100 real rows already filled the page; dev-assets was unshifted on top.
+    const connections = Array.from({ length: 101 }, (_, i) => i);
+    const result = finalizeNonBindingPage(connections, true, 100, 0, 150);
+
+    expect(result.items.length).toBe(100);
+    expect(result.totalCount).toBe(151);
+    expect(result.hasMore).toBe(true);
+  });
+
+  test("does not overcount when the injected row fits within limit", () => {
+    const connections = [0, 1, 2, 3, 4]; // 4 real rows + dev-assets
+    const result = finalizeNonBindingPage(connections, true, 100, 0, 4);
+
+    expect(result.items).toEqual([0, 1, 2, 3, 4]);
+    expect(result.totalCount).toBe(5);
+    expect(result.hasMore).toBe(false);
+  });
+});

--- a/apps/api/src/tools/connection/dev-assets-page.ts
+++ b/apps/api/src/tools/connection/dev-assets-page.ts
@@ -1,0 +1,31 @@
+/**
+ * The dev-assets pseudo-connection is synthetic — it never exists as a
+ * Postgres row, so a page fetched with `offset > 0` can never contain it
+ * the way a real row would be excluded from later pages. Two rules keep it
+ * confined to a single, correctly-sized page in COLLECTION_CONNECTIONS_LIST:
+ *
+ *  - Only *consider* injecting it on the first page of a plain (non-binding)
+ *    listing — otherwise it would reappear at the top of every page.
+ *  - If it's injected onto a non-binding page that SQL already filled to
+ *    `limit`, trim the page back down and fold the extra row into the total
+ *    count (it isn't counted by `sqlTotalCount`, which only reflects DB rows).
+ */
+export function shouldConsiderDevAssetsForPage(
+  needsBindingFilter: boolean,
+  offset: number,
+): boolean {
+  return needsBindingFilter || offset === 0;
+}
+
+export function finalizeNonBindingPage<T>(
+  connections: T[],
+  devAssetsInjected: boolean,
+  limit: number,
+  offset: number,
+  sqlTotalCount: number,
+): { items: T[]; totalCount: number; hasMore: boolean } {
+  const totalCount = devAssetsInjected ? sqlTotalCount + 1 : sqlTotalCount;
+  const items = devAssetsInjected ? connections.slice(0, limit) : connections;
+  const hasMore = offset + limit < totalCount;
+  return { items, totalCount, hasMore };
+}

--- a/apps/api/src/tools/connection/list.ts
+++ b/apps/api/src/tools/connection/list.ts
@@ -37,6 +37,10 @@ import {
   createDevAssetsConnectionEntity,
   usesLocalObjectStorage,
 } from "./dev-assets";
+import {
+  finalizeNonBindingPage,
+  shouldConsiderDevAssetsForPage,
+} from "./dev-assets-page";
 import { type ConnectionEntity, ConnectionEntitySchema } from "./schema";
 import { getConnectionSlug } from "@decocms/shared/utils/connection-slug";
 import { connectionMatchesWhere } from "./where-match";
@@ -212,7 +216,11 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
     // When no external S3 bucket is configured, inject the dev-assets
     // connection so the OBJECT_STORAGE binding is satisfied by the local
     // DevObjectStorage filesystem fallback.
-    if (usesLocalObjectStorage()) {
+    let devAssetsInjected = false;
+    if (
+      usesLocalObjectStorage() &&
+      shouldConsiderDevAssetsForPage(needsBindingFilter, offset)
+    ) {
       const baseUrl = getBaseUrl();
       const devAssetsId = WellKnownOrgMCPId.DEV_ASSETS(organization.id);
 
@@ -234,6 +242,7 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
         );
         if (slugMatches && whereMatches) {
           connections.unshift(devAssetsConnection);
+          devAssetsInjected = true;
         }
       }
     }
@@ -277,13 +286,13 @@ export const COLLECTION_CONNECTIONS_LIST = defineTool({
       };
     }
 
-    // Non-binding path: SQL already handled where/orderBy/pagination
-    const hasMore = offset + limit < sqlTotalCount;
-
-    return {
-      items: connections,
-      totalCount: sqlTotalCount,
-      hasMore,
-    };
+    // Non-binding path: SQL already handled where/orderBy/pagination.
+    return finalizeNonBindingPage(
+      connections,
+      devAssetsInjected,
+      limit,
+      offset,
+      sqlTotalCount,
+    );
   },
 });


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/tools/connection/list.ts` (COLLECTION_CONNECTIONS_LIST) for this tick's focus area.

**Why a maintainer wants this:** when an org falls back to local object storage (no S3 bucket configured — the default for local dev), `COLLECTION_CONNECTIONS_LIST` injects a synthetic "dev-assets" pseudo-connection so `OBJECT_STORAGE`-binding consumers still resolve. That row never exists in Postgres, so the `!connections.some(c => c.id === devAssetsId)` presence check was always false regardless of `offset` — the synthetic row reappeared at the top of *every* page of a plain (non-binding) listing, not just the first. Separately, injecting it onto an already-full SQL page (SQL already applied `limit`/`offset`) pushed that page one row past the caller's requested `limit`, silently breaking the pagination contract.

**Failure scenario:** local/dev org with no S3 configured, more connections than fit on one page. Paginating through `COLLECTION_CONNECTIONS_LIST` (e.g. the UI's connection picker) shows the dev-assets row duplicated on every page, and page 1 can return `limit + 1` items instead of `limit`.

**Fix:** only consider injecting the dev-assets row on the first page of a plain listing (binding-filtered listings already paginate *after* injection using the full merged list, so they were already correct). When it is injected onto a full page, trim the page back to `limit` and fold the extra row into `totalCount`/`hasMore` (it isn't reflected in `sqlTotalCount`, which only counts real DB rows). The trim/recount arithmetic is extracted into `dev-assets-page.ts` — pure functions, unit-tested directly (mirrors the existing `where-match.ts`/`map-with-concurrency.ts` pattern in this same directory), since the tool handler itself only has integration-test coverage requiring a real Postgres instance not available in this environment.

**Reviewer command:** `bun test apps/api/src/tools/connection/dev-assets-page.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (both clean), plus the targeted unit test above. Full CI (including the Postgres-backed `connection-tools.integration.test.ts`) validates the wired-up `list.ts` behavior end-to-end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate `dev-assets` rows in `COLLECTION_CONNECTIONS_LIST` and restores correct pagination when local object storage is used. Page 1 no longer exceeds the requested limit, and counts/hasMore are accurate.

- **Bug Fixes**
  - Only consider injecting `dev-assets` on the first page of plain listings; binding-filtered listings were already correct.
  - When injected onto a full page, trim to `limit` and fold the extra row into `totalCount`/`hasMore`.
  - Added `dev-assets-page.ts` pure helpers with unit tests and updated `list.ts` to use them.

<sup>Written for commit df00ee2d73ca285125ed815db3fc0902b2b1560a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

