### PR TITLE
fix(mcp): stop trusting caller-supplied x-org-id/x-org-slug in the legacy virtual-MCP route

### DIFF
--- a/apps/api/src/api/routes/virtual-mcp.ts
+++ b/apps/api/src/api/routes/virtual-mcp.ts
@@ -48,26 +48,16 @@ export async function handleVirtualMcpRequest(
   const ctx = c.get("studioContext");
 
   try {
-    // Prefer x-org-id header (no DB lookup) over x-org-slug (requires DB lookup).
-    // External MCP clients (Claude Code/Desktop) send NEITHER — the org is in
-    // the URL path (`/api/:org/mcp`), already resolved into `ctx.organization`
-    // by the resolveOrgFromPath middleware. Fall back to it so the aggregate
-    // (Decopilot) endpoint works without the internal UI's x-org-* headers;
-    // otherwise organizationId stays null and the request 400s with
-    // "Agent ID or organization ID is required".
-    const orgId = c.req.header("x-org-id");
-    const orgSlug = c.req.header("x-org-slug");
-
-    const organizationId = orgId
-      ? orgId
-      : orgSlug
-        ? await ctx.db
-            .selectFrom("organization")
-            .select("id")
-            .where("slug", "=", orgSlug)
-            .executeTakeFirst()
-            .then((org) => org?.id)
-        : (ctx.organization?.id ?? null);
+    // `ctx.organization` is the single source of truth for org context —
+    // context-factory already resolves and MEMBERSHIP-VERIFIES x-org-id /
+    // x-org-slug (and the path org, for the canonical /api/:org route) for
+    // session- and OAuth-session-authenticated callers. Re-reading those
+    // headers here independently would let an API key with no organization
+    // in its own metadata (e.g. a webhook-trigger key scoped only to fire one
+    // automation, see tools/automations/trigger-add.ts) name an arbitrary
+    // x-org-id and reach any org's Virtual MCP — API keys are pre-scoped at
+    // mint time and must never be widened by a caller-supplied header.
+    const organizationId = ctx.organization?.id ?? null;
 
     const virtualId = virtualMcpId
       ? virtualMcpId


### PR DESCRIPTION
Bug found while auditing `apps/api/src/api/routes/virtual-mcp.ts` (the legacy `/mcp/gateway|virtual-mcp/:virtualMcpId` handler) for the missing-auth-check pattern this repo keeps finding in org-scoping code.

**The gap:** `handleVirtualMcpRequest` independently read `x-org-id`/`x-org-slug` off the request and trusted them directly as `organizationId` (falling back to `ctx.organization?.id` only when neither header was present), instead of relying on `ctx.organization`.

This was harmless for session- and OAuth-session-authenticated callers, because `context-factory.ts` already membership-verifies those same headers (joined against `member.userId`) before folding the result into `ctx.organization`.

It was **not** harmless for API-key auth. There, `ctx.organization` is set purely from the key's own `metadata.organization` (by design — a key is pre-scoped at mint time and must not be widened by a header). Some API keys carry no organization in their metadata at all — e.g. the webhook-trigger keys minted in `apps/api/src/tools/automations/trigger-add.ts` / `trigger-rotate-token.ts`, scoped only to `FIRE` one specific automation trigger. For those, `ctx.organization` is `undefined`, but the route's own header re-read still resolved an `organizationId` from whatever `x-org-id`/`x-org-slug` the caller sent — no membership check at all. This route never calls `ctx.access.check()`, so nothing else stood between that unverified `organizationId` and the org-ownership check a few lines down (`virtualMcp.organization_id !== organizationId`), which then simply matched. A caller holding *any* webhook-trigger key (from any org they belong to) could set `x-org-id` to a different org's id and, if they also knew (or guessed) a Virtual MCP id in that org, fully connect to that agent's MCP gateway — list/call its tools, resources and prompts — despite the key being scoped to fire one webhook.

**Fix:** use `ctx.organization?.id` directly as `organizationId`, matching exactly what `context-factory.ts` already resolved and verified for the caller's actual auth type. For every legitimate caller this is a no-op (the header value and `ctx.organization.id` were already identical whenever `ctx.organization` was verified from that header); it only changes behavior for the unverified case, where `organizationId` now correctly falls back to `null` — which the existing `if (virtualMcpId && !organizationId) return 400` guard already handles.

Net diff: -20 / +10 lines, single file, behavior-preserving for every non-exploit path.

**How a reviewer confirms this:** read `context-factory.ts`'s API-key branch (`organization: orgMetadata ? {...} : undefined`) alongside `trigger-add.ts`'s `apiKey.create({ metadata: { kind: "webhook_trigger", ... } })` (no `organization` key) to see `ctx.organization` is `undefined` for those keys, then confirm `handleVirtualMcpRequest` no longer reads `c.req.header("x-org-id"/"x-org-slug")` at all.

**Checks run locally:** `bun run fmt` (clean) and `cd apps/api && bunx tsc --noEmit` (clean). This route has no unit-test coverage today and testing it properly needs a real DB + membership rows (e2e tier, per TESTING.md) which isn't runnable in this sandbox — flagging as a good e2e follow-up (an org-B Virtual MCP + an org-A webhook-trigger key should get a 400, not a working MCP session).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop trusting caller-supplied `x-org-id`/`x-org-slug` in the legacy virtual-MCP route. Now the route uses `ctx.organization?.id` as the single source of org context to prevent unauthorized org access via API keys.

- **Bug Fixes**
  - Removed independent header parsing; `organizationId` is derived from `ctx.organization?.id` only.
  - Blocks access with webhook-trigger API keys that lack org metadata; missing org now correctly returns 400.
  - No behavior change for session/OAuth callers whose org was already verified.

<sup>Written for commit d4e5bb6d2642a19bc25fc9d046e85e8770c0fa73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

