### PR TITLE
refactor(settings): resolve STUDIO_PUBLIC_URL/MESH_PUBLIC_URL through Settings, not raw process.env

### DIFF
--- a/apps/api/src/core/server-constants.ts
+++ b/apps/api/src/core/server-constants.ts
@@ -46,7 +46,5 @@ export function getInternalUrl(): string {
  * separate public-URL setting still work.
  */
 export function getPublicUrl(): string {
-  return (
-    process.env.STUDIO_PUBLIC_URL ?? process.env.MESH_PUBLIC_URL ?? getBaseUrl()
-  );
+  return getSettings().publicUrl ?? getBaseUrl();
 }

--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -218,6 +218,31 @@ describe("resolveConfig Studio environment aliases", () => {
   });
 });
 
+describe("resolveConfig public URL", () => {
+  it("prefers STUDIO_PUBLIC_URL over the legacy MESH_PUBLIC_URL alias", () => {
+    const result = resolveConfig(flags, {
+      STUDIO_PUBLIC_URL: "https://studio.example.com",
+      MESH_PUBLIC_URL: "https://legacy.example.com",
+    });
+
+    expect(result.settings.publicUrl).toBe("https://studio.example.com");
+  });
+
+  it("accepts the legacy MESH_PUBLIC_URL during the compatibility window", () => {
+    const result = resolveConfig(flags, {
+      MESH_PUBLIC_URL: "https://legacy.example.com",
+    });
+
+    expect(result.settings.publicUrl).toBe("https://legacy.example.com");
+  });
+
+  it("defaults to undefined when unset", () => {
+    const result = resolveConfig(flags, {});
+
+    expect(result.settings.publicUrl).toBeUndefined();
+  });
+});
+
 describe("resolveConfig external database/nats URL detection", () => {
   it("treats a bracketed IPv6 loopback DATABASE_URL as local, not external", () => {
     const result = resolveConfig(flags, {

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -193,6 +193,7 @@ export function resolveConfig(
     nodeEnv,
     port: toPositiveIntegerOrDefault("PORT", flags.port || envVars.PORT, 3000),
     baseUrl: flags.baseUrl || envVars.BASE_URL,
+    publicUrl: envVars.STUDIO_PUBLIC_URL ?? envVars.MESH_PUBLIC_URL,
     dataDir,
 
     // Database (url resolved after services start)

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -13,6 +13,10 @@ export interface Settings {
   nodeEnv: "production" | "development" | "test";
   port: number;
   baseUrl: string | undefined;
+  /** Externally reachable URL (STUDIO_PUBLIC_URL, legacy MESH_PUBLIC_URL alias)
+   *  for URLs that must resolve from outside the cluster (e.g. the MCP
+   *  endpoint handed to a remote link daemon). Falls back to baseUrl when unset. */
+  publicUrl: string | undefined;
   dataDir: string;
 
   // Database


### PR DESCRIPTION
Env-config hygiene pass over `apps/api/src/settings`: `getPublicUrl()` in `apps/api/src/core/server-constants.ts` read `process.env.STUDIO_PUBLIC_URL`/`MESH_PUBLIC_URL` directly, inconsistent with `getBaseUrl()`/`getInternalUrl()` in the same file, which both go through `getSettings()` — and against the repo rule that config should flow through the settings pipeline, not raw `process.env` reads scattered across call sites.

Why a maintainer wants this: it's the only remaining `process.env.STUDIO_*`/`MESH_*` read left in `server-constants.ts` after `resolve-config.ts` already centralized every other STUDIO_*/legacy-MESH_* alias (`studioJwtSecret`, `dispatchRole`, etc.) into `resolveConfig`/`Settings`. Keeping this one on raw `process.env` is a landmine for a future config test/refactor that assumes all settings values are frozen and sourced from `Settings`.

Fix: added `publicUrl: string | undefined` to `Settings`, resolved in `resolveConfig` as `envVars.STUDIO_PUBLIC_URL ?? envVars.MESH_PUBLIC_URL` (same alias pattern and precedence as the existing `studioJwtSecret`/`dispatchRole` fields), and changed `getPublicUrl()` to `getSettings().publicUrl ?? getBaseUrl()`. Net line delta: +31/-3 (mostly the new test block); behavior is unchanged — same two env vars, same precedence order (STUDIO_PUBLIC_URL, then legacy MESH_PUBLIC_URL, then the existing baseUrl-derived fallback), just sourced from frozen `Settings` instead of ad-hoc `process.env` reads. Confirmed no other test or call site reads/mutates `STUDIO_PUBLIC_URL`/`MESH_PUBLIC_URL` after settings init (`rg` across `apps/api/src` and `packages/e2e`), so migrating to the frozen-settings snapshot introduces no behavior change.

Reviewer check: `bun test apps/api/src/settings/resolve-config.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test file above (61 pass) plus `apps/api/src/settings/index.test.ts` (1 pass) — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the public URL through Settings instead of direct `process.env` reads, and update `getPublicUrl()` to use it. This centralizes config with `getBaseUrl()`/`getInternalUrl()`; behavior and env precedence are unchanged.

- **Refactors**
  - Add `publicUrl` to `Settings`, resolved as `STUDIO_PUBLIC_URL ?? MESH_PUBLIC_URL`.
  - Update `getPublicUrl()` to return `getSettings().publicUrl ?? getBaseUrl()`.
  - Add tests for alias precedence and unset default.

<sup>Written for commit 7927fc05e890459b9505a793628794500e473893. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

