### PR TITLE
fix(auth): stop falling back to a hardcoded Better Auth secret

### DIFF
--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -9,6 +9,7 @@
  * Configuration is file-based (auth-config.json), not environment variables.
  */
 
+import { randomBytes } from "crypto";
 import { getSettings } from "../settings";
 import { getToolsByCategory } from "@decocms/shared/tools/registry-metadata";
 import { sso } from "@better-auth/sso";
@@ -467,8 +468,22 @@ const settings = getSettings();
 // set-auth-jwt header.
 const MAX_INLINE_AVATAR_LENGTH = 256 * 1024;
 
+// Falling back to a fixed string baked into this open-source repo would let
+// anyone who forgets to set BETTER_AUTH_SECRET run with a publicly-known
+// session/cookie signing secret. Generate a random one instead (same
+// trade-off as STUDIO_JWT_SECRET in ./jwt.ts): not persistent across
+// restarts, but never a known constant.
+const authSecret =
+  settings.betterAuthSecret ||
+  (() => {
+    console.warn(
+      "BETTER_AUTH_SECRET not set - generating a random secret (not persistent across restarts)",
+    );
+    return randomBytes(32).toString("base64");
+  })();
+
 export const auth = betterAuth({
-  secret: settings.betterAuthSecret || "deco-default-secret-k7x9m2p4q8w3n5v6",
+  secret: authSecret,
 
   // customAPIKeyGetter probes every `Authorization: Bearer …` as an API key,
   // so OAuth tokens, studio JWTs and stale keys routinely miss and Better Auth


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/auth` for token-validation hardening (JWT signing/verification, org-scoped role resolution).

**The bug:** `betterAuth({ secret: settings.betterAuthSecret || "deco-default-secret-k7x9m2p4q8w3n5v6" })` in `apps/api/src/auth/index.ts` falls back to a fixed string that is baked into this open-source repo whenever `BETTER_AUTH_SECRET` isn't set. Better Auth uses this `secret` to sign sessions/cookies, so any deployment that forgets to configure the env var runs with a publicly-known signing secret — anyone who reads the source (or the CLI `--help` output, which is itself wrong here) can forge them. `apps/api/src/cli.ts` documents `BETTER_AUTH_SECRET` as "auto-generated if not set", which the code never actually did.

**Why a maintainer wants it:** a hardcoded default secret in an open-source auth library is a textbook forgeable-session vulnerability (same class as Rails' old `SECRET_KEY_BASE` issue) — it silently weakens every self-hosted instance that omits the env var, with no warning in logs.

**The fix:** generate a random 32-byte secret at boot when `BETTER_AUTH_SECRET` is unset (with a `console.warn`), exactly mirroring the already-accepted fallback pattern for `STUDIO_JWT_SECRET` in `apps/api/src/auth/jwt.ts` (`getSecret()`) and for `ENCRYPTION_KEY` (documented in `deploy/helm/studio/values.yaml` as "auto-generates a random key on each boot"). Trade-off is identical and already accepted elsewhere in this codebase: sessions don't survive a restart when the secret isn't configured, but the secret is never a known constant.

**How a reviewer verifies:** read `apps/api/src/auth/index.ts` — `settings.betterAuthSecret || "deco-default-secret-k7x9m2p4q8w3n5v6"` is gone; the new `authSecret` computation is the only fallback path, and `BETTER_AUTH_SECRET` being set (the expected production path, e.g. the Helm chart requires overriding its placeholder value) is completely unaffected.

**Checks run locally:** `bun run fmt` (clean, no other files touched) and `cd apps/api && bunx tsc --noEmit` (clean). No existing test exercises this literal (`rg "deco-default-secret"` had exactly one hit, this line) so there's no behavior to invert; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop using a hardcoded Better Auth secret. When BETTER_AUTH_SECRET is missing, generate a random 32-byte secret at boot, log a warning, and accept that sessions won’t persist across restarts.

This removes a forgeable-session risk; deployments already setting BETTER_AUTH_SECRET are unchanged.

<sup>Written for commit 8a852dcc89b9cf7a4fe976483bda99e76b3f023e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

