### PR TITLE
fix(header): translate the mobile sidebar's org/agent switcher aria-labels

### DIFF
--- a/apps/web/src/components/header/shell-breadcrumb.tsx
+++ b/apps/web/src/components/header/shell-breadcrumb.tsx
@@ -61,6 +61,7 @@ function AgentCrumb({
   onOpenHome: () => void;
   onPick: (id: string | null) => void;
 }) {
+  const t = useT();
   const entity = useVirtualMCP(agentId) ?? fallback ?? null;
   const title = entity?.title ?? "Super Agent";
   return (
@@ -68,7 +69,7 @@ function AgentCrumb({
       <button
         type="button"
         onClick={onOpenHome}
-        aria-label={`Open ${title} home`}
+        aria-label={t("header.shellBreadcrumb.openAgentHome", { name: title })}
         className="wco-no-drag flex items-center shrink-0 rounded-md p-1 hover:bg-accent/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
       >
         <AgentAvatar
@@ -103,6 +104,7 @@ function AgentCrumb({
  * in the task list toolbar below it.
  */
 export function OrgSwitcherCrumb({ showName }: { showName?: boolean } = {}) {
+  const t = useT();
   const { org } = useProjectContext();
   const { state: sidebarState, isMobile } = useSidebar();
   const hasPendingInvites = usePendingInvitations().invitations.length > 0;
@@ -118,8 +120,13 @@ export function OrgSwitcherCrumb({ showName }: { showName?: boolean } = {}) {
               type="button"
               aria-label={
                 hasPendingInvites
-                  ? `${org.name} — switch organization (pending invitation)`
-                  : `${org.name} — switch organization`
+                  ? t(
+                      "header.shellBreadcrumb.switchOrganizationPendingInvitation",
+                      { name: org.name },
+                    )
+                  : t("header.shellBreadcrumb.switchOrganization", {
+                      name: org.name,
+                    })
               }
               // pl-[5px] centers the 24px org icon on the same axis (x=25) as the
               // collapsed rail centers it (the 50px icon-rail's midpoint), so the

--- a/apps/web/src/i18n/en/header.ts
+++ b/apps/web/src/i18n/en/header.ts
@@ -18,4 +18,8 @@ export const header = {
   "header.orgSwitcher.noOrganizationsMatch": 'No organizations match "{query}"',
   "header.orgSwitcher.searchOrganizations": "Search organizations...",
   "header.orgSwitcher.unknownOrganization": "Unknown organization",
+  "header.shellBreadcrumb.openAgentHome": "Open {name} home",
+  "header.shellBreadcrumb.switchOrganization": "{name} — switch organization",
+  "header.shellBreadcrumb.switchOrganizationPendingInvitation":
+    "{name} — switch organization (pending invitation)",
 } as const;

--- a/apps/web/src/i18n/pt-br/header.ts
+++ b/apps/web/src/i18n/pt-br/header.ts
@@ -21,4 +21,8 @@ export const header = {
     'Nenhuma organização coincide com "{query}"',
   "header.orgSwitcher.searchOrganizations": "Pesquisar organizações...",
   "header.orgSwitcher.unknownOrganization": "Organização desconhecida",
+  "header.shellBreadcrumb.openAgentHome": "Abrir início de {name}",
+  "header.shellBreadcrumb.switchOrganization": "{name} — trocar organização",
+  "header.shellBreadcrumb.switchOrganizationPendingInvitation":
+    "{name} — trocar organização (convite pendente)",
 } satisfies Record<keyof typeof headerEn, string>;


### PR DESCRIPTION
Hardening follow-up in the mobile sidebar UI area (accessible-labels part of the brief).

`shell-breadcrumb.tsx` renders `OrgSwitcherCrumb` and `AgentSwitcherCrumb` in the mobile sidebar sheet header (`navigation-mobile.tsx`) as well as the desktop topbar. Both built their `aria-label` with a hardcoded English template string (`` `Open ${title} home` ``, `` `${org.name} — switch organization` ``) instead of going through `useT()` — the repo's i18n rule requires every user-facing string, including `aria-label`s, to be translated. The sibling `NewChatCrumb` button in the same file already does this correctly, so the two crumbs were the odd ones out.

A pt-BR screen-reader user opening the mobile nav sheet currently hears these two labels in English while every other label in the same header is translated — that's the concrete, verifiable gap this closes.

Change: added `header.shellBreadcrumb.openAgentHome`, `header.shellBreadcrumb.switchOrganization`, and `header.shellBreadcrumb.switchOrganizationPendingInvitation` keys to `en/header.ts` and `pt-br/header.ts`, and wired `useT()` into `AgentCrumb`/`OrgSwitcherCrumb` in place of the template literals. No behavior change for English users; pt-BR users now get a translated label.

How to verify: switch language to Português (Brasil) in preferences, open the mobile sidebar sheet (narrow viewport), and inspect the org icon / agent avatar buttons' accessible names (e.g. via browser a11y inspector) — they now read in Portuguese.

Checks run locally: `bun run fmt` (clean), `cd apps/web && bunx tsc --noEmit` (passes, including the `satisfies Record<keyof typeof headerEn, string>` completeness check on the pt-br dictionary). No existing test file covers this component. Full CI runs lint/tests for the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes aria-labels for the org switcher and agent avatar in the header by replacing hardcoded English with `useT()`. Fixes English-only screen reader labels in the mobile sidebar; no behavior change for English.

- **Bug Fixes**
  - Use `useT()` in `AgentCrumb` and `OrgSwitcherCrumb` to build aria-labels.
  - Add `header.shellBreadcrumb.openAgentHome`, `header.shellBreadcrumb.switchOrganization`, and `header.shellBreadcrumb.switchOrganizationPendingInvitation` to `en/header.ts` and `pt-br/header.ts`.
  - Pending-invitation state now has a distinct translated label.

<sup>Written for commit 8ff86d1b08b0e47f5c0b374a7a95dd5faf083a44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

