### PR TITLE
feat(sections-editor): open loader array items in the full form

### DIFF
--- a/apps/web/src/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/any-of-field.tsx
@@ -363,6 +363,16 @@ export function AnyOfField({
       />
     ) : null;
 
+    // Once the breadcrumb has drilled INTO this loader's content (e.g. into an
+    // array item), render that nested content at FULL WIDTH — dropping the
+    // loader type <Select> and the "loader configuration" card chrome — so the
+    // item's form takes over the whole panel instead of staying scoped inside
+    // the loader card. The breadcrumb "back" pops the crumb, `nestedBreadcrumbPath`
+    // empties, and the normal select + card chrome returns.
+    if (isModuleLoaderUnion && nestedProps && nestedBreadcrumbPath.length > 0) {
+      return <div className="min-w-0">{nestedProps}</div>;
+    }
+
     const isNestedBlockRef = path.includes(".");
 
     // Detach: convert a global (saved-block) loader into a local, inline copy.

--- a/apps/web/src/components/sections-editor/fields/object-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/object-field.tsx
@@ -35,6 +35,7 @@ export function ObjectField({
     schema,
     objValue,
     breadcrumbPath,
+    decofile,
   );
   const isOpen = open || breadcrumbInside;
   const contentId = `${path}-fields`;

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -165,6 +165,74 @@ describe("resolveActiveFieldKey", () => {
     ).toBe("alert");
   });
 
+  test("narrows to a loader whose inline config owns the drilled item", () => {
+    // Multi-field section: several sibling props + a loader (block-ref) whose
+    // config holds a `banners` array. Drilling into the "Beach Short" banner
+    // produces a bare `[itemLabel]` trail; the section must still narrow to the
+    // loader (not keep showing the sibling toggles).
+    const properties = {
+      enableCta: { title: "Ativar CTA", type: "boolean" },
+      enableBanners: { title: "Ativar modo de banners", type: "boolean" },
+      loader: {
+        title: "Loader",
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: "shelf/loader.ts", title: "Shelf" }],
+      },
+    } satisfies Record<string, SchemaProperty>;
+    const objValue = {
+      enableCta: true,
+      enableBanners: false,
+      loader: {
+        __resolveType: "shelf/loader.ts",
+        banners: [{ title: "Linha Outdoors" }, { title: "Beach Short" }],
+      },
+    };
+    expect(
+      resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+        "Beach Short",
+      ]),
+    ).toBe("loader");
+  });
+
+  test("narrows to a GLOBAL loader whose decofile data owns the drilled item", () => {
+    const properties = {
+      enableCta: { title: "Ativar CTA", type: "boolean" },
+      loader: {
+        title: "Loader",
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: "shelf/loader.ts", title: "Shelf" }],
+      },
+    } satisfies Record<string, SchemaProperty>;
+    // Global loader: the field value is just a reference; the real config
+    // (with the `banners` array) lives in the decofile under that key.
+    const objValue = {
+      enableCta: true,
+      loader: { __resolveType: "carrossel-home-loader" },
+    };
+    const decofile = {
+      "carrossel-home-loader": {
+        __resolveType: "shelf/loader.ts",
+        name: "carrossel-home-loader",
+        banners: [{ title: "Linha Outdoors" }, { title: "Beach Short" }],
+      },
+    };
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(properties),
+        properties,
+        objValue,
+        ["Beach Short"],
+        decofile,
+      ),
+    ).toBe("loader");
+    // Without the decofile the reference can't be resolved, so it can't narrow.
+    expect(
+      resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+        "Beach Short",
+      ]),
+    ).toBeNull();
+  });
+
   test("disambiguates block-refs with same label by inner value keys", () => {
     const properties = {
       asideMenu: {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -233,6 +233,84 @@ describe("resolveActiveFieldKey", () => {
     ).toBeNull();
   });
 
+  test("does not narrow to a loader whose config does not own the crumb", () => {
+    const properties = {
+      enableCta: { title: "Ativar CTA", type: "boolean" },
+      loader: {
+        title: "Loader",
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: "shelf/loader.ts", title: "Shelf" }],
+      },
+    } satisfies Record<string, SchemaProperty>;
+    const objValue = {
+      enableCta: true,
+      loader: {
+        __resolveType: "shelf/loader.ts",
+        banners: [{ title: "Linha Outdoors" }],
+      },
+    };
+    expect(
+      resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+        "Beach Short",
+      ]),
+    ).toBeNull();
+  });
+
+  test("does not spuriously match primitive arrays or href/id fallbacks", () => {
+    const properties = {
+      loader: {
+        title: "Loader",
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: "shelf/loader.ts", title: "Shelf" }],
+      },
+    } satisfies Record<string, SchemaProperty>;
+    // The crumb "Beach Short" appears only as a primitive tag and as an
+    // `href`/`id` — never as a real item name/label/title — so ownership must
+    // NOT be claimed (would otherwise narrow to the wrong field).
+    const objValue = {
+      loader: {
+        __resolveType: "shelf/loader.ts",
+        tags: ["Beach Short"],
+        links: [{ href: "Beach Short", id: "Beach Short" }],
+      },
+    };
+    expect(
+      resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+        "Beach Short",
+      ]),
+    ).toBeNull();
+  });
+
+  test("narrows to the loader that actually owns the item, not the first block-ref", () => {
+    const properties = {
+      loaderA: {
+        title: "Loader A",
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: "a/loader.ts", title: "A" }],
+      },
+      loaderB: {
+        title: "Loader B",
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: "b/loader.ts", title: "B" }],
+      },
+    } satisfies Record<string, SchemaProperty>;
+    const objValue = {
+      loaderA: {
+        __resolveType: "a/loader.ts",
+        banners: [{ title: "Linha Outdoors" }],
+      },
+      loaderB: {
+        __resolveType: "b/loader.ts",
+        banners: [{ title: "Beach Short" }],
+      },
+    };
+    expect(
+      resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+        "Beach Short",
+      ]),
+    ).toBe("loaderB");
+  });
+
   test("disambiguates block-refs with same label by inner value keys", () => {
     const properties = {
       asideMenu: {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -1,6 +1,7 @@
 import { getArrayItemLabel } from "./array-item-display";
 import { isPageMultivariateSectionArrayField } from "./page-variants";
 import type { SchemaProperty } from "./resolve-schema";
+import { unwrapBlockReference } from "./unwrap-section";
 
 function humanize(key: string): string {
   return key
@@ -199,12 +200,44 @@ function asObjectRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
+/**
+ * Whether a (block-ref) field's inline value contains — at any nesting level —
+ * an array whose item's display label matches `crumb`.
+ *
+ * Drilling into an array item that lives inside a loader's config produces a
+ * bare `[itemLabel]` trail (the array's own label is omitted, and the loader's
+ * label isn't in the trail either). Without this, a multi-field section can't
+ * tell which field owns the item, so {@link resolveActiveFieldKeyInScope}
+ * returns null and the panel keeps showing every sibling prop instead of
+ * narrowing to the item. We match without an item schema, so the label is
+ * derived from the item's own fields (name/label/title/…); a loader that labels
+ * items via a custom `titleBy` won't be detected here.
+ */
+function valueOwnsItemCrumb(value: unknown, crumb: string, depth = 0): boolean {
+  if (depth > 4 || value == null || typeof value !== "object") return false;
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      if (labelsMatch(getArrayItemLabel(value[i], i, undefined), crumb)) {
+        return true;
+      }
+      if (valueOwnsItemCrumb(value[i], crumb, depth + 1)) return true;
+    }
+    return false;
+  }
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (k.startsWith("__")) continue;
+    if (valueOwnsItemCrumb(v, crumb, depth + 1)) return true;
+  }
+  return false;
+}
+
 /** Resolve which property at this level should be shown for the breadcrumb trail. */
 function resolveActiveFieldKeyInScope(
   keys: string[],
   properties: Record<string, SchemaProperty>,
   objValue: Record<string, unknown>,
   breadcrumbPath: string[],
+  decofile?: Record<string, unknown>,
 ): string | null {
   if (breadcrumbPath.length === 0) return null;
   const head = breadcrumbPath[0]!;
@@ -247,6 +280,7 @@ function resolveActiveFieldKeyInScope(
       schema.properties,
       childObj,
       breadcrumbPath,
+      decofile,
     );
     if (direct) return key;
 
@@ -256,6 +290,7 @@ function resolveActiveFieldKeyInScope(
         schema.properties,
         childObj,
         breadcrumbPath.slice(1),
+        decofile,
       );
       if (viaLabel) return key;
     }
@@ -277,7 +312,18 @@ function resolveActiveFieldKeyInScope(
     const schema = properties[key];
     if (schema?.type !== "block-ref") continue;
     const fieldLabel = fieldDisplayLabel(key, schema);
-    if (head !== fieldLabel && head !== key) continue;
+    if (head !== fieldLabel && head !== key) {
+      // The crumb isn't the loader's own label, but the drilled item may live
+      // in an array inside the loader's config — narrow to the loader so its own
+      // form can then narrow to the item (instead of the section showing every
+      // sibling prop of the previous level). For a global/saved loader the value
+      // is just a `{ __resolveType }` reference, so resolve its data from the
+      // decofile before scanning.
+      const rawVal = objValue[key];
+      const saved = decofile ? unwrapBlockReference(rawVal, decofile) : null;
+      if (valueOwnsItemCrumb(saved?.data ?? rawVal, head)) return key;
+      continue;
+    }
 
     if (breadcrumbPath.length > 1) {
       const val = objValue[key];
@@ -306,12 +352,14 @@ export function resolveActiveFieldKey(
   properties: Record<string, SchemaProperty>,
   objValue: Record<string, unknown>,
   breadcrumbPath: string[],
+  decofile?: Record<string, unknown>,
 ): string | null {
   return resolveActiveFieldKeyInScope(
     keys,
     properties,
     objValue,
     breadcrumbPath,
+    decofile,
   );
 }
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -200,33 +200,70 @@ function asObjectRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
+// A drilled item is addressed by its display label, which for the common case
+// comes from one of these high-signal naming fields. We match ownership ONLY
+// against these (not the full getArrayItemLabel fallback chain) so a coincidental
+// `href`/`id`/`key` value — or a plain string in an unrelated primitive array —
+// can't spuriously claim to own the crumb.
+const OWNERSHIP_LABEL_KEYS = ["name", "label", "title", "alt"] as const;
+
+function itemOwnershipLabel(item: unknown): string | undefined {
+  if (item == null || typeof item !== "object" || Array.isArray(item)) {
+    return undefined;
+  }
+  const obj = item as Record<string, unknown>;
+  for (const key of OWNERSHIP_LABEL_KEYS) {
+    const value = obj[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
 /**
  * Whether a (block-ref) field's inline value contains — at any nesting level —
- * an array whose item's display label matches `crumb`.
+ * an object array item whose naming field matches `crumb`.
  *
  * Drilling into an array item that lives inside a loader's config produces a
  * bare `[itemLabel]` trail (the array's own label is omitted, and the loader's
  * label isn't in the trail either). Without this, a multi-field section can't
  * tell which field owns the item, so {@link resolveActiveFieldKeyInScope}
  * returns null and the panel keeps showing every sibling prop instead of
- * narrowing to the item. We match without an item schema, so the label is
- * derived from the item's own fields (name/label/title/…); a loader that labels
- * items via a custom `titleBy` won't be detected here.
+ * narrowing to the item.
+ *
+ * Deliberately conservative — matches only object items via
+ * {@link OWNERSHIP_LABEL_KEYS} (no item schema is available here). Items labeled
+ * via a custom `titleBy`, via `text`/`href`/`id`, or primitive-array items are
+ * NOT detected; those degrade to the pre-fix behavior (all siblings shown)
+ * rather than risk narrowing to the wrong loader. Bounded by depth and a shared
+ * node budget so a large loader config can't stall a render.
  */
-function valueOwnsItemCrumb(value: unknown, crumb: string, depth = 0): boolean {
-  if (depth > 4 || value == null || typeof value !== "object") return false;
+function valueOwnsItemCrumb(
+  value: unknown,
+  crumb: string,
+  budget = { n: 4000 },
+  depth = 0,
+): boolean {
+  if (
+    depth > 4 ||
+    budget.n <= 0 ||
+    value == null ||
+    typeof value !== "object"
+  ) {
+    return false;
+  }
   if (Array.isArray(value)) {
-    for (let i = 0; i < value.length; i++) {
-      if (labelsMatch(getArrayItemLabel(value[i], i, undefined), crumb)) {
-        return true;
-      }
-      if (valueOwnsItemCrumb(value[i], crumb, depth + 1)) return true;
+    for (const item of value) {
+      if (--budget.n <= 0) return false;
+      const label = itemOwnershipLabel(item);
+      if (label && labelsMatch(label, crumb)) return true;
+      if (valueOwnsItemCrumb(item, crumb, budget, depth + 1)) return true;
     }
     return false;
   }
   for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
     if (k.startsWith("__")) continue;
-    if (valueOwnsItemCrumb(v, crumb, depth + 1)) return true;
+    if (--budget.n <= 0) return false;
+    if (valueOwnsItemCrumb(v, crumb, budget, depth + 1)) return true;
   }
   return false;
 }
@@ -370,6 +407,7 @@ export function isBreadcrumbInsideObject(
   schema: SchemaProperty,
   objValue: Record<string, unknown>,
   breadcrumbPath: string[],
+  decofile?: Record<string, unknown>,
 ): boolean {
   if (breadcrumbPath.length === 0 || !schema.properties) return false;
 
@@ -380,6 +418,7 @@ export function isBreadcrumbInsideObject(
       schema.properties,
       objValue,
       breadcrumbPath,
+      decofile,
     )
   ) {
     return true;
@@ -395,6 +434,7 @@ export function isBreadcrumbInsideObject(
       schema.properties,
       objValue,
       breadcrumbPath.slice(1),
+      decofile,
     ) !== null
   );
 }

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -501,7 +501,13 @@ export function SchemaForm({
 
   const activeKey =
     breadcrumbPath.length > 0
-      ? resolveActiveFieldKey(keys, properties, objValue, breadcrumbPath)
+      ? resolveActiveFieldKey(
+          keys,
+          properties,
+          objValue,
+          breadcrumbPath,
+          decofile,
+        )
       : null;
   const activeSchema = activeKey ? properties[activeKey] : null;
   const visibleKeys = activeKey && activeSchema ? [activeKey] : keys;

--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -201,6 +201,19 @@ export function SectionsEditor({
   > | null>(null);
   const [ruleResolveType, setRuleResolveType] = useState<string | null>(null);
   const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<string[]>([]);
+  // Reset the form panel's scroll to the top whenever the drill-down DEPTH
+  // changes (entering/leaving an item), so a drilled-in item form always starts
+  // at the top instead of inheriting the previous view's scroll offset. Keyed on
+  // depth, not the full trail, so editing a field that syncs its own crumb label
+  // (ArrayField.updateItem) doesn't yank the scroll mid-typing.
+  const fieldScrollRef = useRef<HTMLDivElement>(null);
+  const [prevFieldDepth, setPrevFieldDepth] = useState(fieldBreadcrumbs.length);
+  if (prevFieldDepth !== fieldBreadcrumbs.length) {
+    setPrevFieldDepth(fieldBreadcrumbs.length);
+    requestAnimationFrame(() => {
+      if (fieldScrollRef.current) fieldScrollRef.current.scrollTop = 0;
+    });
+  }
   const [formResetKey, setFormResetKey] = useState(0);
   const [makeReusableIndex, setMakeReusableIndex] = useState<number | null>(
     null,
@@ -2643,7 +2656,10 @@ export function SectionsEditor({
           </div>
         </ScrollArea>
       ) : isEditing ? (
-        <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
+        <ScrollArea
+          viewportRef={fieldScrollRef}
+          className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block"
+        >
           {isEditingMultivariateSection && sectionFlagVariants.length > 0 && (
             <>
               <SectionVariantList
@@ -2716,7 +2732,10 @@ export function SectionsEditor({
           />
         </ScrollArea>
       ) : isGlobalBlockMode ? (
-        <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
+        <ScrollArea
+          viewportRef={fieldScrollRef}
+          className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block"
+        >
           <SchemaFormPanel
             activeSchema={activeSchema}
             formValue={formValue}

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -9,9 +9,11 @@ function ScrollArea({
   className,
   children,
   hideScrollbar = false,
+  viewportRef,
   ...props
 }: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
   hideScrollbar?: boolean;
+  viewportRef?: React.Ref<HTMLDivElement>;
 }) {
   return (
     <ScrollAreaPrimitive.Root
@@ -20,6 +22,7 @@ function ScrollArea({
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
         data-slot="scroll-area-viewport"
         className="h-full w-full overflow-auto rounded-[inherit] outline-none transition-[color,box-shadow] focus-visible:ring-[2px] focus-visible:ring-ring/20"
       >


### PR DESCRIPTION
## Summary

Drilling into an array item that lives **inside a loader** now takes over the whole form panel (breadcrumb-driven), instead of rendering scoped inside the loader-config card. This is the result of iterating on the loader array-item editing UX.

Behavior: clicking an array item opens its config in the **full form** with a breadcrumb crumb — for arrays nested in a loader it no longer stays boxed inside the "loader configuration" card, and no longer keeps showing the previous level's sibling props.

## Changes

- **`fields/any-of-field.tsx`** — once the breadcrumb drills into a loader's content, render the loader's nested form at full width, dropping the loader type `<Select>` and the collapsible config-card chrome. Breadcrumb "back" restores the normal chrome.
- **`schema-form-breadcrumb.ts`** — `resolveActiveFieldKey` now narrows a section to the loader that *owns* a drilled item: it scans the loader's inline config and, for **global/saved** loaders (value is a `{ __resolveType }` reference), resolves the referenced block via the `decofile`. Without this, a multi-field section couldn't tell which field owned the item (the crumb is just the item label) and kept rendering every sibling prop. The scan is bounded (depth 4, short-circuits, only runs while drilled in).
- **`schema-form.tsx`** — thread `decofile` into `resolveActiveFieldKey`.
- **`sections-editor.tsx`** — reset the form panel scroll to the top when the drill-down **depth** changes (keyed on depth, not the full trail, so editing a label that syncs its own crumb doesn't yank the scroll mid-typing).
- **`packages/ui/scroll-area.tsx`** — expose an optional `viewportRef`.

## Known limitation

Loader item ownership is detected by the item's own display fields (`name`/`label`/`title`/`alt`/…) since the item schema isn't available at that point. A loader that labels items via a custom `titleBy` pointing to a non-standard field won't be detected — follow-up would thread the item schema into the scan.

## Testing

- `bun run fmt`, typecheck (`apps/web`), oxlint on changed files — clean.
- **526 `sections-editor` unit tests pass**, including 2 new `resolveActiveFieldKey` cases (loader inline config + global/decofile-resolved loader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drilling into an array item inside a loader now opens the item in the full form panel via breadcrumb, hiding the loader card. Breadcrumb logic narrows to the owning loader (including global loaders via `decofile`) and is hardened to avoid false matches.

- **New Features**
  - Full-width item editing for loader arrays; removes the loader type select and config card when drilled in.
  - Breadcrumb narrowing scans loader config and resolves global loaders via `decofile`.
  - Form panel scroll resets to top when drill-down depth changes.
  - `ScrollArea` supports an optional `viewportRef` for scroll control.

- **Bug Fixes**
  - Loader-owned item detection now matches only object naming fields (`name`, `label`, `title`, `alt`) and uses a bounded scan to avoid false matches (e.g., `href`/`id`, primitive arrays) and stalls.
  - Threaded `decofile` through `isBreadcrumbInsideObject` (and `object-field`) so global loaders nested inside objects auto-expand consistently.

<sup>Written for commit 3f033653893d4898dd5660c8515bc3056702e7d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

