### PR TITLE
feat(web): Content as pinned main view + loading state

### DIFF
--- a/apps/web/src/components/sandbox/content/content-browser.tsx
+++ b/apps/web/src/components/sandbox/content/content-browser.tsx
@@ -495,7 +495,11 @@ function ContentBrowserReady({
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget>(null);
   const [jsonPageKey, setJsonPageKey] = useState<string | null>(null);
 
-  if (decofileLoading || metaLoading) {
+  // While the dev server is still warming up (repo cloning / preview not yet
+  // ready) the decofile/meta queries are disabled, so they report neither
+  // loading nor data. Show a spinner instead of the "could not load" error —
+  // that error is only meaningful once the dev server is actually running.
+  if (!devServerReady || decofileLoading || metaLoading) {
     return (
       <div className="h-full w-full flex items-center justify-center">
         <Loading01 size={20} className="animate-spin text-muted-foreground" />

--- a/apps/web/src/components/sandbox/content/content-browser.tsx
+++ b/apps/web/src/components/sandbox/content/content-browser.tsx
@@ -282,6 +282,18 @@ export function ContentBrowser({ mode = "content" }: ContentBrowserProps) {
     return <EmptyMessage title="Waiting for sandbox context…" />;
   }
 
+  const phase = vmEvents.lifecycle.phase;
+  const devServerReady = phase === "running";
+  // Terminal daemon phases: no further progress is coming, so the content
+  // browser should surface its error rather than spin. Everything else before
+  // `running` (cloning, installing, starting) is still warming up.
+  const sandboxWarming =
+    !devServerReady &&
+    phase !== "clone-failed" &&
+    phase !== "install-failed" &&
+    phase !== "start-failed" &&
+    phase !== "crashed";
+
   return (
     <ContentBrowserReady
       orgSlug={org.slug}
@@ -289,7 +301,8 @@ export function ContentBrowser({ mode = "content" }: ContentBrowserProps) {
       branch={branch}
       previewUrl={previewUrl}
       mode={mode}
-      devServerReady={vmEvents.lifecycle.phase === "running"}
+      devServerReady={devServerReady}
+      sandboxWarming={sandboxWarming}
     />
   );
 }
@@ -319,6 +332,7 @@ function ContentBrowserReady({
   previewUrl,
   mode,
   devServerReady,
+  sandboxWarming,
 }: {
   orgSlug: string;
   virtualMcpId: string;
@@ -326,6 +340,7 @@ function ContentBrowserReady({
   previewUrl: string | null;
   mode: "content" | "blocks";
   devServerReady: boolean;
+  sandboxWarming: boolean;
 }) {
   const workspace = useBlocksPreviewWorkspace();
   const fetchParams = { orgSlug, virtualMcpId, branch, previewUrl };
@@ -495,11 +510,14 @@ function ContentBrowserReady({
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget>(null);
   const [jsonPageKey, setJsonPageKey] = useState<string | null>(null);
 
-  // While the dev server is still warming up (repo cloning / preview not yet
-  // ready) the decofile/meta queries are disabled, so they report neither
-  // loading nor data. Show a spinner instead of the "could not load" error —
-  // that error is only meaningful once the dev server is actually running.
-  if (!devServerReady || decofileLoading || metaLoading) {
+  // Prefer any data we already have: the committed `.deco/*.gen.json` snapshot
+  // keeps the CMS editable even while the dev server is down (see useDecofile),
+  // so only spin while the data is genuinely absent AND the sandbox is still
+  // warming up (repo cloning / installing / starting). Once it reaches a
+  // terminal phase — or the dev server is up but the fetch failed — fall
+  // through to the error below instead of spinning forever.
+  const dataMissing = !decofile || !meta;
+  if (decofileLoading || metaLoading || (dataMissing && sandboxWarming)) {
     return (
       <div className="h-full w-full flex items-center justify-center">
         <Loading01 size={20} className="animate-spin text-muted-foreground" />
@@ -507,7 +525,7 @@ function ContentBrowserReady({
     );
   }
 
-  if (!decofile || !meta) {
+  if (dataMissing) {
     return <EmptyMessage title="Could not load site data." />;
   }
 

--- a/apps/web/src/i18n/en/virtual-mcp.ts
+++ b/apps/web/src/i18n/en/virtual-mcp.ts
@@ -107,6 +107,7 @@ export const virtualMcp = {
   "virtualMcp.layoutTabContent.chat": "Chat",
   "virtualMcp.layoutTabContent.chatAlwaysShown":
     "Chat is always shown when it is the default view",
+  "virtualMcp.layoutTabContent.content": "Content",
   "virtualMcp.layoutTabContent.layout": "Layout",
   "virtualMcp.layoutTabContent.mainView": "Main view",
   "virtualMcp.layoutTabContent.mainViewDescription":

--- a/apps/web/src/i18n/pt-br/virtual-mcp.ts
+++ b/apps/web/src/i18n/pt-br/virtual-mcp.ts
@@ -110,6 +110,7 @@ export const virtualMcp = {
   "virtualMcp.layoutTabContent.chat": "Chat",
   "virtualMcp.layoutTabContent.chatAlwaysShown":
     "O Chat sempre aparece quando é a visualização padrão",
+  "virtualMcp.layoutTabContent.content": "Conteúdo",
   "virtualMcp.layoutTabContent.layout": "Layout",
   "virtualMcp.layoutTabContent.mainView": "Visualização principal",
   "virtualMcp.layoutTabContent.mainViewDescription":

--- a/apps/web/src/layouts/main-panel-tabs/tab-id.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/tab-id.test.ts
@@ -223,6 +223,12 @@ describe("resolveDefaultTabId", () => {
     );
   });
 
+  test("content → 'content'", () => {
+    expect(resolveDefaultTabId({ defaultMainView: { type: "content" } })).toBe(
+      "content",
+    );
+  });
+
   test("unknown type falls back to 'settings'", () => {
     expect(
       resolveDefaultTabId({ defaultMainView: { type: "automation" } }),

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -354,7 +354,11 @@ export function useMainPanelTabs(ctx: {
   );
 
   const systemTabs: Array<{ id: string; title: string }> = [];
-  if (hasClonableSource && showContentTab) {
+  // A tab configured as the default main view stays pinned in the bar even
+  // before its runtime data is ready (e.g. Content while the repo is still
+  // cloning) — otherwise the bar would drop the tab the user chose to land on.
+  const contentIsDefaultMain = effectiveDefaultMainView?.type === "content";
+  if (hasClonableSource && (showContentTab || contentIsDefaultMain)) {
     systemTabs.push({
       id: "content",
       title: t("common.mainPanelTabs.content"),

--- a/apps/web/src/views/virtual-mcp/layout-tab-content.tsx
+++ b/apps/web/src/views/virtual-mcp/layout-tab-content.tsx
@@ -315,6 +315,10 @@ export function LayoutTabContent({
       value: "preview",
       label: t("virtualMcp.layoutTabContent.preview"),
     });
+    defaultMainOptions.push({
+      value: "content",
+      label: t("virtualMcp.layoutTabContent.content"),
+    });
   }
   for (const pv of pinnedViews) {
     defaultMainOptions.push({


### PR DESCRIPTION
## Summary

Fixes three related gaps around setting **Content** ("Conteúdo") as an agent's default main view:

1. **Content is now selectable as the main view.** The "Visualização principal" (Main view) selector in the agent Layout settings hard-coded its options (Chat, Settings, Automations, Preview + pinned ext-app views) and never offered Content — even though the data model (`FIXED_SYSTEM_TABS`) and the parse/format round-trip already supported it. Added a `content` option gated on `hasClonableSource`, matching how Preview is gated (`layout-tab-content.tsx`).

2. **Loading state instead of an error while the repo clones.** When the dev server isn't ready yet (repo still cloning), the `decofile`/`meta` queries are disabled, so `ContentBrowser` reported neither loading nor data and fell through to **"Could not load site data."**. It now shows a spinner while `!devServerReady`; the error is only meaningful once the dev server is actually running (`content-browser.tsx`).

3. **The Content tab stays in the top bar when it's the default main view.** The tab was only added to the bar when `hasClonableSource && showContentTab`, and `showContentTab` depends on the decofile/meta being loaded — so during cloning the tab disappeared even though it was the configured landing view. It now persists in the bar when it's the `defaultMainView` (`use-main-panel-tabs.ts`).

## Testing

- `bun run check` (typecheck) passes
- `bun run fmt` clean

New i18n keys added (`virtualMcp.layoutTabContent.content`) in both `en` and `pt-br`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows “Content” to be set as the default main view and keeps its tab pinned. Improves the Content loading UX by showing a spinner only while the sandbox is warming and data is absent.

- **New Features**
  - Add “Content” to the Main view selector when a clonable source exists (with new i18n labels).
  - Keep the Content tab pinned when it’s the default, even before data is ready.

- **Bug Fixes**
  - Prefer existing snapshot data over a spinner; only spin when data is missing and the sandbox is still warming. Show the error only after terminal failure phases.
  - Add a unit test for resolving the default tab to “content”.

<sup>Written for commit d5d04dcd5a6739521393ea0655bec5a881e25f66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

