### PR TITLE
feat(org): flags jsonb bag + demo_mode as first flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,18 @@ don't — extend the options or ask. The circuit breaker
 (`mcp-clients/circuit-breaker.ts`) is a different pattern (fault isolation) and
 is intentionally separate.
 
+### Org-level flags
+
+Org boolean toggles live in the `organization_settings.flags` jsonb bag — never
+a new column. Adding one = one line in **`OrgFlagsSchema`**
+(`packages/shared/src/organization/schema.ts`, the single source of truth) +
+its consumer, then `bun run --cwd=apps/api generate:tool-contracts`. Read via
+`useOrgFlag("<flag>")` (web) or `settings?.flags?.<flag>` (api); set via
+`ORGANIZATION_SETTINGS_UPDATE { flags: { <flag>: true } }`. Updates
+shallow-merge (explicit `false` persists, omitted keys survive); unset reads as
+off. Flags are product gating, not access control. Anything non-boolean or ever
+needing an index/constraint gets its own column instead.
+
 ### Style & Formatting
 - **Biome** enforces two-space indentation and double quotes
 - **ALWAYS** run `bun run fmt` after making code changes (pre-commit hook via lefthook)

--- a/apps/api/migrations/148-org-flags.ts
+++ b/apps/api/migrations/148-org-flags.ts
@@ -1,16 +1,18 @@
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 
 /**
  * One jsonb bag for org-level boolean toggles, replacing the
- * column-per-flag pattern (`reports_only` predates this and stays put).
- *
- * The set of valid flags is defined in ONE place —
+ * column-per-flag pattern. The set of valid flags is defined in ONE place —
  * `@decocms/shared/organization/schema.ts` (`OrgFlagsSchema`) — so adding a
  * flag is a one-line schema change plus its consumer, with no new migration.
  *
+ * Also migrates `reports_only` (migration 128) into the bag: non-NULL values
+ * are backfilled as `flags.reports_only` (NULL means "never set" and stays
+ * absent — every flag reads as off), then the column is dropped.
+ *
  * Updates shallow-merge (`flags || $new`) in the storage adapter, so a
  * partial write never wipes neighboring flags. Nullable on purpose: NULL
- * means "no flag ever set" (every flag reads as off).
+ * means "no flag ever set".
  *
  * Flags are UI-cosmetic/product toggles, not access control: nothing here
  * needs a DB index, constraint, or cross-org query — anything that does gets
@@ -21,9 +23,27 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .alterTable("organization_settings")
     .addColumn("flags", "jsonb")
     .execute();
+  await sql`
+    UPDATE organization_settings
+    SET flags = jsonb_build_object('reports_only', reports_only)
+    WHERE reports_only IS NOT NULL
+  `.execute(db);
+  await db.schema
+    .alterTable("organization_settings")
+    .dropColumn("reports_only")
+    .execute();
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("organization_settings")
+    .addColumn("reports_only", "boolean")
+    .execute();
+  await sql`
+    UPDATE organization_settings
+    SET reports_only = (flags ->> 'reports_only')::boolean
+    WHERE flags ? 'reports_only'
+  `.execute(db);
   await db.schema
     .alterTable("organization_settings")
     .dropColumn("flags")

--- a/apps/api/migrations/148-org-flags.ts
+++ b/apps/api/migrations/148-org-flags.ts
@@ -1,0 +1,31 @@
+import type { Kysely } from "kysely";
+
+/**
+ * One jsonb bag for org-level boolean toggles, replacing the
+ * column-per-flag pattern (`reports_only` predates this and stays put).
+ *
+ * The set of valid flags is defined in ONE place —
+ * `@decocms/shared/organization/schema.ts` (`OrgFlagsSchema`) — so adding a
+ * flag is a one-line schema change plus its consumer, with no new migration.
+ *
+ * Updates shallow-merge (`flags || $new`) in the storage adapter, so a
+ * partial write never wipes neighboring flags. Nullable on purpose: NULL
+ * means "no flag ever set" (every flag reads as off).
+ *
+ * Flags are UI-cosmetic/product toggles, not access control: nothing here
+ * needs a DB index, constraint, or cross-org query — anything that does gets
+ * its own column instead.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("organization_settings")
+    .addColumn("flags", "jsonb")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("organization_settings")
+    .dropColumn("flags")
+    .execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -146,6 +146,7 @@ import * as migration144benefitspendingindex from "./144-benefits-pending-index.
 import * as migration145usermodelpreferences from "./145-user-model-preferences.ts";
 import * as migration146organizationmainagent from "./146-organization-main-agent.ts";
 import * as migration147dropagentsandboxtables from "./147-drop-agent-sandbox-tables.ts";
+import * as migration148orgflags from "./148-org-flags.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -317,6 +318,7 @@ const migrations: Record<string, Migration> = {
   "145-user-model-preferences": migration145usermodelpreferences,
   "146-organization-main-agent": migration146organizationmainagent,
   "147-drop-agent-sandbox-tables": migration147dropagentsandboxtables,
+  "148-org-flags": migration148orgflags,
 };
 
 export default migrations;

--- a/apps/api/src/storage/organization-settings.integration.test.ts
+++ b/apps/api/src/storage/organization-settings.integration.test.ts
@@ -1,0 +1,78 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "bun:test";
+import type { OrgFlags } from "@decocms/shared/organization/schema";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../database/test-db-pg";
+import type { StudioDatabase } from "../database";
+import { OrganizationSettingsStorage } from "./organization-settings";
+
+describe("OrganizationSettingsStorage — flags bag", () => {
+  let database: StudioDatabase;
+  let storage: OrganizationSettingsStorage;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
+    storage = new OrganizationSettingsStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  beforeEach(async () => {
+    await database.db.deleteFrom("organization_settings").execute();
+  });
+
+  it("round-trips a flag through insert", async () => {
+    await storage.upsert("org_1", { flags: { demo_mode: true } });
+    const got = await storage.get("org_1");
+    expect(got?.flags).toEqual({ demo_mode: true });
+  });
+
+  it("shallow-merges on update: keys in the write win, other keys survive", async () => {
+    // A key beyond today's schema stands in for a future flag — the jsonb
+    // merge is shape-agnostic and must not wipe keys it doesn't know about.
+    await storage.upsert("org_1", {
+      flags: { future_flag: true } as OrgFlags,
+    });
+    await storage.upsert("org_1", { flags: { demo_mode: true } });
+
+    const got = await storage.get("org_1");
+    expect(got?.flags).toEqual({
+      future_flag: true,
+      demo_mode: true,
+    } as OrgFlags);
+  });
+
+  it("explicit false persists (merge, not truthy-spread)", async () => {
+    await storage.upsert("org_1", { flags: { demo_mode: true } });
+    await storage.upsert("org_1", { flags: { demo_mode: false } });
+    const got = await storage.get("org_1");
+    expect(got?.flags).toEqual({ demo_mode: false });
+  });
+
+  it("updating an unrelated field leaves flags untouched", async () => {
+    await storage.upsert("org_1", { flags: { demo_mode: true } });
+    await storage.upsert("org_1", { main_agent_id: "vmcp-1" });
+    const got = await storage.get("org_1");
+    expect(got?.flags).toEqual({ demo_mode: true });
+    expect(got?.main_agent_id).toBe("vmcp-1");
+  });
+
+  it("reads null when no flag was ever set", async () => {
+    await storage.upsert("org_1", { main_agent_id: "vmcp-1" });
+    expect((await storage.get("org_1"))?.flags).toBeNull();
+  });
+});

--- a/apps/api/src/storage/organization-settings.integration.test.ts
+++ b/apps/api/src/storage/organization-settings.integration.test.ts
@@ -6,7 +6,6 @@ import {
   afterAll,
   beforeEach,
 } from "bun:test";
-import type { OrgFlags } from "@decocms/shared/organization/schema";
 import {
   closeTestPgDatabase,
   connectTestPgDatabase,
@@ -42,18 +41,11 @@ describe("OrganizationSettingsStorage — flags bag", () => {
   });
 
   it("shallow-merges on update: keys in the write win, other keys survive", async () => {
-    // A key beyond today's schema stands in for a future flag — the jsonb
-    // merge is shape-agnostic and must not wipe keys it doesn't know about.
-    await storage.upsert("org_1", {
-      flags: { future_flag: true } as OrgFlags,
-    });
+    await storage.upsert("org_1", { flags: { reports_only: true } });
     await storage.upsert("org_1", { flags: { demo_mode: true } });
 
     const got = await storage.get("org_1");
-    expect(got?.flags).toEqual({
-      future_flag: true,
-      demo_mode: true,
-    } as OrgFlags);
+    expect(got?.flags).toEqual({ reports_only: true, demo_mode: true });
   });
 
   it("explicit false persists (merge, not truthy-spread)", async () => {

--- a/apps/api/src/storage/organization-settings.ts
+++ b/apps/api/src/storage/organization-settings.ts
@@ -45,7 +45,6 @@ export class OrganizationSettingsStorage
           ? JSON.parse(record.default_home_agents)
           : record.default_home_agents
         : null,
-      reports_only: record.reports_only ?? null,
       flags: record.flags
         ? typeof record.flags === "string"
           ? JSON.parse(record.flags)
@@ -67,7 +66,6 @@ export class OrganizationSettingsStorage
         | "registry_config"
         | "simple_mode"
         | "default_home_agents"
-        | "reports_only"
         | "flags"
         | "main_agent_id"
       >
@@ -99,7 +97,6 @@ export class OrganizationSettingsStorage
         registry_config: registryConfigJson,
         simple_mode: simpleModeJson,
         default_home_agents: defaultHomeAgentsJson,
-        reports_only: data?.reports_only ?? null,
         flags: flagsJson,
         main_agent_id: data?.main_agent_id ?? null,
         createdAt: now,
@@ -114,9 +111,6 @@ export class OrganizationSettingsStorage
           default_home_agents: defaultHomeAgentsJson
             ? defaultHomeAgentsJson
             : undefined,
-          // Boolean flag: explicit `false` must persist; `undefined` (field
-          // absent) skips the column in doUpdateSet.
-          reports_only: data?.reports_only,
           // Flags shallow-merge atomically: keys in the update win, omitted
           // keys keep their stored value (explicit `false` persists — merge,
           // not spread-and-replace). Absent field skips the column.
@@ -141,7 +135,6 @@ export class OrganizationSettingsStorage
         registry_config: data?.registry_config ?? null,
         simple_mode: data?.simple_mode ?? null,
         default_home_agents: data?.default_home_agents ?? null,
-        reports_only: data?.reports_only ?? null,
         flags: data?.flags ?? null,
         main_agent_id: data?.main_agent_id ?? null,
         createdAt: now,

--- a/apps/api/src/storage/organization-settings.ts
+++ b/apps/api/src/storage/organization-settings.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import type { Database, OrganizationSettings } from "./types";
 import type { OrganizationSettingsStoragePort } from "./ports";
 
@@ -46,6 +46,11 @@ export class OrganizationSettingsStorage
           : record.default_home_agents
         : null,
       reports_only: record.reports_only ?? null,
+      flags: record.flags
+        ? typeof record.flags === "string"
+          ? JSON.parse(record.flags)
+          : record.flags
+        : null,
       main_agent_id: record.main_agent_id ?? null,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
@@ -63,6 +68,7 @@ export class OrganizationSettingsStorage
         | "simple_mode"
         | "default_home_agents"
         | "reports_only"
+        | "flags"
         | "main_agent_id"
       >
     >,
@@ -83,6 +89,7 @@ export class OrganizationSettingsStorage
     const defaultHomeAgentsJson = data?.default_home_agents
       ? JSON.stringify(data.default_home_agents)
       : null;
+    const flagsJson = data?.flags ? JSON.stringify(data.flags) : null;
     await this.db
       .insertInto("organization_settings")
       .values({
@@ -93,6 +100,7 @@ export class OrganizationSettingsStorage
         simple_mode: simpleModeJson,
         default_home_agents: defaultHomeAgentsJson,
         reports_only: data?.reports_only ?? null,
+        flags: flagsJson,
         main_agent_id: data?.main_agent_id ?? null,
         createdAt: now,
         updatedAt: now,
@@ -109,6 +117,12 @@ export class OrganizationSettingsStorage
           // Boolean flag: explicit `false` must persist; `undefined` (field
           // absent) skips the column in doUpdateSet.
           reports_only: data?.reports_only,
+          // Flags shallow-merge atomically: keys in the update win, omitted
+          // keys keep their stored value (explicit `false` persists — merge,
+          // not spread-and-replace). Absent field skips the column.
+          flags: flagsJson
+            ? sql<string>`coalesce("organization_settings"."flags", '{}'::jsonb) || ${flagsJson}::jsonb`
+            : undefined,
           // Nullable id: explicit `null` clears the main agent; `undefined`
           // (field absent) skips the column so partial updates don't wipe it.
           main_agent_id: data?.main_agent_id,
@@ -128,6 +142,7 @@ export class OrganizationSettingsStorage
         simple_mode: data?.simple_mode ?? null,
         default_home_agents: data?.default_home_agents ?? null,
         reports_only: data?.reports_only ?? null,
+        flags: data?.flags ?? null,
         main_agent_id: data?.main_agent_id ?? null,
         createdAt: now,
         updatedAt: now,

--- a/apps/api/src/storage/ports.ts
+++ b/apps/api/src/storage/ports.ts
@@ -308,7 +308,6 @@ export interface OrganizationSettingsStoragePort {
         | "registry_config"
         | "simple_mode"
         | "default_home_agents"
-        | "reports_only"
         | "flags"
         | "main_agent_id"
       >

--- a/apps/api/src/storage/ports.ts
+++ b/apps/api/src/storage/ports.ts
@@ -309,6 +309,7 @@ export interface OrganizationSettingsStoragePort {
         | "simple_mode"
         | "default_home_agents"
         | "reports_only"
+        | "flags"
         | "main_agent_id"
       >
     >,

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -180,7 +180,6 @@ export interface OrganizationSettingsTable {
   registry_config: JsonObject<RegistryConfig> | null;
   simple_mode: JsonObject<SimpleModeConfig> | null;
   default_home_agents: JsonObject<DefaultHomeAgentsConfig> | null;
-  reports_only: boolean | null;
   // Boolean toggles bag — the flag set lives in OrgFlagsSchema
   // (@decocms/shared/organization/schema); updates shallow-merge.
   flags: JsonObject<OrgFlags> | null;
@@ -197,7 +196,6 @@ export interface OrganizationSettings {
   registry_config: RegistryConfig | null;
   simple_mode: SimpleModeConfig | null;
   default_home_agents: DefaultHomeAgentsConfig | null;
-  reports_only: boolean | null;
   flags: OrgFlags | null;
   main_agent_id: string | null;
   createdAt: Date | string;

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -15,7 +15,10 @@ import type { ColumnType } from "kysely";
 import type { OAuthConfig } from "../tools/connection/schema";
 import type { ChatMessage } from "../api/routes/decopilot/types";
 import type { ProviderId, ThreadStatus } from "@decocms/shared/sdk";
-import type { UserModelPreferences } from "@decocms/shared/organization/schema";
+import type {
+  OrgFlags,
+  UserModelPreferences,
+} from "@decocms/shared/organization/schema";
 import type { ThreadMetadata } from "@decocms/shared/entities";
 import type { PrivateRegistryDatabase } from "./registry/types";
 
@@ -178,6 +181,9 @@ export interface OrganizationSettingsTable {
   simple_mode: JsonObject<SimpleModeConfig> | null;
   default_home_agents: JsonObject<DefaultHomeAgentsConfig> | null;
   reports_only: boolean | null;
+  // Boolean toggles bag — the flag set lives in OrgFlagsSchema
+  // (@decocms/shared/organization/schema); updates shallow-merge.
+  flags: JsonObject<OrgFlags> | null;
   // Virtual MCP id the org lands on (`/$org`) instead of the Super Agent.
   main_agent_id: string | null;
   createdAt: ColumnType<Date, Date | string, never>;
@@ -192,6 +198,7 @@ export interface OrganizationSettings {
   simple_mode: SimpleModeConfig | null;
   default_home_agents: DefaultHomeAgentsConfig | null;
   reports_only: boolean | null;
+  flags: OrgFlags | null;
   main_agent_id: string | null;
   createdAt: Date | string;
   updatedAt: Date | string;

--- a/apps/api/src/tools/organization/settings-get.ts
+++ b/apps/api/src/tools/organization/settings-get.ts
@@ -6,6 +6,7 @@ import {
   RegistryConfigSchema,
   SimpleModeConfigSchema,
   DefaultHomeAgentsConfigSchema,
+  OrgFlagsSchema,
 } from "@decocms/shared/organization/schema";
 
 export const ORGANIZATION_SETTINGS_GET = defineTool({
@@ -29,6 +30,7 @@ export const ORGANIZATION_SETTINGS_GET = defineTool({
     simple_mode: SimpleModeConfigSchema.nullable().optional(),
     default_home_agents: DefaultHomeAgentsConfigSchema.nullable().optional(),
     reports_only: z.boolean().nullable().optional(),
+    flags: OrgFlagsSchema.nullable().optional(),
     main_agent_id: z.string().nullable().optional(),
     createdAt: z.string().datetime().optional().describe("ISO 8601 timestamp"),
     updatedAt: z.string().datetime().optional().describe("ISO 8601 timestamp"),

--- a/apps/api/src/tools/organization/settings-get.ts
+++ b/apps/api/src/tools/organization/settings-get.ts
@@ -29,7 +29,6 @@ export const ORGANIZATION_SETTINGS_GET = defineTool({
     registry_config: RegistryConfigSchema.nullable().optional(),
     simple_mode: SimpleModeConfigSchema.nullable().optional(),
     default_home_agents: DefaultHomeAgentsConfigSchema.nullable().optional(),
-    reports_only: z.boolean().nullable().optional(),
     flags: OrgFlagsSchema.nullable().optional(),
     main_agent_id: z.string().nullable().optional(),
     createdAt: z.string().datetime().optional().describe("ISO 8601 timestamp"),

--- a/apps/api/src/tools/organization/settings-update.test.ts
+++ b/apps/api/src/tools/organization/settings-update.test.ts
@@ -89,4 +89,35 @@ describe("ORGANIZATION_SETTINGS_UPDATE", () => {
       main_agent_id: null,
     });
   });
+
+  it("forwards flags to storage — true and explicit false both persist", async () => {
+    const upsert = (ctx: ReturnType<typeof makeCtx>): ReturnType<typeof mock> =>
+      (
+        ctx as unknown as {
+          storage: {
+            organizationSettings: { upsert: ReturnType<typeof mock> };
+          };
+        }
+      ).storage.organizationSettings.upsert;
+
+    const onCtx = makeCtx({ id: "org-a" });
+    await ORGANIZATION_SETTINGS_UPDATE.handler(
+      { organizationId: "org-a", flags: { demo_mode: true } },
+      onCtx,
+    );
+    expect(upsert(onCtx).mock.calls[0]?.[1]).toMatchObject({
+      flags: { demo_mode: true },
+    });
+
+    // Explicit false must be forwarded (not dropped) so the storage merge can
+    // switch a demo org back to the normal connect gate.
+    const offCtx = makeCtx({ id: "org-a" });
+    await ORGANIZATION_SETTINGS_UPDATE.handler(
+      { organizationId: "org-a", flags: { demo_mode: false } },
+      offCtx,
+    );
+    expect(upsert(offCtx).mock.calls[0]?.[1]).toMatchObject({
+      flags: { demo_mode: false },
+    });
+  });
 });

--- a/apps/api/src/tools/organization/settings-update.ts
+++ b/apps/api/src/tools/organization/settings-update.ts
@@ -6,6 +6,7 @@ import {
   RegistryConfigSchema,
   SimpleModeConfigSchema,
   DefaultHomeAgentsConfigSchema,
+  OrgFlagsSchema,
 } from "@decocms/shared/organization/schema";
 
 export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
@@ -27,6 +28,9 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
     simple_mode: SimpleModeConfigSchema.optional(),
     default_home_agents: DefaultHomeAgentsConfigSchema.optional(),
     reports_only: z.boolean().optional(),
+    flags: OrgFlagsSchema.optional().describe(
+      "Org boolean toggles. Shallow-merged into the stored flags: keys you pass win (explicit false persists), omitted keys keep their value.",
+    ),
     main_agent_id: z
       .string()
       .nullable()
@@ -44,6 +48,7 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
     simple_mode: SimpleModeConfigSchema.nullable().optional(),
     default_home_agents: DefaultHomeAgentsConfigSchema.nullable().optional(),
     reports_only: z.boolean().nullable().optional(),
+    flags: OrgFlagsSchema.nullable().optional(),
     main_agent_id: z.string().nullable().optional(),
     createdAt: z.string().datetime().describe("ISO 8601 timestamp"),
     updatedAt: z.string().datetime().describe("ISO 8601 timestamp"),
@@ -71,6 +76,7 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
         simple_mode: input.simple_mode,
         default_home_agents: input.default_home_agents,
         reports_only: input.reports_only,
+        flags: input.flags,
         main_agent_id: input.main_agent_id,
       },
     );

--- a/apps/api/src/tools/organization/settings-update.ts
+++ b/apps/api/src/tools/organization/settings-update.ts
@@ -27,7 +27,6 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
     registry_config: RegistryConfigSchema.optional(),
     simple_mode: SimpleModeConfigSchema.optional(),
     default_home_agents: DefaultHomeAgentsConfigSchema.optional(),
-    reports_only: z.boolean().optional(),
     flags: OrgFlagsSchema.optional().describe(
       "Org boolean toggles. Shallow-merged into the stored flags: keys you pass win (explicit false persists), omitted keys keep their value.",
     ),
@@ -47,7 +46,6 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
     registry_config: RegistryConfigSchema.nullable().optional(),
     simple_mode: SimpleModeConfigSchema.nullable().optional(),
     default_home_agents: DefaultHomeAgentsConfigSchema.nullable().optional(),
-    reports_only: z.boolean().nullable().optional(),
     flags: OrgFlagsSchema.nullable().optional(),
     main_agent_id: z.string().nullable().optional(),
     createdAt: z.string().datetime().describe("ISO 8601 timestamp"),
@@ -75,7 +73,6 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
         registry_config: input.registry_config,
         simple_mode: input.simple_mode,
         default_home_agents: input.default_home_agents,
-        reports_only: input.reports_only,
         flags: input.flags,
         main_agent_id: input.main_agent_id,
       },

--- a/apps/api/src/tools/reports/setup.test.ts
+++ b/apps/api/src/tools/reports/setup.test.ts
@@ -37,7 +37,7 @@ function makeCtx(opts: {
   existingConnection?: StubConnection;
   existingVirtualMcp?: StubVirtualMcp;
   connectionUpdate?: (id: string, data: Record<string, unknown>) => void;
-  /** Stored reports_only value; undefined = settings row never created. */
+  /** Stored flags.reports_only value; undefined = settings row never created. */
   reportsOnly?: boolean | null;
   settingsUpsert?: (orgId: string, data: Record<string, unknown>) => void;
   /** Org row createdAt; defaults to "just now" (fresh onboarding-made org). */
@@ -95,7 +95,10 @@ function makeCtx(opts: {
         get: async () =>
           opts.reportsOnly === undefined
             ? null
-            : { organizationId: ORG_ID, reports_only: opts.reportsOnly },
+            : {
+                organizationId: ORG_ID,
+                flags: { reports_only: opts.reportsOnly },
+              },
         upsert: async (orgId: string, data: Record<string, unknown>) => {
           opts.settingsUpsert?.(orgId, data);
           return { organizationId: orgId, ...data };
@@ -170,7 +173,9 @@ describe("COMMERCE_DISCOVERY_SETUP", () => {
       ctx,
     );
 
-    expect(upserts).toEqual([{ orgId: ORG_ID, data: { reports_only: true } }]);
+    expect(upserts).toEqual([
+      { orgId: ORG_ID, data: { flags: { reports_only: true } } },
+    ]);
   });
 
   test("setup retry on a fresh org still defaults the flag", async () => {
@@ -187,7 +192,9 @@ describe("COMMERCE_DISCOVERY_SETUP", () => {
       ctx,
     );
 
-    expect(upserts).toEqual([{ orgId: ORG_ID, data: { reports_only: true } }]);
+    expect(upserts).toEqual([
+      { orgId: ORG_ID, data: { flags: { reports_only: true } } },
+    ]);
   });
 
   test("does not clobber an explicit reports_only=false on a fresh org", async () => {

--- a/apps/api/src/tools/reports/setup.ts
+++ b/apps/api/src/tools/reports/setup.ts
@@ -279,9 +279,9 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
       const settings = await ctx.storage.organizationSettings.get(
         organization.id,
       );
-      if (settings?.reports_only == null) {
+      if (settings?.flags?.reports_only == null) {
         await ctx.storage.organizationSettings.upsert(organization.id, {
-          reports_only: true,
+          flags: { reports_only: true },
         });
       }
     }

--- a/apps/web/src/hooks/use-organization-settings.ts
+++ b/apps/web/src/hooks/use-organization-settings.ts
@@ -44,7 +44,6 @@ export interface OrganizationSettings {
   registry_config: RegistryConfig | null;
   simple_mode: SimpleModeConfig | null;
   default_home_agents: DefaultHomeAgentsConfig | null;
-  reports_only: boolean | null;
   flags: OrgFlags | null;
   main_agent_id: string | null;
   createdAt?: string;
@@ -58,7 +57,6 @@ const EMPTY_SETTINGS: OrganizationSettings = {
   registry_config: null,
   simple_mode: null,
   default_home_agents: null,
-  reports_only: null,
   flags: null,
   main_agent_id: null,
 };
@@ -143,7 +141,6 @@ type OrgSettingsUpdateInput = Partial<
     | "registry_config"
     | "simple_mode"
     | "default_home_agents"
-    | "reports_only"
     | "flags"
     | "main_agent_id"
   >
@@ -240,8 +237,7 @@ export function useUpdateSimpleMode() {
  * gating where a brief pre-resolution render is harmless.
  */
 export function useReportsOnly(): boolean {
-  const { data } = useOrganizationSettings((s) => s.reports_only ?? false);
-  return data ?? false;
+  return useOrgFlag("reports_only");
 }
 
 /**

--- a/apps/web/src/hooks/use-organization-settings.ts
+++ b/apps/web/src/hooks/use-organization-settings.ts
@@ -13,7 +13,10 @@ import { callStudioTool, useStudioTools } from "@/lib/studio-tools";
 import type { StudioToolInput as ToolInput } from "@decocms/shared/tools/tool-io";
 
 export type { SimpleModeTier } from "@decocms/shared/organization/schema";
-import type { SimpleModeTier } from "@decocms/shared/organization/schema";
+import type {
+  OrgFlags,
+  SimpleModeTier,
+} from "@decocms/shared/organization/schema";
 
 export interface ModelSlot {
   keyId: string;
@@ -42,6 +45,7 @@ export interface OrganizationSettings {
   simple_mode: SimpleModeConfig | null;
   default_home_agents: DefaultHomeAgentsConfig | null;
   reports_only: boolean | null;
+  flags: OrgFlags | null;
   main_agent_id: string | null;
   createdAt?: string;
   updatedAt?: string;
@@ -55,6 +59,7 @@ const EMPTY_SETTINGS: OrganizationSettings = {
   simple_mode: null,
   default_home_agents: null,
   reports_only: null,
+  flags: null,
   main_agent_id: null,
 };
 
@@ -139,6 +144,7 @@ type OrgSettingsUpdateInput = Partial<
     | "simple_mode"
     | "default_home_agents"
     | "reports_only"
+    | "flags"
     | "main_agent_id"
   >
 >;
@@ -235,6 +241,16 @@ export function useUpdateSimpleMode() {
  */
 export function useReportsOnly(): boolean {
   const { data } = useOrganizationSettings((s) => s.reports_only ?? false);
+  return data ?? false;
+}
+
+/**
+ * Read one org flag from the `flags` bag (see OrgFlagsSchema in
+ * @decocms/shared/organization/schema — the single place flags are defined).
+ * Unset and NULL both read as `false`. Non-blocking, cosmetic-gating only.
+ */
+export function useOrgFlag(flag: keyof OrgFlags): boolean {
+  const { data } = useOrganizationSettings((s) => s.flags?.[flag] ?? false);
   return data ?? false;
 }
 

--- a/apps/web/src/routes/commerce-onboarding/commerce-connect-modal.tsx
+++ b/apps/web/src/routes/commerce-onboarding/commerce-connect-modal.tsx
@@ -28,6 +28,7 @@ import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { ArrowRight } from "@untitledui/icons";
 import { Suspense, useState } from "react";
+import { useOrgFlag } from "@/hooks/use-organization-settings";
 import {
   CompanionMcpsSection,
   CompanionMcpsSectionSkeleton,
@@ -239,7 +240,10 @@ function CommerceConnectModalContent({
     onComplete();
   };
 
-  const ready = hasConnectedSource;
+  // Demo orgs proceed regardless of readiness: the demo's diagnostic and
+  // tasks are pre-baked, so a required-source gate would only break the flow.
+  const demoMode = useOrgFlag("demo_mode");
+  const ready = hasConnectedSource || demoMode;
 
   return (
     <ConnectLayout

--- a/packages/e2e/tests/organization-main-agent.spec.ts
+++ b/packages/e2e/tests/organization-main-agent.spec.ts
@@ -21,7 +21,7 @@ import {
 interface OrgSettings {
   organizationId: string;
   main_agent_id?: string | null;
-  reports_only?: boolean | null;
+  flags?: { reports_only?: boolean } | null;
 }
 
 async function lookupOrgId(orgSlug: string): Promise<string> {
@@ -64,7 +64,7 @@ test.describe("Organization main agent setting", () => {
       request,
       orgSlug,
       "ORGANIZATION_SETTINGS_UPDATE",
-      { organizationId: orgId, reports_only: true },
+      { organizationId: orgId, flags: { reports_only: true } },
     );
     const afterPartial = await callSelfMcpTool<OrgSettings>(
       request,
@@ -73,7 +73,7 @@ test.describe("Organization main agent setting", () => {
       {},
     );
     expect(afterPartial.main_agent_id).toBe("vmcp-main-e2e");
-    expect(afterPartial.reports_only).toBe(true);
+    expect(afterPartial.flags?.reports_only).toBe(true);
 
     // 3. Explicit null clears it (org landing falls back to the Super Agent).
     await callSelfMcpTool<OrgSettings>(
@@ -90,7 +90,7 @@ test.describe("Organization main agent setting", () => {
     );
     expect(afterClear.main_agent_id ?? null).toBeNull();
     // The unrelated field survived the clear.
-    expect(afterClear.reports_only).toBe(true);
+    expect(afterClear.flags?.reports_only).toBe(true);
   });
 
   test("deleting the main agent clears the dangling pointer", async ({

--- a/packages/sandbox/image/Dockerfile
+++ b/packages/sandbox/image/Dockerfile
@@ -16,8 +16,16 @@ RUN apt-get update \
        ripgrep unzip \
   && sed -i 's/^#\s*en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
   && locale-gen \
-  && curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+  # Download to a file, then run: `curl | bash` swallows a failed download
+  # (the pipeline's status is bash's), so a NodeSource 403 silently left the
+  # Debian nodejs (no npm) and the build died stages later with `npm: not
+  # found`. NodeSource 403s are intermittent — retry them like corepack below.
+  && curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors \
+       -o /tmp/nodesource-setup.sh https://deb.nodesource.com/setup_${NODE_MAJOR}.x \
+  && bash /tmp/nodesource-setup.sh \
+  && rm /tmp/nodesource-setup.sh \
   && apt-get install -y --no-install-recommends nodejs \
+  && npm --version \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSL https://deno.land/install.sh \
        | DENO_INSTALL=/opt/deno sh -s -- -y "${DENO_VERSION}" \

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -113,6 +113,29 @@ export type DefaultHomeAgentsConfig = z.infer<
 >;
 
 /**
+ * Org-level boolean toggles, stored in the `organization_settings.flags`
+ * jsonb bag. THE single source of truth: adding a flag is one line here —
+ * storage, the settings tools, and the web hook all derive from this schema.
+ *
+ * Updates are shallow-merged server-side (omitted keys keep their stored
+ * value; explicit `false` persists), so partial writes never wipe neighbors.
+ *
+ * Only boolean toggles belong here. Anything with its own semantics (ids,
+ * structured config, values that would ever need a DB index or constraint)
+ * gets its own column instead.
+ */
+export const OrgFlagsSchema = z.object({
+  demo_mode: z
+    .boolean()
+    .optional()
+    .describe(
+      "Curated demo org: the commerce connect modal proceeds without a configured required data source.",
+    ),
+});
+
+export type OrgFlags = z.infer<typeof OrgFlagsSchema>;
+
+/**
  * Brand context schema - org-scoped company profile
  */
 export const BrandContextSchema = z.object({

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -131,6 +131,12 @@ export const OrgFlagsSchema = z.object({
     .describe(
       "Curated demo org: the commerce connect modal proceeds without a configured required data source.",
     ),
+  reports_only: z
+    .boolean()
+    .optional()
+    .describe(
+      "Curated commerce (reports) look: hides agent navigation, the home Customize button, and the Settings/Automations tabs. Defaulted on for orgs created by commerce onboarding.",
+    ),
 });
 
 export type OrgFlags = z.infer<typeof OrgFlagsSchema>;

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -117,7 +117,13 @@ export interface StudioToolIO {
         | null
         | undefined;
       default_home_agents?: { ids: string[] } | null | undefined;
-      reports_only?: boolean | null | undefined;
+      flags?:
+        | {
+            demo_mode?: boolean | undefined;
+            reports_only?: boolean | undefined;
+          }
+        | null
+        | undefined;
       main_agent_id?: string | null | undefined;
       createdAt?: string | undefined;
       updatedAt?: string | undefined;
@@ -173,7 +179,12 @@ export interface StudioToolIO {
           }
         | undefined;
       default_home_agents?: { ids: string[] } | undefined;
-      reports_only?: boolean | undefined;
+      flags?:
+        | {
+            demo_mode?: boolean | undefined;
+            reports_only?: boolean | undefined;
+          }
+        | undefined;
       main_agent_id?: string | null | undefined;
     };
     output: {
@@ -230,7 +241,13 @@ export interface StudioToolIO {
         | null
         | undefined;
       default_home_agents?: { ids: string[] } | null | undefined;
-      reports_only?: boolean | null | undefined;
+      flags?:
+        | {
+            demo_mode?: boolean | undefined;
+            reports_only?: boolean | undefined;
+          }
+        | null
+        | undefined;
       main_agent_id?: string | null | undefined;
     };
   };


### PR DESCRIPTION
## Summary

Three commits:

**1. `flags` jsonb bag** — replaces the column-per-flag pattern for org-level boolean toggles. Adding a flag as a column touched 10 files across 6 layers (migration → Kysely table → domain type → port → adapter → tool schemas → web hook); with the bag, **a new flag is one line in `OrgFlagsSchema`** (`@decocms/shared/organization/schema` — the single source of truth both API and web derive from) **plus its consumer**.

- Updates shallow-merge atomically in SQL (`coalesce(flags,'{}'::jsonb) || $new`): keys in the write win, omitted keys keep their stored value, explicit `false` persists.
- Only boolean toggles belong in the bag — anything needing an index, constraint, or its own semantics (e.g. `main_agent_id`) stays a column.
- `useOrgFlag("<flag>")` generic reader on the web side, same shared cache entry as the other settings slices.

**2. `demo_mode` as the first flag** — with `flags.demo_mode` on, the commerce-onboarding connect modal's CTA stays enabled without a configured required data source (`ready = hasConnectedSource || demoMode`). For curated demo orgs (event demos) where the diagnostic, kanban tasks, and agent threads are pre-baked, so nothing downstream reads the connections. Defaults off (NULL) for everyone; UI-cosmetic only. Enable via `ORGANIZATION_SETTINGS_UPDATE { flags: { demo_mode: true } }`.

**3. `reports_only` migrated into the bag** — proves the pattern on the pre-existing flag. migration 148 backfills non-NULL values into `flags.reports_only` and drops the column; `COMMERCE_DISCOVERY_SETUP` writes `flags.reports_only`; `useReportsOnly()` delegates to `useOrgFlag()`; settings tools drop the top-level field (tool contracts regenerated, e2e spec updated to the new wire shape). Also documents the pattern in AGENTS.md.

## Testing
- **Real-Postgres integration test** (`organization-settings.integration.test.ts`, ran locally against `postgres:16` with all migrations): insert round-trip, shallow-merge across two flags, explicit `false` persisting, unrelated-field update not wiping flags, null when never set — 5/5 pass.
- **Backfill verified against real Postgres**: seeded rows with `reports_only` true/false/NULL, re-ran migration 148 → `{"reports_only": true}` / `{"reports_only": false}` / NULL respectively.
- Unit: `settings-update.test.ts` (flags passthrough for `true` and explicit `false`), `setup.test.ts` (reports_only defaulting via flags — all 4 cases inverted to the new shape).
- `bun run check`, `bun run lint`, `bun run fmt`, `knip`, tool contracts regenerated — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)