### PR TITLE
ci: cache Bun package cache across all workflows

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,0 +1,33 @@
+name: Setup Bun and install dependencies
+description: >-
+  Install Bun (pinned version), restore the package cache via actions/cache
+  keyed on bun.lock, and run `bun install`. Shared by every workflow that
+  installs workspace dependencies so the pinned Bun version and the cache
+  configuration live in exactly one place.
+
+inputs:
+  bun-version:
+    description: Bun version to install — single source of truth for CI.
+    default: "1.3.14"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Restore Bun package cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          bun-${{ runner.os }}-
+
+    - name: Install dependencies
+      shell: bash
+      # BUN_INSTALL_CACHE_DIR pins Bun's cache to the exact path actions/cache
+      # saves, so the same location holds on Linux and Windows runners.
+      run: BUN_INSTALL_CACHE_DIR="$HOME/.bun/install/cache" bun install

--- a/.github/workflows/daemon-e2e-windows.yml
+++ b/.github/workflows/daemon-e2e-windows.yml
@@ -30,15 +30,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
+      - name: Setup Bun and install dependencies
         # Also installs node-pty's prebuilt ConPTY binary for win32 (no native
         # build step needed — node-pty ships platform prebuilds).
-        run: bun install
+        uses: ./.github/actions/setup-bun
 
       # The fs `grep` route shells out to ripgrep; install it so the test
       # asserts results strictly instead of tolerating "grep unavailable" (see

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -15,11 +15,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Build
         run: bun run build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,14 +101,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        run: bun install
-        working-directory: .
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Start NATS with JetStream
         run: |

--- a/.github/workflows/multi-pod.yml
+++ b/.github/workflows/multi-pod.yml
@@ -45,13 +45,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       # No --wait here: the one-shot `migrate` service exits 0 once schemas
       # are created and `--wait` mis-classifies that as a failure. The test

--- a/.github/workflows/publish-bindings.yml
+++ b/.github/workflows/publish-bindings.yml
@@ -20,17 +20,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
       - name: Setup Node.js for npm registry
         uses: actions/setup-node@v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Check if version changed
         id: version-check

--- a/.github/workflows/publish-create-deco-npm.yaml
+++ b/.github/workflows/publish-create-deco-npm.yaml
@@ -30,17 +30,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Check if version changed
         id: version-check

--- a/.github/workflows/publish-mcp-utils-npm.yaml
+++ b/.github/workflows/publish-mcp-utils-npm.yaml
@@ -20,17 +20,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
       - name: Setup Node.js for npm registry
         uses: actions/setup-node@v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Check if version changed
         id: version-check

--- a/.github/workflows/publish-runtime-npm.yaml
+++ b/.github/workflows/publish-runtime-npm.yaml
@@ -20,17 +20,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
       - name: Setup Node.js for npm registry
         uses: actions/setup-node@v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Generate JSON schema
         run: bun run scripts/generate-json-schema.ts

--- a/.github/workflows/publish-typegen-npm.yaml
+++ b/.github/workflows/publish-typegen-npm.yaml
@@ -20,17 +20,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
       - name: Setup Node.js for npm registry
         uses: actions/setup-node@v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Build
         run: bun run build

--- a/.github/workflows/release-studio-sandbox.yaml
+++ b/.github/workflows/release-studio-sandbox.yaml
@@ -59,15 +59,9 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Setup Bun
+      - name: Setup Bun and install dependencies
         if: steps.tag-check.outputs.exists != 'true'
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        if: steps.tag-check.outputs.exists != 'true'
-        run: bun install
+        uses: ./.github/actions/setup-bun
 
       # The Dockerfile copies daemon/dist/daemon.js into the image.
       - name: Build daemon bundle

--- a/.github/workflows/release-studio.yaml
+++ b/.github/workflows/release-studio.yaml
@@ -121,12 +121,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
       - name: Build combined Studio distribution
         run: bun run build:studio
       - name: Verify combined distribution layout

--- a/.github/workflows/resilience.yml
+++ b/.github/workflows/resilience.yml
@@ -25,13 +25,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Start infrastructure
         # `up --build --wait` pulls base images (postgres, nats, toxiproxy) from

--- a/.github/workflows/sandbox-daemon.yml
+++ b/.github/workflows/sandbox-daemon.yml
@@ -74,13 +74,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       # The fs `grep` route shells out to ripgrep; install it so that test can
       # assert results strictly instead of tolerating "grep unavailable".

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -98,13 +98,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Run migrations
         run: bun run --cwd=apps/api migrate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,13 +71,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Run format check
         run: bun run fmt:check
@@ -90,13 +85,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Run lint
         run: bun run lint
@@ -114,13 +104,8 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Run typecheck
         run: bun run check:ci
@@ -133,13 +118,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Run tests
         # The root command discovers the same filename-based unit tier and runs
@@ -155,13 +135,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Build server bundle
         run: bun run --cwd=apps/api build:server
@@ -189,13 +164,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
 
       - name: Build daemon bundle
         run: bun run --cwd=packages/sandbox build


### PR DESCRIPTION
## Summary

Every CI job ran a cold `bun install` — 20 installs across 15 workflows with zero caching. This extracts a composite action (`.github/actions/setup-bun`) that installs Bun, restores `~/.bun/install/cache` via `actions/cache` keyed on `bun.lock`, and runs `bun install` — so the pinned Bun version and cache config live in exactly one place (same pattern as the existing `start-minio` action).

- Cache key: `bun-<os>-<hash(bun.lock)>`, with an os-level `restore-keys` fallback so a lockfile change still restores a warm cache.
- `BUN_INSTALL_CACHE_DIR` is pinned to `$HOME/.bun/install/cache` in the install step so the cached path is deterministic on Linux **and** the Windows daemon-e2e runner.
- `release-tagging.yaml` keeps its plain `setup-bun` — it never runs `bun install`.

### Behavior change (deliberate)

`publish-*`, `release-studio`, and `deploy-docs` previously ran **unpinned** (latest) Bun; they now run the same `1.3.14` the test suite is validated against. Pinning publish/release to the tested version removes silent drift.

## Testing notes

- All edited YAML parses (`yaml.safe_load` over every workflow + the action).
- Diff is mechanical: each `setup-bun` + `bun install` pair → one `uses: ./.github/actions/setup-bun` step (`if:` guards, comments, and step ordering preserved).
- Note: the `changes` gate in `test.yml` skips the unit-suite jobs for `.github/**`-only PRs, so this PR's own checks report as passed without running — the cache takes effect on the next code PR. First run per key is a cache miss (populates); hits land from the second run on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache Bun dependencies across all CI workflows by introducing a shared `setup-bun` composite action. This speeds up installs and pins Bun to the tested version to avoid drift.

- **Refactors**
  - Added `./.github/actions/setup-bun` to install Bun and run `bun install` across workflows.
  - Restores cache at `~/.bun/install/cache` via `actions/cache@v4` keyed on `bun.lock` (`bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}`) with OS `restore-keys`.
  - Sets `BUN_INSTALL_CACHE_DIR="$HOME/.bun/install/cache"` for consistent paths on Linux and Windows.

- **Dependencies**
  - All workflows now use Bun `1.3.14`; `publish-*`, `release-studio`, and `deploy-docs` were previously unpinned.

<sup>Written for commit bbef8dba82534a191abfb8d0154b4b10d4690c98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

