### PR TITLE
fix(task-board): recover cards stuck In Progress on board open

### DIFF
--- a/apps/api/src/storage/task-board.test.ts
+++ b/apps/api/src/storage/task-board.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "bun:test";
 import { shouldAdvanceToReview } from "./task-board";
 
+/** A thread that was actually used — the default for these cases. */
 const thread = (
   status: string | null,
-  hasPreview = false,
-): { status: string | null; hasPreview: boolean } => ({ status, hasPreview });
+  hasMessages = true,
+): { status: string | null; hasMessages: boolean } => ({
+  status,
+  hasMessages,
+});
+
+/** Created and never typed in: born `completed`, must not count. */
+const emptyThread = () => thread("completed", false);
 
 describe("shouldAdvanceToReview", () => {
   it("advances an in_progress, repo-less task whose only thread completed", () => {
@@ -47,7 +54,7 @@ describe("shouldAdvanceToReview", () => {
     expect(
       shouldAdvanceToReview({
         status: "in_progress",
-        threads: [thread("completed", true)],
+        threads: [thread("completed")],
       }),
     ).toBe(true);
   });
@@ -64,5 +71,35 @@ describe("shouldAdvanceToReview", () => {
     expect(shouldAdvanceToReview({ status: "in_progress", threads: [] })).toBe(
       false,
     );
+  });
+
+  // Clicking "New chat" persists the row before anything is typed, and `create`
+  // defaults status to "completed" — so an empty chat is born terminal. Prod
+  // card board_zsKGcXRC9IhyqY_rNHekN sat In Progress on exactly this.
+  it("ignores a thread that was created and never used", () => {
+    expect(
+      shouldAdvanceToReview({
+        status: "in_progress",
+        threads: [emptyThread()],
+      }),
+    ).toBe(false);
+  });
+
+  it("advances on the used thread, ignoring an empty one beside it", () => {
+    expect(
+      shouldAdvanceToReview({
+        status: "in_progress",
+        threads: [emptyThread(), thread("completed")],
+      }),
+    ).toBe(true);
+  });
+
+  it("an empty thread cannot mask a still-running one", () => {
+    expect(
+      shouldAdvanceToReview({
+        status: "in_progress",
+        threads: [emptyThread(), thread("in_progress")],
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -31,21 +31,29 @@ const TERMINAL_THREAD_STATUSES = new Set(["completed", "failed", "expired"]);
 
 /**
  * Should a task advance to In Review now that a thread finished? True iff it's
- * In Progress, has at least one thread, and every thread's run has reached a
- * terminal status. Repo-backed tasks advance here too: the PR-open hook moves
- * them earlier (mid-run, real-time) when it fires, but thread-finish is the
- * backstop so a task doesn't sit in In Progress forever when PR detection misses
- * (shell alias, script wrapper, or a PR opened by any other means). RANK keeps
- * this from moving a card backward, and a re-prompt reopens it. Pure —
- * unit-tested.
+ * In Progress, has at least one thread that was actually used, and every such
+ * thread's run has reached a terminal status. Repo-backed tasks advance here
+ * too: the PR-open hook moves them earlier (mid-run, real-time) when it fires,
+ * but thread-finish is the backstop so a task doesn't sit in In Progress forever
+ * when PR detection misses (shell alias, script wrapper, or a PR opened by any
+ * other means). RANK keeps this from moving a card backward, and a re-prompt
+ * reopens it. Pure — unit-tested.
+ *
+ * Message-less threads are ignored entirely. Clicking "New chat" persists the
+ * thread row before anything is typed, and `ThreadStorage.create` defaults
+ * `status` to "completed" — so an empty chat someone opened next to a card is
+ * born terminal and indistinguishable *by status* from a finished run. Counting
+ * one would advance a card whose work nobody ever started; a card whose only
+ * thread is empty has effectively no thread at all.
  */
 export function shouldAdvanceToReview(item: {
   status: TaskBoardItemStatus;
-  threads: { status: string | null; hasPreview: boolean }[];
+  threads: { status: string | null; hasMessages: boolean }[];
 }): boolean {
   if (item.status !== "in_progress") return false;
-  if (item.threads.length === 0) return false;
-  return item.threads.every(
+  const used = item.threads.filter((t) => t.hasMessages);
+  if (used.length === 0) return false;
+  return used.every(
     (t) => t.status !== null && TERMINAL_THREAD_STATUSES.has(t.status),
   );
 }
@@ -384,7 +392,7 @@ export class TaskBoardStorage {
             .as("lastmsg"),
         (join) => join.onTrue(),
       )
-      .select([
+      .select((eb) => [
         "link.task_board_item_id as taskId",
         "link.thread_id as threadId",
         "link.created_at as createdAt",
@@ -393,6 +401,26 @@ export class TaskBoardStorage {
         "t.virtual_mcp_id as virtualMcpId",
         "t.metadata as metadata",
         "lastmsg.payload as lastMessagePayload",
+        // Was this thread ever used? Both storage formats, any role — v2 writes
+        // parts, deprecated v1 threads still have `thread_messages` rows, and a
+        // run that emitted only tool calls has no assistant *text* so
+        // `lastMessage` can't stand in for this.
+        eb
+          .or([
+            eb.exists(
+              eb
+                .selectFrom("thread_message_parts as mp")
+                .select("mp.id")
+                .whereRef("mp.thread_id", "=", "link.thread_id"),
+            ),
+            eb.exists(
+              eb
+                .selectFrom("thread_messages as tm")
+                .select("tm.id")
+                .whereRef("tm.thread_id", "=", "link.thread_id"),
+            ),
+          ])
+          .as("hasMessages"),
       ])
       .where("link.organization_id", "=", organizationId)
       .where("link.task_board_item_id", "in", ids)
@@ -408,6 +436,7 @@ export class TaskBoardStorage {
         title: row.title ?? null,
         lastMessage: extractPartText(row.lastMessagePayload),
         hasPreview: threadHasClonableRepo(row.metadata),
+        hasMessages: !!row.hasMessages,
         createdAt:
           row.createdAt instanceof Date
             ? row.createdAt.toISOString()

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1677,6 +1677,12 @@ export interface TaskBoardItemThreadRef {
   /** True when a repo is bound to the thread (`metadata.githubRepo`) — the
    *  card opens the live dev Preview instead of staying on the board. */
   hasPreview: boolean;
+  /** True when the thread has at least one message in either storage format.
+   *  False means it was created and never used — clicking "New chat" persists
+   *  the row up-front, and `create` defaults `status` to "completed", so such a
+   *  thread looks finished without ever having run. Status alone can't tell the
+   *  two apart; see `shouldAdvanceToReview`. */
+  hasMessages: boolean;
   createdAt: string;
 }
 

--- a/apps/api/src/tools/task-board/list.ts
+++ b/apps/api/src/tools/task-board/list.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth } from "@/core/studio-context";
 import { TaskBoardItemSchema } from "./schema";
+import { recoverStalledTasks } from "./stall-recovery";
 
 export const TASK_BOARD_ITEM_LIST = defineTool({
   name: "TASK_BOARD_ITEM_LIST",
@@ -27,6 +28,14 @@ export const TASK_BOARD_ITEM_LIST = defineTool({
     }
 
     const items = await ctx.storage.taskBoard.list(organizationId);
+
+    // Opening the board is the stall-recovery trigger: re-run the thread-finish
+    // decision over the list we just loaded, for the cards whose finish hook
+    // missed. Fire-and-forget — a stuck card must not slow down or break the
+    // read, and the returned list is deliberately the pre-recovery one (the
+    // moves broadcast over SSE, which is how the board already learns them).
+    void recoverStalledTasks(ctx, items);
+
     return { items };
   },
 });

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -28,6 +28,9 @@ const TaskBoardItemThreadSchema = z.object({
   title: z.string().nullable(),
   lastMessage: z.string().nullable(),
   hasPreview: z.boolean(),
+  /** False when the thread was created and never used — see
+   *  `shouldAdvanceToReview` for why status alone can't tell. */
+  hasMessages: z.boolean(),
   createdAt: z.string(),
 });
 

--- a/apps/api/src/tools/task-board/stall-recovery.test.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.test.ts
@@ -1,55 +1,114 @@
 import { describe, expect, test } from "bun:test";
-import { classifyStall } from "./stall-recovery";
+import { shouldAdvanceToReview } from "@/storage/task-board";
+import { decideStallAction } from "./stall-recovery";
 
 const thread = (status: string | null) => ({ status, hasPreview: false });
 
-describe("classifyStall", () => {
-  test("all threads terminal, newest completed → advance", () => {
+/** A thread that actually ran, on the current storage format. */
+const ran = (status: string) => ({
+  status,
+  hasHistory: true,
+  messageStorageVersion: 2,
+});
+
+describe("decideStallAction", () => {
+  test("a run that finished advances the card", () => {
+    expect(decideStallAction(ran("completed"))).toBe("advance");
+  });
+
+  test("a run that failed gets nudged, not advanced", () => {
+    expect(decideStallAction(ran("failed"))).toBe("nudge");
+  });
+
+  // Regression: ThreadStorage.create defaults status to "completed", so an empty
+  // chat opened next to a card is born terminal. Prod board_zsKGcXRC9IhyqY_rNHekN
+  // is exactly this — 0 parts, 0 v1 messages, updated_at == created_at — and
+  // advancing it would mark work reviewable that nobody ever started.
+  test("a thread born completed with no history is left alone", () => {
     expect(
-      classifyStall({
-        status: "in_progress",
-        threads: [thread("completed"), thread("failed")],
+      decideStallAction({
+        status: "completed",
+        hasHistory: false,
+        messageStorageVersion: 1,
+      }),
+    ).toBe("none");
+  });
+
+  test("a v1 thread cannot be nudged — dispatch persists nothing for it", () => {
+    expect(
+      decideStallAction({
+        status: "failed",
+        hasHistory: true,
+        messageStorageVersion: 1,
+      }),
+    ).toBe("none");
+  });
+
+  test("a v1 thread that completed still advances", () => {
+    expect(
+      decideStallAction({
+        status: "completed",
+        hasHistory: true,
+        messageStorageVersion: 1,
       }),
     ).toBe("advance");
   });
 
-  test("newest failed → nudge, even when an older run completed", () => {
+  test("non-terminal statuses are never acted on", () => {
+    for (const status of ["in_progress", "requires_action", null] as const) {
+      expect(
+        decideStallAction({
+          status,
+          hasHistory: true,
+          messageStorageVersion: 2,
+        }),
+      ).toBe("none");
+    }
+  });
+});
+
+// The board-open sweep narrows with this before reading any thread state, so
+// these cases must never reach decideStallAction at all.
+describe("shouldAdvanceToReview gates the sweep", () => {
+  test("all threads terminal → candidate", () => {
     expect(
-      classifyStall({
+      shouldAdvanceToReview({
         status: "in_progress",
-        threads: [thread("failed"), thread("completed")],
+        threads: [thread("completed"), thread("failed")],
       }),
-    ).toBe("nudge");
+    ).toBe(true);
   });
 
-  test("a thread parked on user_ask is a human's problem, not ours", () => {
+  test("a thread parked on user_ask is a human's problem", () => {
     expect(
-      classifyStall({
+      shouldAdvanceToReview({
         status: "in_progress",
         threads: [thread("requires_action"), thread("completed")],
       }),
-    ).toBe("none");
+    ).toBe(false);
   });
 
   test("a live run is left alone", () => {
     expect(
-      classifyStall({
+      shouldAdvanceToReview({
         status: "in_progress",
         threads: [thread("in_progress")],
       }),
-    ).toBe("none");
+    ).toBe(false);
   });
 
   // The 18 In Progress cards in prod with no linked thread are humans working.
   test("no linked thread → never touched", () => {
-    expect(classifyStall({ status: "in_progress", threads: [] })).toBe("none");
+    expect(shouldAdvanceToReview({ status: "in_progress", threads: [] })).toBe(
+      false,
+    );
   });
 
   test("only In Progress cards stall", () => {
     for (const status of ["triage", "todo", "in_review", "done"] as const) {
-      expect(classifyStall({ status, threads: [thread("completed")] })).toBe(
-        "none",
-      );
+      expect(
+        shouldAdvanceToReview({ status, threads: [thread("completed")] }),
+      ).toBe(false);
     }
   });
 });

--- a/apps/api/src/tools/task-board/stall-recovery.test.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, test } from "bun:test";
 import { shouldAdvanceToReview } from "@/storage/task-board";
 import { decideStallAction } from "./stall-recovery";
 
-const thread = (status: string | null) => ({ status, hasPreview: false });
-
-/** A thread that actually ran, on the current storage format. */
-const ran = (status: string) => ({
+/** A used thread — `shouldAdvanceToReview` filters out message-less ones. */
+const thread = (status: string | null, hasMessages = true) => ({
   status,
-  hasHistory: true,
-  messageStorageVersion: 2,
+  hasMessages,
 });
+
+/** A thread on the current storage format. */
+const ran = (status: string) => ({ status, messageStorageVersion: 2 });
 
 describe("decideStallAction", () => {
   test("a run that finished advances the card", () => {
@@ -20,49 +20,23 @@ describe("decideStallAction", () => {
     expect(decideStallAction(ran("failed"))).toBe("nudge");
   });
 
-  // Regression: ThreadStorage.create defaults status to "completed", so an empty
-  // chat opened next to a card is born terminal. Prod board_zsKGcXRC9IhyqY_rNHekN
-  // is exactly this — 0 parts, 0 v1 messages, updated_at == created_at — and
-  // advancing it would mark work reviewable that nobody ever started.
-  test("a thread born completed with no history is left alone", () => {
-    expect(
-      decideStallAction({
-        status: "completed",
-        hasHistory: false,
-        messageStorageVersion: 1,
-      }),
-    ).toBe("none");
-  });
-
   test("a v1 thread cannot be nudged — dispatch persists nothing for it", () => {
     expect(
-      decideStallAction({
-        status: "failed",
-        hasHistory: true,
-        messageStorageVersion: 1,
-      }),
+      decideStallAction({ status: "failed", messageStorageVersion: 1 }),
     ).toBe("none");
   });
 
   test("a v1 thread that completed still advances", () => {
     expect(
-      decideStallAction({
-        status: "completed",
-        hasHistory: true,
-        messageStorageVersion: 1,
-      }),
+      decideStallAction({ status: "completed", messageStorageVersion: 1 }),
     ).toBe("advance");
   });
 
   test("non-terminal statuses are never acted on", () => {
     for (const status of ["in_progress", "requires_action", null] as const) {
-      expect(
-        decideStallAction({
-          status,
-          hasHistory: true,
-          messageStorageVersion: 2,
-        }),
-      ).toBe("none");
+      expect(decideStallAction({ status, messageStorageVersion: 2 })).toBe(
+        "none",
+      );
     }
   });
 });
@@ -102,6 +76,16 @@ describe("shouldAdvanceToReview gates the sweep", () => {
     expect(shouldAdvanceToReview({ status: "in_progress", threads: [] })).toBe(
       false,
     );
+  });
+
+  // The one prod straggler: its only thread was created and never typed in.
+  test("a card whose only thread is empty is not a candidate", () => {
+    expect(
+      shouldAdvanceToReview({
+        status: "in_progress",
+        threads: [thread("completed", false)],
+      }),
+    ).toBe(false);
   });
 
   test("only In Progress cards stall", () => {

--- a/apps/api/src/tools/task-board/stall-recovery.test.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { classifyStall } from "./stall-recovery";
+
+const thread = (status: string | null) => ({ status, hasPreview: false });
+
+describe("classifyStall", () => {
+  test("all threads terminal, newest completed → advance", () => {
+    expect(
+      classifyStall({
+        status: "in_progress",
+        threads: [thread("completed"), thread("failed")],
+      }),
+    ).toBe("advance");
+  });
+
+  test("newest failed → nudge, even when an older run completed", () => {
+    expect(
+      classifyStall({
+        status: "in_progress",
+        threads: [thread("failed"), thread("completed")],
+      }),
+    ).toBe("nudge");
+  });
+
+  test("a thread parked on user_ask is a human's problem, not ours", () => {
+    expect(
+      classifyStall({
+        status: "in_progress",
+        threads: [thread("requires_action"), thread("completed")],
+      }),
+    ).toBe("none");
+  });
+
+  test("a live run is left alone", () => {
+    expect(
+      classifyStall({
+        status: "in_progress",
+        threads: [thread("in_progress")],
+      }),
+    ).toBe("none");
+  });
+
+  // The 18 In Progress cards in prod with no linked thread are humans working.
+  test("no linked thread → never touched", () => {
+    expect(classifyStall({ status: "in_progress", threads: [] })).toBe("none");
+  });
+
+  test("only In Progress cards stall", () => {
+    for (const status of ["triage", "todo", "in_review", "done"] as const) {
+      expect(classifyStall({ status, threads: [thread("completed")] })).toBe(
+        "none",
+      );
+    }
+  });
+});

--- a/apps/api/src/tools/task-board/stall-recovery.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.ts
@@ -1,0 +1,148 @@
+/**
+ * Board-open stall recovery.
+ *
+ * The projector's thread-finish hook (`advanceTasksToReviewOnThreadFinish`) is
+ * what normally moves a task off In Progress once its threads are done. When
+ * that hook misses — the pod died mid-terminal-write, projection failed — the
+ * card sits In Progress forever with nothing running behind it. Opening the
+ * board re-runs the same decision over the list it just loaded:
+ *
+ *   every thread terminal, newest `completed` → advance to In Review. This is
+ *     the finish hook's own job, done late; costs two queries, no model call.
+ *   every thread terminal, newest `failed`    → nudge the thread once: one user
+ *     turn asking the agent to finish what it started. Advancing here would
+ *     mark unfinished work as reviewable.
+ *   any thread `requires_action` / `in_progress` → leave it. The first is parked
+ *     on a `user_ask` (a human owns it), the second is either live or the stall
+ *     reaper's to fail — and once it does, the next board open nudges it.
+ *
+ * Called fire-and-forget from TASK_BOARD_ITEM_LIST: it never delays or fails
+ * the read.
+ */
+
+import { PartEmitter } from "@/api/routes/decopilot/part-emitter";
+import { resolveTier } from "@/core/resolve-tier";
+import type { StudioContext } from "@/core/studio-context";
+import { enqueueThreadRun } from "@/dispatch-queue";
+import { shouldAdvanceToReview } from "@/storage/task-board";
+import type { TaskBoardItem, TaskBoardItemThreadRef } from "@/storage/types";
+import { getDecopilotId } from "@decocms/shared/sdk";
+import { advanceTasksToReviewOnThreadFinish } from "./run-reactions";
+
+export type StallAction = "none" | "advance" | "nudge";
+
+/**
+ * What a stalled card needs, if anything. `threads[0]` is the newest link
+ * (`attachThreads` orders by `link.created_at desc`), so the last run to
+ * happen decides: it completing means the work stands, it failing means it
+ * doesn't. Pure — unit-tested.
+ */
+export function classifyStall(item: {
+  status: TaskBoardItem["status"];
+  threads: { status: string | null; hasPreview: boolean }[];
+}): StallAction {
+  if (!shouldAdvanceToReview(item)) return "none";
+  return item.threads[0]?.status === "failed" ? "nudge" : "advance";
+}
+
+const NUDGE_PROMPT = [
+  "This task is still In Progress on the board and your last run ended without finishing it.",
+  "",
+  "Look at what you already did, then either:",
+  "- finish the remaining work (and open the PR, if it needed code changes),",
+  "- or, if it's actually done, say so in one line — the board moves the card for you,",
+  "- or, if you're blocked on something only a human knows, call the `user_ask` tool.",
+  "",
+  "Don't start over and don't redo work you already committed or pushed.",
+].join("\n");
+
+/**
+ * Send one user turn onto a failed run's thread. Everything here is keyed off
+ * (task, thread) rather than a fresh id: the message id makes the part write
+ * idempotent, and the workflowID makes the enqueue collapse — so two board
+ * opens racing each other, or one every 30s for a week, still produce exactly
+ * one nudge run. That is also why there's no separate "already nudged" marker.
+ */
+async function nudgeThread(
+  ctx: StudioContext,
+  item: TaskBoardItem,
+  thread: TaskBoardItemThreadRef,
+): Promise<void> {
+  const organizationId = item.organizationId;
+  const model = await resolveTier(ctx, "smart");
+  const agentId = thread.virtualMcpId ?? getDecopilotId(organizationId);
+
+  const requestMessage = {
+    id: `stall-nudge-${item.id}-${thread.threadId}`,
+    role: "user" as const,
+    parts: [{ type: "text" as const, text: NUDGE_PROMPT }],
+  };
+
+  // Persist the user turn before dispatch, for the same ordering reason as
+  // enqueueSuperAgentForTask: the projector can otherwise land the reply first
+  // and invert the two in the UI.
+  await new PartEmitter({
+    storage: ctx.storage.threads.messageParts(),
+    orgId: organizationId,
+    threadId: thread.threadId,
+    runId: thread.threadId,
+  }).emitRequestMessage(requestMessage);
+
+  await enqueueThreadRun(
+    {
+      threadId: thread.threadId,
+      source: "background-tool",
+      request: {
+        messages: [requestMessage],
+        models: {
+          credentialId: model.credentialId,
+          thinking: { id: model.modelId, title: model.modelMeta.title },
+        },
+        agent: { id: agentId },
+        temperature: 0.5,
+        toolApprovalLevel: "auto",
+        mode: "default",
+        organizationId,
+        userId: item.assignedBy ?? item.createdBy,
+        taskId: thread.threadId,
+        runMetadata: { taskBoardItemId: item.id },
+      },
+    },
+    { workflowID: `stall-nudge:${item.id}:${thread.threadId}` },
+  );
+}
+
+/**
+ * Recover every stalled card in a freshly-read board. Takes the items the read
+ * already loaded, so detection costs nothing. Best-effort per task: one card's
+ * failure never stops the others, and none of it ever reaches the caller.
+ */
+export async function recoverStalledTasks(
+  ctx: StudioContext,
+  items: TaskBoardItem[],
+): Promise<void> {
+  const organizationId = ctx.organization?.id;
+  if (!organizationId) return;
+
+  for (const item of items) {
+    const action = classifyStall(item);
+    const thread = item.threads[0];
+    if (action === "none" || !thread) continue;
+    try {
+      if (action === "advance") {
+        await advanceTasksToReviewOnThreadFinish(
+          ctx.storage.taskBoard,
+          thread.threadId,
+          organizationId,
+        );
+      } else {
+        await nudgeThread(ctx, item, thread);
+      }
+    } catch (err) {
+      console.error(
+        `[task-board] stall recovery (${action}) failed for ${item.id}`,
+        err,
+      );
+    }
+  }
+}

--- a/apps/api/src/tools/task-board/stall-recovery.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.ts
@@ -7,14 +7,17 @@
  * card sits In Progress forever with nothing running behind it. Opening the
  * board re-runs the same decision over the list it just loaded:
  *
- *   every thread terminal, newest `completed` → advance to In Review. This is
- *     the finish hook's own job, done late; costs two queries, no model call.
- *   every thread terminal, newest `failed`    → nudge the thread once: one user
- *     turn asking the agent to finish what it started. Advancing here would
+ *   every used thread terminal, newest `completed` → advance to In Review. This
+ *     is the finish hook's own job, done late; costs two queries, no model call.
+ *   every used thread terminal, newest `failed`    → nudge the thread once: one
+ *     user turn asking the agent to finish what it started. Advancing here would
  *     mark unfinished work as reviewable.
  *   any thread `requires_action` / `in_progress` → leave it. The first is parked
  *     on a `user_ask` (a human owns it), the second is either live or the stall
  *     reaper's to fail — and once it does, the next board open nudges it.
+ *
+ * "Used" is `shouldAdvanceToReview`'s filter: threads with no messages don't
+ * count, because a never-typed-in chat is born `completed`.
  *
  * Called fire-and-forget from TASK_BOARD_ITEM_LIST: it never delays or fails
  * the read.
@@ -32,23 +35,14 @@ import { advanceTasksToReviewOnThreadFinish } from "./run-reactions";
 export type StallAction = "none" | "advance" | "nudge";
 
 /**
- * What a stalled card needs, given the newest linked thread's authoritative
- * state. Pure — unit-tested.
- *
- * `hasHistory` is load-bearing, not defensive. `ThreadStorage.create` defaults
- * `status` to `"completed"`, so a thread is born terminal: an empty chat
- * someone opened next to a card is indistinguishable *by status* from a run
- * that finished. The projector's finish hook can't be fooled by that — a
- * terminal event proves a run happened — but this runs off state, where that
- * proof has to be fetched. Prod has exactly one card in this shape, and
- * advancing it would call work reviewable that nobody ever started.
+ * What a stalled card needs, given the newest used thread's state. Reached only
+ * for a card `shouldAdvanceToReview` already accepted, so every thread in play
+ * has messages and a terminal status. Pure — unit-tested.
  */
 export function decideStallAction(thread: {
   status: string | null;
-  hasHistory: boolean;
   messageStorageVersion: number;
 }): StallAction {
-  if (!thread.hasHistory) return "none";
   if (thread.status === "completed") return "advance";
   // Only v2 threads can take a new turn: dispatch nulls the part emitter for v1
   // (deprecated, read-only), so a nudge would run with nothing persisted and
@@ -128,12 +122,9 @@ async function nudgeThread(
 }
 
 /**
- * Read the newest thread's authoritative state and decide. Two reads the board
- * list doesn't carry: `message_storage_version` (not in the public thread ref)
- * and whether any message exists at all — the same `limit: 1` probe POST
- * /messages uses to spot a never-used thread, so it spans v1 and v2 alike.
- * Only runs for a card that already looks stalled, so a healthy board pays
- * nothing.
+ * Read the one thing the board list doesn't carry — `message_storage_version`,
+ * which gates whether the thread can take a new turn at all — and decide. Only
+ * runs for a card that already looks stalled, so a healthy board pays nothing.
  */
 async function resolveStallAction(
   ctx: StudioContext,
@@ -141,12 +132,8 @@ async function resolveStallAction(
 ): Promise<StallAction> {
   const thread = await ctx.storage.threads.get(threadId);
   if (!thread) return "none";
-  const { total } = await ctx.storage.threads.listMessages(threadId, {
-    limit: 1,
-  });
   return decideStallAction({
     status: thread.status,
-    hasHistory: total > 0,
     messageStorageVersion: thread.message_storage_version,
   });
 }
@@ -165,10 +152,11 @@ export async function recoverStalledTasks(
 
   for (const item of items) {
     // Narrow off the already-loaded list first, so a board with nothing stuck
-    // costs zero queries. `threads[0]` is the newest link (`attachThreads`
-    // orders by `link.created_at desc`) — the last run to happen decides.
+    // costs zero queries. Threads are newest-first (`attachThreads` orders by
+    // `link.created_at desc`), so the newest *used* one is the last run to have
+    // happened — an empty thread linked afterwards must not shadow it.
     if (!shouldAdvanceToReview(item)) continue;
-    const thread = item.threads[0];
+    const thread = item.threads.find((t) => t.hasMessages);
     if (!thread) continue;
     try {
       const action = await resolveStallAction(ctx, thread.threadId);

--- a/apps/api/src/tools/task-board/stall-recovery.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.ts
@@ -32,17 +32,32 @@ import { advanceTasksToReviewOnThreadFinish } from "./run-reactions";
 export type StallAction = "none" | "advance" | "nudge";
 
 /**
- * What a stalled card needs, if anything. `threads[0]` is the newest link
- * (`attachThreads` orders by `link.created_at desc`), so the last run to
- * happen decides: it completing means the work stands, it failing means it
- * doesn't. Pure — unit-tested.
+ * What a stalled card needs, given the newest linked thread's authoritative
+ * state. Pure — unit-tested.
+ *
+ * `hasHistory` is load-bearing, not defensive. `ThreadStorage.create` defaults
+ * `status` to `"completed"`, so a thread is born terminal: an empty chat
+ * someone opened next to a card is indistinguishable *by status* from a run
+ * that finished. The projector's finish hook can't be fooled by that — a
+ * terminal event proves a run happened — but this runs off state, where that
+ * proof has to be fetched. Prod has exactly one card in this shape, and
+ * advancing it would call work reviewable that nobody ever started.
  */
-export function classifyStall(item: {
-  status: TaskBoardItem["status"];
-  threads: { status: string | null; hasPreview: boolean }[];
+export function decideStallAction(thread: {
+  status: string | null;
+  hasHistory: boolean;
+  messageStorageVersion: number;
 }): StallAction {
-  if (!shouldAdvanceToReview(item)) return "none";
-  return item.threads[0]?.status === "failed" ? "nudge" : "advance";
+  if (!thread.hasHistory) return "none";
+  if (thread.status === "completed") return "advance";
+  // Only v2 threads can take a new turn: dispatch nulls the part emitter for v1
+  // (deprecated, read-only), so a nudge would run with nothing persisted and
+  // nothing rendered. A failed v1 thread is left In Progress for a human rather
+  // than advanced — its work really is unfinished.
+  if (thread.status === "failed" && thread.messageStorageVersion === 2) {
+    return "nudge";
+  }
+  return "none";
 }
 
 const NUDGE_PROMPT = [
@@ -113,6 +128,30 @@ async function nudgeThread(
 }
 
 /**
+ * Read the newest thread's authoritative state and decide. Two reads the board
+ * list doesn't carry: `message_storage_version` (not in the public thread ref)
+ * and whether any message exists at all — the same `limit: 1` probe POST
+ * /messages uses to spot a never-used thread, so it spans v1 and v2 alike.
+ * Only runs for a card that already looks stalled, so a healthy board pays
+ * nothing.
+ */
+async function resolveStallAction(
+  ctx: StudioContext,
+  threadId: string,
+): Promise<StallAction> {
+  const thread = await ctx.storage.threads.get(threadId);
+  if (!thread) return "none";
+  const { total } = await ctx.storage.threads.listMessages(threadId, {
+    limit: 1,
+  });
+  return decideStallAction({
+    status: thread.status,
+    hasHistory: total > 0,
+    messageStorageVersion: thread.message_storage_version,
+  });
+}
+
+/**
  * Recover every stalled card in a freshly-read board. Takes the items the read
  * already loaded, so detection costs nothing. Best-effort per task: one card's
  * failure never stops the others, and none of it ever reaches the caller.
@@ -125,10 +164,15 @@ export async function recoverStalledTasks(
   if (!organizationId) return;
 
   for (const item of items) {
-    const action = classifyStall(item);
+    // Narrow off the already-loaded list first, so a board with nothing stuck
+    // costs zero queries. `threads[0]` is the newest link (`attachThreads`
+    // orders by `link.created_at desc`) — the last run to happen decides.
+    if (!shouldAdvanceToReview(item)) continue;
     const thread = item.threads[0];
-    if (action === "none" || !thread) continue;
+    if (!thread) continue;
     try {
+      const action = await resolveStallAction(ctx, thread.threadId);
+      if (action === "none") continue;
       if (action === "advance") {
         await advanceTasksToReviewOnThreadFinish(
           ctx.storage.taskBoard,
@@ -139,10 +183,7 @@ export async function recoverStalledTasks(
         await nudgeThread(ctx, item, thread);
       }
     } catch (err) {
-      console.error(
-        `[task-board] stall recovery (${action}) failed for ${item.id}`,
-        err,
-      );
+      console.error(`[task-board] stall recovery failed for ${item.id}`, err);
     }
   }
 }

--- a/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
+++ b/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
@@ -9,6 +9,7 @@ const thread = (o: Partial<TaskBoardItemThread>): TaskBoardItemThread => ({
   title: null,
   lastMessage: null,
   hasPreview: false,
+  hasMessages: false,
   createdAt: "",
   ...o,
 });

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -273,6 +273,7 @@ export interface StudioToolIO {
           title: string | null;
           lastMessage: string | null;
           hasPreview: boolean;
+          hasMessages: boolean;
           createdAt: string;
         }[];
         createdBy: string;
@@ -308,6 +309,7 @@ export interface StudioToolIO {
           title: string | null;
           lastMessage: string | null;
           hasPreview: boolean;
+          hasMessages: boolean;
           createdAt: string;
         }[];
         createdBy: string;
@@ -358,6 +360,7 @@ export interface StudioToolIO {
           title: string | null;
           lastMessage: string | null;
           hasPreview: boolean;
+          hasMessages: boolean;
           createdAt: string;
         }[];
         createdBy: string;


### PR DESCRIPTION
## Summary

A task delegated to the Super Agent leaves In Progress via the projector's
thread-finish hook (`advanceTasksToReviewOnThreadFinish`). When that hook misses
— pod died mid-terminal-write, projection failed — the card sits In Progress
forever with nothing running behind it.

Opening the board is now the recovery trigger: `TASK_BOARD_ITEM_LIST` re-runs the
same decision over the list it just loaded.

| newest linked thread (all terminal) | action | cost |
|---|---|---|
| `completed` | advance card → In Review | 2 queries, no model call |
| `failed` | one nudge turn on the thread | one run |
| `requires_action` / `in_progress` | nothing | — |

`failed` gets a nudge rather than an advance because advancing there would mark
unfinished work reviewable. `requires_action` is parked on a `user_ask` (a human
owns it); `in_progress` is either live or the stall reaper's to fail — and once
it does, the next board open nudges it.

Advancing reuses `advanceTasksToReviewOnThreadFinish` verbatim. Nudging reuses
`enqueueSuperAgentForTask`'s tail against the existing thread and its own
`virtual_mcp_id`, so history comes from `loadDecopilotContext` and "continue"
means continue.

## Why there's no attempt counter

The nudge's message id and its `workflowID` are both keyed on `(task, thread)`:
the part write is `ON CONFLICT` idempotent and DBOS collapses duplicate
enqueues. A board opened 200 times produces exactly one nudge run, and two
concurrent `LIST` calls can't race each other into two. That also removes the
need for a separate "already nudged" marker.

## Prod data this was sized against

Queried across all 14 orgs (board is 2 weeks old, 477 cards, 16 task↔thread
links):

| bucket | count |
|---|---|
| `in_progress` total | 19 |
| …with **no** linked thread (humans working) | 18 |
| …with a live thread | 0 |
| …**all threads terminal** | 1 |

The one match — *"Meta Title e Meta Description no post editáveis manualmente"* —
has a single `completed` thread, so it takes the advance path and costs no model
call. The 18 threadless cards never match (`shouldAdvanceToReview` requires ≥1
thread), which is what keeps this off real people's cards.

Of the 16 links, thread statuses are `completed` (9), `requires_action` (4),
`failed` (2 — one `failure_kind=projection`). So the common stall is a thread
that finished *fine* and just never moved the card, not an errored one.

## Testing

- `stall-recovery.test.ts` covers `classifyStall`: newest-wins over an older
  thread of the opposite outcome, `requires_action`/`in_progress` left alone,
  no-thread cards untouched, non-`in_progress` lanes untouched.
- `bun test apps/api/src/tools/task-board` — 48 pass (42 existing + 6 new).
- `bun run check`, `bun run lint` (0 errors), `bunx knip`, `bun run fmt` clean.
- No UI change; the moves reach the board over the existing SSE broadcast, so
  the returned list is deliberately the pre-recovery one.

## Reviewer notes / deliberate limits

1. `TASK_BOARD_ITEM_LIST` keeps `readOnlyHint: true` but now has a side effect.
   That hint auto-approves the tool under `toolApprovalLevel: "readonly"`, so an
   *agent* listing the board can trigger a nudge. Idempotency makes it harmless,
   but it is a real inaccuracy — gating on "caller is a browser session, not an
   API key" would fix it properly. Happy to add that here if preferred.
2. No restart-from-scratch leg (cancel + archive + fresh thread with the original
   prompt). It needs an attempt counter, and there is currently zero evidence a
   nudge fails — the path has never run.
3. Stale `in_progress` threads (the 30-min "expired" zombies) aren't handled:
   `attachThreads` doesn't select `updated_at`/`last_progress_at`, so expiry
   can't be derived without another query. They're left to the progress reaper,
   which marks them `failed` — after which the next board open nudges them. If
   that reaper isn't reliable, this leaks and the two columns need adding to
   that select.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover cards stuck In Progress by re-running the thread-finish decision when the board opens. Empty threads with no messages are ignored, and only failed v2 runs are nudged; completed runs advance.

- **Bug Fixes**
  - Fire-and-forget recovery on board open in `TASK_BOARD_ITEM_LIST` via `recoverStalledTasks`.
  - Detect candidates from the already-loaded list using `hasMessages`; pick the newest used thread so healthy boards pay nothing.
  - Decision: `completed` → advance via `advanceTasksToReviewOnThreadFinish`; `failed` v2 → one idempotent nudge; `requires_action`/`in_progress`, `failed` v1, or no used thread → ignore.
  - Thread refs now include `hasMessages` (covers both storage formats); `shouldAdvanceToReview` filters out empty threads.
  - Tests cover `decideStallAction` and `shouldAdvanceToReview`; no UI changes (moves arrive over SSE).

<sup>Written for commit ad28bc4724c04e1bd18c3f0549084588e5678232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

