### PR TITLE
fix(web): move credits chip to top of sidebar footer

### DIFF
--- a/apps/web/src/components/sidebar/footer/sidebar-footer.tsx
+++ b/apps/web/src/components/sidebar/footer/sidebar-footer.tsx
@@ -148,12 +148,12 @@ export function SidebarAccountFooter() {
   if (isCollapsed) {
     return (
       <SidebarFooter className="px-2 pb-3 gap-1">
+        {showCredits && <SidebarTopActions />}
         {reportsOnly ? (
           <SidebarExtraActionsCommerce />
         ) : (
           <SidebarExtraActions />
         )}
-        {showCredits && <SidebarTopActions />}
         <SidebarMenu>
           <SidebarMenuItem>
             <div className="flex justify-center">
@@ -173,8 +173,8 @@ export function SidebarAccountFooter() {
 
   return (
     <SidebarFooter className="px-2 pb-3 gap-0.5">
-      {reportsOnly ? <SidebarExtraActionsCommerce /> : <SidebarExtraActions />}
       {showCredits && <SidebarTopActions />}
+      {reportsOnly ? <SidebarExtraActionsCommerce /> : <SidebarExtraActions />}
       <SidebarMenu className="gap-0.5">
         <SidebarMenuItem>
           <LinkedDesktopIndicator variant="full" />


### PR DESCRIPTION
## Summary

Moves the credits indicator (`SidebarTopActions`) to be the first item of the sidebar footer section — directly above **Invite members** — instead of rendering after the quick actions.

Applied to both footer layouts (collapsed and expanded) so the ordering is consistent.

## Testing

Visual-only reorder; no logic change. Verify in the sidebar that the credits chip appears above "Invite members" in both expanded and collapsed states.

`bun run fmt` and `bun run lint` pass (lefthook pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)