### PR TITLE
ci: drop the Bun package cache — measured slower than cold install

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,9 +1,11 @@
 name: Setup Bun and install dependencies
 description: >-
-  Install Bun (pinned version), restore the package cache via actions/cache
-  keyed on bun.lock, and run `bun install`. Shared by every workflow that
-  installs workspace dependencies so the pinned Bun version and the cache
-  configuration live in exactly one place.
+  Install Bun (pinned version) and run `bun install`. Shared by every workflow
+  that installs workspace dependencies so the pinned Bun version lives in
+  exactly one place. Deliberately NOT cached: measured on real runs, restoring
+  the ~570MB actions/cache entry (~18s) is slower than a cold `bun install`
+  from npm (~18s cold, and GH runners pull npm at ~70MB/s), while pressuring
+  the repo's 10GB cache quota that buildkit layers share.
 
 inputs:
   bun-version:
@@ -18,16 +20,6 @@ runs:
       with:
         bun-version: ${{ inputs.bun-version }}
 
-    - name: Restore Bun package cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.bun/install/cache
-        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-        restore-keys: |
-          bun-${{ runner.os }}-
-
     - name: Install dependencies
       shell: bash
-      # BUN_INSTALL_CACHE_DIR pins Bun's cache to the exact path actions/cache
-      # saves, so the same location holds on Linux and Windows runners.
-      run: BUN_INSTALL_CACHE_DIR="$HOME/.bun/install/cache" bun install
+      run: bun install


### PR DESCRIPTION
## Summary

Follow-up to #5285. Measured on real runs, the cache is net **zero-to-negative**:

| | pre-#5285 (cold install) | post-#5285 (cache **hit**) |
|---|---|---|
| lint install step | 17s | ~30s (18s restore 570MB + 10.5s warm install) |

GH runners pull npm at ~70MB/s and Bun installs 2911 packages cold in ~18s — downloading the same bytes from actions/cache isn't faster, and each 570MB entry pressures the repo's 10GB cache quota that buildkit layers share.

This removes the `actions/cache` step from the composite action. The composite itself stays: pinning Bun 1.3.14 in one place for all 15 workflows was the part worth keeping.

Existing `bun-*` cache entries expire on their own after 7 days unused.

## Testing notes

- YAML parses; no workflow references the removed step by name.
- `.github/**`-only change — the `changes` gate skips the unit-suite jobs, same as #5285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `actions/cache` package cache from the `setup-bun` composite because cold `bun install` is faster on GitHub runners. Kept the composite to pin the Bun version across workflows.

- **Refactors**
  - Real-run timings: cache hit ≈30s (≈18s restore of ~570MB + ≈10s warm install) vs cold `bun install` ≈18s.
  - Reduces pressure on the repo’s 10GB Actions cache shared with buildkit by avoiding ~570MB entries.
  - Existing `bun-*` cache entries will expire automatically after 7 days of inactivity.

<sup>Written for commit 4c59602f11764e8f35c93e4991ad09f875d4fa49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

