### PR TITLE
feat(web): add SEO fields to blog post editor settings

### DIFF
--- a/apps/web/src/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/web/src/components/sandbox/content/blog/post-editor.tsx
@@ -14,6 +14,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@deco/ui/components/tabs.tsx";
+import { Switch } from "@deco/ui/components/switch.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import { ImageField } from "@/components/sections-editor/fields/image-field";
 import { StringField } from "@/components/sections-editor/fields/string-field";
@@ -300,6 +301,95 @@ function PostSettings({
         value={post.extraProps}
         onChange={(v) => onChange("extraProps", v)}
       />
+      <SeoFields value={post.seo} onChange={(v) => onChange("seo", v)} />
+    </div>
+  );
+}
+
+/**
+ * Edits the post's optional `seo` object (the blog app's `Seo` type:
+ * title/description/image/canonical/noIndexing). Empty fields fall back to
+ * the post's own title/excerpt/cover on the site side, so none is required.
+ */
+function SeoFields({
+  value,
+  onChange,
+}: {
+  value: unknown;
+  onChange: (value: Record<string, unknown>) => void;
+}) {
+  const t = useT();
+  const seo =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  const set = (key: string, v: unknown) => onChange({ ...seo, [key]: v });
+
+  return (
+    <div className="space-y-5 border-t pt-5">
+      <div className="space-y-1">
+        <p className="text-sm font-medium">
+          {t("sandbox.postEditor.seoSectionLabel")}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {t("sandbox.postEditor.seoSectionHint")}
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="post-seo-title">
+          {t("sandbox.postEditor.seoTitleLabel")}
+        </Label>
+        <Input
+          id="post-seo-title"
+          value={str(seo.title)}
+          onChange={(e) => set("title", e.target.value)}
+          className="h-10"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="post-seo-description">
+          {t("sandbox.postEditor.seoDescriptionLabel")}
+        </Label>
+        <Textarea
+          id="post-seo-description"
+          value={str(seo.description)}
+          onChange={(e) => set("description", e.target.value)}
+          rows={2}
+        />
+      </div>
+      <ImageField
+        schema={{
+          type: "string",
+          format: "image-uri",
+          title: t("sandbox.postEditor.seoImageLabel"),
+        }}
+        value={seo.image}
+        onChange={(v) => set("image", v)}
+        path="post-seo-image"
+        label={t("sandbox.postEditor.seoImageLabel")}
+      />
+      <div className="space-y-2">
+        <Label htmlFor="post-seo-canonical">
+          {t("sandbox.postEditor.seoCanonicalLabel")}
+        </Label>
+        <Input
+          id="post-seo-canonical"
+          value={str(seo.canonical)}
+          onChange={(e) => set("canonical", e.target.value)}
+          placeholder={t("sandbox.postEditor.seoCanonicalPlaceholder")}
+          className="h-10"
+        />
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <Label htmlFor="post-seo-no-indexing">
+          {t("sandbox.postEditor.seoNoIndexingLabel")}
+        </Label>
+        <Switch
+          id="post-seo-no-indexing"
+          checked={seo.noIndexing === true}
+          onCheckedChange={(checked) => set("noIndexing", checked)}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -340,6 +340,16 @@ export const sandbox = {
   "sandbox.postEditor.seePreview": "See preview",
   "sandbox.postEditor.selectAuthorsPlaceholder": "Select authors",
   "sandbox.postEditor.selectCategoriesPlaceholder": "Select categories",
+  "sandbox.postEditor.seoCanonicalLabel": "Canonical URL",
+  "sandbox.postEditor.seoCanonicalPlaceholder":
+    "https://example.com/blog/my-post",
+  "sandbox.postEditor.seoDescriptionLabel": "SEO description",
+  "sandbox.postEditor.seoImageLabel": "SEO image",
+  "sandbox.postEditor.seoNoIndexingLabel": "Hide from search engines (noindex)",
+  "sandbox.postEditor.seoSectionHint":
+    "Overrides how this post appears in search engines. Empty fields fall back to the post's title, excerpt and cover image.",
+  "sandbox.postEditor.seoSectionLabel": "SEO",
+  "sandbox.postEditor.seoTitleLabel": "SEO title",
   "sandbox.postEditor.settingsTab": "Settings",
   "sandbox.postEditor.slugLabel": "Slug",
   "sandbox.postEditor.slugPlaceholder": "my-post",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -353,6 +353,17 @@ export const sandbox = {
   "sandbox.postEditor.seePreview": "Ver visualização",
   "sandbox.postEditor.selectAuthorsPlaceholder": "Selecionar autores",
   "sandbox.postEditor.selectCategoriesPlaceholder": "Selecionar categorias",
+  "sandbox.postEditor.seoCanonicalLabel": "URL canônica",
+  "sandbox.postEditor.seoCanonicalPlaceholder":
+    "https://exemplo.com/blog/meu-post",
+  "sandbox.postEditor.seoDescriptionLabel": "Descrição de SEO",
+  "sandbox.postEditor.seoImageLabel": "Imagem de SEO",
+  "sandbox.postEditor.seoNoIndexingLabel":
+    "Ocultar dos mecanismos de busca (noindex)",
+  "sandbox.postEditor.seoSectionHint":
+    "Sobrescreve como este post aparece nos mecanismos de busca. Campos vazios usam o título, resumo e imagem de capa do post.",
+  "sandbox.postEditor.seoSectionLabel": "SEO",
+  "sandbox.postEditor.seoTitleLabel": "Título de SEO",
   "sandbox.postEditor.settingsTab": "Configurações",
   "sandbox.postEditor.slugLabel": "Slug",
   "sandbox.postEditor.slugPlaceholder": "meu-post",


### PR DESCRIPTION
## Summary

The blog app's `BlogPost` type has an optional `seo` field (`{ title?, description?, image?, canonical?, noIndexing? }`) that the Studio post editor never exposed, so posts couldn't have their SEO metadata filled in from the UI.

This adds an **SEO** section to the post editor's Settings tab:

- **SEO title** (input), **SEO description** (textarea), **SEO image** (same `ImageField` as the cover image), **Canonical URL** (input), and a **noindex** switch — matching the blog app's `Seo` type exactly.
- Edits flow through the existing autosave path (`setField("seo", …)` → `stampPostModified` → save), no new infra.
- All fields are optional (the site falls back to the post's title/excerpt/cover), so `missingPostFields` is untouched.
- New `sandbox.postEditor.seo*` i18n keys in `en` and mirrored in `pt-br` (parity enforced by `satisfies` at compile time).

## Testing

- `bun run check` (tsc) passes — also proves pt-br dictionary parity.
- `bun run lint` — 0 errors, no warnings in touched files.
- `bun run fmt` clean.
- UI-only change to the hand-built post settings form; no logic extracted that would warrant a unit test tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an SEO section to the blog post editor Settings so editors can set SEO title, description, image, canonical URL, and noindex per post. Changes autosave into the existing `seo` field; no backend changes.

- **New Features**
  - SEO fields in Settings: title, description, image, canonical URL, noindex.
  - Uses existing autosave on `seo`; no new infra.
  - All fields optional; site falls back to title/excerpt/cover.
  - Added `sandbox.postEditor.seo*` i18n keys in `en` and `pt-br`.

<sup>Written for commit 06744f2a77c3ffaf2557578b83ef926ee766f0f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

