### PR TITLE
perf(test): run the unit tier through native bun test --parallel

### DIFF
--- a/scripts/test-unit.ts
+++ b/scripts/test-unit.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import { readdir } from "node:fs/promises";
-import { availableParallelism } from "node:os";
 import { join, relative } from "node:path";
 
 const repoRoot = join(import.meta.dir, "..");
@@ -47,45 +46,15 @@ const testFiles = (
   .flat()
   .sort();
 
-// One bun process per file keeps the isolation guarantee; a worker pool keeps
-// the wall clock at max(slowest file, total / cores) instead of the serial sum.
-const concurrency = Math.min(availableParallelism(), testFiles.length);
-console.log(
-  `Running ${testFiles.length} isolated unit test files (concurrency ${concurrency})...`,
-);
+console.log(`Running ${testFiles.length} isolated unit test files...`);
 
-let nextIndex = 0;
-const failures: string[] = [];
-
-async function worker(): Promise<void> {
-  while (nextIndex < testFiles.length) {
-    const testFile = testFiles[nextIndex++];
-    if (!testFile) break;
-    const child = Bun.spawn(["bun", "test", testFile], {
-      cwd: repoRoot,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(child.stdout).text(),
-      new Response(child.stderr).text(),
-      child.exited,
-    ]);
-    if (exitCode === 0) {
-      console.log(`✓ ${testFile}`);
-    } else {
-      failures.push(testFile);
-      console.error(`\n✗ ${testFile}\n${stdout}${stderr}`);
-    }
-  }
-}
-
-await Promise.all(Array.from({ length: concurrency }, worker));
-
-if (failures.length > 0) {
-  console.error(`\n${failures.length} test file(s) failed:`);
-  for (const file of failures) {
-    console.error(`  ✗ ${file}`);
-  }
-  process.exit(1);
-}
+// --parallel implies --isolate: each file gets a fresh global object and
+// module registry across a pool of reused worker processes (one per core), so
+// the per-file isolation this tier requires holds without spawning a process
+// per file. Positional args are filters; exact relative paths match only
+// themselves, which is how the tier's filename-based exclusions stay applied.
+const child = Bun.spawn(["bun", "test", "--parallel", ...testFiles], {
+  cwd: repoRoot,
+  stdio: ["inherit", "inherit", "inherit"],
+});
+process.exit(await child.exited);

--- a/scripts/test-unit.ts
+++ b/scripts/test-unit.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { readdir } from "node:fs/promises";
+import { availableParallelism } from "node:os";
 import { join, relative } from "node:path";
 
 const repoRoot = join(import.meta.dir, "..");
@@ -46,16 +47,45 @@ const testFiles = (
   .flat()
   .sort();
 
-console.log(`Running ${testFiles.length} isolated unit test files...`);
+// One bun process per file keeps the isolation guarantee; a worker pool keeps
+// the wall clock at max(slowest file, total / cores) instead of the serial sum.
+const concurrency = Math.min(availableParallelism(), testFiles.length);
+console.log(
+  `Running ${testFiles.length} isolated unit test files (concurrency ${concurrency})...`,
+);
 
-for (const testFile of testFiles) {
-  console.log(`\n▶ ${testFile}`);
-  const child = Bun.spawn(["bun", "test", testFile], {
-    cwd: repoRoot,
-    stdio: ["inherit", "inherit", "inherit"],
-  });
-  const exitCode = await child.exited;
-  if (exitCode !== 0) {
-    process.exit(exitCode);
+let nextIndex = 0;
+const failures: string[] = [];
+
+async function worker(): Promise<void> {
+  while (nextIndex < testFiles.length) {
+    const testFile = testFiles[nextIndex++];
+    if (!testFile) break;
+    const child = Bun.spawn(["bun", "test", testFile], {
+      cwd: repoRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+    if (exitCode === 0) {
+      console.log(`✓ ${testFile}`);
+    } else {
+      failures.push(testFile);
+      console.error(`\n✗ ${testFile}\n${stdout}${stderr}`);
+    }
   }
+}
+
+await Promise.all(Array.from({ length: concurrency }, worker));
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} test file(s) failed:`);
+  for (const file of failures) {
+    console.error(`  ✗ ${file}`);
+  }
+  process.exit(1);
 }


### PR DESCRIPTION
## Summary

`scripts/test-unit.ts` spawned one `bun test` process per file, **one at a time** — 680 files where the median takes ~30ms, so the 234s CI `Run tests` step was almost pure serial spawn overhead, not slow tests.

Bun 1.3.13+ (repo pins 1.3.14) ships [`bun test --parallel`](https://bun.com/blog/bun-v1.3.13): files are distributed across one worker process per core, and the flag **implies `--isolate`** — each file gets a fresh global object and module registry even inside a reused worker. Verified empirically: `globalThis` pollution and module-level state mutations from one file are invisible to the next file in the same worker. That's the isolation guarantee this tier spawned per-file processes to get, minus the 680 process startups.

The runner keeps the filename-based discovery (the tier's `.integration`/`.e2e` exclusions) and hands the files as exact-path filters to a single `bun test --parallel` invocation. Per-file output buffering (no interleaving), failure reporting, and exit code are bun's own. Net diff: **−43/+12**.

**Measured** (full suite, local 10-core):

| runner | wall time |
|---|---|
| serial per-file spawn (before) | ~246s |
| hand-rolled worker pool (first version of this PR) | 66s |
| native `bun test --parallel` | **32s** |

Worker reuse removes the per-file bun startup + transpile cost, which is why native beats the hand-rolled pool 2×. On the 4-vCPU CI runner, expect ~60–90s until #5293 lands (its 60s single-file floor dominates), then ~40s.

## Testing notes

- Full suite through the new runner: 680 files, 6161 pass, 0 fail.
- Failure path: injected a failing test file → reported, exit code 1.
- Isolation probes (module-level state, `mock.module`, `globalThis`) pass under `--parallel=1` (forced worker reuse) and fail under plain serial `bun test` — i.e. `--parallel` is strictly more isolated than the old single-process mode and equivalent to the per-file spawn for these vectors.
- Pre-existing, unrelated: `packages/mcp-utils/src/sandbox/run-code.test.ts` prints a non-fatal `Aborted(Assertion failed: list_empty(&rt->gc_obj_list) ... JS_FreeRuntime)` from the quickjs-wasm teardown in serial mode too; tests pass and exit code is unaffected.

## Follow-up (not in this PR)

`apps/api/src/mcp-clients/circuit-breaker-e2e.test.ts` takes 60s alone (real hanging-server wait) and only lands in the unit tier because its `-e2e.test.ts` name (hyphen) dodges the runner's `.e2e.test.ts` exclusion regex — addressed in #5293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
