### PR TITLE
test(mcp-clients): drop the 60s SDK-default-timeout probe, fix misleading -e2e name

### DIFF
--- a/apps/api/src/mcp-clients/circuit-breaker-http.test.ts
+++ b/apps/api/src/mcp-clients/circuit-breaker-http.test.ts
@@ -1,13 +1,8 @@
 /**
- * E2E test: Circuit breaker with real HTTP MCP servers
- *
- * Starts actual HTTP servers that simulate different failure modes:
- * - Hanging (never responds) → triggers MCP SDK timeout
- * - Connection refused (closed port) → immediate failure
- * - Intermittent (works, then dies)
- *
- * Measures actual timings to verify the circuit breaker prevents
- * the 60s timeout penalty on repeated failures.
+ * Circuit breaker against real local HTTP servers (infrastructure edge only —
+ * see TESTING.md): failing servers trip the circuit, an open circuit rejects
+ * instantly instead of paying the MCP SDK's 60s default connect timeout, and
+ * a success closes it again.
  */
 
 import { describe, expect, it, beforeEach } from "bun:test";
@@ -22,17 +17,6 @@ import {
 } from "./circuit-breaker";
 
 // ─── Test Helpers ────────────────────────────────────────────────────────────
-
-/** Start an HTTP server that never sends a response (simulates timeout) */
-function startHangingServer() {
-  return Bun.serve({
-    port: 0,
-    fetch() {
-      // Never resolve — client will eventually timeout
-      return new Promise(() => {});
-    },
-  });
-}
 
 /** Start an HTTP server that immediately returns 500 */
 function startErrorServer() {
@@ -66,7 +50,7 @@ async function timedConnect(
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
-describe("circuit breaker e2e - real HTTP servers", () => {
+describe("circuit breaker - real HTTP servers", () => {
   beforeEach(() => {
     resetAll();
   });
@@ -86,24 +70,6 @@ describe("circuit breaker e2e - real HTTP servers", () => {
       server.stop(true);
     }
   });
-
-  it("connection to hanging server triggers MCP timeout (~60s)", async () => {
-    const server = startHangingServer();
-    const url = `http://localhost:${server.port}/mcp`;
-
-    try {
-      const result = await timedConnect(url);
-      console.log(`  Hanging server: ${result.durationMs}ms — ${result.error}`);
-
-      expect(result.error).toBeDefined();
-      // This is the key test — proves the 60s timeout hypothesis
-      // MCP SDK default timeout is 60000ms
-      expect(result.durationMs).toBeGreaterThan(55000);
-      expect(result.durationMs).toBeLessThan(70000);
-    } finally {
-      server.stop(true);
-    }
-  }, 90_000); // extend test timeout to 90s
 
   it("circuit breaker prevents repeated 60s waits", async () => {
     const connId = "conn_hanging_test";


### PR DESCRIPTION
## Summary

Follow-up flagged in #5292. The slowest file in the unit suite spent **60 real seconds** on a single test — `connection to hanging server triggers MCP timeout (~60s)` — whose assertion is a property of the **MCP SDK** (its default connect timeout is 60000ms), not of our code. The comment says it outright: *"proves the 60s timeout hypothesis"* — it's a leftover probe from the investigation that motivated the circuit breaker. If the SDK changed that default, nothing of ours breaks; the circuit breaker exists precisely so we never wait for whatever that value is. Deleted, along with its now-orphaned `startHangingServer` helper.

The other four tests stay: they assert real behavior (error server fails fast, circuit opens after 3 failures, open circuit rejects in <5ms, success closes it) and run in **0.5s total**.

Also renamed `circuit-breaker-e2e.test.ts` → `circuit-breaker-http.test.ts`: the `-e2e` suffix only slipped past `scripts/test-unit.ts`'s `.e2e.test` exclusion by a hyphen, and per TESTING.md the remaining tests are legitimately unit-tier (real local `Bun.serve` at the infrastructure edge, no DB/network beyond localhost, sub-second).

Combined with #5292, the unit suite's wall-time floor drops from 60s to the natural pool time (~45s on the 4-vCPU CI runner, from 234s originally).

## Testing notes

- `bun test apps/api/src/mcp-clients/circuit-breaker-http.test.ts`: 4 pass, 0 fail, 498ms.
- No references to the old filename anywhere in the repo (grepped code, configs, docs).
- `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the MCP SDK timeout probe test and renamed the file to reflect unit scope, cutting the slowest unit test from ~60s to ~0.5s. Keeps only the circuit-breaker behavior tests and speeds up CI.

- **Refactors**
  - Deleted the "hanging server triggers MCP timeout (~60s)" test and its `startHangingServer` helper; the 60s wait is an SDK default, not our code.
  - Renamed circuit-breaker-e2e.test.ts to circuit-breaker-http.test.ts to avoid e2e mislabeling per TESTING.md.
  - Retained the real circuit-breaker tests; they complete in ~500ms total.

<sup>Written for commit 3aa7594a56bc008d33fef2afa33ccbf5e87dd3ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

