### PR TITLE
ci(docker-smoke): reuse the sandbox image layer cache the release build publishes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,12 +170,21 @@ jobs:
       - name: Build daemon bundle
         run: bun run --cwd=packages/sandbox build
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build sandbox image
-        run: |
-          docker build \
-            -t studio-sandbox:ci \
-            -f packages/sandbox/image/Dockerfile \
-            packages/sandbox
+        uses: docker/build-push-action@v5
+        with:
+          context: ./packages/sandbox
+          file: ./packages/sandbox/image/Dockerfile
+          load: true
+          tags: studio-sandbox:ci
+          # Read-only reuse of the layer cache release-studio-sandbox already
+          # publishes from main (cache-to mode=max). Deliberately no cache-to:
+          # PR builds add zero cache-quota pressure, and the heavy apt/node
+          # layer only invalidates when the Dockerfile itself changes.
+          cache-from: type=gha
 
       - name: Smoke test
         run: |

--- a/ci-measure-trigger.txt
+++ b/ci-measure-trigger.txt
@@ -1,0 +1,1 @@
+temporary file to force the changes gate on; removed before merge


### PR DESCRIPTION
## Summary

`docker-smoke` rebuilt the sandbox image from scratch on every PR (**~78s**, the bulk of the job's 125s), while `release-studio-sandbox` already publishes a buildx layer cache for the **exact same Dockerfile/context** (`cache-to: type=gha,mode=max`, .github/workflows/release-studio-sandbox.yaml) — those are the `buildkit-blob-*` entries visible in the repo's cache quota, kept warm by every release from main.

This switches the plain `docker build` to buildx (`docker/build-push-action` with `load: true`) and adds **only** `cache-from: type=gha` — deliberately no `cache-to`:

- PR builds read the layers the release already paid for and write nothing → **zero added cache-quota pressure** (the lesson from #5290).
- The heavy layer (apt + NodeSource + Deno + corepack) only invalidates when the Dockerfile changes, so the hit rate should be near-total.
- Expected: image build ~78s → ~20s on hit; docker-smoke job ~125s → ~65s.

## Testing notes

- YAML validated. `.github/**`-only change, so the `changes` gate skips the suite on this PR — the effect shows on the next code PR (same as #5285/#5290; this time the prediction is based on reusing an existing cache, not creating a new one).
- Miss behavior is a plain full build, same as today.
- The smoke test itself is untouched — same `docker run` + `/health` probe against the loaded image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up the `docker-smoke` sandbox image build on PRs by reusing the release build’s Buildx layer cache. Switches to `docker/build-push-action` with read-only `cache-from` for faster builds (~78s → ~20s) without adding cache-quota pressure.

- **Refactors**
  - Switch to `docker/setup-buildx-action` + `docker/build-push-action` with `load: true` and `cache-from: type=gha` only (no `cache-to`).
  - Smoke test is unchanged; on cache miss, it does a full build.
  - Add temporary `ci-measure-trigger.txt` to force the changes gate for measurement; will be removed before merge.

<sup>Written for commit d8c20f5906c2aa669579ff9e0df15c4eb89813d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

