### PR TITLE
ci: cancel superseded PR runs, path-gate sandbox/storage jobs, unblock build job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,12 @@ on:
       - "apps/docs/**"
       - "**/*.md"
   pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # See test.yml for why this gate exists: skip the (required) check on

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -13,6 +13,10 @@ on:
       - '.github/workflows/helm-test.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   sandbox-operator:
     name: sandbox-operator chart

--- a/.github/workflows/multi-pod.yml
+++ b/.github/workflows/multi-pod.yml
@@ -30,8 +30,13 @@ on:
       - "packages/runtime/**"
       - "packages/bindings/**"
       - "tests/multi-pod/**"
+      - "tests/resilience/Dockerfile.studio"
       - ".github/workflows/multi-pod.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   multi-pod:

--- a/.github/workflows/sandbox-daemon.yml
+++ b/.github/workflows/sandbox-daemon.yml
@@ -22,10 +22,15 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  # See test.yml for why this gate exists: skip the (required) check on
-  # workflow/docs/markdown-only PRs without leaving the required check
-  # stuck pending. Pushes to main always run.
+  # See test.yml for why this gate exists: skip the (required) check without
+  # leaving it stuck pending. Here the gate is scoped tighter than test.yml's:
+  # the daemon e2e suite only exercises the sandbox daemon bundle, so it runs
+  # only when the packages feeding that build change. Pushes to main always run.
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -60,8 +65,7 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              .github/*|apps/docs/*|deploy/*|*.md) ;;
-              *) relevant=true; break ;;
+              packages/sandbox/*|packages/typegen/*|packages/shared/*|packages/harness/*) relevant=true; break ;;
             esac
           done <<< "$FILES"
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/storage-integration.yml
+++ b/.github/workflows/storage-integration.yml
@@ -26,10 +26,16 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  # See test.yml for why this gate exists: skip the (required) check on
-  # workflow/docs/markdown-only PRs without leaving the required check
-  # stuck pending. Pushes to main always run.
+  # See test.yml for why this gate exists: skip the (required) check without
+  # leaving it stuck pending. Scoped tighter than test.yml's gate: every
+  # *.integration.test.ts lives under apps/api and imports only apps/api +
+  # packages code, so web/plugins/scripts-only PRs skip the suite entirely.
+  # Pushes to main always run.
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -64,8 +70,8 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              .github/*|apps/docs/*|deploy/*|*.md) ;;
-              *) relevant=true; break ;;
+              *.md) ;;
+              apps/api/*|packages/*) relevant=true; break ;;
             esac
           done <<< "$FILES"
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,16 +16,28 @@ on:
     branches:
       - main
 
+# A force-push to a PR obsoletes the in-flight run — cancel it instead of
+# letting 6 jobs run to completion. Pushes to main all run (no cancel) so
+# every merged commit keeps its own result.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Gate: skip the (required) check jobs when a PR only touches workflow YAML,
   # docs, or markdown. Required checks can't be skipped via workflow-level
   # `paths` filters — a never-scheduled required check blocks the merge forever.
   # A job skipped via `if`, by contrast, reports as passed. So we keep the
   # trigger broad and skip at the job level. Pushes to main always run.
+  #
+  # `sandbox` additionally scopes docker-smoke: the job only exercises the
+  # sandbox daemon bundle + image, so it's skipped unless the PR touches the
+  # packages that feed that build.
   changes:
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
+      sandbox: ${{ steps.filter.outputs.sandbox }}
     steps:
       - name: Detect relevant changes
         id: filter
@@ -38,8 +50,14 @@ jobs:
             # commit, which only touches the version string. release-studio picks
             # that commit up on its own push trigger and cuts the release.
             case "$HEAD_MSG" in
-              '[release]:'*) echo "relevant=false" >> "$GITHUB_OUTPUT" ;;
-              *) echo "relevant=true" >> "$GITHUB_OUTPUT" ;;
+              '[release]:'*)
+                echo "relevant=false" >> "$GITHUB_OUTPUT"
+                echo "sandbox=false" >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                echo "relevant=true" >> "$GITHUB_OUTPUT"
+                echo "sandbox=true" >> "$GITHUB_OUTPUT"
+                ;;
             esac
             exit 0
           fi
@@ -49,19 +67,27 @@ jobs:
             --jq '.[].filename'); then
             echo "Could not list PR files — running to be safe."
             echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "sandbox=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "Changed files:"; echo "$FILES"
-          # Run unless every changed file is workflow/docs/markdown.
+          # relevant: run unless every changed file is workflow/docs/markdown.
+          # sandbox: run docker-smoke only when the sandbox build's inputs
+          # change (the daemon bundle pulls in typegen, shared, and harness).
           relevant=false
+          sandbox=false
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
               .github/*|apps/docs/*|deploy/*|*.md) ;;
-              *) relevant=true; break ;;
+              *) relevant=true ;;
+            esac
+            case "$f" in
+              packages/sandbox/*|packages/typegen/*|packages/shared/*|packages/harness/*) sandbox=true ;;
             esac
           done <<< "$FILES"
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+          echo "sandbox=$sandbox" >> "$GITHUB_OUTPUT"
 
   format:
     needs: changes
@@ -90,6 +116,11 @@ jobs:
 
       - name: Run lint
         run: bun run lint
+
+      # knip only reads source (knip.jsonc references no dist/ paths), so it
+      # lives here instead of serializing after the builds in the build job.
+      - name: Run knip
+        run: bun run knip
 
   typecheck:
     needs: changes
@@ -153,12 +184,9 @@ jobs:
       - name: Verify web output
         run: test -f apps/web/dist/index.html
 
-      - name: Run knip
-        run: bun run knip
-
   docker-smoke:
     needs: changes
-    if: needs.changes.outputs.relevant == 'true'
+    if: needs.changes.outputs.sandbox == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Orchestration fixes from a first-principles audit of all 23 workflows. Nothing changes on pushes to main.

**1. `concurrency` with PR-only cancel on the 6 PR-facing workflows** (test, e2e, sandbox-daemon, storage-integration, multi-pod, helm-test). A force-push previously left the entire superseded run going — e2e alone has a 30-minute ceiling. `cancel-in-progress` is guarded on `pull_request` so main pushes still all complete.

**2. Path-gate the jobs that can't be affected by most PRs.** `docker-smoke` + `sandbox-daemon` only exercise the sandbox daemon bundle/image (inputs: `packages/{sandbox,typegen,shared,harness}` — typegen/shared/harness verified as the bundle's workspace deps); `storage-integration` only exercises `apps/api` + `packages`. All three ran on **every** PR. The `changes` gate now scopes them — a web-only PR drops ~155s of sandbox image build and a postgres+MinIO integration suite it could never break.

⚠️ **Required-check safety**: all gated jobs (`docker-smoke`, `daemon-e2e`, `storage-integration`) are in the branch-protection required list; a job skipped via `if:` reports as passed — the exact mechanism the `changes` gate already uses (see the comment at the top of test.yml). No job was renamed or deleted, so the required contexts `lint/format/typecheck/test/build/docker-smoke/e2e/storage-integration/daemon-e2e` all still report.

**3. `knip` moves from `build` into `lint`.** `knip.jsonc` references no `dist/` paths — it never needed the builds it serialized behind. Trims `build` (a critical-path job, 143s) by ~16s; `lint` goes 23s → ~40s, still far from critical.

**Small strays fixed in passing:** `e2e.yml` gets the `branches: [main]` PR filter every sibling already has (it ran on PRs targeting any branch); `multi-pod.yml`'s `paths:` now includes `tests/resilience/Dockerfile.studio`, which it builds but didn't watch.

**Deliberately NOT done:** merging format/lint/typecheck into one job — all three are required checks, and renaming them requires a branch-protection update in the same motion. Flagged for a maintainer with admin if the runner savings matter.

## Testing notes

- YAML validated on all 6 files. Gate script changes are the same `case` pattern already in place; the sandbox scan drops the early `break` since it now computes two outputs over the full file list.
- `.github/**`-only PR, so the suite gates itself off — behavior shows on subsequent PRs (skips/cancels are directly visible in the Actions UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel superseded PR runs and skip sandbox/storage jobs when unrelated, cutting CI time. Move `knip` to lint to shorten the build path; pushes to main are unchanged.

- **Refactors**
  - Add `concurrency` with PR-only cancel in `test`, `e2e`, `sandbox-daemon`, `storage-integration`, `multi-pod`, `helm-test`.
  - Path-gate `docker-smoke` and `daemon-e2e` to changes under `packages/sandbox`, `packages/typegen`, `packages/shared`, `packages/harness`; gate `storage-integration` to `apps/api` and `packages`.
  - Keep required checks intact: skipped jobs report success; no job renames.
  - Run `knip` in lint instead of build (~16s faster build).
  - Minor fixes: `e2e` PR filter targets `main`; `multi-pod` watches `tests/resilience/Dockerfile.studio`.

<sup>Written for commit 741777da6846e8bd105a764c5e259ada00fdbae6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

