### PR TITLE
fix(multi-pod): build the studio test image once, not 4x

### DIFF
--- a/tests/multi-pod/docker-compose.yml
+++ b/tests/multi-pod/docker-compose.yml
@@ -64,9 +64,13 @@ services:
   # migration step (we override the entrypoint with a direct start command) to
   # avoid races on parallel boot.
   migrate:
+    # The only service with a `build:` — it tags the shared image, and every
+    # mesh pod (which depends_on migrate completing) reuses the tag instead of
+    # rebuilding the same context 4×. Same pattern as the resilience compose.
     build:
       context: ../../
       dockerfile: tests/resilience/Dockerfile.studio
+    image: deco-multipod-studio:latest
     working_dir: /app/apps/api
     command: ["bun", "run", "migrate"]
     environment:
@@ -78,9 +82,7 @@ services:
   # Legacy service identities are part of the resilience-test control contract;
   # Keep the legacy service names stable while the production apps use Studio naming.
   mesh-1: &studio
-    build:
-      context: ../../
-      dockerfile: tests/resilience/Dockerfile.studio
+    image: deco-multipod-studio:latest
     # No restart policy — tests need explicit start/stop control. With
     # `unless-stopped`, `docker kill` is auto-restarted within seconds,
     # which would defeat any pod-death scenario (the SIGKILL'd pod would


### PR DESCRIPTION
## Summary

`tests/multi-pod/docker-compose.yml` declared the same `build:` (context `../../`, `tests/resilience/Dockerfile.studio`) on `migrate` **and** on the `mesh-1` anchor inherited by `mesh-2`/`mesh-3` — with no shared `image:` name, so compose built and tagged **4 separate images of identical content**.

Fix mirrors the resilience compose's existing pattern (`deco-resilience-studio:latest`): `migrate` keeps the `build:` and gains `image: deco-multipod-studio:latest`; the `&studio` anchor swaps its `build:` for that `image:` reference, which `mesh-2`/`mesh-3` inherit. Ordering is already guaranteed — every mesh has `depends_on: migrate: service_completed_successfully`, and compose's build phase tags the image before any service starts.

**Honest scope note (measured):** this is hygiene, not wall-clock speed. The CI run on this PR shows `Start cluster` at **213s vs a 208–227s baseline** (last 6 main runs) — BuildKit was already deduplicating the identical layers locally, so the 4 builds were ~1 real build + 3 cache replays. What this buys: no redundant build invocations/CPU, one unambiguous image tag instead of 4, and parity with the resilience compose pattern.

## Testing notes

- Multi-pod workflow ran on this PR (run [30309695610](https://github.com/decocms/studio/actions/runs/30309695610)): **success** — Start cluster 213s, scenarios 225s, both within baseline. The compose change is behavior-neutral end-to-end.
- `docker compose config` resolves clean: 2 `build:` blocks left (migrate + mock-ai, down from 5) and 4 services sharing `deco-multipod-studio:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
