### PR TITLE
fix(settings): translate the provider-key-row "added ... ago" string

### DIFF
--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -521,6 +521,7 @@ export const settings = {
     "Organization updated successfully",
   "settings.organizationForm.uploadLogoLabel": "Upload organization logo",
   "settings.organizationForm.urlTitle": "URL",
+  "settings.providerKeyRow.addedTimeAgo": "{label} · added {time} ago",
   "settings.providerKeyRow.cancel": "Cancel",
   "settings.providerKeyRow.delete": "Delete",
   "settings.providerKeyRow.deleteApiKey": "Delete API key",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -552,6 +552,7 @@ export const settings = {
   "settings.organizationForm.uploadLogoLabel":
     "Enviar logo da organiza\u00e7\u00e3o",
   "settings.organizationForm.urlTitle": "URL",
+  "settings.providerKeyRow.addedTimeAgo": "{label} · adicionada há {time}",
   "settings.providerKeyRow.cancel": "Cancelar",
   "settings.providerKeyRow.delete": "Excluir",
   "settings.providerKeyRow.deleteApiKey": "Excluir chave de API",

--- a/apps/web/src/views/settings/ai-providers/provider-key-row.tsx
+++ b/apps/web/src/views/settings/ai-providers/provider-key-row.tsx
@@ -65,7 +65,10 @@ export function ProviderKeyRow({ providerKey, provider }: ProviderKeyRowProps) {
     if (isOpenAICompatible) {
       return providerKey.label;
     }
-    return `${providerKey.label} · added ${formatDistanceToNow(new Date(providerKey.createdAt), { locale })} ago`;
+    return t("settings.providerKeyRow.addedTimeAgo", {
+      label: providerKey.label,
+      time: formatDistanceToNow(new Date(providerKey.createdAt), { locale }),
+    });
   })();
 
   const { mutate: deleteKey, isPending: isDeleting } = useMutation({


### PR DESCRIPTION
Follows the i18n conventions in CLAUDE.md ("never hardcode user-facing strings"): `apps/web/src/views/settings/ai-providers/provider-key-row.tsx` built its API-key row subtitle as a raw template literal — `${label} · added ${time} ago` — so pt-BR users saw the literal English words "added" and "ago" wrapped around an otherwise correctly pt-BR-localized date-fns duration.

A maintainer wants this because it's a visible, half-translated string on a settings page that's otherwise fully localized (every other string in this file already goes through `t()`).

Fix: route the string through `t("settings.providerKeyRow.addedTimeAgo", { label, time })`, added the key to both `en/settings.ts` ("{label} · added {time} ago", byte-identical to the old English output) and `pt-br/settings.ts` ("{label} · adicionada há {time}").

To confirm: open Settings → AI Providers with an API key configured, switch language to Portuguese, and see the subtitle render entirely in Portuguese instead of mixing in "added"/"ago".

Checks run locally: `bun run fmt` (clean) and `cd apps/web && bunx tsc --noEmit` (clean — the `satisfies Record<keyof typeof ...>` constraint on the pt-br dictionary would fail to compile if the new key were missing, so this also proves en/pt-br key parity). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the AI Provider key row subtitle by moving "added … ago" into i18n, so pt-BR users see a fully translated string.

- **Bug Fixes**
  - Use `t("settings.providerKeyRow.addedTimeAgo", { label, time })` and add keys in `en/settings.ts` and `pt-br/settings.ts`.

<sup>Written for commit a424590680fd459c6e2472e2e07418c5d35e0fc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

