### PR TITLE
fix(sandbox): recover from a stale rebase-merge left by a crashed daemon

### DIFF
--- a/packages/sandbox/daemon/git/rebase-onto-base.test.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.test.ts
@@ -304,6 +304,31 @@ describe("rebaseOntoBase", () => {
     }
   });
 
+  it("recovers from a stale rebase-merge left by a crashed prior attempt", () => {
+    const { repoDir, cleanup } = setupConflictingRepo();
+    try {
+      // Simulate a daemon crash mid-rebase: a plain conflicting rebase left
+      // `.git/rebase-merge` on disk and HEAD detached, with no `--abort` ever run.
+      try {
+        execSync(`git -C ${repoDir} rebase origin/main`, { stdio: "ignore" });
+      } catch {
+        // expected: conflicts, rebase-merge left behind
+      }
+      expect(existsSync(join(repoDir, ".git/rebase-merge"))).toBe(true);
+
+      rebaseOntoBase(repoDir, "main", { asUser: false });
+
+      expect(existsSync(join(repoDir, ".git/rebase-merge"))).toBe(false);
+      const content = readFileSync(
+        join(repoDir, ".deco/blocks/shipping.json"),
+        "utf-8",
+      );
+      expect(JSON.parse(content)).toEqual({ threshold: 250 });
+    } finally {
+      cleanup();
+    }
+  });
+
   it("throws RebaseBaseBranchNotFoundError for a base branch missing on origin", () => {
     const { repoDir, cleanup } = setupConflictingRepo();
     try {

--- a/packages/sandbox/daemon/git/rebase-onto-base.ts
+++ b/packages/sandbox/daemon/git/rebase-onto-base.ts
@@ -354,6 +354,15 @@ function rebaseOntoBaseInner(
 ): { rebased: boolean } {
   assertValidRemoteBranchName(base);
 
+  // A prior rebase can be left mid-flight if the daemon process was killed
+  // (OOM, container restart) while `git rebase` was running: rebase leaves
+  // HEAD detached and `.git/rebase-merge` on disk. Every future call would
+  // otherwise misreport this as "Cannot rebase from a detached HEAD" below,
+  // permanently bricking rebase for the sandbox. Clear it before checking HEAD.
+  if (isRebaseInProgress(repoDir)) {
+    abortRebase(repoDir);
+  }
+
   const branch = runGit(repoDir, ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (!branch || branch === "HEAD") {
     throw new RebaseBlockedError("Cannot rebase from a detached HEAD");


### PR DESCRIPTION
A bug found by reading `packages/sandbox/daemon/git/rebase-onto-base.ts` in the assigned focus area (sandbox daemon git workflow), not tied to an issue.

**Failure scenario:** if the daemon process is killed (OOM kill, container restart) while `git rebase` is running mid-conflict-resolution, `git rebase` leaves `.git/rebase-merge` on disk and HEAD detached (rebase always checks out the commit being replayed). On the next `/git/rebase` request, `rebaseOntoBaseInner` runs `git rev-parse --abbrev-ref HEAD` before any cleanup, gets back `"HEAD"` (detached), and throws `RebaseBlockedError("Cannot rebase from a detached HEAD")` — a misleading diagnosis, since the sandbox is actually sitting on a real feature branch mid-rebase, not genuinely detached. Nothing else in the daemon (discard, publish) ever runs `git rebase --abort`, so this state is permanent: every future rebase attempt on that sandbox fails with the same confusing error forever.

**Why a maintainer wants this:** this is a real, reproducible data-availability bug (bricks the rebase flow for that sandbox with no recovery path) in the same category as the other rebase-onto-base hardening PRs that have merged (#5124, #5224, #5236).

**The fix:** `rebaseOntoBaseInner` now checks `isRebaseInProgress()` and calls the existing `abortRebase()` helper *before* reading `HEAD`, clearing any stale crash artifact so the requested rebase proceeds normally instead of failing forever.

**Regression test:** added `"recovers from a stale rebase-merge left by a crashed prior attempt"` to `rebase-onto-base.test.ts` — it manually runs a plain conflicting `git rebase origin/main` (no `-X theirs`) and deliberately does NOT abort it, confirms `.git/rebase-merge` exists (reproducing the crash artifact), then calls `rebaseOntoBase()` and asserts it succeeds and clears the stale state. Verified this test fails with the old code (throws `RebaseBlockedError`) and passes with the fix.

**To confirm:** `bun test packages/sandbox/daemon/git/rebase-onto-base.test.ts` (6 pass, 0 fail).

**Locally verified:** `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit` (clean), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Abort stale rebase state left by a crashed daemon so sandbox rebases recover instead of failing with a detached HEAD error.

- **Bug Fixes**
  - Abort any in-progress rebase before checking `HEAD` in `packages/sandbox/daemon/git/rebase-onto-base.ts`.
  - Added a regression test in `packages/sandbox/daemon/git/rebase-onto-base.test.ts` that simulates a crash and verifies cleanup of `.git/rebase-merge`.

<sup>Written for commit 03f156120ff6cad724e54cf94ad606afccbacd9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

