### PR TITLE
fix(home): show the live agent count in the on-home limit hint

### DIFF
--- a/apps/web/src/components/home/add-tile-drawer.tsx
+++ b/apps/web/src/components/home/add-tile-drawer.tsx
@@ -231,6 +231,7 @@ function useHomeBoard(validIds?: ReadonlySet<string>) {
 
   return {
     homeIds,
+    liveCount,
     isOnHome,
     atLimit,
     addAgent,
@@ -309,7 +310,7 @@ function OnHomeSection({
     <div className="flex flex-col gap-1.5">
       <SectionHeader
         title={t("home.addTileDrawer.onHomeTitle")}
-        hint={`${home.homeIds.length}/${HOME_LIMIT}`}
+        hint={`${home.liveCount}/${HOME_LIMIT}`}
       />
       {agents.length === 0 ? (
         <p className="px-3 py-4 text-center text-xs text-muted-foreground">


### PR DESCRIPTION
Found while auditing `default_home_agents` consistency (org settings / home-agents feature) — no linked issue.

The "On home" drawer section header displays `home.homeIds.length/HOME_LIMIT`, which counts every id in the stored `default_home_agents.ids` list, including dangling ids left behind by deleted agents (the codebase deliberately never cleans those up — see the comment at `add-tile-drawer.tsx:204`). Meanwhile `atLimit` — the value that actually disables the Add button — is computed from `liveCount`, which excludes those dead ids. The two numbers can diverge: an org with 8 stored ids where 2 point to deleted agents shows the hint "8/8" (looks completely full) while `atLimit` is `false` and the user can still add 2 more agents. The hint contradicts the actual gate, which reads as a UI bug to any user who deletes an agent that was pinned to home.

Fix: expose the already-computed `liveCount` from `useHomeBoard` and use it for the hint instead of the raw `homeIds.length`, so the displayed count always matches the limit that's actually enforced.

Failure scenario: org has 8 agents pinned to home, deletes 2 of them (their ids linger in `default_home_agents.ids` by design), opens the "Add to home" drawer — hint shows "8/8" but the Add button is still enabled and adding succeeds, since `atLimit` correctly uses the live (non-dead) count.

Reviewer check: `bun test apps/web/src/components/home/add-tile-drawer.test.ts` (existing `nextHomeIdsWithAdd` tests already cover the live-vs-dead counting logic this hint now surfaces correctly).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (clean), and the targeted test file above (5 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the "On home" drawer hint to show the live agent count, excluding deleted agents. The hint now matches the limit that gates the Add button, so boards with stale IDs won’t show as full when space remains.

<sup>Written for commit 8abc8ba85ac19c6aef864fb33c0f69c55e527a0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

