### PR TITLE
fix(virtual-mcp): validate connection ownership on virtual MCP create/update

### DIFF
--- a/apps/api/src/tools/virtual/create.ts
+++ b/apps/api/src/tools/virtual/create.ts
@@ -15,6 +15,7 @@ import {
 } from "../../core/studio-context";
 import { VirtualMCPCreateDataSchema, VirtualMCPEntitySchema } from "./schema";
 import { requireOrgAdminForPinnedField } from "./require-org-admin-for-pin";
+import { requireConnectionsInOrganization } from "./require-connections-in-org";
 import { writeAgentPrompts } from "../../file-storage/agent-prompts";
 /**
  * Random icon+color for new agents (server-side, no React deps).
@@ -117,6 +118,14 @@ export const COLLECTION_VIRTUAL_MCP_CREATE = defineTool({
 
     // `prompts` is seeded to org-fs after creation, not stored on the agent row.
     const { prompts, ...createData } = input.data;
+
+    if (createData.connections.length > 0) {
+      await requireConnectionsInOrganization(
+        ctx,
+        organization.id,
+        createData.connections.map((c) => c.connection_id),
+      );
+    }
 
     // Create the virtual MCP (input.data is already in the correct format)
     // Note: The facade creates a VIRTUAL connection in the connections table

--- a/apps/api/src/tools/virtual/require-connections-in-org.test.ts
+++ b/apps/api/src/tools/virtual/require-connections-in-org.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, mock } from "bun:test";
+import { requireConnectionsInOrganization } from "./require-connections-in-org";
+
+function makeCtx(connections: Record<string, { organization_id: string }>) {
+  return {
+    storage: {
+      connections: {
+        findById: mock(async (id: string, organizationId?: string) => {
+          const conn = connections[id];
+          if (!conn) return null;
+          if (organizationId && conn.organization_id !== organizationId) {
+            return null;
+          }
+          return conn;
+        }),
+      },
+    },
+  } as unknown as Parameters<typeof requireConnectionsInOrganization>[0];
+}
+
+describe("requireConnectionsInOrganization", () => {
+  it("throws when a connection id belongs to a different organization", async () => {
+    // Regression: COLLECTION_VIRTUAL_MCP_CREATE/UPDATE used to insert
+    // connection_aggregations rows for caller-supplied connection ids with no
+    // ownership check, and the aggregator later loads children via
+    // connections.findById(id) with no org filter — letting an org member
+    // wire another org's connection into their own virtual MCP.
+    const ctx = makeCtx({
+      conn_a: { organization_id: "org-a" },
+      conn_other: { organization_id: "org-b" },
+    });
+
+    await expect(
+      requireConnectionsInOrganization(ctx, "org-a", ["conn_a", "conn_other"]),
+    ).rejects.toThrow(/conn_other/);
+  });
+
+  it("throws when a connection id does not exist", async () => {
+    const ctx = makeCtx({ conn_a: { organization_id: "org-a" } });
+
+    await expect(
+      requireConnectionsInOrganization(ctx, "org-a", ["conn_missing"]),
+    ).rejects.toThrow(/conn_missing/);
+  });
+
+  it("resolves when every connection belongs to the caller's organization", async () => {
+    const ctx = makeCtx({
+      conn_a: { organization_id: "org-a" },
+      conn_b: { organization_id: "org-a" },
+    });
+
+    await expect(
+      requireConnectionsInOrganization(ctx, "org-a", ["conn_a", "conn_b"]),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/tools/virtual/require-connections-in-org.ts
+++ b/apps/api/src/tools/virtual/require-connections-in-org.ts
@@ -1,0 +1,25 @@
+/**
+ * Ownership guard for virtual MCP connection references.
+ *
+ * COLLECTION_VIRTUAL_MCP_CREATE/UPDATE accept a list of connection ids to
+ * aggregate into the agent. `connections.findById` only filters by
+ * organization when given one — an unchecked id would let a caller wire in
+ * another org's connection and have its tools (and credentials) proxied
+ * through their own virtual MCP.
+ */
+import type { StudioContext } from "../../core/studio-context";
+
+export async function requireConnectionsInOrganization(
+  ctx: StudioContext,
+  organizationId: string,
+  connectionIds: string[],
+): Promise<void> {
+  const uniqueIds = [...new Set(connectionIds)];
+  const found = await Promise.all(
+    uniqueIds.map((id) => ctx.storage.connections.findById(id, organizationId)),
+  );
+  const missing = uniqueIds.filter((_, i) => !found[i]);
+  if (missing.length > 0) {
+    throw new Error(`Connection not found: ${missing.join(", ")}`);
+  }
+}

--- a/apps/api/src/tools/virtual/update.ts
+++ b/apps/api/src/tools/virtual/update.ts
@@ -14,6 +14,7 @@ import {
 import { writeAgentPrompts } from "../../file-storage/agent-prompts";
 import { VirtualMCPEntitySchema, VirtualMCPUpdateDataSchema } from "./schema";
 import { requireOrgAdminForPinnedField } from "./require-org-admin-for-pin";
+import { requireConnectionsInOrganization } from "./require-connections-in-org";
 
 /**
  * Input schema for updating a virtual MCP
@@ -77,6 +78,14 @@ export const COLLECTION_VIRTUAL_MCP_UPDATE = defineTool({
 
     if (data.pinned !== undefined && data.pinned !== existing.pinned) {
       requireOrgAdminForPinnedField(ctx);
+    }
+
+    if (data.connections?.length) {
+      await requireConnectionsInOrganization(
+        ctx,
+        organization.id,
+        data.connections.map((c) => c.connection_id),
+      );
     }
 
     const virtualMcp = await ctx.storage.virtualMcps.update(


### PR DESCRIPTION
**Source:** cross-tenant security gap found while auditing the virtual-MCP tools for the "MCP security hardening" focus area (adjacent to #5276, which fixed the org-context trust boundary on the legacy virtual-MCP route).

**Bug:** `COLLECTION_VIRTUAL_MCP_CREATE` and `COLLECTION_VIRTUAL_MCP_UPDATE` write `connection_aggregations` rows for every `connections[].connection_id` the caller supplies, with no check that the connection belongs to the caller's organization (`apps/api/src/storage/virtual.ts` `create()`/`update()`). `createVirtualClientFrom` (`apps/api/src/mcp-clients/virtual-mcp/index.ts`) then loads each aggregated child via `ctx.storage.connections.findById(connId)` — called with **no** `organizationId` argument, so it resolves across organizations. Net effect: any org member can attach another org's connection id to their own virtual MCP and have that connection's tools (and the credentials behind it) proxied through their agent's gateway. `VIRTUAL_MCP_PLUGIN_CONFIG_UPDATE` already guards its own single `connectionId` input the same way — create/update never got the equivalent check.

**Fix:** added `requireConnectionsInOrganization()` (`apps/api/src/tools/virtual/require-connections-in-org.ts`) and call it from both `create.ts` and `update.ts` before writing any aggregation, rejecting with `Connection not found: <id>` for any connection_id that isn't found scoped to the caller's org (mirrors the existing plugin-config-update.ts pattern/error shape).

**Regression test:** `apps/api/src/tools/virtual/require-connections-in-org.test.ts` — asserts the guard throws for a connection owned by a different org, throws for a non-existent connection id, and resolves cleanly when every id belongs to the caller's org.

**Reviewer check:** `bun test apps/api/src/tools/virtual/require-connections-in-org.test.ts`

**Local verification:** `bun run fmt` (clean), `cd apps/api && bunx tsc --noEmit` (clean), targeted test above (3 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate virtual MCP connection ownership on create/update to close a cross-tenant access gap. Reject out-of-org or unknown `connection_id`s before writing aggregations.

- **Bug Fixes**
  - Added `requireConnectionsInOrganization` and used in `COLLECTION_VIRTUAL_MCP_CREATE` and `COLLECTION_VIRTUAL_MCP_UPDATE`; throws `Connection not found: <id>` for missing/out-of-org IDs.
  - Added tests in `apps/api/src/tools/virtual/require-connections-in-org.test.ts`.

<sup>Written for commit 651fb6d3e63fa7b6ae6a9eef572320355f3af624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

