### PR TITLE
refactor(storage): use the JsonObject helper for KV/sandbox-state columns

### DIFF
--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1472,7 +1472,7 @@ export interface TriggerCallbackTokenTable {
 export interface KVTable {
   organization_id: string;
   key: string;
-  value: ColumnType<Record<string, unknown>, string, string>;
+  value: JsonObject<Record<string, unknown>>;
   updated_at: ColumnType<Date, Date | string, Date | string>;
 }
 
@@ -1481,7 +1481,7 @@ export interface SandboxProviderStateTable {
   project_ref: string;
   sandbox_provider_kind: string;
   handle: string;
-  state: ColumnType<Record<string, unknown>, string, string>;
+  state: JsonObject<Record<string, unknown>>;
   updated_at: ColumnType<Date, Date | string, Date | string>;
 }
 


### PR DESCRIPTION
**Source**: reduction/consistency fix found while auditing `apps/api/src/storage/types.ts` per this tick's focus area ("API storage type definitions" / JsonArray-JsonObject consistency). Not a duplicate of the open JsonArray double-wrapping PR (#4965, branch `fix/json-array-type-safety-w4`) — that PR fixes `JsonArray<T[]>` misuse on other tables; this PR is a separate, narrower cleanup of two `JsonObject`-shaped columns that hand-rolled the helper's expansion instead of using it.

**What/why**: `KVTable.value` and `SandboxProviderStateTable.state` were declared as `ColumnType<Record<string, unknown>, string, string>` — the exact hand-written expansion of the existing `JsonObject<T> = ColumnType<T, string, string>` helper already used by every other JSON-object column in this file (e.g. `ApiKeyTable.metadata`, `MCPConnectionTable.metadata`, `AsyncResearchThreadTable.settings`). Collapsing the duplication onto the existing helper is a net type-safety/consistency win a maintainer would want, matching the pattern already established in this file.

**Behavior preserved**: `JsonObject<Record<string, unknown>>` expands to the identical `ColumnType<Record<string, unknown>, string, string>` type — a pure textual substitution, zero type-level change. Confirmed via `bunx tsc --noEmit` in `apps/api` staying green (no other file references these two fields with a type that would now mismatch).

**Reviewer command**: `cd apps/api && bunx tsc --noEmit`

**Local checks run**: `bun run fmt` (clean, no changes), `cd apps/api && bunx tsc --noEmit` (green). No test file touched — this is a pure type-alias substitution with no behavior change, so a targeted test isn't applicable; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced manual `ColumnType<...>` types with the `JsonObject` helper for two JSON-object columns to align with the rest of the file. No behavior change; types remain equivalent.

- **Refactors**
  - `KVTable.value`: `ColumnType<Record<string, unknown>, string, string>` → `JsonObject<Record<string, unknown>>`
  - `SandboxProviderStateTable.state`: `ColumnType<Record<string, unknown>, string, string>` → `JsonObject<Record<string, unknown>>`

<sup>Written for commit cadfdbc3adb0810c38b46fd9d13669066566c223. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

