### PR TITLE
refactor(chat): dedupe tier-label lookup in tier-trigger

### DIFF
--- a/apps/web/src/components/chat/tier-trigger.tsx
+++ b/apps/web/src/components/chat/tier-trigger.tsx
@@ -58,6 +58,14 @@ import { ClaudeCodeIcon, CodexIcon, localHarnessBrand } from "./agent-icons";
 
 const TIER_ORDER: ChatTier[] = ["fast", "smart", "thinking"];
 
+function getTierLabels(t: TFunction): Record<ChatTier, string> {
+  return {
+    fast: t("chat.tierTrigger.tierFast"),
+    smart: t("chat.tierTrigger.tierSmart"),
+    thinking: t("chat.tierTrigger.tierThinking"),
+  };
+}
+
 /** One selectable row in the popover — a concrete (runtime, tier) choice. */
 interface TierRow {
   key: string;
@@ -115,12 +123,7 @@ export function TierTriggerPure({
   header,
 }: PureProps) {
   const t = useT();
-  const getTierLabels = (): Record<ChatTier, string> => ({
-    fast: t("chat.tierTrigger.tierFast"),
-    smart: t("chat.tierTrigger.tierSmart"),
-    thinking: t("chat.tierTrigger.tierThinking"),
-  });
-  const tierLabels = getTierLabels();
+  const tierLabels = getTierLabels(t);
   const [open, setOpen] = useState(false);
   const handleSelect = (row: TierRow) => {
     row.onSelect();
@@ -487,12 +490,7 @@ export function TierTrigger() {
     useUserModelPreferencesQuery();
   const updateUserModelPreferences = useUpdateUserModelPreferences();
 
-  const getTierLabels = (): Record<ChatTier, string> => ({
-    fast: t("chat.tierTrigger.tierFast"),
-    smart: t("chat.tierTrigger.tierSmart"),
-    thinking: t("chat.tierTrigger.tierThinking"),
-  });
-  const tierLabels = getTierLabels();
+  const tierLabels = getTierLabels(t);
 
   let groups: TierGroup[];
   if (isLocal) {


### PR DESCRIPTION
Source: reduction found while auditing `apps/web/src/components/chat/tier-trigger.tsx` (assigned focus area this tick) for state-sync/UI issues — the component logic itself is already heavily hardened by recent PRs (#5247, #5253, #5263, #5271), but `TierTriggerPure` and `TierTrigger` each defined byte-identical inline `getTierLabels()` closures building the same `Record<ChatTier, string>` from the same three `t("chat.tierTrigger.tier*")` calls.

Why: one copy is the actual single source of truth for the tier-label map instead of two closures that could silently drift if a label key changes in only one place.

Change: hoisted the closure to a single module-level `getTierLabels(t: TFunction)` that both components call. Net -2 lines, no behavior change — same three keys, same lookup, just relocated out of each component body.

How to confirm: `cd apps/web && bunx tsc --noEmit` (clean), and manually opening the tier-trigger popover (desktop + mobile) — the pill label and popover row titles are unchanged since the returned map is identical.

Locally ran: `bun run fmt` (only this file touched) and a scoped `bunx tsc --noEmit` in `apps/web` (green). Full CI (lint/tests) covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated the tier label lookup by hoisting a shared `getTierLabels(t)` to module scope and using it in `TierTrigger` and `TierTriggerPure`. This removes duplicate closures and keeps a single source of truth for the three tier labels with no behavior change.

<sup>Written for commit 6acb1a6f6c848d7ad2477e120cb616c05ac83f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

