### PR TITLE
feat(task-board): drag-to-reorder kanban cards within a lane

### DIFF
--- a/apps/api/migrations/149-task-board-item-sort-order.ts
+++ b/apps/api/migrations/149-task-board-item-sort-order.ts
@@ -1,0 +1,27 @@
+import { sql, type Kysely } from "kysely";
+
+/**
+ * Manual drag-to-reorder within a lane. Ascending `sort_order` is the lane's
+ * display order; existing rows are backfilled to `-created_at` (in seconds)
+ * so the initial order matches the prior `created_at desc` behavior.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_items")
+    .addColumn("sort_order", "double precision", (col) =>
+      col.notNull().defaultTo(0),
+    )
+    .execute();
+
+  await sql`
+    update task_board_items
+    set sort_order = -extract(epoch from created_at)
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_board_items")
+    .dropColumn("sort_order")
+    .execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -147,6 +147,7 @@ import * as migration145usermodelpreferences from "./145-user-model-preferences.
 import * as migration146organizationmainagent from "./146-organization-main-agent.ts";
 import * as migration147dropagentsandboxtables from "./147-drop-agent-sandbox-tables.ts";
 import * as migration148orgflags from "./148-org-flags.ts";
+import * as migration149taskboarditemsortorder from "./149-task-board-item-sort-order.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -319,6 +320,7 @@ const migrations: Record<string, Migration> = {
   "146-organization-main-agent": migration146organizationmainagent,
   "147-drop-agent-sandbox-tables": migration147dropagentsandboxtables,
   "148-org-flags": migration148orgflags,
+  "149-task-board-item-sort-order": migration149taskboarditemsortorder,
 };
 
 export default migrations;

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -85,7 +85,7 @@ export class TaskBoardStorage {
       .selectFrom("task_board_items")
       .selectAll()
       .where("organization_id", "=", organizationId)
-      .orderBy("created_at", "desc")
+      .orderBy("sort_order", "asc")
       .execute();
 
     const items = rows.map((row) => this.itemFromDbRow(row));
@@ -125,6 +125,16 @@ export class TaskBoardStorage {
   }): Promise<TaskBoardItem> {
     const id = generatePrefixedId("board");
     const now = new Date().toISOString();
+    const status = params.status ?? "triage";
+
+    // New cards land at the top of their lane — one below the current lowest
+    // sort_order (ascending order), matching the prior created_at-desc feel.
+    const { minOrder } = await this.db
+      .selectFrom("task_board_items")
+      .select((eb) => eb.fn.min("sort_order").as("minOrder"))
+      .where("organization_id", "=", params.organizationId)
+      .where("status", "=", status)
+      .executeTakeFirstOrThrow();
 
     const row = await this.db
       .insertInto("task_board_items")
@@ -133,12 +143,13 @@ export class TaskBoardStorage {
         organization_id: params.organizationId,
         title: params.title,
         description: params.description ?? null,
-        status: params.status ?? "triage",
+        status,
         priority: params.priority ?? "medium",
         assignee_id: params.assigneeId ?? null,
         assigned_by: params.assignedBy ?? null,
         due_date: params.dueDate ?? null,
         external_key: params.externalKey ?? null,
+        sort_order: (minOrder ?? 0) - 1,
         created_by: params.by,
         created_at: now,
         updated_by: params.by,
@@ -162,6 +173,7 @@ export class TaskBoardStorage {
       assigneeId?: string | null;
       assignedBy?: string | null;
       dueDate?: string | null;
+      sortOrder?: number;
     },
     by: string,
   ): Promise<TaskBoardItem> {
@@ -181,6 +193,7 @@ export class TaskBoardStorage {
           ? { assigned_by: data.assignedBy }
           : {}),
         ...(data.dueDate !== undefined ? { due_date: data.dueDate } : {}),
+        ...(data.sortOrder !== undefined ? { sort_order: data.sortOrder } : {}),
         updated_by: by,
         updated_at: new Date().toISOString(),
       })
@@ -460,6 +473,7 @@ export class TaskBoardStorage {
     assignee_id: string | null;
     assigned_by: string | null;
     due_date: string | Date | null;
+    sort_order: number;
     created_by: string;
     created_at: string | Date;
     updated_by: string;
@@ -478,6 +492,7 @@ export class TaskBoardStorage {
         row.due_date instanceof Date
           ? row.due_date.toISOString()
           : row.due_date,
+      sortOrder: row.sort_order,
       // Populated by attachThreads for reads; empty for a fresh create.
       threads: [],
       createdBy: row.created_by,

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1622,6 +1622,8 @@ export interface TaskBoardItemTable {
     string | null | undefined,
     string | null
   >;
+  /** Manual drag-to-reorder position within a lane, ascending. */
+  sort_order: ColumnType<number, number | undefined, number>;
   created_by: string;
   created_at: ColumnType<Date, Date | string | undefined, never>;
   updated_by: string;
@@ -1701,6 +1703,8 @@ export interface TaskBoardItem {
   assigneeId: string | null;
   assignedBy: string | null;
   dueDate: string | null;
+  /** Manual drag-to-reorder position within a lane, ascending. */
+  sortOrder: number;
   /** Agent threads linked to this task (most-recent first). */
   threads: TaskBoardItemThreadRef[];
   createdBy: string;

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -59,6 +59,8 @@ export const TaskBoardItemSchema = z.object({
   assigneeId: z.string().nullable(),
   assignedBy: z.string().nullable(),
   dueDate: z.string().datetime().nullable(),
+  // Manual drag-to-reorder position within a lane, ascending.
+  sortOrder: z.number(),
   // Agent threads linked to this task (many-to-many), most-recent first.
   threads: z.array(TaskBoardItemThreadSchema),
   createdBy: z.string(),

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -31,6 +31,8 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     priority: TaskBoardItemPrioritySchema.optional(),
     assigneeId: z.string().nullable().optional(),
     dueDate: z.string().datetime().nullable().optional(),
+    /** New drag-to-reorder position within its lane (ascending). */
+    sortOrder: z.number().optional(),
     /** Link an existing chat thread to this task (many-to-many, idempotent). */
     linkThreadId: z.string().optional(),
   }),
@@ -71,7 +73,8 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
       input.status !== undefined ||
       input.priority !== undefined ||
       input.assigneeId !== undefined ||
-      input.dueDate !== undefined;
+      input.dueDate !== undefined ||
+      input.sortOrder !== undefined;
 
     // Only enqueue on the transition INTO Super Agent, not on every later edit.
     const previous =
@@ -106,6 +109,7 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
               : null
             : undefined,
           dueDate: input.dueDate,
+          sortOrder: input.sortOrder,
         },
         getUserId(ctx)!,
       );

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -3,7 +3,8 @@
  * description, status, priority, assignee), independent of chat threads.
  */
 
-import { useRef, useState } from "react";
+import { Fragment, useRef, useState } from "react";
+import type { DragEvent } from "react";
 import { getInitials } from "@/lib/get-initials";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -488,7 +489,9 @@ export function TaskBoardPage() {
           memberByUserId={memberByUserId}
           onOpen={openTask}
           onCreate={openCreateInLane}
-          onMove={(id, status) => actions.update.mutate({ id, status })}
+          onMove={(id, status, sortOrder) =>
+            actions.update.mutate({ id, status, sortOrder })
+          }
           onAssign={(id, userId) => {
             if (blockSuperAgentWithoutGithub(userId)) return;
             actions.update.mutate({ id, assigneeId: userId ?? undefined });
@@ -659,6 +662,29 @@ function LayoutToggle({
   );
 }
 
+/**
+ * `sortOrder` a dragged card should take to land right before `beforeId`
+ * within `laneItems` (or at the end when `beforeId` is null) — the midpoint
+ * of its new neighbors, so reordering never needs to touch other rows.
+ */
+function insertSortOrder(
+  laneItems: TaskBoardItem[],
+  beforeId: string | null,
+  draggedId: string,
+): number {
+  const filtered = laneItems.filter((i) => i.id !== draggedId);
+  const beforeIndex = beforeId
+    ? filtered.findIndex((i) => i.id === beforeId)
+    : -1;
+  const insertIndex = beforeIndex === -1 ? filtered.length : beforeIndex;
+  const prev = filtered[insertIndex - 1];
+  const next = filtered[insertIndex];
+  if (prev && next) return (prev.sortOrder + next.sortOrder) / 2;
+  if (prev) return prev.sortOrder + 1;
+  if (next) return next.sortOrder - 1;
+  return 0;
+}
+
 function Lanes({
   items,
   members,
@@ -674,12 +700,16 @@ function Lanes({
   memberByUserId: Map<string, Member>;
   onOpen: (item: TaskBoardItem) => void;
   onCreate: (status: TaskBoardItemStatus) => void;
-  onMove: (id: string, status: TaskBoardItemStatus) => void;
+  onMove: (id: string, status: TaskBoardItemStatus, sortOrder: number) => void;
   onAutoFix?: (item: TaskBoardItem) => void;
   onAssign?: (id: string, userId: string | null) => void;
 }) {
   const t = useT();
   const [overLane, setOverLane] = useState<TaskBoardItemStatus | null>(null);
+  // Which card the dragged one would land before, within `overLane` — null
+  // means "at the end of the lane". Drives both the drop math and the
+  // insertion-line indicator.
+  const [dropBeforeId, setDropBeforeId] = useState<string | null>(null);
   const boardRef = useRef<HTMLDivElement>(null);
 
   // Re-run FLIP whenever a card's lane or ordering changes.
@@ -708,17 +738,28 @@ function Lanes({
               onDragOver={(e) => {
                 e.preventDefault();
                 setOverLane(status);
+                // Only reached when not over a card (cards stop propagation),
+                // i.e. the empty area below the last card — drop at the end.
+                setDropBeforeId(null);
               }}
               onDragLeave={(e) => {
                 if (!e.currentTarget.contains(e.relatedTarget as Node)) {
                   setOverLane(null);
+                  setDropBeforeId(null);
                 }
               }}
               onDrop={(e) => {
                 e.preventDefault();
                 const id = e.dataTransfer.getData("text/plain");
-                if (id) onMove(id, status);
+                if (id) {
+                  onMove(
+                    id,
+                    status,
+                    insertSortOrder(laneItems, dropBeforeId, id),
+                  );
+                }
                 setOverLane(null);
+                setDropBeforeId(null);
               }}
               className={cn(
                 "flex w-[300px] shrink-0 flex-col rounded-xl p-1 transition-colors",
@@ -752,36 +793,70 @@ function Lanes({
                   <Plus size={15} />
                 </button>
               </div>
-              <div className="flex min-h-12 flex-col gap-2 pt-1">
+              <div className="flex min-h-12 flex-col pt-1">
                 {laneItems.map((item) => (
-                  <TaskCard
-                    key={item.id}
-                    item={item}
-                    assignee={
-                      item.assigneeId
-                        ? memberByUserId.get(item.assigneeId)
-                        : undefined
-                    }
-                    assignedBy={
-                      item.assignedBy
-                        ? memberByUserId.get(item.assignedBy)
-                        : undefined
-                    }
-                    members={members}
-                    onOpen={() => onOpen(item)}
-                    onAutoFix={onAutoFix ? () => onAutoFix(item) : undefined}
-                    onAssign={
-                      onAssign
-                        ? (userId) => onAssign(item.id, userId)
-                        : undefined
-                    }
-                  />
+                  <Fragment key={item.id}>
+                    <DropDivider
+                      show={overLane === status && dropBeforeId === item.id}
+                    />
+                    <TaskCard
+                      item={item}
+                      assignee={
+                        item.assigneeId
+                          ? memberByUserId.get(item.assigneeId)
+                          : undefined
+                      }
+                      assignedBy={
+                        item.assignedBy
+                          ? memberByUserId.get(item.assignedBy)
+                          : undefined
+                      }
+                      members={members}
+                      onOpen={() => onOpen(item)}
+                      onAutoFix={onAutoFix ? () => onAutoFix(item) : undefined}
+                      onAssign={
+                        onAssign
+                          ? (userId) => onAssign(item.id, userId)
+                          : undefined
+                      }
+                      onDragOverCard={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setOverLane(status);
+                        const rect = e.currentTarget.getBoundingClientRect();
+                        const before = e.clientY - rect.top < rect.height / 2;
+                        if (before) {
+                          setDropBeforeId(item.id);
+                        } else {
+                          const index = laneItems.indexOf(item);
+                          setDropBeforeId(laneItems[index + 1]?.id ?? null);
+                        }
+                      }}
+                    />
+                  </Fragment>
                 ))}
+                <DropDivider
+                  show={overLane === status && dropBeforeId === null}
+                />
               </div>
             </div>
           );
         })}
       </div>
+    </div>
+  );
+}
+
+/** Thin line marking where a dragged card will land between two others. */
+function DropDivider({ show }: { show: boolean }) {
+  return (
+    <div className="flex h-3 shrink-0 items-center px-1">
+      <div
+        className={cn(
+          "h-0.5 w-full rounded-full transition-colors",
+          show ? "bg-primary/20" : "bg-transparent",
+        )}
+      />
     </div>
   );
 }
@@ -794,6 +869,7 @@ function TaskCard({
   onOpen,
   onAutoFix,
   onAssign,
+  onDragOverCard,
 }: {
   item: TaskBoardItem;
   assignee?: Member;
@@ -802,6 +878,7 @@ function TaskCard({
   onOpen: () => void;
   onAutoFix?: () => void;
   onAssign?: (userId: string | null) => void;
+  onDragOverCard?: (e: DragEvent<HTMLButtonElement>) => void;
 }) {
   const t = useT();
   const statusConfig = STATUS_CONFIG[item.status];
@@ -823,6 +900,7 @@ function TaskCard({
         e.dataTransfer.setData("text/plain", item.id);
         e.dataTransfer.effectAllowed = "move";
       }}
+      onDragOver={onDragOverCard}
       onClick={onOpen}
       className="group flex cursor-grab flex-col gap-2 rounded-xl bg-card px-3 py-2.5 text-left card-shadow transition-colors will-change-transform hover:bg-accent/60 active:cursor-grabbing"
       title={item.title}

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -277,6 +277,7 @@ export interface StudioToolIO {
         assigneeId: string | null;
         assignedBy: string | null;
         dueDate: string | null;
+        sortOrder: number;
         threads: {
           threadId: string;
           virtualMcpId: string | null;
@@ -313,6 +314,7 @@ export interface StudioToolIO {
         assigneeId: string | null;
         assignedBy: string | null;
         dueDate: string | null;
+        sortOrder: number;
         threads: {
           threadId: string;
           virtualMcpId: string | null;
@@ -351,6 +353,7 @@ export interface StudioToolIO {
       priority?: "none" | "low" | "medium" | "high" | "urgent" | undefined;
       assigneeId?: string | null | undefined;
       dueDate?: string | null | undefined;
+      sortOrder?: number | undefined;
       linkThreadId?: string | undefined;
     };
     output: {
@@ -364,6 +367,7 @@ export interface StudioToolIO {
         assigneeId: string | null;
         assignedBy: string | null;
         dueDate: string | null;
+        sortOrder: number;
         threads: {
           threadId: string;
           virtualMcpId: string | null;


### PR DESCRIPTION
## What is this contribution about?
Lets users manually reorder task cards within a kanban lane by dragging, not just move them between lanes. Adds a `sort_order` column to `task_board_items` (backfilled from `created_at` so existing order is preserved) and extends the board's existing native HTML5 drag-and-drop to compute a fractional order on drop. A thin divider line between cards shows where the dragged card will land.

## Screenshots/Demonstration
N/A — manual test recommended below.

## How to Test
1. Open the task board (`/$org/board`) with at least two cards in the same lane.
2. Drag a card and drop it above/below another card in the same lane, or into the empty space below the last card.
3. Expected outcome: the card lands where the divider indicator showed, and the order persists after a page reload.

## Migration Notes
Adds Kysely migration `149-task-board-item-sort-order` (new `sort_order` column on `task_board_items`, backfilled from `created_at`). Run `bun run --cwd=apps/api migrate`.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users drag to reorder kanban cards within a lane. Order is saved using a new `sort_order` field, with a thin divider showing the exact drop position.

- **New Features**
  - Added `sort_order` to task items and now sort lanes by `sort_order` ascending.
  - Drag-and-drop computes a midpoint `sortOrder` so only the moved card updates; divider line indicates the insertion point.
  - New cards go to the top of their lane (one below the current lowest order) to match the previous created_at-desc feel.

- **Migration**
  - Run `bun run --cwd=apps/api migrate`. This backfills `sort_order` from `created_at` so existing order is preserved.

<sup>Written for commit 23a46173da15532efdcea925e2f55c40cbec742f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

