### PR TITLE
refactor(thread): derive update status enum from THREAD_STATUSES

### DIFF
--- a/packages/shared/src/thread/schema.ts
+++ b/packages/shared/src/thread/schema.ts
@@ -142,7 +142,7 @@ export const ThreadUpdateDataSchema = z.object({
   description: z.string().nullish().describe("New thread description"),
   hidden: z.boolean().optional().describe("Whether the thread is hidden"),
   status: z
-    .enum(["requires_action", "failed", "in_progress", "completed"])
+    .enum(THREAD_STATUSES)
     .optional()
     .describe(
       "New thread status (user-set override). 'expired' is a computed virtual status and cannot be set directly.",


### PR DESCRIPTION
Source: audit of `packages/shared/src/thread/schema.ts` (thread schema type-safety sweep).

`ThreadUpdateDataSchema.status` hand-listed the four status literals (`"requires_action" | "failed" | "in_progress" | "completed"`) instead of reusing the shared `THREAD_STATUSES` constant from `entities.ts` — the same constant `ThreadEntitySchema.status` already derives from two schemas above it in the same file (`z.enum([...THREAD_STATUSES, "expired"])`). A future addition/removal of a status in `entities.ts` (the single source of truth) would silently desync this schema instead of failing to compile or being updated alongside it.

Payoff: keeps the update-schema union locked to the canonical status list instead of a copy that can drift.

Change is a pure dedup — same four literal values, so the inferred TypeScript type and runtime validation are unchanged (`rg` confirms this was the only other place the four literals were listed verbatim).

Reviewer check: `bun test packages/shared/src/thread/schema.test.ts` and `cd packages/shared && bunx tsc --noEmit`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in `packages/shared` and `apps/api` (both clean), and the targeted test file above (4/4 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor `ThreadUpdateDataSchema.status` to derive its enum from `THREAD_STATUSES` instead of hard-coded literals, keeping it in sync with `entities.ts`. No behavior or type changes; this prevents status drift on future updates.

<sup>Written for commit 42716d00959e4876a94c7ab2a336b37a71bbdcc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

