### PR TITLE
fix(branch-picker): reset picker state when the agent's repo/connection changes

### DIFF
--- a/apps/web/src/components/chat/pills/chat-mode-row.tsx
+++ b/apps/web/src/components/chat/pills/chat-mode-row.tsx
@@ -56,6 +56,9 @@ export function ChatModeRow({ virtualMcp, currentBranch }: SmartProps) {
   const branchPill =
     githubRepo && connectionId ? (
       <BranchPill
+        // Remount on repo/connection change so search/tab/highlight state
+        // from the previous repo doesn't leak into the new one's picker.
+        key={`${connectionId}:${githubRepo.owner}/${githubRepo.name}`}
         orgId={org.id}
         orgSlug={org.slug}
         userId={userId}


### PR DESCRIPTION
**Source:** bug found while auditing `BranchPicker` (github branch-picker UI robustness focus area) for state-management glitches when navigating between repos.

**Why:** `ChatModeRow` renders `<BranchPill>` (which forwards straight to `BranchPicker`) without a `key`, so when the user switches to a different agent — a different GitHub `owner`/`repo`/`connectionId` — while the branch picker's local state (`search`, `tab`, `activeValue`, `isSearchingRemote`) is non-empty, React reuses the same component instance instead of remounting it. The new repo's branches/PRs load correctly via `useBranches`/`useOpenPrs` (their query keys do include owner/repo), but they render underneath the *previous* repo's leftover search text and tab selection — `cmdk`'s built-in fuzzy filter then hides the new repo's items because they don't match a search term the user never typed for this repo, showing a confusing "no branches found" for a repo that clearly has branches.

**Failure scenario:** open the branch picker for agent A's repo, type part of a branch name to filter, close the picker, switch to agent B (a different repo) without a full page reload, open the picker again — it still shows agent A's leftover search filter and picks up agent A's active tab (e.g. "Pull Requests"), filtering out agent B's real branches/PRs.

**Fix:** give `<BranchPill>` a `key` derived from `connectionId:owner/repo` so React remounts (and thus resets all local state on) a genuine repo/connection change — the idiomatic React fix for state that should not carry over across an identity change, without needing `useEffect` (banned in this repo).

**Net diff:** +3/-0, one file, no behavior change for the common case (same repo re-render is unaffected — only a real repo/connection switch remounts the component).

**How to verify:** `cd apps/web && bunx tsc --noEmit` (clean) and `bun test apps/web/src/components/chat/pills/chat-mode-row.test.tsx` (4/4 pass, unaffected by the key addition). A reviewer can also manually reproduce by switching between two GitHub-connected agents in the same session and observing the search/tab state before this fix.

**Checks run locally:** `bun run fmt` (clean), `cd apps/web && bunx tsc --noEmit` (clean), targeted test file above (4 pass). Full suite runs in CI.