### PR TITLE
fix(virtual-mcp): reject delete on well-known synthetic agent ids

### DIFF
--- a/apps/api/src/tools/virtual/delete.ts
+++ b/apps/api/src/tools/virtual/delete.ts
@@ -15,6 +15,7 @@ import {
 } from "../../core/studio-context";
 import { deleteAgentPrompts } from "../../file-storage/agent-prompts";
 import { VirtualMCPEntitySchema } from "./schema";
+import { isUndeletableWellKnownVirtualMcp } from "./well-known-virtual-mcp";
 
 /**
  * Input schema for deleting a virtual MCP
@@ -50,6 +51,14 @@ export const COLLECTION_VIRTUAL_MCP_DELETE = defineTool({
     const organization = requireOrganization(ctx);
 
     await ctx.access.check();
+
+    // These well-known agent ids are synthetic (never a real `connections` row) —
+    // findById() below returns a fake entity for them instead of null, which
+    // would bypass the not-found check and let delete() silently wipe out the
+    // agent's threads (virtual_mcp_id has no DB FK) while reporting success.
+    if (isUndeletableWellKnownVirtualMcp(input.id)) {
+      throw new Error(`Virtual MCP not found: ${input.id}`);
+    }
 
     // Get the virtual MCP before deleting (to return it)
     const existing = await ctx.storage.virtualMcps.findById(input.id);

--- a/apps/api/src/tools/virtual/well-known-virtual-mcp.test.ts
+++ b/apps/api/src/tools/virtual/well-known-virtual-mcp.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { getBrandContextSetupId, getDecopilotId } from "@decocms/shared/sdk";
+import { isUndeletableWellKnownVirtualMcp } from "./well-known-virtual-mcp";
+
+describe("isUndeletableWellKnownVirtualMcp", () => {
+  test("flags the Super Agent (decopilot) id for any org", () => {
+    expect(isUndeletableWellKnownVirtualMcp(getDecopilotId("org_123"))).toBe(
+      true,
+    );
+  });
+
+  test("flags the brand-context-setup id for any org", () => {
+    expect(
+      isUndeletableWellKnownVirtualMcp(getBrandContextSetupId("org_123")),
+    ).toBe(true);
+  });
+
+  test("does not flag a normal virtual MCP id", () => {
+    expect(isUndeletableWellKnownVirtualMcp("conn_abc123")).toBe(false);
+  });
+});

--- a/apps/api/src/tools/virtual/well-known-virtual-mcp.ts
+++ b/apps/api/src/tools/virtual/well-known-virtual-mcp.ts
@@ -1,0 +1,10 @@
+/**
+ * Well-known agents (Super Agent / Decopilot, brand-context-setup) are
+ * synthetic — never a real `connections` row — so they can't be deleted.
+ */
+
+import { isBrandContextSetup, isDecopilot } from "@decocms/shared/sdk";
+
+export function isUndeletableWellKnownVirtualMcp(id: string): boolean {
+  return isDecopilot(id) !== null || isBrandContextSetup(id) !== null;
+}


### PR DESCRIPTION
**Source**: bug found while hardening `apps/api/src/tools/virtual/delete.ts` (virtual-tool delete command safety focus area).

**Why a maintainer wants this**: `COLLECTION_VIRTUAL_MCP_DELETE` looks up the target with `virtualMcps.findById(id)` to run its not-found and org-ownership checks, but `findById` special-cases the well-known Decopilot ("Super Agent") and brand-context-setup ids and returns a synthetic in-memory entity for them instead of `null` — these ids are never real `connections` rows. That synthetic entity's `organization_id` is derived from the id itself, so it also passes the org-ownership check for any org. The tool then proceeds to `virtualMcps.delete(id)`, which unconditionally deletes every `threads` row with `virtual_mcp_id = id` (no DB FK, so no cascade/guard) before touching `connection_aggregations`/`connections` (both no-ops for a synthetic id) — and returns `{ item: existing }` as if the deletion succeeded.

**Failure scenario**: any caller (an MCP client, an agent-loop tool call, a scripted request) that calls `COLLECTION_VIRTUAL_MCP_DELETE` with `id = decopilot_<orgId>` or `brand-context-setup_<orgId>` gets back a success response implying the Super Agent was deleted, while in reality the org's entire Super-Agent thread history is silently wiped and the (undeletable) agent itself is untouched.

**Fix**: reject the delete up front with the same "not found" error used for a normal missing id, via a small extracted `isUndeletableWellKnownVirtualMcp()` helper (`apps/api/src/tools/virtual/well-known-virtual-mcp.ts`), before `findById` is ever consulted.

**Regression test**: `apps/api/src/tools/virtual/well-known-virtual-mcp.test.ts` — pure unit test (no DB) asserting the helper flags both well-known id shapes and leaves ordinary virtual MCP ids alone.

**Reviewer command**: `bun test apps/api/src/tools/virtual/well-known-virtual-mcp.test.ts`

**Local checks run**: `bun run fmt`, `bunx tsc --noEmit` (apps/api), and the targeted test file above — all green. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject delete requests for well-known synthetic virtual MCPs (Decopilot/Super Agent and brand-context-setup) to prevent false success and accidental thread wipes. This blocks deletes for these IDs and keeps org thread history safe.

- **Bug Fixes**
  - Add `isUndeletableWellKnownVirtualMcp` and check it in `COLLECTION_VIRTUAL_MCP_DELETE` before `findById`; throw "Virtual MCP not found".
  - Add unit tests covering Decopilot and brand-context-setup IDs using `@decocms/shared/sdk`.

<sup>Written for commit 1a2120bb0b61e6f8198a2dd4fd73417be4779946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

