### PR TITLE
fix(task-board): stop drag-to-reorder from jumping a card to the end of its own lane

### DIFF
--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { insertSortOrder } from "./config";
+import type { TaskBoardItem } from "./config";
+
+function item(id: string, sortOrder: number): TaskBoardItem {
+  return {
+    id,
+    organizationId: "org-1",
+    title: id,
+    description: null,
+    status: "todo",
+    priority: "none",
+    assigneeId: null,
+    assignedBy: null,
+    dueDate: null,
+    sortOrder,
+    threads: [],
+    createdBy: "user-1",
+    createdAt: new Date().toISOString(),
+    updatedBy: "user-1",
+    updatedAt: new Date().toISOString(),
+  } as TaskBoardItem;
+}
+
+describe("insertSortOrder", () => {
+  const lane = [item("a", 0), item("b", 10), item("c", 20)];
+
+  test("lands between its two new neighbors", () => {
+    // Drop "a" so it lands right before "c" (i.e. between "b" and "c").
+    expect(insertSortOrder(lane, "c", "a")).toBe(15);
+  });
+
+  test("lands at the end when beforeId is null", () => {
+    expect(insertSortOrder(lane, null, "a")).toBe(21);
+  });
+
+  test("lands at the start when there is no prev neighbor", () => {
+    // Drop "c" so it lands right before "a" (i.e. at the very start).
+    expect(insertSortOrder(lane, "a", "c")).toBe(-1);
+  });
+
+  test("hovering the dragged card's own row is a no-op, not a jump to the end", () => {
+    // "b" is dragged and hovered over its own (upper-half) row, which reports
+    // itself as beforeId. It must stay between "a" and "c", not jump last.
+    expect(insertSortOrder(lane, "b", "b")).toBe(10);
+  });
+
+  test("hovering the last card's own row still resolves to the end", () => {
+    expect(insertSortOrder(lane, "c", "c")).toBe(11);
+  });
+});

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -32,6 +32,37 @@ export function primaryThread(
   return item.threads[0];
 }
 
+/**
+ * `sortOrder` a dragged card should take to land right before `beforeId`
+ * within `laneItems` (or at the end when `beforeId` is null) — the midpoint
+ * of its new neighbors, so reordering never needs to touch other rows.
+ */
+export function insertSortOrder(
+  laneItems: TaskBoardItem[],
+  beforeId: string | null,
+  draggedId: string,
+): number {
+  const draggedIndex = laneItems.findIndex((i) => i.id === draggedId);
+  // Hovering the dragged card's own row reports itself as `beforeId` — treat
+  // that as its current successor (a no-op), not "not found", which the
+  // lookup below over `filtered` would otherwise read as "insert at the end".
+  const resolvedBeforeId =
+    beforeId === draggedId
+      ? (laneItems[draggedIndex + 1]?.id ?? null)
+      : beforeId;
+  const filtered = laneItems.filter((i) => i.id !== draggedId);
+  const beforeIndex = resolvedBeforeId
+    ? filtered.findIndex((i) => i.id === resolvedBeforeId)
+    : -1;
+  const insertIndex = beforeIndex === -1 ? filtered.length : beforeIndex;
+  const prev = filtered[insertIndex - 1];
+  const next = filtered[insertIndex];
+  if (prev && next) return (prev.sortOrder + next.sortOrder) / 2;
+  if (prev) return prev.sortOrder + 1;
+  if (next) return next.sortOrder - 1;
+  return 0;
+}
+
 /** Shape of an org member as returned by `useMembers()`, trimmed to the fields used here. */
 export type Member = {
   userId: string;

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/hooks/use-task-board-items";
 import { formatTimeAgo } from "@/lib/format-time";
 import {
+  insertSortOrder,
   isTaskBlocked,
   primaryThread,
   PRIORITY_CONFIG,
@@ -660,29 +661,6 @@ function LayoutToggle({
       {label}
     </button>
   );
-}
-
-/**
- * `sortOrder` a dragged card should take to land right before `beforeId`
- * within `laneItems` (or at the end when `beforeId` is null) — the midpoint
- * of its new neighbors, so reordering never needs to touch other rows.
- */
-function insertSortOrder(
-  laneItems: TaskBoardItem[],
-  beforeId: string | null,
-  draggedId: string,
-): number {
-  const filtered = laneItems.filter((i) => i.id !== draggedId);
-  const beforeIndex = beforeId
-    ? filtered.findIndex((i) => i.id === beforeId)
-    : -1;
-  const insertIndex = beforeIndex === -1 ? filtered.length : beforeIndex;
-  const prev = filtered[insertIndex - 1];
-  const next = filtered[insertIndex];
-  if (prev && next) return (prev.sortOrder + next.sortOrder) / 2;
-  if (prev) return prev.sortOrder + 1;
-  if (next) return next.sortOrder - 1;
-  return 0;
 }
 
 function Lanes({


### PR DESCRIPTION
Follows #5304 (task-board drag-to-reorder) — hardening a real edge case in the new drop logic.

**Bug:** dragging a card and hovering the *top half of its own row* reports the dragged card's own id as `dropBeforeId` (set in `onDragOverCard`). `insertSortOrder` filters the dragged card out of the lane before searching for `beforeId`, so a self-referencing id is never found in the filtered array — the code then falls into the "not found" branch, which means "insert at the very end". Net effect: barely nudging a card, or dropping it back roughly where it started, silently sends it to the end of the lane.

**Fix:** `insertSortOrder` now resolves a `beforeId === draggedId` to the card's current successor first (its next neighbor in the original lane order, or `null` if it was already last), so hovering the dragged card's own row is treated as a no-op instead of "insert at the end". Also extracted the function (byte-identical logic) from `index.tsx` into `config.tsx`, alongside the file's other pure task-board helpers, so it can be unit tested without importing the whole page component.

**Regression test:** `apps/web/src/layouts/task-board/config.test.ts` — `insertSortOrder(lane, "b", "b")` (drag "b", hover its own row) now returns `10`, i.e. unchanged, instead of jumping to the end (`21`); a second case covers hovering the *last* card's own row (still correctly resolves to the end since there's no successor).

Reviewer check: `bun test apps/web/src/layouts/task-board/config.test.ts` (5 pass).

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), and the targeted test above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task-board drag-to-reorder where hovering the top half of a card’s own row sent it to the end of its lane. Self-referential drops are now treated as a no-op so the card stays in place unless actually moved.

- **Bug Fixes**
  - Updated `insertSortOrder` to resolve `beforeId === draggedId` to the card’s current successor; last-card case still lands at the end.
  - Added regression tests in `apps/web/src/layouts/task-board/config.test.ts` to cover self-hover and last-card behavior.

- **Refactors**
  - Extracted `insertSortOrder` from `index.tsx` to `config.tsx` for isolation and unit testing.

<sup>Written for commit f563abb70fdb3428ac8cc768b7fd1f7533fe64db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

