### PR TITLE
fix(sandbox): drop NodeSource — copy Node from the official image instead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    # The suite normally finishes in ~1 min. A single hung file under the
+    # parallel runner stalls the whole job silently (per-file output is
+    # buffered, so the culprit prints nothing) — without this bound that's
+    # GitHub's 6h default; it already cost one 50-minute zombie job.
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/apps/api/src/api/routes/decopilot/sse-keepalive.test.ts
+++ b/apps/api/src/api/routes/decopilot/sse-keepalive.test.ts
@@ -1,29 +1,57 @@
-import { describe, it, expect } from "bun:test";
-import { wrapStreamWithKeepalive } from "./sse-keepalive";
+import { describe, expect, it } from "bun:test";
+import {
+  type KeepaliveTimerFns,
+  wrapStreamWithKeepalive,
+} from "./sse-keepalive";
+
+// No real timers anywhere: the interval is a manually-fired ticker and the
+// source is a test-pushed stream. Deterministic under any CI load (the
+// previous small-real-interval style flaked on the loaded parallel runner),
+// and outputs assert exactly.
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();
 
-function makeSource(
-  chunks: Array<{ delayMs: number; bytes: Uint8Array | string } | "close">,
-): ReadableStream<Uint8Array> {
-  return new ReadableStream<Uint8Array>({
-    async start(controller) {
-      for (const item of chunks) {
-        if (item === "close") {
-          controller.close();
-          return;
-        }
-        if (item.delayMs > 0) {
-          await new Promise((r) => setTimeout(r, item.delayMs));
-        }
-        const value =
-          typeof item.bytes === "string" ? enc.encode(item.bytes) : item.bytes;
-        controller.enqueue(value);
-      }
-      controller.close();
+/** Manually-driven source: the test pushes chunks and closes explicitly. */
+function manualSource() {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
     },
   });
+  return {
+    stream,
+    push: (bytes: string) => controller.enqueue(enc.encode(bytes)),
+    close: () => controller.close(),
+  };
+}
+
+/** Manually-fired interval: `tick()` is one keepalive interval elapsing. */
+function manualTicker() {
+  let callback: (() => void) | null = null;
+  let cleared = false;
+  const timerFns: KeepaliveTimerFns = {
+    setInterval: (fn) => {
+      callback = fn;
+      return "handle";
+    },
+    clearInterval: () => {
+      callback = null;
+      cleared = true;
+    },
+  };
+  return {
+    timerFns,
+    tick: () => callback?.(),
+    wasCleared: () => cleared,
+  };
+}
+
+/** Let pushed chunks flow through the wrapper's read loop (microtasks only —
+ *  load-independent, unlike real timers). */
+async function drain() {
+  for (let i = 0; i < 32; i++) await Promise.resolve();
 }
 
 async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
@@ -39,64 +67,81 @@ async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
 }
 
 describe("wrapStreamWithKeepalive", () => {
-  it("passes through chunks unchanged when source ends quickly", async () => {
-    const source = makeSource([
-      { delayMs: 0, bytes: 'data: {"x":1}\n\n' },
-      { delayMs: 0, bytes: "data: [DONE]\n\n" },
-    ]);
-    const wrapped = wrapStreamWithKeepalive(source, 10_000);
-    const out = await readAll(wrapped);
-    expect(out).toBe('data: {"x":1}\n\ndata: [DONE]\n\n');
+  it("passes through chunks unchanged when no interval elapses", async () => {
+    const source = manualSource();
+    const ticker = manualTicker();
+    const wrapped = wrapStreamWithKeepalive(
+      source.stream,
+      10_000,
+      ticker.timerFns,
+    );
+    const reading = readAll(wrapped);
+    source.push('data: {"x":1}\n\n');
+    source.push("data: [DONE]\n\n");
+    source.close();
+    expect(await reading).toBe('data: {"x":1}\n\ndata: [DONE]\n\n');
   });
 
   it("injects keepalive comments during silent periods", async () => {
-    const source = makeSource([
-      { delayMs: 0, bytes: 'data: {"x":1}\n\n' },
-      { delayMs: 250, bytes: "data: [DONE]\n\n" },
-    ]);
-    // 30ms interval over a 250ms gap (~8 windows) asserting only >=2: timer
-    // chains drift hard on a loaded CI runner under the parallel unit suite,
-    // and the previous 4-window margin flaked there.
-    const wrapped = wrapStreamWithKeepalive(source, 30);
-    const out = await readAll(wrapped);
-    const matches = out.match(/: keepalive\n\n/g) ?? [];
-    expect(matches.length).toBeGreaterThanOrEqual(2);
-    // Real data must still be present and uncorrupted.
-    expect(out).toContain('data: {"x":1}\n\n');
-    expect(out).toContain("data: [DONE]\n\n");
+    const source = manualSource();
+    const ticker = manualTicker();
+    const wrapped = wrapStreamWithKeepalive(
+      source.stream,
+      10_000,
+      ticker.timerFns,
+    );
+    const reading = readAll(wrapped);
+    source.push('data: {"x":1}\n\n');
+    await drain();
+    ticker.tick(); // one silent interval elapses
+    ticker.tick(); // and another
+    source.push("data: [DONE]\n\n");
+    source.close();
+    // Exact interleaving: chunk, two keepalives, final chunk.
+    expect(await reading).toBe(
+      'data: {"x":1}\n\n: keepalive\n\n: keepalive\n\ndata: [DONE]\n\n',
+    );
   });
 
   it("does NOT inject mid-event when chunk ends without \\n\\n boundary", async () => {
-    // Simulate a (hypothetical) future where one event spans two chunks.
-    const source = makeSource([
-      { delayMs: 0, bytes: 'data: {"par' }, // partial — no \n\n yet
-      { delayMs: 80, bytes: 'tial":true}\n\n' }, // completes the event
-    ]);
-    const wrapped = wrapStreamWithKeepalive(source, 20);
-    const out = await readAll(wrapped);
-
-    // No keepalive should appear inside `data: {"...}` payload.
-    // It's OK if heartbeats arrive after the event completes.
-    const firstNewlinePair = out.indexOf("\n\n");
-    expect(firstNewlinePair).toBeGreaterThan(0);
-    const firstEvent = out.slice(0, firstNewlinePair);
-    expect(firstEvent).not.toContain(": keepalive");
-    expect(firstEvent).toBe('data: {"partial":true}');
+    const source = manualSource();
+    const ticker = manualTicker();
+    const wrapped = wrapStreamWithKeepalive(
+      source.stream,
+      10_000,
+      ticker.timerFns,
+    );
+    const reading = readAll(wrapped);
+    source.push('data: {"par'); // partial — no \n\n yet
+    await drain();
+    ticker.tick(); // interval elapses mid-event — must be suppressed
+    source.push('tial":true}\n\n'); // completes the event
+    await drain();
+    ticker.tick(); // boundary reached — this one may fire
+    source.close();
+    expect(await reading).toBe('data: {"partial":true}\n\n: keepalive\n\n');
   });
 
   it("clears the interval when source ends", async () => {
-    const source = makeSource([{ delayMs: 0, bytes: "data: end\n\n" }]);
-    const wrapped = wrapStreamWithKeepalive(source, 10);
-    await readAll(wrapped);
-    // If the interval leaked, this test process would hang on shutdown. Bun
-    // test would surface that. We also assert no spurious keepalives after
-    // close by waiting briefly and confirming the stream remains drained.
-    await new Promise((r) => setTimeout(r, 30));
-    // No assertion needed — the absence of an open handle is the test.
+    const source = manualSource();
+    const ticker = manualTicker();
+    const wrapped = wrapStreamWithKeepalive(
+      source.stream,
+      10_000,
+      ticker.timerFns,
+    );
+    const reading = readAll(wrapped);
+    source.push("data: end\n\n");
+    source.close();
+    await reading;
+    expect(ticker.wasCleared()).toBe(true);
+    // A tick after clear is a no-op, not a crash or a stray enqueue.
+    ticker.tick();
   });
 
-  it("propagates downstream cancel to the source", async () => {
+  it("propagates downstream cancel to the source and clears the interval", async () => {
     let sourceCancelled = false;
+    const ticker = manualTicker();
     const source = new ReadableStream<Uint8Array>({
       async start(controller) {
         controller.enqueue(enc.encode("data: hi\n\n"));
@@ -108,14 +153,13 @@ describe("wrapStreamWithKeepalive", () => {
       },
     });
 
-    const wrapped = wrapStreamWithKeepalive(source, 10_000);
+    const wrapped = wrapStreamWithKeepalive(source, 10_000, ticker.timerFns);
     const reader = wrapped.getReader();
     await reader.read(); // first chunk
     await reader.cancel("client gone");
-
-    // Give the cancel a tick to propagate.
-    await new Promise((r) => setTimeout(r, 5));
+    await drain();
     expect(sourceCancelled).toBe(true);
+    expect(ticker.wasCleared()).toBe(true);
   });
 
   it("propagates source errors", async () => {
@@ -129,7 +173,8 @@ describe("wrapStreamWithKeepalive", () => {
       },
     });
 
-    const wrapped = wrapStreamWithKeepalive(source, 10_000);
+    const ticker = manualTicker();
+    const wrapped = wrapStreamWithKeepalive(source, 10_000, ticker.timerFns);
     const reader = wrapped.getReader();
     const first = await reader.read();
     expect(first.done).toBe(false);
@@ -140,5 +185,6 @@ describe("wrapStreamWithKeepalive", () => {
       caught = e;
     }
     expect(caught instanceof Error && (caught as Error).message).toBe("boom");
+    expect(ticker.wasCleared()).toBe(true);
   });
 });

--- a/apps/api/src/api/routes/decopilot/sse-keepalive.test.ts
+++ b/apps/api/src/api/routes/decopilot/sse-keepalive.test.ts
@@ -52,9 +52,11 @@ describe("wrapStreamWithKeepalive", () => {
   it("injects keepalive comments during silent periods", async () => {
     const source = makeSource([
       { delayMs: 0, bytes: 'data: {"x":1}\n\n' },
-      { delayMs: 120, bytes: "data: [DONE]\n\n" },
+      { delayMs: 250, bytes: "data: [DONE]\n\n" },
     ]);
-    // 30ms interval — should fire ~3-4 times during the 120ms gap.
+    // 30ms interval over a 250ms gap (~8 windows) asserting only >=2: timer
+    // chains drift hard on a loaded CI runner under the parallel unit suite,
+    // and the previous 4-window margin flaked there.
     const wrapped = wrapStreamWithKeepalive(source, 30);
     const out = await readAll(wrapped);
     const matches = out.match(/: keepalive\n\n/g) ?? [];

--- a/apps/api/src/api/routes/decopilot/sse-keepalive.ts
+++ b/apps/api/src/api/routes/decopilot/sse-keepalive.ts
@@ -68,6 +68,20 @@ export function wrapWithSseKeepalive(
   });
 }
 
+/** Injectable interval scheduler — tests drive ticks manually instead of
+ *  waiting on real timers, so they stay deterministic under a loaded
+ *  parallel run. Production uses the globals. */
+export interface KeepaliveTimerFns {
+  setInterval: (fn: () => void, ms: number) => unknown;
+  clearInterval: (handle: unknown) => void;
+}
+
+const REAL_TIMER_FNS: KeepaliveTimerFns = {
+  setInterval: (fn, ms) => setInterval(fn, ms),
+  clearInterval: (handle) =>
+    clearInterval(handle as ReturnType<typeof setInterval>),
+};
+
 /**
  * Lower-level: wrap a `ReadableStream<Uint8Array>` of SSE bytes with
  * periodic keepalive comments. Exposed separately so tests can drive it
@@ -76,11 +90,12 @@ export function wrapWithSseKeepalive(
 export function wrapStreamWithKeepalive(
   source: ReadableStream<Uint8Array>,
   intervalMs: number = DEFAULT_INTERVAL_MS,
+  timerFns: KeepaliveTimerFns = REAL_TIMER_FNS,
 ): ReadableStream<Uint8Array> {
   // These vars are captured by both `start` and `cancel`. They live across
   // the constructor's two method scopes so cancel can reach the active reader.
   let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
-  let timer: ReturnType<typeof setInterval> | null = null;
+  let timer: unknown = null;
   let cleaned = false;
   // Tracks whether the most recent chunk left the byte stream mid-event (no
   // trailing `\n\n`). When true, heartbeats are suppressed until the next
@@ -89,7 +104,7 @@ export function wrapStreamWithKeepalive(
 
   const clearTimer = () => {
     if (timer !== null) {
-      clearInterval(timer);
+      timerFns.clearInterval(timer);
       timer = null;
     }
   };
@@ -110,7 +125,7 @@ export function wrapStreamWithKeepalive(
         }
       };
 
-      timer = setInterval(tryHeartbeat, intervalMs);
+      timer = timerFns.setInterval(tryHeartbeat, intervalMs);
 
       try {
         while (true) {

--- a/apps/api/src/api/routes/decopilot/with-liveness-heartbeat.test.ts
+++ b/apps/api/src/api/routes/decopilot/with-liveness-heartbeat.test.ts
@@ -45,7 +45,9 @@ describe("withLivenessHeartbeat", () => {
   test("injects a data-liveness chunk after intervalMs of silence, then resumes the source", async () => {
     async function* slowThenFast(): AsyncGenerator<UIMessageChunk> {
       yield { type: "text-start", id: "1" };
-      await sleep(80); // spans ~3 heartbeat windows at intervalMs=25
+      // ~6 heartbeat windows at intervalMs=25 for a >=2 assertion — smaller
+      // margins flake under CI CPU contention (parallel unit suite).
+      await sleep(150);
       yield { type: "text-delta", id: "1", delta: "done waiting" };
     }
     const out = await collect(

--- a/apps/api/src/api/routes/decopilot/with-liveness-heartbeat.test.ts
+++ b/apps/api/src/api/routes/decopilot/with-liveness-heartbeat.test.ts
@@ -1,14 +1,62 @@
 import { describe, expect, test } from "bun:test";
-import { sleep } from "@decocms/shared/std";
-// Margins are deliberately generous (intervals in the tens of ms, mostly
-// one-sided lower-bound assertions): under a full parallel `bun test` run a
-// tight window + tight bound flakes on scheduler jitter alone, not a real
-// bug — this bit us once during development with a 10ms interval.
 import type { UIMessageChunk } from "ai";
+import type { HeartbeatSleepFn } from "@decocms/harness/liveness-heartbeat";
 import {
   buildLivenessChunk,
   withLivenessHeartbeat,
 } from "./with-liveness-heartbeat";
+
+// No real timers anywhere: silence is a manually-elapsed clock window and
+// source pacing is a test-resolved gate. Deterministic under any CI load
+// (the previous small-real-interval style flaked on the loaded parallel
+// runner), and heartbeat counts assert exactly.
+
+function manualClock() {
+  const pending: Array<() => void> = [];
+  const sleepFn: HeartbeatSleepFn = (_ms, { signal }) =>
+    new Promise<void>((resolve, reject) => {
+      const entry = () => resolve();
+      pending.push(entry);
+      signal.addEventListener("abort", () => {
+        const i = pending.indexOf(entry);
+        if (i !== -1) pending.splice(i, 1);
+        reject(signal.reason);
+      });
+    });
+  return {
+    sleepFn,
+    pendingWindows: () => pending.length,
+    /** Wait (microtasks only) for the emitter to arm, then elapse a window
+     *  and drain the emit → race → yield → for-await → re-arm chain. The
+     *  drain count is generous because the chain crosses an async generator
+     *  and its consumer (~10 microtasks) — but it's still load-independent:
+     *  microtask scheduling doesn't stretch under CPU contention the way
+     *  real timers do, which is the whole point of this style. */
+    async elapse() {
+      for (let i = 0; i < 50 && pending.length === 0; i++) {
+        await Promise.resolve();
+      }
+      pending.shift()?.();
+      await this.drain();
+    },
+    /** Let the source's immediate chunks flow through (microtasks only) so
+     *  the silence window being elapsed is the one armed AFTER the last real
+     *  chunk — an emit racing an already-arrived chunk loses and is dropped
+     *  by design (the wrapper re-arms on real chunks). */
+    async drain() {
+      for (let i = 0; i < 32; i++) await Promise.resolve();
+    },
+  };
+}
+
+/** A promise the test resolves to let a gated source proceed. */
+function gate() {
+  let open!: () => void;
+  const opened = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { open, opened };
+}
 
 async function collect(
   iter: AsyncGenerator<UIMessageChunk>,
@@ -30,73 +78,84 @@ describe("buildLivenessChunk", () => {
 });
 
 describe("withLivenessHeartbeat", () => {
-  test("no heartbeats when the source is faster than the interval", async () => {
+  test("no heartbeats when the source never goes silent", async () => {
+    const clock = manualClock();
     async function* fast(): AsyncGenerator<UIMessageChunk> {
       yield { type: "text-start", id: "1" };
-      await sleep(5);
       yield { type: "text-delta", id: "1", delta: "hi" };
     }
     const out = await collect(
-      withLivenessHeartbeat(fast(), { intervalMs: 30 }),
+      withLivenessHeartbeat(fast(), { intervalMs: 30, sleepFn: clock.sleepFn }),
     );
     expect(out.map((c) => c.type)).toEqual(["text-start", "text-delta"]);
   });
 
-  test("injects a data-liveness chunk after intervalMs of silence, then resumes the source", async () => {
+  test("injects a data-liveness chunk after a window of silence, then resumes the source", async () => {
+    const clock = manualClock();
+    const silence = gate();
     async function* slowThenFast(): AsyncGenerator<UIMessageChunk> {
       yield { type: "text-start", id: "1" };
-      // ~6 heartbeat windows at intervalMs=25 for a >=2 assertion — smaller
-      // margins flake under CI CPU contention (parallel unit suite).
-      await sleep(150);
+      await silence.opened;
       yield { type: "text-delta", id: "1", delta: "done waiting" };
     }
-    const out = await collect(
-      withLivenessHeartbeat(slowThenFast(), { intervalMs: 25 }),
+    const collecting = collect(
+      withLivenessHeartbeat(slowThenFast(), {
+        intervalMs: 25,
+        sleepFn: clock.sleepFn,
+      }),
     );
-    const types = out.map((c) => c.type);
-    expect(types[0]).toBe("text-start");
-    expect(types.at(-1)).toBe("text-delta");
-    const heartbeats = types.filter((t) => t === "data-liveness");
-    expect(heartbeats.length).toBeGreaterThanOrEqual(2);
-    // Every heartbeat is between the two real chunks, not before/after.
-    expect(types.slice(1, -1).every((t) => t === "data-liveness")).toBe(true);
+    await clock.drain(); // text-start flows; silence begins
+    await clock.elapse(); // first silence window → heartbeat
+    await clock.elapse(); // still silent → second heartbeat
+    silence.open();
+    const out = await collecting;
+    expect(out.map((c) => c.type)).toEqual([
+      "text-start",
+      "data-liveness",
+      "data-liveness",
+      "text-delta",
+    ]);
   });
 
-  test("a real chunk resets the window (disarmed) — no heartbeat right after one arrives", async () => {
+  test("a real chunk resets the window (disarmed) — no heartbeat while chunks keep arriving", async () => {
+    const clock = manualClock();
     async function* steadyDrip(): AsyncGenerator<UIMessageChunk> {
-      // 4 chunks, each 8ms apart, well under the 60ms interval (7.5x
-      // margin) — the window should never elapse because every chunk
-      // re-arms it.
       for (let i = 0; i < 4; i++) {
-        await sleep(8);
         yield { type: "text-delta", id: "1", delta: String(i) };
       }
     }
     const out = await collect(
-      withLivenessHeartbeat(steadyDrip(), { intervalMs: 60 }),
+      withLivenessHeartbeat(steadyDrip(), {
+        intervalMs: 60,
+        sleepFn: clock.sleepFn,
+      }),
     );
+    // The window never elapsed (the test never let it), so pure pass-through.
     expect(out.every((c) => c.type === "text-delta")).toBe(true);
     expect(out).toHaveLength(4);
   });
 
-  test("stops cleanly on source completion — never emits after the stream ends", async () => {
+  test("stops cleanly on source completion — no dangling window after the stream ends", async () => {
+    const clock = manualClock();
     async function* short(): AsyncGenerator<UIMessageChunk> {
       yield { type: "text-start", id: "1" };
     }
     const out = await collect(
-      withLivenessHeartbeat(short(), { intervalMs: 10 }),
+      withLivenessHeartbeat(short(), {
+        intervalMs: 10,
+        sleepFn: clock.sleepFn,
+      }),
     );
     expect(out).toEqual([{ type: "text-start", id: "1" }]);
-    // Give a would-be dangling timer a chance to misfire; collect() already
-    // awaited the generator to natural completion, so nothing further can
-    // be yielded regardless — this just documents the intent.
-    await sleep(30);
+    // Stronger than waiting for a misfire: the emitter was stopped, so no
+    // silence window is left pending at all.
+    expect(clock.pendingWindows()).toBe(0);
   });
 
   test("propagates a source error and stops emitting heartbeats", async () => {
+    const clock = manualClock();
     async function* boom(): AsyncGenerator<UIMessageChunk> {
       yield { type: "text-start", id: "1" };
-      await sleep(5);
       throw new Error("harness exploded");
     }
     let caught: unknown;
@@ -104,6 +163,7 @@ describe("withLivenessHeartbeat", () => {
     try {
       for await (const chunk of withLivenessHeartbeat(boom(), {
         intervalMs: 10,
+        sleepFn: clock.sleepFn,
       })) {
         out.push(chunk);
       }
@@ -113,15 +173,16 @@ describe("withLivenessHeartbeat", () => {
     expect(out).toEqual([{ type: "text-start", id: "1" }]);
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toBe("harness exploded");
+    expect(clock.pendingWindows()).toBe(0);
   });
 
-  test("an early consumer break stops the underlying source and the heartbeat timer", async () => {
+  test("an early consumer break stops the underlying source and the heartbeat window", async () => {
+    const clock = manualClock();
     let sourceCleanedUp = false;
     async function* infinite(): AsyncGenerator<UIMessageChunk> {
       try {
         let i = 0;
         while (true) {
-          await sleep(5);
           yield { type: "text-delta", id: "1", delta: String(i++) };
         }
       } finally {
@@ -131,24 +192,36 @@ describe("withLivenessHeartbeat", () => {
     let count = 0;
     for await (const _chunk of withLivenessHeartbeat(infinite(), {
       intervalMs: 10,
+      sleepFn: clock.sleepFn,
     })) {
       count++;
       if (count === 2) break;
     }
     expect(count).toBe(2);
     expect(sourceCleanedUp).toBe(true);
+    expect(clock.pendingWindows()).toBe(0);
   });
 
   test("a long silence yields multiple heartbeats, not just one", async () => {
+    const clock = manualClock();
+    const silence = gate();
     async function* longSilence(): AsyncGenerator<UIMessageChunk> {
-      await sleep(145); // ~5.8 windows at intervalMs=25
+      await silence.opened;
       yield { type: "finish" };
     }
-    const out = await collect(
-      withLivenessHeartbeat(longSilence(), { intervalMs: 25 }),
+    const collecting = collect(
+      withLivenessHeartbeat(longSilence(), {
+        intervalMs: 25,
+        sleepFn: clock.sleepFn,
+      }),
     );
-    const heartbeats = out.filter((c) => c.type === "data-liveness");
-    expect(heartbeats.length).toBeGreaterThanOrEqual(4);
+    await clock.elapse();
+    await clock.elapse();
+    await clock.elapse();
+    await clock.elapse();
+    silence.open();
+    const out = await collecting;
+    expect(out.filter((c) => c.type === "data-liveness")).toHaveLength(4);
     expect(out.at(-1)?.type).toBe("finish");
   });
 });

--- a/apps/api/src/cli/lib/port-wait.test.ts
+++ b/apps/api/src/cli/lib/port-wait.test.ts
@@ -80,10 +80,27 @@ describe("waitForPort", () => {
 
   it("waits until the port becomes available, then resolves", async () => {
     const port = await ephemeralPort();
-    const promise = waitForPort(port, { intervalMs: 20 });
-    setTimeout(() => {
-      void listenOn("127.0.0.1", port);
-    }, 60);
+    // No real time: the poll loop waits on a test-controlled sleepFn, so the
+    // sequence is explicit — probe misses, listener comes up, poll retries.
+    // (The old version held the port free for a real 60ms setTimeout while
+    // polling on a real 20ms interval; under the parallel suite that both
+    // flaked on timer drift and invited cross-worker ephemeral-port reuse.)
+    const pendingPolls: Array<() => void> = [];
+    const promise = waitForPort(port, {
+      intervalMs: 20,
+      sleepFn: () =>
+        new Promise<void>((resolve) => {
+          pendingPolls.push(resolve);
+        }),
+    });
+    // First probe (real sockets — libuv callbacks, so yield event-loop turns,
+    // not just microtasks) finds the port free and parks on the sleepFn.
+    while (pendingPolls.length === 0) {
+      await new Promise((r) => setImmediate(r));
+    }
+    // Now bring the listener up — awaited, so it's bound before the retry.
+    await listenOn("127.0.0.1", port);
+    pendingPolls.shift()?.();
     expect(await promise).toBe("127.0.0.1");
   });
 });

--- a/apps/api/src/cli/lib/port-wait.test.ts
+++ b/apps/api/src/cli/lib/port-wait.test.ts
@@ -86,21 +86,30 @@ describe("waitForPort", () => {
     // polling on a real 20ms interval; under the parallel suite that both
     // flaked on timer drift and invited cross-worker ephemeral-port reuse.)
     const pendingPolls: Array<() => void> = [];
+    let settled = false;
     const promise = waitForPort(port, {
       intervalMs: 20,
       sleepFn: () =>
         new Promise<void>((resolve) => {
           pendingPolls.push(resolve);
         }),
+    }).then((addr) => {
+      settled = true;
+      return addr;
     });
     // First probe (real sockets — libuv callbacks, so yield event-loop turns,
-    // not just microtasks) finds the port free and parks on the sleepFn.
-    while (pendingPolls.length === 0) {
+    // not just microtasks) finds the port free and parks on the sleepFn. The
+    // `settled` escape matters: if a parallel test worker re-bound the freed
+    // ephemeral port, waitForPort resolves without ever sleeping and this
+    // loop must not spin forever (it hung CI for 50 minutes once).
+    while (pendingPolls.length === 0 && !settled) {
       await new Promise((r) => setImmediate(r));
     }
-    // Now bring the listener up — awaited, so it's bound before the retry.
-    await listenOn("127.0.0.1", port);
-    pendingPolls.shift()?.();
+    if (!settled) {
+      // Bring the listener up — awaited, so it's bound before the retry.
+      await listenOn("127.0.0.1", port);
+      pendingPolls.shift()?.();
+    }
     expect(await promise).toBe("127.0.0.1");
   });
 });

--- a/apps/api/src/cli/lib/port-wait.ts
+++ b/apps/api/src/cli/lib/port-wait.ts
@@ -18,6 +18,8 @@ export async function findRunningAddr(port: number): Promise<string | null> {
 
 export interface WaitForPortOptions {
   intervalMs?: number;
+  /** Injectable wait — tests sequence polls manually instead of real time. */
+  sleepFn?: (ms: number) => Promise<void>;
 }
 
 /**
@@ -25,12 +27,12 @@ export interface WaitForPortOptions {
  */
 export async function waitForPort(
   port: number,
-  { intervalMs = 1000 }: WaitForPortOptions = {},
+  { intervalMs = 1000, sleepFn = sleep }: WaitForPortOptions = {},
 ): Promise<string> {
   for (;;) {
     const addr = await findRunningAddr(port);
     if (addr) return addr;
-    await sleep(intervalMs);
+    await sleepFn(intervalMs);
   }
 }
 

--- a/packages/harness/src/liveness-heartbeat.test.ts
+++ b/packages/harness/src/liveness-heartbeat.test.ts
@@ -1,18 +1,39 @@
 import { describe, expect, test } from "bun:test";
-import { sleep } from "@decocms/shared/std";
 import {
   buildLivenessChunk,
   HeartbeatEmitter,
+  type HeartbeatSleepFn,
   LIVENESS_HEARTBEAT_INTERVAL_MS,
 } from "./liveness-heartbeat";
 
-// Small real intervals (matches this repo's established idle-timeout test
-// style — see nats-chunk-source.test.ts — rather than mocking the clock).
-// Margins are deliberately generous (intervals in the tens of ms, assertions
-// mostly one-sided lower bounds): under a full parallel `bun test` run
-// (hundreds of files/timers contending for the event loop) a tight window
-// with a tight bound flakes on scheduler jitter alone, not a real bug — this
-// bit us once during development with a 10ms interval / exact-count bound.
+// No real timers anywhere: tests inject a manually-driven sleepFn and elapse
+// silence windows explicitly. Deterministic under any CI load (the previous
+// small-real-interval style flaked on the loaded parallel runner), and every
+// count asserts exactly instead of a jitter-tolerant lower bound.
+
+function manualClock() {
+  const pending: Array<() => void> = [];
+  const sleepFn: HeartbeatSleepFn = (_ms, { signal }) =>
+    new Promise<void>((resolve, reject) => {
+      const entry = () => resolve();
+      pending.push(entry);
+      signal.addEventListener("abort", () => {
+        const i = pending.indexOf(entry);
+        if (i !== -1) pending.splice(i, 1);
+        reject(signal.reason);
+      });
+    });
+  return {
+    sleepFn,
+    /** Silence windows currently waiting to elapse (0 or 1 for one emitter). */
+    pendingWindows: () => pending.length,
+    /** Let the pending window elapse and drain the emit → re-arm chain. */
+    async elapse() {
+      pending.shift()?.();
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+    },
+  };
+}
 
 describe("LIVENESS_HEARTBEAT_INTERVAL_MS", () => {
   test("is 30s, comfortably under the 10-minute liveness window", () => {
@@ -22,80 +43,90 @@ describe("LIVENESS_HEARTBEAT_INTERVAL_MS", () => {
 });
 
 describe("HeartbeatEmitter", () => {
-  test("emits every intervalMs while armed", async () => {
+  test("emits once per elapsed window while armed", async () => {
+    const clock = manualClock();
     let emits = 0;
     const emitter = new HeartbeatEmitter({
       intervalMs: 25,
+      sleepFn: clock.sleepFn,
       emit: () => {
         emits++;
       },
     });
     emitter.arm();
-    // ~5.8 windows of headroom for 3 emits: setTimeout chains drift hard on a
-    // loaded 4-vCPU CI runner (parallel bun test workers), and 3.8 windows
-    // already flaked there once.
-    await sleep(25 * 5 + 20);
+    await clock.elapse();
+    await clock.elapse();
+    await clock.elapse();
     emitter.stop();
-    expect(emits).toBeGreaterThanOrEqual(3);
+    expect(emits).toBe(3);
   });
 
   test("a call to arm() before the window elapses resets it (disarmed on real chunk)", async () => {
+    const clock = manualClock();
     let emits = 0;
     const emitter = new HeartbeatEmitter({
       intervalMs: 60,
+      sleepFn: clock.sleepFn,
       emit: () => {
         emits++;
       },
     });
     emitter.arm();
-    // Simulate 3 real chunks arriving well inside the window (7.5x margin)
-    // — each resets the silence clock, so the window never actually elapses.
-    await sleep(8);
+    // 3 real chunks arrive — each re-arm cancels the pending window and
+    // starts a fresh one, so exactly one window is ever pending.
     emitter.arm();
-    await sleep(8);
     emitter.arm();
-    await sleep(8);
     emitter.arm();
     expect(emits).toBe(0);
-    // Now let a full window elapse with no further reset.
-    await sleep(80);
+    expect(clock.pendingWindows()).toBe(1);
+    // Now the window elapses with no further reset.
+    await clock.elapse();
     emitter.stop();
     expect(emits).toBe(1);
   });
 
   test("never emits after stop()", async () => {
+    const clock = manualClock();
     let emits = 0;
     const emitter = new HeartbeatEmitter({
       intervalMs: 10,
+      sleepFn: clock.sleepFn,
       emit: () => {
         emits++;
       },
     });
     emitter.arm();
     emitter.stop();
-    await sleep(40);
+    // stop() aborted the pending window — nothing left to elapse.
+    expect(clock.pendingWindows()).toBe(0);
+    await clock.elapse();
     expect(emits).toBe(0);
   });
 
   test("stop() during an in-flight window suppresses that pending emit", async () => {
+    const clock = manualClock();
     let emits = 0;
     const emitter = new HeartbeatEmitter({
       intervalMs: 60,
+      sleepFn: clock.sleepFn,
       emit: () => {
         emits++;
       },
     });
     emitter.arm();
-    await sleep(5); // well inside the window (12x margin)
+    expect(clock.pendingWindows()).toBe(1);
     emitter.stop();
-    await sleep(80); // past when the (now-cancelled) window would have fired
+    expect(clock.pendingWindows()).toBe(0);
+    await clock.elapse();
     expect(emits).toBe(0);
   });
 
   test("stop() is idempotent and arm() after stop() is a no-op", async () => {
+    const clock = manualClock();
     let emits = 0;
     const emitter = new HeartbeatEmitter({
       intervalMs: 10,
+      sleepFn: clock.sleepFn,
       emit: () => {
         emits++;
       },
@@ -103,36 +134,48 @@ describe("HeartbeatEmitter", () => {
     emitter.stop();
     emitter.stop(); // idempotent — must not throw
     emitter.arm(); // stopped — must stay a no-op
-    await sleep(30);
+    expect(clock.pendingWindows()).toBe(0);
     expect(emits).toBe(0);
   });
 
   test("self-reschedules: a long silence yields multiple heartbeats without re-arming", async () => {
+    const clock = manualClock();
     let emits = 0;
     const emitter = new HeartbeatEmitter({
       intervalMs: 25,
+      sleepFn: clock.sleepFn,
       emit: () => {
         emits++;
       },
     });
     emitter.arm();
-    await sleep(25 * 5 + 20); // ~5.8 windows, no external arm() calls at all
+    // No external arm() calls at all — each emit re-arms the next window.
+    await clock.elapse();
+    await clock.elapse();
+    await clock.elapse();
+    await clock.elapse();
     emitter.stop();
-    expect(emits).toBeGreaterThanOrEqual(4);
+    expect(emits).toBe(4);
   });
 
   test("a rejecting emit stops the scheduler instead of looping forever", async () => {
+    const clock = manualClock();
     let emits = 0;
     const emitter = new HeartbeatEmitter({
       intervalMs: 20,
+      sleepFn: clock.sleepFn,
       emit: () => {
         emits++;
         throw new Error("publish failed");
       },
     });
     emitter.arm();
-    await sleep(20 * 4);
-    // Exactly one emit: the throw stops the scheduler, so it never reschedules.
+    await clock.elapse();
+    // Exactly one emit: the throw stops the scheduler, so it never
+    // rescheduled another window.
+    expect(emits).toBe(1);
+    expect(clock.pendingWindows()).toBe(0);
+    await clock.elapse();
     expect(emits).toBe(1);
   });
 

--- a/packages/harness/src/liveness-heartbeat.test.ts
+++ b/packages/harness/src/liveness-heartbeat.test.ts
@@ -31,8 +31,10 @@ describe("HeartbeatEmitter", () => {
       },
     });
     emitter.arm();
-    // ~3.8 windows of headroom: expect at least 3 emits.
-    await sleep(25 * 3 + 20);
+    // ~5.8 windows of headroom for 3 emits: setTimeout chains drift hard on a
+    // loaded 4-vCPU CI runner (parallel bun test workers), and 3.8 windows
+    // already flaked there once.
+    await sleep(25 * 5 + 20);
     emitter.stop();
     expect(emits).toBeGreaterThanOrEqual(3);
   });

--- a/packages/sandbox/image/Dockerfile
+++ b/packages/sandbox/image/Dockerfile
@@ -2,35 +2,39 @@
 # Published multi-arch (linux/amd64 + linux/arm64) by
 # .github/workflows/release-studio-sandbox.yaml so sandboxes run natively on
 # arm64 nodes (Apple Silicon, arm64 cloud) as well as amd64.
+ARG NODE_MAJOR=26
+
+# Node comes from the official image instead of NodeSource's apt repo: the
+# deb.nodesource.com setup script 403s intermittently (outages last hours and
+# retries don't save the build), while this pull rides the same registry +
+# digest cache the base image already depends on. Multi-arch like the rest.
+FROM node:${NODE_MAJOR}-slim AS node-dist
+
 FROM oven/bun:1.3.14-debian
 
-ARG NODE_MAJOR=26
 ARG COREPACK_VERSION=0.35.0
 ARG DENO_VERSION=v1.46.3
+
+COPY --from=node-dist /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-dist /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+  && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # `locales` + generated `en_US.UTF-8` is load-bearing: repos using
 # `embedded-postgres` refuse to init without it.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-       bash ca-certificates curl git gnupg locales python3 python3-pip \
-       ripgrep unzip \
+       bash ca-certificates curl git gnupg libatomic1 locales python3 \
+       python3-pip ripgrep unzip \
   && sed -i 's/^#\s*en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
   && locale-gen \
-  # Download to a file, then run: `curl | bash` swallows a failed download
-  # (the pipeline's status is bash's), so a NodeSource 403 silently left the
-  # Debian nodejs (no npm) and the build died stages later with `npm: not
-  # found`. NodeSource 403s are intermittent — retry them like corepack below.
-  && curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors \
-       -o /tmp/nodesource-setup.sh https://deb.nodesource.com/setup_${NODE_MAJOR}.x \
-  && bash /tmp/nodesource-setup.sh \
-  && rm /tmp/nodesource-setup.sh \
-  && apt-get install -y --no-install-recommends nodejs \
+  && node --version \
   && npm --version \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSL https://deno.land/install.sh \
        | DENO_INSTALL=/opt/deno sh -s -- -y "${DENO_VERSION}" \
   && ln -s /opt/deno/bin/deno /usr/local/bin/deno \
-  # NodeSource's Node 26 packages no longer ship Corepack.
+  # Node 26 no longer ships Corepack in its dist.
   && (command -v corepack >/dev/null 2>&1 \
        || npm install --global "corepack@${COREPACK_VERSION}") \
   && corepack enable \


### PR DESCRIPTION
## Summary

`deb.nodesource.com` 403s intermittently and outages last hours — today's blocked #5305's `docker-smoke` twice, even with the Dockerfile's 5×10s retry loop. The dependency exists only to get `node` + `npm` onto the sandbox image (user repos need them), and there's a strictly more reliable source: the **official `node:26-slim` image**, via multi-stage `COPY`.

- Same supply chain the build already trusts (Docker registry, digest-cached) — one less third-party shell script piped into the build.
- Multi-arch (amd64/arm64) for free, matching the release build.
- `libatomic1` added to the apt list: the official Node binary links it; `oven/bun`'s debian base doesn't ship it (node-slim's does — this was the one integration gap, caught by a local build).
- Corepack/yarn/pnpm logic untouched (Node 26 dist still ships no corepack).
- `NODE_MAJOR` arg still the single place the major is pinned.

## Testing notes

Local build + full toolchain verification inside the image:
`node v26.5.0` · `npm 11.17.0` · `npx` · `corepack 0.35.0` · `yarn` · `pnpm` · `deno 1.46.3` · `bun 1.3.14` — and the same `/health` daemon smoke test docker-smoke runs, green (`bootId` echo verified).

This PR touches `packages/sandbox/**`, so CI's `docker-smoke` builds this exact Dockerfile on this PR — if NodeSource is still down, that's the proof it works (the build no longer contacts it at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops NodeSource from the sandbox image by copying `node`/`npm` from `node:26-slim`, removing flaky 403s and stabilizing CI. Makes timer-driven tests fully deterministic, adds an injectable sleep to `waitForPort`, and bounds the unit test job to 10 minutes to avoid zombie runs.

- **Dependencies**
  - Copy `node` and `npm` from `node:26-slim`; remove NodeSource setup.
  - Add `libatomic1` for the official Node binary.
  - Keep `NODE_MAJOR` as the single pin; install `corepack@0.35.0` via `npm` if missing; enable Corepack.

- **Bug Fixes**
  - Replace real-timer sleeps with manual clocks in heartbeat and SSE tests; assert exact counts and ordering.
  - `wrapStreamWithKeepalive` accepts injectable `KeepaliveTimerFns` (defaults to real timers) and clears the interval on end, cancel, and error.
  - `waitForPort` supports an injectable `sleepFn`; tests are hang-proof (exit if already settled), and the test job is limited to 10 minutes.

<sup>Written for commit ade2f5358fed5e804d151cde5d19ae9c6bee73f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

