### PR TITLE
fix(header): translate the agent-crumb Super Agent fallback title

### DIFF
--- a/apps/web/src/components/header/shell-breadcrumb.tsx
+++ b/apps/web/src/components/header/shell-breadcrumb.tsx
@@ -63,7 +63,8 @@ function AgentCrumb({
 }) {
   const t = useT();
   const entity = useVirtualMCP(agentId) ?? fallback ?? null;
-  const title = entity?.title ?? "Super Agent";
+  const title =
+    entity?.title ?? t("header.shellBreadcrumb.superAgentDefaultName");
   return (
     <div className="flex min-w-0 items-center gap-0">
       <button

--- a/apps/web/src/i18n/en/header.ts
+++ b/apps/web/src/i18n/en/header.ts
@@ -19,6 +19,7 @@ export const header = {
   "header.orgSwitcher.searchOrganizations": "Search organizations...",
   "header.orgSwitcher.unknownOrganization": "Unknown organization",
   "header.shellBreadcrumb.openAgentHome": "Open {name} home",
+  "header.shellBreadcrumb.superAgentDefaultName": "Super Agent",
   "header.shellBreadcrumb.switchOrganization": "{name} — switch organization",
   "header.shellBreadcrumb.switchOrganizationPendingInvitation":
     "{name} — switch organization (pending invitation)",

--- a/apps/web/src/i18n/pt-br/header.ts
+++ b/apps/web/src/i18n/pt-br/header.ts
@@ -22,6 +22,7 @@ export const header = {
   "header.orgSwitcher.searchOrganizations": "Pesquisar organizações...",
   "header.orgSwitcher.unknownOrganization": "Organização desconhecida",
   "header.shellBreadcrumb.openAgentHome": "Abrir início de {name}",
+  "header.shellBreadcrumb.superAgentDefaultName": "Super Agent",
   "header.shellBreadcrumb.switchOrganization": "{name} — trocar organização",
   "header.shellBreadcrumb.switchOrganizationPendingInvitation":
     "{name} — trocar organização (convite pendente)",


### PR DESCRIPTION
Follow-up hardening after recent shell-breadcrumb.tsx changes (#5279, #5289): `AgentCrumb`'s fallback title (`entity?.title ?? "Super Agent"`) was hardcoded English, violating the repo's i18n rule ("never hardcode user-facing strings in apps/web/src") — every other Super-Agent label in the codebase (e.g. `taskBoard.taskDialog.superAgentDefaultName`, `settings.mainAgent.superAgentOption`) already goes through `t()`, even though the pt-br value is currently the same brand-name text.

Why a maintainer wants it: this is the label shown in the topbar/mobile-sheet agent switcher whenever no persisted agent entity exists yet (the Super Agent is never persisted) — it was the one string in this file that skipped the i18n pipeline that #4f9cde93d (#5279) just added translated aria-labels next to.

Change: added `header.shellBreadcrumb.superAgentDefaultName` to both `en` and `pt-br` header dictionaries and swapped the hardcoded fallback for `t("header.shellBreadcrumb.superAgentDefaultName")` in `shell-breadcrumb.tsx`. No behavior change — same displayed text today, now routed through the translation system so a future locale change doesn't require touching component code.

Reviewer check: open the collapsed-sidebar topbar or mobile sidebar sheet before any agent is persisted — the crumb still reads "Super Agent".

Local verification: `bun run fmt` (clean) and `cd apps/web && bunx tsc --noEmit` (clean, the `pt-br` dictionary's `satisfies Record<keyof typeof headerEn, string>` constraint also proves translation-key parity). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use i18n for the AgentCrumb fallback title instead of the hardcoded "Super Agent". Added `header.shellBreadcrumb.superAgentDefaultName` to `en` and `pt-br`; UI text is unchanged.

<sup>Written for commit 7f7b514cfdd1214680aeaf10e298def84ebd4c32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

