### PR TITLE
fix(org-settings): reject unrecognized keys in ORGANIZATION_SETTINGS_UPDATE flags input

### DIFF
--- a/apps/api/src/tools/organization/settings-update.test.ts
+++ b/apps/api/src/tools/organization/settings-update.test.ts
@@ -120,4 +120,17 @@ describe("ORGANIZATION_SETTINGS_UPDATE", () => {
       flags: { demo_mode: false },
     });
   });
+
+  it("rejects an unrecognized flag key instead of silently stripping it", () => {
+    // Regression: without `.strict()`, Zod drops unknown keys from an object
+    // schema — a mistyped flag name (e.g. `demoMode` instead of `demo_mode`)
+    // would previously validate as `flags: {}`, upsert as a no-op, and report
+    // success with no indication the intended flag was never set.
+    const result = ORGANIZATION_SETTINGS_UPDATE.inputSchema.safeParse({
+      organizationId: "org-a",
+      flags: { demoMode: true },
+    });
+
+    expect(result.success).toBe(false);
+  });
 });

--- a/apps/api/src/tools/organization/settings-update.ts
+++ b/apps/api/src/tools/organization/settings-update.ts
@@ -27,9 +27,14 @@ export const ORGANIZATION_SETTINGS_UPDATE = defineTool({
     registry_config: RegistryConfigSchema.optional(),
     simple_mode: SimpleModeConfigSchema.optional(),
     default_home_agents: DefaultHomeAgentsConfigSchema.optional(),
-    flags: OrgFlagsSchema.optional().describe(
-      "Org boolean toggles. Shallow-merged into the stored flags: keys you pass win (explicit false persists), omitted keys keep their value.",
-    ),
+    // .strict() here (not on the shared OrgFlagsSchema) so a mistyped flag
+    // name is rejected instead of silently stripped and merged as `{}` —
+    // that no-op was indistinguishable from a successful update.
+    flags: OrgFlagsSchema.strict()
+      .optional()
+      .describe(
+        "Org boolean toggles. Shallow-merged into the stored flags: keys you pass win (explicit false persists), omitted keys keep their value.",
+      ),
     main_agent_id: z
       .string()
       .nullable()


### PR DESCRIPTION
Bug found while auditing the org-settings toolchain (settings-get/settings-update/storage) for the api-org-settings cleanup focus area — not tied to a specific issue.

**Why a maintainer wants this:** Zod object schemas silently strip unknown keys by default (no `.strict()`), and `ORGANIZATION_SETTINGS_UPDATE`'s `flags` field is a free-form boolean bag (`OrgFlagsSchema`, source of truth for org toggles like `demo_mode`/`reports_only`) that any MCP client can call. A mistyped key — e.g. `demoMode` instead of `demo_mode` — validated as `flags: {}`, which the storage layer's shallow-merge (`coalesce(flags, '{}') || '{}'::jsonb`) then upserts as a genuine no-op. The call returns 200 with the full settings row, giving the caller zero signal that the flag they intended to set was never persisted — a silent config-loss trap on an org-wide toggle bag that's designed to keep growing.

**Failure scenario (regression test added):** call `ORGANIZATION_SETTINGS_UPDATE` with `{ organizationId, flags: { demoMode: true } }` — before this fix, the input schema silently drops the unrecognized `demoMode` key and validates successfully with `flags: {}`; after this fix, `inputSchema.safeParse(...)` rejects it with an `unrecognized_keys` Zod error, which the MCP server surfaces to the caller as `InvalidParams` instead of a false-success no-op.

**Fix:** add `.strict()` only to the `flags` field's schema instance at this one input call site (`OrgFlagsSchema.strict().optional()`), not to the shared `OrgFlagsSchema` export itself (which is still used loosely for output/other call sites, so this doesn't risk breaking reads of existing rows). Verified this schema is the actual validation boundary — the bundled `@modelcontextprotocol/sdk` (`zod-compat.js`) calls `safeParseAsync` directly against the tool's Zod input schema (or a shape-wrapped version whose nested field references are untouched either way), so `.strict()` on this nested field takes effect at the real wire boundary, not just in this repo's own tests.

**Reviewer check:** `cd apps/api && bunx tsc --noEmit` (green), and `bun test apps/api/src/tools/organization/settings-update.test.ts` (6 pass, including the new regression test).

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace), and the single targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent silent no-op updates in org settings by rejecting unknown keys in the `flags` input. Mistyped flag names now fail validation instead of being stripped.

- **Bug Fixes**
  - Applied `.strict()` to `flags` in `ORGANIZATION_SETTINGS_UPDATE` so unknown keys are rejected (`InvalidParams`) instead of merged as `{}`; shared `OrgFlagsSchema` stays unchanged.
  - Added a regression test that rejects `{ flags: { demoMode: true } }`.

<sup>Written for commit 541e06900678ee4a8a56be10ae51392d1a3cd48f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

