### PR TITLE
fix(sandbox): validate the tenant-committed daemon.json before trusting it

### DIFF
--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -530,6 +530,11 @@ const configUpdateH = makeConfigUpdateHandler({
 
 function hydrate(): void {
   const diskOutcome = readConfig(bootConfig.repoDir);
+  if (diskOutcome.kind === "invalid") {
+    console.warn(
+      `[daemon] ignoring .decocms/daemon.json: ${diskOutcome.reason}`,
+    );
+  }
   if (diskOutcome.kind !== "valid") return;
   const initial: TenantConfig = diskOutcome.config;
   store.hydrate(initial);

--- a/packages/sandbox/daemon/persistence.test.ts
+++ b/packages/sandbox/daemon/persistence.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readConfig } from "./persistence";
+
+function repoWithDaemonJson(contents: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "persistence-test-"));
+  mkdirSync(join(dir, ".decocms"), { recursive: true });
+  writeFileSync(join(dir, ".decocms", "daemon.json"), contents);
+  return dir;
+}
+
+describe("readConfig", () => {
+  const tmpDirs: string[] = [];
+  afterAll(() => {
+    for (const d of tmpDirs) rmSync(d, { recursive: true, force: true });
+  });
+
+  it("returns absent when no file exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "persistence-test-"));
+    tmpDirs.push(dir);
+    expect(readConfig(dir)).toEqual({ kind: "absent" });
+  });
+
+  it("accepts a valid config", () => {
+    const dir = repoWithDaemonJson(
+      JSON.stringify({ application: { port: 3000 } }),
+    );
+    tmpDirs.push(dir);
+    expect(readConfig(dir)).toEqual({
+      kind: "valid",
+      config: { application: { port: 3000 } },
+    });
+  });
+
+  it("rejects a config that fails schema validation instead of trusting it blindly", () => {
+    // Regression: a tenant-committed .decocms/daemon.json bypasses the
+    // daemon-token auth that guards PUT /config, so it must not skip the
+    // same field validation that route enforces (here: port out of range).
+    const dir = repoWithDaemonJson(
+      JSON.stringify({ application: { port: 99999 } }),
+    );
+    tmpDirs.push(dir);
+    const outcome = readConfig(dir);
+    expect(outcome.kind).toBe("invalid");
+  });
+});

--- a/packages/sandbox/daemon/persistence.ts
+++ b/packages/sandbox/daemon/persistence.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { TenantConfig } from "./types";
+import { validateTenantConfig } from "./validate";
 
 const DECOCMS_SUBDIR = ".decocms";
 const DAEMON_JSON = "daemon.json";
@@ -44,5 +45,15 @@ export function readConfig(repoDir: string): ReadOutcome {
   if (!parsed || typeof parsed !== "object") {
     return { kind: "invalid", reason: "not an object" };
   }
-  return { kind: "valid", config: parsed as TenantConfig };
+  const config = parsed as TenantConfig;
+  // This file is tenant-committed, not gated by the daemon-token auth that
+  // protects PUT /config — it must clear the same validation (port range,
+  // package-manager allowlist, env key/size limits, branch format, ...)
+  // before anything trusts it, or a bad committed file could feed
+  // unvalidated values straight into subprocess spawning.
+  const validation = validateTenantConfig(config);
+  if (validation.kind === "invalid") {
+    return { kind: "invalid", reason: validation.reason };
+  }
+  return { kind: "valid", config };
 }


### PR DESCRIPTION
**Source:** bug found while auditing `packages/sandbox/daemon/entry.ts`'s startup/config-loading path for defensive guards.

**Why a maintainer wants this:** `.decocms/daemon.json` is a tenant-committed file (repo comment: "the daemon never writes this file; it exists only if a tenant committed one to the repo themselves") read at daemon boot as a config fallback. The authenticated `PUT /config` route already runs every value through `validateTenantConfig` (port range, package-manager allowlist, env key/size limits, git branch format, operator identity...) before accepting it — but `readConfig()` (used both by `entry.ts`'s boot `hydrate()` and the orchestrator's `fillApplicationDefaults`) skipped that validation entirely and cast the parsed JSON straight to `TenantConfig`. A file that never goes through the daemon-token-gated API therefore ended up *less* validated than one that does, and its fields (e.g. `application.packageManager.path`, which `resolvePmRoot` joins into the install/dev subprocess `cwd` without any containment check, or `application.port`) feed straight into subprocess spawning.

**Failure scenario:** a repo ships (or a contributor commits) a `.decocms/daemon.json` with e.g. `{"application":{"port":99999}}` or a bogus `packageManager.path`. Boot-time `hydrate()` silently accepted it (no logging either way) and merged it into the live config; the orchestrator's `fillApplicationDefaults` would similarly fold the bad field into a patch that then failed `validateTenantConfig` as a whole, silently blocking ALL autodetected defaults (packageManager/runtime/port) from filling in — not just the bad one.

**Fix:** `readConfig()` now runs the parsed config through `validateTenantConfig()` and returns `{ kind: "invalid", reason }` instead of `"valid"` when any field fails — the exact same check the API path already enforces. `entry.ts`'s `hydrate()` now also logs the rejection reason via `console.warn` instead of silently ignoring it (previously true even for JSON-parse failures).

**Regression test:** `packages/sandbox/daemon/persistence.test.ts` (new file) — asserts `readConfig` accepts a valid config, and rejects one with an out-of-range `application.port` instead of trusting it.

**Reviewer verification:** `cd packages/sandbox && bun test daemon/persistence.test.ts`

**Checks run locally:** `bun run fmt` (no changes), `cd packages/sandbox && bunx tsc --noEmit` (clean), `bun test daemon/persistence.test.ts` (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the tenant-committed `.decocms/daemon.json` at boot to align with `PUT /config` validation and block bad values from entering the live config. This prevents invalid ports or `packageManager.path` from reaching subprocess spawning.

- **Bug Fixes**
  - `readConfig()` now runs `validateTenantConfig` and returns `{ kind: "invalid", reason }` on failure.
  - `hydrate()` in `packages/sandbox/daemon/entry.ts` logs a warning and ignores invalid disk config.
  - Added `packages/sandbox/daemon/persistence.test.ts` to cover valid config and reject out-of-range `application.port`.

<sup>Written for commit 1b5e52cf0cc7df4d74b05d7c714eecc53a076caf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

