### PR TITLE
refactor(runtime): remove dead XPTO example types from bindings.ts

### DIFF
--- a/packages/runtime/src/bindings.ts
+++ b/packages/runtime/src/bindings.ts
@@ -1,4 +1,3 @@
-import type { CollectionBinding } from "@decocms/bindings/collections";
 import type { MCPConnection } from "./connection.ts";
 import type { AgentBindingConfig, ResolvedAgentClient } from "./decopilot.ts";
 import type { RequestContext } from "./index.ts";
@@ -350,13 +349,3 @@ export const initializeBindings = <
   // resolves the state in-place
   return traverseAndReplace(ctx.state, ctx) as ResolvedBindings<T, TBindings>;
 };
-
-interface DefaultRegistry extends BindingRegistry {
-  "@deco/studio": CollectionBinding<{ hello: string }, "STUDIO">;
-}
-
-export interface XPTO {
-  STUDIO: Binding<"@deco/meh">;
-}
-
-export type XPTOResolved = ResolvedBindings<XPTO, DefaultRegistry>;


### PR DESCRIPTION
**Source:** dead-code reduction found while sweeping `packages/runtime/src` for type-safety gaps and redundant helpers.

**Why:** `packages/runtime/src/bindings.ts` exported `DefaultRegistry`, `XPTO`, and `XPTOResolved` — leftover scratch/example types (note the placeholder name "XPTO") that have existed since the harness-kernel PR (#3742) and were only ever mechanically renamed (mesh→studio) since, never referenced by any consumer. They add public-API noise to a shared package with zero payoff.

**Net line delta:** -11 / +0. Confirmed unused via `rg -n "XPTO" --type=ts -g '!node_modules'` and `rg -n "DefaultRegistry" --type=ts -g '!node_modules'` — both hit only their own declaration site in `bindings.ts` before this change, no other file in the repo references them. `CollectionBinding` import was also dropped since it became unused after the deletion (confirmed no other use in the file). The real exported type `ResolvedBindings` (used by `index.ts` and consumers) is untouched — only the dead example types built on top of it are removed.

**Reviewer check:** `rg -n "XPTO|DefaultRegistry" --type=ts` returns nothing (repo-wide).

**Verified locally:**
- `bun run fmt` — clean
- `cd packages/runtime && bunx tsc --noEmit` — clean
- `bun test packages/runtime/src/bindings.test.ts` — 2 pass

Full CI validates the rest of the monorepo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead example types (`XPTO`, `XPTOResolved`, `DefaultRegistry`) from `packages/runtime/src/bindings.ts` to reduce public API noise. Dropped the unused `CollectionBinding` import from `@decocms/bindings/collections`; no behavior changes and `ResolvedBindings` stays as-is.

<sup>Written for commit 17dd2eb4a4463270af53751aad64f7d92f823196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

