### PR TITLE
fix(sandbox-proxy): cap file-op and config request body size

### DIFF
--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -89,6 +89,19 @@ function assertSandboxBranchParam(branch: string): void {
 
 const SUGGEST_COMMIT_MAX_BODY_BYTES = 512 * 1024;
 const PREVIEW_INVOKE_MAX_BODY_BYTES = 64 * 1024;
+/**
+ * File-op and config bodies (read/write/mkdir/unlink/rename/glob/grep/config)
+ * are read fully into memory via `c.req.text()` in `proxyDaemon` before being
+ * forwarded to the daemon — unlike suggest-commit/judge-review/preview-invoke
+ * above, they had no size cap at all. 10MB comfortably covers any real source
+ * file while bounding how much an oversized/malicious request can buffer.
+ */
+const FILE_OP_MAX_BODY_BYTES = 10 * 1024 * 1024;
+
+const fileOpBodyLimit = bodyLimit({
+  maxSize: FILE_OP_MAX_BODY_BYTES,
+  onError: (c) => c.json({ error: "Payload too large" }, 413),
+});
 
 /**
  * Quick interactive file ops (read/write/mkdir/unlink/rename/glob) must fail
@@ -495,43 +508,43 @@ export const createSandboxRoutes = () => {
   app.use("/:virtualMcpId/:branch/*", resolveVmClaim);
 
   // -- File write/read (base64-encoded body) --------------------------------
-  app.post("/:virtualMcpId/:branch/write", (c) =>
+  app.post("/:virtualMcpId/:branch/write", fileOpBodyLimit, (c) =>
     proxyDaemon(c, "/_sandbox/write", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/unlink", (c) =>
+  app.post("/:virtualMcpId/:branch/unlink", fileOpBodyLimit, (c) =>
     proxyDaemon(c, "/_sandbox/unlink", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/mkdir", (c) =>
+  app.post("/:virtualMcpId/:branch/mkdir", fileOpBodyLimit, (c) =>
     proxyDaemon(c, "/_sandbox/mkdir", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/rename", (c) =>
+  app.post("/:virtualMcpId/:branch/rename", fileOpBodyLimit, (c) =>
     proxyDaemon(c, "/_sandbox/rename", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/read", (c) =>
+  app.post("/:virtualMcpId/:branch/read", fileOpBodyLimit, (c) =>
     proxyDaemon(c, "/_sandbox/read", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/glob", (c) =>
+  app.post("/:virtualMcpId/:branch/glob", fileOpBodyLimit, (c) =>
     proxyDaemon(c, "/_sandbox/glob", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/grep", (c) =>
+  app.post("/:virtualMcpId/:branch/grep", fileOpBodyLimit, (c) =>
     proxyDaemon(c, "/_sandbox/grep", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
@@ -561,7 +574,7 @@ export const createSandboxRoutes = () => {
       redactRepoDirUnlessDesktop: true,
     }),
   );
-  app.put("/:virtualMcpId/:branch/config", (c) =>
+  app.put("/:virtualMcpId/:branch/config", fileOpBodyLimit, (c) =>
     proxyDaemon(c, "/_sandbox/config", {
       method: "PUT",
       forwardJsonBody: true,


### PR DESCRIPTION
**Source:** a resource-bound/hardening gap found while auditing the agent sandbox proxy routes (`apps/api/src/api/routes/sandbox-proxy.ts`), the surviving relative of the assigned `agent-sandbox-sessions.ts` file (deleted by #5240's revert just before this HEAD).

**Why:** the "quick file ops" (`write`/`unlink`/`mkdir`/`rename`/`read`/`glob`/`grep`) and the `config` PUT route all forward the raw request body to the sandbox daemon by first reading it fully into memory with `c.req.text()` inside `proxyDaemon`. Every other route on this same router that forwards a body (`suggest-commit`, `judge-review`, `preview-invoke`) already caps its size with `bodyLimit`; these did not. Any authenticated org member (or a buggy client) can POST an arbitrarily large body to these endpoints and have it buffered entirely into the Studio API process's memory before ever reaching the daemon.

**Fix:** add a shared 10MB `bodyLimit` (sized to comfortably cover real source-file writes, well under the org-fs upload cap of 500MB used for actual binary uploads) to all the affected routes, rejecting oversized requests with 413 before they're read into memory.

**How to verify:** `bun run fmt` and `cd apps/api && bunx tsc --noEmit` both pass. No existing test exercises the full Hono route table for this file (its test file, `sandbox-proxy.test.ts`, only unit-tests the exported pure helpers `redactRepoDir`/`withClaimGitLock`, per this repo's unit-vs-e2e testing split) — wiring a well-tested Hono middleware into the router isn't itself a new logic path, so no new test was added.

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (both clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 10MB request body cap to sandbox file-op and config endpoints to prevent unbounded buffering and memory spikes. Oversized requests now return 413 before the body is read.

- **Bug Fixes**
  - Apply shared `bodyLimit` to `write`, `unlink`, `mkdir`, `rename`, `read`, `glob`, `grep`, and `config` routes.
  - Aligns with existing caps on `suggest-commit`, `judge-review`, and `preview-invoke`.

<sup>Written for commit 335ca97f39064e4de87006c2ddae1001e2c77bfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

