### PR TITLE
fix(sandbox): refetch the entity when the dev server comes up

### DIFF
--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
@@ -31,7 +31,7 @@ import {
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useProjectContext } from "@/sdk";
-import { KEYS } from "@/lib/query-keys";
+import { KEYS, invalidateVirtualMcpQueries } from "@/lib/query-keys";
 import { exponentialBackoffWithJitter } from "@decocms/shared/std";
 
 import type {
@@ -336,6 +336,13 @@ export function SandboxEventsProvider({
               lp.state.phase === "running" &&
               prevLifecyclePhase !== "running"
             ) {
+              // The claim response can resolve before the pod finishes writing
+              // `previewUrl` into the entity's `sandboxMap` (60s staleTime on
+              // the collection-item query). Without this, `previewUrl` stays
+              // null in the sandbox lifecycle context and the CMS/Content
+              // panels never mount on a cold-start open — only a hard refresh
+              // re-fetches the entity and picks it up.
+              invalidateVirtualMcpQueries(queryClient, org.id);
               const cacheKey = `${org.slug}/${virtualMcpId}/${branch}`;
               void queryClient.invalidateQueries({
                 queryKey: KEYS.decofile(cacheKey),


### PR DESCRIPTION
Fixes #3482.

**Payoff:** the Sections-Editor/Content panel gets permanently stuck on a spinner on a cold-start open of a virtual MCP, requiring a hard page refresh — a first-run experience bug users hit constantly.

**Root cause:** `previewUrl` (which gates the CMS/Content panels — see `sandbox-lifecycle-context.tsx`'s `vmEntry?.previewUrl`) is derived from the virtual MCP entity's `sandboxMap`, fetched via a `useSuspenseQuery` with a 60s `staleTime` and no live-push subscription. `SANDBOX_START` can resolve, and the SSE lifecycle can reach `"running"`, before the pod has finished writing its `previewUrl` into that entity's `sandboxMap` — so on first open, nothing ever re-fetches the entity and `previewUrl` stays `null` until the user does a hard refresh (which re-fetches everything from scratch).

**Fix:** `sandbox-events-context.tsx` already invalidates the decofile/live-meta queries at the `lifecycle.phase === "running"` transition (the exact moment the dev server confirms up). This adds one more invalidation at that same point — the virtual-MCP collection-item query (via the existing `invalidateVirtualMcpQueries` helper) — so the entity refetches and `previewUrl` picks up the freshly-written `sandboxMap` entry without a manual reload.

**Verify:** `bun run fmt` and `cd apps/web && bunx tsc --noEmit` both pass. This is a live-SSE reactivity path (EventSource + entity cache) that isn't cheaply unit-testable without mocks the repo's testing rules disallow for the unit tier — full CI/e2e validates the rest; a reviewer can confirm by opening a virtual MCP from a cold start and immediately switching to the Content/CMS tab (repro steps in #3482) and observing it now self-heals instead of requiring a refresh.

**Diff:** +8/-1, one file, one concern.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a cold-start race that left the Sections-Editor/Content panel stuck on a spinner. When the dev server reports “running,” we now refetch the virtual MCP entity so `previewUrl` updates without a hard refresh.

- **Bug Fixes**
  - On `lifecycle.phase === "running"`, call `invalidateVirtualMcpQueries` to re-fetch the virtual MCP collection-item query and pick up the `sandboxMap` `previewUrl`.

<sup>Written for commit 23955cd1b02bfa858ed80001e11f2bd84cb8b8bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

