### PR TITLE
fix(web): honor chatDefaultOpen when switching to an agent

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1577,9 +1577,16 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                             org: org.slug,
                             taskId: crypto.randomUUID(),
                           },
+                          // Fresh thread on the SAME agent: keep only
+                          // `virtualmcpid` and drop the viewed thread's params
+                          // (its per-thread `main` tab, and `sidepanel`) so the
+                          // target agent's configured default layout resolves —
+                          // don't force chat open on an agent that opts out of
+                          // it (chatDefaultOpen / non-chat defaultMainView).
                           search: (prev) => ({
-                            ...prev,
-                            sidepanel: "chat" as const,
+                            ...(typeof prev.virtualmcpid === "string"
+                              ? { virtualmcpid: prev.virtualmcpid }
+                              : {}),
                           }),
                         })
                       }

--- a/apps/web/src/hooks/use-layout-state.test.ts
+++ b/apps/web/src/hooks/use-layout-state.test.ts
@@ -40,6 +40,21 @@ describe("resolveDefaultPanelState", () => {
     ).toEqual({ sidePanel: null, mainOpen: true });
   });
 
+  test("a Content default with chatDefaultOpen:false keeps the chat closed", () => {
+    // The reported bug: an agent whose main view is Content and that opted out
+    // of the chat panel must land Main-only when no `sidepanel` param is present
+    // (the switch/new-chat paths now omit it — see resolve-task-switch-search).
+    expect(
+      resolveDefaultPanelState({
+        entityMetadata: {
+          defaultMainView: { type: "content" },
+          chatDefaultOpen: false,
+        },
+        ...absentSearch,
+      }),
+    ).toEqual({ sidePanel: null, mainOpen: true });
+  });
+
   test("chatDefaultOpen maps to the Chat side panel", () => {
     expect(
       resolveDefaultPanelState({

--- a/apps/web/src/hooks/use-layout-state.ts
+++ b/apps/web/src/hooks/use-layout-state.ts
@@ -293,12 +293,14 @@ export function useWorkspaceLayoutState(
       // Toast already fired by useCollectionActions; navigate anyway so the
       // route loader's ensure-fallback can retry.
     }
+    // Omit `sidepanel` so the agent-configured default (resolveDefaultPanelState
+    // — honors chatDefaultOpen / defaultMainView) drives whether the chat opens,
+    // instead of forcing it open on an agent that opts out of the chat panel.
     navigate({
       to: routeBase,
       params: makeParams(newTaskId),
       search: (_prev: Record<string, unknown>) => ({
         ...preserveVirtualMcp,
-        sidepanel: "chat" as const,
       }),
     });
   };

--- a/apps/web/src/layouts/resolve-task-switch-search.test.ts
+++ b/apps/web/src/layouts/resolve-task-switch-search.test.ts
@@ -17,9 +17,11 @@ function resolve(
   });
 }
 
-describe("resolveTaskSwitchSearch — no memory (legacy behavior)", () => {
-  test("defaults to chat side panel open, no main", () => {
-    expect(resolve()).toEqual({ sidepanel: "chat" });
+describe("resolveTaskSwitchSearch — no memory (agent default applies)", () => {
+  test("omits sidepanel so the agent-configured default applies", () => {
+    // No saved layout → don't pin the chat panel; resolveDefaultPanelState
+    // decides from the target agent's chatDefaultOpen / defaultMainView.
+    expect(resolve()).toEqual({});
   });
 
   test("carries a system tab forward within the same agent", () => {
@@ -28,7 +30,7 @@ describe("resolveTaskSwitchSearch — no memory (legacy behavior)", () => {
         prev: { virtualmcpid: "repo-1", main: "git" },
         virtualMcpId: "repo-1",
       }),
-    ).toEqual({ virtualmcpid: "repo-1", main: "git", sidepanel: "chat" });
+    ).toEqual({ virtualmcpid: "repo-1", main: "git" });
   });
 
   test("drops per-thread tabs when carrying forward", () => {
@@ -37,7 +39,7 @@ describe("resolveTaskSwitchSearch — no memory (legacy behavior)", () => {
         prev: { virtualmcpid: "repo-1", main: "file:abc" },
         virtualMcpId: "repo-1",
       }),
-    ).toEqual({ virtualmcpid: "repo-1", sidepanel: "chat" });
+    ).toEqual({ virtualmcpid: "repo-1" });
   });
 
   test("agent switch drops the previous view", () => {
@@ -46,7 +48,7 @@ describe("resolveTaskSwitchSearch — no memory (legacy behavior)", () => {
         prev: { virtualmcpid: "repo-1", main: "git" },
         virtualMcpId: "repo-2",
       }),
-    ).toEqual({ virtualmcpid: "repo-2", sidepanel: "chat" });
+    ).toEqual({ virtualmcpid: "repo-2" });
   });
 
   test("param-less Super Agent → repo agent counts as a switch", () => {
@@ -55,21 +57,32 @@ describe("resolveTaskSwitchSearch — no memory (legacy behavior)", () => {
       resolve({ prev: { main: "overview" }, virtualMcpId: "repo-1" }),
     ).toEqual({
       virtualmcpid: "repo-1",
-      sidepanel: "chat",
     });
   });
 
   test("opts.main is an explicit intent that wins", () => {
     expect(
       resolve({ prev: { virtualmcpid: "repo-1" }, opts: { main: "preview" } }),
-    ).toEqual({ virtualmcpid: "repo-1", main: "preview", sidepanel: "chat" });
+    ).toEqual({ virtualmcpid: "repo-1", main: "preview" });
   });
 
   test("opts.autosend appends the sentinel", () => {
     expect(resolve({ opts: { autosend: true } })).toEqual({
-      sidepanel: "chat",
       autosend: AUTOSEND,
     });
+  });
+
+  test("agent switch never forces sidepanel (agent may opt out of chat)", () => {
+    // Regression: switching to an agent configured with a non-chat main view +
+    // chatDefaultOpen:false must not pin `sidepanel=chat`, which would override
+    // that config and open the chat panel anyway. Omitting it lets
+    // resolveDefaultPanelState keep the chat closed per the agent's config.
+    const result = resolve({
+      prev: { virtualmcpid: "repo-1", main: "git" },
+      virtualMcpId: "content-agent",
+    });
+    expect(result).not.toHaveProperty("sidepanel");
+    expect(result).toEqual({ virtualmcpid: "content-agent" });
   });
 });
 
@@ -84,10 +97,10 @@ describe("resolveTaskSwitchSearch — restoring per-thread memory", () => {
   });
 
   test("restores a per-thread tab the thread owned (keyed by task id)", () => {
+    // No remembered sidepanel → omitted, so the agent default applies.
     const savedLayout: ThreadLayout = { main: "file:abc" };
     expect(resolve({ savedLayout })).toEqual({
       main: "file:abc",
-      sidepanel: "chat",
     });
   });
 
@@ -105,7 +118,7 @@ describe("resolveTaskSwitchSearch — restoring per-thread memory", () => {
         virtualMcpId: "repo-1",
         savedLayout,
       }),
-    ).toEqual({ virtualmcpid: "repo-1", main: "preview", sidepanel: "chat" });
+    ).toEqual({ virtualmcpid: "repo-1", main: "preview" });
   });
 
   test("empty saved layout restores the default (no carry-forward)", () => {
@@ -117,14 +130,15 @@ describe("resolveTaskSwitchSearch — restoring per-thread memory", () => {
         virtualMcpId: "repo-1",
         savedLayout: {},
       }),
-    ).toEqual({ virtualmcpid: "repo-1", sidepanel: "chat" });
+    ).toEqual({ virtualmcpid: "repo-1" });
   });
 
   test("opts.main still beats saved layout", () => {
+    // opts.main wins the main slot; the saved sidepanel is not consulted, so it
+    // is omitted and the agent default applies.
     const savedLayout: ThreadLayout = { main: "preview", sidepanel: 0 };
     expect(resolve({ opts: { main: "settings" }, savedLayout })).toEqual({
       main: "settings",
-      sidepanel: "chat",
     });
   });
 });

--- a/apps/web/src/layouts/resolve-task-switch-search.test.ts
+++ b/apps/web/src/layouts/resolve-task-switch-search.test.ts
@@ -72,17 +72,17 @@ describe("resolveTaskSwitchSearch — no memory (agent default applies)", () => 
     });
   });
 
-  test("agent switch never forces sidepanel (agent may opt out of chat)", () => {
-    // Regression: switching to an agent configured with a non-chat main view +
-    // chatDefaultOpen:false must not pin `sidepanel=chat`, which would override
-    // that config and open the chat panel anyway. Omitting it lets
-    // resolveDefaultPanelState keep the chat closed per the agent's config.
-    const result = resolve({
-      prev: { virtualmcpid: "repo-1", main: "git" },
-      virtualMcpId: "content-agent",
-    });
-    expect(result).not.toHaveProperty("sidepanel");
-    expect(result).toEqual({ virtualmcpid: "content-agent" });
+  test("omits sidepanel on agent switch (no saved layout)", () => {
+    // Regression guard: the switch must not pin `sidepanel` in the URL. Its
+    // omission is what lets resolveDefaultPanelState honor the target agent's
+    // chatDefaultOpen / defaultMainView (see use-layout-state.test.ts) instead
+    // of forcing chat open — this function has no access to that config itself.
+    expect(
+      resolve({
+        prev: { virtualmcpid: "repo-1", main: "git" },
+        virtualMcpId: "content-agent",
+      }),
+    ).toEqual({ virtualmcpid: "content-agent" });
   });
 });
 

--- a/apps/web/src/layouts/resolve-task-switch-search.ts
+++ b/apps/web/src/layouts/resolve-task-switch-search.ts
@@ -11,7 +11,11 @@
  *      (git/preview/settings/…) but drop per-thread tabs from the source thread.
  *      Skipped on an agent switch so the new agent's own default resolves.
  *
- * The side panel defaults to chat-open unless the restored layout closed it.
+ * The side panel is only pinned in the URL when the target thread's own
+ * remembered layout recorded one. Otherwise `sidepanel` is omitted so
+ * resolveDefaultPanelState derives the default from the target agent's layout
+ * config (chatDefaultOpen / defaultMainView) — a fresh thread on an agent that
+ * opts out of the chat panel must not be forced chat-open.
  */
 
 import { isPerThreadTab } from "@/layouts/main-panel-tabs/tab-id";
@@ -50,7 +54,10 @@ export function resolveTaskSwitchSearch(
   const targetVmcp = virtualMcpId ?? prevVmcp;
   const isAgentSwitch = targetVmcp !== prevVmcp;
 
-  let sidepanel: "chat" | 0 = "chat";
+  // Only pin a side-panel value when the target thread remembered one; leaving
+  // it undefined omits `sidepanel` from the URL so the agent-configured default
+  // (resolveDefaultPanelState) applies instead of forcing chat open.
+  let sidepanel: "chat" | 0 | undefined;
 
   if (opts?.main) {
     // Explicit intent wins outright — ignore saved/carried layout.
@@ -68,7 +75,7 @@ export function resolveTaskSwitchSearch(
     }
   }
 
-  next.sidepanel = sidepanel;
+  if (sidepanel !== undefined) next.sidepanel = sidepanel;
   if (opts?.autosend) next.autosend = autosendValue;
   return next;
 }


### PR DESCRIPTION
## Summary

The chat panel was opening even for agents configured with **main view = Content** and **"Show chat" off** (`chatDefaultOpen: false`) — see screenshot in the linked issue.

The default-resolution logic (`resolveDefaultPanelState`) was correct: a non-chat main view + `chatDefaultOpen: false` resolves the side panel to closed. The bug was in the **open-agent / task-switch** path: `resolveTaskSwitchSearch` (via `setTaskId` in `shell-layout.tsx`) unconditionally wrote `sidepanel=chat` into the URL unless a *previously-saved* thread layout had closed it. For a fresh thread there is no saved layout, so `sidepanel=chat` got pinned — and an explicit URL param overrides the agent's `chatDefaultOpen: false` config.

## Changes

- **`resolve-task-switch-search.ts`** — only pin `sidepanel` in the URL when the target thread's remembered layout recorded one. Otherwise omit it, letting `resolveDefaultPanelState` derive the default from the agent's own layout config (`chatDefaultOpen` / `defaultMainView`). Chat-default agents still open chat (resolved from config); agents that opt out stay closed.
- **`use-layout-state.ts`** — the in-panel `createNewTask` had the same hardcoded `sidepanel: "chat"`; now it omits it too.
- **Tests** — updated `resolve-task-switch-search.test.ts` to reflect that `sidepanel` is omitted (not forced to `"chat"`) when no saved layout provides one, plus a regression test for the agent-opt-out case.

## Testing

- `bun test apps/web/src/layouts/resolve-task-switch-search.test.ts apps/web/src/hooks/use-layout-state.test.ts` — all pass
- `bun run check` (typecheck) — clean
- `bun run fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat panel opening when switching agents or starting a new thread from Preview by honoring each agent’s `chatDefaultOpen` and `defaultMainView`. Chat stays closed for agents that opt out.

- **Bug Fixes**
  - Only include `sidepanel` in the URL when the target thread’s saved layout recorded one; otherwise omit it so `resolveDefaultPanelState` applies agent defaults.
  - Stop forcing chat open on fresh threads: removed `sidepanel: "chat"` in `createNewTask` (`use-layout-state.ts`) and in Preview’s “Start new thread” (keeps only `virtualmcpid`, drops prior thread params).
  - Tests hardened: expect omitted `sidepanel` for fresh threads, add a `resolveDefaultPanelState` case for content default + `chatDefaultOpen:false`, and tighten the agent-switch regression.

<sup>Written for commit 530925954d05a14a3b5ee36d00f3b153a5e4fad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

