### PR TITLE
fix(chat): refresh thread metadata when load_repo lands in a watched run

### DIFF
--- a/apps/web/src/components/chat/use-open-preview-on-repo-load.test.ts
+++ b/apps/web/src/components/chat/use-open-preview-on-repo-load.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { countLoadedRepos } from "./use-open-preview-on-repo-load";
+
+describe("countLoadedRepos", () => {
+  const load = (over: Record<string, unknown> = {}) => ({
+    type: "tool-load_repo",
+    state: "output-available",
+    output: { success: true },
+    ...over,
+  });
+
+  it("counts each successful load (a switch is a second signal)", () => {
+    expect(countLoadedRepos([])).toBe(0);
+    expect(countLoadedRepos([{ parts: [load()] }])).toBe(1);
+    expect(countLoadedRepos([{ parts: [load()] }, { parts: [load()] }])).toBe(
+      2,
+    );
+  });
+
+  it("ignores in-flight, failed and unrelated parts", () => {
+    expect(
+      countLoadedRepos([
+        { parts: [load({ state: "input-available" })] },
+        { parts: [load({ output: { success: false } })] },
+        { parts: [load({ output: undefined })] },
+        { parts: [{ type: "tool-bash", state: "output-available" }] },
+        { parts: [{ type: "text", text: "load_repo" }] },
+        {},
+      ]),
+    ).toBe(0);
+  });
+});

--- a/apps/web/src/components/chat/use-open-preview-on-repo-load.ts
+++ b/apps/web/src/components/chat/use-open-preview-on-repo-load.ts
@@ -1,52 +1,83 @@
 /**
- * Open the Preview tab the moment `load_repo` succeeds in this chat.
+ * Open the Preview tab — and re-read the thread row — when `load_repo` succeeds
+ * in this chat.
  *
  * The tool emits a transient `data-open-preview` stream chunk (handled in
- * chat-context's observer) which opens the tab live — but a chunk is only seen
- * by the client that is actively streaming the run. Someone VIEWING the chat of
- * a background Super Agent run (opened from the task board's activity card) or
- * reopening a finished run never receives it, so the tab never opens.
+ * chat-context's observer) which opens the tab live AND patches the repo it
+ * bound (`githubRepo` + `sandboxMap`) onto the local thread row — but a chunk is
+ * only seen by the client that is actively streaming the run. Someone VIEWING
+ * the chat of a background Super Agent run (opened from the task board's
+ * activity card) or reopening a finished run never receives it, so the tab never
+ * opens and the row keeps its pre-repo snapshot. That stale row makes the
+ * preview show "no source to preview" even though the repo IS bound
+ * server-side — the `/watch` thread-status event carries no metadata and
+ * `useEnsureTask` short-circuits on the local row, so nothing else fills it in.
  *
  * This is the durable counterpart: it scans the persisted messages for a
  * successful `load_repo` tool result (`tool-load_repo`, `output-available`,
- * `output.success`) and opens `?main=preview`. Fires once per thread and is
- * guarded so it never fights a manual switch away from Preview afterwards.
+ * `output.success`), refreshes the thread's metadata from the server and opens
+ * `?main=preview`. The tab opens once per thread (so it never fights a manual
+ * switch away from Preview afterwards) while the metadata refresh re-runs on a
+ * repo SWITCH — a second `load_repo` binds a different repo and sandbox.
  */
 
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 import { useOptionalChatStream, useOptionalChatTask } from "./context";
+import { useOptionalThreadManager } from "./store/hooks";
 
-export function useOpenPreviewOnRepoLoad(): void {
-  const navigate = useNavigate();
-  const messages = useOptionalChatStream()?.messages ?? [];
-  const taskId = useOptionalChatTask()?.taskId ?? null;
-
-  const repoLoaded = messages.some((m) =>
-    m.parts?.some((p) => {
+/** Successful `load_repo` calls in a message list. A COUNT, not a boolean, so a
+ *  repo switch (a second load) is a distinct signal from the first load. */
+export function countLoadedRepos(
+  messages: readonly { parts?: unknown[] }[],
+): number {
+  let loads = 0;
+  for (const message of messages) {
+    for (const p of message.parts ?? []) {
       const part = p as {
-        type: string;
+        type?: string;
         state?: string;
         output?: { success?: boolean };
       };
-      return (
+      if (
         part.type === "tool-load_repo" &&
         part.state === "output-available" &&
         part.output?.success === true
-      );
-    }),
-  );
+      ) {
+        loads++;
+      }
+    }
+  }
+  return loads;
+}
+
+export function useOpenPreviewOnRepoLoad(): void {
+  const navigate = useNavigate();
+  const manager = useOptionalThreadManager();
+  const messages = useOptionalChatStream()?.messages ?? [];
+  const taskId = useOptionalChatTask()?.taskId ?? null;
+
+  const loads = countLoadedRepos(messages);
 
   const openedFor = useRef<string | null>(null);
+  /** `<taskId>:<loads>` of the last refresh, so switching threads or loading a
+   *  second repo re-reads, but a re-render at the same count does not. */
+  const refreshedKey = useRef<string | null>(null);
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- navigation side effect on a durable stream signal
   useEffect(() => {
-    if (!repoLoaded || !taskId || openedFor.current === taskId) return;
+    if (!loads || !taskId) return;
+    const key = `${taskId}:${loads}`;
+    if (refreshedKey.current !== key) {
+      refreshedKey.current = key;
+      void manager?.refreshThreadMetadata(taskId);
+    }
+    if (openedFor.current === taskId) return;
     openedFor.current = taskId;
     navigate({
       to: ".",
       search: (prev: Record<string, unknown>) => ({ ...prev, main: "preview" }),
       replace: true,
     });
-  }, [repoLoaded, taskId, navigate]);
+  }, [loads, taskId, navigate, manager]);
 }


### PR DESCRIPTION
## Problem

A Super Agent run on the task board loads a repo, and the Preview tab opens onto **"No source to preview — Connect a GitHub repository"** even though the repo is bound and GitHub is connected. A full page reload fixes it (reproduced in `demo-storefront`).

The Preview gate reads `metadata.githubRepo` from the agent or from the local thread row (`preview-tab.tsx:19`):

- The Super Agent is the synthetic Decopilot agent — no `connections` row, so never a repo. The thread row is the only source.
- `load_repo` writes `threads.metadata.githubRepo` server-side (`load-repo.ts:194`), then patches the client via the transient `data-open-preview` chunk (`load-repo.ts:234`) — which, as the hook's own doc comment says, only reaches the client actively streaming the run. A background run has no such client.
- Nothing else fills the gap: the `/watch` `decopilot.thread.status` publishers never send `metadata` (`run-reactor.ts:63,101,133`; `thread-status-events.ts:45`), and `useEnsureTask` short-circuits on `localHit` (`use-ensure-task.ts:54,116`) so the row inserted by that event is never re-read.
- `useRefreshViewedThreadMetadata` was built for this failure mode but is gated to *other people's* threads; a delegated Super Agent thread has `created_by = ` the delegating user (`enqueue-super-agent.ts:42`), so it never fires.

Meanwhile `useOpenPreviewOnRepoLoad` — which reads *persisted* messages — happily opens the tab. Hence the empty state instead of silence.

## Fix

Reuse that same durable signal for the metadata: when a successful `load_repo` appears in the persisted messages, call `manager.refreshThreadMetadata(taskId)` next to the existing `navigate`. The row's `githubRepo` / `sandboxMap` then come from the server for every viewer, streaming or not.

Counted rather than boolean (`countLoadedRepos`) so a repo **switch** — a second `load_repo`, binding a different repo and sandbox — refreshes too; the tab still opens only once per thread so it never fights a manual switch away from Preview.

`useRefreshViewedThreadMetadata` stays: it also covers a teammate's row whose `sandboxMap` was written with no `load_repo` in the messages (the frontend `SANDBOX_START` auto-start path).

## Testing

- New unit test on the extracted pure counter (`countLoadedRepos`): counts each success, ignores in-flight / failed / unrelated parts. `bun test` green.
- `bun run fmt`, `bun run --cwd=apps/web check`, `bun run lint` (0 errors) all pass.
- Not yet verified in a live background Super Agent run — the code path is a viewer-side refetch on a signal that already fires today (it is what opens the tab), so the risk is one extra `COLLECTION_THREADS_GET` per repo load. `applyPatch`'s recency guard drops the patch if the local row is newer, so it cannot clobber a fresher client-side patch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale Preview state after `load_repo` by refreshing thread metadata when a successful load is found in persisted messages. Ensures the Preview tab shows the bound repo for watched Super Agent runs and on reopen.

- **Bug Fixes**
  - On successful `load_repo` in persisted messages, refresh thread metadata and open Preview (opens once per thread).
  - Count successful loads so repo switches trigger another metadata refresh without fighting user navigation.
  - Keep teammate-thread fallback via useRefreshViewedThreadMetadata.

<sup>Written for commit 8e145eb7177f6f9f008ce5e893248ec83a5604e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

