### PR TITLE
fix(i18n): translate hardcoded strings in the backlog paywall banner/modal

### DIFF
--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -1,4 +1,17 @@
 export const taskBoard = {
+  "taskBoard.backlogPaywall.bannerSubtitle":
+    "Unlock the full diagnostic and its tasks land here, from highest priority to lowest.",
+  "taskBoard.backlogPaywall.bannerTitle": "Your action plan is one click away",
+  "taskBoard.backlogPaywall.benefitAgentResolves":
+    "The agent resolves each task and leaves it ready for your review",
+  "taskBoard.backlogPaywall.benefitPrioritizedTasks":
+    "Every diagnostic task, prioritized on your board",
+  "taskBoard.backlogPaywall.benefitRecurringReport":
+    "A recurring report on your site, always up to date",
+  "taskBoard.backlogPaywall.exploreButton": "Explore",
+  "taskBoard.backlogPaywall.modalTitle": "Unlock your action plan",
+  "taskBoard.backlogPaywall.previewAlt": "Preview of your unlocked task board",
+  "taskBoard.backlogPaywall.unlockButton": "Unlock diagnostic",
   "taskBoard.config.priorityHigh": "High",
   "taskBoard.config.priorityLow": "Low",
   "taskBoard.config.priorityMedium": "Medium",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -1,6 +1,20 @@
 import type { taskBoard as taskBoardEn } from "../en/task-board.ts";
 
 export const taskBoard = {
+  "taskBoard.backlogPaywall.bannerSubtitle":
+    "Desbloqueie o diagnóstico completo e as tarefas entram aqui, da maior prioridade para a menor.",
+  "taskBoard.backlogPaywall.bannerTitle": "Seu plano de ação está a um clique",
+  "taskBoard.backlogPaywall.benefitAgentResolves":
+    "O agente resolve cada tarefa e deixa pronta para a sua revisão",
+  "taskBoard.backlogPaywall.benefitPrioritizedTasks":
+    "Todas as tarefas do diagnóstico, priorizadas no seu quadro",
+  "taskBoard.backlogPaywall.benefitRecurringReport":
+    "Um relatório recorrente do seu site, sempre atualizado",
+  "taskBoard.backlogPaywall.exploreButton": "Explorar",
+  "taskBoard.backlogPaywall.modalTitle": "Desbloqueie seu plano de trabalho",
+  "taskBoard.backlogPaywall.previewAlt":
+    "Prévia do seu quadro de tarefas desbloqueado",
+  "taskBoard.backlogPaywall.unlockButton": "Desbloquear diagnóstico",
   "taskBoard.config.priorityHigh": "Alta",
   "taskBoard.config.priorityLow": "Baixa",
   "taskBoard.config.priorityMedium": "Média",

--- a/apps/web/src/layouts/task-board/backlog-paywall.tsx
+++ b/apps/web/src/layouts/task-board/backlog-paywall.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/hooks/use-commerce-diagnostic";
 import { unwrapToolResult } from "@/routes/commerce-onboarding/companions-core";
 import { track } from "@/lib/posthog-client";
+import { useT } from "@/i18n/use-t.ts";
 
 /** A preview of the unlocked board (carries the brand-lime edge), used as the
  *  modal hero — hosted on the deco CDN. */
@@ -40,11 +41,11 @@ const KANBAN_PREVIEW_SRC =
   "https://decoims.com/image?src=decocms%2F7263a67f-fb83-410b-a5f2-e54e87deaaac%2Freport-kanban.png&quality=original&fit=cover";
 
 /** What the unlock buys — kept true to what the paid product delivers. */
-const BENEFITS = [
-  "Todas as tarefas do diagnóstico, priorizadas no seu quadro",
-  "Um relatório recorrente do seu site, sempre atualizado",
-  "O agente resolve cada tarefa e deixa pronta para a sua revisão",
-];
+const BENEFIT_KEYS = [
+  "taskBoard.backlogPaywall.benefitPrioritizedTasks",
+  "taskBoard.backlogPaywall.benefitRecurringReport",
+  "taskBoard.backlogPaywall.benefitAgentResolves",
+] as const;
 
 /** Display-only offer strings (mirrors the report's one-time unlock). */
 const OFFER = { price: "R$ 99", anchor: "R$ 499" };
@@ -52,6 +53,7 @@ const OFFER = { price: "R$ 99", anchor: "R$ 499" };
 /** Pure presentational banner — no hooks, so it renders anywhere (incl. the
  *  dev preview). The container below wires the data + navigation. */
 function BacklogPaywallCard({ onOpen }: { onOpen: () => void }) {
+  const t = useT();
   return (
     <div className="flex flex-col gap-3 rounded-xl bg-card p-4 card-shadow sm:flex-row sm:items-center sm:gap-4">
       <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center">
@@ -60,11 +62,10 @@ function BacklogPaywallCard({ onOpen }: { onOpen: () => void }) {
         </span>
         <div className="flex min-w-0 flex-col">
           <span className="text-sm font-medium text-foreground">
-            Seu plano de ação está a um clique
+            {t("taskBoard.backlogPaywall.bannerTitle")}
           </span>
           <span className="text-sm text-muted-foreground">
-            Desbloqueie o diagnóstico completo e as tarefas entram aqui, da
-            maior prioridade para a menor.
+            {t("taskBoard.backlogPaywall.bannerSubtitle")}
           </span>
         </div>
       </div>
@@ -73,7 +74,7 @@ function BacklogPaywallCard({ onOpen }: { onOpen: () => void }) {
         onClick={onOpen}
         className="w-full gap-2 sm:w-auto sm:shrink-0"
       >
-        Desbloquear diagnóstico
+        {t("taskBoard.backlogPaywall.unlockButton")}
         <ArrowRight size={16} />
       </Button>
     </div>
@@ -95,6 +96,7 @@ function BacklogPaywallModal({
    *  that can (no client) — falls back to opening it. */
   onExpired: () => void;
 }) {
+  const t = useT();
   const [starting, setStarting] = useState(false);
 
   const startCheckout = async () => {
@@ -135,7 +137,7 @@ function BacklogPaywallModal({
         <div className="overflow-hidden rounded-xl bg-muted">
           <img
             src={KANBAN_PREVIEW_SRC}
-            alt="Prévia do seu quadro de tarefas desbloqueado"
+            alt={t("taskBoard.backlogPaywall.previewAlt")}
             className="h-[208px] w-full object-cover object-left-top"
           />
         </div>
@@ -144,17 +146,17 @@ function BacklogPaywallModal({
         <div className="flex flex-col gap-7 px-3 pb-3 pt-7">
           <div className="flex flex-col gap-5">
             <DialogTitle className="text-xl font-semibold text-foreground">
-              Desbloqueie seu plano de trabalho
+              {t("taskBoard.backlogPaywall.modalTitle")}
             </DialogTitle>
             <ul className="flex flex-col gap-3.5">
-              {BENEFITS.map((b) => (
-                <li key={b} className="flex items-start gap-3 text-sm">
+              {BENEFIT_KEYS.map((key) => (
+                <li key={key} className="flex items-start gap-3 text-sm">
                   <CheckCircle
                     size={18}
                     className="mt-0.5 shrink-0 text-success"
                     aria-hidden
                   />
-                  <span className="leading-snug text-foreground">{b}</span>
+                  <span className="leading-snug text-foreground">{t(key)}</span>
                 </li>
               ))}
             </ul>
@@ -178,7 +180,7 @@ function BacklogPaywallModal({
                 disabled={starting}
                 className="order-2 w-full sm:order-none sm:w-auto"
               >
-                Explorar
+                {t("taskBoard.backlogPaywall.exploreButton")}
               </Button>
               <Button
                 onClick={startCheckout}
@@ -188,7 +190,7 @@ function BacklogPaywallModal({
                 {starting ? (
                   <Loading01 size={16} className="animate-spin" />
                 ) : null}
-                Desbloquear diagnóstico
+                {t("taskBoard.backlogPaywall.unlockButton")}
                 {!starting && <ArrowRight size={16} />}
               </Button>
             </div>


### PR DESCRIPTION
**Source:** i18n hardening in the billing/paywall UI area (focus area for this tick).

**Payoff:** `backlog-paywall.tsx` — the commerce-diagnostic backlog banner and its Stripe-checkout unlock modal — rendered every user-facing string (banner copy, benefit list, modal title, image alt text, both CTA buttons) as a hardcoded Portuguese literal, completely bypassing i18n. Every sibling component in `apps/web/src/routes/commerce-onboarding/` routes through `useT()`; this file was the outlier, so switching the app language preference silently had no effect on this banner/modal while it did everywhere else nearby.

**Fix:** Wired all nine strings through `t()` with new `taskBoard.backlogPaywall.*` keys, added to both `apps/web/src/i18n/en/task-board.ts` (real English translations) and `apps/web/src/i18n/pt-br/task-board.ts` (the original Portuguese text, unchanged visually for pt-BR users). No behavior change — same text renders for pt-BR, English now renders for en. The `satisfies Record<keyof typeof taskBoardEn, string>` constraint on the pt-br dict enforces key parity at compile time.

**Reviewer check:** `cd apps/web && bunx tsc --noEmit` (validates the dictionary parity + JSX call sites) — passes clean. Switch language to English in prefs and open the task board for a locked commerce org to see the banner/modal now in English.

**Locally verified:** `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/web` (clean, no errors). No existing test file covers this component; full CI (lint, unit, e2e) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internationalized the backlog paywall banner and unlock modal on the task board. All user-facing copy now uses translations instead of hardcoded Portuguese.

- **Bug Fixes**
  - Routed banner title/subtitle, benefit list, modal title, image alt, and both CTAs through `t()` with new `taskBoard.backlogPaywall.*` keys.
  - Added English strings in `en/task-board.ts`; kept original Portuguese in `pt-br/task-board.ts` with type-checked key parity.
  - No visual change for pt-BR; English users now see correct translations.

<sup>Written for commit 26d631fc4723ace18c141385cd5cfd4929a49f83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

