### PR TITLE
fix(mcp-clients): bound abandoned half-open circuit-breaker probes

### DIFF
--- a/apps/api/src/core/constants.ts
+++ b/apps/api/src/core/constants.ts
@@ -26,6 +26,17 @@ export const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 3;
 /** Cooldown period in ms before allowing a probe request (half-open state) */
 export const CIRCUIT_BREAKER_COOLDOWN_MS = 30_000; // 30 seconds
 
+/**
+ * Max age of an in-flight half-open probe before it's considered abandoned.
+ * A caller can grant itself the probe via assertCircuitClosed() and then throw
+ * before calling recordSuccess/recordFailure (e.g. a caller path that
+ * deliberately skips both, like an auth-recoverable error). Without this
+ * bound, that circuit would fail-fast forever since no future request could
+ * ever win the single-probe slot. Set above the MCP SDK's 60s connect
+ * timeout so a genuinely slow (not abandoned) probe isn't preempted.
+ */
+export const CIRCUIT_BREAKER_HALF_OPEN_PROBE_TIMEOUT_MS = 65_000; // 65 seconds
+
 /** Maximum number of circuit breaker entries to retain in memory */
 export const CIRCUIT_BREAKER_MAX_ENTRIES = 1000;
 

--- a/apps/api/src/mcp-clients/circuit-breaker.test.ts
+++ b/apps/api/src/mcp-clients/circuit-breaker.test.ts
@@ -68,6 +68,28 @@ describe("circuit-breaker", () => {
     expect(() => assertCircuitClosed("conn_a")).toThrow(CircuitOpenError);
   });
 
+  it("recovers a half-open probe abandoned without recordSuccess/recordFailure", () => {
+    for (let i = 0; i < 3; i++) recordFailure("conn_a");
+
+    const circuit = _getCircuitForTest("conn_a");
+    expect(circuit).toBeDefined();
+    circuit!.lastFailureTime = Date.now() - 60_000;
+
+    // Grant the single probe (e.g. a caller path that returns early on an
+    // auth-recoverable error without ever calling recordSuccess/recordFailure).
+    expect(() => assertCircuitClosed("conn_a")).not.toThrow();
+    expect(circuit!.state).toBe("HALF_OPEN");
+
+    // Immediately after, a second request is correctly blocked.
+    expect(() => assertCircuitClosed("conn_a")).toThrow(CircuitOpenError);
+
+    // Simulate the abandoned probe aging past the timeout.
+    circuit!.halfOpenStartedAt = Date.now() - 70_000;
+
+    // A fresh probe should now be granted instead of failing fast forever.
+    expect(() => assertCircuitClosed("conn_a")).not.toThrow();
+  });
+
   it("isolates circuits per connection", () => {
     for (let i = 0; i < 3; i++) recordFailure("conn_a");
 

--- a/apps/api/src/mcp-clients/circuit-breaker.ts
+++ b/apps/api/src/mcp-clients/circuit-breaker.ts
@@ -13,6 +13,7 @@
 import {
   CIRCUIT_BREAKER_COOLDOWN_MS,
   CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+  CIRCUIT_BREAKER_HALF_OPEN_PROBE_TIMEOUT_MS,
   CIRCUIT_BREAKER_MAX_ENTRIES,
 } from "../core/constants";
 import { meter } from "../observability";
@@ -24,6 +25,7 @@ interface CircuitEntry {
   consecutiveFailures: number;
   lastFailureTime: number;
   halfOpenInFlight: boolean;
+  halfOpenStartedAt: number;
 }
 
 const circuits = new Map<string, CircuitEntry>();
@@ -70,9 +72,16 @@ export function assertCircuitClosed(connectionId: string): void {
 
   if (circuit.state === "HALF_OPEN") {
     if (circuit.halfOpenInFlight) {
-      throw new CircuitOpenError(connectionId, 0);
+      const probeAge = Date.now() - circuit.halfOpenStartedAt;
+      if (probeAge < CIRCUIT_BREAKER_HALF_OPEN_PROBE_TIMEOUT_MS) {
+        throw new CircuitOpenError(connectionId, 0);
+      }
+      // The previous probe never reported an outcome (caller threw without
+      // calling recordSuccess/recordFailure) — treat it as abandoned rather
+      // than wedging the circuit open forever, and grant a fresh probe.
     }
     circuit.halfOpenInFlight = true;
+    circuit.halfOpenStartedAt = Date.now();
     return;
   }
 
@@ -81,6 +90,7 @@ export function assertCircuitClosed(connectionId: string): void {
   if (elapsed >= CIRCUIT_BREAKER_COOLDOWN_MS) {
     circuit.state = "HALF_OPEN";
     circuit.halfOpenInFlight = true;
+    circuit.halfOpenStartedAt = Date.now();
     return;
   }
 
@@ -110,6 +120,7 @@ export function recordFailure(connectionId: string): void {
       consecutiveFailures: 1,
       lastFailureTime: Date.now(),
       halfOpenInFlight: false,
+      halfOpenStartedAt: 0,
     });
     return;
   }


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/mcp-clients/circuit-breaker.ts` for graceful-degradation edge cases in the MCP-client circuit breaker (this tick's focus area).

**Payoff:** a legitimate MCP connection can get permanently circuit-broken in a replica's memory, forcing every future proxy request to that connection to fail instantly even after the downstream is healthy again — until process restart or LRU eviction (which may never happen for a low-traffic org).

**Failure scenario:** `assertCircuitClosed()` grants exactly one HALF_OPEN probe by setting `halfOpenInFlight = true`, and only `recordSuccess`/`recordFailure` ever clear it. `apps/api/src/api/routes/proxy.ts` deliberately calls neither when a probe's handshake fails with a recoverable 401 (`"401-style errors are user-recoverable ... they must NOT trip the breaker or disable the connection"` — see the comment at proxy.ts:432), and instead returns the auth response directly. Once that happens during a HALF_OPEN probe, `halfOpenInFlight` is stuck `true` forever, so `assertCircuitClosed()` throws `CircuitOpenError` on every subsequent call for that connection — even after the user completes the OAuth flow and the server is fully reachable again.

**Fix:** track when a probe was granted (`halfOpenStartedAt`). If no outcome (success/failure) arrives within `CIRCUIT_BREAKER_HALF_OPEN_PROBE_TIMEOUT_MS` (65s — deliberately above the MCP SDK's 60s connect timeout so a genuinely slow, still-in-flight probe isn't preempted), the probe is treated as abandoned and a fresh one is granted instead of failing fast indefinitely. Added a regression test (`circuit-breaker.test.ts`) reproducing the stuck state and confirming the timeout releases it.

**Verify:** `bun test apps/api/src/mcp-clients/circuit-breaker.test.ts` (10 pass, includes the new regression test) and `cd apps/api && bunx tsc --noEmit` (clean). Full CI covers the rest.

One concern: only touches the in-memory circuit-breaker's half-open bookkeeping; `proxy.ts`'s auth-error handling is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the MCP client circuit breaker from getting stuck in HALF_OPEN after an auth-recoverable error. Adds a timeout to abandon orphaned probes so healthy connections can recover without a restart.

- **Bug Fixes**
  - Added `CIRCUIT_BREAKER_HALF_OPEN_PROBE_TIMEOUT_MS` (65s) and `halfOpenStartedAt` tracking. If a half-open probe never calls `recordSuccess`/`recordFailure`, it’s treated as abandoned and a fresh probe is granted instead of failing fast forever.
  - Updated `assertCircuitClosed` to honor the timeout; added a regression test to cover the abandoned-probe scenario.

<sup>Written for commit adcf122c5c652ba0d281a4f4d267f30c0f54df36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

