### PR TITLE
fix(task-board): validate linked thread belongs to the caller's org

### DIFF
--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -53,13 +53,21 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     }
 
     // Link an existing chat thread to this task (the "New Chat" flow). Verify
-    // the task is this org's before inserting the (idempotent) join row.
+    // the task AND the thread both belong to this org before inserting the
+    // (idempotent) join row — attachThreads() joins task_board_item_threads
+    // to threads without an org filter, so an unchecked thread id would let
+    // a caller pull another org's thread (title, status, message content)
+    // into their own task board.
     if (input.linkThreadId) {
       const target = await ctx.storage.taskBoard.getById(
         input.id,
         organizationId,
       );
       if (!target) throw new Error(`Task board item not found: ${input.id}`);
+      const thread = await ctx.storage.threads.get(input.linkThreadId);
+      if (!thread) {
+        throw new Error(`Thread not found: ${input.linkThreadId}`);
+      }
       await ctx.storage.taskBoard.linkThread(
         input.id,
         input.linkThreadId,


### PR DESCRIPTION
Follows the same bug class fixed in #5301 (virtual-MCP connection ownership) — an unchecked foreign-org id being wired into the caller's own resource.

**The bug:** `TASK_BOARD_ITEM_UPDATE`'s `linkThreadId` path validated that the *task* (`input.id`) belongs to the caller's org, but never validated that the *thread* (`input.linkThreadId`) does. `TaskBoardStorage.linkThread()` inserts a `task_board_item_threads` row with no check that the thread id actually belongs to that org, and `attachThreads()` (used by both `list()` and `getById()`) inner-joins that table to `threads` with **no org filter on the threads side**. So any authenticated member of org A who supplies a thread id from org B gets that thread's title, status, `virtual_mcp_id`, metadata, and latest assistant message text rendered on org A's task board — a cross-tenant data leak.

**Fix:** look up the thread via the org-scoped `ctx.storage.threads.get(linkThreadId)` (filters by `organization_id` under the hood) before inserting the join row, and throw "Thread not found" if it doesn't resolve — mirroring how `create.ts`/`update.ts` in `tools/virtual/` now validate connection ids via `requireConnectionsInOrganization` (#5301).

**Reviewer check:** `apps/api/src/tools/task-board/update.ts` — confirm `ctx.storage.threads` is `OrgScopedThreadStorage` (`apps/api/src/storage/threads.ts`), whose `.get(id)` already filters by the bound org, so this is a one-line-of-logic fix reusing existing infra, no new query.

**Verified locally:**
- `cd apps/api && bunx tsc --noEmit` — clean.
- `bun run fmt` — clean, no changes.
- No existing test touched this exact path (no test file exists for `update.ts`); a real regression test needs Postgres (the leak only manifests through the `attachThreads` SQL join), which isn't available in this sandbox — full e2e/CI will validate on merge. Note for reviewer: a real-Postgres test asserting a cross-org `linkThreadId` is rejected would be a good addition if desired.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented cross-org thread linking on the task board by validating that `linkThreadId` belongs to the caller’s org before creating the join. This stops leaking another org’s thread title, status, metadata, and last message.

- **Bug Fixes**
  - Validate the thread with org-scoped `ctx.storage.threads.get(linkThreadId)` and throw "Thread not found" if it’s outside the org.
  - Applied in `apps/api/src/tools/task-board/update.ts`; no new queries or schema changes.

<sup>Written for commit ca472d6d8c3a9685d99d69392c23567acc14ee30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

