### PR TITLE
fix(web): self-heal preview iframe stuck on connection-refused

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview-iframe-recovery.ts
+++ b/apps/web/src/components/sandbox/preview/preview-iframe-recovery.ts
@@ -1,0 +1,132 @@
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import { exponentialBackoffWithJitter } from "@decocms/shared/std";
+
+/**
+ * No `load` event within this window after (re)pointing the iframe at a sandbox
+ * URL → treat the navigation as failed. When the dev server is unreachable the
+ * browser paints its own connection-refused page and fires *neither* `load` nor
+ * `error` on the (cross-origin) iframe element, so a timeout is the only
+ * client-side signal that the load never happened. Kept generous so a merely
+ * slow — but succeeding — page load isn't mistaken for a failure.
+ */
+const LOAD_TIMEOUT_MS = 10_000;
+/** First backoff delay before re-pointing the iframe after a failed load. */
+const RETRY_BASE_MS = 1_000;
+/** Backoff ceiling — retries keep going at this cadence until a `load` fires. */
+const RETRY_CAP_MS = 30_000;
+
+/**
+ * Self-healing for the preview iframe.
+ *
+ * When the sandbox dev server is down or still starting, the iframe can end up
+ * on the browser's connection-refused page and stay there: the failed
+ * cross-origin navigation fires no `load`/`error` event, so nothing tells the
+ * app to retry once the server is back (SSE reload signals only fire on port
+ * changes / `.deco` writes / explicit daemon events — not on this recovery).
+ *
+ * This watchdog arms a timer each time the iframe is pointed at a sandbox URL;
+ * if no `load` arrives in {@link LOAD_TIMEOUT_MS} it reassigns `src` to retry,
+ * backing off with jitter up to {@link RETRY_CAP_MS} and re-arming, until a
+ * `load` finally fires — at which point the attempt budget resets. Wire the
+ * returned `handleLoad`/`handleError` into the iframe's `onLoad`/`onError`.
+ *
+ * Only run this for the sandbox surface (`active`): the production fallback is a
+ * best-effort, short-lived cross-origin frame we must not thrash.
+ */
+export function useIframeLoadRecovery({
+  iframeRef,
+  src,
+  active,
+}: {
+  iframeRef: RefObject<HTMLIFrameElement | null>;
+  /** The desired sandbox iframe `src`, or `null` when no sandbox frame is shown. */
+  src: string | null;
+  /** Whether recovery should run (sandbox surface active). */
+  active: boolean;
+}) {
+  const attemptRef = useRef(0);
+  const loadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Read inside timer callbacks so a retry always reloads the current URL, not
+  // the one captured when the watchdog was first armed.
+  const srcRef = useRef(src);
+  const activeRef = useRef(active);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- keep timer callbacks reading the latest src/active
+  srcRef.current = src;
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- keep timer callbacks reading the latest src/active
+  activeRef.current = active;
+
+  const clearTimers = () => {
+    if (loadTimerRef.current) clearTimeout(loadTimerRef.current);
+    if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+    loadTimerRef.current = null;
+    retryTimerRef.current = null;
+  };
+
+  // Arm the load watchdog: if `load` doesn't fire before it elapses, the
+  // navigation failed silently — schedule a backoff reload.
+  const armWatchdog = () => {
+    if (loadTimerRef.current) clearTimeout(loadTimerRef.current);
+    loadTimerRef.current = setTimeout(() => {
+      loadTimerRef.current = null;
+      scheduleReload();
+    }, LOAD_TIMEOUT_MS);
+  };
+
+  const scheduleReload = () => {
+    if (!activeRef.current || !srcRef.current) return;
+    if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+    const delay = exponentialBackoffWithJitter(
+      RETRY_CAP_MS,
+      RETRY_BASE_MS,
+      attemptRef.current,
+      2,
+      0.5,
+    );
+    attemptRef.current += 1;
+    retryTimerRef.current = setTimeout(() => {
+      retryTimerRef.current = null;
+      const iframe = iframeRef.current;
+      const currentSrc = srcRef.current;
+      if (!iframe || !currentSrc || !activeRef.current) return;
+      // Reassign `src` to re-trigger the navigation that never completed.
+      iframe.src = currentSrc;
+      armWatchdog();
+    }, delay);
+  };
+
+  // A `load` fired: the frame reached *some* document. We can't read
+  // cross-origin content to tell a real page from an error page, but a
+  // connection-refused failure fires no `load` at all — so any `load` here means
+  // the request was answered. Treat it as healthy and reset the attempt budget.
+  const handleLoad = () => {
+    attemptRef.current = 0;
+    clearTimers();
+  };
+
+  // `error` on an iframe is unreliable (rarely fires for cross-origin nav
+  // failures), but when it does it's an unambiguous failure — retry immediately.
+  const handleError = () => {
+    if (loadTimerRef.current) {
+      clearTimeout(loadTimerRef.current);
+      loadTimerRef.current = null;
+    }
+    scheduleReload();
+  };
+
+  // Arm on each new sandbox navigation target (and on (re)activation); a changed
+  // `src` is a fresh navigation, so reset the attempt budget. Disarm entirely
+  // while inactive or without a sandbox src.
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- imperative iframe load watchdog + backoff reload lifecycle
+  useEffect(() => {
+    clearTimers();
+    attemptRef.current = 0;
+    if (!active || !src) return;
+    armWatchdog();
+    return clearTimers;
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps -- timer helpers read refs; only src/active gate arming
+  }, [src, active]);
+
+  return { handleLoad, handleError };
+}

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -9,6 +9,7 @@ import { startCmsTour } from "@/components/cms-tour/cms-tour";
 import { TOUR_ANCHORS } from "@/components/cms-tour/anchors";
 import { useInsetContext } from "@/layouts/agent-shell-layout";
 import { resolvePreviewDisplay } from "./preview-display";
+import { useIframeLoadRecovery } from "./preview-iframe-recovery";
 import { sanitizeProductionUrl } from "@decocms/shared/deco-site-production-url";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { useT } from "@/i18n/use-t.ts";
@@ -609,6 +610,17 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- ref read in reload handler
   iframeSrcRef.current = iframeSrc;
+
+  // Self-heal a stuck iframe: when the dev server is/was unreachable the frame
+  // lands on the browser's connection-refused page and fires no load/error
+  // event, so nothing reloads it once the server is back. This watchdog retries
+  // (backoff) until a load fires. Sandbox surface only — never thrash the
+  // best-effort production fallback frame.
+  const iframeRecovery = useIframeLoadRecovery({
+    iframeRef: previewIframeRef,
+    src: display.mode === "sandbox" ? iframeSrc : null,
+    active: display.mode === "sandbox",
+  });
 
   // Daemon is reachable independent of the dev script: ready claim, handle
   // still present, not user-stopped. Gates surfaces (FileExplorer,
@@ -1669,7 +1681,11 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                       src={iframeSrc}
                       className="w-full h-full border-0"
                       title={t("sandbox.preview.devServerPreviewTitle")}
+                      onError={iframeRecovery.handleError}
                       onLoad={() => {
+                        // A load reached the frame — cancel the recovery watchdog
+                        // and reset its backoff before anything else.
+                        iframeRecovery.handleLoad();
                         // The page finished loading — always clear the navigation
                         // indicator first, before any of the early returns below.
                         endNavigation();


### PR DESCRIPTION
## Summary

When the sandbox dev server is down or still starting, the preview iframe (the "Visualização"/CMS view) can land on the browser's **connection-refused page and stay stuck there** — even after the dev server recovers and the preview is otherwise OK. The failed cross-origin navigation fires **neither `load` nor `error`** on the iframe element, so nothing tells the app to reload it. The existing reload triggers only fire on port changes / `.deco` writes / explicit daemon `reload` events / a manual refresh — none of which cover this recovery.

This adds a client-side **load watchdog with capped exponential backoff** that reloads the iframe until a `load` finally fires, then resets.

## How it works

New hook `useIframeLoadRecovery` (`preview-iframe-recovery.ts`):

- Arms a **10s watchdog** each time the iframe is pointed at a sandbox URL. No `load` in that window → treat the navigation as failed (the only reliable client-side signal, since a connection-refused cross-origin nav is silent).
- On failure, reloads by reassigning `src` with **`exponentialBackoffWithJitter`** (base 1s → cap 30s, ×2, jitter 0.5) and re-arms — retrying until a `load` fires, which resets the attempt budget.
- Wired into the iframe's `onLoad` (cancel + reset) and `onError` (immediate retry).
- **Sandbox surface only** — never thrashes the best-effort, cross-origin production fallback frame.

### Cadence

Effective interval per attempt ≈ 10s watchdog + backoff: ~11s early, settling to a reload every **~30–40s** while the server stays down. Recovery latency after the server returns is one cycle (~10–40s).

## Testing notes

- `bun run --cwd=apps/web check` ✅
- `bun run lint` ✅ (no findings on changed files)
- `bun run fmt` ✅

No automated test added: a timer/DOM-driven hook isn't a unit test per `TESTING.md` (would need fake timers + iframe stub), and the real down→up scenario is heavy e2e infra. Happy to add either if preferred.

## Tunables

- `LOAD_TIMEOUT_MS` (10s) — how long before a missing `load` is judged a failure.
- `RETRY_CAP_MS` (30s) — steady-state backoff ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox preview iframe getting stuck on the browser’s connection‑refused page by adding a self‑healing load watchdog that reloads until the dev server responds. Scoped to the sandbox iframe to avoid thrashing the production fallback.

- **Bug Fixes**
  - Added `useIframeLoadRecovery` to arm a 10s load timeout and retry by resetting `src` with jittered exponential backoff (1s base, 30s cap) via `exponentialBackoffWithJitter` from `@decocms/shared/std`.
  - Integrated into `preview.tsx` (`onLoad` cancels/resets, `onError` retries) and gated by sandbox mode.

<sup>Written for commit 20d846573953a34b7146db77f95447798c1c1c52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

