### PR TITLE
fix(auth): fail startup when an env-referenced email provider isn't configured

### DIFF
--- a/apps/api/src/auth/auth-env.test.ts
+++ b/apps/api/src/auth/auth-env.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { authEnvSchema } from "./auth-env";
+
+describe("authEnvSchema", () => {
+  it("accepts an empty env with email/password defaults", () => {
+    const config = authEnvSchema.parse({});
+    expect(config.emailAndPassword).toEqual({ enabled: true });
+    expect(config.emailProviders).toBeUndefined();
+  });
+
+  it("accepts a provider reference that matches a configured provider", () => {
+    const config = authEnvSchema.parse({
+      AUTH_RESEND_API_KEY: "key",
+      AUTH_INVITE_EMAIL_PROVIDER: "resend",
+    });
+    expect(config.inviteEmailProviderId).toBe("resend");
+  });
+
+  it("rejects a provider reference to an unconfigured provider", () => {
+    expect(() =>
+      authEnvSchema.parse({
+        AUTH_RESEND_API_KEY: "key",
+        AUTH_INVITE_EMAIL_PROVIDER: "sendgrid",
+      }),
+    ).toThrow(/AUTH_SENDGRID_API_KEY/);
+  });
+
+  it("rejects AUTH_MAGIC_LINK_ENABLED with no email provider configured", () => {
+    expect(() =>
+      authEnvSchema.parse({ AUTH_MAGIC_LINK_ENABLED: "true" }),
+    ).toThrow(/AUTH_MAGIC_LINK_ENABLED/);
+  });
+
+  it("rejects AUTH_EMAIL_OTP_ENABLED with no email provider configured", () => {
+    expect(() =>
+      authEnvSchema.parse({ AUTH_EMAIL_OTP_ENABLED: "true" }),
+    ).toThrow(/AUTH_EMAIL_OTP_ENABLED/);
+  });
+
+  it("accepts AUTH_MAGIC_LINK_ENABLED when an email provider is configured", () => {
+    const config = authEnvSchema.parse({
+      AUTH_MAGIC_LINK_ENABLED: "true",
+      AUTH_SENDGRID_API_KEY: "key",
+    });
+    expect(config.magicLinkConfig).toEqual({
+      enabled: true,
+      emailProviderId: "sendgrid",
+    });
+  });
+});

--- a/apps/api/src/auth/auth-env.ts
+++ b/apps/api/src/auth/auth-env.ts
@@ -20,7 +20,7 @@ const csv = (fallback: string[]) =>
 
 // ── Schema ───────────────────────────────────────────────────────────
 
-const authEnvSchema = z
+export const authEnvSchema = z
   .object({
     AUTH_EMAIL_PASSWORD_ENABLED: bool(true),
 
@@ -66,6 +66,51 @@ const authEnvSchema = z
     // SSO (Google)
     AUTH_SSO_GOOGLE_CLIENT_ID: z.string().optional(),
     AUTH_SSO_GOOGLE_CLIENT_SECRET: z.string().optional(),
+  })
+  .superRefine((env, ctx) => {
+    const configured = new Set<"resend" | "sendgrid">();
+    if (env.AUTH_RESEND_API_KEY) configured.add("resend");
+    if (env.AUTH_SENDGRID_API_KEY) configured.add("sendgrid");
+
+    const providerRefFields = [
+      "AUTH_INVITE_EMAIL_PROVIDER",
+      "AUTH_RESET_PASSWORD_EMAIL_PROVIDER",
+      "AUTH_MAGIC_LINK_EMAIL_PROVIDER",
+      "AUTH_EMAIL_OTP_EMAIL_PROVIDER",
+    ] as const;
+
+    for (const field of providerRefFields) {
+      const provider = env[field];
+      if (provider && !configured.has(provider)) {
+        const apiKeyVar =
+          provider === "resend"
+            ? "AUTH_RESEND_API_KEY"
+            : "AUTH_SENDGRID_API_KEY";
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [field],
+          message: `${field}="${provider}" but ${apiKeyVar} is not set`,
+        });
+      }
+    }
+
+    if (env.AUTH_MAGIC_LINK_ENABLED && configured.size === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["AUTH_MAGIC_LINK_ENABLED"],
+        message:
+          "AUTH_MAGIC_LINK_ENABLED=true requires AUTH_RESEND_API_KEY or AUTH_SENDGRID_API_KEY to be set",
+      });
+    }
+
+    if (env.AUTH_EMAIL_OTP_ENABLED && configured.size === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["AUTH_EMAIL_OTP_ENABLED"],
+        message:
+          "AUTH_EMAIL_OTP_ENABLED=true requires AUTH_RESEND_API_KEY or AUTH_SENDGRID_API_KEY to be set",
+      });
+    }
   })
   .transform((env) => {
     // ── Social providers ───────────────────────────────────────────


### PR DESCRIPTION
**Source:** bug found while validating apps/api/src/auth/auth-env.ts (this tick's focus area: auth env validation).

**Payoff:** AUTH_INVITE_EMAIL_PROVIDER / AUTH_RESET_PASSWORD_EMAIL_PROVIDER / AUTH_MAGIC_LINK_EMAIL_PROVIDER / AUTH_EMAIL_OTP_EMAIL_PROVIDER were only validated as a `resend`/`sendgrid` enum, never checked against which provider actually has an API key configured. A typo, or forgetting to set the matching `AUTH_*_API_KEY`, silently disables invite emails, password-reset emails, magic-link, or email-OTP in production with zero error — `findEmailProvider()` in `auth/index.ts` just returns `undefined` and the feature is quietly skipped (see the `if (inviteProvider) { ... }` / `if (resetProvider) { ... }` guards around lines 165 and 205). Same silent-disable happens for `AUTH_MAGIC_LINK_ENABLED`/`AUTH_EMAIL_OTP_ENABLED=true` with no email provider configured at all.

**Failure scenario:** ops sets `AUTH_INVITE_EMAIL_PROVIDER=sendgrid` but only `AUTH_RESEND_API_KEY` (not `AUTH_SENDGRID_API_KEY`) — org invites never send, no log, no crash, just silence until a user reports missing email. Fixed by adding a `superRefine` step to `authEnvSchema` that throws a clear `ZodError` (naming the missing `AUTH_*_API_KEY` var) at process startup instead.

**Regression test:** `apps/api/src/auth/auth-env.test.ts` — covers the happy path (empty env, matching provider ref), the new failure modes (mismatched provider ref, `*_ENABLED=true` with no provider), and that a valid magic-link config still parses.

**Reviewer command:** `bun test apps/api/src/auth/auth-env.test.ts`

**Locally ran:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force startup to fail when an auth email provider is referenced but not configured, preventing silent skips of invite, reset, magic-link, and OTP emails. Adds strict env validation in `authEnvSchema` with targeted tests.

- **Bug Fixes**
  - Validate `AUTH_*_EMAIL_PROVIDER` against configured providers (`AUTH_RESEND_API_KEY` / `AUTH_SENDGRID_API_KEY`); throw a clear error if mismatched.
  - Error when `AUTH_MAGIC_LINK_ENABLED` or `AUTH_EMAIL_OTP_ENABLED` is true with no email provider configured.
  - Export `authEnvSchema` and add regression tests for happy and failure paths.

<sup>Written for commit 92512b30c8d7ac06d894ce5bd3606ce01245778e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

