### PR TITLE
fix(chat): translate the locked branch-pill tooltip

### DIFF
--- a/apps/web/src/components/chat/pills/branch-pill.tsx
+++ b/apps/web/src/components/chat/pills/branch-pill.tsx
@@ -6,6 +6,7 @@ import {
 } from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { GitBranch01 } from "@untitledui/icons";
+import { useT } from "@/i18n/use-t.ts";
 import { BranchPicker } from "../../thread/github/branch-picker";
 
 interface Props {
@@ -35,10 +36,11 @@ interface Props {
  * see the active branch without being able to change it.
  */
 export function BranchPill({ locked, placement, value, ...props }: Props) {
+  const t = useT();
   const isHeader = placement === "header";
 
   if (locked) {
-    const branchLabel = value ?? "(no branch)";
+    const branchLabel = value ?? t("chat.branchPill.noBranch");
     return (
       <Tooltip>
         <TooltipTrigger asChild>
@@ -64,8 +66,7 @@ export function BranchPill({ locked, placement, value, ...props }: Props) {
           </span>
         </TooltipTrigger>
         <TooltipContent>
-          This chat is using branch {branchLabel}. Start a new chat to use a
-          different branch.
+          {t("chat.branchPill.lockedTooltip", { branch: branchLabel })}
         </TooltipContent>
       </Tooltip>
     );

--- a/apps/web/src/components/chat/pills/chat-mode-row.test.tsx
+++ b/apps/web/src/components/chat/pills/chat-mode-row.test.tsx
@@ -1,8 +1,10 @@
 import { setupComponentTest } from "../../../../test/setup"; // happy-dom + jest-dom matchers
 setupComponentTest();
 import { describe, expect, it, mock } from "bun:test";
-import { render } from "@testing-library/react";
+import { render, render as renderBare } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 
 // Mock BranchPicker so BranchPill tests don't pull in its heavy
 // network/hook dependencies. The mock just renders a plain <button>
@@ -13,6 +15,17 @@ mock.module("../../thread/github/branch-picker", () => ({
 
 import { ChatModeRowPure } from "./chat-mode-row";
 import { BranchPill } from "./branch-pill";
+
+// BranchPill resolves the locked-tooltip copy via useT(), which reads the
+// language preference through TanStack Query — renders need a QueryClientProvider.
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+const renderWithQueryClient = (ui: Parameters<typeof renderBare>[0]) =>
+  renderBare(ui, { wrapper });
 
 describe("ChatModeRowPure", () => {
   it("returns null when the branch pill is null", () => {
@@ -46,14 +59,14 @@ const BRANCH_PILL_PROPS = {
 
 describe("BranchPill", () => {
   it("renders the lock chip when locked=true", () => {
-    const { getByTestId } = render(
+    const { getByTestId } = renderWithQueryClient(
       <BranchPill {...BRANCH_PILL_PROPS} locked={true} />,
     );
     expect(getByTestId("branch-picker-locked")).toBeInTheDocument();
   });
 
   it("renders BranchPicker (a button) when locked=false", () => {
-    const { getByRole } = render(
+    const { getByRole } = renderWithQueryClient(
       <BranchPill {...BRANCH_PILL_PROPS} locked={false} />,
     );
     expect(getByRole("button")).toBeInTheDocument();

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -40,6 +40,9 @@ export const chat = {
   "chat.assistant.resumedBackgroundTask": "Resumed — background task completed",
   "chat.assistant.resumingTask": "Resuming task...",
   "chat.assistant.toolCallPlural": "{count} tool call(s)",
+  "chat.branchPill.lockedTooltip":
+    "This chat is using branch {branch}. Start a new chat to use a different branch.",
+  "chat.branchPill.noBranch": "(no branch)",
   "chat.brandContext.brand": "Brand",
   "chat.brandContext.brandContextSet": "Brand context set",
   "chat.brandContext.brandSet": "Brand set: {name}",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -44,6 +44,9 @@ export const chat = {
     "Retomado — tarefa em segundo plano concluída",
   "chat.assistant.resumingTask": "Retomando tarefa...",
   "chat.assistant.toolCallPlural": "{count} chamada(s) de ferramenta",
+  "chat.branchPill.lockedTooltip":
+    "Este chat está usando a branch {branch}. Inicie um novo chat para usar uma branch diferente.",
+  "chat.branchPill.noBranch": "(sem branch)",
   "chat.brandContext.brand": "Marca",
   "chat.brandContext.brandContextSet": "Contexto de marca definido",
   "chat.brandContext.brandSet": "Marca definida: {name}",


### PR DESCRIPTION
**Source:** i18n convention violation — bug, not an issue/PR follow-up. `BranchPill` (`apps/web/src/components/chat/pills/branch-pill.tsx`), which the chat-mode row (`chat-mode-row.tsx`) renders for the locked-branch state, hardcoded its tooltip copy ("This chat is using branch X. Start a new chat to use a different branch.") and the "(no branch)" fallback as raw English strings instead of routing them through `useT()`. CLAUDE.md's i18n rule requires every user-facing string in `apps/web/src` to go through the dictionary; this one was missed when the component was written.

**Payoff:** a pt-BR user currently sees an untranslated English tooltip and fallback label on this branch chip — a plain visible i18n gap a maintainer would want closed, matching the repo's established "translate hardcoded UI strings" merge lane.

**Fix:** added `chat.branchPill.lockedTooltip` (with a `{branch}` placeholder) and `chat.branchPill.noBranch` to both `en/chat.ts` and `pt-br/chat.ts`, and swapped the two literals in `branch-pill.tsx` for `t(...)` calls. No behavior change — same copy, same interpolation, now locale-aware.

The existing `BranchPill` render tests broke once the component called `useT()` (which reads the language preference through TanStack Query) — updated them to wrap with a `QueryClientProvider`, following the same pattern already used in `tier-trigger.test.tsx`. All 4 tests in the file still pass.

**Reviewer command:** `cd apps/web && bun test src/components/chat/pills/chat-mode-row.test.tsx`

**Local checks run:** `bun run fmt` (no changes needed), `bunx tsc --noEmit` in `apps/web` (clean), and the targeted test file above (4/4 pass). Full CI covers lint and the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate the locked branch pill tooltip and "(no branch)" label in chat to fix a visible i18n gap. Adds dictionary keys and routes the component through `useT()`; no UI behavior changes.

- **Bug Fixes**
  - Added `chat.branchPill.lockedTooltip` (with `{branch}`) and `chat.branchPill.noBranch` to `en/chat.ts` and `pt-br/chat.ts`; replaced hardcoded strings in `BranchPill` with `useT()`.
  - Updated tests to render with `QueryClientProvider` from `@tanstack/react-query`.

<sup>Written for commit 9b45c0fcd9342d61a3957a456fd7a074f3c31cca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

