### PR TITLE
fix(sandbox-proxy): cap upstream response body size on all proxied routes

### DIFF
--- a/apps/api/src/api/routes/sandbox-proxy.test.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { delay } from "@decocms/shared/std";
-import { redactRepoDir, withClaimGitLock } from "./sandbox-proxy";
+import {
+  readBoundedText,
+  redactRepoDir,
+  UpstreamPayloadTooLargeError,
+  withClaimGitLock,
+} from "./sandbox-proxy";
 
 describe("redactRepoDir", () => {
   it("nulls a container-internal repoDir while preserving other fields", () => {
@@ -31,6 +36,20 @@ describe("redactRepoDir", () => {
   it("passes through JSON that is not an object", () => {
     expect(redactRepoDir("[1,2,3]")).toBe("[1,2,3]");
     expect(redactRepoDir('"repoDir"')).toBe('"repoDir"');
+  });
+});
+
+describe("readBoundedText", () => {
+  it("returns the full body when under the cap", async () => {
+    const res = new Response("hello world");
+    expect(await readBoundedText(res, 1024)).toBe("hello world");
+  });
+
+  it("throws instead of buffering a body over the cap", async () => {
+    const res = new Response("x".repeat(100));
+    await expect(readBoundedText(res, 10)).rejects.toThrow(
+      UpstreamPayloadTooLargeError,
+    );
   });
 });
 

--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -371,7 +371,7 @@ async function proxyDaemon(
       }
     }
 
-    const rawText = await upstream.text();
+    const rawText = await readBoundedText(upstream, FORWARDED_BODY_MAX_BYTES);
     const text =
       opts?.redactRepoDirUnlessDesktop && runner.kind !== "user-desktop"
         ? redactRepoDir(rawText)
@@ -410,9 +410,49 @@ async function proxyDaemon(
     }
     return await resolveAndFetch();
   } catch (err) {
+    if (err instanceof UpstreamPayloadTooLargeError) {
+      return c.json({ error: err.message }, 502);
+    }
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ error: `Daemon unreachable: ${message}` }, 502);
   }
+}
+
+/** Thrown by {@link readBoundedText} when an upstream body exceeds its cap. */
+export class UpstreamPayloadTooLargeError extends Error {}
+
+/**
+ * Read a response body as text, aborting once it exceeds `maxBytes`. The
+ * request-side equivalent (`bodyLimit`/`forwardedBodyLimit`) caps what
+ * clients can send us; this caps what an upstream (the daemon, or a
+ * customer's own preview server) can send back — otherwise a runaway
+ * `git diff`, a chatty exec script, or a huge preview page gets buffered
+ * fully into the Studio API process's memory with no ceiling.
+ */
+export async function readBoundedText(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return response.text();
+
+  const decoder = new TextDecoder();
+  let text = "";
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => {});
+      throw new UpstreamPayloadTooLargeError(
+        `Upstream response exceeded ${maxBytes} bytes`,
+      );
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
 }
 
 /**
@@ -475,7 +515,7 @@ async function fetchDaemonJson<T>(
     throw new Error("SANDBOX_GONE");
   }
 
-  const text = await upstream.text();
+  const text = await readBoundedText(upstream, FORWARDED_BODY_MAX_BYTES);
   if (!upstream.ok) {
     try {
       const err = JSON.parse(text) as { error?: string };
@@ -965,7 +1005,7 @@ export const createSandboxRoutes = () => {
 
     let text: string;
     try {
-      text = await upstream.text();
+      text = await readBoundedText(upstream, FORWARDED_BODY_MAX_BYTES);
     } catch {
       return c.json({ error: "Preview unreachable" }, 502);
     }
@@ -1035,7 +1075,7 @@ export const createSandboxRoutes = () => {
 
       let text: string;
       try {
-        text = await upstream.text();
+        text = await readBoundedText(upstream, FORWARDED_BODY_MAX_BYTES);
       } catch {
         return c.json({ error: "Preview unreachable" }, 502);
       }


### PR DESCRIPTION
**Source:** a hardening follow-up to #5316/#5319, found while auditing the same file (`apps/api/src/api/routes/sandbox-proxy.ts`) for this tick's "sandbox-proxy route robustness" focus area.

**Why:** #5316 and #5319 capped every route that reads a *client* request body fully into memory via `c.req.text()` before forwarding it to the daemon (`forwardedBodyLimit`, 10MB). The response side of the exact same routes has the identical gap: `proxyDaemon`'s `resolveAndFetch` reads the daemon's response via `upstream.text()` with no size ceiling, `fetchDaemonJson` (used by `suggest-commit`/`judge-review`) does the same, and the `preview-fetch`/`preview-invoke` routes read a customer's own preview-server response the same unbounded way. A runaway `git diff`, a chatty exec script writing to stdout, or a large preview page gets buffered entirely into the shared Studio API process's memory — the same DoS-by-memory-exhaustion class #5316/#5319 just closed, just on the other side of the same fetch.

**Fix:** added `readBoundedText(response, maxBytes)`, which reads a `Response` body in chunks via its reader and throws `UpstreamPayloadTooLargeError` once the running total exceeds `maxBytes`, instead of buffering an unbounded amount. Wired it into all four remaining `upstream.text()` call sites in this file, reusing the existing `FORWARDED_BODY_MAX_BYTES` (10MB) constant so the response cap matches the already-established request cap. `proxyDaemon`'s catch block now returns a clear `502` for the new error instead of folding it into the generic "Daemon unreachable" message.

**Regression test:** `readBoundedText` returns the full body under the cap and throws `UpstreamPayloadTooLargeError` (instead of buffering) once a body exceeds it — added to `sandbox-proxy.test.ts`.

**How to verify:** `bun test apps/api/src/api/routes/sandbox-proxy.test.ts` (10 pass, including the 2 new cases); `grep -n 'upstream.text()' apps/api/src/api/routes/sandbox-proxy.ts` now returns nothing — every prior unbounded read goes through `readBoundedText`.

**Checks run locally:** `bun run fmt` and `cd apps/api && bunx tsc --noEmit` (both clean), plus the targeted test above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap upstream response body size to 10MB across all sandbox-proxy routes to prevent memory exhaustion. Responses are now read in chunks, with clear 502 errors when the cap is exceeded.

- **Bug Fixes**
  - Added `readBoundedText(response, maxBytes)` that streams and caps response bodies, throwing `UpstreamPayloadTooLargeError`.
  - Replaced all `upstream.text()` calls in `apps/api/src/api/routes/sandbox-proxy.ts` (`proxyDaemon`, `fetchDaemonJson`, `preview-fetch`, `preview-invoke`) with `readBoundedText`.
  - Reused `FORWARDED_BODY_MAX_BYTES` (10MB) to match the existing request body cap.
  - On oversize upstream bodies, return `502` with a specific error instead of the generic "Daemon unreachable".
  - Added tests for capped reads in `sandbox-proxy.test.ts`.

<sup>Written for commit 1e942fe37b6679144f11636e0c831c9b0962b69b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

