### PR TITLE
fix(reports): translate the hardcoded pt-BR issue-count label in the pages slide

### DIFF
--- a/apps/web/src/i18n/en/reports.ts
+++ b/apps/web/src/i18n/en/reports.ts
@@ -89,6 +89,7 @@ export const reports = {
   "reports.keywordsTemplate.searchesPerMonth": "Searches/mo",
   "reports.listTemplate.moreSignals": "more signals in the full diagnostic",
   "reports.listTemplate.unlockRevenue": "Unlock my revenue",
+  "reports.paginasVariant.found": "found",
   "reports.scanGate.errorBlocked": "This report is not publicly available.",
   "reports.scanGate.errorEmpty":
     "We scanned your store, but the report is still being assembled. Check back soon.",

--- a/apps/web/src/i18n/pt-br/reports.ts
+++ b/apps/web/src/i18n/pt-br/reports.ts
@@ -91,6 +91,7 @@ export const reports = {
   "reports.keywordsTemplate.searchesPerMonth": "Buscas/mês",
   "reports.listTemplate.moreSignals": "outros sinais no diagnóstico completo",
   "reports.listTemplate.unlockRevenue": "Destravar minha receita",
+  "reports.paginasVariant.found": "achados",
   "reports.scanGate.errorBlocked":
     "Este relatório não está disponível publicamente.",
   "reports.scanGate.errorEmpty":

--- a/apps/web/src/routes/reports/templates/paginas-variant.tsx
+++ b/apps/web/src/routes/reports/templates/paginas-variant.tsx
@@ -1,6 +1,7 @@
 import SlideHeader from "./slide-header";
 import TableTemplate from "./table-template";
 import { DECK } from "./tokens";
+import { useT } from "@/i18n/use-t.ts";
 import type { TableProps } from "@decocms/shared/reports/deck-types";
 
 // Severity chips are graded by the engine's pt-BR badge label — the badge tone
@@ -81,6 +82,7 @@ function Cross({ severity }: { severity: string }) {
  * generic bucket 8× is just noise). Same data, no contract change.
  */
 export default function PaginasVariant(props: TableProps) {
+  const t = useT();
   const { eyebrow, headline, annotation, rows, active } = props;
   const groups = groupRows(rows);
   if (!groups) return <TableTemplate {...props} />;
@@ -133,7 +135,7 @@ export default function PaginasVariant(props: TableProps) {
                     className="text-[11px] tabular-nums"
                     style={{ color: DECK.muted, opacity: 0.7 }}
                   >
-                    {group.issues.length} achados
+                    {group.issues.length} {t("reports.paginasVariant.found")}
                   </span>
                 )}
               </div>


### PR DESCRIPTION
## Source

Follows #5325, which fixed the report's mixed-language dictionaries but explicitly scoped to `en/{reports,routes,commerce-onboarding}.ts` plus the specific components it touched. `apps/web/src/routes/reports/templates/paginas-variant.tsx` (the "Problemas por página" slide) wasn't in that PR's file list and still had the same bug class #5325 describes as its "second, smaller class": a string hardcoded in pt-BR that bypasses `t()` entirely, so it renders in Portuguese regardless of the report's `language` setting.

## Why a maintainer wants this

A report viewed with `language: "en"` shows every other label in English but this one card badge (`{count} achados`) stays in Portuguese — exactly the mixed-language symptom #5325 just shipped a fix for, just in a file that fix didn't cover.

## What changed

- Added `reports.paginasVariant.found` to both `i18n/en/reports.ts` ("found") and `i18n/pt-br/reports.ts` ("achados").
- Routed `paginas-variant.tsx`'s issue-count label through `t()` instead of the literal `achados`, following the same `{count} {t(...)}` pattern already used in `list-template.tsx`.

## How to verify

`grep -rn "achados" apps/web/src` now returns nothing. View a report with `language: "en"` — the per-page issue-count badge on the pages slide reads "N found" instead of "N achados"; with `language: "pt-br"` it's unchanged ("N achados").

## Checks run locally

- `bun run fmt` — clean.
- `cd apps/web && bunx tsc --noEmit` — clean (confirms the new `en`/`pt-br` dictionaries still satisfy `Record<keyof typeof reportsEn, string>`).

Full CI (lint, full test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mixed-language issue in the Reports “Paginas” slide by routing the issue-count badge through i18n. Reports in English now show “N found” instead of “N achados”.

- **Bug Fixes**
  - Added `reports.paginasVariant.found` to `i18n/en/reports.ts` and `i18n/pt-br/reports.ts`.
  - Updated `paginas-variant.tsx` to use `t("reports.paginasVariant.found")` for the badge.

<sup>Written for commit 69f550803700b6d88ba6ac901fd24f42b8141f12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

