### PR TITLE
perf(sandbox): mount org-fs volumes concurrently at daemon boot

### DIFF
--- a/packages/sandbox/daemon/org-fs/mount-manager.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.ts
@@ -155,7 +155,15 @@ export class MountManager {
     private readonly platform: string = process.platform,
   ) {}
 
-  /** Serve + mount every configured volume. Never throws. */
+  /**
+   * Serve + mount every configured volume. Never throws. Volumes are
+   * independent (own client/server/rclone process) and each is already a
+   * "never throws, skip on failure" unit, so they mount concurrently instead
+   * of paying every volume's full rclone-spawn + up-to-15s rc-ready wait back
+   * to back — that serialization was pure added sandbox-boot latency once a
+   * deployment mounts more than one or two volumes (home/outputs/uploads +
+   * one entry per public skill set).
+   */
   async start(config: OrgFsMountConfig, appRoot: string): Promise<void> {
     this.config = config;
     this.appRoot = appRoot;
@@ -166,9 +174,7 @@ export class MountManager {
       );
       return;
     }
-    for (const m of config.mounts) {
-      await this.mountOne(m);
-    }
+    await Promise.all(config.mounts.map((m) => this.mountOne(m)));
   }
 
   /**


### PR DESCRIPTION
**Source:** reduction/optimization found while hunting the org-fs filesystem-abstraction area (issue #2884's focus area) — `MountManager.start()` in `packages/sandbox/daemon/org-fs/mount-manager.ts`.

**Why:** `start()` mounted each configured org-fs volume one at a time (`for (...) await this.mountOne(m)`), even though every volume is fully independent — its own `OrgFsClient`, its own loopback WebDAV server, its own rclone process and free port. Each `mountOne` can take real time (spawn rclone, then poll its rc `vfs/list` up to `READY_TIMEOUT_MS` = 15s in the worst case). A sandbox mounts at least 3 volumes today (`home`, `outputs`, `uploads`) plus one more per configured public skill set (`buildOrgFsConfig` in `apps/api/src/file-storage/mount/provisioning.ts`), so the sequential loop directly adds to sandbox boot latency the agent is blocked on — pure serialized network/process-spawn work with no ordering dependency between volumes.

**Fix:** mount all volumes concurrently with `Promise.all(config.mounts.map((m) => this.mountOne(m)))`. `mountOne` already catches its own errors and is a self-contained "never throws, skip on failure" unit (each mount independently tries/logs/skips), so running them concurrently doesn't change failure semantics — a failing volume still just gets skipped, others still mount. `this.active.push(entry)` is a synchronous array push inside each async continuation, so no race there (JS is single-threaded). Total boot time now bounds to the slowest single mount instead of the sum of all of them.

**Verify:** `cd packages/sandbox && bunx tsc --noEmit` (clean) and `bun test packages/sandbox/daemon/org-fs/mount-manager.test.ts` (12 pass, unchanged — the tests already sort results before asserting, so they don't depend on mount order).

**Local checks run:** `bun run fmt`, targeted `tsc --noEmit` in `packages/sandbox`, and the single test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mount org-fs volumes concurrently during sandbox daemon boot to cut startup latency. Boot time is now limited by the slowest mount instead of the sum, aligning with #2884’s org-fs performance focus.

- **Performance**
  - Switched sequential mounts to `Promise.all` in `packages/sandbox/daemon/org-fs/mount-manager.ts`; mounts run independently with unchanged failure semantics.

<sup>Written for commit c2d598f0d3e4d5835109f5c263f69e4b5763190a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

