### PR TITLE
fix(sandbox): bound daemon config-PUT error body reads

### DIFF
--- a/apps/api/src/api/routes/sandbox-proxy.test.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, it } from "bun:test";
 import { delay } from "@decocms/shared/std";
 import {
   readBoundedText,
-  redactRepoDir,
   UpstreamPayloadTooLargeError,
-  withClaimGitLock,
-} from "./sandbox-proxy";
+} from "../../lib/bounded-text";
+import { redactRepoDir, withClaimGitLock } from "./sandbox-proxy";
 
 describe("redactRepoDir", () => {
   it("nulls a container-internal repoDir while preserving other fields", () => {

--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -47,6 +47,10 @@ import {
   parseGithubRepoFromMetadata,
   refreshSandboxGitCredentials,
 } from "../../tools/sandbox/sync-git-credentials";
+import {
+  readBoundedText,
+  UpstreamPayloadTooLargeError,
+} from "../../lib/bounded-text";
 
 // ---- Middleware types -------------------------------------------------------
 
@@ -416,43 +420,6 @@ async function proxyDaemon(
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ error: `Daemon unreachable: ${message}` }, 502);
   }
-}
-
-/** Thrown by {@link readBoundedText} when an upstream body exceeds its cap. */
-export class UpstreamPayloadTooLargeError extends Error {}
-
-/**
- * Read a response body as text, aborting once it exceeds `maxBytes`. The
- * request-side equivalent (`bodyLimit`/`forwardedBodyLimit`) caps what
- * clients can send us; this caps what an upstream (the daemon, or a
- * customer's own preview server) can send back — otherwise a runaway
- * `git diff`, a chatty exec script, or a huge preview page gets buffered
- * fully into the Studio API process's memory with no ceiling.
- */
-export async function readBoundedText(
-  response: Response,
-  maxBytes: number,
-): Promise<string> {
-  const reader = response.body?.getReader();
-  if (!reader) return response.text();
-
-  const decoder = new TextDecoder();
-  let text = "";
-  let total = 0;
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      await reader.cancel().catch(() => {});
-      throw new UpstreamPayloadTooLargeError(
-        `Upstream response exceeded ${maxBytes} bytes`,
-      );
-    }
-    text += decoder.decode(value, { stream: true });
-  }
-  text += decoder.decode();
-  return text;
 }
 
 /**

--- a/apps/api/src/lib/bounded-text.ts
+++ b/apps/api/src/lib/bounded-text.ts
@@ -1,0 +1,34 @@
+/** Thrown by {@link readBoundedText} when a response body exceeds its cap. */
+export class UpstreamPayloadTooLargeError extends Error {}
+
+/**
+ * Read a `Response` body as text, aborting once it exceeds `maxBytes`. Used
+ * anywhere we read a response from an upstream we don't control (the sandbox
+ * daemon, a customer's own preview server) so a runaway or malicious body
+ * never gets buffered fully into this process's memory with no ceiling.
+ */
+export async function readBoundedText(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return response.text();
+
+  const decoder = new TextDecoder();
+  let text = "";
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => {});
+      throw new UpstreamPayloadTooLargeError(
+        `Upstream response exceeded ${maxBytes} bytes`,
+      );
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
+}

--- a/apps/api/src/tools/sandbox/patch-sandbox-operator.ts
+++ b/apps/api/src/tools/sandbox/patch-sandbox-operator.ts
@@ -1,6 +1,10 @@
 import type { SandboxProvider } from "@decocms/sandbox/provider";
 import { coAuthorFromStudioContext } from "../../lib/co-author-identity";
+import { readBoundedText } from "../../lib/bounded-text";
 import type { StudioContext } from "../../core/studio-context";
+
+/** Matches the cap `sandbox-proxy.ts` applies to `/_sandbox/config` responses. */
+const CONFIG_RESPONSE_MAX_BYTES = 10 * 1024 * 1024;
 
 /** Sync the authenticated Studio user into daemon tenant config for co-author. */
 export async function patchSandboxOperator(
@@ -18,7 +22,9 @@ export async function patchSandboxOperator(
   });
 
   if (!res.ok) {
-    const body = await res.text().catch(() => res.statusText);
+    const body = await readBoundedText(res, CONFIG_RESPONSE_MAX_BYTES).catch(
+      () => res.statusText,
+    );
     throw new Error(
       `Failed to patch sandbox operator (${res.status}): ${body}`,
     );

--- a/apps/api/src/tools/sandbox/resolve-env.ts
+++ b/apps/api/src/tools/sandbox/resolve-env.ts
@@ -5,6 +5,10 @@ import {
   SecretNotFoundError,
 } from "../../storage/secrets";
 import type { StudioContext } from "../../core/studio-context";
+import { readBoundedText } from "../../lib/bounded-text";
+
+/** Matches the cap `sandbox-proxy.ts` applies to `/_sandbox/config` responses. */
+const CONFIG_RESPONSE_MAX_BYTES = 10 * 1024 * 1024;
 
 interface ResolveAndPushParams {
   ctx: StudioContext;
@@ -70,7 +74,9 @@ export async function resolveAndPushEnv({
     body: JSON.stringify({ env }),
   });
   if (!res.ok) {
-    const body = await res.text().catch(() => res.statusText);
+    const body = await readBoundedText(res, CONFIG_RESPONSE_MAX_BYTES).catch(
+      () => res.statusText,
+    );
     console.warn(
       `[SANDBOX_START] daemon rejected env patch (${res.status}): ${body}`,
     );

--- a/apps/api/src/tools/sandbox/sync-git-credentials.ts
+++ b/apps/api/src/tools/sandbox/sync-git-credentials.ts
@@ -3,10 +3,14 @@ import type { SandboxProvider } from "@decocms/sandbox/provider";
 import type { StudioContext } from "../../core/studio-context";
 import { RECONNECT_ERROR } from "../../oauth/token-refresh";
 import { coAuthorFromStudioContext } from "../../lib/co-author-identity";
+import { readBoundedText } from "../../lib/bounded-text";
 import {
   buildCloneInfo,
   ensureGithubCloneToken,
 } from "../../shared/github-clone-info";
+
+/** Matches the cap `sandbox-proxy.ts` applies to `/_sandbox/config` responses. */
+const CONFIG_RESPONSE_MAX_BYTES = 10 * 1024 * 1024;
 
 export class GitPushAuthError extends Error {
   constructor(message: string) {
@@ -82,7 +86,9 @@ export async function refreshSandboxGitCredentials(
   });
 
   if (!res.ok) {
-    const body = await res.text().catch(() => res.statusText);
+    const body = await readBoundedText(res, CONFIG_RESPONSE_MAX_BYTES).catch(
+      () => res.statusText,
+    );
     throw new Error(
       `Failed to refresh sandbox git credentials (${res.status}): ${body}`,
     );


### PR DESCRIPTION
Follows #5316/#5319/#5330, which capped every upstream response read in `sandbox-proxy.ts`'s `proxyDaemon` helper against the sandbox daemon's `/_sandbox/config` endpoint (and others) to prevent an unbounded body from being buffered fully into the API process's memory.

Three call sites that PUT directly to `/_sandbox/config` outside that proxy path were missed: `patch-sandbox-operator.ts` (runs on every publish/rebase), `sync-git-credentials.ts` (runs on every publish that pushes to GitHub), and `resolve-env.ts` (runs on sandbox start). Each reads the daemon's error body via a plain `res.text()` with no size cap on the non-ok path, so a compromised or misbehaving daemon can still make the Studio API process buffer an unbounded body into memory on this path — the exact concern the prior three PRs addressed for every other route.

Failure scenario: a sandbox daemon (attacker-controlled or just buggy) returns a huge body with a non-2xx status from `/_sandbox/config`; any of the three call sites (hit on essentially every publish, rebase, or sandbox start) reads it fully into memory with no ceiling, unlike every other route to the same endpoint.

Fix: extracted the existing `readBoundedText`/`UpstreamPayloadTooLargeError` helper out of `sandbox-proxy.ts` into `apps/api/src/lib/bounded-text.ts` (pure move, no behavior change — avoids an api-routes -> tools-layer import), and switched all three call sites to it with the same 10MB cap `sandbox-proxy.ts` already applies to this endpoint.

To verify: `cd apps/api && bunx tsc --noEmit` (clean) and `bun test apps/api/src/api/routes/sandbox-proxy.test.ts apps/api/src/tools/sandbox/sync-git-credentials.test.ts` (14 pass, 0 fail) — both cover the moved/consuming code.

Locally ran: `bun run fmt`, the targeted typecheck above, and the two targeted test files above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds error-body reads on direct PUTs to the sandbox daemon `/_sandbox/config` to prevent unbounded memory usage in the API process. Applies the same 10 MB cap used by the proxy and centralizes the helper.

- **Bug Fixes**
  - Cap non-2xx body reads from `/_sandbox/config` in `patch-sandbox-operator.ts`, `sync-git-credentials.ts`, and `resolve-env.ts` via `readBoundedText` (10 MB).
  - Stops a compromised or buggy daemon from forcing huge error bodies into memory.

- **Refactors**
  - Move `readBoundedText` and `UpstreamPayloadTooLargeError` to `apps/api/src/lib/bounded-text.ts` (no behavior change).
  - Update `sandbox-proxy.test.ts` imports to use the new lib.

<sup>Written for commit 4816327ebd2a83be528380b03c9df1cb752ffe96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

