### PR TITLE
fix(runtime): fix concurrent-write data loss in JsonFileStorage

### DIFF
--- a/packages/runtime/src/trigger-storage.test.ts
+++ b/packages/runtime/src/trigger-storage.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, spyOn } from "bun:test";
-import { StudioKV } from "./trigger-storage.ts";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { JsonFileStorage, StudioKV } from "./trigger-storage.ts";
 
 describe("StudioKV.get", () => {
   const kv = new StudioKV({ url: "https://studio.test", apiKey: "key" });
@@ -46,5 +49,34 @@ describe("StudioKV.get", () => {
       credentials: { callbackUrl: "https://x", callbackToken: "tok" },
       activeTriggerTypes: ["github.push"],
     });
+  });
+});
+
+describe("JsonFileStorage", () => {
+  const state = (token: string) => ({
+    credentials: { callbackUrl: "https://x", callbackToken: token },
+    activeTriggerTypes: ["github.push"],
+  });
+
+  it("keeps both writes when set() is called concurrently before the first load resolves", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "trigger-storage-"));
+    const path = join(dir, "state.json");
+    const storage = new JsonFileStorage({ path });
+
+    try {
+      await Promise.all([
+        storage.set("conn-a", state("token-a")),
+        storage.set("conn-b", state("token-b")),
+      ]);
+
+      expect(await storage.get("conn-a")).toEqual(state("token-a"));
+      expect(await storage.get("conn-b")).toEqual(state("token-b"));
+
+      const onDisk = JSON.parse(await readFile(path, "utf-8"));
+      expect(onDisk["conn-a"]).toEqual(state("token-a"));
+      expect(onDisk["conn-b"]).toEqual(state("token-b"));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/runtime/src/trigger-storage.ts
+++ b/packages/runtime/src/trigger-storage.ts
@@ -159,30 +159,45 @@ interface JsonFileStorageOptions {
 export class JsonFileStorage implements TriggerStorage {
   private path: string;
   private cache: Map<string, TriggerState> | null = null;
+  private loading: Promise<Map<string, TriggerState>> | null = null;
 
   constructor(options: JsonFileStorageOptions) {
     this.path = options.path;
   }
 
+  // Concurrent set()/delete() calls before the first load completes must
+  // share one in-flight read — otherwise each independently reads the file,
+  // builds its own Map, and reassigns `this.cache`, silently dropping
+  // whichever write's Map object loses the race.
   private async load(): Promise<Map<string, TriggerState>> {
     if (this.cache) return this.cache;
-    try {
-      const fs = await import("node:fs/promises");
-      const raw = await fs.readFile(this.path, "utf-8");
-      const data = JSON.parse(raw) as Record<string, TriggerState>;
-      this.cache = new Map(Object.entries(data));
-    } catch (err: unknown) {
-      if (
-        err instanceof Error &&
-        "code" in err &&
-        (err as NodeJS.ErrnoException).code === "ENOENT"
-      ) {
-        this.cache = new Map();
-      } else {
-        throw err;
+    if (this.loading) return this.loading;
+
+    this.loading = (async () => {
+      try {
+        const fs = await import("node:fs/promises");
+        const raw = await fs.readFile(this.path, "utf-8");
+        const data = JSON.parse(raw) as Record<string, TriggerState>;
+        this.cache = new Map(Object.entries(data));
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          "code" in err &&
+          (err as NodeJS.ErrnoException).code === "ENOENT"
+        ) {
+          this.cache = new Map();
+        } else {
+          throw err;
+        }
       }
+      return this.cache as Map<string, TriggerState>;
+    })();
+
+    try {
+      return await this.loading;
+    } finally {
+      this.loading = null;
     }
-    return this.cache;
   }
 
   private async save(): Promise<void> {


### PR DESCRIPTION
Bug found while reviewing the trigger-storage plumbing in `packages/runtime/src/trigger-storage.ts` (the `TriggerStorage` implementation used by `createTriggers()` for dev/single-instance deployments).

**The bug:** `JsonFileStorage.load()` checked `if (this.cache) return this.cache;` but had no guard for a load already in flight. Two concurrent `set()`/`delete()` calls hitting a cold cache (e.g. two connections configuring triggers around the same time right after process start) each independently `readFile`+`JSON.parse` the state file and reassign `this.cache = new Map(...)`. Whichever assignment wins the race becomes the Map that `save()` later serializes — the other call's write is silently dropped from disk even though its `set()`/`delete()` promise resolved successfully.

**The fix:** memoize the in-flight load as a single shared promise (the same pattern already used for `resolveRegistrations()` in `tools.ts`), so concurrent callers await and mutate the exact same Map instance instead of racing separate file reads.

**Regression test:** `packages/runtime/src/trigger-storage.test.ts` — "keeps both writes when set() is called concurrently before the first load resolves". Verified it fails against the old code (asserted `null` instead of the expected persisted state) and passes with the fix.

**To verify:** `bun test packages/runtime/src/trigger-storage.test.ts`

**Locally ran:** `bun run fmt`, `cd packages/runtime && bunx tsc --noEmit` (clean), and the full `packages/runtime/src/trigger-storage.test.ts` + `triggers.test.ts` suites (all green). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data loss in `JsonFileStorage` when concurrent writes happen before the first load. Concurrent callers now share one in-flight load so all writes are preserved.

- **Bug Fixes**
  - Memoized the initial load as a shared promise to avoid racing `readFile` + `this.cache` reassignment.
  - Added a regression test ensuring both concurrent `set()` calls persist.

<sup>Written for commit 3ce9cc38bc0c6d47d472fedd15dc723a41555f08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

