### PR TITLE
fix(sandbox): make daemon.json read async to stop blocking the event loop

### DIFF
--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -528,8 +528,8 @@ const configUpdateH = makeConfigUpdateHandler({
   },
 });
 
-function hydrate(): void {
-  const diskOutcome = readConfig(bootConfig.repoDir);
+async function hydrate(): Promise<void> {
+  const diskOutcome = await readConfig(bootConfig.repoDir);
   if (diskOutcome.kind === "invalid") {
     console.warn(
       `[daemon] ignoring .decocms/daemon.json: ${diskOutcome.reason}`,
@@ -541,7 +541,7 @@ function hydrate(): void {
   orchestrator.handle({ kind: "bootstrap", config: initial });
 }
 
-hydrate();
+await hydrate();
 
 if (!store.read()) {
   console.log(

--- a/packages/sandbox/daemon/persistence.test.ts
+++ b/packages/sandbox/daemon/persistence.test.ts
@@ -1,48 +1,48 @@
 import { afterAll, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readConfig } from "./persistence";
 
-function repoWithDaemonJson(contents: string): string {
-  const dir = mkdtempSync(join(tmpdir(), "persistence-test-"));
-  mkdirSync(join(dir, ".decocms"), { recursive: true });
-  writeFileSync(join(dir, ".decocms", "daemon.json"), contents);
+async function repoWithDaemonJson(contents: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "persistence-test-"));
+  await mkdir(join(dir, ".decocms"), { recursive: true });
+  await writeFile(join(dir, ".decocms", "daemon.json"), contents);
   return dir;
 }
 
 describe("readConfig", () => {
   const tmpDirs: string[] = [];
-  afterAll(() => {
-    for (const d of tmpDirs) rmSync(d, { recursive: true, force: true });
+  afterAll(async () => {
+    for (const d of tmpDirs) await rm(d, { recursive: true, force: true });
   });
 
-  it("returns absent when no file exists", () => {
-    const dir = mkdtempSync(join(tmpdir(), "persistence-test-"));
+  it("returns absent when no file exists", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "persistence-test-"));
     tmpDirs.push(dir);
-    expect(readConfig(dir)).toEqual({ kind: "absent" });
+    expect(await readConfig(dir)).toEqual({ kind: "absent" });
   });
 
-  it("accepts a valid config", () => {
-    const dir = repoWithDaemonJson(
+  it("accepts a valid config", async () => {
+    const dir = await repoWithDaemonJson(
       JSON.stringify({ application: { port: 3000 } }),
     );
     tmpDirs.push(dir);
-    expect(readConfig(dir)).toEqual({
+    expect(await readConfig(dir)).toEqual({
       kind: "valid",
       config: { application: { port: 3000 } },
     });
   });
 
-  it("rejects a config that fails schema validation instead of trusting it blindly", () => {
+  it("rejects a config that fails schema validation instead of trusting it blindly", async () => {
     // Regression: a tenant-committed .decocms/daemon.json bypasses the
     // daemon-token auth that guards PUT /config, so it must not skip the
     // same field validation that route enforces (here: port out of range).
-    const dir = repoWithDaemonJson(
+    const dir = await repoWithDaemonJson(
       JSON.stringify({ application: { port: 99999 } }),
     );
     tmpDirs.push(dir);
-    const outcome = readConfig(dir);
+    const outcome = await readConfig(dir);
     expect(outcome.kind).toBe("invalid");
   });
 });

--- a/packages/sandbox/daemon/persistence.ts
+++ b/packages/sandbox/daemon/persistence.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { TenantConfig } from "./types";
 import { validateTenantConfig } from "./validate";
@@ -22,10 +22,10 @@ export type ReadOutcome =
  * never writes this file; it exists only if a tenant committed one to the
  * repo themselves.
  */
-export function readConfig(repoDir: string): ReadOutcome {
+export async function readConfig(repoDir: string): Promise<ReadOutcome> {
   let raw: string;
   try {
-    raw = readFileSync(configPath(repoDir), "utf-8");
+    raw = await readFile(configPath(repoDir), "utf-8");
   } catch (e) {
     const err = e as NodeJS.ErrnoException;
     if (err.code === "ENOENT") return { kind: "absent" };

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -540,7 +540,7 @@ export class SetupOrchestrator {
    * read-then-write.
    */
   private async fillApplicationDefaults(repoDir: string): Promise<void> {
-    const outcome = readConfig(repoDir);
+    const outcome = await readConfig(repoDir);
     const diskApp =
       outcome.kind === "valid" ? outcome.config.application : undefined;
 


### PR DESCRIPTION
**Source:** hardening follow-up — CONTRIBUTING.md rule #1 / CLAUDE.md gotcha #8 explicitly bans sync fs in `packages/sandbox/daemon/**` because the daemon runs on a single-threaded Bun event loop and Studio tears the daemon down on a single missed health-probe response.

**Why it matters:** `persistence.ts#readConfig` used `readFileSync` to load `.decocms/daemon.json`. It's not just a boot-time call — `orchestrator.ts#fillApplicationDefaults` calls it during `stepClone`, which runs on an already-serving daemon, so every repo clone blocked the event loop (and the health probe) for the duration of that synchronous read.

**Fix:** switched `readConfig` to `node:fs/promises` `readFile` and made it `async`, threading `await` through both call sites (`entry.ts`'s `hydrate()`, now itself async with a top-level `await`, and `orchestrator.ts`'s `fillApplicationDefaults`). Pure behavior-preserving conversion — same validation, same return shape, same error handling — just non-blocking. Updated `persistence.test.ts` to use the async `node:fs/promises` helpers and `await readConfig(...)`.

**Reviewer check:** `cd packages/sandbox && bunx tsc --noEmit` and `bun test packages/sandbox/daemon/persistence.test.ts`.

**Verified locally:** `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox` (green), and the targeted `persistence.test.ts` (3 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make reading `.decocms/daemon.json` async to stop blocking the daemon’s Bun event loop and prevent missed health probes during repo clones. Behavior is unchanged; the read is now non-blocking.

- **Bug Fixes**
  - Switched `readConfig` to `node:fs/promises.readFile` and made it async.
  - Propagated `await` to `entry.ts` `hydrate()` (top-level `await`) and `setup/orchestrator.ts` `fillApplicationDefaults()`.
  - Updated `persistence.test.ts` to async `fs` APIs and `await readConfig`.

<sup>Written for commit 1284562034eb9732f6484fe60daae6ad28312021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

