### PR TITLE
fix(preview): reveal a teammate's sandbox instead of "Reserving sandbox" forever

### DIFF
--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -296,6 +296,10 @@ export interface SandboxLifecycleValue {
   /** Confirm opening another member's thread: releases the auto-start gate so
    *  the sandbox boots on that thread's branch. See `othersThreadLabel`. */
   acknowledgeOthersThread: () => void;
+  /** The resolved sandbox is another member's (read-only view of their running
+   *  sandbox). Its boot progress is unobservable from here — see
+   *  `PreviewDisplayInput.foreignSandbox`. */
+  foreignSandbox: boolean;
 }
 
 const DEFAULT_VALUE: SandboxLifecycleValue = {
@@ -311,6 +315,7 @@ const DEFAULT_VALUE: SandboxLifecycleValue = {
   retry: () => {},
   resume: () => {},
   acknowledgeOthersThread: () => {},
+  foreignSandbox: false,
 };
 
 const SandboxLifecycleContext =
@@ -329,6 +334,7 @@ export function SandboxLifecycleProvider({
   sandboxProviderKind,
   othersThreadLabel,
   othersThreadId,
+  foreignSandbox = false,
   children,
 }: {
   virtualMcpId: string | null;
@@ -347,6 +353,11 @@ export function SandboxLifecycleProvider({
   othersThreadLabel: string | null;
   /** Active thread id — the acknowledgement key (see computeOthersThreadGate). */
   othersThreadId: string | null;
+  /** The `sandboxMap` entry for this branch is another member's, grafted in so a
+   *  read-only viewer resolves their running sandbox (see `VmEventsBridge`).
+   *  Forwarded to the preview display, whose progress gate can never clear for
+   *  it. Defaults false (own sandbox). */
+  foreignSandbox?: boolean;
   children: ReactNode;
 }) {
   const { org } = useProjectContext();
@@ -662,6 +673,7 @@ export function SandboxLifecycleProvider({
     retry,
     resume,
     acknowledgeOthersThread,
+    foreignSandbox,
   };
 
   return (

--- a/apps/web/src/components/sandbox/preview/preview-display.test.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.test.ts
@@ -124,6 +124,56 @@ describe("resolvePreviewDisplay", () => {
     });
   });
 
+  it("shows a foreign sandbox's iframe immediately — its boot is unobservable", () => {
+    // Viewing a teammate's thread: previewUrl is their running sandbox, but the
+    // claim/lifecycle stream is keyed to OUR handle so progressStatus never
+    // leaves "doing". Without the foreignSandbox bypass this pins the blocking
+    // overlay ("Reserving sandbox") forever.
+    const result = resolvePreviewDisplay({
+      previewState: IFRAME,
+      progressStatus: "doing",
+      productionUrl: null,
+      foreignSandbox: true,
+    });
+    expect(result.mode).toBe("sandbox");
+    expect(result.iframeBase).toBe(
+      IFRAME.kind === "iframe" ? IFRAME.previewUrl : null,
+    );
+    expect(result.showBlockingOverlay).toBe(false);
+  });
+
+  it("prefers a foreign sandbox over the production fallback", () => {
+    const result = resolvePreviewDisplay({
+      previewState: IFRAME,
+      progressStatus: "doing",
+      productionUrl: PROD,
+      foreignSandbox: true,
+    });
+    expect(result.mode).toBe("sandbox");
+    expect(result.showWakingPill).toBe(false);
+  });
+
+  it("foreignSandbox does not override the othersThread gate or a bare start", () => {
+    // No previewUrl yet → still the gate / booting path; the bypass only applies
+    // to an already-resolved foreign previewUrl.
+    expect(
+      resolvePreviewDisplay({
+        previewState: OTHERS_THREAD,
+        progressStatus: "doing",
+        productionUrl: PROD,
+        foreignSandbox: true,
+      }).mode,
+    ).toBe("none");
+    expect(
+      resolvePreviewDisplay({
+        previewState: STARTING,
+        progressStatus: "doing",
+        productionUrl: null,
+        foreignSandbox: true,
+      }).showBlockingOverlay,
+    ).toBe(true);
+  });
+
   it("yields the canvas to the othersThread gate — no production leak", () => {
     // A teammate's branch: even with a productionUrl set, don't paint a toolbar
     // or load the production iframe behind the confirmation card.

--- a/apps/web/src/components/sandbox/preview/preview-display.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.ts
@@ -41,6 +41,16 @@ export interface PreviewDisplayInput {
   progressStatus: PhaseStatus;
   /** Live production URL to fall back to while waking, or `null` if unknown. */
   productionUrl: string | null;
+  /**
+   * The resolved sandbox belongs to ANOTHER member (a read-only view of their
+   * thread's already-running sandbox — see the owner graft in `VmEventsBridge`).
+   * Their boot progress is unobservable from here: the claim-phase / daemon
+   * lifecycle stream is keyed to the VIEWER's claim handle, which never
+   * materializes, so `progressStatus` is pinned at `doing` forever. Show the
+   * iframe on `previewUrl` alone instead of waiting out a boot that isn't ours
+   * to watch.
+   */
+  foreignSandbox?: boolean;
 }
 
 const NONE: PreviewDisplay = {
@@ -53,7 +63,7 @@ const NONE: PreviewDisplay = {
 export function resolvePreviewDisplay(
   input: PreviewDisplayInput,
 ): PreviewDisplay {
-  const { previewState, progressStatus, productionUrl } = input;
+  const { previewState, progressStatus, productionUrl, foreignSandbox } = input;
 
   // Suspended / errored / othersThread all render their own dedicated card
   // (the last one is a confirmation gate on a teammate's branch) — hand the
@@ -70,8 +80,13 @@ export function resolvePreviewDisplay(
   // The sandbox surface is showable once a previewUrl exists AND boot is no
   // longer in progress: `done` (running) serves the live app, `failed`/`crashed`
   // serves the daemon's auto-reloading status page — both belong in the iframe,
-  // not behind a "waking" pill.
-  if (previewState.kind === "iframe" && progressStatus !== "doing") {
+  // not behind a "waking" pill. A foreign sandbox skips the progress gate (its
+  // progress is unobservable — see `foreignSandbox`); whatever the owner's
+  // daemon serves is the displayed state.
+  if (
+    previewState.kind === "iframe" &&
+    (foreignSandbox || progressStatus !== "doing")
+  ) {
     return {
       mode: "sandbox",
       iframeBase: previewState.previewUrl,

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -485,6 +485,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     previewState,
     progressStatus: progress.status,
     productionUrl,
+    foreignSandbox: lifecycle.foreignSandbox,
   });
   const previewSurfaceActive = display.mode !== "none";
   const showBootingOverlay = display.showBlockingOverlay;

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -169,6 +169,12 @@ function VmEventsBridge({
     previewOwnerId && currentBranch
       ? threadSandboxMap?.[previewOwnerId]?.[currentBranch]
       : undefined;
+  // True when that grafted entry is someone ELSE's sandbox. Nothing about its
+  // boot is observable from here — the claim/daemon event stream is keyed to the
+  // viewer's own claim handle, which never materializes — so the preview renders
+  // on `previewUrl` alone (see `foreignSandbox` in preview-display) and the
+  // stream stays closed instead of reporting `claiming` forever.
+  const foreignSandbox = !!threadOwnerBranchMap && previewOwnerId !== userId;
   const effectiveSandboxMap: SandboxMap | undefined =
     userId && currentBranch && threadOwnerBranchMap
       ? {
@@ -214,7 +220,8 @@ function VmEventsBridge({
   // vmEntry always agree on which sandbox is active.
   const vmEntry = resolveVmEntry(branchMap, pendingSandboxProviderKind);
   const previewUrl = vmEntry?.previewUrl ?? null;
-  const shouldConnect = Object.keys(branchMap).length > 0 || isStartPending;
+  const shouldConnect =
+    (Object.keys(branchMap).length > 0 || isStartPending) && !foreignSandbox;
 
   return (
     <SandboxEventsProvider
@@ -232,6 +239,7 @@ function VmEventsBridge({
         sandboxProviderKind={pendingSandboxProviderKind}
         othersThreadLabel={othersThreadLabel}
         othersThreadId={activeTask?.id ?? null}
+        foreignSandbox={foreignSandbox}
       >
         <BlocksPreviewWorkspaceProvider
           key={`${virtualMcpId}:${currentBranch ?? "no-branch"}`}


### PR DESCRIPTION
## Problem

Opening another member's thread read-only (e.g. a Super Agent run someone else delegated) leaves the Preview tab stuck on the **"Reserving sandbox"** card indefinitely, even though the run finished and its sandbox is up and serving.

Verified live on `demo-storefront` / `thrd_sUNCH2u3kuYEdSE4mb5Ca`:

- thread `created_by` = `nWsMXI0eo…`, viewer = `gs5vcnW1…`
- `metadata.sandboxMap` holds exactly one entry, under the **owner's** id, with a live `previewUrl`
- the viewer's `GET …/sandbox/:vmid/:branch/events` emits `event: phase {"kind":"claiming"}` and then only keepalives
- `POST …/read` → 404
- no `<iframe>` in the DOM

Chain: `VmEventsBridge` deliberately grafts the owner's `sandboxMap` entry under the viewer's key so `previewUrl` resolves to their running sandbox (without it, acking the others-thread gate kicks off a clone that never resolves). But every sandbox route composes the claim handle from the **caller's** id — `computeClaimHandle({ userId, projectRef })` in `resolveVmClaim` — so for a viewer that handle never materializes. `/events` therefore sits at `claiming`, `derivePhaseProgress` returns `provision/doing`, and `resolvePreviewDisplay` gates the iframe on `progressStatus !== "doing"` → blocking overlay, forever. Studio's 90s no-claim window then fails and the client reconnects, restarting it.

## Fix

Mark the grafted-from-another-member case `foreignSandbox` and let it bypass the progress gate: with a `previewUrl` in hand, whatever the owner's daemon serves is the displayed state — the same contract the gate already applies to `failed`/`crashed`.

Also `enabled={false}` on the events stream for that case. It can only ever say `claiming`, and every reconnect re-runs a 90s no-claim wait plus `/read` 404s against a handle that doesn't exist.

The others-thread confirmation gate is untouched: it still owns the canvas when there is no `previewUrl` (nothing resolved to view), and `foreignSandbox` explicitly does not override it — covered by a test.

## Testing

- 3 new cases in `preview-display.test.ts` (12 pass): foreign sandbox shows its iframe while `progressStatus === "doing"`; it wins over the production fallback; it does **not** override the `othersThread` gate or a bare `starting`.
- `bun run lint` 0 errors; `bun run fmt` clean.
- `bun run --cwd=apps/web check`: the only errors are pre-existing zod v3/v4 `_zod.version.minor` mismatches on `main` (`org-role-detail.tsx`, `virtual-mcp/index.tsx`, `packages/shared/.../connection.ts`) — reproduced with this branch's changes stashed. None in the touched files. Looks like a stale `node_modules` after the release bump.
- Not verified in the browser end-to-end — the repro is a teammate's live sandbox on prod. The three signals above (`phase: claiming`, `/read` 404, no iframe) are what the change targets; worth confirming on the same thread once deployed.

## Follow-up (not in scope)

Everything else on that surface stays handle-keyed, so for a foreign sandbox the Code tab, file explorer, git status and logs will still 404. Either proxy them to the owner's handle for org members who can read the thread, or hide them in read-only view.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Preview getting stuck on “Reserving sandbox” when viewing a teammate’s thread by recognizing a foreign sandbox and showing its iframe right away. Also stops opening the VM events stream in this case to avoid endless “claiming” and 404s.

- **Bug Fixes**
  - Introduced `foreignSandbox` to bypass the progress gate when a teammate’s `previewUrl` is available; iframe renders immediately.
  - Disabled the events stream for foreign sandboxes to prevent perpetual `claiming` and `/read` 404s.
  - Kept the others-thread confirmation gate intact when there’s no `previewUrl`; start/boot flow unchanged.
  - Added tests in `preview-display.test.ts` to cover the bypass and gate interactions.

<sup>Written for commit f3a0f837e22fee681f06cb786ec6151bcc39f826. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

