### PR TITLE
fix(auth): fail startup when SSO env vars are configured without a secret/tenant id

### DIFF
--- a/apps/api/src/auth/auth-env.test.ts
+++ b/apps/api/src/auth/auth-env.test.ts
@@ -47,4 +47,50 @@ describe("authEnvSchema", () => {
       emailProviderId: "sendgrid",
     });
   });
+
+  it("rejects Microsoft SSO configured without a client secret", () => {
+    expect(() =>
+      authEnvSchema.parse({
+        AUTH_SSO_DOMAIN: "acme.com",
+        AUTH_SSO_MS_CLIENT_ID: "client-id",
+        AUTH_SSO_MS_TENANT_ID: "tenant-id",
+      }),
+    ).toThrow(/AUTH_SSO_MS_CLIENT_SECRET/);
+  });
+
+  it("rejects Microsoft SSO configured without a tenant id", () => {
+    expect(() =>
+      authEnvSchema.parse({
+        AUTH_SSO_DOMAIN: "acme.com",
+        AUTH_SSO_MS_CLIENT_ID: "client-id",
+        AUTH_SSO_MS_CLIENT_SECRET: "secret",
+      }),
+    ).toThrow(/AUTH_SSO_MS_TENANT_ID/);
+  });
+
+  it("rejects Google SSO configured without a client secret", () => {
+    expect(() =>
+      authEnvSchema.parse({
+        AUTH_SSO_DOMAIN: "acme.com",
+        AUTH_SSO_GOOGLE_CLIENT_ID: "client-id",
+      }),
+    ).toThrow(/AUTH_SSO_GOOGLE_CLIENT_SECRET/);
+  });
+
+  it("accepts Microsoft SSO when fully configured", () => {
+    const config = authEnvSchema.parse({
+      AUTH_SSO_DOMAIN: "acme.com",
+      AUTH_SSO_MS_CLIENT_ID: "client-id",
+      AUTH_SSO_MS_CLIENT_SECRET: "secret",
+      AUTH_SSO_MS_TENANT_ID: "tenant-id",
+    });
+    expect(config.ssoConfig).toEqual({
+      providerId: "microsoft",
+      domain: "acme.com",
+      MS_TENANT_ID: "tenant-id",
+      MS_CLIENT_ID: "client-id",
+      MS_CLIENT_SECRET: "secret",
+      scopes: ["openid", "email", "profile"],
+    });
+  });
 });

--- a/apps/api/src/auth/auth-env.ts
+++ b/apps/api/src/auth/auth-env.ts
@@ -111,6 +111,38 @@ export const authEnvSchema = z
           "AUTH_EMAIL_OTP_ENABLED=true requires AUTH_RESEND_API_KEY or AUTH_SENDGRID_API_KEY to be set",
       });
     }
+
+    if (env.AUTH_SSO_MS_CLIENT_ID && env.AUTH_SSO_DOMAIN) {
+      if (!env.AUTH_SSO_MS_CLIENT_SECRET) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["AUTH_SSO_MS_CLIENT_SECRET"],
+          message:
+            "AUTH_SSO_MS_CLIENT_ID and AUTH_SSO_DOMAIN are set but AUTH_SSO_MS_CLIENT_SECRET is not",
+        });
+      }
+      if (!env.AUTH_SSO_MS_TENANT_ID) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["AUTH_SSO_MS_TENANT_ID"],
+          message:
+            "AUTH_SSO_MS_CLIENT_ID and AUTH_SSO_DOMAIN are set but AUTH_SSO_MS_TENANT_ID is not",
+        });
+      }
+    }
+
+    if (
+      env.AUTH_SSO_GOOGLE_CLIENT_ID &&
+      env.AUTH_SSO_DOMAIN &&
+      !env.AUTH_SSO_GOOGLE_CLIENT_SECRET
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["AUTH_SSO_GOOGLE_CLIENT_SECRET"],
+        message:
+          "AUTH_SSO_GOOGLE_CLIENT_ID and AUTH_SSO_DOMAIN are set but AUTH_SSO_GOOGLE_CLIENT_SECRET is not",
+      });
+    }
   })
   .transform((env) => {
     // ── Social providers ───────────────────────────────────────────


### PR DESCRIPTION
Follows #5327's hardening of email-provider env validation — that PR added a `superRefine` check so a provider-reference env var that points at an unconfigured provider fails startup with a clear message instead of silently misbehaving. The Microsoft/Google SSO env vars in `apps/api/src/auth/auth-env.ts` had the same gap: `AUTH_SSO_MS_CLIENT_SECRET`, `AUTH_SSO_MS_TENANT_ID`, and `AUTH_SSO_GOOGLE_CLIENT_SECRET` all fall back to `""` via `?? ""` when unset, so an operator who sets `AUTH_SSO_DOMAIN` + `AUTH_SSO_MS_CLIENT_ID` but forgets the secret or tenant id gets a server that boots fine and then fails OAuth token exchange with a cryptic error at login time (empty `clientSecret`, or a broken `https://login.microsoftonline.com//v2.0` issuer URL from an empty tenant id) — same silent-misconfiguration failure mode the email-provider fix just closed.

Failure scenario: set `AUTH_SSO_DOMAIN` and `AUTH_SSO_MS_CLIENT_ID` in prod but omit `AUTH_SSO_MS_CLIENT_SECRET`/`AUTH_SSO_MS_TENANT_ID` — server starts, SSO login silently breaks for every user in that domain instead of the deploy failing fast with an actionable message.

Fix: extend the existing `superRefine` block (same pattern as the email-provider checks) to require `AUTH_SSO_MS_CLIENT_SECRET` + `AUTH_SSO_MS_TENANT_ID` whenever Microsoft SSO is being configured (`AUTH_SSO_MS_CLIENT_ID` + `AUTH_SSO_DOMAIN` set), and `AUTH_SSO_GOOGLE_CLIENT_SECRET` whenever Google SSO is being configured. Added 4 unit tests covering each rejection case plus the fully-configured accept case (mirrors the existing email-provider test style in the same file).

Reviewer command: `bun test apps/api/src/auth/auth-env.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail startup when Microsoft or Google SSO is partially configured to prevent silent login failures. Adds strict env validation in `authEnvSchema` so missing secrets or tenant IDs are caught at boot.

- **Bug Fixes**
  - Require `AUTH_SSO_MS_CLIENT_SECRET` and `AUTH_SSO_MS_TENANT_ID` when `AUTH_SSO_MS_CLIENT_ID` and `AUTH_SSO_DOMAIN` are set; require `AUTH_SSO_GOOGLE_CLIENT_SECRET` when `AUTH_SSO_GOOGLE_CLIENT_ID` and `AUTH_SSO_DOMAIN` are set.
  - Added unit tests for each rejection case and for a fully configured Microsoft SSO accept case.

<sup>Written for commit 0cdcabc65242de68014272c83eefe7d426892fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

