### PR TITLE
fix(search): cap GLOBAL_SEARCH query length at 256 chars

### DIFF
--- a/apps/api/src/tools/search/global-search.test.ts
+++ b/apps/api/src/tools/search/global-search.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "bun:test";
+import { GLOBAL_SEARCH } from "./global-search";
+
+describe("GLOBAL_SEARCH input schema", () => {
+  it("rejects a query longer than 256 characters", () => {
+    const result = GLOBAL_SEARCH.inputSchema.safeParse({
+      query: "a".repeat(257),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a query at the 256 character boundary", () => {
+    const result = GLOBAL_SEARCH.inputSchema.safeParse({
+      query: "a".repeat(256),
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/api/src/tools/search/global-search.ts
+++ b/apps/api/src/tools/search/global-search.ts
@@ -37,6 +37,9 @@ const SearchResultSchema = z.discriminatedUnion("type", [ThreadResultSchema]);
 const InputSchema = z.object({
   query: z
     .string()
+    // Bounded to keep an authenticated caller from forcing a pathologically
+    // long ILIKE substring scan across every searchable resource type.
+    .max(256)
     .describe(
       "Free-text search query. Empty string returns the most recently updated resources.",
     ),


### PR DESCRIPTION
Bug found while auditing GLOBAL_SEARCH (apps/api/src/tools/search/global-search.ts) per issue #2995 (DB latency across MCP tool calls).

`query` was an unbounded `z.string()` forwarded straight into `ctx.storage.threads.list(...)`, which builds a `title ILIKE '%<query>%'` Postgres scan (apps/api/src/storage/threads.ts). Nothing capped the length of that string, so any authenticated caller could send an arbitrarily large `query` and force a pathologically long substring scan on every call — a cheap, real latency/DoS-adjacent gap at a trust boundary (untrusted MCP tool input reaching a DB query with no bound).

The fix mirrors an existing precedent in this same codebase: `FILE_OBJECTS_LIST`'s `search` param (apps/api/src/tools/file-configs/list-objects.ts) is already `z.string().max(256)` with the identical rationale comment. This PR applies the same `.max(256)` bound to `GLOBAL_SEARCH`'s `query` field — no behavior change for any real search query (titles are nowhere near 256 chars), just a ceiling on abuse.

Regression test: `apps/api/src/tools/search/global-search.test.ts` (new, pure unit test, no DB) asserts the input schema accepts a 256-char query and rejects a 257-char one.

Reviewer command: `bun test apps/api/src/tools/search/global-search.test.ts`

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `apps/api`, and the targeted test file above — all green. Full CI validates the rest (including the existing `global-search.integration.test.ts`, which needs Postgres and wasn't run locally).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `GLOBAL_SEARCH` query length to 256 characters to prevent pathologically long Postgres ILIKE scans and mitigate DB latency risk from untrusted tool input. Adds a unit test to enforce the boundary (accepts 256, rejects 257).

<sup>Written for commit de96125a76f920eb8bd743a5af10b7e69259dcd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

