### PR TITLE
fix(bindings): implement MCPClient.forClient in the proxy get trap

### DIFF
--- a/packages/bindings/src/core/client/mcp.ts
+++ b/packages/bindings/src/core/client/mcp.ts
@@ -27,6 +27,15 @@ export const MCPClient = new Proxy(
             connection,
           });
       }
+
+      if (name === "forClient") {
+        return <TDefinition extends readonly ToolBinder[]>(
+          client: ServerClient,
+        ) =>
+          createMCPFetchStub<TDefinition>({
+            client,
+          });
+      }
       return globalThis[name as keyof typeof globalThis];
     },
   },

--- a/packages/bindings/test/mcp-client-for-client.test.ts
+++ b/packages/bindings/test/mcp-client-for-client.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { MCPClient } from "../src/core/client/mcp";
+import type { ServerClient } from "../src/core/client/mcp-client";
+
+const fakeClient: ServerClient = {
+  client: {
+    callTool: (async () => ({
+      content: [],
+    })) as ServerClient["client"]["callTool"],
+    listTools: async () => ({ tools: [] }),
+  },
+};
+
+describe("MCPClient.forClient", () => {
+  it("returns a callable stub instead of undefined", () => {
+    const stub = MCPClient.forClient(fakeClient);
+
+    expect(typeof stub.listTools).toBe("function");
+  });
+});


### PR DESCRIPTION
**Source:** bug found while auditing `packages/bindings/src/core/client/mcp.ts` (this tick's focus area, flagged after the recent TS7-migration touch to this file).

**Why a maintainer wants it:** the `MCPClient` Proxy's type signature advertises two factory methods, `forConnection` and `forClient`, but the `get` trap only ever implemented `forConnection` (going all the way back to when `forClient` was first added to the type) — falling through to `return globalThis[name]`, i.e. `undefined`. Any call to `MCPClient.forClient(...)` compiles fine (the type says it exists) but crashes at runtime with "undefined is not a function" the moment it's invoked, since `createMCPClientProxy`'s options already fully support the `{ client }` shape (`CreateStubForClientAPIOptions`) — the wiring in `mcp.ts` was just missing.

**Failure scenario:** any future caller doing `MCPClient.forClient(serverClient)` (the documented/typed way to build a stub from an already-connected `ServerClient`, as opposed to `forConnection` which builds one from a raw `MCPConnection`) throws instead of returning a usable stub.

**Fix + regression test:** added the missing `forClient` branch, mirroring `forConnection`'s pattern but passing `{ client }` instead of `{ connection }`. Added `packages/bindings/test/mcp-client-for-client.test.ts` (new file, following this package's existing top-level `test/` convention) asserting `MCPClient.forClient(...)` returns a stub with a callable `listTools`, instead of `undefined`.

**Reviewer command:** `bun test packages/bindings/test/mcp-client-for-client.test.ts`

**Local checks run:** `bun run fmt`, `cd packages/bindings && bunx tsc --noEmit` (clean), the new targeted test (passes), and the pre-existing `packages/bindings/test/mcp.test.ts` (still passes, untouched). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a runtime crash where `MCPClient.forClient(...)` was undefined by implementing the missing proxy branch. Calls now return a working stub (e.g., `listTools`) and are covered by a new test.

- **Bug Fixes**
  - Implemented `forClient` in `MCPClient` proxy (`packages/bindings/src/core/client/mcp.ts`) using `createMCPFetchStub({ client })`.
  - Added `packages/bindings/test/mcp-client-for-client.test.ts` to assert the stub exposes a callable `listTools`.

<sup>Written for commit 72343805d764694758a347417bd35dd39ec5687f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

