### PR TITLE
fix(sections-editor): reject decimal/exponent input on integer schema fields

### DIFF
--- a/apps/web/src/components/sections-editor/fields/number-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/number-field.tsx
@@ -2,9 +2,7 @@ import { useState } from "react";
 import { Input } from "@deco/ui/components/input.tsx";
 import { Label } from "@deco/ui/components/label.tsx";
 import type { FieldProps } from "./field-props";
-
-/** Intermediate numeric strings the user can be mid-typing: "", "-", "+", ".", "0.", "1e-", "1e+5". */
-const PARTIAL_NUMBER = /^[+-]?\d*\.?\d*(?:[eE][+-]?\d*)?$/;
+import { isPartialNumericInput } from "./partial-number-input";
 
 /**
  * Number input that keeps the raw typed string in local state instead of
@@ -51,7 +49,8 @@ export function NumberField({
         value={raw}
         onChange={(e) => {
           const next = e.target.value;
-          if (next !== "" && !PARTIAL_NUMBER.test(next)) return;
+          const isInteger = schema.type === "integer";
+          if (next !== "" && !isPartialNumericInput(next, isInteger)) return;
           setRaw(next);
           const parsed = Number(next);
           onChange(next === "" || Number.isNaN(parsed) ? undefined : parsed);

--- a/apps/web/src/components/sections-editor/fields/partial-number-input.test.ts
+++ b/apps/web/src/components/sections-editor/fields/partial-number-input.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { isPartialNumericInput } from "./partial-number-input";
+
+describe("isPartialNumericInput", () => {
+  test("accepts in-progress and complete decimal input for number schemas", () => {
+    for (const value of [
+      "",
+      "-",
+      "+",
+      ".",
+      "0.",
+      "1.5",
+      "1e-",
+      "1e+5",
+      "-3.14",
+    ]) {
+      expect(isPartialNumericInput(value, false)).toBe(true);
+    }
+  });
+
+  test("rejects a decimal point or exponent for integer schemas", () => {
+    for (const value of ["1.5", "1.", ".5", "1e5", "1e-3"]) {
+      expect(isPartialNumericInput(value, true)).toBe(false);
+    }
+  });
+
+  test("accepts in-progress and complete whole-number input for integer schemas", () => {
+    for (const value of ["", "-", "+", "0", "42", "-17"]) {
+      expect(isPartialNumericInput(value, true)).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/components/sections-editor/fields/partial-number-input.ts
+++ b/apps/web/src/components/sections-editor/fields/partial-number-input.ts
@@ -1,0 +1,14 @@
+/** Intermediate numeric strings the user can be mid-typing: "", "-", "+", ".", "0.", "1e-", "1e+5". */
+const PARTIAL_NUMBER = /^[+-]?\d*\.?\d*(?:[eE][+-]?\d*)?$/;
+
+/** Same, but no decimal point or exponent — matches JSON Schema's "integer". */
+const PARTIAL_INTEGER = /^[+-]?\d*$/;
+
+/**
+ * Whether `value` is a valid in-progress (or complete) typed string for a
+ * number input. `isInteger` rejects "1.5" / "1e5" so an `integer` schema
+ * field can never produce a non-integer value.
+ */
+export function isPartialNumericInput(value: string, isInteger: boolean) {
+  return (isInteger ? PARTIAL_INTEGER : PARTIAL_NUMBER).test(value);
+}


### PR DESCRIPTION
Found while doing a post-merge sanity check on #5331 (which wired `apps/web/ct/tests/widget-dispatch.ct.tsx` into CI). That test only asserts the `inputmode` attribute for `number` vs `integer` schema dispatch, so it never caught that `NumberField`'s partial-input regex (`apps/web/src/components/sections-editor/fields/number-field.tsx`) accepted a decimal point and exponent for BOTH `number` and `integer` JSON-schema types.

**Failure scenario**: any tool/section field with an `integer` schema (e.g. a quantity, port, or count) routes through `schema-form.tsx`'s `case "integer"` to the same `NumberField` as `number`. A user typing `1.5` or `1e5` into that field has it accepted keystroke-by-keystroke and `onChange` fires with `Number("1.5") === 1.5` — a non-integer value gets persisted into org config with nothing downstream re-validating it against the integer schema.

**Fix**: extracted the partial-number matcher into `fields/partial-number-input.ts` as `isPartialNumericInput(value, isInteger)`, with a second regex (`^[+-]?\d*$`) used when the schema is `integer` — rejecting `.` and `e` outright instead of only filtering on the shared decimal/exponent-permissive pattern. Behavior for `number` schemas is unchanged (same regex, same acceptance set).

Regression test: `apps/web/src/components/sections-editor/fields/partial-number-input.test.ts` — asserts integer mode rejects `"1.5"`, `"1e5"`, `".5"`, etc. while still accepting in-progress typing (`""`, `"-"`, `"42"`), and that `number` mode is unaffected.

Reviewer command: `cd apps/web && bun test src/components/sections-editor/fields/partial-number-input.test.ts`

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), and the targeted test above (3 pass). Full CI covers the rest (including the ct suite this doesn't touch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects decimal and exponent input in integer fields in the sections editor to prevent non-integer values from being saved. Extracted a shared numeric input validator and wired it into `NumberField`; behavior for `number` schemas is unchanged.

- **Bug Fixes**
  - Added `isPartialNumericInput` in `fields/partial-number-input.ts` with an integer-safe pattern (no "." or "e").
  - Updated `NumberField` to use the validator when `schema.type === "integer"`.
  - Added tests to confirm integer mode rejects decimal/exponent while number mode stays permissive.

<sup>Written for commit 3e66422e37e6bcccce1c1b247e5797499f7af57f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

