### PR TITLE
feat(sandbox): log which cache tier served each dependency install

### DIFF
--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import type { PackageManager } from "../types";
+import { repoHash } from "./golden-cache";
 
 // Guard against a pathological node_modules blowing up the log line.
 const MAX_DEPS = 10_000;
@@ -57,6 +58,60 @@ export interface DepMetricsInput {
   bootId: string;
   repoName?: string;
   branch?: string;
+}
+
+/**
+ * `l1` — reflinked the node-local golden, install skipped.
+ * `miss` — no golden for this (repo, lockfile) on this node; ran a full install.
+ */
+export type RestoreSource = "l1" | "miss";
+
+export interface DepsRestoreInput {
+  source: RestoreSource;
+  /** Credential-bearing is fine — only its stripped hash is emitted. */
+  cloneUrl: string | undefined;
+  /** Whole dependency step, golden probe included (what L2 would replace). */
+  durationMs: number;
+  bootId: string;
+}
+
+/**
+ * One line per completed dependency step, recording which cache tier served
+ * it. This is the number the golden cache cannot report about itself: a hit
+ * needs the pod to land on a node already warm for its repo, so the hit rate
+ * is a property of fleet churn, not of the cache code.
+ *
+ * A log line rather than a metric, for three reasons:
+ *  - it is the only channel that leaves a sandbox pod (see the note on
+ *    `emitInstalledDeps` — egress is locked to 53/443, so no in-cluster OTLP
+ *    collector is reachable);
+ *  - `bootId` is free here and unbounded cardinality as a metric attribute.
+ *    Without it a counter cannot tell "one pod installed three times" from
+ *    "three pods", and `stepInstall` does re-run within a boot (config change,
+ *    reprovision);
+ *  - raw durations beat pre-bucketed histograms when the range is unknown,
+ *    which is the whole point of measuring.
+ *
+ * Sized for the pipeline that drops big lines and samples bursts: ~150 bytes,
+ * one per boot. Both limits are orders of magnitude away — no chunking, no
+ * `sample_rate` correction.
+ */
+export function buildDepsRestoreLine(input: DepsRestoreInput): string {
+  return JSON.stringify({
+    msg: "sandbox.deps.restore",
+    source: input.source,
+    repo_hash: input.cloneUrl ? repoHash(input.cloneUrl) : "unknown",
+    duration_ms: Math.round(input.durationMs),
+    bootId: input.bootId,
+  });
+}
+
+export function emitDepsRestore(input: DepsRestoreInput): void {
+  try {
+    console.log(buildDepsRestoreLine(input));
+  } catch {
+    // never let telemetry break the install path
+  }
 }
 
 // Cap each emitted line SMALL. Measured in prod: the log pipeline stores only

--- a/packages/sandbox/daemon/setup/deps-restore-line.test.ts
+++ b/packages/sandbox/daemon/setup/deps-restore-line.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { buildDepsRestoreLine } from "./dep-metrics";
+
+/**
+ * Both failure modes here are silent. A line over the pipeline's byte cap is
+ * dropped whole (that is what the chunked `sandbox.deps` format exists to
+ * work around), and a credential leaking through the repo label would ship a
+ * git token to the log store without anything erroring.
+ */
+describe("buildDepsRestoreLine", () => {
+  test("emits one small parseable line, credentials stripped", () => {
+    const line = buildDepsRestoreLine({
+      source: "miss",
+      cloneUrl:
+        "https://x-access-token:ghs_SECRETVALUE@github.com/acme/site.git",
+      durationMs: 42_318.7,
+      bootId: "01JB0Z9K2M4N6P8Q",
+    });
+
+    // Well inside the ~600-byte budget the sibling format had to chunk for.
+    expect(Buffer.byteLength(line)).toBeLessThan(300);
+    expect(line).not.toContain("\n");
+
+    const parsed = JSON.parse(line);
+    expect(parsed).toEqual({
+      msg: "sandbox.deps.restore",
+      source: "miss",
+      repo_hash: parsed.repo_hash,
+      duration_ms: 42_319, // rounded — no float noise in the log store
+      bootId: "01JB0Z9K2M4N6P8Q",
+    });
+    expect(parsed.repo_hash).toMatch(/^[0-9a-f]{16}$/);
+
+    // The token must not survive anywhere in the line, hashed or otherwise.
+    expect(line).not.toContain("ghs_SECRETVALUE");
+    expect(line).not.toContain("x-access-token");
+  });
+
+  test("credentials do not change the repo identity", () => {
+    const withCreds = JSON.parse(
+      buildDepsRestoreLine({
+        source: "l1",
+        cloneUrl: "https://user:tok@github.com/acme/site.git",
+        durationMs: 900,
+        bootId: "b",
+      }),
+    );
+    const without = JSON.parse(
+      buildDepsRestoreLine({
+        source: "l1",
+        cloneUrl: "https://github.com/acme/site.git",
+        durationMs: 900,
+        bootId: "b",
+      }),
+    );
+    // Otherwise a token rotation would look like a different repo and split
+    // the hit rate across two series.
+    expect(withCreds.repo_hash).toBe(without.repo_hash);
+  });
+
+  test("a repo-less boot still emits a countable line", () => {
+    const parsed = JSON.parse(
+      buildDepsRestoreLine({
+        source: "miss",
+        cloneUrl: undefined,
+        durationMs: 1,
+        bootId: "b",
+      }),
+    );
+    expect(parsed.repo_hash).toBe("unknown");
+  });
+});

--- a/packages/sandbox/daemon/setup/golden-cache.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.ts
@@ -67,7 +67,7 @@ const LOCKFILES: Record<string, readonly string[]> = {
 };
 
 /** 16 hex chars of sha256, credential-stripped — matches depsCacheEnv's key. */
-function repoHash(cloneUrl: string): string {
+export function repoHash(cloneUrl: string): string {
   let key = cloneUrl;
   try {
     const u = new URL(cloneUrl);

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -29,11 +29,11 @@ import type { Application, Config } from "../types";
 import { materializeAskpass } from "./askpass";
 import { autodetectApplication } from "./autodetect";
 import { type CloneResult, spawnClone } from "./clone";
-import { emitInstalledDeps } from "./dep-metrics";
+import { emitDepsRestore, emitInstalledDeps } from "./dep-metrics";
 import { publishGolden, pruneGoldens, tryRestoreGolden } from "./golden-cache";
 import { gitBaseArgv, gitStepEnv } from "./git-command";
 import { configureGitIdentity } from "./identity";
-import { denoCacheEnv, spawnInstall } from "./install";
+import { denoCacheEnv, resolveCloneUrl, spawnInstall } from "./install";
 import { spawnSetupStep } from "./spawn-step";
 import { installProtectedBranchHook } from "../git/protect-branch";
 
@@ -368,6 +368,10 @@ export class SetupOrchestrator {
       config.repoDir,
       config.application?.packageManager?.path,
     );
+    // Times the WHOLE dependency step, not just the install: a failed golden
+    // probe (stat, partial reflink, cleanup) is real boot latency, and on a
+    // miss the cost L2 would replace is probe + install, not install alone.
+    const depsStartedAt = Date.now();
     if (
       await tryRestoreGolden({
         config,
@@ -378,6 +382,12 @@ export class SetupOrchestrator {
     ) {
       // Restored from an existing golden — nothing to publish.
       this.pendingGolden = null;
+      emitDepsRestore({
+        source: "l1",
+        cloneUrl: resolveCloneUrl(config),
+        durationMs: Date.now() - depsStartedAt,
+        bootId: process.env.DAEMON_BOOT_ID ?? "",
+      });
       this.markInstallSucceeded(config);
       return true;
     }
@@ -419,6 +429,12 @@ export class SetupOrchestrator {
       this.deps.lifecycle.transition({ phase: "install-failed", error });
       return false;
     }
+    emitDepsRestore({
+      source: "miss",
+      cloneUrl: resolveCloneUrl(config),
+      durationMs: Date.now() - depsStartedAt,
+      bootId: process.env.DAEMON_BOOT_ID ?? "",
+    });
     this.markInstallSucceeded(config);
     // Install scripts (postinstall/prepare — lefthook, husky, etc.) can
     // overwrite .git/hooks/pre-push; reinstall so branch protection survives.


### PR DESCRIPTION
Replaces #5339 as the answer to "what is the golden cache's hit rate". Opened after review of that PR pointed out it ships blocked machinery for a question that is answerable today.

## What

One line per completed dependency step, next to the existing `emitInstalledDeps` call:

```json
{"msg":"sandbox.deps.restore","source":"miss","repo_hash":"a1b2…","duration_ms":42319,"bootId":"01JB…"}
```

`source` is `l1` (reflinked the golden, install skipped) or `miss` (ran a full install). `stats by (source) count()` in VictoriaLogs gives the hit rate, and `repo_hash` gives repo-concentration-per-node — the two inputs that size the EFS L2 tier.

## Why a log line and not a metric

- **It's the only channel that leaves a sandbox pod.** Egress is locked to 53/443, so no in-cluster OTLP collector is reachable. `dep-metrics.ts` already documents this two lines above the import.
- **`bootId` is free here and impossible as a metric attribute** — it's unbounded cardinality. Without it a counter can't separate "one pod installed three times" from "three pods", and `stepInstall` does re-run within a boot (config change, reprovision). That would quietly bias the hit rate.
- **Raw durations beat pre-bucketed histograms when the range is what you're measuring.** Picking bucket boundaries requires already knowing the answer.

Sized against the pipeline that drops big lines and samples bursts (the constraints #4271/#4273/#4275 established the hard way): ~100 bytes, one per boot — measured at 97 bytes in the orchestrator test. Both limits are orders of magnitude away, so no chunking and no `sample_rate` correction.

## Timing covers the whole step

`durationMs` starts before the golden probe, not after. A failed probe (stat, partial reflink, cleanup) is real boot latency, and on a miss the cost L2 would replace is probe + install, not install alone.

## Scope note

Only completed steps are recorded — failed installs, the fingerprint-skip path and the no-package-manager early return are not. So the denominator is "dependency steps that finished", which is the right one for "did the cache save a boot", but it is not "installs attempted".

## Testing

- `deps-restore-line.test.ts` — pure builder, no mocks. Asserts the line stays well under the byte budget, that a `ghs_` token in the clone URL survives nowhere in the output, that credentials don't change `repo_hash` (a token rotation must not split the hit rate across two series), and that a repo-less boot still emits a countable line.
- `bun test packages/sandbox/daemon/setup/` → 89 pass. `daemon.e2e.test.ts` → 103 pass.
- `bun run fmt`, `bun run lint` (0 errors), `knip` clean. No new dependencies; daemon bundle unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a small JSON log per completed dependency step to record which cache tier served it and how long it took. This lets us measure the golden cache hit rate and size the EFS L2 tier accurately.

- **New Features**
  - Emit `sandbox.deps.restore` with `source` (`l1` or `miss`), `repo_hash`, `duration_ms`, and `bootId`. Use VictoriaLogs `stats by (source) count()` to get hit rate.
  - Time covers the whole step (golden probe + install) to reflect real boot latency.
  - `repo_hash` is a credential‑stripped 16‑hex hash of the clone URL; emits `"unknown"` when no repo.
  - Sized for the log pipeline and guarded from failures; tests ensure small lines, no credential leaks, and stable hashing across credential changes.

<sup>Written for commit ef208e1ee6c74ab07a928f8d4d232a7012084df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

