### PR TITLE
fix(sandbox): remember the branch a thread's sandbox is actually on

### DIFF
--- a/apps/api/src/api/routes/sandbox-events-handler.ts
+++ b/apps/api/src/api/routes/sandbox-events-handler.ts
@@ -26,8 +26,15 @@ import {
 import {
   getThreadSandboxMap,
   removeThreadSandboxMapEntry,
+  setThreadHeadRef,
+  syntheticBranchToGitRef,
   threadIdFromBranch,
 } from "../../tools/sandbox/thread-repo";
+import {
+  pickRecordableHeadRef,
+  type DaemonHeadStatus,
+} from "../../sandbox/head-ref";
+import { readBoundedText } from "../../lib/bounded-text";
 import type { Env } from "../hono-env";
 
 /**
@@ -153,6 +160,21 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
       });
       if (!lifecycleOk || abortCtl.signal.aborted) return;
 
+      // The daemon is up: this is Studio's chance to learn which branch the
+      // sandbox is ACTUALLY on. Whoever works in there owns HEAD (the Super
+      // Agent commits on a fresh PR branch), and the next boot has to ask for
+      // that ref or it forks from the repo default and the preview serves
+      // pre-change code. Fire-and-forget — one request that must never delay or
+      // fail the stream. See `sandbox/head-ref.ts`.
+      void recordDaemonHeadRef({
+        ctx,
+        runner,
+        claimName,
+        branch,
+        threadId,
+        signal: abortCtl.signal,
+      });
+
       // ---- Phase 2: daemon SSE proxy --------------------------------------
       await proxyDaemonEvents({
         stream,
@@ -164,6 +186,61 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
       clearInterval(heartbeat);
     }
   });
+}
+
+/** Cap on the branch probe — a slow daemon must not keep a request alive. */
+const HEAD_REF_PROBE_TIMEOUT_MS = 5_000;
+/** The probe reads one small JSON object; refuse anything absurd. */
+const HEAD_REF_RESPONSE_MAX_BYTES = 256 * 1024;
+
+/**
+ * Ask the live daemon which branch it's on and persist it on the thread, so the
+ * next provision restores THAT branch instead of the derived one (which the
+ * daemon's HEAD-based shutdown push may never have created). Only for
+ * thread-scoped sandboxes — an agent-level branch is already a real ref.
+ *
+ * Best-effort by construction: every failure path is swallowed. The cost of
+ * losing it is one boot that falls back to today's behavior.
+ */
+async function recordDaemonHeadRef(args: {
+  ctx: StudioContext;
+  runner: SandboxProvider;
+  claimName: string;
+  branch: string;
+  threadId: string | null;
+  signal: AbortSignal;
+}): Promise<void> {
+  const { ctx, runner, claimName, branch, threadId, signal } = args;
+  if (!threadId || !branch.startsWith("thread:")) return;
+  try {
+    const res = await runner.proxyDaemonRequest(
+      claimName,
+      "/_sandbox/git/status",
+      {
+        method: "GET",
+        headers: new Headers({ accept: "application/json" }),
+        body: null,
+        signal: AbortSignal.any([
+          signal,
+          AbortSignal.timeout(HEAD_REF_PROBE_TIMEOUT_MS),
+        ]),
+      },
+    );
+    if (!res.ok) {
+      await res.body?.cancel().catch(() => {});
+      return;
+    }
+    const body = await readBoundedText(res, HEAD_REF_RESPONSE_MAX_BYTES);
+    const status = JSON.parse(body) as DaemonHeadStatus;
+    const headRef = pickRecordableHeadRef({
+      status,
+      requestedRef: syntheticBranchToGitRef(branch),
+    });
+    if (!headRef) return;
+    await setThreadHeadRef(ctx, threadId, headRef);
+  } catch {
+    // Daemon unreachable / bad JSON / aborted — the hint is optional.
+  }
 }
 
 async function isStaleHandle(

--- a/apps/api/src/sandbox/head-ref.test.ts
+++ b/apps/api/src/sandbox/head-ref.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { pickGitBranch, pickRecordableHeadRef } from "./head-ref";
+
+const DERIVED = "sandbox/thread-thrd_abc-conn_1";
+const SYNTHETIC = "thread:thrd_abc/conn_1";
+
+describe("pickRecordableHeadRef", () => {
+  it("records a branch that differs from the requested ref", () => {
+    expect(
+      pickRecordableHeadRef({
+        status: { current: "restore-visible-search", detached: false },
+        requestedRef: DERIVED,
+      }),
+    ).toBe("restore-visible-search");
+  });
+
+  it("skips the requested ref itself — that memory must survive a failed restore", () => {
+    // A boot that couldn't restore leaves HEAD on the derived ref. Recording it
+    // would erase the PR branch and re-break the next boot.
+    expect(
+      pickRecordableHeadRef({
+        status: { current: DERIVED, detached: false },
+        requestedRef: DERIVED,
+      }),
+    ).toBeNull();
+  });
+
+  it("skips detached HEAD, missing, empty and absent status", () => {
+    expect(
+      pickRecordableHeadRef({
+        status: { current: "abc1234", detached: true },
+        requestedRef: DERIVED,
+      }),
+    ).toBeNull();
+    expect(
+      pickRecordableHeadRef({
+        status: { current: null },
+        requestedRef: DERIVED,
+      }),
+    ).toBeNull();
+    expect(
+      pickRecordableHeadRef({ status: { current: "" }, requestedRef: DERIVED }),
+    ).toBeNull();
+    expect(
+      pickRecordableHeadRef({ status: {}, requestedRef: DERIVED }),
+    ).toBeNull();
+    expect(
+      pickRecordableHeadRef({ status: null, requestedRef: DERIVED }),
+    ).toBeNull();
+  });
+
+  it("refuses the repo default — a recorded ref is also the shutdown push target", () => {
+    // Someone runs `git checkout main` in the sandbox. Remembering that would
+    // check main out on the next boot AND aim the daemon's shutdown sync at it.
+    expect(
+      pickRecordableHeadRef({
+        status: { current: "main", detached: false, base: "main" },
+        requestedRef: DERIVED,
+      }),
+    ).toBeNull();
+    // Also refused by name when `base` is missing from the payload.
+    for (const current of ["main", "master", "trunk", "develop", "HEAD"]) {
+      expect(
+        pickRecordableHeadRef({ status: { current }, requestedRef: DERIVED }),
+      ).toBeNull();
+    }
+    // A non-conventional default is caught via `base`.
+    expect(
+      pickRecordableHeadRef({
+        status: { current: "production", base: "production" },
+        requestedRef: DERIVED,
+      }),
+    ).toBeNull();
+    // …and that same name IS recordable when it isn't the default.
+    expect(
+      pickRecordableHeadRef({
+        status: { current: "production", base: "main" },
+        requestedRef: DERIVED,
+      }),
+    ).not.toBeNull();
+  });
+
+  it("records even when nothing was requested (no ref to match)", () => {
+    expect(
+      pickRecordableHeadRef({
+        status: { current: "restore-visible-search" },
+        requestedRef: null,
+      }),
+    ).not.toBeNull();
+  });
+});
+
+describe("pickGitBranch", () => {
+  it("prefers the recorded head ref for a synthetic key when sticky", () => {
+    expect(
+      pickGitBranch({
+        branch: SYNTHETIC,
+        derivedRef: DERIVED,
+        recordedHeadRef: "restore-visible-search",
+        sticky: true,
+      }),
+    ).toBe("restore-visible-search");
+  });
+
+  it("falls back to the derived ref with the flag off — today's behavior", () => {
+    expect(
+      pickGitBranch({
+        branch: SYNTHETIC,
+        derivedRef: DERIVED,
+        recordedHeadRef: "restore-visible-search",
+        sticky: false,
+      }),
+    ).toBe(DERIVED);
+  });
+
+  it("falls back to the derived ref when nothing was recorded", () => {
+    for (const recordedHeadRef of [null, undefined, ""]) {
+      expect(
+        pickGitBranch({
+          branch: SYNTHETIC,
+          derivedRef: DERIVED,
+          recordedHeadRef,
+          sticky: true,
+        }),
+      ).toBe(DERIVED);
+    }
+  });
+
+  it("never rewrites a real (non-synthetic) branch", () => {
+    expect(
+      pickGitBranch({
+        branch: "feat/thing",
+        derivedRef: DERIVED,
+        recordedHeadRef: "restore-visible-search",
+        sticky: true,
+      }),
+    ).toBe("feat/thing");
+  });
+});

--- a/apps/api/src/sandbox/head-ref.ts
+++ b/apps/api/src/sandbox/head-ref.ts
@@ -1,0 +1,106 @@
+/**
+ * Sticky HEAD ref for thread-scoped sandboxes.
+ *
+ * A thread's sandbox boots on a DERIVED ref (`thread:<id>/<conn>` →
+ * `sandbox/thread-<id>-<conn>`, see `syntheticBranchToGitRef`). But whoever
+ * works in the sandbox owns HEAD: the Super Agent is told to commit on a NEW
+ * branch and open a PR (`enqueue-super-agent.ts`), so HEAD moves off the derived
+ * ref and the daemon's shutdown push (`entry.ts`, HEAD-based) publishes the PR
+ * branch instead. The derived ref therefore never lands on the remote, and the
+ * next boot's `ls-remote` misses it and forks from the repo default — the
+ * preview silently serves pre-change `main` while the work sits on the PR branch.
+ *
+ * Fix: remember the branch the sandbox was actually on (`metadata.headRef`) and
+ * ask the daemon for THAT on the next boot. Recorded opportunistically whenever
+ * Studio has a live daemon to ask (the events handler), read at provision time.
+ *
+ * Both decisions are pure functions so the rules are unit-testable without a
+ * daemon: an inverted comparison here would either lose the PR branch or pin the
+ * sandbox to a stale one.
+ */
+
+/** Daemon `/_sandbox/git/status` fields this module needs. */
+export interface DaemonHeadStatus {
+  /** Current branch name, or null when the daemon couldn't resolve one. */
+  current?: string | null;
+  /** True when HEAD is a bare commit — no branch to remember. */
+  detached?: boolean;
+  /** The repo's default branch, from `origin/HEAD`. */
+  base?: string | null;
+}
+
+/**
+ * Branches this must never remember, on top of the repo's own default (`base`).
+ * A recorded ref is checked out on the next boot AND becomes the target of the
+ * daemon's HEAD-based shutdown push — so remembering a shared branch would turn
+ * an idle-evicted sandbox into a push to that branch. The whole point of the
+ * derived `sandbox/thread-*` ref is that sandbox work never lands there.
+ */
+const NEVER_RECORD = new Set(["main", "master", "trunk", "develop", "HEAD"]);
+
+/**
+ * The daemon-reported HEAD worth persisting on the thread, or null.
+ *
+ * Records only a real branch that DIFFERS from the ref we asked the daemon to
+ * check out. Skipping the equal case is what makes this idempotent AND
+ * self-preserving: after a boot that failed to restore (tree forked onto the
+ * derived ref), HEAD reads back as the derived ref, and recording that would
+ * erase the memory of the PR branch and re-break the next boot.
+ *
+ * Consequence, accepted: a human who deliberately switches the sandbox BACK to
+ * the derived ref keeps the older memory and boots onto the PR branch next time.
+ * Preferring the branch that holds the work is the better failure direction.
+ *
+ * Refuses the repo default (`base`) and the {@link NEVER_RECORD} names outright:
+ * a recorded ref is both checked out on the next boot AND the branch the
+ * daemon's shutdown sync pushes, so remembering `main` would aim sandbox work at
+ * `main`.
+ */
+export function pickRecordableHeadRef(args: {
+  status: DaemonHeadStatus | null | undefined;
+  /** The ref Studio asked the daemon to check out for this sandbox. */
+  requestedRef: string | null;
+}): string | null {
+  // Destructured (not `status.current`) so the daemon's field name doesn't trip
+  // the React `ban-ref-current-assignment` lint on a plain JSON payload.
+  const { current: head, detached, base } = args.status ?? {};
+  if (typeof head !== "string" || head.length === 0) return null;
+  if (detached === true) return null;
+  if (head === args.requestedRef) return null;
+  if (NEVER_RECORD.has(head)) return null;
+  if (typeof base === "string" && base.length > 0 && head === base) return null;
+  return head;
+}
+
+/**
+ * The ref Studio asks the daemon to check out.
+ *
+ * `recordedHeadRef` wins when sticky HEAD is enabled — that's the branch the
+ * work is actually on. Everything else keeps today's behavior: the derived ref
+ * for a synthetic thread key, the branch itself for a real one.
+ */
+export function pickGitBranch(args: {
+  /** Isolation key: `thread:<id>[/<conn>]` (synthetic) or a real git ref. */
+  branch: string;
+  /** Derived ref for a synthetic key (`syntheticBranchToGitRef(branch)`). */
+  derivedRef: string;
+  /** `metadata.headRef` recorded from a live daemon, if any. */
+  recordedHeadRef: string | null | undefined;
+  /** Off → derived-ref behavior, unchanged. */
+  sticky: boolean;
+}): string {
+  const isSynthetic = args.branch.startsWith("thread:");
+  if (!isSynthetic) return args.branch;
+  if (args.sticky && args.recordedHeadRef) return args.recordedHeadRef;
+  return args.derivedRef;
+}
+
+/**
+ * Sticky HEAD is a change on the sandbox BOOT path — which branch a sandbox
+ * checks out — so it ships behind its own default-off flag rather than
+ * piggybacking on a neighbour's. Recording runs regardless, so the data is
+ * already there when this is switched on.
+ */
+export function isStickyHeadRefEnabled(): boolean {
+  return process.env.SANDBOX_STICKY_HEAD_REF === "true";
+}

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -50,10 +50,12 @@ import { PACKAGE_MANAGER_CONFIG } from "@decocms/shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import {
   getThreadGithubRepo,
+  getThreadHeadRef,
   setThreadSandboxMapEntry,
   syntheticBranchToGitRef,
   threadIdFromBranch,
 } from "./thread-repo";
+import { isStickyHeadRefEnabled, pickGitBranch } from "../../sandbox/head-ref";
 import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
 import { getSettings } from "../../settings";
 import { getPublicUrl } from "../../core/server-constants";
@@ -413,9 +415,21 @@ async function provisionSandbox(
     // isolation key (thread:*) maps to a real, deterministic ref so work is
     // persisted to git on its own branch — never the repo default. The isolation
     // key itself (projectRef, handle, sandboxMap) stays synthetic below.
-    const gitBranch = branch.startsWith("thread:")
-      ? syntheticBranchToGitRef(branch)
-      : branch;
+    //
+    // A recorded `headRef` (the branch a live daemon last reported for this
+    // thread — e.g. the PR branch the Super Agent committed on) wins over the
+    // derived ref: the derived ref may never have been pushed, in which case
+    // cloning it forks from the repo default and the preview serves pre-change
+    // code while the work sits on the PR branch. Flagged off by default.
+    const stickyHeadRef = isStickyHeadRefEnabled();
+    const gitBranch = pickGitBranch({
+      branch,
+      derivedRef: syntheticBranchToGitRef(branch),
+      recordedHeadRef: stickyHeadRef
+        ? await getThreadHeadRef(ctx, threadIdFromBranch(branch))
+        : null,
+      sticky: stickyHeadRef,
+    });
 
     // Private submodules live in repos the per-repo clone token can't reach;
     // resolve the user's per-host PATs here so they ride the initial daemon

--- a/apps/api/src/tools/sandbox/thread-repo.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.ts
@@ -91,6 +91,40 @@ async function getThreadMeta(
   return (thread.metadata as Record<string, unknown> | null) ?? {};
 }
 
+/**
+ * Read the branch the thread's sandbox was last actually on
+ * (`metadata.headRef`), or null. See `sandbox/head-ref.ts` for why the derived
+ * ref isn't enough. Never throws.
+ */
+export async function getThreadHeadRef(
+  ctx: StudioContext,
+  threadId: string | undefined | null,
+): Promise<string | null> {
+  const meta = await getThreadMeta(ctx, threadId);
+  const ref = (meta as { headRef?: unknown } | null)?.headRef;
+  return typeof ref === "string" && ref.length > 0 ? ref : null;
+}
+
+/**
+ * Persist the branch a live daemon reports for this thread's sandbox. Merged
+ * into existing metadata (never a blind overwrite — `githubRepo` and
+ * `sandboxMap` live in the same bag). No-op when the thread is gone or the ref
+ * is already recorded, so the caller can fire this on every daemon connect.
+ * Never throws: losing the hint only costs the next boot its restore.
+ */
+export async function setThreadHeadRef(
+  ctx: StudioContext,
+  threadId: string,
+  headRef: string,
+): Promise<void> {
+  const meta = await getThreadMeta(ctx, threadId);
+  if (!meta) return;
+  if (meta.headRef === headRef) return;
+  await ctx.storage.threads
+    .update(threadId, { metadata: { ...meta, headRef } })
+    .catch((err) => console.warn("[thread-repo] setThreadHeadRef failed", err));
+}
+
 /** Read the repo bound to a thread, or null. Never throws. */
 export async function getThreadGithubRepo(
   ctx: StudioContext,

--- a/packages/runtime/src/trigger-storage.test.ts
+++ b/packages/runtime/src/trigger-storage.test.ts
@@ -79,4 +79,34 @@ describe("JsonFileStorage", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("writes valid JSON under many concurrent set()/delete() calls", async () => {
+    // Two writers only interleave ~75% of the time, so the case above let the
+    // unserialized-`save()` race through as a flake. A wider fan-out makes the
+    // corrupt-file regression deterministic instead of statistical.
+    const dir = await mkdtemp(join(tmpdir(), "trigger-storage-"));
+    const path = join(dir, "state.json");
+    const storage = new JsonFileStorage({ path });
+    const ids = Array.from({ length: 12 }, (_, i) => `conn-${i}`);
+
+    try {
+      await Promise.all(ids.map((id) => storage.set(id, state(id))));
+      // Deletes share the same save() path — interleave them too.
+      await Promise.all([
+        ...ids.slice(0, 4).map((id) => storage.delete(id)),
+        ...ids.slice(4).map((id) => storage.set(id, state(`${id}-v2`))),
+      ]);
+
+      const onDisk = JSON.parse(await readFile(path, "utf-8"));
+      for (const id of ids.slice(0, 4)) {
+        expect(onDisk[id]).toBeUndefined();
+        expect(await storage.get(id)).toBeNull();
+      }
+      for (const id of ids.slice(4)) {
+        expect(onDisk[id]).toEqual(state(`${id}-v2`));
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/runtime/src/trigger-storage.ts
+++ b/packages/runtime/src/trigger-storage.ts
@@ -200,10 +200,32 @@ export class JsonFileStorage implements TriggerStorage {
     }
   }
 
-  private async save(): Promise<void> {
-    const data = Object.fromEntries(this.cache ?? new Map());
-    const fs = await import("node:fs/promises");
-    await fs.writeFile(this.path, JSON.stringify(data, null, 2));
+  // Serializes writes. The shared-load fix above kept concurrent `set()`s from
+  // clobbering each other's Map, but both still reached `save()`, and two
+  // overlapping `writeFile` calls to the same path interleave their bytes into
+  // unparseable JSON. Chaining makes each write start only after the previous
+  // one finishes.
+  private writing: Promise<void> = Promise.resolve();
+
+  private save(): Promise<void> {
+    const next = this.writing.then(async () => {
+      const fs = await import("node:fs/promises");
+      // Snapshot inside the chained callback, not before it, so a queued write
+      // persists every key committed to the cache while it waited.
+      const data = Object.fromEntries(this.cache ?? new Map());
+      // tmp + rename: rename is atomic, so a crash mid-write (or any reader,
+      // including the next boot's `load()`) never observes a half-written file —
+      // `load()` rethrows a parse error, which would take the process down.
+      // Deterministic tmp name, so a failed write leaves one stale file that the
+      // next save overwrites rather than accumulating.
+      const tmp = `${this.path}.${process.pid}.tmp`;
+      await fs.writeFile(tmp, JSON.stringify(data, null, 2));
+      await fs.rename(tmp, this.path);
+    });
+    // The chain must survive a failed write: swallow here (the caller still sees
+    // the rejection via `next`) so one ENOSPC doesn't poison every later save.
+    this.writing = next.catch(() => {});
+    return next;
   }
 
   async get(connectionId: string): Promise<TriggerState | null> {


### PR DESCRIPTION
## Problem

A Super Agent run made a change, committed it, pushed it, opened a PR — and the Preview keeps serving the **old** code. Running the branch locally shows the change; the sandbox doesn't.

Two subsystems disagree about who owns HEAD:

- `SANDBOX_START` always asks the daemon for a **derived** ref: `thread:<id>/<conn>` → `sandbox/thread-<id>-<conn>` (`start.ts`, `syntheticBranchToGitRef`).
- Whoever works in the sandbox owns HEAD. The Super Agent prompt says *"commit on a new branch, push, and open a pull request"* (`enqueue-super-agent.ts:74`), so HEAD moves off the derived ref — and the daemon's shutdown sync is HEAD-based (`entry.ts:944`, the same `publish()` as `/git/publish`), so it publishes the **PR branch**.
- The derived ref therefore never exists on the remote. Next boot, `ls-remote --exit-code` returns 2 and clone.ts takes its documented path — *"branch not on remote; cloning default and forking locally"* (`clone.ts:454`) — so the tree is **main**.

Observed on `demo-storefront` / `thrd_sUNCH2u3kuYEdSE4mb5Ca`:

- work is on `restore-visible-search` (`45da32d4`, 1 ahead of main, pushed 16:09:42Z)
- no `sandbox/thread-thrd_sUNCH…` ref among the repo's 19 branches (another thread's *is* there)
- sandbox re-provisioned at 16:32:51Z (`sandboxMap.createdAt` moved)
- the public preview HTML (527 KB, `Home Page | Storefront-tanstack`) has **zero** occurrences of `Open search` / `SEARCHBAR`, both introduced by that commit

So every reboot resets the preview to `main` while the work lives on a branch nothing checks out.

## Fix

Remember the branch the sandbox was actually on and ask for **that** next boot:

- **Record** — one `/_sandbox/git/status` probe per events connect (fire-and-forget, 5s timeout, bounded read, every failure swallowed), persisted as `threads.metadata.headRef`. Thread-scoped branches only; an agent-level branch is already a real ref.
- **Prefer** — `pickGitBranch()` at provision time: recorded `headRef` → derived ref → the branch itself.

Two guards, both tested, because a recorded ref is *also* what the daemon's shutdown sync pushes:

- **Never record the repo default** (`base` from the payload) or `main`/`master`/`trunk`/`develop`/`HEAD`. Without this, someone running `git checkout main` in a sandbox would make the next idle eviction push sandbox work to `main`.
- **Never record the requested ref.** After a boot that failed to restore, HEAD reads back as the derived ref; recording it would erase the memory of the PR branch and re-break the next boot.

## Risk / rollout

`SANDBOX_STICKY_HEAD_REF` (default **off**) gates the boot-path preference — a change to which branch a sandbox checks out doesn't get to ride in on deploy. With the flag off the only behavior delta is one extra daemon request per SSE connect plus, at most, one thread-metadata write.

Known and deliberate:

- **Not retroactive.** Nothing was recorded for the already-broken thread, and its tree has since been re-forked from main. Recovering it means checking the branch out in the sandbox (or setting `metadata.headRef` by hand).
- **`metadata` is read-modify-write**, same as the existing `setThreadSandboxMapEntry` / `load_repo` writers, so a concurrent write can still lose a key. This adds another writer on a new trigger — mitigated by the no-op-when-unchanged guard (it writes only when the branch changes), not eliminated. A jsonb-merge write path would fix the whole family and is worth doing separately.
- **Recording depends on someone opening the thread** while the sandbox is alive (that's when the events stream exists). A run nobody watches records nothing. The durable follow-up is to fall back to the linked PR's head branch — Studio already has that via the task-board PR link — which would also make the fix retroactive.

## Testing

- 9 unit tests on the two pure decisions (`pickRecordableHeadRef`, `pickGitBranch`): differing branch recorded, requested ref skipped, detached / null / empty / absent status skipped, repo default refused by `base` and by name, non-default with the same name allowed, flag-off and no-record fallbacks, real branches never rewritten.
- `bun test apps/api/src/tools/sandbox/` → 69 pass. `bun run lint` 0 errors. `bun run fmt` clean.
- `bun run --cwd=apps/api check`: no errors in the touched files. `main` currently has pre-existing zod v3/v4 `_zod.version.minor` errors elsewhere (`preferences-update.ts`, `virtual/list.ts`, `packages/shared/.../connection.ts`) — reproduced with these changes stashed; looks like stale `node_modules` after the release bump.
- **The flag-on path is untested end-to-end** — it needs a real sandbox cluster. Enable it on staging and watch a Super Agent run reboot before turning it on in prod.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandboxes rebooting to main by restoring the actual branch a thread used, so Previews serve the latest changes. Also prevents trigger storage JSON corruption under concurrent writes.

- **Bug Fixes**
  - On daemon connect, probe `/_sandbox/git/status` (fire-and-forget, 5s timeout, 256 KB cap) and save the branch to `threads.metadata.headRef`; only for `thread:*` sandboxes.
  - At provision, prefer the recorded `headRef` over the derived ref when `SANDBOX_STICKY_HEAD_REF` is true; fallback keeps current behavior. Guardrails: never record the repo default (`base`) or `main`/`master`/`trunk`/`develop`/`HEAD`, and never record the requested derived ref.
  - Runtime: serialize `JsonFileStorage` writes and use tmp+rename to avoid corrupted files when concurrent `set()`/`delete()` calls overlap; adds a 12-way stress test.

<sup>Written for commit 5941d286dbdaae222e1423aa64ec8829e0db3bbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

