### PR TITLE
fix(reports): translate the slide-progress-rail aria-label

### DIFF
--- a/apps/web/src/i18n/en/reports.ts
+++ b/apps/web/src/i18n/en/reports.ts
@@ -123,6 +123,7 @@ export const reports = {
     "What did the analysis read wrong on this slide?",
   "reports.signalDeck.feedbackThanks": "Thank you! We'll review this slide.",
   "reports.signalDeck.goToSlide": "Go to {title}",
+  "reports.signalDeck.slidesNav": "Slides",
   "reports.signalDeck.languageLabel": "Report language",
   "reports.signalDeck.linkCopied": "Link copied",
   "reports.signalDeck.measured": "{probed}/{total} measured",

--- a/apps/web/src/i18n/pt-br/reports.ts
+++ b/apps/web/src/i18n/pt-br/reports.ts
@@ -125,6 +125,7 @@ export const reports = {
     "O que a análise leu errado neste slide?",
   "reports.signalDeck.feedbackThanks": "Obrigado! Iremos revisar esse slide.",
   "reports.signalDeck.goToSlide": "Ir para {title}",
+  "reports.signalDeck.slidesNav": "Slides",
   "reports.signalDeck.languageLabel": "Idioma do relatório",
   "reports.signalDeck.linkCopied": "Link copiado",
   "reports.signalDeck.measured": "{probed}/{total} medidos",

--- a/apps/web/src/routes/reports/signal-deck.tsx
+++ b/apps/web/src/routes/reports/signal-deck.tsx
@@ -660,7 +660,7 @@ export default function SignalDeck({
         <nav
           className="absolute right-3 top-1/2 flex -translate-y-1/2 flex-col gap-1.5 transition-opacity duration-300 md:!opacity-100"
           style={{ opacity: navVisible ? 1 : 0 }}
-          aria-label="Slides"
+          aria-label={t("reports.signalDeck.slidesNav")}
         >
           {deck.slides.map((s, i) => (
             <button


### PR DESCRIPTION
**Source**: found while auditing i18n parity in the public report deck (apps/web/src/i18n/{en,pt-br}/reports.ts) — this is the same class of bug fixed by #5332 (hardcoded pt-BR label) and #5325 (English dictionary written in Portuguese), one more instance of a hardcoded, untranslated label in the same file.

**Why a maintainer wants this**: `apps/web/src/routes/reports/signal-deck.tsx` renders the public-facing report deck. Every aria-label in the file (decoHome, languageLabel, userMenuLabel, goToSlide, shareButton, methodology, reportError, previousSlide, nextSlide) goes through `t()` except the side progress-rail `<nav>`, which was hardcoded to the English string `"Slides"` — so a pt-BR screen-reader user hits one untranslated landmark label in an otherwise fully localized deck.

**Fix**: added `reports.signalDeck.slidesNav` to both `en/reports.ts` ("Slides") and `pt-br/reports.ts` ("Slides" — a common loanword in Brazilian Portuguese UI, matching how "SEO"/"Analytics" are kept as-is elsewhere in this same dictionary), and wired `aria-label={t("reports.signalDeck.slidesNav")}` into the nav element (signal-deck.tsx:663). `t` was already in scope in this component (`const t = useT()` at line 35).

**Command to confirm**: `cd apps/web && bunx tsc --noEmit` (green — the `satisfies Record<keyof typeof reportsEn, string>` constraint on the pt-br dictionary would fail to compile if a key were missing).

**Verified locally**: `bun run fmt` (no changes needed) and `cd apps/web && bunx tsc --noEmit` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the slide progress-rail navigation aria-label in the public report deck to remove a hardcoded English label and keep screen-reader landmarks consistent across languages. Added reports.signalDeck.slidesNav to en and pt-br dictionaries and used it in the nav.

<sup>Written for commit c60d91accc361ee6f20b92e07d55607b7a466f75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

