### PR TITLE
perf(e2e): 6 workers on CI + list reporter for per-spec durations

### DIFF
--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -56,15 +56,14 @@ export default defineConfig({
   // last-resort ceiling.
   globalTimeout: 30 * 60 * 1000,
   retries: process.env.CI ? 2 : 0,
-  // CI: 6 workers on the 4-core runner — the specs are HTTP-wait-heavy (they
-  // spend most of their time awaiting the API server, not burning CPU), so
-  // oversubscribing past the core count keeps the pipeline full; 4 (the old
-  // cap) left it ~5min wall, and the Postgres connection budget (each worker
-  // opens its own pg client alongside the app pool) has plenty of headroom at
-  // 6. Local: let Playwright pick (half the CPU count). Every test mints its
+  // CI: cap at 4 — measured, not folklore: 6 workers on the 4-core runner
+  // thrashed (6 chromiums + API server + vite starved each other, timeouts
+  // cascaded into retries and the run hit the 30min globalTimeout, 387s →
+  // 1879s). The specs wait on HTTP but the *server* burns the CPU they wait
+  // on. Local: let Playwright pick (half the CPU count). Every test mints its
   // own user + org with randomized slugs, so DB assertions stay tenant-scoped
   // and parallel-safe.
-  workers: process.env.CI ? 6 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   // `list` on CI so the job log shows per-spec durations — that's how fat
   // specs get found (the html report isn't uploaded anywhere).
   reporter: process.env.CI

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -56,12 +56,20 @@ export default defineConfig({
   // last-resort ceiling.
   globalTimeout: 30 * 60 * 1000,
   retries: process.env.CI ? 2 : 0,
-  // CI: cap at 4 to keep host CPU + the Postgres connection budget predictable
-  // (each worker opens its own pg client alongside the app pool). Local: let
-  // Playwright pick (half the CPU count). Every test mints its own user + org
-  // with randomized slugs, so DB assertions stay tenant-scoped and parallel-safe.
-  workers: process.env.CI ? 4 : undefined,
-  reporter: [["html", { open: "never" }]],
+  // CI: 6 workers on the 4-core runner — the specs are HTTP-wait-heavy (they
+  // spend most of their time awaiting the API server, not burning CPU), so
+  // oversubscribing past the core count keeps the pipeline full; 4 (the old
+  // cap) left it ~5min wall, and the Postgres connection budget (each worker
+  // opens its own pg client alongside the app pool) has plenty of headroom at
+  // 6. Local: let Playwright pick (half the CPU count). Every test mints its
+  // own user + org with randomized slugs, so DB assertions stay tenant-scoped
+  // and parallel-safe.
+  workers: process.env.CI ? 6 : undefined,
+  // `list` on CI so the job log shows per-spec durations — that's how fat
+  // specs get found (the html report isn't uploaded anywhere).
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["html", { open: "never" }]],
   use: {
     baseURL: appOrigin,
     trace: "on-first-retry",


### PR DESCRIPTION
## Summary

Step 1 of attacking the e2e job — at **387s** it's now 3.5x anything else on a PR's critical path. Breakdown from run [30376542646](https://github.com/decocms/studio/actions/runs/30376542646): setup ~70s, webServer boot ~17s, then **~4m50s running 180 specs with `workers: 4`** (= the runner's core count, shared with the API server + vite + chromium).

Two one-line changes:

- **`workers: 4 → 6` on CI.** The specs are HTTP-wait-heavy — they spend most wall time awaiting API responses, not burning CPU — so oversubscribing past the core count keeps the pipeline full. The Postgres connection budget the old cap guarded (one pg client per worker + the app pool) has ample headroom at 6 against postgres:16's default 100 connections.
- **`list` reporter on CI** (html stays for local). The job log showed zero per-spec timings, so fat specs were invisible — one spams `[thread-gate] link work publish failed` retries for ~2.5min of the run. With durations in the log, the next optimization pass can name its targets instead of guessing.

## Measurement

This PR touches `packages/e2e`, so the e2e workflow runs here — its wall time against the 387s baseline is the experiment. If 6 workers thrash (CPU-bound after all), expect flat-or-worse and we revert to 4; the follow-up then is sharding 2× with an aggregator job keeping the required-check name.

## Testing notes

- `tsc --noEmit` clean on `packages/e2e`; `bun run fmt` applied.
- Behavior change is CI-only (`process.env.CI` guards both); local stays half-cores + html reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `list` reporter on CI to show per-spec durations, and keep Playwright workers at 4 after measuring that 6 slowed runs and caused timeouts. CI-only; local behavior stays the same.

- **Performance**
  - CI workers: stay at 4; 6 thrashed the 4-core runner and regressed runtime.
  - CI reporter: add `list` for per-spec durations; keep `html` (no auto-open).

<sup>Written for commit 03ac0707b78e4cbf9f69c2cd19f7b865151d51f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

