### PR TITLE
fix(sandbox-proxy): raise proxied body/response cap to 20MB

### DIFF
--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -97,11 +97,11 @@ const PREVIEW_INVOKE_MAX_BODY_BYTES = 64 * 1024;
  * Every route below that passes `forwardJsonBody: true` has its body read
  * fully into memory via `c.req.text()` in `proxyDaemon` before being
  * forwarded to the daemon — unlike suggest-commit/judge-review/preview-invoke
- * above, they had no size cap at all. 10MB comfortably covers any real source
+ * above, they had no size cap at all. 20MB comfortably covers any real source
  * file or git payload while bounding how much an oversized/malicious request
  * can buffer.
  */
-const FORWARDED_BODY_MAX_BYTES = 10 * 1024 * 1024;
+const FORWARDED_BODY_MAX_BYTES = 20 * 1024 * 1024;
 
 const forwardedBodyLimit = bodyLimit({
   maxSize: FORWARDED_BODY_MAX_BYTES,


### PR DESCRIPTION
Follow-up to #5330 — bumps `FORWARDED_BODY_MAX_BYTES` from 10MB to 20MB.

That constant bounds both sides of the sandbox-proxy routes: the `forwardedBodyLimit` on incoming client bodies and the `readBoundedText` cap on daemon/preview responses. 10MB was tripping on legitimate payloads (large `git diff`s, chatty exec stdout, big preview pages); 20MB still bounds memory per in-flight request.

No other change — the cap is a single constant, tests are unaffected.

**Verified:** `bun test apps/api/src/api/routes/sandbox-proxy.test.ts` (10 pass), `bun run fmt`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the sandbox-proxy cap from 10MB to 20MB for both incoming request bodies and daemon/preview responses to stop valid large payloads from being rejected while keeping per-request memory bounded.

<sup>Written for commit 5a6f2192daaafb79448329115de69d466249fe9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

