### PR TITLE
perf(e2e): serve the production web build + shard the suite 2x

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -191,12 +191,26 @@ jobs:
       - name: Run database migrations
         run: bun run migrate
 
+      # The e2e web build (~70s) is pure function of these inputs — cache the
+      # dist so each shard serves it instead of rebuilding. Exact-match only
+      # (no restore-keys): a stale dist must never be served, so any input
+      # change falls back to a full build. Key includes apps/api/package.json
+      # because __STUDIO_VERSION__ is baked from its version field.
+      - name: Cache web production build
+        id: cache-web-dist
+        uses: actions/cache@v4
+        with:
+          path: apps/web/dist
+          key: web-dist-e2e-${{ runner.os }}-${{ hashFiles('apps/web/src/**', 'apps/web/index.html', 'apps/web/vite.config.ts', 'apps/web/package.json', 'apps/web/tsconfig.json', 'packages/ui/src/**', 'packages/shared/src/**', 'packages/bindings/src/**', 'apps/api/package.json', 'bun.lock') }}
+
       - name: Run e2e tests
         # The suite lives in packages/e2e; its Playwright config spawns the API
         # from apps/api and the web app from apps/web via separate webServer
         # entries. DB/NATS/S3 env are job-level, so both inherit them. Each
         # shard runs its half of the specs against its own full stack.
         working-directory: packages/e2e
+        env:
+          E2E_SKIP_WEB_BUILD: ${{ steps.cache-web-dist.outputs.cache-hit == 'true' && '1' || '' }}
         run: bun run test:e2e --shard=${{ matrix.shard }}/2
 
   # Aggregator carrying the required-check name: branch protection requires a

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,10 +64,17 @@ jobs:
           done <<< "$FILES"
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
 
-  e2e:
+  e2e-shard:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
+    # Backstop above playwright's own 30min globalTimeout so its report wins.
+    timeout-minutes: 35
+    strategy:
+      # One slow/broken shard shouldn't hide the other's result.
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     defaults:
       run:
         working-directory: apps/api
@@ -186,7 +193,25 @@ jobs:
 
       - name: Run e2e tests
         # The suite lives in packages/e2e; its Playwright config spawns the API
-        # from apps/api and Vite from apps/web via separate webServer entries.
-        # DB/NATS/S3 env are job-level, so both inherit them.
+        # from apps/api and the web app from apps/web via separate webServer
+        # entries. DB/NATS/S3 env are job-level, so both inherit them. Each
+        # shard runs its half of the specs against its own full stack.
         working-directory: packages/e2e
-        run: bun run test:e2e
+        run: bun run test:e2e --shard=${{ matrix.shard }}/2
+
+  # Aggregator carrying the required-check name: branch protection requires a
+  # check called "e2e", and matrix jobs report as "e2e-shard (1)"/"(2)" — a
+  # renamed required check would block merges forever. This job is the one
+  # the protection rule sees; skipped shards (docs-only PRs) count as pass,
+  # same as the changes-gate semantics everywhere else.
+  e2e:
+    needs: [changes, e2e-shard]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify shard results
+        run: |
+          case "${{ needs.e2e-shard.result }}" in
+            success|skipped) echo "shards: ${{ needs.e2e-shard.result }}"; exit 0 ;;
+            *) echo "shards: ${{ needs.e2e-shard.result }}"; exit 1 ;;
+          esac

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
+    "preview": "vite preview",
     "build": "bun --bun vite build",
     "check": "tsc --noEmit",
     "test": "bun test src test",

--- a/apps/web/src/globals.d.ts
+++ b/apps/web/src/globals.d.ts
@@ -1,4 +1,5 @@
 declare const __STUDIO_VERSION__: string;
+declare const __E2E_TEST_HOOKS__: boolean;
 
 declare module "*?raw" {
   const content: string;

--- a/apps/web/src/layouts/main-panel-tabs/index.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/index.tsx
@@ -59,10 +59,11 @@ function TabBody({
 }) {
   // Test hook: e2e tests set window.__forceTabError = <activeTab> to deliberately
   // crash the active tab and exercise the ErrorBoundary recovery flow.
-  // Dev-only — the guard ensures this code path is dead-stripped in production
-  // builds (Vite tree-shakes blocks guarded by `import.meta.env.DEV`).
+  // Dead-stripped from real production builds; alive in dev and in the e2e
+  // build (which serves the prod bundle via vite preview — see
+  // packages/e2e/playwright.config.ts) through the E2E_TEST_HOOKS define.
   if (
-    import.meta.env.DEV &&
+    (import.meta.env.DEV || __E2E_TEST_HOOKS__) &&
     typeof window !== "undefined" &&
     (window as unknown as { __forceTabError?: string }).__forceTabError ===
       activeTab

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -16,6 +16,46 @@ const bunServerTarget = `http://localhost:${process.env.PORT || "3000"}`;
 // swallow pull-dispatch work items (e2e: link-proxy.spec.ts,
 // link-dispatch-pull.spec.ts).
 
+// Shared by the dev server AND `vite preview`: e2e serves the production
+// build through preview, and its readiness probe + every spec reach the API
+// through these routes. Both run under Node (see the Bun warning above —
+// preview uses the same http-proxy and needs the same "close" propagation).
+const sharedProxy = {
+  "/api": {
+    target: bunServerTarget,
+    changeOrigin: false,
+    ws: true,
+  },
+  "/mcp": {
+    target: bunServerTarget,
+    changeOrigin: false,
+    ws: true,
+  },
+  "/oauth-proxy": {
+    target: bunServerTarget,
+    changeOrigin: false,
+    ws: true,
+  },
+  "/.well-known": {
+    target: bunServerTarget,
+    changeOrigin: false,
+    ws: true,
+  },
+  "/org": {
+    target: bunServerTarget,
+    changeOrigin: false,
+    ws: true,
+  },
+  "/health": {
+    target: bunServerTarget,
+    changeOrigin: false,
+  },
+  "/metrics": {
+    target: bunServerTarget,
+    changeOrigin: false,
+  },
+};
+
 export default defineConfig({
   define: {
     __STUDIO_VERSION__: JSON.stringify(pkg.version),
@@ -35,41 +75,12 @@ export default defineConfig({
       host: "localhost",
       clientPort: parseInt(process.env.VITE_PORT || "4000", 10),
     },
-    proxy: {
-      "/api": {
-        target: bunServerTarget,
-        changeOrigin: false,
-        ws: true,
-      },
-      "/mcp": {
-        target: bunServerTarget,
-        changeOrigin: false,
-        ws: true,
-      },
-      "/oauth-proxy": {
-        target: bunServerTarget,
-        changeOrigin: false,
-        ws: true,
-      },
-      "/.well-known": {
-        target: bunServerTarget,
-        changeOrigin: false,
-        ws: true,
-      },
-      "/org": {
-        target: bunServerTarget,
-        changeOrigin: false,
-        ws: true,
-      },
-      "/health": {
-        target: bunServerTarget,
-        changeOrigin: false,
-      },
-      "/metrics": {
-        target: bunServerTarget,
-        changeOrigin: false,
-      },
-    },
+    proxy: sharedProxy,
+  },
+  preview: {
+    port: parseInt(process.env.VITE_PORT || "4000", 10),
+    strictPort: true,
+    proxy: sharedProxy,
   },
   clearScreen: false,
   logLevel: "warn",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -59,6 +59,9 @@ const sharedProxy = {
 export default defineConfig({
   define: {
     __STUDIO_VERSION__: JSON.stringify(pkg.version),
+    // Build-time constant so e2e-only hooks (window.__forceTabError) survive
+    // the e2e production build but stay dead-stripped from real prod builds.
+    __E2E_TEST_HOOKS__: JSON.stringify(process.env.E2E_TEST_HOOKS === "1"),
   },
   build: {
     outDir: "dist",

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -43,7 +43,14 @@ const commerceMockKey = "e2e-commerce-key";
 const vaultServiceToken = "e2e-vault-service-token";
 
 const apiServerCommand = `MCP_CACHE_ENABLED=true VAULT_SERVICE_TOKEN=${vaultServiceToken} REPORTS_INTERNAL_API_URL=${commerceMockOrigin} REPORTS_INTERNAL_API_KEY=${commerceMockKey} BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} RUN_IDLE_TIMEOUT_MS=120000 DEPLOYMENT_ADMIN_EMAILS=deployment-admin@e2e.local,deployment-admin-2@e2e.local bun run dev`;
-const webServerCommand = `BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run dev`;
+// CI serves the PRODUCTION build via `vite preview` (same Node proxy as dev —
+// see apps/web/vite.config.ts): the suite's charter is production-like
+// behavior, and the dev server's on-demand transform inflated browser-heavy
+// specs (chat-input-draft's four tests alone cost 51-60s each against cold
+// Vite). Local keeps the dev server for iteration speed.
+const webServerCommand = process.env.CI
+  ? `bun run build && BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run preview`
+  : `BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run dev`;
 
 export default defineConfig({
   testDir: "./tests",

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -48,8 +48,15 @@ const apiServerCommand = `MCP_CACHE_ENABLED=true VAULT_SERVICE_TOKEN=${vaultServ
 // behavior, and the dev server's on-demand transform inflated browser-heavy
 // specs (chat-input-draft's four tests alone cost 51-60s each against cold
 // Vite). Local keeps the dev server for iteration speed.
+// E2E_SKIP_WEB_BUILD=1 is set by the workflow when apps/web/dist was
+// restored from the input-hash cache — serving a stale dist is prevented by
+// the cache key (exact-match only), not by anything here.
+const webBuildStep =
+  process.env.E2E_SKIP_WEB_BUILD === "1"
+    ? ""
+    : "E2E_TEST_HOOKS=1 bun run build && ";
 const webServerCommand = process.env.CI
-  ? `E2E_TEST_HOOKS=1 bun run build && BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run preview`
+  ? `${webBuildStep}BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run preview`
   : `BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run dev`;
 
 export default defineConfig({

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -49,7 +49,7 @@ const apiServerCommand = `MCP_CACHE_ENABLED=true VAULT_SERVICE_TOKEN=${vaultServ
 // specs (chat-input-draft's four tests alone cost 51-60s each against cold
 // Vite). Local keeps the dev server for iteration speed.
 const webServerCommand = process.env.CI
-  ? `bun run build && BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run preview`
+  ? `E2E_TEST_HOOKS=1 bun run build && BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run preview`
   : `BASE_URL=${appOrigin} PORT=${serverPort} VITE_PORT=${appPort} bun run dev`;
 
 export default defineConfig({
@@ -68,7 +68,11 @@ export default defineConfig({
   // Playwright pick (half the CPU count). Every test mints its own user + org
   // with randomized slugs, so DB assertions stay tenant-scoped and parallel-safe.
   workers: process.env.CI ? 4 : undefined,
-  reporter: [["html", { open: "never" }]],
+  // `list` on CI so the job log shows per-spec durations — that's how fat
+  // specs get found (the html report isn't uploaded anywhere).
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["html", { open: "never" }]],
   use: {
     baseURL: appOrigin,
     trace: "on-first-retry",


### PR DESCRIPTION
## Summary

Step 2 on the e2e job (374s baseline, the critical path of every PR). Two structural changes:

**1. CI serves the production web build.** The web `webServer` becomes `bun run build && vite preview` on CI (local keeps the dev server for iteration). Rationale:
- The suite's charter is **production-like behavior** — it already re-enables the MCP cache for exactly that reason; testing the prod bundle is more faithful, not less.
- Dev-mode on-demand transform was the dominant cost of browser-heavy specs: `chat-input-draft`'s four tests cost **51–60s each** against cold Vite (per-spec durations from the new list reporter, [run breakdown](https://github.com/decocms/studio/pull/5352)).
- `vite.config.ts` gains a `preview` block sharing the dev server's proxy table (extracted to `sharedProxy`) — the readiness probe and every spec reach the API through those routes. Preview runs under **Node**, same as dev, for the http-proxy close-event reason documented in that file's header.

**2. Shard 2×.** `strategy.matrix.shard: [1, 2]`, each running `--shard=N/2` against its own full stack (building the web app in-shard is cheaper than any cross-job artifact plumbing — parallel 69s beats serialized wait+download).

⚠️ **Required-check safety:** branch protection requires a check literally named `e2e`; matrix jobs report as `e2e-shard (N)`. An **aggregator job named `e2e`** carries the name — passes on shards `success` or `skipped` (docs-only PRs keep the changes-gate semantics), fails otherwise. No branch-protection change needed.

## Expected

Setup ~70s + build ~69s + half the specs. If prod-serve meaningfully cuts the browser-heavy specs, each shard lands well under 3min wall. This PR touches `packages/e2e` + `apps/web`, so the sharded workflow validates itself here — real numbers on this PR's run.

## Testing notes

- `vite preview` smoke-tested locally: serves the built SPA (200) and engages the proxy routes.
- `tsc` clean on apps/web + packages/e2e; `bun run check` green; YAML validated.
- Kill-switch: revert = 1-line webServerCommand change + matrix removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the production web build in CI e2e, shard the suite 2×, and cache the built `apps/web/dist` between shards to cut wall time and better match production. Adds an aggregator `e2e` check to keep branch protection unchanged.

- **Refactors**
  - CI runs the web app with `bun run build && bun run preview` via `vite preview`; local e2e keeps `dev`. Adds a `__E2E_TEST_HOOKS__` define (enabled only in CI e2e) so the tab error test hook survives the prod build.
  - Added a `preview` script and a `preview` block in `apps/web/vite.config.ts`, extracting a shared proxy used by both dev and preview.
  - Sharded the job into `[1, 2]` using `--shard=N/2`, with `fail-fast: false` and a 35‑minute timeout; each shard reuses a cached `dist` on exact input‑hash match, otherwise builds.
  - Introduced an aggregator job named `e2e` that passes when shards succeed or are skipped; CI uses Playwright’s `list` reporter for per‑spec durations.

<sup>Written for commit 66db1daedba3b7353dfd0fb380ff07b492897894. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

