### PR TITLE
fix(harness): label the Claude Code thinking tier Opus 5 1M

### DIFF
--- a/apps/web/src/components/chat/use-agent-mode.test.ts
+++ b/apps/web/src/components/chat/use-agent-mode.test.ts
@@ -45,10 +45,10 @@ describe("resolveTierSubtitle", () => {
         resolveTierSubtitle("local-claude-code", "smart", explodingT),
       ).toBe("Sonnet 5");
     });
-    it("thinking → Opus 4.8 1M", () => {
+    it("thinking → Opus 5 1M", () => {
       expect(
         resolveTierSubtitle("local-claude-code", "thinking", explodingT),
-      ).toBe("Opus 4.8 1M");
+      ).toBe("Opus 5 1M");
     });
   });
 

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -24,7 +24,7 @@ export const chat = {
   "chat.agentModels.gptSolLabel": "GPT-5.6 Sol",
   "chat.agentModels.gptTerraLabel": "GPT-5.6 Terra",
   "chat.agentModels.haikuLabel": "Haiku 4.5",
-  "chat.agentModels.opusLabel": "Opus 4.8 1M",
+  "chat.agentModels.opusLabel": "Opus 5 1M",
   "chat.agentModels.quickerResponses": "Quicker responses",
   "chat.agentModels.sonnetLabel": "Sonnet 5",
   "chat.approval.acceptButton": "Accept",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -27,7 +27,7 @@ export const chat = {
   "chat.agentModels.gptSolLabel": "GPT-5.6 Sol",
   "chat.agentModels.gptTerraLabel": "GPT-5.6 Terra",
   "chat.agentModels.haikuLabel": "Haiku 4.5",
-  "chat.agentModels.opusLabel": "Opus 4.8 1M",
+  "chat.agentModels.opusLabel": "Opus 5 1M",
   "chat.agentModels.quickerResponses": "Respostas mais rápidas",
   "chat.agentModels.sonnetLabel": "Sonnet 5",
   "chat.approval.acceptButton": "Aceitar",

--- a/packages/harness/src/claude-code/model/agent-tiers.ts
+++ b/packages/harness/src/claude-code/model/agent-tiers.ts
@@ -20,7 +20,7 @@ export type AgentTierMap = Record<ChatTier, AgentTierEntry>;
 const CLAUDE_CODE_TIERS: AgentTierMap = {
   fast: { modelId: "claude-code:haiku", label: "Haiku 4.5" },
   smart: { modelId: "claude-code:sonnet", label: "Sonnet 5" },
-  thinking: { modelId: "claude-code:opus-1m", label: "Opus 4.8 1M" },
+  thinking: { modelId: "claude-code:opus-1m", label: "Opus 5 1M" },
 };
 
 const CODEX_TIERS: AgentTierMap = {

--- a/packages/harness/src/claude-code/model/index.ts
+++ b/packages/harness/src/claude-code/model/index.ts
@@ -103,9 +103,9 @@ export function createClaudeCodeModel(
  * NOTE: The ai-sdk-provider-claude-code SDK only recognises the short aliases
  * "opus", "sonnet", and "haiku". Any other string is passed straight through to
  * the CLI's --model flag. For models not covered by a short alias (Fable 5,
- * Sonnet 5, Opus 4.8 1M) we therefore use the full CLI model ID so the CLI can
+ * Sonnet 5, Opus 5 1M) we therefore use the full CLI model ID so the CLI can
  * resolve it correctly. For example, Sonnet 5 uses `claude-sonnet-5`, while
- * Opus 4.8 with 1M context uses `opus[1m]`.
+ * Opus 5 with 1M context uses `opus[1m]`.
  */
 const CLAUDE_CODE_SDK_MODELS: Record<string, string> = {
   "claude-code:opus": "opus",

--- a/packages/shared/src/models/claude-code-models.ts
+++ b/packages/shared/src/models/claude-code-models.ts
@@ -34,7 +34,7 @@ export const CLAUDE_CODE_MODELS: ModelInfo[] = [
   {
     providerId: "claude-code",
     modelId: "claude-code:opus-1m",
-    title: "Claude Code Opus 4.8 1M",
+    title: "Claude Code Opus 5 1M",
     description: "Most capable, 1M context window",
     capabilities: ["text", "reasoning"],
     limits: { contextWindow: 1_000_000, maxOutputTokens: null },


### PR DESCRIPTION
## Summary

The Claude Code thinking tier is labelled **Opus 4.8 1M**, but nothing is pinned to 4.8.

`resolve_claude_model_id` maps `claude-code:opus-1m` to the SDK alias `opus[1m]`, and the note above it explains why: *"the SDK only recognises the short aliases opus/sonnet/haiku."* The CLI resolves that alias to whatever the current Opus is — so the harness has been running Opus 5 while the UI said 4.8.

`sonnet` was already relabelled "Sonnet 5" at some point; `opus` was missed.

**Label only.** Model ids, SDK aliases, and resolution are untouched — no behaviour change.

## Affected areas

- `packages/harness` — tier map + the doc comment explaining alias resolution
- `packages/shared` — the `CLAUDE_CODE_MODELS` catalog title
- `apps/web` — `chat.agentModels.opusLabel` (en + pt-br) and the test asserting it

## Testing

- `bun run check` clean
- `use-agent-mode` tier-label tests updated and passing (the test encoded the old label, so it was inverted rather than appended to)

## Not included

- `anthropic/claude-opus-4.8` in `decopilot.tsx` / `default-model.ts` — those are real provider model ids resolved against an org's configured catalog, not Claude Code. Changing them needs the 5.0 id to exist upstream; separate call.
- `release-feed.ts` — historical changelog entries announcing the 4.8 rollout. Rewriting those would falsify the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Claude Code thinking tier label from "Opus 4.8 1M" to "Opus 5 1M" so the UI matches the harness, which resolves `claude-code:opus-1m` via `opus[1m]` to the current Opus. Label only; no model IDs, SDK aliases, or behavior changed.

<sup>Written for commit 18aa9eeed8f2adb73974fadf84a21da9036bae0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

