### PR TITLE
ci: group checks by domain — docker-smoke moves under the Sandbox workflow

### DIFF
--- a/.github/workflows/sandbox-daemon.yml
+++ b/.github/workflows/sandbox-daemon.yml
@@ -1,4 +1,4 @@
-name: Sandbox Daemon E2E
+name: Sandbox
 
 # packages/sandbox/daemon/daemon.e2e.test.ts spawns the built daemon binary
 # and exercises real HTTP/SSE endpoints — it's an integration test that
@@ -93,3 +93,48 @@ jobs:
         # All daemon e2e specs end in `.e2e.test.ts` (core + git + proxy +
         # dispatch); the helpers file is `.e2e.helpers.ts` and is not matched.
         run: bun test packages/sandbox/daemon/daemon*.e2e.test.ts
+
+  docker-smoke:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun and install dependencies
+        uses: ./.github/actions/setup-bun
+
+      - name: Build daemon bundle
+        run: bun run --cwd=packages/sandbox build
+
+      - name: Build sandbox image
+        run: |
+          docker build \
+            -t studio-sandbox:ci \
+            -f packages/sandbox/image/Dockerfile \
+            packages/sandbox
+
+      - name: Smoke test
+        run: |
+          docker run -d --name sandbox-smoke -p 19999:9000 \
+            -e DAEMON_TOKEN="$(printf 't%.0s' {1..32})" \
+            -e DAEMON_BOOT_ID="ci-smoke" \
+            -e APP_ROOT=/app \
+            -e PROXY_PORT=9000 \
+            -e DAEMON_NO_AUTOSTART=1 \
+            studio-sandbox:ci
+          for _ in $(seq 1 30); do
+            if curl -fsS http://localhost:19999/health | grep -q '"bootId":"ci-smoke"'; then
+              echo "ok"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "smoke test failed — daemon did not return /health with ci-smoke bootId"
+          docker logs sandbox-smoke
+          exit 1
+
+      - name: Tear down
+        if: always()
+        run: docker rm -f sandbox-smoke || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,15 +29,10 @@ jobs:
   # `paths` filters — a never-scheduled required check blocks the merge forever.
   # A job skipped via `if`, by contrast, reports as passed. So we keep the
   # trigger broad and skip at the job level. Pushes to main always run.
-  #
-  # `sandbox` additionally scopes docker-smoke: the job only exercises the
-  # sandbox daemon bundle + image, so it's skipped unless the PR touches the
-  # packages that feed that build.
   changes:
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
-      sandbox: ${{ steps.filter.outputs.sandbox }}
       web: ${{ steps.filter.outputs.web }}
     steps:
       - name: Detect relevant changes
@@ -53,12 +48,10 @@ jobs:
             case "$HEAD_MSG" in
               '[release]:'*)
                 echo "relevant=false" >> "$GITHUB_OUTPUT"
-                echo "sandbox=false" >> "$GITHUB_OUTPUT"
                 echo "web=false" >> "$GITHUB_OUTPUT"
                 ;;
               *)
                 echo "relevant=true" >> "$GITHUB_OUTPUT"
-                echo "sandbox=true" >> "$GITHUB_OUTPUT"
                 echo "web=true" >> "$GITHUB_OUTPUT"
                 ;;
             esac
@@ -70,16 +63,14 @@ jobs:
             --jq '.[].filename'); then
             echo "Could not list PR files — running to be safe."
             echo "relevant=true" >> "$GITHUB_OUTPUT"
-            echo "sandbox=true" >> "$GITHUB_OUTPUT"
             echo "web=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "Changed files:"; echo "$FILES"
           # relevant: run unless every changed file is workflow/docs/markdown.
-          # sandbox: run docker-smoke only when the sandbox build's inputs
-          # change (the daemon bundle pulls in typegen, shared, and harness).
+          # web: gate for web-component-tests (browser tests only when web
+          # code can be affected).
           relevant=false
-          sandbox=false
           web=false
           while IFS= read -r f; do
             [ -z "$f" ] && continue
@@ -88,14 +79,10 @@ jobs:
               *) relevant=true ;;
             esac
             case "$f" in
-              packages/sandbox/*|packages/typegen/*|packages/shared/*|packages/harness/*) sandbox=true ;;
-            esac
-            case "$f" in
               apps/web/*|packages/ui/*) web=true ;;
             esac
           done <<< "$FILES"
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
-          echo "sandbox=$sandbox" >> "$GITHUB_OUTPUT"
           echo "web=$web" >> "$GITHUB_OUTPUT"
 
   format:
@@ -198,55 +185,10 @@ jobs:
       - name: Verify web output
         run: test -f apps/web/dist/index.html
 
-  docker-smoke:
-    needs: changes
-    if: needs.changes.outputs.sandbox == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Bun and install dependencies
-        uses: ./.github/actions/setup-bun
-
-      - name: Build daemon bundle
-        run: bun run --cwd=packages/sandbox build
-
-      - name: Build sandbox image
-        run: |
-          docker build \
-            -t studio-sandbox:ci \
-            -f packages/sandbox/image/Dockerfile \
-            packages/sandbox
-
-      - name: Smoke test
-        run: |
-          docker run -d --name sandbox-smoke -p 19999:9000 \
-            -e DAEMON_TOKEN="$(printf 't%.0s' {1..32})" \
-            -e DAEMON_BOOT_ID="ci-smoke" \
-            -e APP_ROOT=/app \
-            -e PROXY_PORT=9000 \
-            -e DAEMON_NO_AUTOSTART=1 \
-            studio-sandbox:ci
-          for _ in $(seq 1 30); do
-            if curl -fsS http://localhost:19999/health | grep -q '"bootId":"ci-smoke"'; then
-              echo "ok"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "smoke test failed — daemon did not return /health with ci-smoke bootId"
-          docker logs sandbox-smoke
-          exit 1
-
-      - name: Tear down
-        if: always()
-        run: docker rm -f sandbox-smoke || true
-
   # Playwright component tests for the sections-editor field widgets
   # (apps/web/ct). Self-contained — real chromium, no server/DB — so it lives
   # here rather than e2e.yml, gated to web changes only.
-  component-tests:
+  web-component-tests:
     needs: changes
     if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Makes domain membership readable at a glance in the PR checks UI **without renaming any required check** (that would need a coordinated branch-protection edit — deliberately avoided; every required context keeps its exact name):

- **`docker-smoke` moves verbatim into `sandbox-daemon.yml`, renamed `Sandbox`** — the checks UI groups by workflow, so it now reads `Sandbox / docker-smoke` and `Sandbox / daemon-e2e`. A skip on a web-only PR explains itself. The job inherits that workflow's sandbox-scoped `changes` gate (same path set as the `sandbox` output it used in test.yml, which is removed as orphaned).
- **`component-tests` → `web-component-tests`** — not yet a required check, so the rename is free.

## If you want full domain prefixes later

Renaming the required checks themselves (`sandbox/docker-smoke`, `api/storage-integration`, …) is a one-motion admin task: merge the rename PR and update the ruleset's required-check contexts immediately after. Flagged as opt-in — the workflow-grouping approach here gets most of the readability for none of the risk.

## Testing notes

- YAML validated; required-check names verified unchanged: `lint, format, typecheck, test, build, docker-smoke, e2e, storage-integration, daemon-e2e`.
- `.github/**`-only PR — gates skip the suite here; the grouping is visible on the next code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups CI checks by domain in the GitHub UI without changing any required check names. `docker-smoke` now runs under the `Sandbox` workflow for clearer “Sandbox / …” grouping.

- **Refactors**
  - Renamed workflow to `Sandbox` and moved `docker-smoke` into it; checks show `Sandbox / docker-smoke` and `Sandbox / daemon-e2e`.
  - Gated `docker-smoke` with the workflow’s sandbox-scoped `changes`; removed the old `sandbox` output and job from `test.yml`.
  - Renamed `component-tests` to `web-component-tests` (not required).
  - Kept all required check contexts unchanged to avoid branch-protection updates.

<sup>Written for commit c11bb30c904c3b32b0159b8c29ca0dcb22228b88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

