### PR TITLE
fix(sections-editor): narrow to inline-union field owning a drilled array item

### DIFF
--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -398,6 +398,121 @@ describe("resolveActiveFieldKey", () => {
       ),
     ).toBe("flags");
   });
+
+  describe("inline-union branch drill-down", () => {
+    // `searchProps` is an "A or B" plain-data union; its "Busca avançada" branch
+    // holds a `selectedFacets: Facet[]`. Drilling into a Facet writes a bare
+    // ["Facet"] trail (the union's own label never enters it), so the section
+    // must still narrow to `searchProps` instead of showing every sibling prop.
+    const properties = {
+      searchProps: {
+        title: "Parâmetros de busca",
+        type: "inline-union",
+        inlineUnionBranches: [
+          {
+            title: "Busca avançada",
+            discriminators: { type: "advanced" },
+            schema: {
+              type: "object",
+              properties: {
+                term: { type: "string", title: "Termo de busca" },
+                selectedFacets: {
+                  title: "Filtros base",
+                  type: "array",
+                  items: {
+                    type: "object",
+                    title: "Facet",
+                    properties: {
+                      key: { type: "string", title: "Chave do facet" },
+                      value: { type: "string", title: "Valor do facet" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          {
+            title: "ID de coleção",
+            discriminators: { type: "cluster" },
+            schema: {
+              type: "object",
+              properties: { clusterId: { type: "string", title: "Cluster" } },
+            },
+          },
+        ],
+      },
+      titlesSEOPLPs: {
+        title: "Títulos e textos SEO (PLP)",
+        type: "array",
+        items: { type: "object", properties: { label: { type: "string" } } },
+      },
+      floatingControls: { title: "Controles flutuantes", type: "boolean" },
+    } as Record<string, SchemaProperty>;
+
+    test("narrows to the union field whose selected branch owns the item", () => {
+      // Empty facet ({}) → label falls back to the item schema title "Facet".
+      const objValue = {
+        searchProps: { type: "advanced", selectedFacets: [{}] },
+        titlesSEOPLPs: [],
+        floatingControls: true,
+      };
+      expect(
+        resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+          "Facet",
+        ]),
+      ).toBe("searchProps");
+    });
+
+    test("resolves via the union's own label crumb (viaLabel path)", () => {
+      // Trail led by the union field's label — the drill kept it as a
+      // disambiguator. Must resolve through the `labelsMatch(head, label)` +
+      // slice(1) branch of the inline-union loop, not the direct one.
+      const objValue = {
+        searchProps: { type: "advanced", selectedFacets: [{}] },
+        titlesSEOPLPs: [],
+        floatingControls: true,
+      };
+      expect(
+        resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+          "Parâmetros de busca",
+          "Facet",
+        ]),
+      ).toBe("searchProps");
+    });
+
+    test("does not narrow off an inactive branch's schema", () => {
+      // The "cluster" branch is active (no `selectedFacets` in the value). A
+      // "Facet" crumb — a field only the inactive "advanced" branch declares —
+      // must NOT spuriously narrow to searchProps: the match is gated by the
+      // union value's actual data, which carries no facets here.
+      const objValue = {
+        searchProps: { type: "cluster", clusterId: "123" },
+        titlesSEOPLPs: [],
+        floatingControls: true,
+      };
+      expect(
+        resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+          "Facet",
+        ]),
+      ).toBeNull();
+    });
+
+    test("does not hijack a crumb owned by a sibling array", () => {
+      // Ordering guard: the pre-existing array-item loop resolves the sibling
+      // array before the inline-union loop runs, so adding the union loop must
+      // not pre-empt a real sibling match.
+      const objValue = {
+        searchProps: { type: "advanced", selectedFacets: [{}] },
+        titlesSEOPLPs: [{ label: "Home SEO" }],
+        floatingControls: true,
+      };
+      expect(
+        resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+          "Home SEO",
+        ]),
+      ).toBe("titlesSEOPLPs");
+    });
+  });
 });
 
 describe("isArrayDrillDownField", () => {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -333,6 +333,51 @@ function resolveActiveFieldKeyInScope(
     }
   }
 
+  // Inline-union fields ("A or B" plain-data unions) store the chosen branch's
+  // fields flat on the value, so a nested array inside a branch (e.g.
+  // `searchProps: Advanced | Cluster | …` whose Advanced branch has a
+  // `selectedFacets: Facet[]`) drills into an item that writes a bare
+  // `[itemLabel]` crumb — the union's own label never enters the trail. Recurse
+  // into each branch's properties (against the same union value) so the crumb
+  // resolves to this field; otherwise the panel falls back to showing every
+  // sibling prop while the union field alone narrows to the item.
+  for (const key of keys) {
+    const schema = properties[key];
+    if (
+      schema?.type !== "inline-union" ||
+      !schema.inlineUnionBranches?.length
+    ) {
+      continue;
+    }
+    const childObj = asObjectRecord(objValue[key]);
+    const label = fieldDisplayLabel(key, schema);
+    for (const branch of schema.inlineUnionBranches) {
+      const branchProps = branch.schema?.properties;
+      if (!branchProps) continue;
+      const branchKeys = Object.keys(branchProps);
+
+      const direct = resolveActiveFieldKeyInScope(
+        branchKeys,
+        branchProps,
+        childObj,
+        breadcrumbPath,
+        decofile,
+      );
+      if (direct) return key;
+
+      if (labelsMatch(head, label) || labelsMatch(head, key)) {
+        const viaLabel = resolveActiveFieldKeyInScope(
+          branchKeys,
+          branchProps,
+          childObj,
+          breadcrumbPath.slice(1),
+          decofile,
+        );
+        if (viaLabel) return key;
+      }
+    }
+  }
+
   // Block-ref fields (loader/section selectors) can also be "drilled into"
   // via the breadcrumb path when the head matches the field's key or label.
   // This lets loader props like `page: ProductListingPage` participate in


### PR DESCRIPTION
## Summary

Drilling into an array item nested inside an **inline-union branch** left every sibling section prop rendered in the editor panel instead of narrowing to just the item.

Concrete repro (Torra `SearchResult`): the section's `searchProps` prop is an inline-union (`Busca avançada | ID de coleção | …`); the "Busca avançada" branch holds `selectedFacets: Facet[]` (`Filtros base`, items `{ key, value }`). Clicking a `Facet` navigates in, but the panel keeps showing `Títulos SEO`, `Categorias`, `Filtros`, `Controles flutuantes`, etc.

### Root cause

- Drilling writes a bare `["Facet"]` breadcrumb — `InlineUnionField` passes the trail through without prefixing its own label, so the union's label never enters it.
- `resolveActiveFieldKeyInScope` only recursed into `type === "object"` and `type === "block-ref"` props — **never `inline-union`**. It therefore couldn't attribute `"Facet"` to `searchProps`, returned `null`, and `SchemaForm` hit the `visibleKeys = keys` fallback (all sibling props shown). Only the union field itself did its inner narrowing, which is why `Termo de busca`/`Produtos`/`Ordenação` disappeared but the section's own siblings remained.

### Fix

Add an inline-union recursion loop to `resolveActiveFieldKeyInScope` that recurses into each branch's `properties` against the same union value — mirroring the existing object-recursion path. The `"Facet"` crumb now resolves to `searchProps` and the section narrows correctly.

## Testing

- `apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts`: 2 new tests reproducing the real `SearchResult` shape
  - narrows to the union field whose selected branch owns the item
  - does not hijack a crumb owned by a sibling array
- `tsc --noEmit` clean (`apps/web`)
- 534 sections-editor tests pass; `bun run fmt` applied

## Notes

A sibling latent path exists for `block-ref`-backed arrays (`schema-form-breadcrumb.ts:301` doesn't reuse the block-ref → array item-schema inference). It's a different code path, does not affect this case, and is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes breadcrumb narrowing when drilling into an array item inside an `inline-union` field. The editor now narrows to the union field (e.g., `searchProps`) instead of showing sibling section props.

- **Bug Fixes**
  - Recurse into `inline-union` branches in `resolveActiveFieldKeyInScope` so bare item crumbs (e.g., "Facet") or trails prefixed by the union label resolve to the owning union field.
  - Expanded tests for the `SearchResult` shape: bare item, via union label, inactive-branch no-op, and sibling array precedence.

<sup>Written for commit e3343444556f9a1d1009ff9a64046664ddba2ff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

