### PR TITLE
fix(sandbox): grep content search covers .deco and gitignored files

### DIFF
--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -531,22 +531,33 @@ describe("fs handlers", () => {
   );
 
   (hasRg ? it : it.skip)(
-    "grep: content search covers .deco and gitignored files but skips node_modules",
+    "grep: content search reaches tracked dot-dirs (.deco) but still honors .gitignore, node_modules and .git",
     async () => {
-      // .deco is a hidden dir (skipped by rg's default dotfile rule) and is
-      // often gitignored — the filename glob still surfaces it, so content
-      // search must too, or the two searches disagree.
+      // rg only honors .gitignore inside a git tree — a bare marker dir is
+      // enough to switch it on, so the gitignore assertions below actually
+      // exercise the skip (without this they'd pass regardless).
+      mkdirSync(join(appRoot, ".git"), { recursive: true });
+      // `.deco/blocks/*.json` are the tracked decofile sources — hidden (dot
+      // dir) so rg's default skips them, but the filename glob surfaces them.
+      // --hidden must bring content search in line.
       mkdirSync(join(appRoot, ".deco/blocks"), { recursive: true });
       writeFileSync(
         join(appRoot, ".deco/blocks/pages-home.json"),
         '{"matcher":"needle"}\n',
       );
-      writeFileSync(join(appRoot, ".gitignore"), ".deco/\nignored.txt\n");
-      writeFileSync(join(appRoot, "ignored.txt"), "needle\n");
-      // node_modules is pure noise the glob walk excludes — grep must keep
-      // excluding it even with --hidden/--no-ignore on.
+      // The only gitignored `.deco` entry is the generated merge (a duplicate
+      // of the sources) — plus repo secrets. Neither should be re-admitted.
+      writeFileSync(
+        join(appRoot, ".gitignore"),
+        ".deco/blocks.gen.json\n.env\n",
+      );
+      writeFileSync(join(appRoot, ".deco/blocks.gen.json"), '{"x":"needle"}\n');
+      writeFileSync(join(appRoot, ".env"), "SECRET=needle\n");
+      // node_modules and .git are pure noise; --hidden re-enables descent into
+      // .git, so the !.git exclude must still keep it out.
       mkdirSync(join(appRoot, "node_modules/pkg"), { recursive: true });
       writeFileSync(join(appRoot, "node_modules/pkg/index.js"), "needle\n");
+      writeFileSync(join(appRoot, ".git/config"), "needle\n");
       const h = makeGrepHandler({ appRoot, repoDir: appRoot });
       const res = await h(
         post("/_sandbox/grep", { pattern: "needle", output_mode: "files" }),
@@ -554,8 +565,10 @@ describe("fs handlers", () => {
       const body = (await res.json()) as { results: string };
       const files = body.results.split("\n").filter(Boolean).sort();
       expect(files).toContain(".deco/blocks/pages-home.json");
-      expect(files).toContain("ignored.txt");
+      expect(files).not.toContain(".deco/blocks.gen.json");
+      expect(files).not.toContain(".env");
       expect(files).not.toContain("node_modules/pkg/index.js");
+      expect(files).not.toContain(".git/config");
     },
   );
 

--- a/packages/sandbox/daemon/routes/fs.test.ts
+++ b/packages/sandbox/daemon/routes/fs.test.ts
@@ -530,6 +530,35 @@ describe("fs handlers", () => {
     },
   );
 
+  (hasRg ? it : it.skip)(
+    "grep: content search covers .deco and gitignored files but skips node_modules",
+    async () => {
+      // .deco is a hidden dir (skipped by rg's default dotfile rule) and is
+      // often gitignored — the filename glob still surfaces it, so content
+      // search must too, or the two searches disagree.
+      mkdirSync(join(appRoot, ".deco/blocks"), { recursive: true });
+      writeFileSync(
+        join(appRoot, ".deco/blocks/pages-home.json"),
+        '{"matcher":"needle"}\n',
+      );
+      writeFileSync(join(appRoot, ".gitignore"), ".deco/\nignored.txt\n");
+      writeFileSync(join(appRoot, "ignored.txt"), "needle\n");
+      // node_modules is pure noise the glob walk excludes — grep must keep
+      // excluding it even with --hidden/--no-ignore on.
+      mkdirSync(join(appRoot, "node_modules/pkg"), { recursive: true });
+      writeFileSync(join(appRoot, "node_modules/pkg/index.js"), "needle\n");
+      const h = makeGrepHandler({ appRoot, repoDir: appRoot });
+      const res = await h(
+        post("/_sandbox/grep", { pattern: "needle", output_mode: "files" }),
+      );
+      const body = (await res.json()) as { results: string };
+      const files = body.results.split("\n").filter(Boolean).sort();
+      expect(files).toContain(".deco/blocks/pages-home.json");
+      expect(files).toContain("ignored.txt");
+      expect(files).not.toContain("node_modules/pkg/index.js");
+    },
+  );
+
   (hasRg ? it : it.skip)("glob: returns matching file names", async () => {
     writeFileSync(join(appRoot, "x.txt"), "");
     const h = makeGlobHandler({ appRoot, repoDir: appRoot });

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -536,6 +536,15 @@ export function makeGrepHandler(deps: FsDeps) {
     if (body.context && mode === "content")
       args.push("-C", String(body.context));
     if (body.glob) args.push("--glob", body.glob);
+    // Mirror glob's file-set semantics: the filename walk includes dotfiles
+    // (`dot: true`) and ignores .gitignore, so grep must too — otherwise the
+    // two searches disagree (e.g. `.deco/` shows up by name but never by
+    // content). `--hidden` searches dot-dirs, `--no-ignore` disables the
+    // .gitignore/.git skip, and the exclude globs re-apply the same
+    // GLOB_EXCLUDE_DIRS noise filter the walk uses. These trail any caller
+    // `--glob` so the noise dirs stay excluded regardless of an include glob.
+    args.push("--hidden", "--no-ignore");
+    for (const dir of GLOB_EXCLUDE_DIRS) args.push("--glob", `!${dir}`);
     args.push("--", body.pattern, searchPath);
 
     const limit = resolveGrepResultLimit(body.limit);

--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -536,14 +536,18 @@ export function makeGrepHandler(deps: FsDeps) {
     if (body.context && mode === "content")
       args.push("-C", String(body.context));
     if (body.glob) args.push("--glob", body.glob);
-    // Mirror glob's file-set semantics: the filename walk includes dotfiles
-    // (`dot: true`) and ignores .gitignore, so grep must too — otherwise the
-    // two searches disagree (e.g. `.deco/` shows up by name but never by
-    // content). `--hidden` searches dot-dirs, `--no-ignore` disables the
-    // .gitignore/.git skip, and the exclude globs re-apply the same
-    // GLOB_EXCLUDE_DIRS noise filter the walk uses. These trail any caller
-    // `--glob` so the noise dirs stay excluded regardless of an include glob.
-    args.push("--hidden", "--no-ignore");
+    // `.deco/blocks/*.json` (the decofile sources) are tracked but live under a
+    // dot-dir, so ripgrep's default dotfile skip hides them from content search
+    // even though the filename glob (`dot: true`) surfaces them — the two
+    // searches disagree. `--hidden` fixes that. We deliberately keep honoring
+    // .gitignore/.git/info/exclude: the only gitignored `.deco` entries are the
+    // multi-MB generated merge (`blocks.gen.json`, a duplicate of the sources)
+    // and the sandbox's own local-only artifacts, plus repo secrets like
+    // `.env` — none of which grep should re-admit into the file explorer or the
+    // agent's Grep tool. `--hidden` re-enables descent into `.git` itself, so
+    // the `!.git` entry below is load-bearing; the rest mirror the glob walk's
+    // noise filter and trail any caller `--glob` so those dirs stay excluded.
+    args.push("--hidden");
     for (const dir of GLOB_EXCLUDE_DIRS) args.push("--glob", `!${dir}`);
     args.push("--", body.pattern, searchPath);
 


### PR DESCRIPTION
## Summary

The sandbox file search has two independent paths that disagreed on `.deco`:

- **Filename search** (glob) uses `dot: true` and ignores `.gitignore`, so `.deco/` files show up by name.
- **Content search** (grep) ran `ripgrep` with default flags, which **skip dotfolders** (all of `.deco/`) and **honor `.gitignore`** — so `.deco/` content was never searched.

This affected both the file explorer panel ("NOS ARQUIVOS" / "In files") **and** the agent's grep hook (`onGrep` in `sandbox-fs-hooks.ts`) — they share the same `/_sandbox/grep` handler.

This PR makes grep mirror the glob file-set so both searches cover the same files:

```ts
args.push("--hidden", "--no-ignore");
for (const dir of GLOB_EXCLUDE_DIRS) args.push("--glob", `!${dir}`);
```

- `--hidden` → search dot-dirs like `.deco/`
- `--no-ignore` → don't skip gitignored paths (glob already includes them)
- `!<dir>` excludes re-apply the existing `GLOB_EXCLUDE_DIRS` noise filter (`node_modules`, `dist`, `.next`, …) so `--no-ignore` doesn't flood results. They trail any caller `--glob` so noise dirs stay excluded even with an include glob.

## Testing

- Added `fs.test.ts` case: grep now finds content in `.deco/blocks/*.json` and gitignored files, but still skips `node_modules`.
- `bun test packages/sandbox/daemon/routes/fs.test.ts` → 65 pass, 0 fail
- `bun run fmt`, `check` (tsc), `lint` → clean (only pre-existing unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align sandbox content grep with filename search so both cover the same files. Tracked dot-dirs like `.deco/` are searched; `.gitignore` stays honored and noise dirs like `node_modules`/`.git` remain excluded.

- **Bug Fixes**
  - Updated `/_sandbox/grep` to run `ripgrep` with `--hidden` and to re-apply `GLOB_EXCLUDE_DIRS` via `--glob !<dir>`.
  - Fixed tests to ensure `.deco/blocks/*.json` are found while `.deco/blocks.gen.json`, `.env`, `node_modules`, and `.git` are excluded; added a `.git` marker so ignore rules apply.

<sup>Written for commit f868eb0233b1fbf292ac3c6d3a1de848570d3d4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

