### PR TITLE
fix(sandbox): one sandbox per thread — auto-start it for any org member who opens the thread

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -50,6 +50,7 @@ import {
   ensureGithubCloneToken,
 } from "@/shared/github-clone-info";
 import { resolveRuntimeConfig } from "@/tools/sandbox/helpers";
+import { resolveSandboxUserId } from "@/tools/sandbox/thread-repo";
 import { deriveOffloadAllowlist } from "@/object-storage/offload-allowlist";
 import { getSettings } from "@/settings";
 import type { WorkItemSandbox } from "@/links/link-work-item";
@@ -1945,11 +1946,18 @@ export async function prepareLinkWorkDispatch(
       let sandboxConfig: WorkItemSandbox | null = null;
       if (input.target?.sandboxProviderKind === "user-desktop") {
         try {
+          const branch = input.branch ?? "ephemeral";
           const sandboxHandle = computeDesktopSandboxHandle({
             agentId: input.agent.id,
-            userId: input.userId,
+            // Sandbox identity, not the dispatcher: a thread-scoped branch keys
+            // by the thread's creator, the same resolution SANDBOX_START and the
+            // sandbox proxy use. Normally identical (only the owner can prompt);
+            // keeping it here means a run dispatched on someone else's behalf
+            // still targets that thread's one sandbox instead of a second,
+            // dispatcher-keyed handle the daemon would cold-spawn.
+            userId: await resolveSandboxUserId(ctx, branch, input.userId),
             organizationId: input.organizationId,
-            branch: input.branch ?? "ephemeral",
+            branch,
           });
           sandboxConfig = await resolveLinkSandboxConfig(
             input,

--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -19,6 +19,7 @@ import { composeSandboxRef } from "@decocms/sandbox/provider";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
 import type { ClaimPhase } from "@decocms/sandbox/provider/agent-sandbox";
 import { computeClaimHandle } from "../../sandbox/claim-handle";
+import { resolveSandboxUserId } from "../../tools/sandbox/thread-repo";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import {
   getUserId,
@@ -56,6 +57,10 @@ import {
 
 interface VmClaim {
   claimName: string;
+  /** The authenticated caller. Only credential resolution uses it — sandbox
+   *  identity is `userId` below, which may be someone else (see
+   *  `resolveSandboxUserId`). */
+  callerUserId: string;
   /** Null when no sandbox runner is configured on this studio instance. */
   runner: SandboxProvider | null;
   virtualMcpId: string;
@@ -181,7 +186,16 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
     virtualMcpId,
     branch,
   });
-  const claimName = computeClaimHandle({ userId, projectRef }, branch);
+  // Sandbox identity, NOT the caller: a thread-scoped branch keys by the
+  // thread's creator, so every org member viewing that thread resolves the same
+  // claim and reaches the one sandbox it has. Keyed by the caller, a viewer's
+  // handle never existed — /events reported `claiming` forever and every other
+  // route 404'd. See `resolveSandboxUserId`.
+  const sandboxUserId = await resolveSandboxUserId(ctx, branch, userId);
+  const claimName = computeClaimHandle(
+    { userId: sandboxUserId, projectRef },
+    branch,
+  );
   const virtualMcpMetadata =
     (virtualMcp.metadata as Record<string, unknown>) ?? null;
 
@@ -200,7 +214,7 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
   let runner: SandboxProvider | null;
   try {
     const resolved = await resolveSandboxProvider(ctx, {
-      userId,
+      userId: sandboxUserId,
       branch,
       virtualMcpMetadata,
     });
@@ -215,10 +229,11 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
 
   c.set("vmClaim", {
     claimName,
+    callerUserId: userId,
     runner,
     virtualMcpId,
     branch,
-    userId,
+    userId: sandboxUserId,
     projectRef,
     virtualMcpMetadata,
     connectionIds:
@@ -618,7 +633,9 @@ export const createSandboxRoutes = () => {
             runner: claim.runner,
             handle: claim.claimName,
             orgId: organization.id,
-            userId: claim.userId,
+            // Secrets resolve as the CALLER — viewing a teammate's thread must
+            // never mint their private secrets into the sandbox.
+            userId: claim.callerUserId,
             entries,
           });
         } catch (err) {

--- a/apps/api/src/tools/sandbox/delete.ts
+++ b/apps/api/src/tools/sandbox/delete.ts
@@ -61,14 +61,17 @@ export const SANDBOX_DELETE = defineTool({
       }
       throw err;
     }
-    const { entry, userId } = vmEntry;
+    // `sandboxUserId` is the sandbox's owner (the thread's creator on a
+    // thread-scoped branch), `userId` the caller — so stopping a thread's
+    // sandbox reaches the one sandbox it has, from either side.
+    const { entry, userId, sandboxUserId } = vmEntry;
 
     if (!entry) {
       return { success: true };
     }
 
     const { provider: runner } = await resolveSandboxProvider(ctx, {
-      userId,
+      userId: sandboxUserId,
       branch: input.branch,
       virtualMcpMetadata: vmEntry.metadata,
       explicitKind: kind,
@@ -79,7 +82,7 @@ export const SANDBOX_DELETE = defineTool({
       ctx.storage.virtualMcps,
       input.virtualMcpId,
       userId,
-      userId,
+      sandboxUserId,
       input.branch,
       kind,
     );

--- a/apps/api/src/tools/sandbox/helpers.ts
+++ b/apps/api/src/tools/sandbox/helpers.ts
@@ -23,6 +23,7 @@ import {
 import { PACKAGE_MANAGER_CONFIG } from "@decocms/shared/runtime-defaults";
 import type { PackageManager } from "@decocms/shared/runtime-defaults";
 import { readSandboxMap, resolveVm } from "./sandbox-map";
+import { resolveSandboxUserId } from "./thread-repo";
 
 export type RuntimeConfigMeta = {
   runtime?: {
@@ -103,8 +104,12 @@ export function readValidatedSubmoduleCredentials(
 /**
  * Extracts common auth + lookup boilerplate shared by all VM tools.
  * Validates auth, checks access, fetches and validates the Virtual MCP,
- * and returns the metadata and sandboxMap entry for the current user on the
+ * and returns the metadata and sandboxMap entry for the sandbox's OWNER on the
  * specified branch + kind. `entry` is null when no vm is registered for that triple.
+ *
+ * `userId` is the caller (audit); `sandboxUserId` is who the sandbox is keyed by
+ * — the same resolution SANDBOX_START uses, so a teammate's thread resolves that
+ * thread's one sandbox rather than missing. See `resolveSandboxUserId`.
  */
 export async function requireVmEntry(
   input: {
@@ -125,13 +130,14 @@ export async function requireVmEntry(
   }
   const metadata = (virtualMcp.metadata ?? {}) as Record<string, unknown>;
   const sandboxMap = readSandboxMap(metadata);
+  const sandboxUserId = await resolveSandboxUserId(ctx, input.branch, userId);
   const entry: SandboxRecord | null = resolveVm(
     sandboxMap,
-    userId,
+    sandboxUserId,
     input.branch,
     input.sandboxProviderKind,
   );
-  return { virtualMcp, metadata, userId, entry, organization };
+  return { virtualMcp, metadata, userId, sandboxUserId, entry, organization };
 }
 
 /**

--- a/apps/api/src/tools/sandbox/start.test.ts
+++ b/apps/api/src/tools/sandbox/start.test.ts
@@ -205,12 +205,16 @@ function makeCtx(overrides: {
   userId?: string;
   virtualMcp?: ReturnType<typeof makeVirtualMcp> | null;
   updateSpy?: ReturnType<typeof mock>;
+  /** Row returned by `storage.threads.get` — set `created_by` to exercise the
+   *  thread-owner keying (see resolveSandboxUserId). */
+  thread?: { created_by: string; metadata: Record<string, unknown> } | null;
 }): StudioContext {
   const {
     orgId = ORG_ID,
     userId = USER_ID,
     virtualMcp,
     updateSpy = mock(async () => {}),
+    thread = null,
   } = overrides;
 
   const findById = mock(async (_id: string) => virtualMcp ?? null);
@@ -240,10 +244,11 @@ function makeCtx(overrides: {
       connections: {
         findById: mock(async (_id: string) => ({ metadata: null })),
       },
-      // A `thread:` branch resolves the thread's bound repo; return no thread so
-      // provisioning falls back to the VM's own githubRepo.
+      // A `thread:` branch resolves the thread's creator + bound repo. Default
+      // is no thread, so provisioning falls back to the VM's own githubRepo and
+      // keys the sandbox by the caller.
       threads: {
-        get: mock(async (_id: string) => null),
+        get: mock(async (_id: string) => thread),
         update: mock(async () => {}),
       },
     } as never,
@@ -372,6 +377,39 @@ describe("SANDBOX_START", () => {
         branch: synthetic,
       }),
     );
+  });
+
+  it("keys a thread-scoped sandbox by the thread's creator, not the caller", async () => {
+    // A teammate opening the thread must resume the ONE sandbox that thread has.
+    // Keyed by the caller they got a second sandbox on the same git branch —
+    // undrivable (its claim handle never existed for them) and a rival
+    // shutdown-force-push target. Audit fields stay the caller's.
+    const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
+    const updateSpy = mock(async () => {});
+    const ctx = makeCtx({
+      virtualMcp,
+      updateSpy,
+      userId: "user_viewer",
+      thread: { created_by: USER_ID, metadata: {} },
+    });
+
+    await SANDBOX_START.handler(
+      { virtualMcpId: VMCP_ID, branch: "thread:t1/conn_a" },
+      ctx,
+    );
+
+    const [id] = mockEnsure.mock.calls[0]! as [SandboxId, EnsureOptions];
+    expect(id.userId).toBe(USER_ID);
+
+    const updateCall = (updateSpy.mock.calls as unknown[][])[0]!;
+    // Acting user (audit) is the caller...
+    expect(updateCall[1]).toBe("user_viewer");
+    // ...while the sandboxMap slot belongs to the thread's creator, which is
+    // what the sandbox-proxy's owner-keyed claim lookup resolves.
+    const updated = updateCall[2] as {
+      metadata: { sandboxMap: SandboxMap };
+    };
+    expect(Object.keys(updated.metadata.sandboxMap)).toEqual([USER_ID]);
   });
 
   it("persists sandboxMap entry with handle + previewUrl + sandboxProviderKind", async () => {

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -1,5 +1,9 @@
 /**
- * SANDBOX_START. Keyed by (userId, branch, sandboxProviderKind) in the Virtual MCP's `sandboxMap`.
+ * SANDBOX_START. Keyed by (userId, branch, sandboxProviderKind) in the Virtual
+ * MCP's `sandboxMap`, where `userId` is the sandbox's OWNER — the thread's
+ * creator on a thread-scoped branch, so a member opening a teammate's thread
+ * resumes that thread's single sandbox instead of booting a private copy of the
+ * same git branch (see `resolveSandboxUserId`).
  * Provider-agnostic — dispatches through the active `SandboxProvider`; this
  * handler only does `sandboxMap` bookkeeping. Branch defaults to a Bayer-style
  * `<greek-letter>-<constellation>` name (e.g. `alpha-centauri`) when omitted.
@@ -51,6 +55,7 @@ import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import {
   getThreadGithubRepo,
   getThreadHeadRef,
+  resolveSandboxUserId,
   setThreadSandboxMapEntry,
   syntheticBranchToGitRef,
   threadIdFromBranch,
@@ -128,6 +133,17 @@ export const SANDBOX_START = defineTool({
     const userId = getUserId(ctx);
     if (!userId) throw new Error("User ID required");
 
+    // Whose sandbox this is: the thread's creator for a thread-scoped branch, so
+    // a member opening a teammate's thread resumes the ONE sandbox that thread
+    // has instead of booting a private copy of the same git branch. `userId`
+    // stays the caller for credential resolution + audit — see
+    // resolveSandboxUserId.
+    const sandboxUserId = await resolveSandboxUserId(
+      ctx,
+      resolvedBranch,
+      userId,
+    );
+
     const virtualMcp = await ctx.storage.virtualMcps.findById(
       input.virtualMcpId,
     );
@@ -147,7 +163,7 @@ export const SANDBOX_START = defineTool({
       : undefined;
     const { provider: runner, kind: providerKind } =
       await resolveSandboxProvider(ctx, {
-        userId,
+        userId: sandboxUserId,
         branch: resolvedBranch,
         virtualMcpMetadata: metadata,
         explicitKind,
@@ -155,7 +171,7 @@ export const SANDBOX_START = defineTool({
 
     const existing: SandboxRecord | null = resolveVm(
       readSandboxMap(metadata),
-      userId,
+      sandboxUserId,
       resolvedBranch,
       providerKind,
     );
@@ -176,6 +192,7 @@ export const SANDBOX_START = defineTool({
     const { entry, isNewVm } = await provisionSandbox({
       ctx,
       userId,
+      sandboxUserId,
       orgId: organization.id,
       virtualMcpId: input.virtualMcpId,
       branch: resolvedBranch,
@@ -226,9 +243,11 @@ export async function ensureSandbox(
     throw new Error("Virtual MCP not found");
   }
   const metadata = (virtualMcp.metadata ?? {}) as Record<string, unknown>;
+  // See resolveSandboxUserId: one sandbox per thread, keyed by its creator.
+  const sandboxUserId = await resolveSandboxUserId(ctx, input.branch, userId);
   const existing: SandboxRecord | null = resolveVm(
     readSandboxMap(metadata),
-    userId,
+    sandboxUserId,
     input.branch,
     input.sandboxProviderKind,
   );
@@ -240,7 +259,7 @@ export async function ensureSandbox(
   // restarted via `deco link` relink, leaving the sandboxMap pointing at a
   // dead handle). resolveSandboxProvider is cheap and idempotent.
   const { provider: runner } = await resolveSandboxProvider(ctx, {
-    userId,
+    userId: sandboxUserId,
     branch: input.branch,
     virtualMcpMetadata: metadata,
     explicitKind: providerKind,
@@ -258,7 +277,7 @@ export async function ensureSandbox(
       ctx.storage.virtualMcps,
       input.virtualMcpId,
       userId,
-      userId,
+      sandboxUserId,
       input.branch,
       providerKind,
     ).catch((err) => {
@@ -284,6 +303,7 @@ export async function ensureSandbox(
   const { entry } = await provisionSandbox({
     ctx,
     userId,
+    sandboxUserId,
     orgId: organization.id,
     virtualMcpId: input.virtualMcpId,
     branch: input.branch,
@@ -298,7 +318,13 @@ export async function ensureSandbox(
 
 type StartParams = {
   ctx: StudioContext;
+  /** The caller. Resolves credentials (env secrets, submodule PATs) and stamps
+   *  the audit fields on storage writes. */
   userId: string;
+  /** Whose sandbox this is — the thread's creator for a thread-scoped branch,
+   *  else the caller. Keys the claim, the runner state and the sandboxMap. See
+   *  resolveSandboxUserId. */
+  sandboxUserId: string;
   orgId: string;
   virtualMcpId: string;
   branch: string;
@@ -315,6 +341,7 @@ async function provisionSandbox(
   const {
     ctx,
     userId,
+    sandboxUserId,
     orgId,
     virtualMcpId,
     branch,
@@ -527,7 +554,7 @@ async function provisionSandbox(
   }
 
   const sandbox = await runner.ensure(
-    { userId, projectRef },
+    { userId: sandboxUserId, projectRef },
     {
       // Pass branch explicitly so the runner-side `computeHandle` agrees with
       // the sandbox-proxy's `computeClaimHandle`. Without it, a repo-less
@@ -539,7 +566,9 @@ async function provisionSandbox(
       workload,
       tenant: {
         orgId,
-        userId,
+        // The sandbox's owner, so the pod's `user_id` label/metric matches the
+        // claim handle it answers on.
+        userId: sandboxUserId,
         ...(ctx.organization?.slug ? { orgSlug: ctx.organization.slug } : {}),
         ...(ctx.organization?.name ? { orgName: ctx.organization.name } : {}),
         ...(ctx.auth.user?.email ? { userEmail: ctx.auth.user.email } : {}),
@@ -596,7 +625,7 @@ async function provisionSandbox(
     ctx.storage.virtualMcps,
     virtualMcpId,
     userId,
-    userId,
+    sandboxUserId,
     branch,
     params.providerKind,
     entry,
@@ -610,7 +639,7 @@ async function provisionSandbox(
     await setThreadSandboxMapEntry(
       ctx,
       threadId,
-      userId,
+      sandboxUserId,
       branch,
       params.providerKind,
       entry,

--- a/apps/api/src/tools/sandbox/thread-repo.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.ts
@@ -77,6 +77,39 @@ export function threadIdFromBranch(
   return id || null;
 }
 
+/**
+ * The user a sandbox is KEYED by: a thread-scoped branch (`thread:<id>[/<conn>]`)
+ * keys by the thread's creator, everything else by the caller.
+ *
+ * Sandbox identity is per-user in three places that must agree — the claim
+ * handle (`computeClaimHandle`), `sandbox_runner_state`'s PK, and the
+ * `sandboxMap` key. Keyed by the CALLER, an org member opening a teammate's
+ * thread got a SECOND sandbox: a private clone of the same git branch that
+ * nobody can prompt (the chat is read-only for them) and whose shutdown
+ * force-push races the owner's on that one branch. Keyed by the thread's
+ * creator there is exactly one sandbox per thread, and every member resolves it
+ * identically — a viewer's `/events`, `/read`, git and exec reach the live
+ * daemon, and SANDBOX_START on an evicted one resumes it instead of forking a
+ * copy.
+ *
+ * This is sandbox IDENTITY only. Credential resolution (env secrets, submodule
+ * PATs) and audit fields stay keyed to the CALLER, so viewing a thread never
+ * mints someone else's secrets into a sandbox: a secret the caller can't read is
+ * skipped, exactly as it is today.
+ *
+ * Never throws; an absent thread falls back to the caller.
+ */
+export async function resolveSandboxUserId(
+  ctx: StudioContext,
+  branch: string | null | undefined,
+  callerUserId: string,
+): Promise<string> {
+  const threadId = threadIdFromBranch(branch);
+  if (!threadId) return callerUserId;
+  const thread = await ctx.storage.threads.get(threadId).catch(() => null);
+  return thread?.created_by ?? callerUserId;
+}
+
 /** Read a thread's metadata JSON. Returns `null` only when the thread is
  *  absent (so writers can skip a non-existent row); an existing thread with a
  *  null metadata column returns `{}`. Never throws. `ctx.storage.threads` is

--- a/apps/web/src/components/sandbox/content/content-browser.tsx
+++ b/apps/web/src/components/sandbox/content/content-browser.tsx
@@ -261,11 +261,6 @@ export function ContentBrowser({ mode = "content" }: ContentBrowserProps) {
   const previewUrl = lifecycle.previewUrl;
   const sandboxState = lifecycle.previewState;
 
-  // Another member's thread, not yet acknowledged: blank the editor rather
-  // than booting their sandbox — the confirmation gate lives on Preview. This
-  // also narrows `sandboxState` for SandboxStateRenderer below.
-  if (sandboxState.kind === "othersThread") return null;
-
   if (sandboxState.kind !== "iframe") {
     return (
       <SandboxStateRenderer

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -6,9 +6,7 @@ import {
   shouldSelfHeal,
   computeDrawerStatus,
   buildSandboxStartArgs,
-  deriveOthersThreadLabel,
   overlayThreadSandboxMap,
-  computeOthersThreadGate,
   deriveStartError,
   isRetryableClaimFailure,
   shouldAutoRetryClaim,
@@ -104,15 +102,10 @@ describe("shouldAutoStart", () => {
     userStopped: false,
     isPending: false,
     attempted: false,
-    autoStartBlocked: false,
   };
 
   test("all conditions met → true", () => {
     expect(shouldAutoStart(base)).toBe(true);
-  });
-
-  test("blocked on another member's thread → false", () => {
-    expect(shouldAutoStart({ ...base, autoStartBlocked: true })).toBe(false);
   });
 
   test("no github repo → false", () => {
@@ -158,15 +151,10 @@ describe("shouldSelfHeal", () => {
     lastDeadVmId: null as string | null,
     isPending: false,
     userStopped: false,
-    autoStartBlocked: false,
   };
 
   test("fresh dead vm → true", () => {
     expect(shouldSelfHeal(base)).toBe(true);
-  });
-
-  test("blocked on another member's thread → false (no silent reprovision)", () => {
-    expect(shouldSelfHeal({ ...base, autoStartBlocked: true })).toBe(false);
   });
 
   test("not notFound → false", () => {
@@ -233,55 +221,74 @@ describe("computeDrawerStatus", () => {
       }),
     ).toBe("errored");
   });
-
-  test("othersThread → idle", () => {
-    expect(computeDrawerStatus({ kind: "othersThread", label: "main" })).toBe(
-      "idle",
-    );
-  });
 });
 
 describe("overlayThreadSandboxMap", () => {
   const branch = "thread:t1/conn_1";
   const threadMap = {
-    u1: { [branch]: { "agent-sandbox": entry("agent-sandbox", "mine") } },
-    u2: { [branch]: { "agent-sandbox": entry("agent-sandbox", "theirs") } },
+    owner: { [branch]: { "agent-sandbox": entry("agent-sandbox", "the-one") } },
   } as never;
 
-  test("overlays the viewer's own thread-scoped entry", () => {
+  test("re-keys the thread owner's record onto the viewer", () => {
+    // A thread has ONE sandbox, recorded under its creator and resolved
+    // server-side for whoever opens the thread (resolveSandboxUserId). The
+    // viewer-keyed lookups downstream must find it, or auto-start boots a
+    // second sandbox on the same git branch.
     const result = overlayThreadSandboxMap({
       agentSandboxMap: undefined,
       threadSandboxMap: threadMap,
-      userId: "u1",
+      userId: "viewer",
+      ownerId: "owner",
       branch,
     });
-    expect(result?.u1?.[branch]?.["agent-sandbox"]?.sandboxHandle).toBe("mine");
+    expect(result?.viewer?.[branch]?.["agent-sandbox"]?.sandboxHandle).toBe(
+      "the-one",
+    );
   });
 
-  test("never adopts another member's entry as the viewer's", () => {
-    // The bug: grafting the owner's record under the viewer's key made vmEntry
-    // non-null, which suppressed auto-start AND the others-thread gate — the
-    // viewer ended up with an iframe backed by a claim they can't drive and no
-    // way to start their own sandbox.
+  test("own thread: ownerId absent falls back to the viewer", () => {
     const result = overlayThreadSandboxMap({
       agentSandboxMap: undefined,
-      threadSandboxMap: threadMap,
-      userId: "u3",
+      threadSandboxMap: {
+        me: { [branch]: { "agent-sandbox": entry("agent-sandbox", "mine") } },
+      } as never,
+      userId: "me",
+      ownerId: null,
       branch,
     });
-    expect(result?.u3).toBeUndefined();
+    expect(result?.me?.[branch]?.["agent-sandbox"]?.sandboxHandle).toBe("mine");
   });
 
-  test("keeps the agent's map untouched when the thread has no entry", () => {
+  test("keeps sibling branches on the agent's map", () => {
     const agentMap = {
-      u1: { main: { "agent-sandbox": entry("agent-sandbox", "agent") } },
+      viewer: { main: { "agent-sandbox": entry("agent-sandbox", "agent") } },
+    } as never;
+    const result = overlayThreadSandboxMap({
+      agentSandboxMap: agentMap,
+      threadSandboxMap: threadMap,
+      userId: "viewer",
+      ownerId: "owner",
+      branch,
+    });
+    expect(result?.viewer?.main?.["agent-sandbox"]?.sandboxHandle).toBe(
+      "agent",
+    );
+    expect(result?.viewer?.[branch]?.["agent-sandbox"]?.sandboxHandle).toBe(
+      "the-one",
+    );
+  });
+
+  test("no entry for this branch → the agent's map, unchanged reference", () => {
+    const agentMap = {
+      viewer: { main: { "agent-sandbox": entry("agent-sandbox", "agent") } },
     } as never;
     expect(
       overlayThreadSandboxMap({
         agentSandboxMap: agentMap,
         threadSandboxMap: undefined,
-        userId: "u1",
-        branch: "main",
+        userId: "viewer",
+        ownerId: "owner",
+        branch,
       }),
     ).toBe(agentMap);
   });
@@ -292,77 +299,10 @@ describe("overlayThreadSandboxMap", () => {
         agentSandboxMap: undefined,
         threadSandboxMap: threadMap,
         userId: null,
+        ownerId: "owner",
         branch,
       }),
     ).toBeUndefined();
-  });
-});
-
-describe("deriveOthersThreadLabel", () => {
-  test("own thread (created_by === userId) → null", () => {
-    expect(
-      deriveOthersThreadLabel({
-        userId: "u1",
-        createdBy: "u1",
-        branch: "main",
-        title: "New chat",
-      }),
-    ).toBeNull();
-  });
-
-  test("no userId → null (unauthenticated, don't gate)", () => {
-    expect(
-      deriveOthersThreadLabel({
-        userId: null,
-        createdBy: "u2",
-        branch: "main",
-        title: "New chat",
-      }),
-    ).toBeNull();
-  });
-
-  test("no created_by → null (own/new unsaved thread)", () => {
-    expect(
-      deriveOthersThreadLabel({
-        userId: "u1",
-        createdBy: null,
-        branch: "main",
-        title: "New chat",
-      }),
-    ).toBeNull();
-  });
-
-  test("others thread with a branch → branch (encodes owner)", () => {
-    expect(
-      deriveOthersThreadLabel({
-        userId: "u1",
-        createdBy: "u2",
-        branch: "tavano-321312",
-        title: "New chat",
-      }),
-    ).toBe("tavano-321312");
-  });
-
-  test("others thread with no branch → title fallback", () => {
-    expect(
-      deriveOthersThreadLabel({
-        userId: "u1",
-        createdBy: "u2",
-        branch: null,
-        title: "Fix the banner",
-      }),
-    ).toBe("Fix the banner");
-  });
-
-  test("others thread with neither branch nor title → null", () => {
-    expect(
-      deriveOthersThreadLabel({
-        userId: "u1",
-        createdBy: "u2",
-        branch: null,
-        title: null,
-      }),
-    ).toBeNull();
   });
 });
 
@@ -459,7 +399,6 @@ describe("shouldAutoRetryClaim", () => {
     attempts: 0,
     isPending: false,
     userStopped: false,
-    autoStartBlocked: false,
     alreadyHandled: false,
   };
 
@@ -494,12 +433,6 @@ describe("shouldAutoRetryClaim", () => {
   test("user stopped → false", () => {
     expect(shouldAutoRetryClaim({ ...base, userStopped: true })).toBe(false);
   });
-
-  test("blocked on another member's thread → false", () => {
-    expect(shouldAutoRetryClaim({ ...base, autoStartBlocked: true })).toBe(
-      false,
-    );
-  });
 });
 
 describe("reconcileClaimRetryEpisode", () => {
@@ -527,58 +460,5 @@ describe("reconcileClaimRetryEpisode", () => {
       count: 0,
       handled: false,
     });
-  });
-});
-
-describe("computeOthersThreadGate", () => {
-  test("own thread (no label) → not blocked regardless of ack", () => {
-    expect(
-      computeOthersThreadGate({
-        othersThreadLabel: null,
-        acknowledgedThreadId: null,
-        threadId: "t1",
-      }).autoStartBlocked,
-    ).toBe(false);
-  });
-
-  test("others thread, never acknowledged → blocked", () => {
-    expect(
-      computeOthersThreadGate({
-        othersThreadLabel: "main",
-        acknowledgedThreadId: null,
-        threadId: "t1",
-      }).autoStartBlocked,
-    ).toBe(true);
-  });
-
-  test("others thread, acknowledged this thread → not blocked", () => {
-    expect(
-      computeOthersThreadGate({
-        othersThreadLabel: "main",
-        acknowledgedThreadId: "t1",
-        threadId: "t1",
-      }).autoStartBlocked,
-    ).toBe(false);
-  });
-
-  test("acknowledged a DIFFERENT thread → blocked (re-arms per thread)", () => {
-    expect(
-      computeOthersThreadGate({
-        othersThreadLabel: "main",
-        acknowledgedThreadId: "t1",
-        threadId: "t2",
-      }).autoStartBlocked,
-    ).toBe(true);
-  });
-
-  test("acknowledgement survives a null → assigned branch on the same thread", () => {
-    // Same thread id, so acknowledging while branch was null stays valid once
-    // the server assigns a branch — no re-prompt, no double SANDBOX_START.
-    const acked = computeOthersThreadGate({
-      othersThreadLabel: "New chat", // title fallback (branch was null)
-      acknowledgedThreadId: "t1",
-      threadId: "t1",
-    });
-    expect(acked.autoStartBlocked).toBe(false);
   });
 });

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -7,6 +7,7 @@ import {
   computeDrawerStatus,
   buildSandboxStartArgs,
   deriveOthersThreadLabel,
+  overlayThreadSandboxMap,
   computeOthersThreadGate,
   deriveStartError,
   isRetryableClaimFailure,
@@ -237,6 +238,63 @@ describe("computeDrawerStatus", () => {
     expect(computeDrawerStatus({ kind: "othersThread", label: "main" })).toBe(
       "idle",
     );
+  });
+});
+
+describe("overlayThreadSandboxMap", () => {
+  const branch = "thread:t1/conn_1";
+  const threadMap = {
+    u1: { [branch]: { "agent-sandbox": entry("agent-sandbox", "mine") } },
+    u2: { [branch]: { "agent-sandbox": entry("agent-sandbox", "theirs") } },
+  } as never;
+
+  test("overlays the viewer's own thread-scoped entry", () => {
+    const result = overlayThreadSandboxMap({
+      agentSandboxMap: undefined,
+      threadSandboxMap: threadMap,
+      userId: "u1",
+      branch,
+    });
+    expect(result?.u1?.[branch]?.["agent-sandbox"]?.sandboxHandle).toBe("mine");
+  });
+
+  test("never adopts another member's entry as the viewer's", () => {
+    // The bug: grafting the owner's record under the viewer's key made vmEntry
+    // non-null, which suppressed auto-start AND the others-thread gate — the
+    // viewer ended up with an iframe backed by a claim they can't drive and no
+    // way to start their own sandbox.
+    const result = overlayThreadSandboxMap({
+      agentSandboxMap: undefined,
+      threadSandboxMap: threadMap,
+      userId: "u3",
+      branch,
+    });
+    expect(result?.u3).toBeUndefined();
+  });
+
+  test("keeps the agent's map untouched when the thread has no entry", () => {
+    const agentMap = {
+      u1: { main: { "agent-sandbox": entry("agent-sandbox", "agent") } },
+    } as never;
+    expect(
+      overlayThreadSandboxMap({
+        agentSandboxMap: agentMap,
+        threadSandboxMap: undefined,
+        userId: "u1",
+        branch: "main",
+      }),
+    ).toBe(agentMap);
+  });
+
+  test("no userId / no branch → passthrough", () => {
+    expect(
+      overlayThreadSandboxMap({
+        agentSandboxMap: undefined,
+        threadSandboxMap: threadMap,
+        userId: null,
+        branch,
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -79,6 +79,39 @@ export function shouldSelfHeal(args: ShouldSelfHealArgs): boolean {
   );
 }
 
+/**
+ * Overlay the active thread's sandbox record onto the agent's `sandboxMap` for
+ * the current branch. `load_repo` persists a thread-scoped sandbox on the THREAD
+ * row (the ephemeral Decopilot agent's own map never persists), so the preview
+ * has to read it from there.
+ *
+ * Keyed by the VIEWER's user id, deliberately — never the thread owner's. A
+ * sandbox claim is per-user, so a teammate's entry is a URL you can look at but
+ * not drive (its `/events`, `/read`, git and exec all resolve to a claim you
+ * don't own), and adopting it as yours suppresses BOTH auto-start and the
+ * others-thread confirmation gate, leaving a read-only viewer with no path to a
+ * sandbox at all. Their absent entry is the correct answer: the gate renders,
+ * and confirming it boots the viewer's own sandbox on that thread's branch.
+ */
+export function overlayThreadSandboxMap(args: {
+  agentSandboxMap: SandboxMap | undefined;
+  threadSandboxMap: SandboxMap | undefined;
+  userId: string | null | undefined;
+  branch: string | null | undefined;
+}): SandboxMap | undefined {
+  const { agentSandboxMap, threadSandboxMap, userId, branch } = args;
+  if (!userId || !branch) return agentSandboxMap;
+  const threadBranchMap = threadSandboxMap?.[userId]?.[branch];
+  if (!threadBranchMap) return agentSandboxMap;
+  return {
+    ...(agentSandboxMap ?? {}),
+    [userId]: {
+      ...(agentSandboxMap?.[userId] ?? {}),
+      [branch]: threadBranchMap,
+    },
+  };
+}
+
 /** The gate label for an active thread: non-null iff the thread belongs to
  *  another member (its branch — which encodes the owner — or title as a
  *  fallback). Extracted from the layout so the ownership rule is unit-testable:
@@ -272,6 +305,7 @@ import type { SandboxMap } from "@decocms/shared/sdk/types";
 import { useQueryClient } from "@tanstack/react-query";
 import { invalidateVirtualMcpQueries } from "@/lib/query-keys";
 import { useChatTask } from "@/components/chat/context";
+import { useOptionalThreadManager } from "@/components/chat/store/hooks";
 import {
   sandboxUserStop,
   useSandboxStart,
@@ -296,10 +330,6 @@ export interface SandboxLifecycleValue {
   /** Confirm opening another member's thread: releases the auto-start gate so
    *  the sandbox boots on that thread's branch. See `othersThreadLabel`. */
   acknowledgeOthersThread: () => void;
-  /** The resolved sandbox is another member's (read-only view of their running
-   *  sandbox). Its boot progress is unobservable from here — see
-   *  `PreviewDisplayInput.foreignSandbox`. */
-  foreignSandbox: boolean;
 }
 
 const DEFAULT_VALUE: SandboxLifecycleValue = {
@@ -315,7 +345,6 @@ const DEFAULT_VALUE: SandboxLifecycleValue = {
   retry: () => {},
   resume: () => {},
   acknowledgeOthersThread: () => {},
-  foreignSandbox: false,
 };
 
 const SandboxLifecycleContext =
@@ -333,8 +362,7 @@ export function SandboxLifecycleProvider({
   sandboxMap,
   sandboxProviderKind,
   othersThreadLabel,
-  othersThreadId,
-  foreignSandbox = false,
+  threadId,
   children,
 }: {
   virtualMcpId: string | null;
@@ -351,17 +379,14 @@ export function SandboxLifecycleProvider({
    *  acknowledged, auto-start is held back so we never silently boot a sandbox
    *  on someone else's branch. Null on the user's own thread. */
   othersThreadLabel: string | null;
-  /** Active thread id — the acknowledgement key (see computeOthersThreadGate). */
-  othersThreadId: string | null;
-  /** The `sandboxMap` entry for this branch is another member's, grafted in so a
-   *  read-only viewer resolves their running sandbox (see `VmEventsBridge`).
-   *  Forwarded to the preview display, whose progress gate can never clear for
-   *  it. Defaults false (own sandbox). */
-  foreignSandbox?: boolean;
+  /** Active thread id. Both the acknowledgement key (see computeOthersThreadGate)
+   *  and the row re-read after a successful start (see `onStarted` below). */
+  threadId: string | null;
   children: ReactNode;
 }) {
   const { org } = useProjectContext();
   const { setCurrentTaskBranch } = useChatTask();
+  const manager = useOptionalThreadManager();
   const events = useSandboxEvents();
   const queryClient = useQueryClient();
 
@@ -372,7 +397,7 @@ export function SandboxLifecycleProvider({
   const { autoStartBlocked } = computeOthersThreadGate({
     othersThreadLabel,
     acknowledgedThreadId,
-    threadId: othersThreadId,
+    threadId,
   });
 
   const mcpClient = useMCPClient({
@@ -380,7 +405,19 @@ export function SandboxLifecycleProvider({
     orgId: org.id,
     orgSlug: org.slug,
   });
-  const startVm = useSandboxStart(mcpClient);
+  // Re-read the thread row after every successful start: a thread-scoped sandbox
+  // (`thread:<id>…` — every `load_repo` sandbox) records itself on the THREAD,
+  // not on the agent, so `invalidateVirtualMcpQueries` can't surface it, and the
+  // live `data-open-preview` chunk that patches the row client-side only reaches
+  // whoever ran the tool. Without this the fresh `previewUrl` never reaches the
+  // store and the preview holds the booting overlay until a page reload. Most
+  // visible when booting your own sandbox on a teammate's thread — nothing else
+  // writes that row for you there.
+  const startVm = useSandboxStart(mcpClient, {
+    onStarted: () => {
+      if (threadId) void manager?.refreshThreadMetadata(threadId);
+    },
+  });
   // Destructure mutate/reset so they're stable references for effect deps.
   const { mutate: startVmMutate, reset: startVmReset } = startVm;
 
@@ -657,7 +694,15 @@ export function SandboxLifecycleProvider({
 
   // Confirm opening another member's thread → release the gate. Auto-start
   // becomes eligible on the next render and fires SANDBOX_START for this branch.
-  const acknowledgeOthersThread = () => setAcknowledgedThreadId(othersThreadId);
+  //
+  // ponytail: the sandbox is the viewer's own (claims are per-user) but its git
+  // ref is the thread's, shared with the owner's sandbox — and the daemon
+  // commit+force-pushes its tree on shutdown, so two live sandboxes on one
+  // thread branch are last-shutdown-wins on the remote. That's the same ceiling
+  // two provider-kind siblings of a single user already have. If concurrent
+  // viewers become common, give a non-owner a derived ref forked from the
+  // owner's branch (needs a base-ref option in the daemon's checkout).
+  const acknowledgeOthersThread = () => setAcknowledgedThreadId(threadId);
 
   // Value is recomputed each render; React 19 Compiler handles memoization.
   const value: SandboxLifecycleValue = {
@@ -673,7 +718,6 @@ export function SandboxLifecycleProvider({
     retry,
     resume,
     acknowledgeOthersThread,
-    foreignSandbox,
   };
 
   return (

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -39,10 +39,6 @@ export interface ShouldAutoStartArgs {
   userStopped: boolean;
   isPending: boolean;
   attempted: boolean;
-  /** Held back until the user confirms opening another member's thread — see
-   *  `othersThreadLabel` on the provider. Prevents silently booting a sandbox
-   *  on someone else's branch. */
-  autoStartBlocked: boolean;
 }
 
 export function shouldAutoStart(args: ShouldAutoStartArgs): boolean {
@@ -52,8 +48,7 @@ export function shouldAutoStart(args: ShouldAutoStartArgs): boolean {
     !args.vmEntry &&
     !args.userStopped &&
     !args.isPending &&
-    !args.attempted &&
-    !args.autoStartBlocked
+    !args.attempted
   );
 }
 
@@ -63,9 +58,6 @@ export interface ShouldSelfHealArgs {
   lastDeadVmId: string | null;
   isPending: boolean;
   userStopped: boolean;
-  /** Same gate as auto-start: never silently reprovision a sandbox on another
-   *  member's branch while the confirmation gate is up. */
-  autoStartBlocked: boolean;
 }
 
 export function shouldSelfHeal(args: ShouldSelfHealArgs): boolean {
@@ -74,7 +66,6 @@ export function shouldSelfHeal(args: ShouldSelfHealArgs): boolean {
     !!args.deadVmId &&
     !args.isPending &&
     !args.userStopped &&
-    !args.autoStartBlocked &&
     args.deadVmId !== args.lastDeadVmId
   );
 }
@@ -85,23 +76,26 @@ export function shouldSelfHeal(args: ShouldSelfHealArgs): boolean {
  * row (the ephemeral Decopilot agent's own map never persists), so the preview
  * has to read it from there.
  *
- * Keyed by the VIEWER's user id, deliberately — never the thread owner's. A
- * sandbox claim is per-user, so a teammate's entry is a URL you can look at but
- * not drive (its `/events`, `/read`, git and exec all resolve to a claim you
- * don't own), and adopting it as yours suppresses BOTH auto-start and the
- * others-thread confirmation gate, leaving a read-only viewer with no path to a
- * sandbox at all. Their absent entry is the correct answer: the gate renders,
- * and confirming it boots the viewer's own sandbox on that thread's branch.
+ * Read under the thread's OWNER (`ownerId`), written under the VIEWER
+ * (`userId`) — a thread has exactly ONE sandbox, recorded under its creator, and
+ * the server resolves that same sandbox for every org member who opens the
+ * thread (`resolveSandboxUserId`: the claim handle, runner state and sandboxMap
+ * are all keyed by the creator, not the caller). So the owner's record IS the
+ * viewer's sandbox; re-keying it to the viewer is what makes the rest of this
+ * module — which looks up `sandboxMap[viewerId][branch]` — find it. `ownerId`
+ * absent (a new, unsaved thread) falls back to the viewer.
  */
 export function overlayThreadSandboxMap(args: {
   agentSandboxMap: SandboxMap | undefined;
   threadSandboxMap: SandboxMap | undefined;
   userId: string | null | undefined;
+  ownerId: string | null | undefined;
   branch: string | null | undefined;
 }): SandboxMap | undefined {
   const { agentSandboxMap, threadSandboxMap, userId, branch } = args;
-  if (!userId || !branch) return agentSandboxMap;
-  const threadBranchMap = threadSandboxMap?.[userId]?.[branch];
+  const ownerId = args.ownerId ?? userId;
+  if (!userId || !ownerId || !branch) return agentSandboxMap;
+  const threadBranchMap = threadSandboxMap?.[ownerId]?.[branch];
   if (!threadBranchMap) return agentSandboxMap;
   return {
     ...(agentSandboxMap ?? {}),
@@ -110,38 +104,6 @@ export function overlayThreadSandboxMap(args: {
       [branch]: threadBranchMap,
     },
   };
-}
-
-/** The gate label for an active thread: non-null iff the thread belongs to
- *  another member (its branch — which encodes the owner — or title as a
- *  fallback). Extracted from the layout so the ownership rule is unit-testable:
- *  an inverted comparison here would silently gate the user's own thread. */
-export function deriveOthersThreadLabel(args: {
-  userId: string | null;
-  createdBy: string | null | undefined;
-  branch: string | null | undefined;
-  title: string | null | undefined;
-}): string | null {
-  const isOthers =
-    !!args.userId && !!args.createdBy && args.createdBy !== args.userId;
-  if (!isOthers) return null;
-  return args.branch ?? args.title ?? null;
-}
-
-/** Whether auto-start (and self-heal) must be held back pending confirmation.
- *  Keyed by thread id, not branch: acknowledging a null-branch thread survives
- *  the server later assigning it a branch (no re-prompt / double-start), and
- *  two different members' threads that collide on a branch name don't share an
- *  acknowledgement. Re-arms when the active thread id changes. */
-export function computeOthersThreadGate(args: {
-  othersThreadLabel: string | null;
-  acknowledgedThreadId: string | null;
-  threadId: string | null;
-}): { autoStartBlocked: boolean } {
-  const acknowledged =
-    args.acknowledgedThreadId !== null &&
-    args.acknowledgedThreadId === args.threadId;
-  return { autoStartBlocked: !!args.othersThreadLabel && !acknowledged };
 }
 
 /** Shared SANDBOX_START arg-builder so every call site (auto-start,
@@ -192,7 +154,6 @@ export interface ShouldAutoRetryClaimArgs {
   attempts: number;
   isPending: boolean;
   userStopped: boolean;
-  autoStartBlocked: boolean;
   /** Guard so a single failed episode fires exactly one retry (re-armed when the
    *  phase leaves `failed`). Without it the persistent `failed` phase would
    *  re-fire every render once the mutation settles. */
@@ -206,7 +167,6 @@ export function shouldAutoRetryClaim(args: ShouldAutoRetryClaimArgs): boolean {
     args.attempts < MAX_CLAIM_AUTO_RETRIES &&
     !args.isPending &&
     !args.userStopped &&
-    !args.autoStartBlocked &&
     !args.alreadyHandled
   );
 }
@@ -278,8 +238,6 @@ export function computeDrawerStatus(state: PreviewState): DrawerStatus {
       return "starting";
     case "errored":
       return "errored";
-    case "othersThread":
-      return "idle";
   }
 }
 
@@ -327,9 +285,6 @@ export interface SandboxLifecycleValue {
   restart: () => Promise<void>;
   retry: () => void;
   resume: () => void;
-  /** Confirm opening another member's thread: releases the auto-start gate so
-   *  the sandbox boots on that thread's branch. See `othersThreadLabel`. */
-  acknowledgeOthersThread: () => void;
 }
 
 const DEFAULT_VALUE: SandboxLifecycleValue = {
@@ -344,7 +299,6 @@ const DEFAULT_VALUE: SandboxLifecycleValue = {
   restart: async () => {},
   retry: () => {},
   resume: () => {},
-  acknowledgeOthersThread: () => {},
 };
 
 const SandboxLifecycleContext =
@@ -361,7 +315,6 @@ export function SandboxLifecycleProvider({
   hasActiveGithubRepo,
   sandboxMap,
   sandboxProviderKind,
-  othersThreadLabel,
   threadId,
   children,
 }: {
@@ -374,13 +327,8 @@ export function SandboxLifecycleProvider({
    *  (unlocked). When non-null, entry selection and SANDBOX_START are scoped to
    *  this kind so the preview never silently shows a different-provider sibling. */
   sandboxProviderKind: SandboxProviderKind | null;
-  /** Non-null when the active thread belongs to another member: label to show
-   *  in the confirmation gate (its branch, or title). While set and not yet
-   *  acknowledged, auto-start is held back so we never silently boot a sandbox
-   *  on someone else's branch. Null on the user's own thread. */
-  othersThreadLabel: string | null;
-  /** Active thread id. Both the acknowledgement key (see computeOthersThreadGate)
-   *  and the row re-read after a successful start (see `onStarted` below). */
+  /** Active thread id — the row re-read after a successful start (see
+   *  `onStarted` below). */
   threadId: string | null;
   children: ReactNode;
 }) {
@@ -389,16 +337,6 @@ export function SandboxLifecycleProvider({
   const manager = useOptionalThreadManager();
   const events = useSandboxEvents();
   const queryClient = useQueryClient();
-
-  // Confirmation gate for another member's thread (see computeOthersThreadGate).
-  const [acknowledgedThreadId, setAcknowledgedThreadId] = useState<
-    string | null
-  >(null);
-  const { autoStartBlocked } = computeOthersThreadGate({
-    othersThreadLabel,
-    acknowledgedThreadId,
-    threadId,
-  });
 
   const mcpClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
@@ -486,10 +424,6 @@ export function SandboxLifecycleProvider({
     appPaused,
     userStopped,
     startError,
-    othersThreadGate:
-      autoStartBlocked && othersThreadLabel
-        ? { label: othersThreadLabel }
-        : null,
   });
   const status = computeDrawerStatus(previewState);
 
@@ -511,7 +445,6 @@ export function SandboxLifecycleProvider({
     userStopped,
     isPending: startVm.isPending,
     attempted,
-    autoStartBlocked,
   });
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- bridges external state into a one-shot mutation; no render-time equivalent
   useEffect(() => {
@@ -550,7 +483,6 @@ export function SandboxLifecycleProvider({
     lastDeadVmId: reprovisionedForVmIdRef.current,
     isPending: startVm.isPending,
     userStopped,
-    autoStartBlocked,
   });
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- one-shot reprovision trigger gated on notFound→deadVmId
   useEffect(() => {
@@ -589,7 +521,6 @@ export function SandboxLifecycleProvider({
     attempts: claimRetryEpisode.count,
     isPending: startVm.isPending,
     userStopped,
-    autoStartBlocked,
     alreadyHandled: claimRetryEpisode.handled,
   });
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- bridges the SSE failed phase into a one-shot bounded reprovision
@@ -692,18 +623,6 @@ export function SandboxLifecycleProvider({
   };
   const resume = retry;
 
-  // Confirm opening another member's thread → release the gate. Auto-start
-  // becomes eligible on the next render and fires SANDBOX_START for this branch.
-  //
-  // ponytail: the sandbox is the viewer's own (claims are per-user) but its git
-  // ref is the thread's, shared with the owner's sandbox — and the daemon
-  // commit+force-pushes its tree on shutdown, so two live sandboxes on one
-  // thread branch are last-shutdown-wins on the remote. That's the same ceiling
-  // two provider-kind siblings of a single user already have. If concurrent
-  // viewers become common, give a non-owner a derived ref forked from the
-  // owner's branch (needs a base-ref option in the daemon's checkout).
-  const acknowledgeOthersThread = () => setAcknowledgedThreadId(threadId);
-
   // Value is recomputed each render; React 19 Compiler handles memoization.
   const value: SandboxLifecycleValue = {
     branch,
@@ -717,7 +636,6 @@ export function SandboxLifecycleProvider({
     restart,
     retry,
     resume,
-    acknowledgeOthersThread,
   };
 
   return (

--- a/apps/web/src/components/sandbox/hooks/use-sandbox-start.ts
+++ b/apps/web/src/components/sandbox/hooks/use-sandbox-start.ts
@@ -76,7 +76,16 @@ export const sandboxUserStop = {
     userStoppedSandboxes.has(`${virtualMcpId}::${branch}`),
 };
 
-export function useSandboxStart(client: MinimalMcpClient) {
+export function useSandboxStart(
+  client: MinimalMcpClient,
+  opts?: {
+    /** Ran after every successful start, whichever call site fired it. Lives
+     *  here rather than in each caller's per-call `onSuccess` so it can't be
+     *  forgotten by a new call site — and so it never becomes an effect
+     *  dependency (mutation options are re-read per render; effect deps are not). */
+    onStarted?: () => void;
+  },
+) {
   const queryClient = useQueryClient();
   return useMutation<SandboxStartResult, Error, SandboxStartArgs>({
     mutationKey: SANDBOX_START_MUTATION_KEY,
@@ -107,6 +116,7 @@ export function useSandboxStart(client: MinimalMcpClient) {
     // Per-call onSuccess (via `mutate(args, { onSuccess })`) runs AFTER this.
     onSuccess: () => {
       invalidateVirtualMcpQueries(queryClient);
+      opts?.onStarted?.();
     },
   });
 }

--- a/apps/web/src/components/sandbox/preview/preview-display.test.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.test.ts
@@ -12,7 +12,6 @@ const ERRORED: PreviewState = {
   kind: "errored",
   error: { code: null, message: "boom" },
 };
-const OTHERS_THREAD: PreviewState = { kind: "othersThread", label: "Alice" };
 
 const PROD = "https://acme.com";
 
@@ -114,23 +113,6 @@ describe("resolvePreviewDisplay", () => {
       resolvePreviewDisplay({
         previewState: ERRORED,
         progressStatus: "failed",
-        productionUrl: PROD,
-      }),
-    ).toEqual({
-      mode: "none",
-      iframeBase: null,
-      showBlockingOverlay: false,
-      showWakingPill: false,
-    });
-  });
-
-  it("yields the canvas to the othersThread gate — no production leak", () => {
-    // A teammate's branch: even with a productionUrl set, don't paint a toolbar
-    // or load the production iframe behind the confirmation card.
-    expect(
-      resolvePreviewDisplay({
-        previewState: OTHERS_THREAD,
-        progressStatus: "doing",
         productionUrl: PROD,
       }),
     ).toEqual({

--- a/apps/web/src/components/sandbox/preview/preview-display.test.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.test.ts
@@ -124,56 +124,6 @@ describe("resolvePreviewDisplay", () => {
     });
   });
 
-  it("shows a foreign sandbox's iframe immediately — its boot is unobservable", () => {
-    // Viewing a teammate's thread: previewUrl is their running sandbox, but the
-    // claim/lifecycle stream is keyed to OUR handle so progressStatus never
-    // leaves "doing". Without the foreignSandbox bypass this pins the blocking
-    // overlay ("Reserving sandbox") forever.
-    const result = resolvePreviewDisplay({
-      previewState: IFRAME,
-      progressStatus: "doing",
-      productionUrl: null,
-      foreignSandbox: true,
-    });
-    expect(result.mode).toBe("sandbox");
-    expect(result.iframeBase).toBe(
-      IFRAME.kind === "iframe" ? IFRAME.previewUrl : null,
-    );
-    expect(result.showBlockingOverlay).toBe(false);
-  });
-
-  it("prefers a foreign sandbox over the production fallback", () => {
-    const result = resolvePreviewDisplay({
-      previewState: IFRAME,
-      progressStatus: "doing",
-      productionUrl: PROD,
-      foreignSandbox: true,
-    });
-    expect(result.mode).toBe("sandbox");
-    expect(result.showWakingPill).toBe(false);
-  });
-
-  it("foreignSandbox does not override the othersThread gate or a bare start", () => {
-    // No previewUrl yet → still the gate / booting path; the bypass only applies
-    // to an already-resolved foreign previewUrl.
-    expect(
-      resolvePreviewDisplay({
-        previewState: OTHERS_THREAD,
-        progressStatus: "doing",
-        productionUrl: PROD,
-        foreignSandbox: true,
-      }).mode,
-    ).toBe("none");
-    expect(
-      resolvePreviewDisplay({
-        previewState: STARTING,
-        progressStatus: "doing",
-        productionUrl: null,
-        foreignSandbox: true,
-      }).showBlockingOverlay,
-    ).toBe(true);
-  });
-
   it("yields the canvas to the othersThread gate — no production leak", () => {
     // A teammate's branch: even with a productionUrl set, don't paint a toolbar
     // or load the production iframe behind the confirmation card.

--- a/apps/web/src/components/sandbox/preview/preview-display.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.ts
@@ -41,16 +41,6 @@ export interface PreviewDisplayInput {
   progressStatus: PhaseStatus;
   /** Live production URL to fall back to while waking, or `null` if unknown. */
   productionUrl: string | null;
-  /**
-   * The resolved sandbox belongs to ANOTHER member (a read-only view of their
-   * thread's already-running sandbox — see the owner graft in `VmEventsBridge`).
-   * Their boot progress is unobservable from here: the claim-phase / daemon
-   * lifecycle stream is keyed to the VIEWER's claim handle, which never
-   * materializes, so `progressStatus` is pinned at `doing` forever. Show the
-   * iframe on `previewUrl` alone instead of waiting out a boot that isn't ours
-   * to watch.
-   */
-  foreignSandbox?: boolean;
 }
 
 const NONE: PreviewDisplay = {
@@ -63,7 +53,7 @@ const NONE: PreviewDisplay = {
 export function resolvePreviewDisplay(
   input: PreviewDisplayInput,
 ): PreviewDisplay {
-  const { previewState, progressStatus, productionUrl, foreignSandbox } = input;
+  const { previewState, progressStatus, productionUrl } = input;
 
   // Suspended / errored / othersThread all render their own dedicated card
   // (the last one is a confirmation gate on a teammate's branch) — hand the
@@ -80,13 +70,8 @@ export function resolvePreviewDisplay(
   // The sandbox surface is showable once a previewUrl exists AND boot is no
   // longer in progress: `done` (running) serves the live app, `failed`/`crashed`
   // serves the daemon's auto-reloading status page — both belong in the iframe,
-  // not behind a "waking" pill. A foreign sandbox skips the progress gate (its
-  // progress is unobservable — see `foreignSandbox`); whatever the owner's
-  // daemon serves is the displayed state.
-  if (
-    previewState.kind === "iframe" &&
-    (foreignSandbox || progressStatus !== "doing")
-  ) {
+  // not behind a "waking" pill.
+  if (previewState.kind === "iframe" && progressStatus !== "doing") {
     return {
       mode: "sandbox",
       iframeBase: previewState.previewUrl,

--- a/apps/web/src/components/sandbox/preview/preview-display.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.ts
@@ -55,15 +55,9 @@ export function resolvePreviewDisplay(
 ): PreviewDisplay {
   const { previewState, progressStatus, productionUrl } = input;
 
-  // Suspended / errored / othersThread all render their own dedicated card
-  // (the last one is a confirmation gate on a teammate's branch) — hand the
-  // canvas over so we don't paint a toolbar or load the production iframe
-  // behind/around it.
-  if (
-    previewState.kind === "suspended" ||
-    previewState.kind === "errored" ||
-    previewState.kind === "othersThread"
-  ) {
+  // Suspended / errored render their own dedicated card — hand the canvas over
+  // so we don't paint a toolbar or load the production iframe behind/around it.
+  if (previewState.kind === "suspended" || previewState.kind === "errored") {
     return NONE;
   }
 

--- a/apps/web/src/components/sandbox/preview/preview-state.test.ts
+++ b/apps/web/src/components/sandbox/preview/preview-state.test.ts
@@ -64,45 +64,4 @@ describe("computePreviewState", () => {
       }),
     ).toEqual({ kind: "suspended" });
   });
-
-  test("othersThreadGate with no previewUrl → othersThread (before starting)", () => {
-    expect(
-      computePreviewState({
-        ...base,
-        previewUrl: null,
-        othersThreadGate: { label: "tavano-321312" },
-      }),
-    ).toEqual({ kind: "othersThread", label: "tavano-321312" });
-  });
-
-  test("othersThreadGate but a live previewUrl → iframe (acknowledged, VM is running)", () => {
-    expect(
-      computePreviewState({
-        ...base,
-        othersThreadGate: { label: "tavano-321312" },
-      }),
-    ).toEqual({ kind: "iframe", previewUrl: "http://localhost:5173" });
-  });
-
-  test("gate beats userStopped when no previewUrl (never boot someone else's branch)", () => {
-    expect(
-      computePreviewState({
-        ...base,
-        previewUrl: null,
-        userStopped: true,
-        othersThreadGate: { label: "tavano-321312" },
-      }),
-    ).toEqual({ kind: "othersThread", label: "tavano-321312" });
-  });
-
-  test("gate beats startError when no previewUrl", () => {
-    expect(
-      computePreviewState({
-        ...base,
-        previewUrl: null,
-        startError: { code: null, message: "boom" },
-        othersThreadGate: { label: "tavano-321312" },
-      }),
-    ).toEqual({ kind: "othersThread", label: "tavano-321312" });
-  });
 });

--- a/apps/web/src/components/sandbox/preview/preview-state.ts
+++ b/apps/web/src/components/sandbox/preview/preview-state.ts
@@ -25,31 +25,15 @@ export interface PreviewStateInput {
   userStopped: boolean;
   /** SANDBOX_START rejected (e.g. GitHub not authenticated) with no VM yet. */
   startError: SandboxStartError | null;
-  /**
-   * The active thread belongs to another member and the current user hasn't
-   * acknowledged opening it yet. While set, auto-start is held back and the
-   * preview shows a confirmation gate instead of silently booting a sandbox on
-   * the other member's branch. `label` identifies the thread (its branch, or
-   * title as a fallback). Null once acknowledged, or on the user's own thread.
-   */
-  othersThreadGate?: { label: string } | null;
 }
 
 export type PreviewState =
   | { kind: "starting" }
   | { kind: "suspended" }
   | { kind: "errored"; error: SandboxStartError }
-  | { kind: "othersThread"; label: string }
   | { kind: "iframe"; previewUrl: string };
 
 export function computePreviewState(input: PreviewStateInput): PreviewState {
-  // Gate wins before we ever spin the booting overlay: don't birth a sandbox on
-  // another member's branch until the user confirms. Once a previewUrl exists
-  // the user already acknowledged and the VM is theirs, so the running preview
-  // wins over a stale gate.
-  if (input.othersThreadGate && !input.previewUrl) {
-    return { kind: "othersThread", label: input.othersThreadGate.label };
-  }
   if (input.appPaused || input.userStopped) return { kind: "suspended" };
   // A start error with no live VM is terminal: show it instead of spinning
   // on the booting overlay forever. Once a previewUrl exists the running

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1576,36 +1576,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                   </div>
                 )}
 
-                {previewState.kind === "othersThread" && (
-                  <div className="absolute inset-0 z-30">
-                    <SandboxStateCard
-                      kind="othersThread"
-                      label={previewState.label}
-                      onContinue={lifecycle.acknowledgeOthersThread}
-                      onStartNewThread={() =>
-                        navigate({
-                          to: "/$org/$taskId",
-                          params: {
-                            org: org.slug,
-                            taskId: crypto.randomUUID(),
-                          },
-                          // Fresh thread on the SAME agent: keep only
-                          // `virtualmcpid` and drop the viewed thread's params
-                          // (its per-thread `main` tab, and `sidepanel`) so the
-                          // target agent's configured default layout resolves —
-                          // don't force chat open on an agent that opts out of
-                          // it (chatDefaultOpen / non-chat defaultMainView).
-                          search: (prev) => ({
-                            ...(typeof prev.virtualmcpid === "string"
-                              ? { virtualmcpid: prev.virtualmcpid }
-                              : {}),
-                          }),
-                        })
-                      }
-                    />
-                  </div>
-                )}
-
                 {previewState.kind === "suspended" && (
                   <div className="absolute inset-0 z-30">
                     <SandboxStateCard

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -485,7 +485,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     previewState,
     progressStatus: progress.status,
     productionUrl,
-    foreignSandbox: lifecycle.foreignSandbox,
   });
   const previewSurfaceActive = display.mode !== "none";
   const showBootingOverlay = display.showBlockingOverlay;

--- a/apps/web/src/components/sandbox/preview/state-card.tsx
+++ b/apps/web/src/components/sandbox/preview/state-card.tsx
@@ -1,12 +1,9 @@
 import { Button } from "@deco/ui/components/button.tsx";
 import {
   AlertTriangle,
-  Eye,
   PauseCircle,
   Play,
-  Plus,
   RefreshCw01,
-  Users01,
 } from "@untitledui/icons";
 import { SANDBOX_START_ERROR_CODES } from "@decocms/shared/sandbox-start-errors";
 import { BootingVisual } from "./booting-visual";
@@ -29,43 +26,10 @@ export type SandboxStateCardProps =
       onRetry: () => void;
       /** Link to the org's Connections page, for the GitHub-auth case. */
       connectionsHref?: string;
-    }
-  | {
-      kind: "othersThread";
-      /** Identifies the other member's thread (its branch, or title). */
-      label: string;
-      onContinue: () => void;
-      onStartNewThread: () => void;
     };
 
 export function SandboxStateCard(props: SandboxStateCardProps) {
   const t = useT();
-
-  if (props.kind === "othersThread") {
-    return (
-      <div className="flex h-full w-full items-center justify-center bg-background p-6">
-        <div className="flex w-full max-w-md flex-col items-center gap-4 text-center">
-          <Users01 className="size-12 text-muted-foreground" />
-          <h3 className="text-lg font-medium">
-            {t("sandbox.stateCard.othersThreadTitle")}
-          </h3>
-          <p className="max-w-sm text-sm text-muted-foreground">
-            {t("sandbox.stateCard.othersThreadMessage", { label: props.label })}
-          </p>
-          <div className="mt-2 flex items-center gap-2">
-            <Button variant="outline" onClick={props.onContinue}>
-              <Eye className="size-4" />{" "}
-              {t("sandbox.stateCard.othersThreadContinue")}
-            </Button>
-            <Button onClick={props.onStartNewThread}>
-              <Plus className="size-4" />{" "}
-              {t("sandbox.stateCard.othersThreadNewChat")}
-            </Button>
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   if (props.kind === "starting") {
     return (

--- a/apps/web/src/hooks/use-refresh-viewed-thread-metadata.ts
+++ b/apps/web/src/hooks/use-refresh-viewed-thread-metadata.ts
@@ -6,10 +6,10 @@
  * the live `data-open-preview` stream chunk that patches `githubRepo` /
  * `sandboxMap` onto the client row reaches only the user who ran the tool, and
  * the thread-status SSE carries no metadata. That stale row makes the preview
- * show "no source to preview" and hides the owner's already-running sandbox
- * (the owner-keyed sandbox lookup finds nothing). Force a fresh
- * `COLLECTION_THREADS_GET` and merge it into the store so `activeTask` picks up
- * the current metadata.
+ * show "no source to preview" — and with no `githubRepo` the viewer can't start
+ * their own sandbox on the thread's branch either (`hasActiveGithubRepo` gates
+ * auto-start). Force a fresh `COLLECTION_THREADS_GET` and merge it into the
+ * store so `activeTask` picks up the current metadata.
  *
  * Gated to OTHERS' threads: the owner's own row is kept current by the live
  * stream, so there's nothing to refresh.

--- a/apps/web/src/hooks/use-refresh-viewed-thread-metadata.ts
+++ b/apps/web/src/hooks/use-refresh-viewed-thread-metadata.ts
@@ -6,10 +6,11 @@
  * the live `data-open-preview` stream chunk that patches `githubRepo` /
  * `sandboxMap` onto the client row reaches only the user who ran the tool, and
  * the thread-status SSE carries no metadata. That stale row makes the preview
- * show "no source to preview" — and with no `githubRepo` the viewer can't start
- * their own sandbox on the thread's branch either (`hasActiveGithubRepo` gates
- * auto-start). Force a fresh `COLLECTION_THREADS_GET` and merge it into the
- * store so `activeTask` picks up the current metadata.
+ * show "no source to preview", hides the thread's sandbox record (kept under its
+ * creator's key), and — with no `githubRepo` — blocks auto-start from booting the
+ * thread's sandbox at all (`hasActiveGithubRepo` gates it). Force a fresh
+ * `COLLECTION_THREADS_GET` and merge it into the store so `activeTask` picks up
+ * the current metadata.
  *
  * Gated to OTHERS' threads: the owner's own row is kept current by the live
  * stream, so there's nothing to refresh.

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -594,11 +594,6 @@ export const sandbox = {
   "sandbox.sectionsRightPane.selectSectionTitle": "Select a section to edit",
   "sandbox.stateCard.githubNotAuthenticatedMessage":
     "This agent's GitHub repo isn't authenticated. Reconnect it in Connections, then retry.",
-  "sandbox.stateCard.othersThreadTitle": "You're in someone else's chat",
-  "sandbox.stateCard.othersThreadMessage":
-    "This conversation ({label}) belongs to another member. Continuing here means picking up their work — start a new chat to work on your own instead.",
-  "sandbox.stateCard.othersThreadContinue": "Continue anyway",
-  "sandbox.stateCard.othersThreadNewChat": "Start new chat",
   "sandbox.stateCard.reconnectGithub": "Reconnect GitHub",
   "sandbox.stateCard.resume": "Resume",
   "sandbox.stateCard.resumeToContinue": "Resume to continue.",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -620,11 +620,6 @@ export const sandbox = {
     "Selecione uma seção para editar",
   "sandbox.stateCard.githubNotAuthenticatedMessage":
     "O repositório GitHub deste agente não está autenticado. Reconecte em Conexões e tente novamente.",
-  "sandbox.stateCard.othersThreadTitle": "Você está no chat de outra pessoa",
-  "sandbox.stateCard.othersThreadMessage":
-    "Esta conversa ({label}) é de outro membro. Continuar aqui significa dar sequência ao trabalho dela — comece um novo chat para trabalhar no seu.",
-  "sandbox.stateCard.othersThreadContinue": "Continuar mesmo assim",
-  "sandbox.stateCard.othersThreadNewChat": "Começar novo chat",
   "sandbox.stateCard.reconnectGithub": "Reconectar GitHub",
   "sandbox.stateCard.resume": "Retomar",
   "sandbox.stateCard.resumeToContinue": "Retome para continuar.",

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -62,7 +62,6 @@ import { SandboxEventsProvider } from "@/components/sandbox/hooks/sandbox-events
 import {
   SandboxLifecycleProvider,
   resolveVmEntry,
-  deriveOthersThreadLabel,
   overlayThreadSandboxMap,
   type BranchMapEntryLike,
 } from "@/components/sandbox/hooks/sandbox-lifecycle-context";
@@ -149,29 +148,20 @@ function VmEventsBridge({
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
 
-  // Overlay the thread's own sandbox record for the current branch — see
-  // overlayThreadSandboxMap for why it's keyed by the VIEWER, not the owner.
+  // Overlay the thread's own sandbox record for the current branch. A thread has
+  // ONE sandbox, recorded under its creator and resolved server-side for every
+  // member who opens the thread — see overlayThreadSandboxMap.
   const effectiveSandboxMap = overlayThreadSandboxMap({
     agentSandboxMap: sandboxMap,
     threadSandboxMap: activeTask?.metadata?.sandboxMap as
       | SandboxMap
       | undefined,
     userId,
+    ownerId: activeTask?.created_by,
     branch: currentBranch,
   });
   const effectiveHasGithubRepo =
     hasActiveGithubRepo || agentHasClonableSource(activeTask?.metadata);
-
-  // Someone else's thread: hold auto-start behind a confirmation gate so the
-  // sandbox doesn't silently boot on the creator's branch (mirrors the chat
-  // composer's read-only banner). Ownership rule lives in the pure, tested
-  // deriveOthersThreadLabel; own thread → null (no gate).
-  const othersThreadLabel = deriveOthersThreadLabel({
-    userId: userId ?? null,
-    createdBy: activeTask?.created_by,
-    branch: activeTask?.branch,
-    title: activeTask?.title,
-  });
 
   // Open the events stream only when a sandbox actually exists or a start is
   // in flight — NOT merely because the agent has a GitHub repo configured.
@@ -210,7 +200,6 @@ function VmEventsBridge({
         hasActiveGithubRepo={effectiveHasGithubRepo}
         sandboxMap={effectiveSandboxMap}
         sandboxProviderKind={pendingSandboxProviderKind}
-        othersThreadLabel={othersThreadLabel}
         threadId={activeTask?.id ?? null}
       >
         <BlocksPreviewWorkspaceProvider

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -63,6 +63,7 @@ import {
   SandboxLifecycleProvider,
   resolveVmEntry,
   deriveOthersThreadLabel,
+  overlayThreadSandboxMap,
   type BranchMapEntryLike,
 } from "@/components/sandbox/hooks/sandbox-lifecycle-context";
 import { useEnsureTask } from "@/hooks/use-ensure-task";
@@ -148,43 +149,16 @@ function VmEventsBridge({
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
 
-  // Overlay the thread's own sandbox record for the current branch. `load_repo`
-  // binds a repo to the thread and persists its sandbox there (the ephemeral
-  // Decopilot agent's sandboxMap never persists), so the preview must read the
-  // thread's entry, not just the agent's.
-  const threadSandboxMap = activeTask?.metadata?.sandboxMap as
-    | SandboxMap
-    | undefined;
-  // The thread persists its sandbox under the thread OWNER's user id — yours for
-  // your own thread, the creator's when you're viewing someone else's (read-only).
-  // Read the owner's entry, not the viewer's: for another member's thread the
-  // viewer-keyed lookup misses, `previewUrl` stays null, and the gate's ack then
-  // fires a fresh clone on the owner's branch that never resolves ("Cloning your
-  // repo…" forever). Grafting the owner's entry under the viewer's key lets
-  // previewUrl resolve to the owner's already-running sandbox, so it renders
-  // read-only with no clone. `created_by` absent → falls back to the viewer
-  // (own-thread behavior unchanged).
-  const previewOwnerId = activeTask?.created_by ?? userId;
-  const threadOwnerBranchMap =
-    previewOwnerId && currentBranch
-      ? threadSandboxMap?.[previewOwnerId]?.[currentBranch]
-      : undefined;
-  // True when that grafted entry is someone ELSE's sandbox. Nothing about its
-  // boot is observable from here — the claim/daemon event stream is keyed to the
-  // viewer's own claim handle, which never materializes — so the preview renders
-  // on `previewUrl` alone (see `foreignSandbox` in preview-display) and the
-  // stream stays closed instead of reporting `claiming` forever.
-  const foreignSandbox = !!threadOwnerBranchMap && previewOwnerId !== userId;
-  const effectiveSandboxMap: SandboxMap | undefined =
-    userId && currentBranch && threadOwnerBranchMap
-      ? {
-          ...(sandboxMap ?? {}),
-          [userId]: {
-            ...(sandboxMap?.[userId] ?? {}),
-            [currentBranch]: threadOwnerBranchMap,
-          },
-        }
-      : sandboxMap;
+  // Overlay the thread's own sandbox record for the current branch — see
+  // overlayThreadSandboxMap for why it's keyed by the VIEWER, not the owner.
+  const effectiveSandboxMap = overlayThreadSandboxMap({
+    agentSandboxMap: sandboxMap,
+    threadSandboxMap: activeTask?.metadata?.sandboxMap as
+      | SandboxMap
+      | undefined,
+    userId,
+    branch: currentBranch,
+  });
   const effectiveHasGithubRepo =
     hasActiveGithubRepo || agentHasClonableSource(activeTask?.metadata);
 
@@ -220,8 +194,7 @@ function VmEventsBridge({
   // vmEntry always agree on which sandbox is active.
   const vmEntry = resolveVmEntry(branchMap, pendingSandboxProviderKind);
   const previewUrl = vmEntry?.previewUrl ?? null;
-  const shouldConnect =
-    (Object.keys(branchMap).length > 0 || isStartPending) && !foreignSandbox;
+  const shouldConnect = Object.keys(branchMap).length > 0 || isStartPending;
 
   return (
     <SandboxEventsProvider
@@ -238,8 +211,7 @@ function VmEventsBridge({
         sandboxMap={effectiveSandboxMap}
         sandboxProviderKind={pendingSandboxProviderKind}
         othersThreadLabel={othersThreadLabel}
-        othersThreadId={activeTask?.id ?? null}
-        foreignSandbox={foreignSandbox}
+        threadId={activeTask?.id ?? null}
       >
         <BlocksPreviewWorkspaceProvider
           key={`${virtualMcpId}:${currentBranch ?? "no-branch"}`}


### PR DESCRIPTION
## Problem

Open a thread that isn't yours (e.g. `/demo-storefront/thrd_…?main=preview`): the UI detects the `load_repo`, opens the Preview tab, and renders an iframe — but nothing works. `SANDBOX_START` never fires, and every sandbox route (`/events`, `/read`, git, exec) 404s or reports `claiming` forever.

Sandbox identity was per-**caller** in three places that must agree — the claim handle (`computeClaimHandle`), `sandbox_runner_state`'s PK, and the `sandboxMap` key. So a teammate's sandbox was a URL you could look at but never drive.

The frontend papered over that by grafting the owner's `sandboxMap` entry under the viewer's key. That made `vmEntry` non-null, which silently disabled the two things that would have gotten the viewer a working sandbox:

- `shouldAutoStart` requires `!vmEntry` → auto-start ineligible;
- `computePreviewState` returns `iframe` whenever a `previewUrl` exists, which outranks the `othersThread` confirmation gate → the gate and its "Continue anyway" button never rendered.

Net effect: an undrivable iframe and no path to a sandbox at all.

## Fix — one sandbox per thread, keyed by its creator

A thread-scoped branch (`thread:<id>[/<conn>]`) now keys sandbox **identity** by the thread's creator, not the caller (`resolveSandboxUserId` in `tools/sandbox/thread-repo.ts`). Every org member who opens the thread resolves the *same* sandbox: the claim handle, runner state and `sandboxMap` slot all agree, so a viewer's `/events`, `/read`, git and exec reach the live daemon, and `SANDBOX_START` on an evicted one **resumes** it instead of forking a copy.

Applied at every site that keys a sandbox, so no path can compute a rival handle:

| site | change |
|---|---|
| `SANDBOX_START` | provider resolution, entry lookup, `runner.ensure`, tenant label, both `sandboxMap` writes |
| `ensureSandbox` (dispatch / `load_repo` / fs tools) | same |
| `requireVmEntry` → `SANDBOX_DELETE` | entry lookup + teardown target |
| `sandbox-proxy`'s `resolveVmClaim` | the claim handle every proxy route resolves |
| `computeDesktopSandboxHandle` call site | so a desktop run can't cold-spawn a second, dispatcher-keyed sandbox |

**Credentials and audit stay keyed to the CALLER.** Env secrets (`resolveAndPushEnv`) and submodule PATs (`resolveSubmoduleCredentials`) resolve as whoever made the request, so opening a teammate's thread can never mint their private secrets into a sandbox — a secret the caller can't read is skipped, exactly as today. `vmClaim` carries both (`callerUserId` vs `userId`), and storage writes keep the caller as `actingUserId`.

This also removes the git hazard from the first draft of this PR (which had the viewer boot their *own* sandbox): with one sandbox there's a single writer of the thread's git ref, so the daemon's shutdown commit+force-push can't race a second sandbox on the same branch.

## Auto-start (no gate)

With a single shared sandbox there's nothing to confirm, so the confirmation gate is deleted and a teammate's thread auto-starts exactly like your own: `deriveOthersThreadLabel`, `computeOthersThreadGate`, the `othersThread` preview state + state card + 4 i18n keys (en + pt-br), the `autoStartBlocked` arg on all three predicates, and `foreignSandbox` (which existed only to paint the undrivable iframe). Net −468/+228 lines.

`overlayThreadSandboxMap` reads the thread's record under its **creator** and re-keys it to the viewer, which is what makes the existing viewer-keyed lookups (`sandboxMap[userId][branch]`) find it. It also re-reads the thread row after every successful start (`useSandboxStart({ onStarted })`) — a thread-scoped sandbox records itself on the thread, not the agent, so `invalidateVirtualMcpQueries` can't surface it and the `data-open-preview` chunk only reaches whoever ran the tool; without it the fresh `previewUrl` never reached the store and the preview held the booting overlay until a reload.

## Worth a reviewer's opinion

**Stop/restart is not owner-gated.** A viewer can stop the thread's (now shared) sandbox. It's recoverable — teardown SIGTERMs the daemon, which pushes its tree, and the next start boots it again — but if those controls should be read-only for non-owners, that's a small follow-up in the drawer/toolbar.

## Testing

- `bun test apps/web/src/components/sandbox apps/api/src/tools/sandbox` → 510 pass. New: `SANDBOX_START` keys a thread-scoped sandbox by the creator while the audit user stays the caller; `overlayThreadSandboxMap` re-keys the owner's record onto the viewer.
- `bun run check` (all workspaces incl. `apps/api`), `bun run lint` (16 warnings = unchanged baseline, 0 in touched files), `bunx knip` clean, `bun run fmt`. `bun test apps/web packages/shared` → 2421 pass / 23 pre-existing failures that reproduce on other branches (tests assigning to readonly globals).
- **Not exercised end-to-end with two accounts** — that needs a second org member with a `load_repo`'d thread and a live sandbox provider. The chain was traced in code: auto-start → `SANDBOX_START` (owner-keyed) → `provisionSandbox` writes `sandboxMap[creatorId]` on the thread → `refreshThreadMetadata` → overlay → `previewUrl` → `/events` under the same owner-resolved claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDQVnDvcXwrfiEPEcvr58S
