### PR TITLE
feat(cms): Fast Preview — pull-based draft rendering

### DIFF
--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -502,6 +502,14 @@ async function provisionSandbox(
   // runners free to assign a unique dynamic port (user-desktop needs this;
   // multiple sandboxes on the user's machine share the host network and
   // can't all bind 3000).
+  // Live production URL (already normalized to an https URL by the settings
+  // form). Forwarded so the daemon's Fast Preview route can render the draft
+  // against production. Harmless when Fast Preview is off — the daemon only
+  // reads it when that route is hit.
+  const productionUrl =
+    typeof metadata.productionUrl === "string" && metadata.productionUrl.trim()
+      ? metadata.productionUrl.trim()
+      : undefined;
   const workload: Workload | undefined =
     runtime && packageManager && !cloneOnly
       ? {
@@ -509,6 +517,7 @@ async function provisionSandbox(
           packageManager,
           ...(port !== null ? { devPort: Number(port) } : {}),
           ...(packageManagerPath ? { packageManagerPath } : {}),
+          ...(productionUrl ? { productionUrl } : {}),
         }
       : undefined;
 

--- a/apps/native/crates/local-api/src/router.rs
+++ b/apps/native/crates/local-api/src/router.rs
@@ -165,6 +165,11 @@ pub fn build(
         .route("/exec/:name", post(routes::scripts::exec))
         .route("/exec/:name/kill", post(routes::scripts::exec_kill))
         .route("/events", get(routes::events::events))
+        // GET /_sandbox/decofile — the merged working-tree draft, for Fast
+        // Preview. Guarded like every route in this router (see
+        // routes::decofile's module doc for why this diverges from the
+        // daemon's unauthenticated route).
+        .route("/decofile", get(routes::decofile::decofile))
         .route("/preview-handle", post(routes::proxy::set_preview_handle))
         // GET /_sandbox/repo-dir — see routes::repo_dir's module doc (a
         // git-backed sandbox's absolute workdir, for the webview's

--- a/apps/native/crates/local-api/src/routes/decofile.rs
+++ b/apps/native/crates/local-api/src/routes/decofile.rs
@@ -1,0 +1,339 @@
+//! `GET /_sandbox/decofile` — the working-tree DRAFT decofile, every
+//! `.deco/blocks/*.json` merged, served content-addressed for Fast Preview.
+//!
+//! Byte-parity target: `packages/sandbox/daemon-go/internal/routes/decofile.go`.
+//! Unlike the daemon (where the fetcher is an arbitrary production server
+//! with no way to carry the daemon bearer token), this route sits BEHIND the
+//! `/_sandbox` guard — see `routes/events.rs`'s module doc for why this
+//! crate tightens the daemon's no-auth posture for local-api. Loopback here
+//! isn't reachable from the public internet, so byte-parity with the
+//! daemon's unauthenticated route would only add an unused attack surface.
+//!
+//! Scoped to the process-global `state.repo_dir`/`state.config`/
+//! `state.broadcaster` — exactly like `routes/fs.rs`'s write/read/etc, the
+//! only handlers that ever mutate `.deco/blocks`. The merge here MUST
+//! resolve the same tree those write through, or its version (and the SSE
+//! `decofile` event's version) could drift from what was actually saved.
+//! Deliberately NOT resolved via `AppState::resolve_sandbox_target` — that
+//! per-handle resolution exists for `routes/events.rs`'s multi-sandbox
+//! observability and would silently disagree with `fs.rs` whenever an
+//! "active" sandbox happens to be set.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use axum::extract::State;
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::config::{get_str, ConfigStore};
+use crate::error::ApiError;
+use crate::events::Broadcaster;
+use crate::state::AppState;
+
+use super::fs::generate_decofile_from_blocks;
+
+/// Resolves `.deco/blocks` under the configured package-manager path (repo
+/// root when unset or relative-joined against `repo_dir`) — byte-parity with
+/// the daemon's `paths.ResolvePmRoot` semantics.
+fn blocks_dir(repo_dir: &Path, config: &ConfigStore) -> PathBuf {
+    let snapshot = config.snapshot();
+    let pm_path = snapshot
+        .config
+        .as_ref()
+        .and_then(|c| get_str(c, &["application", "packageManager", "path"]))
+        .filter(|p| !p.is_empty());
+    let root = match pm_path {
+        Some(p) if Path::new(p).is_absolute() => PathBuf::from(p),
+        Some(p) => repo_dir.join(p),
+        None => repo_dir.to_path_buf(),
+    };
+    root.join(".deco").join("blocks")
+}
+
+/// Per-`blocksDir` in-flight merge guards, so concurrent callers (a
+/// connecting SSE client racing a `GET /decofile`, or two tabs) coalesce
+/// onto one multi-MB merge instead of each redoing it. Never held across
+/// anything but the merge itself.
+fn coalescers() -> &'static Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>> {
+    static CELL: OnceLock<Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>> = OnceLock::new();
+    CELL.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Merges the working tree's blocks and derives a version — the single
+/// definition of "what version is the draft", shared by the ETag this route
+/// serves and the `decofile` SSE event `routes/fs.rs`'s mutation handlers
+/// announce, so a consumer's cache key and the announced pointer can never
+/// disagree. `None` when there's no blocks dir to merge.
+///
+/// The version is a fast, non-cryptographic hash over the merged bytes (a
+/// change detector, not a security boundary) — `DefaultHasher` uses fixed
+/// keys, so it's deterministic across calls and process restarts.
+pub(crate) async fn read_decofile(
+    repo_dir: &Path,
+    config: &ConfigStore,
+) -> Option<(String, String)> {
+    let dir = blocks_dir(repo_dir, config);
+    let lock = {
+        let mut table = coalescers().lock().unwrap();
+        table
+            .entry(dir.clone())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    };
+    let _guard = lock.lock().await;
+    let text = generate_decofile_from_blocks(&dir).await?;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    text.hash(&mut hasher);
+    Some((text.clone(), format!("{:x}", hasher.finish())))
+}
+
+/// `.deco/blocks/*.json` — the paths whose write/edit/unlink/mkdir/rename
+/// should trigger a `decofile` re-announce. Case-insensitive (a
+/// case-insensitive filesystem can produce `.deco/blocks/x.JSON`), and
+/// normalizes `\` so a Windows-style relative path still matches.
+fn is_block_path(relative: &str) -> bool {
+    let normalized = relative.replace('\\', "/").to_ascii_lowercase();
+    normalized.contains(".deco/blocks/") && normalized.ends_with(".json")
+}
+
+/// Recomputes the merged blocks' version and, if it changed, broadcasts a
+/// `decofile` event. Called (fire-and-forget) from every `routes::fs`
+/// mutation handler after its own `"file-changed"` emit, filtered to paths
+/// under `.deco/blocks` — mirrors the daemon's `announceDecofileVersion`,
+/// including the unchanged-hash guard so a burst of unrelated saves can't
+/// spam the same version.
+pub(crate) fn maybe_announce(state: &AppState, relative_path: &str) {
+    if !is_block_path(relative_path) {
+        return;
+    }
+    spawn_announce(
+        state.repo_dir.clone(),
+        state.config.clone(),
+        state.broadcaster.clone(),
+    );
+}
+
+/// Unconditional counterpart to [`maybe_announce`] — called once the
+/// clone/checkout step hands off to install (see `setup::install::run`'s
+/// call site), so the initial draft version is published as soon as a
+/// checked-out tree exists. A clone doesn't write through `routes::fs`, so
+/// without this a fresh repo with no `.deco/blocks` WRITE ever observed
+/// would never get an initial `decofile` announce — including, notably, a
+/// decofile-only repo with no package manager configured at all, which
+/// short-circuits before `setup::install` even reaches its own
+/// `"installing"` lifecycle transition.
+pub(crate) fn announce_working_tree_ready(
+    repo_dir: PathBuf,
+    config: Arc<ConfigStore>,
+    broadcaster: Arc<Broadcaster>,
+) {
+    spawn_announce(repo_dir, config, broadcaster);
+}
+
+fn spawn_announce(repo_dir: PathBuf, config: Arc<ConfigStore>, broadcaster: Arc<Broadcaster>) {
+    tokio::spawn(async move {
+        announce(&repo_dir, &config, &broadcaster).await;
+    });
+}
+
+/// Last version announced per `blocksDir`, so a burst of writes across
+/// unrelated blocks doesn't re-broadcast an unchanged merge.
+fn last_versions() -> &'static Mutex<HashMap<PathBuf, String>> {
+    static CELL: OnceLock<Mutex<HashMap<PathBuf, String>>> = OnceLock::new();
+    CELL.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+async fn announce(repo_dir: &Path, config: &ConfigStore, broadcaster: &Broadcaster) {
+    let Some((_, version)) = read_decofile(repo_dir, config).await else {
+        return;
+    };
+    let dir = blocks_dir(repo_dir, config);
+    {
+        let mut table = last_versions().lock().unwrap();
+        if table.get(&dir) == Some(&version) {
+            return;
+        }
+        table.insert(dir, version.clone());
+    }
+    broadcaster.emit("decofile", serde_json::json!({ "version": version }));
+}
+
+pub async fn decofile(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    let Some((text, version)) = read_decofile(&state.repo_dir, &state.config).await else {
+        return ApiError::not_found("No .deco/blocks to serve.").into_response();
+    };
+
+    let etag = format!("W/\"{version}\"");
+    if headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok())
+        == Some(etag.as_str())
+    {
+        return Response::builder()
+            .status(StatusCode::NOT_MODIFIED)
+            .header(header::ETAG, &etag)
+            .body(axum::body::Body::empty())
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
+    }
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/json; charset=utf-8")
+        .header(header::ETAG, &etag)
+        // The draft changes on every save; never let a shared cache hold it.
+        // Callers key their own cache on the ETag instead.
+        .header(header::CACHE_CONTROL, "no-store")
+        .body(axum::body::Body::from(text))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ConfigStore;
+    use crate::tasks::TaskRegistry;
+    use serde_json::json;
+
+    /// Minimal `AppState` for a handler test — mirrors the same-shaped
+    /// helper other route test modules each carry their own copy of (e.g.
+    /// `routes/repo_dir.rs`), pointed at a caller-supplied `repo_dir` so it
+    /// can be a fresh tempdir per test.
+    fn fresh_state(repo_dir: std::path::PathBuf) -> AppState {
+        let config = Arc::new(ConfigStore::new());
+        let app_root = std::env::temp_dir();
+        let logs = Arc::new(crate::log_store::LogStore::new(app_root.join("logs")));
+        let tasks = Arc::new(TaskRegistry::new(logs));
+        let broadcaster = Arc::new(Broadcaster::new());
+        let setup = crate::setup::SetupOrchestrator::new(
+            repo_dir.clone(),
+            repo_dir.clone(),
+            config.clone(),
+            tasks.clone(),
+            broadcaster.clone(),
+        );
+        AppState {
+            update: None,
+            token: "test-token".into(),
+            boot_id: "test-boot".into(),
+            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),
+            agent_sessions: crate::terminal::AgentSessionRegistry::new(),
+            app_root,
+            repo_dir,
+            mode: crate::state::ApiMode::Strict,
+            config,
+            tasks,
+            broadcaster,
+            shutdown: Arc::new(crate::shutdown::ShutdownCoordinator::new()),
+            setup,
+        }
+    }
+
+    fn write_block(dir: &Path, name: &str, body: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(format!("{name}.json")), body).unwrap();
+    }
+
+    #[test]
+    fn is_block_path_matches_only_deco_blocks_json() {
+        assert!(is_block_path(".deco/blocks/pages-home.json"));
+        assert!(is_block_path(".deco/blocks/Header.JSON"));
+        assert!(is_block_path(".deco\\blocks\\pages-home.json"));
+        assert!(!is_block_path(".deco/blocks.gen.json"));
+        assert!(!is_block_path("src/index.ts"));
+        assert!(!is_block_path(".deco/blocks/pages-home.txt"));
+    }
+
+    #[tokio::test]
+    async fn read_decofile_returns_none_with_no_blocks_dir() {
+        let root = tempfile::tempdir().unwrap();
+        let config = ConfigStore::new();
+        assert!(read_decofile(root.path(), &config).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_decofile_produces_a_stable_version_that_changes_with_content() {
+        let root = tempfile::tempdir().unwrap();
+        let blocks = root.path().join(".deco").join("blocks");
+        write_block(&blocks, "pages-home", r#"{"path":"/"}"#);
+        let config = ConfigStore::new();
+
+        let (text1, v1) = read_decofile(root.path(), &config).await.unwrap();
+        assert!(text1.contains("pages-home"));
+        let (_, v2) = read_decofile(root.path(), &config).await.unwrap();
+        assert_eq!(v1, v2, "unchanged content must hash to the same version");
+
+        write_block(&blocks, "pages-home", r#"{"path":"/","x":1}"#);
+        let (_, v3) = read_decofile(root.path(), &config).await.unwrap();
+        assert_ne!(v1, v3, "changed content must change the version");
+    }
+
+    #[tokio::test]
+    async fn read_decofile_respects_package_manager_path() {
+        let root = tempfile::tempdir().unwrap();
+        let blocks = root
+            .path()
+            .join("apps")
+            .join("web")
+            .join(".deco")
+            .join("blocks");
+        write_block(&blocks, "pages-home", r#"{"path":"/"}"#);
+
+        let config = ConfigStore::new();
+        config
+            .patch(json!({ "application": { "packageManager": { "path": "apps/web" } } }))
+            .expect("patch applies");
+
+        let (text, _) = read_decofile(root.path(), &config).await.unwrap();
+        assert!(text.contains("pages-home"));
+    }
+
+    #[tokio::test]
+    async fn decofile_handler_returns_404_with_no_blocks() {
+        let root = tempfile::tempdir().unwrap();
+        let response = super::decofile(
+            State(fresh_state(root.path().to_path_buf())),
+            HeaderMap::new(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn decofile_handler_serves_etag_and_revalidates() {
+        let root = tempfile::tempdir().unwrap();
+        write_block(
+            &root.path().join(".deco").join("blocks"),
+            "pages-home",
+            r#"{"path":"/"}"#,
+        );
+        let state = fresh_state(root.path().to_path_buf());
+
+        let response = super::decofile(State(state.clone()), HeaderMap::new()).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-store"
+        );
+        let etag = response
+            .headers()
+            .get(header::ETAG)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        let mut matching = HeaderMap::new();
+        matching.insert(header::IF_NONE_MATCH, etag.parse().unwrap());
+        let revalidated = super::decofile(State(state.clone()), matching).await;
+        assert_eq!(revalidated.status(), StatusCode::NOT_MODIFIED);
+
+        let mut stale = HeaderMap::new();
+        stale.insert(header::IF_NONE_MATCH, "W/\"deadbeef\"".parse().unwrap());
+        let full = super::decofile(State(state), stale).await;
+        assert_eq!(full.status(), StatusCode::OK);
+    }
+}

--- a/apps/native/crates/local-api/src/routes/events.rs
+++ b/apps/native/crates/local-api/src/routes/events.rs
@@ -106,6 +106,21 @@ async fn initial_frames(target: &crate::sandbox::SandboxTarget) -> Vec<Bytes> {
             &serde_json::json!({ "scripts": scripts }),
         ));
     }
+    // The draft decofile version, recomputed fresh for every connect/switch —
+    // same convention as `branch`/`scripts` above, unlike the daemon's
+    // cached-with-replay approach: this crate has no single process-lifetime
+    // cache to replay from (a per-target one would need a new `AppState`/
+    // `SandboxTarget` field just for this), and a live merge is cheap enough
+    // to redo on each handshake, matching the cost class of the branch-status
+    // and log-tail reads already done here.
+    if let Some((_, version)) =
+        crate::routes::decofile::read_decofile(&target.repo_dir, &target.config).await
+    {
+        initial.push(snapshot::frame(
+            "decofile",
+            &serde_json::json!({ "version": version }),
+        ));
+    }
 
     // Replay each known log SOURCE's combined transcript as ONE `log` frame.
     // The broadcaster is LIVE-only (no per-subscriber backlog), and a

--- a/apps/native/crates/local-api/src/routes/fs.rs
+++ b/apps/native/crates/local-api/src/routes/fs.rs
@@ -344,8 +344,20 @@ pub async fn read(State(state): State<AppState>, body: Bytes) -> Response {
             // Rebuilding it on read is what makes the CMS readable before the
             // dev server has booted — without this the sections editor reports
             // "File not found: .deco/blocks.gen.json" against a repo that
-            // plainly has its blocks. Byte-parity with `daemon/routes/fs.ts`.
-            if file_path.file_name().and_then(|name| name.to_str()) == Some(DECOFILE_GEN_BASENAME) {
+            // plainly has its blocks. Byte-parity with the Go daemon's
+            // `routes/fs.go` (itself byte-parity with the deleted TS daemon).
+            //
+            // Gated on a relative `user_path`: `resolve_read_path` passes an
+            // absolute path straight through unclamped (see its doc comment),
+            // so allowing the fallback there would turn the merge into an
+            // arbitrary sibling-`blocks/` directory glob — this route runs
+            // behind the `/_sandbox` guard, not the daemon's bearer auth, but
+            // the guard is still cheap insurance against a caller pointing an
+            // absolute path at an unrelated `.../blocks.gen.json`.
+            if !Path::new(&user_path).is_absolute()
+                && file_path.file_name().and_then(|name| name.to_str())
+                    == Some(DECOFILE_GEN_BASENAME)
+            {
                 if let Some(dir) = file_path
                     .parent()
                     .map(|dir| dir.join(DECOFILE_BLOCKS_DIRNAME))
@@ -1484,6 +1496,11 @@ pub async fn tools_sync(State(state): State<AppState>, body: Bytes) -> Response 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ConfigStore;
+    use crate::events::Broadcaster;
+    use crate::setup::SetupOrchestrator;
+    use crate::tasks::TaskRegistry;
+    use std::sync::Arc;
 
     /// A fresh worktree has `.deco/blocks/*.json` but not the merged
     /// `blocks.gen.json` (repos gitignore it), and without this rebuild the
@@ -1611,5 +1628,97 @@ mod tests {
             .status()
             .is_ok_and(|status| status.success());
         assert!(!alive, "cancelled grep process survived its owner");
+    }
+
+    /// Byte-parity fixture for `routes/decofile.rs`'s `fresh_state` and the Go
+    /// daemon's `DecofileDeps{RepoDir: dir, Store: config.NewStore()}` — each
+    /// route test module carries its own copy (see `decofile.rs`'s doc
+    /// comment on the convention).
+    fn fresh_state(repo_dir: std::path::PathBuf) -> AppState {
+        let config = Arc::new(ConfigStore::new());
+        let app_root = std::env::temp_dir();
+        let logs = Arc::new(crate::log_store::LogStore::new(app_root.join("logs")));
+        let tasks = Arc::new(TaskRegistry::new(logs));
+        let broadcaster = Arc::new(Broadcaster::new());
+        let setup = SetupOrchestrator::new(
+            repo_dir.clone(),
+            repo_dir.clone(),
+            config.clone(),
+            tasks.clone(),
+            broadcaster.clone(),
+        );
+        AppState {
+            update: None,
+            token: "test-token".into(),
+            boot_id: "test-boot".into(),
+            sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),
+            agent_sessions: crate::terminal::AgentSessionRegistry::new(),
+            app_root,
+            repo_dir,
+            mode: crate::state::ApiMode::Strict,
+            config,
+            tasks,
+            broadcaster,
+            shutdown: Arc::new(crate::shutdown::ShutdownCoordinator::new()),
+            setup,
+        }
+    }
+
+    fn read_body(path: &str) -> Bytes {
+        Bytes::from(serde_json::to_vec(&json!({ "path": path, "full": true })).unwrap())
+    }
+
+    /// A relative request for the absent gen artifact falls back to the
+    /// on-the-fly merge of the sibling blocks sources. Byte-parity with the
+    /// Go daemon's `TestReadDecofileFallbackRelative`.
+    #[tokio::test]
+    async fn read_decofile_fallback_relative_merges() {
+        let root = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(root.path().join(".deco").join("blocks")).unwrap();
+        std::fs::write(
+            root.path().join(".deco").join("blocks").join("a.json"),
+            r#"{"n":1}"#,
+        )
+        .unwrap();
+        let state = fresh_state(root.path().to_path_buf());
+
+        let response = super::read(State(state), read_body(".deco/blocks.gen.json")).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed["kind"], "text");
+        assert_eq!(parsed["content"], r#"{"a":{"n":1}}"#);
+    }
+
+    /// The fallback must refuse an ABSOLUTE path even when it points straight
+    /// at the real repo's gen artifact — `resolve_read_path` passes an
+    /// absolute path through unclamped, so allowing it here would turn the
+    /// merge into an arbitrary sibling-`blocks/` directory glob. Byte-parity
+    /// with the Go daemon's `TestReadDecofileFallbackRefusesAbsolute`: the
+    /// blocks exist and the relative form (above) merges them, yet the
+    /// absolute form to the very same location still 400s.
+    #[tokio::test]
+    async fn read_decofile_fallback_refuses_absolute_path() {
+        let root = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(root.path().join(".deco").join("blocks")).unwrap();
+        std::fs::write(
+            root.path().join(".deco").join("blocks").join("a.json"),
+            r#"{"n":1}"#,
+        )
+        .unwrap();
+        let state = fresh_state(root.path().to_path_buf());
+        let absolute = root
+            .path()
+            .join(".deco")
+            .join("blocks.gen.json")
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(Path::new(&absolute).is_absolute());
+
+        let response = super::read(State(state), read_body(&absolute)).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/apps/native/crates/local-api/src/routes/fs.rs
+++ b/apps/native/crates/local-api/src/routes/fs.rs
@@ -249,9 +249,26 @@ fn base64_encode(data: &[u8]) -> String {
 const DECOFILE_GEN_BASENAME: &str = "blocks.gen.json";
 const DECOFILE_BLOCKS_DIRNAME: &str = "blocks";
 
+/// Repeatedly percent-decodes a filename stem until it stops changing. Real
+/// repos carry both single- and double-encoded stems (`Compre%20Junto.json`,
+/// `Compre%2520Junto.json`); a single decode leaves the double-encoded one
+/// keyed `Compre%20Junto`, a key no `__resolveType` reference resolves.
+/// Mirrors the frontend's documented `decoBlockKeyFromFileStem` fallback: an
+/// invalid-encoding stem keeps its last successfully decoded form.
+fn decode_until_stable(stem: &str) -> String {
+    let mut key = stem.to_string();
+    while let Ok(decoded) = urlencoding::decode(&key) {
+        if decoded.as_ref() == key {
+            break;
+        }
+        key = decoded.into_owned();
+    }
+    key
+}
+
 /// Rebuild `.deco/blocks.gen.json` from the sibling `.deco/blocks/*.json`.
 ///
-/// Each file becomes `{ decodeURIComponent(<stem>): <file contents> }` — the
+/// Each file becomes `{ decode_until_stable(<stem>): <file contents> }` — the
 /// filename stem is the percent-encoded block id, which is what the deco
 /// runtime emits. Contents are spliced in as RAW TEXT rather than parsed and
 /// re-serialized: the payload is routinely multi-megabyte and only the small
@@ -261,7 +278,11 @@ const DECOFILE_BLOCKS_DIRNAME: &str = "blocks";
 /// the caller falls through to its normal not-found path. A malformed block is
 /// not rejected here — the client's own parse fails and it falls back to "no
 /// snapshot", exactly as when the file is genuinely absent.
-async fn generate_decofile_from_blocks(blocks_dir: &std::path::Path) -> Option<String> {
+///
+/// `pub(super)` — also the merge source for `routes::decofile`'s
+/// `GET /_sandbox/decofile`, which serves the same artifact content-addressed
+/// (an ETag over these bytes) rather than as a plain file read.
+pub(super) async fn generate_decofile_from_blocks(blocks_dir: &std::path::Path) -> Option<String> {
     let mut dir = tokio::fs::read_dir(blocks_dir).await.ok()?;
     let mut names: Vec<String> = Vec::new();
     while let Ok(Some(entry)) = dir.next_entry().await {
@@ -287,11 +308,7 @@ async fn generate_decofile_from_blocks(blocks_dir: &std::path::Path) -> Option<S
     let mut parts: Vec<String> = Vec::with_capacity(names.len());
     for name in names {
         let stem = &name[..name.len() - ".json".len()];
-        // A stem that is not valid percent-encoding keeps its literal form,
-        // mirroring the frontend's own fallback.
-        let key = urlencoding::decode(stem)
-            .map(|decoded| decoded.into_owned())
-            .unwrap_or_else(|_| stem.to_string());
+        let key = decode_until_stable(stem);
         let Ok(raw) = tokio::fs::read_to_string(blocks_dir.join(&name)).await else {
             continue;
         };
@@ -439,6 +456,7 @@ pub async fn write(State(state): State<AppState>, body: Bytes) -> Response {
     state
         .broadcaster
         .emit("file-changed", json!({ "path": user_path }));
+    super::decofile::maybe_announce(&state, &user_path);
     Json(json!({ "ok": true, "bytesWritten": content.len() })).into_response()
 }
 
@@ -536,6 +554,7 @@ pub async fn unlink(State(state): State<AppState>, body: Bytes) -> Response {
         state
             .broadcaster
             .emit("file-changed", json!({ "path": raw_path }));
+        super::decofile::maybe_announce(&state, &raw_path);
     }
     Json(json!({ "ok": true, "existed": existed })).into_response()
 }
@@ -575,6 +594,7 @@ pub async fn mkdir(State(state): State<AppState>, body: Bytes) -> Response {
     state
         .broadcaster
         .emit("file-changed", json!({ "path": raw_path }));
+    super::decofile::maybe_announce(&state, &raw_path);
     Json(json!({ "ok": true })).into_response()
 }
 
@@ -643,6 +663,7 @@ pub async fn rename(State(state): State<AppState>, body: Bytes) -> Response {
     state
         .broadcaster
         .emit("file-changed", json!({ "path": raw_to }));
+    super::decofile::maybe_announce(&state, &raw_to);
     Json(json!({ "ok": true })).into_response()
 }
 
@@ -709,6 +730,7 @@ pub async fn edit(State(state): State<AppState>, body: Bytes) -> Response {
     state
         .broadcaster
         .emit("file-changed", json!({ "path": user_path }));
+    super::decofile::maybe_announce(&state, &user_path);
     Json(json!({
         "ok": true,
         "replacements": if replace_all { count } else { 1 },
@@ -1486,6 +1508,26 @@ mod tests {
         assert_eq!(merged, r#"{"Alpha":{"b":2},"Card config":{"a":1}}"#);
         // Valid JSON, and the space in the key really was decoded.
         let parsed: serde_json::Value = serde_json::from_str(&merged).expect("valid json");
+        assert!(parsed.get("Card config").is_some(), "{merged}");
+    }
+
+    /// Real repos carry both single- and double-encoded filenames. Both must
+    /// merge under the real key — a single decode would leave the
+    /// double-encoded one keyed `Compre%20Junto`, which no `__resolveType`
+    /// reference resolves.
+    #[tokio::test]
+    async fn decofile_merge_decodes_double_encoded_stems_until_stable() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let blocks = root.path().join("blocks");
+        std::fs::create_dir_all(&blocks).expect("mkdir");
+        std::fs::write(blocks.join("Compre%2520Junto.json"), r#"{"curated":true}"#).unwrap();
+        std::fs::write(blocks.join("Card%20config.json"), r#"{"plain":true}"#).unwrap();
+
+        let merged = generate_decofile_from_blocks(&blocks)
+            .await
+            .expect("blocks dir merges");
+        let parsed: serde_json::Value = serde_json::from_str(&merged).expect("valid json");
+        assert!(parsed.get("Compre Junto").is_some(), "{merged}");
         assert!(parsed.get("Card config").is_some(), "{merged}");
     }
 

--- a/apps/native/crates/local-api/src/routes/mod.rs
+++ b/apps/native/crates/local-api/src/routes/mod.rs
@@ -8,6 +8,7 @@ pub mod agent_capabilities;
 pub mod agent_hooks;
 pub mod bash;
 pub mod config;
+pub mod decofile;
 pub mod events;
 pub mod fs;
 pub mod git;

--- a/apps/native/crates/local-api/src/setup/install.rs
+++ b/apps/native/crates/local-api/src/setup/install.rs
@@ -89,6 +89,19 @@ fn install_argv(pm: &str) -> Option<&'static [&'static str]> {
 /// itself exits non-zero, after transitioning `lifecycle` to
 /// `install-failed`.
 pub(super) async fn run(orch: &Arc<SetupOrchestrator>, config: &Value) -> bool {
+    // The clone/checkout step (before this one) is what guarantees a
+    // checked-out tree — announce the initial draft decofile version here,
+    // unconditionally, not only from a `.deco/blocks` WRITE: a clone doesn't
+    // write through `routes::fs`, and a decofile-only repo with no package
+    // manager configured returns below before ever reaching an "installing"
+    // transition to hang the announce off of instead. See
+    // `routes::decofile::announce_working_tree_ready`'s doc comment.
+    crate::routes::decofile::announce_working_tree_ready(
+        orch.repo_dir.clone(),
+        orch.config.clone(),
+        orch.broadcaster.clone(),
+    );
+
     // A config that names no package manager may still be a detectable
     // repository — the clone step just put its files on disk. Fill the
     // absence before deciding to skip; see `setup/detect_runtime.rs`.

--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.test.ts
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.test.ts
@@ -3,6 +3,7 @@ import {
   buildDirectDaemonEventsUrl,
   isDirectDaemonEventsGoneStatus,
   isLiveMetaKeyForScope,
+  isWorkingTreeReadyPhase,
 } from "./sandbox-events-context";
 
 describe("buildDirectDaemonEventsUrl", () => {
@@ -65,5 +66,35 @@ describe("isLiveMetaKeyForScope", () => {
     expect(isLiveMetaKeyForScope(scope, "acme", "vmid-1", "other-branch")).toBe(
       false,
     );
+  });
+});
+
+describe("isWorkingTreeReadyPhase", () => {
+  test("false before the repo is on disk", () => {
+    // The cold-start window that strands Fast Preview: the daemon answers, but
+    // `.deco/blocks/` doesn't exist, so /read 400s and useDecofile 502s.
+    expect(isWorkingTreeReadyPhase("idle")).toBe(false);
+    expect(isWorkingTreeReadyPhase("cloning")).toBe(false);
+    expect(isWorkingTreeReadyPhase("clone-failed")).toBe(false);
+  });
+
+  test("checking-out is excluded — the tree is mid-write", () => {
+    expect(isWorkingTreeReadyPhase("checking-out")).toBe(false);
+  });
+
+  test("installing is the trigger — clone done, deps pending", () => {
+    // Precisely the window Fast Preview exists to render in.
+    expect(isWorkingTreeReadyPhase("installing")).toBe(true);
+  });
+
+  test("later phases also count — a warm sandbox can skip past installing", () => {
+    expect(isWorkingTreeReadyPhase("starting")).toBe(true);
+    expect(isWorkingTreeReadyPhase("running")).toBe(true);
+  });
+
+  test("failure phases count — a failed install still leaves a readable tree", () => {
+    expect(isWorkingTreeReadyPhase("install-failed")).toBe(true);
+    expect(isWorkingTreeReadyPhase("start-failed")).toBe(true);
+    expect(isWorkingTreeReadyPhase("crashed")).toBe(true);
   });
 });

--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
@@ -30,7 +30,8 @@ import {
   type ReactNode,
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useProjectContext } from "@/sdk";
+import { useProjectContext, useVirtualMCP } from "@/sdk";
+import { sanitizeProductionUrl } from "@decocms/shared/deco-site-production-url";
 import { KEYS, invalidateVirtualMcpQueries } from "@/lib/query-keys";
 import { exponentialBackoffWithJitter } from "@decocms/shared/std";
 
@@ -205,6 +206,21 @@ export function SandboxEventsProvider({
 }) {
   const { org } = useProjectContext();
   const queryClient = useQueryClient();
+
+  // Fast Preview renders via the daemon with NO dev server, so the
+  // dev-server-gated `.deco/*` reload path below would never fire. Track it (as
+  // a ref, so the SSE closure reads the latest without reconnecting) to still
+  // fire a reload on a Blocks save. We deliberately do NOT invalidate the
+  // decofile query in that mode — the daemon reads `.deco/blocks/*` straight
+  // from disk, and a refetch could revert an optimistic edit against a committed
+  // `blocks.gen.json`.
+  const vmcp = useVirtualMCP(virtualMcpId ?? undefined);
+  const fastPreviewActive =
+    !!sanitizeProductionUrl(vmcp?.metadata?.productionUrl) &&
+    vmcp?.metadata?.fastPreview === true;
+  const fastPreviewActiveRef = useRef(fastPreviewActive);
+  // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- keep the SSE closure reading the latest value without reconnecting
+  fastPreviewActiveRef.current = fastPreviewActive;
   const [phase, setPhase] = useState<ClaimPhase | null>(null);
   const [lifecycle, setLifecycle] = useState<LifecycleState>({ phase: "idle" });
   const [status, setStatus] = useState<DaemonStatus>({ state: "running" });
@@ -421,15 +437,16 @@ export function SandboxEventsProvider({
             const isDecoFile =
               filePath.startsWith(".deco/") || filePath.includes("/.deco/");
             if (isDecoFile) {
-              // Only act while the dev server is running. When it's down
-              // (crashed/paused — the state the committed-snapshot fallback
-              // supports editing in), `blocks.gen.json` is a stale build
-              // artifact the dev server can't regenerate, so invalidating +
-              // refetching it would overwrite the optimistic cache update from
-              // useSaveBlock/useDeleteBlock and the edit would visibly revert.
-              // Leave the optimistic cache as the source of truth; the
-              // lifecycle→running transition re-invalidates onto the live routes.
-              if (prevLifecyclePhase !== "running") return;
+              // Act when the dev server is running OR Fast Preview is on (which
+              // renders via the daemon with no dev server). Otherwise
+              // (crashed/paused — committed-snapshot editing) `blocks.gen.json`
+              // is a stale build artifact the dev server can't regenerate, so
+              // invalidating + refetching it would overwrite the optimistic
+              // cache update from useSaveBlock/useDeleteBlock and the edit would
+              // visibly revert; leave the optimistic cache as the source of
+              // truth until the lifecycle→running transition re-invalidates.
+              const devServerRunning = prevLifecyclePhase === "running";
+              if (!devServerRunning && !fastPreviewActiveRef.current) return;
               // Turn on the preview's loading overlay immediately — before the
               // debounce below — so the pending refresh feels instant instead of
               // only appearing once the reload finally fires.
@@ -451,15 +468,20 @@ export function SandboxEventsProvider({
               if (decofileDebounceTimer) clearTimeout(decofileDebounceTimer);
               decofileDebounceTimer = setTimeout(() => {
                 decofileDebounceTimer = null;
-                void queryClient.invalidateQueries({
-                  queryKey: KEYS.decofile(cacheKey),
-                });
-                // Reload the preview iframe once the rebuild has landed — HMR
+                // Only refetch the decofile when the dev server is running (the
+                // live `/.decofile` route reflects the write). In Fast Preview
+                // the daemon serves the render straight from disk, so skip the
+                // refetch (it would revert an optimistic edit) and just reload.
+                if (devServerRunning) {
+                  void queryClient.invalidateQueries({
+                    queryKey: KEYS.decofile(cacheKey),
+                  });
+                }
+                // Reload the preview iframe once the write has landed — HMR
                 // won't reflect a decofile edit, so this is the only thing that
                 // refreshes the rendered page after a Blocks save (or an
-                // external/agent `.deco/` write). Debounced with the
-                // invalidation above so it fires after the dev server rebuilds,
-                // not against the stale pre-rebuild page.
+                // external/agent `.deco/` write). Debounced so it fires after
+                // the write lands ("save → refresh").
                 for (const fn of reloadHandlers.current) {
                   try {
                     fn();

--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
@@ -72,6 +72,14 @@ export interface SandboxEventsValue {
   branch: BranchMeta;
   /** True after a `gone` event — handle gone, reprovision via SANDBOX_START. */
   notFound: boolean;
+  /**
+   * Content version of the working-tree draft decofile, or null until the
+   * daemon first announces one. Same value `/_sandbox/decofile` serves as its
+   * ETag, so it can be used verbatim in a draft pointer. Changes on every
+   * `.deco/blocks/*` save, which is what lets the preview refresh without
+   * polling.
+   */
+  decofileVersion: string | null;
   scripts: string[];
   activeProcesses: string[];
   getBuffer: (source: string) => string;
@@ -93,6 +101,7 @@ const DEFAULT_VALUE: SandboxEventsValue = {
   status: { state: "running" },
   branch: { kind: "unknown" },
   notFound: false,
+  decofileVersion: null,
   scripts: [],
   activeProcesses: [],
   getBuffer: () => "",
@@ -135,6 +144,7 @@ const DAEMON_EVENT_TYPES: readonly DaemonEventName[] = [
   "branch",
   "reload",
   "file-changed",
+  "decofile",
 ] as const;
 // `log` is broadcast separately — same SSE stream, different shape.
 const LOG_EVENT = "log" as const;
@@ -254,6 +264,7 @@ export function SandboxEventsProvider({
   fastPreviewActiveRef.current = fastPreviewActive;
   const [phase, setPhase] = useState<ClaimPhase | null>(null);
   const [lifecycle, setLifecycle] = useState<LifecycleState>({ phase: "idle" });
+  const [decofileVersion, setDecofileVersion] = useState<string | null>(null);
   const [status, setStatus] = useState<DaemonStatus>({ state: "running" });
   const [branchMeta, setBranchMeta] = useState<BranchMeta>({ kind: "unknown" });
   const [notFound, setNotFound] = useState(false);
@@ -288,6 +299,7 @@ export function SandboxEventsProvider({
     setBranchMeta({ kind: "unknown" });
     prevPortRef.current = null;
     setNotFound(false);
+    setDecofileVersion(null);
     setScripts([]);
     setActiveProcesses([]);
     buffers.current.clear();
@@ -441,6 +453,11 @@ export function SandboxEventsProvider({
             }
             return;
           }
+          case "decofile":
+            setDecofileVersion(
+              (payload as DaemonEventPayload<"decofile">).version,
+            );
+            return;
           case "status":
             setStatus(payload as DaemonEventPayload<"status">);
             return;
@@ -703,6 +720,7 @@ export function SandboxEventsProvider({
     status,
     branch: branchMeta,
     notFound,
+    decofileVersion,
     scripts,
     activeProcesses,
     getBuffer: (source: string) => buffers.current.get(source)?.get() ?? "",

--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
@@ -169,6 +169,37 @@ export function isDirectDaemonEventsGoneStatus(status: number): boolean {
   return status === 404;
 }
 
+/**
+ * Phases that guarantee the repo is checked out on disk.
+ *
+ * The daemon serves the CMS decofile without a dev server: `/read` of
+ * `.deco/blocks.gen.json` falls back to merging `.deco/blocks/*.json` on the
+ * fly. That fallback returns 400 while `.deco/blocks/` is missing — i.e. during
+ * `cloning`/`checking-out` — and `useDecofile` turns that into a 502 it
+ * deliberately never retries. So the read has exactly one good moment to be
+ * re-driven: the first phase that implies a populated working tree.
+ *
+ * `installing` is that moment (clone + checkout done, only deps pending) and is
+ * precisely the window Fast Preview renders in. The later phases are included
+ * because a warm sandbox with cached deps can skip past `installing` between
+ * two SSE frames — and the failure phases because a repo that failed to install
+ * still has a tree the CMS can read.
+ *
+ * `checking-out` is deliberately excluded: the tree is mid-write there.
+ */
+export function isWorkingTreeReadyPhase(
+  phase: LifecycleState["phase"],
+): boolean {
+  return (
+    phase === "installing" ||
+    phase === "install-failed" ||
+    phase === "starting" ||
+    phase === "start-failed" ||
+    phase === "running" ||
+    phase === "crashed"
+  );
+}
+
 async function probeDirectDaemonEventsGone(url: string): Promise<boolean> {
   try {
     const response = await fetch(url, {
@@ -275,7 +306,7 @@ export function SandboxEventsProvider({
     // Tracks the dev-server lifecycle so we can invalidate the CMS queries once
     // it comes up (switching them from the committed `.deco/*.gen.json` snapshot
     // to the live `/.decofile` + `/live/_meta` routes).
-    let prevLifecyclePhase: string | null = null;
+    let prevLifecyclePhase: LifecycleState["phase"] | null = null;
 
     const handleClaimPhase = (e: MessageEvent) => {
       try {
@@ -343,6 +374,30 @@ export function SandboxEventsProvider({
           case "lifecycle": {
             const lp = payload as DaemonEventPayload<"lifecycle">;
             setLifecycle(lp.state);
+            const cacheKeyForBranch = `${org.slug}/${virtualMcpId}/${branch}`;
+            // Working tree just landed (see isWorkingTreeReadyPhase). Re-drive
+            // the two things Fast Preview needs but that nothing else retries:
+            // the decofile — whose cold-start read 502s while the repo is still
+            // cloning and is never retried — and the entity, which carries
+            // `previewUrl` in `sandboxMap` behind a 60s staleTime. Without this
+            // both stay stale until `running` below, stranding Fast Preview
+            // behind the very install it exists to skip.
+            if (
+              isWorkingTreeReadyPhase(lp.state.phase) &&
+              !(
+                prevLifecyclePhase &&
+                isWorkingTreeReadyPhase(prevLifecyclePhase)
+              )
+            ) {
+              invalidateVirtualMcpQueries(queryClient, org.id);
+              // Only when the decofile never loaded (the 502 case) — a
+              // populated cache can hold an optimistic block edit a refetch
+              // would revert, the same hazard the post-write path guards.
+              const decofileKey = KEYS.decofile(cacheKeyForBranch);
+              if (queryClient.getQueryData(decofileKey) === undefined) {
+                void queryClient.invalidateQueries({ queryKey: decofileKey });
+              }
+            }
             // Dev server just came up: swap the CMS queries off the committed
             // `.deco/*.gen.json` snapshot and onto the live routes. This is the
             // trigger they rely on (they're enabled as soon as the daemon is up,
@@ -359,15 +414,14 @@ export function SandboxEventsProvider({
               // panels never mount on a cold-start open — only a hard refresh
               // re-fetches the entity and picks it up.
               invalidateVirtualMcpQueries(queryClient, org.id);
-              const cacheKey = `${org.slug}/${virtualMcpId}/${branch}`;
               void queryClient.invalidateQueries({
-                queryKey: KEYS.decofile(cacheKey),
+                queryKey: KEYS.decofile(cacheKeyForBranch),
               });
               void queryClient.invalidateQueries({
                 predicate: (query) =>
                   query.queryKey[0] === "live-meta" &&
                   typeof query.queryKey[1] === "string" &&
-                  query.queryKey[1].startsWith(`${cacheKey}/`),
+                  query.queryKey[1].startsWith(`${cacheKeyForBranch}/`),
               });
             }
             prevLifecyclePhase = lp.state.phase;

--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
@@ -49,6 +49,10 @@ import type {
   DaemonStatus,
   LifecycleState,
 } from "@decocms/sandbox/shared";
+// One definition, shared with the daemon: it decides when to announce a draft
+// version, Studio decides when to re-drive the CMS queries. They must agree.
+export { isWorkingTreeReadyPhase } from "@decocms/sandbox/shared";
+import { isWorkingTreeReadyPhase } from "@decocms/sandbox/shared";
 
 export type { BranchMeta, DaemonStatus, LifecycleState };
 
@@ -177,37 +181,6 @@ export function buildDirectDaemonEventsUrl(
 
 export function isDirectDaemonEventsGoneStatus(status: number): boolean {
   return status === 404;
-}
-
-/**
- * Phases that guarantee the repo is checked out on disk.
- *
- * The daemon serves the CMS decofile without a dev server: `/read` of
- * `.deco/blocks.gen.json` falls back to merging `.deco/blocks/*.json` on the
- * fly. That fallback returns 400 while `.deco/blocks/` is missing — i.e. during
- * `cloning`/`checking-out` — and `useDecofile` turns that into a 502 it
- * deliberately never retries. So the read has exactly one good moment to be
- * re-driven: the first phase that implies a populated working tree.
- *
- * `installing` is that moment (clone + checkout done, only deps pending) and is
- * precisely the window Fast Preview renders in. The later phases are included
- * because a warm sandbox with cached deps can skip past `installing` between
- * two SSE frames — and the failure phases because a repo that failed to install
- * still has a tree the CMS can read.
- *
- * `checking-out` is deliberately excluded: the tree is mid-write there.
- */
-export function isWorkingTreeReadyPhase(
-  phase: LifecycleState["phase"],
-): boolean {
-  return (
-    phase === "installing" ||
-    phase === "install-failed" ||
-    phase === "starting" ||
-    phase === "start-failed" ||
-    phase === "running" ||
-    phase === "crashed"
-  );
 }
 
 async function probeDirectDaemonEventsGone(url: string): Promise<boolean> {

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -13,6 +13,8 @@ import {
   shouldAutoRetryClaim,
   reconcileClaimRetryEpisode,
   MAX_CLAIM_AUTO_RETRIES,
+  resolvePreviewUrl,
+  sandboxPreviewKey,
   type BranchMapEntryLike,
 } from "./sandbox-lifecycle-context";
 
@@ -523,5 +525,107 @@ describe("reconcileClaimRetryEpisode", () => {
       count: 0,
       handled: false,
     });
+  });
+});
+
+describe("sandboxPreviewKey", () => {
+  test("distinguishes branches of the same vmcp", () => {
+    expect(sandboxPreviewKey("vm1", "main")).not.toBe(
+      sandboxPreviewKey("vm1", "feat"),
+    );
+  });
+
+  test("distinguishes the same branch across vmcps", () => {
+    expect(sandboxPreviewKey("vm1", "main")).not.toBe(
+      sandboxPreviewKey("vm2", "main"),
+    );
+  });
+
+  test("a null branch is its own key, not a wildcard", () => {
+    expect(sandboxPreviewKey("vm1", null)).toBe("vm1::");
+    expect(sandboxPreviewKey("vm1", null)).not.toBe(
+      sandboxPreviewKey("vm1", "main"),
+    );
+  });
+});
+
+describe("resolvePreviewUrl", () => {
+  const KEY = sandboxPreviewKey("vm1", "main");
+  const SEED = { key: KEY, url: "https://claimed.example" };
+
+  test("the recorded entry wins over a seed", () => {
+    expect(
+      resolvePreviewUrl({
+        vmEntry: entry("agent-sandbox", "h1", "https://recorded.example"),
+        seeded: SEED,
+        key: KEY,
+      }),
+    ).toBe("https://recorded.example");
+  });
+
+  test("falls back to the claim seed while the entity query is stale", () => {
+    // The window this exists for: the daemon is up and SANDBOX_START already
+    // returned its URL, but sandboxMap hasn't been refetched yet.
+    expect(resolvePreviewUrl({ vmEntry: null, seeded: SEED, key: KEY })).toBe(
+      "https://claimed.example",
+    );
+  });
+
+  test("falls back when an entry exists but carries no previewUrl", () => {
+    expect(
+      resolvePreviewUrl({
+        vmEntry: entry("agent-sandbox", "h1", null),
+        seeded: SEED,
+        key: KEY,
+      }),
+    ).toBe("https://claimed.example");
+  });
+
+  test("ignores a seed claimed for another branch", () => {
+    // Guards the real hazard: painting the previous branch's sandbox after a
+    // switch. Stale seeds are scoped out, never reset.
+    expect(
+      resolvePreviewUrl({
+        vmEntry: null,
+        seeded: SEED,
+        key: sandboxPreviewKey("vm1", "other"),
+      }),
+    ).toBeNull();
+  });
+
+  test("null with neither source", () => {
+    expect(
+      resolvePreviewUrl({ vmEntry: null, seeded: null, key: KEY }),
+    ).toBeNull();
+  });
+});
+
+describe("resolvePreviewUrl + claim failure (integration of the two rules)", () => {
+  const KEY = sandboxPreviewKey("vm1", "main");
+  const SEED = { key: KEY, url: "https://claimed.example" };
+
+  test("a dropped seed leaves nothing to paint, so the errored card wins", () => {
+    // The provider passes `seeded: null` on a terminal claim failure. Encoded
+    // here because computePreviewState reads any previewUrl as "sandbox live"
+    // and would paint a dead iframe over the error.
+    expect(
+      resolvePreviewUrl({ vmEntry: null, seeded: null, key: KEY }),
+    ).toBeNull();
+  });
+
+  test("a recorded entry still wins on failure — a failed restart can't blank a working preview", () => {
+    expect(
+      resolvePreviewUrl({
+        vmEntry: entry("agent-sandbox", "h1", "https://recorded.example"),
+        seeded: null,
+        key: KEY,
+      }),
+    ).toBe("https://recorded.example");
+  });
+
+  test("the seed applies while no failure is present", () => {
+    expect(resolvePreviewUrl({ vmEntry: null, seeded: SEED, key: KEY })).toBe(
+      "https://claimed.example",
+    );
   });
 });

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -294,6 +294,48 @@ export function computeDrawerStatus(state: PreviewState): DrawerStatus {
   }
 }
 
+/** A `previewUrl` captured from a SANDBOX_START response, scoped to its claim. */
+export interface SeededPreviewUrl {
+  /** `virtualMcpId::branch` this URL was claimed for (see `sandboxPreviewKey`). */
+  key: string;
+  url: string;
+}
+
+/**
+ * Identity of a claim. `branch` is null on a fresh thread — the server names it
+ * in the SANDBOX_START response — so callers seeding from a response pass the
+ * response's branch, not the (still null) prop.
+ */
+export function sandboxPreviewKey(
+  virtualMcpId: string | null,
+  branch: string | null,
+): string {
+  return `${virtualMcpId ?? ""}::${branch ?? ""}`;
+}
+
+/**
+ * The daemon origin to render against.
+ *
+ * SANDBOX_START returns `previewUrl` at claim time, but `vmEntry` reads it from
+ * the entity's `sandboxMap` — a collection query with a 60s staleTime whose only
+ * lifecycle-driven invalidation fires when the dev server reports `running`. So
+ * the recorded value can lag the live daemon by the entire install/boot, which
+ * is exactly the window Fast Preview exists to render in.
+ *
+ * The recorded entry wins when present (authoritative, survives remounts); the
+ * claim response is the fallback. The seed is key-scoped rather than reset on
+ * change, so a stale claim can never paint another branch's sandbox.
+ */
+export function resolvePreviewUrl(args: {
+  vmEntry: BranchMapEntryLike | null;
+  seeded: SeededPreviewUrl | null;
+  key: string;
+}): string | null {
+  const recorded = args.vmEntry?.previewUrl ?? null;
+  if (recorded) return recorded;
+  return args.seeded?.key === args.key ? args.seeded.url : null;
+}
+
 // ---------------------------------------------------------------------------
 // Provider + hook
 // ---------------------------------------------------------------------------
@@ -321,10 +363,36 @@ import {
   sandboxUserStop,
   useSandboxStart,
   type SandboxStartArgs,
+  type SandboxStartResult,
 } from "./use-sandbox-start";
 import { useSandboxEvents } from "./use-sandbox-events";
 import { computePreviewState } from "@/components/sandbox/preview/preview-state";
 import { decodeSandboxStartError } from "@decocms/shared/sandbox-start-errors";
+
+/**
+ * Shared SANDBOX_START `onSuccess`: adopt the branch the server named and record
+ * the claim's `previewUrl` (see `resolvePreviewUrl`).
+ *
+ * Module-level on purpose — every call site passes its dependencies explicitly,
+ * so the identity stays stable and the effects that reference it don't re-fire
+ * each render (React 19 bans useCallback here).
+ */
+function recordSandboxStart(args: {
+  data: SandboxStartResult | undefined;
+  virtualMcpId: string | null;
+  branch: string | null;
+  setCurrentTaskBranch: (branch: string) => void;
+  setSeededPreviewUrl: (seed: SeededPreviewUrl) => void;
+}): void {
+  const { data, virtualMcpId, branch } = args;
+  if (data?.branch && !branch) args.setCurrentTaskBranch(data.branch);
+  if (data?.previewUrl) {
+    args.setSeededPreviewUrl({
+      key: sandboxPreviewKey(virtualMcpId, data.branch ?? branch),
+      url: data.previewUrl,
+    });
+  }
+}
 
 export interface SandboxLifecycleValue {
   branch: string | null;
@@ -416,6 +484,12 @@ export function SandboxLifecycleProvider({
   // Destructure mutate/reset so they're stable references for effect deps.
   const { mutate: startVmMutate, reset: startVmReset } = startVm;
 
+  // `previewUrl` straight off the claim, until the entity query catches up.
+  // Lets Fast Preview render while the dev server is still installing — see
+  // resolvePreviewUrl.
+  const [seededPreviewUrl, setSeededPreviewUrl] =
+    useState<SeededPreviewUrl | null>(null);
+
   // Branch-keyed dedup (replaces both legacy taskId-keyed (preview.tsx) and
   // branch-keyed (VmEventsBridge) dedup refs).
   const autoStartAttemptedForBranchRef = useRef<Set<string>>(new Set());
@@ -453,13 +527,24 @@ export function SandboxLifecycleProvider({
   // matching entry wins; with no entry for that kind (or no kind at all) fall
   // back to whatever is serving the branch. See resolveVmEntry.
   const vmEntry = resolveVmEntry(branchMap, sandboxProviderKind);
-  const previewUrl = vmEntry?.previewUrl ?? null;
+  const failedPhase = events.phase?.kind === "failed" ? events.phase : null;
+  const previewUrl = resolvePreviewUrl({
+    vmEntry,
+    // SANDBOX_START returns a previewUrl at claim time, before the pod is
+    // known-healthy. On a terminal claim failure that handle never came up, so
+    // drop the seed: computePreviewState reads any previewUrl as "the sandbox
+    // is live" and would paint a dead iframe over the errored card. A recorded
+    // vmEntry is different — it means the sandbox did serve at some point, and
+    // the existing rule (a failed restart shouldn't blank a working preview)
+    // still applies.
+    seeded: failedPhase ? null : seededPreviewUrl,
+    key: sandboxPreviewKey(virtualMcpId, branch),
+  });
   const userStopped =
     !!virtualMcpId &&
     !!branch &&
     sandboxUserStop.isStopped(virtualMcpId, branch);
   const appPaused = events.status.state === "paused";
-  const failedPhase = events.phase?.kind === "failed" ? events.phase : null;
   // A retryable claim failure keeps the booting overlay (deriveStartError
   // returns null) while bounded auto-retry still has budget; once exhausted (or
   // for a non-retryable reason) it surfaces the errored card.
@@ -515,7 +600,13 @@ export function SandboxLifecycleProvider({
     );
     startVmMutate(args, {
       onSuccess: (data) => {
-        if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
+        recordSandboxStart({
+          data,
+          virtualMcpId,
+          branch,
+          setCurrentTaskBranch,
+          setSeededPreviewUrl,
+        });
       },
       onError: (err) => {
         console.error("[sandbox-lifecycle] auto-start failed:", err);
@@ -529,6 +620,7 @@ export function SandboxLifecycleProvider({
     sandboxProviderKind,
     startVmMutate,
     setCurrentTaskBranch,
+    setSeededPreviewUrl,
   ]);
 
   // Self-heal: SSE emits `gone` → reprovision via SANDBOX_START. Dedup by
@@ -555,7 +647,13 @@ export function SandboxLifecycleProvider({
     );
     startVmMutate(args, {
       onSuccess: (data) => {
-        if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
+        recordSandboxStart({
+          data,
+          virtualMcpId,
+          branch,
+          setCurrentTaskBranch,
+          setSeededPreviewUrl,
+        });
       },
       onError: (err) => {
         console.error("[sandbox-lifecycle] self-heal failed:", err);
@@ -569,6 +667,7 @@ export function SandboxLifecycleProvider({
     sandboxProviderKind,
     startVmMutate,
     setCurrentTaskBranch,
+    setSeededPreviewUrl,
   ]);
 
   // Auto-retry: a *retryable* terminal claim failure (capacity/scheduling/
@@ -609,7 +708,13 @@ export function SandboxLifecycleProvider({
     );
     startVmMutate(args, {
       onSuccess: (data) => {
-        if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
+        recordSandboxStart({
+          data,
+          virtualMcpId,
+          branch,
+          setCurrentTaskBranch,
+          setSeededPreviewUrl,
+        });
       },
       onError: (err) => {
         console.error("[sandbox-lifecycle] claim auto-retry failed:", err);
@@ -623,6 +728,7 @@ export function SandboxLifecycleProvider({
     sandboxProviderKind,
     startVmMutate,
     setCurrentTaskBranch,
+    setSeededPreviewUrl,
   ]);
 
   // User-driven actions.
@@ -635,7 +741,13 @@ export function SandboxLifecycleProvider({
     );
     startVmMutate(args, {
       onSuccess: (data) => {
-        if (data?.branch && !branch) setCurrentTaskBranch(data.branch);
+        recordSandboxStart({
+          data,
+          virtualMcpId,
+          branch,
+          setCurrentTaskBranch,
+          setSeededPreviewUrl,
+        });
       },
       onError: (err) => {
         console.error("[sandbox-lifecycle] user start failed:", err);

--- a/apps/web/src/components/sandbox/preview/preview-display.test.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.test.ts
@@ -26,6 +26,7 @@ function run(overrides: Partial<PreviewDisplayInput>) {
     progressStatus: "doing",
     productionUrl: PROD,
     fastPreviewActive: false,
+    fastPreviewReady: false,
     ...overrides,
   });
 }
@@ -109,49 +110,82 @@ describe("resolvePreviewDisplay", () => {
   });
 
   describe("Fast Preview", () => {
-    const previewUrl = IFRAME.kind === "iframe" ? IFRAME.previewUrl : "";
-
-    it("renders on the daemon (previewUrl), never the published site", () => {
-      const result = run({
-        previewState: IFRAME,
-        progressStatus: "doing",
-        fastPreviewActive: true,
+    it("drops the pill once the draft render is ready, still based on production", () => {
+      // `iframeBase` stays the PUBLISHED url — the caller layers the daemon
+      // draft URL over it, so the base is always navigable and the URL-bar
+      // label doesn't jump origins when the draft swaps in.
+      expect(
+        run({
+          previewState: IFRAME,
+          progressStatus: "doing",
+          fastPreviewActive: true,
+          fastPreviewReady: true,
+        }),
+      ).toEqual({
+        mode: "production",
+        iframeBase: PROD,
+        showBlockingOverlay: false,
+        showWakingPill: false,
       });
-      expect(result.mode).toBe("production");
-      // The daemon origin, NOT productionUrl — Fast Preview never shows the
-      // published site.
-      expect(result.iframeBase).toBe(previewUrl);
-      expect(result.iframeBase).not.toBe(PROD);
-      expect(result.showWakingPill).toBe(false);
     });
 
-    it("shows a booting overlay (not the published site) while the sandbox provisions", () => {
-      // No previewUrl yet → the daemon can't serve the render; show the overlay,
-      // never fall back to productionUrl.
+    it("shows the published site + pill while the sandbox provisions", () => {
+      // Inverted from the original rule (blocking overlay, never the published
+      // site). Boot should be invisible: the published site holds the canvas
+      // until the draft render is renderable.
       expect(
         run({
           previewState: STARTING,
           progressStatus: "doing",
           fastPreviewActive: true,
+          fastPreviewReady: false,
         }),
       ).toEqual({
-        mode: "none",
-        iframeBase: null,
-        showBlockingOverlay: true,
-        showWakingPill: false,
+        mode: "production",
+        iframeBase: PROD,
+        showBlockingOverlay: false,
+        showWakingPill: true,
       });
     });
 
-    it("never swaps to the sandbox — stays on the daemon render regardless of dev-server state", () => {
+    it("holds the published site when the daemon is up but no page matched yet", () => {
+      // previewUrl exists, but the decofile hasn't yielded a page key, so the
+      // draft URL isn't buildable. Keep the pill rather than blanking.
+      const result = run({
+        previewState: IFRAME,
+        progressStatus: "doing",
+        fastPreviewActive: true,
+        fastPreviewReady: false,
+      });
+      expect(result.mode).toBe("production");
+      expect(result.iframeBase).toBe(PROD);
+      expect(result.showWakingPill).toBe(true);
+    });
+
+    it("never swaps to the sandbox — the draft render owns the canvas regardless of dev-server state", () => {
       for (const progressStatus of ["done", "failed"] as const) {
         const result = run({
           previewState: IFRAME,
           progressStatus,
           fastPreviewActive: true,
+          fastPreviewReady: true,
         });
         expect(result.mode).toBe("production");
-        expect(result.iframeBase).toBe(previewUrl);
+        expect(result.iframeBase).toBe(PROD);
       }
+    });
+
+    it("does not fall through to the sandbox while waiting for the draft", () => {
+      // Even with the dev server up, Fast Preview must not hand the canvas to
+      // the sandbox iframe — that's the surface it deliberately replaces.
+      const result = run({
+        previewState: IFRAME,
+        progressStatus: "done",
+        fastPreviewActive: true,
+        fastPreviewReady: false,
+      });
+      expect(result.mode).toBe("production");
+      expect(result.showWakingPill).toBe(true);
     });
   });
 });

--- a/apps/web/src/components/sandbox/preview/preview-display.test.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { resolvePreviewDisplay } from "./preview-display";
+import {
+  type PreviewDisplayInput,
+  resolvePreviewDisplay,
+} from "./preview-display";
 import type { PreviewState } from "./preview-state";
 
 const IFRAME: PreviewState = {
@@ -15,15 +18,21 @@ const ERRORED: PreviewState = {
 
 const PROD = "https://acme.com";
 
+// Fast Preview off is the default for the pre-existing behavior cases; each test
+// overrides what it exercises.
+function run(overrides: Partial<PreviewDisplayInput>) {
+  return resolvePreviewDisplay({
+    previewState: STARTING,
+    progressStatus: "doing",
+    productionUrl: PROD,
+    fastPreviewActive: false,
+    ...overrides,
+  });
+}
+
 describe("resolvePreviewDisplay", () => {
   it("shows the sandbox iframe once boot is done (running)", () => {
-    expect(
-      resolvePreviewDisplay({
-        previewState: IFRAME,
-        progressStatus: "done",
-        productionUrl: PROD,
-      }),
-    ).toEqual({
+    expect(run({ previewState: IFRAME, progressStatus: "done" })).toEqual({
       mode: "sandbox",
       iframeBase: IFRAME.kind === "iframe" ? IFRAME.previewUrl : null,
       showBlockingOverlay: false,
@@ -32,23 +41,13 @@ describe("resolvePreviewDisplay", () => {
   });
 
   it("shows the sandbox iframe (crash page) on a failed boot, not production", () => {
-    const result = resolvePreviewDisplay({
-      previewState: IFRAME,
-      progressStatus: "failed",
-      productionUrl: PROD,
-    });
+    const result = run({ previewState: IFRAME, progressStatus: "failed" });
     expect(result.mode).toBe("sandbox");
     expect(result.showWakingPill).toBe(false);
   });
 
   it("falls back to production + pill while a fresh boot is in progress", () => {
-    expect(
-      resolvePreviewDisplay({
-        previewState: STARTING,
-        progressStatus: "doing",
-        productionUrl: PROD,
-      }),
-    ).toEqual({
+    expect(run({ previewState: STARTING, progressStatus: "doing" })).toEqual({
       mode: "production",
       iframeBase: PROD,
       showBlockingOverlay: false,
@@ -56,13 +55,11 @@ describe("resolvePreviewDisplay", () => {
     });
   });
 
-  it("falls back to production + pill while the sandbox iframe is still warming", () => {
+  it("falls back to production + pill while the sandbox iframe is still warming (Fast Preview off)", () => {
     // previewUrl exists (kind === "iframe") but the dev server isn't up yet.
-    const result = resolvePreviewDisplay({
-      previewState: IFRAME,
-      progressStatus: "doing",
-      productionUrl: PROD,
-    });
+    // With Fast Preview off the production surface is the published stopgap, so
+    // the pill stays up until the dev server is routable.
+    const result = run({ previewState: IFRAME, progressStatus: "doing" });
     expect(result.mode).toBe("production");
     expect(result.iframeBase).toBe(PROD);
     expect(result.showWakingPill).toBe(true);
@@ -70,7 +67,7 @@ describe("resolvePreviewDisplay", () => {
 
   it("keeps the blocking overlay while booting when there is no production URL", () => {
     expect(
-      resolvePreviewDisplay({
+      run({
         previewState: STARTING,
         progressStatus: "doing",
         productionUrl: null,
@@ -84,7 +81,7 @@ describe("resolvePreviewDisplay", () => {
   });
 
   it("keeps the blocking overlay for a warming iframe with no production URL", () => {
-    const result = resolvePreviewDisplay({
+    const result = run({
       previewState: IFRAME,
       progressStatus: "doing",
       productionUrl: null,
@@ -94,13 +91,7 @@ describe("resolvePreviewDisplay", () => {
   });
 
   it("yields the canvas to the suspended card (no overlay, no pill)", () => {
-    expect(
-      resolvePreviewDisplay({
-        previewState: SUSPENDED,
-        progressStatus: "doing",
-        productionUrl: PROD,
-      }),
-    ).toEqual({
+    expect(run({ previewState: SUSPENDED, progressStatus: "doing" })).toEqual({
       mode: "none",
       iframeBase: null,
       showBlockingOverlay: false,
@@ -109,17 +100,58 @@ describe("resolvePreviewDisplay", () => {
   });
 
   it("yields the canvas to the errored card (no overlay, no pill)", () => {
-    expect(
-      resolvePreviewDisplay({
-        previewState: ERRORED,
-        progressStatus: "failed",
-        productionUrl: PROD,
-      }),
-    ).toEqual({
+    expect(run({ previewState: ERRORED, progressStatus: "failed" })).toEqual({
       mode: "none",
       iframeBase: null,
       showBlockingOverlay: false,
       showWakingPill: false,
+    });
+  });
+
+  describe("Fast Preview", () => {
+    const previewUrl = IFRAME.kind === "iframe" ? IFRAME.previewUrl : "";
+
+    it("renders on the daemon (previewUrl), never the published site", () => {
+      const result = run({
+        previewState: IFRAME,
+        progressStatus: "doing",
+        fastPreviewActive: true,
+      });
+      expect(result.mode).toBe("production");
+      // The daemon origin, NOT productionUrl — Fast Preview never shows the
+      // published site.
+      expect(result.iframeBase).toBe(previewUrl);
+      expect(result.iframeBase).not.toBe(PROD);
+      expect(result.showWakingPill).toBe(false);
+    });
+
+    it("shows a booting overlay (not the published site) while the sandbox provisions", () => {
+      // No previewUrl yet → the daemon can't serve the render; show the overlay,
+      // never fall back to productionUrl.
+      expect(
+        run({
+          previewState: STARTING,
+          progressStatus: "doing",
+          fastPreviewActive: true,
+        }),
+      ).toEqual({
+        mode: "none",
+        iframeBase: null,
+        showBlockingOverlay: true,
+        showWakingPill: false,
+      });
+    });
+
+    it("never swaps to the sandbox — stays on the daemon render regardless of dev-server state", () => {
+      for (const progressStatus of ["done", "failed"] as const) {
+        const result = run({
+          previewState: IFRAME,
+          progressStatus,
+          fastPreviewActive: true,
+        });
+        expect(result.mode).toBe("production");
+        expect(result.iframeBase).toBe(previewUrl);
+      }
     });
   });
 });

--- a/apps/web/src/components/sandbox/preview/preview-display.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.ts
@@ -11,6 +11,13 @@
  * as the sandbox handle exists — well before the dev server is routable — so we
  * gate the sandbox surface on `progressStatus` (boot no longer in progress),
  * NOT on the mere existence of `previewUrl`.
+ *
+ * Both modes share one shape: the published site holds the canvas until
+ * something better is ready, then that swaps in. Fast Preview does not change
+ * the surface, only *when* it's ready — its draft render needs the daemon alone
+ * (up shortly after the clone), where the normal path waits out install + dev
+ * server. So the blocking overlay is only for projects with no production URL
+ * at all; Fast Preview requires one, so it never reaches that branch.
  */
 
 import type { PreviewState } from "./preview-state";
@@ -42,13 +49,20 @@ export interface PreviewDisplayInput {
   /** Live production URL to fall back to while waking, or `null` if unknown. */
   productionUrl: string | null;
   /**
-   * Fast Preview is on (its switch is enabled AND a production URL is set). When
-   * true the surface is the sandbox daemon's Fast Preview render (the caller
-   * builds `previewUrl/_sandbox/fast-preview`) — never the published site, and
-   * never the dev server. Until the sandbox handle exists, a blocking booting
-   * overlay is shown instead of the published page.
+   * Fast Preview is on (its switch is enabled AND a production URL is set).
+   * Fast Preview does not change the *surface* — it changes when the surface is
+   * ready. Both modes paint the published site while the sandbox boots; Fast
+   * Preview swaps in the daemon's draft render (ready after the clone) where the
+   * normal path waits for the dev server (ready at `running`).
    */
   fastPreviewActive: boolean;
+  /**
+   * The caller could actually build `previewUrl/_sandbox/fast-preview` — it has
+   * both the daemon origin and a matched page. Only meaningful with
+   * `fastPreviewActive`. False means the draft render isn't renderable yet, so
+   * the published site keeps the canvas (with the waking pill) instead.
+   */
+  fastPreviewReady: boolean;
 }
 
 const NONE: PreviewDisplay = {
@@ -61,8 +75,13 @@ const NONE: PreviewDisplay = {
 export function resolvePreviewDisplay(
   input: PreviewDisplayInput,
 ): PreviewDisplay {
-  const { previewState, progressStatus, productionUrl, fastPreviewActive } =
-    input;
+  const {
+    previewState,
+    progressStatus,
+    productionUrl,
+    fastPreviewActive,
+    fastPreviewReady,
+  } = input;
 
   // Suspended / errored render their own dedicated card — hand the canvas over
   // so we don't paint a toolbar or load the production iframe behind/around it.
@@ -70,24 +89,17 @@ export function resolvePreviewDisplay(
     return NONE;
   }
 
-  // Fast Preview renders ONLY the daemon draft (`previewUrl/_deco/fast-preview`)
-  // and NEVER the published site. Once the sandbox handle exists the daemon can
-  // serve it (iframeBase = the daemon origin); until then, a blocking booting
-  // overlay — not `productionUrl`. The dev server is irrelevant, so this ignores
-  // `progressStatus` entirely.
-  if (fastPreviewActive) {
-    if (previewState.kind === "iframe") {
-      return {
-        mode: "production",
-        iframeBase: previewState.previewUrl,
-        showBlockingOverlay: false,
-        showWakingPill: false,
-      };
-    }
+  // Fast Preview's draft render, the moment it's renderable. It needs only the
+  // daemon (up shortly after the clone), so this deliberately ignores
+  // `progressStatus` — waiting for the dev server is the whole cost it exists to
+  // skip. `iframeBase` stays the PUBLISHED url: the caller layers the draft URL
+  // over it, so every production-mode base is a page we can actually navigate to
+  // (and the URL-bar label doesn't jump between origins mid-boot).
+  if (fastPreviewActive && fastPreviewReady && productionUrl) {
     return {
-      mode: "none",
-      iframeBase: null,
-      showBlockingOverlay: true,
+      mode: "production",
+      iframeBase: productionUrl,
+      showBlockingOverlay: false,
       showWakingPill: false,
     };
   }
@@ -95,8 +107,13 @@ export function resolvePreviewDisplay(
   // The sandbox surface is showable once a previewUrl exists AND boot is no
   // longer in progress: `done` (running) serves the live app, `failed`/`crashed`
   // serves the daemon's auto-reloading status page — both belong in the iframe,
-  // not behind a "waking" pill.
-  if (previewState.kind === "iframe" && progressStatus !== "doing") {
+  // not behind a "waking" pill. Fast Preview skips this branch entirely — its
+  // draft render above owns the canvas instead of the dev server.
+  if (
+    !fastPreviewActive &&
+    previewState.kind === "iframe" &&
+    progressStatus !== "doing"
+  ) {
     return {
       mode: "sandbox",
       iframeBase: previewState.previewUrl,
@@ -105,9 +122,11 @@ export function resolvePreviewDisplay(
     };
   }
 
-  // Fast Preview OFF: while the sandbox boots, show the published site as a
-  // temporary stopgap + a "waking" pill until the dev server is routable and the
-  // `sandbox` swap above takes over.
+  // Nothing better is ready yet — paint the published site + a "waking" pill.
+  // Shared by both modes: Fast Preview holds here until the daemon can render
+  // the draft, the normal path until the dev server is routable. Fast Preview
+  // guarantees a `productionUrl` (its gate requires one), so it always lands
+  // here rather than on the blocking overlay below.
   if (productionUrl) {
     return {
       mode: "production",

--- a/apps/web/src/components/sandbox/preview/preview-display.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.ts
@@ -41,6 +41,14 @@ export interface PreviewDisplayInput {
   progressStatus: PhaseStatus;
   /** Live production URL to fall back to while waking, or `null` if unknown. */
   productionUrl: string | null;
+  /**
+   * Fast Preview is on (its switch is enabled AND a production URL is set). When
+   * true the surface is the sandbox daemon's Fast Preview render (the caller
+   * builds `previewUrl/_sandbox/fast-preview`) — never the published site, and
+   * never the dev server. Until the sandbox handle exists, a blocking booting
+   * overlay is shown instead of the published page.
+   */
+  fastPreviewActive: boolean;
 }
 
 const NONE: PreviewDisplay = {
@@ -53,12 +61,35 @@ const NONE: PreviewDisplay = {
 export function resolvePreviewDisplay(
   input: PreviewDisplayInput,
 ): PreviewDisplay {
-  const { previewState, progressStatus, productionUrl } = input;
+  const { previewState, progressStatus, productionUrl, fastPreviewActive } =
+    input;
 
   // Suspended / errored render their own dedicated card — hand the canvas over
   // so we don't paint a toolbar or load the production iframe behind/around it.
   if (previewState.kind === "suspended" || previewState.kind === "errored") {
     return NONE;
+  }
+
+  // Fast Preview renders ONLY the daemon draft (`previewUrl/_deco/fast-preview`)
+  // and NEVER the published site. Once the sandbox handle exists the daemon can
+  // serve it (iframeBase = the daemon origin); until then, a blocking booting
+  // overlay — not `productionUrl`. The dev server is irrelevant, so this ignores
+  // `progressStatus` entirely.
+  if (fastPreviewActive) {
+    if (previewState.kind === "iframe") {
+      return {
+        mode: "production",
+        iframeBase: previewState.previewUrl,
+        showBlockingOverlay: false,
+        showWakingPill: false,
+      };
+    }
+    return {
+      mode: "none",
+      iframeBase: null,
+      showBlockingOverlay: true,
+      showWakingPill: false,
+    };
   }
 
   // The sandbox surface is showable once a previewUrl exists AND boot is no
@@ -74,8 +105,9 @@ export function resolvePreviewDisplay(
     };
   }
 
-  // Still booting (fresh boot with no previewUrl yet, or a warming iframe).
-  // Prefer the live production site so the user sees their site immediately.
+  // Fast Preview OFF: while the sandbox boots, show the published site as a
+  // temporary stopgap + a "waking" pill until the dev server is routable and the
+  // `sandbox` swap above takes over.
   if (productionUrl) {
     return {
       mode: "production",

--- a/apps/web/src/components/sandbox/preview/preview-display.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.ts
@@ -55,14 +55,14 @@ export interface PreviewDisplayInput {
    * Preview swaps in the daemon's draft render (ready after the clone) where the
    * normal path waits for the dev server (ready at `running`).
    */
-  fastPreviewActive: boolean;
+  fastPreviewActive?: boolean;
   /**
    * The caller could actually build `previewUrl/_sandbox/fast-preview` — it has
    * both the daemon origin and a matched page. Only meaningful with
    * `fastPreviewActive`. False means the draft render isn't renderable yet, so
    * the published site keeps the canvas (with the waking pill) instead.
    */
-  fastPreviewReady: boolean;
+  fastPreviewReady?: boolean;
 }
 
 const NONE: PreviewDisplay = {
@@ -79,8 +79,10 @@ export function resolvePreviewDisplay(
     previewState,
     progressStatus,
     productionUrl,
-    fastPreviewActive,
-    fastPreviewReady,
+    // Optional: a caller that knows nothing about Fast Preview gets exactly
+    // the pre-existing behaviour.
+    fastPreviewActive = false,
+    fastPreviewReady = false,
   } = input;
 
   // Suspended / errored render their own dedicated card — hand the canvas over

--- a/apps/web/src/components/sandbox/preview/preview-display.ts
+++ b/apps/web/src/components/sandbox/preview/preview-display.ts
@@ -57,10 +57,10 @@ export interface PreviewDisplayInput {
    */
   fastPreviewActive?: boolean;
   /**
-   * The caller could actually build `previewUrl/_sandbox/fast-preview` — it has
-   * both the daemon origin and a matched page. Only meaningful with
-   * `fastPreviewActive`. False means the draft render isn't renderable yet, so
-   * the published site keeps the canvas (with the waking pill) instead.
+   * The caller could actually build the draft URL — it has the sandbox handle
+   * and a draft version. Only meaningful with `fastPreviewActive`. False means
+   * the draft isn't addressable yet, so the published site keeps the canvas
+   * (with the waking pill) instead.
    */
   fastPreviewReady?: boolean;
 }

--- a/apps/web/src/components/sandbox/preview/preview-label.test.ts
+++ b/apps/web/src/components/sandbox/preview/preview-label.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import { buildPreviewLabel } from "./preview-label";
+
+const NO_SERVER = "No server running";
+
+describe("buildPreviewLabel", () => {
+  it("shows the production host under Fast Preview / production surface", () => {
+    // iframeBase is production — the label must follow it, not the sandbox.
+    expect(
+      buildPreviewLabel({
+        iframeBase: "https://acme.com",
+        resolvedPath: "/",
+        activeGlobalSectionName: null,
+        noServerLabel: NO_SERVER,
+      }),
+    ).toBe("acme.com");
+  });
+
+  it("shows the sandbox host when the sandbox surface is live", () => {
+    expect(
+      buildPreviewLabel({
+        iframeBase: "https://abc.deco.host",
+        resolvedPath: "/",
+        activeGlobalSectionName: null,
+        noServerLabel: NO_SERVER,
+      }),
+    ).toBe("abc.deco.host");
+  });
+
+  it("appends a non-root path to the host", () => {
+    expect(
+      buildPreviewLabel({
+        iframeBase: "https://acme.com",
+        resolvedPath: "/products/shoes",
+        activeGlobalSectionName: null,
+        noServerLabel: NO_SERVER,
+      }),
+    ).toBe("acme.com/products/shoes");
+  });
+
+  it("omits the path for the root route", () => {
+    expect(
+      buildPreviewLabel({
+        iframeBase: "https://acme.com:8443",
+        resolvedPath: "/",
+        activeGlobalSectionName: null,
+        noServerLabel: NO_SERVER,
+      }),
+    ).toBe("acme.com:8443");
+  });
+
+  it("prefers the pinned global section name over any host", () => {
+    expect(
+      buildPreviewLabel({
+        iframeBase: "https://acme.com",
+        resolvedPath: "/",
+        activeGlobalSectionName: "Header",
+        noServerLabel: NO_SERVER,
+      }),
+    ).toBe("Header");
+  });
+
+  it("falls back to the no-server label when nothing is loaded", () => {
+    expect(
+      buildPreviewLabel({
+        iframeBase: null,
+        resolvedPath: "/",
+        activeGlobalSectionName: null,
+        noServerLabel: NO_SERVER,
+      }),
+    ).toBe(NO_SERVER);
+  });
+
+  it("returns the raw base when it isn't a parseable URL", () => {
+    expect(
+      buildPreviewLabel({
+        iframeBase: "not a url",
+        resolvedPath: "/",
+        activeGlobalSectionName: null,
+        noServerLabel: NO_SERVER,
+      }),
+    ).toBe("not a url");
+  });
+});

--- a/apps/web/src/components/sandbox/preview/preview-label.ts
+++ b/apps/web/src/components/sandbox/preview/preview-label.ts
@@ -1,0 +1,32 @@
+/**
+ * The URL-bar label for the preview toolbar — the domain (plus path) the user
+ * sees for the currently rendered page.
+ *
+ * It derives the host from `iframeBase` — the URL actually loaded in the iframe
+ * — NOT from the sandbox `previewUrl`. Under Fast Preview / the waking fallback
+ * the iframe shows the production origin, so the label must follow it or it
+ * drifts (showing the sandbox `.localhost` while production is on screen).
+ */
+export function buildPreviewLabel(input: {
+  /** The URL loaded in the iframe (`display.iframeBase`): production or sandbox. */
+  iframeBase: string | null;
+  /** Current resolved path (template filled in). `"/"` renders as bare host. */
+  resolvedPath: string;
+  /** Name of the pinned global section, if one is being previewed. */
+  activeGlobalSectionName: string | null;
+  /** Fallback shown when there's no surface loaded (`mode === "none"`). */
+  noServerLabel: string;
+}): string {
+  // A pinned global section is previewed on a synthetic page — show its name,
+  // not a host, exactly as before.
+  if (input.activeGlobalSectionName) return input.activeGlobalSectionName;
+  const base = input.iframeBase;
+  if (!base) return input.noServerLabel;
+  try {
+    const url = new URL(base);
+    const path = input.resolvedPath === "/" ? "" : input.resolvedPath;
+    return `${url.host}${path}`;
+  } catch {
+    return base;
+  }
+}

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -501,7 +501,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // which only deco's own runtime honoured and could only render one component
   // statically.
   //
-  // Needs the sandbox handle and a draft version — NOT the dev server, and
+  // Needs the daemon origin and a draft version — NOT the dev server, and
   // notably not `currentPageKey` any more: the site does its own routing, so
   // the preview no longer waits on the decofile query that used to stall the
   // whole surface behind a cold-start 502.
@@ -512,13 +512,10 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // Computed BEFORE `display`: it is an input to that decision, so it must not
   // depend on `display.mode` in turn.
   const draftPreviewUrl =
-    fastPreviewEnabled &&
-    productionUrl &&
-    vmEntry?.sandboxHandle &&
-    decofileVersion
+    fastPreviewEnabled && productionUrl && previewUrl && decofileVersion
       ? buildDraftPreviewUrl({
           productionUrl,
-          sandboxHandle: vmEntry.sandboxHandle,
+          previewUrl,
           version: decofileVersion,
           path: resolvedPath,
         })

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -10,6 +10,7 @@ import { TOUR_ANCHORS } from "@/components/cms-tour/anchors";
 import { useInsetContext } from "@/layouts/agent-shell-layout";
 import { resolvePreviewDisplay } from "./preview-display";
 import { useIframeLoadRecovery } from "./preview-iframe-recovery";
+import { buildPreviewLabel } from "./preview-label";
 import { sanitizeProductionUrl } from "@decocms/shared/deco-site-production-url";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { useT } from "@/i18n/use-t.ts";
@@ -81,7 +82,10 @@ import {
 } from "@/components/sections-editor/page-path-utils";
 import { decoBlockFileViewPath } from "@/components/sections-editor/deco-block-key";
 import { findLivePageResolveType } from "@/components/sections-editor/section-catalog";
-import { buildGlobalSectionPreviewUrl } from "@/components/sections-editor/section-preview-url";
+import {
+  buildFastPreviewDaemonUrl,
+  buildGlobalSectionPreviewUrl,
+} from "@/components/sections-editor/section-preview-url";
 import { useCreatePage } from "@/components/sections-editor/use-create-page";
 import { CreatePageModal } from "@/components/sections-editor/create-page-modal";
 import { toast } from "sonner";
@@ -263,6 +267,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const pagesContainerRef = useRef<HTMLDivElement>(null);
   const [createPageDialogOpen, setCreatePageDialogOpen] = useState(false);
   const [createPageError, setCreatePageError] = useState<string | undefined>();
+  // Bumped after a Blocks save so the Fast Preview daemon frame re-navigates and
+  // the daemon re-reads the fresh `.deco/blocks/*` (the "save → refresh" step).
+  const [fastPreviewNonce, setFastPreviewNonce] = useState(0);
   const [activeGlobalSection, setActiveGlobalSection] =
     useState<GlobalSectionEntry | null>(null);
   /** Overrides iframe src for global-section live previews (stable URL, not recomputed). */
@@ -460,10 +467,10 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // Live production URL of the linked site, persisted on the agent's
   // `metadata.productionUrl` at import time (deco.cx reports the real domain,
   // which can be a custom one — so we store it rather than guess it). Used as a
-  // Lovable-style fallback: while the sandbox dev server is still waking, paint
-  // the published site in the iframe (non-blocking) instead of a blank overlay,
-  // then swap to the sandbox preview once it's up. `null` (no field, or a site
-  // imported before this was persisted) → the original blocking overlay is kept.
+  // published-site fallback while the sandbox provisions (non-blocking) instead
+  // of a blank overlay; once the daemon is up, Fast Preview swaps to the daemon
+  // render (`fastPreviewDaemonUrl` below). `null` (no field, or a site imported
+  // before this was persisted) → the original blocking overlay is kept.
   const inset = useInsetContext();
   const productionUrl =
     inset?.entity?.id === virtualMcpId
@@ -478,6 +485,15 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
       ? inset.entity.metadata?.ui?.layout?.cmsDefaultOpen
       : null) ?? false;
 
+  // Fast Preview (opt-in switch in CMS settings): render the draft against
+  // `productionUrl` instead of the published site while the sandbox boots.
+  // Requires BOTH the switch and a production URL — a bare flag is inert
+  // (nothing to render against), and `productionUrl` is non-null only for this
+  // agent's entity, so reading `metadata.fastPreview` off the same object is
+  // safe.
+  const fastPreviewEnabled =
+    !!productionUrl && inset?.entity?.metadata?.fastPreview === true;
+
   // The recorded previewUrl flips previewState to "iframe" as soon as the
   // sandbox handle exists — well before the public preview proxy is routable —
   // so the sandbox surface is gated on `progress.status` (boot no longer in
@@ -488,9 +504,39 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     previewState,
     progressStatus: progress.status,
     productionUrl,
+    fastPreviewActive: fastPreviewEnabled,
   });
   const previewSurfaceActive = display.mode !== "none";
-  const showBootingOverlay = display.showBlockingOverlay;
+
+  // Fast Preview render (gated by the CMS switch): render the CURRENT
+  // working-tree draft via the sandbox DAEMON's `/_deco/fast-preview` route,
+  // which merges `.deco/blocks/*` and POSTs it (server-side, no URL cap) to the
+  // site's production `/live/previews`. Available once the daemon is up
+  // (`previewUrl`) — no dev server needed. `null` (daemon not up yet, or no page
+  // matched) → the booting overlay owns the canvas; Fast Preview NEVER falls
+  // back to the published site. `fastPreviewNonce` is bumped after a Blocks save
+  // so the frame re-navigates and the daemon re-reads the fresh draft.
+  const fastPreviewDaemonUrl =
+    fastPreviewEnabled &&
+    display.mode === "production" &&
+    previewUrl &&
+    currentPageKey
+      ? buildFastPreviewDaemonUrl({
+          previewUrl,
+          pageBlockKey: currentPageKey,
+          path: resolvedPath,
+          pathTemplate: currentPath,
+          nonce: fastPreviewNonce,
+        })
+      : null;
+
+  // Show the booting overlay while Fast Preview is waiting for the daemon render
+  // (no published-site stopgap), on top of the normal blocking-overlay cases.
+  const showBootingOverlay =
+    display.showBlockingOverlay ||
+    (fastPreviewEnabled &&
+      display.mode === "production" &&
+      !fastPreviewDaemonUrl);
 
   const iframeSrc =
     display.mode === "sandbox"
@@ -502,13 +548,19 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           workspace.state.variantOverride ?? [],
         )
       : display.mode === "production"
-        ? // Production is a different origin: no sandbox-only overrides
-          // (directPreviewUrl / variant matcher) apply. Load the current path
-          // best-effort; the published site serves its own committed pages.
-          withDeviceHint(
-            new URL(resolvedPath, display.iframeBase!).href,
-            previewDeviceSize,
-          )
+        ? fastPreviewEnabled
+          ? // Fast Preview: ONLY the daemon draft render — never the published
+            // site. `null` while the page/daemon isn't ready yet → the booting
+            // overlay owns the canvas (see `showBootingOverlay`).
+            fastPreviewDaemonUrl
+            ? withDeviceHint(fastPreviewDaemonUrl, previewDeviceSize)
+            : null
+          : // Fast Preview off: published site best-effort while the sandbox
+            // provisions (its own committed pages).
+            withDeviceHint(
+              new URL(resolvedPath, display.iframeBase!).href,
+              previewDeviceSize,
+            )
         : null;
 
   // "Open outside the preview pane". In a browser that's a new tab; inside the
@@ -639,12 +691,31 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // lands on the browser's connection-refused page and fires no load/error
   // event, so nothing reloads it once the server is back. This watchdog retries
   // (backoff) until a load fires. Sandbox surface only — never thrash the
-  // best-effort production fallback frame.
+  // best-effort production fallback frame, nor the Fast Preview daemon frame,
+  // which has its own cross-origin navigation path below.
   const iframeRecovery = useIframeLoadRecovery({
     iframeRef: previewIframeRef,
     src: display.mode === "sandbox" ? iframeSrc : null,
     active: display.mode === "sandbox",
   });
+
+  // Fast Preview refresh backstop: the daemon frame is cross-origin (the daemon
+  // host), so the shared reload path can't `.reload()` it. When the daemon URL
+  // changes — a page switch or a nonce bump after a save — force-navigate the
+  // frame. The nonce guarantees a distinct URL, and the ref guard makes the
+  // first paint (React already set `src`) and unrelated re-renders no-ops.
+  const lastFastPreviewUrlRef = useRef<string | null>(null);
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- imperative cross-origin iframe navigation on draft change; .reload() throws cross-origin
+  useEffect(() => {
+    if (!fastPreviewDaemonUrl || !iframeSrc) return;
+    if (lastFastPreviewUrlRef.current === fastPreviewDaemonUrl) return;
+    lastFastPreviewUrlRef.current = fastPreviewDaemonUrl;
+    const iframe = previewIframeRef.current;
+    if (iframe && iframe.getAttribute("src") !== iframeSrc) {
+      beginNavigation();
+      iframe.src = iframeSrc;
+    }
+  }, [fastPreviewDaemonUrl, iframeSrc]);
 
   // Daemon is reachable independent of the dev script: ready claim, handle
   // still present, not user-stopped. Gates surfaces (FileExplorer,
@@ -838,8 +909,15 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   // Fires on the daemon "reload" event and on debounced `.deco/` file changes
   // (Blocks saves, external/agent decofile writes) — the only refresh path for
-  // decofile edits, which the framework's HMR doesn't cover.
+  // decofile edits, which the framework's HMR doesn't cover. In Fast Preview the
+  // frame is the daemon render, so "refresh" = bump the nonce (new URL → the
+  // frame re-navigates, the daemon re-reads the just-saved `.deco/blocks/*`);
+  // the sandbox path uses the normal reload.
   useSandboxReloadHandler(() => {
+    if (fastPreviewDaemonUrl) {
+      setFastPreviewNonce((n) => n + 1);
+      return;
+    }
     reloadPreviewPreservingScroll();
   });
   // Show the loading overlay the instant a `.deco/` change is detected, ahead of
@@ -873,17 +951,15 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     }
   };
 
-  const previewLabel = (() => {
-    if (!previewUrl) return t("sandbox.preview.noServerRunning");
-    if (activeGlobalSection) return activeGlobalSection.name;
-    try {
-      const url = new URL(previewUrl);
-      const path = resolvedPath === "/" ? "" : resolvedPath;
-      return `${url.host}${path}`;
-    } catch {
-      return previewUrl;
-    }
-  })();
+  // Domain shown in the URL bar follows what's actually in the iframe
+  // (`display.iframeBase`) — production under Fast Preview, the sandbox
+  // otherwise — so the label never drifts from the rendered page.
+  const previewLabel = buildPreviewLabel({
+    iframeBase: display.iframeBase,
+    resolvedPath,
+    activeGlobalSectionName: activeGlobalSection?.name ?? null,
+    noServerLabel: t("sandbox.preview.noServerRunning"),
+  });
 
   const navigatePreviewToPage = (page: PageEntry) => {
     // The iframe loads the template with any stored param values filled in.

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -494,33 +494,20 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const fastPreviewEnabled =
     !!productionUrl && inset?.entity?.metadata?.fastPreview === true;
 
-  // The recorded previewUrl flips previewState to "iframe" as soon as the
-  // sandbox handle exists — well before the public preview proxy is routable —
-  // so the sandbox surface is gated on `progress.status` (boot no longer in
-  // progress), not on `previewUrl` alone. `resolvePreviewDisplay` decides what
-  // to paint: the sandbox iframe, the production fallback + a waking pill, or
-  // (no production URL) today's blocking booting overlay.
-  const display = resolvePreviewDisplay({
-    previewState,
-    progressStatus: progress.status,
-    productionUrl,
-    fastPreviewActive: fastPreviewEnabled,
-  });
-  const previewSurfaceActive = display.mode !== "none";
-
   // Fast Preview render (gated by the CMS switch): render the CURRENT
-  // working-tree draft via the sandbox DAEMON's `/_deco/fast-preview` route,
+  // working-tree draft via the sandbox DAEMON's `/_sandbox/fast-preview` route,
   // which merges `.deco/blocks/*` and POSTs it (server-side, no URL cap) to the
   // site's production `/live/previews`. Available once the daemon is up
-  // (`previewUrl`) — no dev server needed. `null` (daemon not up yet, or no page
-  // matched) → the booting overlay owns the canvas; Fast Preview NEVER falls
-  // back to the published site. `fastPreviewNonce` is bumped after a Blocks save
-  // so the frame re-navigates and the daemon re-reads the fresh draft.
+  // (`previewUrl`) and a page is matched — no dev server needed. `null` means
+  // not renderable yet, and the published site keeps the canvas until it is.
+  // `fastPreviewNonce` is bumped after a Blocks save so the frame re-navigates
+  // and the daemon re-reads the fresh draft.
+  //
+  // Computed BEFORE `display` — it is an input to the display decision (which
+  // needs to know whether the draft is renderable), so it must not depend on
+  // `display.mode` in turn.
   const fastPreviewDaemonUrl =
-    fastPreviewEnabled &&
-    display.mode === "production" &&
-    previewUrl &&
-    currentPageKey
+    fastPreviewEnabled && previewUrl && currentPageKey
       ? buildFastPreviewDaemonUrl({
           previewUrl,
           pageBlockKey: currentPageKey,
@@ -530,13 +517,20 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
         })
       : null;
 
-  // Show the booting overlay while Fast Preview is waiting for the daemon render
-  // (no published-site stopgap), on top of the normal blocking-overlay cases.
-  const showBootingOverlay =
-    display.showBlockingOverlay ||
-    (fastPreviewEnabled &&
-      display.mode === "production" &&
-      !fastPreviewDaemonUrl);
+  // The recorded previewUrl flips previewState to "iframe" as soon as the
+  // sandbox handle exists — well before the public preview proxy is routable —
+  // so the sandbox surface is gated on `progress.status` (boot no longer in
+  // progress), not on `previewUrl` alone. `resolvePreviewDisplay` decides what
+  // to paint: the sandbox iframe, the published site + a waking pill, or
+  // (no production URL) the blocking booting overlay.
+  const display = resolvePreviewDisplay({
+    previewState,
+    progressStatus: progress.status,
+    productionUrl,
+    fastPreviewActive: fastPreviewEnabled,
+    fastPreviewReady: !!fastPreviewDaemonUrl,
+  });
+  const previewSurfaceActive = display.mode !== "none";
 
   const iframeSrc =
     display.mode === "sandbox"
@@ -548,19 +542,16 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           workspace.state.variantOverride ?? [],
         )
       : display.mode === "production"
-        ? fastPreviewEnabled
-          ? // Fast Preview: ONLY the daemon draft render — never the published
-            // site. `null` while the page/daemon isn't ready yet → the booting
-            // overlay owns the canvas (see `showBootingOverlay`).
-            fastPreviewDaemonUrl
-            ? withDeviceHint(fastPreviewDaemonUrl, previewDeviceSize)
-            : null
-          : // Fast Preview off: published site best-effort while the sandbox
-            // provisions (its own committed pages).
-            withDeviceHint(
+        ? // The published site is the base for both modes while the sandbox
+          // provisions; Fast Preview layers its daemon draft render over it the
+          // moment that's renderable. Same origin either way (the draft carries
+          // `<base href="<productionUrl>">`), so the swap changes content, not
+          // surface.
+          withDeviceHint(
+            fastPreviewDaemonUrl ??
               new URL(resolvedPath, display.iframeBase!).href,
-              previewDeviceSize,
-            )
+            previewDeviceSize,
+          )
         : null;
 
   // "Open outside the preview pane". In a browser that's a new tab; inside the
@@ -1661,7 +1652,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                   </div>
                 )}
 
-                {showBootingOverlay && (
+                {display.showBlockingOverlay && (
                   <div className="absolute inset-0 z-30">
                     <SandboxStateCard
                       kind="starting"

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -550,10 +550,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
         )
       : display.mode === "production"
         ? // The published site is the base for both modes while the sandbox
-          // provisions; Fast Preview layers its daemon draft render over it the
-          // moment that's renderable. Same origin either way (the draft carries
-          // `<base href="<productionUrl>">`), so the swap changes content, not
-          // surface.
+          // provisions; Fast Preview swaps in the same page carrying a
+          // `?__draft=` pointer the moment one exists. Same origin either way,
+          // so the swap changes content, not surface.
           withDeviceHint(
             draftPreviewUrl ?? new URL(resolvedPath, display.iframeBase!).href,
             previewDeviceSize,
@@ -567,8 +566,24 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     ? ("sandbox.preview.openInBrowser" as const)
     : ("sandbox.preview.openInNewTab" as const);
 
+  /**
+   * URL for "open in new tab" — the same page, minus Studio's viewport hint.
+   *
+   * `deviceHint` exists to make the embedded frame mimic the selected device;
+   * it has no business in a link someone pastes to a colleague. Under Fast
+   * Preview this is the draft URL itself, which is shareable precisely because
+   * the pointer is a query param on the site's own route.
+   */
+  const openInNewTabUrl =
+    display.mode === "production"
+      ? (draftPreviewUrl ??
+        (display.iframeBase
+          ? new URL(resolvedPath, display.iframeBase).href
+          : null))
+      : (iframeSrc ?? display.iframeBase);
+
   const handleOpenPreview = async () => {
-    const url = iframeSrc ?? display.iframeBase;
+    const url = openInNewTabUrl;
     if (!url) return;
     if (!isDesktopApp) {
       window.open(url, "_blank", "noopener");
@@ -1350,6 +1365,11 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           </div>
         )}
       </div>
+      {/* Available on every surface. Under Fast Preview `iframeSrc` is the
+          site's own page URL carrying `?__draft=<handle>@<version>`, so the
+          opened tab renders the same draft — an ordinary, shareable link. That
+          was not true of the old `/live/previews` render, which is why this
+          button used to be sandbox-only. */}
       <Tooltip>
         <TooltipTrigger asChild>
           <ToolbarIconButton

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -83,7 +83,7 @@ import {
 import { decoBlockFileViewPath } from "@/components/sections-editor/deco-block-key";
 import { findLivePageResolveType } from "@/components/sections-editor/section-catalog";
 import {
-  buildFastPreviewDaemonUrl,
+  buildDraftPreviewUrl,
   buildGlobalSectionPreviewUrl,
 } from "@/components/sections-editor/section-preview-url";
 import { useCreatePage } from "@/components/sections-editor/use-create-page";
@@ -269,7 +269,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const [createPageError, setCreatePageError] = useState<string | undefined>();
   // Bumped after a Blocks save so the Fast Preview daemon frame re-navigates and
   // the daemon re-reads the fresh `.deco/blocks/*` (the "save → refresh" step).
-  const [fastPreviewNonce, setFastPreviewNonce] = useState(0);
   const [activeGlobalSection, setActiveGlobalSection] =
     useState<GlobalSectionEntry | null>(null);
   /** Overrides iframe src for global-section live previews (stable URL, not recomputed). */
@@ -313,6 +312,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const vmEntry = lifecycle.vmEntry;
   const previewUrl = lifecycle.previewUrl;
   const lifecyclePhase = vmEvents.lifecycle.phase;
+  const decofileVersion = vmEvents.decofileVersion;
   const devServerReady = lifecyclePhase === "running";
 
   const isDesktopSandbox = vmEntry?.sandboxProviderKind === "user-desktop";
@@ -469,7 +469,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // which can be a custom one — so we store it rather than guess it). Used as a
   // published-site fallback while the sandbox provisions (non-blocking) instead
   // of a blank overlay; once the daemon is up, Fast Preview swaps to the daemon
-  // render (`fastPreviewDaemonUrl` below). `null` (no field, or a site imported
+  // render (`draftPreviewUrl` below). `null` (no field, or a site imported
   // before this was persisted) → the original blocking overlay is kept.
   const inset = useInsetContext();
   const productionUrl =
@@ -494,26 +494,33 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const fastPreviewEnabled =
     !!productionUrl && inset?.entity?.metadata?.fastPreview === true;
 
-  // Fast Preview render (gated by the CMS switch): render the CURRENT
-  // working-tree draft via the sandbox DAEMON's `/_sandbox/fast-preview` route,
-  // which merges `.deco/blocks/*` and POSTs it (server-side, no URL cap) to the
-  // site's production `/live/previews`. Available once the daemon is up
-  // (`previewUrl`) and a page is matched — no dev server needed. `null` means
-  // not renderable yet, and the published site keeps the canvas until it is.
-  // `fastPreviewNonce` is bumped after a Blocks save so the frame re-navigates
-  // and the daemon re-reads the fresh draft.
+  // Fast Preview (gated by the CMS switch): render the site's REAL page on
+  // `productionUrl`, carrying a `?__draft=<handle>@<version>` pointer that the
+  // site's framework resolves by pulling the merged working-tree decofile from
+  // the sandbox daemon. Replaces POSTing the decofile at `/live/previews`,
+  // which only deco's own runtime honoured and could only render one component
+  // statically.
   //
-  // Computed BEFORE `display` — it is an input to the display decision (which
-  // needs to know whether the draft is renderable), so it must not depend on
-  // `display.mode` in turn.
-  const fastPreviewDaemonUrl =
-    fastPreviewEnabled && previewUrl && currentPageKey
-      ? buildFastPreviewDaemonUrl({
-          previewUrl,
-          pageBlockKey: currentPageKey,
+  // Needs the sandbox handle and a draft version — NOT the dev server, and
+  // notably not `currentPageKey` any more: the site does its own routing, so
+  // the preview no longer waits on the decofile query that used to stall the
+  // whole surface behind a cold-start 502.
+  //
+  // `version` changes on every `.deco/blocks/*` save (the daemon's `decofile`
+  // event), which re-navigates the frame — no cache-busting nonce needed.
+  //
+  // Computed BEFORE `display`: it is an input to that decision, so it must not
+  // depend on `display.mode` in turn.
+  const draftPreviewUrl =
+    fastPreviewEnabled &&
+    productionUrl &&
+    vmEntry?.sandboxHandle &&
+    decofileVersion
+      ? buildDraftPreviewUrl({
+          productionUrl,
+          sandboxHandle: vmEntry.sandboxHandle,
+          version: decofileVersion,
           path: resolvedPath,
-          pathTemplate: currentPath,
-          nonce: fastPreviewNonce,
         })
       : null;
 
@@ -528,7 +535,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     progressStatus: progress.status,
     productionUrl,
     fastPreviewActive: fastPreviewEnabled,
-    fastPreviewReady: !!fastPreviewDaemonUrl,
+    fastPreviewReady: !!draftPreviewUrl,
   });
   const previewSurfaceActive = display.mode !== "none";
 
@@ -548,8 +555,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           // `<base href="<productionUrl>">`), so the swap changes content, not
           // surface.
           withDeviceHint(
-            fastPreviewDaemonUrl ??
-              new URL(resolvedPath, display.iframeBase!).href,
+            draftPreviewUrl ?? new URL(resolvedPath, display.iframeBase!).href,
             previewDeviceSize,
           )
         : null;
@@ -691,22 +697,22 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   });
 
   // Fast Preview refresh backstop: the daemon frame is cross-origin (the daemon
-  // host), so the shared reload path can't `.reload()` it. When the daemon URL
-  // changes — a page switch or a nonce bump after a save — force-navigate the
-  // frame. The nonce guarantees a distinct URL, and the ref guard makes the
+  // host), so the shared reload path can't `.reload()` it. When the draft URL
+  // changes — a page switch, or a new version after a save — force-navigate the
+  // frame. The version makes the URL distinct, and the ref guard makes the
   // first paint (React already set `src`) and unrelated re-renders no-ops.
-  const lastFastPreviewUrlRef = useRef<string | null>(null);
+  const lastDraftUrlRef = useRef<string | null>(null);
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- imperative cross-origin iframe navigation on draft change; .reload() throws cross-origin
   useEffect(() => {
-    if (!fastPreviewDaemonUrl || !iframeSrc) return;
-    if (lastFastPreviewUrlRef.current === fastPreviewDaemonUrl) return;
-    lastFastPreviewUrlRef.current = fastPreviewDaemonUrl;
+    if (!draftPreviewUrl || !iframeSrc) return;
+    if (lastDraftUrlRef.current === draftPreviewUrl) return;
+    lastDraftUrlRef.current = draftPreviewUrl;
     const iframe = previewIframeRef.current;
     if (iframe && iframe.getAttribute("src") !== iframeSrc) {
       beginNavigation();
       iframe.src = iframeSrc;
     }
-  }, [fastPreviewDaemonUrl, iframeSrc]);
+  }, [draftPreviewUrl, iframeSrc]);
 
   // Daemon is reachable independent of the dev script: ready claim, handle
   // still present, not user-stopped. Gates surfaces (FileExplorer,
@@ -900,15 +906,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   // Fires on the daemon "reload" event and on debounced `.deco/` file changes
   // (Blocks saves, external/agent decofile writes) — the only refresh path for
-  // decofile edits, which the framework's HMR doesn't cover. In Fast Preview the
-  // frame is the daemon render, so "refresh" = bump the nonce (new URL → the
-  // frame re-navigates, the daemon re-reads the just-saved `.deco/blocks/*`);
-  // the sandbox path uses the normal reload.
+  // decofile edits, which the framework's HMR doesn't cover. In Fast Preview
+  // the refresh is already driven by the draft VERSION: the same write emits a
+  // `decofile` event, the new version changes `draftPreviewUrl`, and the effect
+  // above re-navigates the frame. Reloading here as well would race that with a
+  // stale URL, so this path yields; the sandbox path uses the normal reload.
   useSandboxReloadHandler(() => {
-    if (fastPreviewDaemonUrl) {
-      setFastPreviewNonce((n) => n + 1);
-      return;
-    }
+    if (draftPreviewUrl) return;
     reloadPreviewPreservingScroll();
   });
   // Show the loading overlay the instant a `.deco/` change is detected, ahead of

--- a/apps/web/src/components/sandbox/runtime-card/fast-preview-field.tsx
+++ b/apps/web/src/components/sandbox/runtime-card/fast-preview-field.tsx
@@ -1,0 +1,59 @@
+import {
+  Controller,
+  type Control,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form";
+import { Label } from "@deco/ui/components/label.tsx";
+import { Switch } from "@deco/ui/components/switch.tsx";
+import { sanitizeProductionUrl } from "@decocms/shared/deco-site-production-url";
+import { useT } from "@/i18n/use-t.ts";
+
+// The Fast Preview switch (`metadata.fastPreview`). Gated on the production URL:
+// Fast Preview renders the draft against that URL, so with none set there's
+// nothing to render against — the switch stays disabled (and visually off) until
+// one is provided. `productionUrl` is passed by the parent from
+// `form.watch("metadata.productionUrl")` so the switch reacts to edits without
+// this leaf owning the form type. Generic over the parent schema, mirroring
+// `ProductionUrlField`.
+export interface FastPreviewFieldProps<T extends FieldValues> {
+  control: Control<T>;
+  /** Current `metadata.productionUrl` value (watched by the parent). */
+  productionUrl: string | null | undefined;
+}
+
+export function FastPreviewField<T extends FieldValues>({
+  control,
+  productionUrl,
+}: FastPreviewFieldProps<T>) {
+  const t = useT();
+  const hasProductionUrl = !!sanitizeProductionUrl(productionUrl);
+  return (
+    <Controller
+      control={control}
+      name={"metadata.fastPreview" as FieldPath<T>}
+      render={({ field }) => (
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex flex-col gap-0.5">
+            <Label htmlFor="fast-preview">
+              {t("sandbox.cmsSettings.fastPreview.label")}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {hasProductionUrl
+                ? t("sandbox.cmsSettings.fastPreview.description")
+                : t("sandbox.cmsSettings.fastPreview.needsProductionUrl")}
+            </p>
+          </div>
+          <Switch
+            id="fast-preview"
+            // Reflect the stored intent, but never show "on" without a URL to
+            // render against — the preview gate requires both anyway.
+            checked={!!field.value && hasProductionUrl}
+            disabled={!hasProductionUrl}
+            onCheckedChange={(checked) => field.onChange(checked)}
+          />
+        </div>
+      )}
+    />
+  );
+}

--- a/apps/web/src/components/sandbox/runtime-card/fast-preview-field.tsx
+++ b/apps/web/src/components/sandbox/runtime-card/fast-preview-field.tsx
@@ -33,9 +33,12 @@ export function FastPreviewField<T extends FieldValues>({
       control={control}
       name={"metadata.fastPreview" as FieldPath<T>}
       render={({ field }) => (
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex flex-col gap-0.5">
-            <Label htmlFor="fast-preview">
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-0.5 min-w-0">
+            <Label
+              htmlFor="fast-preview"
+              className="font-normal text-foreground"
+            >
               {t("sandbox.cmsSettings.fastPreview.label")}
             </Label>
             <p className="text-xs text-muted-foreground">
@@ -46,6 +49,7 @@ export function FastPreviewField<T extends FieldValues>({
           </div>
           <Switch
             id="fast-preview"
+            className="shrink-0"
             // Reflect the stored intent, but never show "on" without a URL to
             // render against — the preview gate requires both anyway.
             checked={!!field.value && hasProductionUrl}

--- a/apps/web/src/components/sandbox/runtime-card/field-description-tooltips-field.tsx
+++ b/apps/web/src/components/sandbox/runtime-card/field-description-tooltips-field.tsx
@@ -22,9 +22,12 @@ export function FieldDescriptionTooltipsField<T extends FieldValues>({
       control={control}
       name={"metadata.fieldDescriptionTooltips" as FieldPath<T>}
       render={({ field }) => (
-        <div className="flex items-center justify-between gap-3">
-          <div className="space-y-0.5">
-            <Label htmlFor="field-description-tooltips">
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-0.5 min-w-0">
+            <Label
+              htmlFor="field-description-tooltips"
+              className="font-normal text-foreground"
+            >
               {t("sandbox.fieldDescriptionTooltipsField.label")}
             </Label>
             <p className="text-xs text-muted-foreground">
@@ -33,6 +36,7 @@ export function FieldDescriptionTooltipsField<T extends FieldValues>({
           </div>
           <Switch
             id="field-description-tooltips"
+            className="shrink-0"
             checked={(field.value as boolean | null | undefined) ?? false}
             onCheckedChange={(next) => field.onChange(next)}
           />

--- a/apps/web/src/components/sections-editor/section-preview-url.test.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.test.ts
@@ -1,57 +1,71 @@
 import { describe, expect, it } from "bun:test";
-import { buildFastPreviewDaemonUrl } from "./section-preview-url";
+import { buildDraftPreviewUrl } from "./section-preview-url";
 
-describe("buildFastPreviewDaemonUrl", () => {
-  it("targets /_sandbox/fast-preview on the daemon (previewUrl) origin", () => {
-    const href = buildFastPreviewDaemonUrl({
-      previewUrl: "https://abc.deco.host/ignored?x=1",
-      pageBlockKey: "pages-home-abc",
-      path: "/",
-      pathTemplate: "/",
-      nonce: 0,
-    });
-    const url = new URL(href);
-    expect(url.origin).toBe("https://abc.deco.host");
-    expect(url.pathname).toBe("/_sandbox/fast-preview");
-  });
+const PROD = "https://www.acme.com";
 
-  it("passes the page block key, path, and pathTemplate as query params", () => {
+describe("buildDraftPreviewUrl", () => {
+  it("targets the real page on the production origin", () => {
+    // Not the daemon and not /live/previews: the site renders its OWN route, so
+    // hydration and in-preview navigation work.
     const url = new URL(
-      buildFastPreviewDaemonUrl({
-        previewUrl: "https://abc.deco.host",
-        pageBlockKey: "site/pages/Landing.tsx",
-        path: "/lp/shoes",
-        pathTemplate: "/lp/:slug",
-        nonce: 3,
+      buildDraftPreviewUrl({
+        productionUrl: PROD,
+        sandboxHandle: "gimenes-abc-1234",
+        version: "ff00",
+        path: "/blog/hello",
       }),
     );
-    expect(url.searchParams.get("component")).toBe("site/pages/Landing.tsx");
-    expect(url.searchParams.get("path")).toBe("/lp/shoes");
-    expect(url.searchParams.get("pathTemplate")).toBe("/lp/:slug");
+    expect(url.origin).toBe(PROD);
+    expect(url.pathname).toBe("/blog/hello");
   });
 
-  it("carries the nonce so a bump produces a distinct URL (forces reload)", () => {
-    const base = {
-      previewUrl: "https://abc.deco.host",
-      pageBlockKey: "pages-home-abc",
-      path: "/",
-      pathTemplate: "/",
-    };
-    const a = buildFastPreviewDaemonUrl({ ...base, nonce: 1 });
-    const b = buildFastPreviewDaemonUrl({ ...base, nonce: 2 });
-    expect(new URL(a).searchParams.get("__cb")).toBe("1");
-    expect(a).not.toBe(b);
+  it("carries the pointer as <handle>@<version>, never a URL", () => {
+    // A URL here would make the site fetch caller-supplied origins — the SSRF
+    // surface the suffix-based design exists to avoid.
+    const url = new URL(
+      buildDraftPreviewUrl({
+        productionUrl: PROD,
+        sandboxHandle: "gimenes-abc-1234",
+        version: "ff00",
+        path: "/",
+      }),
+    );
+    expect(url.searchParams.get("__draft")).toBe("gimenes-abc-1234@ff00");
   });
 
-  it("does not embed the decofile (no URL-size cap)", () => {
-    const href = buildFastPreviewDaemonUrl({
-      previewUrl: "https://abc.deco.host",
-      pageBlockKey: "pages-home-abc",
-      path: "/",
-      pathTemplate: "/",
-      nonce: 0,
-    });
-    expect(href).not.toContain("__decofile");
-    expect(href.length).toBeLessThan(200);
+  it("changes with the version, so a save re-navigates the frame", () => {
+    const at = (version: string) =>
+      buildDraftPreviewUrl({
+        productionUrl: PROD,
+        sandboxHandle: "h",
+        version,
+        path: "/",
+      });
+    expect(at("v1")).not.toBe(at("v2"));
+  });
+
+  it("preserves a production origin that carries a trailing slash", () => {
+    const url = new URL(
+      buildDraftPreviewUrl({
+        productionUrl: "https://fila.vtex.app/",
+        sandboxHandle: "h",
+        version: "v1",
+        path: "/institucional/historia",
+      }),
+    );
+    expect(url.origin).toBe("https://fila.vtex.app");
+    expect(url.pathname).toBe("/institucional/historia");
+  });
+
+  it("keeps path params already filled in", () => {
+    const url = new URL(
+      buildDraftPreviewUrl({
+        productionUrl: PROD,
+        sandboxHandle: "h",
+        version: "v1",
+        path: "/produto/tenis-123/p",
+      }),
+    );
+    expect(url.pathname).toBe("/produto/tenis-123/p");
   });
 });

--- a/apps/web/src/components/sections-editor/section-preview-url.test.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.test.ts
@@ -10,7 +10,7 @@ describe("buildDraftPreviewUrl", () => {
     const url = new URL(
       buildDraftPreviewUrl({
         productionUrl: PROD,
-        sandboxHandle: "gimenes-abc-1234",
+        previewUrl: "https://gimenes-abc-1234.preview-studio.decocms.com",
         version: "ff00",
         path: "/blog/hello",
       }),
@@ -19,25 +19,42 @@ describe("buildDraftPreviewUrl", () => {
     expect(url.pathname).toBe("/blog/hello");
   });
 
-  it("carries the pointer as <handle>@<version>, never a URL", () => {
-    // A URL here would make the site fetch caller-supplied origins — the SSRF
-    // surface the suffix-based design exists to avoid.
+  it("carries the token as <host[:port]>@<version> — an authority, never a URL", () => {
+    // The site validates the authority against its configured preview-API
+    // domains and derives the scheme itself; a full URL here would be the
+    // SSRF surface the design exists to avoid.
     const url = new URL(
       buildDraftPreviewUrl({
         productionUrl: PROD,
-        sandboxHandle: "gimenes-abc-1234",
+        previewUrl: "https://gimenes-abc-1234.preview-studio.decocms.com",
         version: "ff00",
         path: "/",
       }),
     );
-    expect(url.searchParams.get("__draft")).toBe("gimenes-abc-1234@ff00");
+    expect(url.searchParams.get("__draft")).toBe(
+      "gimenes-abc-1234.preview-studio.decocms.com@ff00",
+    );
+  });
+
+  it("keeps the desktop link's per-run port in the token", () => {
+    const url = new URL(
+      buildDraftPreviewUrl({
+        productionUrl: PROD,
+        previewUrl: "http://gimenes-abc-1234.localhost:60534",
+        version: "v1",
+        path: "/",
+      }),
+    );
+    expect(url.searchParams.get("__draft")).toBe(
+      "gimenes-abc-1234.localhost:60534@v1",
+    );
   });
 
   it("changes with the version, so a save re-navigates the frame", () => {
     const at = (version: string) =>
       buildDraftPreviewUrl({
         productionUrl: PROD,
-        sandboxHandle: "h",
+        previewUrl: "https://h.preview-studio.decocms.com",
         version,
         path: "/",
       });
@@ -48,7 +65,7 @@ describe("buildDraftPreviewUrl", () => {
     const url = new URL(
       buildDraftPreviewUrl({
         productionUrl: "https://fila.vtex.app/",
-        sandboxHandle: "h",
+        previewUrl: "https://h.preview-studio.decocms.com",
         version: "v1",
         path: "/institucional/historia",
       }),
@@ -61,7 +78,7 @@ describe("buildDraftPreviewUrl", () => {
     const url = new URL(
       buildDraftPreviewUrl({
         productionUrl: PROD,
-        sandboxHandle: "h",
+        previewUrl: "https://h.preview-studio.decocms.com",
         version: "v1",
         path: "/produto/tenis-123/p",
       }),

--- a/apps/web/src/components/sections-editor/section-preview-url.test.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { buildFastPreviewDaemonUrl } from "./section-preview-url";
 
 describe("buildFastPreviewDaemonUrl", () => {
-  it("targets /_deco/fast-preview on the daemon (previewUrl) origin", () => {
+  it("targets /_sandbox/fast-preview on the daemon (previewUrl) origin", () => {
     const href = buildFastPreviewDaemonUrl({
       previewUrl: "https://abc.deco.host/ignored?x=1",
       pageBlockKey: "pages-home-abc",
@@ -12,7 +12,7 @@ describe("buildFastPreviewDaemonUrl", () => {
     });
     const url = new URL(href);
     expect(url.origin).toBe("https://abc.deco.host");
-    expect(url.pathname).toBe("/_deco/fast-preview");
+    expect(url.pathname).toBe("/_sandbox/fast-preview");
   });
 
   it("passes the page block key, path, and pathTemplate as query params", () => {

--- a/apps/web/src/components/sections-editor/section-preview-url.test.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { buildFastPreviewDaemonUrl } from "./section-preview-url";
+
+describe("buildFastPreviewDaemonUrl", () => {
+  it("targets /_deco/fast-preview on the daemon (previewUrl) origin", () => {
+    const href = buildFastPreviewDaemonUrl({
+      previewUrl: "https://abc.deco.host/ignored?x=1",
+      pageBlockKey: "pages-home-abc",
+      path: "/",
+      pathTemplate: "/",
+      nonce: 0,
+    });
+    const url = new URL(href);
+    expect(url.origin).toBe("https://abc.deco.host");
+    expect(url.pathname).toBe("/_deco/fast-preview");
+  });
+
+  it("passes the page block key, path, and pathTemplate as query params", () => {
+    const url = new URL(
+      buildFastPreviewDaemonUrl({
+        previewUrl: "https://abc.deco.host",
+        pageBlockKey: "site/pages/Landing.tsx",
+        path: "/lp/shoes",
+        pathTemplate: "/lp/:slug",
+        nonce: 3,
+      }),
+    );
+    expect(url.searchParams.get("component")).toBe("site/pages/Landing.tsx");
+    expect(url.searchParams.get("path")).toBe("/lp/shoes");
+    expect(url.searchParams.get("pathTemplate")).toBe("/lp/:slug");
+  });
+
+  it("carries the nonce so a bump produces a distinct URL (forces reload)", () => {
+    const base = {
+      previewUrl: "https://abc.deco.host",
+      pageBlockKey: "pages-home-abc",
+      path: "/",
+      pathTemplate: "/",
+    };
+    const a = buildFastPreviewDaemonUrl({ ...base, nonce: 1 });
+    const b = buildFastPreviewDaemonUrl({ ...base, nonce: 2 });
+    expect(new URL(a).searchParams.get("__cb")).toBe("1");
+    expect(a).not.toBe(b);
+  });
+
+  it("does not embed the decofile (no URL-size cap)", () => {
+    const href = buildFastPreviewDaemonUrl({
+      previewUrl: "https://abc.deco.host",
+      pageBlockKey: "pages-home-abc",
+      path: "/",
+      pathTemplate: "/",
+      nonce: 0,
+    });
+    expect(href).not.toContain("__decofile");
+    expect(href.length).toBeLessThan(200);
+  });
+});

--- a/apps/web/src/components/sections-editor/section-preview-url.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.ts
@@ -30,31 +30,37 @@ export function buildGlobalSectionPreviewUrl(
 }
 
 /**
- * Fast Preview URL. Points at the sandbox **daemon**'s `/_sandbox/fast-preview`
- * route (served from `previewUrl`, the daemon origin). The daemon merges the
- * working-tree `.deco/blocks/*` into a decofile and POSTs it — server-side, no
- * URL-size cap, no CORS — to the site's production `/live/previews/<pageBlockKey>`
- * (the always-on deco runtime), returning the rendered draft with a `<base>`
- * pointing at production so assets resolve there.
+ * Fast Preview URL — the site's own page, rendered against the working-tree
+ * draft.
  *
- * The decofile is NOT in this URL (the daemon reads it from disk), so the frame
- * just needs re-navigating when content changes — bump `nonce` to force it.
- * `pageBlockKey` is the decofile key of the page (e.g. `pages-home-…`).
+ * Points at the REAL page on `productionUrl` and carries a `?__draft=` pointer.
+ * The site's framework resolves that pointer by fetching the merged decofile
+ * from the sandbox daemon (`<handle>.<suffix>/_sandbox/decofile`) and rendering
+ * its own routes against it.
+ *
+ * This replaces pushing the decofile into a POST body: only deco's own runtime
+ * honours a POST render, while Next.js and most frameworks render on GET. Going
+ * through the site's normal route also means hydration and in-preview
+ * navigation work, instead of a single statically-rendered component.
+ *
+ * The pointer is `<handle>@<version>`, never a URL — the site builds the origin
+ * from a configured suffix, so there is no SSRF surface. `version` is the
+ * daemon's content ETag, so the site caches per version and re-fetches only
+ * when the draft actually changes; a new version after a save is what refreshes
+ * the frame, which is why no cache-busting nonce is needed here.
  */
-export function buildFastPreviewDaemonUrl(input: {
-  previewUrl: string;
-  pageBlockKey: string;
+export function buildDraftPreviewUrl(input: {
+  /** Published site origin — the draft renders against this deployment. */
+  productionUrl: string;
+  /** Sandbox handle; the site resolves it under its configured origin suffix. */
+  sandboxHandle: string;
+  /** Draft content version (the daemon's ETag), from the `decofile` event. */
+  version: string;
+  /** Path to render, with any `:param` values already filled in. */
   path: string;
-  pathTemplate: string;
-  nonce: number | string;
 }): string {
-  const url = new URL("/_sandbox/fast-preview", input.previewUrl);
-  url.searchParams.set("component", input.pageBlockKey);
-  url.searchParams.set("path", input.path);
-  url.searchParams.set("pathTemplate", input.pathTemplate);
-  // Re-navigation nonce: the daemon re-reads `.deco/blocks/*` on each request,
-  // so a fresh value forces the frame to reload the latest draft after a save.
-  url.searchParams.set("__cb", String(input.nonce));
+  const url = new URL(input.path, input.productionUrl);
+  url.searchParams.set("__draft", `${input.sandboxHandle}@${input.version}`);
   return url.toString();
 }
 

--- a/apps/web/src/components/sections-editor/section-preview-url.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.ts
@@ -43,24 +43,26 @@ export function buildGlobalSectionPreviewUrl(
  * through the site's normal route also means hydration and in-preview
  * navigation work, instead of a single statically-rendered component.
  *
- * The pointer is `<handle>@<version>`, never a URL — the site builds the origin
- * from a configured suffix, so there is no SSRF surface. `version` is the
- * daemon's content ETag, so the site caches per version and re-fetches only
- * when the draft actually changes; a new version after a save is what refreshes
- * the frame, which is why no cache-busting nonce is needed here.
+ * The token is `<host[:port]>@<version>` — the AUTHORITY of the daemon origin,
+ * never a full URL. The site validates it against its configured preview-API
+ * domains and derives the scheme itself, so there is no SSRF surface, and the
+ * authority carries the desktop link's per-run port for free. `version` is the
+ * daemon's content ETag: the site caches per version, and a new version after
+ * a save is what refreshes the frame — no cache-busting nonce needed.
  */
 export function buildDraftPreviewUrl(input: {
   /** Published site origin — the draft renders against this deployment. */
   productionUrl: string;
-  /** Sandbox handle; the site resolves it under its configured origin suffix. */
-  sandboxHandle: string;
+  /** Daemon origin (`previewUrl`); its authority becomes the token's host. */
+  previewUrl: string;
   /** Draft content version (the daemon's ETag), from the `decofile` event. */
   version: string;
   /** Path to render, with any `:param` values already filled in. */
   path: string;
 }): string {
   const url = new URL(input.path, input.productionUrl);
-  url.searchParams.set("__draft", `${input.sandboxHandle}@${input.version}`);
+  const host = new URL(input.previewUrl).host;
+  url.searchParams.set("__draft", `${host}@${input.version}`);
   return url.toString();
 }
 

--- a/apps/web/src/components/sections-editor/section-preview-url.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.ts
@@ -30,7 +30,7 @@ export function buildGlobalSectionPreviewUrl(
 }
 
 /**
- * Fast Preview URL. Points at the sandbox **daemon**'s `/_deco/fast-preview`
+ * Fast Preview URL. Points at the sandbox **daemon**'s `/_sandbox/fast-preview`
  * route (served from `previewUrl`, the daemon origin). The daemon merges the
  * working-tree `.deco/blocks/*` into a decofile and POSTs it — server-side, no
  * URL-size cap, no CORS — to the site's production `/live/previews/<pageBlockKey>`
@@ -48,7 +48,7 @@ export function buildFastPreviewDaemonUrl(input: {
   pathTemplate: string;
   nonce: number | string;
 }): string {
-  const url = new URL("/_deco/fast-preview", input.previewUrl);
+  const url = new URL("/_sandbox/fast-preview", input.previewUrl);
   url.searchParams.set("component", input.pageBlockKey);
   url.searchParams.set("path", input.path);
   url.searchParams.set("pathTemplate", input.pathTemplate);

--- a/apps/web/src/components/sections-editor/section-preview-url.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.ts
@@ -29,6 +29,35 @@ export function buildGlobalSectionPreviewUrl(
   return url.toString();
 }
 
+/**
+ * Fast Preview URL. Points at the sandbox **daemon**'s `/_deco/fast-preview`
+ * route (served from `previewUrl`, the daemon origin). The daemon merges the
+ * working-tree `.deco/blocks/*` into a decofile and POSTs it — server-side, no
+ * URL-size cap, no CORS — to the site's production `/live/previews/<pageBlockKey>`
+ * (the always-on deco runtime), returning the rendered draft with a `<base>`
+ * pointing at production so assets resolve there.
+ *
+ * The decofile is NOT in this URL (the daemon reads it from disk), so the frame
+ * just needs re-navigating when content changes — bump `nonce` to force it.
+ * `pageBlockKey` is the decofile key of the page (e.g. `pages-home-…`).
+ */
+export function buildFastPreviewDaemonUrl(input: {
+  previewUrl: string;
+  pageBlockKey: string;
+  path: string;
+  pathTemplate: string;
+  nonce: number | string;
+}): string {
+  const url = new URL("/_deco/fast-preview", input.previewUrl);
+  url.searchParams.set("component", input.pageBlockKey);
+  url.searchParams.set("path", input.path);
+  url.searchParams.set("pathTemplate", input.pathTemplate);
+  // Re-navigation nonce: the daemon re-reads `.deco/blocks/*` on each request,
+  // so a fresh value forces the frame to reload the latest draft after a save.
+  url.searchParams.set("__cb", String(input.nonce));
+  return url.toString();
+}
+
 export function buildSectionPreviewUrl(
   previewBaseUrl: string,
   livePageResolveType: string,

--- a/apps/web/src/components/sections-editor/use-decofile.ts
+++ b/apps/web/src/components/sections-editor/use-decofile.ts
@@ -74,9 +74,12 @@ export function useDecofile(
     },
     enabled: !!params,
     staleTime: 30_000,
-    // 502 = preview unreachable / nothing available yet. The sandbox lifecycle
-    // re-invalidates this query when the dev server comes up (see
-    // sandbox-events-context), so retrying just hammers a known-down endpoint.
+    // 502 = preview unreachable / nothing available yet. Retrying just hammers
+    // a known-down endpoint; sandbox-events-context re-invalidates this query
+    // on first daemon contact (and again when the dev server reports
+    // `running`), so the recovery is event-driven. The first-contact trigger is
+    // load-bearing for Fast Preview: it renders off the daemon alone, so
+    // waiting for `running` would strand it behind the install it skips.
     retry: (failureCount, error) =>
       (error as { status?: number }).status !== 502 && failureCount < 2,
     retryDelay: (attempt) =>

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -508,9 +508,18 @@ export const sandbox = {
   "sandbox.redirectEditor.typePermanent": "Permanent ({status})",
   "sandbox.redirectEditor.typePlaceholder": "Type",
   "sandbox.redirectEditor.typeTemporary": "Temporary ({status})",
+  "sandbox.cmsSettings.title": "CMS",
+  "sandbox.cmsSettings.preview.title": "Preview",
+  "sandbox.cmsSettings.preview.description":
+    "See your changes before they go live.",
+  "sandbox.cmsSettings.fastPreview.label": "Fast Preview",
+  "sandbox.cmsSettings.fastPreview.description":
+    "Preview changes on your preview server instead of the sandbox.",
+  "sandbox.cmsSettings.fastPreview.needsProductionUrl":
+    "Set a preview server above to enable Fast Preview.",
   "sandbox.productionUrlField.description":
-    "Shown in the preview while the dev server is starting, so you can view and edit right away.",
-  "sandbox.productionUrlField.label": "Production URL",
+    "Your live server's address, used to preview content. Required for Fast Preview.",
+  "sandbox.productionUrlField.label": "Preview server",
   "sandbox.productionUrlField.placeholder": "https://example.com",
   "sandbox.fieldDescriptionTooltipsField.label":
     "Show field descriptions as tooltips",

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -517,12 +517,14 @@ export const sandbox = {
     "Preview changes on your preview server instead of the sandbox.",
   "sandbox.cmsSettings.fastPreview.needsProductionUrl":
     "Set a preview server above to enable Fast Preview.",
+  "sandbox.cmsSettings.editing.title": "Editing",
+  "sandbox.cmsSettings.editing.description":
+    "Customize the content-editing experience in the blocks form.",
   "sandbox.productionUrlField.description":
     "Your live server's address, used to preview content. Required for Fast Preview.",
   "sandbox.productionUrlField.label": "Preview server",
   "sandbox.productionUrlField.placeholder": "https://example.com",
-  "sandbox.fieldDescriptionTooltipsField.label":
-    "Show field descriptions as tooltips",
+  "sandbox.fieldDescriptionTooltipsField.label": "Compact descriptions",
   "sandbox.fieldDescriptionTooltipsField.description":
     "In the blocks form, show a field's description as a hover tooltip on its title instead of text below the title.",
   "sandbox.repoRow.label": "Repository",

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -417,7 +417,7 @@ export const sandbox = {
   "sandbox.preview.searchPagesAndComponents": "Search pages and components...",
   "sandbox.preview.startingPreview": "Starting your preview",
   "sandbox.preview.startingPreviewHint":
-    "You can make changes now — they'll appear once the preview is ready.",
+    "Showing your published site. You can make changes now — they'll appear once the preview is ready.",
   "sandbox.preview.templateNoLongerExists":
     "Selected template no longer exists.",
   "sandbox.preview.urlCopiedToClipboard": "URL copied to clipboard",

--- a/apps/web/src/i18n/en/virtual-mcp.ts
+++ b/apps/web/src/i18n/en/virtual-mcp.ts
@@ -117,7 +117,7 @@ export const virtualMcp = {
     "What users see when they first open this agent.",
   "virtualMcp.layoutTabContent.noInteractiveTools":
     "None of the connected servers expose interactive tools.",
-  "virtualMcp.layoutTabContent.openCms": "Open CMS",
+  "virtualMcp.layoutTabContent.openCms": "Auto-open editor",
   "virtualMcp.layoutTabContent.openCmsDescription":
     "Open the CMS automatically when the preview is ready to edit content.",
   "virtualMcp.layoutTabContent.pinnedViews": "Pinned views",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -540,12 +540,14 @@ export const sandbox = {
     "Pré-visualize alterações no seu servidor de preview em vez do sandbox.",
   "sandbox.cmsSettings.fastPreview.needsProductionUrl":
     "Defina um servidor de preview acima para ativar o Preview Rápido.",
+  "sandbox.cmsSettings.editing.title": "Edição",
+  "sandbox.cmsSettings.editing.description":
+    "Personalize a experiência de edição de conteúdo no formulário de blocos.",
   "sandbox.productionUrlField.description":
     "O endereço do seu servidor ativo, usado para pré-visualizar conteúdo. Necessário para o Preview Rápido.",
   "sandbox.productionUrlField.label": "Servidor de preview",
   "sandbox.productionUrlField.placeholder": "https://exemplo.com",
-  "sandbox.fieldDescriptionTooltipsField.label":
-    "Mostrar descrições de campo como tooltip",
+  "sandbox.fieldDescriptionTooltipsField.label": "Descrições compactas",
   "sandbox.fieldDescriptionTooltipsField.description":
     "No formulário de blocos, exibe a descrição do campo como um tooltip ao passar o mouse sobre o título, em vez de texto abaixo do título.",
   "sandbox.repoRow.label": "Repositório",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -531,9 +531,18 @@ export const sandbox = {
   "sandbox.redirectEditor.typePermanent": "Permanente ({status})",
   "sandbox.redirectEditor.typePlaceholder": "Tipo",
   "sandbox.redirectEditor.typeTemporary": "Temporário ({status})",
+  "sandbox.cmsSettings.title": "CMS",
+  "sandbox.cmsSettings.preview.title": "Preview",
+  "sandbox.cmsSettings.preview.description":
+    "Veja suas alterações antes de publicá-las.",
+  "sandbox.cmsSettings.fastPreview.label": "Preview Rápido",
+  "sandbox.cmsSettings.fastPreview.description":
+    "Pré-visualize alterações no seu servidor de preview em vez do sandbox.",
+  "sandbox.cmsSettings.fastPreview.needsProductionUrl":
+    "Defina um servidor de preview acima para ativar o Preview Rápido.",
   "sandbox.productionUrlField.description":
-    "Exibida no preview enquanto o servidor de desenvolvimento inicia, para você já visualizar e editar.",
-  "sandbox.productionUrlField.label": "URL de produção",
+    "O endereço do seu servidor ativo, usado para pré-visualizar conteúdo. Necessário para o Preview Rápido.",
+  "sandbox.productionUrlField.label": "Servidor de preview",
   "sandbox.productionUrlField.placeholder": "https://exemplo.com",
   "sandbox.fieldDescriptionTooltipsField.label":
     "Mostrar descrições de campo como tooltip",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -437,7 +437,7 @@ export const sandbox = {
     "Procurar páginas e componentes...",
   "sandbox.preview.startingPreview": "Iniciando seu preview",
   "sandbox.preview.startingPreviewHint":
-    "Você já pode fazer alterações — elas aparecem quando o preview estiver pronto.",
+    "Mostrando seu site publicado. Você já pode fazer alterações — elas aparecem quando o preview estiver pronto.",
   "sandbox.preview.templateNoLongerExists":
     "O modelo selecionado não existe mais.",
   "sandbox.preview.urlCopiedToClipboard":

--- a/apps/web/src/i18n/pt-br/virtual-mcp.ts
+++ b/apps/web/src/i18n/pt-br/virtual-mcp.ts
@@ -120,7 +120,7 @@ export const virtualMcp = {
     "O que os usuários veem quando abrem este agente pela primeira vez.",
   "virtualMcp.layoutTabContent.noInteractiveTools":
     "Nenhum dos servidores conectados expõe ferramentas interativas.",
-  "virtualMcp.layoutTabContent.openCms": "Abrir CMS",
+  "virtualMcp.layoutTabContent.openCms": "Abrir editor automaticamente",
   "virtualMcp.layoutTabContent.openCmsDescription":
     "Abrir o CMS automaticamente quando a visualização estiver pronta para editar conteúdo.",
   "virtualMcp.layoutTabContent.pinnedViews": "Visualizações fixadas",

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -32,10 +32,6 @@ import {
 } from "@deco/ui/components/dialog.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Card, CardContent } from "@deco/ui/components/card.tsx";
-import {
-  RadioGroup,
-  RadioGroupItem,
-} from "@deco/ui/components/radio-group.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import {
   Tooltip,
@@ -81,6 +77,8 @@ import { RepoRow } from "@/components/sandbox/runtime-card/repo-row";
 import { RuntimeFields } from "@/components/sandbox/runtime-card/runtime-fields";
 import { ProductionUrlField } from "@/components/sandbox/runtime-card/production-url-field";
 import { FieldDescriptionTooltipsField } from "@/components/sandbox/runtime-card/field-description-tooltips-field";
+import { FastPreviewField } from "@/components/sandbox/runtime-card/fast-preview-field";
+import { PublishPolicyField } from "./publish-policy-field";
 
 type DialogState = {
   shareDialogOpen: boolean;
@@ -1053,89 +1051,52 @@ function VirtualMcpDetailViewWithData({
             {/* Development agent section (link a dev counterpart) */}
             <DevAgentSetup virtualMcp={virtualMcp} />
 
-            {/* Publishing section (code agents only) */}
-            {hasGithubRepo && (
-              <div className="flex flex-col gap-3">
-                <div className="flex flex-col gap-1">
-                  <h2 className="text-sm font-medium text-foreground">
-                    {t("virtualMcp.virtualMcp.publishing")}
-                  </h2>
-                  <p className="text-sm text-muted-foreground">
-                    {t("virtualMcp.virtualMcp.publishingDescription")}
-                  </p>
-                </div>
-                <Card className="p-6">
-                  <CardContent className="p-0">
-                    <Controller
-                      name="metadata.publishPolicy"
-                      control={form.control}
-                      render={({ field }) => (
-                        <RadioGroup
-                          value={field.value ?? "smart"}
-                          onValueChange={(value) => {
-                            field.onChange(value);
-                            flushAndSave();
-                          }}
-                          className="gap-4"
-                        >
-                          {(
-                            [
-                              {
-                                value: "smart",
-                                label: t(
-                                  "virtualMcp.virtualMcp.publishPolicySmart",
-                                ),
-                                description: t(
-                                  "virtualMcp.virtualMcp.publishPolicySmartDescription",
-                                ),
-                              },
-                              {
-                                value: "code-review",
-                                label: t(
-                                  "virtualMcp.virtualMcp.publishPolicyCodeReview",
-                                ),
-                                description: t(
-                                  "virtualMcp.virtualMcp.publishPolicyCodeReviewDescription",
-                                ),
-                              },
-                              {
-                                value: "open",
-                                label: t(
-                                  "virtualMcp.virtualMcp.publishPolicyOpen",
-                                ),
-                                description: t(
-                                  "virtualMcp.virtualMcp.publishPolicyOpenDescription",
-                                ),
-                              },
-                            ] as const
-                          ).map((option) => (
-                            <label
-                              key={option.value}
-                              htmlFor={`publish-policy-${option.value}`}
-                              className="flex cursor-pointer items-start gap-3"
-                            >
-                              <RadioGroupItem
-                                id={`publish-policy-${option.value}`}
-                                value={option.value}
-                                className="mt-0.5"
-                              />
-                              <div className="flex flex-col gap-0.5">
-                                <span className="text-sm font-medium text-foreground">
-                                  {option.label}
-                                </span>
-                                <span className="text-sm text-muted-foreground">
-                                  {option.description}
-                                </span>
-                              </div>
-                            </label>
-                          ))}
-                        </RadioGroup>
-                      )}
-                    />
-                  </CardContent>
-                </Card>
+            {/* CMS section — Fast Preview + Publishing (how CMS/code changes
+                reach the live site). Publishing is code-agent only. */}
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-sm font-medium text-foreground">
+                  {t("sandbox.cmsSettings.title")}
+                </h2>
               </div>
-            )}
+              <Card className="p-6 gap-5">
+                <CardContent className="p-0 space-y-6">
+                  {/* Preview — preview URL + the Fast Preview switch it gates
+                      (a URL is required for Fast Preview to take effect). */}
+                  <div className="space-y-4">
+                    <div className="flex flex-col gap-1">
+                      <h3 className="text-sm font-medium text-foreground">
+                        {t("sandbox.cmsSettings.preview.title")}
+                      </h3>
+                      <p className="text-sm text-muted-foreground">
+                        {t("sandbox.cmsSettings.preview.description")}
+                      </p>
+                    </div>
+                    <ProductionUrlField control={form.control} />
+                    <FastPreviewField
+                      control={form.control}
+                      productionUrl={form.watch("metadata.productionUrl")}
+                    />
+                  </div>
+                  {hasGithubRepo && (
+                    <div className="space-y-4 border-t border-border pt-6">
+                      <div className="flex flex-col gap-1">
+                        <h3 className="text-sm font-medium text-foreground">
+                          {t("virtualMcp.virtualMcp.publishing")}
+                        </h3>
+                        <p className="text-sm text-muted-foreground">
+                          {t("virtualMcp.virtualMcp.publishingDescription")}
+                        </p>
+                      </div>
+                      <PublishPolicyField
+                        control={form.control}
+                        onCommit={flushAndSave}
+                      />
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
 
             {/* Sandbox section */}
             <div className="flex flex-col gap-3">
@@ -1147,7 +1108,6 @@ function VirtualMcpDetailViewWithData({
               <Card className="p-6 gap-5">
                 <CardContent className="p-0 space-y-5">
                   <RepoRow repo={runtimeCardRepo} />
-                  <ProductionUrlField control={form.control} />
                   <FieldDescriptionTooltipsField control={form.control} />
                   <RuntimeFields control={form.control} />
                   <EnvVarsField

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -32,6 +32,8 @@ import {
 } from "@deco/ui/components/dialog.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { Card, CardContent } from "@deco/ui/components/card.tsx";
+import { Label } from "@deco/ui/components/label.tsx";
+import { Switch } from "@deco/ui/components/switch.tsx";
 import { Textarea } from "@deco/ui/components/textarea.tsx";
 import {
   Tooltip,
@@ -69,7 +71,10 @@ import { ALL_ITEMS_SELECTED } from "./selection-utils";
 import { VirtualMcpFormSchema, type VirtualMcpFormData } from "./types";
 import { VirtualMCPShareModal } from "./virtual-mcp-share-modal";
 import { getActiveGithubRepo } from "@/lib/github-repo";
-import { agentHasConnectedGithub } from "@/lib/agent-capabilities";
+import {
+  agentHasClonableSource,
+  agentHasConnectedGithub,
+} from "@/lib/agent-capabilities";
 import { DevAgentSetup } from "@/components/dev-agent/dev-agent-setup.tsx";
 import { EnvVarsField } from "@/components/sandbox/runtime-card/env-vars-field";
 import { SubmoduleCredentialsField } from "@/components/sandbox/runtime-card/submodule-credentials-field";
@@ -319,6 +324,15 @@ function VirtualMcpDetailViewWithData({
 
   // GitHub repo connected (real auth) — instructions become read-only
   const hasGithubRepo = agentHasConnectedGithub(virtualMcp);
+
+  // Gates the "Open CMS" toggle — same condition LayoutTabContent uses to
+  // gate Preview/Content as a main-view option (a Start Website template or a
+  // connected GitHub repo).
+  const hasClonableSource = agentHasClonableSource(virtualMcp?.metadata);
+  const layoutMeta = form.watch("metadata.ui.layout") ?? null;
+  // Off by default (absent / null → false): the CMS auto-opens in Preview only
+  // when an agent explicitly opts in via this toggle.
+  const cmsDefaultOpen = layoutMeta?.cmsDefaultOpen ?? false;
 
   // Repo info for the Runtime card (display-only — loose check is intentional)
   const githubRepoForRuntimeCard = getActiveGithubRepo(virtualMcp);
@@ -1060,26 +1074,28 @@ function VirtualMcpDetailViewWithData({
                 </h2>
               </div>
               <Card className="p-6 gap-5">
-                <CardContent className="p-0 space-y-6">
-                  {/* Preview — preview URL + the Fast Preview switch it gates
-                      (a URL is required for Fast Preview to take effect). */}
-                  <div className="space-y-4">
-                    <div className="flex flex-col gap-1">
-                      <h3 className="text-sm font-medium text-foreground">
-                        {t("sandbox.cmsSettings.preview.title")}
-                      </h3>
-                      <p className="text-sm text-muted-foreground">
-                        {t("sandbox.cmsSettings.preview.description")}
-                      </p>
-                    </div>
-                    <ProductionUrlField control={form.control} />
-                    <FastPreviewField
-                      control={form.control}
-                      productionUrl={form.watch("metadata.productionUrl")}
-                    />
+                {/* Preview — preview URL + the Fast Preview switch it gates
+                    (a URL is required for Fast Preview to take effect). */}
+                <CardContent className="p-0 space-y-5">
+                  <div className="flex flex-col gap-1">
+                    <h3 className="text-sm font-medium text-foreground">
+                      {t("sandbox.cmsSettings.preview.title")}
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      {t("sandbox.cmsSettings.preview.description")}
+                    </p>
                   </div>
-                  {hasGithubRepo && (
-                    <div className="space-y-4 border-t border-border pt-6">
+                  <ProductionUrlField control={form.control} />
+                  <FastPreviewField
+                    control={form.control}
+                    productionUrl={form.watch("metadata.productionUrl")}
+                  />
+                </CardContent>
+
+                {hasGithubRepo && (
+                  <>
+                    <div className="border-t border-border -mx-6" />
+                    <CardContent className="p-0 space-y-5">
                       <div className="flex flex-col gap-1">
                         <h3 className="text-sm font-medium text-foreground">
                           {t("virtualMcp.virtualMcp.publishing")}
@@ -1092,8 +1108,47 @@ function VirtualMcpDetailViewWithData({
                         control={form.control}
                         onCommit={flushAndSave}
                       />
+                    </CardContent>
+                  </>
+                )}
+
+                {/* Editing — content-editing preferences (auto-open the CMS,
+                    compact field descriptions). */}
+                <div className="border-t border-border -mx-6" />
+                <CardContent className="p-0 space-y-5">
+                  <div className="flex flex-col gap-1">
+                    <h3 className="text-sm font-medium text-foreground">
+                      {t("sandbox.cmsSettings.editing.title")}
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      {t("sandbox.cmsSettings.editing.description")}
+                    </p>
+                  </div>
+                  {hasClonableSource && (
+                    <div className="flex items-center justify-between gap-4">
+                      <div className="space-y-0.5 min-w-0">
+                        <Label className="font-normal text-foreground">
+                          {t("virtualMcp.layoutTabContent.openCms")}
+                        </Label>
+                        <p className="text-xs text-muted-foreground">
+                          {t("virtualMcp.layoutTabContent.openCmsDescription")}
+                        </p>
+                      </div>
+                      <Switch
+                        className="shrink-0"
+                        checked={cmsDefaultOpen}
+                        onCheckedChange={(checked) => {
+                          form.setValue(
+                            "metadata.ui.layout",
+                            { ...layoutMeta, cmsDefaultOpen: checked },
+                            { shouldDirty: true },
+                          );
+                          flushAndSave();
+                        }}
+                      />
                     </div>
                   )}
+                  <FieldDescriptionTooltipsField control={form.control} />
                 </CardContent>
               </Card>
             </div>
@@ -1108,7 +1163,6 @@ function VirtualMcpDetailViewWithData({
               <Card className="p-6 gap-5">
                 <CardContent className="p-0 space-y-5">
                   <RepoRow repo={runtimeCardRepo} />
-                  <FieldDescriptionTooltipsField control={form.control} />
                   <RuntimeFields control={form.control} />
                   <EnvVarsField
                     control={form.control}

--- a/apps/web/src/views/virtual-mcp/layout-tab-content.tsx
+++ b/apps/web/src/views/virtual-mcp/layout-tab-content.tsx
@@ -127,9 +127,6 @@ export function LayoutTabContent({
   const layoutMeta = form.watch("metadata.ui.layout") ?? null;
   const currentDefaultMain = layoutMeta?.defaultMainView ?? null;
   const chatDefaultOpen = layoutMeta?.chatDefaultOpen ?? false;
-  // Off by default (absent / null → false): the CMS auto-opens in Preview only
-  // when an agent explicitly opts in via this toggle.
-  const cmsDefaultOpen = layoutMeta?.cmsDefaultOpen ?? false;
   // Convert the stored {type, id, toolName} object into the string composite
   // key used by the <Select> UI. Legacy tab types fold into "settings".
   const defaultMainView = (() => {
@@ -168,7 +165,6 @@ export function LayoutTabContent({
   const writeLayout = (next: {
     defaultMainView?: { type: string; id?: string; toolName?: string } | null;
     chatDefaultOpen?: boolean | null;
-    cmsDefaultOpen?: boolean | null;
   }) => {
     form.setValue(
       "metadata.ui.layout",
@@ -400,27 +396,6 @@ export function LayoutTabContent({
               )}
             </Tooltip>
           </div>
-
-          {hasClonableSource && (
-            <div className="flex items-center justify-between gap-4">
-              <div className="space-y-0.5 min-w-0">
-                <Label className="font-normal text-foreground">
-                  {t("virtualMcp.layoutTabContent.openCms")}
-                </Label>
-                <p className="text-xs text-muted-foreground">
-                  {t("virtualMcp.layoutTabContent.openCmsDescription")}
-                </p>
-              </div>
-              <Switch
-                className="shrink-0"
-                checked={cmsDefaultOpen}
-                onCheckedChange={(checked) => {
-                  writeLayout({ cmsDefaultOpen: checked });
-                  flushAndSave();
-                }}
-              />
-            </div>
-          )}
         </CardContent>
 
         {hasPinnedContent && (

--- a/apps/web/src/views/virtual-mcp/publish-policy-field.tsx
+++ b/apps/web/src/views/virtual-mcp/publish-policy-field.tsx
@@ -1,0 +1,86 @@
+import {
+  Controller,
+  type Control,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form";
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@deco/ui/components/radio-group.tsx";
+import { useT } from "@/i18n/use-t.ts";
+
+// The publish-policy radio group (`metadata.publishPolicy`): how a code agent's
+// CMS/code changes reach the live site — direct publish vs. PR review. Extracted
+// from the settings view so it can compose inside the CMS section. Generic over
+// the parent schema, mirroring the other metadata field editors. Code-agent only
+// — the caller gates on a connected GitHub repo.
+export interface PublishPolicyFieldProps<T extends FieldValues> {
+  control: Control<T>;
+  /** Settings auto-save on change — persist immediately (blur-equivalent). */
+  onCommit: () => void;
+}
+
+export function PublishPolicyField<T extends FieldValues>({
+  control,
+  onCommit,
+}: PublishPolicyFieldProps<T>) {
+  const t = useT();
+  const options = [
+    {
+      value: "smart",
+      label: t("virtualMcp.virtualMcp.publishPolicySmart"),
+      description: t("virtualMcp.virtualMcp.publishPolicySmartDescription"),
+    },
+    {
+      value: "code-review",
+      label: t("virtualMcp.virtualMcp.publishPolicyCodeReview"),
+      description: t(
+        "virtualMcp.virtualMcp.publishPolicyCodeReviewDescription",
+      ),
+    },
+    {
+      value: "open",
+      label: t("virtualMcp.virtualMcp.publishPolicyOpen"),
+      description: t("virtualMcp.virtualMcp.publishPolicyOpenDescription"),
+    },
+  ] as const;
+  return (
+    <Controller
+      name={"metadata.publishPolicy" as FieldPath<T>}
+      control={control}
+      render={({ field }) => (
+        <RadioGroup
+          value={(field.value as string | null) ?? "smart"}
+          onValueChange={(value) => {
+            field.onChange(value);
+            onCommit();
+          }}
+          className="gap-4"
+        >
+          {options.map((option) => (
+            <label
+              key={option.value}
+              htmlFor={`publish-policy-${option.value}`}
+              className="flex cursor-pointer items-start gap-3"
+            >
+              <RadioGroupItem
+                id={`publish-policy-${option.value}`}
+                value={option.value}
+                className="mt-0.5"
+              />
+              <div className="flex flex-col gap-0.5">
+                <span className="text-sm font-medium text-foreground">
+                  {option.label}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  {option.description}
+                </span>
+              </div>
+            </label>
+          ))}
+        </RadioGroup>
+      )}
+    />
+  );
+}

--- a/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
@@ -71,6 +71,19 @@ describe("GET /_sandbox/decofile", () => {
     expect(body["pages-home"]).toEqual({ path: "/", sections: [] });
   });
 
+  test("decodes double-encoded filenames to the real block key", async () => {
+    // Real repos carry both encodings: `Compre%20Junto.json` (single) and
+    // `Compre%2520Junto.json` (double). Both must merge under "Compre Junto" —
+    // a single decode leaves the double-encoded one keyed "Compre%20Junto",
+    // which no `__resolveType` reference resolves.
+    await writeBlock(d!, "Compre%2520Junto", { curated: true });
+    await writeBlock(d!, "Card%20config", { plain: true });
+
+    const res = await fetch(url(d!, "/_sandbox/decofile"));
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(Object.keys(body).sort()).toEqual(["Card config", "Compre Junto"]);
+  });
+
   test("is unauthenticated — the fetcher is a site, not the cluster", async () => {
     // Deliberately no Authorization header: the production server pulling this
     // has no daemon token. Matched ahead of the bearer gate in entry.ts.

--- a/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
@@ -12,6 +12,7 @@ import {
   type Daemon,
   HOOK_TIMEOUT_MS,
   jsonAuthHeaders,
+  readSseUntil,
   startDaemon,
   stopDaemon,
   url,
@@ -115,6 +116,50 @@ describe("GET /_sandbox/decofile", () => {
     expect(stale.status).toBe(200);
     expect((await stale.text()).length).toBeGreaterThan(0);
   });
+
+  test("announces a new version on the events stream after a block write", async () => {
+    // The signal Studio rebuilds its draft pointer from. Without it a save
+    // would not refresh the preview — Studio would have to poll a multi-MB
+    // payload just to read its hash.
+    await writeBlock(d!, "pages-home", { path: "/", sections: [] });
+
+    // Land the write while the stream is open, so the event is observed live
+    // rather than replayed from connect.
+    const pending = readSseUntil(url(d!, "/_sandbox/events"), {
+      predicate: (acc) => acc.includes("event: decofile"),
+      deadlineMs: 15_000,
+    });
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Write through the daemon's own route rather than straight to disk: that
+    // is how the CMS actually saves a block, and it signals `onWorkingTreeWrite`
+    // directly. A bare fs write would rely on BranchStatusMonitor's watcher,
+    // which only starts once the repo is a real git checkout.
+    const saved = await fetch(url(d!, "/_sandbox/write"), {
+      method: "POST",
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({
+        path: ".deco/blocks/pages-home.json",
+        content: JSON.stringify({ path: "/", sections: [{ n: 1 }] }),
+      }),
+    });
+    expect(saved.status).toBe(200);
+
+    const { text } = await pending;
+    const line = text
+      .split("\n")
+      .find((l) => l.startsWith("data:") && l.includes("version"));
+    expect(line).toBeDefined();
+    const { version } = JSON.parse(line!.slice("data:".length).trim()) as {
+      version: string;
+    };
+
+    // Must be the SAME value the route serves as its ETag — one definition, or
+    // Studio's pointer and the framework's cache key drift apart.
+    const res = await fetch(url(d!, "/_sandbox/decofile"));
+    await res.text();
+    expect(res.headers.get("etag")).toBe(`W/"${version}"`);
+  }, 30_000);
 });
 
 // Inlined copy of the web consumer's stripLineNumbers (read-committed-file.ts →

--- a/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
@@ -136,10 +136,22 @@ describe("GET /_sandbox/decofile", () => {
     // payload just to read its hash.
     await writeBlock(d!, "pages-home", { path: "/", sections: [] });
 
+    // The connect handshake also carries a decofile event now (the pre-write
+    // version), so "an event arrived" is not enough — wait for one whose
+    // version DIFFERS from the pre-write state to prove the live announce.
+    const before = await fetch(url(d!, "/_sandbox/decofile"));
+    await before.text();
+    const preVersion = (before.headers.get("etag") ?? "").replace(
+      /^W\/"|"$/g,
+      "",
+    );
+    const versionsIn = (acc: string): string[] =>
+      [...acc.matchAll(/"version":"([0-9a-f]+)"/g)].map((m) => m[1] ?? "");
+
     // Land the write while the stream is open, so the event is observed live
     // rather than replayed from connect.
     const pending = readSseUntil(url(d!, "/_sandbox/events"), {
-      predicate: (acc) => acc.includes("event: decofile"),
+      predicate: (acc) => versionsIn(acc).some((v) => v !== preVersion),
       deadlineMs: 15_000,
     });
     await new Promise((r) => setTimeout(r, 500));
@@ -159,6 +171,41 @@ describe("GET /_sandbox/decofile", () => {
     expect(saved.status).toBe(200);
 
     const { text } = await pending;
+    const version = versionsIn(text).find((v) => v !== preVersion);
+    expect(version).toBeDefined();
+
+    // Must be the SAME value the route serves as its ETag — one definition, or
+    // Studio's pointer and the framework's cache key drift apart.
+    const res = await fetch(url(d!, "/_sandbox/decofile"));
+    await res.text();
+    expect(res.headers.get("etag")).toBe(`W/"${version}"`);
+  }, 30_000);
+
+  test("replays the version to a client that connects AFTER the announce", async () => {
+    // A thread switch or page reload opens a fresh events stream long after
+    // tree-land already announced the version. Without a handshake replay that
+    // client waits on `decofile` forever and Fast Preview never starts.
+    await writeBlock(d!, "pages-home", { path: "/", sections: [] });
+
+    // Trigger an announce via the daemon's own write route, then let the
+    // debounce + merge land before connecting.
+    const saved = await fetch(url(d!, "/_sandbox/write"), {
+      method: "POST",
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({
+        path: ".deco/blocks/pages-home.json",
+        content: JSON.stringify({ path: "/", sections: [{ n: 2 }] }),
+      }),
+    });
+    expect(saved.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 1_500));
+
+    // Fresh connection, no writes after this point: the version must come
+    // from the handshake snapshot alone.
+    const { text } = await readSseUntil(url(d!, "/_sandbox/events"), {
+      predicate: (acc) => acc.includes("event: decofile"),
+      deadlineMs: 10_000,
+    });
     const line = text
       .split("\n")
       .find((l) => l.startsWith("data:") && l.includes("version"));
@@ -167,11 +214,22 @@ describe("GET /_sandbox/decofile", () => {
       version: string;
     };
 
-    // Must be the SAME value the route serves as its ETag — one definition, or
-    // Studio's pointer and the framework's cache key drift apart.
     const res = await fetch(url(d!, "/_sandbox/decofile"));
     await res.text();
     expect(res.headers.get("etag")).toBe(`W/"${version}"`);
+  }, 30_000);
+
+  test("computes and broadcasts a version for a connecting client even when no announce ever ran", async () => {
+    // A daemon restarted over an already-cloned tree: blocks are on disk but
+    // the daemon never saw a write, so nothing is cached. The connect path
+    // must compute one rather than leave the client waiting.
+    await writeBlock(d!, "pages-home", { path: "/", sections: [] });
+
+    const { text } = await readSseUntil(url(d!, "/_sandbox/events"), {
+      predicate: (acc) => acc.includes("event: decofile"),
+      deadlineMs: 10_000,
+    });
+    expect(text).toContain("event: decofile");
   }, 30_000);
 });
 

--- a/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
@@ -1,15 +1,13 @@
 /**
- * Daemon conformance suite — DECOFILE /read fallback.
+ * Black-box e2e for GET /_sandbox/decofile.
  *
- * `.deco/blocks.gen.json` is the runtime's merge of every `.deco/blocks/*.json`;
- * repos commonly gitignore it, so a fresh sandbox has the block sources but not
- * the merged artifact. When the file is absent, GET-equivalent POST /read must
- * synthesize the merge on the fly (keyed by the decoded filename stem) so the
- * CMS is readable before the dev server boots — instead of the plain
- * "File not found" a normal absent file gets. Black-box throughout.
+ * The route a production site pulls its draft from (pull-based Fast Preview).
+ * Same contract as the rest of the daemon suite: spawn the built daemon, talk
+ * to it over HTTP, assert only on responses and the workspace filesystem.
  */
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-
+import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import {
   type Daemon,
   HOOK_TIMEOUT_MS,
@@ -17,10 +15,107 @@ import {
   startDaemon,
   stopDaemon,
   url,
-  writeRepoFile,
 } from "./daemon.e2e.helpers";
 
-const toBody = (obj: unknown) => JSON.stringify(obj);
+let d: Daemon | null = null;
+
+/** `<appRoot>/repo/.deco/blocks` — the sources the decofile is merged from. */
+function blocksDir(daemon: Daemon): string {
+  return join(daemon.appDir, "repo", ".deco", "blocks");
+}
+
+async function writeBlock(
+  daemon: Daemon,
+  name: string,
+  body: unknown,
+): Promise<void> {
+  await mkdir(blocksDir(daemon), { recursive: true });
+  await writeFile(
+    join(blocksDir(daemon), `${name}.json`),
+    JSON.stringify(body),
+    "utf-8",
+  );
+}
+
+beforeEach(async () => {
+  d = await startDaemon();
+}, HOOK_TIMEOUT_MS);
+
+afterEach(async () => {
+  await stopDaemon(d);
+  d = null;
+}, HOOK_TIMEOUT_MS);
+
+describe("GET /_sandbox/decofile", () => {
+  test("404s when there are no blocks to merge", async () => {
+    const res = await fetch(url(d!, "/_sandbox/decofile"));
+    expect(res.status).toBe(404);
+  });
+
+  test("serves the merged blocks with a content ETag", async () => {
+    await writeBlock(d!, "pages-home", { path: "/", sections: [] });
+    await writeBlock(d!, "Header", {
+      __resolveType: "site/sections/Header.tsx",
+    });
+
+    const res = await fetch(url(d!, "/_sandbox/decofile"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("etag")).toMatch(/^W\/"[0-9a-f]+"$/);
+    // Never let a shared cache hold an unpublished draft.
+    expect(res.headers.get("cache-control")).toBe("no-store");
+
+    const body = (await res.json()) as Record<string, unknown>;
+    // Filename stem is the block key — the shape the deco runtime emits.
+    expect(Object.keys(body).sort()).toEqual(["Header", "pages-home"]);
+    expect(body["pages-home"]).toEqual({ path: "/", sections: [] });
+  });
+
+  test("is unauthenticated — the fetcher is a site, not the cluster", async () => {
+    // Deliberately no Authorization header: the production server pulling this
+    // has no daemon token. Matched ahead of the bearer gate in entry.ts.
+    await writeBlock(d!, "pages-home", { path: "/", sections: [] });
+    const res = await fetch(url(d!, "/_sandbox/decofile"));
+    expect(res.status).toBe(200);
+  });
+
+  test("ETag is stable across reads and changes with content", async () => {
+    await writeBlock(d!, "pages-home", { path: "/", sections: [] });
+
+    const first = await fetch(url(d!, "/_sandbox/decofile"));
+    const etag1 = first.headers.get("etag");
+    await first.text();
+
+    const again = await fetch(url(d!, "/_sandbox/decofile"));
+    const etag2 = again.headers.get("etag");
+    await again.text();
+    expect(etag2).toBe(etag1);
+
+    await writeBlock(d!, "pages-home", { path: "/", sections: [{ x: 1 }] });
+    const changed = await fetch(url(d!, "/_sandbox/decofile"));
+    await changed.text();
+    expect(changed.headers.get("etag")).not.toBe(etag1);
+  });
+
+  test("revalidates: 304 on a matching ETag, full body on a stale one", async () => {
+    await writeBlock(d!, "pages-home", { path: "/", sections: [] });
+
+    const first = await fetch(url(d!, "/_sandbox/decofile"));
+    const etag = first.headers.get("etag") ?? "";
+    await first.text();
+
+    const fresh = await fetch(url(d!, "/_sandbox/decofile"), {
+      headers: { "if-none-match": etag },
+    });
+    expect(fresh.status).toBe(304);
+    expect((await fresh.text()).length).toBe(0);
+
+    const stale = await fetch(url(d!, "/_sandbox/decofile"), {
+      headers: { "if-none-match": 'W/"deadbeef"' },
+    });
+    expect(stale.status).toBe(200);
+    expect((await stale.text()).length).toBeGreaterThan(0);
+  });
+});
 
 // Inlined copy of the web consumer's stripLineNumbers (read-committed-file.ts →
 // file-explorer/utils.ts): strips a leading `^\d+\t` from every `\n`-split line.
@@ -32,27 +127,19 @@ const stripLineNumbers = (content: string): string =>
     .map((line) => line.replace(/^\d+\t/, ""))
     .join("\n");
 
-const read = (d: Daemon, path: string) =>
+const readFallback = (d: Daemon, path: string) =>
   fetch(url(d, "/_sandbox/read"), {
     method: "POST",
     headers: jsonAuthHeaders(),
-    body: toBody({ path, full: true }),
+    body: JSON.stringify({ path, full: true }),
   });
 
 describe("daemon e2e: decofile /read fallback", () => {
-  let d: Daemon;
-  beforeAll(async () => {
-    d = await startDaemon();
-  }, HOOK_TIMEOUT_MS);
-  afterAll(async () => {
-    await stopDaemon(d);
-  }, HOOK_TIMEOUT_MS);
-
   it("synthesizes blocks.gen.json from .deco/blocks/*.json when absent", async () => {
-    await writeRepoFile(d, "site-a/.deco/blocks/b.json", `{"n":2}`);
-    await writeRepoFile(d, "site-a/.deco/blocks/a.json", `{"n":1}`);
+    await writeBlock(d!, "b", { n: 2 });
+    await writeBlock(d!, "a", { n: 1 });
 
-    const res = await read(d, "site-a/.deco/blocks.gen.json");
+    const res = await readFallback(d!, ".deco/blocks.gen.json");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { kind: string; content: string };
     expect(body.kind).toBe("text");
@@ -68,12 +155,19 @@ describe("daemon e2e: decofile /read fallback", () => {
     // so the merged blob is multi-line. The real consumer always does
     // JSON.parse(stripLineNumbers(content)) — exercise that exact path, not a
     // bare JSON.parse, so a regression that re-numbers this response is caught.
-    const hero = JSON.stringify({ title: "Hi", count: 3 }, null, 2);
-    const shelf = JSON.stringify({ items: [1, 2] }, null, 2);
-    await writeRepoFile(d, "site-pretty/.deco/blocks/hero.json", hero);
-    await writeRepoFile(d, "site-pretty/.deco/blocks/shelf.json", shelf);
+    await mkdir(blocksDir(d!), { recursive: true });
+    await writeFile(
+      join(blocksDir(d!), "hero.json"),
+      JSON.stringify({ title: "Hi", count: 3 }, null, 2),
+      "utf-8",
+    );
+    await writeFile(
+      join(blocksDir(d!), "shelf.json"),
+      JSON.stringify({ items: [1, 2] }, null, 2),
+      "utf-8",
+    );
 
-    const res = await read(d, "site-pretty/.deco/blocks.gen.json");
+    const res = await readFallback(d!, ".deco/blocks.gen.json");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { content: string };
     expect(body.content).toContain("\n"); // genuinely multi-line
@@ -84,24 +178,20 @@ describe("daemon e2e: decofile /read fallback", () => {
   });
 
   it("decodes percent-encoded block stems until stable", async () => {
-    await writeRepoFile(
-      d,
-      "site-b/.deco/blocks/Compre%2520Junto.json",
-      `{"x":1}`,
-    );
-    const res = await read(d, "site-b/.deco/blocks.gen.json");
+    await writeBlock(d!, "Compre%2520Junto", { x: 1 });
+    const res = await readFallback(d!, ".deco/blocks.gen.json");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { content: string };
     expect(JSON.parse(body.content)).toEqual({ "Compre Junto": { x: 1 } });
   });
 
   it("still 400s for a genuinely absent file with no blocks dir", async () => {
-    const res = await read(d, "site-c/.deco/blocks.gen.json");
+    const res = await readFallback(d!, "nope/.deco/blocks.gen.json");
     expect(res.status).toBe(400);
   });
 
   it("does not synthesize for a non-decofile absent file", async () => {
-    const res = await read(d, "site-a/nope.json");
+    const res = await readFallback(d!, "nope.json");
     expect(res.status).toBe(400);
   });
 });

--- a/packages/sandbox/daemon-go/internal/events/types.go
+++ b/packages/sandbox/daemon-go/internal/events/types.go
@@ -24,6 +24,25 @@ var AllPhases = []string{
 	PhaseStartFailed, PhaseCrashed,
 }
 
+// IsWorkingTreeReadyPhase reports phases that guarantee the repo is checked
+// out on disk.
+//
+// PhaseInstalling is the first: clone and checkout are done, only dependency
+// installation remains — which is precisely the window draft preview renders
+// in. PhaseCheckingOut is excluded because the tree is mid-write. The failure
+// phases count: a repo that failed to install still has a readable tree.
+//
+// Mirrors the TypeScript daemon-protocol.ts helper of the same name — the
+// daemon uses it to decide when to announce a draft decofile version, Studio
+// to decide when to re-drive the CMS queries. Those answers must agree.
+func IsWorkingTreeReadyPhase(phase string) bool {
+	switch phase {
+	case PhaseInstalling, PhaseInstallFailed, PhaseStarting, PhaseStartFailed, PhaseRunning, PhaseCrashed:
+		return true
+	}
+	return false
+}
+
 type LifecycleState struct {
 	Phase       string
 	To          string

--- a/packages/sandbox/daemon-go/internal/routes/decofile.go
+++ b/packages/sandbox/daemon-go/internal/routes/decofile.go
@@ -1,27 +1,15 @@
 package routes
 
 import (
-	"encoding/json"
 	"hash/fnv"
 	"net/http"
-	"net/url"
-	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
-	"strings"
-	"sync"
 
 	"github.com/decocms/studio/sandbox-daemon/internal/config"
+	"github.com/decocms/studio/sandbox-daemon/internal/decofile"
 	"github.com/decocms/studio/sandbox-daemon/internal/httpx"
 	"github.com/decocms/studio/sandbox-daemon/internal/paths"
-)
-
-// On-disk name of the merged decofile artifact, and the directory it merges —
-// shared with `Read`'s `.deco/blocks.gen.json` fallback in fs.go.
-const (
-	decofileGenBasename   = "blocks.gen.json"
-	decofileBlocksDirname = "blocks"
 )
 
 type DecofileDeps struct {
@@ -36,122 +24,7 @@ func (d DecofileDeps) blocksDir() string {
 	if cfg := d.Store.Read(); cfg != nil {
 		pmPath = cfg.PmPath()
 	}
-	return filepath.Join(paths.ResolvePmRoot(d.RepoDir, pmPath), ".deco", decofileBlocksDirname)
-}
-
-// decodeUntilStable repeatedly percent-decodes a filename stem until it stops
-// changing. Real repos carry both single- and double-encoded stems
-// (`Compre%20Junto.json`, `Compre%2520Junto.json`); a single decode leaves the
-// double-encoded one keyed `Compre%20Junto`, a key no `__resolveType`
-// reference resolves. Mirrors the frontend's documented
-// decoBlockKeyFromFileStem fallback: an invalid-encoding stem keeps its last
-// successfully decoded form. url.PathUnescape (not QueryUnescape) so a
-// literal `+` in a block name is left alone, matching JS decodeURIComponent.
-func decodeUntilStable(stem string) string {
-	key := stem
-	for {
-		decoded, err := url.PathUnescape(key)
-		if err != nil || decoded == key {
-			return key
-		}
-		key = decoded
-	}
-}
-
-// generateDecofileFromBlocks rebuilds the merged decofile from the sibling
-// `.deco/blocks/*.json` files so the CMS is readable before the dev server is
-// up. Maps each file to `{ [decodeUntilStable(stem)]: <file contents> }`,
-// sorted by filename for a deterministic, byte-for-byte result.
-//
-// The merged text is built by splicing raw file bytes rather than
-// unmarshal/marshal round-tripping through Go values — this payload is
-// routinely multi-MB, and a malformed block isn't caught here; the client's
-// parse fails and falls back to "no snapshot", same as the read/write/edit
-// handlers already gate.
-//
-// Returns ok=false when there's no blocks dir (nothing to merge).
-func generateDecofileFromBlocks(blocksDir string) (string, bool) {
-	entries, err := os.ReadDir(blocksDir)
-	if err != nil {
-		return "", false
-	}
-	var names []string
-	for _, e := range entries {
-		if e.Type().IsRegular() && strings.HasSuffix(strings.ToLower(e.Name()), ".json") {
-			names = append(names, e.Name())
-		}
-	}
-	if len(names) == 0 {
-		return "", false
-	}
-	sort.Strings(names)
-
-	var b strings.Builder
-	b.WriteByte('{')
-	first := true
-	for _, name := range names {
-		stem := name[:len(name)-len(".json")]
-		raw, err := os.ReadFile(filepath.Join(blocksDir, name))
-		if err != nil {
-			continue
-		}
-		content := strings.TrimSpace(string(raw))
-		// Skip empty files — `"key":` with no value would break the merged JSON.
-		if content == "" {
-			continue
-		}
-		key := decodeUntilStable(stem)
-		keyJSON, err := json.Marshal(key)
-		if err != nil {
-			continue
-		}
-		if !first {
-			b.WriteByte(',')
-		}
-		first = false
-		b.Write(keyJSON)
-		b.WriteByte(':')
-		b.WriteString(content)
-	}
-	b.WriteByte('}')
-	return b.String(), true
-}
-
-type decofileBuild struct {
-	done chan struct{}
-	text string
-	ok   bool
-}
-
-var (
-	decofileBuildMu  sync.Mutex
-	decofileInFlight = map[string]*decofileBuild{}
-)
-
-// generateDecofileFromBlocksDeduped coalesces concurrent merges for the same
-// blocksDir onto one build: concurrent cold reads (multiple tabs/users on a
-// shared sandbox during boot) would otherwise each redo the same multi-MB
-// merge. The in-flight entry is removed once the build settles, so this is a
-// coalescer, not a cache — the next read after settle rebuilds.
-func generateDecofileFromBlocksDeduped(blocksDir string) (string, bool) {
-	decofileBuildMu.Lock()
-	if b, inFlight := decofileInFlight[blocksDir]; inFlight {
-		decofileBuildMu.Unlock()
-		<-b.done
-		return b.text, b.ok
-	}
-	b := &decofileBuild{done: make(chan struct{})}
-	decofileInFlight[blocksDir] = b
-	decofileBuildMu.Unlock()
-
-	b.text, b.ok = generateDecofileFromBlocks(blocksDir)
-
-	decofileBuildMu.Lock()
-	delete(decofileInFlight, blocksDir)
-	decofileBuildMu.Unlock()
-	close(b.done)
-
-	return b.text, b.ok
+	return filepath.Join(paths.ResolvePmRoot(d.RepoDir, pmPath), ".deco", decofile.BlocksDirname)
 }
 
 type MergedDecofile struct {
@@ -164,7 +37,7 @@ type MergedDecofile struct {
 // serves it as an ETag and the `decofile` SSE event announces it, so a
 // consumer's cache key and Studio's draft pointer can never disagree.
 func ReadDecofile(deps DecofileDeps) (MergedDecofile, bool) {
-	text, ok := generateDecofileFromBlocksDeduped(deps.blocksDir())
+	text, ok := decofile.GenerateFromBlocksDeduped(deps.blocksDir())
 	if !ok {
 		return MergedDecofile{}, false
 	}

--- a/packages/sandbox/daemon-go/internal/routes/decofile.go
+++ b/packages/sandbox/daemon-go/internal/routes/decofile.go
@@ -1,0 +1,209 @@
+package routes
+
+import (
+	"encoding/json"
+	"hash/fnv"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/decocms/studio/sandbox-daemon/internal/config"
+	"github.com/decocms/studio/sandbox-daemon/internal/httpx"
+	"github.com/decocms/studio/sandbox-daemon/internal/paths"
+)
+
+type DecofileDeps struct {
+	RepoDir string
+	Store   *config.Store
+}
+
+// blocksDir resolves `.deco/blocks` under the package path (the dev-script
+// cwd) when the project isn't at the repo root.
+func (d DecofileDeps) blocksDir() string {
+	pmPath := ""
+	if cfg := d.Store.Read(); cfg != nil {
+		pmPath = cfg.PmPath()
+	}
+	return filepath.Join(paths.ResolvePmRoot(d.RepoDir, pmPath), ".deco", "blocks")
+}
+
+// decodeUntilStable repeatedly percent-decodes a filename stem until it stops
+// changing. Real repos carry both single- and double-encoded stems
+// (`Compre%20Junto.json`, `Compre%2520Junto.json`); a single decode leaves the
+// double-encoded one keyed `Compre%20Junto`, a key no `__resolveType`
+// reference resolves. Mirrors the frontend's documented
+// decoBlockKeyFromFileStem fallback: an invalid-encoding stem keeps its last
+// successfully decoded form. url.PathUnescape (not QueryUnescape) so a
+// literal `+` in a block name is left alone, matching JS decodeURIComponent.
+func decodeUntilStable(stem string) string {
+	key := stem
+	for {
+		decoded, err := url.PathUnescape(key)
+		if err != nil || decoded == key {
+			return key
+		}
+		key = decoded
+	}
+}
+
+// generateDecofileFromBlocks rebuilds the merged decofile from the sibling
+// `.deco/blocks/*.json` files so the CMS is readable before the dev server is
+// up. Maps each file to `{ [decodeUntilStable(stem)]: <file contents> }`,
+// sorted by filename for a deterministic, byte-for-byte result.
+//
+// The merged text is built by splicing raw file bytes rather than
+// unmarshal/marshal round-tripping through Go values — this payload is
+// routinely multi-MB, and a malformed block isn't caught here; the client's
+// parse fails and falls back to "no snapshot", same as the read/write/edit
+// handlers already gate.
+//
+// Returns ok=false when there's no blocks dir (nothing to merge).
+func generateDecofileFromBlocks(blocksDir string) (string, bool) {
+	entries, err := os.ReadDir(blocksDir)
+	if err != nil {
+		return "", false
+	}
+	var names []string
+	for _, e := range entries {
+		if e.Type().IsRegular() && strings.HasSuffix(strings.ToLower(e.Name()), ".json") {
+			names = append(names, e.Name())
+		}
+	}
+	if len(names) == 0 {
+		return "", false
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	b.WriteByte('{')
+	first := true
+	for _, name := range names {
+		stem := name[:len(name)-len(".json")]
+		raw, err := os.ReadFile(filepath.Join(blocksDir, name))
+		if err != nil {
+			continue
+		}
+		content := strings.TrimSpace(string(raw))
+		// Skip empty files — `"key":` with no value would break the merged JSON.
+		if content == "" {
+			continue
+		}
+		key := decodeUntilStable(stem)
+		keyJSON, err := json.Marshal(key)
+		if err != nil {
+			continue
+		}
+		if !first {
+			b.WriteByte(',')
+		}
+		first = false
+		b.Write(keyJSON)
+		b.WriteByte(':')
+		b.WriteString(content)
+	}
+	b.WriteByte('}')
+	return b.String(), true
+}
+
+type decofileBuild struct {
+	done chan struct{}
+	text string
+	ok   bool
+}
+
+var (
+	decofileBuildMu  sync.Mutex
+	decofileInFlight = map[string]*decofileBuild{}
+)
+
+// generateDecofileFromBlocksDeduped coalesces concurrent merges for the same
+// blocksDir onto one build: concurrent cold reads (multiple tabs/users on a
+// shared sandbox during boot) would otherwise each redo the same multi-MB
+// merge. The in-flight entry is removed once the build settles, so this is a
+// coalescer, not a cache — the next read after settle rebuilds.
+func generateDecofileFromBlocksDeduped(blocksDir string) (string, bool) {
+	decofileBuildMu.Lock()
+	if b, inFlight := decofileInFlight[blocksDir]; inFlight {
+		decofileBuildMu.Unlock()
+		<-b.done
+		return b.text, b.ok
+	}
+	b := &decofileBuild{done: make(chan struct{})}
+	decofileInFlight[blocksDir] = b
+	decofileBuildMu.Unlock()
+
+	b.text, b.ok = generateDecofileFromBlocks(blocksDir)
+
+	decofileBuildMu.Lock()
+	delete(decofileInFlight, blocksDir)
+	decofileBuildMu.Unlock()
+	close(b.done)
+
+	return b.text, b.ok
+}
+
+type MergedDecofile struct {
+	Text    string
+	Version string
+}
+
+// ReadDecofile merges the working-tree blocks and derives their version — the
+// single definition of "what version is the draft". The Decofile route
+// serves it as an ETag and the `decofile` SSE event announces it, so a
+// consumer's cache key and Studio's draft pointer can never disagree.
+func ReadDecofile(deps DecofileDeps) (MergedDecofile, bool) {
+	text, ok := generateDecofileFromBlocksDeduped(deps.blocksDir())
+	if !ok {
+		return MergedDecofile{}, false
+	}
+	// A fast, non-cryptographic hash over the merged bytes — a change
+	// detector, not a security boundary.
+	h := fnv.New64a()
+	h.Write([]byte(text))
+	return MergedDecofile{Text: text, Version: strconv.FormatUint(h.Sum64(), 16)}, true
+}
+
+// Decofile serves `GET /_sandbox/decofile` — the working-tree DRAFT decofile,
+// every `.deco/blocks/*.json` merged — for a production site to pull and
+// render against (pull-based Fast Preview).
+//
+// Unauthenticated, like its neighbours `/_sandbox/{events,scripts,idle}`: the
+// fetcher is an arbitrary production server, not the cluster, so it cannot
+// carry the daemon bearer token. Registered ahead of the token gate in
+// main.go.
+//
+// Content-addressed: the response carries an ETag over the merged bytes, so
+// callers cache by version and re-fetch only when the draft actually
+// changed.
+func Decofile(deps DecofileDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		merged, ok := ReadDecofile(deps)
+		if !ok {
+			httpx.Error(w, http.StatusNotFound, "No .deco/blocks to serve.")
+			return
+		}
+
+		etag := `W/"` + merged.Version + `"`
+		if r.Header.Get("If-None-Match") == etag {
+			w.Header().Set("ETag", etag)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+
+		h := w.Header()
+		h.Set("Content-Type", "application/json; charset=utf-8")
+		h.Set("ETag", etag)
+		// The draft changes on every save; never let a shared cache hold it.
+		// Callers key their own cache on the ETag instead.
+		h.Set("Cache-Control", "no-store")
+		// Server-to-server fetch, but the browser may probe it during dev.
+		h.Set("Access-Control-Allow-Origin", "*")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(merged.Text))
+	}
+}

--- a/packages/sandbox/daemon-go/internal/routes/decofile.go
+++ b/packages/sandbox/daemon-go/internal/routes/decofile.go
@@ -17,6 +17,13 @@ import (
 	"github.com/decocms/studio/sandbox-daemon/internal/paths"
 )
 
+// On-disk name of the merged decofile artifact, and the directory it merges —
+// shared with `Read`'s `.deco/blocks.gen.json` fallback in fs.go.
+const (
+	decofileGenBasename   = "blocks.gen.json"
+	decofileBlocksDirname = "blocks"
+)
+
 type DecofileDeps struct {
 	RepoDir string
 	Store   *config.Store
@@ -29,7 +36,7 @@ func (d DecofileDeps) blocksDir() string {
 	if cfg := d.Store.Read(); cfg != nil {
 		pmPath = cfg.PmPath()
 	}
-	return filepath.Join(paths.ResolvePmRoot(d.RepoDir, pmPath), ".deco", "blocks")
+	return filepath.Join(paths.ResolvePmRoot(d.RepoDir, pmPath), ".deco", decofileBlocksDirname)
 }
 
 // decodeUntilStable repeatedly percent-decodes a filename stem until it stops

--- a/packages/sandbox/daemon-go/internal/routes/decofile_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/decofile_test.go
@@ -1,0 +1,156 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/decocms/studio/sandbox-daemon/internal/config"
+)
+
+func writeBlock(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir blocks dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write block %s: %v", name, err)
+	}
+}
+
+func TestGenerateDecofileFromBlocksNoDirReturnsNotOk(t *testing.T) {
+	dir := t.TempDir()
+	_, ok := generateDecofileFromBlocks(filepath.Join(dir, "blocks"))
+	if ok {
+		t.Fatal("expected ok=false when the blocks dir does not exist")
+	}
+}
+
+func TestGenerateDecofileFromBlocksMergesSortsAndSkipsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writeBlock(t, dir, "pages-home", `{"path":"/","sections":[]}`)
+	writeBlock(t, dir, "Header", `{"__resolveType":"site/sections/Header.tsx"}`)
+	// An empty file must not produce a `"key":` with no value.
+	if err := os.WriteFile(filepath.Join(dir, "empty.json"), []byte("  \n"), 0o644); err != nil {
+		t.Fatalf("write empty block: %v", err)
+	}
+
+	text, ok := generateDecofileFromBlocks(dir)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(text), &merged); err != nil {
+		t.Fatalf("merged text is not valid JSON: %v\n%s", err, text)
+	}
+	if len(merged) != 2 {
+		t.Fatalf("expected 2 keys (empty file skipped), got %d: %v", len(merged), merged)
+	}
+	if _, ok := merged["Header"]; !ok {
+		t.Errorf("missing Header key in %v", merged)
+	}
+	if _, ok := merged["pages-home"]; !ok {
+		t.Errorf("missing pages-home key in %v", merged)
+	}
+}
+
+func TestGenerateDecofileFromBlocksDecodesUntilStable(t *testing.T) {
+	dir := t.TempDir()
+	// Real repos carry both single- and double-encoded filenames. Both must
+	// merge under the real key.
+	writeBlock(t, dir, "Compre%2520Junto", `{"curated":true}`)
+	writeBlock(t, dir, "Card%20config", `{"plain":true}`)
+
+	text, ok := generateDecofileFromBlocks(dir)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(text), &merged); err != nil {
+		t.Fatalf("merged text is not valid JSON: %v\n%s", err, text)
+	}
+	for _, key := range []string{"Compre Junto", "Card config"} {
+		if _, ok := merged[key]; !ok {
+			t.Errorf("expected decoded key %q in %v", key, merged)
+		}
+	}
+}
+
+func TestDecofileHandlerReturns404WhenNoBlocks(t *testing.T) {
+	dir := t.TempDir()
+	deps := DecofileDeps{RepoDir: dir, Store: config.NewStore()}
+
+	req := httptest.NewRequest(http.MethodGet, "/decofile", nil)
+	rec := httptest.NewRecorder()
+	Decofile(deps)(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestDecofileHandlerServesEtagAndRevalidates(t *testing.T) {
+	dir := t.TempDir()
+	writeBlock(t, filepath.Join(dir, ".deco", "blocks"), "pages-home", `{"path":"/","sections":[]}`)
+	deps := DecofileDeps{RepoDir: dir, Store: config.NewStore()}
+
+	req := httptest.NewRequest(http.MethodGet, "/decofile", nil)
+	rec := httptest.NewRecorder()
+	Decofile(deps)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if rec.Header().Get("Cache-Control") != "no-store" {
+		t.Errorf("expected no-store cache-control, got %q", rec.Header().Get("Cache-Control"))
+	}
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("expected an ETag header")
+	}
+
+	// Matching If-None-Match revalidates to 304 with an empty body.
+	req2 := httptest.NewRequest(http.MethodGet, "/decofile", nil)
+	req2.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	Decofile(deps)(rec2, req2)
+	if rec2.Code != http.StatusNotModified {
+		t.Fatalf("expected 304, got %d", rec2.Code)
+	}
+	if rec2.Body.Len() != 0 {
+		t.Errorf("expected an empty 304 body, got %q", rec2.Body.String())
+	}
+
+	// A stale If-None-Match still gets the full body.
+	req3 := httptest.NewRequest(http.MethodGet, "/decofile", nil)
+	req3.Header.Set("If-None-Match", `W/"deadbeef"`)
+	rec3 := httptest.NewRecorder()
+	Decofile(deps)(rec3, req3)
+	if rec3.Code != http.StatusOK {
+		t.Fatalf("expected 200 for a stale ETag, got %d", rec3.Code)
+	}
+}
+
+func TestDecofileHandlerRespectsPackageManagerPath(t *testing.T) {
+	dir := t.TempDir()
+	writeBlock(t, filepath.Join(dir, "apps", "web", ".deco", "blocks"), "pages-home", `{"path":"/"}`)
+
+	store := config.NewStore()
+	store.Hydrate(&config.TenantConfig{
+		Application: &config.Application{
+			PackageManager: &config.PackageManagerConfig{Path: config.Str("apps/web")},
+		},
+	})
+	deps := DecofileDeps{RepoDir: dir, Store: store}
+
+	req := httptest.NewRequest(http.MethodGet, "/decofile", nil)
+	rec := httptest.NewRecorder()
+	Decofile(deps)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/packages/sandbox/daemon-go/internal/routes/decofile_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/decofile_test.go
@@ -1,7 +1,6 @@
 package routes
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -18,64 +17,6 @@ func writeBlock(t *testing.T, dir, name, body string) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, name+".json"), []byte(body), 0o644); err != nil {
 		t.Fatalf("write block %s: %v", name, err)
-	}
-}
-
-func TestGenerateDecofileFromBlocksNoDirReturnsNotOk(t *testing.T) {
-	dir := t.TempDir()
-	_, ok := generateDecofileFromBlocks(filepath.Join(dir, "blocks"))
-	if ok {
-		t.Fatal("expected ok=false when the blocks dir does not exist")
-	}
-}
-
-func TestGenerateDecofileFromBlocksMergesSortsAndSkipsEmpty(t *testing.T) {
-	dir := t.TempDir()
-	writeBlock(t, dir, "pages-home", `{"path":"/","sections":[]}`)
-	writeBlock(t, dir, "Header", `{"__resolveType":"site/sections/Header.tsx"}`)
-	// An empty file must not produce a `"key":` with no value.
-	if err := os.WriteFile(filepath.Join(dir, "empty.json"), []byte("  \n"), 0o644); err != nil {
-		t.Fatalf("write empty block: %v", err)
-	}
-
-	text, ok := generateDecofileFromBlocks(dir)
-	if !ok {
-		t.Fatal("expected ok=true")
-	}
-	var merged map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(text), &merged); err != nil {
-		t.Fatalf("merged text is not valid JSON: %v\n%s", err, text)
-	}
-	if len(merged) != 2 {
-		t.Fatalf("expected 2 keys (empty file skipped), got %d: %v", len(merged), merged)
-	}
-	if _, ok := merged["Header"]; !ok {
-		t.Errorf("missing Header key in %v", merged)
-	}
-	if _, ok := merged["pages-home"]; !ok {
-		t.Errorf("missing pages-home key in %v", merged)
-	}
-}
-
-func TestGenerateDecofileFromBlocksDecodesUntilStable(t *testing.T) {
-	dir := t.TempDir()
-	// Real repos carry both single- and double-encoded filenames. Both must
-	// merge under the real key.
-	writeBlock(t, dir, "Compre%2520Junto", `{"curated":true}`)
-	writeBlock(t, dir, "Card%20config", `{"plain":true}`)
-
-	text, ok := generateDecofileFromBlocks(dir)
-	if !ok {
-		t.Fatal("expected ok=true")
-	}
-	var merged map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(text), &merged); err != nil {
-		t.Fatalf("merged text is not valid JSON: %v\n%s", err, text)
-	}
-	for _, key := range []string{"Compre Junto", "Card config"} {
-		if _, ok := merged[key]; !ok {
-			t.Errorf("expected decoded key %q in %v", key, merged)
-		}
 	}
 }
 

--- a/packages/sandbox/daemon-go/internal/routes/events.go
+++ b/packages/sandbox/daemon-go/internal/routes/events.go
@@ -20,10 +20,19 @@ type EventsDeps struct {
 	GetActiveTasks       func() []events.ActiveTaskSummary
 	GetStatus            func() events.DaemonStatus
 	GetBranchMeta        func() events.BranchMeta
+	// GetDecofileVersion returns the last announced draft decofile version,
+	// ok=false when none has been computed yet this boot.
+	GetDecofileVersion func() (string, bool)
+	// OnDecofileVersionUnknown is called (after this client is registered) when
+	// GetDecofileVersion reports none cached, so a daemon restarted over an
+	// already-cloned tree computes and broadcasts one instead of leaving a
+	// connecting client waiting forever.
+	OnDecofileVersionUnknown func()
 }
 
 // EventsStream serves the daemon SSE stream. Handshake order is contract:
-// lifecycle → per-source log replay → scripts → tasks → status → branch.
+// lifecycle → per-source log replay → scripts → tasks → status → branch →
+// decofile.
 func EventsStream(deps EventsDeps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if deps.Broadcaster.Size() >= MaxSseClients {
@@ -79,10 +88,22 @@ func EventsStream(deps EventsDeps) http.HandlerFunc {
 		if !write(events.SseFrame("branch", map[string]any{"meta": deps.GetBranchMeta()})) {
 			return
 		}
-		flush()
 
+		// Register before checking the decofile version: when none is cached
+		// yet, OnDecofileVersionUnknown triggers an async recompute+broadcast,
+		// and this client must already be a registered listener to receive it —
+		// otherwise the announcement is fired before anyone can hear it.
 		client := deps.Broadcaster.Register()
 		defer deps.Broadcaster.Unregister(client)
+
+		if version, ok := deps.GetDecofileVersion(); ok {
+			if !write(events.SseFrame("decofile", map[string]any{"version": version})) {
+				return
+			}
+		} else {
+			deps.OnDecofileVersionUnknown()
+		}
+		flush()
 
 		heartbeat := time.NewTicker(heartbeatInterval)
 		defer heartbeat.Stop()

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/decocms/studio/sandbox-daemon/internal/activity"
 	"github.com/decocms/studio/sandbox-daemon/internal/auth"
 	"github.com/decocms/studio/sandbox-daemon/internal/config"
+	"github.com/decocms/studio/sandbox-daemon/internal/decofile"
 	"github.com/decocms/studio/sandbox-daemon/internal/dispatch"
 	"github.com/decocms/studio/sandbox-daemon/internal/events"
 	"github.com/decocms/studio/sandbox-daemon/internal/gitx"
@@ -96,6 +97,10 @@ type daemon struct {
 	fileChangedTimer *time.Timer
 	pendingPaths     map[string]struct{}
 
+	decofileDeps        routes.DecofileDeps
+	decofileMu          sync.Mutex
+	lastDecofileVersion string
+
 	shuttingDown bool
 
 	// treeLock serializes every mutation of the shared working tree. Shared
@@ -112,7 +117,7 @@ type daemon struct {
 // sandboxHandlers is the daemon API's leaf handlers, built once and mounted
 // under each prefix by registerSandboxRoutes.
 type sandboxHandlers struct {
-	events, scripts                       http.HandlerFunc
+	events, scripts, decofile             http.HandlerFunc
 	configRead, configUpdate, orgfsConfig http.HandlerFunc
 	tasksList, tasksGet, tasksDelete      http.HandlerFunc
 	tasksKill, tasksKillAll, tasksStream  http.HandlerFunc
@@ -182,10 +187,43 @@ func (d *daemon) emitFileChanged(path string) {
 		d.pendingPaths = map[string]struct{}{}
 		d.fileChangedTimer = nil
 		d.fileChangedMu.Unlock()
+		touchedBlocks := false
 		for p := range paths {
 			d.broadcaster.Emit("file-changed", map[string]string{"path": p})
+			if decofile.IsBlockPath(p) {
+				touchedBlocks = true
+			}
+		}
+		if touchedBlocks {
+			go d.announceDecofileVersion()
 		}
 	})
+}
+
+// announceDecofileVersion recomputes the merged blocks' version and, if it
+// changed, broadcasts it. The single trigger point for both "tree just
+// landed" (lifecycle.OnTransition) and "a blocks file changed"
+// (emitFileChanged) — the unchanged-hash guard means the two paths can't
+// double-emit.
+func (d *daemon) announceDecofileVersion() {
+	merged, ok := routes.ReadDecofile(d.decofileDeps)
+	if !ok {
+		return
+	}
+	d.decofileMu.Lock()
+	if merged.Version == d.lastDecofileVersion {
+		d.decofileMu.Unlock()
+		return
+	}
+	d.lastDecofileVersion = merged.Version
+	d.decofileMu.Unlock()
+	d.broadcaster.Emit("decofile", map[string]any{"version": merged.Version})
+}
+
+func (d *daemon) getDecofileVersion() (string, bool) {
+	d.decofileMu.Lock()
+	defer d.decofileMu.Unlock()
+	return d.lastDecofileVersion, d.lastDecofileVersion != ""
 }
 
 func (d *daemon) onProbeChange(s probe.State) {
@@ -311,10 +349,12 @@ func (d *daemon) treeGuarded(fn http.HandlerFunc) http.HandlerFunc {
 // once per prefix: /_sandbox is canonical, /_decopilot_vm is served for one
 // release window.
 func (d *daemon) registerSandboxRoutes(mux *http.ServeMux, pre string, h sandboxHandlers) {
-	// Unauthenticated: liveness, the event stream, script discovery, preflight.
+	// Unauthenticated: liveness, the event stream, script discovery, the draft
+	// decofile pull, preflight.
 	mux.HandleFunc("GET "+pre+"/idle", routes.Idle())
 	mux.HandleFunc("GET "+pre+"/events", h.events)
 	mux.HandleFunc("GET "+pre+"/scripts", h.scripts)
+	mux.HandleFunc("GET "+pre+"/decofile", h.decofile)
 	mux.HandleFunc("OPTIONS "+pre, corsPreflight)
 	mux.HandleFunc("OPTIONS "+pre+"/", corsPreflight)
 
@@ -550,6 +590,7 @@ func main() {
 	}
 
 	d.store = config.NewStore()
+	d.decofileDeps = routes.DecofileDeps{RepoDir: repoDir, Store: d.store}
 	d.installState = setup.NewInstallState()
 	d.lifecycle = lifecycle.New(d.broadcaster)
 	d.lifecycle.OnStartPhase = func(status string, durationMs int64) {
@@ -573,6 +614,13 @@ func main() {
 			d.readyOnce.Do(func() {
 				telemetry.RecordReady(context.Background(), time.Since(processStartedAt).Milliseconds())
 			})
+		}
+		// Working tree just landed (see events.IsWorkingTreeReadyPhase). Announce
+		// the initial draft version here too, not only from emitFileChanged: a
+		// clone doesn't write through the daemon's fs routes, so on a fresh
+		// sandbox no `.deco/blocks` write is ever observed to trigger it.
+		if events.IsWorkingTreeReadyPhase(next.Phase) && !events.IsWorkingTreeReadyPhase(prev.Phase) {
+			go d.announceDecofileVersion()
 		}
 	}
 
@@ -762,13 +810,16 @@ func main() {
 			return proc.DiscoverScripts(cwd, cfg.PmName())
 		}),
 		events: routes.EventsStream(routes.EventsDeps{
-			Broadcaster:          d.broadcaster,
-			GetLifecycle:         d.lifecycle.Current,
-			GetDiscoveredScripts: d.orchestrator.DiscoveredScripts,
-			GetActiveTasks:       d.getActiveTasks,
-			GetStatus:            d.getStatus,
-			GetBranchMeta:        d.branchStatus.GetLast,
+			Broadcaster:              d.broadcaster,
+			GetLifecycle:             d.lifecycle.Current,
+			GetDiscoveredScripts:     d.orchestrator.DiscoveredScripts,
+			GetActiveTasks:           d.getActiveTasks,
+			GetStatus:                d.getStatus,
+			GetBranchMeta:            d.branchStatus.GetLast,
+			GetDecofileVersion:       d.getDecofileVersion,
+			OnDecofileVersionUnknown: func() { go d.announceDecofileVersion() },
 		}),
+		decofile: routes.Decofile(d.decofileDeps),
 		configRead: routes.ConfigRead(routes.ConfigDeps{
 			DaemonBootId:    bootId,
 			Store:           d.store,

--- a/packages/sandbox/daemon-protocol.ts
+++ b/packages/sandbox/daemon-protocol.ts
@@ -109,6 +109,30 @@ export type LifecycleState =
   /** Was running, stopped responding to the probe. */
   | { phase: "crashed" };
 
+/**
+ * Phases that guarantee the repo is checked out on disk.
+ *
+ * `installing` is the first: clone and checkout are done, only dependency
+ * installation remains — which is precisely the window draft preview renders
+ * in. `checking-out` is excluded because the tree is mid-write. The failure
+ * phases count: a repo that failed to install still has a readable tree.
+ *
+ * Shared so the daemon (when to announce a draft version) and Studio (when to
+ * re-drive the CMS queries) cannot drift apart on what "the tree exists" means.
+ */
+export function isWorkingTreeReadyPhase(
+  phase: LifecycleState["phase"],
+): boolean {
+  return (
+    phase === "installing" ||
+    phase === "install-failed" ||
+    phase === "starting" ||
+    phase === "start-failed" ||
+    phase === "running" ||
+    phase === "crashed"
+  );
+}
+
 /** Git metadata, separate from lifecycle. `unknown` until the first compute. */
 export type BranchMeta =
   | { kind: "unknown" }
@@ -154,6 +178,15 @@ export interface DaemonEventMap {
   branch: { meta: BranchMeta };
   reload: Record<string, never>;
   "file-changed": { path: string };
+  /**
+   * The working-tree draft decofile changed, and its new content version.
+   *
+   * Same value the `/_sandbox/decofile` route serves as its `ETag` — one
+   * definition, so a consumer's pointer and the framework's cache key cannot
+   * disagree. Lets Studio rebuild a draft pointer on save instead of polling
+   * for it.
+   */
+  decofile: { version: string };
 }
 
 export type DaemonEventName = keyof DaemonEventMap;

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1377,7 +1377,6 @@ export class AgentSandboxProvider implements SandboxProvider {
       // Sent on every ensure that carries opts, so a warm-pool pod inheriting a
       // previous claim's clone-only config gets it cleared on a normal one.
       ...(opts ? { cloneOnly: opts.cloneOnly === true } : {}),
-      productionUrl: opts?.workload?.productionUrl,
     });
   }
 

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1377,6 +1377,7 @@ export class AgentSandboxProvider implements SandboxProvider {
       // Sent on every ensure that carries opts, so a warm-pool pod inheriting a
       // previous claim's clone-only config gets it cleared on a normal one.
       ...(opts ? { cloneOnly: opts.cloneOnly === true } : {}),
+      productionUrl: opts?.workload?.productionUrl,
     });
   }
 

--- a/packages/sandbox/server/provider/shared/build-config-payload.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.ts
@@ -18,8 +18,6 @@ export function buildConfigPayload(args: {
   tenant?: EnsureOptions["tenant"];
   /** Checkout only — the daemon skips install + dev server. */
   cloneOnly?: boolean;
-  /** Live production URL for the Fast Preview daemon route (see Application). */
-  productionUrl?: string;
 }): Partial<TenantConfig> | null {
   const repo = args.repo;
   const git = repo
@@ -58,7 +56,6 @@ export function buildConfigPayload(args: {
         packageManager,
         runtime: args.runtime,
         ...(args.port !== undefined ? { port: args.port } : {}),
-        ...(args.productionUrl ? { productionUrl: args.productionUrl } : {}),
       }
     : undefined;
 

--- a/packages/sandbox/server/provider/shared/build-config-payload.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.ts
@@ -18,6 +18,8 @@ export function buildConfigPayload(args: {
   tenant?: EnsureOptions["tenant"];
   /** Checkout only — the daemon skips install + dev server. */
   cloneOnly?: boolean;
+  /** Live production URL for the Fast Preview daemon route (see Application). */
+  productionUrl?: string;
 }): Partial<TenantConfig> | null {
   const repo = args.repo;
   const git = repo
@@ -56,6 +58,7 @@ export function buildConfigPayload(args: {
         packageManager,
         runtime: args.runtime,
         ...(args.port !== undefined ? { port: args.port } : {}),
+        ...(args.productionUrl ? { productionUrl: args.productionUrl } : {}),
       }
     : undefined;
 

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -40,7 +40,7 @@ export interface Workload {
   packageManagerPath?: string;
   /**
    * Live production URL of the linked site (from `metadata.productionUrl`).
-   * Forwarded to the daemon so the `/_deco/fast-preview` route can render the
+   * Forwarded to the daemon so the `/_sandbox/fast-preview` route can render the
    * working-tree decofile against production without the dev server.
    */
   productionUrl?: string;

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -38,6 +38,12 @@ export interface Workload {
   devPort?: number;
   /** Subdirectory inside the repo where the package manager manifest lives (e.g. `apps/web`). */
   packageManagerPath?: string;
+  /**
+   * Live production URL of the linked site (from `metadata.productionUrl`).
+   * Forwarded to the daemon so the `/_deco/fast-preview` route can render the
+   * working-tree decofile against production without the dev server.
+   */
+  productionUrl?: string;
 }
 
 export interface EnsureOptions {

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -38,12 +38,6 @@ export interface Workload {
   devPort?: number;
   /** Subdirectory inside the repo where the package manager manifest lives (e.g. `apps/web`). */
   packageManagerPath?: string;
-  /**
-   * Live production URL of the linked site (from `metadata.productionUrl`).
-   * Forwarded to the daemon so the `/_sandbox/fast-preview` route can render the
-   * working-tree decofile against production without the dev server.
-   */
-  productionUrl?: string;
 }
 
 export interface EnsureOptions {

--- a/packages/sandbox/shared.ts
+++ b/packages/sandbox/shared.ts
@@ -7,6 +7,7 @@ export type {
   DaemonStatus,
   LifecycleState,
 } from "./daemon-protocol";
+export { isWorkingTreeReadyPhase } from "./daemon-protocol";
 
 export const PLUGIN_ID = "MCP User Sandbox";
 export const PLUGIN_DESCRIPTION =

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -607,25 +607,27 @@ const publishPolicyMetadataField = PublishPolicySchema.nullable()
 
 /**
  * Reusable `metadata.fastPreview` field. When true — and `productionUrl` is set —
- * the CMS preview renders the current working-tree draft against the production
- * deployment's `/live/previews` route (pushing the draft decofile as a
- * per-request override) instead of waiting for the sandbox dev server to boot.
- * The gate requires BOTH the flag and a production URL, so a bare flag with no
- * URL is inert.
+ * the CMS preview renders the site's own real page on the production
+ * deployment, carrying a `?__draft=<daemon-host>@<version>` pointer that the
+ * site's framework resolves by pulling the merged working-tree decofile from
+ * the sandbox daemon's `GET /_sandbox/decofile`, instead of waiting for the
+ * sandbox dev server to boot. The gate requires BOTH the flag and a
+ * production URL, so a bare flag with no URL is inert.
  *
  * It changes *when* the preview is ready, not which surface is shown: both modes
  * paint the published site while the sandbox provisions, but Fast Preview swaps
  * in the draft render as soon as the daemon can serve it (shortly after the
- * clone) rather than at dev-server `running`. The draft render is static — no
- * hydration or navigation — and it keeps the canvas for as long as Fast Preview
- * is on; the sandbox dev-server surface is not swapped in behind it.
+ * clone) rather than at dev-server `running`. The draft render is the site's
+ * own page — real routing and hydration, not a static single-component
+ * render — and it keeps the canvas for as long as Fast Preview is on; the
+ * sandbox dev-server surface is not swapped in behind it.
  */
 const fastPreviewMetadataField = z
   .boolean()
   .nullable()
   .optional()
   .describe(
-    "Enable Fast Preview: render the draft instantly against productionUrl's /live/previews route while the sandbox boots. Requires productionUrl to be set to take effect.",
+    "Enable Fast Preview: render the draft instantly on productionUrl's own page via a ?__draft pointer while the sandbox boots. Requires productionUrl to be set to take effect.",
   );
 
 /**

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -607,12 +607,18 @@ const publishPolicyMetadataField = PublishPolicySchema.nullable()
 
 /**
  * Reusable `metadata.fastPreview` field. When true — and `productionUrl` is set —
- * the CMS preview renders the current working-tree draft instantly against the
- * production deployment's `/live/previews` route (pushing the draft decofile as
- * a per-request override) instead of waiting for the sandbox dev server to boot.
+ * the CMS preview renders the current working-tree draft against the production
+ * deployment's `/live/previews` route (pushing the draft decofile as a
+ * per-request override) instead of waiting for the sandbox dev server to boot.
  * The gate requires BOTH the flag and a production URL, so a bare flag with no
- * URL is inert. The instant render is static (no hydration/navigation); the
- * sandbox surface takes over for interactivity once it's up.
+ * URL is inert.
+ *
+ * It changes *when* the preview is ready, not which surface is shown: both modes
+ * paint the published site while the sandbox provisions, but Fast Preview swaps
+ * in the draft render as soon as the daemon can serve it (shortly after the
+ * clone) rather than at dev-server `running`. The draft render is static — no
+ * hydration or navigation — and it keeps the canvas for as long as Fast Preview
+ * is on; the sandbox dev-server surface is not swapped in behind it.
  */
 const fastPreviewMetadataField = z
   .boolean()

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -606,6 +606,23 @@ const publishPolicyMetadataField = PublishPolicySchema.nullable()
   );
 
 /**
+ * Reusable `metadata.fastPreview` field. When true — and `productionUrl` is set —
+ * the CMS preview renders the current working-tree draft instantly against the
+ * production deployment's `/live/previews` route (pushing the draft decofile as
+ * a per-request override) instead of waiting for the sandbox dev server to boot.
+ * The gate requires BOTH the flag and a production URL, so a bare flag with no
+ * URL is inert. The instant render is static (no hydration/navigation); the
+ * sandbox surface takes over for interactivity once it's up.
+ */
+const fastPreviewMetadataField = z
+  .boolean()
+  .nullable()
+  .optional()
+  .describe(
+    "Enable Fast Preview: render the draft instantly against productionUrl's /live/previews route while the sandbox boots. Requires productionUrl to be set to take effect.",
+  );
+
+/**
  * Virtual MCP entity schema - single source of truth
  * Compliant with collections binding pattern
  */
@@ -689,6 +706,7 @@ export const VirtualMCPEntitySchema = z.object({
         .describe(
           "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
         ),
+      fastPreview: fastPreviewMetadataField,
     })
     .loose()
     .describe("Metadata"),
@@ -802,6 +820,7 @@ export const VirtualMCPCreateDataSchema = z.object({
         .describe(
           "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
         ),
+      fastPreview: fastPreviewMetadataField,
     })
     .loose()
     .nullable()
@@ -896,6 +915,7 @@ export const VirtualMCPUpdateDataSchema = z.object({
         .describe(
           "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
         ),
+      fastPreview: fastPreviewMetadataField,
     })
     .loose()
     .nullable()


### PR DESCRIPTION
Studio half of pull-based Fast Preview: the preview iframe goes to the site's **real page** on `productionUrl` with `?__draft=<host[:port]>@<version>`, and the sandbox daemon serves the draft decofile the site pulls. Supersedes #5232 (closed by a branch rename; described the pre-redesign push model).

| Repo | PR |
|---|---|
| `decocms/blocks` | [#409](https://github.com/decocms/blocks/pull/409) — published as `7.28.0-beta.1` |
| `deco-sites/faststore-fila` | [#271](https://github.com/deco-sites/faststore-fila/pull/271) — first adopter |

## Why the push model had to go

The daemon POSTed a multi-MB decofile to `/live/previews` per navigation. Only deco's own runtime honours a POST render (Next renders on GET); it produced a single statically-rendered component — no hydration, no navigation, client components invoked server-side; and the payload was re-sent every time. Pull inverts it: the site fetches the decofile once per version and renders its own route.

## Daemon

- **`GET /_sandbox/decofile`** — merged working-tree `.deco/blocks/*`, content-addressed (weak ETag, 304 on match). Unauthenticated by design, beside `/events`/`/scripts`/`/idle`: the fetcher is an arbitrary production server with no daemon token. Raw-text merge — no multi-MB `JSON.parse` on the single-threaded loop.
- Filename stems **decode until stable**: repos carry double-encoded names (`Compre%2520Junto.json`); a single decode produced keys no reference resolves.
- **`decofile: { version }`** on the events stream — emitted when the working tree lands (post-clone; a clone writes nothing through the daemon, so a write-only signal never fires) and on `.deco/blocks/*` writes (debounced, deduped by hash). Version comes from the same function as the route's ETag, so Studio's pointer and the framework's cache key cannot drift.
- `/_deco/fast-preview` moved under `/_sandbox`, then deleted with the push model — `/_deco` was a one-route namespace that shadowed the proxied dev server. The `productionUrl` plumbed Studio→daemon solely to feed it is deleted too.

## Studio UI

- `buildDraftPreviewUrl` → real page URL + pointer; `fastPreviewReady` keys off the version; the version replaces the cache-busting nonce (a save mints a version → URL changes → frame re-navigates).
- **Boot UX**: Fast Preview shares main's published-site fallback — published site + waking pill hold the canvas until the draft is renderable; the blocking "Cloning… / Installing packages…" overlay is gone from this path. Three underlying fixes: `previewUrl` seeded from the SANDBOX_START claim (was: 60s-stale entity query invalidated only at dev-server `running`); decofile query re-driven when the daemon lifecycle first reaches a tree-ready phase (was: cold-start 502, never retried); shared `isWorkingTreeReadyPhase` so daemon and Studio agree on what "tree exists" means.
- Open-in-new-tab restored on the Fast Preview surface — the draft URL is an ordinary shareable page URL now (opened without `deviceHint`).

## Testing

Full `bun run check` clean; ~1700 unit tests incl. new daemon e2e (route contract: 404-no-blocks, ETag stability, 304/200 revalidation, unauthenticated access, double-encoded keys, version event == ETag). Verified live against a desktop sandbox + the fila beta: cold boot with no overlay, save→auto-refresh, two threads with isolated drafts, PDP/landing/home drafts.

## Rollout / not yet done

- Gated on existing `metadata.fastPreview`; the framework side has its own default-off env — neither activates on upgrade alone.
- **Not mergeable until blocks#409 ships a non-beta**: an older `@decocms/blocks` ignores the pointer and silently renders published content.
- Staging pass on a real cluster sandbox (`*.preview-studio.decocms.com`) still pending — also where the CDN no-store question gets settled.
- Follow-ups deliberately out of scope: migrate Studio's section previews off `/live/previews` GET so that route can be retired; converge `useDecofile` onto `/_sandbox/decofile` (removes the dev-server dependency + invalidation choreography); draft binding for `/deco/invoke` (deferred sections render published).
