### PR TITLE
feat(commerce-onboarding): show connection details on connected companion cards

### DIFF
--- a/apps/web/src/routes/commerce-onboarding/companion-card-view.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-card-view.tsx
@@ -134,16 +134,53 @@ export function ConfigureAction({
 }
 
 /** The "Connected ✓" label + trailing controls (gear, unlink) passed as
- *  `controls`. Kept presentational so the preview can render mock controls. */
-export function ConnectedAction({ controls }: { controls?: ReactNode }) {
+ *  `controls`. `detail` (repo full name, GA4 property, etc.) replaces the
+ *  generic "Conectado" text once known, so the label itself identifies what's
+ *  linked instead of repeating it next to the gear. Kept presentational so the
+ *  preview can render mock controls. */
+export function ConnectedAction({
+  detail,
+  controls,
+}: {
+  detail?: string | null;
+  controls?: ReactNode;
+}) {
   const t = useT();
   return (
     <div className="flex items-center gap-1">
       <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
         <CheckCircle size={16} className="text-success" />{" "}
-        {t("commerceOnboarding.companionCard.connected")}
+        {detail ? (
+          <span className="max-w-40 truncate text-foreground">{detail}</span>
+        ) : (
+          t("commerceOnboarding.companionCard.connected")
+        )}
       </span>
       {controls}
     </div>
+  );
+}
+
+/** The gear config trigger for a connected source. Shared by both the
+ *  shared-SA and OAuth lanes in {@link CompanionCard} so they can't drift, and
+ *  by the dev preview so it renders pixel-identical to production. */
+export function ConnectedConfigButton({
+  ariaLabel,
+  onClick,
+}: {
+  ariaLabel: string;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      className="shrink-0"
+      onClick={onClick}
+      aria-label={ariaLabel}
+    >
+      <Settings01 size={16} />
+    </Button>
   );
 }

--- a/apps/web/src/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-card.tsx
@@ -17,7 +17,7 @@ import {
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { useMCPClient } from "@/sdk";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { LinkBroken01, Loading01, Settings01 } from "@untitledui/icons";
+import { Loading01, SlashCircle01 } from "@untitledui/icons";
 import { Suspense, useState } from "react";
 import { toast } from "sonner";
 import type { CompanionCardModel } from "./companions-core.ts";
@@ -30,6 +30,7 @@ import {
   ConfigureAction,
   ConnectAction,
   ConnectedAction,
+  ConnectedConfigButton,
 } from "./companion-card-view.tsx";
 import { COMPANION_CONFIG_FORMS } from "./companion-forms/registry.ts";
 import { SaBindingForm } from "./companion-forms/sa-binding-form.tsx";
@@ -90,7 +91,7 @@ function UnlinkButton({
           {disconnecting ? (
             <Loading01 size={16} className="animate-spin" />
           ) : (
-            <LinkBroken01 size={16} />
+            <SlashCircle01 size={16} />
           )}
         </Button>
       </TooltipTrigger>
@@ -152,36 +153,66 @@ export function CompanionCard({
         primary={card.required}
       />
     ) : card.satisfied && linkedConnectionId ? (
-      <div className="flex items-center justify-end gap-1 sm:justify-start">
-        {/* Own Suspense boundary: CompanionConfiguration opens the companion's
-            own MCP client (useMCPClient → useSuspenseQuery). Isolating it keeps
-            a connecting companion from reverting the whole grid to skeletons. */}
-        <Suspense fallback={<ConfigGearFallback />}>
-          <CompanionConfiguration
-            card={card}
-            org={org}
-            selfClient={selfClient}
-            connectionId={linkedConnectionId}
-            contextSiteUrl={siteUrl}
-            variant={needsConfig ? "configure" : "gear"}
-            disabled={disabled}
-            autoOpen={
-              needsConfig ||
-              shouldAutoOpenCompanionConfig({
+      needsConfig ? (
+        <div className="flex items-center justify-end gap-1 sm:justify-start">
+          <Suspense fallback={<ConfigGearFallback />}>
+            <CompanionConfiguration
+              card={card}
+              org={org}
+              selfClient={selfClient}
+              connectionId={linkedConnectionId}
+              contextSiteUrl={siteUrl}
+              variant="configure"
+              disabled={disabled}
+              autoOpen={shouldAutoOpenCompanionConfig({
                 autoOpenFieldKey: autoOpenConfigFieldKey,
                 card,
-              })
-            }
-            onAutoOpenHandled={onAutoOpenConfigHandled}
+              })}
+              onAutoOpenHandled={onAutoOpenConfigHandled}
+            />
+          </Suspense>
+          <UnlinkButton
+            title={card.title}
+            disconnecting={disconnecting}
+            disabled={disabled}
+            onDisconnect={onDisconnect}
           />
-        </Suspense>
-        <UnlinkButton
-          title={card.title}
-          disconnecting={disconnecting}
-          disabled={disabled}
-          onDisconnect={onDisconnect}
+        </div>
+      ) : (
+        <ConnectedAction
+          detail={card.connectedDetail}
+          controls={
+            <>
+              {/* Own Suspense boundary: CompanionConfiguration opens the
+                  companion's own MCP client (useMCPClient →
+                  useSuspenseQuery). Isolating it keeps a connecting companion
+                  from reverting the whole grid to skeletons. */}
+              <Suspense fallback={<ConfigGearFallback />}>
+                <CompanionConfiguration
+                  card={card}
+                  org={org}
+                  selfClient={selfClient}
+                  connectionId={linkedConnectionId}
+                  contextSiteUrl={siteUrl}
+                  variant="gear"
+                  disabled={disabled}
+                  autoOpen={shouldAutoOpenCompanionConfig({
+                    autoOpenFieldKey: autoOpenConfigFieldKey,
+                    card,
+                  })}
+                  onAutoOpenHandled={onAutoOpenConfigHandled}
+                />
+              </Suspense>
+              <UnlinkButton
+                title={card.title}
+                disconnecting={disconnecting}
+                disabled={disabled}
+                onDisconnect={onDisconnect}
+              />
+            </>
+          }
         />
-      </div>
+      )
     ) : (
       <ConnectAction
         connecting={connecting}
@@ -243,22 +274,17 @@ function SaConnectAction({
     <>
       {card.satisfied ? (
         <ConnectedAction
+          detail={card.connectedDetail}
           controls={
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  className="shrink-0"
-                  onClick={() => setOpen(true)}
-                  aria-label={t(
+                <ConnectedConfigButton
+                  ariaLabel={t(
                     "commerceOnboarding.companionCard.configureAriaLabel",
                     { title: card.title },
                   )}
-                >
-                  <Settings01 size={16} />
-                </Button>
+                  onClick={() => setOpen(true)}
+                />
               </TooltipTrigger>
               <TooltipContent>
                 {t("commerceOnboarding.companionCard.editConfiguration")}
@@ -422,19 +448,13 @@ function CompanionConfiguration({
     ) : (
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            className="shrink-0"
-            onClick={() => setDialogOpen(true)}
-            aria-label={t(
+          <ConnectedConfigButton
+            ariaLabel={t(
               "commerceOnboarding.companionCard.configureAriaLabel",
               { title: card.title },
             )}
-          >
-            <Settings01 size={16} />
-          </Button>
+            onClick={() => setDialogOpen(true)}
+          />
         </TooltipTrigger>
         <TooltipContent>
           {savedConfigEntries.length > 0

--- a/apps/web/src/routes/commerce-onboarding/companions-core.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions-core.ts
@@ -122,7 +122,7 @@ export function isCompanionConfigured(args: {
 /** The human-identifiable connected item for a satisfied binding — repo full
  *  name, GA4 property id, GSC site, VTEX account — shown instead of the config
  *  gear once connected. Mirrors {@link isCompanionConfigured}'s field lookups. */
-export function getConnectedDetail(args: {
+function getConnectedDetail(args: {
   bindingType: string;
   companionConfig: Record<string, unknown> | null | undefined;
   cdConfig: Record<string, unknown> | null | undefined;

--- a/apps/web/src/routes/commerce-onboarding/companions-core.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions-core.ts
@@ -68,6 +68,10 @@ export interface CompanionCardModel {
   /** The SA-bound resource (GA4 property id / GSC site) when boundVia === "sa",
    *  so the card can prefill it for viewing/editing. Null otherwise. */
   boundResource: string | null;
+  /** Human-identifiable connected item (repo full name, GA4 property id, GSC
+   *  site, VTEX account) shown in place of the config gear once satisfied. Null
+   *  when not yet configured or the binding has nothing to display. */
+  connectedDetail: string | null;
 }
 
 /** Providers connected through the shared-SA lane, keyed by binding type
@@ -112,6 +116,37 @@ export function isCompanionConfigured(args: {
     default:
       // Bindings with no post-link config step are usable as soon as linked.
       return true;
+  }
+}
+
+/** The human-identifiable connected item for a satisfied binding — repo full
+ *  name, GA4 property id, GSC site, VTEX account — shown instead of the config
+ *  gear once connected. Mirrors {@link isCompanionConfigured}'s field lookups. */
+export function getConnectedDetail(args: {
+  bindingType: string;
+  companionConfig: Record<string, unknown> | null | undefined;
+  cdConfig: Record<string, unknown> | null | undefined;
+}): string | null {
+  const { companionConfig, cdConfig } = args;
+  switch (args.bindingType) {
+    case "vtex":
+      return typeof companionConfig?.accountName === "string"
+        ? companionConfig.accountName
+        : null;
+    case "google-analytics":
+      return typeof companionConfig?.propertyId === "string"
+        ? companionConfig.propertyId
+        : null;
+    case "google-search-console":
+      return typeof companionConfig?.siteUrl === "string"
+        ? companionConfig.siteUrl
+        : null;
+    case "github":
+      return typeof cdConfig?.github_repo === "string"
+        ? cdConfig.github_repo
+        : null;
+    default:
+      return null;
   }
 }
 
@@ -400,6 +435,13 @@ export function buildCompanionCards(args: {
       configurationState: linkedConnection?.configuration_state ?? null,
       boundVia,
       boundResource: saBinding?.resource ?? null,
+      connectedDetail: satisfied
+        ? getConnectedDetail({
+            bindingType: req.bindingType,
+            companionConfig: linkedConnection?.configuration_state ?? null,
+            cdConfig: args.configurationState ?? null,
+          })
+        : null,
     });
   }
   return cards;


### PR DESCRIPTION
## Summary
- Once a companion source (Google Analytics, GitHub, VTEX, Google Search Console) is connected, its card now shows the actual linked item (GA4 property id, repo full name, VTEX account name, GSC site) in place of the generic "Connected" label — the label itself identifies what's linked instead of a plain checkmark + "Conectado".
- Unified the two connection lanes (shared-SA for GA4/GSC, OAuth-based for GitHub/VTEX) onto the same `ConnectedAction` treatment so both read consistently: `✓ <name> [gear] [unlink]`.
- Swapped the unlink icon from `LinkBroken01` (a busy multi-stroke "broken chain + sparks" glyph) to `SlashCircle01`, which matches the gear icon's clean, closed-shape visual weight.

## Test plan
- [x] `bun run --cwd=apps/web check` (typecheck) passes
- [x] `bun test apps/web/src/routes/commerce-onboarding/companions-core.test.ts` passes (49 tests)
- [x] `bun run fmt` / `bun run lint` clean
- [x] Verified visually in a local dev-only preview (light + dark mode) via Playwright screenshots — connected rows for GA4, GitHub, VTEX, and the no-detail fallback all render correctly with no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the actual linked item on connected companion cards (GA4 property ID, GitHub repo, VTEX account, GSC site) instead of a generic “Connected” label. Unifies the connected UI across both lanes and tweaks icons for clearer actions.

- **New Features**
  - Replaces “Connected” with the linked item; falls back to the label when no detail exists.
  - Adds `connectedDetail` to the card model and computes it via `getConnectedDetail`; rendered through `ConnectedAction(detail)`.
  - Uses a shared `ConnectedConfigButton` for the gear across both lanes (keeps Suspense isolation) and swaps the unlink icon to `SlashCircle01` from `@untitledui/icons`.

- **Bug Fixes**
  - Unexports `getConnectedDetail` (internal to `buildCompanionCards`) to satisfy `knip` CI.

<sup>Written for commit 5134ab774c6047a9f97cb1c8a33042a76989906c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

