### PR TITLE
feat(decopilot): tag OpenRouter requests with org via X-Title header

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -329,15 +329,17 @@ async function resolveSecretModelSource(
 
   // OpenRouter surfaces `X-Title` as the app name in its dashboard/rankings.
   // Tag it with the org so per-tenant traffic is attributable. `deco` is the
-  // OpenRouter provider behind the deco AI gateway, so it gets the same tag.
+  // OpenRouter provider behind the deco AI gateway — tag it distinctly so its
+  // traffic is separable from direct-OpenRouter usage.
   if (source.providerId === "openrouter" || source.providerId === "deco") {
     const orgName =
       ctx.organization?.name ?? ctx.organization?.slug ?? organizationId;
+    const appName = source.providerId === "deco" ? "Deco" : "Studio";
     return {
       ...source,
       extraHeaders: {
         ...source.extraHeaders,
-        "X-Title": `Studio - ${orgName}`,
+        "X-Title": `${appName} - ${orgName}`,
       },
     };
   }

--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -334,7 +334,7 @@ async function resolveSecretModelSource(
   if (source.providerId === "openrouter" || source.providerId === "deco") {
     const orgName =
       ctx.organization?.name ?? ctx.organization?.slug ?? organizationId;
-    const appName = source.providerId === "deco" ? "Deco" : "Studio";
+    const appName = source.providerId === "deco" ? "deco AI Gateway" : "Studio";
     return {
       ...source,
       extraHeaders: {

--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -321,11 +321,28 @@ async function resolveSecretModelSource(
     credentialId,
     organizationId,
   );
-  return createSecretModelSource({
+  const source = createSecretModelSource({
     providerId: keyInfo.providerId,
     apiKey,
     modelId,
   });
+
+  // OpenRouter surfaces `X-Title` as the app name in its dashboard/rankings.
+  // Tag it with the org so per-tenant traffic is attributable. `deco` is the
+  // OpenRouter provider behind the deco AI gateway, so it gets the same tag.
+  if (source.providerId === "openrouter" || source.providerId === "deco") {
+    const orgName =
+      ctx.organization?.name ?? ctx.organization?.slug ?? organizationId;
+    return {
+      ...source,
+      extraHeaders: {
+        ...source.extraHeaders,
+        "X-Title": `Studio - ${orgName}`,
+      },
+    };
+  }
+
+  return source;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

When Decopilot runs against the **OpenRouter** provider (and the OpenRouter-backed **deco** gateway), send an `X-Title` header so per-tenant traffic is attributable. OpenRouter surfaces `X-Title` as the app name in its dashboard/rankings.

The header value is `Studio - <org>`, where `<org>` prefers the org name, falls back to slug, then the raw org id.

## Implementation

The `extraHeaders` seam already existed end-to-end but was never populated:

`DecopilotSecretModelSource.extraHeaders` (`packages/harness/src/sources.ts`) → `createProviderFromSecret` → `createOpenRouter({ ..., headers: extraHeaders })` (`provider-from-secret.ts`).

This PR populates it in `resolveSecretModelSource` (`apps/api/src/api/routes/decopilot/dispatch-run.ts`), the one place where both `ctx.organization` (name/slug) and the resolved `providerId` are in scope. The header is only attached for `openrouter` / `deco`; all other providers are untouched.

## Testing notes

- `bun run fmt` ✅
- `tsc --noEmit` (apps/api) ✅

## Affected areas

- Decopilot dispatch path only. No behavior change for non-OpenRouter providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `X-Title` to Decopilot OpenRouter requests so traffic is attributed per org in the OpenRouter dashboard. Applies to `openrouter` and the `deco` gateway; other providers are unchanged.

- **New Features**
  - Set `X-Title: Studio - <org>` for `openrouter` and `X-Title: deco AI Gateway - <org>` for `deco` (org uses name, else slug, else org ID).
  - Populate the existing `extraHeaders` seam in the Decopilot dispatch path only for provider IDs `openrouter` and `deco`.

<sup>Written for commit d06ad314d8f171e6b26794065ec0c354616a0e41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

