### PR TITLE
fix(sandbox): make the org-fs config relay write async

### DIFF
--- a/packages/sandbox/daemon/routes/orgfs-config.ts
+++ b/packages/sandbox/daemon/routes/orgfs-config.ts
@@ -13,7 +13,7 @@
  * keep their boot-env path.
  */
 
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { mkdir, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { parseOrgFsConfig } from "../org-fs/config";
 import { jsonResponse } from "./body-parser";
@@ -32,10 +32,10 @@ export function makeOrgFsConfigHandler(opts: {
     if (!opts.configPath) return jsonResponse({ written: false });
     try {
       // Atomic write: the sidecar must never read a torn file.
-      mkdirSync(dirname(opts.configPath), { recursive: true });
+      await mkdir(dirname(opts.configPath), { recursive: true });
       const tmp = join(dirname(opts.configPath), `.config-${process.pid}.tmp`);
-      writeFileSync(tmp, raw);
-      renameSync(tmp, opts.configPath);
+      await writeFile(tmp, raw);
+      await rename(tmp, opts.configPath);
       return jsonResponse({ written: true });
     } catch (err) {
       log("sidecar config relay failed", err);


### PR DESCRIPTION
Follows the CONTRIBUTING.md rule #1 sync-to-async cleanup already applied to the daemon.json read path (#5336) and the docs comment on the sandbox daemon's single-threaded event loop.

The daemon's `POST /_sandbox/orgfs-config` route handler (`packages/sandbox/daemon/routes/orgfs-config.ts`) wrote its relay file with `mkdirSync`/`writeFileSync`/`renameSync` directly inside the request handler. Any sync fs call in the daemon blocks its single-threaded event loop for every other in-flight request while it runs — including the health probe Studio polls to decide whether the sandbox is alive; a single missed probe marks the sandbox dead and tears it down / triggers recovery (see CLAUDE.md gotcha #8 and CONTRIBUTING.md rule #1).

Fix: swapped the three sync `node:fs` calls for their `node:fs/promises` equivalents (`mkdir`/`writeFile`/`rename`), same behavior (still an atomic write-then-rename), just off the event loop.

Reviewer check: `cd packages/sandbox && bunx tsc --noEmit` and `bun test packages/sandbox/daemon/routes/orgfs-config.test.ts` (existing 3 tests, unmodified, still cover the write/parent-creation/reject/no-op paths and pass unchanged).

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox`, and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the sandbox org-fs config relay to async I/O to avoid blocking the daemon event loop and missing health probes. Keeps the same atomic write-then-rename behavior.

- **Bug Fixes**
  - Replaced `mkdirSync`/`writeFileSync`/`renameSync` with `await`ed `mkdir`/`writeFile`/`rename` from `node:fs/promises`.
  - Change applies to `POST /_sandbox/orgfs-config` in packages/sandbox/daemon/routes/orgfs-config.ts; existing tests remain unchanged and pass.

<sup>Written for commit 750bb07392d899d2cb4407bf8d1f9c65418c5232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

