### PR TITLE
fix(search): derive expired status for stale in_progress threads in GLOBAL_SEARCH

### DIFF
--- a/apps/api/src/tools/search/global-search.ts
+++ b/apps/api/src/tools/search/global-search.ts
@@ -17,6 +17,7 @@
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
 import { requireOrganization } from "../../core/studio-context";
+import { normalizeThreadForResponse } from "../thread/helpers";
 
 const SEARCHABLE_TYPES = ["thread"] as const;
 
@@ -110,7 +111,10 @@ export const GLOBAL_SEARCH = defineTool({
           virtual_mcp_id: thread.virtual_mcp_id ?? null,
           run_config:
             (thread.run_config as Record<string, unknown> | null) ?? null,
-          status: thread.status ?? null,
+          // Same expiry derivation as THREAD_LIST/GET/etc. — otherwise a
+          // stale in_progress run shows "in_progress" here but "expired"
+          // everywhere else in the app.
+          status: normalizeThreadForResponse(thread).status,
         });
       }
     }


### PR DESCRIPTION
Bug found while auditing recent changes to `apps/api/src/tools/search/global-search.ts`.

Every other thread-returning tool (`THREAD_LIST`, `THREAD_GET`, `THREAD_CREATE`, `THREAD_UPDATE`, `THREAD_DELETE`) routes the raw storage row through `normalizeThreadForResponse()`, which derives a virtual `"expired"` status for threads stuck in `in_progress` for more than 30 minutes (`THREAD_EXPIRY_MS`, `apps/api/src/tools/thread/helpers.ts`). `GLOBAL_SEARCH` was the one outlier: it read `thread.status` straight off the DB row, so a dead/stale run showed up as `"in_progress"` in search results while the exact same thread showed `"expired"` in the thread list, monitoring view, and sidebar — an inconsistent, misleading state for anyone searching for a thread they think is still running.

Fix: import the same `normalizeThreadForResponse` helper already used everywhere else and use its derived `.status` instead of the raw field. No new logic — this just wires an existing, already-tested derivation into the one call site that was missing it.

Failure scenario before the fix: a thread's run silently dies (pod crash, no terminal write) while `status` is still `"in_progress"` in the DB. 31+ minutes later, `THREAD_LIST` correctly shows it as `"expired"`, but `GLOBAL_SEARCH` for the same thread still returns `"in_progress"`.

Reviewer command: `cd apps/api && bunx tsc --noEmit && bun test src/tools/thread/helpers.test.ts src/tools/search/global-search.test.ts`

Locally verified: `bunx tsc --noEmit` (apps/api workspace) is clean; `src/tools/thread/helpers.test.ts` (11 pass) — the pure unit suite covering the exact expiry-derivation logic now reused here — and `src/tools/search/global-search.test.ts` (2 pass) both pass. The DB-backed `global-search.integration.test.ts` needs a live Postgres this sandbox doesn't have, so it wasn't run locally; full CI covers it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent thread status in Global Search by deriving `expired` for stale `in_progress` runs, matching the rest of the app. Search results now show the same status as thread list and monitoring views.

- **Bug Fixes**
  - Use `normalizeThreadForResponse` in `GLOBAL_SEARCH` to derive status instead of the raw DB value.
  - Aligns search results with `THREAD_LIST`, `THREAD_GET`, `THREAD_CREATE`, `THREAD_UPDATE`, and `THREAD_DELETE`.

<sup>Written for commit 9d05d97f138d4b925c23a51974a47b903a143e35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

