### PR TITLE
fix(chat): translate hardcoded "Subtask" fallback label

### DIFF
--- a/apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx
@@ -444,6 +444,7 @@ function BackgroundSubtaskBody({
  *  (`…/jobs/:jobId/stream`) while the panel is open, falling back to the
  *  persisted nested rows once the run completes / the live buffer is purged. */
 function BackgroundSubtaskCard({ part }: SubtaskPartProps) {
+  const t = useT();
   const jobId = (part.output as { jobId?: string } | undefined)?.jobId;
   const { taskId: threadId } = useChatTask();
   const { org } = useProjectContext();
@@ -474,13 +475,13 @@ function BackgroundSubtaskCard({ part }: SubtaskPartProps) {
       icon={
         <IntegrationIcon
           icon={undefined}
-          name="Subtask"
+          name={t("chat.subtask.subtaskNoun")}
           size="2xs"
           className="rounded-xs"
           fallbackIcon={<Users03 />}
         />
       }
-      title="Subtask"
+      title={t("chat.subtask.subtaskNoun")}
       summary={summary}
       state={running ? "loading" : "idle"}
       onOpenChange={setOpen}
@@ -496,6 +497,7 @@ function BackgroundSubtaskCard({ part }: SubtaskPartProps) {
 }
 
 export function SubtaskPartFallback(props: SubtaskPartProps) {
+  const t = useT();
   const onFlip = useFlipToBackground(props.part.toolCallId);
   if (isBackgroundStart(props.part.output))
     return <BackgroundSubtaskCard {...props} />;
@@ -505,7 +507,7 @@ export function SubtaskPartFallback(props: SubtaskPartProps) {
       icon={
         <IntegrationIcon
           icon={undefined}
-          name="Subtask"
+          name={t("chat.subtask.subtaskNoun")}
           size="2xs"
           className="rounded-xs"
           fallbackIcon={<Users03 />}
@@ -529,6 +531,7 @@ export function SubtaskPartFallback(props: SubtaskPartProps) {
  * <Suspense fallback={<SubtaskPartFallback ... />}> by the caller.
  */
 export function SubtaskPart(props: SubtaskPartProps) {
+  const t = useT();
   const target = useConnection(props.part.input?.agent_id);
   const onFlip = useFlipToBackground(props.part.toolCallId);
   if (isBackgroundStart(props.part.output))
@@ -540,7 +543,7 @@ export function SubtaskPart(props: SubtaskPartProps) {
       icon={
         <IntegrationIcon
           icon={target?.icon}
-          name={target?.title ?? "Subtask"}
+          name={target?.title ?? t("chat.subtask.subtaskNoun")}
           size="2xs"
           className="rounded-xs"
           fallbackIcon={<Users03 />}

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -371,6 +371,7 @@ export const chat = {
   "chat.subtask.resultLabel": "Result",
   "chat.subtask.running": "Running…",
   "chat.subtask.runningInBackground": "Running in the background…",
+  "chat.subtask.subtaskNoun": "Subtask",
   "chat.subtask.taskLabel": "Task",
   "chat.takeScreenshot.failed": "Failed",
   "chat.takeScreenshot.screenshot": "Screenshot",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -382,6 +382,7 @@ export const chat = {
   "chat.subtask.resultLabel": "Resultado",
   "chat.subtask.running": "Executando…",
   "chat.subtask.runningInBackground": "Executando em background…",
+  "chat.subtask.subtaskNoun": "Subtarefa",
   "chat.subtask.taskLabel": "Tarefa",
   "chat.takeScreenshot.failed": "Falhou",
   "chat.takeScreenshot.screenshot": "Captura de tela",


### PR DESCRIPTION
**Source:** i18n-consistency sweep of the chat locale files (apps/web/src/i18n/en/chat.ts, apps/web/src/i18n/pt-br/chat.ts). The dictionaries themselves are fully in sync (type-checked key parity via `satisfies Record<keyof typeof chatEn, string>`, and no placeholder mismatches — verified programmatically), but `subtask.tsx` bypassed the dictionary entirely for its fallback label.

**Payoff:** the subtask card's icon `name` and `title` fell back to the literal string `"Subtask"` in three spots (`BackgroundSubtaskCard`, `SubtaskPartFallback`, `SubtaskPart`) instead of `t(...)`, so a pt-br user sees English text on any backgrounded subtask or one with no resolvable agent target — a direct violation of the repo's "never hardcode user-facing strings" i18n rule.

**Fix:** added `chat.subtask.subtaskNoun` ("Subtask" / "Subtarefa") to both locale dictionaries and swapped the three hardcoded literals for `t("chat.subtask.subtaskNoun")` in the three components, which already have hook access (two already render other `t(...)` calls in this same file). Left the `buildSubtaskRowConfig`/`extractSubtaskResponse` pure functions alone — they carry an existing `ponytail:` comment acknowledging they intentionally can't reach `t()` at module scope, which is a separate, larger scope.

**Reviewer check:** open a chat with a backgrounded subtask or one targeting a deleted/unresolvable agent under the pt-br locale and confirm the card shows "Subtarefa" instead of "Subtask".

**Verified locally:**
- `bun run fmt`
- `cd apps/web && bunx tsc --noEmit` (pt-br's `satisfies Record<keyof typeof chatEn, string>` proves the new key is present in both locales)
- `bun test apps/web/src/components/chat/message/parts/tool-call-part/subtask.test.ts` (15 pass, unaffected by this change)

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded "Subtask" fallback labels with i18n so background and fallback subtask cards show translated text (e.g., "Subtarefa" in `pt-br`).

- **Bug Fixes**
  - Added `chat.subtask.subtaskNoun` to `apps/web/src/i18n/en/chat.ts` and `apps/web/src/i18n/pt-br/chat.ts`.
  - Updated `BackgroundSubtaskCard`, `SubtaskPartFallback`, and `SubtaskPart` in `apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx` to use `t("chat.subtask.subtaskNoun")` for icon name and title.

<sup>Written for commit e405adb928dc81e3b316c2500c7437767ddd7c51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

