### PR TITLE
fix(sandbox): make the write-file daemon route async

### DIFF
--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { readdir, readFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -305,8 +305,8 @@ export function makeWriteHandler(deps: FsDeps) {
     const jsonError = invalidDecofileBlockJson(body.path ?? "", body.content);
     if (jsonError)
       return jsonResponse({ error: `Refusing to write ${jsonError}` }, 400);
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, body.content, "utf-8");
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, body.content, "utf-8");
     deps.onWorkingTreeWrite?.(body.path ?? "");
     return jsonResponse({
       ok: true,


### PR DESCRIPTION
Follows the same sync-to-async cleanup already applied to the daemon.json read path (#5336) and the org-fs config relay (#5367), per CONTRIBUTING.md rule #1 / CLAUDE.md gotcha #8: the sandbox daemon runs on a single-threaded Bun event loop, and any sync fs call in a request handler blocks every other in-flight request — including the health probe Studio polls to decide whether the sandbox is alive. A single missed probe marks the sandbox dead and tears it down / triggers recovery.

`makeWriteHandler` in `packages/sandbox/daemon/routes/fs.ts` — the handler backing every file save from the editor/agent, and the most frequently hit fs route — still called `fs.mkdirSync`/`fs.writeFileSync` directly inside the request handler.

Fix: swapped the two sync `node:fs` calls for their `node:fs/promises` equivalents (`mkdir`/`writeFile`). Same behavior (still create-parent-then-write), just off the event loop. Net diff: -3/+3, all pre-existing logic (JSON validation, `onWorkingTreeWrite` signal, response shape) untouched.

Reviewer check: `cd packages/sandbox && bunx tsc --noEmit` and `bun test packages/sandbox/daemon/routes/fs.test.ts` (existing suite, including several `write:` cases, unmodified and still passing).

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox`, and the targeted test file above — all green (56 pass / 9 skip / 0 fail). Full CI validates the rest.

Note: `routes/fs.ts` has several other handlers (read/unlink/mkdir/rename/glob/grep) with the same sync-fs pattern — left out of this PR to keep it to one handler/one concern; worth a follow-up sweep.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the sandbox write-file route async to avoid blocking the Bun event loop and prevent missed health probes. Replaced `node:fs` sync calls (`mkdirSync`, `writeFileSync`) with `node:fs/promises` (`mkdir`, `writeFile`); behavior and response remain the same.

<sup>Written for commit 6aa0f108ee9ae1ba004e7ae6f8f72b29cbf6ac8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

