### PR TITLE
feat(sandbox): remove 20MB body cap on daemon proxy routes

### DIFF
--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -48,10 +48,6 @@ import {
   parseGithubRepoFromMetadata,
   refreshSandboxGitCredentials,
 } from "../../tools/sandbox/sync-git-credentials";
-import {
-  readBoundedText,
-  UpstreamPayloadTooLargeError,
-} from "../../lib/bounded-text";
 
 // ---- Middleware types -------------------------------------------------------
 
@@ -98,20 +94,6 @@ function assertSandboxBranchParam(branch: string): void {
 
 const SUGGEST_COMMIT_MAX_BODY_BYTES = 512 * 1024;
 const PREVIEW_INVOKE_MAX_BODY_BYTES = 64 * 1024;
-/**
- * Every route below that passes `forwardJsonBody: true` has its body read
- * fully into memory via `c.req.text()` in `proxyDaemon` before being
- * forwarded to the daemon — unlike suggest-commit/judge-review/preview-invoke
- * above, they had no size cap at all. 20MB comfortably covers any real source
- * file or git payload while bounding how much an oversized/malicious request
- * can buffer.
- */
-const FORWARDED_BODY_MAX_BYTES = 20 * 1024 * 1024;
-
-const forwardedBodyLimit = bodyLimit({
-  maxSize: FORWARDED_BODY_MAX_BYTES,
-  onError: (c) => c.json({ error: "Payload too large" }, 413),
-});
 
 /**
  * Quick interactive file ops (read/write/mkdir/unlink/rename/glob) must fail
@@ -390,7 +372,7 @@ async function proxyDaemon(
       }
     }
 
-    const rawText = await readBoundedText(upstream, FORWARDED_BODY_MAX_BYTES);
+    const rawText = await upstream.text();
     const text =
       opts?.redactRepoDirUnlessDesktop && runner.kind !== "user-desktop"
         ? redactRepoDir(rawText)
@@ -429,9 +411,6 @@ async function proxyDaemon(
     }
     return await resolveAndFetch();
   } catch (err) {
-    if (err instanceof UpstreamPayloadTooLargeError) {
-      return c.json({ error: err.message }, 502);
-    }
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ error: `Daemon unreachable: ${message}` }, 502);
   }
@@ -497,7 +476,7 @@ async function fetchDaemonJson<T>(
     throw new Error("SANDBOX_GONE");
   }
 
-  const text = await readBoundedText(upstream, FORWARDED_BODY_MAX_BYTES);
+  const text = await upstream.text();
   if (!upstream.ok) {
     try {
       const err = JSON.parse(text) as { error?: string };
@@ -531,43 +510,43 @@ export const createSandboxRoutes = () => {
   app.use("/:virtualMcpId/:branch/*", resolveVmClaim);
 
   // -- File write/read (base64-encoded body) --------------------------------
-  app.post("/:virtualMcpId/:branch/write", forwardedBodyLimit, (c) =>
+  app.post("/:virtualMcpId/:branch/write", (c) =>
     proxyDaemon(c, "/_sandbox/write", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/unlink", forwardedBodyLimit, (c) =>
+  app.post("/:virtualMcpId/:branch/unlink", (c) =>
     proxyDaemon(c, "/_sandbox/unlink", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/mkdir", forwardedBodyLimit, (c) =>
+  app.post("/:virtualMcpId/:branch/mkdir", (c) =>
     proxyDaemon(c, "/_sandbox/mkdir", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/rename", forwardedBodyLimit, (c) =>
+  app.post("/:virtualMcpId/:branch/rename", (c) =>
     proxyDaemon(c, "/_sandbox/rename", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/read", forwardedBodyLimit, (c) =>
+  app.post("/:virtualMcpId/:branch/read", (c) =>
     proxyDaemon(c, "/_sandbox/read", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/glob", forwardedBodyLimit, (c) =>
+  app.post("/:virtualMcpId/:branch/glob", (c) =>
     proxyDaemon(c, "/_sandbox/glob", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
     }),
   );
-  app.post("/:virtualMcpId/:branch/grep", forwardedBodyLimit, (c) =>
+  app.post("/:virtualMcpId/:branch/grep", (c) =>
     proxyDaemon(c, "/_sandbox/grep", {
       forwardJsonBody: true,
       signal: quickFileOpSignal(c),
@@ -597,7 +576,7 @@ export const createSandboxRoutes = () => {
       redactRepoDirUnlessDesktop: true,
     }),
   );
-  app.put("/:virtualMcpId/:branch/config", forwardedBodyLimit, (c) =>
+  app.put("/:virtualMcpId/:branch/config", (c) =>
     proxyDaemon(c, "/_sandbox/config", {
       method: "PUT",
       forwardJsonBody: true,
@@ -704,57 +683,53 @@ export const createSandboxRoutes = () => {
       ]),
     }),
   );
-  app.post("/:virtualMcpId/:branch/git/diff", forwardedBodyLimit, (c) =>
+  app.post("/:virtualMcpId/:branch/git/diff", (c) =>
     proxyDaemon(c, "/_sandbox/git/diff", {
       forwardJsonBody: true,
       map404to410: true,
     }),
   );
-  app.post(
-    "/:virtualMcpId/:branch/git/publish",
-    forwardedBodyLimit,
-    async (c) => {
-      const runner = requireRunner(c);
-      if (runner instanceof Response) return runner;
+  app.post("/:virtualMcpId/:branch/git/publish", async (c) => {
+    const runner = requireRunner(c);
+    if (runner instanceof Response) return runner;
 
-      const { claimName, virtualMcpMetadata, connectionIds } = c.get("vmClaim");
-      const ctx = c.var.studioContext;
+    const { claimName, virtualMcpMetadata, connectionIds } = c.get("vmClaim");
+    const ctx = c.var.studioContext;
 
-      return withClaimGitLock(claimName, async () => {
-        try {
-          await patchSandboxOperator(ctx, runner, claimName);
-          const githubRepo = parseGithubRepoFromMetadata(
-            virtualMcpMetadata,
-            connectionIds,
+    return withClaimGitLock(claimName, async () => {
+      try {
+        await patchSandboxOperator(ctx, runner, claimName);
+        const githubRepo = parseGithubRepoFromMetadata(
+          virtualMcpMetadata,
+          connectionIds,
+        );
+        if (githubRepo) {
+          await refreshSandboxGitCredentials(
+            ctx,
+            runner,
+            claimName,
+            githubRepo,
           );
-          if (githubRepo) {
-            await refreshSandboxGitCredentials(
-              ctx,
-              runner,
-              claimName,
-              githubRepo,
-            );
-          }
-        } catch (err) {
-          if (err instanceof GitPushAuthError) {
-            return c.json(
-              { error: err.message },
-              403,
-              SANDBOX_PROXY_CACHE_HEADERS,
-            );
-          }
-          const message = err instanceof Error ? err.message : String(err);
-          return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
         }
+      } catch (err) {
+        if (err instanceof GitPushAuthError) {
+          return c.json(
+            { error: err.message },
+            403,
+            SANDBOX_PROXY_CACHE_HEADERS,
+          );
+        }
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
+      }
 
-        return proxyDaemon(c, "/_sandbox/git/publish", {
-          forwardJsonBody: true,
-          map404to410: true,
-        });
+      return proxyDaemon(c, "/_sandbox/git/publish", {
+        forwardJsonBody: true,
+        map404to410: true,
       });
-    },
-  );
-  app.post("/:virtualMcpId/:branch/git/discard", forwardedBodyLimit, (c) => {
+    });
+  });
+  app.post("/:virtualMcpId/:branch/git/discard", (c) => {
     const { claimName } = c.get("vmClaim");
     return withClaimGitLock(claimName, () =>
       proxyDaemon(c, "/_sandbox/git/discard", {
@@ -763,31 +738,27 @@ export const createSandboxRoutes = () => {
       }),
     );
   });
-  app.post(
-    "/:virtualMcpId/:branch/git/rebase",
-    forwardedBodyLimit,
-    async (c) => {
-      const runner = requireRunner(c);
-      if (runner instanceof Response) return runner;
+  app.post("/:virtualMcpId/:branch/git/rebase", async (c) => {
+    const runner = requireRunner(c);
+    if (runner instanceof Response) return runner;
 
-      const { claimName } = c.get("vmClaim");
-      const ctx = c.var.studioContext;
+    const { claimName } = c.get("vmClaim");
+    const ctx = c.var.studioContext;
 
-      return withClaimGitLock(claimName, async () => {
-        try {
-          await patchSandboxOperator(ctx, runner, claimName);
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
-        }
+    return withClaimGitLock(claimName, async () => {
+      try {
+        await patchSandboxOperator(ctx, runner, claimName);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
+      }
 
-        return proxyDaemon(c, "/_sandbox/git/rebase", {
-          forwardJsonBody: true,
-          map404to410: true,
-        });
+      return proxyDaemon(c, "/_sandbox/git/rebase", {
+        forwardJsonBody: true,
+        map404to410: true,
       });
-    },
-  );
+    });
+  });
   app.post(
     "/:virtualMcpId/:branch/git/suggest-commit",
     bodyLimit({
@@ -989,7 +960,7 @@ export const createSandboxRoutes = () => {
 
     let text: string;
     try {
-      text = await readBoundedText(upstream, FORWARDED_BODY_MAX_BYTES);
+      text = await upstream.text();
     } catch {
       return c.json({ error: "Preview unreachable" }, 502);
     }
@@ -1059,7 +1030,7 @@ export const createSandboxRoutes = () => {
 
       let text: string;
       try {
-        text = await readBoundedText(upstream, FORWARDED_BODY_MAX_BYTES);
+        text = await upstream.text();
       } catch {
         return c.json({ error: "Preview unreachable" }, 502);
       }


### PR DESCRIPTION
## Summary

Removes the shared 20MB body cap (`FORWARDED_BODY_MAX_BYTES`) on the sandbox daemon proxy routes in `apps/api/src/api/routes/sandbox-proxy.ts`. Real source files and git diffs forwarded through these routes could exceed 20MB and hit a `413`/`502`.

## Changes

- Delete `FORWARDED_BODY_MAX_BYTES` (20MB) and the `forwardedBodyLimit` middleware.
- Remove that middleware from every daemon-forwarded route: `write`, `unlink`, `mkdir`, `rename`, `read`, `glob`, `grep`, `config`, `git/diff`, `git/publish`, `git/discard`, `git/rebase`.
- Read daemon and preview responses with `upstream.text()` instead of `readBoundedText(upstream, FORWARDED_BODY_MAX_BYTES)` (4 call sites).
- Drop the now-dead `UpstreamPayloadTooLargeError` catch branch and the unused `bounded-text` import.

**Left intact** (separate, smaller caps — not the 20MB daemon cap): `git/suggest-commit` and `git/judge-review` (512KB), `preview-invoke` request bodies (64KB). The `bounded-text.ts` lib stays — still used by `sync-git-credentials`, `patch-sandbox-operator`, `resolve-env`, `sandbox-events-handler`.

## Testing

- `bun run fmt` ✅
- `bun run --cwd=apps/api check` (tsc) ✅
- `bun run lint` ✅ (0 errors)
- `bun test apps/api/src/api/routes/sandbox-proxy.test.ts` ✅ (10 pass)

## Note

This cap bounded how much an oversized/malicious request body or daemon/preview response buffers into API-process memory. Removing it fully means both request bodies and upstream responses are now read with no ceiling. If a guardrail is still desired, an alternative would be bumping the cap to a large value (e.g. 256MB) rather than removing it — open to that if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the shared 20MB body cap from sandbox daemon proxy routes to avoid 413/502 errors on large source files and git diffs. Bodies and upstream responses are now read without a ceiling; smaller per-route caps remain.

- **Bug Fixes**
  - Deleted `FORWARDED_BODY_MAX_BYTES` and removed `forwardedBodyLimit` from daemon-forwarded routes (`write`, `unlink`, `mkdir`, `rename`, `read`, `glob`, `grep`, `config`, `git/*`).
  - Switched to `upstream.text()` for daemon/preview responses; removed `readBoundedText` and the `UpstreamPayloadTooLargeError` branch.
  - Kept existing smaller caps: `git/suggest-commit` and `git/judge-review` (512KB), `preview-invoke` (64KB). `bounded-text.ts` stays in use for other endpoints.

<sup>Written for commit f054ef903ab63a4c0e4b12f3e92f8ce1203b6827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

