### PR TITLE
fix(sandbox): make the unlink daemon route async

### DIFF
--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -1,5 +1,13 @@
 import fs from "node:fs";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -343,17 +351,17 @@ export function makeUnlinkHandler(deps: FsDeps) {
     if (!filePath) return jsonResponse({ error: "Path escapes app root" }, 400);
     let existed = true;
     try {
-      const stat = fs.statSync(filePath);
-      if (stat.isDirectory()) {
+      const fileStat = await stat(filePath);
+      if (fileStat.isDirectory()) {
         if (!body.recursive) {
           return jsonResponse(
             { error: "Refusing to unlink directory without recursive: true" },
             400,
           );
         }
-        fs.rmSync(filePath, { recursive: true, force: true });
+        await rm(filePath, { recursive: true, force: true });
       } else {
-        fs.unlinkSync(filePath);
+        await unlink(filePath);
       }
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {


### PR DESCRIPTION
Follows the same sync-to-async cleanup already applied to the daemon's write-file route (#5370), the daemon.json read path (#5336), and the org-fs config relay (#5367), per CONTRIBUTING.md rule #1 / CLAUDE.md gotcha #8: the sandbox daemon runs on a single-threaded Bun event loop, and any sync fs call in a request handler blocks every other in-flight request — including the health probe Studio polls to decide whether the sandbox is alive. A single missed probe marks the sandbox dead and tears it down / triggers recovery.

`makeUnlinkHandler` in `packages/sandbox/daemon/routes/fs.ts` — the handler backing every file/directory delete from the editor/agent — still called `fs.statSync`/`fs.rmSync`/`fs.unlinkSync` directly inside the request handler.

Fix: swapped the three sync `node:fs` calls for their `node:fs/promises` equivalents (`stat`/`rm`/`unlink`). Same behavior (still stat-then-branch-on-directory, same ENOENT handling for idempotency), just off the event loop. Net diff: -5/+13 (mostly the import list reflow), all pre-existing logic (recursive-delete gate, `.git` protection, `onWorkingTreeWrite` signal, idempotent-on-missing response shape) untouched.

Reviewer check: `cd packages/sandbox && bunx tsc --noEmit` and `bun test packages/sandbox/daemon/routes/fs.test.ts` (existing suite, including several `unlink:` cases, unmodified and still passing).

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox`, and the targeted test file above — all green (56 pass / 9 skip / 0 fail). Full CI validates the rest.

Note: `routes/fs.ts` still has other handlers (mkdir/rename/edit/glob) with the same sync-fs pattern — left out of this PR to keep it to one handler/one concern; worth further follow-ups.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the sandbox unlink route async to avoid blocking the single-threaded Bun event loop and missing health probes. Replaces sync `node:fs` calls with `node:fs/promises` while keeping behavior the same.

- **Bug Fixes**
  - Updated `makeUnlinkHandler` in `packages/sandbox/daemon/routes/fs.ts` to use `stat`, `rm`, and `unlink` from `node:fs/promises`.
  - Preserves logic: stat-then-branch for directories, recursive-delete gate, `.git` protection, idempotent ENOENT handling, and `onWorkingTreeWrite` signal.

<sup>Written for commit 70fb80f0076043fa810516d7e71fbe096fcd6ac3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

