### PR TITLE
fix(sandbox): make the daemon mkdir route async

### DIFF
--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -392,7 +392,7 @@ export function makeMkdirHandler(deps: FsDeps) {
     const dirPath = safePath(deps.appRoot, deps.repoDir, body.path);
     if (!dirPath) return jsonResponse({ error: "Path escapes app root" }, 400);
     try {
-      fs.mkdirSync(dirPath, { recursive: true });
+      await mkdir(dirPath, { recursive: true });
     } catch (err) {
       return jsonResponse({ error: (err as Error).message }, 500);
     }


### PR DESCRIPTION
Follows #5372 (unlink daemon route made async) and #5336 — continuing the sweep of blocking sync fs calls in `packages/sandbox/daemon/routes/fs.ts`.

The daemon runs on a single-threaded Bun event loop (CONTRIBUTING.md rule #1). `makeMkdirHandler` called `fs.mkdirSync`, which blocks that loop for the duration of the syscall. Studio polls the daemon's HTTP health probe and tears the sandbox down on a single missed probe, so any sync fs call on this path is a latent sandbox-recovery trigger under load.

Change: swap `fs.mkdirSync(dirPath, { recursive: true })` for the already-imported `await mkdir(dirPath, { recursive: true })` from `node:fs/promises`. No behavior change — same recursive-mkdir semantics, same error handling.

To confirm: `bun test packages/sandbox/daemon/routes/fs.test.ts` (56 pass, covers `makeMkdirHandler`).

Locally ran: `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit` (clean), and the targeted test file above. Full CI validates the rest.

Remaining sync calls in the same file (`statSync`/`readFileSync`/`renameSync`/`rmSync`/`readdirSync`/etc. in rename, edit, glob, grep handlers) are left for follow-up PRs, one handler at a time, per the established pattern.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the sandbox daemon `mkdir` route async in `packages/sandbox/daemon/routes/fs.ts` to prevent blocking the Bun event loop and avoid health probe misses that can tear down the sandbox. Swapped `fs.mkdirSync` for `await mkdir` from `node:fs/promises`; behavior is unchanged (recursive mkdir and error handling).

<sup>Written for commit 42e6b9738ff782440af12dd92746ec7d25852421. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

