### PR TITLE
fix(decopilot): send HTTP-Referer to OpenRouter for app attribution

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -327,10 +327,12 @@ async function resolveSecretModelSource(
     modelId,
   });
 
-  // OpenRouter surfaces `X-Title` as the app name in its dashboard/rankings.
-  // Tag it with the org so per-tenant traffic is attributable. `deco` is the
-  // OpenRouter provider behind the deco AI gateway — tag it distinctly so its
-  // traffic is separable from direct-OpenRouter usage.
+  // OpenRouter identifies the app by `HTTP-Referer` (that's what promotes a
+  // request out of the "Unknown" bucket in its dashboard/rankings); `X-Title`
+  // only sets the display name. Both are required — a title without a referer
+  // stays Unknown. Referer is a fixed Studio URL so all traffic rolls up under
+  // one app; `X-Title` carries the org (and distinguishes `deco`, the
+  // OpenRouter provider behind the deco AI gateway, from direct-OpenRouter use).
   if (source.providerId === "openrouter" || source.providerId === "deco") {
     const orgName =
       ctx.organization?.name ?? ctx.organization?.slug ?? organizationId;
@@ -339,6 +341,7 @@ async function resolveSecretModelSource(
       ...source,
       extraHeaders: {
         ...source.extraHeaders,
+        "HTTP-Referer": "https://studio.decocms.com",
         "X-Title": `${appName} - ${orgName}`,
       },
     };


### PR DESCRIPTION
## Summary

Studio's OpenRouter traffic was showing up as **98.9% "Unknown"** in the OpenRouter dashboard even after shipping the `X-Title` header.

Root cause: OpenRouter identifies the calling app by the **`HTTP-Referer`** header — per their docs, *"HTTP-Referer: Identifies your app on openrouter.ai"*. `X-Title` only sets the **display name**. We were sending only `X-Title`, so nothing anchored the requests to a named app and they all fell into "Unknown".

For contrast, the `deco-sites/admin` repo (which *does* get attributed — it shows as `Decopilot - <site>`) sends **both** headers.

## Change

Add a fixed `HTTP-Referer: https://studio.decocms.com` alongside the existing `X-Title` in `resolveSecretModelSource` (`dispatch-run.ts`). Fixed referer → all Studio traffic rolls up under a single **"Studio"** app; `X-Title` still carries the org name (and distinguishes `deco` gateway traffic from direct OpenRouter). No change needed in `provider-from-secret.ts` — it already spreads `extraHeaders` into the `createOpenRouter` `headers` option.

## Testing / affected areas

- Confirmed the header reaches the provider: `createOpenRouter` spreads `options.headers` into its request headers (verified in the installed `@openrouter/ai-sdk-provider@2.9.1` dist).
- Confirmed the `deco`/`openrouter` runtime path hits `openrouter.ai` directly (no gateway stripping the header).
- No existing test asserts the header contract (grepped unit + e2e tiers), so none to invert.
- `bun run fmt` clean.

Note: OpenRouter's dashboard aggregates with delay, so "Unknown" will keep growing briefly after deploy before the named app appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send `HTTP-Referer` with OpenRouter requests so Studio traffic is attributed to a single app instead of "Unknown". `X-Title` remains for the display name with org context.

- **Bug Fixes**
  - Add `HTTP-Referer: https://studio.decocms.com` for `openrouter` and `deco` providers in `resolveSecretModelSource` (`dispatch-run.ts`).
  - Keep `X-Title: <appName> - <org>` to distinguish direct OpenRouter from the `deco` gateway.

<sup>Written for commit 2b97f1e1d7cb4234f10e86f19e112b997b32358f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

