### PR TITLE
fix(chat): translate subtask agent fallback label

### DIFF
--- a/apps/web/src/components/chat/context-panel.tsx
+++ b/apps/web/src/components/chat/context-panel.tsx
@@ -155,7 +155,8 @@ function SubtaskAgentInfo({
   isError: boolean;
 }) {
   const agent = useVirtualMCP(agentId);
-  const agentTitle = agent?.title ?? "Subtask";
+  const t = useT();
+  const agentTitle = agent?.title ?? t("chat.subtask.subtaskNoun");
   const agentIcon = agent?.icon ?? null;
   return (
     <>


### PR DESCRIPTION
## Summary
The SubtaskAgentInfo component in context-panel.tsx used a hardcoded English fallback "Subtask" when rendering an agent that has no title. Now uses the i18n key `chat.subtask.subtaskNoun` so Portuguese users see the localized "Subtarefa" instead.

## Why
Part of a broader audit of chat UI i18n coverage: ensures all user-facing fallback text respects the user's language preference.

## Testing
- `bunx tsc --noEmit` in apps/web: ✓ no type errors
- `bun run fmt`: ✓ no formatting issues
- Behavior unchanged: English output still "Subtask", now properly localized for all languages

## Verification
Run: `git show fix/subtask-agent-fallback-i18n-w3` — diff shows exactly one line changed: fallback value now calls `t()` instead of hardcoding the string.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localize the fallback title in `SubtaskAgentInfo`: use `t('chat.subtask.subtaskNoun')` instead of the hardcoded "Subtask". This shows the correct label in the user's language (e.g., Portuguese "Subtarefa") while keeping English unchanged.

<sup>Written for commit 06d713660fc5e594582e8426219ca6c1e70d5ad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

