### PR TITLE
fix(chat): show latency badge on subtask tool-call rows

### DIFF
--- a/apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx
@@ -24,7 +24,7 @@ import { MessageUsageStats } from "../../../usage-stats.tsx";
 import type { UsageStats as UsageStatsType } from "@/lib/usage-utils.ts";
 import { MessageTextPart } from "../text-part.tsx";
 import { extractTextFromOutput, getToolPartErrorText } from "../utils.ts";
-import { ToolCallShell } from "./common.tsx";
+import { LatencyLabel, ToolCallShell } from "./common.tsx";
 import { getEffectiveState } from "./utils.tsx";
 
 /**
@@ -211,6 +211,7 @@ function SubtaskCard({
   summary,
   state,
   usage,
+  latency,
   onOpenChange,
   onFlip,
   children,
@@ -220,6 +221,8 @@ function SubtaskCard({
   summary?: ReactNode;
   state: "loading" | "error" | "idle";
   usage?: UsageStatsType | null;
+  /** Latency of the tool call, in seconds. */
+  latency?: number;
   /** Notified when the panel opens/closes — lets a caller gate a live tail. */
   onOpenChange?: (open: boolean) => void;
   /** When set and the subtask is still running, show a "run in background"
@@ -275,6 +278,7 @@ function SubtaskCard({
             <div className="flex-1" />
           )}
           <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground/40 opacity-0 transition-opacity [@media(hover:hover)]:group-hover/tool:opacity-100" />
+          <LatencyLabel latency={latency} />
           <MessageUsageStats usage={usage} />
         </button>
         {onFlip && isLoading ? (
@@ -523,6 +527,7 @@ export function SubtaskPartFallback(props: SubtaskPartProps) {
       summary={summary}
       state={state}
       usage={usage}
+      latency={props.latency}
       onFlip={isFlippable(props.part) ? onFlip : undefined}
     >
       <SubtaskResultBody part={props.part} />
@@ -562,6 +567,7 @@ export function SubtaskPart(props: SubtaskPartProps) {
       summary={summary}
       state={state}
       usage={usage}
+      latency={props.latency}
       onFlip={isFlippable(props.part) ? onFlip : undefined}
     >
       <SubtaskResultBody part={props.part} />


### PR DESCRIPTION
**Source:** UI-consistency bug found while reviewing the subtask tool-call component (`apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx`) and its test.

**Why:** `assistant.tsx` already computes and passes a `latency` prop into `SubtaskPartFallback`/`SubtaskPart` (`latency: getMeta(part.toolCallId)?.latencySeconds`), and every sibling tool-call component that accepts this same prop (`web-search.tsx`, `generate-image.tsx`, `agent-create.tsx`, `agent-list.tsx`, `connection-list.tsx`, `brand-context.tsx`, `take-screenshot.tsx`) renders it via the shared `LatencyLabel` badge from `common.tsx`. `subtask.tsx` was the one outlier: it declared `latency` on `SubtaskPartProps` but never read it, so the value was computed on every render and silently dropped — subtask rows never showed how long the call took, unlike every other tool call in the transcript.

**Fix:** thread `latency` through `SubtaskCard` and render it with the same shared `<LatencyLabel />` badge used everywhere else, right before the usage-stats badge (matching the `trailing`-then-`usage` ordering `ToolCallShell` uses for the rest of the tool-call rows). Only the two foreground render paths (`SubtaskPartFallback`, `SubtaskPart`) wire it up; `BackgroundSubtaskCard` is left untouched since its underlying tool-call latency reflects the (fast) flip-to-background call, not the subagent run duration, so showing it there would be misleading.

**Net change:** +7/-1, one file, behavior-preserving elsewhere — `LatencyLabel` already renders `null` when `latency` is unset (as it is for every existing call site that doesn't happen to have a value), so no visual change for any row where latency isn't available.

**To verify:** open a chat with a completed subtask call and confirm a duration badge (e.g. "2.3s") now appears next to the usage stats, matching the badge shown on e.g. a web-search or generate-image tool call.

**Checks run locally:**
- `bun run fmt`
- `cd apps/web && bunx tsc --noEmit` (clean)
- `bun test apps/web/src/components/chat/message/parts/tool-call-part/subtask.test.ts` (15 pass — unaffected, this is a pure UI prop-wiring change with no logic covered by that suite)

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the latency badge on subtask tool-call rows so users can see how long each subtask took, consistent with other tool calls. The `latency` prop is now threaded and rendered via `LatencyLabel` next to usage stats.

- **Bug Fixes**
  - Pass `latency` into `SubtaskCard` and display with `LatencyLabel` before usage stats.
  - Leave background subtasks unchanged to avoid showing misleading durations.
  - No breaking changes; `LatencyLabel` renders nothing when `latency` is missing.

<sup>Written for commit d09a47a538c9a4023b85a390d70d5c3d6a67667e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

