### PR TITLE
fix(decopilot): sanitize org name before use in OpenRouter X-Title header

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.test.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.test.ts
@@ -2,8 +2,25 @@ import { describe, expect, test } from "bun:test";
 import {
   assertSinglePersistedRequestMessage,
   buildDurableDispatchInput,
+  sanitizeHeaderValue,
 } from "./dispatch-run";
 import type { ChatMessage } from "./types";
+
+describe("sanitizeHeaderValue", () => {
+  test("strips CR/LF so an org display name can't break header construction", () => {
+    expect(sanitizeHeaderValue("Acme\r\nX-Injected: evil")).toBe(
+      "Acme  X-Injected: evil",
+    );
+  });
+
+  test("strips other control characters and trims the result", () => {
+    expect(sanitizeHeaderValue("  Acme\tInc\x00  ")).toBe("Acme Inc");
+  });
+
+  test("leaves an ordinary org name untouched", () => {
+    expect(sanitizeHeaderValue("Acme Inc")).toBe("Acme Inc");
+  });
+});
 
 describe("assertSinglePersistedRequestMessage", () => {
   test("returns the persisted user message matching the durable message id", () => {

--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -311,6 +311,14 @@ export function buildHarnessWorkspaceInput(input: {
   };
 }
 
+// Org display names are free-text (ORGANIZATION_UPDATE allows any
+// character up to 255 long) but get spliced into the `X-Title` header sent
+// to OpenRouter. A `\r`/`\n` there breaks header construction outright and
+// other control chars are meaningless in an HTTP header value, so strip them.
+export function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[\0-\x1f\x7f]/g, " ").trim();
+}
+
 async function resolveSecretModelSource(
   ctx: StudioContext,
   organizationId: string,
@@ -334,8 +342,9 @@ async function resolveSecretModelSource(
   // one app; `X-Title` carries the org (and distinguishes `deco`, the
   // OpenRouter provider behind the deco AI gateway, from direct-OpenRouter use).
   if (source.providerId === "openrouter" || source.providerId === "deco") {
-    const orgName =
-      ctx.organization?.name ?? ctx.organization?.slug ?? organizationId;
+    const orgName = sanitizeHeaderValue(
+      ctx.organization?.name ?? ctx.organization?.slug ?? organizationId,
+    );
     const appName = source.providerId === "deco" ? "deco AI Gateway" : "Studio";
     return {
       ...source,


### PR DESCRIPTION
Follows #5376 (HTTP-Referer for OpenRouter attribution) — hardening the sibling `X-Title` header that same code path builds.

`resolveSecretModelSource` builds the OpenRouter `X-Title` header as `${appName} - ${orgName}`, where `orgName` comes straight from `ctx.organization?.name`. That name is free-text: `ORGANIZATION_UPDATE`'s schema is `z.string().min(1).max(255)` with no character restriction, so any org member with update rights (or anyone who pastes a name with a stray control character) can set an org display name containing `\r`/`\n`. Once that name is spliced into the header value, the underlying fetch call throws (`Invalid header value` — CRLF is invalid in an HTTP header), breaking every decopilot OpenRouter call for that org until the name is fixed.

Fix: added a small `sanitizeHeaderValue` helper that strips control characters (`\x00`-`\x1f`, `\x7f`) and trims, and applied it to `orgName` before it's used in the header. This is a pure function with no I/O, so it's directly unit-testable without mocking `StudioContext`.

Failure scenario before the fix: an org named `"Acme\nX-Injected: evil"` (or with any other control character) causes every OpenRouter/`deco` decopilot chat request for that org to fail outright with a header-construction error, since `resolveSecretModelSource` passes the raw name into `extraHeaders["X-Title"]`.

Regression test: `sanitizeHeaderValue` in `dispatch-run.test.ts` covers CRLF stripping, other control characters + trimming, and the happy path (ordinary names pass through unchanged).

Reviewer command: `bun test apps/api/src/api/routes/decopilot/dispatch-run.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), and the targeted test file above (11 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitize organization names before building the OpenRouter `X-Title` header to prevent header-construction errors. This stops decopilot requests from failing when org names include CR/LF or other control characters.

- **Bug Fixes**
  - Added `sanitizeHeaderValue` to strip control characters (`\x00-\x1f`, `\x7f`) and trim.
  - Applied it to `orgName` in `resolveSecretModelSource` when composing `X-Title`.
  - Added unit tests in `dispatch-run.test.ts` for CR/LF, other control chars, and normal names.

<sup>Written for commit fefe3553f5d5307728c3bcb654712c0d897741d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

