### PR TITLE
fix(sandbox): clear the thread's sandboxMap entry on SANDBOX_DELETE

### DIFF
--- a/apps/api/src/tools/sandbox/delete.test.ts
+++ b/apps/api/src/tools/sandbox/delete.test.ts
@@ -95,15 +95,20 @@ function makeCtx(overrides: {
   userId?: string;
   virtualMcp?: ReturnType<typeof makeVirtualMcp> | null;
   updateSpy?: ReturnType<typeof mock>;
+  thread?: { id: string; metadata: Record<string, unknown> } | null;
+  threadUpdateSpy?: ReturnType<typeof mock>;
 }): StudioContext {
   const {
     orgId = "org_1",
     userId = "user-1",
     virtualMcp,
     updateSpy = mock(async () => {}),
+    thread = null,
+    threadUpdateSpy = mock(async () => {}),
   } = overrides;
 
   const findById = mock(async (_id: string) => virtualMcp ?? null);
+  const threadGet = mock(async (_id: string) => thread);
 
   return {
     auth: {
@@ -123,6 +128,7 @@ function makeCtx(overrides: {
     },
     storage: {
       virtualMcps: { findById, update: updateSpy },
+      threads: { get: threadGet, update: threadUpdateSpy },
     } as never,
     timings: {
       measure: async <T>(_name: string, cb: () => Promise<T>) => await cb(),
@@ -362,6 +368,56 @@ describe("SANDBOX_DELETE", () => {
 
     expect(result).toEqual({ success: true });
     expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("also clears the thread's sandboxMap entry for a thread-scoped branch", async () => {
+    const threadBranch = "thread:thread_1";
+    const metadata: Metadata = {
+      sandboxMap: makeSandboxMap(
+        "user-1",
+        threadBranch,
+        "agent-sandbox",
+        HOSTED_ENTRY,
+      ),
+    };
+    const virtualMcp = makeVirtualMcp("org_1", metadata);
+    const updateSpy = mock(async () => {});
+    const threadUpdateSpy = mock(async () => {});
+    const thread = {
+      id: "thread_1",
+      metadata: {
+        sandboxMap: makeSandboxMap(
+          "user-1",
+          threadBranch,
+          "agent-sandbox",
+          HOSTED_ENTRY,
+        ),
+      },
+    };
+    const ctx = makeCtx({ virtualMcp, updateSpy, thread, threadUpdateSpy });
+
+    const result = await SANDBOX_DELETE.handler(
+      {
+        virtualMcpId: "vmcp_1",
+        branch: threadBranch,
+        sandboxProviderKind: "agent-sandbox",
+      },
+      ctx,
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(mockDelete).toHaveBeenCalledWith(HOSTED_ENTRY.sandboxHandle);
+    // Agent-row entry cleared.
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    // Thread's own copy cleared too — this is what the UI overlays on top of
+    // the agent's sandboxMap, so leaving it stale kept showing the deleted
+    // sandbox's previewUrl/handle.
+    expect(threadUpdateSpy).toHaveBeenCalledTimes(1);
+    const threadUpdateCall = (threadUpdateSpy.mock.calls as unknown[][])[0]!;
+    const threadUpdated = (
+      threadUpdateCall[1] as { metadata: { sandboxMap: SandboxMap } }
+    ).metadata;
+    expect(threadUpdated.sandboxMap["user-1"]).toBeUndefined();
   });
 
   it("throws 'User ID required' when userId is unavailable", async () => {

--- a/apps/api/src/tools/sandbox/delete.ts
+++ b/apps/api/src/tools/sandbox/delete.ts
@@ -9,6 +9,7 @@ import { normalizeSandboxProviderKind } from "@decocms/sandbox/provider";
 import { defineTool } from "../../core/define-tool";
 import { requireVmEntry } from "./helpers";
 import { removeSandboxMapEntry } from "./sandbox-map";
+import { removeThreadSandboxMapEntry, threadIdFromBranch } from "./thread-repo";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 
 const sandboxProviderKindInputSchema = z.enum([
@@ -86,6 +87,23 @@ export const SANDBOX_DELETE = defineTool({
       input.branch,
       kind,
     );
+    // Thread-scoped branches (`thread:<id>[/<conn>]`) ALSO get the record
+    // persisted on the THREAD by every provisioning path — the agent-row write
+    // above is a no-op for the synthetic Decopilot agent, and the frontend
+    // overlays the thread's sandboxMap on top of the agent's (see
+    // `setThreadSandboxMapEntry`). Without this, deleting a thread-scoped
+    // sandbox left the thread's copy stale, so the UI kept showing the
+    // torn-down handle/previewUrl for that thread.
+    const threadId = threadIdFromBranch(input.branch);
+    if (threadId) {
+      await removeThreadSandboxMapEntry(
+        ctx,
+        threadId,
+        sandboxUserId,
+        input.branch,
+        kind,
+      );
+    }
 
     await runner
       .delete(entry.sandboxHandle)


### PR DESCRIPTION
Bug found while auditing `apps/api/src/tools/sandbox/` (start.ts, thread-repo.ts, delete.ts) for lifecycle consistency.

A thread-scoped sandbox branch (`thread:<id>[/<conn>]`) persists its sandbox record on the THREAD's own metadata, not just the owning agent's — every provisioning path in `provisionSandbox` (start.ts) calls `setThreadSandboxMapEntry` in addition to the agent-row write, because the agent write is a no-op for the synthetic Decopilot agent. The frontend (`overlayThreadSandboxMap` in `apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx`) overlays the thread's copy on top of the agent's when rendering the preview panel — it's the only place the previewUrl/handle come from for these sandboxes.

`SANDBOX_DELETE` only ever called `removeSandboxMapEntry` (the agent-row entry). It never cleared the thread's own copy, so deleting a thread-scoped sandbox left a dangling `sandboxHandle`/`previewUrl` in `threads.metadata.sandboxMap` pointing at an already-torn-down sandbox — the UI kept showing it as still present for that thread. The codebase's own self-heal path (`sandbox-events-handler.ts`'s `cleanupStaleEntry`, added for the same reason: "A dangling sandboxHandle left in thread metadata makes every client SSE reconnect re-enter this stale path") already clears the thread copy for stale-handle recovery — this fix applies the same cleanup to the explicit user-driven delete path, which was missing it.

Failure scenario: open a thread whose sandbox auto-started (thread-scoped branch), call `SANDBOX_DELETE`, then reopen the same thread — the panel still shows the deleted sandbox's previewUrl/handle because `threads.metadata.sandboxMap` was never updated.

Fix: after clearing the agent-row entry, also call `removeThreadSandboxMapEntry` when the branch is thread-scoped (`threadIdFromBranch(branch)` is non-null).

Regression test added in `delete.test.ts`: asserts that deleting a thread-scoped branch clears both the agent's `virtualMcps` row and the thread's `threads.metadata.sandboxMap` copy.

Reviewer check: `bun test apps/api/src/tools/sandbox/delete.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale sandbox UI after deleting a thread-scoped sandbox. `SANDBOX_DELETE` now also clears the thread’s `metadata.sandboxMap`, so the preview no longer appears after deletion.

- **Bug Fixes**
  - In `apps/api/src/tools/sandbox/delete.ts`, call `removeThreadSandboxMapEntry` when `threadIdFromBranch` detects a `thread:<id>[/<conn>]` branch, in addition to clearing the agent entry.
  - Added a regression test in `apps/api/src/tools/sandbox/delete.test.ts` to assert both the agent `virtualMcps` row and the thread `metadata.sandboxMap` are cleared.

<sup>Written for commit ab1632365e787bdc148ef4891ef58a347d8f47c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

