### PR TITLE
feat(library): open on the org home folder, system folders inside it

### DIFF
--- a/apps/api/src/api/routes/org-fs.ts
+++ b/apps/api/src/api/routes/org-fs.ts
@@ -455,9 +455,11 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
     }
   });
 
-  // Path search (case-insensitive substring) across every volume, newest
-  // first — the Library's search box. Volume-less by design, so it lives
-  // above the `/:volume/*` routes.
+  // Path search (case-insensitive substring), newest first — the Library's
+  // search box. Cross-volume by default; `volume` (+ optional `prefix`) narrows
+  // it to one volume and directory subtree, which is what the Library does while
+  // you're browsing inside a folder. Volume-less by design (the volume is a
+  // query param, not a path segment), so it lives above the `/:volume/*` routes.
   app.get("/search", async (c) => {
     const ctx = c.get("studioContext");
     if (!ctx.auth?.user?.id) {
@@ -477,6 +479,11 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       Math.max(Number(c.req.query("limit")) || DEFAULT_RECENT_LIMIT, 1),
       MAX_RECENT_LIMIT,
     );
+    const scopeVolume = c.req.query("volume") || null;
+    if (scopeVolume !== null && !isValidVolume(scopeVolume)) {
+      return c.json({ error: "Invalid volume name" }, 400);
+    }
+    const prefix = c.req.query("prefix") || undefined;
     try {
       // Two manifests: the org's own volumes plus the deployment's shared
       // public sets (pseudo-org, gated to the configured set volumes like
@@ -485,13 +492,27 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       const publicVolumes = getPublicSets().map((s) =>
         publicVolumeForSet(s.set),
       );
+      // A `public-<set>` volume lives in the shared pseudo-org, every other
+      // volume in the org's own — so a scoped search hits exactly one manifest,
+      // and scoping to an unconfigured `public-*` volume hits neither.
+      const scopedPublic = scopeVolume !== null && isPublicVolume(scopeVolume);
+      const ownVolumes = scopeVolume === null ? undefined : [scopeVolume];
+      const pubVolumes =
+        scopeVolume === null
+          ? publicVolumes
+          : scopedPublic && publicVolumes.includes(scopeVolume)
+            ? [scopeVolume]
+            : [];
       const [own, pub] = await Promise.all([
-        ctx.orgFs.searchWithEffectivePublic(q, limit),
-        publicVolumes.length > 0
+        scopedPublic
+          ? []
+          : ctx.orgFs.searchWithEffectivePublic(q, limit, ownVolumes, prefix),
+        pubVolumes.length > 0
           ? buildPublicOrgFs(ctx).searchWithEffectivePublic(
               q,
               limit,
-              publicVolumes,
+              pubVolumes,
+              prefix,
             )
           : [],
       ]);

--- a/apps/api/src/file-storage/org-fs.integration.test.ts
+++ b/apps/api/src/file-storage/org-fs.integration.test.ts
@@ -164,6 +164,35 @@ describe("OrgFs service (integration)", () => {
     expect(await fs.searchWithEffectivePublic("sales", 10, [])).toEqual([]);
   });
 
+  it("searchWithEffectivePublic narrows to a directory subtree", async () => {
+    await fs.write("skills", "reports/Q1-Sales.md", "1", { actor: ACTOR });
+    await fs.write("skills", "reports/deep/Q2-Sales.md", "2", { actor: ACTOR });
+    await fs.write("skills", "reports-archive/Q0-Sales.md", "3", {
+      actor: ACTOR,
+    });
+    await fs.write("skills", "sales-loose.md", "4", { actor: ACTOR });
+
+    // Recursive under the dir; siblings and same-prefix dir names excluded.
+    expect(
+      (await fs.searchWithEffectivePublic("sales", 10, undefined, "reports"))
+        .map((e) => e.path)
+        .toSorted(),
+    ).toEqual(["reports/Q1-Sales.md", "reports/deep/Q2-Sales.md"]);
+
+    // A prefix must be a whole path segment, and LIKE metacharacters are literal.
+    expect(
+      await fs.searchWithEffectivePublic("sales", 10, undefined, "report"),
+    ).toEqual([]);
+    expect(
+      await fs.searchWithEffectivePublic("sales", 10, undefined, "_"),
+    ).toEqual([]);
+
+    // Prefix composes with volume narrowing.
+    expect(
+      await fs.searchWithEffectivePublic("sales", 10, ["outputs"], "reports"),
+    ).toEqual([]);
+  });
+
   it("filesExist batch-probes live files only", async () => {
     await fs.write("skills", "seo/SKILL.md", "skill", { actor: ACTOR });
     await fs.mkdir("skills", "plain", { actor: ACTOR });

--- a/apps/api/src/file-storage/org-fs.ts
+++ b/apps/api/src/file-storage/org-fs.ts
@@ -287,12 +287,14 @@ export class OrgFs {
    * Path search (case-insensitive substring) with `effectivePublic` per
    * entry — the Library's search box. Searches every volume unless
    * `volumes` narrows it (the public-sets pseudo-org passes its configured
-   * set volumes).
+   * set volumes), and the whole volume unless `pathPrefix` narrows it to one
+   * directory subtree (the Library scopes search to the folder you're in).
    */
   async searchWithEffectivePublic(
     query: string,
     limit: number,
     volumes?: string[],
+    pathPrefix?: string,
   ): Promise<Array<OrgFsEntry & { effectivePublic: boolean }>> {
     return this.withEffectivePublic(
       await this.manifest.searchFiles({
@@ -300,6 +302,7 @@ export class OrgFs {
         query,
         limit,
         volumes,
+        pathPrefix: pathPrefix ? normalizeFsPath(pathPrefix) : undefined,
       }),
     );
   }

--- a/apps/api/src/storage/org-fs.ts
+++ b/apps/api/src/storage/org-fs.ts
@@ -575,6 +575,9 @@ export class OrgFsEntryStorage {
     limit: number;
     /** Restrict to these volumes (unset = all of the org's volumes). */
     volumes?: string[];
+    /** Restrict to entries under this directory, recursively (unset = the
+     *  whole volume). Normalized, no trailing slash. */
+    pathPrefix?: string;
   }): Promise<OrgFsEntry[]> {
     if (params.volumes && params.volumes.length === 0) return [];
     // Escape LIKE metacharacters so the query is a literal substring.
@@ -586,6 +589,9 @@ export class OrgFsEntryStorage {
       .where("deleted_at", "is", null)
       .where("path", "ilike", `%${escaped}%`);
     if (params.volumes) qb = qb.where("volume", "in", params.volumes);
+    if (params.pathPrefix) {
+      qb = qb.where("path", "like", `${escapeLike(params.pathPrefix)}/%`);
+    }
     const rows = await qb
       .select(COLUMNS)
       .orderBy("seq", "desc")

--- a/apps/docs/client/src/content/deco-studio/en/studio/library.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/library.mdx
@@ -8,22 +8,31 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## What is the Library?
 
-**Library** is a file browser for your organization's shared filesystem — reachable from the top of the left sidebar. It's the human-facing window onto the same files your agents read and write: anything an agent saves to the org filesystem shows up here, and anything you drop here is available to your agents.
+**Library** is a file browser for your organization's shared filesystem — reachable from the **Library** tab at the top of the main panel. It's the human-facing window onto the same files your agents read and write: anything an agent saves to the org filesystem shows up here, and anything you drop here is available to your agents.
 
 Think of it as your organization's shared drive, with a few well-known areas.
 
-## Volumes
+## Your home folder
 
-The Library is organized into volumes:
+The Library opens on your organization's own folder, named after your org. It's shared and free-form: this is where agents record durable knowledge and where you keep context you want every agent to be able to reach. Everyone in the org can edit it.
 
-- **Home** — the org's shared, free-form home folder. This is where agents record durable knowledge and where you keep context you want every agent to be able to reach. Editable by everyone.
-- **Uploads** — files attached to conversations land here automatically. When you drop a file into a chat, it's available to the agent without a copy step.
-- **Outputs** — the shared output folder for agent runs. Files an agent produces during a run surface here.
-- **Public sets** — curated, read-only skill sets synced from versioned repositories, exposed for agents to reference.
+### System folders
 
-A **Recently added** feed across all volumes sits at the top so you can jump back to whatever you (or your agents) touched last. Navigate with breadcrumbs; the current location is reflected in the page URL, so you can link a teammate straight to a folder.
+Three folders inside it are filled by the product rather than by hand. They carry a distinct grey folder icon so they're easy to tell apart from folders your team made:
 
-You can drag and drop files directly into any editable volume to upload them.
+- **uploads** — files attached to conversations land here automatically. When you drop a file into a chat, it's available to the agent without a copy step. Files uploaded from the Library's landing view also go here.
+- **outputs** — files an agent produces during a run surface here, grouped by run.
+- **skills** — curated, read-only skill sets synced from versioned repositories, exposed for agents to reference. Read-only: they're updated from their GitHub source, not edited here.
+
+They're mounted as separate volumes under the hood (see the mount table below), but you browse them as part of one tree.
+
+### Navigating
+
+Navigate with breadcrumbs — the trail always starts at your org's folder and is the only place the current folder is named. The current location is reflected in the page URL, so you can link a teammate straight to a folder.
+
+The search box follows you: at the landing view it searches every file in the org, and inside a folder it searches only that folder and everything under it (the placeholder tells you which). A **Recently added** feed across all volumes sits at the bottom of the landing view so you can jump back to whatever you (or your agents) touched last.
+
+You can drag and drop files directly into any editable folder to upload them.
 
 ## Brands
 
@@ -75,16 +84,16 @@ A badge on the card reflects the current share mode. For password-protected node
 
 ## How it maps to the sandbox
 
-The Library and the agent sandbox are two views of the same filesystem. Inside a sandbox these volumes are mounted under `org/`:
+The Library and the agent sandbox are two views of the same filesystem. The Library names your home folder after your org and nests the system folders inside it, but the paths agents use never change — they're mounted under `org/`:
 
-| Library volume | Sandbox path |
+| Library folder | Sandbox path |
 |---|---|
-| Home | `org/home/` |
-| Uploads | `org/upload` |
-| Outputs | `org/output` |
-| Public sets | `org/public/<set>` |
+| `<your-org>` (home) | `org/home/` |
+| `<your-org>/uploads` | `org/upload` |
+| `<your-org>/outputs` | `org/output` |
+| `<your-org>/skills/<set>` | `org/public/<set>` |
 
-Files written to the Home folder and to Outputs sync to your organization's cloud storage and are visible to every member and agent. External changes appear inside a running sandbox within about a second.
+Files written to your home folder and to outputs sync to your organization's cloud storage and are visible to every member and agent. External changes appear inside a running sandbox within about a second.
 
 <Callout type="info">
   For how agents use these folders at runtime — recording durable knowledge, reading chat attachments, writing run output — see [Decopilot → Overview](/en/studio/decopilot/overview#built-in-tools).

--- a/apps/docs/client/src/content/deco-studio/en/studio/library.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/library.mdx
@@ -20,7 +20,7 @@ The Library opens on your organization's own folder, named after your org. It's 
 
 Three folders inside it are filled by the product rather than by hand. They carry a distinct grey folder icon so they're easy to tell apart from folders your team made:
 
-- **uploads** — files attached to conversations land here automatically. When you drop a file into a chat, it's available to the agent without a copy step. Files uploaded from the Library's landing view also go here.
+- **uploads** — files attached to conversations land here automatically. When you drop a file into a chat, it's available to the agent without a copy step.
 - **outputs** — files an agent produces during a run surface here, grouped by run.
 - **skills** — curated, read-only skill sets synced from versioned repositories, exposed for agents to reference. Read-only: they're updated from their GitHub source, not edited here.
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/library.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/library.mdx
@@ -20,7 +20,7 @@ A Library abre na pasta da sua própria organização, com o nome da sua org. El
 
 Três pastas dentro dela são preenchidas pelo produto, não à mão. Elas têm um ícone de pasta cinza distinto, fácil de diferenciar das pastas que seu time criou:
 
-- **uploads** — arquivos anexados a conversas caem aqui automaticamente. Quando você solta um arquivo num chat, ele fica disponível para o agent sem nenhum passo de cópia. Arquivos enviados a partir da tela inicial da Library também vão para cá.
+- **uploads** — arquivos anexados a conversas caem aqui automaticamente. Quando você solta um arquivo num chat, ele fica disponível para o agent sem nenhum passo de cópia.
 - **outputs** — arquivos que um agent produz durante uma execução aparecem aqui, agrupados por execução.
 - **skills** — conjuntos de skills curados e somente leitura, sincronizados a partir de repositórios versionados, expostos para os agents consultarem. Somente leitura: eles são atualizados a partir da fonte no GitHub, não editados aqui.
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/library.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/library.mdx
@@ -8,22 +8,31 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## O que é a Library?
 
-A **Library** é um navegador de arquivos para o filesystem compartilhado da sua organização — acessível pelo topo da sidebar esquerda. É a janela voltada para pessoas sobre os mesmos arquivos que seus agents leem e escrevem: tudo o que um agent salva no filesystem da org aparece aqui, e tudo o que você solta aqui fica disponível para seus agents.
+A **Library** é um navegador de arquivos para o filesystem compartilhado da sua organização — acessível pela aba **Library** no topo do painel principal. É a janela voltada para pessoas sobre os mesmos arquivos que seus agents leem e escrevem: tudo o que um agent salva no filesystem da org aparece aqui, e tudo o que você solta aqui fica disponível para seus agents.
 
 Pense nela como o drive compartilhado da sua organização, com algumas áreas bem conhecidas.
 
-## Volumes
+## Sua pasta home
 
-A Library é organizada em volumes:
+A Library abre na pasta da sua própria organização, com o nome da sua org. Ela é compartilhada e de formato livre: é aqui que os agents registram conhecimento durável e onde você guarda o contexto que quer deixar ao alcance de todos os agents. Todo mundo na org pode editar.
 
-- **Home** — a pasta home compartilhada e de formato livre da org. É aqui que os agents registram conhecimento durável e onde você guarda o contexto que quer deixar ao alcance de todos os agents. Editável por todo mundo.
-- **Uploads** — arquivos anexados a conversas caem aqui automaticamente. Quando você solta um arquivo num chat, ele fica disponível para o agent sem nenhum passo de cópia.
-- **Outputs** — a pasta de output compartilhada das execuções de agents. Arquivos que um agent produz durante uma execução aparecem aqui.
-- **Public sets** — public sets de skills curados e somente leitura, sincronizados a partir de repositórios versionados, expostos para os agents consultarem.
+### Pastas de sistema
 
-Um feed de **Recently added** que cruza todos os volumes fica no topo, para você voltar rapidamente a qualquer coisa que você (ou seus agents) tocou por último. Navegue pelos breadcrumbs; a localização atual é refletida na URL da página, então você pode mandar para um colega o link direto de uma pasta.
+Três pastas dentro dela são preenchidas pelo produto, não à mão. Elas têm um ícone de pasta cinza distinto, fácil de diferenciar das pastas que seu time criou:
 
-Você pode arrastar e soltar arquivos diretamente em qualquer volume editável para fazer upload.
+- **uploads** — arquivos anexados a conversas caem aqui automaticamente. Quando você solta um arquivo num chat, ele fica disponível para o agent sem nenhum passo de cópia. Arquivos enviados a partir da tela inicial da Library também vão para cá.
+- **outputs** — arquivos que um agent produz durante uma execução aparecem aqui, agrupados por execução.
+- **skills** — conjuntos de skills curados e somente leitura, sincronizados a partir de repositórios versionados, expostos para os agents consultarem. Somente leitura: eles são atualizados a partir da fonte no GitHub, não editados aqui.
+
+Por baixo dos panos são volumes separados (veja a tabela de mounts abaixo), mas você navega por eles como uma única árvore.
+
+### Navegação
+
+Navegue pelos breadcrumbs — a trilha sempre começa na pasta da sua org e é o único lugar em que a pasta atual é nomeada. A localização atual é refletida na URL da página, então você pode mandar para um colega o link direto de uma pasta.
+
+A busca acompanha você: na tela inicial ela busca todos os arquivos da org, e dentro de uma pasta ela busca só aquela pasta e tudo abaixo dela (o placeholder diz qual dos dois). Um feed de **Recently added** que cruza todos os volumes fica no final da tela inicial, para você voltar rapidamente a qualquer coisa que você (ou seus agents) tocou por último.
+
+Você pode arrastar e soltar arquivos diretamente em qualquer pasta editável para fazer upload.
 
 ## Brands
 
@@ -75,16 +84,16 @@ Um badge no card reflete o modo de compartilhamento atual. Para nós protegidos 
 
 ## Como ela mapeia para o sandbox
 
-A Library e o sandbox do agent são duas visões do mesmo filesystem. Dentro de um sandbox, esses volumes são montados em `org/`:
+A Library e o sandbox do agent são duas visões do mesmo filesystem. A Library nomeia sua pasta home com o nome da sua org e aninha as pastas de sistema dentro dela, mas os caminhos que os agents usam nunca mudam — eles são montados em `org/`:
 
-| Volume da Library | Caminho no sandbox |
+| Pasta na Library | Caminho no sandbox |
 |---|---|
-| Home | `org/home/` |
-| Uploads | `org/upload` |
-| Outputs | `org/output` |
-| Public sets | `org/public/<set>` |
+| `<sua-org>` (home) | `org/home/` |
+| `<sua-org>/uploads` | `org/upload` |
+| `<sua-org>/outputs` | `org/output` |
+| `<sua-org>/skills/<set>` | `org/public/<set>` |
 
-Arquivos escritos na pasta Home e em Outputs sincronizam com o cloud storage da sua organização e ficam visíveis para todos os membros e agents. Mudanças externas aparecem dentro de um sandbox em execução em cerca de um segundo.
+Arquivos escritos na sua pasta home e em outputs sincronizam com o cloud storage da sua organização e ficam visíveis para todos os membros e agents. Mudanças externas aparecem dentro de um sandbox em execução em cerca de um segundo.
 
 <Callout type="info">
   Para entender como os agents usam essas pastas em runtime — registrando conhecimento durável, lendo anexos de chat, escrevendo o output de uma execução — veja [Decopilot → Visão geral](/pt-br/studio/decopilot/overview#built-in-tools).

--- a/apps/web/src/components/folder-icon.tsx
+++ b/apps/web/src/components/folder-icon.tsx
@@ -10,20 +10,48 @@
  * like skills/outputs. `readOnly` adds a small view-only badge on the
  * corner — an eye (the Drive convention), not a lock: read-only sets are
  * public, a padlock would misread as "private".
+ *
+ * `tone` picks the palette: Finder blue for folders people make, graphite for
+ * the system folders the product fills (uploads/outputs/skills), so "nobody
+ * made this by hand" reads at a glance.
  */
 
 import { useId } from "react";
 import type { ComponentType, SVGProps } from "react";
 import { Eye } from "@untitledui/icons";
 
+const TONES = {
+  default: {
+    backFrom: "#4D87DF",
+    backTo: "#296FE8",
+    frontFrom: "#72B6FA",
+    frontTo: "#5BB1EF",
+    stripe: "#84CDFB",
+    glyph: "#014AC9",
+  },
+  system: {
+    backFrom: "#8A94A6",
+    backTo: "#6B7687",
+    frontFrom: "#B6BEC9",
+    frontTo: "#A3ADBA",
+    stripe: "#D5DBE3",
+    glyph: "#3D4757",
+  },
+} as const;
+
+export type FolderTone = keyof typeof TONES;
+
 export function FolderIcon({
   glyph: Glyph,
   readOnly,
+  tone = "default",
   ...props
 }: {
   glyph?: ComponentType<SVGProps<SVGSVGElement>>;
   readOnly?: boolean;
+  tone?: FolderTone;
 } & SVGProps<SVGSVGElement>) {
+  const colors = TONES[tone];
   // Gradient ids must be unique per instance — folder cards render many of
   // these on one page and a hidden duplicate id can break url() references.
   const id = useId();
@@ -62,8 +90,8 @@ export function FolderIcon({
         opacity="0.25"
       />
       {/* bottom stripes */}
-      <rect y="25.81" width="32" height="0.552" fill="#84CDFB" />
-      <rect y="27.05" width="32" height="0.552" fill="#84CDFB" />
+      <rect y="25.81" width="32" height="0.552" fill={colors.stripe} />
+      <rect y="27.05" width="32" height="0.552" fill={colors.stripe} />
       {/* well-known-folder glyph, embossed on the body (design's glyph blue) */}
       {Glyph && (
         <Glyph
@@ -72,7 +100,7 @@ export function FolderIcon({
           width={11}
           height={11}
           strokeWidth={2.2}
-          style={{ color: "#014AC9", opacity: 0.55 }}
+          style={{ color: colors.glyph, opacity: 0.55 }}
         />
       )}
       {/* read-only corner badge — eye = view-only (Drive convention) */}
@@ -104,8 +132,8 @@ export function FolderIcon({
           y2="9.53"
           gradientUnits="userSpaceOnUse"
         >
-          <stop offset="0.3" stopColor="#4D87DF" />
-          <stop offset="1" stopColor="#296FE8" />
+          <stop offset="0.3" stopColor={colors.backFrom} />
+          <stop offset="1" stopColor={colors.backTo} />
         </linearGradient>
         <radialGradient
           id={frontId}
@@ -115,8 +143,8 @@ export function FolderIcon({
           gradientUnits="userSpaceOnUse"
           gradientTransform="matrix(1.6 0 0 2.1538 16 19.22)"
         >
-          <stop stopColor="#72B6FA" />
-          <stop offset="1" stopColor="#5BB1EF" />
+          <stop stopColor={colors.frontFrom} />
+          <stop offset="1" stopColor={colors.frontTo} />
         </radialGradient>
       </defs>
     </svg>

--- a/apps/web/src/hooks/use-org-fs.ts
+++ b/apps/web/src/hooks/use-org-fs.ts
@@ -167,15 +167,31 @@ export function useOrgFsRecent(limit = 60, opts?: { enabled?: boolean }) {
   });
 }
 
+const SEARCH_LIMIT = 50;
+
+/** Narrow a search to one volume and (optionally) one directory subtree. */
+export interface OrgFsSearchScope {
+  volume: string;
+  /** In-volume directory to search under ("" = the whole volume). */
+  prefix: string;
+}
+
 /**
- * Path search (case-insensitive substring) across every volume, newest
- * first — the Library's search box. Only runs for non-empty queries;
- * previous results stay on screen while a new query loads.
+ * Path search (case-insensitive substring), newest first — the Library's search
+ * box. Cross-volume by default; `scope` narrows it to one volume + directory
+ * subtree, which is what the Library does while you're inside a folder. Only
+ * runs for non-empty queries; previous results stay on screen while a new
+ * query loads.
  */
-export function useOrgFsSearch(query: string, limit = 50) {
+export function useOrgFsSearch(query: string, scope?: OrgFsSearchScope) {
   const { org } = useProjectContext();
   return useQuery({
-    queryKey: KEYS.orgFsSearch(org.id, query),
+    queryKey: KEYS.orgFsSearch(
+      org.id,
+      query,
+      scope?.volume ?? "",
+      scope?.prefix ?? "",
+    ),
     enabled: query.length > 0,
     // Keep previous results on screen between keystrokes, but only within
     // the same org — switching orgs doesn't remount this hook, so without
@@ -183,8 +199,16 @@ export function useOrgFsSearch(query: string, limit = 50) {
     placeholderData: (previousData, previousQuery) =>
       previousQuery?.queryKey[1] === org.id ? previousData : undefined,
     queryFn: async () => {
+      const params = new URLSearchParams({
+        q: query,
+        limit: String(SEARCH_LIMIT),
+      });
+      if (scope) {
+        params.set("volume", scope.volume);
+        if (scope.prefix) params.set("prefix", scope.prefix);
+      }
       const res = await fsFetch(
-        `/api/${encodeURIComponent(org.slug)}/fs/search?q=${encodeURIComponent(query)}&limit=${limit}`,
+        `/api/${encodeURIComponent(org.slug)}/fs/search?${params}`,
       );
       return ((await res.json()) as { entries: OrgFsRecentEntry[] }).entries;
     },

--- a/apps/web/src/i18n/en/library.ts
+++ b/apps/web/src/i18n/en/library.ts
@@ -111,9 +111,9 @@ export const library = {
   "library.library.newFolderTitle": "New folder",
   "library.library.readOnly": "Read-only",
   "library.library.refresh": "Refresh",
+  "library.library.searchInPlaceholder": "Search files in {folder}…",
   "library.library.searchPlaceholder": "Search all files…",
   "library.library.theLibrary": "the library",
-  "library.library.title": "Library",
   "library.library.uploadFailed": "Upload failed",
   "library.library.uploadFile": "Upload file",
   "library.library.uploadedMultiple": "Uploaded {count} files",
@@ -130,10 +130,7 @@ export const library = {
   "library.libraryViews.files": "Files",
   "library.libraryViews.filesCount": "{count} files",
   "library.libraryViews.folders": "Folders",
-  "library.libraryViews.library": "Library",
   "library.libraryViews.noFilesMatch": 'No files match "{query}".',
-  "library.libraryViews.noFilesYet":
-    "No files yet — upload one, or ask an agent to produce something.",
   "library.libraryViews.noPublicSkillSetsConfigured":
     "No public skill sets are configured.",
   "library.libraryViews.readOnly": "Read-only",
@@ -141,11 +138,10 @@ export const library = {
   "library.libraryViews.searchResults": "{count} result(s)",
   "library.libraryViews.skillSetsCount": "{count} sets",
   "library.libraryViews.skills": "Skills",
-  "library.libraryViews.volumeHomeDescription":
-    "Your organization's home folder",
   "library.libraryViews.volumeOutputsDescription": "Agent run outputs",
   "library.libraryViews.volumeUploadsDescription": "Files your team uploads",
   "library.previewContent.close": "Close",
+  "library.seeInLibrary.label": "See in library",
   "library.previewContent.download": "Download",
   "library.previewContent.fileNotAvailable":
     "This file is no longer available.",

--- a/apps/web/src/i18n/en/library.ts
+++ b/apps/web/src/i18n/en/library.ts
@@ -106,6 +106,8 @@ export const library = {
   "library.library.folderCreateFailed": "Failed to create folder",
   "library.library.folderCreated": 'Folder "{name}" created',
   "library.library.folderNamePlaceholder": "folder-name",
+  "library.library.folderNameReserved":
+    '"{name}" is a system folder here — pick another name.',
   "library.library.newFolder": "New folder",
   "library.library.newFolderDescription": "Create a folder in {path}.",
   "library.library.newFolderTitle": "New folder",

--- a/apps/web/src/i18n/pt-br/library.ts
+++ b/apps/web/src/i18n/pt-br/library.ts
@@ -117,9 +117,9 @@ export const library = {
   "library.library.newFolderTitle": "Nova pasta",
   "library.library.readOnly": "Apenas leitura",
   "library.library.refresh": "Atualizar",
+  "library.library.searchInPlaceholder": "Pesquisar arquivos em {folder}…",
   "library.library.searchPlaceholder": "Pesquisar todos os arquivos…",
   "library.library.theLibrary": "a biblioteca",
-  "library.library.title": "Biblioteca",
   "library.library.uploadFailed": "Falha ao enviar",
   "library.library.uploadFile": "Enviar arquivo",
   "library.library.uploadedMultiple": "Enviados {count} arquivos",
@@ -136,11 +136,8 @@ export const library = {
   "library.libraryViews.files": "Arquivos",
   "library.libraryViews.filesCount": "{count} arquivo(s)",
   "library.libraryViews.folders": "Pastas",
-  "library.libraryViews.library": "Biblioteca",
   "library.libraryViews.noFilesMatch":
     'Nenhum arquivo corresponde a "{query}".',
-  "library.libraryViews.noFilesYet":
-    "Nenhum arquivo ainda — envie um ou peça a um agente para produzir algo.",
   "library.libraryViews.noPublicSkillSetsConfigured":
     "Nenhum conjunto de skills público configurado.",
   "library.libraryViews.readOnly": "Somente leitura",
@@ -148,13 +145,12 @@ export const library = {
   "library.libraryViews.searchResults": "{count} resultado(s)",
   "library.libraryViews.skillSetsCount": "{count} conjunto(s)",
   "library.libraryViews.skills": "Skills",
-  "library.libraryViews.volumeHomeDescription":
-    "Pasta inicial da sua organização",
   "library.libraryViews.volumeOutputsDescription":
     "Saídas de execução de agentes",
   "library.libraryViews.volumeUploadsDescription":
     "Arquivos que seu time envia",
   "library.previewContent.close": "Fechar",
+  "library.seeInLibrary.label": "Ver na biblioteca",
   "library.previewContent.download": "Baixar",
   "library.previewContent.fileNotAvailable":
     "Este arquivo não está mais disponível.",

--- a/apps/web/src/i18n/pt-br/library.ts
+++ b/apps/web/src/i18n/pt-br/library.ts
@@ -112,6 +112,8 @@ export const library = {
   "library.library.folderCreateFailed": "Falha ao criar pasta",
   "library.library.folderCreated": 'Pasta "{name}" criada',
   "library.library.folderNamePlaceholder": "nome-da-pasta",
+  "library.library.folderNameReserved":
+    '"{name}" é uma pasta do sistema aqui — escolha outro nome.',
   "library.library.newFolder": "Nova pasta",
   "library.library.newFolderDescription": "Criar uma pasta em {path}.",
   "library.library.newFolderTitle": "Nova pasta",

--- a/apps/web/src/layouts/library/cards.tsx
+++ b/apps/web/src/layouts/library/cards.tsx
@@ -32,7 +32,7 @@ import {
 } from "@deco/ui/components/dropdown-menu.tsx";
 import { useT, type TFunction } from "@/i18n/use-t.ts";
 import { describeFileType, FileTypeIcon } from "@/components/file-type-icon";
-import { FolderIcon } from "@/components/folder-icon";
+import { FolderIcon, type FolderTone } from "@/components/folder-icon";
 import { KEYS } from "@/lib/query-keys";
 import { parseBrandTokens } from "./brand";
 import { parseSkillMd } from "./skill";
@@ -339,6 +339,7 @@ export function FolderCard({
   meta,
   subtitle,
   glyph,
+  tone,
   readOnly,
   publicState,
   onOpen,
@@ -354,6 +355,8 @@ export function FolderCard({
   subtitle?: string;
   /** Well-known-folder mark rendered on the folder body (skills/outputs/…). */
   glyph?: ComponentType<SVGProps<SVGSVGElement>>;
+  /** Folder palette — graphite for the system folders the product fills. */
+  tone?: FolderTone;
   /** View-only corner badge (public sets). */
   readOnly?: boolean;
   /** Public badge state (own = published here, inherited = via a parent). */
@@ -379,6 +382,7 @@ export function FolderCard({
         icon={
           <FolderIcon
             glyph={glyph}
+            tone={tone}
             readOnly={readOnly}
             className="size-8 shrink-0"
           />

--- a/apps/web/src/layouts/library/index.tsx
+++ b/apps/web/src/layouts/library/index.tsx
@@ -67,6 +67,7 @@ import {
   type PendingDelete,
   PublicSetsView,
   SearchResultsView,
+  SYSTEM_FOLDER_NAMES,
   VolumeView,
 } from "./library-views";
 
@@ -169,29 +170,22 @@ export function LibraryPage({
   // Depth counter so dragenter/leave bubbling from child cards doesn't flicker.
   const dragDepth = useRef(0);
 
-  // Uploads made from the landing view land in the uploads volume root —
-  // visible org-wide, outside any thread folder (those belong to
-  // chat-attachment flows). Inside any other folder they land in that folder.
-  const uploadVolume = location.readOnly
-    ? null
-    : location.isHomeRoot
-      ? "uploads"
-      : (location.volume ?? "uploads");
-  const uploadDir = location.isHomeRoot ? "" : location.dirPath;
-  const { upload } = useOrgFsMutations(uploadVolume ?? "uploads");
-  // New folders and drag-moves act on the folder being browsed — which at the
-  // landing view is the home volume, NOT the uploads volume that receives
-  // uploads. Read-only locations (public sets) allow neither.
+  // Every writer — upload, new folder, drag-move — acts on the folder being
+  // browsed, so what you drop always shows up in the listing you're looking at.
+  // (The `uploads` volume still receives chat attachments; that's a different
+  // flow.) Read-only locations (public sets) allow none of it.
   const browseVolume = location.readOnly ? null : location.volume;
-  const { mkdir, move } = useOrgFsMutations(browseVolume ?? HOME_MOUNT_PATH);
+  const { upload, mkdir, move } = useOrgFsMutations(
+    browseVolume ?? HOME_MOUNT_PATH,
+  );
   // Deletes can target any volume (the recent feed is cross-volume), so they
   // get their own hook instance bound to the pending entry's volume.
   const { remove } = useOrgFsMutations(pendingDelete?.volume ?? "uploads");
 
   async function handleUpload(files: FileList | null) {
-    if (!uploadVolume || !files || files.length === 0) return;
+    if (!browseVolume || !files || files.length === 0) return;
     try {
-      await upload.mutateAsync({ dir: uploadDir, files: [...files] });
+      await upload.mutateAsync({ dir: location.dirPath, files: [...files] });
       toast.success(
         files.length === 1
           ? t("library.library.uploadedSingle", {
@@ -208,12 +202,9 @@ export function LibraryPage({
     }
   }
 
-  // Drag-and-drop upload — same destination as the Upload button: the current
-  // folder, or the uploads volume at root. Off in read-only locations.
-  const canDrop = uploadVolume !== null;
-  const dropLabel = location.isHomeRoot
-    ? "uploads"
-    : segmentLabel(location.segments.at(-1) ?? "this folder");
+  // Drag-and-drop upload — same destination as the Upload button: the folder
+  // being browsed. Off in read-only locations.
+  const canDrop = browseVolume !== null;
 
   function dragHasFiles(e: React.DragEvent) {
     return e.dataTransfer.types.includes("Files");
@@ -246,6 +237,10 @@ export function LibraryPage({
   async function handleCreateFolder() {
     const name = newFolderName.trim();
     if (!browseVolume || !name) return;
+    if (location.isHomeRoot && SYSTEM_FOLDER_NAMES.has(name.toLowerCase())) {
+      toast.error(t("library.library.folderNameReserved", { name }));
+      return;
+    }
     try {
       const dir = location.dirPath;
       await mkdir.mutateAsync(dir ? `${dir}/${name}` : name);
@@ -290,6 +285,16 @@ export function LibraryPage({
       setRenameOpen(false);
       setRenameTarget(null);
       setRenameName("");
+      return;
+    }
+    // Same reserved names as folder creation — a rename is the other way to
+    // land a hand-made folder on top of a system-folder card.
+    if (
+      renameTarget.kind === "dir" &&
+      location.isHomeRoot &&
+      SYSTEM_FOLDER_NAMES.has(newName.toLowerCase())
+    ) {
+      toast.error(t("library.library.folderNameReserved", { name: newName }));
       return;
     }
     try {
@@ -345,11 +350,20 @@ export function LibraryPage({
     queryClient.invalidateQueries({ queryKey: KEYS.orgFsPublicSets(org.id) });
   }
 
-  // Right-clicking empty space creates a folder here. Entry cards preventDefault
-  // on their own context menu (they open rename), so `defaultPrevented` is what
-  // separates "empty space" from "on a card" as the event bubbles up.
+  // Right-clicking empty space creates a folder here. This listens on the whole
+  // page, so anything interactive has to opt out first: entry cards that own a
+  // rename menu call preventDefault, and everything else (the search box, the
+  // toolbar, the cards with no menu of their own) keeps its native menu — a
+  // right-click meant for "paste" must never become "new folder".
   function handleContextMenuEmpty(e: React.MouseEvent) {
     if (e.defaultPrevented || !browseVolume) return;
+    if (
+      (e.target as HTMLElement).closest(
+        "input, textarea, button, a, [role='button']",
+      )
+    ) {
+      return;
+    }
     e.preventDefault();
     setNewFolderOpen(true);
   }
@@ -368,7 +382,7 @@ export function LibraryPage({
           <div className="flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed border-primary px-10 py-8 text-center">
             <Upload01 size={28} className="text-primary" />
             <p className="text-sm font-medium text-foreground">
-              {t("library.library.dropToUpload", { location: dropLabel })}
+              {t("library.library.dropToUpload", { location: locationLabel })}
             </p>
           </div>
         </div>

--- a/apps/web/src/layouts/library/index.tsx
+++ b/apps/web/src/layouts/library/index.tsx
@@ -1,13 +1,17 @@
 /**
- * Library (/$org/files) — the org filesystem as a Drive-like home (Figma
- * qFc7wr91 node 7870-5644). Replaces the settings → Files table browser.
+ * Library — the org filesystem as a Drive-like home (Figma qFc7wr91 node
+ * 7870-5644).
  *
- * A global search box (cross-volume `/fs/search`) sits above every view;
- * typing swaps the active listing for its results. Root: "Recently added"
- * (cross-volume `/fs/recent` feed) + Folders (volumes and public sets).
- * Browsing into a folder swaps to a breadcrumbed listing of that directory
- * in the same card language. Browse location lives in `?path=` and the open
- * preview in `?preview=`, so both are linkable and survive reload.
+ * It opens on the org's own home folder, named after the org: no synthetic
+ * "root" listing of volumes and nothing labelled "home". The other volumes
+ * (`uploads`, `outputs`, `public`) present as system folders inside it — same
+ * mounts, different framing. The breadcrumb is the only place the current
+ * folder is named, which frees the header row for the search box.
+ *
+ * Search sits in that row and follows you: cross-volume at the home root,
+ * narrowed to the current folder's subtree anywhere else. Browse location lives
+ * in `?path=` and the open preview in `?preview=`, so both are linkable and
+ * survive reload.
  */
 
 import { useRef, useState } from "react";
@@ -45,21 +49,24 @@ import {
   DialogTitle,
 } from "@deco/ui/components/dialog.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
+import {
+  HOME_MOUNT_PATH,
+  homeDisplayName,
+} from "@decocms/shared/organization/home-mount";
 import { KEYS } from "@/lib/query-keys";
 import { useDebouncedValue } from "@/hooks/use-debounced-value.ts";
 import { useOrgFsMutations } from "@/hooks/use-org-fs";
-import { basename, parseLibraryPath } from "./location";
+import { basename, parseLibraryPath, segmentLabel } from "./location";
 import { BrandPreviewDialog } from "./brand-preview";
 import { ShareDialog, type ShareTarget } from "./file-share-button";
 import { LibraryPreviewDialog } from "./preview-dialog";
 import { SkillPreviewDialog } from "./skill-preview";
 import {
   Breadcrumbs,
+  LIBRARY_VOLUMES,
   type PendingDelete,
   PublicSetsView,
-  RootView,
   SearchResultsView,
-  VOLUMES,
   VolumeView,
 } from "./library-views";
 
@@ -84,9 +91,10 @@ export function LibraryPage({
     skill?: string;
     brand?: string;
   };
-  const browsePath = search.path ?? "";
+  // The home folder is the top of the tree, so a missing (or emptied) `?path=`
+  // lands there rather than on a volumes listing.
+  const browsePath = search.path || HOME_MOUNT_PATH;
   const location = parseLibraryPath(browsePath);
-  const isRoot = location.segments.length === 0;
 
   const setSearchParam = (
     key: "path" | "preview" | "skill" | "brand",
@@ -124,10 +132,25 @@ export function LibraryPage({
     onOpenBrandOverride ??
     ((brandPath: string) => openPreview("brand", brandPath));
 
-  // Global file search — cross-volume, so it lives above the browse
-  // location and stays visible while inside any folder.
+  // The search box lives in the header row and follows the browse location:
+  // cross-volume at the home root, narrowed to this folder's subtree elsewhere.
+  // (`volume === null` is the `public` sets listing — global there; scoping it
+  // would need a multi-volume filter.)
   const [searchText, setSearchText] = useState("");
   const searchQuery = useDebouncedValue(searchText.trim(), 300);
+  const searchScope =
+    !location.isHomeRoot && location.volume !== null
+      ? { volume: location.volume, prefix: location.dirPath }
+      : undefined;
+  const searchPlaceholder = searchScope
+    ? t("library.library.searchInPlaceholder", {
+        folder: segmentLabel(location.segments.at(-1) ?? ""),
+      })
+    : t("library.library.searchPlaceholder");
+  // What to call the current folder in copy — never the internal "home".
+  const locationLabel = location.isHomeRoot
+    ? homeDisplayName(org.slug)
+    : segmentLabel(location.segments.at(-1) ?? "");
 
   const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(
     null,
@@ -146,14 +169,22 @@ export function LibraryPage({
   // Depth counter so dragenter/leave bubbling from child cards doesn't flicker.
   const dragDepth = useRef(0);
 
-  // Root uploads land in the uploads volume root — visible org-wide, outside
-  // any thread folder (those belong to chat-attachment flows).
+  // Uploads made from the landing view land in the uploads volume root —
+  // visible org-wide, outside any thread folder (those belong to
+  // chat-attachment flows). Inside any other folder they land in that folder.
   const uploadVolume = location.readOnly
     ? null
-    : (location.volume ?? "uploads");
-  const uploadDir = location.volume ? location.dirPath : "";
-  const { upload, mkdir, move } = useOrgFsMutations(uploadVolume ?? "uploads");
-  // Deletes can target any volume (the root feed is cross-volume), so they
+    : location.isHomeRoot
+      ? "uploads"
+      : (location.volume ?? "uploads");
+  const uploadDir = location.isHomeRoot ? "" : location.dirPath;
+  const { upload } = useOrgFsMutations(uploadVolume ?? "uploads");
+  // New folders and drag-moves act on the folder being browsed — which at the
+  // landing view is the home volume, NOT the uploads volume that receives
+  // uploads. Read-only locations (public sets) allow neither.
+  const browseVolume = location.readOnly ? null : location.volume;
+  const { mkdir, move } = useOrgFsMutations(browseVolume ?? HOME_MOUNT_PATH);
+  // Deletes can target any volume (the recent feed is cross-volume), so they
   // get their own hook instance bound to the pending entry's volume.
   const { remove } = useOrgFsMutations(pendingDelete?.volume ?? "uploads");
 
@@ -180,9 +211,9 @@ export function LibraryPage({
   // Drag-and-drop upload — same destination as the Upload button: the current
   // folder, or the uploads volume at root. Off in read-only locations.
   const canDrop = uploadVolume !== null;
-  const dropLabel = isRoot
+  const dropLabel = location.isHomeRoot
     ? "uploads"
-    : (location.segments.at(-1) ?? "this folder");
+    : segmentLabel(location.segments.at(-1) ?? "this folder");
 
   function dragHasFiles(e: React.DragEvent) {
     return e.dataTransfer.types.includes("Files");
@@ -214,9 +245,10 @@ export function LibraryPage({
 
   async function handleCreateFolder() {
     const name = newFolderName.trim();
-    if (!uploadVolume || !name) return;
+    if (!browseVolume || !name) return;
     try {
-      await mkdir.mutateAsync(uploadDir ? `${uploadDir}/${name}` : name);
+      const dir = location.dirPath;
+      await mkdir.mutateAsync(dir ? `${dir}/${name}` : name);
       toast.success(t("library.library.folderCreated", { name }));
       setNewFolderOpen(false);
       setNewFolderName("");
@@ -298,9 +330,9 @@ export function LibraryPage({
   }
 
   function refresh() {
-    for (const v of VOLUMES) {
+    for (const volume of LIBRARY_VOLUMES) {
       queryClient.invalidateQueries({
-        queryKey: KEYS.orgFsVolume(org.id, v.id),
+        queryKey: KEYS.orgFsVolume(org.id, volume),
       });
     }
     if (location.volume) {
@@ -313,8 +345,11 @@ export function LibraryPage({
     queryClient.invalidateQueries({ queryKey: KEYS.orgFsPublicSets(org.id) });
   }
 
+  // Right-clicking empty space creates a folder here. Entry cards preventDefault
+  // on their own context menu (they open rename), so `defaultPrevented` is what
+  // separates "empty space" from "on a card" as the event bubbles up.
   function handleContextMenuEmpty(e: React.MouseEvent) {
-    if (!isRoot || location.readOnly || !uploadVolume) return;
+    if (e.defaultPrevented || !browseVolume) return;
     e.preventDefault();
     setNewFolderOpen(true);
   }
@@ -340,102 +375,90 @@ export function LibraryPage({
       )}
       <div className="h-full overflow-y-auto">
         <div className="mx-auto flex w-full max-w-[900px] flex-col gap-10 px-6 py-10 lg:px-10">
-          <div className="flex flex-col gap-2">
-            {!isRoot && (
+          {/* One header row: the breadcrumb names the location (no heading
+              repeating it), and the reclaimed space holds the search box. */}
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="min-w-0 flex-1 basis-full sm:basis-auto">
               <Breadcrumbs
                 segments={location.segments}
                 onNavigate={onOpenDir}
               />
-            )}
-            <div className="flex items-center gap-2">
-              <h1 className="min-w-0 flex-1 truncate text-xl font-medium text-foreground">
-                {isRoot
-                  ? t("library.library.title")
-                  : (location.segments.at(-1) ?? t("library.library.title"))}
-              </h1>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={refresh}
-                aria-label={t("library.library.refresh")}
-              >
-                <RefreshCw01 size={14} />
-              </Button>
-              {!isRoot && uploadVolume && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setNewFolderOpen(true)}
-                >
-                  <Plus size={14} />
-                  {t("library.library.newFolder")}
-                </Button>
-              )}
-              {location.readOnly ? (
-                <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                  <Eye size={12} />
-                  {t("library.library.readOnly")}
-                </span>
-              ) : (
-                <Button
-                  size="sm"
-                  disabled={upload.isPending}
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  <Upload01 size={14} />
-                  {upload.isPending
-                    ? t("library.library.uploading")
-                    : t("library.library.uploadFile")}
-                </Button>
-              )}
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                className="hidden"
-                onChange={(e) => void handleUpload(e.target.files)}
-              />
             </div>
-          </div>
-
-          <div className="relative">
-            <SearchLg
-              size={16}
-              className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
-            />
-            <Input
-              value={searchText}
-              onChange={(e) => setSearchText(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") setSearchText("");
-              }}
-              placeholder={t("library.library.searchPlaceholder")}
-              className="h-10 rounded-xl pr-9 pl-9"
-            />
-            {searchText && (
+            <div className="relative w-full shrink-0 sm:w-56">
+              <SearchLg
+                size={16}
+                className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") setSearchText("");
+                }}
+                placeholder={searchPlaceholder}
+                className="h-9 rounded-xl pr-9 pl-9"
+              />
+              {searchText && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="absolute top-1/2 right-1.5 size-7 -translate-y-1/2"
+                  onClick={() => setSearchText("")}
+                  aria-label={t("library.library.clearSearch")}
+                >
+                  <XClose size={14} />
+                </Button>
+              )}
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={refresh}
+              aria-label={t("library.library.refresh")}
+            >
+              <RefreshCw01 size={14} />
+            </Button>
+            {browseVolume && (
               <Button
-                variant="ghost"
-                size="icon"
-                className="absolute top-1/2 right-1.5 size-7 -translate-y-1/2"
-                onClick={() => setSearchText("")}
-                aria-label={t("library.library.clearSearch")}
+                variant="outline"
+                size="sm"
+                onClick={() => setNewFolderOpen(true)}
               >
-                <XClose size={14} />
+                <Plus size={14} />
+                {t("library.library.newFolder")}
               </Button>
             )}
+            {location.readOnly ? (
+              <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Eye size={12} />
+                {t("library.library.readOnly")}
+              </span>
+            ) : (
+              <Button
+                size="sm"
+                disabled={upload.isPending}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Upload01 size={14} />
+                {upload.isPending
+                  ? t("library.library.uploading")
+                  : t("library.library.uploadFile")}
+              </Button>
+            )}
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={(e) => void handleUpload(e.target.files)}
+            />
           </div>
 
           {searchQuery ? (
             <SearchResultsView
               query={searchQuery}
+              scope={searchScope}
               stale={searchText.trim() !== searchQuery}
-              onOpenFile={onOpenFile}
-              onShare={setShareTarget}
-              onDelete={setPendingDelete}
-            />
-          ) : isRoot ? (
-            <RootView
-              onOpenDir={onOpenDir}
               onOpenFile={onOpenFile}
               onShare={setShareTarget}
               onDelete={setPendingDelete}
@@ -494,7 +517,7 @@ export function LibraryPage({
             <DialogTitle>{t("library.library.newFolderTitle")}</DialogTitle>
             <DialogDescription>
               {t("library.library.newFolderDescription", {
-                path: browsePath || t("library.library.theLibrary"),
+                path: locationLabel || t("library.library.theLibrary"),
               })}
             </DialogDescription>
           </DialogHeader>

--- a/apps/web/src/layouts/library/library-views.tsx
+++ b/apps/web/src/layouts/library/library-views.tsx
@@ -1,19 +1,17 @@
 import type { ComponentType, SVGProps } from "react";
 import { useProjectContext } from "@/sdk";
-import {
-  ChevronRight,
-  Globe01,
-  Home01,
-  Stars01,
-  Upload01,
-} from "@untitledui/icons";
+import { ChevronRight, Stars01, Upload01, Zap } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Skeleton } from "@deco/ui/components/skeleton.tsx";
-import { homeDisplayName } from "@decocms/shared/organization/home-mount";
+import {
+  HOME_MOUNT_PATH,
+  homeDisplayName,
+} from "@decocms/shared/organization/home-mount";
 import { useT } from "@/i18n/use-t.ts";
 import type { TranslationKey } from "@/i18n/en/index.ts";
 import {
   type OrgFsEntry,
+  type OrgFsSearchScope,
   type ShareMode,
   useOrgFsFileUrl,
   useOrgFsList,
@@ -37,6 +35,7 @@ import {
   browsePathForEntry,
   type LibraryLocation,
   publicSetOf,
+  segmentLabel,
 } from "./location";
 import type { ShareTarget } from "./file-share-button";
 
@@ -58,23 +57,23 @@ function publicStateOf(e: {
   return undefined;
 }
 
-/** The volumes every sandbox mounts (see file-storage/mount/provisioning.ts).
- *  `glyph` marks the folder body, Finder-special-folder style. Skills are
- *  deliberately absent — they live in versioned repos (public sets), not as
- *  an editable cloud volume. */
-export const VOLUMES = [
+/** The volumes every sandbox mounts (see file-storage/mount/provisioning.ts) —
+ *  what the refresh button revalidates. The Library presents `home` as the top
+ *  of the tree and the rest as system folders inside it. */
+export const LIBRARY_VOLUMES = [HOME_MOUNT_PATH, "uploads", "outputs"] as const;
+
+/** Volumes filled by chat and by agent work rather than by hand, presented as
+ *  system folders inside the home listing: graphite tone + a body glyph, so it
+ *  reads as "the product owns this". Their mounts are unchanged — only the
+ *  presentation moved (and `public` presents as "skills", see `segmentLabel`). */
+const SYSTEM_FOLDERS = [
   {
-    id: "home",
-    descriptionKey: "library.libraryViews.volumeHomeDescription" as const,
-    glyph: Home01,
-  },
-  {
-    id: "uploads",
+    volume: "uploads",
     descriptionKey: "library.libraryViews.volumeUploadsDescription" as const,
     glyph: Upload01,
   },
   {
-    id: "outputs",
+    volume: "outputs",
     descriptionKey: "library.libraryViews.volumeOutputsDescription" as const,
     glyph: Stars01,
   },
@@ -169,14 +168,11 @@ function EmptyNote({ children }: { children: React.ReactNode }) {
 
 function VolumeFolderCard({
   volume,
-  displayName,
   descriptionKey,
   glyph,
   onOpen,
 }: {
   volume: string;
-  /** Card label when it differs from the volume id (home shows the slug). */
-  displayName?: string;
   descriptionKey: TranslationKey;
   glyph?: ComponentType<SVGProps<SVGSVGElement>>;
   onOpen: () => void;
@@ -185,7 +181,7 @@ function VolumeFolderCard({
   const usage = useOrgFsUsage(volume);
   return (
     <FolderCard
-      name={displayName ?? volume}
+      name={volume}
       meta={
         usage.data
           ? t("library.libraryViews.filesCount", { count: usage.data.files })
@@ -193,11 +189,57 @@ function VolumeFolderCard({
       }
       subtitle={t(descriptionKey)}
       glyph={glyph}
+      tone="system"
       onOpen={onOpen}
     />
   );
 }
 
+/**
+ * The system folders, rendered first inside the home listing. They're separate
+ * volumes under the hood (mounted elsewhere in the sandbox) but a member has no
+ * reason to know that — here they're just the folders chat and agents fill.
+ *
+ * `public` presents as "skills". A hand-made `home/skills/` folder can therefore
+ * sit next to it; the two stay distinguishable by tone, the read-only eye badge,
+ * the subtitle, and this card coming first.
+ */
+function SystemFolders({ onOpenDir }: { onOpenDir: (path: string) => void }) {
+  const t = useT();
+  const publicSets = useOrgFsPublicSets();
+  const setCount = publicSets.data?.length ?? 0;
+  return (
+    <>
+      {SYSTEM_FOLDERS.map((f) => (
+        <VolumeFolderCard
+          key={f.volume}
+          volume={f.volume}
+          descriptionKey={f.descriptionKey}
+          glyph={f.glyph}
+          onOpen={() => onOpenDir(f.volume)}
+        />
+      ))}
+      {setCount > 0 && (
+        <FolderCard
+          name={segmentLabel("public")}
+          meta={t("library.libraryViews.skillSetsCount", { count: setCount })}
+          subtitle={t("library.libraryViews.curatedSkillSetsReadOnly")}
+          glyph={Zap}
+          tone="system"
+          readOnly
+          onOpen={() => onOpenDir("public")}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * Location trail — the only place the current folder is named (there's no page
+ * heading duplicating it). The org's home volume IS the top of the tree, so its
+ * segment folds into the root crumb, which is labelled with the org itself; the
+ * sibling volumes (uploads/outputs/public) hang off that crumb.
+ */
 export function Breadcrumbs({
   segments,
   onNavigate,
@@ -205,19 +247,28 @@ export function Breadcrumbs({
   segments: string[];
   onNavigate: (path: string) => void;
 }) {
-  const t = useT();
+  const { org } = useProjectContext();
+  const rest = segments[0] === HOME_MOUNT_PATH ? segments.slice(1) : segments;
+  const offset = segments.length - rest.length;
+  const atRoot = rest.length === 0;
   return (
     <div className="flex min-w-0 flex-wrap items-center gap-1 text-sm">
-      <button
-        type="button"
-        className="text-muted-foreground hover:text-foreground hover:underline"
-        onClick={() => onNavigate("")}
-      >
-        {t("library.libraryViews.library")}
-      </button>
-      {segments.map((seg, i) => {
-        const prefix = segments.slice(0, i + 1).join("/");
-        const isLast = i === segments.length - 1;
+      {atRoot ? (
+        <span className="truncate font-medium text-foreground">
+          {homeDisplayName(org.slug)}
+        </span>
+      ) : (
+        <button
+          type="button"
+          className="truncate text-muted-foreground hover:text-foreground hover:underline"
+          onClick={() => onNavigate(HOME_MOUNT_PATH)}
+        >
+          {homeDisplayName(org.slug)}
+        </button>
+      )}
+      {rest.map((seg, i) => {
+        const prefix = segments.slice(0, offset + i + 1).join("/");
+        const isLast = i === rest.length - 1;
         return (
           <span key={prefix} className="flex min-w-0 items-center gap-1">
             <ChevronRight
@@ -226,7 +277,7 @@ export function Breadcrumbs({
             />
             {isLast ? (
               <span className="truncate font-medium text-foreground">
-                {seg}
+                {segmentLabel(seg)}
               </span>
             ) : (
               <button
@@ -234,7 +285,7 @@ export function Breadcrumbs({
                 className="truncate text-muted-foreground hover:text-foreground hover:underline"
                 onClick={() => onNavigate(prefix)}
               >
-                {seg}
+                {segmentLabel(seg)}
               </button>
             )}
           </span>
@@ -245,17 +296,22 @@ export function Breadcrumbs({
 }
 
 /**
- * Global search results — cross-volume, shown in place of whatever listing
- * is active (root or folder) while the search box has a query.
+ * Search results, shown in place of whatever listing is active while the search
+ * box has a query. Cross-volume at the home root, narrowed to the current
+ * folder's subtree everywhere else (`scope`) — so the placeholder's promise
+ * ("Search files in decks") is what actually happens.
  */
 export function SearchResultsView({
   query,
+  scope,
   stale,
   onOpenFile,
   onShare,
   onDelete,
 }: {
   query: string;
+  /** Narrow to one volume + directory subtree; unset = cross-volume. */
+  scope?: OrgFsSearchScope;
   /** The input is ahead of `query` (still inside the debounce window). */
   stale: boolean;
   onOpenFile: (previewPath: string) => void;
@@ -265,7 +321,7 @@ export function SearchResultsView({
   const t = useT();
   const { org } = useProjectContext();
   const fileUrl = useOrgFsFileUrl();
-  const search = useOrgFsSearch(query);
+  const search = useOrgFsSearch(query, scope);
 
   const shareFile = (e: OrgFsEntry & { volume: string }) =>
     onShare({
@@ -323,14 +379,16 @@ export function SearchResultsView({
   );
 }
 
-/** Root view: Recently added + Folders (volumes/public). */
-export function RootView({
-  onOpenDir,
+/**
+ * Cross-volume "Recently added" feed. Sits at the BOTTOM of the home listing
+ * (folders first — that's what people came for) and only there: it spans every
+ * volume, so it would be a lie inside any single folder.
+ */
+function RecentlyAdded({
   onOpenFile,
   onShare,
   onDelete,
 }: {
-  onOpenDir: (path: string) => void;
   onOpenFile: (previewPath: string) => void;
   onShare: (target: ShareTarget) => void;
   onDelete: (pending: PendingDelete) => void;
@@ -338,7 +396,6 @@ export function RootView({
   const t = useT();
   const { org } = useProjectContext();
   const recent = useOrgFsRecent();
-  const publicSets = useOrgFsPublicSets();
   const fileUrl = useOrgFsFileUrl();
 
   const shareFile = (e: OrgFsEntry & { volume: string }) =>
@@ -351,75 +408,39 @@ export function RootView({
       url: publicFileUrl(fileUrl(e.volume, e.path)),
     });
 
+  if (recent.isPending) {
+    return (
+      <div className="flex flex-col gap-3">
+        <SectionLabel>{t("library.libraryViews.recentlyAdded")}</SectionLabel>
+        <GridSkeleton />
+      </div>
+    );
+  }
   const recentlyAdded = (recent.data ?? []).slice(0, RECENTLY_ADDED_COUNT);
+  if (recentlyAdded.length === 0) return null;
 
   return (
-    <>
-      {recent.isPending ? (
-        <div className="flex flex-col gap-3">
-          <SectionLabel>{t("library.libraryViews.recentlyAdded")}</SectionLabel>
-          <GridSkeleton />
-        </div>
-      ) : recentlyAdded.length > 0 ? (
-        <div className="flex flex-col gap-3">
-          <SectionLabel>{t("library.libraryViews.recentlyAdded")}</SectionLabel>
-          <CardsGrid>
-            {recentlyAdded.map((e) => (
-              <RecentFileCard
-                key={`${e.volume}/${e.path}`}
-                filename={basename(e.path)}
-                updatedAt={e.updatedAt}
-                size={e.size}
-                downloadUrl={fileUrl(e.volume, e.path)}
-                subtitle={locationOf(e.volume, e.path, org.slug)}
-                publicState={publicStateOf(e)}
-                onOpen={() => onOpenFile(`${e.volume}/${e.path}`)}
-                onShare={() => shareFile(e)}
-                onDelete={() =>
-                  onDelete({ volume: e.volume, path: e.path, kind: "file" })
-                }
-              />
-            ))}
-          </CardsGrid>
-        </div>
-      ) : (
-        <EmptyNote>{t("library.libraryViews.noFilesYet")}</EmptyNote>
-      )}
-
-      <div className="flex flex-col gap-3">
-        <SectionLabel>{t("library.libraryViews.folders")}</SectionLabel>
-        <CardsGrid>
-          {VOLUMES.map((v) => (
-            <VolumeFolderCard
-              key={v.id}
-              volume={v.id}
-              // The home volume presents as the org itself: its display label is
-              // the org slug (with a reserved-slug fallback to "home" so two
-              // cards aren't both named e.g. "public"). The agent-facing mount
-              // path is always `org/home/` regardless of this label.
-              displayName={
-                v.id === "home" ? homeDisplayName(org.slug) : undefined
-              }
-              descriptionKey={v.descriptionKey}
-              glyph={v.glyph}
-              onOpen={() => onOpenDir(v.id)}
-            />
-          ))}
-          {(publicSets.data?.length ?? 0) > 0 && (
-            <FolderCard
-              name="public"
-              meta={t("library.libraryViews.skillSetsCount", {
-                count: publicSets.data?.length ?? 0,
-              })}
-              subtitle={t("library.libraryViews.curatedSkillSetsReadOnly")}
-              glyph={Globe01}
-              readOnly
-              onOpen={() => onOpenDir("public")}
-            />
-          )}
-        </CardsGrid>
-      </div>
-    </>
+    <div className="flex flex-col gap-3">
+      <SectionLabel>{t("library.libraryViews.recentlyAdded")}</SectionLabel>
+      <CardsGrid>
+        {recentlyAdded.map((e) => (
+          <RecentFileCard
+            key={`${e.volume}/${e.path}`}
+            filename={basename(e.path)}
+            updatedAt={e.updatedAt}
+            size={e.size}
+            downloadUrl={fileUrl(e.volume, e.path)}
+            subtitle={locationOf(e.volume, e.path, org.slug)}
+            publicState={publicStateOf(e)}
+            onOpen={() => onOpenFile(browsePathForEntry(e.volume, e.path))}
+            onShare={() => shareFile(e)}
+            onDelete={() =>
+              onDelete({ volume: e.volume, path: e.path, kind: "file" })
+            }
+          />
+        ))}
+      </CardsGrid>
+    </div>
   );
 }
 
@@ -455,7 +476,11 @@ export function PublicSetsView({
   );
 }
 
-/** Listing of one directory inside a volume. */
+/**
+ * Listing of one directory inside a volume — and, at the home root, the
+ * Library's landing view: the system folders lead the folder grid and the
+ * cross-volume "Recently added" feed closes the page.
+ */
 export function VolumeView({
   location,
   onOpenDir,
@@ -484,7 +509,25 @@ export function VolumeView({
   const listing = useOrgFsList(volume, location.dirPath);
   const fileUrl = useOrgFsFileUrl();
 
-  if (listing.isPending) return <GridSkeleton rows={2} />;
+  // The system folders don't depend on this listing, so they render straight
+  // away on the landing view instead of flashing a skeleton.
+  const systemFolders = location.isHomeRoot ? (
+    <SystemFolders onOpenDir={onOpenDir} />
+  ) : null;
+
+  if (listing.isPending) {
+    return (
+      <>
+        {systemFolders && (
+          <div className="flex flex-col gap-3">
+            <SectionLabel>{t("library.libraryViews.folders")}</SectionLabel>
+            <CardsGrid>{systemFolders}</CardsGrid>
+          </div>
+        )}
+        <GridSkeleton rows={2} />
+      </>
+    );
+  }
   if (listing.isError) {
     return (
       <p className="text-sm text-destructive">
@@ -506,7 +549,8 @@ export function VolumeView({
   );
   const files = entries.filter((e) => e.kind === "file");
 
-  if (entries.length === 0) {
+  // An empty home root still has the system folders and the recent feed to show.
+  if (entries.length === 0 && !location.isHomeRoot) {
     return (
       <EmptyNote>
         {location.readOnly
@@ -588,10 +632,11 @@ export function VolumeView({
           </CardsGrid>
         </div>
       )}
-      {dirs.length > 0 && (
+      {(dirs.length > 0 || systemFolders) && (
         <div className="flex flex-col gap-3">
           <SectionLabel>{t("library.libraryViews.folders")}</SectionLabel>
           <CardsGrid>
+            {systemFolders}
             {dirs.map((e) => (
               <FolderCard
                 key={e.path}
@@ -636,6 +681,13 @@ export function VolumeView({
             ))}
           </CardsGrid>
         </div>
+      )}
+      {location.isHomeRoot && (
+        <RecentlyAdded
+          onOpenFile={onOpenFile}
+          onShare={onShare}
+          onDelete={onDelete}
+        />
       )}
     </>
   );

--- a/apps/web/src/layouts/library/library-views.tsx
+++ b/apps/web/src/layouts/library/library-views.tsx
@@ -515,9 +515,21 @@ export function VolumeView({
   onMove?: (fromPath: string, toDir: string) => void;
 }) {
   const t = useT();
+  const { org } = useProjectContext();
   const volume = location.volume ?? "";
   const listing = useOrgFsList(volume, location.dirPath);
   const fileUrl = useOrgFsFileUrl();
+
+  // A folder that predates the system-folder cards (or that an agent wrote)
+  // can already be named `uploads`/`outputs`/`skills`. Both cards render — the
+  // real one still opens and renames normally — but two cards under one label
+  // is a lie, so the home-volume one carries its path to tell them apart.
+  // New collisions are rejected at the writers; this is for the ones already
+  // out there, which we won't rename behind the org's back.
+  const disambiguate = (name: string) =>
+    location.isHomeRoot && SYSTEM_FOLDER_NAMES.has(name.toLowerCase())
+      ? `${homeDisplayName(org.slug)}/${name}`
+      : undefined;
 
   // The system folders don't depend on this listing, so they render straight
   // away on the landing view instead of flashing a skeleton.
@@ -652,6 +664,7 @@ export function VolumeView({
                 key={e.path}
                 name={basename(e.path)}
                 meta={timeAgo(e.updatedAt)}
+                subtitle={disambiguate(basename(e.path))}
                 readOnly={location.readOnly}
                 publicState={publicStateOf(e)}
                 onOpen={() => onOpenDir(browsePathFor(location, e.path))}

--- a/apps/web/src/layouts/library/library-views.tsx
+++ b/apps/web/src/layouts/library/library-views.tsx
@@ -79,6 +79,15 @@ const SYSTEM_FOLDERS = [
   },
 ] as const;
 
+/** The names the home listing already occupies with system-folder cards. A
+ *  hand-made folder with one of these names would sit in the same grid under
+ *  the same label but point somewhere else, so the writers reject it at the
+ *  home root. Lowercased — "Uploads" reads as the same folder to a human. */
+export const SYSTEM_FOLDER_NAMES: ReadonlySet<string> = new Set([
+  ...SYSTEM_FOLDERS.map((f) => f.volume),
+  segmentLabel("public"),
+]);
+
 const RECENTLY_ADDED_COUNT = 6;
 
 /** "volume/dir" a cross-volume entry lives in — home shows the org slug,
@@ -200,9 +209,10 @@ function VolumeFolderCard({
  * volumes under the hood (mounted elsewhere in the sandbox) but a member has no
  * reason to know that — here they're just the folders chat and agents fill.
  *
- * `public` presents as "skills". A hand-made `home/skills/` folder can therefore
- * sit next to it; the two stay distinguishable by tone, the read-only eye badge,
- * the subtitle, and this card coming first.
+ * Their labels (`uploads`, `outputs`, and `public` presenting as "skills") are
+ * therefore reserved at the home root: a hand-made folder with one of those
+ * names would land in this same grid under the same label but point at a
+ * different volume. `SYSTEM_FOLDER_NAMES` is what the writers check.
  */
 function SystemFolders({ onOpenDir }: { onOpenDir: (path: string) => void }) {
   const t = useT();

--- a/apps/web/src/layouts/library/location.test.ts
+++ b/apps/web/src/layouts/library/location.test.ts
@@ -1,14 +1,26 @@
 import { describe, expect, it } from "bun:test";
-import { basename, browsePathFor, parseLibraryPath } from "./location";
+import {
+  basename,
+  browsePathFor,
+  parseLibraryPath,
+  segmentLabel,
+} from "./location";
 
 describe("parseLibraryPath", () => {
-  it("parses the root", () => {
+  it("parses the empty path (not UI-reachable, but still valid)", () => {
     const loc = parseLibraryPath("");
     expect(loc.volume).toBeNull();
     expect(loc.dirPath).toBe("");
     expect(loc.isPublic).toBe(false);
     expect(loc.readOnly).toBe(false);
     expect(loc.segments).toEqual([]);
+    expect(loc.isHomeRoot).toBe(false);
+  });
+
+  it("flags only the home volume root as the landing view", () => {
+    expect(parseLibraryPath("home").isHomeRoot).toBe(true);
+    expect(parseLibraryPath("home/docs").isHomeRoot).toBe(false);
+    expect(parseLibraryPath("uploads").isHomeRoot).toBe(false);
   });
 
   it("parses a volume root", () => {
@@ -52,6 +64,13 @@ describe("browsePathFor", () => {
   it("keeps the public/<set> spelling", () => {
     const loc = parseLibraryPath("public/core");
     expect(browsePathFor(loc, "skills/web")).toBe("public/core/skills/web");
+  });
+});
+
+describe("segmentLabel", () => {
+  it("presents the public volume as skills, everything else as-is", () => {
+    expect(segmentLabel("public")).toBe("skills");
+    expect(segmentLabel("uploads")).toBe("uploads");
   });
 });
 

--- a/apps/web/src/layouts/library/location.ts
+++ b/apps/web/src/layouts/library/location.ts
@@ -1,16 +1,21 @@
 /**
  * Library browse-path grammar (the `?path=` search param).
  *
- * The Library projects the org filesystem as one tree: the first segment is
- * the volume, and the synthetic `public` namespace maps
- * `public/<set>/...` → readonly volume `public-<set>` (mirroring the
- * sandbox's `org/public/<set>` mounts).
+ * The Library projects the org filesystem as one tree rooted at the org's
+ * `home` volume: the first segment is the volume, and the synthetic `public`
+ * namespace maps `public/<set>/...` → readonly volume `public-<set>`
+ * (mirroring the sandbox's `org/public/<set>` mounts).
  *
- *   ""                     → root (volumes listing)
+ *   "home"                 → the landing view (the org's home folder)
  *   "uploads/docs"         → volume "uploads", dir "docs"
  *   "public"               → public sets listing
  *   "public/core/skills"   → volume "public-core", dir "skills"
+ *
+ * `""` still parses (empty location) but is not reachable from the UI — the
+ * page falls back to `HOME_MOUNT_PATH`.
  */
+
+import { HOME_MOUNT_PATH } from "@decocms/shared/organization/home-mount";
 
 export interface LibraryLocation {
   /** Raw path segments, as browsed (incl. the `public/<set>` prefix). */
@@ -22,6 +27,9 @@ export interface LibraryLocation {
   isPublic: boolean;
   publicSet: string | null;
   readOnly: boolean;
+  /** The Library's landing view: the root of the org's home volume. The
+   *  system-folder cards and the "Recently added" feed live only here. */
+  isHomeRoot: boolean;
 }
 
 export function parseLibraryPath(path: string): LibraryLocation {
@@ -41,7 +49,16 @@ export function parseLibraryPath(path: string): LibraryLocation {
     isPublic,
     publicSet,
     readOnly: isPublic,
+    isHomeRoot: volume === HOME_MOUNT_PATH && dirPath === "",
   };
+}
+
+/** Display label for a browse-path segment. The `public` volume presents as
+ *  "skills" — it holds the shared read-only skill sets — while the browse path
+ *  and the sandbox mount stay `public/<set>`. Not translated: these are path
+ *  identifiers, like `uploads`. */
+export function segmentLabel(segment: string): string {
+  return segment === "public" ? "skills" : segment;
 }
 
 /** Browse path for an in-volume entry path, from the current location. */

--- a/apps/web/src/layouts/library/see-in-library-link.tsx
+++ b/apps/web/src/layouts/library/see-in-library-link.tsx
@@ -8,8 +8,10 @@
 import { Button } from "@deco/ui/components/button.tsx";
 import { Folder } from "@untitledui/icons";
 import { useNavigate } from "@tanstack/react-router";
+import { useT } from "@/i18n/use-t.ts";
 
 export function SeeInLibraryLink({ previewPath }: { previewPath: string }) {
+  const t = useT();
   const navigate = useNavigate();
   const parentPath = previewPath.split("/").slice(0, -1).join("/");
 
@@ -18,7 +20,11 @@ export function SeeInLibraryLink({ previewPath }: { previewPath: string }) {
       to: ".",
       search: (prev: Record<string, unknown>) => ({
         ...prev,
-        main: `library:${parentPath}`,
+        // The Library is the `files` main-panel tab; `path` is what navigates
+        // it. (This used to set a `library:<path>` tab id that no parser knew,
+        // so the button did nothing.)
+        main: "files",
+        path: parentPath || undefined,
         preview: previewPath,
         skill: undefined,
         brand: undefined,
@@ -34,7 +40,7 @@ export function SeeInLibraryLink({ previewPath }: { previewPath: string }) {
       className="shrink-0 gap-1.5 text-xs text-muted-foreground"
     >
       <Folder size={14} />
-      See in library
+      {t("library.seeInLibrary.label")}
     </Button>
   );
 }

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -487,11 +487,12 @@ export const KEYS = {
   // volume named like the segment can never collide; mutations invalidate it
   // explicitly alongside the volume prefix.
   orgFsRecent: (orgId: string) => ["org-fs-recent", orgId] as const,
-  // Cross-volume path search (Library search box). The root key is the
-  // prefix mutations invalidate; per-query keys nest under it.
+  // Path search (Library search box) — cross-volume, or narrowed to one
+  // volume + directory subtree when browsing inside a folder. The root key is
+  // the prefix mutations invalidate; per-query keys nest under it.
   orgFsSearchRoot: (orgId: string) => ["org-fs-search", orgId] as const,
-  orgFsSearch: (orgId: string, query: string) =>
-    ["org-fs-search", orgId, query] as const,
+  orgFsSearch: (orgId: string, query: string, volume: string, prefix: string) =>
+    ["org-fs-search", orgId, query, volume, prefix] as const,
   // Skill folders (dirs with SKILL.md) across home + public sets — the
   // attachable-skill set for agent knowledge.
   orgFsSkills: (orgId: string) => ["org-fs-skills", orgId] as const,


### PR DESCRIPTION
## Why

The Library leaked its implementation at every turn:

- It opened on a synthetic **root** view listing *volumes* — a card named after the org slug, subtitled "Your organization's home folder", sitting next to `uploads` / `outputs` / `public` — with **Recently added** pushed above them. Folders, the thing you actually came for, were below the fold.
- Clicking the org card navigated to browse path `home`, so the breadcrumb **and** the `<h1>` both read **"home"**. Nobody knows that `{org_name}` == `home`.
- The folder name was rendered twice (breadcrumb + heading), burning vertical space.
- The search box said **"Search all files"** even three folders deep.

## What changed

1. **Lands on the org's home folder, named after the org.** The `path=""` root view is deleted — home is the top of the tree, and the breadcrumb starts at `homeDisplayName(org.slug)`. Nothing in the UI says "home".
2. **`uploads` / `outputs` / `public` are system folders *inside* home**, in a graphite folder tone (vs Finder-blue for folders people make) so "the product fills this" reads at a glance. `public` presents as **skills**. Mounts and browse paths are untouched — `orgFsMountPath` and the agent-facing `org/home/…` paths are unchanged.
3. **Duplicate `<h1>` gone.** The breadcrumb is the only name; the search box moves into the reclaimed header row.
4. **Search really scopes.** `volume` + `prefix` query params on `GET /fs/search` thread down to a new `pathPrefix` filter in `searchFiles`. Global at the home root ("Search all files…"), scoped to the current subtree everywhere else ("Search files in decks…") — the label now matches the behavior instead of lying about it.
5. **Recently added moves to the bottom** of home, and only appears there. It's cross-volume, so it would be a lie inside a single folder.

## Two bugs the restructure exposed

Both are consequences of home becoming a real browsable folder, fixed in this PR rather than left for a hardening pass:

- **`mkdir`/`move` were bound to the _upload_ volume.** "New folder" at the landing view would have created the folder in `uploads`, and drag-move at home would have moved within the wrong volume. They now bind to the browsed volume. Uploads still target `uploads` from the landing view (unchanged behavior).
- **The empty-area right-click → new-folder gate fired only at the root**, which now has entry cards under it. Right-clicking a card would have opened rename *and* new-folder. It now keys off `defaultPrevented`, which the cards already set.

Also fixes **"See in library"** — dead since it set `main: "library:<path>"`, a tab id no parser handles — and routes its hardcoded English label through `t()`.

## Screenshots

| Home (landing) | Inside a folder |
|---|---|
| Folders first (system folders lead, graphite + glyph + read-only eye on skills), then Files, then Recently added. Breadcrumb reads the org slug. | `{org} > decks`, placeholder scopes to the folder. |

| Scoped search | Global search |
|---|---|
| `"sales"` inside `decks` → **1 result**. | Same query at home → **5 results**, every volume. |

## Testing

- **Unit** — `location.test.ts` gains `isHomeRoot` + `segmentLabel` cases.
- **Real-Postgres integration** — new `searchWithEffectivePublic` case covers prefix scoping: recursive under the dir, a same-prefix sibling dir (`reports-archive`) excluded, `_` treated literally, and composition with volume narrowing. Verified it *fails* when the prefix filter is removed.
- **End-to-end against a real dev server** (throwaway Playwright spec, not committed): signup → seed files across `home`/`uploads`/`outputs` → walk home → folder → system folder → skills. Asserted the landing view names the org and has no `<h1>`, section order is `Folders, Files, Recently added`, the scoped search returns 1 where the global returns 5, `skills` is read-only with no write actions, and a new folder created at the landing view lands in `home` (checked over the API, not just the UI).
- `bun run fmt`, `bun run check`, `bun run lint` (same 16 pre-existing warnings, 0 errors), `bunx knip` clean. `bun test apps/web/src`: 2173 pass / 23 fail vs. baseline 2171 / **23** — same pre-existing failures, +2 from the new tests.

## Docs

`studio/library.mdx` (en + pt-br) rewritten to describe the home-first tree, the system folders, and the scoped search. The sandbox mount table now shows `<your-org>/uploads → org/upload` etc., making explicit that the presentation moved and the mounts did not.

## Deliberately skipped

- Multi-volume search scope at the `public` sets listing (stays global there — `volume === null`).
- Hoisting the system cards above the Skills/Brands sections; they're first among *Folders*, not first on the page, when a skill dir sits in the home root.
- Declaring `path`/`skill`/`brand` in the route `validateSearch` schemas. Verified in `@tanstack/router-core` that unknown params survive both navigation and reload (`{...parentSearch, ...strictSearch}`, `search.strict` unset) — which is why `?skill=` works today. Unchanged by this PR either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open the Library directly in your org’s home folder and show `uploads`/`outputs`/`public` (as “skills”) as system folders inside it. Search now scopes to the folder you’re in; the UI is cleaner and actions target the folder you’re browsing.

- New Features
  - Home-first navigation: breadcrumb starts at your org; duplicate heading removed; search moved into the header.
  - System folders inside home: graphite-toned icons; `public` presents as “skills” and is read-only. Mounts and browse paths are unchanged.
  - Scoped search: `GET /fs/search` accepts `volume` and `prefix` to limit results to a volume and directory subtree; global at home, scoped elsewhere.
  - “Recently added” moved to the bottom of home and only appears there.

- Bug Fixes
  - Writers act on what you’re browsing: upload/new-folder/drag‑move now target the current folder; chat attachments still land in `uploads`.
  - Right‑click “New folder” only fires on empty space; inputs/buttons/links keep their native menus.
  - Reserved names at home: `uploads`/`outputs`/`skills` can’t be created or renamed at the home root; if one already exists, its card shows its full path to distinguish it from the system folder.
  - “See in library” now navigates via the Files tab using `path`, and its label is localized.

<sup>Written for commit 946422db915fbff754eafaf2c3fd2f74cec9b23c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

