### PR TITLE
fix(task-board): unassigning via the lane picker was a silent no-op

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -495,7 +495,12 @@ export function TaskBoardPage() {
           }
           onAssign={(id, userId) => {
             if (blockSuperAgentWithoutGithub(userId)) return;
-            actions.update.mutate({ id, assigneeId: userId ?? undefined });
+            // `userId` is `null` for "Unassigned" — `?? undefined` used to
+            // coalesce that into "field not provided", silently no-opping the
+            // unassign since TASK_BOARD_ITEM_UPDATE treats undefined as
+            // unchanged. `assigneeId` is nullable in the update schema, so
+            // pass `userId` through as-is.
+            actions.update.mutate({ id, assigneeId: userId });
           }}
           onAutoFix={
             reportsOnly


### PR DESCRIPTION
Found while auditing the task-board area around the new activity-log merge (#5354) — the inline lane assign circle shares the same assignee-update path the activity feature now logs.

**Bug**: the lane's inline assign-circle picker (`AssigneePickerContent`'s "Unassigned" item) calls `onSelect(null)`. That reaches `apps/web/src/layouts/task-board/index.tsx`'s `onAssign` handler, which sent `actions.update.mutate({ id, assigneeId: userId ?? undefined })`. Since `null ?? undefined` evaluates to `undefined`, and `TASK_BOARD_ITEM_UPDATE` treats an `undefined assigneeId` as "field not provided" (its `hasFieldUpdate`/`assigneeChanged` checks are all `!== undefined`), clicking "Unassigned" from a card's inline picker never patched the server. The optimistic cache patch would briefly show it unassigned, then the invalidated refetch snaps the card back to its previous assignee — a silent no-op with no error, and no `assignee_changed` activity entry either.

**Failure scenario**: open a lane, click a card's assign circle, choose "Unassigned" — the card keeps its original assignee after the query settles.

**Fix**: `assigneeId` is already `z.string().nullable().optional()` in the update schema, so pass `userId` (typed `string | null`) straight through instead of coalescing `null` into `undefined`.

**Reviewer check**: `cd apps/web && bunx tsc --noEmit` (clean — `userId` is already the correct type for the mutation input). This is a one-line UI-wiring fix with no separate testable unit (the file isn't under RTL/component-test coverage in this repo; the assignment tool logic itself is unchanged and untouched).

**Locally ran**: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix task-board lane picker so choosing “Unassigned” actually clears the assignee. We now send `assigneeId: null` to the update instead of omitting the field, so the server patches correctly and the card stays unassigned (with activity logged).

<sup>Written for commit 19c8d1f8aa735e78efd7450ddd9d5cc64e2141db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

