### PR TITLE
fix(agent-shell): announce loading/error states to screen readers

### DIFF
--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -96,7 +96,10 @@ function ActiveTaskBoundary({ children }: { children?: React.ReactNode }) {
   return (
     <ErrorBoundary
       fallback={
-        <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+        <div
+          role="alert"
+          className="flex-1 flex items-center justify-center text-sm text-muted-foreground"
+        >
           {t("agentShellLayout.agentShellLayout.chatLoadingError")}
         </div>
       }
@@ -293,7 +296,10 @@ function MobileTaskWorkspace({
           {mobileSurface === "main" ? (
             <ErrorBoundary
               fallback={
-                <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+                <div
+                  role="alert"
+                  className="flex-1 flex items-center justify-center text-sm text-muted-foreground"
+                >
                   {t("agentShellLayout.agentShellLayout.somethingWentWrong")}
                 </div>
               }
@@ -408,7 +414,11 @@ function AgentInsetProvider() {
     return (
       <InsetContext value={insetContextValue}>
         <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
-          <div className="flex h-full items-center justify-center bg-background card-shadow rounded-[0.75rem] text-sm text-muted-foreground">
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex h-full items-center justify-center bg-background card-shadow rounded-[0.75rem] text-sm text-muted-foreground"
+          >
             <Loading01 className="size-4 animate-spin mr-2" />
             {t("agentShellLayout.agentShellLayout.creatingTask")}
           </div>
@@ -421,7 +431,10 @@ function AgentInsetProvider() {
     return (
       <InsetContext value={insetContextValue}>
         <div className="flex-1 min-h-0 pr-1.5 pb-1.5 overflow-hidden">
-          <div className="flex flex-col h-full items-center justify-center gap-2 bg-background card-shadow rounded-[0.75rem] p-8 text-sm">
+          <div
+            role="alert"
+            className="flex flex-col h-full items-center justify-center gap-2 bg-background card-shadow rounded-[0.75rem] p-8 text-sm"
+          >
             <div className="font-medium">
               {t("agentShellLayout.agentShellLayout.taskUnavailable")}
             </div>


### PR DESCRIPTION
A concrete accessibility gap in the agent-shell layout: `AgentInsetProvider`'s task-creating spinner and its three error states (task-load error, the chat side-panel `ErrorBoundary` fallback, and the mobile main-panel `ErrorBoundary` fallback) render visible text/spinners but carry no ARIA semantics, so a screen-reader user gets no announcement when the task starts loading, fails to load, or the chat/main panel crashes.

Why a maintainer wants it: these are exactly the four transient states in this file's core render path (loading, task error, chat error, main-panel error) and none of them was announced — a real, verifiable accessibility gap in the layout the ticket's focus area calls out.

Fix: add `role="status" aria-live="polite"` to the creating-task spinner and `role="alert"` to the three error fallbacks, mirroring the identical pattern already used in `apps/web/src/routes/commerce-onboarding/loading-state.tsx` (`role="status" aria-live="polite"` wrapping a spinner+label). No layout/behavior change — pure ARIA attribute additions on existing DOM nodes.

How to verify: open a task and throttle/kill the network to hit the "Creating task…" and "Task unavailable" states, or inspect the accessibility tree (Chrome DevTools > Accessibility) for the four affected `div`s and confirm the new roles are present.

Locally ran: `bun run fmt` (clean) and `cd apps/web && bunx tsc --noEmit` (clean, no new type errors). Full CI validates lint/build/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Announces agent-shell loading and error states to screen readers. Adds `role="status" aria-live="polite"` to the creating-task spinner and `role="alert"` to the task-load, chat, and mobile main-panel error fallbacks; no UI or behavior changes.

<sup>Written for commit 3aa9e4fbd74c4107c6db46760268f2b0c4693625. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

