### PR TITLE
refactor(api): drop the legacy ai-providers/agent-tiers re-export shim

### DIFF
--- a/apps/api/src/ai-providers/agent-tiers.ts
+++ b/apps/api/src/ai-providers/agent-tiers.ts
@@ -1,5 +1,0 @@
-// Moved into the harness tree (used by the claude-code model test). Shim
-// keeps the legacy `@/ai-providers/agent-tiers` specifier working for
-// cluster callers. New code imports from
-// `@/harnesses/claude-code/model/agent-tiers`.
-export * from "@decocms/harness/claude-code/model/agent-tiers";

--- a/apps/api/src/api/routes/decopilot/routes.ts
+++ b/apps/api/src/api/routes/decopilot/routes.ts
@@ -12,7 +12,7 @@ import {
   resolveTier,
   tryResolveTier,
 } from "@/core/resolve-tier";
-import { resolveAgentTier } from "@/ai-providers/agent-tiers";
+import { resolveAgentTier } from "@decocms/harness/claude-code/model/agent-tiers";
 import {
   ChatTierSchema,
   type ChatTier,


### PR DESCRIPTION
Source: net code reduction found while hunting the agent-tier model machinery (packages/harness/src/claude-code/model/agent-tiers.ts and its callers) — that file itself, plus the codex model resolver and the web tier-subtitle logic, are already tightly covered by regression tests (see index.test.ts's guard for PR #3760's drift bug), so this PR targets a real dead-indirection instead.

`apps/api/src/ai-providers/agent-tiers.ts` was a one-line `export *` shim kept to preserve the legacy `@/ai-providers/agent-tiers` import specifier after the tier logic moved into the harness package. A repo-wide grep showed exactly one remaining consumer: `apps/api/src/api/routes/decopilot/routes.ts`. `apps/web` already imports `resolveAgentTier` directly from `@decocms/harness/claude-code/model/agent-tiers`, so this PR updates the one remaining call site to do the same and deletes the now-referenceless shim file.

Behavior is unchanged — it's the same `resolveAgentTier` function, just imported directly instead of through a re-export. Net: -6 / +1 lines, one file deleted.

How to verify: `rg -n "ai-providers/agent-tiers"` (no hits left except in git history), and `cd apps/api && bunx tsc --noEmit`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in apps/api (clean), `bun test apps/api/src/api/routes/decopilot/routes.test.ts` (25 pass) and `bun test packages/harness/src/claude-code/model/index.test.ts` (5 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the legacy `apps/api/src/ai-providers/agent-tiers.ts` re-export shim and updated `apps/api/src/api/routes/decopilot/routes.ts` to import `resolveAgentTier` directly from `@decocms/harness/claude-code/model/agent-tiers`. Behavior is unchanged; this reduces indirection and aligns imports with `apps/web`.

<sup>Written for commit d10845b5ca98a2c59c22bfaadecf6b30fbae482b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

