### PR TITLE
Revert "fix(sandbox): clear the thread's sandboxMap entry on SANDBOX_DELETE"

### DIFF
--- a/apps/api/src/tools/sandbox/delete.test.ts
+++ b/apps/api/src/tools/sandbox/delete.test.ts
@@ -95,20 +95,15 @@ function makeCtx(overrides: {
   userId?: string;
   virtualMcp?: ReturnType<typeof makeVirtualMcp> | null;
   updateSpy?: ReturnType<typeof mock>;
-  thread?: { id: string; metadata: Record<string, unknown> } | null;
-  threadUpdateSpy?: ReturnType<typeof mock>;
 }): StudioContext {
   const {
     orgId = "org_1",
     userId = "user-1",
     virtualMcp,
     updateSpy = mock(async () => {}),
-    thread = null,
-    threadUpdateSpy = mock(async () => {}),
   } = overrides;
 
   const findById = mock(async (_id: string) => virtualMcp ?? null);
-  const threadGet = mock(async (_id: string) => thread);
 
   return {
     auth: {
@@ -128,7 +123,6 @@ function makeCtx(overrides: {
     },
     storage: {
       virtualMcps: { findById, update: updateSpy },
-      threads: { get: threadGet, update: threadUpdateSpy },
     } as never,
     timings: {
       measure: async <T>(_name: string, cb: () => Promise<T>) => await cb(),
@@ -368,56 +362,6 @@ describe("SANDBOX_DELETE", () => {
 
     expect(result).toEqual({ success: true });
     expect(mockDelete).not.toHaveBeenCalled();
-  });
-
-  it("also clears the thread's sandboxMap entry for a thread-scoped branch", async () => {
-    const threadBranch = "thread:thread_1";
-    const metadata: Metadata = {
-      sandboxMap: makeSandboxMap(
-        "user-1",
-        threadBranch,
-        "agent-sandbox",
-        HOSTED_ENTRY,
-      ),
-    };
-    const virtualMcp = makeVirtualMcp("org_1", metadata);
-    const updateSpy = mock(async () => {});
-    const threadUpdateSpy = mock(async () => {});
-    const thread = {
-      id: "thread_1",
-      metadata: {
-        sandboxMap: makeSandboxMap(
-          "user-1",
-          threadBranch,
-          "agent-sandbox",
-          HOSTED_ENTRY,
-        ),
-      },
-    };
-    const ctx = makeCtx({ virtualMcp, updateSpy, thread, threadUpdateSpy });
-
-    const result = await SANDBOX_DELETE.handler(
-      {
-        virtualMcpId: "vmcp_1",
-        branch: threadBranch,
-        sandboxProviderKind: "agent-sandbox",
-      },
-      ctx,
-    );
-
-    expect(result).toEqual({ success: true });
-    expect(mockDelete).toHaveBeenCalledWith(HOSTED_ENTRY.sandboxHandle);
-    // Agent-row entry cleared.
-    expect(updateSpy).toHaveBeenCalledTimes(1);
-    // Thread's own copy cleared too — this is what the UI overlays on top of
-    // the agent's sandboxMap, so leaving it stale kept showing the deleted
-    // sandbox's previewUrl/handle.
-    expect(threadUpdateSpy).toHaveBeenCalledTimes(1);
-    const threadUpdateCall = (threadUpdateSpy.mock.calls as unknown[][])[0]!;
-    const threadUpdated = (
-      threadUpdateCall[1] as { metadata: { sandboxMap: SandboxMap } }
-    ).metadata;
-    expect(threadUpdated.sandboxMap["user-1"]).toBeUndefined();
   });
 
   it("throws 'User ID required' when userId is unavailable", async () => {

--- a/apps/api/src/tools/sandbox/delete.ts
+++ b/apps/api/src/tools/sandbox/delete.ts
@@ -9,7 +9,6 @@ import { normalizeSandboxProviderKind } from "@decocms/sandbox/provider";
 import { defineTool } from "../../core/define-tool";
 import { requireVmEntry } from "./helpers";
 import { removeSandboxMapEntry } from "./sandbox-map";
-import { removeThreadSandboxMapEntry, threadIdFromBranch } from "./thread-repo";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 
 const sandboxProviderKindInputSchema = z.enum([
@@ -87,23 +86,6 @@ export const SANDBOX_DELETE = defineTool({
       input.branch,
       kind,
     );
-    // Thread-scoped branches (`thread:<id>[/<conn>]`) ALSO get the record
-    // persisted on the THREAD by every provisioning path — the agent-row write
-    // above is a no-op for the synthetic Decopilot agent, and the frontend
-    // overlays the thread's sandboxMap on top of the agent's (see
-    // `setThreadSandboxMapEntry`). Without this, deleting a thread-scoped
-    // sandbox left the thread's copy stale, so the UI kept showing the
-    // torn-down handle/previewUrl for that thread.
-    const threadId = threadIdFromBranch(input.branch);
-    if (threadId) {
-      await removeThreadSandboxMapEntry(
-        ctx,
-        threadId,
-        sandboxUserId,
-        input.branch,
-        kind,
-      );
-    }
 
     await runner
       .delete(entry.sandboxHandle)


### PR DESCRIPTION
Reverts decocms/studio#5380

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that cleared a thread’s `sandboxMap` on `SANDBOX_DELETE`, restoring the original behavior where only the agent-level entry is removed. Removes the thread cleanup logic and its related test.

<sup>Written for commit ea7388d4d4385e34456bcf229670859f8ea80124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

