### PR TITLE
feat(sandbox): auto fast-forward idle sandbox to base branch on boot

### DIFF
--- a/packages/sandbox/daemon/git/fast-forward-to-base.test.ts
+++ b/packages/sandbox/daemon/git/fast-forward-to-base.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fastForwardToBase } from "./fast-forward-to-base";
+
+const GITCFG =
+  "-c init.defaultBranch=main -c user.email=test@example.com " +
+  "-c user.name=test -c commit.gpgsign=false";
+const GIT_OPTS = { stdio: "ignore" as const };
+
+function git(cwd: string, cmd: string): void {
+  execSync(`git ${GITCFG} -C ${cwd} ${cmd}`, GIT_OPTS);
+}
+
+function writeCommit(dir: string, file: string, content: string, msg: string) {
+  writeFileSync(join(dir, file), content, "utf-8");
+  git(dir, "add .");
+  git(dir, `commit -m "${msg}"`);
+}
+
+/**
+ * Bare origin with `main` (2 commits) and a `feat/x` forked from main's FIRST
+ * commit and pushed — i.e. behind main by one commit, no local commits of its
+ * own. `workspace` is a clone of `feat/x`, the "idle sandbox".
+ */
+function setupBehindRepo(): {
+  repoDir: string;
+  bare: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "ff-to-base-"));
+  const bare = join(root, "origin.git");
+  const seed = join(root, "seed");
+
+  execSync(`git ${GITCFG} init --bare ${bare}`, GIT_OPTS);
+  execSync(`git ${GITCFG} init ${seed}`, GIT_OPTS);
+
+  writeCommit(seed, "readme.md", "v1\n", "initial");
+  git(seed, "branch -M main");
+  git(seed, `remote add origin ${bare}`);
+  git(seed, "push -u origin main");
+
+  // Fork feat/x from main@v1 (no extra commits) and push it.
+  git(seed, "checkout -b feat/x");
+  git(seed, "push -u origin feat/x");
+
+  // main moves on.
+  git(seed, "checkout main");
+  writeCommit(seed, "readme.md", "v2\n", "advance main");
+  git(seed, "push origin main");
+
+  const repoDir = join(root, "workspace");
+  execSync(`git ${GITCFG} clone --branch feat/x ${bare} ${repoDir}`, GIT_OPTS);
+  git(repoDir, "config user.email test@example.com");
+  git(repoDir, "config user.name test");
+  // `git clone` already sets origin/HEAD -> origin/main, which fastForwardToBase
+  // reads to discover the base branch.
+
+  return {
+    repoDir,
+    bare,
+    cleanup: () => execSync(`rm -rf ${root}`, { stdio: "ignore" }),
+  };
+}
+
+function headContent(repoDir: string, file: string): string {
+  return execSync(`git ${GITCFG} -C ${repoDir} show HEAD:${file}`, {
+    encoding: "utf-8",
+  }).trim();
+}
+
+describe("fastForwardToBase", () => {
+  it("fast-forwards a clean branch that is behind base and pushes", async () => {
+    const { repoDir, bare, cleanup } = setupBehindRepo();
+    try {
+      const result = await fastForwardToBase(repoDir, { asUser: false });
+
+      expect(result.fastForwarded).toBe(true);
+      expect(result.base).toBe("main");
+      expect(result.branch).toBe("feat/x");
+      expect(result.aheadOfBase).toBe(0);
+      expect(result.behindBase).toBe(1);
+      expect(result.pushed).toBe(true);
+
+      // Working tree now carries main's advance.
+      expect(headContent(repoDir, "readme.md")).toBe("v2");
+
+      // origin/feat/x advanced too (non-force push landed).
+      const remoteFeat = execSync(
+        `git ${GITCFG} -C ${repoDir} rev-parse origin/feat/x`,
+        { encoding: "utf-8" },
+      ).trim();
+      const remoteMain = execSync(
+        `git ${GITCFG} --git-dir=${bare} rev-parse main`,
+        { encoding: "utf-8" },
+      ).trim();
+      expect(remoteFeat).toBe(remoteMain);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("skips when the branch has local commits (diverged)", async () => {
+    const { repoDir, cleanup } = setupBehindRepo();
+    try {
+      // Add a local commit → aheadOfBase becomes 1.
+      writeCommit(repoDir, "local.txt", "mine\n", "local work");
+
+      const result = await fastForwardToBase(repoDir, { asUser: false });
+
+      expect(result.fastForwarded).toBe(false);
+      expect(result.skipped).toBe("diverged");
+      expect(result.aheadOfBase).toBe(1);
+      // Untouched: still on the local commit, not main's v2.
+      expect(headContent(repoDir, "readme.md")).toBe("v1");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("skips when already up to date with base", async () => {
+    const { repoDir, cleanup } = setupBehindRepo();
+    try {
+      // First call brings it up to date...
+      await fastForwardToBase(repoDir, { asUser: false });
+      // ...second call is a no-op.
+      const result = await fastForwardToBase(repoDir, { asUser: false });
+
+      expect(result.fastForwarded).toBe(false);
+      expect(result.skipped).toBe("up-to-date");
+      expect(result.behindBase).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("refuses to fast-forward a protected (default) branch", async () => {
+    const { repoDir, cleanup } = setupBehindRepo();
+    try {
+      git(repoDir, "checkout main");
+      const result = await fastForwardToBase(repoDir, { asUser: false });
+
+      expect(result.fastForwarded).toBe(false);
+      expect(result.skipped).toBe("protected-branch");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("skips on a detached HEAD", async () => {
+    const { repoDir, cleanup } = setupBehindRepo();
+    try {
+      git(repoDir, "checkout --detach HEAD");
+      const result = await fastForwardToBase(repoDir, { asUser: false });
+
+      expect(result.fastForwarded).toBe(false);
+      expect(result.skipped).toBe("detached-head");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/sandbox/daemon/git/fast-forward-to-base.ts
+++ b/packages/sandbox/daemon/git/fast-forward-to-base.ts
@@ -1,0 +1,146 @@
+import { gitAsync } from "./git-async";
+import { protectedBranches } from "./protect-branch";
+
+/**
+ * Why a fast-forward did NOT happen. Every value is an expected, benign
+ * condition — never an error the caller must surface.
+ */
+export type FastForwardSkipReason =
+  | "detached-head"
+  | "protected-branch"
+  | "base-unavailable"
+  | "diverged"
+  | "up-to-date"
+  | "blocked";
+
+export interface FastForwardResult {
+  fastForwarded: boolean;
+  base: string;
+  branch: string | null;
+  aheadOfBase: number;
+  behindBase: number;
+  /** Whether the fast-forwarded HEAD was pushed to `origin/<branch>`. */
+  pushed: boolean;
+  skipped?: FastForwardSkipReason;
+}
+
+export interface FastForwardOptions {
+  /** Production daemon drops to the deco user; tests run git as current user. */
+  asUser?: boolean;
+}
+
+/**
+ * Advance the current branch to `origin/<base>` by pure fast-forward, then
+ * push, when the branch is CLEAN OF LOCAL COMMITS (`aheadOfBase === 0`) and
+ * merely behind base. This is the "idle sandbox, no changes" case: the user
+ * opened a sandbox, never committed, and base moved on while it sat idle — so
+ * a re-clone shows stale content. Fast-forward is conflict-free by
+ * construction (no history rewrite, no force-push), which is why it can run
+ * unattended on boot; anything with local commits (`aheadOfBase > 0`) is left
+ * for the manual, conflict-resolving `rebaseOntoBase` path.
+ *
+ * Best-effort and non-throwing for every expected condition (detached HEAD,
+ * protected branch, offline, diverged, up-to-date, or a dirty working tree
+ * that would block the ff-only merge) — it returns a `skipped` reason instead,
+ * so a caller on the boot path never has to guard it. Uses {@link gitAsync}
+ * throughout so it never blocks the daemon's single event loop.
+ */
+export async function fastForwardToBase(
+  repoDir: string,
+  options?: FastForwardOptions,
+): Promise<FastForwardResult> {
+  const asUser = options?.asUser ?? true;
+  const env = { ...process.env, GIT_CEILING_DIRECTORIES: repoDir };
+  const run = (args: string[]) =>
+    gitAsync(["-c", "safe.directory=*", ...args], {
+      cwd: repoDir,
+      env,
+      asUser,
+    });
+  const tryRun = async (args: string[]): Promise<string | null> => {
+    try {
+      return await run(args);
+    } catch {
+      return null;
+    }
+  };
+
+  let base =
+    (await tryRun(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])) ??
+    "";
+  if (base.startsWith("origin/")) base = base.slice("origin/".length);
+  if (!base) base = "main";
+
+  const branch = await tryRun(["rev-parse", "--abbrev-ref", "HEAD"]);
+
+  const skip = (
+    reason: FastForwardSkipReason,
+    fields?: Partial<FastForwardResult>,
+  ): FastForwardResult => ({
+    fastForwarded: false,
+    base,
+    branch: branch ?? null,
+    aheadOfBase: 0,
+    behindBase: 0,
+    pushed: false,
+    skipped: reason,
+    ...fields,
+  });
+
+  if (!branch || branch === "HEAD") return skip("detached-head");
+  // Same guard as rebaseOntoBase/publish: a sandbox on main/master/default must
+  // never auto-push. Fast-forward wouldn't force-push, but a sandbox is never
+  // meant to advance a protected branch unattended.
+  if (protectedBranches(repoDir).has(branch)) return skip("protected-branch");
+
+  // Fetch base ourselves: the boot's base fetch is fired detached (off the
+  // critical path in stepClone) and may not have landed yet. Prune so a base
+  // deleted on origin surfaces as base-unavailable below rather than a stale
+  // ref that silently fast-forwards to a dead commit.
+  await tryRun(["fetch", "-p", "origin", base]);
+
+  const upstream = `origin/${base}`;
+  if ((await tryRun(["rev-parse", "--verify", "--quiet", upstream])) === null) {
+    return skip("base-unavailable");
+  }
+
+  const lr = await tryRun([
+    "rev-list",
+    "--left-right",
+    "--count",
+    `${upstream}...HEAD`,
+  ]);
+  const m = lr?.match(/^(\d+)\s+(\d+)$/);
+  const behindBase = m ? Number(m[1]) : 0;
+  const aheadOfBase = m ? Number(m[2]) : 0;
+
+  // Local commits present → this is not "no changes". Leave it for the manual
+  // rebase button, which resolves conflicts and force-pushes deliberately.
+  if (aheadOfBase > 0) return skip("diverged", { aheadOfBase, behindBase });
+  if (behindBase === 0) return skip("up-to-date", { aheadOfBase, behindBase });
+
+  // Pure fast-forward: no new commit, no history rewrite. `--ff-only` refuses
+  // (leaving the tree untouched) if uncommitted local edits would be
+  // overwritten — treat that as a benign skip, not a failure.
+  if ((await tryRun(["merge", "--ff-only", upstream])) === null) {
+    return skip("blocked", { aheadOfBase, behindBase });
+  }
+
+  // Best-effort NON-force push so origin/<branch> (and any open PR) advances,
+  // and the next evict→re-clone starts fresh instead of stale again. Because
+  // aheadOfBase was 0, the new HEAD is a descendant of the old origin/<branch>,
+  // so this is itself a fast-forward push — it can never clobber. A
+  // non-fast-forward rejection (someone else pushed) is expected: skip it, the
+  // local fast-forward stands.
+  const pushed =
+    (await tryRun(["push", "origin", `HEAD:refs/heads/${branch}`])) !== null;
+
+  return {
+    fastForwarded: true,
+    base,
+    branch,
+    aheadOfBase,
+    behindBase,
+    pushed,
+  };
+}

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -15,6 +15,7 @@ import type { Broadcaster } from "../events/broadcast";
 import type { DaemonStatus } from "../events/types";
 import type { BranchStatusMonitor } from "../git/branch-status";
 import { ensureGitExclude } from "../git-exclude";
+import { fastForwardToBase } from "../git/fast-forward-to-base";
 import { gitSync } from "../git/git-sync";
 import { spawnCheckoutBranch } from "../git/checkout-branch";
 import { syncOriginRemote } from "../git/sync-origin-remote";
@@ -338,8 +339,36 @@ export class SetupOrchestrator {
     // exec, and repoDir doesn't exist until clone returns).
     await this.gitSetup(config);
     await this.fillApplicationDefaults(config.repoDir);
+    // Advance an idle-and-unchanged sandbox to its base branch BEFORE install,
+    // so install runs against the up-to-date lockfile. No-op unless the branch
+    // is clean-of-commits + behind base. Only fires on boot (fresh/adopt/
+    // warm-pool re-bootstrap) — a live resume keeps the same daemon and is
+    // intentionally out of scope for now (its content is at most idle-TTL stale,
+    // not the days-stale case this targets).
+    await this.maybeFastForwardToBase(config.repoDir);
     this.deps.branchStatus.refresh();
     return true;
+  }
+
+  /**
+   * Fast-forward the checked-out branch to `origin/<base>` when it has no local
+   * commits and merely fell behind while idle. Best-effort and non-throwing, so
+   * a failure never blocks the boot.
+   */
+  private async maybeFastForwardToBase(repoDir: string): Promise<void> {
+    try {
+      const result = await fastForwardToBase(repoDir);
+      if (result.fastForwarded) {
+        this.chunk(
+          `[orchestrator] fast-forwarded ${result.branch} to origin/${result.base} ` +
+            `(+${result.behindBase} commits${result.pushed ? ", pushed" : ""})\r\n`,
+        );
+      }
+    } catch (e) {
+      this.rawChunk(
+        `\r\n[orchestrator] fast-forward to base failed: ${(e as Error).message}\r\n`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

An idle sandbox is re-provisioned as a **fresh clone** whenever the pod has been evicted (15-min idle TTL), so returning days later restores the branch at its **last-pushed point** and shows stale content — base moved on while the sandbox sat idle, but nothing ever reconciled it. Divergence-from-base was continuously *detected* (`BranchStatusMonitor`) but acting on it was always user-initiated (the manual rebase button).

This adds an automatic reconciliation on boot for the safe, "no changes" case.

## What it does

- New `daemon/git/fast-forward-to-base.ts` → `fastForwardToBase(repoDir)`:
  - Resolves the base from `origin/HEAD`, reads the current branch.
  - **Only acts when the branch is clean of local commits (`aheadOfBase === 0`) and merely behind base** → a pure `git merge --ff-only` (no history rewrite, no force-push), followed by a best-effort **non-force** push so `origin/<branch>` and any open PR advance and the next evict→re-clone starts fresh instead of stale again.
  - Refuses protected (main/master/default) and detached-HEAD states; treats a dirty-tree `--ff-only` block, offline, diverged, and up-to-date as benign skips.
  - Anything with local commits (`aheadOfBase > 0`) is left untouched for the manual, conflict-resolving `rebaseOntoBase` path.
- Wired into `SetupOrchestrator.stepClone` **after clone/checkout, before install** (so install runs against the up-to-date lockfile). Best-effort and non-throwing so it never blocks boot.
- Uses `gitAsync` throughout — never blocks the daemon's single event loop.

## Safety

Fast-forward on `aheadOfBase === 0` is conflict-free by construction, which is why it's safe to run unattended: no merge conflicts possible, no force-push, and the non-force push can never clobber `origin`. It only fires on boot (fresh / adopt / warm-pool re-bootstrap); a **live resume** keeps the same daemon and is intentionally out of scope (its content is at most idle-TTL-minutes stale, not the days-stale case this targets).

## Scope note

Runs on **every boot, unconditionally** (no feature flag). It is self-limited by the guards above — "always *tries*, acts only when safe." Because it's on a boot hot path, the only mitigation if a `git fetch` misbehaves in prod is that the call is best-effort and never blocks boot; there is no runtime kill-switch. Happy to add a default-on env kill-switch (`SANDBOX_AUTO_FAST_FORWARD=0` to disable) if we want an escape hatch — say the word.

## Testing

`packages/sandbox/daemon/git/fast-forward-to-base.test.ts` — real git in temp dirs, 5 cases: happy fast-forward+push, `diverged` (local commit → untouched), `up-to-date`, protected branch refused, detached HEAD skipped. All pass.

- `bun test packages/sandbox/daemon/git/fast-forward-to-base.test.ts` ✅ (5 pass)
- `bun run --cwd=packages/sandbox check` (typecheck) ✅
- `bun run fmt` ✅ · lint clean on changed files · knip clean (no orphaned exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically fast-forwards idle sandboxes to their base branch on boot when they have no local commits, keeping them up to date and avoiding stale installs. If safe, it also pushes the fast-forward to `origin` so future re-clones start fresh.

- **New Features**
  - Added `fastForwardToBase(repoDir)` to advance a clean branch to `origin/<base>` via `--ff-only`, then attempt a non-force push to `origin/<branch>`.
  - Wired into `SetupOrchestrator.stepClone` after clone/checkout and before install; best-effort, non-throwing, and uses `gitAsync`.
  - Skips protected branches and detached HEAD; treats offline/dirty/diverged/up-to-date states as no-ops. Tests cover fast-forward, diverged, up-to-date, protected, and detached cases.

<sup>Written for commit b7fb71a8a938755b3948c499c4add024c59340e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

