### PR TITLE
fix(sandbox): make the daemon edit route async

### DIFF
--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -479,7 +479,7 @@ export function makeEditHandler(deps: FsDeps) {
 
     let content: string;
     try {
-      content = fs.readFileSync(filePath, "utf-8");
+      content = await readFile(filePath, "utf-8");
     } catch {
       return jsonResponse({ error: `File not found: ${body.path}` }, 400);
     }
@@ -500,7 +500,7 @@ export function makeEditHandler(deps: FsDeps) {
     const jsonError = invalidDecofileBlockJson(body.path ?? "", updated);
     if (jsonError)
       return jsonResponse({ error: `Refusing to write ${jsonError}` }, 400);
-    fs.writeFileSync(filePath, updated, "utf-8");
+    await writeFile(filePath, updated, "utf-8");
     deps.onWorkingTreeWrite?.(body.path ?? "");
     return jsonResponse({
       ok: true,


### PR DESCRIPTION
Follows #5370/#5372/#5375, which converted the daemon's write/unlink/mkdir routes from sync to async fs calls. The `edit` route (`makeEditHandler` in `packages/sandbox/daemon/routes/fs.ts`) still used `fs.readFileSync`/`fs.writeFileSync`, so a large file edit blocks the daemon's single-threaded event loop, which can cause a missed health probe and trigger sandbox teardown/recovery (see CONTRIBUTING.md rule #1).

This PR swaps those two calls for the already-imported `readFile`/`writeFile` from `node:fs/promises`, with `await`. Behavior is unchanged (same error handling, same return shape) — only the read/write path stops blocking the loop.

Other sync fs calls remain in this file (`read`, `rename`, `glob`, `upload_to_url` handlers) and are left for follow-up PRs, matching the established one-route-per-PR pattern.

Reviewer check: `bun test packages/sandbox/daemon/routes/fs.test.ts` (56 pass, 0 fail).

Locally verified: `cd packages/sandbox && bunx tsc --noEmit` (clean), targeted test file above (all green), `bun run fmt` (no changes needed). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the sandbox daemon `edit` route async to avoid blocking the event loop on large file edits, preventing missed health probes and sandbox teardown. Replaces sync `fs.readFileSync`/`fs.writeFileSync` with `readFile`/`writeFile` from `node:fs/promises`, with no behavior changes.

<sup>Written for commit 83aa7bc2377f79053f7ac97c2a983599c431d76c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

