### PR TITLE
fix(decopilot): send fixed X-Title to OpenRouter instead of org name

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.test.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.test.ts
@@ -2,25 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   assertSinglePersistedRequestMessage,
   buildDurableDispatchInput,
-  sanitizeHeaderValue,
 } from "./dispatch-run";
 import type { ChatMessage } from "./types";
-
-describe("sanitizeHeaderValue", () => {
-  test("strips CR/LF so an org display name can't break header construction", () => {
-    expect(sanitizeHeaderValue("Acme\r\nX-Injected: evil")).toBe(
-      "Acme  X-Injected: evil",
-    );
-  });
-
-  test("strips other control characters and trims the result", () => {
-    expect(sanitizeHeaderValue("  Acme\tInc\x00  ")).toBe("Acme Inc");
-  });
-
-  test("leaves an ordinary org name untouched", () => {
-    expect(sanitizeHeaderValue("Acme Inc")).toBe("Acme Inc");
-  });
-});
 
 describe("assertSinglePersistedRequestMessage", () => {
   test("returns the persisted user message matching the durable message id", () => {

--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -311,14 +311,6 @@ export function buildHarnessWorkspaceInput(input: {
   };
 }
 
-// Org display names are free-text (ORGANIZATION_UPDATE allows any
-// character up to 255 long) but get spliced into the `X-Title` header sent
-// to OpenRouter. A `\r`/`\n` there breaks header construction outright and
-// other control chars are meaningless in an HTTP header value, so strip them.
-export function sanitizeHeaderValue(value: string): string {
-  return value.replace(/[\0-\x1f\x7f]/g, " ").trim();
-}
-
 async function resolveSecretModelSource(
   ctx: StudioContext,
   organizationId: string,
@@ -338,20 +330,16 @@ async function resolveSecretModelSource(
   // OpenRouter identifies the app by `HTTP-Referer` (that's what promotes a
   // request out of the "Unknown" bucket in its dashboard/rankings); `X-Title`
   // only sets the display name. Both are required — a title without a referer
-  // stays Unknown. Referer is a fixed Studio URL so all traffic rolls up under
-  // one app; `X-Title` carries the org (and distinguishes `deco`, the
-  // OpenRouter provider behind the deco AI gateway, from direct-OpenRouter use).
+  // stays Unknown. Both are surfaced publicly on OpenRouter's app rankings, so
+  // they carry fixed brand values only — never anything tenant-derived (org
+  // name/slug/id) that would leak onto a public leaderboard.
   if (source.providerId === "openrouter" || source.providerId === "deco") {
-    const orgName = sanitizeHeaderValue(
-      ctx.organization?.name ?? ctx.organization?.slug ?? organizationId,
-    );
-    const appName = source.providerId === "deco" ? "deco AI Gateway" : "Studio";
     return {
       ...source,
       extraHeaders: {
         ...source.extraHeaders,
         "HTTP-Referer": "https://studio.decocms.com",
-        "X-Title": `${appName} - ${orgName}`,
+        "X-Title": "deco",
       },
     };
   }


### PR DESCRIPTION
## Summary

The `X-Title` and `HTTP-Referer` headers sent to OpenRouter are **public data** — OpenRouter uses them to identify and rank apps on its public rankings/leaderboards.

`X-Title` previously carried the org display name (`` `${appName} - ${orgName}` ``), leaking a tenant-derived value onto a public leaderboard. This PR sends a **fixed brand value (`"deco"`)** for both the `openrouter` and `deco` providers.

## Changes

- `apps/api/src/api/routes/decopilot/dispatch-run.ts`: `X-Title` is now the fixed string `"deco"`; `HTTP-Referer` stays the fixed `https://studio.decocms.com`.
- Removed the now-orphaned `sanitizeHeaderValue` helper (it only existed to sanitize the org name into the header) and its tests.
- Updated the comment to note both headers are public and must only carry fixed brand values.

## Note / trade-off

Traffic from both the `openrouter` and `deco` providers now rolls up under the same `"deco"` title in the OpenRouter dashboard. This drops the previous per-org segmentation and the "deco AI Gateway" vs "Studio" distinction — intentional, since those either leaked tenant data (org) or weren't worth reintroducing. Easy to add back a non-sensitive fixed distinction if desired.

## Testing

- `bun test apps/api/src/api/routes/decopilot/dispatch-run.test.ts` — passing
- `bun run --cwd=apps/api check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop leaking org names to OpenRouter by sending a fixed `X-Title: deco`. All traffic from `openrouter` and `deco` now shows as "deco", with `HTTP-Referer` unchanged at https://studio.decocms.com.

- **Bug Fixes**
  - Set `X-Title` to "deco" for `openrouter` and `deco`.
  - Kept `HTTP-Referer` fixed to https://studio.decocms.com.
  - Updated comments to note both headers are public and must use fixed brand values.

- **Refactors**
  - Removed `sanitizeHeaderValue` and its tests.

<sup>Written for commit 5f9e713d2076137b9ff506d7295100a686a1e92d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

