### PR TITLE
fix(decopilot): don't surface a producer timeout as an assistant message

### DIFF
--- a/apps/api/src/api/routes/decopilot/projector-workflow.test.ts
+++ b/apps/api/src/api/routes/decopilot/projector-workflow.test.ts
@@ -343,6 +343,10 @@ describe("runProjectorWorkflowBody", () => {
     expect(recordFailCall?.runId).toBe("run_1");
     expect(recordFailCall?.orgId).toBe("org_1");
     expect(recordFailCall?.distinctId).toBe("user_1");
+    // The fold's synthesized "Error: producer produced no output before
+    // timeout" bubble is a projector internal, not an assistant reply — the
+    // failed terminal is the signal, so the bubble must be deleted.
+    expect(calls.filter((c) => c.kind === "clear-error")).toHaveLength(1);
   });
 
   test("tool-calls + approval-requested → requires_action, no recordCompleted", async () => {

--- a/apps/api/src/api/routes/decopilot/projector-workflow.ts
+++ b/apps/api/src/api/routes/decopilot/projector-workflow.ts
@@ -417,6 +417,16 @@ export async function runProjectorWorkflowBody(
         kind,
       });
     }
+    // On a liveness breach the fold's error part came from OUR OWN stream
+    // error, so the thread rendered the assistant saying "Error: producer
+    // produced no output before timeout" — a projector implementation detail,
+    // not a reply. The `failed` terminal (+ the liveness `failure_reason`) is
+    // the user-visible signal, so drop the bubble. Scoped to the synthesized
+    // message id: whatever step parts the producer did publish before going
+    // silent live under the harness message id and are untouched.
+    if (isLivenessBreach) {
+      await rt.clearSynthesizedError(input.runId, input.fenceToken);
+    }
     // Re-throw so DBOS records the workflow failure (poison run — projection
     // itself threw after exhausting retries; NOT a harness-error run). This
     // holds for the liveness case too: the consume step genuinely failed to

--- a/packages/e2e/tests/decopilot-unified-control-plane.spec.ts
+++ b/packages/e2e/tests/decopilot-unified-control-plane.spec.ts
@@ -385,6 +385,12 @@ test.describe("decopilot desktop — executor death mid-run reaches a liveness t
         expect(row.failureKind).toBe("liveness");
         expect(row.failureReason ?? "").toContain("liveness");
       }).toPass({ timeout: 170_000, intervals: [2_000, 5_000, 10_000] });
+
+      // The liveness terminal is the ONLY signal. The projector's own stream
+      // error must never land in the thread as the assistant saying "Error:
+      // producer produced no output before timeout" — that string is a
+      // projector implementation detail, not a reply.
+      expect(await fetchErrorPartTexts(db, threadId)).toEqual([]);
     } finally {
       await daemon?.close();
       await db.end();


### PR DESCRIPTION
## Summary

A thread on prod rendered this as the assistant's reply:

> Error: producer produced no output before timeout

That string is `StreamIdleTimeoutError`'s message — a projector internal, not a reply.

**Why it happened.** Since T3 the thread gate starts the executor and immediately opens the projector's live tail without awaiting the child (`consume-run-projection.ts`), so `natsChunkSource` races `iterator.next()` against a 10-min `sleep` (`RUN_IDLE_TIMEOUT_MS`) and throws `StreamIdleTimeoutError` when the run's JetStream subject stays silent. A producer that never gets as far as opening its harness stream (sandbox provisioning failure, or a child parked in the app-level per-pod concurrency gate) publishes nothing — not even a `data-liveness` heartbeat, since those only start once `dispatchHarnessChunks()` is being pulled.

That error is thrown *through* the AI-SDK fold, so `consumeHarnessStream`'s `onError` persists a synthesized assistant part `Error: ${err.message}` (`part-row-builder.ts` `emitError`). `runProjectorWorkflowBody` then correctly does `markRunFailed(kind: "liveness", reason: "liveness: no stream events for 10m")` — but `clearSynthesizedError` was only called on *successful* terminals, so the bubble stayed.

**The fix.** Clear the synthesized error on the liveness path too. The `failed` terminal + `failure_reason` is the user-visible signal. Scoped to the synthesized message id, so whatever step parts the producer did publish before going silent are untouched.

## Testing notes

- `projector-workflow.test.ts` — extended the existing `StreamIdleTimeoutError` test to assert the bubble is cleared (23 pass).
- `decopilot-unified-control-plane.spec.ts` — extended the liveness e2e proof (fake daemon publishes a few chunks then goes silent) to assert no `kind='error'` part survives.
- `bun run check` and `bun run lint` clean (17 pre-existing web warnings, 0 errors).

## Affected areas / follow-ups

- **No chat-body affordance for `failed`.** `failed` has UI treatment only in list/chrome surfaces (`lib/task-status.ts` → sidebar group, task-row icon, board chip, status sound). Inside `components/chat/` the status is read only for `in_progress`/`expired`; the error banner in `chat/highlight/` is driven by client-side `chatError` from an in-band AI-SDK error chunk, never by thread status. And the reason never reaches the client — `createDecopilotThreadStatusEvent` has no `reason` field and `failure_reason` has zero readers in `apps/web/src`. So a producer timeout now shows: user message, empty space, red chip in the sidebar. Making it legible in-chat is a separate change (thread `reason` into the status event + render `StatusHighlight variant="error"` off `status === "failed"`).
- **`StreamGapError` leaks the same way** on its non-settled branch (`Error: missing seq 1` as an assistant bubble). Same one-line fix; left out to keep this diff to the reported bug.
- Not addressed here: *why* the producer stalled on that specific run. I couldn't read the thread (`COLLECTION_THREADS_GET` returns null cross-org) and didn't dig through prod logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents internal projector timeouts from showing up as an assistant reply. On a liveness breach, we now clear the synthesized error bubble and rely on the run’s failed status.

- **Bug Fixes**
  - Clear the synthesized error when `StreamIdleTimeoutError` occurs, so “Error: producer produced no output before timeout” is not rendered as a reply.
  - Scope the clear to the synthesized message id; any real step parts remain.
  - Extend unit and e2e tests to assert the bubble is removed and no `kind='error'` part persists.

<sup>Written for commit eb5a5a6cea20ab3be97bc80524a8e08975ea1edb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

