### PR TITLE
fix(connections): keep connection slug in sync so detail pages stop 404ing

### DIFF
--- a/apps/api/migrations/152-repair-connection-slug.ts
+++ b/apps/api/migrations/152-repair-connection-slug.ts
@@ -1,0 +1,85 @@
+/**
+ * Repair Connection Slug
+ *
+ * The `slug` column added in 054 is a denormalization of app_name/connection_url/
+ * title, and the UI links to a connection by the slug it derives from those same
+ * fields. Rows whose column drifted from that derivation (a stale slug left by an
+ * update that cleared app_name, or a NULL from a writer that skipped the column)
+ * are unreachable: the connection shows up in the list but its detail page 404s.
+ *
+ * Recompute the column for every non-VIRTUAL row. VIRTUAL rows are excluded on
+ * purpose — they aren't routed by slug, and giving them one would enable links to
+ * a page that filters them out.
+ *
+ * NOTE: slug logic is inlined (same as 054) so the migration stays deterministic
+ * regardless of future changes to the shared getConnectionSlug function.
+ */
+
+import { type Kysely, sql } from "kysely";
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/\//g, "-")
+    .replace(/[^a-z0-9\s_-]+/g, "")
+    .replace(/[\s_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function computeSlug(row: {
+  id: string;
+  app_name: string | null;
+  connection_url: string | null;
+  title: string;
+}): string {
+  if (row.app_name) return row.app_name;
+  if (row.connection_url) {
+    try {
+      const parsed = new URL(row.connection_url);
+      const host = parsed.port
+        ? `${parsed.hostname}-${parsed.port}`
+        : parsed.hostname;
+      const raw = (host + parsed.pathname).replace(/\/+$/, "");
+      return slugify(raw);
+    } catch {
+      return slugify(row.connection_url);
+    }
+  }
+  if (row.title) return slugify(row.title);
+  return row.id;
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const rows = (await sql`
+    SELECT id, app_name, connection_url, title, slug
+    FROM connections
+    WHERE connection_type != 'VIRTUAL'
+  `.execute(db)) as {
+    rows: Array<{
+      id: string;
+      app_name: string | null;
+      connection_url: string | null;
+      title: string;
+      slug: string | null;
+    }>;
+  };
+
+  let repaired = 0;
+  for (const row of rows.rows) {
+    const slug = computeSlug(row);
+    if (slug === row.slug) continue;
+    await sql`UPDATE connections SET slug = ${slug} WHERE id = ${row.id}`.execute(
+      db,
+    );
+    repaired++;
+  }
+
+  if (repaired > 0) {
+    console.log(`[152] repaired ${repaired} drifted connection slug(s)`);
+  }
+}
+
+export async function down(): Promise<void> {
+  // Data repair only — the previous (drifted) values are not worth restoring.
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -150,6 +150,7 @@ import * as migration148orgflags from "./148-org-flags.ts";
 import * as migration149taskboarditemsortorder from "./149-task-board-item-sort-order.ts";
 import * as migration150taskboardactivity from "./150-task-board-activity.ts";
 import * as migration151taskboardtags from "./151-task-board-tags.ts";
+import * as migration152repairconnectionslug from "./152-repair-connection-slug.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -325,6 +326,7 @@ const migrations: Record<string, Migration> = {
   "149-task-board-item-sort-order": migration149taskboarditemsortorder,
   "150-task-board-activity": migration150taskboardactivity,
   "151-task-board-tags": migration151taskboardtags,
+  "152-repair-connection-slug": migration152repairconnectionslug,
 };
 
 export default migrations;

--- a/apps/api/src/storage/connection.integration.test.ts
+++ b/apps/api/src/storage/connection.integration.test.ts
@@ -367,6 +367,43 @@ describe("ConnectionStorage", () => {
       });
       expect(updated.slug).toBe("new-app-name");
     });
+
+    it("should recompute slug on update when app_name is cleared", async () => {
+      const conn = await storage.create({
+        organization_id: "org_123",
+        created_by: "user_123",
+        title: "Slug Clear Test",
+        app_name: "cleared-app",
+        connection_type: "HTTP",
+        connection_url: "https://cleared.example.com/api/mcp",
+      });
+      expect(conn.slug).toBe("cleared-app");
+
+      const updated = await storage.update(conn.id, { app_name: null });
+      expect(updated.slug).toBe("clearedexamplecom-api-mcp");
+
+      // The slug is what the UI links by, so the connection must stay findable.
+      const { items } = await storage.list("org_123", {
+        slug: "clearedexamplecom-api-mcp",
+      });
+      expect(items.map((c) => c.id)).toContain(conn.id);
+    });
+
+    it("should recompute slug on update when only the token changes", async () => {
+      const conn = await storage.create({
+        organization_id: "org_123",
+        created_by: "user_123",
+        title: "Slug Untouched Test",
+        app_name: "untouched-app",
+        connection_type: "HTTP",
+        connection_url: "https://untouched.example.com",
+      });
+
+      const updated = await storage.update(conn.id, {
+        connection_token: "tok_123",
+      });
+      expect(updated.slug).toBe("untouched-app");
+    });
   });
 
   describe("update", () => {

--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -368,22 +368,23 @@ export class ConnectionStorage implements ConnectionStoragePort {
       return connection;
     }
 
-    // Recompute slug if any slug-relevant field changed
+    // The slug column is a denormalization of app_name/connection_url/title, and
+    // the UI links to a connection by the slug it derives from those same fields
+    // (getConnectionSlug). Any drift makes the connection unreachable — its detail
+    // page 404s while the list still shows it. So recompute from the merged row on
+    // every update, using presence (not `??`) so an explicit null clears the field
+    // it was derived from instead of silently keeping the old slug.
     const slugData: Record<string, unknown> = { ...data };
-    if (
-      data.app_name !== undefined ||
-      data.connection_url !== undefined ||
-      data.title !== undefined
-    ) {
-      const existing = await this.findById(id);
-      if (existing) {
-        slugData.slug = getConnectionSlug({
-          app_name: data.app_name ?? existing.app_name,
-          connection_url: data.connection_url ?? existing.connection_url,
-          title: data.title ?? existing.title,
-          id,
-        });
-      }
+    const existing = await this.findById(id);
+    if (existing) {
+      const merged = <K extends keyof ConnectionEntity>(key: K) =>
+        data[key] === undefined ? existing[key] : data[key];
+      slugData.slug = getConnectionSlug({
+        app_name: merged("app_name"),
+        connection_url: merged("connection_url"),
+        title: merged("title"),
+        id,
+      });
     }
 
     const serialized = await this.serializeConnection({


### PR DESCRIPTION
## Problem

A connection that exists, shows up in **Connections**, and is happily used by an agent renders **"Connection not found"** on its detail page (repro in prod: `/deco/settings/connections/ai-sitedecosite-api-mcp`).

The route has two independent sources of truth for the slug:

- the **frontend** links by `getConnectionSlug(connection)` — derived client-side from `app_name` → `connection_url` → `title`;
- the **backend** resolves `/$org/settings/connections/$appSlug` with `COLLECTION_CONNECTIONS_LIST { slug }`, which is a SQL equality match on the persisted `connections.slug` column.

The moment those disagree the connection is unreachable — the list still renders it (derived), the detail page finds nothing (column).

## Fixes

1. **`ConnectionStorage.update()` could leave the column stale.** It recomputed with `data.x ?? existing.x`, so an update that explicitly clears `app_name` fell back to the *old* `app_name` and kept an `app_name`-derived slug, while the entity had already moved to a URL-derived one. Now the slug is recomputed from the merged row on every update, using key presence instead of `??`.

2. **Migration `152-repair-connection-slug`** recomputes the column for every non-VIRTUAL row whose stored slug differs from the derived value — this is what unbricks rows already drifted in prod (stale *or* NULL). VIRTUAL rows are deliberately skipped: they are not routed by slug, and giving them one would enable links to a page that filters them out.

Verified locally against real Postgres: a row with a stale slug and a row with a NULL slug both repair to `ai-sitedecosite-api-mcp` (the reported URL), an already-correct row and a VIRTUAL row are untouched.

## Testing

- `apps/api/src/storage/connection.integration.test.ts` (real Postgres): new case for the cleared-`app_name` recompute — **fails before this change** (`cleared-app` instead of `clearedexamplecom-api-mcp`) — plus a case asserting an unrelated field update leaves the slug alone. 32/32 pass with the fix.
- `bun test apps/api/migrations/index.test.ts`, `bun run --cwd=apps/api check`, `bun run fmt`, `bun run lint` clean.
- Ran locally on Postgres 14 (CI's storage-integration workflow uses 16).

## Follow-up not in this PR

The structural fix is to stop deriving slugs on the client at all — the entity already carries `slug`, so links could use it directly and the column would be the single source of truth. That touches ~6 call sites and needs a story for NULL-slug (VIRTUAL) rows, so it is left out; this PR closes the known drift producer and repairs the data.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404s on connection detail pages by keeping the persisted slug in sync with the client-derived slug and repairing drifted rows. Existing broken connections are fixed by a data migration.

- **Bug Fixes**
  - In `ConnectionStorage.update()`, always recompute `slug` from the merged row using key presence (not `??`), so clearing `app_name` correctly shifts to a URL- or title-derived slug and prevents drift.

- **Migration**
  - Adds `152-repair-connection-slug` to recompute `connections.slug` for all non-`VIRTUAL` rows where the stored value differs from the derived one; `VIRTUAL` rows are skipped.

<sup>Written for commit b7122ac1c4e1901862a3e5675007bf035152c628. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

