### PR TITLE
fix(harness): clamp full-page screenshots below Anthropic's 8000px limit

### DIFF
--- a/packages/harness/src/decopilot/built-in-tools/portable-media-tools.test.ts
+++ b/packages/harness/src/decopilot/built-in-tools/portable-media-tools.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { buildScreenshotOptions, jpegHeight } from "./portable-media-tools";
+
+describe("buildScreenshotOptions", () => {
+  it("captures the viewport when fullPage is off", () => {
+    expect(buildScreenshotOptions(false)).toMatchObject({ fullPage: false });
+  });
+
+  it("captures the whole page on the first attempt", () => {
+    expect(buildScreenshotOptions(true)).toMatchObject({ fullPage: true });
+  });
+
+  it("clips instead of fullPage on the clamped retry — they are exclusive", () => {
+    const options = buildScreenshotOptions(true, true);
+    expect(options).not.toHaveProperty("fullPage");
+    expect(options).toMatchObject({
+      clip: { x: 0, y: 0, width: 1280, height: 7000 },
+    });
+  });
+});
+
+/** Minimal JPEG: SOI, an APP0 segment to skip over, then SOF0 with dimensions. */
+function jpegWith(height: number, width = 1280): Uint8Array {
+  const sof = [
+    0xff,
+    0xc0,
+    0x00,
+    0x11,
+    0x08,
+    (height >> 8) & 0xff,
+    height & 0xff,
+    (width >> 8) & 0xff,
+    width & 0xff,
+    0x03,
+    0x01,
+    0x11,
+    0x00,
+    0x02,
+    0x11,
+    0x01,
+    0x03,
+    0x11,
+    0x01,
+  ];
+  return new Uint8Array([
+    0xff,
+    0xd8,
+    0xff,
+    0xe0,
+    0x00,
+    0x04,
+    0x00,
+    0x00,
+    ...sof,
+  ]);
+}
+
+describe("jpegHeight", () => {
+  it("reads the height past intervening segments", () => {
+    expect(jpegHeight(jpegWith(842))).toBe(842);
+  });
+
+  it("reads heights above the 8000px ceiling that broke thrd_uY3x6c0d", () => {
+    expect(jpegHeight(jpegWith(21_314))).toBe(21_314);
+  });
+
+  it("returns null for non-JPEG bytes rather than guessing", () => {
+    expect(jpegHeight(new Uint8Array([0x89, 0x50, 0x4e, 0x47]))).toBeNull();
+  });
+
+  it("returns null on a truncated file", () => {
+    expect(jpegHeight(new Uint8Array([0xff, 0xd8, 0xff, 0xe0]))).toBeNull();
+  });
+});

--- a/packages/harness/src/decopilot/built-in-tools/portable-media-tools.ts
+++ b/packages/harness/src/decopilot/built-in-tools/portable-media-tools.ts
@@ -12,6 +12,54 @@ const FILES_URL_PATTERN = /\/api\/[^/]+\/files\/([^?#]+)/;
 const MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024;
 const DEFAULT_VIEWPORT = { width: 1280, height: 800 };
 const JPEG_QUALITY = 80;
+/**
+ * Anthropic rejects any image over 8000px on either side, and an oversized
+ * screenshot poisons the thread permanently: it is inlined as base64 into the
+ * message history, so every later turn replays it and gets the same 400. A
+ * full-page capture of a long landing page blows past this easily.
+ */
+const MAX_SCREENSHOT_HEIGHT = 7000;
+
+/** Puppeteer rejects `clip` together with `fullPage` — they are exclusive. */
+export function buildScreenshotOptions(fullPage: boolean, clamped = false) {
+  return {
+    ...(fullPage && clamped
+      ? {
+          clip: {
+            x: 0,
+            y: 0,
+            width: DEFAULT_VIEWPORT.width,
+            height: MAX_SCREENSHOT_HEIGHT,
+          },
+        }
+      : { fullPage }),
+    type: "jpeg" as const,
+    quality: JPEG_QUALITY,
+  };
+}
+
+/**
+ * Height of a JPEG, read off its SOF marker. Returns null if the bytes aren't
+ * a JPEG we can parse — callers treat that as "assume it's fine".
+ */
+export function jpegHeight(bytes: Uint8Array): number | null {
+  if (bytes[0] !== 0xff || bytes[1] !== 0xd8) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let i = 2;
+  while (i + 9 < bytes.length) {
+    if (bytes[i] !== 0xff) return null;
+    const marker = bytes[i + 1] as number;
+    // SOF0-SOF15 carry the frame dimensions; C4/C8/CC are other segments.
+    if (
+      marker >= 0xc0 &&
+      marker <= 0xcf &&
+      ![0xc4, 0xc8, 0xcc].includes(marker)
+    )
+      return view.getUint16(i + 5);
+    i += 2 + view.getUint16(i + 2);
+  }
+  return null;
+}
 
 export interface PortableMediaObjectStorage {
   put(
@@ -332,22 +380,22 @@ export function createPortableTakeScreenshotTool(
             error: "BROWSERLESS_TOKEN is not configured.",
           };
         }
-        const response = await fetch(
-          `${BROWSERLESS_BASE_URL}/screenshot?token=${encodeURIComponent(token)}`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              url: input.url,
-              options: {
-                fullPage: input.fullPage ?? false,
-                type: "jpeg",
-                quality: JPEG_QUALITY,
-              },
-              viewport: DEFAULT_VIEWPORT,
-            }),
-          },
-        );
+        const fullPage = input.fullPage ?? false;
+        const shoot = async (clamped: boolean) =>
+          await fetch(
+            `${BROWSERLESS_BASE_URL}/screenshot?token=${encodeURIComponent(token)}`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                url: input.url,
+                options: buildScreenshotOptions(fullPage, clamped),
+                viewport: DEFAULT_VIEWPORT,
+              }),
+            },
+          );
+
+        let response = await shoot(false);
         if (!response.ok) {
           const errorText = await response.text().catch(() => "Unknown error");
           return {
@@ -357,7 +405,24 @@ export function createPortableTakeScreenshotTool(
           };
         }
 
-        const imgBytes = new Uint8Array(await response.arrayBuffer());
+        let imgBytes = new Uint8Array(await response.arrayBuffer());
+        const height = jpegHeight(imgBytes);
+        if (fullPage && height !== null && height > MAX_SCREENSHOT_HEIGHT) {
+          response = await shoot(true);
+          const clipped = response.ok
+            ? new Uint8Array(await response.arrayBuffer())
+            : null;
+          // Emitting an oversized capture would brick the thread, so fail the
+          // tool call instead — the model can retry without `fullPage`.
+          if (!clipped || (jpegHeight(clipped) ?? 0) > MAX_SCREENSHOT_HEIGHT) {
+            return {
+              success: false as const,
+              error: `Full-page screenshot of ${input.url} is ${height}px tall, over the ${MAX_SCREENSHOT_HEIGHT}px limit, and the clipped retry did not come back within it. Retry with fullPage: false.`,
+              url: input.url,
+            };
+          }
+          imgBytes = clipped;
+        }
         const mediaType = "image/jpeg";
         const key = `screenshots/${crypto.randomUUID()}.jpg`;
         let uri: string;


### PR DESCRIPTION
## Summary

A full-page `take_screenshot` of a long page comes back well over 8000px tall. Anthropic rejects any image over 8000px on either side — and because the screenshot is inlined as **base64 into the message history**, every subsequent turn replays it and gets the same 400. The thread is bricked permanently: "try again" can't work, and neither can the board's stall-nudge.

Real incident: `thrd_uY3x6c0d6aMC1cimbF12E` (Super Agent task on decocms.com, org `deco-studio`) took a full-page shot of the home page, then failed three turns in a row with

```
[Anthropic] messages.4.content.1.image.source.base64.data:
At least one of the image dimensions exceed max allowed size: 8000 pixels
```

…at `messages.4`, then `messages.6` as the index shifted. Thread ended `failed`, no PR. `packages/harness/src/decopilot/built-in-tools/portable-media-tools.ts` passed `fullPage` straight through to Browserless with no dimension bound.

## Change

- Read the height off the returned JPEG's SOF marker (`jpegHeight`).
- Only when a **full-page** capture exceeds 7000px, re-shoot clipped to the top 7000px. Puppeteer treats `clip` and `fullPage` as mutually exclusive, so the clamped call swaps one for the other.
- If the clipped retry still isn't within the limit, **fail the tool call** instead of emitting the image. A failed tool call is recoverable; a poisoned history is not.

Screenshots that already fit are untouched — same single request, same bytes. No unconditional clipping, so short pages don't get a white tail (which would waste most of the model's ~1568px downsample budget).

## Testing

- `bun test packages/harness/src/decopilot/built-in-tools/` — 87 pass, incl. 7 new covering the option builder (clip replaces fullPage, only on the clamped retry) and the JPEG parser (normal height, >8000 height, non-JPEG, truncated).
- `bun run --cwd=packages/harness check` clean, `bun run lint` clean, `bunx knip` clean, `bun run fmt` applied.

⚠️ Not verified against live Browserless — no `BROWSERLESS_TOKEN` locally. The retry path assumes `chrome.browserless.io` (v1) honors `options.clip` beyond the viewport. If it doesn't, the second height check catches it and the tool errors out cleanly instead of poisoning the thread — so the failure mode is bounded either way, but worth one manual full-page screenshot of a long page after deploy.

## Not in scope

That thread's *first* failure was a separate bug — `Error: producer produced no output before timeout` at 18:09, with the sandbox coming up at 18:13. Untouched here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp full-page screenshots in the harness to 7000px to stay under Anthropic’s 8000px image limit and prevent threads from being bricked by oversized images. Oversized captures are retried with a clipped top region; if still too tall, the tool call fails instead of emitting the image.

- **Bug Fixes**
  - Detects tall full-page screenshots and re-shoots with `clip` to 7000px; otherwise returns a recoverable tool error.
  - Adds `jpegHeight` to read height from JPEG SOF and `buildScreenshotOptions` to swap `fullPage` for `clip` on retry.
  - Leaves normal screenshots unchanged; uses `jpeg` at quality 80 with the default viewport. Tests added for option building and JPEG parsing in `packages/harness/src/decopilot/built-in-tools/portable-media-tools.test.ts`.

<sup>Written for commit ba69b9f88aaca3cb96f318b732bac051ce6ba579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

