### PR TITLE
fix(decopilot): size the output-token budget off active tools only

### DIFF
--- a/apps/api/src/harnesses/decopilot/harness-deps.ts
+++ b/apps/api/src/harnesses/decopilot/harness-deps.ts
@@ -84,6 +84,7 @@ async function runClusterEngine(
     connectionsData: args.connectionsData,
     extraTools: args.extraTools,
     additionalSystemMessages: args.additionalSystemMessages,
+    activeToolNames: args.activeToolNames,
     // Subtask core runs cap the loop at SUBAGENT_STEP_LIMIT (Task 17).
     stepLimit: args.stepLimit,
   });

--- a/apps/api/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/api/src/harnesses/decopilot/run-agent-loop.ts
@@ -30,7 +30,10 @@ import type { ModelsConfig } from "@decocms/harness/types";
 import type { ToolApprovalLevel } from "@decocms/harness/decopilot/mcp-tools";
 import type { GithubRepo, UsageStats } from "@decocms/shared/sdk";
 import { createLanguageModel } from "@decocms/harness/decopilot/studio-provider";
-import { resolveMaxOutputTokens } from "@decocms/harness/decopilot/harness-constants";
+import {
+  resolveMaxOutputTokens,
+  selectActiveTools,
+} from "@decocms/harness/decopilot/harness-constants";
 import { estimateJsonTokens } from "@decocms/harness/decopilot/built-in-tools/read-tool-output";
 import {
   PARENT_STEP_LIMIT,
@@ -75,6 +78,10 @@ export interface RunAgentLoopOptions {
   /** Pre-resolved prompt data (threads/interests/agents) for the system prompt. */
   userContext?: import("@decocms/harness/types").HarnessUserContext;
   codingWorkspace?: CodingWorkspacePromptInput;
+  /** Tools `prepareStep` will activate. Sizes the output-token budget; without
+   *  it the budget is sized off every assembled tool, including the ones
+   *  enable_tool gating keeps out of the request. */
+  activeToolNames?: string[];
   stepLimit?: number;
   toolApprovalLevel?: ToolApprovalLevel;
   planMode?: boolean;
@@ -265,7 +272,7 @@ export async function runAgentLoop(
       opts.models.thinking.limits,
       estimateJsonTokens(systemMessages) +
         estimateJsonTokens(opts.messages) +
-        estimateJsonTokens(tools),
+        estimateJsonTokens(selectActiveTools(tools, opts.activeToolNames)),
     ),
     stopWhen: stepCountIs(stepLimit),
     abortSignal: opts.abortSignal,

--- a/packages/harness/src/decopilot/engine.ts
+++ b/packages/harness/src/decopilot/engine.ts
@@ -124,6 +124,11 @@ export interface RunEngineArgs {
   extraTools: ToolSet;
   /** Per-request inline <system> blocks + the currently-enabled-tools tail. */
   additionalSystemMessages: SystemModelMessage[];
+  /** Names `prepareStep` will pass as `activeTools` — the only tools whose
+   *  schemas reach the provider. The engine sizes its output-token budget off
+   *  these, not the full set: with enable_tool gating, `tools` can hold
+   *  hundreds of schemas while a step sends a couple dozen. */
+  activeToolNames?: string[];
   /** Optional step-budget override. The shared core passes
    *  `SUBAGENT_STEP_LIMIT` for delegated `subtask` runs (`kind: "subtask"`);
    *  main runs leave it undefined so the engine derives its default

--- a/packages/harness/src/decopilot/harness-constants.test.ts
+++ b/packages/harness/src/decopilot/harness-constants.test.ts
@@ -1,8 +1,83 @@
 import { describe, expect, it } from "bun:test";
-import { DEFAULT_MAX_TOKENS } from "./harness-constants";
+import {
+  DEFAULT_MAX_TOKENS,
+  resolveMaxOutputTokens,
+  selectActiveTools,
+} from "./harness-constants";
 
 describe("harness-constants", () => {
   it("exposes the default max tokens", () => {
     expect(DEFAULT_MAX_TOKENS).toBe(32768);
+  });
+});
+
+describe("selectActiveTools", () => {
+  const tools = { a: {}, b: {}, c: {} };
+
+  it("keeps only the named tools", () => {
+    expect(Object.keys(selectActiveTools(tools, ["a", "c"]))).toEqual([
+      "a",
+      "c",
+    ]);
+  });
+
+  it("passes the full set through when no names are given", () => {
+    expect(selectActiveTools(tools, undefined)).toBe(tools);
+  });
+
+  it("returns nothing for an empty active list — not everything", () => {
+    expect(selectActiveTools(tools, [])).toEqual({});
+  });
+
+  it("ignores names with no matching tool", () => {
+    expect(Object.keys(selectActiveTools(tools, ["a", "gone"]))).toEqual(["a"]);
+  });
+});
+
+describe("resolveMaxOutputTokens", () => {
+  const haiku = { contextWindow: 200_000, maxOutputTokens: 64_000 };
+
+  it("grants the model's full output budget on a normal prompt", () => {
+    expect(resolveMaxOutputTokens(haiku, 52_000)).toBe(64_000);
+  });
+
+  it("falls back to the default when the model reports no limits", () => {
+    expect(resolveMaxOutputTokens(undefined, 52_000)).toBe(DEFAULT_MAX_TOKENS);
+  });
+
+  it("shrinks the budget as the prompt approaches half the window", () => {
+    expect(resolveMaxOutputTokens(haiku, 90_000)).toBe(20_000);
+  });
+
+  it("floors at 1024 once the estimate exceeds half the window", () => {
+    expect(resolveMaxOutputTokens(haiku, 120_000)).toBe(1024);
+  });
+});
+
+// Regression: thread 0ab7046d ran anthropic/claude-haiku-4.5 (200k window, 64k
+// output) with 758 assembled tools but only 23 active. Estimating the full set
+// pushed the input estimate past 99,488 — half the window — so all five turns
+// came back with exactly 1024 completion tokens and finishReason "length", and
+// each "continue" click only made the input longer.
+describe("the 758-tool regression", () => {
+  const haiku = { contextWindow: 200_000, maxOutputTokens: 64_000 };
+  const schema = { x: "y".repeat(400) };
+  const tools = Object.fromEntries(
+    Array.from({ length: 758 }, (_, i) => [`tool_${i}`, schema]),
+  );
+  const activeNames = Object.keys(tools).slice(0, 23);
+  const estimate = (v: unknown) => Math.ceil(JSON.stringify(v).length / 4);
+  const prompt = 44_000;
+
+  it("collapses to the 1024 floor when sized off every assembled tool", () => {
+    const all = prompt + estimate(selectActiveTools(tools, undefined));
+    expect(all).toBeGreaterThan(99_488);
+    expect(resolveMaxOutputTokens(haiku, all)).toBe(1024);
+  });
+
+  it("keeps the full budget when sized off the active tools only", () => {
+    const active = prompt + estimate(selectActiveTools(tools, activeNames));
+    expect(active).toBeLessThan(99_488);
+    expect(resolveMaxOutputTokens(haiku, active)).toBe(64_000);
   });
 });

--- a/packages/harness/src/decopilot/harness-constants.ts
+++ b/packages/harness/src/decopilot/harness-constants.ts
@@ -1,12 +1,33 @@
 export const DEFAULT_MAX_TOKENS = 32768;
 
 /**
+ * The tools whose schemas actually reach the provider. `prepareStep` narrows
+ * each request to `activeTools`, so an agent behind enable_tool gating can hold
+ * hundreds of assembled tools while sending a couple dozen. Sizing the input
+ * estimate off the full set inflates it several-fold, and since the estimate is
+ * doubled below, that pins the output budget to the 1024 floor and truncates
+ * every single response (`finishReason: "length"`).
+ */
+export function selectActiveTools<T extends Record<string, unknown>>(
+  tools: T,
+  activeToolNames: string[] | undefined,
+): Record<string, unknown> {
+  if (!activeToolNames) return tools;
+  const active = new Set(activeToolNames);
+  return Object.fromEntries(
+    Object.entries(tools).filter(([name]) => active.has(name)),
+  );
+}
+
+/**
  * Clamp the per-request output budget so input + output fits the context
  * window. Some providers (e.g. OpenRouter) report `max_completion_tokens` ≈
  * `context_length`; passing it raw overflows the window once any prompt is
  * added and the provider rejects the whole request. Reserves 2x the input
  * estimate because token estimation is rough (tool schemas especially) —
  * over-reserving output is harmless, undercounting input re-triggers overflow.
+ *
+ * Feed this an estimate over `selectActiveTools`, not the whole assembled set.
  */
 export function resolveMaxOutputTokens(
   limits: { contextWindow?: number; maxOutputTokens?: number } | undefined,

--- a/packages/harness/src/decopilot/run-stream.ts
+++ b/packages/harness/src/decopilot/run-stream.ts
@@ -497,6 +497,11 @@ export async function* runDecopilotStream(
       ...processedSystemMessages,
       ...(enabledToolsSystemMessage ? [enabledToolsSystemMessage] : []),
     ],
+    activeToolNames: [
+      ...builtInToolNames,
+      ...("enable_tool" in streamTools ? ["enable_tool"] : []),
+      ...enabledTools,
+    ],
     // Subtask runs cap the engine at SUBAGENT_STEP_LIMIT (Task 17); main runs
     // use the per-automation `maxAgentSteps` override when set, else leave it
     // undefined so the engine derives PARENT_STEP_LIMIT.


### PR DESCRIPTION
## Summary

Every response from a tool-heavy agent was truncated at **exactly 1024 tokens** with `finishReason: "length"`, regardless of the model's real output limit.

`resolveMaxOutputTokens` (`packages/harness/src/decopilot/harness-constants.ts`) reserves `contextWindow − 2 × inputEstimate`, floored at 1024. The estimate at `run-agent-loop.ts:264` summed **every assembled tool schema**. But `prepareStep` narrows each request to `activeTools` (`agent-loop-state.ts:134`), so an agent behind enable_tool gating holds hundreds of schemas and sends a couple dozen. The estimate ran several times the real prompt; doubling it ate the whole context window; the budget hit the floor.

## Evidence

Production thread `0ab7046d-7d17-4477-b62e-c31b35325c50`, agent `vir_2fv6J0qgUZW0Lon_czVwP`, model `anthropic/claude-haiku-4.5` — 200k context, **64000** max output. Its own telemetry: `_request.tools: 758, activeTools: 23`.

| turn | prompt tokens | completion | finishReason |
|---|---|---|---|
| 1 | 54,003 | **1024** | length |
| 2 | 52,328 | **1024** | length |
| 3 | 51,886 | **1024** | length |
| 4 | 51,917 | **1024** | length |
| 5 | 51,961 | **1024** | length |

Entitled to 64,000 output tokens, given 1,024 — 1/62nd — every turn. Working the threshold backwards: `200000 − 2E ≤ 1024` needs `E ≥ 99,488`, while the true prompt was 51,961.

The user-facing shape is worse than a truncated reply. Each truncation raised the "Response incomplete" banner, whose Continue button appends a user message — which grows the input, which the budget math punishes further. Five clicks, five identical 1024-token truncations, ~$0.40 burned, thread ended `failed`.

## Change

Thread `activeToolNames` from `run-stream.ts` (the same expression the `_request.activeTools` telemetry already computes) through `RunEngineArgs` → `harness-deps` → `runAgentLoop`, and estimate over `selectActiveTools(tools, activeToolNames)`.

Callers that omit it keep the old full-set behavior — of the other two `runAgentLoop` callers, the subtask path activates every passthrough tool anyway (`isDelegatedSubagent`), so its estimate is unchanged either way.

## Testing

`bun test packages/harness/src/decopilot/` — 194 pass, 10 new. Includes a regression case built from the real shape (758 tools, 23 active, ~44k prompt) asserting the floor with the full set and the model's full 64k with the active set. Typecheck clean on `packages/harness` and `apps/api`; lint and knip clean.

## Left alone deliberately

Two related cliffs I did **not** touch, since neither caused this and both change behavior more broadly:

- **The `× 2` over-reserve.** With a correct estimate it's fine here (2 × 52k leaves 96k), but it still means any prompt past *half* the context window starts losing output budget, and past half it hits the floor. A 200k model effectively caps usable input at 100k.
- **The `Math.max(1024, …)` floor itself.** It converts "input doesn't fit" into silent per-turn truncation instead of a loud error. That's what made this look like a flaky model for five turns instead of failing once with a reason.

Also noticed while debugging: that thread is `status = 'failed'` with **both** `failure_reason` and `failure_kind` NULL, so nothing recorded why.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 1024-token truncations by sizing the output-token budget using only tools that are actually active in the request. This restores the model’s full output allowance for tool-gated agents and stops repeated “length” finishes.

- **Bug Fixes**
  - Budget max output tokens from active tool schemas only, not all assembled tools.
  - Thread `activeToolNames` from `run-stream` → engine → `runAgentLoop`, and estimate with `selectActiveTools`.
  - Add regression tests covering large assembled sets vs. small active sets.
  - Backward compatible: callers without `activeToolNames` keep previous behavior; subtask path unchanged.

<sup>Written for commit 46d5bbe0610ecb77224fe0636cabe765964608c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

