### PR TITLE
fix(sandbox): report the no-install path so the cache denominator is knowable

### DIFF
--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -64,13 +64,21 @@ export interface DepMetricsInput {
  * `l1` — reflinked the node-local golden, install skipped.
  * `l2` — extracted the shared cross-node archive; this node was cold.
  * `miss` — neither tier had it; ran a full install.
+ * `no-install` — the runtime needed no install step at all, so no cache of
+ *   any tier could have helped. Deno projects take this path (deno fetches at
+ *   runtime and there is no `node_modules`), as does a repo with no manifest.
  *
- * The split is the whole point: `l1`/`miss` alone cannot tell you whether
- * adding L2 helped, only that some boots are still cold. `l2` is the count of
- * boots that L2 rescued from a full install, and its `duration_ms` next to
- * `miss`'s is what says whether the rescue was worth the shared store.
+ * The split is the whole point. `l1`/`miss` alone cannot say whether adding L2
+ * helped, only that some boots are still cold: `l2` is the count of boots the
+ * shared archive rescued, and its `duration_ms` beside `miss`'s is the saving.
+ *
+ * `no-install` is what makes the DENOMINATOR knowable, and it is load-bearing
+ * for the buy decision. Without it, a boot the cache cannot serve is
+ * indistinguishable from no boot at all — so a fleet that is mostly Deno reads
+ * as "barely any dependency traffic" instead of "this cache is inapplicable
+ * here", and its share is the ceiling on what any golden tier can ever win.
  */
-export type RestoreSource = "l1" | "l2" | "miss";
+export type RestoreSource = "l1" | "l2" | "miss" | "no-install";
 
 export interface DepsRestoreInput {
   source: RestoreSource;

--- a/packages/sandbox/daemon/setup/orchestrator.test.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.test.ts
@@ -925,3 +925,88 @@ describe("SetupOrchestrator dependency-cache reporting", () => {
     }
   });
 });
+
+describe("SetupOrchestrator no-install reporting", () => {
+  async function drain(o: {
+    isRunning: () => boolean;
+    pendingCount: () => number;
+  }) {
+    const deadline = Date.now() + 15_000;
+    while (o.isRunning() || o.pendingCount() > 0) {
+      if (Date.now() > deadline) throw new Error("orchestrator hung");
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  }
+
+  /**
+   * Measured in prod: most live sandboxes are Deno, which needs no install and
+   * so emitted nothing at all — making "the cache cannot help this runtime"
+   * indistinguishable from "no traffic", and the hit-rate denominator
+   * unknowable. This pins the label to that branch.
+   */
+  it("reports source=no-install for a runtime with no install step", async () => {
+    const { dir, cleanup } = tempRoot();
+    const logged: string[] = [];
+    const realLog = console.log;
+    try {
+      const repoDir = join(dir, "repo");
+      mkdirSync(repoDir);
+      // Deno project: a task-bearing deno.json and no package manifest, so
+      // spawnInstall has nothing to run.
+      writeFileSync(
+        join(repoDir, "deno.json"),
+        JSON.stringify({ tasks: { dev: "echo hi" } }),
+      );
+
+      const broadcaster = new Broadcaster(1024);
+      const { lifecycle } = makeLifecycleSpy(broadcaster);
+      const orchestrator = new SetupOrchestrator({
+        bootConfig: { appRoot: dir, repoDir },
+        store: {
+          read: () => ({
+            application: { packageManager: { name: "deno" }, runtime: "deno" },
+            git: {
+              repository: { cloneUrl: "https://github.com/acme/site.git" },
+            },
+            runtimePathDirs: [],
+          }),
+          hydrate: () => {},
+          applyInternal: async () => ({
+            kind: "applied",
+            before: null,
+            after: {},
+            transition: { kind: "no-op" },
+          }),
+        } as never,
+        taskManager: {
+          spawn: async () => ({ id: "t1" }),
+          killByLogName: () => 0,
+          waitForLogNamesIdle: async () => {},
+          runningCommandByLogName: () => null,
+          onTaskExit: () => () => {},
+        } as never,
+        setStatus: () => {},
+        getStatus: () => ({ state: "running" as const }),
+        broadcaster,
+        installState: { isInstalledFor: () => false, mark: () => {} } as never,
+        logsDir: dir,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
+      });
+
+      console.log = (...args: unknown[]) => {
+        logged.push(args.map(String).join(" "));
+      };
+      orchestrator.resumeFrom("install");
+      await drain(orchestrator);
+      console.log = realLog;
+
+      const line = logged.find((l) => l.includes('"sandbox.deps.restore"'));
+      expect(line).toBeDefined();
+      expect(JSON.parse(line as string).source).toBe("no-install");
+    } finally {
+      console.log = realLog;
+      cleanup();
+    }
+  });
+});

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -466,6 +466,15 @@ export class SetupOrchestrator {
     // the install fingerprint so resume doesn't retry on every boot.
     if (!installPromise) {
       installTee.close();
+      // Reported, not silent: this is the path every Deno project takes, and
+      // without a line here "no data" and "the cache is irrelevant for this
+      // runtime" look identical in the log store.
+      emitDepsRestore({
+        source: "no-install",
+        cloneUrl: resolveCloneUrl(config),
+        durationMs: Date.now() - depsStartedAt,
+        bootId: process.env.DAEMON_BOOT_ID ?? "",
+      });
       this.markInstallSucceeded(config);
       return true;
     }


### PR DESCRIPTION
Follow-up to #5346/#5351. Found while checking whether the L2 cache is live in prod — it isn't, but the metric that will judge it has a blind spot big enough to change the buy decision.

## The gap

`sandbox.deps.restore` emits on a restore hit and on a completed install. It emits nothing on the `installPromise === null` early return — and that's the path **every Deno project takes**: deno fetches at runtime, there is no `node_modules`, so no golden tier (L1 or the L2 EFS archive) can ever help it.

Measured in prod just now, 12 live sandbox pods on image `1.26.1`:

| | count |
|---|---|
| `[dev] $ deno task dev` | **4** |
| bun / npm / pnpm / yarn | 1 |
| unclaimed or idle, no dev script | 7 |
| **emitted any `sandbox.deps*` line** | **1** |

So today the log reads as "barely any dependency traffic" when the truth is "most of these boots are a runtime the cache cannot serve."

## Why it blocks the decision, not just the dashboard

The Deno share is the **ceiling** on what any golden tier can win. Without a line on that path it is invisible, and we'd be sizing an EFS filesystem against a denominator we can't see — buying a shared filesystem to serve a fraction of boots we never measured.

`no-install` makes the denominator knowable:

```
stats by (source) count()
  l1 | l2 | miss   → tiers, hit rate, and the saving
  no-install       → boots no cache can ever serve
```

## The one real datapoint the metric did produce

```json
{"msg":"sandbox.deps.restore","source":"miss","repo_hash":"f73290d25d81db55","duration_ms":26652}
```

`deco-sites/decocms-tanstack`, 312 deps, **26.6s** cold install. That's the per-boot cost L2 would shave — worth having on the record since it's the first prod figure for it.

## Testing

New orchestrator test drives a Deno project (task-bearing `deno.json`, no package manifest) so `spawnInstall` has nothing to run, and asserts the label. Guarded: deleting the emit fails it (verified 13 pass / 1 fail).

`bun test packages/sandbox/daemon/setup/` → 98 pass. `knip` clean, `lint` 0 errors.

## Scope

Deliberately not instrumented: the fingerprint-skip resume path. A resume isn't a cold boot and `studio.sandbox.ensure.outcome` already splits fresh vs resume — adding an arm here would double-count.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit `no-install` events in `sandbox.deps.restore` so cache metrics include boots with no install step. This makes Deno and manifest-less repos visible and lets us size L2 correctly.

- **Bug Fixes**
  - Added `no-install` to `RestoreSource` and emit when `installPromise` is null (e.g., Deno, no manifest).
  - Wrote an orchestrator test that runs a Deno project and asserts `source: "no-install"`.
  - Left resume/fingerprint-skip path untouched to avoid double counting.

<sup>Written for commit 50295de9b921a835be55abd15b4d3c5f76c0033a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

