### PR TITLE
fix(native): draw the org filesystem as a tree, restore memory writes

### DIFF
--- a/apps/native/crates/local-api/src/sandbox/org_prompt.rs
+++ b/apps/native/crates/local-api/src/sandbox/org_prompt.rs
@@ -8,11 +8,16 @@
 //!
 //! ## Why it cannot be reused verbatim
 //!
-//! Three things differ on the desktop, and each one would be a lie if the
+//! Four things differ on the desktop, and each one would be a lie if the
 //! cluster's wording were copied across:
 //!
-//! 1. **Paths are absolute.** The agent's cwd is the git worktree, and `org`
-//!    is its SIBLING, not a child — a relative `org/...` does not resolve.
+//! 1. **Paths must be resolvable from a cwd that is not the filesystem.** The
+//!    agent stands in the git worktree and `org` is its SIBLING, so a bare
+//!    `org/...` does not resolve. A tree rooted at one absolute path is how
+//!    this block satisfies that: the root is stated once and every row is
+//!    read against it, which SHOWS the sibling layout instead of asserting it
+//!    in prose — and costs one long path instead of eight. That repetition
+//!    was measured at ~270 tokens per turn on a real sandbox path.
 //! 2. **Uploads and outputs are thread-scoped subdirectories** of an org-wide
 //!    volume (`uploads/<thread>/`), where the cluster hands the agent a
 //!    per-run symlink at the bare path `org/upload/`. Naming the exact
@@ -23,42 +28,92 @@
 //!    mechanism, so this block says to READ them instead of claiming they are
 //!    already in context. Telling an agent its memory is loaded when it is not
 //!    is worse than saying nothing.
+//! 4. **Deliverables have exactly one destination.** They go to
+//!    `outputs/<thread>/`; `home/` stays writable so memory can accumulate,
+//!    but it is for durable facts, not output files. Anything outside the
+//!    volumes is ordinary local disk, so a stray write there succeeds,
+//!    reaches nobody, and gives the agent no signal it went wrong — the one
+//!    failure it cannot detect for itself, which is why the block says so
+//!    outright rather than trusting the layout to imply it.
 
 use std::path::Path;
 
 /// Build the `<organization-filesystem>` block for one dispatch.
 ///
-/// `org_dir` is the sandbox's own view directory (`<sandbox>/org`), whose
-/// entries are symlinks into the shared per-org mounts.
+/// `org_dir` is the organization filesystem the agent can reach: the
+/// sandbox's own view directory (`<sandbox>/org`, whose entries are symlinks
+/// into the shared per-org mounts) for a git-backed agent, or the mount root
+/// itself for a gitless one — which is also the agent's cwd, so the tree
+/// below is drawn differently for each.
 pub fn build(org_dir: &Path, thread_id: &str, user_id: Option<&str>) -> String {
-    let org = org_dir.display();
     let user = user_id.unwrap_or("<your-user-id>");
+    // A git-backed agent stands in `<sandbox>/repo` with the org filesystem
+    // BESIDE it, so the tree is rooted at the shared parent: showing both
+    // siblings is what makes "beside, not below" obvious, where the prose
+    // this replaces had to assert it. A gitless agent stands IN the org
+    // filesystem, where that assertion is simply false, so its tree is
+    // rooted at the filesystem itself and omits the `repo/` sibling.
+    let git_backed = org_dir.file_name().is_some_and(|name| name == "org");
+    let root = match (git_backed, org_dir.parent()) {
+        (true, Some(sandbox)) => sandbox.display().to_string(),
+        _ => org_dir.display().to_string(),
+    };
+    let org = org_dir.display();
+
+    let mut rows: Vec<(String, String)> = Vec::with_capacity(6);
+    if git_backed {
+        rows.push((
+            "├── repo/".to_string(),
+            "your working directory (git)".to_string(),
+        ));
+        rows.push((
+            "└── org/".to_string(),
+            "the organization filesystem".to_string(),
+        ));
+    }
+    let nest = if git_backed { "    " } else { "" };
+    rows.push((
+        format!("{nest}├── outputs/{thread_id}/"),
+        "WRITE deliverables here — the only path that carries them back to the organization"
+            .to_string(),
+    ));
+    rows.push((
+        format!("{nest}├── uploads/{thread_id}/"),
+        "files the user attached to THIS conversation".to_string(),
+    ));
+    rows.push((
+        format!("{nest}├── home/"),
+        format!(
+            "shared org knowledge, indexed by MEMORY.md and users/{user}/MEMORY.md. Read on \
+             demand — none of it is in your context already. Write anywhere here to record \
+             durable facts, updating stale notes rather than appending duplicates"
+        ),
+    ));
+    rows.push((
+        format!("{nest}└── public/"),
+        "curated skill sets, read-only".to_string(),
+    ));
+
+    // One column, computed from the rows themselves: a hand-counted pad drifts
+    // the moment a path or a thread id changes length.
+    let column = rows.iter().map(|(path, _)| path.chars().count()).max();
+    let tree = rows
+        .iter()
+        .map(|(path, gloss)| {
+            let pad = " ".repeat(column.unwrap_or_default() - path.chars().count() + 2);
+            format!("{path}{pad}{gloss}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
     format!(
         "<organization-filesystem>\n\
-         The organization filesystem is mounted on this machine at `{org}/`. These are \
-         absolute paths — your working directory is the git repository, and the \
-         organization filesystem is beside it, so relative `org/...` paths will not resolve.\n\
-         - `{org}/home/` — the org's shared home folder, editable and shared across every \
-         agent, member, and run. Organize it freely with subfolders. Consult it only when a \
-         task needs background you don't already have (past decisions, preferences, project \
-         facts, gotchas) — then read it first. Do NOT browse it in response to greetings, \
-         small talk, or questions you can answer directly. Record durable knowledge here as \
-         you learn it; prefer small focused markdown files over one big log, and update stale \
-         notes instead of appending duplicates.\n\
-         - `{org}/home/MEMORY.md` — the ORGANIZATION memory index: durable facts shared with \
-         everyone in this org. Read it when you need that background; it is not loaded for you.\n\
-         - `{org}/home/users/{user}/MEMORY.md` — your USER memory index: facts and preferences \
-         specific to the current user, not shared with other members. Also read on demand.\n\
-         Keep both indexes concise — a curated list of durable facts and one-line pointers to \
-         deeper notes elsewhere in the home folder. When you learn something worth remembering \
-         across sessions, edit the matching file (user-specific → user memory; org-wide → \
-         organization memory); update existing lines instead of appending duplicates.\n\
-         - `{org}/public/<set>/` — curated read-only skill sets. This directory is mounted \
-         read-only; writes to it will fail.\n\
-         - `{org}/uploads/{thread_id}/` — files the user attached to THIS conversation are \
-         already here; read them directly (no copy step needed).\n\
-         - `{org}/outputs/{thread_id}/` — write final deliverables here; they are shared back \
-         to the organization under this conversation's folder.\n\
+         {root}/\n\
+         {tree}\n\
+         Deliverables belong at the absolute path `{org}/outputs/{thread_id}/`. Nothing \
+         outside the directories above is part of the organization filesystem: a write \
+         elsewhere is accepted with NO error and is then invisible to everyone, forever, so \
+         a write that succeeded is not evidence you used the right path.\n\
          </organization-filesystem>"
     )
 }
@@ -75,26 +130,31 @@ mod tests {
         )
     }
 
-    /// The whole point of the desktop variant: a relative `org/...` does not
-    /// resolve from the agent's cwd, so every path must be absolute.
+    /// Every path stays RESOLVABLE from the agent's cwd — the invariant the
+    /// old prose satisfied by spelling all five paths absolutely, and this
+    /// version satisfies by rooting a tree at one absolute path. Inverted
+    /// deliberately: the rows are relative BY DESIGN, so asserting they are
+    /// absolute would pin the cost the tree exists to remove. What must not
+    /// regress is a relative path presented OUTSIDE the tree, where there is
+    /// no root to read it against.
     #[test]
-    fn every_path_is_absolute() {
+    fn the_tree_is_rooted_at_one_absolute_path() {
         let prompt = sample();
-        for path in [
-            "/data/sandboxes/h1/org/home/",
-            "/data/sandboxes/h1/org/home/MEMORY.md",
-            "/data/sandboxes/h1/org/public/<set>/",
-            "/data/sandboxes/h1/org/uploads/thread-42/",
-            "/data/sandboxes/h1/org/outputs/thread-42/",
-        ] {
-            assert!(prompt.contains(path), "missing {path}");
-        }
-        // No bare relative reference that would silently fail to resolve.
-        assert!(!prompt.contains("`org/home"), "leaked a relative org path");
         assert!(
-            !prompt.contains("`org/upload"),
-            "leaked a relative org path"
+            prompt.starts_with("<organization-filesystem>\n/data/sandboxes/h1/\n"),
+            "the absolute root must be the first thing under the tag: {prompt}"
         );
+        // The sibling layout, shown rather than asserted in a sentence.
+        assert!(prompt.contains("├── repo/"), "{prompt}");
+        assert!(prompt.contains("└── org/"), "{prompt}");
+        for row in ["├── outputs/", "├── uploads/", "├── home/", "└── public/"]
+        {
+            assert!(prompt.contains(row), "missing tree row {row}");
+        }
+        // The prose below the tree must never name a bare relative path: with
+        // no tree to anchor it, `org/...` does not resolve from the cwd.
+        let prose = prompt.split("└── public/").nth(1).unwrap();
+        assert!(!prose.contains("`org/"), "relative path outside the tree");
     }
 
     /// Uploads/outputs are thread-scoped: naming the exact directory is what
@@ -102,15 +162,16 @@ mod tests {
     #[test]
     fn uploads_and_outputs_are_scoped_to_this_thread() {
         let other = build(Path::new("/data/sandboxes/h1/org"), "thread-99", None);
-        assert!(other.contains("/org/uploads/thread-99/"));
+        assert!(other.contains("uploads/thread-99/"));
+        assert!(other.contains("/org/outputs/thread-99/"), "{other}");
         assert!(!other.contains("thread-42"));
     }
 
     #[test]
     fn the_user_memory_path_carries_the_user_id() {
-        assert!(sample().contains("/org/home/users/user-7/MEMORY.md"));
-        let anon = build(Path::new("/o"), "t", None);
-        assert!(anon.contains("/o/home/users/<your-user-id>/MEMORY.md"));
+        assert!(sample().contains("users/user-7/MEMORY.md"));
+        let anon = build(Path::new("/o/org"), "t", None);
+        assert!(anon.contains("users/<your-user-id>/MEMORY.md"));
     }
 
     /// The desktop auto-loads nothing, so the block must not claim otherwise —
@@ -130,5 +191,91 @@ mod tests {
     #[test]
     fn says_public_is_read_only() {
         assert!(sample().contains("read-only"));
+    }
+
+    /// Deliverables have ONE destination, and the reason is spelled out
+    /// because a stray write SUCCEEDS (anything outside the volumes is plain
+    /// local disk) while reaching nobody. Observed in practice:
+    /// `<org>/fs-test.html` never appeared in the library.
+    #[test]
+    fn names_outputs_as_the_deliverable_destination() {
+        let prompt = sample();
+        assert!(
+            prompt.contains("`/data/sandboxes/h1/org/outputs/thread-42/`"),
+            "the write rule must name the absolute destination"
+        );
+        assert!(
+            prompt.contains("accepted with NO error") && prompt.contains("invisible"),
+            "the warning must say a stray write silently succeeds, not that it fails"
+        );
+    }
+
+    /// Memory is writable: an agent that may only READ its memory never
+    /// records what it learns, and the indexes go stale forever. The
+    /// deliverable rule above is what keeps this from being a second
+    /// destination for output files — `home/` is for durable facts.
+    #[test]
+    fn memory_stays_writable() {
+        let prompt = sample();
+        assert!(
+            prompt.contains("Write anywhere here to record durable facts"),
+            "home/ must be writable for memory to accumulate"
+        );
+        assert!(
+            prompt.contains("updating stale notes rather than appending duplicates"),
+            "unbounded appends turn a memory index into a log"
+        );
+    }
+
+    /// A gitless agent's cwd IS the organization filesystem, so the tree must
+    /// not show a `repo/` sibling — and must not be rooted a level above,
+    /// which would name a directory the agent has no business in.
+    #[test]
+    fn a_gitless_agent_gets_a_tree_rooted_at_the_filesystem() {
+        let prompt = build(Path::new("/data/orgs/acme"), "thread-42", Some("user-7"));
+        assert!(prompt.contains("/data/orgs/acme/\n"), "{prompt}");
+        assert!(!prompt.contains("repo/"), "gitless agents have no repo");
+        assert!(
+            prompt.contains("`/data/orgs/acme/outputs/thread-42/`"),
+            "the absolute deliverable path must still be exact"
+        );
+    }
+
+    /// The block is prepended to every turn, so its length is a recurring
+    /// cost — and the long absolute root is what dominates it. Stating the
+    /// root once and drawing relative rows under it is the whole point of the
+    /// tree; re-interpolating it per line would quietly undo that.
+    #[test]
+    fn states_the_long_root_path_at_most_twice() {
+        let root = "/data/sandboxes/h1";
+        assert!(
+            sample().matches(root).count() <= 2,
+            "the root path is repeated; the tree exists to avoid that"
+        );
+        assert!(sample().lines().count() <= 12);
+    }
+
+    /// The glosses line up in one column regardless of how long a thread id
+    /// or path is, so the tree stays readable rather than ragged.
+    #[test]
+    fn the_gloss_column_is_computed_not_hand_counted() {
+        let long = build(
+            Path::new("/data/sandboxes/h1/org"),
+            "a-very-long-thread-identifier-0000",
+            Some("user-7"),
+        );
+        let columns: Vec<usize> = long
+            .lines()
+            .filter(|line| line.contains("── "))
+            .filter_map(|line| {
+                line.find("  ")
+                    .map(|_| line.rfind("  ").unwrap_or_default())
+            })
+            .collect();
+        assert!(columns.len() >= 4, "expected the tree rows");
+        assert!(
+            long.contains("a-very-long-thread-identifier-0000/  "),
+            "the longest row still gets its two-space gutter"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The `<organization-filesystem>` block is the **only** thing the native backend injects into a system prompt — claude via `--append-system-prompt`, codex via `developer_instructions` — prepended to every turn of every thread. It had two problems and a latent bug.

**Cost.** The block interpolated the absolute org path **eight times**. A real sandbox path is 118 characters, so that was ~944 characters — roughly **270 tokens per turn** — spent restating one prefix. Rooting a tree at the path states it twice: once as the root, once as the deliverable destination, where being wrong is silent and the repetition is worth paying for.

**Clarity.** The old block listed four directories and left the agent to choose a destination — a choice it cannot make safely, because everything outside the volumes is ordinary local disk: a stray write *succeeds*, reaches nobody, and returns no error to learn from. This happened in practice; `<org>/fs-test.html` never appeared in the library. Deliverables now have one stated destination, and the warning says the part that actually bites: *a write that succeeded is not evidence you used the right path.*

**Latent bug.** `decopilot.rs` computes two layouts — a git-backed agent whose org filesystem is a **sibling** of its cwd, and a gitless agent whose cwd **is** the filesystem — and the prose hardcoded the sibling story ("your working directory is the git repository and this filesystem sits beside it"), which is false for the second. Showing the layout instead of asserting it makes both honest; the gitless tree drops the `repo/` row entirely.

`home/` stays writable. An agent that may only *read* its memory never records what it learns, and the indexes go stale forever.

## Before / after

Before (git-backed, real path):

```
The organization filesystem is mounted at `/Users/…/gimenes-l4k3h5sm/org/`. These are absolute
paths: your working directory is the git repository and this filesystem sits beside it, so
relative `org/...` paths will not resolve.
WRITE ONLY to `/Users/…/gimenes-l4k3h5sm/org/outputs/<thread>/`. …
- `/Users/…/gimenes-l4k3h5sm/org/uploads/<thread>/` — …
- `/Users/…/gimenes-l4k3h5sm/org/home/` — … `/Users/…/org/home/MEMORY.md` … `/Users/…/org/home/users/<user>/MEMORY.md` …
- `/Users/…/gimenes-l4k3h5sm/org/public/<set>/` — …
```

After:

```
/Users/…/gimenes-l4k3h5sm/
├── repo/                     your working directory (git)
└── org/                      the organization filesystem
    ├── outputs/<thread>/     WRITE deliverables here — the only path that carries them back…
    ├── uploads/<thread>/     files the user attached to THIS conversation
    ├── home/                 shared org knowledge, indexed by MEMORY.md and users/<user>/MEMORY.md.
                              Read on demand… Write anywhere here to record durable facts…
    └── public/               curated skill sets, read-only
Deliverables belong at the absolute path `/Users/…/org/outputs/<thread>/`. Nothing outside the
directories above is part of the organization filesystem: a write elsewhere is accepted with NO
error and is then invisible to everyone, forever…
```

## Testing

`cargo test --workspace` green (801 local-api), `cargo clippy --workspace --all-targets` zero warnings, `cargo fmt --all` clean. Both prompt variants rendered against a real production path and reviewed.

The absolute-paths test was **inverted rather than deleted**: rows are relative *by design* under a stated root, so asserting they are absolute would pin the exact cost the tree removes. What it now guards is a relative path appearing in the prose *outside* the tree, where no root anchors it. New coverage for the gitless shape, memory writability, root-repetition (≤2), and the computed gloss column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Draws the organization filesystem as a single rooted tree in the system prompt to cut repeated path cost and make the layout clear. Restores memory writes and sets one explicit deliverable destination to prevent silent mis-writes.

- **New Features**
  - Show the filesystem as a tree rooted at one absolute path; include the `repo/` sibling only for git-backed agents.
  - Deliverables must go to `outputs/<thread>/` (absolute path); warn that writes elsewhere succeed but are invisible.
  - Keep `home/` writable for durable knowledge; read memory on demand.

- **Bug Fixes**
  - Correct the layout for gitless agents (cwd is the filesystem) and drop the `repo/` row in that case.
  - Ensure paths stay resolvable by rooting a tree and avoiding bare relative paths in prose.
  - Update tests for gitless shape, memory writability, single-root repetition (≤2), and computed gloss column alignment.

<sup>Written for commit e4d2daea6b31674f16ed5092e9e69a7ddcd4a3be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

