### PR TITLE
fix(sandbox): make the daemon read route async

### DIFF
--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import {
   mkdir,
+  open,
   readdir,
   readFile,
   rm,
@@ -228,9 +229,9 @@ export function makeReadHandler(deps: FsDeps) {
     if (!filePath)
       return jsonResponse({ error: "Path escapes project root" }, 400);
 
-    let stat: fs.Stats;
+    let fileStat: fs.Stats;
     try {
-      stat = fs.statSync(filePath);
+      fileStat = await stat(filePath);
     } catch {
       // Decofile fallback: when `.deco/blocks.gen.json` is absent (commonly
       // gitignored), regenerate it on the fly from the sibling `.deco/blocks/`
@@ -248,29 +249,32 @@ export function makeReadHandler(deps: FsDeps) {
       }
       return jsonResponse({ error: `File not found: ${body.path}` }, 400);
     }
-    if (stat.isDirectory()) {
+    if (fileStat.isDirectory()) {
       return jsonResponse({ error: "Path is a directory" }, 400);
     }
-    const fd = fs.openSync(filePath, "r");
-    const probe = Buffer.alloc(Math.min(8192, stat.size));
-    fs.readSync(fd, probe, 0, probe.length, 0);
-    fs.closeSync(fd);
+    const probe = Buffer.alloc(Math.min(8192, fileStat.size));
+    const fd = await open(filePath, "r");
+    try {
+      await fd.read(probe, 0, probe.length, 0);
+    } finally {
+      await fd.close();
+    }
 
     const imageMediaType = sniffImageMediaType(probe);
     if (imageMediaType) {
-      if (stat.size > MAX_IMAGE_BYTES) {
+      if (fileStat.size > MAX_IMAGE_BYTES) {
         return jsonResponse(
           {
-            error: `Image too large (${stat.size} bytes; cap is ${MAX_IMAGE_BYTES})`,
+            error: `Image too large (${fileStat.size} bytes; cap is ${MAX_IMAGE_BYTES})`,
           },
           400,
         );
       }
-      const bytes = fs.readFileSync(filePath);
+      const bytes = await readFile(filePath);
       return jsonResponse({
         kind: "image",
         mediaType: imageMediaType,
-        size: stat.size,
+        size: fileStat.size,
         base64: bytes.toString("base64"),
       });
     }
@@ -284,7 +288,7 @@ export function makeReadHandler(deps: FsDeps) {
         400,
       );
 
-    const raw = fs.readFileSync(filePath, "utf-8");
+    const raw = await readFile(filePath, "utf-8");
     const lines = raw.split("\n");
     const offset = body.full ? 1 : Math.max(1, body.offset ?? 1);
     const limit = body.full ? lines.length : (body.limit ?? 2000);


### PR DESCRIPTION
Continues the sync-fs-to-async cleanup in the sandbox daemon (CONTRIBUTING.md rule #1) started by #5372 (unlink), #5375 (mkdir), and #5391 (edit) — the daemon runs on a single-threaded Bun event loop and Studio tears down a sandbox on a single missed health probe.

**Why a maintainer wants it:** `makeReadHandler` (the `/read` route, the daemon's most-hit file-content endpoint) still used `fs.statSync` / `fs.openSync` / `fs.readSync` / `fs.closeSync` / `fs.readFileSync` — every file read (including full-file text reads and up-to-5MB image reads) blocked the event loop for the read's duration, which could stall the health probe under concurrent load.

**Change:** swap those for `node:fs/promises` equivalents (`stat`, `open`+`FileHandle.read`+`close`, `readFile`), matching the pattern already used by the sibling write/edit handlers in the same file. Pure mechanical async conversion — no behavior change (same error paths, same probe-then-decide-image-vs-text logic).

**Verify:** `cd packages/sandbox && bunx tsc --noEmit` and `bun test packages/sandbox/daemon/routes/fs.test.ts` (56 pass, 9 skip, 0 fail — pre-existing suite, no assertions changed).

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in `packages/sandbox`, and the single `fs.test.ts` file. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert the sandbox daemon `/read` route to async I/O so it no longer blocks the event loop. This prevents stalls on large text/image reads and makes health probes more reliable.

- **Refactors**
  - Replaced `fs.statSync`/`openSync`/`readSync`/`closeSync`/`readFileSync` with `stat`, `open`+`FileHandle.read`+`close`, and `readFile` from `node:fs/promises`.
  - No behavior change: same errors and image/text sniffing; matches the write/edit handlers.

<sup>Written for commit 2d30aa970f33821311bd688915ccec60f450d890. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

