### PR TITLE
fix(auth): invalidate cached member role on removal

### DIFF
--- a/apps/api/src/core/context-factory.ts
+++ b/apps/api/src/core/context-factory.ts
@@ -394,7 +394,7 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
       },
 
       removeMember: async (data) => {
-        await auth.api.removeMember({
+        return auth.api.removeMember({
           headers,
           body: data,
         });

--- a/apps/api/src/core/studio-context.ts
+++ b/apps/api/src/core/studio-context.ts
@@ -47,6 +47,9 @@ export type ListOrganizationsResult = Awaited<
   ReturnType<BetterAuthApi["listOrganizations"]>
 >;
 export type AddMemberResult = Awaited<ReturnType<BetterAuthApi["addMember"]>>;
+export type RemoveMemberResult = Awaited<
+  ReturnType<BetterAuthApi["removeMember"]>
+>;
 export type ListMembersResult = Awaited<
   ReturnType<BetterAuthApi["listMembers"]>
 >;
@@ -136,7 +139,7 @@ export interface BoundAuthClient {
     removeMember(data: {
       memberIdOrEmail: string;
       organizationId?: string;
-    }): Promise<void>;
+    }): Promise<RemoveMemberResult>;
 
     listMembers(options?: {
       organizationId?: string;

--- a/apps/api/src/tools/organization/member-remove.test.ts
+++ b/apps/api/src/tools/organization/member-remove.test.ts
@@ -2,14 +2,18 @@ import { describe, expect, it, mock } from "bun:test";
 import { ORGANIZATION_MEMBER_REMOVE } from "./member-remove";
 
 function makeCtx(organization: { id: string } | undefined) {
-  const removeMember = mock(async () => {});
+  const removeMember = mock(async () => ({
+    member: { id: "member-1", userId: "removed-user-1" },
+  }));
+  const invalidateMemberRole = mock(() => {});
   const ctx = {
     auth: { user: { id: "user-1" } },
     organization,
     access: { check: mock(async () => {}) },
     boundAuth: { organization: { removeMember } },
+    invalidateMemberRole,
   } as unknown as Parameters<typeof ORGANIZATION_MEMBER_REMOVE.handler>[1];
-  return { ctx, removeMember };
+  return { ctx, removeMember, invalidateMemberRole };
 }
 
 describe("ORGANIZATION_MEMBER_REMOVE", () => {
@@ -44,5 +48,22 @@ describe("ORGANIZATION_MEMBER_REMOVE", () => {
       organizationId: "org-a",
       memberIdOrEmail: "member@example.com",
     });
+  });
+
+  it("invalidates the removed member's cached role", async () => {
+    // Regression: the cached role fast-path (member-role-cache.ts) was never
+    // invalidated on removal, so a just-removed admin/owner kept passing
+    // permission checks until the cache TTL expired.
+    const { ctx, invalidateMemberRole } = makeCtx({ id: "org-a" });
+
+    await ORGANIZATION_MEMBER_REMOVE.handler(
+      { organizationId: "org-a", memberIdOrEmail: "member@example.com" },
+      ctx,
+    );
+
+    expect(invalidateMemberRole).toHaveBeenCalledWith(
+      "removed-user-1",
+      "org-a",
+    );
   });
 });

--- a/apps/api/src/tools/organization/member-remove.ts
+++ b/apps/api/src/tools/organization/member-remove.ts
@@ -58,14 +58,15 @@ export const ORGANIZATION_MEMBER_REMOVE = defineTool({
     // Remove member via Better Auth. The paid-seat release happens in the
     // afterRemoveMember organization hook (auth/index.ts) — the canonical
     // removal boundary, covering every path, not just this tool.
-    await ctx.boundAuth.organization.removeMember({
+    const removed = await ctx.boundAuth.organization.removeMember({
       organizationId,
       memberIdOrEmail: input.memberIdOrEmail,
     });
 
-    // Invalidate cached role — we don't have the userId here but
-    // invalidateOrg would be too broad; the TTL will handle cleanup
-    // for removed members since the DB row is gone.
+    // Invalidate the removed member's cached role immediately — otherwise a
+    // just-removed admin/owner keeps passing the cached-role permission
+    // fast-path (see member-role-cache.ts) for up to the cache's TTL.
+    ctx.invalidateMemberRole?.(removed.member.userId, organizationId);
 
     const actorId = getUserId(ctx);
     if (actorId) {


### PR DESCRIPTION
**Source:** bug found while hunting the role-escalation focus area — `apps/api/src/auth/member-role-cache.ts` caches `member.role` lookups for 2 minutes to avoid a DB hit on every request, and every other role-mutation path (`member-update-role.ts`) explicitly invalidates the cache entry after mutating. `member-remove.ts` was the one path that didn't: it had a comment acknowledging "we don't have the userId here" and left cleanup to the TTL.

**Why a maintainer wants this:** the underlying `auth.api.removeMember` call already returns `{ member: { userId, ... } }`, but the `boundAuth.organization.removeMember` wrapper in `context-factory.ts` discarded it and returned `void`. That's an easy fix — thread the return value through instead of relying on a 2-minute exposure window.

**Failure scenario:** an owner removes an admin from an org. For up to 2 minutes afterward, any request from that now-removed admin that hits the `AccessControl` cached-role fast-path (see `member-role-cache.ts`) still resolves their stale `admin` role from cache, so admin-gated tools keep succeeding briefly after removal instead of failing immediately.

**Fix:** `context-factory.ts`'s `removeMember` now returns Better Auth's response instead of discarding it; `studio-context.ts` types this as `RemoveMemberResult` (mirroring `AddMemberResult`/`UpdateMemberRoleResult`); `member-remove.ts` calls `ctx.invalidateMemberRole?.(removed.member.userId, organizationId)` after the removal succeeds, exactly like `member-update-role.ts` already does. Added a regression test (`member-remove.test.ts`) asserting `invalidateMemberRole` is called with the removed user's id.

**Reviewer command:** `cd apps/api && bun test src/tools/organization/member-remove.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace, clean), and the targeted test file above (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Immediately invalidates a removed member’s cached role so access is revoked right away. The removal path now returns the Better Auth `removeMember` result, enabling invalidation by `userId`.

- **Bug Fixes**
  - `context-factory`: return `auth.api.removeMember` result instead of `void`.
  - `studio-context`: add `RemoveMemberResult` and update `BoundAuthClient.removeMember` signature.
  - `member-remove`: call `ctx.invalidateMemberRole(removed.member.userId, organizationId)` after removal.
  - Test: add regression test ensuring role cache is invalidated for the removed user.

<sup>Written for commit ed334426defa618290279b8a63c56243ab14f015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

