### PR TITLE
feat(auth): capture WhatsApp Concierge signup attribution

### DIFF
--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -550,7 +550,7 @@ export const auth = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        after: async (user) => {
+        after: async (user, context) => {
           // Tag the PostHog person record with email/name BEFORE the
           // user_signed_up capture so that event lands on a person record
           // that already has $set: { email } applied.
@@ -560,6 +560,12 @@ export const auth = betterAuth({
             name: user.name ?? null,
             emailVerified: !!user.emailVerified,
           });
+
+          // WhatsApp Concierge (or any other channel) attribution, set as a
+          // first-party cookie by the web client on landing. Absent for the
+          // vast majority of signups.
+          const signupRef = context?.getCookie("studio_signup_ref") ?? null;
+          const signupSrc = context?.getCookie("studio_signup_src") ?? null;
 
           // Top-of-funnel signup event. Fires once per new user account,
           // before any org is created. Use this (not organization_created)
@@ -572,6 +578,8 @@ export const auth = betterAuth({
               email_domain: user.email?.split("@")[1]?.toLowerCase() ?? null,
               email_verified: !!user.emailVerified,
               has_name: !!user.name,
+              ...(signupRef ? { signup_ref: signupRef } : {}),
+              ...(signupSrc ? { signup_src: signupSrc } : {}),
             },
           });
 

--- a/apps/web/src/lib/signup-attribution.test.ts
+++ b/apps/web/src/lib/signup-attribution.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { captureSignupAttribution } from "./signup-attribution";
+
+// Minimal in-memory cookie jar stubbing `document.cookie`, so this stays a
+// pure unit test (no happy-dom cookie-attribute parsing needed).
+function installCookieJar() {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      get cookie() {
+        return Array.from(store, ([k, v]) => `${k}=${v}`).join("; ");
+      },
+      set cookie(pair: string) {
+        const [name, value] = (pair.split(";")[0] ?? "").split("=");
+        if (name) store.set(name, value ?? "");
+      },
+    },
+  });
+  return store;
+}
+
+describe("captureSignupAttribution", () => {
+  beforeEach(() => {
+    installCookieJar();
+  });
+
+  test("sets ref and src cookies when both present", () => {
+    captureSignupAttribution({ ref: "wa8hcxfm", src: "wa" });
+    expect(document.cookie).toContain(`studio_signup_ref=wa8hcxfm`);
+    expect(document.cookie).toContain(`studio_signup_src=wa`);
+  });
+
+  test("no-ops when neither param is present", () => {
+    captureSignupAttribution({});
+    expect(document.cookie).toBe("");
+  });
+
+  test("first touch wins: does not overwrite an existing cookie", () => {
+    captureSignupAttribution({ ref: "first" });
+    captureSignupAttribution({ ref: "second" });
+    expect(document.cookie).toContain("studio_signup_ref=first");
+    expect(document.cookie).not.toContain("second");
+  });
+});

--- a/apps/web/src/lib/signup-attribution.ts
+++ b/apps/web/src/lib/signup-attribution.ts
@@ -1,0 +1,31 @@
+const REF_COOKIE = "studio_signup_ref";
+const SRC_COOKIE = "studio_signup_src";
+const MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+
+function getCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+  return match?.[1] ? decodeURIComponent(match[1]) : null;
+}
+
+function setCookie(name: string, value: string) {
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${MAX_AGE_SECONDS}; samesite=lax`;
+}
+
+/**
+ * Persists the WhatsApp Concierge `ref`/`src` query params (if present) into
+ * first-party cookies so they survive the rest of the signup funnel — page
+ * navigations, email verification, and OAuth round-trips all drop query
+ * params but keep cookies. First touch wins: never overwrites an existing
+ * cookie from an earlier visit.
+ */
+export function captureSignupAttribution(search: {
+  ref?: string;
+  src?: string;
+}) {
+  if (search.ref && !getCookie(REF_COOKIE)) {
+    setCookie(REF_COOKIE, search.ref);
+  }
+  if (search.src && !getCookie(SRC_COOKIE)) {
+    setCookie(SRC_COOKIE, search.src);
+  }
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -50,6 +50,9 @@ const loginRoute = createRoute({
       scope: z.string().optional(),
       code_challenge: z.string().optional(),
       code_challenge_method: z.string().optional(),
+      // WhatsApp Concierge attribution (e.g. ?src=wa&ref=<leadId>)
+      src: z.string().optional(),
+      ref: z.string().optional(),
     }),
   ),
 });

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -2,6 +2,7 @@ import { AuthEntry } from "@/components/auth-entry";
 import { AuthSplitLayout } from "@/components/auth-split-layout";
 import { SplashScreen } from "@/components/splash-screen";
 import { authClient } from "@/lib/auth-client";
+import { captureSignupAttribution } from "@/lib/signup-attribution";
 import { Navigate, useSearch } from "@tanstack/react-router";
 
 /**
@@ -50,7 +51,14 @@ export default function LoginRoute() {
     scope,
     code_challenge,
     code_challenge_method,
+    src,
+    ref,
   } = searchParams;
+
+  // Persist WhatsApp Concierge attribution into cookies so it survives OAuth
+  // round-trips and email verification. Idempotent (first touch wins), so
+  // safe to call on every render — no effect needed.
+  captureSignupAttribution({ src, ref });
 
   // Prevent open redirect — only allow relative paths
   const next =


### PR DESCRIPTION
Follows #3747 (Signup attribution: capture WhatsApp Concierge `ref` and notify the bot on conversion). Scoped down per the triage comment already on that issue — this ships only the Studio-only half (thread `ref`/`src` through signup), independently shippable and testable without the Concierge webhook call, which is a separate follow-up needing that repo's endpoint contract + a shared secret.

**Why:** the Concierge bot hands prospects a tracked link (`?src=wa&ref=<leadId>`), but Studio currently drops those params the moment the user navigates away from `/login` — through OAuth round-trips or email verification — so there is no way to attribute a completed signup back to a WhatsApp lead.

**What changed:**
- `/login` now accepts `ref`/`src` query params.
- On landing, `captureSignupAttribution()` persists them into first-party cookies (`studio_signup_ref`, `studio_signup_src`, 30-day expiry, first-touch-wins) — cookies survive OAuth redirects and page navigations where query params don't.
- On account creation (the existing Better Auth `user.create.after` hook, which already fires the `user_signed_up` PostHog event once per new account), the hook reads those cookies via the endpoint context's `getCookie()` and adds `signup_ref`/`signup_src` to the event properties when present. No DB migration needed — PostHog properties are schemaless, satisfying the issue's "nice to have" of independent Studio-side channel attribution.
- No-op when `ref`/`src` are absent (the vast majority of signups): no cookie is set, no extra properties are added.

Not in this PR (separate, per the existing issue triage): the server-to-server `POST /event` call back to the Concierge on conversion — that needs the Concierge's shared auth token wired in as a server secret first.

**How to verify:** visit `/login?src=wa&ref=test123`, complete signup, and confirm the `user_signed_up` PostHog event carries `signup_ref: "test123"` / `signup_src: "wa"`. A repeat visit with a different `ref` must not overwrite the original cookie.

**Local checks run:** `bun run fmt`; `bunx tsc --noEmit` in both `apps/web` and `apps/api` (clean); `bun test apps/web/src/lib/signup-attribution.test.ts` (3 pass) covering both-present, both-absent, and first-touch-wins cases. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist WhatsApp Concierge signup attribution by capturing `src`/`ref` from `/login`, storing them in cookies, and attaching them to the `user_signed_up` event. This keeps lead tracking through OAuth/email flows and enables Studio-side channel attribution in PostHog without DB changes.

- **New Features**
  - `/login` accepts `src` and `ref`; `captureSignupAttribution()` saves them to `studio_signup_src`/`studio_signup_ref` cookies (30 days, first-touch wins).
  - In the `Better Auth` `user.create.after` hook, cookies are read and `signup_src`/`signup_ref` are added to the `user_signed_up` PostHog event.
  - No-op when params are absent; safe for all signups.

<sup>Written for commit 590b2610f3c6d6c926b1f80fdcecc547be592472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

