### PR TITLE
fix(sandbox): make the daemon rename route async

### DIFF
--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -3,6 +3,7 @@ import {
   mkdir,
   readdir,
   readFile,
+  rename,
   rm,
   stat,
   unlink,
@@ -429,12 +430,12 @@ export function makeRenameHandler(deps: FsDeps) {
       return jsonResponse({ error: "Path escapes app root" }, 400);
     }
     try {
-      fs.statSync(fromPath);
+      await stat(fromPath);
     } catch {
       return jsonResponse({ error: `Path not found: ${body.from}` }, 400);
     }
     try {
-      fs.statSync(toPath);
+      await stat(toPath);
       return jsonResponse({ error: `Path already exists: ${body.to}` }, 400);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -442,8 +443,8 @@ export function makeRenameHandler(deps: FsDeps) {
       }
     }
     try {
-      fs.mkdirSync(path.dirname(toPath), { recursive: true });
-      fs.renameSync(fromPath, toPath);
+      await mkdir(path.dirname(toPath), { recursive: true });
+      await rename(fromPath, toPath);
     } catch (err) {
       return jsonResponse({ error: (err as Error).message }, 500);
     }


### PR DESCRIPTION
Follows #5403 (async read route) — continues converting the sandbox daemon's fs routes off blocking sync I/O, one route per PR (see also #5333, #5336).

The daemon runs on a single-threaded Bun event loop and Studio tears down/recovers a sandbox on a single missed health probe. `makeRenameHandler` in `packages/sandbox/daemon/routes/fs.ts` called `fs.statSync` (twice), `fs.mkdirSync`, and `fs.renameSync` — each one blocks the loop for the duration of the syscall, so a rename on a large/slow filesystem (or heavy concurrent traffic) could starve the health probe and get the sandbox killed.

Swapped all four for their `node:fs/promises` equivalents (`stat`, `mkdir`, `rename`) already imported/used elsewhere in this file. Purely mechanical, behavior-preserving — same checks, same error responses, same order of operations.

Reviewer check: `bun test packages/sandbox/daemon/routes/fs.test.ts` (existing `rename:` cases cover the moved-file and destination-already-exists paths).

Locally ran: `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit`, and the targeted test file above — all green. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the sandbox daemon’s rename route async to avoid blocking the single-threaded event loop. This reduces the chance of health probe timeouts on slow filesystems and improves sandbox stability.

- **Refactors**
  - Replaced `fs.statSync`, `fs.mkdirSync`, and `fs.renameSync` with `stat`, `mkdir`, and `rename` from `node:fs/promises`.
  - Preserved existing checks and error responses; no behavior changes.

<sup>Written for commit 92ca56837bc6cf061883b4b987837826c2823cdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

