### PR TITLE
perf(task-board): index the latest-assistant-text-part lookup

### DIFF
--- a/apps/api/migrations/153-task-board-latest-assistant-part-index.ts
+++ b/apps/api/migrations/153-task-board-latest-assistant-part-index.ts
@@ -1,0 +1,22 @@
+import { sql, type Kysely } from "kysely";
+
+/**
+ * The task board's `attachThreads` query does a per-linked-thread lateral
+ * join fetching the latest assistant text part (`role = 'assistant' AND kind
+ * = 'text'`) for the card preview — the same "latest row of a kind" shape as
+ * migration 098's `idx_tmp_finish_anchor`, but with no matching partial index.
+ * Without it, Postgres walks `idx_tmp_thread_created_id` backwards from the
+ * newest `created_at`, skipping every non-matching part (tool calls, deltas,
+ * reasoning) until it finds one — the more turns a thread has, the more rows
+ * it discards per task board list. Every board list/get call runs this once
+ * per linked thread.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE INDEX idx_tmp_latest_assistant_text ON thread_message_parts (thread_id, created_at DESC, id DESC) WHERE role = 'assistant' AND kind = 'text'`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_tmp_latest_assistant_text").execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -151,6 +151,7 @@ import * as migration149taskboarditemsortorder from "./149-task-board-item-sort-
 import * as migration150taskboardactivity from "./150-task-board-activity.ts";
 import * as migration151taskboardtags from "./151-task-board-tags.ts";
 import * as migration152repairconnectionslug from "./152-repair-connection-slug.ts";
+import * as migration153taskboardlatestassistantpartindex from "./153-task-board-latest-assistant-part-index.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -327,6 +328,8 @@ const migrations: Record<string, Migration> = {
   "150-task-board-activity": migration150taskboardactivity,
   "151-task-board-tags": migration151taskboardtags,
   "152-repair-connection-slug": migration152repairconnectionslug,
+  "153-task-board-latest-assistant-part-index":
+    migration153taskboardlatestassistantpartindex,
 };
 
 export default migrations;


### PR DESCRIPTION
Follows #2995 ("DB latency amplifies significantly across MCP tool calls") — investigating the task-board storage layer's query helpers per that issue's ask.

`TaskBoardStorage.attachThreads()` (`apps/api/src/storage/task-board.ts`) runs a per-linked-thread `leftJoinLateral` fetching the latest assistant text part for each thread's card preview, on every board list/get call. `thread_message_parts` only carries `(thread_id, created_at, id)` and a `finish`-kind partial index (migration 098) — nothing supports a `role = 'assistant' AND kind = 'text'` filter, so Postgres has to walk backward from the newest row per thread, discarding every non-matching part (tool calls, deltas, reasoning) until it finds a match. Cost grows with a thread's turn count, and this runs once per linked thread on every board fetch.

Adds a partial index scoped to `(role = 'assistant', kind = 'text')`, ordered `(thread_id, created_at DESC, id DESC)` — the same "latest row of a kind" partial-index trick migration 098's `idx_tmp_finish_anchor` already uses for a different kind, so this is a one-line follow of an established pattern, not a new one.

Net change: +25/-0, one migration file + its registration. Behavior-preserving — it only adds an index, no schema/query change.

To verify: `bun run --cwd=apps/api migrate`, then `EXPLAIN ANALYZE` the `attachThreads` lateral-join query against a thread with many parts — it should hit `idx_tmp_latest_assistant_text` instead of scanning `idx_tmp_thread_created_id` backward.

Ran locally: `bun run fmt`, `bunx tsc --noEmit` in `apps/api`, and the targeted `apps/api/migrations/index.test.ts` (guards every migration file is registered in `index.ts`, per a real past incident) — all green. No local Postgres available in this environment to actually run the migration; full CI covers that.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up task board list/get by indexing the “latest assistant text part” lookup in `attachThreads()`. Adds a partial index on `thread_message_parts` to avoid backward scans through non-matching parts; behavior is unchanged.

- **Migration**
  - Adds `153-task-board-latest-assistant-part-index` creating `idx_tmp_latest_assistant_text` on `(thread_id, created_at DESC, id DESC)` with `WHERE role = 'assistant' AND kind = 'text'`.
  - Run `bun run --cwd=apps/api migrate`. Optional: `EXPLAIN` the `attachThreads` lateral join to confirm it uses `idx_tmp_latest_assistant_text`.

<sup>Written for commit 0253133462a11067ac63c6c217854f147487c5a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

