### PR TITLE
fix(chat): add aria-labels to queue tray icon-only buttons

### DIFF
--- a/apps/web/src/components/chat/queue-tray.tsx
+++ b/apps/web/src/components/chat/queue-tray.tsx
@@ -66,6 +66,7 @@ export function QueueTray({ taskId }: { taskId: string }) {
               type="button"
               variant="ghost"
               size="icon-sm"
+              aria-label={t("chat.queueTray.sendNow")}
               onClick={() => void stop()}
             >
               <ArrowUp size={14} />
@@ -96,6 +97,7 @@ export function QueueTray({ taskId }: { taskId: string }) {
               variant="ghost"
               size="icon-sm"
               title={t("chat.queueTray.removeFromQueue")}
+              aria-label={t("chat.queueTray.removeFromQueue")}
               onClick={() =>
                 void actions.cancel(taskId, item.messageId).then((ok) => {
                   if (ok) {


### PR DESCRIPTION
**Source:** bug found while auditing the chat panel (Mesh UI stability focus area) — no linked issue.

**Why:** `QueueTray` (`apps/web/src/components/chat/queue-tray.tsx`) renders two icon-only, text-less buttons — "send now" (promotes the queued message) and "remove from queue" (cancels a queued message). Neither had an `aria-label`: the "send now" button had no accessible name at all (only a hover tooltip), and "remove" relied solely on a `title` attribute, which screen readers don't reliably announce. This follows the repeating aria-label merge lane (#4903, #5047, #5096, #5226, #5271).

**Fix:** Added `aria-label` to both buttons, reusing the existing `chat.queueTray.sendNow` / `chat.queueTray.removeFromQueue` i18n strings (already translated to pt-br) — no new copy needed.

**Reviewer check:** `bunx tsc --noEmit` in `apps/web`, or open a thread with a queued message and inspect the accessible name of both buttons via devtools/axe.

**Verified locally:** `bun run fmt` (clean) and `bunx tsc --noEmit` in the repo root (clean, 0 errors). No test file needed — this is a static JSX attribute addition, not logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-labels to the icon-only “Send now” and “Remove from queue” buttons in `QueueTray`, using existing `chat.queueTray.sendNow` and `chat.queueTray.removeFromQueue` i18n strings. This gives both buttons clear accessible names for screen readers and improves chat panel accessibility.

<sup>Written for commit 48c6b6f9d25b6282e425f6cdac7d1516b8c5d912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

