### PR TITLE
fix(search): treat a whitespace-only GLOBAL_SEARCH query as no query

### DIFF
--- a/apps/api/src/tools/search/global-search.test.ts
+++ b/apps/api/src/tools/search/global-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { GLOBAL_SEARCH } from "./global-search";
+import { GLOBAL_SEARCH, normalizeSearchQuery } from "./global-search";
 
 describe("GLOBAL_SEARCH input schema", () => {
   it("rejects a query longer than 256 characters", () => {
@@ -14,5 +14,23 @@ describe("GLOBAL_SEARCH input schema", () => {
       query: "a".repeat(256),
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("normalizeSearchQuery", () => {
+  it("treats an empty string as no query", () => {
+    expect(normalizeSearchQuery("")).toBeUndefined();
+  });
+
+  it("treats a whitespace-only string as no query", () => {
+    expect(normalizeSearchQuery("   \n\t ")).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace from a real query", () => {
+    expect(normalizeSearchQuery("  foo  ")).toBe("foo");
+  });
+
+  it("leaves an already-trimmed query unchanged", () => {
+    expect(normalizeSearchQuery("foo bar")).toBe("foo bar");
   });
 });

--- a/apps/api/src/tools/search/global-search.ts
+++ b/apps/api/src/tools/search/global-search.ts
@@ -69,6 +69,16 @@ function toIso(value: string | Date | null | undefined): string {
   return typeof value === "string" ? value : value.toISOString();
 }
 
+/**
+ * Trims the query and treats a whitespace-only string as "no query" so it
+ * falls back to the documented "most recently updated" behavior instead of
+ * ILIKE-matching a literal run of whitespace against titles.
+ */
+export function normalizeSearchQuery(query: string): string | undefined {
+  const trimmed = query.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 export const GLOBAL_SEARCH = defineTool({
   name: "GLOBAL_SEARCH",
   description:
@@ -97,7 +107,7 @@ export const GLOBAL_SEARCH = defineTool({
       const { threads, total } = await ctx.storage.threads.list(undefined, {
         limit,
         offset: 0,
-        search: input.query,
+        search: normalizeSearchQuery(input.query),
         includeArchived: false,
       });
       totalCount += total;


### PR DESCRIPTION
Bug found while auditing the GLOBAL_SEARCH tool (offset pagination itself is already covered by open PR #5387, which this does not touch or duplicate).

The tool's own docstring promises "Empty string returns the most recently updated resources," but `GLOBAL_SEARCH` passed `input.query` straight through to `ThreadsStorage.list()`, which does `if (options?.search)` (a truthy check) before applying `ilike "%<search>%"`. A whitespace-only query like `"   "` is truthy, so instead of falling back to "most recent" it silently filters on a literal run of spaces in `title` — almost always zero results, breaking the documented contract for any client that submits a query the user only whitespace-padded (e.g. a search box blurred after typing then deleting). The same untrimmed pass-through also meant a query like `"  foo  "` would fail to match a title of `"foo"` because the ILIKE pattern included the stray spaces.

Fix: added a small pure `normalizeSearchQuery()` helper in `global-search.ts` that trims the query and maps an all-whitespace result to `undefined` (the same "no filter" value `ThreadsStorage.list()` already treats as "no search"), and used it in the handler instead of the raw `input.query`. No change to `ThreadsStorage.list()` itself, no change to the offset/pagination fields.

Failure scenario before the fix: `GLOBAL_SEARCH({ query: "   " })` returns `{ items: [], totalCount: 0 }` for an org with recent threads, instead of the documented "most recently updated" listing.

Regression test: `apps/api/src/tools/search/global-search.test.ts` now covers `normalizeSearchQuery` directly (pure function, no DB/mocks) for empty string, whitespace-only, padded, and already-trimmed queries.

Reviewer check: `bun test apps/api/src/tools/search/global-search.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test file above — all green. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats whitespace-only `GLOBAL_SEARCH` queries as no query, restoring the “most recently updated” fallback. Also trims surrounding spaces so padded queries match as expected.

- **Bug Fixes**
  - Added normalizeSearchQuery to trim input and map empty/whitespace to undefined; used for the `search` option in `ThreadsStorage.list`.
  - Added tests for empty, whitespace-only, padded, and already-trimmed inputs.

<sup>Written for commit 1be9287f65752f5ebbf6abdab02386cd25a68775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

