### PR TITLE
fix(sandbox): refresh install fingerprint after boot fast-forward

### DIFF
--- a/packages/sandbox/daemon/setup/orchestrator.test.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { execSync } from "node:child_process";
 import {
   mkdirSync,
   mkdtempSync,
@@ -1009,4 +1010,129 @@ describe("SetupOrchestrator no-install reporting", () => {
       cleanup();
     }
   });
+});
+
+describe("SetupOrchestrator install fingerprint after boot fast-forward", () => {
+  const GITCFG =
+    "-c init.defaultBranch=main -c user.email=test@example.com " +
+    "-c user.name=test -c commit.gpgsign=false";
+  const GIT_OPTS = { stdio: "ignore" as const };
+  function git(cwd: string, cmd: string): void {
+    execSync(`git ${GITCFG} -C ${cwd} ${cmd}`, GIT_OPTS);
+  }
+  function headOf(cwd: string): string {
+    return execSync(`git ${GITCFG} -C ${cwd} rev-parse HEAD`, {
+      encoding: "utf-8",
+    }).trim();
+  }
+
+  /** Bare origin with `main` (2 commits) and `feat/x` forked from main's
+   *  first commit — behind main by one, no local commits — cloned into
+   *  `repoDir` at `feat/x`, mirroring an idle sandbox resuming on boot. */
+  function setupIdleClone(root: string): { bare: string; repoDir: string } {
+    const bare = join(root, "origin.git");
+    const seed = join(root, "seed");
+    execSync(`git ${GITCFG} init --bare ${bare}`, GIT_OPTS);
+    execSync(`git ${GITCFG} init ${seed}`, GIT_OPTS);
+    writeFileSync(join(seed, "readme.md"), "v1\n");
+    git(seed, "add .");
+    git(seed, 'commit -m "initial"');
+    git(seed, "branch -M main");
+    git(seed, `remote add origin ${bare}`);
+    git(seed, "push -u origin main");
+    git(seed, "checkout -b feat/x");
+    git(seed, "push -u origin feat/x");
+    git(seed, "checkout main");
+    writeFileSync(join(seed, "readme.md"), "v2\n");
+    git(seed, "add .");
+    git(seed, 'commit -m "advance main"');
+    git(seed, "push origin main");
+
+    const repoDir = join(root, "repo");
+    execSync(
+      `git ${GITCFG} clone --branch feat/x ${bare} ${repoDir}`,
+      GIT_OPTS,
+    );
+    git(repoDir, "config user.email test@example.com");
+    git(repoDir, "config user.name test");
+    return { bare, repoDir };
+  }
+
+  async function drain(o: {
+    isRunning: () => boolean;
+    pendingCount: () => number;
+  }) {
+    const deadline = Date.now() + 15_000;
+    while (o.isRunning() || o.pendingCount() > 0) {
+      if (Date.now() > deadline) throw new Error("orchestrator hung");
+      await new Promise((r) => setTimeout(r, 20));
+    }
+  }
+
+  // A boot-time fast-forward (#5390) advances the branch past whatever
+  // gitSetup's checkout captured. The install-skip cache fingerprints against
+  // `currentBranchHead`, so if that field isn't re-read afterward, it stays
+  // pinned to the pre-fast-forward commit — letting a lockfile change that
+  // rode in on the fast-forward slip past the cache on the next cycle.
+  it("fingerprints install against the post-fast-forward HEAD, not the pre-checkout one", async () => {
+    const root = mkdtempSync(join(tmpdir(), "orch-ff-"));
+    try {
+      const { bare, repoDir } = setupIdleClone(root);
+      const broadcaster = new Broadcaster(1024);
+      const { lifecycle } = makeLifecycleSpy(broadcaster);
+      let capturedHead: string | undefined;
+
+      const orchestrator = new SetupOrchestrator({
+        bootConfig: { appRoot: root, repoDir },
+        store: {
+          read: () => ({
+            git: { repository: { cloneUrl: bare, branch: "feat/x" } },
+            application: {},
+          }),
+          hydrate: () => {},
+          applyInternal: async () => ({
+            kind: "applied",
+            before: null,
+            after: {},
+            transition: { kind: "no-op" },
+          }),
+        } as never,
+        taskManager: {
+          spawn: async () => ({ id: "t1" }),
+          killByLogName: () => 0,
+          waitForLogNamesIdle: async () => {},
+          runningCommandByLogName: () => null,
+          onTaskExit: () => () => {},
+        } as never,
+        setStatus: () => {},
+        getStatus: () => ({ state: "running" as const }),
+        broadcaster,
+        installState: {
+          isInstalledFor: (
+            _config: unknown,
+            branchHead: string | undefined,
+          ) => {
+            capturedHead = branchHead;
+            return false;
+          },
+          mark: () => {},
+        } as never,
+        logsDir: root,
+        lifecycle,
+        branchStatus: makeMonitorStub(),
+      });
+
+      orchestrator.handle({
+        kind: "branch-change",
+        from: "main",
+        to: "feat/x",
+      });
+      await drain(orchestrator);
+
+      expect(capturedHead).toBeDefined();
+      expect(capturedHead).toBe(headOf(repoDir));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 20_000);
 });

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -358,6 +358,11 @@ export class SetupOrchestrator {
     // intentionally out of scope for now (its content is at most idle-TTL stale,
     // not the days-stale case this targets).
     await this.maybeFastForwardToBase(config.repoDir);
+    // Re-read HEAD: a fast-forward above may have moved it past what gitSetup's
+    // checkout captured. installState fingerprints against this field, so a
+    // stale (pre-fast-forward) value would let a changed lockfile slip past
+    // the install-skip cache on the next cycle.
+    this.refreshBranchHead();
     this.deps.branchStatus.refresh();
     return true;
   }
@@ -734,7 +739,6 @@ export class SetupOrchestrator {
         );
       }
     }
-    this.refreshBranchHead();
   }
 
   private markInstallSucceeded(config: Config): void {


### PR DESCRIPTION
Bug found while reading `packages/sandbox/daemon/setup/orchestrator.ts` after the recent auto-fast-forward feature (#5390) and the no-install reporting fix (#5398).

**Bug**: `stepClone()` calls `gitSetup(config)` (which checks out the branch and calls `refreshBranchHead()` to snapshot `currentBranchHead`) and only afterward calls `maybeFastForwardToBase(config.repoDir)`. `stepInstall()`'s install-skip cache (`installState.isInstalledFor(config, this.currentBranchHead)`) and its `markInstallSucceeded` call both key off that same `currentBranchHead` field. Since the field is captured *before* the fast-forward runs, it's fingerprinting against the pre-fast-forward commit even though the fast-forward may have just advanced the branch (and its lockfile) further.

**Failure scenario**: an idle sandbox on branch `feat/x` (no local commits) resumes on boot. `feat/x` is behind `origin/main`. The fast-forward advances `feat/x` to `origin/main` before install runs, and install correctly picks up the new lockfile from disk — but the success is recorded under the *stale, pre-fast-forward* commit SHA. On a later boot/resume cycle where `feat/x` lands back at that same pre-ff commit (e.g. base hasn't moved further yet), the install-skip cache matches that stale fingerprint and skips the install entirely, even though a fresh fast-forward in that same cycle may have just changed the lockfile again.

**Fix**: move the `refreshBranchHead()` call to run after `maybeFastForwardToBase()` in `stepClone`, so the fingerprint reflects the actual commit that was installed against (removed the now-redundant call inside `gitSetup`, its only caller).

**Regression test**: added `SetupOrchestrator install fingerprint after boot fast-forward` in `orchestrator.test.ts` — sets up a real local bare repo with `main` two commits ahead of `feat/x`, clones `feat/x`, drives the orchestrator through a `branch-change` transition, and asserts the branch-head value passed into `installState.isInstalledFor` equals the actual post-fast-forward `git rev-parse HEAD`. Verified the test fails (captures the pre-fast-forward SHA) on the pre-fix code and passes after the fix.

**To verify**: `cd packages/sandbox/daemon && bun test setup/orchestrator.test.ts -t "post-fast-forward"`

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox` (clean), and the single targeted test file above (14/15 pass; the one pre-existing failure — "reinstalls the pre-push hook after an install script clobbers it" — fails identically on main due to a missing `corepack` binary in this local sandbox, unrelated to this change). Full CI runs the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stale install fingerprint after boot-time fast-forward by re-reading `HEAD` after the fast-forward. This ensures the install cache keys off the post-FF commit and avoids skipping needed installs when the lockfile changes.

- **Bug Fixes**
  - In `stepClone()`, run `maybeFastForwardToBase()` before `refreshBranchHead()`, and remove the redundant refresh in `gitSetup()`, so the fingerprint uses the post-fast-forward SHA.
  - Added a regression test that verifies `installState.isInstalledFor` receives the post-FF `HEAD`.

<sup>Written for commit e2dd1536fd62bd67ef8cb47ee5c3813be3dc6289. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

