### PR TITLE
fix(dispatch): keep queued hosted runs alive and visible

### DIFF
--- a/apps/api/src/api/routes/decopilot/run-status-stage.ts
+++ b/apps/api/src/api/routes/decopilot/run-status-stage.ts
@@ -4,6 +4,9 @@ import type { StreamBuffer } from "./stream-buffer";
 const RUN_STATUS_STAGES = [
   "waiting-runner",
   "starting-run",
+  // Queued behind this pod's concurrent-run cap (hosted-run-concurrency.ts),
+  // re-published on the heartbeat interval for as long as the wait lasts.
+  "waiting-capacity",
   "gathering-context",
   "preparing-tools",
   "starting-assistant",

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -2,7 +2,7 @@
   "auth/install-studio-pack-workflow.ts": "e284b2fd9950d5cc803d66a3b79e86258968b7d9a124cf2746363f8a4f7513a3",
   "automations/dbos-workflow.ts": "e30103f5b7fc7f5f556e7b840e3444020163d5f6701b0a5fb96579e3f62251bd",
   "billing/sync-org-benefits.ts": "53ebb1e30d7583e0db9f341f14272226602211f10a370c5220c22dda4fbcf8f6",
-  "dispatch-queue/hosted-harness-workflow.ts": "b33797ef494c63fb4d24af91ff8dea7878f388280986647376659fd2077a670c",
+  "dispatch-queue/hosted-harness-workflow.ts": "91a32a83cc7e47a77a19fc442a58b620dc83faadc1f615b99ba4cded1215d26d",
   "dispatch-queue/thread-gate-workflow.ts": "5ca2539eca2db6a24c9efb492b0563c72ace37064a5cd9c46dec23c19865ae78",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
   "harnesses/decopilot/background-tool-workflow.ts": "a71d1850652b2553aea37c41fe217a9f6deb0b0e60e91efd87e1c6105b483715",

--- a/apps/api/src/dispatch-queue/hosted-harness-workflow.test.ts
+++ b/apps/api/src/dispatch-queue/hosted-harness-workflow.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { sleep } from "@decocms/shared/std";
 import { synthesizedErrorMessageId } from "@/api/routes/decopilot/message-ids";
 import type { WithLastAckSeq } from "@/api/routes/decopilot/ingest-run";
+import { buildRunStatusChunk } from "@/api/routes/decopilot/run-status-stage";
 import type { StudioContext } from "@/core/studio-context";
+import { acquireHostedRunSlot, hostedRunStats } from "./hosted-run-concurrency";
 import {
   buildTerminalErrorChunks,
   hostedChildWorkflowId,
@@ -332,6 +335,70 @@ describe("half-terminal invariant (T9 proof obligation 1): done is never publish
     // done was never published — the half-terminal invariant.
     expect(streamBuffer.publishRawChunk).toHaveBeenCalledTimes(1);
     expect(streamBuffer.publishDone).not.toHaveBeenCalled();
+  });
+});
+
+// Regression: a run parked at the per-pod concurrency cap published NOTHING
+// while it waited. The parent gate is already live-tailing the run's subject
+// with a RUN_IDLE_TIMEOUT_MS silence window, so a queue longer than that window
+// failed the turn as a liveness breach before the loop had started — and the
+// child then ran anyway under a fence nobody was projecting. The parked run now
+// publishes `waiting-capacity` (which both resets that window and is the only
+// feedback a queued run gives the UI).
+describe("a run queued at the concurrency cap", () => {
+  const input: HostedHarnessInput = {
+    runId: "run-parked",
+    fenceToken: "fence-parked",
+    threadId: "thread-parked",
+    request: {
+      organizationId: "org-1",
+      userId: "user-1",
+    } as SerializableDispatchRunInput,
+  };
+
+  test("publishes waiting-capacity while parked, and starts the loop only once a slot frees", async () => {
+    // Saturate the real gate by holding every slot it has, so the run under
+    // test genuinely parks (no env/module games — the cap is read once at
+    // import time).
+    const held = await Promise.all(
+      Array.from({ length: hostedRunStats().max }, () =>
+        acquireHostedRunSlot(),
+      ),
+    );
+    try {
+      const dispatchRunFn = mock(() => Promise.resolve({ taskId: "t" }));
+      const streamBuffer = {
+        publishRawChunk: mock(() => Promise.resolve(true)),
+        publishDone: mock(() => Promise.resolve(true)),
+      } as unknown as NonNullable<HostedHarnessRuntime["deps"]["streamBuffer"]>;
+      setHostedHarnessRuntime({
+        dispatchRunFn,
+        studioContextFactory: async () => null,
+        deps: {
+          runRegistry: {} as HostedHarnessRuntime["deps"]["runRegistry"],
+          cancelBroadcast:
+            {} as HostedHarnessRuntime["deps"]["cancelBroadcast"],
+          streamBuffer,
+        },
+      });
+
+      const run = runHostedHarness(input, {} as StudioContext);
+      // Let the park's publish settle (it is fire-and-forget by design — the
+      // status must never delay the run).
+      await sleep(0);
+
+      expect(streamBuffer.publishRawChunk).toHaveBeenCalledWith(
+        input.runId,
+        buildRunStatusChunk("waiting-capacity"),
+      );
+      expect(dispatchRunFn).not.toHaveBeenCalled();
+
+      held[0]?.();
+      await run;
+      expect(dispatchRunFn).toHaveBeenCalledTimes(1);
+    } finally {
+      for (const release of held) release();
+    }
   });
 });
 

--- a/apps/api/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/api/src/dispatch-queue/hosted-harness-workflow.ts
@@ -73,6 +73,8 @@
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import type { UIMessageChunk } from "ai";
+import { HeartbeatEmitter } from "@decocms/harness/liveness-heartbeat";
+import { publishRunStatusStage } from "@/api/routes/decopilot/run-status-stage";
 import type {
   DispatchRunDeps,
   DispatchRunRuntimeInput,
@@ -209,25 +211,6 @@ export async function runHostedHarness(
     studioCtx.metadata.runMetadata = request.runMetadata;
   }
 
-  // A Super Agent task run is starting to execute — move its card to In Progress.
-  // Fire-and-forget: the transition is best-effort and must not delay the loop.
-  void advanceTaskBoardForRun(studioCtx, "in_progress", input.threadId);
-
-  // If the user re-engaged a task that had moved to In Review, pull it back to
-  // In Progress. Link-based (`task_board_item_threads`), so it fires for a
-  // re-prompt that carries no run metadata — unlike the forward advance above.
-  //
-  // Skipped when `runMetadata.taskBoardItemId` is set: that means this
-  // execution IS the Super Agent's own task run (dispatched by
-  // `enqueueSuperAgentForTask`, or DBOS recovering/retrying it after a pod
-  // death) — never a human re-prompt, which never carries that key. Firing
-  // unconditionally here would regress an already-reviewed card (PR opened,
-  // pod died, DBOS re-runs the workflow) back to In Progress every time the
-  // run resumes, with no second PR coming to re-advance it.
-  if (!request.runMetadata?.taskBoardItemId) {
-    void reopenTasksOnThreadRun(studioCtx, input.threadId);
-  }
-
   // No wall-clock cap: a hosted run lives as long as it makes progress. The
   // RunRegistry idle reaper aborts + fails a run that goes RUN_IDLE_TIMEOUT_MS
   // with no progress (see run-registry.ts). The AbortController is retained for
@@ -237,8 +220,58 @@ export async function runHostedHarness(
   // Cap concurrent agent loops per pod (see hosted-run-concurrency.ts). The
   // slot is held only for the loop itself, not the ctx resolution above; excess
   // runs park here until a slot frees.
-  const releaseSlot = await acquireHostedRunSlot();
+  //
+  // A parked run must keep publishing or it dies for being quiet: the parent
+  // gate already tails this run's subject under a RUN_IDLE_TIMEOUT_MS silence
+  // window (consume-run-projection.ts), so a longer park failed the turn as a
+  // liveness breach before the loop started — and the child then ran anyway,
+  // streaming under a fence nobody projected. `waiting-capacity`, re-published
+  // on the heartbeat interval, resets that window (any message does — see
+  // nats-chunk-source.ts) and is the only feedback a queued run gives the UI.
+  let parked = false;
+  const parkedStatus = new HeartbeatEmitter({
+    emit: () => publishWaitingCapacity(rt, input),
+  });
+  const releaseSlot = await acquireHostedRunSlot(() => {
+    parked = true;
+    void publishWaitingCapacity(rt, input);
+    parkedStatus.arm();
+  }).finally(() => parkedStatus.stop());
+
   try {
+    // Stop, pressed while this run was still queued, cancels this child
+    // workflow — but DBOS cannot interrupt a step that already started, and a
+    // parked step has no registered run for the in-memory abort to reach
+    // either (see `cancelActiveThreadRun` in routes.ts). Without this check a
+    // cancelled run starts its agent loop here, minutes after the user stopped
+    // it. Only a run that actually parked can have been cancelled in that
+    // window, so the healthy path pays nothing.
+    if (parked && (await hostedRunWasCancelled(input))) {
+      throw new Error("run cancelled while queued for a free runner");
+    }
+
+    // A Super Agent task run is starting to execute — move its card to In
+    // Progress. Fire-and-forget: the transition is best-effort and must not
+    // delay the loop. Deliberately AFTER the slot acquire: a parked run has
+    // not started, and flipping the card on enqueue made the board show every
+    // queued task as In Progress while the pod was only running its cap.
+    void advanceTaskBoardForRun(studioCtx, "in_progress", input.threadId);
+
+    // If the user re-engaged a task that had moved to In Review, pull it back to
+    // In Progress. Link-based (`task_board_item_threads`), so it fires for a
+    // re-prompt that carries no run metadata — unlike the forward advance above.
+    //
+    // Skipped when `runMetadata.taskBoardItemId` is set: that means this
+    // execution IS the Super Agent's own task run (dispatched by
+    // `enqueueSuperAgentForTask`, or DBOS recovering/retrying it after a pod
+    // death) — never a human re-prompt, which never carries that key. Firing
+    // unconditionally here would regress an already-reviewed card (PR opened,
+    // pod died, DBOS re-runs the workflow) back to In Progress every time the
+    // run resumes, with no second PR coming to re-advance it.
+    if (!request.runMetadata?.taskBoardItemId) {
+      void reopenTasksOnThreadRun(studioCtx, input.threadId);
+    }
+
     await rt.dispatchRunFn(
       { ...request, abortSignal: abortController.signal },
       studioCtx,
@@ -246,6 +279,38 @@ export async function runHostedHarness(
     );
   } finally {
     releaseSlot();
+  }
+}
+
+/** The stage a run publishes while it waits for a free slot. */
+const publishWaitingCapacity = (
+  rt: HostedHarnessRuntime,
+  input: HostedHarnessInput,
+): Promise<void> =>
+  publishRunStatusStage(rt.deps.streamBuffer, input.runId, "waiting-capacity");
+
+/**
+ * Was THIS attempt's child workflow cancelled while it sat parked? Reads DBOS's
+ * own status for the child id, which `cancelHostedHarness` flips — so the check
+ * is per-attempt, unlike the thread-level `cancel_requested_at` flag, which a
+ * previous turn's Stop leaves set and would make a healthy queued turn skip
+ * itself. A read failure reports "not cancelled": losing a cancel is better
+ * than refusing to run a live turn.
+ */
+async function hostedRunWasCancelled(
+  input: HostedHarnessInput,
+): Promise<boolean> {
+  try {
+    const status = await DBOS.getWorkflowStatus(
+      hostedChildWorkflowId(input.runId, input.fenceToken),
+    );
+    return status?.status === "CANCELLED";
+  } catch (err) {
+    console.error(
+      `[hostedHarness] could not read child status for run=${input.runId} fence=${input.fenceToken}`,
+      err,
+    );
+    return false;
   }
 }
 

--- a/apps/api/src/dispatch-queue/hosted-run-concurrency.ts
+++ b/apps/api/src/dispatch-queue/hosted-run-concurrency.ts
@@ -69,7 +69,17 @@ export const hostedRunStats = (): {
   max: number;
 } => ({ active: gate.active, pending: gate.pending, max: MAX });
 
-export const acquireHostedRunSlot = (): Promise<() => void> => {
+/**
+ * Acquire a run slot. `onPark` fires (synchronously, before the wait) only when
+ * this caller has to queue for a slot — the same condition the log below
+ * reports. Callers use it to tell the user their run is waiting: a parked run
+ * publishes nothing on its own, and silence on a run's subject is what the
+ * projector's idle window reads as a dead executor (see
+ * `hosted-harness-workflow.ts`'s `runHostedHarness`).
+ */
+export const acquireHostedRunSlot = (
+  onPark?: () => void,
+): Promise<() => void> => {
   // Log when a run parks so a saturating pod is visible in prod — the whole
   // point of the cap. (gate exposes active/pending for exactly this.)
   if (gate.active >= MAX) {
@@ -78,6 +88,7 @@ export const acquireHostedRunSlot = (): Promise<() => void> => {
       pending: gate.pending,
       max: MAX,
     });
+    onPark?.();
   }
   return gate.acquire();
 };

--- a/apps/web/src/components/chat/run-status.ts
+++ b/apps/web/src/components/chat/run-status.ts
@@ -3,6 +3,7 @@ export const RUN_STATUS_STAGE_ORDER = [
   "received",
   "waiting-runner",
   "starting-run",
+  "waiting-capacity",
   "gathering-context",
   "preparing-tools",
   "starting-assistant",
@@ -33,6 +34,11 @@ export const RUN_STATUS_COPY: Record<RunStatusStage, RunStatusCopy> = {
   "starting-run": {
     label: "Getting started",
     detail: "Setting up to work on your message",
+  },
+  "waiting-capacity": {
+    label: "Waiting for a free runner",
+    detail:
+      "Other runs are using every slot — this one starts as soon as one frees up",
   },
   "gathering-context": {
     label: "Reading the chat",


### PR DESCRIPTION
## Problem

Running many tasks at once — bulk-assigning cards to the Super Agent is the easy way — pushes runs past the per-pod cap of concurrent hosted agent loops (`DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS`, default 3). Everything above the cap parks inside `runHostedHarness`'s DBOS step and publishes **nothing**.

That silence is fatal. By the time the child parks, the parent thread gate has already opened `consumeRunProjection` on the run's subject, which enforces a `RUN_IDLE_TIMEOUT_MS` (10 min) silence window:

1. queue longer than 10 min → the turn is failed as `liveness: no stream events for 10m`, **before the agent loop started**;
2. the child later gets its slot and runs the whole loop anyway, streaming under a fence nobody projects — a full agent loop paid for output that never lands;
3. on the board the card is In Progress with a `failed` thread, so the next board open "recovers" it by nudging a **duplicate** run onto the same thread.

Symptoms reported: chats that hang with no feedback, and no signal anywhere that a run is queued behind a concurrency limit.

## Changes

- **Park visibly.** A queued run publishes a new `waiting-capacity` run-status stage on park and re-publishes it on the liveness heartbeat interval (reusing `HeartbeatEmitter`). Any message on the subject resets the projector's idle window, so waiting no longer reads as a dead executor — and the chat shows *why* it is waiting instead of an indefinite "Thinking…".
- **Honest board.** The card advances to In Progress only after the slot is acquired. Flipping it at enqueue made the board claim every queued task was running while the pod ran only its cap.
- **Stop actually stops a queued run.** DBOS can't interrupt a step that already started, and a parked step has no registered run for the in-memory abort to reach — so a cancelled run used to start its loop minutes after the user pressed Stop. Now checked per-attempt against the child workflow's own status (the thread-level cancel flag survives past turns and would false-positive).

## Notes

Changes live in the step **body** only — no DBOS step added, removed or reordered — so this is recovery-compatible: source-guard snapshot re-baselined, no `DBOS_WORKFLOW_VERSION` bump.

## Testing

- `bun test apps/api/src/dispatch-queue/ apps/api/src/api/routes/decopilot/run-status-stage.test.ts apps/web/src/components/chat/` — 465 pass, 0 fail. New regression test saturates the real gate so the run under test genuinely parks, then asserts it publishes `waiting-capacity` and does not start the loop until a slot frees.
- `bun run --cwd=apps/api check`, `bun run --cwd=apps/web check`, `bun run lint` (0 errors), `bun run fmt` clean.
- Not exercised end-to-end against a live pod/NATS — the liveness-kill path is derived from reading `consume-run-projection.ts` → `natsChunkSource`'s per-pull idle window, not reproduced in a running cluster.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queued hosted runs now stay alive and visible when the pod hits its concurrency cap. We publish a heartbeat status while waiting, only move the task card once a slot is free, and respect Stop pressed during the queue.

- **Bug Fixes**
  - Publish a waiting status while queued and re-emit on a heartbeat to keep the run alive; prevents idle timeouts before the loop starts.
  - Advance the task board to In Progress only after a slot is acquired.
  - If Stop is pressed while queued, the run aborts before starting (checked via the child workflow status).

- **New Features**
  - Added a new run-status stage "waiting-capacity" with chat copy explaining the wait.

<sup>Written for commit 37d256d12a85999910cb94db4d5de8f47d46343d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

