### PR TITLE
fix(task-board): translate assign-avatar button and add aria-label

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -288,7 +288,8 @@ function AssigneeDisplay({
       <PopoverTrigger asChild>
         <button
           type="button"
-          title="Assign"
+          title={t("taskBoard.taskBoard.assignButton")}
+          aria-label={t("taskBoard.taskBoard.assignButton")}
           onClick={(e) => {
             e.stopPropagation();
             setOpen(true);


### PR DESCRIPTION
**Source:** found while auditing task-board UI/i18n polish for icon-only controls missing aria-labels and untranslated strings (recurring merge lane — see #4903, #5408).

**Why a maintainer wants this:** the unassigned-avatar "Assign" trigger in the task-board card row (`AssigneeDisplay` in `apps/web/src/layouts/task-board/index.tsx`) was the one icon-only control on the board left with a hardcoded English `title` and no `aria-label` at all — it shows literal "Assign" to pt-br users and is invisible to screen readers, both inconsistent with every sibling control in the same file (all of which go through `t()` and set `aria-label`).

**Fix:** reuse the existing `taskBoard.taskBoard.assignButton` key (already defined and translated to pt-br as "Atribuir", already used by the bulk-actions toolbar) for both `title` and the new `aria-label`, instead of the literal string.

**Net change:** +2/-1 in `apps/web/src/layouts/task-board/index.tsx`. Behavior-preserving — same button, same translation key already shipped in both `en/task-board.ts` and `pt-br/task-board.ts`, no new dictionary entries needed.

**To verify:** open a task board with an unassigned task that has assignable members, hover/inspect the empty-avatar button in the card row — tooltip and (via a11y tree) accessible name now read "Assign" (or "Atribuir" in pt-br) instead of a raw untranslated string with no accessible name.

**Checks run locally:** `bun run fmt` (clean) and `cd apps/web && bunx tsc --noEmit` (clean). Full CI validates lint/tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate the unassigned-avatar "Assign" button on the task board and add an aria-label for accessibility. Uses the existing `taskBoard.taskBoard.assignButton` key for both tooltip and accessible name, matching other icon-only controls.

<sup>Written for commit d834cfe215c12d0ad03f390292d5a89536b08250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

