### PR TITLE
fix(sandbox): make the daemon URL-transfer routes async

### DIFF
--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -715,7 +715,7 @@ export function makeWriteFromUrlHandler(deps: FsDeps) {
       );
     }
 
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    await mkdir(path.dirname(filePath), { recursive: true });
 
     // pipeline() guarantees: backpressure honored, errors propagate
     // through the chain, all streams destroyed on failure. The Transform
@@ -739,7 +739,7 @@ export function makeWriteFromUrlHandler(deps: FsDeps) {
       // Any failure (network RST, TLS error, size cap, write fault)
       // leaves a partial file. Remove it so a later skill step can't
       // read a half-baked artifact.
-      fs.rmSync(filePath, { force: true });
+      await rm(filePath, { force: true });
       return jsonResponse(
         {
           error: abortController.signal.aborted
@@ -782,24 +782,26 @@ export function makeUploadToUrlHandler(deps: FsDeps) {
       return jsonResponse({ error: "Path escapes project root" }, 400);
     }
 
-    let stat: fs.Stats;
+    let fileStat: fs.Stats;
     try {
-      stat = fs.statSync(filePath);
+      fileStat = await stat(filePath);
     } catch {
       return jsonResponse({ error: `File not found: ${body.path}` }, 400);
     }
-    if (stat.isDirectory()) {
+    if (fileStat.isDirectory()) {
       return jsonResponse({ error: "Path is a directory" }, 400);
     }
-    if (stat.size > MAX_TRANSFER_BYTES) {
+    if (fileStat.size > MAX_TRANSFER_BYTES) {
       return jsonResponse(
-        { error: `File too large (${stat.size} > ${MAX_TRANSFER_BYTES})` },
+        {
+          error: `File too large (${fileStat.size} > ${MAX_TRANSFER_BYTES})`,
+        },
         413,
       );
     }
 
     const headers: Record<string, string> = {
-      "Content-Length": String(stat.size),
+      "Content-Length": String(fileStat.size),
     };
     if (body.contentType) headers["Content-Type"] = body.contentType;
 
@@ -844,7 +846,7 @@ export function makeUploadToUrlHandler(deps: FsDeps) {
         502,
       );
     }
-    return jsonResponse({ ok: true, size: stat.size });
+    return jsonResponse({ ok: true, size: fileStat.size });
   };
 }
 


### PR DESCRIPTION
Follows #5403/#5406, which converted the daemon's read and rename routes off blocking sync fs calls. `write_from_url` and `upload_to_url` in `packages/sandbox/daemon/routes/fs.ts` still called `fs.mkdirSync`/`fs.rmSync`/`fs.statSync` directly in the request handler.

Per CONTRIBUTING.md rule #1, the sandbox daemon runs on a single-threaded Bun event loop — any sync fs call blocks it from answering its HTTP health probe, and Studio tears down / recovers a sandbox on a single missed probe. `mkdirSync`/`statSync` ran on every call to these routes, and `rmSync` ran on every failed transfer.

The fix swaps each sync call for its already-imported `node:fs/promises` equivalent (`mkdir`/`rm`/`stat` were already imported and used elsewhere in the file) — a straight 1:1 behavior-preserving substitution, same as the prior read/rename PRs. Renamed the local `stat` variable to `fileStat` to avoid shadowing the imported `stat` function.

To verify: `cd packages/sandbox && bunx tsc --noEmit`, then `bun test packages/sandbox/daemon/routes/fs.test.ts` (56 pass, 0 fail — existing coverage of this file passes unchanged since behavior is identical).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (packages/sandbox workspace), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the sandbox daemon’s URL-transfer routes async to avoid blocking the single-threaded event loop and prevent health probe timeouts. Replaced sync `fs` calls in `write_from_url` and `upload_to_url` with `node:fs/promises` to keep behavior the same while non-blocking.

- **Bug Fixes**
  - Swapped `mkdirSync`/`rmSync`/`statSync` for `mkdir`/`rm`/`stat` in `packages/sandbox/daemon/routes/fs.ts`.
  - Renamed local `stat` to `fileStat` to avoid shadowing the imported `stat` function.

<sup>Written for commit 10874d98d17417f395cc15d93127c0f997e72f43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

