### PR TITLE
fix(native): ship unsigned when Apple signing secrets are absent

### DIFF
--- a/.github/workflows/release-native.yaml
+++ b/.github/workflows/release-native.yaml
@@ -139,22 +139,45 @@ jobs:
             -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
           security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
 
-      - name: tauri build
+      # Tauri's CLI signs whenever APPLE_SIGNING_IDENTITY is *defined* — and
+      # an `env:` mapping of an unset secret defines it as "", so mapping the
+      # secrets directly onto `tauri build` made every unconfigured run die
+      # in codesign with `no identity found` instead of shipping unsigned.
+      # Export each var only when its secret is non-empty; a var that is
+      # absent (not empty) leaves an unsigned build
+      # (https://v2.tauri.app/distribute/sign/macos/).
+      #
+      # TAURI_SIGNING_* signs the updater artifact the day tauri.conf enables
+      # the `updater` bundle target. Wired in this SHIPPING job (not just
+      # native.yml's non-shipping CI build) so no edit is needed here on
+      # release day; a no-op while that target stays dormant.
+      - name: Export signing env
         if: steps.guard.outputs.release == 'true'
-        working-directory: apps/native
         env:
-          # Consumed by the Tauri CLI when non-empty; absent secrets leave an
-          # unsigned build (https://v2.tauri.app/distribute/sign/macos/).
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # Signs the updater artifact the day tauri.conf enables the
-          # `updater` bundle target. Wired in the SHIPPING job (not just
-          # native.yml's non-shipping CI build) so no edit is needed here on
-          # release day; a no-op while that target stays dormant.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        # Heredoc form because TAURI_SIGNING_PRIVATE_KEY may be multiline.
+        run: |
+          for VAR in APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD \
+                     APPLE_TEAM_ID TAURI_SIGNING_PRIVATE_KEY \
+                     TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+            if [ -n "${!VAR}" ]; then
+              {
+                echo "$VAR<<__SIGNING_EOF__"
+                echo "${!VAR}"
+                echo "__SIGNING_EOF__"
+              } >> "$GITHUB_ENV"
+            fi
+          done
+
+      - name: tauri build
+        if: steps.guard.outputs.release == 'true'
+        working-directory: apps/native
+        # Signing env (when configured) comes from "Export signing env" above.
         # The binary's version comes from apps/native/package.json — the one
         # release-tagging bumps — overriding Cargo.toml's static workspace
         # version, so the DMG, the About panel, and the cask all agree.
@@ -276,4 +299,3 @@ jobs:
           done
           echo "::error::cask bump push failed after retries"
           exit 1
-          git push "$REMOTE" HEAD:main

--- a/Casks/deco.rb
+++ b/Casks/deco.rb
@@ -25,6 +25,7 @@ cask "deco" do
   depends_on arch: :arm64
   depends_on macos: :big_sur
   depends_on formula: "git"
+  depends_on formula: "ripgrep"
 
   app "deco.app"
 

--- a/Casks/deco.rb
+++ b/Casks/deco.rb
@@ -24,6 +24,7 @@ cask "deco" do
 
   depends_on arch: :arm64
   depends_on macos: :big_sur
+  depends_on formula: "git"
 
   app "deco.app"
 


### PR DESCRIPTION
## Summary

The first two `Release Native` runs (30539722985, 30539745290) both died in `tauri build`:

```
Signing with identity ""
: no identity found
Error failed to bundle project: failed codesign application
```

Mapping `${{ secrets.APPLE_SIGNING_IDENTITY }}` directly onto the step's `env:` defines the variable as an **empty string** when the secret is unset — and Tauri's CLI signs whenever the var is *defined*, not merely non-empty. So the "fork-safe dormant scaffolding" contract (unsigned build until the six `APPLE_*` secrets land) never actually held: no release could succeed.

- New **Export signing env** step writes each of the six signing vars to `$GITHUB_ENV` only when its secret is non-empty (heredoc form — the updater private key may be multiline). Absent vars ⇒ unsigned build, per https://v2.tauri.app/distribute/sign/macos/.
- `native.yml` is unaffected — it deliberately never wires `APPLE_*` (its comment documents this exact failure mode).
- Removed the unreachable `git push` after `exit 1` in the cask-bump retry loop (actionlint SC2317).
- `Casks/deco.rb`: `depends_on formula: "git"` for the tools the app spawns. Note this only covers brew installs; the app still needs runtime resolution since Finder-launched apps don't have `/opt/homebrew/bin` on PATH.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` — parses.
- `actionlint` — only pre-existing info-level notes remain.
- `brew style` on the tap with the edited cask — no offenses.
- After merge: `workflow_dispatch` Release Native to cut `native-v4.147.0` (the documented repair path — merging this PR won't retrigger it, since it doesn't touch `apps/native/package.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Release Native workflow to ship unsigned macOS builds when Apple signing secrets are absent, preventing codesign failures. The cask now declares `git` and `ripgrep` to support spawned tools and sandbox file search.

- **Bug Fixes**
  - Export `APPLE_*` and `TAURI_SIGNING_*` to `$GITHUB_ENV` only when secrets are non-empty (heredoc supports multiline keys).
  - Remove unreachable `git push` after `exit 1` in the cask-bump retry loop.

- **Dependencies**
  - Add `depends_on formula: "git"` in `Casks/deco.rb`.
  - Add `depends_on formula: "ripgrep"` for `rg` used by the sandbox file-search route.

<sup>Written for commit aa419798b962676db6d3c398f23296751e6f4f8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

