### PR TITLE
fix(native): cask-bump push must authenticate as the release bot app

### DIFF
--- a/.github/workflows/release-native.yaml
+++ b/.github/workflows/release-native.yaml
@@ -47,8 +47,18 @@ jobs:
     env:
       BUN_VERSION: "1.3.14"
     steps:
+      # persist-credentials: false — checkout would otherwise store the
+      # default GITHUB_TOKEN as an http.extraheader Authorization header,
+      # which git keeps sending even on a push to an explicit
+      # x-access-token URL; the header wins, so the cask-bump push below
+      # authenticated as github-actions[bot] (not a ruleset bypass actor)
+      # and main's protection rejected it. Nothing else in this job needs
+      # persisted creds: the repo is public (fetches work anonymously) and
+      # every gh/push step supplies its own token.
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Read app version
         id: version


### PR DESCRIPTION
## Summary

Run 30541865181 (dispatched after #5414) proved the signing fix: the build shipped and [`native-v4.147.0`](https://github.com/decocms/studio/releases/tag/native-v4.147.0) was published with the DMG + zip. But the final **Bump Homebrew cask** step failed all 5 retries with `GH013: Repository rule violations` — so `Casks/deco.rb` on main is still the `0.1.0` / `sha256 :no_check` placeholder and the tap remains uninstallable.

Root cause: the job's `actions/checkout` (no `token:`) persists the default `GITHUB_TOKEN` as an `http.https://github.com/.extraheader` Authorization header. Git keeps sending that header even on a push to the explicit `https://x-access-token:<app-token>@github.com/…` remote — the header wins over URL credentials — so the push authenticated as `github-actions[bot]`, which is not among main's ruleset bypass actors (the `decocms` app, id 2708739, is). release-tagging pushes fine because its checkout uses the app token, so its persisted header IS the app's.

Fix: `persist-credentials: false` on the checkout, leaving the app-token URL as the only credential at push time. Nothing else in the job needs persisted creds — the repo is public (the bump loop's `git fetch origin main` works anonymously) and the `gh` steps supply their own `GH_TOKEN`.

## Testing

- YAML parses; `actionlint` shows only pre-existing info notes.
- After merge: `gh workflow run release-native.yaml` — the `workflow_dispatch` repair path rebuilds, re-uploads the `native-v4.147.0` assets with `--clobber`, and the cask bump should now land on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Homebrew cask bump by making the push authenticate as the release app, not `github-actions[bot]`. Disables persisted checkout credentials so the app token is used on push.

- **Bug Fixes**
  - Set `persist-credentials: false` on `actions/checkout@v4` in `release-native.yaml`.
  - Stops the default `GITHUB_TOKEN` `http.extraheader` from overriding the app token during `git push`.
  - Allows the cask bump to bypass main’s rules via the `decocms` app and update `Casks/deco.rb`.

<sup>Written for commit 6b5852e48fe6ae53acef289e827cc18126246049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

