### PR TITLE
fix(native): rename the cask to deco-studio — bare "deco" is shadowed

### DIFF
--- a/.github/workflows/release-native.yaml
+++ b/.github/workflows/release-native.yaml
@@ -16,7 +16,7 @@
 # six APPLE_* secrets land, the same workflow signs, notarizes and staples
 # with no further edits.
 #
-# The Homebrew cask (Casks/deco.rb — this repo doubles as the
+# The Homebrew cask (Casks/deco-studio.rb — this repo doubles as the
 # tap) is bumped by this workflow after the release assets exist, committed
 # straight to main with the same App token release-tagging uses. That commit
 # touches only Casks/**, which no other workflow's paths match, so it
@@ -226,7 +226,7 @@ jobs:
           DMG: ${{ steps.assets.outputs.dmg }}
         run: |
           set -euo pipefail
-          NOTES="macOS (Apple Silicon) desktop app. Install via Homebrew: \`brew tap decocms/studio https://github.com/decocms/studio && brew install --cask deco\` — or download the DMG below."
+          NOTES="macOS (Apple Silicon) desktop app. Install via Homebrew: \`brew tap decocms/studio https://github.com/decocms/studio && brew install --cask deco-studio\` — or download the DMG below."
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
             gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" \
               --title "deco $VERSION" --notes "$NOTES"
@@ -267,7 +267,7 @@ jobs:
           import re, sys
 
           version, sha = sys.argv[1], sys.argv[2]
-          path = "Casks/deco.rb"
+          path = "Casks/deco-studio.rb"
           s = open(path).read()
           # Anchor to the INDENTED stanza lines. The header comment mentions
           # `sha256 :no_check` too, but comment lines start with `#`, so
@@ -295,11 +295,11 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
             render_cask
-            if git diff --quiet -- Casks/deco.rb; then
+            if git diff --quiet -- Casks/deco-studio.rb; then
               echo "cask already at $VERSION; nothing to push"
               exit 0
             fi
-            git add Casks/deco.rb
+            git add Casks/deco-studio.rb
             git commit -m "[chore]: bump homebrew cask to $VERSION"
             if git push "$REMOTE" HEAD:main; then
               echo "cask pushed (attempt $attempt)"

--- a/Casks/deco-studio.rb
+++ b/Casks/deco-studio.rb
@@ -2,7 +2,7 @@
 # tap:
 #
 #   brew tap decocms/studio https://github.com/decocms/studio
-#   brew install --cask deco
+#   brew install --cask deco-studio
 #
 # `version` and `sha256` are maintained by .github/workflows/release-native.yaml,
 # which rewrites them after each desktop release's assets are published —
@@ -13,12 +13,12 @@
 # `brew install` will 404. The first desktop release (which cuts automatically
 # once a version bump lands on main) rewrites both to real values and the tap
 # becomes installable. Until then this file only reserves the cask name.
-cask "deco" do
+cask "deco-studio" do
   version "4.147.0"
   sha256 "7ef9c2346f7ac0e201a77d57e6039a3c270521641dd99a767b2d708635342ba6"
 
   url "https://github.com/decocms/studio/releases/download/native-v#{version}/deco-#{version}-aarch64.zip"
-  name "deco"
+  name "deco studio"
   desc "Open-source control plane for MCP traffic — desktop app"
   homepage "https://github.com/decocms/studio"
 


### PR DESCRIPTION
## Summary

Installing on a real machine surfaced a name collision: `homebrew/cask` already owns a **deprecated `deco` cask** (0.7.1, disabled 2026-04-30), and official-tap names win unqualified resolution — so `brew install --cask deco` silently installs that defunct app instead of ours, even with our tap added. Verified `deco-studio` is free in both homebrew/cask and homebrew/core (local search + formulae.brew.sh 404s).

- `Casks/deco.rb` → `Casks/deco-studio.rb`, token `deco-studio`, header/name updated.
- `release-native.yaml`: cask path in the bump script + release-notes install command updated.
- Token-only rename: app bundle stays `deco.app`, asset names unchanged, the existing `native-v4.147.0` release stays valid — the cask keeps its real version/sha256, so **no re-cut needed**; the tap serves `deco-studio` as soon as this merges.

The install command becomes:

```bash
brew tap decocms/studio https://github.com/decocms/studio
brew install --cask deco-studio
```

## Testing

- `brew info --cask deco-studio` / formulae.brew.sh confirm the name is unclaimed.
- After merge: update the tap clone and `brew install --cask deco-studio` end-to-end (will also fix up the published 4.147.0 release notes, which still say `--cask deco`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Homebrew cask to `deco-studio` to avoid the `homebrew/cask` `deco` collision, so the short install command resolves to our app: `brew install --cask deco-studio`. Updated workflow references and release notes to `Casks/deco-studio.rb`; app bundle (`deco.app`) and release assets stay the same, so no new release is needed.

<sup>Written for commit 70fef128785ce5774fb7e4bc2f2d837316f4214f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

