### PR TITLE
feat(native): one-line install script at /install.sh + cask caveats

### DIFF
--- a/Casks/deco-studio.rb
+++ b/Casks/deco-studio.rb
@@ -29,6 +29,15 @@ cask "deco-studio" do
 
   app "deco.app"
 
+  # Drop this block once releases are signed + notarized (the six APPLE_*
+  # secrets in release-native.yaml) — at that point Gatekeeper passes and
+  # the quarantine flag no longer needs clearing.
+  caveats <<~EOS
+    deco studio is not yet signed/notarized, so macOS reports the app as
+    "damaged" on first launch. Clear the quarantine flag and relaunch:
+      xattr -dr com.apple.quarantine "#{appdir}/deco.app"
+  EOS
+
   zap trash: [
     "~/Library/Application Support/com.decocms.studio",
     "~/Library/Caches/com.decocms.studio",

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# deco studio installer for macOS (Apple Silicon).
+#
+#   curl -fsSL https://studio.decocms.com/install.sh | sh
+#
+# What this does, in order (no sudo anywhere):
+#   1. adds the decocms/studio Homebrew tap (this repo doubles as the tap)
+#   2. marks the tap trusted (Homebrew >= 6 otherwise prompts on install)
+#   3. installs or upgrades the deco-studio cask
+#   4. while builds are unsigned: clears macOS's quarantine flag so the app
+#      can launch (macOS reports unsigned downloads as "damaged"). This step
+#      is skipped automatically once releases are signed and notarized.
+#
+# Source: https://github.com/decocms/studio (apps/web/public/install.sh)
+set -eu
+
+APP="/Applications/deco.app"
+CASK="deco-studio"
+TAP="decocms/studio"
+TAP_URL="https://github.com/decocms/studio"
+RELEASES="https://github.com/decocms/studio/releases"
+
+say() { printf '\033[1m[deco studio]\033[0m %s\n' "$1"; }
+fail() {
+  printf '\033[1;31m[deco studio]\033[0m %s\n' "$1" >&2
+  exit 1
+}
+
+[ "$(uname -s)" = "Darwin" ] ||
+  fail "this installer is macOS-only. Downloads: $RELEASES"
+
+[ "$(uname -m)" = "arm64" ] ||
+  fail "only Apple Silicon builds exist so far. Watch $RELEASES for Intel."
+
+command -v brew > /dev/null 2>&1 ||
+  fail "Homebrew is required (https://brew.sh) — or grab the DMG: $RELEASES"
+
+say "adding the $TAP tap"
+brew tap "$TAP" "$TAP_URL"
+
+# Homebrew >= 6 gates third-party taps behind a trust prompt; trusting here
+# keeps the install below non-interactive. Older Homebrew has no such command.
+if brew trust --help > /dev/null 2>&1; then
+  say "trusting the $TAP tap"
+  brew trust "$TAP"
+fi
+
+if brew list --cask "$CASK" > /dev/null 2>&1; then
+  say "upgrading $CASK"
+  brew upgrade --cask "$CASK" ||
+    say "already up to date"
+else
+  say "installing $CASK"
+  brew install --cask "$CASK"
+fi
+
+[ -d "$APP" ] || fail "expected $APP after install; check brew output above"
+
+# Unsigned builds arrive quarantined and macOS refuses to open them
+# ("damaged"). Only strip the flag while Gatekeeper actually rejects the
+# app — once releases are signed + notarized this becomes a no-op.
+if ! spctl --assess --type execute "$APP" > /dev/null 2>&1; then
+  say "builds are not yet notarized; clearing the quarantine flag"
+  xattr -dr com.apple.quarantine "$APP"
+fi
+
+say "launching"
+open "$APP"
+say "done — deco.app is installed. Upgrade later with: brew upgrade --cask $CASK"


### PR DESCRIPTION
## Summary

Follow-up to #5418, closing out the desktop-app onboarding flow:

- **`apps/web/public/install.sh`** → served at `https://studio.decocms.com/install.sh` by the existing asset server (Vite copies `public/` into the build root; `@decocms/runtime/asset-server` serves any existing file). Usage:
  ```bash
  curl -fsSL https://studio.decocms.com/install.sh | sh
  ```
  POSIX sh, `set -eu`, no sudo. Checks macOS + arm64 + brew, taps `decocms/studio`, runs `brew trust` when the command exists (Homebrew ≥ 6), installs or upgrades `deco-studio`, then — only while `spctl` actually rejects the app — announces and clears the quarantine flag, and launches. The Gatekeeper step self-disables once releases are signed + notarized.

- **`Casks/deco-studio.rb`**: `caveats` block printing the same quarantine workaround at `brew install` time for users who go through brew directly. The release workflow's cask-bump regexes only rewrite the `version`/`sha256` stanza lines, so the block survives bumps.

## Testing

- `shellcheck` clean, `sh -n` ok, `ruby -c` on the cask ok.
- Script test-run on a machine with everything already installed: tap/trust idempotent, upgrade path handled ("already up to date"), conditional quarantine strip fired (build unsigned), app launched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-line install script at /install.sh to simplify macOS setup for Deco Studio, plus cask caveats to guide users past Gatekeeper until builds are signed and notarized.

- **New Features**
  - Install script served at https://studio.decocms.com/install.sh; usage: curl -fsSL https://studio.decocms.com/install.sh | sh
  - Checks macOS arm64 and `brew`; taps `decocms/studio`, runs `brew trust` when available, installs or upgrades `deco-studio`, clears quarantine if `spctl` rejects, then launches (no sudo).
  - `Casks/deco-studio.rb`: adds `caveats` with the same temporary quarantine instructions for users installing via `brew`; will be removed after notarization.

<sup>Written for commit a8ec1cdca3860b0b37d23fdfeb963dbc49dee3ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

