### PR TITLE
refactor(mcp-clients): drop the vestigial _strategy param from createVirtualClientFrom

### DIFF
--- a/apps/api/src/api/routes/home-next-actions.ts
+++ b/apps/api/src/api/routes/home-next-actions.ts
@@ -133,13 +133,9 @@ async function defaultHomeAgentNextActions(
         });
 
         try {
-          const client = await createVirtualClientFrom(
-            virtualMcp,
-            ctx,
-            "passthrough",
-            false,
-            { listTimeoutMs: LIST_PROMPTS_TIMEOUT_MS },
-          );
+          const client = await createVirtualClientFrom(virtualMcp, ctx, false, {
+            listTimeoutMs: LIST_PROMPTS_TIMEOUT_MS,
+          });
           try {
             const { prompts } = await client.listPrompts();
             // `homePrompts: null/undefined` means "all prompts"; an

--- a/apps/api/src/api/routes/virtual-mcp.ts
+++ b/apps/api/src/api/routes/virtual-mcp.ts
@@ -180,7 +180,6 @@ export async function handleVirtualMcpRequest(
           const result = await createVirtualClientFrom(
             virtualMcp,
             ctx,
-            "passthrough",
             false,
             // Serves the agent's MCP (incl. the desktop daemon); surface the
             // skill catalog in the instructions it reads.

--- a/apps/api/src/harnesses/decopilot/harness-deps.ts
+++ b/apps/api/src/harnesses/decopilot/harness-deps.ts
@@ -167,17 +167,11 @@ export function buildClusterEnvironmentTools(args: {
               runContext.branch ?? undefined,
             ).catch(() => null);
           }
-          return createVirtualClientFrom(
-            vm,
-            ctx,
-            "passthrough",
-            opts?.superUser ?? false,
-            {
-              listTimeoutMs: opts?.listTimeoutMs,
-              includeSkillsCatalog: true,
-              additionalConnections: devConnection ? [devConnection] : [],
-            },
-          );
+          return createVirtualClientFrom(vm, ctx, opts?.superUser ?? false, {
+            listTimeoutMs: opts?.listTimeoutMs,
+            includeSkillsCatalog: true,
+            additionalConnections: devConnection ? [devConnection] : [],
+          });
         },
         provider: modelRuntime.thinking.provider,
         imageProvider:

--- a/apps/api/src/harnesses/decopilot/resolve-subagent.ts
+++ b/apps/api/src/harnesses/decopilot/resolve-subagent.ts
@@ -57,7 +57,6 @@ export async function resolveSubagent(
     const mcpClient = await createVirtualClientFrom(
       effectiveVirtualMcp,
       ctx,
-      "passthrough",
       superUser,
       { includeSkillsCatalog: true },
     );

--- a/apps/api/src/harnesses/decopilot/tools.ts
+++ b/apps/api/src/harnesses/decopilot/tools.ts
@@ -129,9 +129,9 @@ export interface AssembleDecopilotToolsExtras {
   backgroundDispatcher?: BackgroundDispatcher | null;
   /**
    * Portable MCP-client seam (HarnessDeps `mcpForAgent`). Generalizes the
-   * cluster's in-process `createVirtualClientFrom(virtualMcp, ctx,
-   * "passthrough", superUser, { listTimeoutMs })` so the daemon/desktop can
-   * swap in an HTTP `Client` at the agent's `mcp.url`. The cluster impl
+   * cluster's in-process `createVirtualClientFrom(virtualMcp, ctx, superUser,
+   * { listTimeoutMs })` so the daemon/desktop can swap in an HTTP `Client` at
+   * the agent's `mcp.url`. The cluster impl
    * (supplied by `index.ts`) loads the Virtual MCP by id and returns a live
    * `PassthroughClient`; the caller owns closing it via `result.close()`.
    */

--- a/apps/api/src/mcp-clients/virtual-mcp/index.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/index.ts
@@ -53,7 +53,7 @@ export async function createVirtualClient(
   }
 
   // Create client from virtual MCP entity
-  return createVirtualClientFrom(virtualMcp, ctx, "passthrough", superUser);
+  return createVirtualClientFrom(virtualMcp, ctx, superUser);
 }
 
 /**
@@ -62,14 +62,12 @@ export async function createVirtualClient(
  *
  * @param virtualMcp - Virtual MCP entity from database
  * @param ctx - Studio context for creating proxies
- * @param _strategy - Kept for backward compatibility, always uses passthrough
  * @param superUser - Whether to use superuser mode for background processes
  * @returns Client instance with aggregated tools, resources, and prompts
  */
 export async function createVirtualClientFrom(
   virtualMcp: VirtualMCPEntity,
   ctx: StudioContext,
-  _strategy: "passthrough",
   superUser = false,
   options?: {
     listTimeoutMs?: number;


### PR DESCRIPTION
Follows issue #4468 (WI-2): the Virtual-MCP client factory carries a `_strategy: "passthrough"` parameter documented as "kept for backward compatibility, always uses passthrough" — a vestigial single-member union left over from a docs-only "3 strategies" abstraction (full-context / smart-selection / code-execution) where only passthrough ever shipped.

A maintainer wants this gone because it's dead plumbing every caller has to thread through for no behavioral effect, and it invites a reader to think a real strategy choice is being made.

Confirmed behavior-preserving: `rg -n 'createVirtualClientFrom\(' apps/api packages` shows all 5 call sites (`mcp-clients/virtual-mcp/index.ts`, `api/routes/home-next-actions.ts`, `api/routes/virtual-mcp.ts`, `harnesses/decopilot/resolve-subagent.ts`, `harnesses/decopilot/harness-deps.ts`) passed the literal string `"passthrough"` — the parameter was read nowhere in the function body (already prefixed `_strategy`). No tests reference the removed parameter position.

Net: -26/+12 lines, one dead-parameter removal, no behavior change.

Reviewer check: `cd apps/api && bunx tsc --noEmit` (green — confirms every call site still type-checks with the shorter signature).

Locally ran: `bun run fmt` (clean) and `cd apps/api && bunx tsc --noEmit` (clean, 0 errors). Full CI (lint, full typecheck, test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `_strategy` parameter from `createVirtualClientFrom` and updates all callers, simplifying the Virtual MCP client API with no behavior change. Aligns with Linear WI-2 (#4468) by removing the docs-only “strategy” plumbing (only passthrough exists).

- **Refactors**
  - Drop `_strategy: "passthrough"` from `createVirtualClientFrom` and `createVirtualClient`.
  - Update 5 call sites to the shorter signature and refresh comments.
  - No functional changes; the parameter was ignored.

<sup>Written for commit 6d718f09928c8e818ba70a0cbf72137702d81cb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

