### PR TITLE
fix(native): login-screen logo 404, stale-session login wedge, and release-build inspectability

### DIFF
--- a/apps/native/Cargo.toml
+++ b/apps/native/Cargo.toml
@@ -69,7 +69,14 @@ tempfile = "3"
 # minimize merge friction with `crates/upstream` (built in parallel), which
 # is expected to add its own (`keyring`, etc.) below these rather than
 # interleaving.
-tauri = { version = "2", features = ["config-json5"] }
+# `devtools` keeps the webview inspectable in RELEASE builds too (Safari's
+# Develop menu can attach; launching with `RUST_LOG` set auto-opens the
+# inspector — see `src-tauri/src/setup.rs`). The packaged app has no file
+# logging and no in-webview console capture, so without this a
+# production-only rendering or CSP failure is undiagnosable. Uses private
+# WebKit API on macOS — fine for the Homebrew cask channel, would need
+# dropping for an App Store build.
+tauri = { version = "2", features = ["config-json5", "devtools"] }
 # Dev-only MCP bridge for @hypothesi/tauri-mcp-server (registered under
 # `#[cfg(debug_assertions)]` in src-tauri/src/lib.rs — never in release).
 tauri-plugin-mcp-bridge = "0.12"

--- a/apps/native/crates/local-api/src/router.rs
+++ b/apps/native/crates/local-api/src/router.rs
@@ -668,6 +668,14 @@ fn try_serve_ui(runtime: &MainRuntime, req: &Request) -> Option<Response> {
     if !ui::is_safe_asset_path(path) {
         return Some(ApiError::not_found("Not found").into_response());
     }
+    // Browsers request bundle files percent-encoded (`/logos/deco%20logo.svg`
+    // for the on-disk `logos/deco logo.svg`) while providers do exact
+    // raw-path lookup. Decoding is only safe AFTER `is_safe_asset_path`: it
+    // rejects every encoded traversal byte (%2e/%2f/%5c) on the raw path, so
+    // a decode can change a file name, never the directory structure. An
+    // undecodable path (invalid UTF-8 escape) stays raw and can only miss.
+    let decoded = urlencoding::decode(path).unwrap_or(std::borrow::Cow::Borrowed(path));
+    let path = decoded.as_ref();
 
     if matches!(path, "/" | "/index.html") {
         return Some(index_response(provider, runtime, req.method()));
@@ -756,6 +764,14 @@ mod tests {
                     Bytes::from_static(b"console.log('ok')"),
                     "text/javascript",
                     "public, max-age=31536000, immutable",
+                )),
+                // Space in the file name on purpose: the real bundle ships
+                // `logos/deco logo.svg`, which browsers request as
+                // `/logos/deco%20logo.svg`.
+                "/logos/deco logo.svg" => Some(UiAsset::new(
+                    Bytes::from_static(b"<svg/>"),
+                    "image/svg+xml",
+                    "no-cache",
                 )),
                 _ => None,
             }
@@ -855,6 +871,37 @@ mod tests {
             "public, max-age=31536000, immutable"
         );
         assert_eq!(asset.headers()[header::CONTENT_TYPE], "text/javascript");
+    }
+
+    #[tokio::test]
+    async fn percent_encoded_asset_paths_decode_before_lookup_but_traversal_stays_rejected() {
+        let (app, _root) = embedded_router();
+
+        let logo = app
+            .clone()
+            .oneshot(request(Method::GET, "/logos/deco%20logo.svg"))
+            .await
+            .unwrap();
+        assert_eq!(logo.status(), StatusCode::OK);
+        assert_eq!(logo.headers()[header::CONTENT_TYPE], "image/svg+xml");
+
+        // Decoding must never open up traversal: encoded dot/slash/backslash
+        // bytes are rejected on the RAW path, before any decode happens.
+        for path in [
+            "/logos/%2e%2e/secret.svg",
+            "/logos/..%2Fsecret.svg",
+            "/logos/%5c..%5csecret.svg",
+        ] {
+            assert_eq!(
+                app.clone()
+                    .oneshot(request(Method::GET, path))
+                    .await
+                    .unwrap()
+                    .status(),
+                StatusCode::NOT_FOUND,
+                "{path} should stay rejected"
+            );
+        }
     }
 
     #[tokio::test]

--- a/apps/native/crates/upstream/src/login.rs
+++ b/apps/native/crates/upstream/src/login.rs
@@ -178,24 +178,7 @@ pub async fn perform_interactive_login(
         .await
         .inspect_err(|e| tracing::error!(error = %e, "auth_login: session bridge failed"))?;
 
-    // Better Auth prefixes its session cookie with `__Secure-` whenever it
-    // issues secure cookies, which it does BY DEFAULT on an https baseURL
-    // (mesh sets no `advanced.useSecureCookies` override, so the installed
-    // better-auth's `createCookieGetter` rule — literally
-    // `baseURL.startsWith("https://")` — applies). `get-session` reads the
-    // cookie back by that EXACT prefixed name, so forwarding an unprefixed
-    // `better-auth.session_token` to an https upstream is silently ignored:
-    // the bearer probe still reports signed-in, but the real shell's session
-    // gate finds no cookie and bounces the user to /login. Match Better Auth's
-    // own rule so the forwarded Cookie NAME is byte-identical to a browser
-    // sign-in (the hybrid cookie-relay path in `bridge.rs` gets this for free
-    // by capturing the real `Set-Cookie`; this system-browser path has to
-    // reconstruct the name itself).
-    let cookie_name = if target.starts_with("https://") {
-        "__Secure-better-auth.session_token"
-    } else {
-        "better-auth.session_token"
-    };
+    let cookie_name = session_cookie_name(&target);
     tracing::info!(
         cookie_name,
         "auth_login: session cookie minted; login complete"
@@ -260,7 +243,28 @@ pub async fn perform_interactive_login(
 /// half-signed-in state, exactly the bug this bridge exists to close. A
 /// clear, surfaced login error is strictly better than reintroducing it
 /// through a different door.
-async fn mint_session_from_access_token(
+/// Better Auth prefixes its session cookie with `__Secure-` whenever it
+/// issues secure cookies, which it does BY DEFAULT on an https baseURL
+/// (mesh sets no `advanced.useSecureCookies` override, so the installed
+/// better-auth's `createCookieGetter` rule — literally
+/// `baseURL.startsWith("https://")` — applies). `get-session` reads the
+/// cookie back by that EXACT prefixed name, so forwarding an unprefixed
+/// `better-auth.session_token` to an https upstream is silently ignored:
+/// the bearer probe still reports signed-in, but the real shell's session
+/// gate finds no cookie and bounces the user to /login. Match Better Auth's
+/// own rule so the forwarded Cookie NAME is byte-identical to a browser
+/// sign-in (the hybrid cookie-relay path in `bridge.rs` gets this for free
+/// by capturing the real `Set-Cookie`; the system-browser login path and
+/// `session.rs`'s cookie re-mint both have to reconstruct the name).
+pub(crate) fn session_cookie_name(target: &str) -> &'static str {
+    if target.starts_with("https://") {
+        "__Secure-better-auth.session_token"
+    } else {
+        "better-auth.session_token"
+    }
+}
+
+pub(crate) async fn mint_session_from_access_token(
     http: &reqwest::Client,
     target: &str,
     access_token: &str,

--- a/apps/native/crates/upstream/src/session.rs
+++ b/apps/native/crates/upstream/src/session.rs
@@ -64,6 +64,17 @@ use crate::tokens::{
 /// doc comment for why that distinction matters).
 const PROBE_PATH: &str = "/api/links/me";
 
+/// `GET /api/auth/get-session` — the endpoint the production web shell's own
+/// sign-in gate authenticates with, using the durable session COOKIE
+/// ([`StoredSession::cookie`]), never the OAuth bearer. Better Auth answers
+/// `200` with a session object for a live cookie and `200 null` for a dead
+/// or missing one — which is exactly why [`PROBE_PATH`] alone is not enough:
+/// a valid bearer with a dead cookie reports `signed_in: true` here while
+/// the shell bounces the user to an in-webview `/login` page whose social
+/// buttons cannot work (blocked external navigation). See
+/// `UpstreamSession::confirm_shell_session`.
+const SESSION_PROBE_PATH: &str = "/api/auth/get-session";
+
 /// "at most once per 5 min" — the contract doc's exact throttle window for
 /// `status()`'s network revalidation.
 pub const STATUS_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
@@ -207,10 +218,10 @@ impl UpstreamSession {
     }
 
     /// The DURABLE, Keychain-persisted Better Auth session cookie for this
-    /// session's host, if one was ever captured — `None` for a
-    /// system-browser (`login()`) session, which never has one (see
-    /// `tokens.rs`'s `StoredSession::cookie` doc comment), or for a host
-    /// with no stored session at all.
+    /// session's host, if one was ever captured or minted — `None` only for
+    /// a host with no stored session at all, or a legacy pre-cookie-field
+    /// session (which `confirm_shell_session`'s re-mint heals on the next
+    /// revalidation; see `tokens.rs`'s `StoredSession::cookie` doc comment).
     ///
     /// This is what `routes/upstream.rs` attaches (as a plain `Cookie:`
     /// header) on EVERY app-API request for the rest of this
@@ -329,11 +340,13 @@ impl UpstreamSession {
 
         match self.ensure_fresh_session(session.clone()).await {
             Ok(fresh) => match self.probe_upstream(&fresh.access_token).await {
-                ProbeOutcome::Authenticated => self.publish_signed_in(&fresh),
+                ProbeOutcome::Authenticated => self.confirm_shell_session(fresh).await,
                 ProbeOutcome::Unauthenticated => {
                     match self.force_refresh_session(fresh.clone()).await {
                         Ok(refreshed) => match self.probe_upstream(&refreshed.access_token).await {
-                            ProbeOutcome::Authenticated => self.publish_signed_in(&refreshed),
+                            ProbeOutcome::Authenticated => {
+                                self.confirm_shell_session(refreshed).await
+                            }
                             ProbeOutcome::Unauthenticated => {
                                 self.hard_sign_out(
                                     "upstream rejected an access token after a forced refresh",
@@ -722,11 +735,128 @@ impl UpstreamSession {
             Err(e) => ProbeOutcome::Inconclusive(e.to_string()),
         }
     }
+
+    /// Probes [`SESSION_PROBE_PATH`] with the durable session cookie — the
+    /// credential the web shell actually signs in with. Only an explicit
+    /// "no session" answer (`200 null`, a `401`, or no stored cookie at
+    /// all) is [`CookieProbeOutcome::Dead`]; every other failure is
+    /// `Inconclusive` and must not trigger a re-mint or sign-out, mirroring
+    /// [`Self::probe_upstream`]'s fail-open posture.
+    async fn probe_cookie_session(&self, stored: &StoredSession) -> CookieProbeOutcome {
+        let Some(cookie) = stored.cookie.as_deref() else {
+            return CookieProbeOutcome::Dead("no durable session cookie is stored".to_string());
+        };
+        let res = self
+            .0
+            .http
+            .get(format!("{}{SESSION_PROBE_PATH}", self.0.target))
+            .header(reqwest::header::COOKIE, cookie)
+            .send()
+            .await;
+        match res {
+            Ok(r) if r.status().is_success() => match r.json::<serde_json::Value>().await {
+                Ok(value) if value.is_null() => CookieProbeOutcome::Dead(
+                    "get-session does not recognize the stored cookie".to_string(),
+                ),
+                Ok(_) => CookieProbeOutcome::Valid,
+                Err(e) => {
+                    CookieProbeOutcome::Inconclusive(format!("malformed get-session response: {e}"))
+                }
+            },
+            Ok(r) if r.status() == reqwest::StatusCode::UNAUTHORIZED => {
+                CookieProbeOutcome::Dead("HTTP 401".to_string())
+            }
+            Ok(r) => CookieProbeOutcome::Inconclusive(format!("HTTP {}", r.status())),
+            Err(e) => CookieProbeOutcome::Inconclusive(e.to_string()),
+        }
+    }
+
+    /// The second half of `force_revalidate`'s authenticated branch: a valid
+    /// BEARER is not enough to report `signed_in: true`. The production
+    /// shell signs in with the durable session cookie, and a dead cookie
+    /// under a live bearer strands the user on an in-webview `/login` page
+    /// whose social buttons cannot work — the desktop gate mounts the main
+    /// shell on this status, so the status must vouch for the credential
+    /// the shell will actually use.
+    ///
+    /// A dead cookie is first HEALED, not punished: the same mesh bridge
+    /// `login()` uses re-mints a fresh session from the just-validated
+    /// bearer, transparently. Only the bridge explicitly refusing to mint
+    /// (`401`/`403` — the upstream rejecting a bearer it validated moments
+    /// ago) reads as a truly unusable session and signs out; any transient
+    /// bridge failure keeps the signed-in state, consistent with this
+    /// crate's "a network hiccup must never read as sign the user out."
+    async fn confirm_shell_session(&self, fresh: StoredSession) -> StatusResult {
+        match self.probe_cookie_session(&fresh).await {
+            CookieProbeOutcome::Valid => self.publish_signed_in(&fresh),
+            CookieProbeOutcome::Inconclusive(reason) => {
+                tracing::debug!(
+                    reason,
+                    "session-cookie probe inconclusive; keeping signed-in state"
+                );
+                self.publish_signed_in(&fresh)
+            }
+            CookieProbeOutcome::Dead(reason) => {
+                tracing::info!(
+                    reason,
+                    "stored session cookie is dead; re-minting via the session bridge"
+                );
+                match login::mint_session_from_access_token(
+                    &self.0.http,
+                    &self.0.target,
+                    &fresh.access_token,
+                )
+                .await
+                {
+                    Ok(token_value) => {
+                        let mut healed = fresh;
+                        healed.cookie = Some(format!(
+                            "{}={}",
+                            login::session_cookie_name(&self.0.target),
+                            token_value
+                        ));
+                        // Mirrors `remember_cookie`: cache only what the
+                        // store actually holds, and a failed persist still
+                        // reports signed in — the next revalidation simply
+                        // re-mints again.
+                        match self.0.store.save(&self.0.host, healed.clone()).await {
+                            Ok(()) => self.cache_session(Some(healed.clone())),
+                            Err(err) => {
+                                tracing::warn!(error = %err, "failed to persist the re-minted session cookie");
+                            }
+                        }
+                        self.publish_signed_in(&healed)
+                    }
+                    Err(LoginError::SessionBridgeRejected(status @ (401 | 403), body)) => {
+                        self.hard_sign_out(&format!(
+                            "session cookie is dead and the bridge refused to re-mint: HTTP {status} {body}"
+                        ))
+                        .await
+                    }
+                    Err(err) => {
+                        tracing::debug!(error = %err, "session-cookie re-mint failed transiently; keeping signed-in state");
+                        self.publish_signed_in(&fresh)
+                    }
+                }
+            }
+        }
+    }
 }
 
 enum ProbeOutcome {
     Authenticated,
     Unauthenticated,
+    Inconclusive(String),
+}
+
+/// Outcome of probing the durable session COOKIE — the credential the web
+/// shell signs in with, distinct from the OAuth bearer [`ProbeOutcome`]
+/// covers.
+enum CookieProbeOutcome {
+    Valid,
+    /// The upstream explicitly does not recognize the cookie (or none is
+    /// stored) — the shell WOULD bounce to `/login` despite a valid bearer.
+    Dead(String),
     Inconclusive(String),
 }
 
@@ -923,6 +1053,95 @@ mod tests {
         Ok,
         AlwaysUnauthorized,
         AlwaysServerError,
+    }
+
+    #[derive(Clone, Copy)]
+    enum GetSessionBehavior {
+        Live,
+        Null,
+        ServerError,
+    }
+
+    #[derive(Clone, Copy)]
+    enum MintBehavior {
+        Mint,
+        Unauthorized,
+    }
+
+    /// A full shell-shaped upstream: bearer probe always OK, plus the two
+    /// cookie-session endpoints `confirm_shell_session` talks to. Returns
+    /// (target, mint call counter, last Cookie header the get-session probe
+    /// saw).
+    async fn spawn_shell_server(
+        get_session: GetSessionBehavior,
+        mint: MintBehavior,
+    ) -> (
+        String,
+        Arc<AtomicUsize>,
+        Arc<std::sync::Mutex<Option<String>>>,
+    ) {
+        let mint_calls = Arc::new(AtomicUsize::new(0));
+        let seen_cookie = Arc::new(std::sync::Mutex::new(None));
+        let mint_calls_route = mint_calls.clone();
+        let seen_cookie_route = seen_cookie.clone();
+        let app = Router::new()
+            .route(
+                "/api/links/me",
+                get(|| async { (StatusCode::OK, Json(serde_json::json!(null))) }),
+            )
+            .route(
+                "/api/auth/get-session",
+                get(move |headers: axum::http::HeaderMap| {
+                    let seen = seen_cookie_route.clone();
+                    async move {
+                        *seen.lock().unwrap() = headers
+                            .get(axum::http::header::COOKIE)
+                            .and_then(|v| v.to_str().ok())
+                            .map(str::to_string);
+                        match get_session {
+                            GetSessionBehavior::Live => (
+                                StatusCode::OK,
+                                Json(serde_json::json!({
+                                    "session": {"id": "s1"},
+                                    "user": {"id": "u1"},
+                                })),
+                            ),
+                            GetSessionBehavior::Null => {
+                                (StatusCode::OK, Json(serde_json::json!(null)))
+                            }
+                            GetSessionBehavior::ServerError => (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                Json(serde_json::json!({"error": "boom"})),
+                            ),
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/api/auth/desktop/session-from-oauth",
+                post(move || {
+                    let calls = mint_calls_route.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        match mint {
+                            MintBehavior::Mint => (
+                                StatusCode::OK,
+                                Json(serde_json::json!({"sessionToken": "minted-123"})),
+                            ),
+                            MintBehavior::Unauthorized => (
+                                StatusCode::UNAUTHORIZED,
+                                Json(serde_json::json!({"error": "unauthorized"})),
+                            ),
+                        }
+                    }
+                }),
+            );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (format!("http://{addr}"), mint_calls, seen_cookie)
     }
 
     use axum::http::StatusCode;
@@ -1173,6 +1392,75 @@ mod tests {
 
         let status = session.force_revalidate().await;
         assert!(status.signed_in);
+    }
+
+    #[tokio::test]
+    async fn force_revalidate_keeps_a_live_shell_cookie_without_reminting() {
+        let (target, mint_calls, seen_cookie) =
+            spawn_shell_server(GetSessionBehavior::Live, MintBehavior::Mint).await;
+        let store = seeded_store(&target, valid_session(&target));
+        let session = UpstreamSession::new(target, store);
+
+        let status = session.force_revalidate().await;
+        assert!(status.signed_in);
+        assert_eq!(mint_calls.load(Ordering::SeqCst), 0);
+        // The probe authenticated with the DURABLE stored cookie — the same
+        // credential the web shell will use.
+        assert_eq!(
+            seen_cookie.lock().unwrap().as_deref(),
+            Some("better-auth.session_token=test")
+        );
+    }
+
+    #[tokio::test]
+    async fn force_revalidate_heals_a_dead_shell_cookie_by_reminting_from_the_valid_bearer() {
+        let (target, mint_calls, _seen) =
+            spawn_shell_server(GetSessionBehavior::Null, MintBehavior::Mint).await;
+        let store = seeded_store(&target, valid_session(&target));
+        let session = UpstreamSession::new(target.clone(), store.clone());
+
+        let status = session.force_revalidate().await;
+        assert!(status.signed_in);
+        assert_eq!(mint_calls.load(Ordering::SeqCst), 1);
+        // The re-minted cookie is persisted durably (http target → the
+        // unprefixed Better Auth cookie name).
+        let healed = store.load(&host_key(&target)).await.unwrap().unwrap();
+        assert_eq!(
+            healed.cookie.as_deref(),
+            Some("better-auth.session_token=minted-123")
+        );
+    }
+
+    #[tokio::test]
+    async fn force_revalidate_signs_out_when_a_dead_shell_cookie_cannot_be_reminted() {
+        // The exact wedge this closes: bearer probe fine, cookie session
+        // dead, bridge refuses to mint — previously reported
+        // `signed_in: true` and stranded the user on an in-webview /login
+        // page with a non-functional social button.
+        let (target, mint_calls, _seen) =
+            spawn_shell_server(GetSessionBehavior::Null, MintBehavior::Unauthorized).await;
+        let store = seeded_store(&target, valid_session(&target));
+        let session = UpstreamSession::new(target.clone(), store.clone());
+
+        let status = session.force_revalidate().await;
+        assert!(!status.signed_in);
+        assert_eq!(mint_calls.load(Ordering::SeqCst), 1);
+        // Hard sign-out: the unusable credentials are gone from the store.
+        assert!(store.load(&host_key(&target)).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn force_revalidate_fails_open_when_the_cookie_probe_is_inconclusive() {
+        let (target, mint_calls, _seen) =
+            spawn_shell_server(GetSessionBehavior::ServerError, MintBehavior::Mint).await;
+        let store = seeded_store(&target, valid_session(&target));
+        let session = UpstreamSession::new(target, store);
+
+        let status = session.force_revalidate().await;
+        assert!(status.signed_in);
+        // A 5xx from get-session is not proof the cookie is bad — no
+        // re-mint, no sign-out.
+        assert_eq!(mint_calls.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/apps/native/src-tauri/src/setup.rs
+++ b/apps/native/src-tauri/src/setup.rs
@@ -374,7 +374,15 @@ pub async fn run(app: &tauri::AppHandle) -> Result<(), SetupError> {
             }
         });
     }
-    builder.build().map_err(SetupError::Window)?;
+    let window = builder.build().map_err(SetupError::Window)?;
+    // The `devtools` cargo feature (workspace Cargo.toml) makes the webview
+    // inspectable even in release builds. Auto-opening rides the same switch
+    // as native-side logging: a packaged run under `RUST_LOG=…` is a
+    // debugging session, so one env var yields both Rust logs and the web
+    // inspector. A normal Finder launch (no RUST_LOG) never pops it.
+    if std::env::var("RUST_LOG").is_ok_and(|level| !level.is_empty()) {
+        window.open_devtools();
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Three fixes for the packaged desktop app, found while debugging a real "can't log in" wedge on an installed 4.147.0:

1. **Logo 404 — percent-decode UI asset request paths.** Browsers request `/logos/deco%20logo.svg` for the bundled `logos/deco logo.svg`, but `try_serve_ui` passed the raw encoded path to the provider's exact lookup, so every space-named public asset 404'd (the login screen's deco logo, most visibly). Decoding happens only AFTER `is_safe_asset_path`, which rejects encoded traversal bytes (`%2e`/`%2f`/`%5c`) on the raw path — a decode can change a file name, never the directory structure.

2. **Stale-session login wedge — `auth_status` must vouch for the cookie, not just the bearer.** `force_revalidate` only probed the OAuth bearer (`/api/links/me`); the production shell signs in with the durable session *cookie*. A dead cookie under a live bearer reported `signed_in: true`, so the desktop gate mounted the main shell, which bounced to an in-webview `/login` page whose social buttons dead-end (external navigation is blocked by the webview policy — verified live: the click POSTs `/api/auth/sign-in/social` and the follow-up navigation to Google is silently swallowed). The authenticated branch now also probes `/api/auth/get-session` with the stored cookie, and a dead cookie is **healed** by re-minting through the same mesh bridge `login()` uses. Only an explicit 401/403 from the bridge signs out; transient failures stay fail-open.

3. **Release builds are now inspectable.** The packaged app had no file logging, no console capture, and the MCP bridge is debug-only — webview-side failures were undiagnosable. The `devtools` tauri feature is now compiled into release builds, and the inspector auto-opens when `RUST_LOG` is set (the same env var that already turns on native-side logging). A normal Finder launch never pops it. Uses private WebKit API on macOS — fine for the Homebrew cask channel, would need dropping for an App Store build.

## Testing

- `cargo test -p local-api -p upstream -p deco`: 802 + 109 + 17, all green.
- New tests: percent-encoded asset serving + encoded-traversal rejection (router); live-cookie/heal/sign-out/fail-open matrix for `confirm_shell_session` (session).
- Live-verified the logo 404 and the blocked social-login navigation against a running installed app (`https://local.studio.decocms.com:43120`); the wedge chain in fix 2 is reproduced from its debug logs.

## Affected areas

`apps/native` only (local-api router, upstream session revalidation, Tauri shell setup). No JS/TS changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the login-screen logo 404 and the stale-session login wedge in the packaged desktop app, and keeps release builds inspectable for easier debugging.

- **Bug Fixes**
  - Decode percent-encoded UI asset paths before lookup so files with spaces resolve (e.g., `/logos/deco%20logo.svg`); traversal remains blocked by raw-path checks.
  - `auth_status` now verifies the durable session cookie via `/api/auth/get-session`, not just the OAuth bearer. Dead cookies are healed by re-minting through the mesh bridge and persisted; only explicit 401/403 signs out, transient errors fail open.

- **Developer Experience**
  - Enabled `tauri` `devtools` in release builds and auto-open the webview inspector when `RUST_LOG` is set; normal launches remain unchanged.

<sup>Written for commit 3410cd02d116a7287d4a0927c9472fa91bdae0e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

