### PR TITLE
feat(web): general availability of the Studio beta app — in-product install

### DIFF
--- a/apps/web/src/components/chat/no-ai-provider-empty-state.tsx
+++ b/apps/web/src/components/chat/no-ai-provider-empty-state.tsx
@@ -15,6 +15,11 @@ import { KEYS } from "@/lib/query-keys";
 import { useStudioTools } from "@/lib/studio-tools";
 import { useQuery } from "@tanstack/react-query";
 import type { BrandContext } from "@decocms/shared/entities";
+import {
+  DownloadAppDialog,
+  isMacDesktopBrowser,
+} from "@/components/download-app-dialog";
+import { useIsDesktopApp } from "@/hooks/use-is-desktop-app";
 import { ConnectDesktopDialog } from "./connect-desktop-dialog";
 import { ClaudeCodeIcon, CodexIcon } from "./agent-icons";
 import { useOptionalChatPrefs } from "./context";
@@ -95,6 +100,14 @@ export function NoAiProviderEmptyState({
     useState<ProviderSelection | null>(null);
   const [gridOpen, setGridOpen] = useState(false);
   const [desktopDialogOpen, setDesktopDialogOpen] = useState(false);
+  const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
+  const isDesktopApp = useIsDesktopApp();
+  // The acquisition path for macOS browser users is the desktop app itself,
+  // not the `bunx decocms link` CLI — so while no desktop is linked, the
+  // monitor button offers the download instead of the connect dialog. Once a
+  // link is online (or inside the app, or off-mac) the connect/status dialog
+  // remains the right destination.
+  const offerDownload = isMacDesktopBrowser() && !isDesktopApp && !link.online;
 
   const aiProviders = useAiProviders();
   const providers = aiProviders?.providers ?? [];
@@ -172,11 +185,17 @@ export function NoAiProviderEmptyState({
         ) : (
           <button
             type="button"
-            onClick={() => setDesktopDialogOpen(true)}
+            onClick={() =>
+              offerDownload
+                ? setDownloadDialogOpen(true)
+                : setDesktopDialogOpen(true)
+            }
             aria-label={
-              link.online
-                ? t("chat.noAiProviderEmptyState.desktopLinkedLabel")
-                : t("chat.noAiProviderEmptyState.connectDesktopLabel")
+              offerDownload
+                ? t("downloadApp.openLabel")
+                : link.online
+                  ? t("chat.noAiProviderEmptyState.desktopLinkedLabel")
+                  : t("chat.noAiProviderEmptyState.connectDesktopLabel")
             }
             className={cn(
               badgeClass,
@@ -252,6 +271,11 @@ export function NoAiProviderEmptyState({
       <ConnectDesktopDialog
         open={desktopDialogOpen}
         onOpenChange={setDesktopDialogOpen}
+      />
+
+      <DownloadAppDialog
+        open={downloadDialogOpen}
+        onOpenChange={setDownloadDialogOpen}
       />
     </div>
   );

--- a/apps/web/src/components/download-app-dialog.tsx
+++ b/apps/web/src/components/download-app-dialog.tsx
@@ -1,0 +1,76 @@
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Check, Copy01 } from "@untitledui/icons";
+import { useState } from "react";
+import { useT } from "@/i18n/use-t.ts";
+
+// The install script is served by this same deployment
+// (apps/web/public/install.sh), so the command stays correct on any host —
+// studio.decocms.com or a self-hosted instance.
+function installCommand(): string {
+  return `curl -fsSL ${window.location.origin}/install.sh | sh`;
+}
+
+// Deliberately narrower than keyboard-shortcuts' isMac, which also matches
+// iPhone/iPad (and iPadOS reports "Macintosh"): touch devices can't run the
+// terminal installer, so they must not be offered the download.
+export function isMacDesktopBrowser(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    /Mac/.test(navigator.platform) &&
+    !("ontouchend" in document)
+  );
+}
+
+interface DownloadAppDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DownloadAppDialog({
+  open,
+  onOpenChange,
+}: DownloadAppDialogProps) {
+  const t = useT();
+  const [copied, setCopied] = useState(false);
+  const command = installCommand();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("downloadApp.title")}</DialogTitle>
+          <DialogDescription>{t("downloadApp.description")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-sm">
+          <span className="flex-1 truncate">{command}</span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={t("downloadApp.copyLabel")}
+            onClick={() => {
+              navigator.clipboard.writeText(command).then(() => {
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+              });
+            }}
+          >
+            {copied ? <Check size={14} /> : <Copy01 size={14} />}
+          </Button>
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          {t("downloadApp.appleSiliconNote")}
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/download-app-dialog.tsx
+++ b/apps/web/src/components/download-app-dialog.tsx
@@ -49,27 +49,29 @@ export function DownloadAppDialog({
           <DialogDescription>{t("downloadApp.description")}</DialogDescription>
         </DialogHeader>
 
-        <div className="flex items-center gap-2 rounded-md bg-muted px-3 py-2 font-mono text-sm">
-          <span className="flex-1 truncate">{command}</span>
+        <div className="flex flex-col gap-3">
+          <code className="block rounded-md border bg-muted px-3 py-2.5 font-mono text-xs leading-relaxed break-all whitespace-pre-wrap select-all">
+            {command}
+          </code>
           <Button
             type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label={t("downloadApp.copyLabel")}
+            className="w-full gap-2"
             onClick={() => {
               navigator.clipboard.writeText(command).then(() => {
                 setCopied(true);
-                setTimeout(() => setCopied(false), 1500);
+                setTimeout(() => setCopied(false), 2000);
               });
             }}
           >
-            {copied ? <Check size={14} /> : <Copy01 size={14} />}
+            {copied ? <Check size={16} /> : <Copy01 size={16} />}
+            {copied ? t("downloadApp.copiedLabel") : t("downloadApp.copyLabel")}
           </Button>
         </div>
 
-        <p className="text-xs text-muted-foreground">
-          {t("downloadApp.appleSiliconNote")}
-        </p>
+        <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+          <p>{t("downloadApp.terminalHint")}</p>
+          <p>{t("downloadApp.appleSiliconNote")}</p>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/components/release-channel/floating-release-card.tsx
+++ b/apps/web/src/components/release-channel/floating-release-card.tsx
@@ -2,6 +2,7 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { useState } from "react";
 import { AnnouncementCard } from "@/components/announcement-card";
 import { DownloadAppDialog } from "@/components/download-app-dialog";
+import { useIsDesktopApp } from "@/hooks/use-is-desktop-app";
 import { useReleaseSeenState } from "@/hooks/use-release-seen-state";
 import { useT } from "@/i18n/use-t.ts";
 import { authClient } from "@/lib/auth-client";
@@ -48,10 +49,14 @@ export function FloatingReleaseCard() {
   const { data: session } = authClient.useSession();
   const { isSeen, markSeen } = useReleaseSeenState();
   const [downloadOpen, setDownloadOpen] = useState(false);
+  const isDesktopApp = useIsDesktopApp();
   const now = Date.now();
   const candidate = pickFloatingCandidate(now);
 
   if (!candidate) return null;
+  // An install prompt inside the installed app is noise — skip releases
+  // whose CTA is the download action when running in the Tauri shell.
+  if (isDesktopApp && candidate.cta && "action" in candidate.cta) return null;
   if (!isUserOldEnoughForReleaseNotice(session?.user?.createdAt, now)) {
     return null;
   }

--- a/apps/web/src/components/release-channel/floating-release-card.tsx
+++ b/apps/web/src/components/release-channel/floating-release-card.tsx
@@ -2,7 +2,6 @@ import { Button } from "@deco/ui/components/button.tsx";
 import { useState } from "react";
 import { AnnouncementCard } from "@/components/announcement-card";
 import { DownloadAppDialog } from "@/components/download-app-dialog";
-import { useIsDesktopApp } from "@/hooks/use-is-desktop-app";
 import { useReleaseSeenState } from "@/hooks/use-release-seen-state";
 import { useT } from "@/i18n/use-t.ts";
 import { authClient } from "@/lib/auth-client";
@@ -49,14 +48,10 @@ export function FloatingReleaseCard() {
   const { data: session } = authClient.useSession();
   const { isSeen, markSeen } = useReleaseSeenState();
   const [downloadOpen, setDownloadOpen] = useState(false);
-  const isDesktopApp = useIsDesktopApp();
   const now = Date.now();
   const candidate = pickFloatingCandidate(now);
 
   if (!candidate) return null;
-  // An install prompt inside the installed app is noise — skip releases
-  // whose CTA is the download action when running in the Tauri shell.
-  if (isDesktopApp && candidate.cta && "action" in candidate.cta) return null;
   if (!isUserOldEnoughForReleaseNotice(session?.user?.createdAt, now)) {
     return null;
   }

--- a/apps/web/src/components/release-channel/floating-release-card.tsx
+++ b/apps/web/src/components/release-channel/floating-release-card.tsx
@@ -1,5 +1,7 @@
 import { Button } from "@deco/ui/components/button.tsx";
+import { useState } from "react";
 import { AnnouncementCard } from "@/components/announcement-card";
+import { DownloadAppDialog } from "@/components/download-app-dialog";
 import { useReleaseSeenState } from "@/hooks/use-release-seen-state";
 import { useT } from "@/i18n/use-t.ts";
 import { authClient } from "@/lib/auth-client";
@@ -45,6 +47,7 @@ export function FloatingReleaseCard() {
   const t = useT();
   const { data: session } = authClient.useSession();
   const { isSeen, markSeen } = useReleaseSeenState();
+  const [downloadOpen, setDownloadOpen] = useState(false);
   const now = Date.now();
   const candidate = pickFloatingCandidate(now);
 
@@ -76,9 +79,17 @@ export function FloatingReleaseCard() {
       }
       actions={
         candidate.cta ? (
-          <Button asChild size="sm" onClick={() => markSeen(candidate.id)}>
-            <a href={candidate.cta.href}>{candidate.cta.label}</a>
-          </Button>
+          "href" in candidate.cta ? (
+            <Button asChild size="sm" onClick={() => markSeen(candidate.id)}>
+              <a href={candidate.cta.href}>{candidate.cta.label}</a>
+            </Button>
+          ) : (
+            // Not markSeen here: seeing the release unmounts this card — and
+            // the dialog with it. Marked when the dialog closes instead.
+            <Button size="sm" onClick={() => setDownloadOpen(true)}>
+              {candidate.cta.label}
+            </Button>
+          )
         ) : null
       }
     >
@@ -98,6 +109,14 @@ export function FloatingReleaseCard() {
           </li>
         ))}
       </ul>
+
+      <DownloadAppDialog
+        open={downloadOpen}
+        onOpenChange={(open) => {
+          setDownloadOpen(open);
+          if (!open) markSeen(candidate.id);
+        }}
+      />
     </AnnouncementCard>
   );
 }

--- a/apps/web/src/i18n/en/download-app.ts
+++ b/apps/web/src/i18n/en/download-app.ts
@@ -1,5 +1,5 @@
 export const downloadApp = {
-  "downloadApp.title": "Download the deco studio app",
+  "downloadApp.title": "Download the Studio app",
   "downloadApp.description":
     "The app installs from your Mac's Terminal — copy the command below, paste it there, and press Return.",
   "downloadApp.copyLabel": "Copy install command",
@@ -8,5 +8,5 @@ export const downloadApp = {
     "Tip: press ⌘ Space and type “Terminal” to open it.",
   "downloadApp.appleSiliconNote":
     "For Apple Silicon Macs (M1 and newer) — Windows coming soon. Requires Homebrew.",
-  "downloadApp.openLabel": "Download the deco studio app",
+  "downloadApp.openLabel": "Download the Studio app",
 } as const;

--- a/apps/web/src/i18n/en/download-app.ts
+++ b/apps/web/src/i18n/en/download-app.ts
@@ -1,9 +1,12 @@
 export const downloadApp = {
-  "downloadApp.title": "Download the desktop app",
+  "downloadApp.title": "Download the deco studio app",
   "downloadApp.description":
-    "Run this command in your terminal to install the app with Homebrew.",
+    "The app installs from your Mac's Terminal — copy the command below, paste it there, and press Return.",
   "downloadApp.copyLabel": "Copy install command",
+  "downloadApp.copiedLabel": "Copied — now paste it in Terminal",
+  "downloadApp.terminalHint":
+    "Tip: press ⌘ Space and type “Terminal” to open it.",
   "downloadApp.appleSiliconNote":
-    "macOS on Apple Silicon only for now. Requires Homebrew.",
-  "downloadApp.openLabel": "Download the desktop app",
+    "For Apple Silicon Macs (M1 and newer) — Windows coming soon. Requires Homebrew.",
+  "downloadApp.openLabel": "Download the deco studio app",
 } as const;

--- a/apps/web/src/i18n/en/download-app.ts
+++ b/apps/web/src/i18n/en/download-app.ts
@@ -7,6 +7,6 @@ export const downloadApp = {
   "downloadApp.terminalHint":
     "Tip: press ⌘ Space and type “Terminal” to open it.",
   "downloadApp.appleSiliconNote":
-    "For Apple Silicon Macs (M1 and newer) — Windows coming soon. Requires Homebrew.",
+    "For Apple Silicon Macs (M1 and newer) — Windows coming soon.",
   "downloadApp.openLabel": "Download the Studio app",
 } as const;

--- a/apps/web/src/i18n/en/download-app.ts
+++ b/apps/web/src/i18n/en/download-app.ts
@@ -1,0 +1,9 @@
+export const downloadApp = {
+  "downloadApp.title": "Download the desktop app",
+  "downloadApp.description":
+    "Run this command in your terminal to install the app with Homebrew.",
+  "downloadApp.copyLabel": "Copy install command",
+  "downloadApp.appleSiliconNote":
+    "macOS on Apple Silicon only for now. Requires Homebrew.",
+  "downloadApp.openLabel": "Download the desktop app",
+} as const;

--- a/apps/web/src/i18n/en/index.ts
+++ b/apps/web/src/i18n/en/index.ts
@@ -19,6 +19,7 @@ import { home } from "./home.ts";
 import { header } from "./header.ts";
 import { filePicker } from "./file-picker.ts";
 import { devAgent } from "./dev-agent.ts";
+import { downloadApp } from "./download-app.ts";
 import { details } from "./details.ts";
 import { deck } from "./deck.ts";
 import { connections } from "./connections.ts";
@@ -59,6 +60,7 @@ export const en = {
   ...header,
   ...filePicker,
   ...devAgent,
+  ...downloadApp,
   ...details,
   ...deck,
   ...connections,

--- a/apps/web/src/i18n/pt-br/download-app.ts
+++ b/apps/web/src/i18n/pt-br/download-app.ts
@@ -1,7 +1,7 @@
 import type { downloadApp as downloadAppEn } from "../en/download-app.ts";
 
 export const downloadApp = {
-  "downloadApp.title": "Baixar o app do deco studio",
+  "downloadApp.title": "Baixar o app do Studio",
   "downloadApp.description":
     "O app é instalado pelo Terminal do seu Mac — copie o comando abaixo, cole lá e pressione Return.",
   "downloadApp.copyLabel": "Copiar comando de instalação",
@@ -10,5 +10,5 @@ export const downloadApp = {
     "Dica: pressione ⌘ Espaço e digite “Terminal” para abri-lo.",
   "downloadApp.appleSiliconNote":
     "Para Macs com Apple Silicon (M1 ou mais novo) — Windows em breve. Requer o Homebrew.",
-  "downloadApp.openLabel": "Baixar o app do deco studio",
+  "downloadApp.openLabel": "Baixar o app do Studio",
 } satisfies Record<keyof typeof downloadAppEn, string>;

--- a/apps/web/src/i18n/pt-br/download-app.ts
+++ b/apps/web/src/i18n/pt-br/download-app.ts
@@ -1,11 +1,14 @@
 import type { downloadApp as downloadAppEn } from "../en/download-app.ts";
 
 export const downloadApp = {
-  "downloadApp.title": "Baixar o app para desktop",
+  "downloadApp.title": "Baixar o app do deco studio",
   "downloadApp.description":
-    "Execute este comando no seu terminal para instalar o app com o Homebrew.",
+    "O app é instalado pelo Terminal do seu Mac — copie o comando abaixo, cole lá e pressione Return.",
   "downloadApp.copyLabel": "Copiar comando de instalação",
+  "downloadApp.copiedLabel": "Copiado — agora cole no Terminal",
+  "downloadApp.terminalHint":
+    "Dica: pressione ⌘ Espaço e digite “Terminal” para abri-lo.",
   "downloadApp.appleSiliconNote":
-    "Por enquanto, apenas macOS com Apple Silicon. Requer o Homebrew.",
-  "downloadApp.openLabel": "Baixar o app para desktop",
+    "Para Macs com Apple Silicon (M1 ou mais novo) — Windows em breve. Requer o Homebrew.",
+  "downloadApp.openLabel": "Baixar o app do deco studio",
 } satisfies Record<keyof typeof downloadAppEn, string>;

--- a/apps/web/src/i18n/pt-br/download-app.ts
+++ b/apps/web/src/i18n/pt-br/download-app.ts
@@ -1,0 +1,11 @@
+import type { downloadApp as downloadAppEn } from "../en/download-app.ts";
+
+export const downloadApp = {
+  "downloadApp.title": "Baixar o app para desktop",
+  "downloadApp.description":
+    "Execute este comando no seu terminal para instalar o app com o Homebrew.",
+  "downloadApp.copyLabel": "Copiar comando de instalação",
+  "downloadApp.appleSiliconNote":
+    "Por enquanto, apenas macOS com Apple Silicon. Requer o Homebrew.",
+  "downloadApp.openLabel": "Baixar o app para desktop",
+} satisfies Record<keyof typeof downloadAppEn, string>;

--- a/apps/web/src/i18n/pt-br/download-app.ts
+++ b/apps/web/src/i18n/pt-br/download-app.ts
@@ -9,6 +9,6 @@ export const downloadApp = {
   "downloadApp.terminalHint":
     "Dica: pressione ⌘ Espaço e digite “Terminal” para abri-lo.",
   "downloadApp.appleSiliconNote":
-    "Para Macs com Apple Silicon (M1 ou mais novo) — Windows em breve. Requer o Homebrew.",
+    "Para Macs com Apple Silicon (M1 ou mais novo) — Windows em breve.",
   "downloadApp.openLabel": "Baixar o app do Studio",
 } satisfies Record<keyof typeof downloadAppEn, string>;

--- a/apps/web/src/i18n/pt-br/index.ts
+++ b/apps/web/src/i18n/pt-br/index.ts
@@ -19,6 +19,7 @@ import { home } from "./home.ts";
 import { header } from "./header.ts";
 import { filePicker } from "./file-picker.ts";
 import { devAgent } from "./dev-agent.ts";
+import { downloadApp } from "./download-app.ts";
 import { details } from "./details.ts";
 import { deck } from "./deck.ts";
 import { connections } from "./connections.ts";
@@ -57,6 +58,7 @@ export const ptBR = {
   ...header,
   ...filePicker,
   ...devAgent,
+  ...downloadApp,
   ...details,
   ...deck,
   ...connections,

--- a/apps/web/src/lib/release-feed.ts
+++ b/apps/web/src/lib/release-feed.ts
@@ -9,6 +9,7 @@ import {
   Zap,
 } from "@untitledui/icons";
 import type { ComponentType } from "react";
+import { isDesktopAppEnvironment } from "@/hooks/use-is-desktop-app";
 
 export interface ReleaseBullet {
   icon: ComponentType<{ size?: number; className?: string }>;
@@ -34,7 +35,7 @@ export interface Release {
  * Release feed, newest first. Add new entries at the top.
  * The latest entry is the floating-card candidate; older entries live only in the inbox.
  */
-export const RELEASES: Release[] = [
+const ALL_RELEASES: Release[] = [
   {
     id: "native-app-macos",
     date: "2026-07-30",
@@ -267,3 +268,10 @@ export const RELEASES: Release[] = [
     ],
   },
 ];
+
+// An install prompt inside the installed app is noise: when the Tauri build
+// flag is set, drop releases whose CTA is the download action at the source,
+// so every consumer (floating card, inbox counts) agrees.
+export const RELEASES: Release[] = isDesktopAppEnvironment()
+  ? ALL_RELEASES.filter((release) => !(release.cta && "action" in release.cta))
+  : ALL_RELEASES;

--- a/apps/web/src/lib/release-feed.ts
+++ b/apps/web/src/lib/release-feed.ts
@@ -1,5 +1,6 @@
 import {
   CheckCircle,
+  CpuChip01,
   FilterLines,
   Inbox01,
   Monitor01,
@@ -35,23 +36,33 @@ export interface Release {
  */
 export const RELEASES: Release[] = [
   {
-    id: "desktop-app-macos",
+    id: "native-app-macos",
     date: "2026-07-30",
     eyebrow: "Now Available",
-    title: "The deco studio desktop app is here",
+    title: "The deco studio app is here",
     bullets: [
       {
-        icon: Monitor01,
-        title: "A native Mac app",
-        body: "Run deco studio as a desktop app, with your org's filesystem mounted natively. macOS on Apple Silicon only for now — more platforms coming.",
+        icon: Zap,
+        title: "Faster CMS previews",
+        body: "Every draft gets its own git worktree on your machine, so previews render instantly as you edit.",
       },
       {
-        icon: Zap,
-        title: "One-line install",
-        body: "Install and update through Homebrew with a single terminal command — click Download for Mac to copy it.",
+        icon: Monitor01,
+        title: "Apple Silicon only — Windows coming soon",
+        body: "Today's builds target macOS on Apple Silicon; Windows is next.",
+      },
+      {
+        icon: CpuChip01,
+        title: "Works on more modest machines",
+        body: "The app is entirely rewritten in Rust, with a smaller memory footprint than the Bun-based runtime.",
+      },
+      {
+        icon: Stars02,
+        title: "Native Claude Code & Codex support",
+        body: "State-of-the-art coding agents, running natively against your local files.",
       },
     ],
-    cta: { label: "Download for Mac", action: "download-app" },
+    cta: { label: "Install on Mac", action: "download-app" },
     learnMoreHref: "https://github.com/decocms/studio/releases",
   },
   {

--- a/apps/web/src/lib/release-feed.ts
+++ b/apps/web/src/lib/release-feed.ts
@@ -39,7 +39,7 @@ export const RELEASES: Release[] = [
     id: "native-app-macos",
     date: "2026-07-30",
     eyebrow: "Now Available",
-    title: "The Studio app is here",
+    title: "New beta studio app",
     bullets: [
       {
         icon: Zap,

--- a/apps/web/src/lib/release-feed.ts
+++ b/apps/web/src/lib/release-feed.ts
@@ -2,6 +2,7 @@ import {
   CheckCircle,
   FilterLines,
   Inbox01,
+  Monitor01,
   Stars02,
   Users03,
   Zap,
@@ -20,7 +21,11 @@ export interface Release {
   title: string;
   eyebrow?: string;
   bullets: ReleaseBullet[];
-  cta?: { label: string; href: string };
+  // href navigates; action is handled by the card (currently only opening
+  // the desktop-app download dialog).
+  cta?:
+    | { label: string; href: string }
+    | { label: string; action: "download-app" };
   learnMoreHref?: string;
 }
 
@@ -29,6 +34,26 @@ export interface Release {
  * The latest entry is the floating-card candidate; older entries live only in the inbox.
  */
 export const RELEASES: Release[] = [
+  {
+    id: "desktop-app-macos",
+    date: "2026-07-30",
+    eyebrow: "Now Available",
+    title: "The deco studio desktop app is here",
+    bullets: [
+      {
+        icon: Monitor01,
+        title: "A native Mac app",
+        body: "Run deco studio as a desktop app, with your org's filesystem mounted natively. macOS on Apple Silicon only for now — more platforms coming.",
+      },
+      {
+        icon: Zap,
+        title: "One-line install",
+        body: "Install and update through Homebrew with a single terminal command — click Download for Mac to copy it.",
+      },
+    ],
+    cta: { label: "Download for Mac", action: "download-app" },
+    learnMoreHref: "https://github.com/decocms/studio/releases",
+  },
   {
     id: "codex-gpt-5-6-defaults",
     date: "2026-07-13",

--- a/apps/web/src/lib/release-feed.ts
+++ b/apps/web/src/lib/release-feed.ts
@@ -39,7 +39,7 @@ export const RELEASES: Release[] = [
     id: "native-app-macos",
     date: "2026-07-30",
     eyebrow: "Now Available",
-    title: "The deco studio app is here",
+    title: "The Studio app is here",
     bullets: [
       {
         icon: Zap,

--- a/apps/web/src/lib/release-feed.ts
+++ b/apps/web/src/lib/release-feed.ts
@@ -47,19 +47,19 @@ export const RELEASES: Release[] = [
         body: "Every draft gets its own git worktree on your machine, so previews render instantly as you edit.",
       },
       {
-        icon: Monitor01,
-        title: "Apple Silicon only — Windows coming soon",
-        body: "Today's builds target macOS on Apple Silicon; Windows is next.",
-      },
-      {
-        icon: CpuChip01,
-        title: "Works on more modest machines",
-        body: "The app is entirely rewritten in Rust, with a smaller memory footprint than the Bun-based runtime.",
-      },
-      {
         icon: Stars02,
         title: "Native Claude Code & Codex support",
         body: "State-of-the-art coding agents, running natively against your local files.",
+      },
+      {
+        icon: CpuChip01,
+        title: "Boosted performance",
+        body: "Entirely rewritten in Rust with a smaller memory footprint than the Bun-based runtime — fast even on modest machines.",
+      },
+      {
+        icon: Monitor01,
+        title: "Apple Silicon only — Windows coming soon",
+        body: "Today's builds target macOS on Apple Silicon; Windows is next.",
       },
     ],
     cta: { label: "Install on Mac", action: "download-app" },


### PR DESCRIPTION
## Summary

Final distribution leg: surface the desktop app download inside Studio itself.

- **`DownloadAppDialog`** (`components/download-app-dialog.tsx`) — same copy-to-clipboard pattern as `ConnectDesktopDialog`, showing `curl -fsSL <origin>/install.sh | sh` (origin-relative, so self-hosted instances hand out their own installer) with an "Apple Silicon only for now — requires Homebrew" note. Strings i18n'd (en + pt-BR, new `downloadApp` domain).
- **Chat empty state** — the monitor ("link") button now opens the download dialog instead of the connect-desktop dialog, but only when it's the acquisition moment: macOS desktop browser, not inside the native app, and no desktop link online. A live link keeps the status dialog (it shows detected local agents); non-mac and touch devices keep today's behavior entirely (`isMacDesktopBrowser` excludes iPadOS's "Macintosh" platform via touch detection).
- **Release note** — new `desktop-app-macos` entry in the release feed (floating card + inbox badge), Apple-Silicon-only stated in the bullets, with a "Download for Mac" CTA that opens the same dialog. `Release.cta` widened to `{href} | {action: "download-app"}`, narrowed with an `in` check (no casts). Mark-seen moves to dialog close because marking on click unmounts the card — and would have unmounted the dialog with it.

## Testing

- `bun run --cwd apps/web check` ✓ (also proves pt-BR key parity)
- `bun test` release-channel + release-seen-state suites: 11 pass
- `bun run lint` 0 errors, knip no new findings, `bun run fmt` applied
- Manual QA worth doing on preview: macOS browser chat empty state (button opens download dialog, copy works), non-mac/desktop-app fallback to connect dialog, release card CTA → dialog → dismiss-on-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-product install flow for the Studio app: a download dialog with a copyable Terminal command, hooked into the chat empty state for macOS browsers, plus a release note that opens the same dialog and is hidden inside the desktop app. Copy uses “Studio app,” the CTA reads “Install on Mac,” and the release title is “New beta studio app,” with benefits first and the Homebrew note removed.

- **New Features**
  - `DownloadAppDialog` shows `curl -fsSL ${window.location.origin}/install.sh | sh` with a full-width “Copy install command” button, a Terminal tip, and an Apple Silicon–only note; i18n in `en` and `pt-BR` under `downloadApp`.
  - Chat empty state: on macOS desktop browsers, outside the app, and with no desktop link online, the monitor button opens the download dialog; otherwise it opens the connect/status dialog. `isMacDesktopBrowser` excludes iPadOS; aria‑label uses `downloadApp.openLabel`.
  - Release feed: new `native-app-macos` entry titled “New beta studio app.” CTA supports `href` or `{ action: "download-app" }` and shows “Install on Mac”; the floating card opens the dialog and marks seen on dialog close. Benefits listed first; platform note last.

- **Bug Fixes**
  - Filter download‑action releases from `RELEASES` when inside the native desktop app via `isDesktopAppEnvironment()`, so all consumers omit the install card.

<sup>Written for commit 7bca5e21d0c4537a7636c8f223009e841cc88f4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

