### PR TITLE
feat(native): stop publishing git work on app close

### DIFF
--- a/apps/native/crates/local-api/src/lib.rs
+++ b/apps/native/crates/local-api/src/lib.rs
@@ -4,8 +4,8 @@
 //! axum, no sidecar" decision and the native implementation contract §5). This
 //! file is a MECHANICAL EXTRACTION of the boot sequence that used to live
 //! entirely in `main.rs`'s `fn main()`: every side effect (dir creation,
-//! `AppState` construction, router build, listener bind,
-//! `routes::git::register`) is byte-for-byte unchanged, just reachable
+//! `AppState` construction, router build, listener bind) is byte-for-byte
+//! unchanged, just reachable
 //! from a function signature instead of only from a binary's entrypoint.
 //! `main.rs` now calls into [`boot_from_env`] for exactly what its old
 //! `main()` body did — the daemon-parity and local-api contract e2e
@@ -37,9 +37,11 @@
 //!
 //! Shutdown is an explicit ordered pipeline: stop listener admission; close
 //! request/setup admission; reap chat harnesses; concurrently TERM→KILL and
-//! join every global/per-sandbox process owner; run git publish; perform one
-//! final awaited registry sweep; then join (or abort+join) both axum tasks.
-//! The app-root instance lock remains held until those joins complete.
+//! join every global/per-sandbox process owner; perform one final awaited
+//! registry sweep; then join (or abort+join) both axum tasks. The app-root
+//! instance lock remains held until those joins complete. There is NO git
+//! publish on shutdown — local worktrees are durable and are reused as-is on
+//! the next launch (see `routes/git.rs`'s "No publish on shutdown" section).
 
 mod auth;
 mod client_auth;
@@ -72,7 +74,7 @@ pub use config::ConfigStore;
 pub use events::Broadcaster;
 pub use sandbox::SandboxManager;
 pub use setup::SetupOrchestrator;
-pub use shutdown::{ShutdownCoordinator, ShutdownHook};
+pub use shutdown::ShutdownCoordinator;
 pub use state::{ApiMode, AppState};
 pub use tasks::{KillSignal, TaskRegistry};
 pub use ui::{UiAsset, UiAssetProvider};
@@ -235,9 +237,9 @@ pub enum StartError {
 /// Each listener's serve loop runs on its own `tokio::spawn`'d task; dropping
 /// a `ServerHandle` WITHOUT calling [`ServerHandle::shutdown`] leaves both
 /// tasks running detached (nothing calls `abort()` on drop by design). An
-/// unclean process exit, e.g. `SIGKILL`, bypasses git publish and every local
-/// cleanup hook; harnesses have their own parent-death watchdog, but callers
-/// must use `shutdown()` for the complete ordered reap/publish/drain contract.
+/// unclean process exit, e.g. `SIGKILL`, bypasses every local cleanup step;
+/// harnesses have their own parent-death watchdog, but callers must use
+/// `shutdown()` for the complete ordered reap/drain contract.
 pub struct ServerHandle {
     port: u16,
     preview_port: u16,
@@ -458,9 +460,11 @@ impl ServerHandle {
         }
 
         // Defense-in-depth for global, non-setup request tasks: admission is
-        // already closed, so this final snapshot is complete and awaited. It
-        // runs BEFORE publish: a task that survives means quiescence was not
-        // proven and git must not race it.
+        // already closed, so this final snapshot is complete and awaited.
+        // There is deliberately NO git publish here: local worktrees are
+        // durable and are reused as-is on the next launch (see
+        // `routes/git.rs`'s "No publish on shutdown" module-doc section), so
+        // close never blocks on a network push.
         let final_tasks = state
             .tasks
             .kill_all_and_wait(CHILD_TERM_GRACE, CHILD_KILL_GRACE)
@@ -473,40 +477,12 @@ impl ServerHandle {
             );
         }
 
-        // Only the git publish hook remains registered. Publishing while any
-        // child family is merely "timed out" would trade shutdown latency for
-        // silent worktree corruption, so skip it unless EVERY owner proved
-        // quiescence. Listener/serve cleanup still continues either way.
         let process_tree_quiescent = decopilot_stopped
             && dispatch_stopped
             && global_setup_stopped
             && sandbox_setups_stopped
             && final_tasks_stopped
             && mutation_quiescence.is_quiescent();
-        if process_tree_quiescent {
-            state.shutdown.run().await;
-        } else {
-            tracing::error!(
-                "shutdown: skipping git publish because child quiescence was not proven"
-            );
-        }
-
-        // A publish hook owns its Git process tree through a hidden registry
-        // entry. If the coordinator's bounded hook budget expires, it drops
-        // only the hook waiter; the detached owner remains enumerable here.
-        // Attempt the same bounded TERM -> KILL + join policy as every other
-        // process family, and report any owner that still cannot prove exit.
-        let post_publish_tasks = state
-            .tasks
-            .kill_all_and_wait(CHILD_TERM_GRACE, CHILD_KILL_GRACE)
-            .await;
-        let post_publish_stopped = post_publish_tasks.remaining.is_empty();
-        if !post_publish_stopped {
-            tracing::error!(
-                remaining = ?post_publish_tasks.remaining,
-                "shutdown: post-publish git owners did not fully stop"
-            );
-        }
 
         // `with_graceful_shutdown` waits for every in-flight response. The
         // events SSE stream can intentionally live forever, so poll each
@@ -547,7 +523,7 @@ impl ServerHandle {
         // bounded, but another server in this process cannot acquire the same
         // root and race the old owner. The OS still closes the descriptor on
         // normal exit, SIGTERM escalation, or SIGKILL.
-        if process_tree_quiescent && post_publish_stopped {
+        if process_tree_quiescent {
             drop(_instance_lock);
         } else {
             tracing::error!(
@@ -559,8 +535,7 @@ impl ServerHandle {
 }
 
 /// Builds `AppState`, the router, binds the listener, and spawns the
-/// server in the background. See the module doc comment for the shutdown
-/// hooks this registers.
+/// server in the background.
 pub async fn start(opts: StartOptions) -> Result<ServerHandle, StartError> {
     start_with_client_auth(opts, ClientAuthMode::Bearer).await
 }
@@ -739,10 +714,6 @@ pub async fn start_with_client_auth(
         setup: setup_orchestrator,
         sandbox_manager,
     };
-
-    // Git family's SIGTERM/shutdown publish hook — see
-    // `routes/git.rs`'s module doc ("Shutdown-hook wiring").
-    routes::git::register(&state);
 
     // Clear worktree registrations orphaned by a sandbox directory that
     // vanished while the app was down; git would otherwise refuse to re-add a

--- a/apps/native/crates/local-api/src/routes/git.rs
+++ b/apps/native/crates/local-api/src/routes/git.rs
@@ -33,18 +33,15 @@
 //! faithfully — see the two env profiles ([`route_env`]/[`ceiling_env`])
 //! and the per-function doc comments below.
 //!
-//! ## Shutdown-hook wiring
+//! ## No publish on shutdown
 //!
-//! [`register`] builds the SIGTERM publish-on-shutdown hook (byte-parity
-//! with `entry.ts::shutdown()`) and registers it via
-//! `state.shutdown.register(..)`. `main.rs` (shared) calls
-//! `routes::git::register(&state);` once, right after `AppState` is
-//! constructed and before `axum::serve` starts — the only point in this
-//! crate a `git`-owned file can reach at boot time without editing
-//! `main.rs` itself. See `register_publishes_on_shutdown_run` below for a
-//! direct test of the hook body (it drives `state.shutdown.run()` rather
-//! than an OS signal, since the daemon e2e harness always `SIGKILL`s and
-//! never exercises this path — see `daemon.e2e.helpers.ts::stopDaemon`).
+//! Unlike the cluster daemon (`entry.ts::shutdown()` publishes because its
+//! sandbox filesystem dies with the pod), this crate runs on the user's own
+//! machine: worktrees are durable and `SandboxManager::ensure` reuses a
+//! valid checkout as-is on the next launch. Publishing here is therefore
+//! only ever user-triggered (the [`publish`] route) — app close leaves
+//! local work local, committed or not, instead of blocking exit on a
+//! network push.
 //!
 //! ## `"branch"` broadcaster event
 //!
@@ -324,128 +321,6 @@ where
         .map_err(ApiError::internal)?;
     cancel_on_drop.disarm();
     result
-}
-
-/// Registers the publish-on-SIGTERM shutdown hook. See the module doc's
-/// "Shutdown-hook wiring" section — called once from `main.rs` right after
-/// `AppState` is constructed.
-pub fn register(state: &AppState) {
-    let hook_state = state.clone();
-    let shutdown = state.shutdown.clone();
-    shutdown.register(Box::new(move || {
-        let hook_state = hook_state.clone();
-        Box::pin(async move { run_owned_shutdown_publish(hook_state).await })
-    }));
-}
-
-/// The shutdown coordinator may drop this waiter when its 20-second hook
-/// budget expires. The actual publish owner is detached and remains hidden in
-/// `TaskRegistry`, so the post-hook registry sweep can still TERM -> KILL it
-/// and wait for its process-group join before the app-root lock is released.
-async fn run_owned_shutdown_publish(state: AppState) {
-    let operation_state = state.clone();
-    run_owned_shutdown_operation(state, async move {
-        publish_all_on_shutdown(&operation_state).await
-    })
-    .await;
-}
-
-async fn run_owned_shutdown_operation<F>(state: AppState, operation: F)
-where
-    F: Future<Output = ()> + Send + 'static,
-{
-    let (_kill_handle, result_rx) =
-        spawn_git_operation_owner(state, "git shutdown publish", operation);
-    match result_rx.await {
-        Ok(Ok(())) => {}
-        Ok(Err(message)) => tracing::error!(message, "shutdown git owner failed"),
-        Err(error) => tracing::error!(%error, "shutdown git owner stopped unexpectedly"),
-    }
-}
-
-/// Publishes every materialized per-handle sandbox worktree and then the
-/// process-global repository after their process owners have quiesced. Child
-/// worktrees go first: when an app-root repo contains `sandboxes/*`, publishing
-/// the parent first records the old embedded-repo gitlink and spends the hook's
-/// finite budget before the user's actual sandbox changes. Workdirs are
-/// deduplicated and processed serially: two sandboxes can share one remote,
-/// and concurrent fetch/add/commit/push sequences would race that remote's
-/// branch and credential helpers.
-async fn publish_all_on_shutdown(state: &AppState) {
-    let mut seen = HashSet::new();
-    let mut repo_dirs = Vec::new();
-    let materialized = state
-        .sandbox_manager
-        .snapshot()
-        .into_iter()
-        .map(|sandbox| sandbox.workdir.clone());
-    let durable = durable_sandbox_repo_dirs(state).await;
-    for repo_dir in materialized
-        .chain(durable)
-        .chain(std::iter::once(state.repo_dir.clone()))
-    {
-        if seen.insert(repo_dir.clone()) {
-            repo_dirs.push(repo_dir);
-        }
-    }
-
-    for repo_dir in repo_dirs {
-        match publish_internal(&repo_dir, "").await {
-            Ok(true) => {
-                tracing::info!(repo = %repo_dir.display(), "shutdown: git publish succeeded")
-            }
-            Ok(false) => tracing::debug!(
-                repo = %repo_dir.display(),
-                "shutdown: directory is not a git repository, nothing to publish"
-            ),
-            Err(error) => tracing::warn!(
-                repo = %repo_dir.display(),
-                %error,
-                "shutdown: git publish failed"
-            ),
-        }
-    }
-}
-
-/// Enumerates persisted sandbox worktrees without resurrecting their runtime.
-///
-/// A fresh process starts with an empty `SandboxManager` map, but worktrees
-/// with unsynced user changes may remain from a prior crash. Shutdown must
-/// publish those too — even when the user never focused that chat during this
-/// launch. Re-running `ensure()` here would start install/dev work after
-/// admission is closed, so this reads the durable record only.
-///
-/// Reads the REGISTRY, not the sidecars. The registry is the declared
-/// authority (see `sandbox::registry`'s module doc); sidecars are a legacy
-/// mirror whose writes are explicitly best-effort and swallowed. Enumerating
-/// by sidecar meant a sandbox that registered fine but whose sidecar write
-/// failed was invisible here — and its unsynced work silently never pushed.
-/// The old identity re-derivation is gone with it: the registry row IS the
-/// identity, already validated by `validate_identity` on the way in, so there
-/// is no second `compute_handle` call to drift out of step with
-/// `normalize_branch` (it did: it defaulted a missing branch to `main`, so
-/// every `staging` worktree failed its own check and was skipped).
-async fn durable_sandbox_repo_dirs(state: &AppState) -> Vec<PathBuf> {
-    let handles = match state.sandbox_manager.registered_handles() {
-        Ok(handles) => handles,
-        Err(error) => {
-            tracing::warn!(%error, "shutdown: could not list registered sandboxes to publish");
-            return Vec::new();
-        }
-    };
-    let mut dirs = Vec::new();
-    for handle in handles {
-        match state.sandbox_manager.registry_record(&handle) {
-            Ok(Some(record)) => dirs.push(record.workdir_path),
-            Ok(None) => {}
-            Err(error) => tracing::warn!(
-                handle,
-                %error,
-                "shutdown: could not read a sandbox record; skipping its publish"
-            ),
-        }
-    }
-    dirs
 }
 
 async fn require_git_repo(repo_dir: &Path) -> ApiResult<()> {
@@ -2209,38 +2084,6 @@ mod tests {
         assert!(!ran.load(std::sync::atomic::Ordering::SeqCst));
     }
 
-    #[tokio::test]
-    async fn dropped_shutdown_hook_waiter_leaves_an_enumerable_owner() {
-        let root = TempDir::new().unwrap();
-        let state = test_app_state(root.path());
-        let (started_tx, started_rx) = oneshot::channel();
-        let hook_state = state.clone();
-        let hook_waiter = tokio::spawn(async move {
-            run_owned_shutdown_operation(hook_state, async move {
-                let controller = GIT_PROCESS_CONTROLLER.with(Clone::clone);
-                let _ = started_tx.send(());
-                controller.wait_for_change(None).await;
-            })
-            .await;
-        });
-
-        started_rx.await.expect("shutdown publish owner started");
-        // Equivalent to ShutdownCoordinator's hook timeout dropping the hook
-        // future: only the waiter dies; the detached operation remains in the
-        // registry for the top-level post-hook sweep.
-        hook_waiter.abort();
-        let _ = hook_waiter.await;
-
-        let sweep = state
-            .tasks
-            .kill_all_and_wait(Duration::from_secs(1), Duration::from_secs(1))
-            .await;
-        assert_eq!(sweep.initially_running, 1);
-        assert_eq!(sweep.term_signaled, 1);
-        assert_eq!(sweep.kill_signaled, 0);
-        assert!(sweep.remaining.is_empty());
-    }
-
     #[cfg(unix)]
     #[tokio::test]
     async fn slow_git_group_is_term_kill_reaped_before_owner_finalizes() {
@@ -2419,15 +2262,7 @@ mod tests {
     /// point at the same directory) for tests that do not materialize a
     /// per-handle sandbox.
     fn test_app_state(dir: &Path) -> AppState {
-        test_app_state_at(dir, dir)
-    }
-
-    /// Production keeps the app root and process-global repository separate:
-    /// `<app_root>/repo` and `<app_root>/sandboxes/<handle>/repo`. Tests that
-    /// exercise both repositories must preserve that boundary, otherwise an
-    /// empty sandbox directory is falsely discovered as part of its parent Git
-    /// worktree before the clone step can initialize it.
-    fn test_app_state_at(app_root: &Path, repo_dir: &Path) -> AppState {
+        let (app_root, repo_dir) = (dir, dir);
         let config = std::sync::Arc::new(crate::config::ConfigStore::new());
         let logs = std::sync::Arc::new(crate::log_store::LogStore::new(app_root.join("logs")));
         let tasks = std::sync::Arc::new(crate::tasks::TaskRegistry::new(logs));
@@ -2646,126 +2481,6 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, RouteError::InvalidBranchName(_)));
-    }
-
-    /// Mirrors `daemon.git.e2e.test.ts`'s "SIGTERM triggers a graceful
-    /// publish to origin before exit" — but drives the hook directly via
-    /// `ShutdownCoordinator::run()` instead of an OS signal, since the real
-    /// signal path requires the (currently unwired, see module doc)
-    /// `register(&state)` call in `main.rs`.
-    #[tokio::test]
-    async fn register_publishes_on_shutdown_run() {
-        let repo = setup_repo();
-        std::fs::write(repo.work_dir.join("graceful.txt"), "saved on shutdown\n").unwrap();
-        assert!(!remote_has_branch(&repo.bare_dir, "sandbox-work"));
-
-        let state = test_app_state(&repo.work_dir);
-        register(&state);
-        state.shutdown.run().await;
-
-        assert!(remote_has_branch(&repo.bare_dir, "sandbox-work"));
-    }
-
-    #[tokio::test]
-    async fn shutdown_hook_publishes_materialized_sandbox_worktrees_too() {
-        let global = setup_repo();
-        let sandbox_origin = setup_repo();
-        git(
-            &sandbox_origin.work_dir,
-            &["push", "-q", "-u", "origin", "sandbox-work"],
-        );
-
-        let state = test_app_state_at(global.root.path(), &global.work_dir);
-        let sandbox = state
-            .sandbox_manager
-            .ensure(&crate::sandbox::GitSandboxConfig {
-                virtual_mcp_id: "shutdown-publish-sandbox".to_string(),
-                clone_url: sandbox_origin.bare_dir.to_string_lossy().into_owned(),
-                branch: Some("sandbox-work".to_string()),
-                ..Default::default()
-            })
-            .await
-            .expect("materialize sandbox worktree");
-        std::fs::write(
-            sandbox.workdir.join("sandbox-shutdown.txt"),
-            "saved from sandbox\n",
-        )
-        .unwrap();
-
-        register(&state);
-        state.shutdown.run().await;
-
-        let shown = Command::new("git")
-            .args([
-                "--git-dir",
-                sandbox_origin.bare_dir.to_str().unwrap(),
-                "show",
-                "refs/heads/sandbox-work:sandbox-shutdown.txt",
-            ])
-            .output()
-            .unwrap();
-        assert!(
-            shown.status.success(),
-            "sandbox worktree was not published: {}",
-            String::from_utf8_lossy(&shown.stderr)
-        );
-        assert_eq!(
-            String::from_utf8_lossy(&shown.stdout),
-            "saved from sandbox\n"
-        );
-    }
-
-    #[tokio::test]
-    async fn shutdown_hook_publishes_persisted_worktree_absent_from_fresh_manager() {
-        let global = setup_repo();
-        let sandbox_origin = setup_repo();
-        git(
-            &sandbox_origin.work_dir,
-            &["push", "-q", "-u", "origin", "sandbox-work"],
-        );
-
-        let materializer = test_app_state_at(global.root.path(), &global.work_dir);
-        let sandbox = materializer
-            .sandbox_manager
-            .ensure(&crate::sandbox::GitSandboxConfig {
-                virtual_mcp_id: "persisted-shutdown-publish".to_string(),
-                clone_url: sandbox_origin.bare_dir.to_string_lossy().into_owned(),
-                branch: Some("sandbox-work".to_string()),
-                ..Default::default()
-            })
-            .await
-            .expect("materialize durable sandbox worktree");
-        std::fs::write(
-            sandbox.workdir.join("persisted-shutdown.txt"),
-            "saved after a later boot\n",
-        )
-        .unwrap();
-
-        // Model a new process: its in-memory map starts empty, while the
-        // worktree and validated sidecar created above remain on disk.
-        let fresh = test_app_state_at(global.root.path(), &global.work_dir);
-        assert!(fresh.sandbox_manager.snapshot().is_empty());
-        register(&fresh);
-        fresh.shutdown.run().await;
-
-        let shown = Command::new("git")
-            .args([
-                "--git-dir",
-                sandbox_origin.bare_dir.to_str().unwrap(),
-                "show",
-                "refs/heads/sandbox-work:persisted-shutdown.txt",
-            ])
-            .output()
-            .unwrap();
-        assert!(
-            shown.status.success(),
-            "persisted sandbox worktree was not published: {}",
-            String::from_utf8_lossy(&shown.stderr)
-        );
-        assert_eq!(
-            String::from_utf8_lossy(&shown.stdout),
-            "saved after a later boot\n"
-        );
     }
 
     #[tokio::test]

--- a/apps/native/crates/local-api/src/routes/intercept/decopilot.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/decopilot.rs
@@ -4508,7 +4508,7 @@ mod tests {
         };
         tokio::task::yield_now().await;
 
-        state.shutdown.run().await;
+        state.shutdown.begin_shutdown().await;
         drop(lifecycle_guard);
         let response = sender.await.unwrap();
 

--- a/apps/native/crates/local-api/src/sandbox/manager.rs
+++ b/apps/native/crates/local-api/src/sandbox/manager.rs
@@ -262,11 +262,6 @@ impl SandboxManager {
         self.registry.record(handle)
     }
 
-    /// Every handle with a durable registry row, regardless of agent.
-    pub(crate) fn registered_handles(&self) -> Result<Vec<String>, String> {
-        self.registry.handles()
-    }
-
     /// Every durable sandbox this agent has claimed — the registry-backed
     /// replacement for walking `worktrees/` and reading sidecars on request
     /// paths.

--- a/apps/native/crates/local-api/src/shutdown.rs
+++ b/apps/native/crates/local-api/src/shutdown.rs
@@ -1,38 +1,27 @@
-//! Graceful-shutdown hook registry.
+//! Graceful-shutdown admission control.
 //!
-//! The daemon's `entry.ts::shutdown()` runs a git publish ("sync all local
-//! changes to remote") BEFORE unmounting org-fs, on SIGTERM, with the
-//! reasoning that syncing the user's work is the only irrecoverable step —
-//! see the comment above `shutdown()` in `packages/sandbox/daemon/entry.ts`.
-//! Local-api needs the same shape (the git family's e2e asserts a
-//! shutdown-triggered publish) but must not let the `git` module reach into
-//! `main.rs` to register itself — that would make `main.rs` a shared file
-//! every family edits. Instead, `main.rs` owns one `ShutdownCoordinator` in
-//! `AppState` and calls `run()` after the SIGTERM signal fires; any family
-//! that needs a shutdown-time action calls `state.shutdown.register(..)`
-//! from its own route-registration code (e.g. `routes::git::register`, if
-//! that family adds one) without ever touching `main.rs`.
+//! `main.rs` owns one `ShutdownCoordinator` in `AppState`. Request paths that
+//! start side-effecting work enter a short critical section via
+//! [`ShutdownCoordinator::admit_work`]; the top-level shutdown pipeline in
+//! `lib.rs::ServerHandle::shutdown` calls [`ShutdownCoordinator::begin_shutdown`]
+//! to close admission and wait for sections that already won the race, then
+//! runs its explicit ordered reap/drain phases inline.
 //!
-//! Hooks are NOT retried and NOT guaranteed to run under SIGKILL. The native
-//! queue lifecycle black-box suite delivers a real SIGTERM to pin the graceful
-//! path; crash-recovery tests use SIGKILL separately to pin the watchdog path.
+//! There is deliberately no shutdown-hook registry here anymore: its only
+//! production registrant was the git publish-on-close hook, removed because
+//! local worktrees are durable across launches (see `routes/git.rs`'s
+//! "No publish on shutdown" section). Nothing here is guaranteed to run
+//! under SIGKILL; crash recovery is the watchdog's job.
 
 use std::future::Future;
-use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::sync::Arc;
 
-use futures_util::FutureExt;
 use tokio::sync::{RwLock, RwLockReadGuard};
-use tokio::time::Instant;
 
 use crate::mutation::MutationCoordinator;
 
-pub type ShutdownHook = Box<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
-
 pub struct ShutdownCoordinator {
-    hooks: Mutex<Vec<ShutdownHook>>,
     accepting_work: AtomicBool,
     admission: RwLock<()>,
     mutations: Arc<MutationCoordinator>,
@@ -41,7 +30,6 @@ pub struct ShutdownCoordinator {
 impl ShutdownCoordinator {
     pub fn new() -> Self {
         Self {
-            hooks: Mutex::new(Vec::new()),
             accepting_work: AtomicBool::new(true),
             admission: RwLock::new(()),
             mutations: Arc::new(MutationCoordinator::new()),
@@ -62,7 +50,7 @@ impl ShutdownCoordinator {
     ///
     /// Keep the returned guard alive through the durable enqueue and worker
     /// launch. That makes the boundary linear: either the work is visible to
-    /// the shutdown hook's snapshot, or it is rejected before being accepted.
+    /// shutdown's snapshot, or it is rejected before being accepted.
     pub async fn admit_work(&self) -> Option<RwLockReadGuard<'_, ()>> {
         if !self.accepting_work.load(Ordering::SeqCst) {
             return None;
@@ -86,61 +74,6 @@ impl ShutdownCoordinator {
             drop(barrier);
         }
     }
-
-    /// Register a hook to run once, in registration order, during graceful
-    /// shutdown. Hooks should still log their own expected errors, but this
-    /// coordinator isolates both a panic and a timeout so neither can suppress
-    /// later cleanup.
-    pub fn register(&self, hook: ShutdownHook) {
-        match self.hooks.lock() {
-            Ok(mut hooks) => hooks.push(hook),
-            Err(poisoned) => poisoned.into_inner().push(hook),
-        }
-    }
-
-    /// Drain and run every registered hook in registration order. Panics are
-    /// isolated so one family cannot suppress later cleanup, and the complete
-    /// ordered pipeline has one wall-clock deadline rather than multiplying a
-    /// timeout by the number of hooks.
-    pub async fn run(&self) {
-        self.run_with_deadline(Duration::from_secs(20)).await;
-    }
-
-    async fn run_with_deadline(&self, budget: Duration) {
-        self.begin_shutdown().await;
-        let hooks: Vec<ShutdownHook> = {
-            let mut guard = match self.hooks.lock() {
-                Ok(g) => g,
-                Err(poisoned) => poisoned.into_inner(),
-            };
-            std::mem::take(&mut *guard)
-        };
-        let deadline = Instant::now() + budget;
-        let hook_count = hooks.len();
-        for (index, hook) in hooks.into_iter().enumerate() {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            // Reserve an equal share of the remaining global budget for every
-            // later hook. A wedged early hook must not suppress git publish or
-            // child-process finalization; each hook is attempted in order while
-            // the sum of their slices remains bounded by `budget`.
-            let hooks_left = u32::try_from(hook_count - index).unwrap_or(u32::MAX);
-            let hook_budget = remaining / hooks_left;
-            let guarded = std::panic::AssertUnwindSafe(async move { hook().await }).catch_unwind();
-            match tokio::time::timeout(hook_budget, guarded).await {
-                Ok(Ok(())) => {}
-                Ok(Err(_panic)) => {
-                    tracing::error!(hook_index = index, "shutdown hook panicked; continuing")
-                }
-                Err(_) => {
-                    tracing::error!(
-                        hook_index = index,
-                        ?hook_budget,
-                        "shutdown hook exceeded its reserved deadline; continuing"
-                    );
-                }
-            }
-        }
-    }
 }
 
 impl Default for ShutdownCoordinator {
@@ -152,23 +85,20 @@ impl Default for ShutdownCoordinator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     #[tokio::test]
-    async fn admission_linearizes_in_flight_work_before_shutdown_hooks() {
+    async fn admission_linearizes_in_flight_work_before_shutdown_barrier() {
         let coordinator = Arc::new(ShutdownCoordinator::new());
         let admitted = coordinator.admit_work().await.expect("admitted work");
         let order = Arc::new(Mutex::new(Vec::new()));
-        let hook_order = order.clone();
-        coordinator.register(Box::new(move || {
-            let hook_order = hook_order.clone();
-            Box::pin(async move { hook_order.lock().unwrap().push("hook") })
-        }));
 
         let runner = {
             let coordinator = coordinator.clone();
+            let barrier_order = order.clone();
             tokio::spawn(async move {
-                coordinator.run_with_deadline(Duration::from_secs(1)).await;
+                coordinator.begin_shutdown().await;
+                barrier_order.lock().unwrap().push("barrier");
             })
         };
         while coordinator.accepting_work.load(Ordering::SeqCst) {
@@ -180,7 +110,7 @@ mod tests {
         order.lock().unwrap().push("admitted");
         drop(admitted);
         runner.await.unwrap();
-        assert_eq!(*order.lock().unwrap(), ["admitted", "hook"]);
+        assert_eq!(*order.lock().unwrap(), ["admitted", "barrier"]);
     }
 
     #[tokio::test]
@@ -194,59 +124,5 @@ mod tests {
         first_barrier.await;
         coordinator.begin_shutdown().await;
         assert!(coordinator.admit_work().await.is_none());
-    }
-
-    #[tokio::test]
-    async fn hook_panic_isolated_and_order_continues() {
-        let coordinator = ShutdownCoordinator::new();
-        let order = Arc::new(Mutex::new(Vec::new()));
-        let first = order.clone();
-        coordinator.register(Box::new(move || {
-            let first = first.clone();
-            Box::pin(async move {
-                first.lock().unwrap().push(1);
-                panic!("synthetic shutdown panic");
-            })
-        }));
-        let second = order.clone();
-        coordinator.register(Box::new(move || {
-            let second = second.clone();
-            Box::pin(async move { second.lock().unwrap().push(2) })
-        }));
-
-        coordinator.run_with_deadline(Duration::from_secs(1)).await;
-        assert_eq!(*order.lock().unwrap(), [1, 2]);
-    }
-
-    #[tokio::test]
-    async fn all_hooks_share_one_wall_clock_deadline() {
-        let coordinator = ShutdownCoordinator::new();
-        coordinator.register(Box::new(|| {
-            Box::pin(async { std::future::pending::<()>().await })
-        }));
-        let later_order = Arc::new(Mutex::new(Vec::new()));
-        let second_order = later_order.clone();
-        coordinator.register(Box::new(move || {
-            let second_order = second_order.clone();
-            Box::pin(async move { second_order.lock().unwrap().push(2) })
-        }));
-        let third_order = later_order.clone();
-        coordinator.register(Box::new(move || {
-            let third_order = third_order.clone();
-            Box::pin(async move { third_order.lock().unwrap().push(3) })
-        }));
-        let started = Instant::now();
-        coordinator
-            .run_with_deadline(Duration::from_millis(30))
-            .await;
-        assert!(
-            started.elapsed() < Duration::from_millis(100),
-            "deadline must be global, not multiplied per hook"
-        );
-        assert_eq!(
-            *later_order.lock().unwrap(),
-            [2, 3],
-            "a hanging earlier hook must not suppress second or third cleanup"
-        );
     }
 }

--- a/apps/native/e2e/fs-shutdown.e2e.test.ts
+++ b/apps/native/e2e/fs-shutdown.e2e.test.ts
@@ -2,9 +2,11 @@
  * Black-box ordering contract for filesystem mutation shutdown.
  *
  * A slow streaming `write_from_url` must never write directly into the Git
- * worktree. SIGTERM cancels and joins its detached preparation owner before
- * the shutdown publish hook runs: an earlier completed write is pushed, while
- * neither a partial target nor mutation-stage residue reaches the repository.
+ * worktree. SIGTERM cancels and joins its detached preparation owner, and
+ * shutdown deliberately performs NO git commit or push: an earlier completed
+ * write survives in the worktree uncommitted (durable local state, reused on
+ * the next launch), the remote stays untouched, and neither a partial target
+ * nor mutation-stage residue reaches the repository.
  */
 import { spawnSync } from "node:child_process";
 import {
@@ -51,7 +53,7 @@ function git(cwd: string, args: string[], allowFailure = false): string {
   return result.stdout;
 }
 
-function configurePublishFixture(localApi: LocalApi): string {
+function configureOriginFixture(localApi: LocalApi): string {
   const root = mkdtempSync(join(tmpdir(), "native-fs-shutdown-origin-"));
   originRoot = root;
   const bare = join(root, "origin.git");
@@ -78,10 +80,10 @@ afterEach(async () => {
 });
 
 describeLocalApi("local-api e2e: filesystem shutdown ordering", () => {
-  it("cancels a staged download before publishing and leaves no partial worktree file", async () => {
+  it("cancels a staged download, keeps completed work local and unpushed, and leaves no partial worktree file", async () => {
     const first = await startLocalApi({ LOCAL_API_TOKEN_STORE: "memory" });
     api = first;
-    const bare = configurePublishFixture(first);
+    const bare = configureOriginFixture(first);
     const repo = join(first.workdir, "repo");
 
     const completed = await fetch(url(first, "/_sandbox/write"), {
@@ -89,7 +91,7 @@ describeLocalApi("local-api e2e: filesystem shutdown ordering", () => {
       headers: jsonAuthHeaders(),
       body: JSON.stringify({
         path: "before-shutdown.txt",
-        content: "must be published\n",
+        content: "must stay local\n",
       }),
     });
     expect(completed.status).toBe(200);
@@ -149,12 +151,20 @@ describeLocalApi("local-api e2e: filesystem shutdown ordering", () => {
     expect(Date.now() - shutdownStartedAt).toBeLessThan(15_000);
     expect(first.proc.exitCode).toBe(0);
     expect(existsSync(join(repo, "slow-download.bin"))).toBe(false);
+    // The completed write survives shutdown in the worktree, uncommitted:
+    // shutdown neither commits nor pushes local work.
     expect(readFileSync(join(repo, "before-shutdown.txt"), "utf8")).toBe(
-      "must be published\n",
+      "must stay local\n",
     );
-    expect(git(bare, ["show", "sandbox-work:before-shutdown.txt"]).trim()).toBe(
-      "must be published",
+    expect(git(repo, ["status", "--porcelain"])).toContain(
+      "before-shutdown.txt",
     );
+    const publishedToRemote = spawnSync(
+      "git",
+      ["show", "sandbox-work:before-shutdown.txt"],
+      { cwd: bare, encoding: "utf8" },
+    );
+    expect(publishedToRemote.status).not.toBe(0);
     const partialInRemote = spawnSync(
       "git",
       ["show", "sandbox-work:slow-download.bin"],
@@ -170,8 +180,8 @@ describeLocalApi("local-api e2e: filesystem shutdown ordering", () => {
       }
     }, RETRY_OPTIONS);
 
-    // The instance lock remains held until mutation cancellation, publish,
-    // and listener drain all finish. Immediate same-root restart proves no
+    // The instance lock remains held until mutation cancellation and
+    // listener drain finish. Immediate same-root restart proves no
     // detached filesystem owner retained the previous server lifecycle.
     const restarted = await startLocalApi(
       { LOCAL_API_TOKEN_STORE: "memory" },

--- a/apps/native/src-tauri/src/shutdown.rs
+++ b/apps/native/src-tauri/src/shutdown.rs
@@ -1,8 +1,9 @@
 //! Graceful shutdown: window close / app exit stops the in-process
-//! local-api server, which itself runs local-api's OWN registered
-//! shutdown hooks (chat/dispatch reap, pre-publish task sweep, git publish,
-//! then an unconditional task-sweep fallback — see `crates/local-api/src/lib.rs`)
-//! before letting axum drain and stop.
+//! local-api server, which runs its own ordered pipeline (chat/dispatch
+//! reap, child TERM→KILL sweeps, final task-registry sweep — see
+//! `crates/local-api/src/lib.rs`) before letting axum drain and stop.
+//! No git publish happens here: local worktrees are durable and are
+//! reused as-is on the next launch, so close never blocks on the network.
 //!
 //! Wired from the top-level `.run(|app, event| ..)` callback in `lib.rs`
 //! on [`tauri::RunEvent::ExitRequested`] — this fires for BOTH a normal


### PR DESCRIPTION
## Summary

The native app's window-close path ran a git publish (add + commit + push of every sandbox worktree plus the app-root repo, serially, network-bound) before letting the process exit. That behavior was inherited from the cluster daemon, where the sandbox filesystem dies with the pod and an unpushed change is a lost change.

Locally that rationale doesn't hold: worktrees are durable and `SandboxManager::ensure` reuses a valid checkout as-is on the next launch (only partial/invalid clones are re-cloned, and branch-drift repair is a plain checkout that fails on a dirty tree rather than discarding work). So closing the app now leaves work exactly where it is — local and uncommitted — and never blocks exit on the network. Publishing is only ever user-triggered via the explicit publish route.

## Changes

- **`routes/git.rs`**: delete the publish-on-shutdown hook (`register`, `run_owned_shutdown_publish`, `publish_all_on_shutdown`, `durable_sandbox_repo_dirs`) and the four unit tests pinning it; module doc gains a "No publish on shutdown" section documenting the intent.
- **`lib.rs`**: drop the hook registration at boot and the two publish phases of `ServerHandle::shutdown` (the quiescence-gated `shutdown.run()` and the post-publish git-owner sweep). All process-safety phases are unchanged: admission fences, harness reaps, TERM→KILL child sweeps, final task-registry sweep, bounded HTTP drain, and the quiescence-gated instance-lock release.
- **`shutdown.rs`**: remove the now-dead shutdown-hook registry (the publish hook was its only production registrant); `ShutdownCoordinator` is now purely admission/mutation lifecycle.
- **`sandbox/manager.rs`**: remove orphaned `registered_handles`.
- **`e2e/fs-shutdown.e2e.test.ts`**: inverted — SIGTERM must leave a completed write **uncommitted** in the worktree, push **nothing** to origin, and still cancel in-flight downloads with no partial file, no mutation-stage residue, and a clean same-root restart.
- **`src-tauri/src/shutdown.rs`**: doc comment updated.

The cluster daemon (`packages/sandbox/daemon`) keeps its publish-on-SIGTERM behavior — this only changes the native local-api.

## Testing

- `cargo test -p local-api --lib`: 795 pass
- Full native e2e suite against the built binary (`LOCAL_API_E2E_CMD=... bun test e2e`): 160 pass across 23 files, including the inverted `fs-shutdown` contract
- `cargo clippy -p local-api --all-targets` clean; `bun run fmt` + `cargo fmt` applied (lefthook pre-commit passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-publishing Git changes when the native app closes. Closing the app no longer blocks on network I/O; work stays local in the worktree until the user explicitly publishes.

- **Refactors**
  - Removed the publish-on-shutdown hook and the shutdown-hook registry; `ShutdownCoordinator` now only manages admission/mutation lifecycle.
  - Dropped publish phases from `ServerHandle::shutdown`; process-safety steps (reaps, TERM→KILL sweeps, drain, quiescence-gated instance-lock) are unchanged.
  - Removed `SandboxManager::registered_handles`; updated docs and tests, including an inverted e2e that expects uncommitted local changes and no remote push, and a test switch to `begin_shutdown`.

- **Migration**
  - If you relied on auto-publish at exit, use the in-app Publish action or call the `publish` route.
  - No change to the cluster daemon in `packages/sandbox/daemon`, which still publishes on SIGTERM.

<sup>Written for commit c0cc5f19774c5c6772c897f6033ffcaaa454a3e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

