### PR TITLE
fix(task-board): clear multi-select when switching to list view

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -542,7 +542,14 @@ export function TaskBoardPage() {
             <div className="inline-flex rounded-lg bg-muted p-0.5">
               <LayoutToggle
                 active={layout === "list"}
-                onClick={() => setLayout("list")}
+                onClick={() => {
+                  setLayout("list");
+                  // Selection is a board-only concept (List has no way to see
+                  // or change which cards are selected) — leaving it wedges
+                  // the floating bulk-action bar on-screen, operating on a
+                  // selection the user can no longer see.
+                  clearSelection();
+                }}
                 icon={List}
                 label={t("common.taskBoard.listView")}
               />


### PR DESCRIPTION
Follows #5374's multi-select/bulk-actions feature (kanban lanes).

Multi-card selection is only manageable from the board layout — the List layout's `ListRow` has no selection UI at all (no checkbox, no shift-click handler, no highlight). But `selectedIds` state lives at the page level and the floating `SelectionBar` (Move to / Change priority / Assign / Due date / Add tag / Delete) renders unconditionally whenever `selectedIds.size > 0`, regardless of `layout`.

Failure scenario: select several cards in Board view, switch to List view (e.g. to review), and the bulk-action bar stays pinned at the bottom with the same selection — now invisible, since List has no way to show or edit which cards are selected. A stray click on "Delete" in that bar bulk-deletes tasks the user can no longer see are selected.

Fix: clear the selection when switching to List view, since selection is a board-only concept.

Reviewer check: `cd apps/web && bunx tsc --noEmit` (clean). No dedicated test added — this is a one-line behavioral wiring fix (call `clearSelection()` alongside the existing `setLayout("list")`), not new pure logic to unit test.

Locally verified: `bun run fmt` (no changes) and `bunx tsc --noEmit` in apps/web (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clear multi-select when switching to List view on the task board so the bulk-action bar doesn’t stay active on hidden selections. Prevents accidental bulk actions (e.g., Delete) on tasks the user can’t see are selected.

<sup>Written for commit 20a76a43a7ea14737ad2bd6f6f524a7903d9da67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

