### PR TITLE
fix(threads): escape ILIKE wildcards in free-text thread search

### DIFF
--- a/apps/api/src/storage/threads.test.ts
+++ b/apps/api/src/storage/threads.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "bun:test";
+import { escapeLikePattern } from "./threads";
+
+describe("escapeLikePattern", () => {
+  it("escapes % so it matches a literal percent sign", () => {
+    expect(escapeLikePattern("100%")).toBe("100\\%");
+  });
+
+  it("escapes _ so it matches a literal underscore", () => {
+    expect(escapeLikePattern("foo_bar")).toBe("foo\\_bar");
+  });
+
+  it("escapes a literal backslash", () => {
+    expect(escapeLikePattern("a\\b")).toBe("a\\\\b");
+  });
+
+  it("leaves plain text unchanged", () => {
+    expect(escapeLikePattern("hello world")).toBe("hello world");
+  });
+});

--- a/apps/api/src/storage/threads.ts
+++ b/apps/api/src/storage/threads.ts
@@ -22,6 +22,11 @@ function toIsoString(v: Date | string): string {
   return typeof v === "string" ? v : v.toISOString();
 }
 
+/** Escapes LIKE/ILIKE wildcards so a free-text `search` term matches a literal substring. */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}
+
 // ============================================================================
 // Org-Scoped Thread Storage (repository pattern)
 // ============================================================================
@@ -579,7 +584,11 @@ export class SqlThreadStorage implements ThreadStoragePort {
       );
     }
     if (options?.search) {
-      query = query.where("title", "ilike", `%${options.search}%`);
+      query = query.where(
+        "title",
+        "ilike",
+        `%${escapeLikePattern(options.search)}%`,
+      );
     }
     if (options?.status) {
       query = query.where("status", "=", options.status as ThreadStatus);
@@ -617,7 +626,11 @@ export class SqlThreadStorage implements ThreadStoragePort {
       );
     }
     if (options?.search) {
-      countQuery = countQuery.where("title", "ilike", `%${options.search}%`);
+      countQuery = countQuery.where(
+        "title",
+        "ilike",
+        `%${escapeLikePattern(options.search)}%`,
+      );
     }
     if (options?.status) {
       countQuery = countQuery.where(


### PR DESCRIPTION
**Source**: bug found while auditing GLOBAL_SEARCH's pagination/validation path (apps/api/src/tools/search/global-search.ts) — the search text it forwards is validated for length but never escaped before hitting the DB.

**Bug**: `ThreadStorage.list()` in `apps/api/src/storage/threads.ts` builds its ILIKE filter as `` `%${options.search}%` `` with the raw user-supplied text. `%` and `_` are ILIKE wildcard metacharacters, so a search for e.g. `"100%"` or `"foo_bar"` doesn't match those titles literally — it matches any run of characters where `%` is, and any single character where `_` is. This is the query path shared by both `THREAD_LIST` and `GLOBAL_SEARCH`, so both return wrong (too broad or too narrow) results whenever a title or query contains those characters. `apps/api/src/storage/org-fs.ts` already hit this exact issue for its own free-text search and escapes LIKE metacharacters before interpolating (`escapeLike`) — this PR applies the same fix to threads.

**Fix**: added `escapeLikePattern()` (same `[\\%_]` escape as org-fs.ts's helper) and applied it to both the `list()` result query and its paired count query before building the ILIKE pattern. Behavior-preserving for any search text without `%`, `_`, or `\` — only the previously-broken wildcard case changes (now matches literally, as documented/expected for a free-text title search).

**Verify**: `cd apps/api && bun test src/storage/threads.test.ts` — new pure unit tests on `escapeLikePattern` covering `%`, `_`, `\`, and plain text. Storage-layer behavior beyond the pure escape function is exercised by the existing `threads.integration.test.ts` in CI (this laptop has no local Postgres to run it).

**Checked locally**: `bun run fmt` (no-op), `bunx tsc --noEmit` in `apps/api` (clean), targeted test above (4/4 pass). Full CI (lint, full typecheck, integration/e2e) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes free-text thread search by escaping ILIKE wildcards so `%`, `_`, and `\` match literally. This returns accurate results for `THREAD_LIST` and `GLOBAL_SEARCH` when queries or titles include those characters.

- **Bug Fixes**
  - Added `escapeLikePattern()` in `apps/api/src/storage/threads.ts` to escape `[\\%_]`.
  - Applied escaping to both the results and count ILIKE queries in `SqlThreadStorage`.
  - Added unit tests in `apps/api/src/storage/threads.test.ts` covering `%`, `_`, `\`, and plain text.

<sup>Written for commit e223ea810de7bb982e229d7e540eac0599b6f960. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

