### PR TITLE
fix(sections-editor): disambiguate colliding array-item labels

### DIFF
--- a/apps/web/ct/tests/array-object-drilldown.ct.tsx
+++ b/apps/web/ct/tests/array-object-drilldown.ct.tsx
@@ -275,6 +275,46 @@ test("deleting a row removes the right item from the array", async ({
     .toEqual({ cards: [{ name: "Beta" }] });
 });
 
+test("colliding fallback-title rows are position-disambiguated and each drills into its own content", async ({
+  mount,
+}) => {
+  // The osklen bug: object-array items with no name/title field all fall back
+  // to the item schema `title` ("Spec"), so every row's label collided and
+  // navigation collapsed every item back to the first ("all items show the
+  // same content"). Rows must now render as "Spec 1/2/3", and drilling a
+  // NON-first row must uniquely address that row (no reliance on a transient
+  // open-index), showing its own value.
+  const meta = sectionWithProps({
+    specs: {
+      type: "array",
+      title: "Specs",
+      items: {
+        type: "object",
+        title: "Spec",
+        properties: { body: { type: "string", title: "Body" } },
+      },
+    },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ specs: [{ body: "a" }, { body: "b" }, { body: "c" }] }}
+    />,
+  );
+
+  await expect(itemRow(component, "Spec 1")).toBeVisible();
+  await expect(itemRow(component, "Spec 2")).toBeVisible();
+  await expect(itemRow(component, "Spec 3")).toBeVisible();
+
+  await itemRow(component, "Spec 3").click();
+
+  await expect.poll(() => readBreadcrumb(component)).toContain("Spec 3");
+  const body = component.getByLabel("Body");
+  await expect(body).toHaveAttribute("id", "specs.2.body");
+  await expect(body).toHaveValue("c");
+});
+
 test("fallback label 'Item 1' when itemSchema has no titleBy/title and item has no name", async ({
   mount,
 }) => {

--- a/apps/web/src/components/sections-editor/array-item-display.test.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.test.ts
@@ -93,6 +93,57 @@ describe("getArrayItemLabel", () => {
       "BannerCarrouselDepartment",
     );
   });
+
+  describe("collision disambiguation (siblings)", () => {
+    // An object array with no distinguishing field: every item's label falls
+    // back to the item schema title, so all rows collapse to one string. The
+    // breadcrumb addresses an item by its label and the transient open-index is
+    // wiped whenever the form subtree remounts (formResetKey), so a non-unique
+    // label makes every item resolve back to the first one — the "all items
+    // show the same content" bug. Positional suffixes keep them addressable.
+    const itemSchema: SchemaProperty = {
+      type: "object",
+      title: "ProductSpecifications",
+      properties: { body: { type: "string" } },
+    };
+    const specs = [{ body: "a" }, { body: "b" }, { body: "c" }];
+
+    test("suffixes the position when the base label collides", () => {
+      expect(getArrayItemLabel(specs[0], 0, itemSchema, specs)).toBe(
+        "ProductSpecifications 1",
+      );
+      expect(getArrayItemLabel(specs[2], 2, itemSchema, specs)).toBe(
+        "ProductSpecifications 3",
+      );
+    });
+
+    test("leaves a unique label untouched", () => {
+      const mixed = [{ title: "Alpha" }, { title: "Beta" }];
+      const schema: SchemaProperty = {
+        type: "object",
+        properties: { title: { type: "string" } },
+      };
+      expect(getArrayItemLabel(mixed[0], 0, schema, mixed)).toBe("Alpha");
+      expect(getArrayItemLabel(mixed[1], 1, schema, mixed)).toBe("Beta");
+    });
+
+    test("only the colliding items get a suffix", () => {
+      const mixed = [{ title: "Dup" }, { title: "Unique" }, { title: "Dup" }];
+      const schema: SchemaProperty = {
+        type: "object",
+        properties: { title: { type: "string" } },
+      };
+      expect(getArrayItemLabel(mixed[0], 0, schema, mixed)).toBe("Dup 1");
+      expect(getArrayItemLabel(mixed[1], 1, schema, mixed)).toBe("Unique");
+      expect(getArrayItemLabel(mixed[2], 2, schema, mixed)).toBe("Dup 3");
+    });
+
+    test("no siblings argument keeps the legacy bare label", () => {
+      expect(getArrayItemLabel(specs[1], 1, itemSchema)).toBe(
+        "ProductSpecifications",
+      );
+    });
+  });
 });
 
 describe("getArrayItemImageSrc", () => {

--- a/apps/web/src/components/sections-editor/array-item-display.test.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   getArrayItemImageSrc,
   getArrayItemLabel,
+  getArrayItemLabels,
   renderMustacheTemplate,
 } from "./array-item-display";
 import type { SchemaProperty } from "./resolve-schema";
@@ -143,6 +144,57 @@ describe("getArrayItemLabel", () => {
         "ProductSpecifications",
       );
     });
+  });
+});
+
+describe("getArrayItemLabels (batch disambiguation)", () => {
+  const titleSchema = (title: string): SchemaProperty => ({
+    type: "object",
+    title,
+    properties: { body: { type: "string" } },
+  });
+
+  test("suffixes every item when they all share the fallback title", () => {
+    const items = [{ body: "a" }, { body: "b" }, { body: "c" }];
+    expect(getArrayItemLabels(items, titleSchema("Spec"))).toEqual([
+      "Spec 1",
+      "Spec 2",
+      "Spec 3",
+    ]);
+  });
+
+  test("disambiguates NFC/NFD near-duplicates the resolver would treat as equal", () => {
+    // "café" composed (U+00E9) vs decomposed (e + U+0301). labelsMatch
+    // NFC-normalizes both, so a bare label would collapse them to index 0.
+    const schema: SchemaProperty = {
+      type: "object",
+      properties: { name: { type: "string" } },
+    };
+    const items = [{ name: "café" }, { name: "café" }];
+    const labels = getArrayItemLabels(items, schema);
+    expect(labels[0]).not.toBe(labels[1]);
+    expect(labels[0]!.normalize("NFC")).not.toBe(labels[1]!.normalize("NFC"));
+  });
+
+  test("keeps the final set unique when a suffix collides with a literal label", () => {
+    // ["X","X","X 2"]: naive per-item suffixing yields "X 1","X 2","X 2".
+    const schema: SchemaProperty = {
+      type: "object",
+      properties: { title: { type: "string" } },
+    };
+    const items = [{ title: "X" }, { title: "X" }, { title: "X 2" }];
+    const labels = getArrayItemLabels(items, schema);
+    expect(new Set(labels).size).toBe(labels.length);
+    expect(labels[0]).toBe("X 1");
+  });
+
+  test("leaves unique labels untouched", () => {
+    const schema: SchemaProperty = {
+      type: "object",
+      properties: { title: { type: "string" } },
+    };
+    const items = [{ title: "Alpha" }, { title: "Beta" }];
+    expect(getArrayItemLabels(items, schema)).toEqual(["Alpha", "Beta"]);
   });
 });
 

--- a/apps/web/src/components/sections-editor/array-item-display.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.ts
@@ -175,17 +175,64 @@ function baseArrayItemLabel(
 }
 
 /**
- * Display label for an array item.
+ * Normalize a label the same way breadcrumb matching does (`labelsMatch` in
+ * schema-form-breadcrumb.ts) so collision detection here agrees with crumb
+ * resolution there. Duplicated locally rather than imported to avoid a cyclic
+ * dependency (that module already imports from this one).
+ */
+function normalizeLabel(label: string): string {
+  return label.normalize("NFC").trim();
+}
+
+/**
+ * Display labels for a whole array, disambiguated so every label is unique.
  *
- * When `siblings` is provided and this item's base label is shared by another
- * item in the array (e.g. an object array with no name/title field, so every
- * row falls back to the item schema's static `title`), the label is suffixed
- * with the item's position so it stays unique. Uniqueness is not cosmetic: the
- * breadcrumb addresses an array item by its label, and the only other handle —
- * the transiently-opened index in `ArrayField` — is reset whenever the form
- * subtree remounts (a `formResetKey` bump on back/breadcrumb navigation). A
- * non-unique label would then collapse every item back to the first one on the
- * next remount, so the editor appears to show the same content for every item.
+ * When an item's base label is shared by another item (e.g. an object array
+ * with no name/title field, so every row falls back to the item schema's static
+ * `title`), the label is suffixed with the item's position. Uniqueness is not
+ * cosmetic: the breadcrumb addresses an array item by its label, and the only
+ * other handle — the transiently-opened index in `ArrayField` — is reset
+ * whenever the form subtree remounts (a `formResetKey` bump on back/breadcrumb
+ * navigation). A non-unique label would then collapse every item back to the
+ * first one on the next remount, so the editor appears to show the same content
+ * for every item.
+ *
+ * Computed as a set (not per item) so the result is globally unique and
+ * deterministic in `(items, itemSchema)` — the crumb built from this list
+ * re-resolves to the same index even when a positional suffix happens to equal
+ * another row's literal label. Comparison uses `normalizeLabel` to match the
+ * resolver, so NFC/NFD and whitespace near-duplicates disambiguate too.
+ */
+export function getArrayItemLabels(
+  items: unknown[],
+  itemSchema?: SchemaProperty,
+): string[] {
+  const bases = items.map((item, i) => baseArrayItemLabel(item, i, itemSchema));
+  const baseCounts = new Map<string, number>();
+  for (const base of bases) {
+    const key = normalizeLabel(base);
+    baseCounts.set(key, (baseCounts.get(key) ?? 0) + 1);
+  }
+  const seen = new Set<string>();
+  return bases.map((base, i) => {
+    let label =
+      (baseCounts.get(normalizeLabel(base)) ?? 0) > 1
+        ? `${base} ${i + 1}`
+        : base;
+    // A suffixed label can still coincide with another row's literal label;
+    // keep extending (positions are unique, so this terminates quickly) until
+    // the final set has no duplicates.
+    while (seen.has(normalizeLabel(label))) label = `${label} ${i + 1}`;
+    seen.add(normalizeLabel(label));
+    return label;
+  });
+}
+
+/**
+ * Display label for a single array item. Pass `siblings` (the whole array) to
+ * get a label disambiguated against the others — see {@link getArrayItemLabels}.
+ * Callers that build or resolve a breadcrumb crumb MUST pass `siblings` so the
+ * built and resolved labels agree; only genuinely single-item callers omit it.
  */
 export function getArrayItemLabel(
   item: unknown,
@@ -193,13 +240,13 @@ export function getArrayItemLabel(
   itemSchema?: SchemaProperty,
   siblings?: unknown[],
 ): string {
-  const base = baseArrayItemLabel(item, index, itemSchema);
-  if (!siblings || siblings.length < 2) return base;
-  const collides = siblings.some(
-    (other, i) =>
-      i !== index && baseArrayItemLabel(other, i, itemSchema) === base,
+  if (!siblings || siblings.length < 2) {
+    return baseArrayItemLabel(item, index, itemSchema);
+  }
+  return (
+    getArrayItemLabels(siblings, itemSchema)[index] ??
+    baseArrayItemLabel(item, index, itemSchema)
   );
-  return collides ? `${base} ${index + 1}` : base;
 }
 
 function getArrayItemImageTemplate(

--- a/apps/web/src/components/sections-editor/array-item-display.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.ts
@@ -104,7 +104,7 @@ function readTitleByValue(
   return undefined;
 }
 
-export function getArrayItemLabel(
+function baseArrayItemLabel(
   item: unknown,
   index: number,
   itemSchema?: SchemaProperty,
@@ -172,6 +172,34 @@ export function getArrayItemLabel(
     }
   }
   return `Item ${index + 1}`;
+}
+
+/**
+ * Display label for an array item.
+ *
+ * When `siblings` is provided and this item's base label is shared by another
+ * item in the array (e.g. an object array with no name/title field, so every
+ * row falls back to the item schema's static `title`), the label is suffixed
+ * with the item's position so it stays unique. Uniqueness is not cosmetic: the
+ * breadcrumb addresses an array item by its label, and the only other handle —
+ * the transiently-opened index in `ArrayField` — is reset whenever the form
+ * subtree remounts (a `formResetKey` bump on back/breadcrumb navigation). A
+ * non-unique label would then collapse every item back to the first one on the
+ * next remount, so the editor appears to show the same content for every item.
+ */
+export function getArrayItemLabel(
+  item: unknown,
+  index: number,
+  itemSchema?: SchemaProperty,
+  siblings?: unknown[],
+): string {
+  const base = baseArrayItemLabel(item, index, itemSchema);
+  if (!siblings || siblings.length < 2) return base;
+  const collides = siblings.some(
+    (other, i) =>
+      i !== index && baseArrayItemLabel(other, i, itemSchema) === base,
+  );
+  return collides ? `${base} ${index + 1}` : base;
 }
 
 function getArrayItemImageTemplate(

--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -184,7 +184,7 @@ export function ArrayField({
   }
 
   const itemLabel = (item: unknown, index: number) =>
-    getArrayItemLabel(arrayItemDisplayValue(item), index, itemSchema);
+    getArrayItemLabel(arrayItemDisplayValue(item), index, itemSchema, items);
 
   const openItem = (index: number) => {
     if (suppressClickRef.current) return;
@@ -205,7 +205,7 @@ export function ArrayField({
     onChange(next);
     const nextIndex = next.length - 1;
     setOpenIndex(nextIndex);
-    const labelText = getArrayItemLabel(item, nextIndex, itemSchema);
+    const labelText = getArrayItemLabel(item, nextIndex, itemSchema, next);
     onBreadcrumbChange?.(
       buildArrayDrillDownBreadcrumb(
         breadcrumbPath,
@@ -242,7 +242,7 @@ export function ArrayField({
     onChange(next);
     const nextIndex = next.length - 1;
     setOpenIndex(nextIndex);
-    const labelText = getArrayItemLabel(defaultVal, nextIndex, itemSchema);
+    const labelText = getArrayItemLabel(defaultVal, nextIndex, itemSchema, next);
     onBreadcrumbChange?.(
       buildArrayDrillDownBreadcrumb(
         breadcrumbPath,
@@ -309,7 +309,12 @@ export function ArrayField({
     // Update the breadcrumb so resolveArrayItemSelection keeps matching.
     if (index === selectedIndex && selectedIndex !== null) {
       const oldLabel = itemLabel(items[index], index);
-      const newLabel = getArrayItemLabel(val, index, itemSchema);
+      const newLabel = getArrayItemLabel(
+        arrayItemDisplayValue(next[index]),
+        index,
+        itemSchema,
+        next,
+      );
       if (oldLabel !== newLabel) {
         const crumbIndex = findBreadcrumbLabelIndex(breadcrumbPath, oldLabel);
         if (crumbIndex >= 0) {

--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -22,7 +22,11 @@ import { toast } from "sonner";
 import { useT } from "@/i18n/use-t.ts";
 import { SORTABLE_DROP_ANIMATION } from "@/lib/dnd-drop-animation.ts";
 import { cn } from "@deco/ui/lib/utils.ts";
-import { getArrayItemImageSrc, getArrayItemLabel } from "../array-item-display";
+import {
+  getArrayItemImageSrc,
+  getArrayItemLabel,
+  getArrayItemLabels,
+} from "../array-item-display";
 import {
   arrayItemDisplayValue,
   hideArrayItem,
@@ -133,9 +137,11 @@ export function ArrayField({
   // pickers have their own hide flow, and primitive arrays can't be wrapped.
   const canHideItems = !usesSectionPicker && itemSchema?.type === "object";
   // Index of the item the user has explicitly opened. Array items are addressed
-  // in the breadcrumb by their mutable, non-unique display label, so this lets
-  // selection stay on the opened row even when its label collides with another
-  // item's (e.g. after Duplicate, or while typing a name/alt another item uses).
+  // in the breadcrumb by their (mutable) display label; `getArrayItemLabels`
+  // keeps those labels unique, but this preferred index still pins selection to
+  // the opened row through the brief window where an edit makes labels churn
+  // (e.g. typing a name/alt that momentarily matches a sibling before the
+  // positional suffix settles).
   const [openIndex, setOpenIndex] = useState<number | null>(null);
 
   const selection = resolveArrayItemSelection(
@@ -183,8 +189,12 @@ export function ArrayField({
     setEntries((current) => resizeArrayEntries(current, items.length));
   }
 
-  const itemLabel = (item: unknown, index: number) =>
-    getArrayItemLabel(arrayItemDisplayValue(item), index, itemSchema, items);
+  const itemLabel = (
+    item: unknown,
+    index: number,
+    siblings: unknown[] = items,
+  ) =>
+    getArrayItemLabel(arrayItemDisplayValue(item), index, itemSchema, siblings);
 
   const openItem = (index: number) => {
     if (suppressClickRef.current) return;
@@ -242,7 +252,12 @@ export function ArrayField({
     onChange(next);
     const nextIndex = next.length - 1;
     setOpenIndex(nextIndex);
-    const labelText = getArrayItemLabel(defaultVal, nextIndex, itemSchema, next);
+    const labelText = getArrayItemLabel(
+      defaultVal,
+      nextIndex,
+      itemSchema,
+      next,
+    );
     onBreadcrumbChange?.(
       buildArrayDrillDownBreadcrumb(
         breadcrumbPath,
@@ -309,12 +324,7 @@ export function ArrayField({
     // Update the breadcrumb so resolveArrayItemSelection keeps matching.
     if (index === selectedIndex && selectedIndex !== null) {
       const oldLabel = itemLabel(items[index], index);
-      const newLabel = getArrayItemLabel(
-        arrayItemDisplayValue(next[index]),
-        index,
-        itemSchema,
-        next,
-      );
+      const newLabel = itemLabel(next[index], index, next);
       if (oldLabel !== newLabel) {
         const crumbIndex = findBreadcrumbLabelIndex(breadcrumbPath, oldLabel);
         if (crumbIndex >= 0) {
@@ -481,32 +491,38 @@ export function ArrayField({
               strategy={verticalListSortingStrategy}
             >
               <div className="min-w-0 overflow-hidden rounded-xl border border-border/50 p-1.5">
-                {entries.map((entry) => {
-                  const item = items[entry.index];
-                  if (item === undefined) return null;
-                  const labelText = itemLabel(item, entry.index);
-                  const imageSrc = getArrayItemImageSrc(
-                    arrayItemDisplayValue(item),
-                    itemSchema,
-                  );
-                  return (
-                    <SortableArrayRow
-                      key={entry.id}
-                      sortableId={entry.id}
-                      labelText={labelText}
-                      imageSrc={imageSrc}
-                      hidden={isArrayItemHidden(item)}
-                      onToggleHidden={
-                        canHideItems
-                          ? () => toggleItemHidden(entry.index)
-                          : undefined
-                      }
-                      onOpen={() => openItem(entry.index)}
-                      onDuplicate={() => duplicateItem(entry.index)}
-                      onRemove={() => removeItem(entry.index)}
-                    />
-                  );
-                })}
+                {(() => {
+                  // Compute disambiguated labels once for the whole list rather
+                  // than per row (each derivation scans all siblings).
+                  const itemLabels = getArrayItemLabels(items, itemSchema);
+                  return entries.map((entry) => {
+                    const item = items[entry.index];
+                    if (item === undefined) return null;
+                    const labelText =
+                      itemLabels[entry.index] ?? itemLabel(item, entry.index);
+                    const imageSrc = getArrayItemImageSrc(
+                      arrayItemDisplayValue(item),
+                      itemSchema,
+                    );
+                    return (
+                      <SortableArrayRow
+                        key={entry.id}
+                        sortableId={entry.id}
+                        labelText={labelText}
+                        imageSrc={imageSrc}
+                        hidden={isArrayItemHidden(item)}
+                        onToggleHidden={
+                          canHideItems
+                            ? () => toggleItemHidden(entry.index)
+                            : undefined
+                        }
+                        onOpen={() => openItem(entry.index)}
+                        onDuplicate={() => duplicateItem(entry.index)}
+                        onRemove={() => removeItem(entry.index)}
+                      />
+                    );
+                  });
+                })()}
               </div>
             </SortableContext>
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -14,6 +14,7 @@ import {
   resolveArrayItemSelection,
   isBreadcrumbInsideObject,
 } from "./schema-form-breadcrumb";
+import { getArrayItemLabels } from "./array-item-display";
 import { PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE } from "./section-types";
 
 describe("normalizeBreadcrumbLabel", () => {
@@ -844,6 +845,42 @@ describe("resolveArrayItemSelection", () => {
           5,
         ),
       ).toEqual({ index: 1, innerPath: [] });
+    });
+  });
+});
+
+describe("array item label build↔resolve round-trip", () => {
+  // The fix's core promise: a crumb built from getArrayItemLabels must resolve
+  // back to the same item with no transient state — this is what survives a
+  // form remount. Exercises both seams together, not hand-copied literals.
+  const roundTrips = (items: unknown[], schema: SchemaProperty) => {
+    const labels = getArrayItemLabels(items, schema);
+    labels.forEach((label, i) => {
+      expect(
+        resolveArrayItemSelection("Items", [label], items, schema),
+      ).toEqual({ index: i, innerPath: [] });
+    });
+  };
+
+  test("colliding fallback-title items each resolve to their own index", () => {
+    roundTrips([{ body: "a" }, { body: "b" }, { body: "c" }], {
+      type: "object",
+      title: "Spec",
+      properties: { body: { type: "string" } },
+    });
+  });
+
+  test("NFC/NFD near-duplicates round-trip to distinct indices", () => {
+    roundTrips([{ name: "café" }, { name: "café" }], {
+      type: "object",
+      properties: { name: { type: "string" } },
+    });
+  });
+
+  test("suffix-vs-literal collision still round-trips uniquely", () => {
+    roundTrips([{ title: "X" }, { title: "X" }, { title: "X 2" }], {
+      type: "object",
+      properties: { title: { type: "string" } },
     });
   });
 });

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -785,22 +785,40 @@ describe("resolveArrayItemSelection", () => {
     ).toEqual({ index: 0, innerPath: [] });
   });
 
-  describe("duplicate labels (preferredIndex)", () => {
-    // Two items resolve to the same crumb — e.g. after Duplicate, or while
-    // editing a label field (alt/name/title) to a value a sibling already uses.
+  describe("duplicate labels", () => {
+    // Two items share a base label ("Hello") — e.g. after Duplicate, or when an
+    // object array has no distinguishing field so every row falls back to the
+    // item schema title. getArrayItemLabel disambiguates them positionally
+    // ("Hello 1" / "Hello 2"), so each item stays uniquely addressable by its
+    // crumb even after a form remount clears the transiently-opened index.
     const dupItems = [{ title: "Hello" }, { title: "Hello" }];
 
-    test("without preferredIndex, first matching item wins", () => {
+    test("addresses each duplicate by its positional crumb (no preferredIndex)", () => {
       expect(
-        resolveArrayItemSelection("Cards", ["Hello"], dupItems, itemSchema),
+        resolveArrayItemSelection("Cards", ["Hello 1"], dupItems, itemSchema),
       ).toEqual({ index: 0, innerPath: [] });
+      expect(
+        resolveArrayItemSelection("Cards", ["Hello 2"], dupItems, itemSchema),
+      ).toEqual({ index: 1, innerPath: [] });
     });
 
-    test("keeps the opened item when its label collides with an earlier sibling", () => {
-      // Editing item 1 whose label just became equal to item 0's — selection
-      // must stay on 1, not snap back to 0 (the focus-loss bug).
+    test("a bare (non-disambiguated) crumb no longer matches a duplicate", () => {
+      // The old behaviour silently resolved a shared label to the first item;
+      // now the crumb must carry the position, so a bare label finds nothing.
       expect(
-        resolveArrayItemSelection("Cards", ["Hello"], dupItems, itemSchema, 1),
+        resolveArrayItemSelection("Cards", ["Hello"], dupItems, itemSchema),
+      ).toBeNull();
+    });
+
+    test("keeps the opened item when a preferredIndex is supplied", () => {
+      expect(
+        resolveArrayItemSelection(
+          "Cards",
+          ["Hello 2"],
+          dupItems,
+          itemSchema,
+          1,
+        ),
       ).toEqual({ index: 1, innerPath: [] });
     });
 
@@ -816,10 +834,16 @@ describe("resolveArrayItemSelection", () => {
       ).toEqual({ index: 1, innerPath: [] });
     });
 
-    test("ignores an out-of-range preferredIndex", () => {
+    test("falls back to crumb search when preferredIndex is out of range", () => {
       expect(
-        resolveArrayItemSelection("Cards", ["Hello"], dupItems, itemSchema, 5),
-      ).toEqual({ index: 0, innerPath: [] });
+        resolveArrayItemSelection(
+          "Cards",
+          ["Hello 2"],
+          dupItems,
+          itemSchema,
+          5,
+        ),
+      ).toEqual({ index: 1, innerPath: [] });
     });
   });
 });

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -300,7 +300,7 @@ function resolveActiveFieldKeyInScope(
     if (!Array.isArray(val)) continue;
     const itemSchema = schema.items;
     for (let i = 0; i < val.length; i++) {
-      const itemLabel = getArrayItemLabel(val[i], i, itemSchema);
+      const itemLabel = getArrayItemLabel(val[i], i, itemSchema, val);
       if (labelsMatch(itemLabel, head)) return key;
     }
   }
@@ -509,14 +509,14 @@ function findItemIndexForCrumb(
     preferredIndex >= 0 &&
     preferredIndex < items.length &&
     labelsMatch(
-      getArrayItemLabel(items[preferredIndex], preferredIndex, itemSchema),
+      getArrayItemLabel(items[preferredIndex], preferredIndex, itemSchema, items),
       crumb,
     )
   ) {
     return preferredIndex;
   }
   return items.findIndex((item, i) =>
-    labelsMatch(getArrayItemLabel(item, i, itemSchema), crumb),
+    labelsMatch(getArrayItemLabel(item, i, itemSchema, items), crumb),
   );
 }
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -1,4 +1,4 @@
-import { getArrayItemLabel } from "./array-item-display";
+import { getArrayItemLabels } from "./array-item-display";
 import { isPageMultivariateSectionArrayField } from "./page-variants";
 import type { SchemaProperty } from "./resolve-schema";
 import { unwrapBlockReference } from "./unwrap-section";
@@ -251,11 +251,22 @@ function valueOwnsItemCrumb(
   ) {
     return false;
   }
+  // A colliding item's crumb carries a positional suffix ("Dup 1"), but the
+  // ownership labels scanned here are bare (no item schema is available at this
+  // nesting level), so also try the crumb with a trailing " N" stripped. This
+  // only widens matching, and the actual item is still pinned downstream by the
+  // suffix-aware resolveArrayItemSelection.
+  const crumbBase = crumb.replace(/\s+\d+$/, "");
   if (Array.isArray(value)) {
     for (const item of value) {
       if (--budget.n <= 0) return false;
       const label = itemOwnershipLabel(item);
-      if (label && labelsMatch(label, crumb)) return true;
+      if (
+        label &&
+        (labelsMatch(label, crumb) || labelsMatch(label, crumbBase))
+      ) {
+        return true;
+      }
       if (valueOwnsItemCrumb(item, crumb, budget, depth + 1)) return true;
     }
     return false;
@@ -298,11 +309,8 @@ function resolveActiveFieldKeyInScope(
     if (!schema || !isArrayDrillDownField(schema, objValue[key])) continue;
     const val = objValue[key];
     if (!Array.isArray(val)) continue;
-    const itemSchema = schema.items;
-    for (let i = 0; i < val.length; i++) {
-      const itemLabel = getArrayItemLabel(val[i], i, itemSchema, val);
-      if (labelsMatch(itemLabel, head)) return key;
-    }
+    const labels = getArrayItemLabels(val, schema.items);
+    if (labels.some((label) => labelsMatch(label, head))) return key;
   }
 
   for (const key of keys) {
@@ -504,20 +512,12 @@ function findItemIndexForCrumb(
   crumb: string,
   preferredIndex?: number | null,
 ): number {
-  if (
-    preferredIndex != null &&
-    preferredIndex >= 0 &&
-    preferredIndex < items.length &&
-    labelsMatch(
-      getArrayItemLabel(items[preferredIndex], preferredIndex, itemSchema, items),
-      crumb,
-    )
-  ) {
-    return preferredIndex;
+  const labels = getArrayItemLabels(items, itemSchema);
+  const preferred = preferredIndex != null ? labels[preferredIndex] : undefined;
+  if (preferred !== undefined && labelsMatch(preferred, crumb)) {
+    return preferredIndex!;
   }
-  return items.findIndex((item, i) =>
-    labelsMatch(getArrayItemLabel(item, i, itemSchema, items), crumb),
-  );
+  return labels.findIndex((label) => labelsMatch(label, crumb));
 }
 
 export function resolveArrayItemSelection(


### PR DESCRIPTION
## Summary

Fixes the osklen bug where a nested array of same-typed items (e.g. `DetailsSpecifications` → **Product Specifications**) shows **the same content for every item** in the editor.

**Root cause.** Object array items with no `name`/`title`/`alt`/… field all fall back to the item schema's static `title`, so every row's breadcrumb label is identical ("ProductSpecifications"). The editor addresses an array item by that label; the only tie-breaker was a transient local `openIndex` in `ArrayField`. But the panel remounts the whole form via `key={formResetKey}` on every back/breadcrumb navigation, which wipes `openIndex`. After a remount an ambiguous crumb resolves via `findIndex` → **index 0**, so opening any item silently reverts to the first item's content.

**Fix.** `getArrayItemLabel` is now collision-aware: given the sibling array, an item whose base label duplicates another's is suffixed with its position (`ProductSpecifications 1`, `…2`, …). The same label is used both to build and to resolve the crumb, so each item stays uniquely addressable across remounts, deep-links and breadcrumb navigation — with no reliance on `openIndex`. Unique labels are untouched; as a bonus the list rows and breadcrumb become distinguishable too.

## Changes
- `array-item-display.ts` — positional disambiguation in `getArrayItemLabel` (new optional `siblings` arg)
- `fields/array-field.tsx` — passes `siblings` at the 4 sites that derive a label (list rows / open / append / add / label-sync)
- `schema-form-breadcrumb.ts` — passes `siblings` in the crumb→item matching (`resolveActiveFieldKeyInScope`, `findItemIndexForCrumb`)

## Testing
- New pure-logic tests for the disambiguation in `array-item-display.test.ts`.
- Inverted the `schema-form-breadcrumb.test.ts` cases that encoded the old behaviour (a bare shared label resolving to item 0) to the new contract (positional crumb `"Hello 2"` → index 1; a bare duplicate label now resolves to `null`).
- 541 sections-editor tests pass; `bun run check` clean; `bun run lint` reports no new errors.

Reproduced end-to-end against a real TipTap editor during development (opening item #3 showed "RICH-TWO", then a remount reverted it to "RICH-ZERO" — fixed). That component-level repro isn't committed because the unit-test runner can't resolve the repo's `@deco/ui/*.js` imports (Vite-only); regression coverage lives in the pure-logic tier where the fix is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where array items with the same base label showed the same content after navigation. Labels are now computed as a unique, position-aware set so each item stays correctly addressable in the list and breadcrumb.

- **Bug Fixes**
  - Added `getArrayItemLabels` to batch-generate globally unique labels (NFC-normalized); extends positional suffix until unique and handles suffix-vs-literal collisions. `getArrayItemLabel` delegates when `siblings` are provided.
  - `ArrayField` computes labels once per render and uses them for list rows and open/append/add/update; passes `siblings` so labels stay stable during edits, with `preferredIndex` keeping selection pinned.
  - Breadcrumb uses batched labels in `resolveActiveFieldKeyInScope` and `findItemIndexForCrumb`; positional crumbs like "Hello 2" resolve correctly, and bare duplicate labels no longer match.
  - Ownership narrowing (`valueOwnsItemCrumb`) tolerates trailing positional suffixes inside nested configs.
  - Tests cover batch disambiguation, NFC/NFD near-duplicates, suffix-vs-literal uniqueness, a build↔resolve round-trip, and Playwright CT verifies end-to-end drilldown for colliding fallback-title items.

<sup>Written for commit 608c075bae9826e72d2e02aa157c31a1d13abcdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

