### PR TITLE
ci(release-studio): notify docs agent webhook after release

### DIFF
--- a/.github/workflows/release-studio.yaml
+++ b/.github/workflows/release-studio.yaml
@@ -617,7 +617,11 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Notify the docs agent that a new Studio version shipped. The agent decides
-  # whether the docs need updating from the payload (version + commit range).
+  # whether the docs need updating from the CHANGE RANGE between the previous
+  # release and this one — NOT the release-bump commit alone, whose diff is only
+  # the version bump in package.json. We resolve the previous release tag and
+  # send a `compare_url` (previous_tag...tag) so the agent diffs the real
+  # feature changes.
   # This is a convenience hook and must NEVER red the release: it no-ops when
   # the webhook isn't configured, and a failed call is logged, not fatal.
   #   * URL   -> repo variable  DOCS_AGENT_WEBHOOK_URL   (not sensitive)
@@ -637,6 +641,30 @@ jobs:
       - name: Skip notice (webhook not configured)
         if: env.WEBHOOK_URL == '' || env.WEBHOOK_TOKEN == ''
         run: echo "::notice::DOCS_AGENT_WEBHOOK_URL / DOCS_AGENT_WEBHOOK_TOKEN not set — skipping the docs-agent notification."
+      - uses: actions/checkout@v4
+        if: env.WEBHOOK_URL != '' && env.WEBHOOK_TOKEN != ''
+        with:
+          # Full history + tags so we can resolve the previous release tag.
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+      - name: Resolve previous release tag
+        id: range
+        if: env.WEBHOOK_URL != '' && env.WEBHOOK_TOKEN != ''
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force --quiet || true
+          TAG="v${VERSION}"
+          # Nearest release tag reachable from this tag's first parent. Empty on
+          # the very first release (agent then falls back to the sha alone).
+          PREV="$(git describe --tags --abbrev=0 --match 'v*' "${TAG}^" 2>/dev/null || true)"
+          echo "prev_tag=${PREV}" >> "$GITHUB_OUTPUT"
+          if [ -n "$PREV" ]; then
+            echo "compare_url=${{ github.server_url }}/${{ github.repository }}/compare/${PREV}...${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "compare_url=" >> "$GITHUB_OUTPUT"
+          fi
       - name: Call docs-agent webhook
         if: env.WEBHOOK_URL != '' && env.WEBHOOK_TOKEN != ''
         run: |
@@ -646,8 +674,10 @@ jobs:
             "event": "studio.released",
             "version": "${{ needs.prepare.outputs.version }}",
             "tag": "v${{ needs.prepare.outputs.version }}",
+            "previous_tag": "${{ steps.range.outputs.prev_tag }}",
             "repository": "${{ github.repository }}",
             "sha": "${{ inputs.ref || github.sha }}",
+            "compare_url": "${{ steps.range.outputs.compare_url }}",
             "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           }
           EOF
@@ -663,5 +693,5 @@ jobs:
           if [ "${code:0:1}" != "2" ]; then
             echo "::warning::docs-agent webhook returned HTTP $code (non-blocking)"
           else
-            echo "Notified docs agent for v${{ needs.prepare.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "Notified docs agent for v${{ needs.prepare.outputs.version }} (range ${{ steps.range.outputs.prev_tag }}...v${{ needs.prepare.outputs.version }})" >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
Add a terminal `notify-docs-agent` job to the Release Studio pipeline that POSTs to a configurable webhook once a Studio release is actually cut, so a docs agent can decide whether the docs need updating for the new version.

- Fires only after the `release` job succeeds (no re-ping on re-runs where the version already existed).
- URL from repo variable `DOCS_AGENT_WEBHOOK_URL`; bearer from repo secret `DOCS_AGENT_WEBHOOK_TOKEN` (sent as `Authorization: Bearer`).
- Non-blocking: no-ops when unconfigured and downgrades a non-2xx response to a warning, mirroring the `bump-deco-apps-cd` convenience-hook pattern — it must never red the release.

## What is this contribution about?
> Describe your changes and why they're needed.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a terminal `notify-docs-agent` job to the Release Studio workflow that POSTs to a configurable webhook after a successful release so a docs agent can decide if docs need updates. The hook is non-blocking and skips when unconfigured.

- **New Features**
  - Runs only after `release` succeeds; avoids re-pings on reruns where the version already exists.
  - Uses `DOCS_AGENT_WEBHOOK_URL` and `DOCS_AGENT_WEBHOOK_TOKEN` (sent as `Authorization: Bearer`).
  - Resolves the previous release tag and includes `previous_tag` and a `compare_url` (prev...tag), plus version, tag, sha, and `run_url` (gracefully empty on first release).
  - Treats non-2xx webhook responses as warnings; never fails the release.

<sup>Written for commit 76cfde7ce91af2d6690c8c80f52fcc0045c69955. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

