### PR TITLE
fix(native): pin no-publish-on-close divergence in daemon parity allowlist

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -118,12 +118,14 @@ jobs:
   # ---------------------------------------------------------------------
   # 2. daemon-e2e-vs-rust — the parity oracle: build the release local-api
   #    binary, point packages/sandbox's curated 5-file daemon e2e suite at
-  #    it via DAEMON_E2E_CMD, and assert the EXACT documented 133 pass / 7
-  #    fail outcome — not just the counts. apps/native/docs/
-  #    the native parity contract pins the 7 failing test names as intentional
-  #    auth/CORS tightening (+ one harness self-check artifact); a NEW
-  #    failure (regression) or a VANISHED one (doc gone stale) both fail
-  #    this job via apps/native/scripts/ci/check-junit-allowlist.mjs.
+  #    it via DAEMON_E2E_CMD, and assert the EXACT pinned failing-test set
+  #    in scripts/ci/daemon-parity-allowlist.json — not just the counts.
+  #    Each pinned name is an intentional divergence: auth/CORS tightening,
+  #    one harness self-check artifact, and the local app's deliberate
+  #    no-publish-on-close shutdown (worktrees are durable on a user's
+  #    machine, unlike a pod's — see local-api's routes/git.rs module doc).
+  #    A NEW failure (regression) or a VANISHED one (allowlist gone stale)
+  #    both fail this job via apps/native/scripts/ci/check-junit-allowlist.mjs.
   #
   #    `daemon.proxy.e2e.test.ts` + `daemon.ws-proxy.e2e.test.ts` (12 tests,
   #    formerly "all pass") are DELIBERATELY excluded from this curated set

--- a/apps/native/scripts/ci/daemon-parity-allowlist.json
+++ b/apps/native/scripts/ci/daemon-parity-allowlist.json
@@ -7,5 +7,6 @@
   "daemon e2e: smoke, CORS, dual-prefix > no-auth GETs tolerate an arbitrary Authorization header",
   "daemon e2e: smoke, CORS, dual-prefix > POST /_decopilot_vm/bash (legacy prefix) with bearer is not 401/404",
   "daemon e2e: SSE wire shapes — lifecycle, branch, scripts > cloning a repo with no start script drives all three to a terminal, coherent state",
-  "daemon e2e: git (cloned repo) > POST /git/publish pushes past a failing pre-push hook"
+  "daemon e2e: git (cloned repo) > POST /git/publish pushes past a failing pre-push hook",
+  "daemon e2e: git (cloned repo) > SIGTERM triggers a graceful publish to origin before exit"
 ]


### PR DESCRIPTION
## Summary

Follow-up to #5423, which removed the native app's git publish on close. The `daemon-e2e-vs-rust` parity job runs the daemon's e2e suite against the Rust local-api and asserts an **exact** failing-test set via `daemon-parity-allowlist.json`; the daemon's "SIGTERM triggers a graceful publish to origin before exit" now fails against local-api **by design** (local worktrees are durable across launches, unlike a pod's filesystem), so main's Native workflow is currently red on that single unpinned failure.

This pins that test as the 10th documented intentional divergence and refreshes the workflow's comment block, which still described the pre-#5423 "133 pass / 7 fail" state.

The checker's output on the #5423 run confirms this is the only delta: `140 tests, 10 failing, 9 pinned … NEW failure(s) (1): daemon e2e: git (cloned repo) > SIGTERM triggers a graceful publish to origin before exit`.

## Testing

- The allowlist gate itself is exercised by the `daemon-e2e-vs-rust` job on this PR — it should now report an exact set match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the intentional “no publish on close” divergence by adding the SIGTERM publish-on-exit test to the daemon parity allowlist so the native `daemon-e2e-vs-rust` job matches the expected failing-test set and stays green. Also refreshes the workflow comment to state we assert the exact pinned failures and note the shutdown behavior change.

<sup>Written for commit a55eb29bcdf1b2d3ab1073468796e353d4540421. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

