### PR TITLE
ci(release-tagging): author version bumps as decocms-release[bot]

### DIFF
--- a/.github/workflows/release-tagging.yaml
+++ b/.github/workflows/release-tagging.yaml
@@ -288,8 +288,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Same identity as release-native.yaml's cask bump: both pushes
+          # already authenticate as the release bot App, so main's history
+          # shows ONE bot, not github-actions[bot] + decocms-release[bot].
+          git config user.name "decocms-release[bot]"
+          git config user.email "decocms-release[bot]@users.noreply.github.com"
           git add ${{ steps.update_versions.outputs.changed_paths }}
 
           if git diff --cached --quiet; then


### PR DESCRIPTION
## Summary

Main's history currently shows two bot identities: `github-actions[bot]` authoring the `[release]: bump changed workspace versions` commits and `decocms-release[bot]` authoring the `[chore]: bump homebrew cask` commits. Both pushes already authenticate with the same release-bot GitHub App token (#5415) — the version-bump workflow just stamped its commits with the generic `github-actions[bot]` git identity.

This sets `release-tagging.yaml`'s git user to the same `decocms-release[bot]` identity `release-native.yaml`'s cask bump uses, so main shows a single release bot.

No behavioral change beyond the commit author: all CI guards skip release commits by the `[release]:` message prefix (verified — no workflow gates on commit author/actor identity), and the push authentication is untouched.

## Testing

- `grep` confirms no workflow conditions on `github-actions[bot]` as an identity (only comments remain).
- Verified `release-native.yaml` uses exactly `decocms-release[bot]` / `decocms-release[bot]@users.noreply.github.com`, now mirrored here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the git author for version-bump commits in `release-tagging.yaml` to `decocms-release[bot]` so the main branch shows a single release bot. CI behavior is unchanged, as guards rely on the `[release]:` prefix, not the commit author.

<sup>Written for commit d52d7c1cf536eb35b0689f27be320694e85642da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

