### PR TITLE
fix(web): add aria-label to file-tab icon-only toolbar buttons

### DIFF
--- a/apps/web/src/layouts/main-panel-tabs/file-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/file-tab.tsx
@@ -54,7 +54,12 @@ function FileToolbar({
       </div>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={t("mainPanelTabs.fileTab.download")}
+            asChild
+          >
             <a href={file.downloadUrl} download={file.filename}>
               <Download01 size={14} />
             </a>
@@ -69,6 +74,7 @@ function FileToolbar({
           <Button
             variant="ghost"
             size="icon"
+            aria-label={t("mainPanelTabs.fileTab.openInNewTab")}
             onClick={() => window.open(file.downloadUrl, "_blank", "noopener")}
           >
             <LinkExternal01 size={14} />
@@ -80,7 +86,12 @@ function FileToolbar({
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon" onClick={onClose}>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={t("mainPanelTabs.fileTab.close")}
+            onClick={onClose}
+          >
             <XClose size={14} />
           </Button>
         </TooltipTrigger>


### PR DESCRIPTION
**Source**: bug found while sweeping `apps/web/src` for accessibility gaps in the main-panel-tabs directory.

**Payoff**: the three toolbar buttons in `FileTab` (download / open-in-new-tab / close) are icon-only with a Radix `Tooltip` but no `aria-label`. Radix's tooltip wiring only adds `aria-describedby` (a supplementary description), not an accessible name, so screen readers announce these as unlabeled "button" — same class of bug fixed in #4903, #5047, #5096, #5226, #5271, #5385, #5412. The sibling file `code-tab.tsx` already follows the correct `aria-label` pattern for its icon-only IDE-launch buttons, confirming `file-tab.tsx` was simply missed.

**Fix**: added `aria-label={t(...)}` to each of the three buttons, reusing the existing translation strings already used in the adjacent `TooltipContent` (`mainPanelTabs.fileTab.download` / `.openInNewTab` / `.close`) — no new i18n keys needed, no behavior change.

**Verify**: open a thread with a file output, tab into the file preview toolbar with a screen reader (or inspect the accessibility tree) and confirm each icon button now announces its action.

**Checks run locally**: `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/web` (clean). No test file covers this component; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds aria-labels to the three icon-only buttons in the FileTab toolbar so screen readers announce their actions; reuses existing i18n strings with no UI or behavior changes.

- **Bug Fixes**
  - Added aria-labels to Download, Open in new tab, and Close buttons using existing `mainPanelTabs.fileTab.*` translations.
  - Resolves unlabeled “button” announcements; tooltips alone were not providing accessible names.

<sup>Written for commit 9eda91e8ad7369e73ca2157d643609d93d11aa29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

