### PR TITLE
fix(chat): translate todo status aria-labels in highlight component

### DIFF
--- a/apps/web/src/components/chat/highlight/todos.tsx
+++ b/apps/web/src/components/chat/highlight/todos.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@deco/ui/lib/utils.ts";
 import type { Todo } from "@decocms/harness/decopilot/built-in-tools/todo-write";
+import { useT } from "@/i18n/use-t";
 import { CollapsibleHighlight } from "./collapsible-highlight";
 import { type ChipIcon, deriveChipLabel } from "./derive-chip-label";
 
@@ -78,10 +79,11 @@ function TodoCheckbox({ status }: { status: Todo["status"] }) {
 }
 
 function ChipStatusIcon({ status }: { status: ChipIcon }) {
+  const t = useT();
   if (status === "completed") {
     return (
       <span
-        aria-label="completed"
+        aria-label={t("chat.todoStatus.completed")}
         className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-sm bg-primary"
       >
         <svg
@@ -101,14 +103,14 @@ function ChipStatusIcon({ status }: { status: ChipIcon }) {
   if (status === "in_progress") {
     return (
       <span
-        aria-label="in progress"
+        aria-label={t("chat.todoStatus.inProgress")}
         className="inline-block w-2 h-2 rounded-full bg-primary animate-pulse shrink-0"
       />
     );
   }
   return (
     <span
-      aria-label="pending"
+      aria-label={t("chat.todoStatus.pending")}
       className="inline-block w-3.5 h-3.5 rounded-sm border-[1.5px] border-muted-foreground/50 shrink-0"
     />
   );

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -464,4 +464,7 @@ export const chat = {
   "chat.modelPreferences.autoPicked": "auto-picked",
   "chat.modelPreferences.loadFailed":
     "Couldn't load your model choices. What you see below may not match what your chats use.",
+  "chat.todoStatus.completed": "completed",
+  "chat.todoStatus.inProgress": "in progress",
+  "chat.todoStatus.pending": "pending",
 } as const;

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -478,4 +478,7 @@ export const chat = {
   "chat.modelPreferences.autoPicked": "escolhido automaticamente",
   "chat.modelPreferences.loadFailed":
     "Não foi possível carregar suas escolhas de modelo. O que aparece abaixo pode não corresponder ao que seus chats usam.",
+  "chat.todoStatus.completed": "concluído",
+  "chat.todoStatus.inProgress": "em progresso",
+  "chat.todoStatus.pending": "pendente",
 } satisfies Record<keyof typeof chatEn, string>;


### PR DESCRIPTION
## Summary
Replace hardcoded aria-labels in the TodosHighlight component with translatable i18n keys, ensuring accessibility strings in the chat todo list are localized for both English and Portuguese-Brazilian users.

## Changes
- Added 3 new i18n keys to `apps/web/src/i18n/en/chat.ts`: `chat.todoStatus.completed`, `chat.todoStatus.inProgress`, `chat.todoStatus.pending`
- Added corresponding Portuguese translations to `apps/web/src/i18n/pt-br/chat.ts`
- Updated `apps/web/src/components/chat/highlight/todos.tsx` to use `useT()` hook and reference the new i18n keys in ChipStatusIcon aria-labels

## Verification
- TypeScript type checking: ✅ `bunx tsc --noEmit` (no errors)
- Related unit tests: ✅ `bun test src/components/chat/highlight/derive-chip-label.test.ts` (6 pass)
- Related unit tests: ✅ `bun test src/components/chat/highlight/derive-current-todos.test.ts` (4 pass)
- Code formatting: ✅ `bun run fmt`

## Testing
Run `bunx tsc --noEmit` in the `apps/web` workspace to verify type safety, then `bun test src/components/chat/highlight/derive-chip-label.test.ts` to confirm component integration tests still pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized todo status chip aria-labels in the chat highlight to use i18n keys. This fixes untranslated assistive text and ensures correct labels in English and pt-BR.

- **Bug Fixes**
  - Replaced hardcoded aria-labels with `useT()` lookups in `apps/web/src/components/chat/highlight/todos.tsx`.
  - Added `chat.todoStatus.completed`, `chat.todoStatus.inProgress`, and `chat.todoStatus.pending` to `apps/web/src/i18n/en/chat.ts` and `apps/web/src/i18n/pt-br/chat.ts`.

<sup>Written for commit 8d4e2af8acc553feb55ed6aac6985da53b229eaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

