### PR TITLE
fix(native): restore renamed file from HEAD on discard instead of deleting it

### DIFF
--- a/apps/native/crates/local-api/src/routes/git.rs
+++ b/apps/native/crates/local-api/src/routes/git.rs
@@ -750,6 +750,10 @@ struct GitStatusFile {
     path: String,
     index: String,
     working_dir: String,
+    /// Pre-rename path, present only for R/C entries (`-z` emits it as the
+    /// next null-separated field) — byte-parity with
+    /// `porcelain.ts::PorcelainFileStatus.origPath`.
+    orig_path: Option<String>,
 }
 
 fn parse_porcelain_entry(entry: &str) -> Option<(char, char, String)> {
@@ -772,7 +776,7 @@ fn parse_porcelain_entry(entry: &str) -> Option<(char, char, String)> {
 
 /// Parses full `git status --porcelain=v1 -z` output. Rename/copy entries
 /// (`index` is `R`/`C`) are followed by the original path as a second `-z`
-/// segment — skip it, matching `porcelain.ts::parsePorcelainFiles`.
+/// segment, captured as `orig_path` — matching `porcelain.ts::parsePorcelainFiles`.
 fn parse_porcelain_files(out: &str) -> Vec<GitStatusFile> {
     let parts: Vec<&str> = out.split('\0').collect();
     let mut files = Vec::new();
@@ -782,14 +786,17 @@ fn parse_porcelain_files(out: &str) -> Vec<GitStatusFile> {
         if !entry.is_empty() {
             if let Some((index, working, path)) = parse_porcelain_entry(entry) {
                 let is_rename_or_copy = index == 'R' || index == 'C';
+                let mut orig_path = None;
+                if is_rename_or_copy {
+                    i += 1;
+                    orig_path = parts.get(i).filter(|s| !s.is_empty()).map(|s| s.to_string());
+                }
                 files.push(GitStatusFile {
                     path,
                     index: index.to_string(),
                     working_dir: working.to_string(),
+                    orig_path,
                 });
-                if is_rename_or_copy {
-                    i += 1;
-                }
             }
         }
         i += 1;
@@ -1315,7 +1322,25 @@ async fn discard_files(
 
     let mut to_restore = Vec::new();
     let mut to_delete = Vec::new();
+    // A renamed file's new path never existed at HEAD, so the `is_new` check
+    // below would treat it as untracked and unlink it outright — losing the
+    // content entirely, since the original path is already gone from the
+    // working tree too. Discarding a rename must instead restore the
+    // original file from HEAD and unstage + drop the new path.
+    let mut to_restore_from_head = Vec::new();
+    let mut renamed_new_paths = Vec::new();
     for fp in &validated {
+        if let Some(orig_path) = status
+            .files
+            .iter()
+            .find(|f| &f.path == fp)
+            .and_then(|f| f.orig_path.clone())
+        {
+            to_restore_from_head.push(orig_path);
+            renamed_new_paths.push(fp.clone());
+            to_delete.push(fp.clone());
+            continue;
+        }
         let is_new = status.not_added.contains(fp)
             || status.created.contains(fp)
             || read_ref_file(repo_dir, "HEAD", fp, &env).await.is_none();
@@ -1326,6 +1351,22 @@ async fn discard_files(
         }
     }
 
+    if !to_restore_from_head.is_empty() {
+        // Unstage the rename's "new path added" side before restoring the
+        // original — otherwise it survives in the index even after the
+        // working tree file below is deleted.
+        let mut reset_args: Vec<String> = vec!["reset".to_string(), "--".to_string()];
+        reset_args.extend(renamed_new_paths);
+        run_git(repo_dir, &reset_args, &env)
+            .await
+            .map_err(|e| e.message)?;
+        let mut checkout_args: Vec<String> =
+            vec!["checkout".to_string(), "HEAD".to_string(), "--".to_string()];
+        checkout_args.extend(to_restore_from_head);
+        run_git(repo_dir, &checkout_args, &env)
+            .await
+            .map_err(|e| e.message)?;
+    }
     if !to_restore.is_empty() {
         let mut args: Vec<String> = vec!["checkout".to_string(), "--".to_string()];
         args.extend(to_restore);
@@ -1942,7 +1983,8 @@ mod tests {
             GitStatusFile {
                 path: "untracked.txt".into(),
                 index: "?".into(),
-                working_dir: "?".into()
+                working_dir: "?".into(),
+                orig_path: None
             }
         );
         assert_eq!(
@@ -1950,7 +1992,8 @@ mod tests {
             GitStatusFile {
                 path: "modified.txt".into(),
                 index: " ".into(),
-                working_dir: "M".into()
+                working_dir: "M".into(),
+                orig_path: None
             }
         );
     }
@@ -1962,7 +2005,9 @@ mod tests {
         assert_eq!(files.len(), 2);
         assert_eq!(files[0].path, "new.txt");
         assert_eq!(files[0].index, "R");
+        assert_eq!(files[0].orig_path.as_deref(), Some("old.txt"));
         assert_eq!(files[1].path, "other.txt");
+        assert_eq!(files[1].orig_path, None);
     }
 
     #[test]
@@ -2350,6 +2395,31 @@ mod tests {
             std::fs::read_to_string(repo.work_dir.join("README.md")).unwrap(),
             "hello\n"
         );
+    }
+
+    #[tokio::test]
+    async fn discard_restores_renamed_file_instead_of_deleting_it() {
+        let repo = setup_repo();
+        std::fs::rename(
+            repo.work_dir.join("README.md"),
+            repo.work_dir.join("RENAMED.md"),
+        )
+        .unwrap();
+        git(&repo.work_dir, &["add", "-A"]);
+        discard_files(&repo.work_dir, &repo.work_dir, &["RENAMED.md".to_string()])
+            .await
+            .unwrap();
+        assert!(
+            !repo.work_dir.join("RENAMED.md").exists(),
+            "renamed path must not survive discard"
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.work_dir.join("README.md")).unwrap(),
+            "hello\n",
+            "original content must be restored from HEAD, not lost"
+        );
+        let status = compute_working_tree_status(&repo.work_dir).await.unwrap();
+        assert!(status.files.is_empty(), "discard must leave a clean tree");
     }
 
     #[tokio::test]

--- a/apps/native/crates/local-api/src/routes/git.rs
+++ b/apps/native/crates/local-api/src/routes/git.rs
@@ -789,7 +789,10 @@ fn parse_porcelain_files(out: &str) -> Vec<GitStatusFile> {
                 let mut orig_path = None;
                 if is_rename_or_copy {
                     i += 1;
-                    orig_path = parts.get(i).filter(|s| !s.is_empty()).map(|s| s.to_string());
+                    orig_path = parts
+                        .get(i)
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string());
                 }
                 files.push(GitStatusFile {
                     path,


### PR DESCRIPTION
## Source

Data-loss bug found while auditing `apps/native`'s git routes for parity with `packages/sandbox/daemon/routes/git.ts` (this file's own module doc claims byte-parity with that daemon file). The daemon already carries a fix for this exact bug (see its `discard()` comment: "A renamed file's new path never existed at HEAD..."); the Rust local-api port of `discard_files` never received the equivalent fix.

## The bug

`discard_files` classified a file as "new" (untracked) whenever `git show HEAD:<path>` failed for that path. For a renamed file, `status.files` only records the **new** path (the porcelain `-z` old-path segment was parsed and skipped, never kept), and the new path never existed at HEAD by definition — so a rename was always misclassified as "new" and the discard handler just `unlink`'d the new path. The original content (already gone from its old path in the working tree, since it was renamed) was permanently lost, with nothing recoverable from git.

Failure scenario: rename `README.md` → `RENAMED.md` in a sandbox worktree, then call `POST /_sandbox/git/discard` with `["RENAMED.md"]`. Before this fix, both `README.md` and `RENAMED.md` end up missing from the working tree. After this fix, `README.md` is restored from HEAD and `RENAMED.md` is removed — i.e. the rename is cleanly discarded.

## Fix

Ports the daemon's fix: `GitStatusFile` now keeps the porcelain rename entry's pre-rename path (`orig_path`, matching `PorcelainFileStatus.origPath` in `porcelain.ts`). `discard_files` checks for a renamed entry first, and for those, unstages the new path (`git reset --`) and restores the original path from HEAD (`git checkout HEAD --`) before deleting the new path — instead of falling into the untracked/new-file branch.

## Testing

- New regression test `discard_restores_renamed_file_instead_of_deleting_it` in `apps/native/crates/local-api/src/routes/git.rs`: renames a tracked file, stages it, discards it, and asserts the original content is restored (not lost) and the tree ends up clean.
- Updated `parses_rename_entry_consuming_orig_path` to assert `orig_path` is captured for the rename entry and absent for a plain modify entry.
- `cd apps/native && cargo test -p local-api --lib routes::git::` — 25 passed, 0 failed (includes the new test and all existing `discard_*`/porcelain tests).

A reviewer can confirm with the same targeted command above. Full CI (`cargo test -p local-api --lib`, clippy, native e2e) validates the rest — `cargo fmt`/`cargo clippy` weren't runnable locally (rustfmt/clippy components aren't installed in this environment), so please double-check formatting in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data loss when discarding renamed files in the native Git routes by restoring the original file from `HEAD` and removing the new path. Also formats the changed file with `cargo fmt`.

- **Bug Fixes**
  - Capture `orig_path` from porcelain `R/C` entries when parsing status.
  - In `discard_files`, detect renames, unstage the new path (`git reset --`), restore the original from `HEAD` (`git checkout HEAD --`), then delete the new path.
  - Add regression test for rename discard; update parsing tests to assert `orig_path`.

<sup>Written for commit 764620899f33179744ac8523d17d6b720afed650. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

