### PR TITLE
fix(native): keep chat model selector local

### DIFF
--- a/apps/web/src/components/chat/chat-context.tsx
+++ b/apps/web/src/components/chat/chat-context.tsx
@@ -46,7 +46,7 @@ import type { HarnessId } from "@decocms/harness/types";
 import {
   AGENT_OPTION_PINS,
   agentOptionFor,
-  preferredLocalAgentOption,
+  resolveNativeAgentOption,
   resolveOfflineAgentOption,
   type AgentOption,
 } from "./pills/agent-options";
@@ -498,10 +498,9 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
   // used to mis-route to an offline link. A fresh org starts with no pick
   // (`null`), letting the server choose its default.
   //
-  // Everything else (`pendingHarnessId`, `pendingSandboxProviderKind`,
-  // the request body's harnessId/sandboxProviderKind) derives from this
-  // through `AGENT_OPTION_PINS`, so the pill display and the submit can
-  // never disagree.
+  // Web derives the pending harness/sandbox pair from this value. Native
+  // filters it through its local-only resolver below. Both surfaces still read
+  // the same effective pair, so the pill display and submit cannot disagree.
   const [pendingAgentOption, setPendingAgentOption] =
     useLocalStorage<AgentOption | null>(
       LOCALSTORAGE_KEYS.chatLastAgentOption(locator),
@@ -526,44 +525,41 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
         )
       : null;
 
-  // Capability probes are advisory — we don't rewrite the harness for a missing
-  // CLI (cloud chat via the org router works even where the cloud *sandbox*
-  // doesn't). The one exception is a desktop pick whose link is *confirmed*
-  // offline: it can't run anywhere and nothing prompted the user to reconnect,
-  // so we auto-switch it to cloud. Derived (not persisted), so the desktop pick
-  // returns on its own once the link reconnects.
+  // Capability probes are advisory on web — we don't rewrite the harness for a
+  // missing CLI (cloud chat via the org router works even where the cloud
+  // *sandbox* doesn't). The one exception is a desktop pick whose link is
+  // *confirmed* offline: it can't run anywhere and nothing prompted the user to
+  // reconnect, so we auto-switch it to cloud. Derived (not persisted), so the
+  // desktop pick returns on its own once the link reconnects.
   const link = useCurrentLink();
 
-  // The desktop app has no cloud/Decopilot surface to fall back to, so an
-  // un-set pick must never resolve to `decopilot` the way it does on web —
-  // that pins the thread to `agent-sandbox` (see `AGENT_OPTION_PINS`) and the
-  // sandbox is provisioned in the cloud instead of on this machine. Defaulting
-  // to the locally-detected CLI keeps the pin on `user-desktop`, which is the
-  // kind local-api intercepts. Derived, not persisted, so it re-resolves on its
-  // own as `LINK_CURRENT_GET` reports CLIs; an explicit user pick always wins.
   const isDesktopApp = useIsDesktopApp();
   const availability = useAgentOptionAvailability();
-  const desktopDefaultOption = isDesktopApp
-    ? preferredLocalAgentOption(availability)
-    : null;
-
-  const selectedAgentOption = resolveOfflineAgentOption(
-    pendingAgentOption ?? desktopDefaultOption,
+  // Native has no cloud/Decopilot surface. Ignore stale cloud prefs there and
+  // recover early native threads that pinned a local harness without the
+  // expected sandbox tuple. While cold CLI detection is unresolved this stays
+  // null; TierTrigger renders that state as local-pending, never as cloud.
+  const nativeAgentOption = resolveNativeAgentOption({
+    pendingOption: pendingAgentOption,
+    lockedHarness: taskCtxForLock?.isThreadLocked
+      ? taskCtxForLock.lockedHarness
+      : null,
+    availability,
+  });
+  const webSelectedAgentOption = resolveOfflineAgentOption(
+    pendingAgentOption,
     link.ready && !link.online,
   );
 
-  // When the thread is locked, the agent option is dictated by the persisted
-  // (harness, sandbox) pair — period. Otherwise, fall through to the user's
-  // selected global picker.
-  //
-  // When the thread is locked but the (harness, sandbox) tuple doesn't map
-  // to a known AgentOption (legacy/trigger-created rows), we intentionally
-  // surface `null` here rather than falling through to the global picker.
-  // The submit path is server-enforced anyway; consumers (pills, etc.)
-  // should consult isThreadLocked for the "locked" affordance and avoid
-  // showing the global selection on a locked thread.
-  const effectiveAgentOption: AgentOption | null =
-    taskCtxForLock?.isThreadLocked ? lockedAgentOption : selectedAgentOption;
+  // On web, a locked thread is dictated by its persisted (harness, sandbox)
+  // pair; an unknown tuple surfaces null instead of falling through to the
+  // global picker. Native is different: every runnable harness is local, and
+  // `nativeAgentOption` recovers older rows by their local harness alone.
+  const effectiveAgentOption: AgentOption | null = isDesktopApp
+    ? nativeAgentOption
+    : taskCtxForLock?.isThreadLocked
+      ? lockedAgentOption
+      : webSelectedAgentOption;
 
   const effectivePins = effectiveAgentOption
     ? AGENT_OPTION_PINS[effectiveAgentOption]

--- a/apps/web/src/components/chat/pills/agent-options.test.ts
+++ b/apps/web/src/components/chat/pills/agent-options.test.ts
@@ -8,6 +8,7 @@ import {
   agentOptionFor,
   agentOptionIsAvailable,
   preferredLocalAgentOption,
+  resolveNativeAgentOption,
   resolveOfflineAgentOption,
 } from "./agent-options";
 
@@ -136,6 +137,65 @@ describe("preferredLocalAgentOption", () => {
         codex: false,
       }),
     ).toBeNull();
+  });
+});
+
+describe("resolveNativeAgentOption", () => {
+  test("does not turn unresolved native detection into cloud Decopilot", () => {
+    const unresolved = {
+      ...ALL_AVAILABLE,
+      claudeCode: false,
+      codex: false,
+    };
+    for (const pendingOption of [null, "decopilot"] as const) {
+      expect(
+        resolveNativeAgentOption({
+          pendingOption,
+          lockedHarness: null,
+          availability: unresolved,
+        }),
+      ).toBeNull();
+    }
+  });
+
+  test("ignores a stale persisted Decopilot choice", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: "decopilot",
+        lockedHarness: null,
+        availability: ALL_AVAILABLE,
+      }),
+    ).toBe("claude-code-desktop");
+  });
+
+  test("uses Codex when it is the only detected local CLI", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: null,
+        lockedHarness: null,
+        availability: { ...ALL_AVAILABLE, claudeCode: false },
+      }),
+    ).toBe("codex-desktop");
+  });
+
+  test("preserves an explicit local choice", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: "codex-desktop",
+        lockedHarness: null,
+        availability: ALL_AVAILABLE,
+      }),
+    ).toBe("codex-desktop");
+  });
+
+  test("a locked local harness wins without requiring its sandbox tuple", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: "codex-desktop",
+        lockedHarness: "claude-code",
+        availability: ALL_AVAILABLE,
+      }),
+    ).toBe("claude-code-desktop");
   });
 });
 

--- a/apps/web/src/components/chat/pills/agent-options.ts
+++ b/apps/web/src/components/chat/pills/agent-options.ts
@@ -6,6 +6,7 @@ import {
 } from "@/sdk";
 
 export type AgentOption = "decopilot" | "claude-code-desktop" | "codex-desktop";
+type LocalAgentOption = Exclude<AgentOption, "decopilot">;
 
 export interface AgentPins {
   harness: HarnessId;
@@ -78,10 +79,39 @@ export interface AgentOptionAvailability {
  */
 export function preferredLocalAgentOption(
   availability: AgentOptionAvailability,
-): AgentOption | null {
+): LocalAgentOption | null {
   if (availability.claudeCode) return "claude-code-desktop";
   if (availability.codex) return "codex-desktop";
   return null;
+}
+
+/**
+ * Resolve the only agent options a native build may expose.
+ *
+ * Native has no cloud runtime, so a stale persisted Decopilot pick must never
+ * win. A locked local harness also wins by harness alone: early native builds
+ * could pin a Claude Code/Codex thread before `sandbox_provider_kind` was
+ * available, and requiring the full tuple would misclassify that local thread
+ * as cloud.
+ *
+ * Returns null while CLI detection is still unresolved and there is no prior
+ * local choice. The native model selector treats that as local-pending rather
+ * than falling back to provider models.
+ */
+export function resolveNativeAgentOption({
+  pendingOption,
+  lockedHarness,
+  availability,
+}: {
+  pendingOption: AgentOption | null;
+  lockedHarness: HarnessId | null;
+  availability: AgentOptionAvailability;
+}): LocalAgentOption | null {
+  if (lockedHarness === "claude-code") return "claude-code-desktop";
+  if (lockedHarness === "codex") return "codex-desktop";
+  if (pendingOption === "claude-code-desktop") return pendingOption;
+  if (pendingOption === "codex-desktop") return pendingOption;
+  return preferredLocalAgentOption(availability);
 }
 
 /**

--- a/apps/web/src/components/chat/tier-trigger.tsx
+++ b/apps/web/src/components/chat/tier-trigger.tsx
@@ -32,6 +32,7 @@ import { useT, type TFunction } from "@/i18n/use-t.ts";
 import type { ChatTier } from "@decocms/shared/organization/schema";
 import {
   resolveTierSubtitle,
+  shouldUseLocalModels,
   useAgentMode,
   useChatTier,
   useSetChatTier,
@@ -475,7 +476,7 @@ export function TierTrigger() {
   const locked = taskCtx?.isThreadLocked ?? false;
   const isDesktopApp = useIsDesktopApp();
   const hasLocal = availability.claudeCode || availability.codex;
-  const isLocal = mode !== "cloud-decopilot";
+  const isLocal = shouldUseLocalModels(mode, isDesktopApp);
   // Cloud rows only: org config + this user's overrides, wired into each
   // row's cog popover below.
   const org = useSimpleMode();

--- a/apps/web/src/components/chat/use-agent-mode.test.ts
+++ b/apps/web/src/components/chat/use-agent-mode.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   agentModeFromOption,
   resolveTierSubtitle,
+  shouldUseLocalModels,
   type AgentMode,
 } from "./use-agent-mode";
 import type { AgentOption } from "./pills/agent-options";
@@ -30,6 +31,18 @@ describe("agentModeFromOption", () => {
 
   it("agentModeFromOption(null) defaults to cloud-decopilot", () => {
     expect(agentModeFromOption(null)).toBe("cloud-decopilot");
+  });
+});
+
+describe("shouldUseLocalModels", () => {
+  it("keeps native on local models while runtime detection is pending", () => {
+    expect(shouldUseLocalModels("cloud-decopilot", true)).toBe(true);
+  });
+
+  it("keeps cloud models on web and local models for explicit local modes", () => {
+    expect(shouldUseLocalModels("cloud-decopilot", false)).toBe(false);
+    expect(shouldUseLocalModels("local-claude-code", false)).toBe(true);
+    expect(shouldUseLocalModels("local-codex", false)).toBe(true);
   });
 });
 

--- a/apps/web/src/components/chat/use-agent-mode.ts
+++ b/apps/web/src/components/chat/use-agent-mode.ts
@@ -34,6 +34,18 @@ export function useAgentMode(): AgentMode {
   return agentModeFromOption(pendingAgentOption);
 }
 
+/**
+ * Whether the chat-input selector must use the fixed local CLI catalogs.
+ * Native never exposes cloud/provider models, including while local CLI
+ * detection is still pending and the effective option is temporarily null.
+ */
+export function shouldUseLocalModels(
+  mode: AgentMode,
+  isDesktopApp: boolean,
+): boolean {
+  return isDesktopApp || mode !== "cloud-decopilot";
+}
+
 /** Current chat tier from prefs. Defaults to "smart" via prefs. */
 export function useChatTier(): ChatTier {
   return useChatPrefs().simpleModeTier;

--- a/packages/sandbox/daemon/org-fs/sidecar.test.ts
+++ b/packages/sandbox/daemon/org-fs/sidecar.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { sleep } from "@decocms/shared/std";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { runSidecar, type SidecarMountManager } from "./sidecar";
 
@@ -26,6 +27,41 @@ function fakeManager() {
   return { manager, calls, stopped: () => stopped };
 }
 
+function sidecarLogSignals() {
+  const invalidConfigRead = Promise.withResolvers<void>();
+  const mounted = Promise.withResolvers<void>();
+  return {
+    invalidConfigRead: invalidConfigRead.promise,
+    mounted: mounted.promise,
+    log(message: string) {
+      if (message === "invalid org-fs config file; waiting for rewrite") {
+        invalidConfigRead.resolve();
+      }
+      if (message.startsWith("mounted ")) {
+        mounted.resolve();
+      }
+    },
+  };
+}
+
+async function waitForSignal(
+  signal: Promise<void>,
+  description: string,
+): Promise<void> {
+  const timeoutController = new AbortController();
+  const timeout = sleep(1_000, { signal: timeoutController.signal }).then(
+    () => {
+      throw new Error(`timed out waiting for ${description}`);
+    },
+  );
+  try {
+    await Promise.race([signal, timeout]);
+  } finally {
+    timeoutController.abort();
+    await timeout.catch(() => {});
+  }
+}
+
 const CONFIG = JSON.stringify({
   baseUrl: "http://studio",
   orgSlug: "acme",
@@ -47,6 +83,7 @@ describe("runSidecar", () => {
 
   it("waits for the config file, mounts, writes status, unmounts on abort", async () => {
     const { manager, calls, stopped } = fakeManager();
+    const signals = sidecarLogSignals();
     const ac = new AbortController();
     const run = runSidecar({
       configPath: configPath(),
@@ -55,27 +92,32 @@ describe("runSidecar", () => {
       manager,
       signal: ac.signal,
       pollMs: 5,
+      log: signals.log,
     });
-    // no config yet → nothing mounted
-    await Bun.sleep(20);
-    expect(calls.length).toBe(0);
 
-    writeFileSync(configPath(), CONFIG);
-    await Bun.sleep(40);
-    expect(calls.length).toBe(1);
-    expect(calls[0]?.appRoot).toBe("/app");
-    const status = JSON.parse(readFileSync(statusPath(), "utf8"));
-    expect(status.mounts).toEqual([
-      { volume: "skills", mountPath: "/app/org/skills" },
-    ]);
+    try {
+      // no config yet → nothing mounted
+      await sleep(20);
+      expect(calls.length).toBe(0);
 
-    ac.abort();
-    await run;
+      writeFileSync(configPath(), CONFIG);
+      await waitForSignal(signals.mounted, "sidecar mount");
+      expect(calls.length).toBe(1);
+      expect(calls[0]?.appRoot).toBe("/app");
+      const status = JSON.parse(readFileSync(statusPath(), "utf8"));
+      expect(status.mounts).toEqual([
+        { volume: "skills", mountPath: "/app/org/skills" },
+      ]);
+    } finally {
+      ac.abort();
+      await run;
+    }
     expect(stopped()).toBe(1);
   });
 
   it("ignores an invalid config file and keeps waiting", async () => {
     const { manager, calls } = fakeManager();
+    const signals = sidecarLogSignals();
     const ac = new AbortController();
     writeFileSync(configPath(), "{not json");
     const run = runSidecar({
@@ -85,14 +127,18 @@ describe("runSidecar", () => {
       manager,
       signal: ac.signal,
       pollMs: 5,
+      log: signals.log,
     });
-    await Bun.sleep(25);
-    expect(calls.length).toBe(0);
-    writeFileSync(configPath(), CONFIG);
-    await Bun.sleep(40);
-    expect(calls.length).toBe(1);
-    ac.abort();
-    await run;
+    try {
+      await waitForSignal(signals.invalidConfigRead, "invalid config read");
+      expect(calls.length).toBe(0);
+      writeFileSync(configPath(), CONFIG);
+      await waitForSignal(signals.mounted, "sidecar mount");
+      expect(calls.length).toBe(1);
+    } finally {
+      ac.abort();
+      await run;
+    }
   });
 
   it("exits without mounting when aborted while waiting", async () => {
@@ -106,7 +152,7 @@ describe("runSidecar", () => {
       signal: ac.signal,
       pollMs: 5,
     });
-    await Bun.sleep(15);
+    await sleep(15);
     ac.abort();
     await run;
     expect(calls.length).toBe(0);
@@ -115,6 +161,7 @@ describe("runSidecar", () => {
 
   it("creates the status file's parent dir", async () => {
     const { manager } = fakeManager();
+    const signals = sidecarLogSignals();
     const ac = new AbortController();
     const nested = join(dir, "deep", "status.json");
     writeFileSync(configPath(), CONFIG);
@@ -125,10 +172,14 @@ describe("runSidecar", () => {
       manager,
       signal: ac.signal,
       pollMs: 5,
+      log: signals.log,
     });
-    await Bun.sleep(40);
-    expect(JSON.parse(readFileSync(nested, "utf8")).mounts.length).toBe(1);
-    ac.abort();
-    await run;
+    try {
+      await waitForSignal(signals.mounted, "sidecar mount");
+      expect(JSON.parse(readFileSync(nested, "utf8")).mounts.length).toBe(1);
+    } finally {
+      ac.abort();
+      await run;
+    }
   });
 });


### PR DESCRIPTION
## What is this contribution about?

Native could render cloud provider models in the chat-input tier selector while local CLI detection was still cold, when a stale Decopilot preference was persisted, or when an older local thread lacked the expected sandbox pin.

- Keep the native selector on the fixed Claude Code/Codex catalogs, including while detection is pending.
- Ignore stale Decopilot preferences in native while preserving the existing web cloud/local behavior.
- Recover locked native Claude Code/Codex threads by harness even when their sandbox tuple is legacy.
- Add pure regression coverage for cold detection, stale preferences, Codex-only availability, explicit local choices, and legacy locked threads.

## Screenshots/Demonstration

Not included: this fixes state-dependent selector contents rather than layout or styling.

## How to Test

1. Run `bun test apps/web/src/components/chat/pills/agent-options.test.ts apps/web/src/components/chat/use-agent-mode.test.ts apps/web/src/components/chat/tier-trigger.test.tsx`.
2. Run `bun run check`.
3. Build the native frontend with `bun run --cwd=apps/web build:native`.
4. In native, open the chat model selector during a cold launch or with a stale stored Decopilot option.
5. Confirm it never shows cloud provider models and resolves to detected Claude Code/Codex models. On web, confirm Cloud still shows provider models and This device still shows local models.

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (not needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the native chat model selector local-only, showing only Claude Code/Codex and never cloud provider models. This also ignores stale Decopilot prefs and restores older native threads without a sandbox tuple.

- **Bug Fixes**
  - Added resolveNativeAgentOption and used it in the native path to pick local CLIs by harness, ignore persisted `decopilot`, and recover legacy locked threads.
  - Kept web behavior unchanged; locked tuples still rule and offline auto-switch still uses resolveOfflineAgentOption.
  - Updated TierTrigger with shouldUseLocalModels so native always uses local catalogs, including while detection is pending.
  - Added regression tests for cold detection, stale prefs, Codex-only availability, explicit local choices, and legacy locked threads.
  - Synchronized `org-fs` sidecar polling tests to reduce flakiness by waiting on log signals with timeouts instead of fixed sleeps.

<sup>Written for commit b05b697fd5303292bf7df5f3f724fe2a8d29c05a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

