### PR TITLE
fix(task-board): spin the in-progress icon, pulse it in warning when blocked

### DIFF
--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { insertSortOrder, runSortOrders } from "./config";
+import { insertSortOrder, runSortOrders, statusIconClassName } from "./config";
 import type { TaskBoardItem } from "./config";
 
 function item(id: string, sortOrder: number): TaskBoardItem {
@@ -67,5 +67,25 @@ describe("runSortOrders", () => {
   test("the whole run sits at or before the drop slot", () => {
     for (const order of runSortOrders(10, 5))
       expect(order).toBeLessThanOrEqual(10);
+  });
+});
+
+describe("statusIconClassName", () => {
+  const working = { ...item("a", 0), status: "in_progress" } as TaskBoardItem;
+  const blocked = {
+    ...working,
+    threads: [{ status: "requires_action" }],
+  } as TaskBoardItem;
+
+  test("an in-progress task spins", () => {
+    expect(statusIconClassName(working)).toContain("animate-spin");
+  });
+
+  test("one waiting on input pulses in warning instead", () => {
+    expect(statusIconClassName(blocked)).toBe("text-warning animate-pulse");
+  });
+
+  test("other statuses keep their static class", () => {
+    expect(statusIconClassName(item("a", 0))).toBe("text-muted-foreground");
   });
 });

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -30,6 +30,17 @@ export function isTaskBlocked(item: TaskBoardItem): boolean {
   return item.threads.some((t) => t.status === "requires_action");
 }
 
+/**
+ * Status-icon classes for a task card/row. An in-progress task's spinner spins,
+ * but one waiting on input stops spinning and pulses in `warning` — same token
+ * as its "Needs input" badge, so a stalled task doesn't look like it's working.
+ */
+export function statusIconClassName(item: TaskBoardItem): string {
+  return item.status === "in_progress" && isTaskBlocked(item)
+    ? "text-warning animate-pulse"
+    : STATUS_CONFIG[item.status].iconClassName;
+}
+
 /** The thread to surface in the card — the most recent linked run. */
 export function primaryThread(
   item: TaskBoardItem,
@@ -110,7 +121,7 @@ export const STATUS_CONFIG: Record<
   in_progress: {
     labelKey: "taskBoard.config.statusInProgress",
     icon: Loading02,
-    iconClassName: "text-primary",
+    iconClassName: "text-primary animate-spin",
   },
   in_review: {
     labelKey: "taskBoard.config.statusInReview",

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -71,6 +71,7 @@ import {
   PRIORITIES,
   PRIORITY_CONFIG,
   runSortOrders,
+  statusIconClassName,
   STATUS_CONFIG,
   STATUSES,
   SUPER_AGENT_ASSIGNEE_ID,
@@ -1302,8 +1303,7 @@ function TaskCard({
   onDragOverCard?: (e: DragEvent<HTMLButtonElement>) => void;
 }) {
   const t = useT();
-  const statusConfig = STATUS_CONFIG[item.status];
-  const StatusIcon = statusConfig.icon;
+  const StatusIcon = STATUS_CONFIG[item.status].icon;
   const lastMessage = primaryThread(item)?.lastMessage;
 
   const showAutoFix =
@@ -1340,7 +1340,7 @@ function TaskCard({
       <div className="flex items-start gap-2">
         <StatusIcon
           size={16}
-          className={cn("mt-px shrink-0", statusConfig.iconClassName)}
+          className={cn("mt-px shrink-0", statusIconClassName(item))}
         />
         <span className="min-w-0 flex-1 text-sm font-medium leading-snug text-foreground line-clamp-2">
           {item.title}
@@ -1404,15 +1404,17 @@ function ListRow({
   assignedBy?: Member;
   onOpen: () => void;
 }) {
-  const config = STATUS_CONFIG[item.status];
-  const StatusIcon = config.icon;
+  const StatusIcon = STATUS_CONFIG[item.status].icon;
   return (
     <button
       type="button"
       onClick={onOpen}
       className="flex items-center gap-3 rounded-xl bg-card px-4 py-3 text-left card-shadow transition-colors hover:bg-accent/60"
     >
-      <StatusIcon size={16} className={cn("shrink-0", config.iconClassName)} />
+      <StatusIcon
+        size={16}
+        className={cn("shrink-0", statusIconClassName(item))}
+      />
       <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
         {item.title}
       </span>


### PR DESCRIPTION
The `Loading02` spinner on in-progress lanes/cards was static — it looked like a spinner that had frozen. Now it actually spins.

A task waiting on human input (`requires_action`) stops spinning and pulses in `text-warning` instead, matching the `warning` token on its "Needs input" badge — so a stalled task no longer reads as "working".

- `STATUS_CONFIG.in_progress.iconClassName` gains `animate-spin` (covers lane header, card, list row, dialog status picker).
- New `statusIconClassName(item)` in `config.tsx` overrides that for blocked in-progress tasks; used by the card and the list row.

## Testing
- `bun test apps/web/src/layouts/task-board/config.test.ts` — 3 new cases (spins / pulses in warning / other statuses unchanged).
- `bun run lint` 0 errors, `bun run fmt` clean.

Screenshot: static-vs-animated doesn't survive a still image — the visible delta is the In Progress lane icon rotating and each blocked card's icon fading orange.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make in-progress task icons actually spin. If a task is waiting on input, the icon now stops spinning and pulses in warning to show it’s blocked.

- **Bug Fixes**
  - Added `animate-spin` to `STATUS_CONFIG.in_progress.iconClassName` so lane headers, cards, list rows, and the status picker animate.
  - Introduced `statusIconClassName(item)` to set `text-warning animate-pulse` for blocked in-progress tasks; used by TaskCard and ListRow.
  - Added tests for spin/pulse behavior and verified other statuses are unchanged.

<sup>Written for commit e476c0e59fc3eea367658ce3996d9d3fefa8aeba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

