### PR TITLE
fix(ci): stop cancelling main's native runs; skip release-bump pushes

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -44,9 +44,22 @@ on:
     - cron: "17 3 * * *" # nightly, arbitrary off-hour offset to dodge the top-of-hour stampede
   workflow_dispatch: {}
 
+# Cancel superseded runs on PR branches, but QUEUE on main: with
+# cancel-in-progress everywhere, every main push killed the previous
+# commit's in-flight jobs (tauri-build runs 10-20 min; merges land minutes
+# apart), so nearly every main commit ended with cancelled — rendered as a
+# red X — checks, and only the last commit of a burst ever completed
+# post-merge verification. GitHub holds at most one queued run per group,
+# so bursts still collapse to "in-progress finishes, newest waits".
+#
+# Relatedly, every job below also skips `[release]:` bump pushes (see the
+# jobs' `if:`): the bot's bump touches only package.json versions, seconds
+# after the merge commit that was already verified — building it doubled
+# main's native runs for zero extra signal. release-native.yaml, not this
+# workflow, owns the shipping build of the bumped version.
 concurrency:
   group: native-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   BUN_VERSION: "1.3.14"
@@ -62,7 +75,10 @@ jobs:
   #    this phase doesn't need to carry.
   # ---------------------------------------------------------------------
   rust-checks:
-    if: github.event_name != 'schedule'
+    if: >-
+      github.event_name != 'schedule' &&
+      !(github.event_name == 'push' &&
+        startsWith(github.event.head_commit.message, '[release]:'))
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -140,7 +156,10 @@ jobs:
   #    `real-ui-passthrough.e2e.test.ts`).
   # ---------------------------------------------------------------------
   daemon-e2e-vs-rust:
-    if: github.event_name != 'schedule'
+    if: >-
+      github.event_name != 'schedule' &&
+      !(github.event_name == 'push' &&
+        startsWith(github.event.head_commit.message, '[release]:'))
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -218,7 +237,10 @@ jobs:
   #    the bar is simply "all green" — no allowlist needed.
   # ---------------------------------------------------------------------
   contract-suite:
-    if: github.event_name != 'schedule'
+    if: >-
+      github.event_name != 'schedule' &&
+      !(github.event_name == 'push' &&
+        startsWith(github.event.head_commit.message, '[release]:'))
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -260,7 +282,10 @@ jobs:
   #    release-native.yaml, the secret-gated release job.
   # ---------------------------------------------------------------------
   tauri-build:
-    if: github.event_name != 'schedule'
+    if: >-
+      github.event_name != 'schedule' &&
+      !(github.event_name == 'push' &&
+        startsWith(github.event.head_commit.message, '[release]:'))
     runs-on: macos-latest
     timeout-minutes: 45
     env:


### PR DESCRIPTION
## Summary

Why every merged commit on main shows a red ✗: `native.yml`'s concurrency group (`native-…-${{ github.ref }}`, `cancel-in-progress: true`) is shared by all main pushes, and since every merge is followed seconds later by its `[release]:` bump (which touches `apps/native/package.json`, a workflow path), each push cancelled the previous commit's in-flight 10–20-min native jobs. GitHub renders cancelled checks as red ✗ — so during busy periods nearly every main commit ends "failed", real failures are indistinguishable at a glance, and only the last commit of a burst ever completes post-merge verification.

Two changes:

1. **`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`** — PR branches keep superseding (correct there); main queues. GitHub holds at most one queued run per group, so bursts collapse to "in-progress finishes, newest waits" instead of a cancel cascade.
2. **Skip `[release]:` bump pushes** in the four build/test jobs (`rust-checks`, `contract-suite`, `daemon-e2e-vs-rust`, `tauri-build`): the bot's bump touches only package.json versions seconds after the already-verified merge commit — it doubled main's native runs for zero extra signal. `release-native.yaml` owns the shipping build of bumped versions. Skipped jobs render as grey "skipped", not red.

`stub-seam-nightly` (schedule/dispatch-gated) is untouched.

## Testing

- YAML parses; `actionlint` clean (only pre-existing notes elsewhere).
- Expression check: `github.event.head_commit` only exists on `push` events, hence the `github.event_name == 'push' &&` guard so PR runs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop cancel cascades on `main` for the native workflow and skip `[release]:` bump pushes to remove red ✗ noise and cut duplicate runs.

- **Bug Fixes**
  - Queue `main` runs instead of canceling: `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` in `native.yml` concurrency; PR branches still cancel superseded runs.
  - Skip bot version bump pushes for build/test jobs (`rust-checks`, `contract-suite`, `daemon-e2e-vs-rust`, `tauri-build`): ignore `push` commits with messages starting `[release]:`; `release-native.yaml` handles shipping builds.

<sup>Written for commit e86e381fe1106408ed0727b4bcb15dbe229d6c27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

