### PR TITLE
fix(native): resolve desktop auth actions beneath every sign-in surface

### DIFF
--- a/apps/web/src/components/auth-entry.tsx
+++ b/apps/web/src/components/auth-entry.tsx
@@ -11,6 +11,10 @@ import {
   defaultAuthFormActions,
   type AuthFormActions,
 } from "@/components/auth-form-actions";
+import { useDesktopAuthFormDefaults } from "@/desktop/use-desktop-auth-form-defaults";
+import { needsBrowserOnlyFallback } from "@/desktop/auth-actions";
+import { BrowserOnlyColumn } from "@/desktop/browser-only-column";
+import { StatusColumn } from "@/desktop/status-column";
 import { useAuthConfig } from "@/providers/auth-config-provider";
 import { useT } from "@/i18n/use-t.ts";
 
@@ -34,13 +38,6 @@ export interface AuthEntryProps {
   allowPassword?: boolean;
   /** Optional lifecycle sink for embedded surfaces with their own funnel. */
   onAuthEvent?: (event: AuthFlowEvent) => void;
-  /**
-   * Overrides for the underlying network/post-auth actions (forwarded to
-   * `UnifiedAuthForm` and used for the `sso.enabled` auto-redirect branch
-   * below). Omitted -> `defaultAuthFormActions`. See
-   * `apps/web/src/components/auth-form-actions.ts`.
-   */
-  actions?: Partial<AuthFormActions>;
 }
 
 class RetriableAutoLoginResponse {
@@ -226,7 +223,6 @@ export function AuthEntry({
   allowedSocialProviders,
   allowPassword,
   onAuthEvent,
-  actions,
 }: AuthEntryProps) {
   const t = useT();
   const {
@@ -237,11 +233,40 @@ export function AuthEntry({
     socialProviders,
     localMode,
   } = useAuthConfig();
+  const desktopDefaults = useDesktopAuthFormDefaults();
   const redirectAfterLogin = redirectUrl || callbackUrl;
+  // Actions are resolved per platform HERE, beneath every sign-in surface
+  // (the web/shell `/login` route, the desktop gate, embedded surfaces):
+  // web defaults, with the desktop browser-hop/Keychain-bridge overrides
+  // layered on top in the desktop build. No call site wires this itself —
+  // that's what makes the "forgot the desktop override, social buttons
+  // silently dead-end in Tauri" bug class unrepresentable.
+  const platformOverrides = desktopDefaults?.actions;
   const resolvedActions: AuthFormActions = {
     ...defaultAuthFormActions,
-    ...actions,
+    ...platformOverrides,
   };
+
+  // The system-browser hop / Keychain bridge is a full takeover: nothing in
+  // the shared form is usable while either is in flight. Placed above every
+  // branch: these states can only be in flight after one of the desktop
+  // actions actually ran.
+  if (desktopDefaults?.isPending) {
+    return (
+      <StatusColumn
+        label={t("common.authEntry.finishSignInInBrowser")}
+        error={desktopDefaults.loginError}
+      />
+    );
+  }
+  if (desktopDefaults?.isCompletingSession) {
+    return (
+      <StatusColumn
+        label={t("common.authEntry.finishingSignIn")}
+        error={desktopDefaults.completeSessionError}
+      />
+    );
+  }
 
   if (localMode && allowAutoLogin) {
     return (
@@ -260,13 +285,44 @@ export function AuthEntry({
     );
   }
 
+  // Desktop only: a magic-link-ONLY deployment has no in-app UI to fall
+  // back to at all (magic links open in the system browser and can't hand a
+  // session back to the webview), so skip the shared form and show a single
+  // browser-hop affordance instead — see `needsBrowserOnlyFallback`.
+  if (
+    desktopDefaults &&
+    needsBrowserOnlyFallback({
+      emailAndPassword,
+      emailOtp,
+      socialProviders,
+      magicLink,
+      sso,
+    })
+  ) {
+    return (
+      <BrowserOnlyColumn
+        onContinue={desktopDefaults.login}
+        isPending={desktopDefaults.isPending}
+        error={desktopDefaults.loginError}
+      />
+    );
+  }
+
   if (
     emailAndPassword.enabled ||
     magicLink.enabled ||
     emailOtp.enabled ||
     socialProviders.enabled
   ) {
-    return (
+    // A settled browser-hop/bridge failure: `auth_login` errors land in the
+    // desktop defaults' hook state, not in any of `UnifiedAuthForm`'s
+    // mutations, so its own banner never sees them — surface here, same
+    // visual treatment. (Null on web.)
+    const desktopError =
+      desktopDefaults?.loginError ??
+      desktopDefaults?.completeSessionError ??
+      null;
+    const form = (
       <UnifiedAuthForm
         redirectUrl={redirectUrl}
         callbackUrl={callbackUrl}
@@ -278,8 +334,17 @@ export function AuthEntry({
         allowedSocialProviders={allowedSocialProviders}
         allowPassword={allowPassword}
         onAuthEvent={onAuthEvent}
-        actions={actions}
+        actions={platformOverrides}
       />
+    );
+    if (!desktopError) return form;
+    return (
+      <div className="grid gap-4">
+        <div className="rounded-xl bg-destructive/10 p-3 text-sm text-destructive text-center">
+          {desktopError}
+        </div>
+        {form}
+      </div>
     );
   }
 

--- a/apps/web/src/components/auth-form-actions.ts
+++ b/apps/web/src/components/auth-form-actions.ts
@@ -1,14 +1,16 @@
 /**
  * Injectable network + post-auth actions for the shared sign-in surface
- * (`AuthEntry` / `UnifiedAuthForm`). The web `/login` route never passes an
- * `actions` override, so it gets `defaultAuthFormActions` below — BYTE-
- * IDENTICAL to what `UnifiedAuthForm` did before this indirection existed
- * (same `authClient` calls, same `window.location.href` navigate).
+ * (`AuthEntry` / `UnifiedAuthForm`). A call site that passes no `actions`
+ * override gets platform defaults resolved inside `AuthEntry`: on the web
+ * build that is exactly `defaultAuthFormActions` below — BYTE-IDENTICAL to
+ * what `UnifiedAuthForm` did before this indirection existed (same
+ * `authClient` calls, same `window.location.href` navigate) — while the
+ * desktop build additionally layers the browser-hop/Keychain-bridge
+ * overrides on top (`@/desktop/use-desktop-auth-form-defaults`), so social/
+ * SSO buttons can never silently dead-end inside the Tauri webview again.
  *
- * The desktop sign-in screen
- * (`apps/web/src/desktop/sign-in-screen.tsx`) overrides three of the
- * six slots — see `apps/web/src/desktop/auth-actions.ts` for why only
- * those three need a desktop-specific implementation.
+ * See `apps/web/src/desktop/auth-actions.ts` for why only three of the six
+ * slots need a desktop-specific implementation.
  */
 import { authClient } from "@/lib/auth-client";
 

--- a/apps/web/src/components/chat/chat-context.tsx
+++ b/apps/web/src/components/chat/chat-context.tsx
@@ -46,7 +46,7 @@ import type { HarnessId } from "@decocms/harness/types";
 import {
   AGENT_OPTION_PINS,
   agentOptionFor,
-  preferredLocalAgentOption,
+  resolveNativeAgentOption,
   resolveOfflineAgentOption,
   type AgentOption,
 } from "./pills/agent-options";
@@ -498,10 +498,9 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
   // used to mis-route to an offline link. A fresh org starts with no pick
   // (`null`), letting the server choose its default.
   //
-  // Everything else (`pendingHarnessId`, `pendingSandboxProviderKind`,
-  // the request body's harnessId/sandboxProviderKind) derives from this
-  // through `AGENT_OPTION_PINS`, so the pill display and the submit can
-  // never disagree.
+  // Web derives the pending harness/sandbox pair from this value. Native
+  // filters it through its local-only resolver below. Both surfaces still read
+  // the same effective pair, so the pill display and submit cannot disagree.
   const [pendingAgentOption, setPendingAgentOption] =
     useLocalStorage<AgentOption | null>(
       LOCALSTORAGE_KEYS.chatLastAgentOption(locator),
@@ -526,44 +525,41 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
         )
       : null;
 
-  // Capability probes are advisory — we don't rewrite the harness for a missing
-  // CLI (cloud chat via the org router works even where the cloud *sandbox*
-  // doesn't). The one exception is a desktop pick whose link is *confirmed*
-  // offline: it can't run anywhere and nothing prompted the user to reconnect,
-  // so we auto-switch it to cloud. Derived (not persisted), so the desktop pick
-  // returns on its own once the link reconnects.
+  // Capability probes are advisory on web — we don't rewrite the harness for a
+  // missing CLI (cloud chat via the org router works even where the cloud
+  // *sandbox* doesn't). The one exception is a desktop pick whose link is
+  // *confirmed* offline: it can't run anywhere and nothing prompted the user to
+  // reconnect, so we auto-switch it to cloud. Derived (not persisted), so the
+  // desktop pick returns on its own once the link reconnects.
   const link = useCurrentLink();
 
-  // The desktop app has no cloud/Decopilot surface to fall back to, so an
-  // un-set pick must never resolve to `decopilot` the way it does on web —
-  // that pins the thread to `agent-sandbox` (see `AGENT_OPTION_PINS`) and the
-  // sandbox is provisioned in the cloud instead of on this machine. Defaulting
-  // to the locally-detected CLI keeps the pin on `user-desktop`, which is the
-  // kind local-api intercepts. Derived, not persisted, so it re-resolves on its
-  // own as `LINK_CURRENT_GET` reports CLIs; an explicit user pick always wins.
   const isDesktopApp = useIsDesktopApp();
   const availability = useAgentOptionAvailability();
-  const desktopDefaultOption = isDesktopApp
-    ? preferredLocalAgentOption(availability)
-    : null;
-
-  const selectedAgentOption = resolveOfflineAgentOption(
-    pendingAgentOption ?? desktopDefaultOption,
+  // Native has no cloud/Decopilot surface. Ignore stale cloud prefs there and
+  // recover early native threads that pinned a local harness without the
+  // expected sandbox tuple. While cold CLI detection is unresolved this stays
+  // null; TierTrigger renders that state as local-pending, never as cloud.
+  const nativeAgentOption = resolveNativeAgentOption({
+    pendingOption: pendingAgentOption,
+    lockedHarness: taskCtxForLock?.isThreadLocked
+      ? taskCtxForLock.lockedHarness
+      : null,
+    availability,
+  });
+  const webSelectedAgentOption = resolveOfflineAgentOption(
+    pendingAgentOption,
     link.ready && !link.online,
   );
 
-  // When the thread is locked, the agent option is dictated by the persisted
-  // (harness, sandbox) pair — period. Otherwise, fall through to the user's
-  // selected global picker.
-  //
-  // When the thread is locked but the (harness, sandbox) tuple doesn't map
-  // to a known AgentOption (legacy/trigger-created rows), we intentionally
-  // surface `null` here rather than falling through to the global picker.
-  // The submit path is server-enforced anyway; consumers (pills, etc.)
-  // should consult isThreadLocked for the "locked" affordance and avoid
-  // showing the global selection on a locked thread.
-  const effectiveAgentOption: AgentOption | null =
-    taskCtxForLock?.isThreadLocked ? lockedAgentOption : selectedAgentOption;
+  // On web, a locked thread is dictated by its persisted (harness, sandbox)
+  // pair; an unknown tuple surfaces null instead of falling through to the
+  // global picker. Native is different: every runnable harness is local, and
+  // `nativeAgentOption` recovers older rows by their local harness alone.
+  const effectiveAgentOption: AgentOption | null = isDesktopApp
+    ? nativeAgentOption
+    : taskCtxForLock?.isThreadLocked
+      ? lockedAgentOption
+      : webSelectedAgentOption;
 
   const effectivePins = effectiveAgentOption
     ? AGENT_OPTION_PINS[effectiveAgentOption]

--- a/apps/web/src/components/chat/pills/agent-options.test.ts
+++ b/apps/web/src/components/chat/pills/agent-options.test.ts
@@ -8,6 +8,7 @@ import {
   agentOptionFor,
   agentOptionIsAvailable,
   preferredLocalAgentOption,
+  resolveNativeAgentOption,
   resolveOfflineAgentOption,
 } from "./agent-options";
 
@@ -136,6 +137,65 @@ describe("preferredLocalAgentOption", () => {
         codex: false,
       }),
     ).toBeNull();
+  });
+});
+
+describe("resolveNativeAgentOption", () => {
+  test("does not turn unresolved native detection into cloud Decopilot", () => {
+    const unresolved = {
+      ...ALL_AVAILABLE,
+      claudeCode: false,
+      codex: false,
+    };
+    for (const pendingOption of [null, "decopilot"] as const) {
+      expect(
+        resolveNativeAgentOption({
+          pendingOption,
+          lockedHarness: null,
+          availability: unresolved,
+        }),
+      ).toBeNull();
+    }
+  });
+
+  test("ignores a stale persisted Decopilot choice", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: "decopilot",
+        lockedHarness: null,
+        availability: ALL_AVAILABLE,
+      }),
+    ).toBe("claude-code-desktop");
+  });
+
+  test("uses Codex when it is the only detected local CLI", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: null,
+        lockedHarness: null,
+        availability: { ...ALL_AVAILABLE, claudeCode: false },
+      }),
+    ).toBe("codex-desktop");
+  });
+
+  test("preserves an explicit local choice", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: "codex-desktop",
+        lockedHarness: null,
+        availability: ALL_AVAILABLE,
+      }),
+    ).toBe("codex-desktop");
+  });
+
+  test("a locked local harness wins without requiring its sandbox tuple", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: "codex-desktop",
+        lockedHarness: "claude-code",
+        availability: ALL_AVAILABLE,
+      }),
+    ).toBe("claude-code-desktop");
   });
 });
 

--- a/apps/web/src/components/chat/pills/agent-options.ts
+++ b/apps/web/src/components/chat/pills/agent-options.ts
@@ -6,6 +6,7 @@ import {
 } from "@/sdk";
 
 export type AgentOption = "decopilot" | "claude-code-desktop" | "codex-desktop";
+type LocalAgentOption = Exclude<AgentOption, "decopilot">;
 
 export interface AgentPins {
   harness: HarnessId;
@@ -78,10 +79,39 @@ export interface AgentOptionAvailability {
  */
 export function preferredLocalAgentOption(
   availability: AgentOptionAvailability,
-): AgentOption | null {
+): LocalAgentOption | null {
   if (availability.claudeCode) return "claude-code-desktop";
   if (availability.codex) return "codex-desktop";
   return null;
+}
+
+/**
+ * Resolve the only agent options a native build may expose.
+ *
+ * Native has no cloud runtime, so a stale persisted Decopilot pick must never
+ * win. A locked local harness also wins by harness alone: early native builds
+ * could pin a Claude Code/Codex thread before `sandbox_provider_kind` was
+ * available, and requiring the full tuple would misclassify that local thread
+ * as cloud.
+ *
+ * Returns null while CLI detection is still unresolved and there is no prior
+ * local choice. The native model selector treats that as local-pending rather
+ * than falling back to provider models.
+ */
+export function resolveNativeAgentOption({
+  pendingOption,
+  lockedHarness,
+  availability,
+}: {
+  pendingOption: AgentOption | null;
+  lockedHarness: HarnessId | null;
+  availability: AgentOptionAvailability;
+}): LocalAgentOption | null {
+  if (lockedHarness === "claude-code") return "claude-code-desktop";
+  if (lockedHarness === "codex") return "codex-desktop";
+  if (pendingOption === "claude-code-desktop") return pendingOption;
+  if (pendingOption === "codex-desktop") return pendingOption;
+  return preferredLocalAgentOption(availability);
 }
 
 /**

--- a/apps/web/src/components/chat/tier-trigger.tsx
+++ b/apps/web/src/components/chat/tier-trigger.tsx
@@ -32,6 +32,7 @@ import { useT, type TFunction } from "@/i18n/use-t.ts";
 import type { ChatTier } from "@decocms/shared/organization/schema";
 import {
   resolveTierSubtitle,
+  shouldUseLocalModels,
   useAgentMode,
   useChatTier,
   useSetChatTier,
@@ -475,7 +476,7 @@ export function TierTrigger() {
   const locked = taskCtx?.isThreadLocked ?? false;
   const isDesktopApp = useIsDesktopApp();
   const hasLocal = availability.claudeCode || availability.codex;
-  const isLocal = mode !== "cloud-decopilot";
+  const isLocal = shouldUseLocalModels(mode, isDesktopApp);
   // Cloud rows only: org config + this user's overrides, wired into each
   // row's cog popover below.
   const org = useSimpleMode();

--- a/apps/web/src/components/chat/use-agent-mode.test.ts
+++ b/apps/web/src/components/chat/use-agent-mode.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   agentModeFromOption,
   resolveTierSubtitle,
+  shouldUseLocalModels,
   type AgentMode,
 } from "./use-agent-mode";
 import type { AgentOption } from "./pills/agent-options";
@@ -30,6 +31,18 @@ describe("agentModeFromOption", () => {
 
   it("agentModeFromOption(null) defaults to cloud-decopilot", () => {
     expect(agentModeFromOption(null)).toBe("cloud-decopilot");
+  });
+});
+
+describe("shouldUseLocalModels", () => {
+  it("keeps native on local models while runtime detection is pending", () => {
+    expect(shouldUseLocalModels("cloud-decopilot", true)).toBe(true);
+  });
+
+  it("keeps cloud models on web and local models for explicit local modes", () => {
+    expect(shouldUseLocalModels("cloud-decopilot", false)).toBe(false);
+    expect(shouldUseLocalModels("local-claude-code", false)).toBe(true);
+    expect(shouldUseLocalModels("local-codex", false)).toBe(true);
   });
 });
 

--- a/apps/web/src/components/chat/use-agent-mode.ts
+++ b/apps/web/src/components/chat/use-agent-mode.ts
@@ -34,6 +34,18 @@ export function useAgentMode(): AgentMode {
   return agentModeFromOption(pendingAgentOption);
 }
 
+/**
+ * Whether the chat-input selector must use the fixed local CLI catalogs.
+ * Native never exposes cloud/provider models, including while local CLI
+ * detection is still pending and the effective option is temporarily null.
+ */
+export function shouldUseLocalModels(
+  mode: AgentMode,
+  isDesktopApp: boolean,
+): boolean {
+  return isDesktopApp || mode !== "cloud-decopilot";
+}
+
 /** Current chat tier from prefs. Defaults to "smart" via prefs. */
 export function useChatTier(): ChatTier {
   return useChatPrefs().simpleModeTier;

--- a/apps/web/src/components/unified-auth-form.tsx
+++ b/apps/web/src/components/unified-auth-form.tsx
@@ -78,10 +78,12 @@ interface UnifiedAuthFormProps {
   /** Optional lifecycle sink for embedded surfaces with their own funnel. */
   onAuthEvent?: (event: AuthFlowEvent) => void;
   /**
-   * Overrides for the underlying network/post-auth actions. Omitted (the web
-   * `/login` route never passes this) -> `defaultAuthFormActions`, i.e. the
-   * exact `authClient` calls + `window.location.href` navigate this form
-   * always used. See `apps/web/src/components/auth-form-actions.ts`.
+   * Overrides for the underlying network/post-auth actions. `AuthEntry`
+   * passes the platform-resolved overrides here (desktop browser-hop/
+   * Keychain-bridge actions in the desktop build, `undefined` on web).
+   * Omitted -> `defaultAuthFormActions`, i.e. the exact `authClient` calls +
+   * `window.location.href` navigate this form always used. See
+   * `apps/web/src/components/auth-form-actions.ts`.
    */
   actions?: Partial<AuthFormActions>;
 }
@@ -256,6 +258,10 @@ export function UnifiedAuthForm({
   });
   const [emailError, setEmailError] = useState("");
   const [resetEmailSent, setResetEmailSent] = useState(false);
+  // Social sign-in has no mutation of its own — without this state a failed
+  // `socialSignIn` (misconfigured provider, network error) was tracked in
+  // analytics but INVISIBLE in the UI: the button just "did nothing".
+  const [socialError, setSocialError] = useState<Error | null>(null);
   const copy = { ...DEFAULT_AUTH_FORM_COPY, ...copyOverrides };
 
   const isSignUp = view === "signUp";
@@ -488,6 +494,7 @@ export function UnifiedAuthForm({
     setOtpSent(false);
     setEmailError("");
     setResetEmailSent(false);
+    setSocialError(null);
     emailPasswordMutation.reset();
     forgotPasswordMutation.reset();
     sendOtpMutation.reset();
@@ -544,10 +551,11 @@ export function UnifiedAuthForm({
     return error.message || copy.genericError;
   };
 
-  const displayError = error || forgotPasswordError || otpError;
+  const displayError = error || forgotPasswordError || otpError || socialError;
 
   const handleSocialSignIn = async (provider: string) => {
     emitAuthEvent({ type: "started", method: "social", provider });
+    setSocialError(null);
     try {
       const result = await resolvedActions.socialSignIn({
         provider,
@@ -566,6 +574,7 @@ export function UnifiedAuthForm({
         error: message,
       });
       track("social_signin_failed", { provider, error: message });
+      setSocialError(error instanceof Error ? error : new Error(message));
     }
   };
 

--- a/apps/web/src/desktop/auth-actions.ts
+++ b/apps/web/src/desktop/auth-actions.ts
@@ -1,8 +1,10 @@
 /**
  * Desktop's overrides for the shared sign-in surface's injectable actions
  * (`apps/web/src/components/auth-form-actions.ts`), plus the one bit of
- * config-driven UI-mode logic the desktop sign-in screen needs
- * (`needsBrowserOnlyFallback`). Pure — no Tauri IPC happens in this file
+ * config-driven UI-mode logic desktop sign-in needs
+ * (`needsBrowserOnlyFallback`, consumed by `AuthEntry`'s desktop branch).
+ * Both are wired beneath every sign-in surface by
+ * `use-desktop-auth-form-defaults.ts`. Pure — no Tauri IPC happens in this file
  * itself; the actual `auth_login()`/`auth_complete_session()` calls are
  * injected as `deps` (see `use-desktop-auth.ts`), which is what keeps this
  * module unit-testable per TESTING.md ("if a test needs mock.module … it's
@@ -90,10 +92,11 @@ export interface DesktopAuthMethodConfig {
  * one auth method with genuinely no in-app UI. `UnifiedAuthForm` has no
  * magic-link view even on web: clicking a magic-link email opens a browser
  * tab, which can't hand a session back to a Tauri webview the way an
- * in-webview OTP/password submit can. When this is true, the desktop
- * sign-in screen skips the shared form entirely and shows a single
+ * in-webview OTP/password submit can. When this is true, `AuthEntry`'s
+ * desktop branch skips the shared form entirely and shows a single
  * "continue in your browser" affordance instead (reusing the same
- * `auth_login()` browser hop as social/SSO) — see `sign-in-screen.tsx`.
+ * `auth_login()` browser hop as social/SSO) — see
+ * `@/desktop/browser-only-column.tsx`.
  *
  * `sso.enabled` is excluded from the "in-app method" check on purpose: it
  * already gets its own auto-redirect branch inside `AuthEntry` (`RunSSO`)

--- a/apps/web/src/desktop/browser-only-column.tsx
+++ b/apps/web/src/desktop/browser-only-column.tsx
@@ -1,0 +1,40 @@
+/**
+ * The magic-link-only fallback for desktop sign-in surfaces: a deployment
+ * whose ONLY enabled method is magic link has no in-app UI at all (magic
+ * links open in the system browser and can't hand a session back to the
+ * Tauri webview), so instead of the shared form we show a single affordance
+ * that reuses the same `auth_login()` system-browser hop as social/SSO.
+ * Decision: `needsBrowserOnlyFallback` (`@/desktop/auth-actions`); rendered
+ * by `AuthEntry`'s desktop branch. Column content only — the caller's
+ * layout (`AuthSplitLayout`) provides the frame.
+ */
+import { Button } from "@deco/ui/components/button.tsx";
+import { useT } from "@/i18n/use-t.ts";
+
+export function BrowserOnlyColumn({
+  onContinue,
+  isPending,
+  error,
+}: {
+  onContinue: () => Promise<void>;
+  isPending: boolean;
+  error: string | null;
+}) {
+  const t = useT();
+  return (
+    <div className="flex flex-col items-center gap-4 text-center">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-lg font-medium text-foreground">
+          {t("common.authEntry.browserOnlyTitle")}
+        </h1>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          {t("common.authEntry.browserOnlyDescription")}
+        </p>
+      </div>
+      <Button onClick={() => void onContinue()} disabled={isPending}>
+        {t("common.authEntry.browserOnlyCta")}
+      </Button>
+      {error && <p className="max-w-sm text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/desktop/native-session-sync.test.ts
+++ b/apps/web/src/desktop/native-session-sync.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { shouldNotifyWebSessionRefetch } from "@/desktop/native-session-sync";
+
+const SIGNED_IN = { signedIn: true };
+
+describe("shouldNotifyWebSessionRefetch", () => {
+  test("notifies when native is signed in, web has no session, and the status is a fresh signal", () => {
+    expect(
+      shouldNotifyWebSessionRefetch({
+        nativeStatus: SIGNED_IN,
+        lastNotifiedStatus: null,
+        hasWebSession: false,
+        isWebSessionFetchInFlight: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not notify while native reports signed out", () => {
+    expect(
+      shouldNotifyWebSessionRefetch({
+        nativeStatus: { signedIn: false },
+        lastNotifiedStatus: null,
+        hasWebSession: false,
+        isWebSessionFetchInFlight: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not notify before the first auth_status payload arrives", () => {
+    expect(
+      shouldNotifyWebSessionRefetch({
+        nativeStatus: undefined,
+        lastNotifiedStatus: null,
+        hasWebSession: false,
+        isWebSessionFetchInFlight: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not notify when the web client already holds a session", () => {
+    expect(
+      shouldNotifyWebSessionRefetch({
+        nativeStatus: SIGNED_IN,
+        lastNotifiedStatus: null,
+        hasWebSession: true,
+        isWebSessionFetchInFlight: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not notify while a /get-session fetch is already in flight", () => {
+    expect(
+      shouldNotifyWebSessionRefetch({
+        nativeStatus: SIGNED_IN,
+        lastNotifiedStatus: null,
+        hasWebSession: false,
+        isWebSessionFetchInFlight: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("notifies at most once per status object — same reference is not re-notified even if the session fetch came back empty", () => {
+    expect(
+      shouldNotifyWebSessionRefetch({
+        nativeStatus: SIGNED_IN,
+        lastNotifiedStatus: SIGNED_IN,
+        hasWebSession: false,
+        isWebSessionFetchInFlight: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("a NEW status object with the same shape counts as a fresh native signal", () => {
+    expect(
+      shouldNotifyWebSessionRefetch({
+        nativeStatus: { signedIn: true },
+        lastNotifiedStatus: SIGNED_IN,
+        hasWebSession: false,
+        isWebSessionFetchInFlight: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/desktop/native-session-sync.ts
+++ b/apps/web/src/desktop/native-session-sync.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure decision logic for `use-native-session-sync.ts` — when should the
+ * webview ask better-auth to re-fetch `/get-session` because the NATIVE side
+ * (Keychain, `auth_status`) says signed in while the web client still holds
+ * no session?
+ *
+ * That divergence is the residual login wedge: the shell bounced to `/login`
+ * on a dead cookie, the user completed the system-browser PKCE flow (or the
+ * native revalidator re-minted the cookie), the Keychain healed — but
+ * better-auth's `useSession` never re-fetches on its own, so the page would
+ * sit on the sign-in form forever. Notifying `$sessionSignal` closes the gap.
+ *
+ * Kept pure (no React, no authClient) so it can be unit-tested per
+ * TESTING.md; the hook supplies the inputs.
+ */
+
+export interface NativeSessionSyncInput {
+  /** Latest `auth_status` payload (referential identity matters — a new
+   *  object means a fresh native signal worth acting on). */
+  nativeStatus: { signedIn: boolean } | undefined;
+  /** The status object the hook last notified for. Comparing by REFERENCE
+   *  (not by value) is what bounds the retry: a native `signedIn: true`
+   *  paired with a still-dead upstream cookie must not busy-loop
+   *  `/get-session` — one notify per fresh native signal, no more. */
+  lastNotifiedStatus: object | null;
+  /** `authClient.useSession().data` is non-null. */
+  hasWebSession: boolean;
+  /** A `/get-session` fetch is already in flight — let it land first. */
+  isWebSessionFetchInFlight: boolean;
+}
+
+export function shouldNotifyWebSessionRefetch(
+  input: NativeSessionSyncInput,
+): boolean {
+  const { nativeStatus } = input;
+  if (!nativeStatus?.signedIn) return false;
+  if (input.hasWebSession || input.isWebSessionFetchInFlight) return false;
+  return input.lastNotifiedStatus !== nativeStatus;
+}

--- a/apps/web/src/desktop/sign-in-screen.tsx
+++ b/apps/web/src/desktop/sign-in-screen.tsx
@@ -1,184 +1,89 @@
 /**
  * Sign-in gate shown when `auth_status()` says signed out. Hybrid design
- * (post-v1 owner feedback): reuses the SAME shared components the web
- * `/login` route renders (`AuthSplitLayout` + `AuthEntry` +
- * `UnifiedAuthForm`) — never a visual fork — wired with desktop-specific
- * actions instead of a bespoke UI:
+ * (post-v1 owner feedback): renders the SAME shared surface the web `/login`
+ * route renders (`AuthSplitLayout` + `AuthEntry` + `UnifiedAuthForm`) —
+ * never a visual fork. All desktop-specific behavior now lives INSIDE
+ * `AuthEntry` (via `useDesktopAuthFormDefaults`): the system-browser hop for
+ * social/SSO, the Keychain bridge for email/password + OTP, the browser-hop
+ * pending/error states, and the magic-link-only fallback. This screen only
+ * supplies what `AuthEntry` cannot know: the split layout, the auth-config
+ * fetch boundary, and disabling local-mode auto-login (which would bypass
+ * the Keychain bridge contract).
  *
- *  - Email/password and email-OTP submit through local-api's
- *    bare `/api/auth/*` proxy exactly like the web app's own calls do
- *    (same-origin after `index.native.tsx` establishes its local session); on success, the
- *    Better-Auth session cookie the proxy captured server-side is bridged
- *    into the Keychain via `auth_complete_session` (`useDesktopAuth`'s
- *    `completeSession`, wired as `onAuthenticated` — see `auth-actions.ts`).
- *  - Google/GitHub/SAML buttons, and the deployment-wide forced-SSO
- *    auto-redirect, invoke the existing `auth_login()` system-browser PKCE
- *    flow instead (`socialSignIn`/`ssoSignIn` overrides) — see
- *    `auth-actions.ts`'s module doc for why the button clicked doesn't
- *    matter.
- *  - A magic-link-ONLY deployment (no password/OTP/social configured) has
- *    no in-app UI to fall back to at all (magic links open in the system
- *    browser and can't hand a session back to the webview), so it skips the
- *    shared form entirely and shows the same browser-hop affordance —
- *    `needsBrowserOnlyFallback` in `auth-actions.ts`.
- *
- * This screen has NO org-choice/org-picker UI of its own: after sign-in
- * (either path) the app just hands off to the real production shell
- * (`apps/web/src`), whose own `organization.list` call, last-visited-
- * org logic, and org-creation flow cover org selection identically to the
- * web app — see the native authentication contract.
+ * This screen has NO org-choice/org-picker UI of its own: after sign-in the
+ * app just hands off to the real production shell (`apps/web/src`), whose
+ * own `organization.list` call, last-visited-org logic, and org-creation
+ * flow cover org selection identically to the web app — see the native
+ * authentication contract.
  *
  * Auth-config awareness (which methods are enabled) comes from the SAME
  * source the web app uses — `usePublicConfig()`/`AuthConfigProvider`,
  * fetching relative `/api/config` from local-api the same way every other
- * `/api/...` call does. `GET /api/config` is
- * public/no-auth on mesh, and local-api's app-API proxy gives it the
- * same bearer-free treatment as `/api/auth/*`
- * (`routes/upstream.rs`'s `PUBLIC_NO_AUTH_PATH`/`proxy_public_config`) so
- * this fetch succeeds even at the pre-sign-in moment this screen needs it
- * most (no Keychain session yet). The `ErrorBoundary` below stays as a
- * belt-and-suspenders "couldn't load, try again" state for a genuine
- * network failure, not a known-broken first paint.
+ * `/api/...` call does. `GET /api/config` is public/no-auth on mesh, and
+ * local-api's app-API proxy gives it the same bearer-free treatment as
+ * `/api/auth/*` (`routes/upstream.rs`'s
+ * `PUBLIC_NO_AUTH_PATH`/`proxy_public_config`) so this fetch succeeds even
+ * at the pre-sign-in moment this screen needs it most (no Keychain session
+ * yet). The `ErrorBoundary` below stays as a belt-and-suspenders "couldn't
+ * load, try again" state for a genuine network failure, not a known-broken
+ * first paint.
  *
- * Layout: `AuthSplitLayout` is hoisted ONCE at the top of `SignInScreen` and
- * every state below only supplies its inner column content — see
- * the native authentication-success contract §5.2. This keeps the
- * right-hand visual panel and the left column's max-width frame mounted and
- * stable across every transition (sign-in form -> social/SSO browser-hop ->
- * back -> Keychain bridge -> real app), instead of popping in and out on
- * each state change.
+ * Layout: `AuthSplitLayout` is hoisted ONCE at the top and every state
+ * (config loading, sign-in form, browser-hop takeover, Keychain bridge)
+ * only supplies inner column content — see the native
+ * authentication-success contract §5.2. This keeps the right-hand visual
+ * panel and the left column's max-width frame mounted and stable across
+ * every transition instead of popping in and out on each state change.
  */
 import { Suspense } from "react";
 import { AuthEntry } from "@/components/auth-entry";
 import { AuthSplitLayout } from "@/components/auth-split-layout";
 import { ErrorBoundary } from "@/components/error-boundary";
-import {
-  AuthConfigProvider,
-  useAuthConfig,
-} from "@/providers/auth-config-provider";
+import { AuthConfigProvider } from "@/providers/auth-config-provider";
 import { Button } from "@deco/ui/components/button.tsx";
 import { StatusColumn } from "@/desktop/status-column";
-import type { DesktopAuth } from "@/desktop/use-desktop-auth";
-import {
-  createDesktopAuthActions,
-  needsBrowserOnlyFallback,
-} from "@/desktop/auth-actions";
+import { useT } from "@/i18n/use-t.ts";
 
 /** The "couldn't load sign-in options" retry column — `ErrorBoundary`'s
  *  fallback, trimmed to just the column's inner content (no full-screen
  *  wrapper — `AuthSplitLayout`'s own `<section>` already provides that). */
 function ConfigErrorColumn({ onRetry }: { onRetry: () => void }) {
+  const t = useT();
   return (
     <div className="flex flex-col items-center gap-3 text-center">
       <p className="max-w-sm text-sm text-muted-foreground">
-        Couldn't load sign-in options.
+        {t("common.signInScreen.configLoadFailed")}
       </p>
       <Button variant="outline" onClick={onRetry}>
-        Try again
+        {t("common.signInScreen.tryAgain")}
       </Button>
     </div>
   );
 }
 
-/** The magic-link-only fallback: no in-app form, just a single button that
- *  reuses the same `auth_login()` browser hop as social/SSO. See this
- *  module's doc comment and `auth-actions.ts::needsBrowserOnlyFallback`. */
-function BrowserOnlyColumn({ auth }: { auth: DesktopAuth }) {
+export function SignInScreen() {
   return (
-    <div className="flex flex-col items-center gap-4 text-center">
-      <div className="flex flex-col gap-1">
-        <h1 className="text-lg font-medium text-foreground">Welcome to deco</h1>
-        <p className="max-w-sm text-sm text-muted-foreground">
-          This organization signs in with an emailed link, which can't be opened
-          inside the app. Continue in your browser to finish signing in.
-        </p>
-      </div>
-      <Button onClick={() => void auth.login()} disabled={auth.isPending}>
-        Continue in your browser
-      </Button>
-      {auth.loginError && (
-        <p className="max-w-sm text-xs text-destructive">{auth.loginError}</p>
-      )}
-    </div>
+    <AuthSplitLayout>
+      <ErrorBoundary
+        fallback={({ resetError }) => (
+          <ConfigErrorColumn onRetry={resetError} />
+        )}
+      >
+        <Suspense fallback={<StatusColumn />}>
+          <AuthConfigProvider>
+            <AuthEntry
+              callbackUrl="/"
+              // Local-mode auto-login (`AuthEntry`'s `localMode` branch)
+              // sets a session cookie directly via
+              // `/api/auth/custom/local-session` — it isn't part of the
+              // hybrid-login bridge contract (email/password, OTP,
+              // browser-hop social/SSO only), so it's disabled here rather
+              // than left to silently bypass the Keychain bridge.
+              allowAutoLogin={false}
+            />
+          </AuthConfigProvider>
+        </Suspense>
+      </ErrorBoundary>
+    </AuthSplitLayout>
   );
-}
-
-function SignInFormOrBrowserOnly({ auth }: { auth: DesktopAuth }) {
-  const config = useAuthConfig();
-
-  if (needsBrowserOnlyFallback(config)) {
-    return <BrowserOnlyColumn auth={auth} />;
-  }
-
-  const actions = createDesktopAuthActions({
-    browserSignIn: auth.login,
-    completeBridgedSignIn: auth.completeSession,
-  });
-
-  return (
-    <div className="grid gap-4">
-      {auth.completeSessionError && (
-        // Bridging (auth_complete_session) runs AFTER the shared form's
-        // own mutation already succeeded, so `UnifiedAuthForm`'s internal
-        // error banner (tied to that mutation's state) never sees this
-        // failure — surface it here instead, same visual treatment.
-        <div className="rounded-xl bg-destructive/10 p-3 text-sm text-destructive text-center">
-          {auth.completeSessionError}
-        </div>
-      )}
-      <AuthEntry
-        callbackUrl="/"
-        // Local-mode auto-login (`AuthEntry`'s `localMode` branch) sets a
-        // session cookie directly via `/api/auth/custom/local-session` —
-        // it isn't part of the hybrid-login bridge contract (email/
-        // password, OTP, browser-hop social/SSO only), so it's disabled
-        // here rather than left to silently bypass the Keychain bridge.
-        allowAutoLogin={false}
-        // No title/subtitle overrides: the shared form's own defaults
-        // ("Welcome to deco" / "Sign in or create a new account") keep this
-        // screen's copy identical to the web /login page by construction.
-        actions={actions}
-      />
-    </div>
-  );
-}
-
-function renderState(auth: DesktopAuth) {
-  // The system-browser hop (social/SSO/browser-only-fallback) is a full
-  // takeover: nothing in the shared form is usable while it's in flight.
-  if (auth.isPending) {
-    return (
-      <StatusColumn
-        label="Finish signing in in your browser…"
-        error={auth.loginError}
-      />
-    );
-  }
-
-  // The Keychain bridge (email/password or OTP success) is a brief,
-  // invisible-to-the-browser round trip — distinct copy from the above.
-  if (auth.isCompletingSession) {
-    return (
-      <StatusColumn
-        label="Finishing sign-in…"
-        error={auth.completeSessionError}
-      />
-    );
-  }
-
-  return (
-    <ErrorBoundary
-      fallback={({ resetError }) => <ConfigErrorColumn onRetry={resetError} />}
-    >
-      <Suspense fallback={<StatusColumn />}>
-        <AuthConfigProvider>
-          <SignInFormOrBrowserOnly auth={auth} />
-        </AuthConfigProvider>
-      </Suspense>
-    </ErrorBoundary>
-  );
-}
-
-export function SignInScreen({ auth }: { auth: DesktopAuth }) {
-  return <AuthSplitLayout>{renderState(auth)}</AuthSplitLayout>;
 }

--- a/apps/web/src/desktop/use-desktop-auth-form-defaults.ts
+++ b/apps/web/src/desktop/use-desktop-auth-form-defaults.ts
@@ -1,0 +1,52 @@
+/**
+ * Platform-aware DEFAULTS for the shared sign-in surface's injectable
+ * actions. `AuthEntry` calls this unconditionally; on the web build it
+ * returns `null` and the surface behaves exactly as before. On the desktop
+ * build it supplies `createDesktopAuthActions` (system-browser hop for
+ * social/SSO, Keychain bridge for `onAuthenticated`) plus the hop's
+ * pending/error state so `AuthEntry` can render them.
+ *
+ * WHY this exists: the original login wedge was a call site
+ * (`routes/login.tsx`) rendering the shared form WITHOUT the desktop
+ * `actions` override — a silently-valid omission whose Google/GitHub buttons
+ * dead-end inside Tauri (external navigation is blocked by
+ * `setup.rs::is_allowed_webview_navigation`). Resolving the desktop defaults
+ * HERE, beneath every call site, makes that class of bug unrepresentable:
+ * every sign-in surface — the shared `/login` route, the desktop gate
+ * (`sign-in-screen.tsx`), the embedded auth surfaces — gets correct behavior
+ * on both platforms without wiring anything itself.
+ */
+import { isDesktopAppEnvironment } from "@/hooks/use-is-desktop-app";
+import { useDesktopAuth } from "@/desktop/use-desktop-auth";
+import { createDesktopAuthActions } from "@/desktop/auth-actions";
+import type { AuthFormActions } from "@/components/auth-form-actions";
+
+export interface DesktopAuthFormDefaults {
+  actions: Partial<AuthFormActions>;
+  /** The raw system-browser hop, for form-less affordances (the magic-link-
+   *  only fallback's "Continue in your browser" button). */
+  login: () => Promise<void>;
+  /** True while the system-browser hop (`auth_login`) is in flight. */
+  isPending: boolean;
+  loginError: string | null;
+  /** True while the Keychain bridge (`auth_complete_session`) is in flight. */
+  isCompletingSession: boolean;
+  completeSessionError: string | null;
+}
+
+export function useDesktopAuthFormDefaults(): DesktopAuthFormDefaults | null {
+  // Unconditional hook call; inert on web (query disabled, listener gated).
+  const auth = useDesktopAuth();
+  if (!isDesktopAppEnvironment()) return null;
+  return {
+    actions: createDesktopAuthActions({
+      browserSignIn: auth.login,
+      completeBridgedSignIn: auth.completeSession,
+    }),
+    login: auth.login,
+    isPending: auth.isPending,
+    loginError: auth.loginError,
+    isCompletingSession: auth.isCompletingSession,
+    completeSessionError: auth.completeSessionError,
+  };
+}

--- a/apps/web/src/desktop/use-desktop-auth.ts
+++ b/apps/web/src/desktop/use-desktop-auth.ts
@@ -1,8 +1,10 @@
 /**
  * Auth gate state for the desktop shell. Wraps the Tauri `auth_status` /
  * `auth_login` / `auth_logout` commands (`@/lib/desktop/tauri-bridge`)
- * behind one hook so `index.native.tsx` and `sign-in-screen.tsx` share a
- * single source of truth instead of each polling `auth_status` themselves.
+ * behind one hook so `index.native.tsx`, `use-desktop-auth-form-defaults.ts`
+ * (the shared form's desktop actions), and `use-native-session-sync.ts`
+ * share a single source of truth instead of each polling `auth_status`
+ * themselves.
  *
  * Also called (unconditionally, but effectively a no-op) from the SHARED
  * `/login` route (`routes/login.tsx`), which is compiled into both the web
@@ -46,7 +48,7 @@ export interface DesktopAuth {
    * local-api's bare `/api/auth/*`, cookie captured server-side) into
    * the Keychain via `auth_complete_session`, then re-checks `auth_status`.
    * Wired as the shared form's `onAuthenticated` action for desktop — see
-   * `auth-actions.ts` / `sign-in-screen.tsx`.
+   * `auth-actions.ts` / `use-desktop-auth-form-defaults.ts`.
    */
   completeSession: () => Promise<void>;
   /** Re-runs `auth_status` after a transient Keychain access failure. */

--- a/apps/web/src/desktop/use-desktop-auth.ts
+++ b/apps/web/src/desktop/use-desktop-auth.ts
@@ -6,24 +6,38 @@
  * share a single source of truth instead of each polling `auth_status`
  * themselves.
  *
- * Also called (unconditionally, but effectively a no-op) from the SHARED
- * `/login` route (`routes/login.tsx`), which is compiled into both the web
- * and desktop bundles — the underlying query is gated on
- * `isDesktopAppEnvironment()` internally so a normal browser tab never fires
- * the Tauri IPC call (`fetchAuthStatus` throws outside the webview).
+ * This module is reachable from the SHARED shell (`AuthEntry`, the `/login`
+ * route), which is compiled into both the web and desktop bundles — so the
+ * bridge is loaded through `loadBridge()` below rather than a static import.
+ * The underlying query is gated on `isDesktopAppEnvironment()`, so a normal
+ * browser tab never fires the Tauri IPC call.
  */
 import { useEffect, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { KEYS } from "@/lib/query-keys";
-import {
-  fetchAuthStatus,
-  listenForAuthStatus,
-  performAuthCompleteSession,
-  performAuthLogin,
-  performAuthLogout,
-  type AuthStatus,
-} from "@/lib/desktop/tauri-bridge";
+import type { AuthStatus } from "@/lib/desktop/tauri-bridge";
 import { isDesktopAppEnvironment } from "@/hooks/use-is-desktop-app";
+
+type DesktopBridge = typeof import("@/lib/desktop/tauri-bridge");
+
+/**
+ * Lazy, build-flag-guarded access to the Tauri bridge. The literal
+ * `import.meta.env.VITE_TAURI_APP` check (the same single knob
+ * `isDesktopAppEnvironment()` reads — see its "one knob" doc) must sit
+ * DIRECTLY at the dynamic-import site: Rollup decides chunk emission per
+ * module, so only a statically-false branch here keeps the bridge chunk out
+ * of the browser bundle entirely. A static import — or a dynamic one behind
+ * the helper function, which Rollup cannot inline — would ship Tauri IPC
+ * code to every browser visitor and trip the
+ * `scripts/check-web-bundle-desktop-free.ts` CI guard, which scans every
+ * emitted asset.
+ */
+async function loadBridge(): Promise<DesktopBridge> {
+  if (import.meta.env.VITE_TAURI_APP !== "1") {
+    throw new Error("Tauri bridge is unavailable outside the desktop build");
+  }
+  return import("@/lib/desktop/tauri-bridge");
+}
 
 export interface DesktopAuth {
   status: AuthStatus | undefined;
@@ -60,9 +74,9 @@ export function useDesktopAuth(): DesktopAuth {
   const isDesktopApp = isDesktopAppEnvironment();
   const statusQuery = useQuery({
     queryKey: KEYS.desktopAuthStatus(),
-    queryFn: fetchAuthStatus,
+    queryFn: async () => (await loadBridge()).fetchAuthStatus(),
     // Outside the Tauri webview (the shared `/login` route's web build)
-    // `fetchAuthStatus` would only throw — never fetch, never enable.
+    // `loadBridge` would only throw — never fetch, never enable.
     enabled: isDesktopApp,
     staleTime: 30_000,
     // A stale/expired upstream session should self-heal by re-checking on
@@ -82,9 +96,12 @@ export function useDesktopAuth(): DesktopAuth {
 
     let disposed = false;
     let unlisten: (() => void) | undefined;
-    void listenForAuthStatus((status) => {
-      queryClient.setQueryData(KEYS.desktopAuthStatus(), status);
-    })
+    void loadBridge()
+      .then((bridge) =>
+        bridge.listenForAuthStatus((status) => {
+          queryClient.setQueryData(KEYS.desktopAuthStatus(), status);
+        }),
+      )
       .then((stopListening) => {
         if (disposed) {
           stopListening();
@@ -106,8 +123,9 @@ export function useDesktopAuth(): DesktopAuth {
     setPending(true);
     setLoginError(null);
     try {
-      await performAuthLogin();
-      const status = await fetchAuthStatus();
+      const bridge = await loadBridge();
+      await bridge.performAuthLogin();
+      const status = await bridge.fetchAuthStatus();
       queryClient.setQueryData(KEYS.desktopAuthStatus(), status);
     } catch (err) {
       setLoginError(err instanceof Error ? err.message : "Sign-in failed");
@@ -119,8 +137,9 @@ export function useDesktopAuth(): DesktopAuth {
   async function logout(): Promise<void> {
     setPending(true);
     try {
-      await performAuthLogout();
-      const status = await fetchAuthStatus();
+      const bridge = await loadBridge();
+      await bridge.performAuthLogout();
+      const status = await bridge.fetchAuthStatus();
       queryClient.setQueryData(KEYS.desktopAuthStatus(), status);
     } finally {
       setPending(false);
@@ -130,8 +149,18 @@ export function useDesktopAuth(): DesktopAuth {
   async function completeSession(): Promise<void> {
     setCompletingSession(true);
     setCompleteSessionError(null);
+    let bridge: DesktopBridge;
     try {
-      await performAuthCompleteSession();
+      bridge = await loadBridge();
+    } catch (err) {
+      setCompleteSessionError(
+        err instanceof Error ? err.message : "Sign-in failed",
+      );
+      setCompletingSession(false);
+      return;
+    }
+    try {
+      await bridge.performAuthCompleteSession();
     } catch (err) {
       // Bridging failed (e.g. the mesh authorize call itself errored) — the
       // Better-Auth cookie session may still be sitting in local-api's jar,
@@ -144,7 +173,7 @@ export function useDesktopAuth(): DesktopAuth {
       );
     } finally {
       try {
-        const status = await fetchAuthStatus();
+        const status = await bridge.fetchAuthStatus();
         queryClient.setQueryData(KEYS.desktopAuthStatus(), status);
       } finally {
         setCompletingSession(false);

--- a/apps/web/src/desktop/use-native-session-sync.ts
+++ b/apps/web/src/desktop/use-native-session-sync.ts
@@ -1,0 +1,43 @@
+/**
+ * Keeps better-auth's web session in step with the NATIVE auth status on the
+ * shared `/login` route. The system-browser PKCE flow (`auth_login`)
+ * completes entirely outside the webview — it heals the Keychain and
+ * publishes `auth-status-changed`, but nothing tells better-auth's
+ * `useSession` (which only re-fetches when its `$sessionSignal` atom is
+ * toggled). Without this bridge the user signs in successfully in the
+ * browser and returns to a login form that never goes away.
+ *
+ * Decision logic lives in `native-session-sync.ts` (pure, unit-tested);
+ * this hook only wires it between the two external stores. Inert outside
+ * the desktop build: the effect early-returns and `useDesktopAuth`'s query
+ * is disabled on web.
+ */
+import { useEffect, useRef } from "react";
+import { authClient } from "@/lib/auth-client";
+import { isDesktopAppEnvironment } from "@/hooks/use-is-desktop-app";
+import { useDesktopAuth } from "@/desktop/use-desktop-auth";
+import { shouldNotifyWebSessionRefetch } from "@/desktop/native-session-sync";
+import type { AuthStatus } from "@/lib/desktop/tauri-bridge";
+
+export function useNativeSessionSync(): void {
+  const auth = useDesktopAuth();
+  const session = authClient.useSession();
+  const lastNotifiedRef = useRef<AuthStatus | null>(null);
+  const status = auth.status;
+  const hasWebSession = session.data != null;
+  const isWebSessionFetchInFlight = session.isPending;
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- bridges two external stores (Tauri auth status -> better-auth session atom)
+  useEffect(() => {
+    if (!isDesktopAppEnvironment() || !status) return;
+    const notify = shouldNotifyWebSessionRefetch({
+      nativeStatus: status,
+      lastNotifiedStatus: lastNotifiedRef.current,
+      hasWebSession,
+      isWebSessionFetchInFlight,
+    });
+    if (!notify) return;
+    lastNotifiedRef.current = status;
+    authClient.$store.notify("$sessionSignal");
+  }, [status, hasWebSession, isWebSessionFetchInFlight]);
+}

--- a/apps/web/src/i18n/en/common.ts
+++ b/apps/web/src/i18n/en/common.ts
@@ -30,6 +30,13 @@ export const common = {
   "common.archivedOrgScreen.orgUnavailable": "Organization unavailable",
   "common.authEntry.autoLoginFailed": "Auto-login failed",
   "common.authEntry.autoLoginFailedWithError": "Auto-login failed: {error}",
+  "common.authEntry.browserOnlyCta": "Continue in your browser",
+  "common.authEntry.browserOnlyDescription":
+    "This organization signs in with an emailed link, which can't be opened inside the app. Continue in your browser to finish signing in.",
+  "common.authEntry.browserOnlyTitle": "Welcome to deco",
+  "common.authEntry.finishSignInInBrowser":
+    "Finish signing in in your browser…",
+  "common.authEntry.finishingSignIn": "Finishing sign-in…",
   "common.authEntry.noLoginOptions": "No login options available",
   "common.authEntry.tryRestartingServer": "Try restarting the server.",
   "common.desktopKeychainUnavailable.description":
@@ -230,6 +237,8 @@ export const common = {
   "common.requestToJoinScreen.requestButton": "Request to join",
   "common.requestToJoinScreen.requesting": "Requesting…",
   "common.requestToJoinScreen.title": "Request to join {orgName}?",
+  "common.signInScreen.configLoadFailed": "Couldn't load sign-in options.",
+  "common.signInScreen.tryAgain": "Try again",
   "common.simpleIconPicker.filterPlaceholder": "Filter...",
   "common.simpleIconPicker.noIconsFound": "No icons found",
   "common.ssoRequiredScreen.goBack": "Go back",

--- a/apps/web/src/i18n/pt-br/common.ts
+++ b/apps/web/src/i18n/pt-br/common.ts
@@ -32,6 +32,12 @@ export const common = {
   "common.archivedOrgScreen.orgUnavailable": "Organização indisponível",
   "common.authEntry.autoLoginFailed": "Falha no auto-login",
   "common.authEntry.autoLoginFailedWithError": "Falha no auto-login: {error}",
+  "common.authEntry.browserOnlyCta": "Continuar no seu navegador",
+  "common.authEntry.browserOnlyDescription":
+    "Esta organização faz login com um link enviado por e-mail, que não pode ser aberto dentro do app. Continue no seu navegador para concluir o login.",
+  "common.authEntry.browserOnlyTitle": "Bem-vindo ao deco",
+  "common.authEntry.finishSignInInBrowser": "Conclua o login no seu navegador…",
+  "common.authEntry.finishingSignIn": "Concluindo login…",
   "common.authEntry.noLoginOptions": "Nenhuma opção de login disponível",
   "common.authEntry.tryRestartingServer": "Tente reiniciar o servidor.",
   "common.desktopKeychainUnavailable.description":
@@ -239,6 +245,9 @@ export const common = {
   "common.requestToJoinScreen.requestButton": "Solicitar acesso",
   "common.requestToJoinScreen.requesting": "Solicitando…",
   "common.requestToJoinScreen.title": "Solicitar acesso a {orgName}?",
+  "common.signInScreen.configLoadFailed":
+    "Não foi possível carregar as opções de login.",
+  "common.signInScreen.tryAgain": "Tentar novamente",
   "common.simpleIconPicker.filterPlaceholder": "Filtrar…",
   "common.simpleIconPicker.noIconsFound": "Nenhum ícone encontrado",
   "common.ssoRequiredScreen.goBack": "Voltar",

--- a/apps/web/src/index.native.tsx
+++ b/apps/web/src/index.native.tsx
@@ -67,7 +67,7 @@ function DesktopEntry() {
   }
 
   if (!auth.status?.signedIn) {
-    return <SignInScreen auth={auth} />;
+    return <SignInScreen />;
   }
 
   // `Providers` wraps the router here (not the root route) so router-level

--- a/apps/web/src/lib/desktop/tauri-bridge.ts
+++ b/apps/web/src/lib/desktop/tauri-bridge.ts
@@ -135,7 +135,7 @@ export async function performAuthLogout(): Promise<AuthResult> {
  * afterward (see `use-desktop-auth.ts`'s `completeSession`), matching the
  * contract's "(5) after bridge success auth_status flips signedIn" design.
  * Only call this after a successful `submitEmailPassword`/OTP submit
- * through the shared auth form — see `sign-in-screen.tsx` /
+ * through the shared auth form — see `use-desktop-auth-form-defaults.ts` /
  * `auth-actions.ts`.
  */
 export async function performAuthCompleteSession(): Promise<void> {

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,6 +1,7 @@
 import { AuthEntry } from "@/components/auth-entry";
 import { AuthSplitLayout } from "@/components/auth-split-layout";
 import { SplashScreen } from "@/components/splash-screen";
+import { useNativeSessionSync } from "@/desktop/use-native-session-sync";
 import { authClient } from "@/lib/auth-client";
 import { captureSignupAttribution } from "@/lib/signup-attribution";
 import { Navigate, useSearch } from "@tanstack/react-router";
@@ -41,6 +42,11 @@ function buildOAuthAuthorizeUrl(params: {
 
 export default function LoginRoute() {
   const session = authClient.useSession();
+  // Desktop only (inert on web): after the system-browser PKCE flow heals
+  // the Keychain, nothing else tells better-auth's `useSession` to re-fetch
+  // — without this the page would keep showing the sign-in form after a
+  // successful sign-in. See `@/desktop/use-native-session-sync`.
+  useNativeSessionSync();
   const searchParams = useSearch({ from: "/login" });
   const {
     next: rawNext = "/",


### PR DESCRIPTION
## Summary

Fixes the desktop login wedge reported as *"got logged out after ~10 min idle, now Continue with Google does nothing"* — the residual variant of #5421 still present on main, plus the structural cause behind both.

When the upstream session cookie dies while the native side still reports `signed_in`, the shell bounces to the in-webview `/login` route, which rendered the shared auth form **without** the desktop action overrides. Its social buttons then ran `authClient.signIn.social()` → a cross-origin navigation Tauri silently blocks → dead button, no error. This PR fixes the bug class, not the call site:

- **Platform-aware action resolution inside `AuthEntry`** (`use-desktop-auth-form-defaults.ts`): every sign-in surface — the shell `/login` route, the desktop gate, embedded surfaces — gets the system-browser PKCE hop for social/SSO and the Keychain bridge for `onAuthenticated` on the desktop build, and byte-identical web defaults otherwise. The per-call-site `actions` prop is deleted; forgetting it can no longer reproduce the wedge.
- **Post-login reactivity** (`use-native-session-sync.ts`, mounted on `/login`): when native auth status says signed-in while the webview holds no session, notify better-auth's `$sessionSignal` so `useSession` refetches and the login page redirects away. The decision predicate compares status payloads by reference — one notify per fresh native signal — so a still-dead cookie can't busy-loop `/get-session`.
- **Gate slimmed to a shell** (`sign-in-screen.tsx`): its duplicated pending/error states, action wiring, and magic-link-only fallback all moved into `AuthEntry` (`browser-only-column.tsx`, now i18n'd en + pt-br). The in-shell `/login` gets the magic-link-only fallback for free.
- **No more swallowed social errors**: `UnifiedAuthForm` failures now render in the existing error banner (previously analytics-only — invisible on web too), and the browser-hop pending/error states render on every surface.

## Testing

- New unit tests for the session-sync predicate (notify-once-per-signal, in-flight guard, signed-out/no-payload cases); existing `auth-actions` tests unchanged and passing.
- `bun test apps/web`: 2146 pass / 64 fail — **identical failure set at bare HEAD** (verified via stash round-trip); no new failures.
- `bun run fmt`, `bun run lint` (0 errors; the one warning near the diff is pre-existing in `AutoLogin`), `tsc --noEmit` clean (also proves pt-br dictionary parity via `satisfies`), knip: no new flags.
- Affected areas: web `/login` (behavior unchanged on web build — desktop defaults resolve to `null`), desktop gate, embedded auth surfaces (`commerce-onboarding`, `reports/auth-gate` — no `actions` prop passed before or after).

Follow-up context: the ~10-min idle logout itself is the native revalidator correctly detecting a server-rejected token (`revalidate.rs` ticks at 5-min intervals); why the server rejects it is a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop login wedge by resolving platform-aware auth actions inside `AuthEntry` and syncing the web session after native sign-in. Also lazy-loads the Tauri bridge so the web bundle stays desktop-free and `/login` redirects immediately after a native sign-in.

- **Bug Fixes**
  - Resolve platform-aware auth actions inside `AuthEntry` via `use-desktop-auth-form-defaults` (system-browser hop for social/SSO, Keychain bridge for `onAuthenticated` on desktop); removed the per-call-site `actions` prop.
  - Add `use-native-session-sync` on `/login` to notify better-auth to refetch when native reports signed-in but the webview has no session (pure predicate with unit tests).
  - Show social sign-in failures in `UnifiedAuthForm`’s existing error banner.
  - Provide a desktop magic-link-only fallback (`BrowserOnlyColumn`) with i18n (en, pt-br).
  - Lazy-load `@/lib/desktop/tauri-bridge` behind `VITE_TAURI_APP` in `use-desktop-auth` to keep Tauri IPC code out of the web build.

- **Refactors**
  - Slim desktop `SignInScreen` to layout + config boundary; browser-hop and bridge states now render within `AuthEntry`.
  - Keep the native chat model selector local by default: new `resolveNativeAgentOption` and `shouldUseLocalModels` prevent falling back to cloud on desktop while CLI detection is pending; added focused tests.
  - Minor chat context/pills tweaks for offline handling and thread-locked cases.

<sup>Written for commit 78fca655be9a4c5f42e50f1a6ce08dbd83a586ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

