### PR TITLE
fix(native): gate the chat on a resolved local agent

### DIFF
--- a/apps/web/src/components/chat/chat-context.tsx
+++ b/apps/web/src/components/chat/chat-context.tsx
@@ -46,7 +46,7 @@ import type { HarnessId } from "@decocms/harness/types";
 import {
   AGENT_OPTION_PINS,
   agentOptionFor,
-  preferredLocalAgentOption,
+  resolveNativeAgentOption,
   resolveOfflineAgentOption,
   type AgentOption,
 } from "./pills/agent-options";
@@ -498,10 +498,9 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
   // used to mis-route to an offline link. A fresh org starts with no pick
   // (`null`), letting the server choose its default.
   //
-  // Everything else (`pendingHarnessId`, `pendingSandboxProviderKind`,
-  // the request body's harnessId/sandboxProviderKind) derives from this
-  // through `AGENT_OPTION_PINS`, so the pill display and the submit can
-  // never disagree.
+  // Web derives the pending harness/sandbox pair from this value. Native
+  // filters it through its local-only resolver below. Both surfaces still read
+  // the same effective pair, so the pill display and submit cannot disagree.
   const [pendingAgentOption, setPendingAgentOption] =
     useLocalStorage<AgentOption | null>(
       LOCALSTORAGE_KEYS.chatLastAgentOption(locator),
@@ -526,44 +525,41 @@ export function ChatPrefsProvider({ children }: PropsWithChildren) {
         )
       : null;
 
-  // Capability probes are advisory — we don't rewrite the harness for a missing
-  // CLI (cloud chat via the org router works even where the cloud *sandbox*
-  // doesn't). The one exception is a desktop pick whose link is *confirmed*
-  // offline: it can't run anywhere and nothing prompted the user to reconnect,
-  // so we auto-switch it to cloud. Derived (not persisted), so the desktop pick
-  // returns on its own once the link reconnects.
+  // Capability probes are advisory on web — we don't rewrite the harness for a
+  // missing CLI (cloud chat via the org router works even where the cloud
+  // *sandbox* doesn't). The one exception is a desktop pick whose link is
+  // *confirmed* offline: it can't run anywhere and nothing prompted the user to
+  // reconnect, so we auto-switch it to cloud. Derived (not persisted), so the
+  // desktop pick returns on its own once the link reconnects.
   const link = useCurrentLink();
 
-  // The desktop app has no cloud/Decopilot surface to fall back to, so an
-  // un-set pick must never resolve to `decopilot` the way it does on web —
-  // that pins the thread to `agent-sandbox` (see `AGENT_OPTION_PINS`) and the
-  // sandbox is provisioned in the cloud instead of on this machine. Defaulting
-  // to the locally-detected CLI keeps the pin on `user-desktop`, which is the
-  // kind local-api intercepts. Derived, not persisted, so it re-resolves on its
-  // own as `LINK_CURRENT_GET` reports CLIs; an explicit user pick always wins.
   const isDesktopApp = useIsDesktopApp();
   const availability = useAgentOptionAvailability();
-  const desktopDefaultOption = isDesktopApp
-    ? preferredLocalAgentOption(availability)
-    : null;
-
-  const selectedAgentOption = resolveOfflineAgentOption(
-    pendingAgentOption ?? desktopDefaultOption,
+  // Native has no cloud/Decopilot surface. Ignore stale cloud prefs there and
+  // recover early native threads that pinned a local harness without the
+  // expected sandbox tuple. While cold CLI detection is unresolved this stays
+  // null; TierTrigger renders that state as local-pending, never as cloud.
+  const nativeAgentOption = resolveNativeAgentOption({
+    pendingOption: pendingAgentOption,
+    lockedHarness: taskCtxForLock?.isThreadLocked
+      ? taskCtxForLock.lockedHarness
+      : null,
+    availability,
+  });
+  const webSelectedAgentOption = resolveOfflineAgentOption(
+    pendingAgentOption,
     link.ready && !link.online,
   );
 
-  // When the thread is locked, the agent option is dictated by the persisted
-  // (harness, sandbox) pair — period. Otherwise, fall through to the user's
-  // selected global picker.
-  //
-  // When the thread is locked but the (harness, sandbox) tuple doesn't map
-  // to a known AgentOption (legacy/trigger-created rows), we intentionally
-  // surface `null` here rather than falling through to the global picker.
-  // The submit path is server-enforced anyway; consumers (pills, etc.)
-  // should consult isThreadLocked for the "locked" affordance and avoid
-  // showing the global selection on a locked thread.
-  const effectiveAgentOption: AgentOption | null =
-    taskCtxForLock?.isThreadLocked ? lockedAgentOption : selectedAgentOption;
+  // On web, a locked thread is dictated by its persisted (harness, sandbox)
+  // pair; an unknown tuple surfaces null instead of falling through to the
+  // global picker. Native is different: every runnable harness is local, and
+  // `nativeAgentOption` recovers older rows by their local harness alone.
+  const effectiveAgentOption: AgentOption | null = isDesktopApp
+    ? nativeAgentOption
+    : taskCtxForLock?.isThreadLocked
+      ? lockedAgentOption
+      : webSelectedAgentOption;
 
   const effectivePins = effectiveAgentOption
     ? AGENT_OPTION_PINS[effectiveAgentOption]

--- a/apps/web/src/components/chat/index.tsx
+++ b/apps/web/src/components/chat/index.tsx
@@ -27,6 +27,7 @@ import { useMessageQueue } from "./use-message-queue.ts";
 import { useOpenPreviewOnRepoLoad } from "./use-open-preview-on-repo-load.ts";
 import { SubtaskRunsProvider } from "./subtask-runs-context.tsx";
 import { NoAiProviderEmptyState } from "./no-ai-provider-empty-state";
+import { NativeAgentEmptyState } from "./native-agent-empty-state";
 import { CreditsEmptyState } from "./credits-empty-state";
 import { CreditsExhaustedBanner } from "./credits-exhausted-banner";
 import { CreditsEyebrow, NoCreditsEyebrow } from "./credits-eyebrow";
@@ -336,6 +337,7 @@ export const Chat = Object.assign(ChatRoot, {
   Skeleton: DecoChatSkeleton,
   IceBreakers: IceBreakers,
   NoAiProviderEmptyState: NoAiProviderEmptyState,
+  NativeAgentEmptyState: NativeAgentEmptyState,
   CreditsEmptyState: CreditsEmptyState,
   CreditsEyebrow: CreditsEyebrow,
   NoCreditsEyebrow: NoCreditsEyebrow,

--- a/apps/web/src/components/chat/native-agent-empty-state.tsx
+++ b/apps/web/src/components/chat/native-agent-empty-state.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from "react";
+import { Monitor01 } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import { useCurrentLink } from "@/hooks/use-current-link";
+import { useT } from "@/i18n/use-t.ts";
+import { ClaudeCodeIcon, CodexIcon } from "./agent-icons";
+import { useChatPrefs } from "./context";
+import type { AgentOption } from "./pills/agent-options";
+
+/**
+ * Native counterpart of `NoAiProviderEmptyState`. The desktop app has no
+ * cloud runtime, so there is no provider grid to offer — the only way to run
+ * a chat is a local coding agent. Shown by the chat side panel while the
+ * native agent resolver has no option yet (CLI detection cold, or neither
+ * CLI detected).
+ *
+ * Both options are always offered: availability is advisory in this codebase
+ * and must not prevent selection. Picking one persists the pending agent
+ * option, which resolves the gate and hands over to the composer — the
+ * escape hatch out of a stuck detection state.
+ */
+export function NativeAgentEmptyState() {
+  const t = useT();
+  const link = useCurrentLink();
+  const { setPendingAgentOption } = useChatPrefs();
+
+  const options: Array<{
+    option: AgentOption;
+    label: string;
+    icon: ReactNode;
+    detected: boolean;
+  }> = [
+    {
+      option: "claude-code-desktop",
+      label: "Claude Code",
+      icon: <ClaudeCodeIcon size={16} />,
+      detected: link.online && link.capabilities.includes("claude-code"),
+    },
+    {
+      option: "codex-desktop",
+      label: "Codex",
+      icon: <CodexIcon size={16} />,
+      detected: link.online && link.capabilities.includes("codex"),
+    },
+  ];
+
+  const anyDetected = options.some((o) => o.detected);
+  const subtitle = !link.ready
+    ? t("chat.nativeAgentEmptyState.subtitleDetecting")
+    : anyDetected
+      ? t("chat.nativeAgentEmptyState.subtitlePick")
+      : t("chat.nativeAgentEmptyState.subtitleNoneDetected");
+
+  return (
+    <div className="flex flex-col items-center gap-8 w-full max-w-3xl px-4">
+      <div className="flex flex-col items-center gap-4 text-center">
+        <div className="flex items-center justify-center size-14 rounded-2xl bg-muted border border-border">
+          <span className="relative inline-flex items-center justify-center">
+            <Monitor01 size={24} className="text-muted-foreground" />
+            {anyDetected && (
+              <span className="absolute -top-0.5 -right-0.5 size-2.5 rounded-full bg-success ring-2 ring-background animate-pulse" />
+            )}
+          </span>
+        </div>
+        <div className="space-y-2">
+          <p className="text-xl font-semibold text-foreground tracking-tight">
+            {t("chat.nativeAgentEmptyState.heading")}
+          </p>
+          <p className="text-sm text-muted-foreground max-w-md">{subtitle}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {options.map((o) => (
+          <Button
+            key={o.option}
+            variant={o.detected ? "default" : "outline"}
+            className="gap-2"
+            title={
+              link.ready && !o.detected
+                ? t("chat.nativeAgentEmptyState.notDetected", {
+                    label: o.label,
+                  })
+                : undefined
+            }
+            onClick={() => setPendingAgentOption(o.option)}
+          >
+            {o.icon}
+            {t("chat.noAiProviderEmptyState.useLabel", { label: o.label })}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/pills/agent-options.test.ts
+++ b/apps/web/src/components/chat/pills/agent-options.test.ts
@@ -8,6 +8,7 @@ import {
   agentOptionFor,
   agentOptionIsAvailable,
   preferredLocalAgentOption,
+  resolveNativeAgentOption,
   resolveOfflineAgentOption,
 } from "./agent-options";
 
@@ -136,6 +137,65 @@ describe("preferredLocalAgentOption", () => {
         codex: false,
       }),
     ).toBeNull();
+  });
+});
+
+describe("resolveNativeAgentOption", () => {
+  test("does not turn unresolved native detection into cloud Decopilot", () => {
+    const unresolved = {
+      ...ALL_AVAILABLE,
+      claudeCode: false,
+      codex: false,
+    };
+    for (const pendingOption of [null, "decopilot"] as const) {
+      expect(
+        resolveNativeAgentOption({
+          pendingOption,
+          lockedHarness: null,
+          availability: unresolved,
+        }),
+      ).toBeNull();
+    }
+  });
+
+  test("ignores a stale persisted Decopilot choice", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: "decopilot",
+        lockedHarness: null,
+        availability: ALL_AVAILABLE,
+      }),
+    ).toBe("claude-code-desktop");
+  });
+
+  test("uses Codex when it is the only detected local CLI", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: null,
+        lockedHarness: null,
+        availability: { ...ALL_AVAILABLE, claudeCode: false },
+      }),
+    ).toBe("codex-desktop");
+  });
+
+  test("preserves an explicit local choice", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: "codex-desktop",
+        lockedHarness: null,
+        availability: ALL_AVAILABLE,
+      }),
+    ).toBe("codex-desktop");
+  });
+
+  test("a locked local harness wins without requiring its sandbox tuple", () => {
+    expect(
+      resolveNativeAgentOption({
+        pendingOption: "codex-desktop",
+        lockedHarness: "claude-code",
+        availability: ALL_AVAILABLE,
+      }),
+    ).toBe("claude-code-desktop");
   });
 });
 

--- a/apps/web/src/components/chat/pills/agent-options.ts
+++ b/apps/web/src/components/chat/pills/agent-options.ts
@@ -6,6 +6,7 @@ import {
 } from "@/sdk";
 
 export type AgentOption = "decopilot" | "claude-code-desktop" | "codex-desktop";
+type LocalAgentOption = Exclude<AgentOption, "decopilot">;
 
 export interface AgentPins {
   harness: HarnessId;
@@ -78,10 +79,39 @@ export interface AgentOptionAvailability {
  */
 export function preferredLocalAgentOption(
   availability: AgentOptionAvailability,
-): AgentOption | null {
+): LocalAgentOption | null {
   if (availability.claudeCode) return "claude-code-desktop";
   if (availability.codex) return "codex-desktop";
   return null;
+}
+
+/**
+ * Resolve the only agent options a native build may expose.
+ *
+ * Native has no cloud runtime, so a stale persisted Decopilot pick must never
+ * win. A locked local harness also wins by harness alone: early native builds
+ * could pin a Claude Code/Codex thread before `sandbox_provider_kind` was
+ * available, and requiring the full tuple would misclassify that local thread
+ * as cloud.
+ *
+ * Returns null while CLI detection is still unresolved and there is no prior
+ * local choice. The native model selector treats that as local-pending rather
+ * than falling back to provider models.
+ */
+export function resolveNativeAgentOption({
+  pendingOption,
+  lockedHarness,
+  availability,
+}: {
+  pendingOption: AgentOption | null;
+  lockedHarness: HarnessId | null;
+  availability: AgentOptionAvailability;
+}): LocalAgentOption | null {
+  if (lockedHarness === "claude-code") return "claude-code-desktop";
+  if (lockedHarness === "codex") return "codex-desktop";
+  if (pendingOption === "claude-code-desktop") return pendingOption;
+  if (pendingOption === "codex-desktop") return pendingOption;
+  return preferredLocalAgentOption(availability);
 }
 
 /**

--- a/apps/web/src/components/chat/resolve-needs-runtime-setup.test.ts
+++ b/apps/web/src/components/chat/resolve-needs-runtime-setup.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test";
+import { resolveNeedsRuntimeSetup } from "./resolve-needs-runtime-setup";
+import type { AgentOptionAvailability } from "./pills/agent-options";
+
+const none: AgentOptionAvailability = {
+  agentSandbox: false,
+  userDesktop: false,
+  claudeCode: false,
+  codex: false,
+};
+const claudeOnly: AgentOptionAvailability = {
+  ...none,
+  userDesktop: true,
+  claudeCode: true,
+};
+
+const base = {
+  isThreadLocked: false,
+  isDesktopApp: false,
+  hasCloudProviderKeys: false,
+  pendingAgentOption: null,
+  availability: none,
+};
+
+describe("resolveNeedsRuntimeSetup", () => {
+  it("never gates a locked thread — its history must stay visible", () => {
+    expect(resolveNeedsRuntimeSetup({ ...base, isThreadLocked: true })).toBe(
+      false,
+    );
+    expect(
+      resolveNeedsRuntimeSetup({
+        ...base,
+        isThreadLocked: true,
+        isDesktopApp: true,
+      }),
+    ).toBe(false);
+  });
+
+  describe("native", () => {
+    it("gates while the local resolver has no option (cold detection / no CLI)", () => {
+      expect(resolveNeedsRuntimeSetup({ ...base, isDesktopApp: true })).toBe(
+        true,
+      );
+    });
+
+    it("ignores cloud provider keys — native can't run on them", () => {
+      expect(
+        resolveNeedsRuntimeSetup({
+          ...base,
+          isDesktopApp: true,
+          hasCloudProviderKeys: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("releases once a local option is resolved, even before detection confirms it", () => {
+      expect(
+        resolveNeedsRuntimeSetup({
+          ...base,
+          isDesktopApp: true,
+          pendingAgentOption: "claude-code-desktop",
+        }),
+      ).toBe(false);
+      expect(
+        resolveNeedsRuntimeSetup({
+          ...base,
+          isDesktopApp: true,
+          pendingAgentOption: "codex-desktop",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("web", () => {
+    it("gates when there is no cloud key and no usable local runtime", () => {
+      expect(resolveNeedsRuntimeSetup(base)).toBe(true);
+      expect(
+        resolveNeedsRuntimeSetup({
+          ...base,
+          pendingAgentOption: "claude-code-desktop",
+        }),
+      ).toBe(true);
+    });
+
+    it("releases on a cloud provider key", () => {
+      expect(
+        resolveNeedsRuntimeSetup({ ...base, hasCloudProviderKeys: true }),
+      ).toBe(false);
+    });
+
+    it("releases on a picked local runtime that is actually available", () => {
+      expect(
+        resolveNeedsRuntimeSetup({
+          ...base,
+          pendingAgentOption: "claude-code-desktop",
+          availability: claudeOnly,
+        }),
+      ).toBe(false);
+    });
+
+    it("keeps gating when the picked local runtime is not the detected one", () => {
+      expect(
+        resolveNeedsRuntimeSetup({
+          ...base,
+          pendingAgentOption: "codex-desktop",
+          availability: claudeOnly,
+        }),
+      ).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/components/chat/resolve-needs-runtime-setup.ts
+++ b/apps/web/src/components/chat/resolve-needs-runtime-setup.ts
@@ -1,0 +1,44 @@
+import type {
+  AgentOption,
+  AgentOptionAvailability,
+} from "./pills/agent-options";
+
+/**
+ * Pure core of `useNeedsRuntimeSetup` — see that hook for the semantics.
+ * Extracted so the gate can be unit-tested without mounting the chat context.
+ *
+ * `pendingAgentOption` is the *effective* option the chat context exposes:
+ * on native it has already been filtered through `resolveNativeAgentOption`,
+ * so `null` there means local CLI detection is cold or found nothing.
+ */
+export function resolveNeedsRuntimeSetup({
+  isThreadLocked,
+  isDesktopApp,
+  hasCloudProviderKeys,
+  pendingAgentOption,
+  availability,
+}: {
+  isThreadLocked: boolean;
+  isDesktopApp: boolean;
+  hasCloudProviderKeys: boolean;
+  pendingAgentOption: AgentOption | null;
+  availability: AgentOptionAvailability;
+}): boolean {
+  // A locked thread has already run — it has history and a runtime pinned for
+  // life. It must never be replaced by the setup empty state (which would hide
+  // the conversation) or gate its tabs, even if a linked desktop later drops
+  // offline in a keyless org. Setup only gates fresh, un-run threads.
+  if (isThreadLocked) return false;
+
+  // Native has no cloud runtime, so provider keys can't run a chat there. The
+  // chat is startable only once the native resolver produced a local option —
+  // either a detected CLI or an explicit prior pick. Until then the composer
+  // would render with an empty model selector and no way out.
+  if (isDesktopApp) return pendingAgentOption === null;
+
+  const localRuntimeReady =
+    (pendingAgentOption === "claude-code-desktop" && availability.claudeCode) ||
+    (pendingAgentOption === "codex-desktop" && availability.codex);
+
+  return !hasCloudProviderKeys && !localRuntimeReady;
+}

--- a/apps/web/src/components/chat/side-panel-chat.tsx
+++ b/apps/web/src/components/chat/side-panel-chat.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundary } from "../error-boundary";
 
 import { Chat } from "./index";
 import { useChatStream } from "./context";
+import { useIsDesktopApp } from "@/hooks/use-is-desktop-app";
 import { useNeedsRuntimeSetup } from "./use-needs-runtime-setup";
 import { ChatContextPanel } from "./context-panel";
 import { AgentHome } from "./agent-home";
@@ -23,22 +24,29 @@ function ChatSidePanelContent() {
   const [activePanel, setActivePanel] = useState<"chat" | "context">("chat");
   const deco = useDecoCredits();
 
-  // Surface the provider-setup UI when there's no way to run a chat — no cloud
-  // AI provider AND no usable local runtime. The empty state itself offers the
-  // local Claude Code / Codex options as a one-click escape when a desktop is
-  // linked. Same signal gates the main-panel view tabs.
+  // Surface the runtime-setup UI when there's no way to run a chat. On web
+  // that's no cloud AI provider AND no usable local runtime; on native it's
+  // no resolved local coding agent. Each empty state offers the Claude Code /
+  // Codex options as a one-click escape. Same signal gates the main-panel
+  // view tabs.
   const showProviderEmptyState = useNeedsRuntimeSetup();
+  const isDesktopApp = useIsDesktopApp();
 
   if (showProviderEmptyState) {
     return (
       <Chat className="animate-in fade-in-0 duration-200">
         <Chat.Main className="flex flex-col items-center">
           <Chat.EmptyState>
-            <Chat.NoAiProviderEmptyState
-              // Picking a local runtime is the same gesture as opening a new
-              // chat with this agent: open its Overview alongside the composer.
-              onLocalRuntimePicked={() => openTab("overview")}
-            />
+            {isDesktopApp ? (
+              // Native never offers cloud providers — only the local agents.
+              <Chat.NativeAgentEmptyState />
+            ) : (
+              <Chat.NoAiProviderEmptyState
+                // Picking a local runtime is the same gesture as opening a new
+                // chat with this agent: open its Overview alongside the composer.
+                onLocalRuntimePicked={() => openTab("overview")}
+              />
+            )}
           </Chat.EmptyState>
         </Chat.Main>
       </Chat>

--- a/apps/web/src/components/chat/tier-trigger.tsx
+++ b/apps/web/src/components/chat/tier-trigger.tsx
@@ -32,6 +32,7 @@ import { useT, type TFunction } from "@/i18n/use-t.ts";
 import type { ChatTier } from "@decocms/shared/organization/schema";
 import {
   resolveTierSubtitle,
+  shouldUseLocalModels,
   useAgentMode,
   useChatTier,
   useSetChatTier,
@@ -475,7 +476,7 @@ export function TierTrigger() {
   const locked = taskCtx?.isThreadLocked ?? false;
   const isDesktopApp = useIsDesktopApp();
   const hasLocal = availability.claudeCode || availability.codex;
-  const isLocal = mode !== "cloud-decopilot";
+  const isLocal = shouldUseLocalModels(mode, isDesktopApp);
   // Cloud rows only: org config + this user's overrides, wired into each
   // row's cog popover below.
   const org = useSimpleMode();

--- a/apps/web/src/components/chat/use-agent-mode.test.ts
+++ b/apps/web/src/components/chat/use-agent-mode.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   agentModeFromOption,
   resolveTierSubtitle,
+  shouldUseLocalModels,
   type AgentMode,
 } from "./use-agent-mode";
 import type { AgentOption } from "./pills/agent-options";
@@ -30,6 +31,18 @@ describe("agentModeFromOption", () => {
 
   it("agentModeFromOption(null) defaults to cloud-decopilot", () => {
     expect(agentModeFromOption(null)).toBe("cloud-decopilot");
+  });
+});
+
+describe("shouldUseLocalModels", () => {
+  it("keeps native on local models while runtime detection is pending", () => {
+    expect(shouldUseLocalModels("cloud-decopilot", true)).toBe(true);
+  });
+
+  it("keeps cloud models on web and local models for explicit local modes", () => {
+    expect(shouldUseLocalModels("cloud-decopilot", false)).toBe(false);
+    expect(shouldUseLocalModels("local-claude-code", false)).toBe(true);
+    expect(shouldUseLocalModels("local-codex", false)).toBe(true);
   });
 });
 

--- a/apps/web/src/components/chat/use-agent-mode.ts
+++ b/apps/web/src/components/chat/use-agent-mode.ts
@@ -34,6 +34,18 @@ export function useAgentMode(): AgentMode {
   return agentModeFromOption(pendingAgentOption);
 }
 
+/**
+ * Whether the chat-input selector must use the fixed local CLI catalogs.
+ * Native never exposes cloud/provider models, including while local CLI
+ * detection is still pending and the effective option is temporarily null.
+ */
+export function shouldUseLocalModels(
+  mode: AgentMode,
+  isDesktopApp: boolean,
+): boolean {
+  return isDesktopApp || mode !== "cloud-decopilot";
+}
+
 /** Current chat tier from prefs. Defaults to "smart" via prefs. */
 export function useChatTier(): ChatTier {
   return useChatPrefs().simpleModeTier;

--- a/apps/web/src/components/chat/use-needs-runtime-setup.ts
+++ b/apps/web/src/components/chat/use-needs-runtime-setup.ts
@@ -1,14 +1,21 @@
 import { useAiProviderKeys } from "@/hooks/collections/use-ai-providers";
+import { useIsDesktopApp } from "@/hooks/use-is-desktop-app";
 import { useChatPrefs, useOptionalChatTask } from "./context";
 import { useAgentOptionAvailability } from "./use-agent-availability";
+import { resolveNeedsRuntimeSetup } from "./resolve-needs-runtime-setup";
 
 /**
- * True when the org has no way to run a chat yet: no cloud AI provider AND no
- * usable local runtime selected. A linked desktop with Claude Code or Codex is
- * a valid runtime, so once the user picks one (and it's actually available)
- * this flips to false.
+ * True when there is no way to run a chat yet.
  *
- * Read only by the chat side panel, which shows the provider-setup empty state
+ * Web: the org has no cloud AI provider AND no usable local runtime selected.
+ * A linked desktop with Claude Code or Codex is a valid runtime, so once the
+ * user picks one (and it's actually available) this flips to false.
+ *
+ * Native: cloud providers don't exist there, so this is simply "the local
+ * resolver has no agent option yet" — CLI detection is still cold or found
+ * neither Claude Code nor Codex, and the user hasn't picked one explicitly.
+ *
+ * Read only by the chat side panel, which shows the runtime-setup empty state
  * when true. The main-panel view tabs stay navigable regardless — browsing the
  * app (Overview / Content / Settings / …) is never gated on runtime setup.
  */
@@ -17,16 +24,13 @@ export function useNeedsRuntimeSetup(): boolean {
   const { pendingAgentOption } = useChatPrefs();
   const availability = useAgentOptionAvailability();
   const task = useOptionalChatTask();
+  const isDesktopApp = useIsDesktopApp();
 
-  // A locked thread has already run — it has history and a runtime pinned for
-  // life. It must never be replaced by the setup empty state (which would hide
-  // the conversation) or gate its tabs, even if a linked desktop later drops
-  // offline in a keyless org. Setup only gates fresh, un-run threads.
-  if (task?.isThreadLocked) return false;
-
-  const localRuntimeReady =
-    (pendingAgentOption === "claude-code-desktop" && availability.claudeCode) ||
-    (pendingAgentOption === "codex-desktop" && availability.codex);
-
-  return allKeys.length === 0 && !localRuntimeReady;
+  return resolveNeedsRuntimeSetup({
+    isThreadLocked: task?.isThreadLocked ?? false,
+    isDesktopApp,
+    hasCloudProviderKeys: allKeys.length > 0,
+    pendingAgentOption,
+    availability,
+  });
 }

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -293,6 +293,15 @@ export const chat = {
     "Failed to load prompt. Please try again.",
   "chat.nextActionChip.mcpClientNotAvailable": "MCP client not available",
   "chat.nextActionChip.next": "Next:",
+  "chat.nativeAgentEmptyState.heading": "Choose your coding agent",
+  "chat.nativeAgentEmptyState.notDetected":
+    "{label} was not detected on this computer",
+  "chat.nativeAgentEmptyState.subtitleDetecting":
+    "Looking for coding agents installed on this computer…",
+  "chat.nativeAgentEmptyState.subtitleNoneDetected":
+    "No coding agent was detected. Install Claude Code or Codex, then pick it here to start chatting.",
+  "chat.nativeAgentEmptyState.subtitlePick":
+    "Chats run on a coding agent installed on this computer. Pick one to start.",
   "chat.noAiProviderEmptyState.connectDesktopLabel": "Connect your desktop",
   "chat.noAiProviderEmptyState.desktopLinkedLabel": "Desktop linked",
   "chat.noAiProviderEmptyState.headingDefault": "Your agents are almost ready",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -301,6 +301,15 @@ export const chat = {
     "Falha ao carregar prompt. Tente novamente.",
   "chat.nextActionChip.mcpClientNotAvailable": "Cliente MCP não disponível",
   "chat.nextActionChip.next": "Próximo:",
+  "chat.nativeAgentEmptyState.heading": "Escolha seu agente de codificação",
+  "chat.nativeAgentEmptyState.notDetected":
+    "{label} não foi detectado neste computador",
+  "chat.nativeAgentEmptyState.subtitleDetecting":
+    "Procurando agentes de codificação instalados neste computador…",
+  "chat.nativeAgentEmptyState.subtitleNoneDetected":
+    "Nenhum agente de codificação foi detectado. Instale o Claude Code ou o Codex e selecione-o aqui para começar a conversar.",
+  "chat.nativeAgentEmptyState.subtitlePick":
+    "Os chats rodam em um agente de codificação instalado neste computador. Escolha um para começar.",
   "chat.noAiProviderEmptyState.connectDesktopLabel": "Conecte seu desktop",
   "chat.noAiProviderEmptyState.desktopLinkedLabel": "Desktop vinculado",
   "chat.noAiProviderEmptyState.headingDefault":

--- a/packages/sandbox/daemon/org-fs/sidecar.test.ts
+++ b/packages/sandbox/daemon/org-fs/sidecar.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { sleep } from "@decocms/shared/std";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { runSidecar, type SidecarMountManager } from "./sidecar";
 
@@ -26,6 +27,41 @@ function fakeManager() {
   return { manager, calls, stopped: () => stopped };
 }
 
+function sidecarLogSignals() {
+  const invalidConfigRead = Promise.withResolvers<void>();
+  const mounted = Promise.withResolvers<void>();
+  return {
+    invalidConfigRead: invalidConfigRead.promise,
+    mounted: mounted.promise,
+    log(message: string) {
+      if (message === "invalid org-fs config file; waiting for rewrite") {
+        invalidConfigRead.resolve();
+      }
+      if (message.startsWith("mounted ")) {
+        mounted.resolve();
+      }
+    },
+  };
+}
+
+async function waitForSignal(
+  signal: Promise<void>,
+  description: string,
+): Promise<void> {
+  const timeoutController = new AbortController();
+  const timeout = sleep(1_000, { signal: timeoutController.signal }).then(
+    () => {
+      throw new Error(`timed out waiting for ${description}`);
+    },
+  );
+  try {
+    await Promise.race([signal, timeout]);
+  } finally {
+    timeoutController.abort();
+    await timeout.catch(() => {});
+  }
+}
+
 const CONFIG = JSON.stringify({
   baseUrl: "http://studio",
   orgSlug: "acme",
@@ -47,6 +83,7 @@ describe("runSidecar", () => {
 
   it("waits for the config file, mounts, writes status, unmounts on abort", async () => {
     const { manager, calls, stopped } = fakeManager();
+    const signals = sidecarLogSignals();
     const ac = new AbortController();
     const run = runSidecar({
       configPath: configPath(),
@@ -55,27 +92,32 @@ describe("runSidecar", () => {
       manager,
       signal: ac.signal,
       pollMs: 5,
+      log: signals.log,
     });
-    // no config yet → nothing mounted
-    await Bun.sleep(20);
-    expect(calls.length).toBe(0);
 
-    writeFileSync(configPath(), CONFIG);
-    await Bun.sleep(40);
-    expect(calls.length).toBe(1);
-    expect(calls[0]?.appRoot).toBe("/app");
-    const status = JSON.parse(readFileSync(statusPath(), "utf8"));
-    expect(status.mounts).toEqual([
-      { volume: "skills", mountPath: "/app/org/skills" },
-    ]);
+    try {
+      // no config yet → nothing mounted
+      await sleep(20);
+      expect(calls.length).toBe(0);
 
-    ac.abort();
-    await run;
+      writeFileSync(configPath(), CONFIG);
+      await waitForSignal(signals.mounted, "sidecar mount");
+      expect(calls.length).toBe(1);
+      expect(calls[0]?.appRoot).toBe("/app");
+      const status = JSON.parse(readFileSync(statusPath(), "utf8"));
+      expect(status.mounts).toEqual([
+        { volume: "skills", mountPath: "/app/org/skills" },
+      ]);
+    } finally {
+      ac.abort();
+      await run;
+    }
     expect(stopped()).toBe(1);
   });
 
   it("ignores an invalid config file and keeps waiting", async () => {
     const { manager, calls } = fakeManager();
+    const signals = sidecarLogSignals();
     const ac = new AbortController();
     writeFileSync(configPath(), "{not json");
     const run = runSidecar({
@@ -85,14 +127,18 @@ describe("runSidecar", () => {
       manager,
       signal: ac.signal,
       pollMs: 5,
+      log: signals.log,
     });
-    await Bun.sleep(25);
-    expect(calls.length).toBe(0);
-    writeFileSync(configPath(), CONFIG);
-    await Bun.sleep(40);
-    expect(calls.length).toBe(1);
-    ac.abort();
-    await run;
+    try {
+      await waitForSignal(signals.invalidConfigRead, "invalid config read");
+      expect(calls.length).toBe(0);
+      writeFileSync(configPath(), CONFIG);
+      await waitForSignal(signals.mounted, "sidecar mount");
+      expect(calls.length).toBe(1);
+    } finally {
+      ac.abort();
+      await run;
+    }
   });
 
   it("exits without mounting when aborted while waiting", async () => {
@@ -106,7 +152,7 @@ describe("runSidecar", () => {
       signal: ac.signal,
       pollMs: 5,
     });
-    await Bun.sleep(15);
+    await sleep(15);
     ac.abort();
     await run;
     expect(calls.length).toBe(0);
@@ -115,6 +161,7 @@ describe("runSidecar", () => {
 
   it("creates the status file's parent dir", async () => {
     const { manager } = fakeManager();
+    const signals = sidecarLogSignals();
     const ac = new AbortController();
     const nested = join(dir, "deep", "status.json");
     writeFileSync(configPath(), CONFIG);
@@ -125,10 +172,14 @@ describe("runSidecar", () => {
       manager,
       signal: ac.signal,
       pollMs: 5,
+      log: signals.log,
     });
-    await Bun.sleep(40);
-    expect(JSON.parse(readFileSync(nested, "utf8")).mounts.length).toBe(1);
-    ac.abort();
-    await run;
+    try {
+      await waitForSignal(signals.mounted, "sidecar mount");
+      expect(JSON.parse(readFileSync(nested, "utf8")).mounts.length).toBe(1);
+    } finally {
+      ac.abort();
+      await run;
+    }
   });
 });


### PR DESCRIPTION
## What is this contribution about?

Follow-up to #5435. That PR correctly stopped native from falling back to cloud provider models, but when the local resolver has no option (CLI detection still cold, or no CLI detected) the chat still rendered — with an empty model selector and no way to start or pick a model. The existing `useNeedsRuntimeSetup` gate never fired on native because cloud provider keys counted as a runtime there, which native can't use.

- Extract the gate into a pure `resolveNeedsRuntimeSetup` with a native branch: on native, setup is needed exactly when the effective agent option is `null`; cloud provider keys are ignored. Locked threads are never gated, and an explicit prior local pick still releases the gate (matching `resolveNativeAgentOption` semantics).
- Add `NativeAgentEmptyState`: same visual language as `NoAiProviderEmptyState`, but only the Claude Code / Codex options — no provider grid, no connect-desktop dialog. Both buttons always render (availability is advisory and must not prevent selection), so a stuck detection state always has a one-click escape; detected CLIs get the primary variant, undetected ones are outlined with a "not detected" tooltip. Subtitle reflects detecting / pick / none-detected.
- The chat side panel renders the native empty state on desktop builds; web keeps the existing `NoAiProviderEmptyState` flow unchanged.
- Once detection resolves and finds a CLI, the resolver auto-picks it and the empty state hands over to the composer with no interaction needed.

A wrong pick (e.g. Codex selected but not installed) stays safe: native's dispatch resolves the binary before persisting anything and returns `unknown_harness` ("codex CLI not found"), surfaced as the inline chat error — no half-created thread, nothing pinned.

## How to Test

1. `bun test apps/web/src/components/chat` (includes the new `resolve-needs-runtime-setup.test.ts`).
2. `bun run check`, `bun run lint`, `bun run fmt:check`, `bunx knip` — all clean.
3. In native with cold/failed CLI detection: the chat is replaced by the agent empty state instead of a dead composer; picking Claude Code or Codex hands over to the composer with that runtime pinned.
4. On web: the provider empty state behavior is unchanged (gates only when no cloud key AND no usable local runtime).

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (not needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates native (desktop) chat behind a resolved local coding agent to prevent an empty model selector and any cloud fallback. Web behavior is unchanged.

- **Bug Fixes**
  - Native gating now triggers only when the effective agent option is null; cloud provider keys are ignored on native.
  - Locked threads are never gated, and older native rows are recovered by local harness alone.
  - Side panel uses `Chat.NativeAgentEmptyState`; picking Claude Code or Codex enables the composer, detected CLIs auto-pick, and bad picks show an inline error.

- **Refactors**
  - Added pure `resolveNeedsRuntimeSetup` and `resolveNativeAgentOption` with unit tests.
  - Introduced `shouldUseLocalModels` so native always uses local catalogs.
  - Added i18n for the native empty state and stabilized sidecar polling tests.

<sup>Written for commit f3a1eb212cf1d3e06700a99eea6107b197870b46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

