### PR TITLE
fix(harness): read_tool_output can't see truncated MCP outputs

### DIFF
--- a/apps/api/src/harnesses/decopilot/assemble-agent-tools.ts
+++ b/apps/api/src/harnesses/decopilot/assemble-agent-tools.ts
@@ -65,6 +65,11 @@ export interface AssembleAgentToolsOptions {
    * extraTools instead.
    */
   fullBuiltInParams?: Omit<BuiltinToolParams, "toolOutputMap">;
+  /** The caller's `read_tool_output` map. The main-agent path MUST pass it:
+   *  its `read_tool_output` comes in via `extraTools` bound to that map, so a
+   *  fresh one here would swallow every truncated MCP output. Omitted by the
+   *  subagent path, which takes its built-ins from `fullBuiltInParams`. */
+  toolOutputMap?: Map<string, string>;
 }
 
 export interface AssembleAgentToolsResult {
@@ -76,7 +81,7 @@ export interface AssembleAgentToolsResult {
 export async function assembleAgentTools(
   opts: AssembleAgentToolsOptions,
 ): Promise<AssembleAgentToolsResult> {
-  const toolOutputMap = new Map<string, string>();
+  const toolOutputMap = opts.toolOutputMap ?? new Map<string, string>();
 
   // 1. MCP tools — truncation always on.
   const { tools: mcpTools, nameMap } = await toolsFromMCP(

--- a/apps/api/src/harnesses/decopilot/harness-deps.ts
+++ b/apps/api/src/harnesses/decopilot/harness-deps.ts
@@ -83,6 +83,7 @@ async function runClusterEngine(
     passthroughClient: args.passthroughClient,
     connectionsData: args.connectionsData,
     extraTools: args.extraTools,
+    toolOutputMap: args.toolOutputMap,
     additionalSystemMessages: args.additionalSystemMessages,
     activeToolNames: args.activeToolNames,
     // Subtask core runs cap the loop at SUBAGENT_STEP_LIMIT (Task 17).
@@ -206,6 +207,7 @@ export function buildClusterEnvironmentTools(args: {
         connectionTitleMap: assembled.connectionTitleMap,
         serverInstructions: assembled.serverInstructions,
         passthroughClient: assembled.passthroughClient,
+        toolOutputMap,
         writer: sideChannel.writer,
         pendingImages,
         sideChunks: sideChannel.stream,

--- a/apps/api/src/harnesses/decopilot/run-agent-loop.ts
+++ b/apps/api/src/harnesses/decopilot/run-agent-loop.ts
@@ -112,6 +112,10 @@ export interface RunAgentLoopOptions {
    *  built from `enabledTools` reconstructed from message history). Subagents
    *  don't pass this. Merged last so parent extras shadow assembled tools. */
   extraTools?: ToolSet;
+  /** The caller's `read_tool_output` backing map. Parent passes it so the MCP
+   *  tools assembled here and the `read_tool_output` arriving via `extraTools`
+   *  share one map. Subagents omit it (their built-ins are assembled here). */
+  toolOutputMap?: Map<string, string>;
   /** Full built-in params for a SUBAGENT — gives a delegated subagent the
    *  parent's heavy built-ins (vm file tools, generate_image, web_search) instead
    *  of the light core. Forwarded verbatim to `assembleAgentTools`. */
@@ -206,6 +210,7 @@ export async function runAgentLoop(
     onToolCalled,
     onPrOpened,
     fullBuiltInParams: opts.subagentBuiltInParams,
+    toolOutputMap: opts.toolOutputMap,
   });
   // Merge extra tools (e.g., parent's state-dependent `enable_tool`) after
   // the shared assembler. Parent extras shadow assembled tools intentionally.

--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { insertSortOrder, runSortOrders } from "./config";
+import { insertSortOrder, runSortOrders, statusIconClassName } from "./config";
 import type { TaskBoardItem } from "./config";
 
 function item(id: string, sortOrder: number): TaskBoardItem {
@@ -67,5 +67,25 @@ describe("runSortOrders", () => {
   test("the whole run sits at or before the drop slot", () => {
     for (const order of runSortOrders(10, 5))
       expect(order).toBeLessThanOrEqual(10);
+  });
+});
+
+describe("statusIconClassName", () => {
+  const working = { ...item("a", 0), status: "in_progress" } as TaskBoardItem;
+  const blocked = {
+    ...working,
+    threads: [{ status: "requires_action" }],
+  } as TaskBoardItem;
+
+  test("an in-progress task spins", () => {
+    expect(statusIconClassName(working)).toContain("animate-spin");
+  });
+
+  test("one waiting on input pulses in warning instead", () => {
+    expect(statusIconClassName(blocked)).toBe("text-warning animate-pulse");
+  });
+
+  test("other statuses keep their static class", () => {
+    expect(statusIconClassName(item("a", 0))).toBe("text-muted-foreground");
   });
 });

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -30,6 +30,17 @@ export function isTaskBlocked(item: TaskBoardItem): boolean {
   return item.threads.some((t) => t.status === "requires_action");
 }
 
+/**
+ * Status-icon classes for a task card/row. An in-progress task's spinner spins,
+ * but one waiting on input stops spinning and pulses in `warning` — same token
+ * as its "Needs input" badge, so a stalled task doesn't look like it's working.
+ */
+export function statusIconClassName(item: TaskBoardItem): string {
+  return item.status === "in_progress" && isTaskBlocked(item)
+    ? "text-warning animate-pulse"
+    : STATUS_CONFIG[item.status].iconClassName;
+}
+
 /** The thread to surface in the card — the most recent linked run. */
 export function primaryThread(
   item: TaskBoardItem,
@@ -110,7 +121,7 @@ export const STATUS_CONFIG: Record<
   in_progress: {
     labelKey: "taskBoard.config.statusInProgress",
     icon: Loading02,
-    iconClassName: "text-primary",
+    iconClassName: "text-primary animate-spin",
   },
   in_review: {
     labelKey: "taskBoard.config.statusInReview",

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -71,6 +71,7 @@ import {
   PRIORITIES,
   PRIORITY_CONFIG,
   runSortOrders,
+  statusIconClassName,
   STATUS_CONFIG,
   STATUSES,
   SUPER_AGENT_ASSIGNEE_ID,
@@ -1302,8 +1303,7 @@ function TaskCard({
   onDragOverCard?: (e: DragEvent<HTMLButtonElement>) => void;
 }) {
   const t = useT();
-  const statusConfig = STATUS_CONFIG[item.status];
-  const StatusIcon = statusConfig.icon;
+  const StatusIcon = STATUS_CONFIG[item.status].icon;
   const lastMessage = primaryThread(item)?.lastMessage;
 
   const showAutoFix =
@@ -1340,7 +1340,7 @@ function TaskCard({
       <div className="flex items-start gap-2">
         <StatusIcon
           size={16}
-          className={cn("mt-px shrink-0", statusConfig.iconClassName)}
+          className={cn("mt-px shrink-0", statusIconClassName(item))}
         />
         <span className="min-w-0 flex-1 text-sm font-medium leading-snug text-foreground line-clamp-2">
           {item.title}
@@ -1404,15 +1404,17 @@ function ListRow({
   assignedBy?: Member;
   onOpen: () => void;
 }) {
-  const config = STATUS_CONFIG[item.status];
-  const StatusIcon = config.icon;
+  const StatusIcon = STATUS_CONFIG[item.status].icon;
   return (
     <button
       type="button"
       onClick={onOpen}
       className="flex items-center gap-3 rounded-xl bg-card px-4 py-3 text-left card-shadow transition-colors hover:bg-accent/60"
     >
-      <StatusIcon size={16} className={cn("shrink-0", config.iconClassName)} />
+      <StatusIcon
+        size={16}
+        className={cn("shrink-0", statusIconClassName(item))}
+      />
       <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
         {item.title}
       </span>

--- a/packages/harness/src/decopilot/engine.ts
+++ b/packages/harness/src/decopilot/engine.ts
@@ -66,6 +66,12 @@ export interface HarnessAssembledTools {
   /** The live MCP passthrough client (in-process on the cluster, HTTP on the
    *  desktop). The adapter owns its lifecycle. */
   passthroughClient: Client;
+  /** Oversized tool outputs stashed for `read_tool_output`. The engine
+   *  re-assembles the MCP tools internally, so it MUST write into this same
+   *  map — `read_tool_output` (a built-in, injected via `extraTools`) is bound
+   *  to it. Two maps = every read_tool_output on an MCP output returns
+   *  "Available ids: (none)". */
+  toolOutputMap: Map<string, string>;
 
   // ── Per-run streaming wiring owned by the adapter ───────────────────
   /** Forwarded UIMessageStreamWriter the built-in tools stream output through. */
@@ -122,6 +128,9 @@ export interface RunEngineArgs {
   /** Built-in tools + the state-dependent enable_tool, merged after the
    *  engine's own assembly. */
   extraTools: ToolSet;
+  /** The run's `read_tool_output` backing map — the engine binds its
+   *  re-assembled MCP tools to THIS map instead of minting its own. */
+  toolOutputMap?: Map<string, string>;
   /** Per-request inline <system> blocks + the currently-enabled-tools tail. */
   additionalSystemMessages: SystemModelMessage[];
   /** Names `prepareStep` will pass as `activeTools` — the only tools whose

--- a/packages/harness/src/decopilot/run-core.test.ts
+++ b/packages/harness/src/decopilot/run-core.test.ts
@@ -81,6 +81,7 @@ function makeToolRuntime(opts: {
   };
   tools?: ToolSet;
   captured?: { args?: RunEngineArgs };
+  bundleRef?: { bundle?: HarnessAssembledTools };
 }) {
   const tools: ToolSet = opts.tools ?? ({} as ToolSet);
   const bundle: HarnessAssembledTools = {
@@ -96,10 +97,12 @@ function makeToolRuntime(opts: {
       listPrompts: async () => ({ prompts: [] }),
       getInstructions: () => "",
     } as never,
+    toolOutputMap: new Map(),
     writer: { write: () => {}, merge: () => {} } as never,
     pendingImages: [],
     close: async () => {},
   };
+  if (opts.bundleRef) opts.bundleRef.bundle = bundle;
   return {
     buildEnvironmentTools: async () => bundle,
     runEngine: async (args: RunEngineArgs): Promise<AssembledEngineHandle> => {
@@ -303,6 +306,34 @@ describe("runDecopilotCore conversation input", () => {
 
     expect(captured.args?.messages).toHaveLength(2);
   });
+
+  test("engine gets the run's read_tool_output map, not a fresh one", async () => {
+    const input: RunDecopilotCoreDeps["input"] = {
+      ...baseInput,
+      signal: new AbortController().signal,
+    };
+    const captured: { args?: RunEngineArgs } = {};
+    const bundleRef: { bundle?: HarnessAssembledTools } = {};
+
+    for await (const _ of runDecopilotCore({
+      input,
+      modelRuntime,
+      toolRuntime: makeToolRuntime({
+        chunks: [{ type: "finish" } as UIMessageChunk],
+        totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        captured,
+        bundleRef,
+      }),
+      kind: "main",
+    })) {
+      // drain
+    }
+
+    // The engine re-assembles the MCP tools. If it binds them to its own map,
+    // every truncated MCP output is written where `read_tool_output` (bound to
+    // the bundle's map via extraTools) can't see it — "Available ids: (none)".
+    expect(captured.args?.toolOutputMap).toBe(bundleRef.bundle!.toolOutputMap);
+  });
 });
 
 describe("usage roll-up (parent final metadata includes child tokens)", () => {
@@ -337,6 +368,7 @@ describe("usage roll-up (parent final metadata includes child tokens)", () => {
             listPrompts: async () => ({ prompts: [] }),
             getInstructions: () => "",
           } as never,
+          toolOutputMap: new Map(),
           writer: { write: () => {}, merge: () => {} } as never,
           pendingImages: [],
           close: async () => {},

--- a/packages/harness/src/decopilot/run-stream.ts
+++ b/packages/harness/src/decopilot/run-stream.ts
@@ -487,6 +487,9 @@ export async function* runDecopilotStream(
     // etc.) as extraTools so the engine's lightweight assembled set is
     // overridden with the complete set. Also inject enable_tool, which is
     // state-dependent (built from enabledTools reconstructed above).
+    // The engine re-assembles the MCP tools; bind them to the run's map so
+    // their truncated outputs land where `read_tool_output` looks.
+    toolOutputMap: tools.toolOutputMap,
     extraTools: {
       ...(tools.builtInTools as ToolSet),
       ...(tools.connectionsBlockTools.length > 0 && streamTools.enable_tool


### PR DESCRIPTION
## The bug

Any `read_tool_output` call against an oversized **MCP tool** output returns:

> `Tool output not found for tool call id: toolu_… . Available ids: (none)`

Repro in prod: thread `3fa41db6-b6ee-4fe0-a30e-cb05a68c4ae6` — the model calls `a9rahl3_list_orgs` (470 KB result), gets the "output is too long, use read_tool_output" preview, calls `read_tool_output` twice with the right ids, gets `(none)` both times, gives up on the balance data and falls back to a `subtask` that re-fetches the same 470 KB (~116k prompt tokens).

## Cause

Two `toolOutputMap` instances:

- `buildEnvironmentTools` (`harness-deps.ts`) creates **map A** and builds the built-ins against it — including `read_tool_output`. These reach the engine via `extraTools`.
- The engine re-assembles the MCP passthrough tools in `runAgentLoop` → `assembleAgentTools`, which did `const toolOutputMap = new Map()` — **map B**. The truncation branch in `mcp-tools.ts`'s `toModelOutput` writes the full output into map B.

`read_tool_output` reads map A. Map B is written and never read.

Only MCP outputs are affected — built-ins that stash large results (`vm` read/bash, `scrape_url`, `inspect_page`, `web_search`) come in through `extraTools` and share map A. And a *cross-turn* read works, because `processConversation` converts prior-turn outputs against the outer tool set. Both are why this went unnoticed.

## Fix

Thread the run's map through instead of minting a second one:

`HarnessAssembledTools.toolOutputMap` → `RunEngineArgs.toolOutputMap` → `runAgentLoop` → `assembleAgentTools` (`opts.toolOutputMap ?? new Map()`).

The subagent path keeps minting its own — its built-ins are assembled in the same call, so they already agree.

## Testing

- `packages/harness/src/decopilot/run-core.test.ts` — new test asserts the engine receives the bundle's map by identity. Verified it fails on `main` and passes with the fix.
- `bun test packages/harness/src/decopilot/run-core.test.ts` → 9 pass.
- `bun run --cwd=packages/harness check`, `bun run --cwd=apps/api check`, `bun run fmt`, `bun run lint` all clean.

Not covered: no e2e — reproducing needs a live MCP server returning >32k tokens.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `read_tool_output` not finding truncated MCP tool outputs by using a single shared `toolOutputMap` across the run. Also updates task board icons: spin while in progress, pulse in warning when blocked.

- **Bug Fixes**
  - Harness: Thread the run’s `toolOutputMap` from `HarnessAssembledTools` → `RunEngineArgs` → `runAgentLoop` → `assembleAgentTools` (using `opts.toolOutputMap ?? new Map()`), so MCP tools and `read_tool_output` use the same map. Prevents “Tool output not found … Available ids: (none)” on large outputs. Adds a unit test to assert the engine receives the bundle’s map.
  - Task board: The in-progress status icon now spins; if the task is waiting on input (`requires_action`), it stops spinning and pulses with `text-warning` via a new `statusIconClassName`. Tests updated.

<sup>Written for commit 0559b5d383f244843597d9beae6e53a0219fd4af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

