### PR TITLE
refactor(sandbox): make the daemon glob route's directory walk async

### DIFF
--- a/packages/sandbox/daemon/routes/fs.ts
+++ b/packages/sandbox/daemon/routes/fs.ts
@@ -923,15 +923,15 @@ type GlobScanState = {
 };
 
 /** Depth-bounded directory walk — avoids scanning the full tree for maxDepth. */
-function walkRepoWithinMaxDepth(
+async function walkRepoWithinMaxDepth(
   absDir: string,
   repoRelDir: string,
   maxDepth: number,
   state: GlobScanState,
-): boolean {
+): Promise<boolean> {
   let entries: fs.Dirent[];
   try {
-    entries = fs.readdirSync(absDir, { withFileTypes: true });
+    entries = await readdir(absDir, { withFileTypes: true });
   } catch {
     return false;
   }
@@ -956,7 +956,7 @@ function walkRepoWithinMaxDepth(
       state.directoryPaths.add(childRel);
       if (depth < maxDepth) {
         const childAbs = path.join(absDir, entry.name);
-        if (walkRepoWithinMaxDepth(childAbs, childRel, maxDepth, state)) {
+        if (await walkRepoWithinMaxDepth(childAbs, childRel, maxDepth, state)) {
           return true;
         }
       }
@@ -1086,7 +1086,7 @@ export function makeGlobHandler(deps: FsDeps) {
           directoryPaths,
           resultLimit,
         };
-        truncated = walkRepoWithinMaxDepth(
+        truncated = await walkRepoWithinMaxDepth(
           searchPath,
           repoRelativePrefix(searchPath, deps.repoDir),
           maxDepth,
@@ -1104,7 +1104,7 @@ export function makeGlobHandler(deps: FsDeps) {
           const abs = path.join(searchPath, rel);
           let relPath: string;
           try {
-            const stat = fs.statSync(abs);
+            const fileStat = await stat(abs);
             relPath = toRepoRelativePath(abs, searchPath, deps.repoDir);
             const depth = pathSegmentDepth(relPath);
             if (maxDepth !== undefined && depth > maxDepth) {
@@ -1112,13 +1112,13 @@ export function makeGlobHandler(deps: FsDeps) {
                 relPath,
                 maxDepth,
                 directoryPaths,
-                stat.isFile(),
+                fileStat.isFile(),
               );
               continue;
             }
-            if (stat.isDirectory()) {
+            if (fileStat.isDirectory()) {
               directoryPaths.add(relPath);
-            } else if (stat.isFile()) {
+            } else if (fileStat.isFile()) {
               filePaths.push(relPath);
             }
           } catch {


### PR DESCRIPTION
Follows #5403/#5406/#5336/#5367 (CONTRIBUTING.md rule #1: no sync fs in the sandbox daemon's single-threaded event loop — it blocks the health probe Studio polls, and a missed probe tears the sandbox down/triggers recovery).

`makeGlobHandler`'s `maxDepth` walk (`walkRepoWithinMaxDepth`) used `fs.readdirSync`, and the plain `Bun.Glob` branch used `fs.statSync` on every matched entry — both run synchronously inside the request handler. This PR swaps both for the already-imported `readdir`/`stat` promises from `node:fs/promises`, no behavior change (same recursion, same return values, just awaited).

Net: -9/+9, pure sync→async swap, no logic change.

Reviewer command: `cd packages/sandbox && bun test daemon/routes/fs.test.ts` (56 pass, 9 skip, 0 fail — covers `makeGlobHandler` including the `maxDepth` walk path).

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox` (clean), and the targeted test file above. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the sandbox daemon’s glob route async to avoid blocking the event loop and health probes. Swaps sync FS calls for async equivalents with no behavior change.

- **Refactors**
  - Replaced `fs.readdirSync` with `readdir` from `node:fs/promises` and made `walkRepoWithinMaxDepth` async.
  - Replaced `fs.statSync` with `stat` in the `Bun.Glob` branch.

<sup>Written for commit 00ef7bc314f71561843ad5b1ae0c67d676be1b86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

