### PR TITLE
fix(auth): associate form labels with their inputs via id/htmlFor

### DIFF
--- a/apps/web/src/components/unified-auth-form.tsx
+++ b/apps/web/src/components/unified-auth-form.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useAuthConfig } from "@/providers/auth-config-provider";
 import { track } from "@/lib/posthog-client";
@@ -263,6 +263,11 @@ export function UnifiedAuthForm({
   // analytics but INVISIBLE in the UI: the button just "did nothing".
   const [socialError, setSocialError] = useState<Error | null>(null);
   const copy = { ...DEFAULT_AUTH_FORM_COPY, ...copyOverrides };
+  const formId = useId();
+  const emailFieldId = `${formId}-email`;
+  const nameFieldId = `${formId}-name`;
+  const passwordFieldId = `${formId}-password`;
+  const otpFieldId = `${formId}-otp`;
 
   const isSignUp = view === "signUp";
   const isForgotPassword = view === "forgotPassword";
@@ -716,6 +721,7 @@ export function UnifiedAuthForm({
             >
               <div className="grid gap-2">
                 <label
+                  htmlFor={emailFieldId}
                   className={cn(
                     "text-sm font-medium text-foreground",
                     compact && "sr-only",
@@ -724,6 +730,7 @@ export function UnifiedAuthForm({
                   {copy.emailLabel}
                 </label>
                 <Input
+                  id={emailFieldId}
                   type="email"
                   placeholder={copy.emailPlaceholder}
                   value={email}
@@ -760,6 +767,7 @@ export function UnifiedAuthForm({
             >
               <div className="grid gap-2">
                 <label
+                  htmlFor={otpFieldId}
                   className={cn(
                     "text-sm font-medium text-foreground",
                     compact && "sr-only",
@@ -768,6 +776,7 @@ export function UnifiedAuthForm({
                   {copy.verificationCodeLabel}
                 </label>
                 <Input
+                  id={otpFieldId}
                   type="text"
                   placeholder={copy.enterCodePlaceholder}
                   value={otp}
@@ -817,10 +826,14 @@ export function UnifiedAuthForm({
       {isForgotPassword && emailAndPasswordEnabled && !resetEmailSent && (
         <form onSubmit={handleForgotPassword} className="grid gap-4">
           <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
+            <label
+              htmlFor={emailFieldId}
+              className="block text-sm font-medium text-foreground mb-2"
+            >
               {copy.emailLabel}
             </label>
             <Input
+              id={emailFieldId}
               type="email"
               placeholder="you@example.com"
               value={email}
@@ -852,10 +865,14 @@ export function UnifiedAuthForm({
         <form onSubmit={handleEmailPassword} className="grid gap-5">
           {isSignUp && (
             <div>
-              <label className="block text-sm font-medium text-foreground mb-2">
+              <label
+                htmlFor={nameFieldId}
+                className="block text-sm font-medium text-foreground mb-2"
+              >
                 {copy.nameLabel}
               </label>
               <Input
+                id={nameFieldId}
                 type="text"
                 placeholder={copy.namePlaceholder}
                 value={name}
@@ -867,10 +884,14 @@ export function UnifiedAuthForm({
             </div>
           )}
           <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
+            <label
+              htmlFor={emailFieldId}
+              className="block text-sm font-medium text-foreground mb-2"
+            >
               {copy.emailLabel}
             </label>
             <Input
+              id={emailFieldId}
               type="email"
               placeholder="you@example.com"
               value={email}
@@ -887,7 +908,10 @@ export function UnifiedAuthForm({
           </div>
           <div>
             <div className="flex items-center justify-between mb-2">
-              <label className="block text-sm font-medium text-foreground">
+              <label
+                htmlFor={passwordFieldId}
+                className="block text-sm font-medium text-foreground"
+              >
                 {copy.passwordLabel}
               </label>
               {!isSignUp && resetPassword.enabled && (
@@ -901,6 +925,7 @@ export function UnifiedAuthForm({
               )}
             </div>
             <Input
+              id={passwordFieldId}
               type="password"
               placeholder="••••••••"
               value={password}


### PR DESCRIPTION
## What

Every `<label>` in `UnifiedAuthForm` (email, name, password, verification-code fields — across the email/password, forgot-password, and OTP views, in both `default` and `compact` layouts) was rendered as a plain sibling of its `<input>`, with no `htmlFor`/`id` pair. `packages/ui`'s `Input` doesn't auto-generate an id, so none of these were ever programmatically associated. A screen reader announces nothing when the field receives focus — a real accessibility regression on the one screen every user hits before anything else (web `/login`, the desktop sign-in gate, and every embedded auth surface that renders this shared form).

## Why now

This form is the single shared sign-in surface across web, the desktop app, and embedded auth surfaces (per #5438's consolidation), so the label gap affects every login entry point at once — a small, safe, high-leverage fix.

## Fix

Generate a stable per-instance id with React's `useId()` and wire `id`/`htmlFor` across all four fields (email, name, password, OTP) in all three form branches. Purely additive attributes — no behavior, styling, or layout change.

## Verification

- `cd apps/web && bunx tsc --noEmit` — clean.
- `bun run fmt` — clean.
- Manual read-through: every `<label>` now has a matching `id` on its paired `<Input>`; `useId()` keeps ids unique per form instance so multiple embedded auth surfaces on the same page (e.g. compact variants) can't collide.

A reviewer can confirm by rendering `UnifiedAuthForm` and checking each label's `htmlFor` matches its input's `id` in the DOM, or via any axe/accessibility linter on `/login`.

No test file exists for this presentational component; this is a JSX-only attribute change verified by typecheck + review, not new logic needing a regression test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Associates all `UnifiedAuthForm` labels with their inputs via `id`/`htmlFor` to restore screen reader announcements and improve accessibility across web, desktop, and embedded auth. No UI or behavior changes.

- **Bug Fixes**
  - Use React `useId()` to generate per-instance IDs and connect labels/inputs via `id`/`htmlFor`.
  - Covers email, name, password, and OTP fields across sign-in, forgot-password, and OTP views in both default and compact layouts; prevents ID collisions with multiple forms.

<sup>Written for commit 5a44f0a76d070fc0aaf53164a46cfbb9b7759424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

