### PR TITLE
fix(sections-editor): translate SchemaForm's empty-fields state

### DIFF
--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { useT } from "@/i18n/use-t.ts";
 import { resolveSchema } from "./resolve-schema";
 import type { LiveMeta, SchemaProperty } from "./resolve-schema";
 import type { FieldProps } from "./fields/field-props";
@@ -431,6 +432,7 @@ export function SchemaForm({
   onRequestAddSection?: FieldProps["onRequestAddSection"];
   sandbox?: FieldProps["sandbox"];
 }) {
+  const t = useT();
   const properties = schema.properties;
   // The resolved root can itself be a single union field — a discriminated
   // block config whose props are a plain `A | B | C` union (e.g. the VTEX
@@ -502,7 +504,7 @@ export function SchemaForm({
   if (keys.length === 0) {
     return (
       <div className="px-3 py-6 text-center text-xs text-muted-foreground">
-        No editable fields on this section.
+        {t("sectionsEditor.sectionsEditor.noEditableFields")}
       </div>
     );
   }

--- a/apps/web/src/i18n/en/sections-editor.ts
+++ b/apps/web/src/i18n/en/sections-editor.ts
@@ -194,6 +194,8 @@ export const sectionsEditor = {
     "This is a global section. Changes apply everywhere this section is used across your site.",
   "sectionsEditor.sectionsEditor.globalSectionTooltip":
     "A global section is a reusable block shared across your site. Editing it here updates it everywhere it's used.",
+  "sectionsEditor.sectionsEditor.noEditableFields":
+    "No editable fields on this section.",
   "sectionsEditor.sectionsEditor.noEditableFieldsForGlobalBlock":
     "No editable fields for this global block.",
   "sectionsEditor.sectionsEditor.noEditableFieldsForVariant":

--- a/apps/web/src/i18n/pt-br/sections-editor.ts
+++ b/apps/web/src/i18n/pt-br/sections-editor.ts
@@ -205,6 +205,8 @@ export const sectionsEditor = {
     "Esta é uma seção global. As alterações são aplicadas em todos os lugares em que esta seção é usada em seu site.",
   "sectionsEditor.sectionsEditor.globalSectionTooltip":
     "Uma seção global é um bloco reutilizável compartilhado em seu site. Editá-la aqui atualiza em todos os lugares onde é usada.",
+  "sectionsEditor.sectionsEditor.noEditableFields":
+    "Nenhum campo editável nesta seção.",
   "sectionsEditor.sectionsEditor.noEditableFieldsForGlobalBlock":
     "Nenhum campo editável para este bloco global.",
   "sectionsEditor.sectionsEditor.noEditableFieldsForVariant":


### PR DESCRIPTION
**Source**: bug found while hardening the sections-editor focus area (i18n coverage gap, no linked issue).

**Why a maintainer wants this**: `apps/web/src/components/sections-editor/schema-form.tsx`'s SchemaForm renders "No editable fields on this section." as a hardcoded English JSX string, so pt-br users see English text here even though the identical message is already fully translated for the sibling empty states in `sandbox.ts` (`sandbox.availableSectionEditor.noEditableFields` / `sandbox.savedSectionEditor.noEditableFields`) and `sections-editor.ts` (`noEditableFieldsForGlobalBlock` / `noEditableFieldsForVariant`) — this is the one remaining untranslated copy of that pattern in the file.

**Fix**: added a new `sectionsEditor.sectionsEditor.noEditableFields` key (en + pt-br, matching the existing sibling copy/format) and routed the JSX through `useT()`/`t(...)` like every other string in this component tree.

**Reviewer check**: `cd apps/web && bunx tsc --noEmit` (clean) and `bun test apps/web/src/components/sections-editor/schema-form.test.ts` (8 pass).

**Locally run**: `bun run fmt`, targeted `tsc --noEmit` in `apps/web`, and the single `schema-form.test.ts` file — all green. Full CI validates lint/the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internationalized the SchemaForm empty state by replacing the hardcoded "No editable fields on this section." with `useT()` and `sectionsEditor.sectionsEditor.noEditableFields`. Adds en and pt-br translations so the message matches other sections-editor empty states and shows correctly for pt-br users.

<sup>Written for commit 20809a1ea2979500288e778306edb7b8c56158ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

