### PR TITLE
refactor(auth): remove unused invalidateOrg from MemberRoleCache

### DIFF
--- a/apps/api/src/auth/member-role-cache.ts
+++ b/apps/api/src/auth/member-role-cache.ts
@@ -15,14 +15,11 @@ export interface MemberRoleCache {
   set(userId: string, organizationId: string, role: string): void;
   /** Invalidate a specific user+org entry */
   invalidate(userId: string, organizationId: string): void;
-  /** Invalidate all entries for an organization (e.g. bulk role changes) */
-  invalidateOrg(organizationId: string): void;
 }
 
 interface CacheEntry {
   role: string;
   expiresAt: number;
-  organizationId: string;
 }
 
 function cacheKey(userId: string, organizationId: string): string {
@@ -74,21 +71,12 @@ export function createMemberRoleCache(options?: {
       cache.set(key, {
         role,
         expiresAt: Date.now() + ttlMs,
-        organizationId,
       });
       evictExpired();
     },
 
     invalidate(userId, organizationId) {
       cache.delete(cacheKey(userId, organizationId));
-    },
-
-    invalidateOrg(organizationId) {
-      for (const [key, entry] of cache) {
-        if (entry.organizationId === organizationId) {
-          cache.delete(key);
-        }
-      }
     },
   };
 }


### PR DESCRIPTION
## Source
Dead-code reduction found while auditing `apps/api/src/auth` for token/scope-hygiene issues (the main candidate in that area, wildcard connection-scope escalation, is already covered by open PR #5021 — this is a distinct, unrelated finding from the same audit pass).

## Why
`MemberRoleCache.invalidateOrg(organizationId)` was never called anywhere in the codebase — only `invalidate(userId, organizationId)` is used, by `member-add`/`member-remove`/`member-update-role`. Confirmed via `rg -n "invalidateOrg"` across the whole repo (`apps/**`, `packages/**`): the only hits are the interface declaration and implementation itself. Removing it also lets the `CacheEntry.organizationId` field go — it was write-only, kept solely to support the org-wide sweep `invalidateOrg` did.

## Change
-12/+0 in `apps/api/src/auth/member-role-cache.ts`. Behavior-preserving: `get`/`set`/`invalidate` are untouched, only the dead method and its now-unused backing field are removed.

## Verification
- `rg -n "invalidateOrg"` — zero remaining references after the change.
- `cd apps/api && bunx tsc --noEmit` — clean.
- `bun run fmt` — no formatting changes needed.
- No existing test file covers this module (`member-role-cache.ts` has no `.test.ts`), so nothing to update.

Reviewer check: `rg -n "invalidateOrg" apps/api apps/web packages` should return nothing.

Full CI (lint, typecheck across all workspaces, test suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused invalidateOrg from the member role cache and dropped the now-unused organizationId field to reduce dead code. get/set/invalidate are unchanged; behavior is the same.

<sup>Written for commit 52b475cc880a040b17ede009db94a4bc0e6d01c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

