### PR TITLE
fix(task-board): reset FLIP overflow clip when an animation is interrupted

### DIFF
--- a/apps/web/src/layouts/task-board/use-flip-lanes.test.ts
+++ b/apps/web/src/layouts/task-board/use-flip-lanes.test.ts
@@ -1,0 +1,64 @@
+import { setupComponentTest } from "../../../test/setup";
+setupComponentTest();
+import { describe, expect, it } from "bun:test";
+import { renderHook } from "@testing-library/react";
+import { useFlipLanes } from "./use-flip-lanes";
+
+/** Builds `<div data-lane-scroll><div data-flip-id="card" data-flip-lane="..." /></div>`
+ *  and lets each render control the card's reported rect, so a lane change can
+ *  be simulated without a real layout engine (happy-dom's rects are all 0). */
+function setup() {
+  const lane = document.createElement("div");
+  lane.dataset.laneScroll = "todo";
+  const card = document.createElement("div");
+  card.dataset.flipId = "card";
+  card.dataset.flipLane = "todo";
+  lane.appendChild(card);
+  document.body.appendChild(lane);
+
+  let rect = { left: 0, top: 0 };
+  card.getBoundingClientRect = () =>
+    ({ ...rect, right: 0, bottom: 0, width: 0, height: 0 }) as DOMRect;
+
+  const containerRef = { current: lane };
+  return {
+    lane,
+    card,
+    containerRef,
+    moveTo: (next: { left: number; top: number }, laneName: string) => {
+      rect = next;
+      card.dataset.flipLane = laneName;
+    },
+  };
+}
+
+describe("useFlipLanes", () => {
+  it("resets a lane-changer's lifted overflow clip even if a new signature interrupts the animation before it settles", () => {
+    const { lane, containerRef, moveTo } = setup();
+
+    // Stub rAF so the animation never gets to its own settle callback — this
+    // stands in for a second lane change landing within the same frame.
+    const originalRaf = window.requestAnimationFrame;
+    window.requestAnimationFrame = () => 1;
+
+    const { rerender } = renderHook(
+      ({ signature }: { signature: string }) =>
+        useFlipLanes(containerRef, signature, true),
+      { initialProps: { signature: "card:todo" } },
+    );
+
+    // Move the card into another lane — triggers the FLIP, which lifts the
+    // clip on its home lane synchronously.
+    moveTo({ left: 0, top: 300 }, "done");
+    rerender({ signature: "card:done" });
+    expect(lane.style.overflow).toBe("visible");
+
+    // A second signature change lands before the (stubbed) rAF ever fired —
+    // no further movement this time, just tearing the previous effect down.
+    rerender({ signature: "card:done:reordered" });
+
+    expect(lane.style.overflow).toBe("");
+
+    window.requestAnimationFrame = originalRaf;
+  });
+});

--- a/apps/web/src/layouts/task-board/use-flip-lanes.ts
+++ b/apps/web/src/layouts/task-board/use-flip-lanes.ts
@@ -132,6 +132,18 @@ export function useFlipLanes(
     return () => {
       cancelAnimationFrame(raf);
       for (const t of cleanups) clearTimeout(t);
+      // A new signature can land mid-flight (that's the point of staggering —
+      // see the module doc), which tears this effect down before the timeouts
+      // above ever get to reset what they set. Without this, a lane-changer's
+      // home lane is left permanently `overflow: visible`, unclipped. Reclip is
+      // idempotent (a second call for an already-settled lane is a no-op), so
+      // running it unconditionally here is safe.
+      for (const m of moved) {
+        m.el.style.transition = "";
+        m.el.style.transform = "";
+        m.el.style.zIndex = "";
+        if (m.lane) reclip(m.el.closest("[data-lane-scroll]"));
+      }
     };
   }, [signature, containerRef, enabled]);
 }


### PR DESCRIPTION
## What
Follows up on #5439 (kanban drag-and-drop → dnd-kit). `useFlipLanes` lifts a lane's `overflow` clip (and sets the moving card's inline `transform`/`zIndex`) synchronously whenever a card changes lanes, then relies on a `setTimeout` scheduled inside a `requestAnimationFrame` callback to restore it once the CSS transition finishes.

## Failure scenario
The hook's own module doc says concurrent lane changes are expected and deliberately staggered ("Concurrent moves are staggered ... without holding back the underlying data"). If a new `signature` arrives (another card moves, an SSE-driven auto-move, a bulk "Move to") before the pending timeout fires, React tears the effect down and the returned cleanup only did `cancelAnimationFrame` + `clearTimeout` — it never undid the synchronous lift. The result: the lane's `overflow` style is stuck at `visible` forever (breaking that lane's scroll clipping — cards can visually spill outside the rounded lane container), and the ref-counted `unclipped` map is left with a leaked count so a later, unrelated reclip can't fully unwind it either.

This is a real regression introduced by #5439 — the unclip/reclip mechanism is new in that PR (`git log` confirms `use-flip-lanes.ts` had no such clipping logic before it).

## Fix
Run the same reset (transition/transform/zIndex clear + `reclip`) from the effect's own cleanup, not just from the settle timeout. `reclip` is ref-counted and idempotent, so calling it an extra time on the normal, uninterrupted path is a no-op — behavior on that path is unchanged.

## Test
`apps/web/src/layouts/task-board/use-flip-lanes.test.ts` — stubs `requestAnimationFrame` to never fire (simulating an interrupted-before-paint animation), moves a card into another lane, then re-renders with a new signature and asserts the lane's `overflow` style is reset rather than stuck at `visible`. Confirmed it fails on the pre-fix code (`Expected: "" / Received: "visible"`) and passes after the fix.

## To verify
```
bun test apps/web/src/layouts/task-board/use-flip-lanes.test.ts
cd apps/web && bunx tsc --noEmit
```

## Checks run locally
`bun run fmt`, `bunx tsc --noEmit` (apps/web), and the single targeted test file above — all green. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where lane overflow stayed visible when a card move was interrupted. Lanes now re-clip and card styles reset even if a new signature arrives mid-animation.

- **Bug Fixes**
  - In `useFlipLanes`, run the same reset and `reclip` in the effect cleanup to restore `overflow`, `transform`, and `zIndex` when an animation is interrupted.
  - Added `apps/web/src/layouts/task-board/use-flip-lanes.test.ts` to simulate a pre-paint interruption and verify the lane’s `overflow` resets correctly.

<sup>Written for commit 931aa8d023bba148c0aa1e8968a77ef5040d5672. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

