### PR TITLE
fix(native): repair PATH for GUI launches so spawned binaries resolve

### DIFF
--- a/apps/native/crates/harness/src/detect.rs
+++ b/apps/native/crates/harness/src/detect.rs
@@ -274,7 +274,15 @@ async fn run_probe_capture(argv: &[String], args: &[&str], timeout: Duration) ->
     cmd.stdin(std::process::Stdio::null());
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
-    let mut child = cmd.spawn().ok()?;
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            // ENOENT here is how a broken PATH (e.g. a GUI launch before the
+            // shell's repair) manifests — never swallow it invisibly.
+            tracing::debug!(%program, %error, "agent probe spawn failed");
+            return None;
+        }
+    };
     let mut stdout = child.stdout.take()?;
     let mut stderr = child.stderr.take()?;
 

--- a/apps/native/crates/harness/src/title.rs
+++ b/apps/native/crates/harness/src/title.rs
@@ -97,7 +97,13 @@ pub async fn generate_title(
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .kill_on_drop(true);
-    let mut child = command.spawn().ok()?;
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            tracing::debug!(binary = %binary, %error, "title generation spawn failed");
+            return None;
+        }
+    };
     let mut stdout = child.stdout.take()?;
 
     let collected = tokio::time::timeout(timeout, async {

--- a/apps/native/crates/local-api/src/routes/bash.rs
+++ b/apps/native/crates/local-api/src/routes/bash.rs
@@ -143,6 +143,16 @@ fn build_command(command: &str, cwd: &Path, env: Option<&HashMap<String, String>
     if let Some(env) = env {
         cmd.env_clear();
         cmd.envs(env);
+        // Bounded divergence from the parity rule above: without this, a
+        // caller env that omits PATH leaves the shell with no lookup path at
+        // all — and in a GUI-launched app the process PATH (repaired at boot
+        // by the Tauri shell's `env_path`) is the only usable one anywhere.
+        // A caller-supplied PATH still wins untouched.
+        if !env.contains_key("PATH") {
+            if let Some(path) = std::env::var_os("PATH") {
+                cmd.env("PATH", path);
+            }
+        }
     }
     cmd
 }

--- a/apps/native/crates/local-api/src/setup/install.rs
+++ b/apps/native/crates/local-api/src/setup/install.rs
@@ -196,7 +196,14 @@ async fn run_install_cmd(
             Ok(child) => child,
             Err(error) => {
                 orch.tasks.finalize(&task_id, TaskStatus::Failed, -1, false);
-                return Err(format!("{cmd}: {error}"));
+                // Same actionable-hint precedent as routes/fs.rs's ripgrep
+                // message: name the culprit and point at a fix.
+                let message = if error.kind() == std::io::ErrorKind::NotFound {
+                    format!("{cmd} not found on PATH: {error}. Install {cmd}, then retry setup.")
+                } else {
+                    format!("{cmd}: {error}")
+                };
+                return Err(message);
             }
         };
     let (Some(mut stdout_pipe), Some(mut stderr_pipe)) = (child.take_stdout(), child.take_stderr())

--- a/apps/native/src-tauri/src/env_path.rs
+++ b/apps/native/src-tauri/src/env_path.rs
@@ -1,0 +1,227 @@
+//! PATH repair for GUI launches.
+//!
+//! macOS starts Finder/Dock-launched apps with launchd's minimal PATH
+//! (`/usr/bin:/bin:/usr/sbin:/sbin`), so user-installed binaries — `claude`,
+//! `codex`, `bun`, `rg`, Homebrew's `git` — are invisible to every child this
+//! process spawns. All spawn sites (harness probes, setup installs, the
+//! script runner) rely on the inherited environment, so repairing PATH once
+//! here, before `local-api` boots, fixes them all.
+//!
+//! Two layers, both additive (entries are only ever appended, never removed):
+//! 1. Ask the user's login shell for its PATH (sources `~/.zprofile` /
+//!    `~/.bash_profile`, where Homebrew and bun put their exports). Bounded
+//!    by a timeout so a hung profile cannot stall boot.
+//! 2. Append well-known install directories that exist on disk — covers
+//!    users whose exports live only in interactive-shell config (`~/.zshrc`),
+//!    which a non-interactive login shell never sources.
+
+/// Repairs the process PATH in place. Call once at startup, before anything
+/// spawns children. No-op on Windows, where GUI apps inherit the user PATH.
+pub fn repair() {
+    #[cfg(unix)]
+    unix::repair();
+}
+
+#[cfg(unix)]
+mod unix {
+    use std::path::PathBuf;
+    use std::process::Stdio;
+    use std::time::{Duration, Instant};
+
+    /// Upper bound on the login-shell probe. Typical profiles answer in well
+    /// under 200ms; a profile that blocks (waiting on a tty, a network call)
+    /// must not hold the app's first window hostage.
+    const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+    const DELIM_START: &str = "__DECO_PATH>";
+    const DELIM_END: &str = "<DECO_PATH__";
+
+    pub(super) fn repair() {
+        let inherited = std::env::var("PATH").unwrap_or_default();
+        let probed = probe_login_shell_path(PROBE_TIMEOUT);
+        let fallbacks: Vec<PathBuf> = fallback_dirs()
+            .into_iter()
+            .filter(|dir| dir.is_dir())
+            .collect();
+        let repaired = compose_path(probed.as_deref(), &inherited, &fallbacks);
+        if repaired != inherited {
+            // Safe in edition 2021; runs before local-api's runtime exists,
+            // and the only thread spawned so far (the probe's pipe reader)
+            // has been joined.
+            std::env::set_var("PATH", &repaired);
+            tracing::info!(
+                probe_ok = probed.is_some(),
+                path = %repaired,
+                "repaired PATH for GUI launch"
+            );
+        }
+    }
+
+    /// Runs `$SHELL -l -c 'printf …$PATH…'` and extracts the delimited value.
+    /// Login (`-l`) but NOT interactive: `-i` can block on prompt frameworks
+    /// or tty access, and login config is where PATH exports belong anyway.
+    /// Delimiters keep profile chatter on stdout from corrupting the value.
+    fn probe_login_shell_path(timeout: Duration) -> Option<String> {
+        let shell = std::env::var("SHELL")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "/bin/zsh".to_string());
+        let script = format!("printf '%s' \"{DELIM_START}$PATH{DELIM_END}\"");
+        let mut child = std::process::Command::new(&shell)
+            .args(["-l", "-c", &script])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?;
+
+        // Drain stdout on a thread so a chatty profile can never fill the
+        // pipe buffer and deadlock against our exit-polling below.
+        let mut stdout = child.stdout.take()?;
+        let reader = std::thread::spawn(move || {
+            use std::io::Read;
+            let mut buffer = String::new();
+            let _ = stdout.read_to_string(&mut buffer);
+            buffer
+        });
+
+        let deadline = Instant::now() + timeout;
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) if Instant::now() >= deadline => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = reader.join();
+                    tracing::warn!(%shell, "login-shell PATH probe timed out");
+                    return None;
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(25)),
+                Err(_) => {
+                    let _ = reader.join();
+                    return None;
+                }
+            }
+        };
+        let output = reader.join().ok()?;
+        if !status.success() {
+            tracing::warn!(%shell, %status, "login-shell PATH probe failed");
+            return None;
+        }
+        extract_delimited(&output).map(str::to_string)
+    }
+
+    /// Pulls the PATH value out from between the probe delimiters, rejecting
+    /// anything that doesn't contain at least one absolute directory.
+    fn extract_delimited(output: &str) -> Option<&str> {
+        let start = output.find(DELIM_START)? + DELIM_START.len();
+        let end = output[start..].find(DELIM_END)? + start;
+        let path = &output[start..end];
+        path.split(':')
+            .any(|entry| entry.starts_with('/'))
+            .then_some(path)
+    }
+
+    /// Well-known per-user and Homebrew install locations. Existence is
+    /// checked by the caller so unit tests can inject temp dirs.
+    fn fallback_dirs() -> Vec<PathBuf> {
+        let mut dirs = Vec::new();
+        if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+            dirs.push(home.join(".bun/bin"));
+            dirs.push(home.join(".local/bin"));
+            dirs.push(home.join(".cargo/bin"));
+            dirs.push(home.join(".deno/bin"));
+        }
+        dirs.push(PathBuf::from("/opt/homebrew/bin"));
+        dirs.push(PathBuf::from("/usr/local/bin"));
+        dirs
+    }
+
+    /// Ordered, deduplicated union: probed login-shell PATH first (it is the
+    /// user's own ordering), then any inherited entries it lacks (never drop
+    /// what we were launched with), then the existing fallback dirs.
+    fn compose_path(probed: Option<&str>, inherited: &str, fallbacks: &[PathBuf]) -> String {
+        let mut entries: Vec<PathBuf> = Vec::new();
+        let push = |entry: PathBuf, entries: &mut Vec<PathBuf>| {
+            if !entry.as_os_str().is_empty() && !entries.contains(&entry) {
+                entries.push(entry);
+            }
+        };
+        for entry in std::env::split_paths(probed.unwrap_or_default()) {
+            push(entry, &mut entries);
+        }
+        for entry in std::env::split_paths(inherited) {
+            push(entry, &mut entries);
+        }
+        for entry in fallbacks {
+            push(entry.clone(), &mut entries);
+        }
+        std::env::join_paths(entries)
+            .ok()
+            .and_then(|joined| joined.into_string().ok())
+            .unwrap_or_else(|| inherited.to_string())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn compose_keeps_probed_order_and_appends_missing_inherited() {
+            let out = compose_path(
+                Some("/opt/homebrew/bin:/usr/bin:/bin"),
+                "/usr/bin:/bin:/usr/sbin:/sbin",
+                &[],
+            );
+            assert_eq!(out, "/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin");
+        }
+
+        #[test]
+        fn compose_without_probe_preserves_inherited_and_adds_fallbacks() {
+            let out = compose_path(
+                None,
+                "/usr/bin:/bin",
+                &[
+                    PathBuf::from("/opt/homebrew/bin"),
+                    PathBuf::from("/usr/bin"),
+                ],
+            );
+            assert_eq!(out, "/usr/bin:/bin:/opt/homebrew/bin");
+        }
+
+        #[test]
+        fn compose_drops_duplicate_and_empty_entries() {
+            let out = compose_path(Some("/a::/b:/a"), "/b:/c", &[]);
+            assert_eq!(out, "/a:/b:/c");
+        }
+
+        #[test]
+        fn extract_delimited_ignores_profile_noise() {
+            let noisy = format!("motd banner\n{DELIM_START}/opt/homebrew/bin:/usr/bin{DELIM_END}");
+            assert_eq!(
+                extract_delimited(&noisy),
+                Some("/opt/homebrew/bin:/usr/bin")
+            );
+        }
+
+        #[test]
+        fn extract_delimited_rejects_garbage() {
+            assert_eq!(extract_delimited("no delimiters"), None);
+            let relative = format!("{DELIM_START}not-a-path{DELIM_END}");
+            assert_eq!(extract_delimited(&relative), None);
+        }
+
+        #[test]
+        fn existing_dir_filter_matches_caller_contract() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let present = tmp.path().join("bin");
+            std::fs::create_dir(&present).expect("mkdir");
+            let missing = tmp.path().join("nope");
+            let dirs: Vec<PathBuf> = [present.clone(), missing]
+                .into_iter()
+                .filter(|dir| dir.is_dir())
+                .collect();
+            assert_eq!(dirs, vec![present]);
+        }
+    }
+}

--- a/apps/native/src-tauri/src/lib.rs
+++ b/apps/native/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod auth;
 mod commands;
 mod control_origin;
 mod csp;
+mod env_path;
 mod local_tls;
 mod selftest;
 mod setup;
@@ -22,6 +23,12 @@ pub fn run() {
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
         .init();
+
+    // Must run before `setup::run` boots local-api: every child spawn (agent
+    // detection, `bun install`, the script runner, ripgrep) inherits this
+    // process's environment, and a Finder/Dock launch starts with launchd's
+    // minimal PATH. See `env_path` for the repair strategy and its bounds.
+    env_path::repair();
 
     let mut builder = tauri::Builder::default().plugin(tauri_plugin_opener::init());
 


### PR DESCRIPTION
## Summary

macOS starts Finder/Dock-launched apps with launchd's minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`), and the desktop shell had **zero PATH handling** — every child spawn inherited that env verbatim. Consequences:

- `claude`/`codex` detection probes (`crates/harness/src/detect.rs`) failed with ENOENT, **silently** (`.ok()?`), so `capabilities` came back empty and the chat stayed gated on the "No coding agent was detected" empty state — even with Claude Code installed.
- Setup's `bun install` (`setup/install.rs`) failed with a raw `bun: No such file or directory (os error 2)`.
- The `sh -c "bun run dev"` script runner and ripgrep (`routes/fs.rs`) hit the same wall; all shells are non-login, so `~/.zprofile` never rescued them.

## Fix

**One repair at boot** (`src-tauri/src/env_path.rs`, called at the top of `run()` before local-api starts, so every descendant inherits it):

1. **Login-shell probe** — `$SHELL -l -c` printing a delimiter-wrapped `$PATH`, bounded by a 3s timeout (a hung profile can't stall boot; stdout drained on a thread so a chatty profile can't deadlock the pipe). Login-not-interactive on purpose: `-i` can block on prompt frameworks, and login config is where Homebrew/bun put exports.
2. **Well-known-dirs fallback** — appends `~/.bun/bin`, `~/.local/bin`, `~/.cargo/bin`, `~/.deno/bin`, `/opt/homebrew/bin`, `/usr/local/bin` when they exist and are missing — covers exports living only in `~/.zshrc` (interactive-only), which the probe can't see.

Purely additive: probed order first, inherited entries never dropped, ordered dedup. No-op on Windows. No new dependencies — hand-rolled with `std` only.

**Hardening in the same pass:**

- `routes/bash.rs`: caller-supplied env that omits `PATH` no longer leaves the shell with no lookup path — the repaired process PATH is injected (a caller-supplied `PATH` still wins untouched). Bounded, documented divergence from the bash.ts byte-parity rule.
- `detect.rs` / `title.rs`: spawn failures are now logged instead of swallowed — the reason this bug left no trace.
- `setup/install.rs`: ENOENT now surfaces as `bun not found on PATH: …. Install bun, then retry setup.`, mirroring the ripgrep hint precedent in `routes/fs.rs`.

## Testing

- 6 new unit tests in `env_path.rs` (compose ordering/dedup/empty-entry handling, delimiter extraction incl. profile-noise and garbage rejection, existing-dir filter contract).
- `cargo test -p deco -p harness -p local-api`: 926 tests pass; `cargo clippy --workspace --all-targets` clean; `cargo fmt` applied.
- Manual verification: launch the packaged `.app` from Finder (not a terminal — terminal launches inherit the shell PATH and mask the bug) and confirm agent detection + setup install succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing `PATH` on macOS GUI launches so spawned binaries resolve. Restores agent detection and `bun`-based setup when the app is opened from Finder or the Dock.

- **Bug Fixes**
  - Repair `PATH` once at boot in `src-tauri` by probing `$SHELL -l -c` (3s timeout) and appending existing fallbacks: `~/.bun/bin`, `~/.local/bin`, `~/.cargo/bin`, `~/.deno/bin`, `/opt/homebrew/bin`, `/usr/local/bin`. Additive and ordered; no-op on Windows.
  - Inject the process `PATH` in `routes/bash.rs` when a caller env omits it (caller `PATH` still wins).
  - Log spawn failures in `harness/src/detect.rs` and `harness/src/title.rs` instead of swallowing them.
  - In `setup/install.rs`, show a clear hint when `bun` is missing: “bun not found on PATH … Install bun, then retry setup.”

<sup>Written for commit 24d63a0c84c357d3b077c8005eaed7ab8cc836ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

