### PR TITLE
fix(web): hardcode the deco-cms GitHub App install URL in CTAs

### DIFF
--- a/apps/api/src/tools/github/list-user-orgs.ts
+++ b/apps/api/src/tools/github/list-user-orgs.ts
@@ -35,7 +35,6 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
         type: z.string(),
       }),
     ),
-    appSlug: z.string().optional(),
   }),
   handler: async (input, ctx) => {
     await ctx.access.check();
@@ -92,7 +91,6 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
       type: string;
     }> = [];
 
-    let appSlug: string | undefined;
     let page = 1;
     const perPage = 100;
 
@@ -142,16 +140,11 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
         installations: Array<{
           id: number;
           account: { login: string; avatar_url: string; type: string };
-          app_slug?: string;
-          app?: { slug?: string };
         }>;
         total_count: number;
       };
 
       for (const inst of data.installations) {
-        if (!appSlug) {
-          appSlug = inst.app_slug ?? inst.app?.slug;
-        }
         installations.push({
           installationId: inst.id,
           login: inst.account.login,
@@ -164,6 +157,6 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
       page++;
     }
 
-    return { installations, ...(appSlug ? { appSlug } : {}) };
+    return { installations };
   },
 });

--- a/apps/web/src/components/github-repo-picker.tsx
+++ b/apps/web/src/components/github-repo-picker.tsx
@@ -41,7 +41,10 @@ import {
 import { useAutoInstallGitHub } from "@/hooks/use-auto-install-github";
 import { useNavigateToAgent } from "@/hooks/use-navigate-to-agent";
 import { GitHubIcon } from "@/components/icons/github-icon";
-import { fetchGithubInstallations } from "@/lib/github-installations";
+import {
+  fetchGithubInstallations,
+  githubAppInstallUrl,
+} from "@/lib/github-installations";
 import { getOrgGithubConnections } from "@decocms/shared/github-repo-scope";
 import { provisionRepoScopedGithubConnection } from "@/lib/provision-repo-scoped-github-connection";
 import { LOCALSTORAGE_KEYS } from "@/lib/localstorage-keys";
@@ -628,9 +631,7 @@ function InstallationPicker({
   const data = installationsQuery.data;
   if (!data) return null;
 
-  const installUrl = data.appSlug
-    ? `https://github.com/apps/${data.appSlug}/installations/new`
-    : "https://github.com/settings/installations";
+  const installUrl = githubAppInstallUrl(data.appSlug);
 
   if (data.installations.length === 0) {
     return (

--- a/apps/web/src/components/github-repo-picker.tsx
+++ b/apps/web/src/components/github-repo-picker.tsx
@@ -43,7 +43,7 @@ import { useNavigateToAgent } from "@/hooks/use-navigate-to-agent";
 import { GitHubIcon } from "@/components/icons/github-icon";
 import {
   fetchGithubInstallations,
-  githubAppInstallUrl,
+  GITHUB_APP_INSTALL_URL,
 } from "@/lib/github-installations";
 import { getOrgGithubConnections } from "@decocms/shared/github-repo-scope";
 import { provisionRepoScopedGithubConnection } from "@/lib/provision-repo-scoped-github-connection";
@@ -631,8 +631,6 @@ function InstallationPicker({
   const data = installationsQuery.data;
   if (!data) return null;
 
-  const installUrl = githubAppInstallUrl(data.appSlug);
-
   if (data.installations.length === 0) {
     return (
       <div className="flex-1 flex flex-col overflow-hidden">
@@ -668,7 +666,11 @@ function InstallationPicker({
 
           <div className="mt-5 flex items-center gap-2">
             <Button asChild size="sm">
-              <a href={installUrl} target="_blank" rel="noopener noreferrer">
+              <a
+                href={GITHUB_APP_INSTALL_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 {t("common.githubRepoPicker.chooseRepositories")}
                 <LinkExternal01 size={14} />
               </a>
@@ -742,7 +744,7 @@ function InstallationPicker({
 
       <div className="px-4 py-3 border-t border-border shrink-0">
         <a
-          href={installUrl}
+          href={GITHUB_APP_INSTALL_URL}
           target="_blank"
           rel="noopener noreferrer"
           className="text-xs text-muted-foreground hover:text-foreground transition-colors"

--- a/apps/web/src/components/import-from-deco-dialog.tsx
+++ b/apps/web/src/components/import-from-deco-dialog.tsx
@@ -19,6 +19,7 @@ import { getOrgGithubConnections } from "@decocms/shared/github-repo-scope";
 import {
   fetchGithubInstallations,
   findGithubInstallation,
+  githubAppInstallUrl,
 } from "@/lib/github-installations";
 import { provisionRepoScopedGithubConnection } from "@/lib/provision-repo-scoped-github-connection";
 import {
@@ -193,9 +194,7 @@ export function ImportFromDecoDialog({
         githubRepo.owner,
       );
       if (!githubInstallation) {
-        const installUrl = appSlug
-          ? `https://github.com/apps/${appSlug}/installations/new`
-          : "https://github.com/settings/installations";
+        const installUrl = githubAppInstallUrl(appSlug);
         throw new Error(
           t("common.importFromDecoDialog.installGithubApp", {
             owner: githubRepo.owner,

--- a/apps/web/src/components/import-from-deco-dialog.tsx
+++ b/apps/web/src/components/import-from-deco-dialog.tsx
@@ -19,7 +19,7 @@ import { getOrgGithubConnections } from "@decocms/shared/github-repo-scope";
 import {
   fetchGithubInstallations,
   findGithubInstallation,
-  githubAppInstallUrl,
+  GITHUB_APP_INSTALL_URL,
 } from "@/lib/github-installations";
 import { provisionRepoScopedGithubConnection } from "@/lib/provision-repo-scoped-github-connection";
 import {
@@ -178,7 +178,7 @@ export function ImportFromDecoDialog({
 
       track("deco_site_import_started", { site_name: siteName });
 
-      const { installations, appSlug } = await fetchGithubInstallations(
+      const { installations } = await fetchGithubInstallations(
         (req) => client.callTool(req),
         effectiveGithubConnection.id,
       );
@@ -194,11 +194,10 @@ export function ImportFromDecoDialog({
         githubRepo.owner,
       );
       if (!githubInstallation) {
-        const installUrl = githubAppInstallUrl(appSlug);
         throw new Error(
           t("common.importFromDecoDialog.installGithubApp", {
             owner: githubRepo.owner,
-            installUrl,
+            installUrl: GITHUB_APP_INSTALL_URL,
           }),
         );
       }

--- a/apps/web/src/lib/github-installations.ts
+++ b/apps/web/src/lib/github-installations.ts
@@ -1,3 +1,14 @@
+/**
+ * Fallback GitHub App slug for when GITHUB_LIST_USER_ORGS can't report one —
+ * the slug is harvested from the user's installations, so a user with zero
+ * installations (the exact case that needs the install link) never gets it.
+ */
+const DEFAULT_GITHUB_APP_SLUG = "deco-cms";
+
+export function githubAppInstallUrl(appSlug?: string): string {
+  return `https://github.com/apps/${appSlug ?? DEFAULT_GITHUB_APP_SLUG}/installations/new`;
+}
+
 export type GithubInstallation = {
   installationId: number;
   login: string;

--- a/apps/web/src/lib/github-installations.ts
+++ b/apps/web/src/lib/github-installations.ts
@@ -1,13 +1,5 @@
-/**
- * Fallback GitHub App slug for when GITHUB_LIST_USER_ORGS can't report one —
- * the slug is harvested from the user's installations, so a user with zero
- * installations (the exact case that needs the install link) never gets it.
- */
-const DEFAULT_GITHUB_APP_SLUG = "deco-cms";
-
-export function githubAppInstallUrl(appSlug?: string): string {
-  return `https://github.com/apps/${appSlug ?? DEFAULT_GITHUB_APP_SLUG}/installations/new`;
-}
+export const GITHUB_APP_INSTALL_URL =
+  "https://github.com/apps/deco-cms/installations/new";
 
 export type GithubInstallation = {
   installationId: number;
@@ -24,7 +16,7 @@ type McpCallTool = (req: {
 export async function fetchGithubInstallations(
   selfCallTool: McpCallTool,
   connectionId: string,
-): Promise<{ installations: GithubInstallation[]; appSlug?: string }> {
+): Promise<{ installations: GithubInstallation[] }> {
   const result = await selfCallTool({
     name: "GITHUB_LIST_USER_ORGS",
     arguments: { connectionId },
@@ -37,7 +29,6 @@ export async function fetchGithubInstallations(
   try {
     return JSON.parse(content) as {
       installations: GithubInstallation[];
-      appSlug?: string;
     };
   } catch {
     throw new Error("Invalid response from GITHUB_LIST_USER_ORGS");

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -6622,7 +6622,6 @@ export interface StudioToolIO {
         avatarUrl: string;
         type: string;
       }[];
-      appSlug?: string | undefined;
     };
   };
   LINK_CURRENT_GET: {


### PR DESCRIPTION
## Summary

A user with **zero GitHub App installations** — the exact case that renders the "no repositories" empty state in the import-from-GitHub picker — got a CTA linking to `https://github.com/settings/installations` instead of the app install page. That settings page is an empty list for someone who never installed the app: a dead end.

Root cause: the install URL was built from an `appSlug` that `GITHUB_LIST_USER_ORGS` harvested from the user's installations returned by GitHub's `GET /user/installations` — so with zero installations there was no slug to build the URL from. Since the app is always `deco-cms`, that whole round-trip was pointless plumbing; this PR replaces it with a hardcoded constant.

## Changes

- `apps/web/src/lib/github-installations.ts`: new `GITHUB_APP_INSTALL_URL` constant (`https://github.com/apps/deco-cms/installations/new`, which GitHub redirects to its `select_target` page); `fetchGithubInstallations` no longer returns `appSlug`.
- `apps/web/src/components/github-repo-picker.tsx`: empty-state "Choose repositories" CTA and the "Install GitHub App" footer link use the constant.
- `apps/web/src/components/import-from-deco-dialog.tsx`: same for the install URL embedded in the "install the app for this owner" error message.
- `apps/api/src/tools/github/list-user-orgs.ts`: dropped the `appSlug` harvesting and output field entirely.
- `packages/shared/src/tools/tool-io.ts`: regenerated tool contracts.

## Testing

- `bun run fmt` — clean
- `bun run check` (all workspaces) — passes
- `bun run lint` — 0 errors, no warnings in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)