### PR TITLE
native updater/1 release pipeline

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -325,8 +325,9 @@ jobs:
       github.event_name != 'schedule'
     runs-on: macos-latest
     timeout-minutes: 45
-    env:
-      # --- macOS code signing + notarization (Apple Developer ID) ---------
+    # (No job-level env: both signing families below are deliberately unwired
+    # in this non-shipping job.)
+    # --- macOS code signing + notarization (Apple Developer ID) ---------
       # All optional. Human-required setup (cert enrollment, notarization
       # credentials) — see the native release contract (§5.3,
       # dormant scaffolding). Required secret names, each consumed only by
@@ -351,14 +352,12 @@ jobs:
       # application: failed to import keychain certificate", from a cert that
       # is present but not importable. Wiring them cost a green CI and bought
       # nothing. Signing belongs to the separate, secret-gated release job.
-      # --- Tauri updater artifact signing (separate keypair; unrelated to
-      #     Apple code signing above) — only takes effect once
-      #     tauri.conf.json5 configures the `updater` bundle target, which
-      #     is still dormant (the native release contract
-      #     §"Updater"). Wired here now so no further workflow edit is
-      #     needed once that config lands.
-      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      # --- Tauri updater artifact signing: NOT wired here, by design.
+      #     createUpdaterArtifacts is enabled only by release-native.yaml's
+      #     --config overlay (never the committed tauri.conf.json5), so this
+      #     job can never produce updater artifacts and has no use for the
+      #     minisign key. The key is step-scoped onto the release build —
+      #     see release-native.yaml's "tauri build" step.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -441,6 +440,14 @@ jobs:
       # step immediately before this one rather than reverting it to
       # local-only.
       - name: Boot smoke (DESKTOP_SELFTEST=1, hidden window)
+        # DECOCMS_DISABLE_AUTO_UPDATE: this job builds the RELEASE profile at
+        # the committed version 0.1.0 — without the kill-switch, a
+        # plugin-registered updater would see the prod channel as "newer" and
+        # download ~80 MB over the CI bundle mid-smoke. Belt-and-braces: the
+        # updater task also refuses to spawn under DESKTOP_SELFTEST=1 and at
+        # the 0.1.0 placeholder version.
+        env:
+          DECOCMS_DISABLE_AUTO_UPDATE: "1"
         run: bun run --cwd apps/native smoke:boot
 
   # ---------------------------------------------------------------------

--- a/.github/workflows/release-native.yaml
+++ b/.github/workflows/release-native.yaml
@@ -21,6 +21,38 @@
 # straight to main with the same App token release-tagging uses. That commit
 # touches only Casks/**, which no other workflow's paths match, so it
 # triggers nothing.
+#
+# ## Updater channel (Tauri self-update)
+#
+# Alongside the immutable native-v<version> release, this workflow maintains
+# a ROLLING `native-updates` prerelease holding a single latest.json asset —
+# the manifest the desktop app's Tauri updater polls. Prerelease keeps it out
+# of GitHub's /releases/latest forever (latest = most recent non-prerelease).
+# Promotion is throttled to ~daily and decided by the unit-tested
+# apps/native/scripts/ci/native-update-channel.mjs (fail-open-to-promote on
+# any ambiguous manifest state; a workflow_dispatch bypasses the throttle for
+# urgent fixes and for healing a half-failed promotion). The manifest is
+# uploaded strictly AFTER the .app.tar.gz + .sig land on the immutable
+# release, so it can never reference missing assets.
+#
+# Caveats: enabling GitHub's opt-in "immutable releases" repo setting would
+# break the latest.json clobber — revisit this design before turning that
+# on. Clobbered same-name assets can serve stale from the CDN briefly
+# (tolerable at daily cadence).
+#
+# ## Updater signing runbook
+#
+# The minisign keypair (TAURI_SIGNING_PRIVATE_KEY/_PASSWORD, in the
+# `native-release` environment) signs updater artifacts; its PUBLIC key is
+# pinned in apps/native/src-tauri/tauri.conf.json5. Consequences:
+# - KEY LOSS: no future update verifies — the cask is the break-glass
+#   channel (`brew upgrade --greedy --cask deco-studio`); keep the cask
+#   bump below working forever.
+# - KEY LEAK: there is no revocation; rotation = new keypair + cask-forced
+#   fleet reinstall. Audit escrow access.
+# - BAD RELEASE: the updater never downgrades — ship a NEWER fixed release
+#   (use the force_promote dispatch input if inside the throttle window).
+#   Broken-cannot-launch installs recover via cask reinstall.
 name: Release Native
 
 on:
@@ -31,7 +63,15 @@ on:
       - "apps/native/package.json"
   # Manual escape hatch: re-cut a release whose run failed halfway, or cut
   # the first one. The tag-exists guard keeps this idempotent.
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      force_promote:
+        description: >-
+          Bypass the ~daily updater-channel throttle (urgent fix, or healing
+          a half-failed promotion). Never regresses the channel to an older
+          version regardless.
+        type: boolean
+        default: false
 
 concurrency:
   group: release-native-main
@@ -39,11 +79,21 @@ concurrency:
 
 permissions:
   contents: write
+  # The failure-alert step files/updates a GitHub issue.
+  issues: write
 
 jobs:
   release:
     runs-on: macos-latest
     timeout-minutes: 60
+    # Updater signing secrets live here (deployment branch policy: main).
+    # Environments cannot restrict by workflow FILE — any main-branch
+    # workflow declaring this environment could read them — but that still
+    # beats repo-wide secrets, which every workflow (including the seven
+    # npm-publish ones) can read. Referencing a not-yet-created environment
+    # is safe: GitHub auto-creates it unprotected on first run; tighten it
+    # in repo settings.
+    environment: native-release
     env:
       BUN_VERSION: "1.3.14"
     steps:
@@ -90,6 +140,34 @@ jobs:
           else
             echo "release=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # apps/api and apps/native versions are ONE release line
+      # (scripts/release-changes.ts bumps them together). The proxy's
+      # STUDIO_WEB_VERSION is baked from apps/api while the binary/manifest
+      # version comes from apps/native — a single-sided bump would ship a
+      # permanent version-drift nag in the shell, so fail loudly here.
+      - name: Assert api/native version lockstep
+        if: steps.guard.outputs.release == 'true'
+        run: |
+          API_VERSION=$(node -p "require('./apps/api/package.json').version")
+          NATIVE_VERSION="${{ steps.version.outputs.version }}"
+          if [ "$API_VERSION" != "$NATIVE_VERSION" ]; then
+            echo "::error::version lockstep broken: apps/api=$API_VERSION apps/native=$NATIVE_VERSION (scripts/release-changes.ts bumps them together — a single-sided bump is an offset forever)"
+            exit 1
+          fi
+
+      # Inverts the fork-safe silence for this ONE secret: the build below
+      # requests updater artifacts (createUpdaterArtifacts), which REQUIRE
+      # the minisign key — a missing secret must fail here with a clear
+      # name, not inside `tauri build`. The secret value never enters a
+      # shell (the `env:` mapping is only compared for emptiness).
+      - name: Assert updater signing secret
+        if: steps.guard.outputs.release == 'true' && env.HAVE_SIGNING_KEY != 'true'
+        env:
+          HAVE_SIGNING_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' && 'true' || 'false' }}
+        run: |
+          echo "::error::TAURI_SIGNING_PRIVATE_KEY is not set (native-release environment). Generate/escrow per apps/native/docs/native-updater-plan.md Phase 0, then set TAURI_SIGNING_PRIVATE_KEY and TAURI_SIGNING_PRIVATE_KEY_PASSWORD."
+          exit 1
 
       - name: Setup Rust toolchain
         if: steps.guard.outputs.release == 'true'
@@ -157,10 +235,9 @@ jobs:
       # absent (not empty) leaves an unsigned build
       # (https://v2.tauri.app/distribute/sign/macos/).
       #
-      # TAURI_SIGNING_* signs the updater artifact the day tauri.conf enables
-      # the `updater` bundle target. Wired in this SHIPPING job (not just
-      # native.yml's non-shipping CI build) so no edit is needed here on
-      # release day; a no-op while that target stays dormant.
+      # NOTE: TAURI_SIGNING_* is deliberately NOT exported here — $GITHUB_ENV
+      # makes it visible to every later step (third-party CLI code, the cask
+      # python, gh). It is step-scoped onto `tauri build` below instead.
       - name: Export signing env
         if: steps.guard.outputs.release == 'true'
         env:
@@ -168,13 +245,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        # Heredoc form because TAURI_SIGNING_PRIVATE_KEY may be multiline.
         run: |
           for VAR in APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD \
-                     APPLE_TEAM_ID TAURI_SIGNING_PRIVATE_KEY \
-                     TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+                     APPLE_TEAM_ID; do
             if [ -n "${!VAR}" ]; then
               {
                 echo "$VAR<<__SIGNING_EOF__"
@@ -187,13 +260,24 @@ jobs:
       - name: tauri build
         if: steps.guard.outputs.release == 'true'
         working-directory: apps/native
-        # Signing env (when configured) comes from "Export signing env" above.
+        # Apple signing env (when configured) comes from "Export signing env"
+        # above; the updater minisign key is step-scoped HERE only. The CLI is
+        # pinned (never @latest): the signer/bundler executing with the key in
+        # scope must not change under us, and env-var-supplied key PASSWORDS
+        # have a version-sensitive history (tauri#13485) — verify signing
+        # still works when bumping this pin.
         # The binary's version comes from apps/native/package.json — the one
         # release-tagging bumps — overriding Cargo.toml's static workspace
         # version, so the DMG, the About panel, and the cask all agree.
+        # createUpdaterArtifacts lives in this overlay, NOT in the committed
+        # tauri.conf.json5 — committed, it would fail every secretless
+        # (fork/PR) build with a signing error.
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
-          bunx @tauri-apps/cli@latest build \
-            --config "{\"version\": \"${{ steps.version.outputs.version }}\"}"
+          bunx @tauri-apps/cli@2.11.4 build \
+            --config "{\"version\": \"${{ steps.version.outputs.version }}\", \"bundle\": {\"createUpdaterArtifacts\": true}}"
 
       - name: Package release assets
         if: steps.guard.outputs.release == 'true'
@@ -203,15 +287,25 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           ZIP="deco-$VERSION-aarch64.zip"
           DMG_OUT="deco-$VERSION-aarch64.dmg"
+          TARGZ="deco-$VERSION-aarch64.app.tar.gz"
           # ditto preserves signatures, resource forks and the executable bit
           # — a plain `zip` bundle strips what codesign later needs intact.
           ditto -c -k --keepParent "macos/deco.app" "$ZIP"
           DMG_SRC=$(ls dmg/*.dmg | head -1)
           cp "$DMG_SRC" "$DMG_OUT"
-          echo "zip=apps/native/target/release/bundle/$ZIP" >> "$GITHUB_OUTPUT"
-          echo "dmg=apps/native/target/release/bundle/$DMG_OUT" >> "$GITHUB_OUTPUT"
+          # Updater artifacts (createUpdaterArtifacts in the build overlay):
+          # the tar.gz the updater downloads and the minisign signature that
+          # goes INTO latest.json.
+          cp "macos/deco.app.tar.gz" "$TARGZ"
+          cp "macos/deco.app.tar.gz.sig" "$TARGZ.sig"
           shasum -a 256 "$ZIP" | cut -d' ' -f1 > zip.sha256
-          echo "sha256=$(cat zip.sha256)" >> "$GITHUB_OUTPUT"
+          {
+            echo "zip=apps/native/target/release/bundle/$ZIP"
+            echo "dmg=apps/native/target/release/bundle/$DMG_OUT"
+            echo "targz=apps/native/target/release/bundle/$TARGZ"
+            echo "sig=apps/native/target/release/bundle/$TARGZ.sig"
+            echo "sha256=$(cat zip.sha256)"
+          } >> "$GITHUB_OUTPUT"
 
       # Create-or-update: on a repair dispatch the tag already exists, so
       # re-uploading the assets (--clobber) heals a run that died here or
@@ -224,18 +318,70 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           ZIP: ${{ steps.assets.outputs.zip }}
           DMG: ${{ steps.assets.outputs.dmg }}
+          TARGZ: ${{ steps.assets.outputs.targz }}
+          SIG: ${{ steps.assets.outputs.sig }}
         run: |
           set -euo pipefail
           NOTES="macOS (Apple Silicon) desktop app. Install via Homebrew: \`brew tap decocms/studio https://github.com/decocms/studio && brew install --cask deco-studio\` — or download the DMG below."
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
             gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" \
               --title "deco $VERSION" --notes "$NOTES"
-            gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber "$ZIP" "$DMG"
+            gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber \
+              "$ZIP" "$DMG" "$TARGZ" "$SIG"
           else
             gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
               --target "$GITHUB_SHA" --title "deco $VERSION" --notes "$NOTES" \
-              "$ZIP" "$DMG"
+              "$ZIP" "$DMG" "$TARGZ" "$SIG"
           fi
+
+      # Runs strictly AFTER the immutable release holds the .app.tar.gz +
+      # .sig, so a manifest can never reference missing assets. Promotion is
+      # decided by the unit-tested script (throttle, never-regress, fail-open
+      # semantics — see its header); the decision is surfaced as a ::notice::
+      # so silent-skip streaks are greppable. Manifest generation happens in
+      # $RUNNER_TEMP: the cask step below hard-resets the worktree.
+      - name: Promote updater channel
+        if: steps.guard.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          SIG: ${{ steps.assets.outputs.sig }}
+          FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force_promote && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+          CHANNEL_TAG="native-updates"
+          CURRENT="$RUNNER_TEMP/current-latest.json"
+          MANIFEST="$RUNNER_TEMP/latest.json"
+          DECISION="$RUNNER_TEMP/decision.json"
+
+          # First-ever promotion: the channel release (or its asset) doesn't
+          # exist yet — the script treats an unreadable file as "no manifest"
+          # and promotes.
+          gh release download "$CHANNEL_TAG" --repo "$GITHUB_REPOSITORY" \
+            -p latest.json -O "$CURRENT" || rm -f "$CURRENT"
+
+          FORCE_FLAG=""
+          [ "$FORCE" = "true" ] && FORCE_FLAG="--force"
+          node apps/native/scripts/ci/native-update-channel.mjs should-promote \
+            --candidate "$VERSION" --current-file "$CURRENT" $FORCE_FLAG > "$DECISION"
+          PROMOTE=$(node -p "require('$DECISION').promote")
+          REASON=$(node -p "require('$DECISION').reason")
+          echo "::notice::updater channel decision: promote=$PROMOTE ($REASON)"
+          if [ "$PROMOTE" != "true" ]; then
+            exit 0
+          fi
+
+          node apps/native/scripts/ci/native-update-channel.mjs build \
+            --version "$VERSION" --sig-file "$SIG" \
+            --repo "$GITHUB_REPOSITORY" > "$MANIFEST"
+
+          gh release view "$CHANNEL_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1 || \
+            gh release create "$CHANNEL_TAG" --repo "$GITHUB_REPOSITORY" \
+              --prerelease --title "deco update channel" \
+              --notes "Rolling updater manifest polled by the desktop app. Do not install from here — use the latest native-v release or Homebrew."
+          gh release upload "$CHANNEL_TAG" --repo "$GITHUB_REPOSITORY" \
+            --clobber "$MANIFEST"
+          echo "::notice::updater channel promoted to $VERSION"
 
       # Gated on the App credentials EXISTING: a fork without them still
       # builds and publishes the (unsigned) release above — this only skips
@@ -309,3 +455,28 @@ jobs:
           done
           echo "::error::cask bump push failed after retries"
           exit 1
+
+      # A failed release means unbounded, INVISIBLE staleness: the shell
+      # suppresses version drift by design, so nothing nags users and the
+      # update channel silently stops moving. Surface the failure as a
+      # GitHub issue (created once, then commented) — the || true guards
+      # keep a broken alert from masking the real failure.
+      - name: Alert on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          TAG="${{ steps.version.outputs.tag }}"
+          BODY="Release run for \`${TAG:-unknown}\` failed: $RUN_URL
+
+          A failed native release stalls the desktop updater channel invisibly (drift is suppressed in the shell by design). Repair: fix the cause, then re-run via workflow_dispatch (idempotent; pass force_promote to bypass the channel throttle if needed)."
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --search "\"release-native failed\" in:title" --state open \
+            --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body "$BODY" || true
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "release-native failed (${TAG:-unknown})" --body "$BODY" || true
+          fi

--- a/apps/native/README.md
+++ b/apps/native/README.md
@@ -145,6 +145,31 @@ Run `bun run fmt` after changes.
   re-established after an application restart rather than orphaned.
 - Subprocess logs are file-backed and bounded; memory holds only live fan-out.
 
+## Self-update channel (operations)
+
+The packaged app auto-updates via the Tauri updater: it polls `latest.json`
+on the rolling `native-updates` GitHub prerelease, which
+`release-native.yaml` promotes at most ~daily (unit-tested logic in
+`scripts/ci/native-update-channel.mjs`). Design and full rationale:
+[`docs/native-updater-plan.md`](./docs/native-updater-plan.md).
+
+Operator notes:
+
+- **Signing key** (`TAURI_SIGNING_PRIVATE_KEY`/`_PASSWORD`, GitHub
+  environment `native-release`): the public key is pinned in
+  `src-tauri/tauri.conf.json5`. Losing the private key permanently strands
+  the installed base on the updater — the Homebrew cask is the break-glass
+  recovery channel (`brew upgrade --greedy --cask deco-studio`), so the CI
+  cask bump must keep working forever. A leaked key has no revocation:
+  rotation = new keypair + cask-forced reinstall.
+- **Bad release**: the updater never downgrades. Ship a newer fixed release;
+  use the `force_promote` dispatch input of `release-native.yaml` to bypass
+  the ~daily channel throttle.
+- **Kill switch**: `DECOCMS_DISABLE_AUTO_UPDATE=1` disables the updater task
+  (warn-logged every cycle). A Finder-launched app does not inherit shell
+  env — use `launchctl setenv DECOCMS_DISABLE_AUTO_UPDATE 1` or a terminal
+  launch when debugging.
+
 ## Related documentation
 
 - [Studio Web](../web/README.md)

--- a/apps/native/docs/native-updater-plan.md
+++ b/apps/native/docs/native-updater-plan.md
@@ -1,0 +1,655 @@
+# Native auto-updater — v1 implementation plan (macOS)
+
+Goal: the desktop app updates itself. All hard logic lives in Rust; the web UI
+reuses the existing `VersionCheckDialog` ("A new version is ready") card with
+one native-gated edge: on desktop builds its button calls the Rust backend
+instead of `window.location.reload()`.
+
+Design summary (settled in design review + critique pass):
+
+- The Rust backend **auto-checks, auto-downloads, and auto-installs** updates
+  in the background. On macOS the install swaps the `.app` on disk while the
+  running process is untouched — install-eagerly is safe because nothing
+  re-reads the bundle path at runtime.
+- The **existing drift mechanism is the notification channel**: the proxy's
+  `rewrite_config_version` (which today pins `/api/config`'s `config.version`
+  to the embedded bundle version so the browser-refresh nag never fires in the
+  shell) gains one branch — once an update is *installed on disk*, it reports
+  the staged version instead. The untouched dialog polls, sees drift twice,
+  and shows the card. No new wire contract, no new poll, no new component.
+- The card's button, under `useIsDesktopApp()`, POSTs a new local-api route
+  that triggers a **graceful** restart via Tauri's `request_restart()` —
+  documented to deliver `RunEvent::ExitRequested` reliably, so the repo's
+  single shutdown pipeline (child sweeps, drain, instance-lock release) always
+  runs. We do NOT add `tauri-plugin-process` or any webview updater
+  capability: the trigger stays a Rust-side callback, keeping the webview IPC
+  surface closed (capabilities/default.json gains nothing — worth a CI grep
+  assertion that `updater:`/`process:` permissions never appear there).
+- Update source of truth is a **rolling `native-updates` prerelease** on
+  GitHub holding one `latest.json`, clobbered as the *last* step of
+  `release-native.yaml`. `releases/latest/download/…` is unusable in this repo
+  (seven workflows create stable releases across six tag schemes; Studio `v*`
+  dominates "latest"), and serving the manifest from the app/web dist is
+  broken by construction (the `.sig` exists only after the native build;
+  self-hosted instances would freeze at their build version).
+- `bundle.createUpdaterArtifacts` is **never committed** to
+  `tauri.conf.json5` — it is enabled only via the release workflow's existing
+  `--config` overlay (JSON Merge Patch per RFC 7396, so the nested `bundle`
+  key augments rather than clobbers). Committed config with a pubkey +
+  updater artifacts would fail every secretless (fork/PR) build. Conversely
+  the release job asserts the signing secret is present and fails loudly.
+- The updater never runs outside a real shipped build. Three independent
+  gates, because `#[cfg(not(debug_assertions))]` alone is NOT enough —
+  `native.yml`'s `tauri-build` job and `boot-smoke.ts` build the **release**
+  profile at the committed `version: "0.1.0"`, which would see prod as
+  "newer" and download ~80 MB over the CI bundle on every PR run:
+  1. `#[cfg(not(debug_assertions))]` (mirror of the debug-only mcp-bridge
+     registration) — covers dev loops;
+  2. skip spawn when `selftest::is_enabled()` **or** the running version is
+     the committed `0.1.0` placeholder — covers CI/smoke release builds;
+  3. `DECOCMS_DISABLE_AUTO_UPDATE=1` honored at runtime and exported in
+     `native.yml`'s boot-smoke step and `boot-smoke.ts` as belt-and-braces.
+     The kill-switch logs `tracing::warn!` on every skipped cycle (silent
+     freezes must be greppable in support diagnostics), and support docs must
+     note a Finder-launched app doesn't inherit shell env — it needs
+     `launchctl setenv` or a terminal launch.
+
+Explicit non-goals for v1 (recorded so nobody "just adds" them):
+
+- **Upstream-served update channel.** An upstream-controlled `latest.json` is
+  unsigned (only the artifact is minisigned): a hostile self-hosted upstream
+  could pair a high `version` with an old validly-signed artifact. v2 needs a
+  signed manifest or a version-pin resolved against GitHub, Rust-side
+  (`UpdaterBuilder::endpoints()` from `upstream::global().target()`). v1
+  endpoint is the static GitHub URL. Note the same attack against the GitHub
+  channel itself IS closed in v1 — see the version-pairing check in Phase 2a.
+- **Run-aware restart gating.** The restart is an explicit user click on a
+  card that only appears when an update is verifiably staged. A "N agent runs
+  will be stopped" confirm can layer on later without structural change.
+- **Linux/Windows.** The staged-state machine lives in one Rust module so the
+  Windows difference (install force-exits the app — install must couple to
+  restart consent there) becomes a branch, not a redesign.
+- **Migrating pre-updater installs.** Brew users converge via the CI cask
+  bump. Users who installed the DMG directly on a pre-updater version are
+  stranded silently (no plugin, drift suppressed) — accepted deliberately;
+  the cask/DMG release notes are the only channel to reach them.
+
+## Merge order & shippability
+
+`Phase 0 → Phase 1 → Phase 2 (+ Phase 4 in the same PR) → Phase 3`, each
+independently shippable:
+
+- Phase 0 must precede Phase 1's merge (the new signing-secret assertion
+  would otherwise fail every release).
+- Phase 1 before Phase 2 is harmless: manifest published, nothing consumes it.
+- Phase 4 (`auto_updates true`) must ride the **Phase 2 PR**: merging the
+  plugin + pubkey means the next release-tagging bump ships a self-updating
+  binary, and from that moment `brew upgrade` would downgrade self-updated
+  installs.
+- Phase 3 before Phase 2 would be safe-but-dead (the card cannot appear in
+  native without a staged version), but the order above avoids shipping a
+  button that 404s.
+- **Channel-promotion launch gate**: code merges freely, but do not run the
+  first real promotion (and do not merge Phase 4) until the manual test
+  (below) passes its go/no-go criteria — in particular the Keychain
+  observation. Unsigned builds change CDHash every update, which breaks
+  Keychain item ACLs (per `crates/upstream/src/tokens.rs`'s own docs); at
+  ~daily promotion cadence a forced re-login per update is strictly worse
+  than the status quo. The dormant `APPLE_*` Developer ID + notarization
+  scaffolding in `release-native.yaml:133-158` activates on secrets alone —
+  it should land before or with the first promotion.
+
+---
+
+## Phase 0 — signing key (existential; do first)
+
+No minisign material exists anywhere in the repo; the `TAURI_SIGNING_*`
+exports in both workflows are fork-safe dormant scaffolding. Whichever key
+signs the first shipped updater release is permanent: the pubkey ships pinned
+in every binary, and losing the private key strands the entire installed base.
+
+1. `bunx @tauri-apps/cli@^2 signer generate -w ~/.tauri/decocms-updater.key`
+   with a password. (Not `bunx tauri …` — that resolves the npm package
+   literally named `tauri`, the v1 CLI. `-w` requires the path argument.)
+2. Escrow private key + password in the org password manager (offline copy),
+   NOT only in GitHub (secrets are write-only; a GitHub-only copy is a single
+   point of loss).
+3. Set `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` in
+   a GitHub **Environment** (e.g. `native-release`) with a deployment branch
+   policy restricted to `main`. Precision on what that buys: Environments
+   cannot restrict by workflow *file* — any workflow that runs on `main` and
+   declares `environment: native-release` can read them (that requires a
+   reviewed merge; optionally add required reviewers). This is still strictly
+   narrower than repo-wide secrets, which every workflow — including the
+   seven npm-publish workflows — can read. Phase 1 MUST add the matching
+   `environment:` key to the `release` job or the secret resolves empty and
+   every release fails.
+4. The public key goes into `tauri.conf.json5` in Phase 2.
+5. Runbooks (durable home: `release-native.yaml`'s header comment +
+   `apps/native/README.md`, not this plan):
+   - **Key loss** → cask is the break-glass channel: users recover via
+     `brew upgrade --greedy --cask deco-studio`; keep the CI cask bump
+     forever.
+   - **Key leak** → there is no revocation channel; rotation = new key +
+     cask-forced reinstall of the fleet. Audit escrow access; treat the
+     GitHub Environment as the only CI holder.
+   - **Bad release shipped** → the updater never downgrades; the fix is
+     promoting a *newer* fixed release (use the `force_promote` dispatch
+     input below if inside the throttle window). Broken-cannot-launch →
+     cask reinstall.
+
+## Phase 1 — release pipeline (`.github/workflows/release-native.yaml`)
+
+All steps in the existing single `release` job, in this order:
+
+1. **`environment: native-release`** on the job (see Phase 0.3).
+2. **Lockstep assertion** (new step, after the existing `Read app version`
+   step): fail the release loudly if `apps/api/package.json` and
+   `apps/native/package.json` versions differ. `crates/local-api/build.rs`
+   bakes `STUDIO_WEB_VERSION` from apps/api while the manifest/binary version
+   comes from apps/native — equal only by the release-changes.ts lockstep; a
+   single-sided bump would otherwise ship the permanent-nag state.
+3. **Signing-secret assertion** (new step): a step with
+   `if: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY == '' }}` that `exit 1`s with a
+   pointer to Phase 0. The secret value never enters a shell; never inline
+   `${{ secrets.* }}` into a `run:` body (multiline key = parse/injection
+   hazard and only per-line masking).
+4. **Build** — pin the CLI to an exact version (no `@latest`: the signer/
+   bundler executing with the key in scope must not change under us; also
+   verify once against the pinned version that env-var-supplied key
+   *passwords* work — tauri#13485/plugins-workspace#2710 report password-
+   via-env failures) and extend the existing overlay:
+
+   ```yaml
+   run: bunx @tauri-apps/cli@2.x.y build --config "{\"version\": \"$VERSION\", \"bundle\": {\"createUpdaterArtifacts\": true}}"
+   ```
+
+   Scope `TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)` as step-level `env:` on this
+   step only — not `$GITHUB_ENV` (the current dormant export makes the
+   permanent key visible to every later step, including third-party CLI
+   code, the cask python, and `gh`). The `APPLE_*` export step is unchanged.
+5. **Collect updater artifacts** (extend the `assets` step): the bundler
+   emits `target/release/bundle/macos/deco.app.tar.gz` (+ `.sig`). Copy to
+   versioned names `deco-$VERSION-aarch64.app.tar.gz`(+`.sig`) and add both
+   to the existing `gh release upload` for the immutable `native-v$VERSION`
+   release (alongside ZIP + DMG).
+6. **Assemble `latest.json` + decide promotion — via a tested script.** The
+   throttle/manifest logic is real logic that must not first execute in a
+   production release on a BSD-date macOS runner. Add
+   `apps/native/scripts/ci/native-update-channel.mjs` (zero-dep Node, the
+   `check-junit-allowlist.mjs` convention) exporting two pure functions with
+   co-located unit tests, and a thin CLI entry the workflow calls:
+   - `buildLatestJson({version, sigContents, notesUrl, pubDate})` —
+     structured JSON construction (never shell/string interpolation; the
+     `.sig` is base64 today but correctness-by-construction is free). Shape:
+
+     ```json
+     {
+       "version": "$VERSION",
+       "pub_date": "<RFC 3339>",
+       "notes": "<native-v$VERSION release URL>",
+       "platforms": {
+         "darwin-aarch64": {
+           "url": "https://github.com/decocms/studio/releases/download/native-v$VERSION/deco-$VERSION-aarch64.app.tar.gz",
+           "signature": "<contents of the .sig file>"
+         }
+       }
+     }
+     ```
+
+     Platform keys extend later (`darwin-x86_64`, `linux-x86_64`,
+     `windows-x86_64`) without shape changes. Note: the updater validates
+     the WHOLE file before reading `version` — when platform keys are added,
+     one malformed entry bricks updates for all platforms.
+   - `shouldPromote({currentManifest, candidateVersion, now, force})` with
+     fail-open-to-promote semantics, in order:
+     1. no current manifest / unparseable JSON → **promote** (first run:
+        guard the `gh release download native-updates -p latest.json -O -`
+        with `|| true` — it exits non-zero before the release exists);
+     2. `currentManifest.version >= candidateVersion` (semver) → **skip**
+        (prevents a repair-dispatch on an old ref from regressing the
+        channel);
+     3. `force` (a `force_promote: true` `workflow_dispatch` input) →
+        **promote** — the escape hatch for urgent fixes inside the window
+        and for healing a half-failed promotion;
+     4. `pub_date` missing, unparseable, or **in the future** → **promote**
+        (a clobbered far-future date must not freeze the channel forever;
+        clock skew heals instead of wedging);
+     5. `pub_date` age < 20 h → **skip** (the throttle: releases track the
+        ~12×/day cloud cadence at ~80 MB/artifact; auto-download must cost
+        ~one artifact/day). Else **promote**.
+7. **Promote the channel — LAST**:
+   - `gh release view native-updates || gh release create native-updates
+     --prerelease --title "deco update channel" --notes "Rolling updater
+     manifest. Do not install from here."` — `prerelease` keeps it out of
+     GitHub's `releases/latest` forever (REST semantics: latest = most
+     recent non-prerelease, non-draft).
+   - `gh release upload native-updates latest.json --clobber` — idempotent,
+     matching the workflow's re-run-only-heals repair semantics. Ordering
+     guarantee: the manifest can never reference assets that don't exist yet.
+   - Workflow-header caveats to record: GitHub's opt-in "immutable releases"
+     repo setting would break the clobber; clobbered same-name assets can
+     serve stale from the CDN briefly (tolerable at daily cadence).
+8. **Failure alerting** (new step, concrete): `if: failure()` step following
+   the fork-safe webhook pattern of `release-studio.yaml`'s docs-agent step
+   (skip-when-unconfigured, warn on non-2xx) — or, with no webhook secret
+   configured, create/update a pinned GitHub issue via `gh`. Rationale: a
+   failed release today means unbounded, invisible staleness (drift is
+   suppressed by design), and a throttle bug that always skips exits
+   *successfully* — so also emit a `::notice::` with the promotion decision
+   on every run to make silent-skip streaks greppable.
+
+`native.yml` changes: export `DECOCMS_DISABLE_AUTO_UPDATE=1` in the
+boot-smoke step (see gate 3 above). Nothing else — the committed config never
+requests updater artifacts, so PR/fork builds stay green.
+
+## Phase 2 — Rust
+
+Interface-change note: this phase touches three contract-governed surfaces —
+a `router.rs` route, an `AppState` field, and the `StartOptions`/`UpdateHooks`
+pub API (`state.rs` carries the same "file an interface request" header as
+`router.rs`). Treat them as ONE interface request and update the
+module-ownership contract doc alongside. AppState (not the `lib.rs`
+global-publish pattern used for `org_mount::set_credentials`) is the right
+home because the consuming handlers already extract `State<AppState>`; a
+separate field (not `EmbeddedOptions`) because embedded *debug* builds have
+no updater either — the axes differ.
+
+### 2a. `apps/native/src-tauri` — plugin, config, background task, restart trigger
+
+- `Cargo.toml`s: add `tauri-plugin-updater = "2"` to the workspace-dep table
+  in `apps/native/Cargo.toml` and `workspace = true` in
+  `src-tauri/Cargo.toml` (repo pattern). The locked `tauri` 2.11.5 already
+  has `request_restart` (added 2.4.0) and the post-update relaunch fix
+  (tauri PR #12313).
+- `tauri.conf.json5`: add (committed — safe: `createUpdaterArtifacts`
+  defaults to false and the signing requirement triggers only when artifacts
+  are produced):
+
+  ```json5
+  plugins: {
+    updater: {
+      pubkey: "<public key from Phase 0>",
+      endpoints: [
+        "https://github.com/decocms/studio/releases/download/native-updates/latest.json",
+      ],
+    },
+  },
+  ```
+
+  Invariant to keep greppable (CI assertion is one line):
+  `dangerousInsecureTransportProtocol` must never appear in this file or any
+  `--config` overlay — it is the only thing between "pinned pubkey over TLS"
+  and plaintext manifest fetch.
+- `src/lib.rs`: register `tauri_plugin_updater::Builder::new().build()` under
+  `#[cfg(not(debug_assertions))]`. The cfg-gate is load-bearing, not
+  belt-and-suspenders: the plugin never auto-checks, but a debug binary with
+  the plugin registered and config present *would* self-update if anything
+  called `check()`.
+- New module `src/updater.rs`:
+  - A constructor `updater::init() -> (UpdateHooks, impl FnOnce(AppHandle))`
+    so the watch channel exists **before** `StartOptions` is built at
+    `setup.rs:274` and the spawn happens after the server starts (next to
+    `spawn_auth_status_bridge`/`revalidate::spawn`, setup.rs:307-312) —
+    ordering enforced by types, not convention.
+  - **Pure decision logic lives OUTSIDE any cfg-gated module** (release-only
+    cfg would compile its tests out of `cargo test --workspace`, which runs
+    the dev profile — the test would appear to exist while never running).
+    Only the spawn is gated.
+  - Spawn gates (see design summary): `cfg(not(debug_assertions))` AND
+    `!selftest::is_enabled()` AND running version ≠ `0.1.0` AND
+    `DECOCMS_DISABLE_AUTO_UPDATE` unset (warn-log every skipped cycle when
+    set).
+  - Loop: `tokio::time::interval` of **30 minutes** (`MissedTickBehavior::Delay`,
+    first tick consumed → the first check runs one interval after boot, no
+    boot contention). Deliberately NOT the 5-min revalidate cadence: the
+    manifest changes ≤ ~1.2×/day and card latency is dominated by the
+    dialog's own 5-min × 2-confirmation poll anyway; 5-min checks would be
+    ~288 no-op manifest fetches/day.
+  - Per tick:
+    1. `check()` with `UpdaterBuilder::timeout(…)` set. `check()` itself
+       gates on remote > running (semver, built-in) — do not re-implement
+       that comparison. Skip if the manifest version `==` the staged version
+       (plain `!=` supersede semantics — a strict "newer than staged" would
+       block channel rollforward after a botched release; semver ordering vs
+       staged is not needed and hand-rolled comparison invites bugs).
+    2. Skip if this version is memoized as failed and its backoff hasn't
+       elapsed — **the failure memo is required, not polish**: without it, a
+       persistently failing install (TCC block, disk full, bad signature)
+       re-downloads ~80 MB every tick forever (~worst case tens of GB/day
+       per affected client). One `(version, attempts, next_retry_at)` memo +
+       exponential backoff capped at ~24 h; reset when a new version appears.
+       Optional cheap pre-flight: skip download when free disk < ~3×
+       artifact size.
+    3. Set an `installing` flag (see 2b — the restart route 409s while it is
+       up), then `download(…)` with a generous `tokio::time::timeout` (a
+       stalled stream must not wedge the loop forever; downloads are not
+       resumable — record that as a known v2 item), progress via the chunk
+       callback at `tracing::debug!`.
+    4. **Version-pairing check (v1 downgrade defense)**: before installing,
+       verify the downloaded bundle's embedded version
+       (`Info.plist` `CFBundleShortVersionString` from the tar.gz) equals the
+       manifest's `version`. The minisign signature covers the artifact
+       bytes but NOT the manifest's version field, and nine-plus workflows
+       in this repo hold `contents: write` on the release surface — without
+       this check, any of those tokens compromised = silent fleet-wide
+       downgrade to an old validly-signed build. With it, a lying manifest
+       can no longer pair a high version with an old artifact.
+    5. `install()` under `spawn_blocking` (it is synchronous gunzip+untar+
+       swap I/O; `setup.rs:246` documents the same rationale for TLS
+       minting). Note the download buffers ~80-100 MB in RAM transiently —
+       acceptable on desktop; recorded so a future memory report doesn't
+       "fix" it blindly.
+    6. On success: clear `installing`, `staged_tx.send(Some(version))`,
+       clear the failure memo. On failure: clear `installing`, record the
+       memo, `tracing::warn!` — except **signature verification failure gets
+       its own distinct, greppable error line** (it means channel tampering
+       or a botched key rotation, categorically different from offline/404,
+       which stay silent by design).
+- Restart trigger: `setup.rs` passes
+  `Arc<dyn Fn() + Send + Sync>` = `move || app_handle.request_restart()` into
+  `StartOptions`. `request_restart` delivers `ExitRequested` (→
+  `shutdown::run_blocking` → full pipeline → respawn); the take-once in
+  `shutdown.rs:18-31` tolerates duplicate delivery. Two recorded caveats:
+  `restart_on_exit` is sticky, so a user quit racing a just-fired restart
+  becomes a relaunch (narrow, harmless, worth a comment); and macOS has an
+  open not-always-relaunching report (tauri#13923) — "process actually
+  respawns" is an explicit manual-test pass criterion, not an assumption.
+
+### 2b. `apps/native/crates/local-api` — state, rewrite branch, restart route
+
+- `lib.rs` — extend `StartOptions` (standalone binary and tests leave it
+  `None`; the compile-driven touchpoints are `boot_from_env`, the `lib.rs`
+  tests, and `routes::intercept::test_state` + the per-module `test_state()`
+  fns):
+
+  ```rust
+  /// Desktop-app self-update integration. `None` outside the packaged shell.
+  pub update: Option<UpdateHooks>,
+
+  pub struct UpdateHooks {
+      /// Version an update task has installed on disk; `None` until staged.
+      pub staged_version: tokio::sync::watch::Receiver<Option<String>>,
+      /// True while `download_and_install` is running (install serialization).
+      pub installing: Arc<AtomicBool>,
+      /// Graceful app restart (Tauri `request_restart`).
+      pub request_restart: Arc<dyn Fn() + Send + Sync>,
+  }
+  ```
+
+  Store on `AppState` (`state.rs`) under the interface-request framing above.
+- `routes/upstream.rs` — the staged-version branch. The wiring is slightly
+  more than one line and the plan owns that: `rewrite_config_version` and its
+  caller `proxy_public_config` have no `AppState` — thread the staged value
+  (and hooks presence) down from `proxy` through both signatures. Extract the
+  selection as a pure, unit-testable fn:
+
+  ```rust
+  /// Staged updates win; otherwise pin to the embedded bundle's version.
+  fn reported_config_version(staged: Option<&str>, baked: &str) -> Option<String>
+  ```
+
+  and fix the interplay with the existing empty-`STUDIO_WEB_VERSION`
+  early-return at upstream.rs:801: a staged `Some` must be reported even when
+  the baked constant is empty (today's guard would silently suppress it).
+  `patch_config_version` stays pure and untouched. Semantics: drift reaches
+  the webview **iff** an update is installed on disk and ready.
+  Update the module doc (784-799): the banner appears "in the browser — or
+  in the shell when, and only when, a staged update makes its action real."
+- `router.rs` — **the route MUST be inside a guard-carrying sub-router; the
+  guard is not inherited at the top level.** A bare top-level `.route()`
+  would get only `require_expected_host` — no Origin check on POST, no
+  session cookie — i.e. an unauthenticated restart endpoint (a hostile
+  previewed-sandbox page could then kill the user's runs with a `no-cors`
+  POST). Concretely: mount under the existing `/_local` namespace as
+  `/_local/update/restart` inside a guarded nest (pattern: the `/threads` /
+  `app_api` sub-routers that carry `.layer(guard)`). `/_local` rather than a
+  bare `/update` because bare paths are upstream-proxyable/SPA-fallback
+  surface — the underscore namespaces are the repo's reserved-local
+  convention (`is_reserved_api_path`, router.rs:728-746) — and because the
+  Vite native dev proxy already forwards `/_local` (a bare `/update` would
+  need a Vite change just to be testable in the dev loop).
+- New `routes/update.rs` — `POST /_local/update/restart`:
+  - `409 Conflict` when `state.update` is `None` (standalone), when no
+    version is staged, **or while `installing` is true** — restarting during
+    a superseding `download_and_install` would re-exec a half-swapped
+    bundle; the updater task sets the flag before download and clears it
+    after install completes (this is the serialization the frontend's "409
+    race" narrative depends on).
+  - Otherwise `202 Accepted`, then invoke `request_restart` from a spawned
+    task after ~100 ms. The delay is best-effort flush, not a guarantee (the
+    shutdown path drops connections immediately); losing the race costs a
+    cosmetic network error on a dying page.
+
+## Phase 3 — frontend (the only UI change)
+
+`apps/web/src/components/version-check-dialog.tsx`:
+
+- `const isDesktopApp = useIsDesktopApp();`
+- Use the repo's mutation idiom (62 `useMutation` call sites; shape per
+  `request-to-join-screen.tsx:24-38`) rather than hand-rolled state — and
+  note plain `fetch` **resolves** on 409, so an `.ok` check is what makes the
+  button recover, exactly the bug four reviewers flagged in the first draft:
+
+  ```tsx
+  const restartMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/_local/update/restart", { method: "POST" });
+      if (!res.ok) throw new Error(`restart failed: ${res.status}`);
+    },
+  });
+  ```
+
+  Button:
+
+  ```tsx
+  <Button
+    size="sm"
+    disabled={restartMutation.isPending}
+    onClick={() =>
+      isDesktopApp
+        ? restartMutation.mutate()
+        : window.location.reload()
+    }
+  >
+    {isDesktopApp
+      ? t("announcements.version.restart")
+      : t("announcements.version.refresh")}
+    <RefreshCw01 size={14} />
+  </Button>
+  ```
+
+  On 202 the app window closes and relaunches — no further UI state. On 409
+  (staged update superseded mid-download) or network failure the mutation
+  errors, `isPending` resets, the button re-enables; the next poll
+  re-converges the card. A supersede also flickers the card for one ~5-min
+  poll (drift count resets) — expected, harmless.
+- Description swaps under the same gate:
+  `isDesktopApp ? t("announcements.version.descriptionNative") : t("announcements.version.description")`.
+- Title, eyebrow, aria-label, dismiss, and `currentSession` footer stay
+  shared.
+- **Delete the orphaned previous-incarnation keys** in the same PR (checklist
+  item 5): `common.versionCheckDialog.available` / `.outdatedVersion` /
+  `.refresh` in `en/common.ts:278-281` + `pt-br/common.ts:288-291` are
+  referenced by no component (verify with grep at implementation time).
+
+i18n — `apps/web/src/i18n/en/announcements.ts` gains:
+
+```ts
+"announcements.version.descriptionNative":
+  "An update is installed and ready. Restart the app to start using it.",
+"announcements.version.restart": "Restart to update",
+```
+
+`apps/web/src/i18n/pt-br/announcements.ts` mirrors (compile-enforced):
+
+```ts
+"announcements.version.descriptionNative":
+  "Uma atualização foi instalada e está pronta. Reinicie o aplicativo para começar a usá-la.",
+"announcements.version.restart": "Reiniciar para atualizar",
+```
+
+Note: the earlier idea of gating `VersionCheckDialog` out of native entirely
+is **superseded** — the dialog is deliberately dual-purpose and stays mounted
+unconditionally at `shell-layout.tsx:368`.
+
+## Phase 4 — Homebrew cask (`Casks/deco-studio.rb`)
+
+Add `auto_updates true`, **in the Phase 2 PR** (see merge order). Without it,
+`brew upgrade` compares the tap version to its install receipt and reinstalls
+(downgrades) over a self-updated app; with it, upgrades skip the cask by
+default (`--greedy` still overwrites — fine, the app self-updates back). Keep
+the CI cask auto-bump exactly as is (fresh installs need a recent baseline,
+and the cask is the key-loss recovery path).
+
+## Testing
+
+Per the repo's two tiers and "test each behavior you touch":
+
+- **Rust unit / in-process (`cargo test`)**:
+  - `reported_config_version` pure fn: staged-Some wins; None → baked;
+    staged-Some with empty baked still reports staged.
+  - In-process proxy tests for the staged branch — the existing precedent in
+    this exact test module (axum stub upstream on a `TcpListener` +
+    `test_state`, cf. the set-cookie proxy test ~upstream.rs:1540): staged
+    `None` → embedded version reported; staged `Some` → staged reported;
+    flip mid-life (send after first request; second request reports staged —
+    also covers watch freshness).
+  - Router-level tests for `/_local/update/restart` with stubbed
+    `UpdateHooks` (`request_restart` = flag-flip closure): 202 flips the
+    flag; 409 when hooks absent; 409 when hooks present but nothing staged
+    (distinct branch); 409 while `installing` is set. This also pins that
+    the route landed *inside* the guard (an unauthenticated request must
+    401/403, not 409).
+  - Updater decision logic (memoized-failure/backoff/supersede) as pure fns
+    in an **always-compiled** module (see 2a — cfg-gated tests silently
+    never run).
+- **Workflow script unit tests**: `native-update-channel.mjs`'s
+  `shouldPromote` (all five branches, incl. future `pub_date` → promote,
+  `>=` version → skip, force → promote) and `buildLatestJson` (structure,
+  escaping) — co-located, `bun test`, per the `boot-smoke-paths.ts`
+  precedent.
+- **Native e2e** (`apps/native/e2e`, standalone binary, `update: None`):
+  - Add `{ name: "update: restart", path: "/_local/update/restart" }` to
+    `auth-matrix.e2e.test.ts`'s `CASES` — covers no-bearer/wrong-bearer 401
+    and correct-bearer-not-401 (409) for free; no one-off auth test.
+  - `GET /api/config` rewrite still pins the embedded version with no update
+    handle: assert the reported version is NOT the stub upstream's sentinel
+    (e.g. `9.9.9`) and is semver-shaped (the harness can't know the baked
+    constant statically).
+  - Daemon-parity/stub-seam allowlists are unaffected (they replay the
+    daemon's own test files, which never touch these routes) — recorded so
+    reviewers don't re-derive it. A `LOCAL_API_STAGED_VERSION` env seam for
+    black-box staged-path coverage was considered and deliberately NOT
+    added — the in-process tests above cover it without widening the
+    standalone surface.
+- **Web**: no new unit tests — the `isDesktopApp` fork is build-time-gated,
+  response handling is `useMutation` (its `.ok` throw is the tested-idiom
+  path), and the pure drift fns are already covered by
+  `version-check-dialog.test.ts`; the pt-br mirror is compile-enforced.
+  Checklist item 4 (grep all tiers for changed strings): browser copy is
+  unchanged; native copy is behind new keys; `packages/e2e` asserts on
+  neither (verified by grep).
+
+## Manual test — executable runbook (gate for channel promotion)
+
+The production endpoint is baked into the installed app, so "publish N to a
+staging tag" alone tests nothing. Mechanism: a `workflow_dispatch` staging
+mode of `release-native.yaml` (input `staging: true`) that (a) uploads to a
+`native-updates-staging` rolling prerelease instead, and (b) builds with the
+existing `--config` overlay extended to override
+`plugins.updater.endpoints` to the staging URL. Same signing keypair. This
+makes the test a repeatable runbook instead of archaeology — there is
+otherwise NO end-to-end integration path for the updater at all.
+
+On macOS 14+: install staging-N−1 via the real cask flow (quarantine-cleared),
+publish staging-N, then verify — pass criteria, go/no-go for first real
+promotion:
+
+1. Background download+install succeeds (App Management TCC does not block
+   the bundle swap; the `.app` on disk is N).
+2. The card appears — worst case ~35-40 min with the 30-min check interval +
+   two 5-min drift confirmations (do NOT expect "~10 minutes").
+3. "Restart to update" → the process **actually respawns** into N (explicit
+   criterion — open report tauri#13923 says macOS restart can quit without
+   relaunching; the instance lock must have been released by the graceful
+   pipeline), with no orphan rclone/harness processes.
+4. Keychain: session survives, or the forced re-login is observed and the
+   **promotion gate holds** until Developer ID + notarization land.
+5. Note: a translocated app (direct-DMG download run from quarantine) runs
+   from a read-only path — install fails into the (memoized, backed-off)
+   warn path forever. Cask installs avoid translocation; record the
+   direct-DMG limitation in the release notes.
+
+## Follow-ups (recorded, out of v1)
+
+- Developer ID + notarization — may be pulled INTO v1 by the promotion gate.
+- Run-aware restart confirm ("N agent runs will be stopped").
+- v2 upstream-controlled channel: signed manifest or version-pin design,
+  Rust-side runtime endpoints.
+- Linux/Windows platform keys + the Windows install-couples-to-exit branch.
+- Persisted monotonic high-water mark (refuse to stage below the highest
+  version ever staged) + freeze/replay telemetry (log when the installed
+  version regresses below the last manifest version seen). The v1
+  version-pairing check already closes the lying-manifest downgrade; these
+  harden freeze detection.
+- Resumable/streaming downloads (plugin buffers in RAM; no resume today).
+
+## Critique Decisions
+
+Eight-perspective review (correctness, security, architecture, testing,
+performance, scope, duplication, documentation) applied to the first draft.
+
+**Adopted (the significant ones):**
+- CI/smoke release-profile exposure: added the selftest/0.1.0/env triple
+  gate (correctness + architecture, independently).
+- Route moved to `/_local/update/restart` inside an explicitly guarded nest —
+  the draft's snippet would have shipped an unauthenticated restart endpoint
+  (security + architecture, independently).
+- Install/restart serialization (`installing` flag; 409 while installing) —
+  the draft's own 409 narrative had no backend to make it true.
+- Failure memo + backoff in the updater loop — without it a persistent
+  install failure re-downloads ~80 MB per tick forever.
+- Version-pairing check before install as v1 downgrade defense (manifest is
+  unsigned and writable by nine-plus workflow tokens).
+- `useMutation` + `.ok` handling — `fetch` resolves on 409; the draft's
+  `.catch` left the button dead (flagged by four reviewers independently).
+- Testing rewrite: pure `reported_config_version` fn (the draft's unit test
+  targeted an *unchanged* function), decision logic out of cfg-gated code
+  (tests would silently never run), in-process staged-path proxy tests,
+  auth-matrix membership, tested promotion script (BSD `date` hazard).
+- Throttle hardening: fail-open-to-promote semantics, semver gate,
+  `force_promote` dispatch bypass, first-run guard.
+- Developer ID reframed as a launch gate on channel promotion (not on code).
+- Signer command fixed (`bunx tauri` resolves the v1 CLI), pinned build CLI,
+  step-scoped signing env, `environment:` consistency between Phases 0/1.
+- Executable staging-mode manual test with explicit relaunch (tauri#13923)
+  and Keychain go/no-go criteria; realistic card-latency bound.
+- 30-min check interval (manifest changes ≤ ~1.2×/day; card latency is
+  dominated by the dialog poll), `download`/`install` split with
+  `spawn_blocking`, check/download timeouts.
+- Dead `common.versionCheckDialog.*` key deletion; `jq`-free structured
+  manifest assembly; concrete `if: failure()` alerting; merge-order section;
+  kill-switch logging + Finder-env caveat; runbooks (key loss/leak/bad
+  release) with a durable home; App Translocation and DMG-direct-install
+  acceptances; interface-request framing extended to `state.rs`.
+
+**Rejected:**
+- `LOCAL_API_STAGED_VERSION` standalone env seam for black-box staged-path
+  e2e — in-process tests cover it; keeping the standalone surface minimal
+  outweighs black-box purity here.
+- Extracting a shared interval-loop helper — four sites × three configs is
+  a config-heavy wrapper around ~4 lines; inline mirroring is the repo's
+  accepted idiom.
+
+**Adapted:**
+- Persisted high-water mark: deferred to follow-ups — the version-pairing
+  check closes the active downgrade attack; the mark only hardens freeze
+  detection, which is already a recorded follow-up.
+- "Newer than running AND staged" comparison: simplified to delegating
+  running-vs-remote entirely to `check()` (built-in semver) and plain `!=`
+  vs staged — strict ordering would block channel rollforward and duplicate
+  the plugin's comparator.
+- JS `relaunch()` rationale: the plugin has since migrated to
+  `request_restart` internally; the decision (no plugin, no webview
+  capability, Rust-side trigger) stands on IPC-surface grounds alone.

--- a/apps/native/docs/native-updater-plan.md
+++ b/apps/native/docs/native-updater-plan.md
@@ -305,7 +305,10 @@ no updater either — the axes differ.
     boot contention). Deliberately NOT the 5-min revalidate cadence: the
     manifest changes ≤ ~1.2×/day and card latency is dominated by the
     dialog's own 5-min × 2-confirmation poll anyway; 5-min checks would be
-    ~288 no-op manifest fetches/day.
+    ~288 no-op manifest fetches/day. `DECOCMS_UPDATE_CHECK_INTERVAL_SECS`
+    (floored at 15 s) overrides the interval for spikes and the manual
+    runbook — harmless in the threat model (a local process able to set env
+    already has the kill switch).
   - Per tick:
     1. `check()` with `UpdaterBuilder::timeout(…)` set. `check()` itself
        gates on remote > running (semver, built-in) — do not re-implement
@@ -569,7 +572,11 @@ promotion:
 1. Background download+install succeeds (App Management TCC does not block
    the bundle swap; the `.app` on disk is N).
 2. The card appears — worst case ~35-40 min with the 30-min check interval +
-   two 5-min drift confirmations (do NOT expect "~10 minutes").
+   two 5-min drift confirmations (do NOT expect "~10 minutes"). For spikes
+   and this runbook, `DECOCMS_UPDATE_CHECK_INTERVAL_SECS` (floored at 15 s;
+   terminal-launched processes only — Finder launches don't inherit shell
+   env) shortens the updater's own interval; the dialog's two 5-min poll
+   confirmations still bound how fast the card itself appears.
 3. "Restart to update" → the process **actually respawns** into N (explicit
    criterion — open report tauri#13923 says macOS restart can quit without
    relaunching; the instance lock must have been released by the graceful

--- a/apps/native/docs/native-updater-plan.md
+++ b/apps/native/docs/native-updater-plan.md
@@ -7,16 +7,29 @@ instead of `window.location.reload()`.
 
 Design summary (settled in design review + critique pass):
 
-- The Rust backend **auto-checks, auto-downloads, and auto-installs** updates
-  in the background. On macOS the install swaps the `.app` on disk while the
-  running process is untouched — install-eagerly is safe because nothing
-  re-reads the bundle path at runtime.
+- The Rust backend **auto-checks, auto-downloads, and auto-verifies** updates
+  in the background, then **defers the actual install to the exit path**.
+  AMENDMENT (2026-07-31, found by the live signed-in spike): the original
+  design installed eagerly on the theory that "nothing re-reads the bundle
+  path at runtime" — but macOS ITSELF does. Keychain access validates the
+  calling process's code identity against its binary ON DISK; the moment the
+  updater swapped the bundle, every Keychain operation failed
+  (`errSecErrnoBase+ENOENT`, surfaced as "keychain unavailable: Platform
+  failure: UNIX[No such file or directory]") — sign-in broke outright and
+  rotated-refresh-token saves would fail silently until restart, risking a
+  forced sign-out. Instead: download → signature + version-pairing verify →
+  stage the archive under `<app_root>/updates/` → install ONLY inside the
+  exit path, after local-api has drained (no Keychain writers left). Both
+  the card's restart and a plain quit funnel through `ExitRequested`, so one
+  apply point still gives install-on-quit, and the Keychain-broken window is
+  zero. Stale staged archives are cleaned at boot (crash = one re-download).
 - The **existing drift mechanism is the notification channel**: the proxy's
   `rewrite_config_version` (which today pins `/api/config`'s `config.version`
   to the embedded bundle version so the browser-refresh nag never fires in the
-  shell) gains one branch — once an update is *installed on disk*, it reports
-  the staged version instead. The untouched dialog polls, sees drift twice,
-  and shows the card. No new wire contract, no new poll, no new component.
+  shell) gains one branch — once an update is *staged, verified and ready*,
+  it reports the staged version instead. The untouched dialog polls, sees
+  drift twice, and shows the card. No new wire contract, no new poll, no new
+  component.
 - The card's button, under `useIsDesktopApp()`, POSTs a new local-api route
   that triggers a **graceful** restart via Tauri's `request_restart()` —
   documented to deliver `RunEvent::ExitRequested` reliably, so the repo's
@@ -579,6 +592,14 @@ symlink on a non-allowed platform") — run the app from a symlink-free path
 unaffected) — and use a throwaway `identifier` override
 (`com.decocms.studio.spike`) in BOTH builds so the spike gets its own app
 root/instance lock instead of colliding with a running dev or prod app.
+
+A second, SIGNED-IN spike round (2026-07-31) caught the eager-install
+Keychain regression described in the design summary: with the bundle swapped
+under the running process, every `auth_login` completed OAuth and then died
+at the Keychain write ("keychain unavailable … UNIX[No such file or
+directory]") — three times in a row, live. That finding produced the
+deferred-install amendment; the runbook's Keychain pass criterion below is
+exactly the regression test for it.
 
 On macOS 14+: install staging-N−1 via the real cask flow (quarantine-cleared),
 publish staging-N, then verify — pass criteria, go/no-go for first real

--- a/apps/native/docs/native-updater-plan.md
+++ b/apps/native/docs/native-updater-plan.md
@@ -565,6 +565,21 @@ existing `--config` overlay extended to override
 makes the test a repeatable runbook instead of archaeology — there is
 otherwise NO end-to-end integration path for the updater at all.
 
+Verified by a full local spike (2026-07-30, macOS 26): two `--config`-versioned
+release builds + a `python3 -m http.server` channel — check → download →
+signature verify → version-pairing check → eager install (on-disk `.app`
+swapped while the old process runs) → `/api/config` reporting the staged
+version → `POST /_local/update/restart` 202 → graceful shutdown → **relaunch
+into the new version ~2 s later** (tauri#13923 did not reproduce), with the
+relaunched process's own check correctly finding nothing to do. Two
+spike-environment gotchas for whoever reruns it: the updater plugin REFUSES
+to construct when `current_exe()` contains a symlink ("StartingBinary …
+symlink on a non-allowed platform") — run the app from a symlink-free path
+(`/private/tmp/...`, not `/tmp/...`; real `/Applications` installs are
+unaffected) — and use a throwaway `identifier` override
+(`com.decocms.studio.spike`) in BOTH builds so the spike gets its own app
+root/instance lock instead of colliding with a running dev or prod app.
+
 On macOS 14+: install staging-N−1 via the real cask flow (quarantine-cleared),
 publish staging-N, then verify — pass criteria, go/no-go for first real
 promotion:

--- a/apps/native/scripts/boot-smoke.ts
+++ b/apps/native/scripts/boot-smoke.ts
@@ -272,6 +272,11 @@ async function main(): Promise<void> {
         // Set DESKTOP_SELFTEST_VISIBLE=0 to force the old hidden behavior.
         DESKTOP_SELFTEST_VISIBLE: process.env.DESKTOP_SELFTEST_VISIBLE ?? "1",
         DESKTOP_SELFTEST_OUT: outFile,
+        // This is a RELEASE-profile build at the committed 0.1.0 placeholder
+        // version — never let it "update" itself from the production channel
+        // mid-smoke. (The updater task also refuses to spawn under selftest
+        // and at 0.1.0; this is belt-and-braces for local runs.)
+        DECOCMS_DISABLE_AUTO_UPDATE: "1",
         // Boot smoke validates the shell/IPC contract, not the operator's real
         // login. Never let its auth-status probe open a macOS ACL dialog for the
         // production Keychain item; persistence itself is covered by the

--- a/apps/native/scripts/ci/native-update-channel.mjs
+++ b/apps/native/scripts/ci/native-update-channel.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// Updater-channel logic for release-native.yaml, extracted so the decision
+// rules run under `bun test` instead of first executing in a production
+// release on a BSD-date macOS runner (the boot-smoke-paths.ts precedent:
+// risky script logic lives in a tested module; the workflow keeps only `gh`
+// invocations). Zero dependencies, plain Node — same conventions as
+// check-junit-allowlist.mjs.
+//
+// The "channel" is the rolling `native-updates` prerelease whose single
+// `latest.json` asset the Tauri updater polls. Promotion is throttled to
+// ~daily (releases track the ~12x/day cloud cadence at ~80 MB/artifact) and
+// every skip/promote decision is printed by the workflow as a ::notice:: so
+// silent-skip streaks are greppable.
+
+/** Strict `X.Y.Z` (optional leading `v`) → `[major, minor, patch]`, else null.
+ * Release versions come from release-changes.ts and are always a plain
+ * triple; anything else (prerelease tags, garbage from a clobbered manifest)
+ * deliberately fails to parse and falls through to the fail-open branches. */
+export function parseSemver(version) {
+  if (typeof version !== "string") return null;
+  const m = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(version.trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** -1 | 0 | 1, or null when either side is unparseable. */
+export function compareSemver(a, b) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return null;
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+export const THROTTLE_MS = 20 * 60 * 60 * 1000;
+
+/**
+ * Decide whether to clobber the channel manifest with `candidateVersion`.
+ *
+ * Fail-open-to-promote by design: every ambiguous state (missing manifest,
+ * unparseable JSON, bad or FUTURE pub_date) promotes. A clobbered far-future
+ * pub_date must not freeze the channel forever, and clock skew heals instead
+ * of wedging. The only skips are "channel already has this or newer" and the
+ * ~daily throttle — and a `workflow_dispatch` force bypasses the throttle
+ * (urgent fixes, healing a half-failed promotion).
+ *
+ * @param {object} args
+ * @param {object|null} args.currentManifest parsed latest.json, or null when
+ *   absent/unreadable (first-ever promotion, corrupt asset)
+ * @param {string} args.candidateVersion this release's version
+ * @param {number} args.nowMs epoch millis
+ * @param {boolean} args.force workflow_dispatch force-promote input
+ * @returns {{ promote: boolean, reason: string }}
+ */
+export function shouldPromote({
+  currentManifest,
+  candidateVersion,
+  nowMs,
+  force,
+}) {
+  if (!currentManifest || typeof currentManifest !== "object") {
+    return { promote: true, reason: "no existing channel manifest" };
+  }
+
+  const cmp = compareSemver(currentManifest.version, candidateVersion);
+  if (cmp === 1) {
+    // Never regress the channel — a repair dispatch running on an old ref
+    // must not replace a newer manifest. Not even --force overrides this.
+    return {
+      promote: false,
+      reason: `channel already at newer ${currentManifest.version}`,
+    };
+  }
+  if (cmp === 0 && !force) {
+    // Same version: idempotent skip. A forced dispatch still re-promotes so
+    // a corrupt-but-parseable manifest of the current version can be healed.
+    return {
+      promote: false,
+      reason: `channel already at ${currentManifest.version}`,
+    };
+  }
+
+  if (force) {
+    return { promote: true, reason: "forced by workflow_dispatch" };
+  }
+
+  const pubDateMs = Date.parse(currentManifest.pub_date ?? "");
+  if (Number.isNaN(pubDateMs) || pubDateMs > nowMs) {
+    return {
+      promote: true,
+      reason: "manifest pub_date missing, invalid, or in the future",
+    };
+  }
+  const ageMs = nowMs - pubDateMs;
+  if (ageMs < THROTTLE_MS) {
+    const ageH = (ageMs / 3_600_000).toFixed(1);
+    return {
+      promote: false,
+      reason: `throttled: manifest is ${ageH}h old (< 20h)`,
+    };
+  }
+  return { promote: true, reason: "manifest older than 20h" };
+}
+
+/**
+ * Assemble latest.json for the Tauri updater. Structured construction, never
+ * shell/string interpolation — the signature is base64 today but correctness
+ * stays by-construction. The updater validates the WHOLE file before reading
+ * `version`, so when platform keys are added later one malformed entry
+ * bricks updates for all platforms — keep every entry complete.
+ *
+ * `url` points at the immutable native-v<version> release asset, so an old
+ * manifest never dangles; `signature` is the CONTENTS of the .sig file (a
+ * path or URL does not work, per the updater docs).
+ */
+export function buildLatestJson({ version, signature, repo, pubDate }) {
+  if (!parseSemver(version)) {
+    throw new Error(
+      `refusing to build manifest for unparseable version ${JSON.stringify(version)}`,
+    );
+  }
+  if (typeof signature !== "string" || signature.trim() === "") {
+    throw new Error("missing updater signature contents");
+  }
+  return {
+    version,
+    pub_date: pubDate,
+    notes: `https://github.com/${repo}/releases/tag/native-v${version}`,
+    platforms: {
+      "darwin-aarch64": {
+        url: `https://github.com/${repo}/releases/download/native-v${version}/deco-${version}-aarch64.app.tar.gz`,
+        signature: signature.trim(),
+      },
+    },
+  };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--force") args.force = true;
+    else if (a.startsWith("--")) args[a.slice(2)] = argv[++i];
+  }
+  return args;
+}
+
+async function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  const args = parseArgs(rest);
+  const { readFileSync } = await import("node:fs");
+
+  if (cmd === "should-promote") {
+    let currentManifest = null;
+    try {
+      currentManifest = JSON.parse(readFileSync(args["current-file"], "utf8"));
+    } catch {
+      // absent or unreadable manifest → null → fail-open promote
+    }
+    const decision = shouldPromote({
+      currentManifest,
+      candidateVersion: args.candidate,
+      nowMs: Date.now(),
+      force: args.force === true,
+    });
+    process.stdout.write(JSON.stringify(decision));
+    return;
+  }
+
+  if (cmd === "build") {
+    const manifest = buildLatestJson({
+      version: args.version,
+      signature: readFileSync(args["sig-file"], "utf8"),
+      repo: args.repo,
+      pubDate: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    });
+    process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+    return;
+  }
+
+  process.stderr.write(
+    "usage: native-update-channel.mjs should-promote --candidate <ver> --current-file <path> [--force]\n" +
+      "       native-update-channel.mjs build --version <ver> --sig-file <path> --repo <owner/repo>\n",
+  );
+  process.exit(2);
+}
+
+// Only run the CLI when invoked directly, so tests can import the pure fns.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    process.stderr.write(`${err?.stack ?? err}\n`);
+    process.exit(1);
+  });
+}

--- a/apps/native/scripts/ci/native-update-channel.test.ts
+++ b/apps/native/scripts/ci/native-update-channel.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildLatestJson,
+  compareSemver,
+  parseSemver,
+  shouldPromote,
+  THROTTLE_MS,
+} from "./native-update-channel.mjs";
+
+const NOW = Date.parse("2026-07-30T12:00:00Z");
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+
+const manifest = (version: string, pubDate?: string) => ({
+  version,
+  ...(pubDate !== undefined ? { pub_date: pubDate } : {}),
+});
+
+describe("parseSemver / compareSemver", () => {
+  test("parses plain and v-prefixed triples", () => {
+    expect(parseSemver("4.150.13")).toEqual([4, 150, 13]);
+    expect(parseSemver("v1.2.3")).toEqual([1, 2, 3]);
+  });
+
+  test("rejects prerelease, partial, and garbage strings", () => {
+    expect(parseSemver("1.2.3-beta.1")).toBeNull();
+    expect(parseSemver("1.2")).toBeNull();
+    expect(parseSemver("")).toBeNull();
+    expect(parseSemver(undefined as unknown as string)).toBeNull();
+  });
+
+  test("compares numerically, not lexically", () => {
+    expect(compareSemver("0.10.0", "0.9.0")).toBe(1);
+    expect(compareSemver("4.150.9", "4.150.13")).toBe(-1);
+    expect(compareSemver("4.150.13", "4.150.13")).toBe(0);
+    expect(compareSemver("garbage", "1.0.0")).toBeNull();
+  });
+});
+
+describe("shouldPromote", () => {
+  const base = { candidateVersion: "4.151.0", nowMs: NOW, force: false };
+
+  test("promotes when no manifest exists (first run / unreadable asset)", () => {
+    expect(shouldPromote({ ...base, currentManifest: null }).promote).toBe(
+      true,
+    );
+  });
+
+  test("never regresses: skips when channel is newer, even forced", () => {
+    const current = manifest("9.0.0", iso(THROTTLE_MS * 2));
+    expect(shouldPromote({ ...base, currentManifest: current }).promote).toBe(
+      false,
+    );
+    expect(
+      shouldPromote({ ...base, currentManifest: current, force: true }).promote,
+    ).toBe(false);
+  });
+
+  test("same version: idempotent skip, but force re-promotes (heal path)", () => {
+    const current = manifest("4.151.0", iso(THROTTLE_MS * 2));
+    expect(shouldPromote({ ...base, currentManifest: current }).promote).toBe(
+      false,
+    );
+    expect(
+      shouldPromote({ ...base, currentManifest: current, force: true }).promote,
+    ).toBe(true);
+  });
+
+  test("force bypasses the throttle for a newer candidate", () => {
+    const current = manifest("4.150.13", iso(60_000));
+    expect(shouldPromote({ ...base, currentManifest: current }).promote).toBe(
+      false,
+    );
+    expect(
+      shouldPromote({ ...base, currentManifest: current, force: true }).promote,
+    ).toBe(true);
+  });
+
+  test("fail-open: missing, unparseable, or FUTURE pub_date promotes", () => {
+    for (const bad of [
+      manifest("4.150.13"),
+      manifest("4.150.13", "not a date"),
+      manifest("4.150.13", new Date(NOW + 3_600_000).toISOString()),
+    ]) {
+      expect(shouldPromote({ ...base, currentManifest: bad }).promote).toBe(
+        true,
+      );
+    }
+  });
+
+  test("throttles a fresh manifest, promotes a stale one", () => {
+    const fresh = manifest("4.150.13", iso(THROTTLE_MS - 60_000));
+    const stale = manifest("4.150.13", iso(THROTTLE_MS + 60_000));
+    expect(shouldPromote({ ...base, currentManifest: fresh }).promote).toBe(
+      false,
+    );
+    expect(shouldPromote({ ...base, currentManifest: stale }).promote).toBe(
+      true,
+    );
+  });
+
+  test("unparseable channel version falls through to the throttle branches", () => {
+    const weird = manifest("not-a-version", iso(THROTTLE_MS * 2));
+    expect(shouldPromote({ ...base, currentManifest: weird }).promote).toBe(
+      true,
+    );
+  });
+});
+
+describe("buildLatestJson", () => {
+  test("builds the exact updater contract shape", () => {
+    const out = buildLatestJson({
+      version: "4.151.0",
+      signature: "c2lnbmF0dXJl\n",
+      repo: "decocms/studio",
+      pubDate: "2026-07-30T12:00:00Z",
+    });
+    expect(out).toEqual({
+      version: "4.151.0",
+      pub_date: "2026-07-30T12:00:00Z",
+      notes: "https://github.com/decocms/studio/releases/tag/native-v4.151.0",
+      platforms: {
+        "darwin-aarch64": {
+          url: "https://github.com/decocms/studio/releases/download/native-v4.151.0/deco-4.151.0-aarch64.app.tar.gz",
+          signature: "c2lnbmF0dXJl",
+        },
+      },
+    });
+  });
+
+  test("refuses unparseable versions and empty signatures", () => {
+    expect(() =>
+      buildLatestJson({
+        version: "oops",
+        signature: "sig",
+        repo: "decocms/studio",
+        pubDate: "2026-07-30T12:00:00Z",
+      }),
+    ).toThrow(/unparseable version/);
+    expect(() =>
+      buildLatestJson({
+        version: "1.0.0",
+        signature: "  ",
+        repo: "decocms/studio",
+        pubDate: "2026-07-30T12:00:00Z",
+      }),
+    ).toThrow(/signature/);
+  });
+});


### PR DESCRIPTION
## What is this contribution about?

Phase 1 of the native self-updater (stacked 1/3 — see `apps/native/docs/native-updater-plan.md` on this branch): the release pipeline produces signed Tauri updater artifacts and maintains a rolling update channel.

- `release-native.yaml` builds with `createUpdaterArtifacts` **via the `--config` overlay only** (the committed `tauri.conf.json5` stays secretless-build-safe for fork/PR CI), uploads `deco-<v>-aarch64.app.tar.gz` + `.sig` to the immutable `native-v<v>` release, and promotes `latest.json` onto a rolling `native-updates` **prerelease** (prerelease ⇒ it can never capture `releases/latest`).
- Promotion decisions live in the unit-tested `apps/native/scripts/ci/native-update-channel.mjs`: never-regress semver gate, ~daily throttle (~12 releases/day × ~80 MB must not all hit clients), fail-open-to-promote on ambiguous manifest state (incl. clobbered future `pub_date`), `force_promote` dispatch bypass. Every decision is a `::notice::`.
- Hardening: api/native version-lockstep assertion, loud signing-secret assertion, minisign key step-scoped onto the pinned-CLI build step (no `$GITHUB_ENV` exposure to later steps), `if: failure()` alerting issue (a failed release stalls the channel invisibly — drift is suppressed in the shell by design), `DECOCMS_DISABLE_AUTO_UPDATE=1` on CI/local boot-smoke.
- Docs: updater design doc + operator runbook (key loss/leak, bad release, kill switch) in `apps/native/README.md`.

**Phase 0 is done (2026-07-31)**: the `native-release` environment exists (branch policy: `main`) with `TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)` set, and the keypair is escrowed in 1Password. Merging is unblocked.

## Screenshots/Demonstration

CI/workflow-only — no UI. The channel flow was validated end-to-end by three local spikes (recipe + findings recorded in the plan doc's runbook section).

## How to Test

1. `cd apps/native && bun test scripts` — 16 cases covering every `shouldPromote` branch and `buildLatestJson` shape/escaping.
2. `actionlint .github/workflows/release-native.yaml .github/workflows/native.yml` — at parity with main (only the pre-existing SC2012 info note).
3. Inspect the promotion step ordering: `latest.json` is clobbered onto `native-updates` strictly AFTER the `.app.tar.gz` + `.sig` upload to the immutable tag, so the manifest can never reference missing assets.

## Migration Notes

First release after merge cuts updater artifacts and creates the rolling `native-updates` prerelease automatically (idempotent; `workflow_dispatch` repairs). Do NOT enable GitHub's opt-in "immutable releases" repo setting — it would break the manifest clobber (documented in the workflow header).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a signed auto-update release pipeline for the macOS app. CI builds signed updater artifacts, maintains a rolling `native-updates` channel with a throttled, tested promotion flow, and installs updates on app exit to avoid macOS Keychain issues.

- **New Features**
  - `release-native.yaml` builds with `createUpdaterArtifacts` (overlay only), pins `@tauri-apps/cli@2.11.4`, step-scopes the minisign key, and uploads `.app.tar.gz` + `.sig` alongside ZIP/DMG to the immutable `native-v<version>` release; runs in the `native-release` environment.
  - Promotes `latest.json` on a rolling `native-updates` prerelease after assets land; never regresses, throttled (~20h), fail‑open on ambiguous state, and can be forced via `workflow_dispatch` (`force_promote`). Decisions and manifest assembly live in `apps/native/scripts/ci/native-update-channel.mjs` with unit tests.
  - Asserts `TAURI_SIGNING_PRIVATE_KEY` exists and `apps/api`/`apps/native` versions match; on failure, files/updates a GitHub issue. CI hardening: updater keys are not wired in `native.yml`; boot smoke sets `DECOCMS_DISABLE_AUTO_UPDATE=1`.
  - Docs/Runbook: updater plan, check‑interval override (`DECOCMS_UPDATE_CHECK_INTERVAL_SECS`), operator notes (key loss/leak, kill switch), verified local updater spike, and the amendment to install on app exit.

- **Migration**
  - Create GitHub Environment `native-release`.
  - Add `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` to that environment.
  - Optional: Apple signing/notarization secrets to ship notarized DMGs.

<sup>Written for commit ec8dfccad7f4b1a3ccd21765e7a7ef4d20b67778. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



