### PR TITLE
feat(native): self-update via the tauri updater, staged through the version card

### DIFF
--- a/Casks/deco-studio.rb
+++ b/Casks/deco-studio.rb
@@ -27,6 +27,14 @@ cask "deco-studio" do
   depends_on formula: "git"
   depends_on formula: "ripgrep"
 
+  # The app updates itself (Tauri updater — see
+  # apps/native/docs/native-updater-plan.md). Without this, `brew upgrade`
+  # compares the tap version against its install receipt and REINSTALLS
+  # (downgrades) over a self-updated app. `--greedy` still overwrites, which
+  # is fine (the app self-updates back) and is the documented break-glass
+  # recovery path if the updater signing key is ever lost.
+  auto_updates true
+
   app "deco.app"
 
   # Drop this block once releases are signed + notarized (the six APPLE_*

--- a/apps/native/Cargo.lock
+++ b/apps/native/Cargo.lock
@@ -82,6 +82,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,15 +964,19 @@ name = "deco"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "flate2",
  "local-api",
+ "plist",
  "rand 0.8.7",
  "rcgen",
  "serde",
  "serde_json",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-mcp-bridge",
  "tauri-plugin-opener",
+ "tauri-plugin-updater",
  "tempfile",
  "thiserror 1.0.69",
  "time",
@@ -982,6 +995,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2345,6 +2369,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +2735,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -3143,6 +3203,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -3180,6 +3241,18 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3338,6 +3411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,6 +3430,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4047,15 +4140,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.11",
@@ -4139,6 +4237,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,6 +4266,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4188,6 +4325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4580,6 +4726,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4801,7 +4963,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -4835,6 +4997,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4857,7 +5030,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4979,7 +5152,7 @@ dependencies = [
  "block2 0.5.1",
  "futures-util",
  "image",
- "jni",
+ "jni 0.21.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -5021,6 +5194,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5030,7 +5236,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2 0.6.4",
  "objc2-ui-kit 0.3.2",
  "objc2-web-kit 0.3.2",
@@ -5053,7 +5259,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
@@ -6100,6 +6306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6391,6 +6606,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6437,11 +6661,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6481,6 +6722,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6497,6 +6744,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6517,10 +6770,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6541,6 +6806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6557,6 +6828,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6577,6 +6854,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6593,6 +6876,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -6667,7 +6956,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2 0.6.4",
@@ -6712,6 +7001,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -6896,6 +7195,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/apps/native/Cargo.toml
+++ b/apps/native/Cargo.toml
@@ -81,6 +81,10 @@ tauri = { version = "2", features = ["config-json5", "devtools"] }
 # `#[cfg(debug_assertions)]` in src-tauri/src/lib.rs — never in release).
 tauri-plugin-mcp-bridge = "0.12"
 tauri-plugin-opener = "2"
+# Self-update (registered under `#[cfg(not(debug_assertions))]` — the exact
+# mirror of mcp-bridge above; see src-tauri/src/updater.rs for the full
+# gating story).
+tauri-plugin-updater = "2"
 tauri-build = { version = "2", features = ["config-json5"] }
 # `crates/upstream`'s OAuth/Keychain-specific deps (`keyring`, `sha2`,
 # `base64`, `dirs`) are declared directly in `crates/upstream/Cargo.toml`

--- a/apps/native/crates/local-api/src/lib.rs
+++ b/apps/native/crates/local-api/src/lib.rs
@@ -75,7 +75,7 @@ pub use events::Broadcaster;
 pub use sandbox::SandboxManager;
 pub use setup::SetupOrchestrator;
 pub use shutdown::ShutdownCoordinator;
-pub use state::{ApiMode, AppState};
+pub use state::{ApiMode, AppState, UpdateHooks};
 pub use tasks::{KillSignal, TaskRegistry};
 pub use ui::{UiAsset, UiAssetProvider};
 
@@ -107,6 +107,9 @@ pub struct StartOptions {
     /// cookie jars) AND a secure context (Web Crypto); only TLS gives both.
     /// Standalone/bearer callers and the tests keep plain HTTP.
     pub tls: Option<TlsFiles>,
+    /// Desktop-app self-update integration — see [`UpdateHooks`]. `None`
+    /// outside the packaged Tauri shell (standalone binary, tests).
+    pub update: Option<UpdateHooks>,
 }
 
 /// Paths to the material [`start`] serves HTTPS with.
@@ -713,6 +716,7 @@ pub async fn start_with_client_auth(
         shutdown: shutdown.clone(),
         setup: setup_orchestrator,
         sandbox_manager,
+        update: opts.update,
     };
 
     // Clear worktree registrations orphaned by a sandbox directory that
@@ -938,6 +942,8 @@ pub async fn boot_from_env() {
         // The standalone binary serves plain HTTP: local HTTPS exists for the
         // desktop webview's origin, and nothing here has a webview.
         tls: None,
+        // Self-update belongs to the packaged Tauri shell only.
+        update: None,
     })
     .await
     {
@@ -1214,6 +1220,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let options = |boot_id: &str| StartOptions {
             tls: None,
+            update: None,
             token: "t".repeat(32),
             boot_id: boot_id.to_string(),
             app_root: dir.path().to_path_buf(),

--- a/apps/native/crates/local-api/src/router.rs
+++ b/apps/native/crates/local-api/src/router.rs
@@ -229,6 +229,14 @@ pub fn build(
             "/_auth/mcp-callback/result",
             get(routes::mcp_callback::result).delete(routes::mcp_callback::discard),
         )
+        // Apply a staged self-update by restarting through the graceful
+        // shutdown pipeline — see routes::update's module doc. Lives in this
+        // guard-carrying sub-router deliberately: a top-level `.route()`
+        // would get only `require_expected_host` (no Origin check on POST,
+        // no session cookie), i.e. an unauthenticated restart trigger.
+        // Mounted in BOTH auth modes so the standalone binary answers its
+        // documented 409 and the e2e auth matrix can cover the route.
+        .route("/_local/update/restart", post(routes::update::restart))
         .layer(middleware::from_fn_with_state(guard_state.clone(), guard));
 
     let mut app = Router::new()

--- a/apps/native/crates/local-api/src/routes/bash.rs
+++ b/apps/native/crates/local-api/src/routes/bash.rs
@@ -587,6 +587,7 @@ mod tests {
             broadcaster.clone(),
         );
         AppState {
+            update: None,
             token: Arc::from("test-token"),
             boot_id: Arc::from("test-boot"),
             sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),

--- a/apps/native/crates/local-api/src/routes/events.rs
+++ b/apps/native/crates/local-api/src/routes/events.rs
@@ -371,6 +371,7 @@ mod tests {
             broadcaster.clone(),
         );
         AppState {
+            update: None,
             token: "test-token".into(),
             boot_id: "test-boot".into(),
             app_root: app_root.to_path_buf(),

--- a/apps/native/crates/local-api/src/routes/git.rs
+++ b/apps/native/crates/local-api/src/routes/git.rs
@@ -2323,6 +2323,7 @@ mod tests {
             broadcaster.clone(),
         );
         AppState {
+            update: None,
             token: "test-token".into(),
             boot_id: "test-boot".into(),
             sandbox_manager: crate::sandbox::SandboxManager::new(app_root.to_path_buf()),

--- a/apps/native/crates/local-api/src/routes/intercept/mod.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/mod.rs
@@ -256,6 +256,7 @@ pub(crate) fn test_state(root: &std::path::Path) -> AppState {
         broadcaster,
         shutdown: Arc::new(crate::shutdown::ShutdownCoordinator::new()),
         setup,
+        update: None,
     }
 }
 

--- a/apps/native/crates/local-api/src/routes/mod.rs
+++ b/apps/native/crates/local-api/src/routes/mod.rs
@@ -21,6 +21,7 @@ pub mod scripts;
 pub mod setup;
 pub mod tasks;
 pub mod threads;
+pub mod update;
 pub mod upstream;
 pub mod webdav;
 pub mod ws_proxy;

--- a/apps/native/crates/local-api/src/routes/proxy.rs
+++ b/apps/native/crates/local-api/src/routes/proxy.rs
@@ -1224,6 +1224,7 @@ mod tests {
             broadcaster.clone(),
         );
         AppState {
+            update: None,
             token: "test-token".into(),
             boot_id: "test-boot".into(),
             sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),

--- a/apps/native/crates/local-api/src/routes/repo_dir.rs
+++ b/apps/native/crates/local-api/src/routes/repo_dir.rs
@@ -93,6 +93,7 @@ mod tests {
             broadcaster.clone(),
         );
         AppState {
+            update: None,
             token: "test-token".into(),
             boot_id: "test-boot".into(),
             sandbox_manager,

--- a/apps/native/crates/local-api/src/routes/scripts.rs
+++ b/apps/native/crates/local-api/src/routes/scripts.rs
@@ -744,6 +744,7 @@ mod tests {
             broadcaster.clone(),
         );
         AppState {
+            update: None,
             token: Arc::from("test-token"),
             boot_id: Arc::from("test-boot"),
             sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),

--- a/apps/native/crates/local-api/src/routes/setup.rs
+++ b/apps/native/crates/local-api/src/routes/setup.rs
@@ -395,6 +395,7 @@ mod tests {
             broadcaster.clone(),
         );
         AppState {
+            update: None,
             token: "test-token".into(),
             boot_id: "test-boot".into(),
             sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),

--- a/apps/native/crates/local-api/src/routes/tasks.rs
+++ b/apps/native/crates/local-api/src/routes/tasks.rs
@@ -301,6 +301,7 @@ mod tests {
             broadcaster.clone(),
         );
         AppState {
+            update: None,
             token: Arc::from("test-token"),
             boot_id: Arc::from("test-boot"),
             sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),

--- a/apps/native/crates/local-api/src/routes/update.rs
+++ b/apps/native/crates/local-api/src/routes/update.rs
@@ -1,0 +1,146 @@
+//! `POST /_local/update/restart` — apply a staged self-update by restarting
+//! the app through the shell's graceful-shutdown pipeline.
+//!
+//! The webview's version card calls this (desktop builds only) instead of
+//! `window.location.reload()`: a reload re-serves the bundle embedded in the
+//! RUNNING binary, so it can never pick up the new `.app` the updater staged
+//! on disk — only a process restart can. The restart callback is Tauri's
+//! `request_restart`, which delivers `RunEvent::ExitRequested`, so the single
+//! shutdown path (child sweeps, drain, instance-lock release) always runs
+//! before the respawn.
+//!
+//! 409s are the contract, not errors: the card only renders when
+//! `/api/config` reports a staged version, but the state can move between
+//! that poll and this click (update superseded and re-downloading, or no
+//! hooks at all in the standalone binary). The webview treats any non-2xx by
+//! re-enabling the button and letting the next poll re-converge.
+//!
+//! Mounted under `/_local` (the reserved local-only namespace, like
+//! `/_auth`): a bare path would be SPA-fallback/upstream-proxy surface, and
+//! the Vite native dev proxy already forwards `/_local`.
+
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde_json::json;
+
+use crate::error::ApiError;
+use crate::state::AppState;
+
+/// Delay between flushing the `202 Accepted` and triggering the restart —
+/// best-effort only (shutdown drops connections immediately); losing the
+/// race costs a cosmetic network error on a page that is going away.
+const RESTART_RESPONSE_FLUSH: Duration = Duration::from_millis(100);
+
+pub async fn restart(State(state): State<AppState>) -> Response {
+    let Some(hooks) = state.update.as_ref() else {
+        return ApiError::conflict("self-update is not available in this process").into_response();
+    };
+    if hooks.installing.load(Ordering::SeqCst) {
+        return ApiError::conflict("an update install is in progress; retry shortly")
+            .into_response();
+    }
+    let Some(version) = hooks.staged_version.borrow().clone() else {
+        return ApiError::conflict("no update is staged").into_response();
+    };
+
+    tracing::info!(%version, "restarting to apply staged update");
+    let request_restart = hooks.request_restart.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(RESTART_RESPONSE_FLUSH).await;
+        request_restart();
+    });
+    (StatusCode::ACCEPTED, Json(json!({ "restarting": version }))).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    use axum::extract::State;
+    use axum::http::StatusCode;
+
+    use super::restart;
+    use crate::state::{AppState, UpdateHooks};
+
+    /// The three 409 branches are distinct states, not one: no hooks at all
+    /// (standalone binary), hooks but nothing staged, and hooks mid-install.
+    fn state_with(update: Option<UpdateHooks>) -> (AppState, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = crate::routes::intercept::test_state(dir.path());
+        state.update = update;
+        (state, dir)
+    }
+
+    fn hooks(
+        staged: Option<&str>,
+        installing: bool,
+    ) -> (
+        UpdateHooks,
+        tokio::sync::watch::Sender<Option<String>>,
+        Arc<AtomicBool>,
+    ) {
+        let (tx, rx) = tokio::sync::watch::channel(staged.map(str::to_string));
+        let restarted = Arc::new(AtomicBool::new(false));
+        let restarted_flag = restarted.clone();
+        let hooks = UpdateHooks {
+            staged_version: rx,
+            installing: Arc::new(AtomicBool::new(installing)),
+            request_restart: Arc::new(move || {
+                restarted_flag.store(true, Ordering::SeqCst);
+            }),
+        };
+        (hooks, tx, restarted)
+    }
+
+    #[tokio::test]
+    async fn conflicts_when_no_update_integration_exists() {
+        let (state, _dir) = state_with(None);
+        let res = restart(State(state)).await;
+        assert_eq!(res.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn conflicts_when_nothing_is_staged() {
+        let (h, _tx, restarted) = hooks(None, false);
+        let (state, _dir) = state_with(Some(h));
+        let res = restart(State(state)).await;
+        assert_eq!(res.status(), StatusCode::CONFLICT);
+        assert!(!restarted.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn conflicts_while_an_install_is_in_flight() {
+        // Restarting mid-swap could re-exec a half-replaced bundle — the
+        // updater task sets `installing` before download and clears it after
+        // install; a staged version from the PREVIOUS cycle must not bypass
+        // that fence.
+        let (h, _tx, restarted) = hooks(Some("5.0.0"), true);
+        let (state, _dir) = state_with(Some(h));
+        let res = restart(State(state)).await;
+        assert_eq!(res.status(), StatusCode::CONFLICT);
+        assert!(!restarted.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn accepted_then_invokes_the_restart_callback() {
+        let (h, _tx, restarted) = hooks(Some("5.0.0"), false);
+        let (state, _dir) = state_with(Some(h));
+        let res = restart(State(state)).await;
+        assert_eq!(res.status(), StatusCode::ACCEPTED);
+        // The callback fires after the response-flush delay, on a spawned
+        // task — poll rather than sleep a fixed wall-clock amount.
+        for _ in 0..100 {
+            if restarted.load(Ordering::SeqCst) {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!("request_restart was never invoked after the 202");
+    }
+}

--- a/apps/native/crates/local-api/src/routes/update.rs
+++ b/apps/native/crates/local-api/src/routes/update.rs
@@ -3,11 +3,13 @@
 //!
 //! The webview's version card calls this (desktop builds only) instead of
 //! `window.location.reload()`: a reload re-serves the bundle embedded in the
-//! RUNNING binary, so it can never pick up the new `.app` the updater staged
-//! on disk — only a process restart can. The restart callback is Tauri's
+//! RUNNING binary, so it can never pick up the update the shell staged —
+//! only a process restart can. The restart callback is Tauri's
 //! `request_restart`, which delivers `RunEvent::ExitRequested`, so the single
-//! shutdown path (child sweeps, drain, instance-lock release) always runs
-//! before the respawn.
+//! shutdown path (child sweeps, drain, instance-lock release) always runs,
+//! the staged update is INSTALLED at the end of it (deferred apply — see
+//! `src-tauri`'s `updater` module doc for the Keychain rationale), and only
+//! then does the process respawn into the new version.
 //!
 //! 409s are the contract, not errors: the card only renders when
 //! `/api/config` reports a staged version, but the state can move between

--- a/apps/native/crates/local-api/src/routes/upstream.rs
+++ b/apps/native/crates/local-api/src/routes/upstream.rs
@@ -191,8 +191,16 @@ pub async fn proxy(State(state): State<AppState>, req: Request) -> Response {
     }
 
     if path == PUBLIC_NO_AUTH_PATH {
+        // Staged self-update version, if the Tauri shell has installed one on
+        // disk (see `UpdateHooks`). The borrow is dropped within the
+        // statement — never held across an await.
+        let staged = state
+            .update
+            .as_ref()
+            .and_then(|hooks| hooks.staged_version.borrow().clone());
         return proxy_public_config(
             &session,
+            staged,
             &parts.method,
             &path_and_query,
             &parts.headers,
@@ -742,6 +750,7 @@ async fn attach_persisted_cookie(
 /// but every branch of this proxy keeps the same invariant uniformly).
 async fn proxy_public_config(
     session: &upstream::UpstreamSession,
+    staged_version: Option<String>,
     method: &Method,
     path_and_query: &str,
     headers: &HeaderMap,
@@ -766,7 +775,7 @@ async fn proxy_public_config(
 
     let url = format!("{}{path_and_query}", session.target());
     match send_once_no_bearer(method, &url, &out_headers, body.clone()).await {
-        Ok(resp) => rewrite_config_version(resp).await,
+        Ok(resp) => rewrite_config_version(resp, staged_version.as_deref()).await,
         Err(ProxyError::Network(msg)) => {
             ApiError::bad_gateway(format!("upstream unreachable: {msg}")).into_response()
         }
@@ -782,7 +791,8 @@ async fn proxy_public_config(
 const STUDIO_WEB_VERSION: &str = env!("STUDIO_WEB_VERSION");
 
 /// Answers `GET /api/config` with the version of the bundle actually running
-/// inside this app, not the upstream deployment's.
+/// inside this app — or, when a self-update has been INSTALLED on disk, the
+/// staged version — never the upstream deployment's.
 ///
 /// `version-check-dialog.tsx` polls this route every 5 minutes and nags "A new
 /// version is ready" once the reported version differs from the bundle's own
@@ -790,15 +800,24 @@ const STUDIO_WEB_VERSION: &str = env!("STUDIO_WEB_VERSION");
 /// many times a day, so proxied unchanged that banner is guaranteed to fire in
 /// the desktop app — and its "Refresh" action cannot possibly help, because the
 /// webview loads a bundle packaged into the app, not whatever upstream now
-/// serves. Rewriting the field keeps the two in agreement, so the banner only
-/// ever appears in the browser, where reloading genuinely fetches new assets.
+/// serves. Rewriting the field keeps the two in agreement, so the banner
+/// appears only in the browser, where reloading genuinely fetches new assets —
+/// or in the shell when, and only when, a staged update makes its action real
+/// (there the desktop-gated button restarts into the new bundle via
+/// `/_local/update/restart` instead of reloading).
 ///
 /// Every other field is passed through untouched: this rewrites one string, it
 /// does not reimplement the payload. Non-2xx, non-JSON, unparseable, or
 /// unexpectedly-shaped bodies stream through unchanged, as does an empty
-/// `STUDIO_WEB_VERSION`.
-async fn rewrite_config_version(upstream: reqwest::Response) -> Response {
-    if STUDIO_WEB_VERSION.is_empty() || !upstream.status().is_success() {
+/// `STUDIO_WEB_VERSION` with nothing staged.
+async fn rewrite_config_version(
+    upstream: reqwest::Response,
+    staged_version: Option<&str>,
+) -> Response {
+    let Some(report) = reported_config_version(staged_version, STUDIO_WEB_VERSION) else {
+        return build_response(upstream).await;
+    };
+    if !upstream.status().is_success() {
         return build_response(upstream).await;
     }
 
@@ -811,7 +830,7 @@ async fn rewrite_config_version(upstream: reqwest::Response) -> Response {
         return ApiError::bad_gateway("upstream config body was unreadable").into_response();
     };
 
-    let patched = patch_config_version(&bytes, STUDIO_WEB_VERSION);
+    let patched = patch_config_version(&bytes, &report);
 
     let body = match patched {
         Some(json) => {
@@ -831,6 +850,24 @@ async fn rewrite_config_version(upstream: reqwest::Response) -> Response {
     *res.status_mut() = status;
     *res.headers_mut() = headers;
     res
+}
+
+/// Which version `/api/config` should report to the webview: a staged
+/// self-update wins (its restart action is real); otherwise pin to the
+/// embedded bundle's version; `None` (pass upstream through untouched) only
+/// when there is nothing meaningful to report at all. A staged version must
+/// win even when the baked constant is empty (unreadable manifest at build
+/// time) — the old `STUDIO_WEB_VERSION.is_empty()` early-return would have
+/// silently suppressed a ready update.
+///
+/// Pure (no I/O) so the contract is unit-testable without standing up a
+/// proxy, per TESTING.md.
+fn reported_config_version(staged: Option<&str>, baked: &str) -> Option<String> {
+    match staged {
+        Some(version) => Some(version.to_string()),
+        None if baked.is_empty() => None,
+        None => Some(baked.to_string()),
+    }
 }
 
 /// Replaces `config.version` in a `GET /api/config` body, or `None` when the
@@ -1403,6 +1440,28 @@ mod tests {
     }
 
     #[test]
+    fn reported_config_version_prefers_staged_and_survives_empty_baked() {
+        // Staged wins over the embedded bundle's version…
+        assert_eq!(
+            reported_config_version(Some("5.0.0"), "4.150.13").as_deref(),
+            Some("5.0.0")
+        );
+        // …including when the baked constant is empty (unreadable manifest at
+        // build time) — the old is_empty() early-return suppressed this.
+        assert_eq!(
+            reported_config_version(Some("5.0.0"), "").as_deref(),
+            Some("5.0.0")
+        );
+        // No staged update: pin to the embedded version as always.
+        assert_eq!(
+            reported_config_version(None, "4.150.13").as_deref(),
+            Some("4.150.13")
+        );
+        // Nothing meaningful to report: pass upstream through untouched.
+        assert_eq!(reported_config_version(None, ""), None);
+    }
+
+    #[test]
     fn patch_config_version_passes_through_unexpected_shapes() {
         // Not JSON at all (an HTML error page from a proxy in front of us).
         assert!(patch_config_version(b"<html>nope</html>", "4.125.3").is_none());
@@ -1733,8 +1792,64 @@ mod tests {
         let headers = HeaderMap::new();
         let body = axum::body::Bytes::new();
 
-        let res = proxy_public_config(&session, &Method::GET, "/api/config", &headers, &body).await;
+        let res =
+            proxy_public_config(&session, None, &Method::GET, "/api/config", &headers, &body).await;
         assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    /// The staged-self-update branch of the version rewrite, end to end
+    /// through the proxy against a real in-process upstream: with nothing
+    /// staged the upstream's version (a sentinel here — in production the
+    /// cloud deployment's, ~12x/day ahead) must be replaced by the embedded
+    /// bundle's; with a staged version, the staged one wins. This is what
+    /// makes the webview's drift card fire iff a restart can actually help.
+    #[tokio::test]
+    async fn proxy_public_config_reports_staged_version_over_upstream_sentinel() {
+        let app = Router::new().route(
+            "/api/config",
+            get(|| async { Json(json!({"config": {"version": "9.9.9", "other": true}})) }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        let target = format!("http://{addr}");
+        let store = Arc::new(MemoryTokenStore::new());
+        let session = UpstreamSession::new(target, store);
+        let headers = HeaderMap::new();
+        let body = axum::body::Bytes::new();
+
+        let reported_version = |res: Response| async move {
+            let bytes = axum::body::to_bytes(res.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            value["config"]["version"].as_str().unwrap().to_string()
+        };
+
+        // Nothing staged: never the upstream sentinel — the embedded
+        // version (or passthrough only if STUDIO_WEB_VERSION were empty,
+        // which the build asserts against elsewhere).
+        let res =
+            proxy_public_config(&session, None, &Method::GET, "/api/config", &headers, &body).await;
+        assert_eq!(res.status(), StatusCode::OK);
+        let version = reported_version(res).await;
+        assert_ne!(version, "9.9.9");
+        assert_eq!(version, STUDIO_WEB_VERSION);
+
+        // Staged: the staged version wins over both.
+        let res = proxy_public_config(
+            &session,
+            Some("5.0.0-staged".to_string()),
+            &Method::GET,
+            "/api/config",
+            &headers,
+            &body,
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(reported_version(res).await, "5.0.0-staged");
     }
 
     #[tokio::test]
@@ -1785,7 +1900,8 @@ mod tests {
         );
         let body = axum::body::Bytes::new();
 
-        let res = proxy_public_config(&session, &Method::GET, "/api/config", &headers, &body).await;
+        let res =
+            proxy_public_config(&session, None, &Method::GET, "/api/config", &headers, &body).await;
         assert_eq!(res.status(), StatusCode::OK);
         assert_eq!(
             seen_auth.lock().unwrap().as_deref(),

--- a/apps/native/crates/local-api/src/sandbox/target.rs
+++ b/apps/native/crates/local-api/src/sandbox/target.rs
@@ -129,6 +129,7 @@ mod tests {
             broadcaster.clone(),
         );
         AppState {
+            update: None,
             token: "test-token".into(),
             boot_id: "test-boot".into(),
             sandbox_manager: crate::sandbox::SandboxManager::new(app_root.clone()),

--- a/apps/native/crates/local-api/src/state.rs
+++ b/apps/native/crates/local-api/src/state.rs
@@ -26,13 +26,16 @@ use crate::tasks::TaskRegistry;
 /// change together with the `/_local/update/restart` route in `router.rs`.
 #[derive(Clone)]
 pub struct UpdateHooks {
-    /// Version the update task has installed on disk, `None` until an
-    /// install completes. Read by the `/api/config` proxy rewrite so the
-    /// webview's version-drift card fires iff an update is actually staged.
+    /// Version the update task has downloaded, verified, and staged for
+    /// apply-at-exit; `None` until staging completes. Read by the
+    /// `/api/config` proxy rewrite so the webview's version-drift card
+    /// fires iff an update is actually ready. (The install itself is
+    /// deferred to the shell's exit path — swapping the bundle under a live
+    /// process breaks macOS Keychain access.)
     pub staged_version: tokio::sync::watch::Receiver<Option<String>>,
-    /// True while a download/install cycle is running. The restart route
-    /// refuses (409) while set — restarting mid-swap could re-exec a
-    /// half-replaced bundle.
+    /// True while a download/verify/stage cycle is running. The restart
+    /// route refuses (409) while set — restarting mid-restage would race
+    /// the pending-archive swap.
     pub installing: Arc<AtomicBool>,
     /// Graceful app restart (Tauri `request_restart` — delivers
     /// `ExitRequested`, so the single shutdown pipeline runs first).

--- a/apps/native/crates/local-api/src/state.rs
+++ b/apps/native/crates/local-api/src/state.rs
@@ -6,6 +6,7 @@
 //! coherent across all 8 families.
 
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use crate::config::ConfigStore;
@@ -14,6 +15,29 @@ use crate::sandbox::SandboxManager;
 use crate::setup::SetupOrchestrator;
 use crate::shutdown::ShutdownCoordinator;
 use crate::tasks::TaskRegistry;
+
+/// Desktop-app self-update integration, injected by the Tauri shell via
+/// `StartOptions::update`. `None` outside the packaged shell (the standalone
+/// binary, tests) — a separate axis from embedded-vs-bearer auth, because
+/// embedded DEBUG builds have no updater either.
+///
+/// Interface note (module-ownership contract): this struct and the
+/// `AppState`/`StartOptions` fields carrying it were added as ONE interface
+/// change together with the `/_local/update/restart` route in `router.rs`.
+#[derive(Clone)]
+pub struct UpdateHooks {
+    /// Version the update task has installed on disk, `None` until an
+    /// install completes. Read by the `/api/config` proxy rewrite so the
+    /// webview's version-drift card fires iff an update is actually staged.
+    pub staged_version: tokio::sync::watch::Receiver<Option<String>>,
+    /// True while a download/install cycle is running. The restart route
+    /// refuses (409) while set — restarting mid-swap could re-exec a
+    /// half-replaced bundle.
+    pub installing: Arc<AtomicBool>,
+    /// Graceful app restart (Tauri `request_restart` — delivers
+    /// `ExitRequested`, so the single shutdown pipeline runs first).
+    pub request_restart: Arc<dyn Fn() + Send + Sync>,
+}
 
 /// `LOCAL_API_MODE` — see `cors.rs`'s module doc for exactly what this
 /// changes (origin-allowlist breadth only, never auth, never a wildcard
@@ -75,4 +99,6 @@ pub struct AppState {
     /// sniffed dev port. A non-git thread never touches this field — the
     /// plain `repo_dir`/`setup` path above is unchanged.
     pub sandbox_manager: Arc<SandboxManager>,
+    /// See [`UpdateHooks`]. `None` outside the packaged desktop shell.
+    pub update: Option<UpdateHooks>,
 }

--- a/apps/native/e2e/auth-matrix.e2e.test.ts
+++ b/apps/native/e2e/auth-matrix.e2e.test.ts
@@ -51,6 +51,11 @@ const CASES: Case[] = [
     path: "/_sandbox/runs/some-run",
     method: "DELETE",
   },
+  // Correct-bearer answers 409 here (the standalone binary has no update
+  // integration — `StartOptions.update: None`), which satisfies the
+  // matrix's not-401 assertion; the 401 rows prove the route landed inside
+  // the guard rather than as an unauthenticated top-level route.
+  { name: "update: restart", path: "/_local/update/restart" },
 ];
 
 describeLocalApi("local-api e2e: auth matrix", () => {
@@ -95,6 +100,18 @@ describeLocalApi("local-api e2e: auth matrix", () => {
       expect(res.status).not.toBe(401);
     });
   }
+
+  it("update restart answers 409 in the standalone binary (no update integration)", async () => {
+    // The desktop shell injects UpdateHooks via StartOptions.update; the
+    // standalone binary never does, so the route's documented contract here
+    // is exactly 409 — never 404 (the route exists in both auth modes) and
+    // never 202 (nothing can be staged).
+    const res = await fetch(url(a, "/_local/update/restart"), {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(409);
+  });
 
   it("an empty configured token rejects everything (fail closed)", async () => {
     // A daemon spawned without a token must never accept a blank `Bearer `.

--- a/apps/native/src-tauri/Cargo.toml
+++ b/apps/native/src-tauri/Cargo.toml
@@ -44,6 +44,15 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tauri-plugin-mcp-bridge = { workspace = true }
 tauri-plugin-opener = { workspace = true }
+tauri-plugin-updater = { workspace = true }
+# Single-consumer deps for the updater's version-pairing check (inspecting
+# the downloaded .app.tar.gz's Info.plist before install — see
+# src/updater.rs::bundle_short_version). Declared here, not in the workspace
+# table, per the "single-consumer dep stays local" precedent
+# crates/harness/Cargo.toml set for portable-pty.
+flate2 = "1"
+tar = "0.4"
+plist = "1"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/apps/native/src-tauri/src/lib.rs
+++ b/apps/native/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod setup;
 mod shutdown;
 mod state;
 mod ui_assets;
+mod updater;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -37,6 +38,17 @@ pub fn run() {
     #[cfg(debug_assertions)]
     {
         builder = builder.plugin(tauri_plugin_mcp_bridge::init());
+    }
+
+    // Self-update — release builds only, the exact mirror of the debug-only
+    // mcp-bridge above. The cfg-gate is load-bearing, not belt-and-braces: a
+    // debug binary with the plugin registered and the committed
+    // plugins.updater config WOULD self-update from the production channel
+    // if anything called check(). The background task has further runtime
+    // gates — see `updater`'s module doc.
+    #[cfg(not(debug_assertions))]
+    {
+        builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
     }
 
     let app = builder

--- a/apps/native/src-tauri/src/setup.rs
+++ b/apps/native/src-tauri/src/setup.rs
@@ -271,6 +271,12 @@ pub async fn run(app: &tauri::AppHandle) -> Result<(), SetupError> {
     embedded.listener_host = Some(control.listener_host());
     embedded.ui_assets = bundled_ui;
     embedded.preview_cookie_selftest = selftest_mode;
+    // Built BEFORE StartOptions so the staged-version channel and restart
+    // callback exist for local-api's `/api/config` rewrite and
+    // `/_local/update/restart` route; the background task itself only spawns
+    // after the server is up (below). `hooks()` is `None` in every non-release
+    // context — see `updater`'s module doc for the gating story.
+    let updater = crate::updater::init(app);
     let handle = local_api::start_embedded(
         local_api::StartOptions {
             // Serve the leaf minted above: the webview's origin must be a
@@ -286,6 +292,7 @@ pub async fn run(app: &tauri::AppHandle) -> Result<(), SetupError> {
             app_root,
             port: control.listener_port,
             mode: local_api::ApiMode::Strict,
+            update: updater.hooks(),
         },
         embedded,
     )
@@ -310,6 +317,8 @@ pub async fn run(app: &tauri::AppHandle) -> Result<(), SetupError> {
         upstream_session,
         upstream::revalidate::DEFAULT_INTERVAL,
     ));
+    // Background self-update loop (no-op outside packaged release builds).
+    updater.spawn();
 
     let webview_url = WebviewUrl::External(
         browser_origin

--- a/apps/native/src-tauri/src/setup.rs
+++ b/apps/native/src-tauri/src/setup.rs
@@ -276,7 +276,7 @@ pub async fn run(app: &tauri::AppHandle) -> Result<(), SetupError> {
     // `/_local/update/restart` route; the background task itself only spawns
     // after the server is up (below). `hooks()` is `None` in every non-release
     // context — see `updater`'s module doc for the gating story.
-    let updater = crate::updater::init(app);
+    let updater = crate::updater::init(app, &app_root);
     let handle = local_api::start_embedded(
         local_api::StartOptions {
             // Serve the leaf minted above: the webview's origin must be a

--- a/apps/native/src-tauri/src/shutdown.rs
+++ b/apps/native/src-tauri/src/shutdown.rs
@@ -28,4 +28,12 @@ pub fn run_blocking(app: &AppHandle) {
     };
     tracing::info!("app exit requested: shutting down local-api");
     tauri::async_runtime::block_on(handle.shutdown());
+    // Apply a staged self-update ONLY here, after local-api has drained:
+    // swapping the bundle under a live process breaks macOS Keychain access
+    // (code identity is validated against the binary on disk), so the swap
+    // must happen when no Keychain writer is left. Covers both the restart
+    // button and a plain quit — this is what makes install-on-quit true.
+    // Inside the take-once guard above, so a duplicate ExitRequested cannot
+    // double-apply.
+    crate::updater::apply_pending_update();
 }

--- a/apps/native/src-tauri/src/updater.rs
+++ b/apps/native/src-tauri/src/updater.rs
@@ -1,0 +1,456 @@
+//! Background self-update: check → download → verify → install, silently.
+//!
+//! The design (see `apps/native/docs/native-updater-plan.md`): the packaged
+//! app polls the rolling `native-updates` GitHub prerelease's `latest.json`,
+//! auto-installs anything newer, and publishes the staged version into
+//! local-api via [`local_api::UpdateHooks`]. The `/api/config` proxy rewrite
+//! then reports the staged version, the webview's existing version card
+//! fires, and its button POSTs `/_local/update/restart` — which calls the
+//! `request_restart` closure built here (Tauri's `request_restart`, the
+//! variant documented to deliver `RunEvent::ExitRequested`, so
+//! `shutdown::run_blocking`'s pipeline always runs before the respawn; plain
+//! `restart()`/JS `relaunch()` skip those events on the main thread).
+//!
+//! On macOS the install swaps the `.app` on disk while the running process
+//! keeps serving from its own open inode — install-eagerly is safe, and even
+//! a plain quit+reopen lands on the new version.
+//!
+//! The task never runs outside a real shipped build — three independent
+//! gates, because `cfg!(debug_assertions)` alone is NOT enough: CI's
+//! `tauri-build` job and `boot-smoke.ts` build the RELEASE profile at the
+//! committed `0.1.0` placeholder version, which would see prod as "newer"
+//! and download ~80 MB over the CI bundle mid-smoke:
+//! 1. debug builds compile the spawn out of reach (the plugin itself is only
+//!    registered under `cfg(not(debug_assertions))` in `lib.rs`);
+//! 2. [`init`] refuses under `selftest::is_enabled()` or at the `0.1.0`
+//!    placeholder version;
+//! 3. `DECOCMS_DISABLE_AUTO_UPDATE` is honored per cycle (warn-logged every
+//!    time — a silently frozen updater must be greppable in diagnostics).
+//!
+//! All errors are swallowed to tracing: offline, a blocked github.com, or
+//! the 404 window while a release is publishing are silent no-ops (the card
+//! just doesn't appear). The one exception is a SIGNATURE failure, which
+//! gets a distinct error line — it means channel tampering or a botched key
+//! rotation, categorically different from flaky networks.
+
+use std::io::Read;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::watch;
+
+/// tauri.conf.json5's committed placeholder — only release-workflow builds
+/// (`--config {"version": ...}`) carry a real version.
+const PLACEHOLDER_VERSION: &str = "0.1.0";
+const KILL_SWITCH_ENV: &str = "DECOCMS_DISABLE_AUTO_UPDATE";
+/// Deliberately NOT the 5-minute revalidate cadence: the channel manifest
+/// moves at most ~1.2x/day (release-workflow throttle) and card latency is
+/// dominated by the dialog's own 5-min × 2-confirmation poll — a 5-minute
+/// check would be ~288 no-op manifest fetches a day.
+const CHECK_INTERVAL: Duration = Duration::from_secs(30 * 60);
+/// Manifest fetch timeout; a stalled check must not wedge the loop.
+const CHECK_TIMEOUT: Duration = Duration::from_secs(30);
+/// Whole-download bound. Generous (the artifact is ~80-100 MB and the
+/// plugin buffers it in RAM with no resume); a stalled stream without this
+/// would block the loop's single future forever.
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// Built by [`init`] before local-api boots (the hooks ride
+/// `StartOptions::update`); [`Updater::spawn`] starts the background task
+/// after the server is up. Split so the channel-before-`StartOptions`
+/// ordering is enforced by types, not convention.
+pub struct Updater {
+    hooks: Option<local_api::UpdateHooks>,
+    task: Option<TaskParts>,
+}
+
+struct TaskParts {
+    app: tauri::AppHandle,
+    staged_tx: watch::Sender<Option<String>>,
+    installing: Arc<AtomicBool>,
+}
+
+pub fn init(app: &tauri::AppHandle) -> Updater {
+    if !enabled(app) {
+        return Updater {
+            hooks: None,
+            task: None,
+        };
+    }
+    let (staged_tx, staged_rx) = watch::channel(None);
+    let installing = Arc::new(AtomicBool::new(false));
+    let restart_handle = app.clone();
+    let hooks = local_api::UpdateHooks {
+        staged_version: staged_rx,
+        installing: installing.clone(),
+        request_restart: Arc::new(move || restart_handle.request_restart()),
+    };
+    Updater {
+        hooks: Some(hooks),
+        task: Some(TaskParts {
+            app: app.clone(),
+            staged_tx,
+            installing,
+        }),
+    }
+}
+
+impl Updater {
+    /// `None` whenever the task will not run — local-api then keeps its
+    /// standalone behavior (`/_local/update/restart` answers 409, the
+    /// `/api/config` rewrite pins the embedded version).
+    pub fn hooks(&self) -> Option<local_api::UpdateHooks> {
+        self.hooks.clone()
+    }
+
+    pub fn spawn(self) {
+        let Some(parts) = self.task else { return };
+        // Dropping the JoinHandle detaches the task; the process lifetime is
+        // the intended owner, same as upstream::revalidate.
+        drop(tauri::async_runtime::spawn(run(parts)));
+    }
+}
+
+fn enabled(app: &tauri::AppHandle) -> bool {
+    if cfg!(debug_assertions) {
+        return false;
+    }
+    if crate::selftest::is_enabled() {
+        tracing::info!("self-update disabled: selftest mode");
+        return false;
+    }
+    let version = app.package_info().version.to_string();
+    if version == PLACEHOLDER_VERSION {
+        tracing::info!(
+            "self-update disabled: placeholder version {PLACEHOLDER_VERSION} (non-release build)"
+        );
+        return false;
+    }
+    true
+}
+
+fn kill_switch_active() -> bool {
+    std::env::var_os(KILL_SWITCH_ENV).is_some_and(|value| !value.is_empty() && value != "0")
+}
+
+async fn run(parts: TaskParts) {
+    let mut interval = tokio::time::interval(CHECK_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // The first tick completes immediately; consuming it here means the
+    // first real check runs one full interval after boot — no boot-path
+    // contention, mirroring upstream::revalidate's first-tick handling.
+    interval.tick().await;
+    let mut memo: Option<FailureMemo> = None;
+    loop {
+        interval.tick().await;
+        if kill_switch_active() {
+            tracing::warn!("self-update skipped: {KILL_SWITCH_ENV} is set");
+            continue;
+        }
+        cycle(&parts, &mut memo).await;
+    }
+}
+
+async fn cycle(parts: &TaskParts, memo: &mut Option<FailureMemo>) {
+    use tauri_plugin_updater::UpdaterExt;
+
+    let updater = match parts.app.updater_builder().timeout(CHECK_TIMEOUT).build() {
+        Ok(updater) => updater,
+        Err(error) => {
+            tracing::warn!(%error, "self-update: updater construction failed");
+            return;
+        }
+    };
+    // check() itself gates on remote > running (built-in semver comparison);
+    // this code never re-implements that half.
+    let update = match updater.check().await {
+        Ok(Some(update)) => update,
+        Ok(None) => return,
+        Err(error) => {
+            // Offline / blocked endpoint / publish-window 404: silent by
+            // design — never surface a red path to the UI from here.
+            tracing::debug!(%error, "self-update: check failed (offline or channel unavailable)");
+            return;
+        }
+    };
+
+    let candidate = update.version.clone();
+    let staged = parts.staged_tx.borrow().clone();
+    match decide(&candidate, staged.as_deref(), memo.as_ref(), Instant::now()) {
+        Decision::AlreadyStaged => return,
+        Decision::Backoff => {
+            tracing::debug!(%candidate, "self-update: in failure backoff, skipping");
+            return;
+        }
+        Decision::Attempt => {}
+    }
+
+    tracing::info!(%candidate, "self-update: downloading");
+    // `installing` fences the restart route for the whole download+install:
+    // restarting mid-swap could re-exec a half-replaced bundle.
+    parts.installing.store(true, Ordering::SeqCst);
+    let result = download_verify_install(&update, &candidate).await;
+    parts.installing.store(false, Ordering::SeqCst);
+
+    match result {
+        Ok(()) => {
+            *memo = None;
+            // Receivers only observe; send failure (no receivers) is fine.
+            let _ = parts.staged_tx.send(Some(candidate.clone()));
+            tracing::info!(%candidate, "self-update: installed and staged; restart applies it");
+        }
+        Err(error) => {
+            let failure = record_failure(memo.take(), &candidate, Instant::now());
+            if error.signature_related {
+                // Channel tampering or a botched key rotation — categorically
+                // different from a flaky network; keep it loudly greppable.
+                tracing::error!(
+                    %candidate,
+                    error = %error.message,
+                    "self-update: SIGNATURE VERIFICATION FAILED"
+                );
+            } else {
+                tracing::warn!(
+                    %candidate,
+                    attempts = failure.attempts,
+                    error = %error.message,
+                    "self-update: install attempt failed; backing off"
+                );
+            }
+            *memo = Some(failure);
+        }
+    }
+}
+
+struct InstallError {
+    message: String,
+    signature_related: bool,
+}
+
+impl InstallError {
+    fn new(message: String) -> Self {
+        let signature_related = message.to_ascii_lowercase().contains("signature");
+        Self {
+            message,
+            signature_related,
+        }
+    }
+}
+
+async fn download_verify_install(
+    update: &tauri_plugin_updater::Update,
+    expected_version: &str,
+) -> Result<(), InstallError> {
+    let bytes = tokio::time::timeout(DOWNLOAD_TIMEOUT, update.download(|_, _| {}, || {}))
+        .await
+        .map_err(|_| InstallError::new("download timed out".to_string()))?
+        .map_err(|error| InstallError::new(format!("download failed: {error}")))?;
+
+    // Version-pairing check (v1 downgrade defense): the minisign signature
+    // covers the archive bytes but NOT the manifest's `version` field, and
+    // the manifest lives on a mutable release asset writable by every
+    // workflow token with contents:write. Without this, a lying manifest
+    // could pair a high `version` with an old validly-signed artifact and
+    // silently roll the fleet back. The bundle's own Info.plist version IS
+    // signature-covered, so requiring it to match closes the pairing attack.
+    let embedded = bundle_short_version(&bytes)
+        .map_err(|error| InstallError::new(format!("bundle inspection failed: {error}")))?;
+    if embedded != expected_version {
+        return Err(InstallError::new(format!(
+            "version-pairing mismatch: manifest claims {expected_version} but the signed bundle is {embedded} — refusing to install"
+        )));
+    }
+
+    // install() is synchronous gunzip+untar+swap I/O — off the runtime
+    // worker, same rationale as setup.rs's TLS spawn_blocking.
+    let update = update.clone();
+    tauri::async_runtime::spawn_blocking(move || update.install(bytes))
+        .await
+        .map_err(|join| InstallError::new(format!("install task failed: {join}")))?
+        .map_err(|error| InstallError::new(format!("install failed: {error}")))?;
+    Ok(())
+}
+
+/// `CFBundleShortVersionString` of the top-level `.app` inside the updater
+/// tar.gz (`<name>.app/Contents/Info.plist` — exactly depth 3, so a nested
+/// framework's plist can never shadow the bundle's own).
+fn bundle_short_version(targz: &[u8]) -> Result<String, String> {
+    let decoder = flate2::read::GzDecoder::new(targz);
+    let mut archive = tar::Archive::new(decoder);
+    let entries = archive
+        .entries()
+        .map_err(|error| format!("unreadable archive: {error}"))?;
+    for entry in entries {
+        let mut entry = entry.map_err(|error| format!("unreadable archive entry: {error}"))?;
+        let path = entry
+            .path()
+            .map_err(|error| format!("unreadable entry path: {error}"))?;
+        let components: Vec<String> = path
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect();
+        let is_bundle_plist = components.len() == 3
+            && components[0].ends_with(".app")
+            && components[1] == "Contents"
+            && components[2] == "Info.plist";
+        if !is_bundle_plist {
+            continue;
+        }
+        let mut plist_bytes = Vec::new();
+        entry
+            .read_to_end(&mut plist_bytes)
+            .map_err(|error| format!("unreadable Info.plist: {error}"))?;
+        let value = plist::Value::from_reader(std::io::Cursor::new(plist_bytes))
+            .map_err(|error| format!("unparseable Info.plist: {error}"))?;
+        return value
+            .as_dictionary()
+            .and_then(|dict| dict.get("CFBundleShortVersionString"))
+            .and_then(|v| v.as_string())
+            .map(str::to_string)
+            .ok_or_else(|| "Info.plist has no CFBundleShortVersionString".to_string());
+    }
+    Err("no <name>.app/Contents/Info.plist in archive".to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Pure decision logic — always compiled (release-only cfg would silently
+// compile these tests out of `cargo test --workspace`, which runs the dev
+// profile), only the spawn side above is gated by `enabled()`.
+
+#[derive(Debug, PartialEq, Eq)]
+enum Decision {
+    Attempt,
+    AlreadyStaged,
+    Backoff,
+}
+
+/// One remembered failing version. Without this memo a persistently failing
+/// install (TCC block, full disk, bad signature) would re-download the full
+/// artifact EVERY tick, forever — the memo turns that into exponential
+/// backoff, reset the moment a different version appears on the channel.
+struct FailureMemo {
+    version: String,
+    attempts: u32,
+    next_retry_at: Instant,
+}
+
+fn decide(
+    candidate: &str,
+    staged: Option<&str>,
+    memo: Option<&FailureMemo>,
+    now: Instant,
+) -> Decision {
+    // Plain equality, not semver ordering: a channel ROLLFORWARD after a
+    // botched release must be able to replace an already-staged version in
+    // either direction; check() already guarantees candidate > running.
+    if staged == Some(candidate) {
+        return Decision::AlreadyStaged;
+    }
+    if let Some(memo) = memo {
+        if memo.version == candidate && now < memo.next_retry_at {
+            return Decision::Backoff;
+        }
+    }
+    Decision::Attempt
+}
+
+fn record_failure(memo: Option<FailureMemo>, version: &str, now: Instant) -> FailureMemo {
+    let attempts = match &memo {
+        Some(memo) if memo.version == version => memo.attempts + 1,
+        _ => 1,
+    };
+    FailureMemo {
+        version: version.to_string(),
+        attempts,
+        next_retry_at: now + backoff_after(attempts),
+    }
+}
+
+/// 1h, 2h, 4h, 8h, 16h, 24h cap.
+fn backoff_after(attempts: u32) -> Duration {
+    let hours = 1u64 << attempts.saturating_sub(1).min(5);
+    Duration::from_secs(hours.min(24) * 3600)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HOUR: Duration = Duration::from_secs(3600);
+
+    #[test]
+    fn backoff_doubles_and_caps_at_a_day() {
+        assert_eq!(backoff_after(1), HOUR);
+        assert_eq!(backoff_after(2), 2 * HOUR);
+        assert_eq!(backoff_after(5), 16 * HOUR);
+        assert_eq!(backoff_after(6), 24 * HOUR);
+        assert_eq!(backoff_after(60), 24 * HOUR);
+    }
+
+    #[test]
+    fn decide_skips_staged_backs_off_failures_and_resets_on_new_versions() {
+        let now = Instant::now();
+        assert_eq!(
+            decide("2.0.0", Some("2.0.0"), None, now),
+            Decision::AlreadyStaged
+        );
+        // A different staged version (even a NEWER one — channel rollforward)
+        // is attempted; ordering is check()'s job.
+        assert_eq!(decide("2.0.0", Some("3.0.0"), None, now), Decision::Attempt);
+
+        let memo = record_failure(None, "2.0.0", now);
+        assert_eq!(memo.attempts, 1);
+        assert_eq!(decide("2.0.0", None, Some(&memo), now), Decision::Backoff);
+        // Backoff elapsed → retry.
+        assert_eq!(
+            decide("2.0.0", None, Some(&memo), now + 2 * HOUR),
+            Decision::Attempt
+        );
+        // A NEW version is never held back by an old version's memo.
+        assert_eq!(decide("2.1.0", None, Some(&memo), now), Decision::Attempt);
+
+        // Repeated failures of the same version escalate; a different
+        // version resets the counter.
+        let memo = record_failure(Some(memo), "2.0.0", now);
+        assert_eq!(memo.attempts, 2);
+        let memo = record_failure(Some(memo), "2.1.0", now);
+        assert_eq!(memo.attempts, 1);
+    }
+
+    #[test]
+    fn bundle_short_version_reads_the_top_level_app_plist_only() {
+        let plist_xml = |version: &str| {
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleShortVersionString</key><string>{version}</string>
+</dict></plist>"#
+            )
+        };
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut add = |path: &str, contents: &str| {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, path, contents.as_bytes())
+                .unwrap();
+        };
+        // A nested framework plist that must NOT win, plus the real one.
+        add(
+            "deco.app/Contents/Frameworks/X.framework/Info.plist",
+            &plist_xml("9.9.9"),
+        );
+        add("deco.app/Contents/Info.plist", &plist_xml("4.151.0"));
+        let tar_bytes = builder.into_inner().unwrap();
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        std::io::Write::write_all(&mut encoder, &tar_bytes).unwrap();
+        let targz = encoder.finish().unwrap();
+
+        assert_eq!(bundle_short_version(&targz).unwrap(), "4.151.0");
+        assert!(bundle_short_version(b"not a tarball").is_err());
+    }
+}

--- a/apps/native/src-tauri/src/updater.rs
+++ b/apps/native/src-tauri/src/updater.rs
@@ -44,6 +44,10 @@ use tokio::sync::watch;
 /// (`--config {"version": ...}`) carry a real version.
 const PLACEHOLDER_VERSION: &str = "0.1.0";
 const KILL_SWITCH_ENV: &str = "DECOCMS_DISABLE_AUTO_UPDATE";
+/// Spike/manual-runbook override for [`CHECK_INTERVAL`] (seconds, floored at
+/// 15 so a typo can't hot-loop against GitHub). Harmless in the threat
+/// model: a local process able to set env already has the kill switch above.
+const CHECK_INTERVAL_ENV: &str = "DECOCMS_UPDATE_CHECK_INTERVAL_SECS";
 /// Deliberately NOT the 5-minute revalidate cadence: the channel manifest
 /// moves at most ~1.2x/day (release-workflow throttle) and card latency is
 /// dominated by the dialog's own 5-min × 2-confirmation poll — a 5-minute
@@ -134,8 +138,20 @@ fn kill_switch_active() -> bool {
     std::env::var_os(KILL_SWITCH_ENV).is_some_and(|value| !value.is_empty() && value != "0")
 }
 
+/// [`CHECK_INTERVAL`] unless the override env holds a parseable second
+/// count; floored, never trusted below 15 s. Pure so the parsing is
+/// unit-testable.
+fn check_interval(override_secs: Option<&str>) -> Duration {
+    override_secs
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(|secs| Duration::from_secs(secs.max(15)))
+        .unwrap_or(CHECK_INTERVAL)
+}
+
 async fn run(parts: TaskParts) {
-    let mut interval = tokio::time::interval(CHECK_INTERVAL);
+    let mut interval = tokio::time::interval(check_interval(
+        std::env::var(CHECK_INTERVAL_ENV).ok().as_deref(),
+    ));
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     // The first tick completes immediately; consuming it here means the
     // first real check runs one full interval after boot — no boot-path
@@ -378,6 +394,16 @@ mod tests {
     use super::*;
 
     const HOUR: Duration = Duration::from_secs(3600);
+
+    #[test]
+    fn check_interval_override_parses_and_floors() {
+        assert_eq!(check_interval(None), CHECK_INTERVAL);
+        assert_eq!(check_interval(Some("nonsense")), CHECK_INTERVAL);
+        assert_eq!(check_interval(Some("")), CHECK_INTERVAL);
+        assert_eq!(check_interval(Some("120")), Duration::from_secs(120));
+        // Floored: a typo can't hot-loop against the channel.
+        assert_eq!(check_interval(Some("1")), Duration::from_secs(15));
+    }
 
     #[test]
     fn backoff_doubles_and_caps_at_a_day() {

--- a/apps/native/src-tauri/src/updater.rs
+++ b/apps/native/src-tauri/src/updater.rs
@@ -1,19 +1,27 @@
-//! Background self-update: check → download → verify → install, silently.
+//! Background self-update: check → download → verify → stage, silently;
+//! the actual INSTALL happens in the exit path ([`apply_pending_update`]).
 //!
 //! The design (see `apps/native/docs/native-updater-plan.md`): the packaged
 //! app polls the rolling `native-updates` GitHub prerelease's `latest.json`,
-//! auto-installs anything newer, and publishes the staged version into
-//! local-api via [`local_api::UpdateHooks`]. The `/api/config` proxy rewrite
-//! then reports the staged version, the webview's existing version card
-//! fires, and its button POSTs `/_local/update/restart` — which calls the
+//! downloads and verifies anything newer, stages the archive under
+//! `<app_root>/updates/`, and publishes the staged version into local-api
+//! via [`local_api::UpdateHooks`]. The `/api/config` proxy rewrite then
+//! reports the staged version, the webview's existing version card fires,
+//! and its button POSTs `/_local/update/restart` — which calls the
 //! `request_restart` closure built here (Tauri's `request_restart`, the
 //! variant documented to deliver `RunEvent::ExitRequested`, so
-//! `shutdown::run_blocking`'s pipeline always runs before the respawn; plain
-//! `restart()`/JS `relaunch()` skip those events on the main thread).
+//! `shutdown::run_blocking`'s pipeline always runs before the respawn).
 //!
-//! On macOS the install swaps the `.app` on disk while the running process
-//! keeps serving from its own open inode — install-eagerly is safe, and even
-//! a plain quit+reopen lands on the new version.
+//! Install is DEFERRED to the exit path deliberately — an earlier design
+//! installed eagerly and the live spike caught the consequence: macOS
+//! validates a process's code identity against its binary ON DISK, so the
+//! moment the bundle was swapped under the running app every Keychain
+//! operation failed ("keychain unavailable … UNIX[No such file or
+//! directory]") — sign-in broke and rotated-refresh-token saves would fail
+//! silently until restart. Applying inside `shutdown.rs`, after local-api
+//! has drained, means no Keychain writer can ever observe a swapped bundle,
+//! and because BOTH the card's restart and a plain quit funnel through
+//! `ExitRequested`, install-on-quit still holds.
 //!
 //! The task never runs outside a real shipped build — three independent
 //! gates, because `cfg!(debug_assertions)` alone is NOT enough: CI's
@@ -34,8 +42,9 @@
 //! rotation, categorically different from flaky networks.
 
 use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use tokio::sync::watch;
@@ -73,15 +82,35 @@ struct TaskParts {
     app: tauri::AppHandle,
     staged_tx: watch::Sender<Option<String>>,
     installing: Arc<AtomicBool>,
+    updates_dir: PathBuf,
 }
 
-pub fn init(app: &tauri::AppHandle) -> Updater {
+/// The staged, fully verified update waiting for [`apply_pending_update`].
+/// Process-global (not `AppState`) because the apply site is the shutdown
+/// path in `src-tauri`, after local-api has already been torn down.
+struct PendingUpdate {
+    version: String,
+    archive: PathBuf,
+    update: tauri_plugin_updater::Update,
+}
+
+fn pending_slot() -> &'static Mutex<Option<PendingUpdate>> {
+    static PENDING: OnceLock<Mutex<Option<PendingUpdate>>> = OnceLock::new();
+    PENDING.get_or_init(|| Mutex::new(None))
+}
+
+pub fn init(app: &tauri::AppHandle, app_root: &Path) -> Updater {
     if !enabled(app) {
         return Updater {
             hooks: None,
             task: None,
         };
     }
+    let updates_dir = app_root.join("updates");
+    // A staged archive from a crashed previous session is stale by
+    // definition (its PendingUpdate handle died with the process); the loop
+    // below re-downloads if the channel still offers that version.
+    let _ = std::fs::remove_dir_all(&updates_dir);
     let (staged_tx, staged_rx) = watch::channel(None);
     let installing = Arc::new(AtomicBool::new(false));
     let restart_handle = app.clone();
@@ -96,7 +125,38 @@ pub fn init(app: &tauri::AppHandle) -> Updater {
             app: app.clone(),
             staged_tx,
             installing,
+            updates_dir,
         }),
+    }
+}
+
+/// Install the staged update, if any. Called from `shutdown::run_blocking`
+/// AFTER local-api has drained — the bundle swap happens when no Keychain
+/// writer is left to observe it, and since both the card's restart and a
+/// plain quit funnel through `ExitRequested`, this is also what makes
+/// install-on-quit true. Failures log and fall through: the process exits
+/// on the old version and the next boot re-downloads.
+pub fn apply_pending_update() {
+    let pending = pending_slot().lock().ok().and_then(|mut slot| slot.take());
+    let Some(pending) = pending else { return };
+    tracing::info!(version = %pending.version, "self-update: applying staged update before exit");
+    let bytes = match std::fs::read(&pending.archive) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            tracing::error!(%error, "self-update: staged archive unreadable; exiting without applying");
+            return;
+        }
+    };
+    // install() re-verifies the minisign signature over these exact bytes,
+    // so a staged file tampered with between stage and apply fails closed.
+    match pending.update.install(bytes) {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&pending.archive);
+            tracing::info!(version = %pending.version, "self-update: applied; relaunch runs the new version");
+        }
+        Err(error) => {
+            tracing::error!(%error, "self-update: apply failed; exiting on the current version");
+        }
     }
 }
 
@@ -203,18 +263,25 @@ async fn cycle(parts: &TaskParts, memo: &mut Option<FailureMemo>) {
     }
 
     tracing::info!(%candidate, "self-update: downloading");
-    // `installing` fences the restart route for the whole download+install:
-    // restarting mid-swap could re-exec a half-replaced bundle.
+    // `installing` fences the restart route for the whole download+stage:
+    // a restart mid-restage would race the pending-archive swap.
     parts.installing.store(true, Ordering::SeqCst);
-    let result = download_verify_install(&update, &candidate).await;
+    let result = download_verify_stage(&update, &candidate, &parts.updates_dir).await;
     parts.installing.store(false, Ordering::SeqCst);
 
     match result {
-        Ok(()) => {
+        Ok(archive) => {
             *memo = None;
+            if let Ok(mut slot) = pending_slot().lock() {
+                *slot = Some(PendingUpdate {
+                    version: candidate.clone(),
+                    archive,
+                    update: update.clone(),
+                });
+            }
             // Receivers only observe; send failure (no receivers) is fine.
             let _ = parts.staged_tx.send(Some(candidate.clone()));
-            tracing::info!(%candidate, "self-update: installed and staged; restart applies it");
+            tracing::info!(%candidate, "self-update: verified and staged; applies on restart or quit");
         }
         Err(error) => {
             let failure = record_failure(memo.take(), &candidate, Instant::now());
@@ -254,10 +321,11 @@ impl InstallError {
     }
 }
 
-async fn download_verify_install(
+async fn download_verify_stage(
     update: &tauri_plugin_updater::Update,
     expected_version: &str,
-) -> Result<(), InstallError> {
+    updates_dir: &Path,
+) -> Result<PathBuf, InstallError> {
     let bytes = tokio::time::timeout(DOWNLOAD_TIMEOUT, update.download(|_, _| {}, || {}))
         .await
         .map_err(|_| InstallError::new("download timed out".to_string()))?
@@ -274,18 +342,30 @@ async fn download_verify_install(
         .map_err(|error| InstallError::new(format!("bundle inspection failed: {error}")))?;
     if embedded != expected_version {
         return Err(InstallError::new(format!(
-            "version-pairing mismatch: manifest claims {expected_version} but the signed bundle is {embedded} — refusing to install"
+            "version-pairing mismatch: manifest claims {expected_version} but the signed bundle is {embedded} — refusing to stage"
         )));
     }
 
-    // install() is synchronous gunzip+untar+swap I/O — off the runtime
-    // worker, same rationale as setup.rs's TLS spawn_blocking.
-    let update = update.clone();
-    tauri::async_runtime::spawn_blocking(move || update.install(bytes))
+    // Stage to disk instead of installing NOW: swapping the bundle under the
+    // running process breaks macOS Keychain access (see the module doc).
+    // Sync fs on a blocking thread — ~80-100 MB write.
+    let dir = updates_dir.to_path_buf();
+    let version = expected_version.to_string();
+    tauri::async_runtime::spawn_blocking(move || stage_archive(&dir, &version, &bytes))
         .await
-        .map_err(|join| InstallError::new(format!("install task failed: {join}")))?
-        .map_err(|error| InstallError::new(format!("install failed: {error}")))?;
-    Ok(())
+        .map_err(|join| InstallError::new(format!("stage task failed: {join}")))?
+        .map_err(|error| InstallError::new(format!("staging failed: {error}")))
+}
+
+/// Clear-then-write: at most ONE pending archive ever exists, so a
+/// superseding version can never leave the old one behind and the apply
+/// path never has to disambiguate.
+fn stage_archive(dir: &Path, version: &str, bytes: &[u8]) -> std::io::Result<PathBuf> {
+    let _ = std::fs::remove_dir_all(dir);
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join(format!("pending-{version}.app.tar.gz"));
+    std::fs::write(&path, bytes)?;
+    Ok(path)
 }
 
 /// `CFBundleShortVersionString` of the top-level `.app` inside the updater
@@ -442,6 +522,19 @@ mod tests {
         assert_eq!(memo.attempts, 2);
         let memo = record_failure(Some(memo), "2.1.0", now);
         assert_eq!(memo.attempts, 1);
+    }
+
+    #[test]
+    fn stage_archive_is_clear_then_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let updates = dir.path().join("updates");
+        let first = stage_archive(&updates, "9.0.1", b"first").unwrap();
+        assert_eq!(std::fs::read(&first).unwrap(), b"first");
+        // A superseding stage removes the previous archive entirely.
+        let second = stage_archive(&updates, "9.0.2", b"second").unwrap();
+        assert!(!first.exists());
+        assert_eq!(std::fs::read(&second).unwrap(), b"second");
+        assert_eq!(std::fs::read_dir(&updates).unwrap().count(), 1);
     }
 
     #[test]

--- a/apps/native/src-tauri/tauri.conf.json5
+++ b/apps/native/src-tauri/tauri.conf.json5
@@ -98,6 +98,25 @@
       csp: "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost; img-src 'self' https: data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-src 'self'",
     },
   },
+  // Self-update. Safe to commit: the plugin never auto-checks (updates run
+  // only through src/updater.rs, which is release-gated), the pubkey alone
+  // triggers no build-time signing requirement, and updater ARTIFACTS are
+  // only produced by release-native.yaml's --config overlay
+  // (createUpdaterArtifacts) — committed here it would fail every secretless
+  // fork/PR build. INVARIANT: never add dangerousInsecureTransportProtocol —
+  // it is the only thing between "pinned pubkey over TLS" and a plaintext
+  // manifest fetch. The endpoint is the rolling `native-updates` prerelease
+  // (see release-native.yaml's channel-promotion step); the private key
+  // lives in the `native-release` GitHub environment, runbook in
+  // apps/native/README.md.
+  plugins: {
+    updater: {
+      pubkey: "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDdFNTlGMEQ0MzA4NzYzNzQKUldSMFk0Y3cxUEJaZm9MVTlLVEduVVVwRXVPOVluTlRIdGNTVmx0SGluN2M4WHIybVMvUXRsSzEK",
+      endpoints: [
+        "https://github.com/decocms/studio/releases/download/native-updates/latest.json",
+      ],
+    },
+  },
   bundle: {
     active: true,
     targets: ["app", "dmg"],


### PR DESCRIPTION
## Summary

Phase 2 of the native self-updater (stacked 2/3, on #5454): the Rust core. The packaged shell auto-checks/downloads/verifies updates in the background, stages them, and **installs only in the exit path** — the webview's existing drift card surfaces them with no new wire contract.

- **`src-tauri/src/updater.rs`**: 30-min interval task (check/download timeouts; per-version failure memo with 1h→24h exponential backoff so a persistently failing cycle can't re-download ~80 MB per tick). Before staging, the downloaded bundle's own `Info.plist` version must equal the manifest's — the manifest is an unsigned mutable asset writable by every `contents: write` workflow token, so this **version-pairing check is the v1 downgrade defense**. Signature failures get a distinct greppable error line.
- **Deferred install (found by a live signed-in spike)**: the original eager install swapped the bundle under the running process — and macOS validates a process's code identity against its binary ON DISK, so every subsequent Keychain operation failed (sign-in broke outright; rotated-refresh-token saves would fail silently until restart, risking a forced sign-out). The cycle now stages the verified archive under `<app_root>/updates/` (clear-then-write; stale archives cleaned at boot) and `shutdown::run_blocking` applies it after local-api drains, inside the take-once guard. Both the restart button and a plain quit funnel through `ExitRequested`, so install-on-quit holds and the Keychain-broken window is zero. `install()` re-verifies the signature over the staged bytes, so on-disk tampering fails closed.
- **Never runs outside real shipped builds** (three gates): release-only plugin registration; `init()` refuses under selftest or at the committed `0.1.0` placeholder (CI's `tauri-build`/boot-smoke build the RELEASE profile at 0.1.0 and must never pull prod over the CI bundle); `DECOCMS_DISABLE_AUTO_UPDATE` honored per cycle, warn-logged. `DECOCMS_UPDATE_CHECK_INTERVAL_SECS` (floored 15s) shortens the interval for spikes/runbook.
- **local-api** (one interface change spanning `state.rs` + `StartOptions` + `router.rs`): `UpdateHooks` (staged-version watch channel, `installing` fence, `request_restart` callback) rides `StartOptions.update`; the `/api/config` rewrite reports the staged version — so the drift card fires **iff a restart can actually help**; new guarded `POST /_local/update/restart` triggers `request_restart` (delivers `ExitRequested` ⇒ shutdown pipeline ⇒ deferred apply ⇒ respawn), 409ing when nothing is staged or a stage cycle is in flight.
- **Cask**: `auto_updates true` in the same change — otherwise `brew upgrade` downgrades self-updated installs.

## Testing

- `cargo test --workspace`: 850+ pass, including staged-vs-sentinel proxy rewrite (in-process stub upstream), all three distinct 409 branches + the 202→callback path, backoff/decision logic, clear-then-write staging, and the Info.plist pairing check (synthetic tar.gz with a decoy framework plist).
- `cargo clippy --workspace --all-targets`: clean. `cargo fmt`: applied.
- e2e (release binary over the wire): `update: restart` in the auth matrix (401/401/not-401) + explicit standalone-409 contract test.
- **Verified by two live local spikes** (full recipe in the plan doc's runbook): 9.0.0→9.0.1 over a localhost channel — check/download/verify/stage, `/api/config` reporting staged, 202 restart, graceful shutdown, **relaunch into the new version ~2s later** (tauri#13923 did not reproduce). The second, signed-in round is what caught the eager-install Keychain regression this PR now fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)