### PR TITLE
feat(web): restart-to-update in the version card on desktop builds

### DIFF
--- a/apps/web/src/components/version-check-dialog.tsx
+++ b/apps/web/src/components/version-check-dialog.tsx
@@ -1,9 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { Button } from "@deco/ui/components/button.tsx";
 import { RefreshCw01 } from "@untitledui/icons";
 import type { PublicConfig } from "@decocms/shared/config";
 import { AnnouncementCard } from "@/components/announcement-card";
+import { useIsDesktopApp } from "@/hooks/use-is-desktop-app";
 import { useT } from "@/i18n/use-t.ts";
 import { KEYS } from "@/lib/query-keys";
 
@@ -50,9 +51,32 @@ export function shouldShowVersionAnnouncement(
  * publicConfig query used for boot) and prompts a refresh once the deployed
  * server version drifts — consistently, across repeated polls — from this
  * bundle's build-time __STUDIO_VERSION__.
+ *
+ * Dual-purpose by design. In the browser, the server IS the truth and
+ * "Refresh now" reloads the newly deployed bundle. In the desktop app the
+ * Rust proxy pins config.version to the embedded bundle's version, so drift
+ * only ever appears when the shell's background updater has INSTALLED a new
+ * version on disk — a webview reload can't pick that up (the running binary
+ * serves its own embedded assets), so the button instead POSTs the local
+ * restart route, which applies the staged update through the graceful
+ * shutdown pipeline. A 409 means the staged state moved since the last poll
+ * (e.g. a newer update superseded it mid-download): re-enable the button and
+ * let the next poll re-converge — fetch resolves on 409, so the reset lives
+ * in the !res.ok throw, not in catch alone.
  */
 export function VersionCheckDialog() {
   const t = useT();
+  const isDesktopApp = useIsDesktopApp();
+  const restartMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/_local/update/restart", { method: "POST" });
+      if (!res.ok) {
+        throw new Error(`restart failed: ${res.status}`);
+      }
+      // 202 accepted: the app window is about to close and relaunch on the
+      // new version — leave the button disabled for the page's short rest.
+    },
+  });
   const { data: serverVersion, dataUpdatedAt } = useQuery({
     queryKey: KEYS.appVersionCheck(),
     queryFn: async () => {
@@ -89,7 +113,11 @@ export function VersionCheckDialog() {
       dismissLabel={t("announcements.version.dismiss")}
       eyebrow={t("announcements.version.eyebrow")}
       title={t("announcements.version.title")}
-      description={t("announcements.version.description")}
+      description={t(
+        isDesktopApp
+          ? "announcements.version.descriptionNative"
+          : "announcements.version.description",
+      )}
       icon={<RefreshCw01 size={16} />}
       tone="system"
       onDismiss={() => setDismissedVersion(drift.version)}
@@ -97,8 +125,18 @@ export function VersionCheckDialog() {
         version: __STUDIO_VERSION__,
       })}
       actions={
-        <Button size="sm" onClick={() => window.location.reload()}>
-          {t("announcements.version.refresh")}
+        <Button
+          size="sm"
+          disabled={restartMutation.isPending}
+          onClick={() =>
+            isDesktopApp ? restartMutation.mutate() : window.location.reload()
+          }
+        >
+          {t(
+            isDesktopApp
+              ? "announcements.version.restart"
+              : "announcements.version.refresh",
+          )}
           <RefreshCw01 size={14} />
         </Button>
       }

--- a/apps/web/src/components/version-check-dialog.tsx
+++ b/apps/web/src/components/version-check-dialog.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { Button } from "@deco/ui/components/button.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
 import { RefreshCw01 } from "@untitledui/icons";
 import type { PublicConfig } from "@decocms/shared/config";
 import { AnnouncementCard } from "@/components/announcement-card";
@@ -105,6 +106,21 @@ export function VersionCheckDialog() {
 
   const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
 
+  // Locked through SUCCESS, not just isPending: after the 202 the app drains,
+  // applies the staged update, and relaunches — a few seconds during which
+  // this page is already dying. Re-enabling on success would offer a second
+  // click to a doomed window. Only an error (409 staged-state race, network
+  // blip) re-enables, letting the next poll re-converge the card.
+  const restarting =
+    isDesktopApp && (restartMutation.isPending || restartMutation.isSuccess);
+  const handleAction = () =>
+    isDesktopApp ? restartMutation.mutate() : window.location.reload();
+  const actionLabelKey = isDesktopApp
+    ? restarting
+      ? "announcements.version.restarting"
+      : "announcements.version.restart"
+    : ("announcements.version.refresh" as const);
+
   if (!shouldShowVersionAnnouncement(drift, dismissedVersion)) return null;
 
   return (
@@ -125,19 +141,9 @@ export function VersionCheckDialog() {
         version: __STUDIO_VERSION__,
       })}
       actions={
-        <Button
-          size="sm"
-          disabled={restartMutation.isPending}
-          onClick={() =>
-            isDesktopApp ? restartMutation.mutate() : window.location.reload()
-          }
-        >
-          {t(
-            isDesktopApp
-              ? "announcements.version.restart"
-              : "announcements.version.refresh",
-          )}
-          <RefreshCw01 size={14} />
+        <Button size="sm" disabled={restarting} onClick={handleAction}>
+          {t(actionLabelKey)}
+          <RefreshCw01 size={14} className={cn(restarting && "animate-spin")} />
         </Button>
       }
     />

--- a/apps/web/src/i18n/en/announcements.ts
+++ b/apps/web/src/i18n/en/announcements.ts
@@ -13,6 +13,9 @@ export const announcements = {
   "announcements.version.title": "A new version is ready",
   "announcements.version.description":
     "Refresh to load the latest Studio updates.",
+  "announcements.version.descriptionNative":
+    "An update is installed and ready. Restart the app to start using it.",
   "announcements.version.currentSession": "Current session · {version}",
   "announcements.version.refresh": "Refresh now",
+  "announcements.version.restart": "Restart to update",
 } as const;

--- a/apps/web/src/i18n/en/announcements.ts
+++ b/apps/web/src/i18n/en/announcements.ts
@@ -14,7 +14,7 @@ export const announcements = {
   "announcements.version.description":
     "Refresh to load the latest Studio updates.",
   "announcements.version.descriptionNative":
-    "An update is installed and ready. Restart the app to start using it.",
+    "An update is ready. Restart the app to finish installing it.",
   "announcements.version.currentSession": "Current session · {version}",
   "announcements.version.refresh": "Refresh now",
   "announcements.version.restart": "Restart to update",

--- a/apps/web/src/i18n/en/announcements.ts
+++ b/apps/web/src/i18n/en/announcements.ts
@@ -18,4 +18,5 @@ export const announcements = {
   "announcements.version.currentSession": "Current session · {version}",
   "announcements.version.refresh": "Refresh now",
   "announcements.version.restart": "Restart to update",
+  "announcements.version.restarting": "Restarting…",
 } as const;

--- a/apps/web/src/i18n/en/common.ts
+++ b/apps/web/src/i18n/en/common.ts
@@ -276,10 +276,6 @@ export const common = {
     "Failed to start chat. Please try again.",
   "common.useStartThreadFromPrompt.mcpClientNotAvailable":
     "MCP client not available",
-  "common.versionCheckDialog.available": "A new version is available",
-  "common.versionCheckDialog.outdatedVersion":
-    "You're viewing an outdated version of this page. Refresh to get the latest updates.",
-  "common.versionCheckDialog.refresh": "Refresh",
   "common.createAgentDropdown.createFromScratch": "Create from scratch",
   "common.createAgentDropdown.importFromGitHub": "Import from GitHub",
   "common.createAgentDropdown.importFromDeco": "Import from deco.cx",

--- a/apps/web/src/i18n/pt-br/announcements.ts
+++ b/apps/web/src/i18n/pt-br/announcements.ts
@@ -16,7 +16,7 @@ export const announcements = {
   "announcements.version.description":
     "Atualize a página para carregar as novidades do Studio.",
   "announcements.version.descriptionNative":
-    "Uma atualização foi instalada e está pronta. Reinicie o aplicativo para começar a usá-la.",
+    "Uma atualização está pronta. Reinicie o aplicativo para concluir a instalação.",
   "announcements.version.currentSession": "Sessão atual · {version}",
   "announcements.version.refresh": "Atualizar agora",
   "announcements.version.restart": "Reiniciar para atualizar",

--- a/apps/web/src/i18n/pt-br/announcements.ts
+++ b/apps/web/src/i18n/pt-br/announcements.ts
@@ -15,6 +15,9 @@ export const announcements = {
   "announcements.version.title": "Uma nova versão está pronta",
   "announcements.version.description":
     "Atualize a página para carregar as novidades do Studio.",
+  "announcements.version.descriptionNative":
+    "Uma atualização foi instalada e está pronta. Reinicie o aplicativo para começar a usá-la.",
   "announcements.version.currentSession": "Sessão atual · {version}",
   "announcements.version.refresh": "Atualizar agora",
+  "announcements.version.restart": "Reiniciar para atualizar",
 } satisfies Record<keyof typeof announcementsEn, string>;

--- a/apps/web/src/i18n/pt-br/announcements.ts
+++ b/apps/web/src/i18n/pt-br/announcements.ts
@@ -20,4 +20,5 @@ export const announcements = {
   "announcements.version.currentSession": "Sessão atual · {version}",
   "announcements.version.refresh": "Atualizar agora",
   "announcements.version.restart": "Reiniciar para atualizar",
+  "announcements.version.restarting": "Reiniciando…",
 } satisfies Record<keyof typeof announcementsEn, string>;

--- a/apps/web/src/i18n/pt-br/common.ts
+++ b/apps/web/src/i18n/pt-br/common.ts
@@ -286,10 +286,6 @@ export const common = {
     "Falha ao iniciar o chat. Tente novamente.",
   "common.useStartThreadFromPrompt.mcpClientNotAvailable":
     "Cliente MCP não disponível",
-  "common.versionCheckDialog.available": "Uma nova versão está disponível",
-  "common.versionCheckDialog.outdatedVersion":
-    "Você está visualizando uma versão desatualizada desta página. Atualize para obter as últimas atualizações.",
-  "common.versionCheckDialog.refresh": "Atualizar",
   "common.createAgentDropdown.createFromScratch": "Criar do zero",
   "common.createAgentDropdown.importFromGitHub": "Importar do GitHub",
   "common.createAgentDropdown.importFromDeco": "Importar do deco.cx",


### PR DESCRIPTION
## What is this contribution about?

Phase 3 of the native self-updater (stacked 3/3, on #5455): the only UI change. The existing version-drift card becomes dual-purpose:

- Browser: unchanged — "Refresh now" reloads the freshly deployed bundle.
- Desktop (`useIsDesktopApp()`): the button POSTs `/_local/update/restart`, applying the update the shell staged (a webview reload can never pick that up — the running binary serves its own embedded assets). Copy: "An update is ready. Restart the app to finish installing it." / "Restart to update" (en + pt-br, compile-enforced mirror).
- The POST rides `useMutation` with an explicit `!res.ok` throw — `fetch` **resolves** on the 409 staged-state races, so that check (not `catch`) re-enables the button and lets the next poll re-converge.
- Restart affordance: while in flight AND after the 202 the button shows "Restarting…" with a spinning icon and stays disabled — the app is draining/applying/relaunching, so re-enabling on success would offer a second click to a dying window. Only an error re-enables.
- Deletes the orphaned `common.versionCheckDialog.*` keys (en + pt-br) — zero references outside the dictionaries.

## Screenshots/Demonstration

Validated live in a signed-in spike (9.0.0 → 9.0.1 over a localhost channel): card rendered, button clicked, spinner shown, app relaunched into the new version ~2 s later. The card's layout is unchanged — only strings and the button's action differ, and only in the desktop build.

## How to Test

1. `bun run check` (all workspaces — proves the pt-br mirror), `bun run lint`, `bun test src/components/version-check-dialog.test.ts` (apps/web).
2. Full end-to-end: the local spike recipe in `apps/native/docs/native-updater-plan.md` → "Manual test — executable runbook".
3. Browser regression: the card still shows "Refresh now" and reloads (unchanged path).

## Migration Notes

None — no storage, no API contract changes. Two new i18n keys + three deleted dead ones.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “restart to update” to the version card for desktop builds with a clearer action state. In the browser it still reloads; in the desktop app it restarts the shell to apply a staged update and reflects that the update is ready, not yet installed.

- **New Features**
  - Dual-purpose card: detects desktop via `useIsDesktopApp`; button POSTs `/_local/update/restart` with `useMutation`, swaps label to “Restarting…”, spins the icon, and stays disabled through success. On non-OK (e.g. 409), throws to re-enable and let the next poll converge.
  - i18n: adds `announcements.version.descriptionNative`, `announcements.version.restart`, and `announcements.version.restarting` in `en` and `pt-br`, clarifying the update is ready and needs a restart to finish installing.

- **Refactors**
  - Removes orphaned `common.versionCheckDialog.*` keys.

<sup>Written for commit 820395a11aeace8802af9ec0c8057aadcf6c703f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


