### PR TITLE
fix(native): detect the package manager from the checkout when the config names none

### DIFF
--- a/apps/native/crates/local-api/src/config/store.rs
+++ b/apps/native/crates/local-api/src/config/store.rs
@@ -11,8 +11,9 @@
 //! Every OTHER family only ever calls the read-only accessors
 //! (`snapshot()`, `is_configured()`) — for `/health`'s `configured` field,
 //! the exec/scripts family's "409 when no package manager is configured
-//! yet" gate, and git's "409 not-ready" gate. Only `routes/config.rs` calls
-//! `patch()`.
+//! yet" gate, and git's "409 not-ready" gate. `patch()` has three callers:
+//! `routes/config.rs` (the wire), `SandboxManager::apply_config` (dispatch
+//! hints), and `setup/detect_runtime.rs` (workdir-detected workload).
 //!
 //! Byte-parity target: `packages/sandbox/daemon/config-store/` (`classify.ts`
 //! precedence, `merge.ts` deep-merge, `validate.ts` field validation,

--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
@@ -39,6 +39,7 @@ use serde_json::{json, Value};
 use crate::error::ApiError;
 use crate::routes::upstream;
 use crate::sandbox::GitSandboxConfig;
+use crate::setup::detect_runtime::runtime_for_package_manager;
 use crate::state::AppState;
 
 /// The preview listener's port, published by [`crate::start`] once it binds.
@@ -165,18 +166,6 @@ pub(crate) fn branch_for_virtual_mcp(state: &AppState, virtual_mcp_id: &str) -> 
         fallback.get_or_insert(branch);
     }
     fallback.unwrap_or_else(|| EPHEMERAL_BRANCH.to_string())
-}
-
-/// `metadata.runtime.selected` names a package manager; `application.runtime`
-/// wants the JS runtime that drives it. Byte-parity with
-/// `packages/shared/src/runtime-defaults.ts::PACKAGE_MANAGER_CONFIG[pm].runtime`.
-fn runtime_for_package_manager(package_manager: &str) -> Option<&'static str> {
-    match package_manager {
-        "npm" | "pnpm" | "yarn" => Some("node"),
-        "bun" => Some("bun"),
-        "deno" => Some("deno"),
-        _ => None,
-    }
 }
 
 /// Build the sandbox config from a virtual MCP's `metadata`, or `None` when it

--- a/apps/native/crates/local-api/src/setup/detect_runtime.rs
+++ b/apps/native/crates/local-api/src/setup/detect_runtime.rs
@@ -1,0 +1,253 @@
+//! Workdir-based package-manager detection for sandboxes whose config names
+//! no `application.packageManager`.
+//!
+//! "Import from GitHub" deliberately writes no `metadata.runtime` — it relies
+//! on the control plane's `SANDBOX_START` lockfile probe
+//! (`apps/api/src/shared/github-runtime-detect.ts`). The desktop app never
+//! calls that tool: `routes/intercept/sandbox_lifecycle.rs` answers
+//! `SANDBOX_START` locally from `metadata.runtime.selected` alone, so every
+//! fresh import used to come up clone-only and die in `setup/dev.rs` with
+//! "no package manager configured". The desktop has something the remote
+//! probe never had — the cloned repository on disk — so when the config is
+//! silent, sniff the checkout instead of failing.
+//!
+//! [`DETECTION_ORDER`] mirrors the server probe's `LOCKFILES` list
+//! (first match wins, bare `package.json` defaults to bun) so both providers
+//! agree on the runtime for the same repository. Detection only ever FILLS AN
+//! ABSENCE: a `packageManager` already present in the config — user-pinned in
+//! the VM's runtime card, or persisted from an earlier run — is never
+//! overridden.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+
+use super::SetupOrchestrator;
+use crate::log_store::app_key;
+
+/// Byte-parity with `github-runtime-detect.ts::LOCKFILES` — ordered,
+/// first match wins.
+const DETECTION_ORDER: [(&str, &str); 8] = [
+    ("deno.json", "deno"),
+    ("deno.jsonc", "deno"),
+    ("bun.lock", "bun"),
+    ("bunfig.toml", "bun"),
+    ("pnpm-lock.yaml", "pnpm"),
+    ("yarn.lock", "yarn"),
+    ("package-lock.json", "npm"),
+    ("package.json", "bun"),
+];
+
+/// `metadata.runtime.selected` names a package manager; `application.runtime`
+/// wants the JS runtime that drives it. Byte-parity with
+/// `packages/shared/src/runtime-defaults.ts::PACKAGE_MANAGER_CONFIG[pm].runtime`.
+pub(crate) fn runtime_for_package_manager(package_manager: &str) -> Option<&'static str> {
+    match package_manager {
+        "npm" | "pnpm" | "yarn" => Some("node"),
+        "bun" => Some("bun"),
+        "deno" => Some("deno"),
+        _ => None,
+    }
+}
+
+/// First [`DETECTION_ORDER`] marker present at the repository root, or `None`
+/// for a repo no supported package manager claims (clone-only stays
+/// clone-only).
+fn detect_from_workdir(repo_dir: &Path) -> Option<(&'static str, &'static str)> {
+    DETECTION_ORDER
+        .iter()
+        .find(|(marker, _)| repo_dir.join(marker).is_file())
+        .map(|&(marker, pm)| (pm, marker))
+}
+
+/// Returns `config` with `application.packageManager.name` guaranteed-if-
+/// detectable: when the config already names one, or the workdir names none,
+/// the input is returned unchanged; otherwise the orchestrator's
+/// [`crate::config::ConfigStore`] is patched with the detected package
+/// manager + runtime and the refreshed config is returned.
+///
+/// Runs inside the setup pipeline (install/dev), which is serial per
+/// sandbox, so the patch lands before either step reads the config — no
+/// coordination with `SandboxManager` is needed. The patch is deliberately
+/// NOT written back to the sandbox registry row or sidecar: detection is a
+/// pure function of the checkout, so a restarted process simply re-detects
+/// after clone, and a sparse durable record keeps meaning "nothing pinned".
+pub(super) async fn ensure_package_manager(orch: &Arc<SetupOrchestrator>, config: &Value) -> Value {
+    let configured = crate::config::get_str(config, &["application", "packageManager", "name"])
+        .filter(|name| !name.is_empty());
+    if configured.is_some() {
+        return config.clone();
+    }
+
+    let Some((pm, marker)) = detect_from_workdir(&orch.repo_dir) else {
+        return config.clone();
+    };
+
+    let mut application = json!({ "packageManager": { "name": pm } });
+    if let Some(runtime) = runtime_for_package_manager(pm) {
+        application["runtime"] = json!(runtime);
+    }
+    if let Err(error) = orch.config.patch(json!({ "application": application })) {
+        // A failed patch (e.g. racing identity conflict) must not fail the
+        // step — the caller just proceeds with the config it had, and
+        // `dev::run` still diagnoses the missing package manager.
+        emit(
+            orch,
+            &format!(
+                "[runtime] detected '{pm}' but could not apply it: {}\r\n",
+                error.body
+            ),
+        )
+        .await;
+        return config.clone();
+    }
+
+    emit(
+        orch,
+        &format!("[runtime] no package manager configured; detected '{pm}' from {marker}\r\n"),
+    )
+    .await;
+
+    orch.current_config().unwrap_or_else(|| config.clone())
+}
+
+/// Appends to the combined `"setup"` transcript + live `"log"` frame — the
+/// same untracked-probe path `clone.rs::emit_chunk` uses for `task_id: None`
+/// (detection has no registered task of its own to attribute output to).
+async fn emit(orch: &Arc<SetupOrchestrator>, text: &str) {
+    orch.tasks.logs().append(&app_key("setup"), text).await;
+    orch.broadcaster
+        .emit("log", json!({ "source": "setup", "data": text }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ConfigStore;
+    use crate::events::Broadcaster;
+    use crate::log_store::LogStore;
+    use crate::tasks::TaskRegistry;
+    use std::path::PathBuf;
+
+    fn orchestrator(repo_dir: PathBuf, root: &Path) -> Arc<SetupOrchestrator> {
+        let logs = Arc::new(LogStore::new(root.join("logs")));
+        SetupOrchestrator::new(
+            repo_dir,
+            root.to_path_buf(),
+            Arc::new(ConfigStore::new()),
+            Arc::new(TaskRegistry::new(logs)),
+            Arc::new(Broadcaster::new()),
+        )
+    }
+
+    fn repo_with(files: &[&str]) -> (tempfile::TempDir, PathBuf) {
+        let root = tempfile::tempdir().unwrap();
+        let repo = root.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        for file in files {
+            std::fs::write(repo.join(file), "{}").unwrap();
+        }
+        (root, repo)
+    }
+
+    #[test]
+    fn detection_order_is_first_match_wins() {
+        let (_root, repo) = repo_with(&["package.json", "deno.json"]);
+        assert_eq!(detect_from_workdir(&repo), Some(("deno", "deno.json")));
+
+        let (_root, repo) = repo_with(&["yarn.lock", "bun.lock"]);
+        assert_eq!(detect_from_workdir(&repo), Some(("bun", "bun.lock")));
+
+        let (_root, repo) = repo_with(&["package-lock.json", "package.json"]);
+        assert_eq!(
+            detect_from_workdir(&repo),
+            Some(("npm", "package-lock.json"))
+        );
+    }
+
+    #[test]
+    fn bare_package_json_defaults_to_bun() {
+        let (_root, repo) = repo_with(&["package.json"]);
+        assert_eq!(detect_from_workdir(&repo), Some(("bun", "package.json")));
+    }
+
+    #[test]
+    fn empty_repo_detects_nothing() {
+        let (_root, repo) = repo_with(&[]);
+        assert_eq!(detect_from_workdir(&repo), None);
+    }
+
+    #[test]
+    fn directories_named_like_markers_do_not_count() {
+        let (_root, repo) = repo_with(&[]);
+        std::fs::create_dir_all(repo.join("deno.json")).unwrap();
+        assert_eq!(detect_from_workdir(&repo), None);
+    }
+
+    #[tokio::test]
+    async fn fills_missing_package_manager_and_runtime_from_the_workdir() {
+        let (root, repo) = repo_with(&["pnpm-lock.yaml"]);
+        let orch = orchestrator(repo, root.path());
+        orch.config
+            .patch(json!({ "git": { "repository": { "cloneUrl": "https://example.com/r.git" } } }))
+            .unwrap();
+        let config = orch.current_config().unwrap();
+
+        let enriched = ensure_package_manager(&orch, &config).await;
+
+        assert_eq!(
+            crate::config::get_str(&enriched, &["application", "packageManager", "name"]),
+            Some("pnpm")
+        );
+        assert_eq!(
+            crate::config::get_str(&enriched, &["application", "runtime"]),
+            Some("node")
+        );
+        // The orchestrator's own store carries the patch, so install/dev
+        // re-reading current_config() see the same thing.
+        assert_eq!(
+            crate::config::get_str(
+                &orch.current_config().unwrap(),
+                &["application", "packageManager", "name"]
+            ),
+            Some("pnpm")
+        );
+    }
+
+    #[tokio::test]
+    async fn a_configured_package_manager_is_never_overridden() {
+        let (root, repo) = repo_with(&["deno.json"]);
+        let orch = orchestrator(repo, root.path());
+        orch.config
+            .patch(json!({
+                "git": { "repository": { "cloneUrl": "https://example.com/r.git" } },
+                "application": { "packageManager": { "name": "yarn" }, "runtime": "node" },
+            }))
+            .unwrap();
+        let config = orch.current_config().unwrap();
+
+        let enriched = ensure_package_manager(&orch, &config).await;
+
+        assert_eq!(
+            crate::config::get_str(&enriched, &["application", "packageManager", "name"]),
+            Some("yarn")
+        );
+    }
+
+    #[tokio::test]
+    async fn an_undetectable_repo_leaves_the_config_untouched() {
+        let (root, repo) = repo_with(&[]);
+        let orch = orchestrator(repo, root.path());
+        orch.config
+            .patch(json!({ "git": { "repository": { "cloneUrl": "https://example.com/r.git" } } }))
+            .unwrap();
+        let config = orch.current_config().unwrap();
+
+        let enriched = ensure_package_manager(&orch, &config).await;
+
+        assert!(
+            crate::config::get_str(&enriched, &["application", "packageManager", "name"]).is_none()
+        );
+    }
+}

--- a/apps/native/crates/local-api/src/setup/detect_runtime.rs
+++ b/apps/native/crates/local-api/src/setup/detect_runtime.rs
@@ -65,28 +65,73 @@ fn detect_from_workdir(repo_dir: &Path) -> Option<(&'static str, &'static str)> 
 /// detectable: when the config already names one, or the workdir names none,
 /// the input is returned unchanged; otherwise the orchestrator's
 /// [`crate::config::ConfigStore`] is patched with the detected package
-/// manager + runtime and the refreshed config is returned.
+/// manager (+ runtime, unless one is already pinned) and the refreshed
+/// config is returned.
 ///
-/// Runs inside the setup pipeline (install/dev), which is serial per
-/// sandbox, so the patch lands before either step reads the config — no
-/// coordination with `SandboxManager` is needed. The patch is deliberately
-/// NOT written back to the sandbox registry row or sidecar: detection is a
-/// pure function of the checkout, so a restarted process simply re-detects
-/// after clone, and a sparse durable record keeps meaning "nothing pinned".
+/// The pipeline's own steps are serial per sandbox, but the workdir's WRITER
+/// is not always on that worker — `SandboxManager::ensure` runs the clone
+/// inline — so detection refuses to sniff while an acquisition task is still
+/// running (see [`acquisition_in_flight`]). The patch is deliberately NOT
+/// written back to the sandbox registry row or sidecar: detection is a pure
+/// function of the checkout, so a restarted process simply re-detects after
+/// clone. (Note the registry's own semantics cut the other way: once a USER
+/// pin has been persisted there, `merge_durable_config` resurrects it on
+/// every later sparse dispatch, so clearing a pin never returns a sandbox to
+/// auto-detection — a pre-existing gap this module inherits rather than
+/// fixes.)
 pub(super) async fn ensure_package_manager(orch: &Arc<SetupOrchestrator>, config: &Value) -> Value {
-    let configured = crate::config::get_str(config, &["application", "packageManager", "name"])
+    // Freshest snapshot, not the caller's argument: the caller's value was
+    // read when the step was scheduled, and a user pin applied since then
+    // must win. (The store has no compare-and-swap, so a pin landing between
+    // this read and the patch below can still lose — but the window is a few
+    // file stats wide instead of a whole pipeline step.)
+    let config = orch.current_config().unwrap_or_else(|| config.clone());
+    let configured = crate::config::get_str(&config, &["application", "packageManager", "name"])
         .filter(|name| !name.is_empty());
     if configured.is_some() {
-        return config.clone();
+        return config;
     }
 
-    let Some((pm, marker)) = detect_from_workdir(&orch.repo_dir) else {
-        return config.clone();
+    // Only a git-backed sandbox has a checkout worth sniffing. A blank
+    // sandbox's repo_dir can still contain leftover files from an earlier
+    // tenancy of a shared directory — never promote those into a workload.
+    if crate::config::get_str(&config, &["git", "repository", "cloneUrl"])
+        .filter(|url| !url.is_empty())
+        .is_none()
+    {
+        return config;
+    }
+
+    // A clone/checkout in flight means repo_dir is mid-population: marker
+    // files appear one by one (git writes the index in sorted order, so
+    // `package.json` lands well before `pnpm-lock.yaml`), and a sniff now
+    // could latch the wrong manager until restart — detection only ever
+    // fills an absence. The acquiring task is finalized before Install/Start
+    // resume, so the pipeline's own steps never find this gate closed.
+    if acquisition_in_flight(orch) {
+        return config;
+    }
+
+    // Detect where install/dev will actually run: a configured
+    // `packageManager.path` scopes both to a subdirectory. An invalid path
+    // means those steps are about to fail with their own diagnostic — don't
+    // guess a workload from the wrong directory in the meantime.
+    let root = match super::install::pm_root(&config, &orch.repo_dir).await {
+        Ok(root) => root,
+        Err(_) => return config,
+    };
+    let Some((pm, marker)) = detect_from_workdir(&root) else {
+        return config;
     };
 
     let mut application = json!({ "packageManager": { "name": pm } });
-    if let Some(runtime) = runtime_for_package_manager(pm) {
-        application["runtime"] = json!(runtime);
+    let runtime_pinned = crate::config::get_str(&config, &["application", "runtime"])
+        .filter(|runtime| !runtime.is_empty())
+        .is_some();
+    if !runtime_pinned {
+        if let Some(runtime) = runtime_for_package_manager(pm) {
+            application["runtime"] = json!(runtime);
+        }
     }
     if let Err(error) = orch.config.patch(json!({ "application": application })) {
         // A failed patch (e.g. racing identity conflict) must not fail the
@@ -100,7 +145,7 @@ pub(super) async fn ensure_package_manager(orch: &Arc<SetupOrchestrator>, config
             ),
         )
         .await;
-        return config.clone();
+        return config;
     }
 
     emit(
@@ -109,7 +154,20 @@ pub(super) async fn ensure_package_manager(orch: &Arc<SetupOrchestrator>, config
     )
     .await;
 
-    orch.current_config().unwrap_or_else(|| config.clone())
+    orch.current_config().unwrap_or(config)
+}
+
+/// A running clone/checkout task means the workdir is being populated right
+/// now. Command strings are the ones `setup/clone.rs` registers
+/// (`"git clone <url>"` / `"git checkout <branch>"`) — matched on the prefix
+/// so a URL or branch never confuses the check.
+fn acquisition_in_flight(orch: &Arc<SetupOrchestrator>) -> bool {
+    orch.tasks
+        .list(Some(&[crate::tasks::TaskStatus::Running]))
+        .iter()
+        .any(|task| {
+            task.command.starts_with("git clone ") || task.command.starts_with("git checkout ")
+        })
 }
 
 /// Appends to the combined `"setup"` transcript + live `"log"` frame — the
@@ -232,6 +290,110 @@ mod tests {
         assert_eq!(
             crate::config::get_str(&enriched, &["application", "packageManager", "name"]),
             Some("yarn")
+        );
+    }
+
+    #[tokio::test]
+    async fn detection_waits_out_a_running_acquisition() {
+        use crate::tasks::{now_ms, TaskEntry, TaskStatus, TaskSummary};
+
+        let (root, repo) = repo_with(&["bun.lock"]);
+        let orch = orchestrator(repo, root.path());
+        orch.config
+            .patch(json!({ "git": { "repository": { "cloneUrl": "https://example.com/r.git" } } }))
+            .unwrap();
+        orch.tasks.insert(TaskEntry::new(
+            TaskSummary {
+                id: "clone-task".to_string(),
+                command: "git clone https://example.com/r.git".to_string(),
+                status: TaskStatus::Running,
+                exit_code: None,
+                started_at: now_ms(),
+                finished_at: None,
+                timed_out: false,
+                truncated: false,
+                log_name: Some("setup".to_string()),
+                intentional: None,
+            },
+            None,
+        ));
+        let config = orch.current_config().unwrap();
+
+        let enriched = ensure_package_manager(&orch, &config).await;
+
+        // A half-populated checkout must never be sniffed: the clone task is
+        // still running, so the config stays workload-less until it isn't.
+        assert!(
+            crate::config::get_str(&enriched, &["application", "packageManager", "name"]).is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn detection_respects_a_scoped_package_manager_path() {
+        let (root, repo) = repo_with(&["package.json"]);
+        std::fs::create_dir_all(repo.join("web")).unwrap();
+        std::fs::write(repo.join("web/deno.json"), "{}").unwrap();
+        let orch = orchestrator(repo, root.path());
+        orch.config
+            .patch(json!({
+                "git": { "repository": { "cloneUrl": "https://example.com/r.git" } },
+                "application": { "packageManager": { "path": "web" } },
+            }))
+            .unwrap();
+        let config = orch.current_config().unwrap();
+
+        let enriched = ensure_package_manager(&orch, &config).await;
+
+        // Install/dev run in `web/`, so detection must read `web/deno.json`,
+        // not the repo root's bare package.json (which would say bun).
+        assert_eq!(
+            crate::config::get_str(&enriched, &["application", "packageManager", "name"]),
+            Some("deno")
+        );
+        assert_eq!(
+            crate::config::get_str(&enriched, &["application", "runtime"]),
+            Some("deno")
+        );
+    }
+
+    #[tokio::test]
+    async fn a_blank_sandbox_never_promotes_leftover_files() {
+        let (root, repo) = repo_with(&["package.json"]);
+        let orch = orchestrator(repo, root.path());
+        let config = json!({ "operator": { "userName": "Op", "userEmail": "op@example.com" } });
+
+        let enriched = ensure_package_manager(&orch, &config).await;
+
+        // No git.repository -> nothing was cloned here; whatever files sit in
+        // the directory belong to no workload this sandbox declared.
+        assert!(
+            crate::config::get_str(&enriched, &["application", "packageManager", "name"]).is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pinned_runtime_survives_detection() {
+        let (root, repo) = repo_with(&["bun.lock"]);
+        let orch = orchestrator(repo, root.path());
+        orch.config
+            .patch(json!({
+                "git": { "repository": { "cloneUrl": "https://example.com/r.git" } },
+                "application": { "runtime": "node" },
+            }))
+            .unwrap();
+        let config = orch.current_config().unwrap();
+
+        let enriched = ensure_package_manager(&orch, &config).await;
+
+        assert_eq!(
+            crate::config::get_str(&enriched, &["application", "packageManager", "name"]),
+            Some("bun")
+        );
+        // Only the ABSENT field is filled: the explicitly configured runtime
+        // is not rewritten to bun.lock's implied runtime.
+        assert_eq!(
+            crate::config::get_str(&enriched, &["application", "runtime"]),
+            Some("node")
         );
     }
 

--- a/apps/native/crates/local-api/src/setup/dev.rs
+++ b/apps/native/crates/local-api/src/setup/dev.rs
@@ -839,6 +839,52 @@ mod tests {
         assert!(msg.contains("test"));
     }
 
+    #[tokio::test]
+    async fn start_only_resume_detects_installs_then_diagnoses_the_missing_starter() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        // Detectable (package-lock -> npm) but with NO dev/start script: the
+        // Start-only path must detect, run the Install it skipped, and then
+        // fail with the missing-STARTER diagnostic — never the
+        // missing-package-manager one this change retires for detectable
+        // repos. No dev server spawns, so the test stays deterministic.
+        std::fs::write(repo.join("package.json"), r#"{"name":"x"}"#).unwrap();
+        std::fs::write(repo.join("package-lock.json"), "{}").unwrap();
+        let logs = Arc::new(crate::log_store::LogStore::new(dir.path().join("logs")));
+        let orch = SetupOrchestrator::new(
+            repo.clone(),
+            repo.clone(),
+            Arc::new(crate::config::ConfigStore::new()),
+            Arc::new(crate::tasks::TaskRegistry::new(logs)),
+            Arc::new(crate::events::Broadcaster::new()),
+        );
+        orch.config
+            .patch(serde_json::json!({
+                "git": { "repository": { "cloneUrl": "https://example.com/r.git" } }
+            }))
+            .unwrap();
+        let config = orch.current_config().unwrap();
+
+        run(&orch, &config).await;
+
+        let lifecycle = orch.lifecycle_snapshot();
+        assert_eq!(lifecycle["phase"], "start-failed", "{lifecycle:?}");
+        let error = lifecycle["error"].as_str().unwrap();
+        assert!(
+            !error.contains("no package manager configured"),
+            "a detectable repo must get past the package-manager gate: {error:?}"
+        );
+        assert_eq!(
+            get_str(
+                &orch.current_config().unwrap(),
+                &["application", "packageManager", "name"]
+            ),
+            Some("npm"),
+            "detection ran on the Start-only path"
+        );
+    }
+
     #[test]
     fn start_only_discovery_restores_the_scripts_snapshot() {
         let dir = tempfile::tempdir().unwrap();

--- a/apps/native/crates/local-api/src/setup/dev.rs
+++ b/apps/native/crates/local-api/src/setup/dev.rs
@@ -105,11 +105,29 @@ use crate::config::get_str;
 /// (byte-parity with `diagnoseNoStartCommand`) and returns without spawning
 /// anything.
 pub(super) async fn run(orch: &Arc<SetupOrchestrator>, config: &Value) {
+    // A Start-only resume (no-op config transition) skips Install, so a
+    // repository whose package manager was never configured arrives here
+    // undetected. Fill the absence from the checkout, and when that is what
+    // named the manager, run the skipped install before starting — the
+    // detected manager's dependencies were never fetched.
+    let had_pm = get_str(config, &["application", "packageManager", "name"])
+        .filter(|s| !s.is_empty())
+        .is_some();
+    let enriched = super::detect_runtime::ensure_package_manager(orch, config).await;
+    if !had_pm
+        && get_str(&enriched, &["application", "packageManager", "name"])
+            .filter(|s| !s.is_empty())
+            .is_some()
+        && !super::install::run(orch, &enriched).await
+    {
+        return;
+    }
+    let config = &enriched;
     let Some(pm) =
         get_str(config, &["application", "packageManager", "name"]).filter(|s| !s.is_empty())
     else {
         orch.transition_lifecycle(super::start_failed(
-            "no package manager configured — update the VM config to enable a dev server",
+            "no package manager configured and none detected in the repository — update the VM config to enable a dev server",
         ));
         return;
     };

--- a/apps/native/crates/local-api/src/setup/install.rs
+++ b/apps/native/crates/local-api/src/setup/install.rs
@@ -89,6 +89,10 @@ fn install_argv(pm: &str) -> Option<&'static [&'static str]> {
 /// itself exits non-zero, after transitioning `lifecycle` to
 /// `install-failed`.
 pub(super) async fn run(orch: &Arc<SetupOrchestrator>, config: &Value) -> bool {
+    // A config that names no package manager may still be a detectable
+    // repository — the clone step just put its files on disk. Fill the
+    // absence before deciding to skip; see `setup/detect_runtime.rs`.
+    let config = &super::detect_runtime::ensure_package_manager(orch, config).await;
     let Some(pm) = crate::config::get_str(config, &["application", "packageManager", "name"])
         .filter(|s| !s.is_empty())
     else {

--- a/apps/native/crates/local-api/src/setup/install.rs
+++ b/apps/native/crates/local-api/src/setup/install.rs
@@ -295,6 +295,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_detectable_repo_installs_without_a_configured_package_manager() {
+        let root = tempfile::tempdir().unwrap();
+        let repo = root.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        // npm deliberately: it is the one detected manager whose binary the
+        // CI image (and any Node toolchain) reliably ships. An empty
+        // manifest keeps the real `npm install` offline and instant.
+        std::fs::write(repo.join("package.json"), "{}").unwrap();
+        std::fs::write(repo.join("package-lock.json"), "{}").unwrap();
+        let orch = test_orchestrator(repo.clone(), root.path());
+        orch.config
+            .patch(json!({ "git": { "repository": { "cloneUrl": "https://example.com/r.git" } } }))
+            .unwrap();
+        let config = orch.current_config().unwrap();
+
+        // The regression this whole module exists for: a fresh import ships
+        // no packageManager, and Install used to skip silently on it.
+        assert!(run(&orch, &config).await);
+
+        assert_eq!(
+            crate::config::get_str(
+                &orch.current_config().unwrap(),
+                &["application", "packageManager", "name"]
+            ),
+            Some("npm"),
+            "detection must land in the store the next step re-reads"
+        );
+    }
+
+    #[tokio::test]
     async fn package_manager_root_resolves_repo_relative_directory() {
         let root = tempfile::tempdir().unwrap();
         let repo = root.path().join("repo");

--- a/apps/native/crates/local-api/src/setup/mod.rs
+++ b/apps/native/crates/local-api/src/setup/mod.rs
@@ -63,6 +63,7 @@
 //! own module doc for the fix in detail.
 
 pub mod clone;
+pub(crate) mod detect_runtime;
 pub mod dev;
 pub mod install;
 


### PR DESCRIPTION
## Summary

Fresh "Import from GitHub" desktop imports came up clone-only and died with **"no package manager configured — update the VM config to enable a dev server"**, for every repo type. Root cause (traced live against a repro): the import flow deliberately writes no `metadata.runtime` because it relies on the control plane's `SANDBOX_START` lockfile probe — but the desktop app **intercepts `SANDBOX_START` locally** (`routes/intercept/sandbox_lifecycle.rs`) and never calls that tool, so nothing anywhere detects the runtime. (Imports that seemed to work were an illusion: `merge_durable_config` resurrecting a stale `package_manager` from an earlier sandbox record for the same handle.)

The desktop has something the remote probe never had: the cloned repository on disk. New `setup/detect_runtime.rs` sniffs the checkout when `application.packageManager` is absent, using the same first-match-wins marker order as `github-runtime-detect.ts` (`deno.json`, `deno.jsonc`, `bun.lock`, `bunfig.toml`, `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `package.json`→bun), patches the orchestrator's config store before install/dev read it, and dedups `runtime_for_package_manager` into one shared home.

Hardened by an adversarial multi-agent review pass; each confirmed finding has a fix + test:
- Detection refuses to sniff while a clone/checkout task is running (git populates the workdir in sorted index order, so a mid-clone sniff latches the wrong manager until restart).
- Detection reads the `pm_root`-scoped directory, matching where install/dev actually run when `packageManager.path` is configured.
- A blank sandbox (no `git.repository`) never promotes leftover files into a workload.
- A user-pinned `application.runtime` is never rewritten; detection re-reads the freshest config snapshot so a pin applied mid-pipeline wins.
- A Start-only resume that skipped Install runs it inline after a successful detection, so dependencies exist before the dev server starts.

**Known gap flagged for follow-up (pre-existing, documented in-code):** once a pin has been persisted to the sandbox registry, `merge_durable_config` resurrects it on every later sparse dispatch — clearing a pin in the VM config never returns a sandbox to auto-detection.

## Testing

- 13 new in-file cargo tests (detection order/edge cases, config-store propagation, acquisition gate, path scoping, pinned-runtime survival, blank-sandbox gate, install wiring with a real `npm install`, and the Start-only detect→install→diagnose path).
- `cargo test -p local-api`: 810 passed. `cargo fmt` + `cargo clippy --all-targets`: clean.

Stacked: the follow-up PR (case-colliding branch mirror fix) is based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect the package manager from the cloned repository when the config has no `application.packageManager`, so fresh GitHub imports install and start without manual setup. If detection happens on a Start-only resume, `Install` runs inline before starting.

- **New Features**
  - Workdir detection matches the server’s marker order (`deno.json`/`deno.jsonc`, `bun.lock`/`bunfig.toml`, `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `package.json`→`bun`).
  - Patches the config store with the detected `packageManager` and sets `application.runtime` via `runtime_for_package_manager` when unset.
  - Never overrides a configured package manager or a user-pinned runtime.
  - Start-only resumes now run `Install` after successful detection.

- **Bug Fixes**
  - Skips detection while clone/checkout tasks are running.
  - Detects in the `packageManager.path` directory when set.
  - Ignores blank sandboxes without a `git.repository`.
  - Keeps undetectable repos clone-only with a clear “no package manager configured and none detected” message.

<sup>Written for commit 3d6f208bc73601b9850cd9ec56e6e9087b32ca43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

