### PR TITLE
fix(auth): announce UnifiedAuthForm errors to screen readers

### DIFF
--- a/apps/web/src/components/unified-auth-form.tsx
+++ b/apps/web/src/components/unified-auth-form.tsx
@@ -265,6 +265,7 @@ export function UnifiedAuthForm({
   const copy = { ...DEFAULT_AUTH_FORM_COPY, ...copyOverrides };
   const formId = useId();
   const emailFieldId = `${formId}-email`;
+  const emailErrorId = `${formId}-email-error`;
   const nameFieldId = `${formId}-name`;
   const passwordFieldId = `${formId}-password`;
   const otpFieldId = `${formId}-otp`;
@@ -639,14 +640,20 @@ export function UnifiedAuthForm({
 
       {/* Error message */}
       {displayError && (
-        <div className="rounded-xl bg-destructive/10 p-3 text-sm text-destructive text-center">
+        <div
+          role="alert"
+          className="rounded-xl bg-destructive/10 p-3 text-sm text-destructive text-center"
+        >
           {getErrorMessage(displayError)}
         </div>
       )}
 
       {/* Success message for forgot password */}
       {resetEmailSent && (
-        <div className="rounded-xl bg-success/10 p-3 text-sm text-success text-center">
+        <div
+          role="status"
+          className="rounded-xl bg-success/10 p-3 text-sm text-success text-center"
+        >
           {copy.resetEmailSent}
         </div>
       )}
@@ -739,10 +746,17 @@ export function UnifiedAuthForm({
                   required
                   disabled={isLoading}
                   aria-invalid={!!emailError}
+                  aria-describedby={emailError ? emailErrorId : undefined}
                   className="h-11 rounded-lg"
                 />
                 {emailError && (
-                  <p className="text-xs text-destructive">{emailError}</p>
+                  <p
+                    id={emailErrorId}
+                    role="alert"
+                    className="text-xs text-destructive"
+                  >
+                    {emailError}
+                  </p>
                 )}
               </div>
 
@@ -842,10 +856,17 @@ export function UnifiedAuthForm({
               required
               disabled={isLoading}
               aria-invalid={!!emailError}
+              aria-describedby={emailError ? emailErrorId : undefined}
               className="h-11 rounded-lg"
             />
             {emailError && (
-              <p className="text-xs text-destructive mt-1.5">{emailError}</p>
+              <p
+                id={emailErrorId}
+                role="alert"
+                className="text-xs text-destructive mt-1.5"
+              >
+                {emailError}
+              </p>
             )}
           </div>
 
@@ -900,10 +921,17 @@ export function UnifiedAuthForm({
               required
               disabled={isLoading}
               aria-invalid={!!emailError}
+              aria-describedby={emailError ? emailErrorId : undefined}
               className="h-11 rounded-lg"
             />
             {emailError && (
-              <p className="text-xs text-destructive mt-1.5">{emailError}</p>
+              <p
+                id={emailErrorId}
+                role="alert"
+                className="text-xs text-destructive mt-1.5"
+              >
+                {emailError}
+              </p>
             )}
           </div>
           <div>


### PR DESCRIPTION
## What

Follows up on #5443 (which associated `UnifiedAuthForm`'s labels with their inputs via `id`/`htmlFor`). That PR fixed field *labels*, but the form's error feedback is still invisible to screen readers:

- The submission-error banner (shown when sign-in/sign-up/OTP/reset-password fails) and the reset-email-sent success banner are plain `<div>`s with no `aria-live` region, so a screen reader user who submits the form and gets an error hears nothing at all.
- The three inline `emailError` validation messages (OTP, forgot-password, and email/password forms) render next to the `Input` but are never wired via `aria-describedby`, so focusing the invalid field doesn't announce why it's invalid — despite the field already carrying `aria-invalid`.

## Failure scenario

A screen-reader user submits invalid credentials or an already-registered email on `/login` (or any embedded auth surface using this shared form, per #5438's consolidation): the error text appears visually but is never announced, since nothing marks it as a live region. The same gap applies to the field-level email-format error.

## Fix

Purely additive ARIA attributes, no behavior/layout change:
- `role="alert"` on the top-level error banner (assertive, since it reports a failed submission).
- `role="status"` on the success banner (polite).
- `role="alert"` + a stable `id` on each of the three `emailError` paragraphs, referenced via `aria-describedby` on their corresponding `Input` (only set when the error is present).

## To verify
```
cd apps/web && bunx tsc --noEmit
```
Manual read-through / axe-linter on `/login`: each error state now exposes an accessible name/description and gets announced without requiring focus to move.

## Checks run locally
`bun run fmt` and `bunx tsc --noEmit` (apps/web) — both clean. No test file exists for this presentational component (same as #5443); this is a JSX-only attribute change. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Announces `UnifiedAuthForm` errors and success messages to screen readers. Adds ARIA roles and descriptions so users hear feedback without moving focus.

- **Bug Fixes**
  - Add `role="alert"` to the submission-error banner and `role="status"` to the reset-email success banner.
  - Link inline email validation messages to the input via `aria-describedby` using a stable `id`; mark those messages with `role="alert"`.
  - No layout or behavior changes; attributes are added only when errors are present.

<sup>Written for commit 1a94b38c8190aa25f00d2a5e40eeb31c0c7fe546. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

