### PR TITLE
fix(web): Accept Invitation crashes with 'Cannot read properties of null (reading navigate)'

### DIFF
--- a/apps/web/src/providers/better-auth-ui-provider.tsx
+++ b/apps/web/src/providers/better-auth-ui-provider.tsx
@@ -1,12 +1,18 @@
-import { Link, useNavigate } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 
 import { authClient } from "@/lib/auth-client";
+import { router } from "@/router";
 import { AuthUIProvider } from "@daveyplate/better-auth-ui";
 import type { PropsWithChildren } from "react";
 
+// `BetterAuthUIProvider` is mounted above `<RouterProvider>` (see
+// index.web.tsx) so its context reaches route components too. That means
+// `useNavigate()` can't be used here — it resolves the router via React
+// context, which isn't established yet at this point in the tree, and
+// silently returns a null router in production (only warns in dev). Use the
+// `router` singleton's imperative `.navigate()` instead; it works regardless
+// of where in the tree it's called from.
 export function BetterAuthUIProvider({ children }: PropsWithChildren) {
-  const navigate = useNavigate();
-
   return (
     <AuthUIProvider
       authClient={authClient}
@@ -15,8 +21,8 @@ export function BetterAuthUIProvider({ children }: PropsWithChildren) {
         basePath: "/",
         pathMode: "slug",
       }}
-      navigate={(href) => navigate({ to: href })}
-      replace={(href) => navigate({ to: href, replace: true })}
+      navigate={(href) => router.navigate({ to: href })}
+      replace={(href) => router.navigate({ to: href, replace: true })}
       Link={({ href, className, children, ...props }) => (
         <Link to={href} className={className} {...props}>
           {children}


### PR DESCRIPTION
## Summary
- `BetterAuthUIProvider` is mounted *above* `<RouterProvider>` in both `index.web.tsx` and `index.native.tsx`. It built the `navigate`/`replace` props passed to `better-auth-ui` via `useNavigate()`, but that hook resolves the router through React context — which doesn't exist yet at that point in the tree.
- `useRouter()` silently returns `null` in that case in production (it only `console.warn`s in dev), so the resulting `navigate`/`replace` closures captured a null router.
- Any better-auth-ui flow that redirects after success crashed with `Cannot read properties of null (reading 'navigate')`, dumping the user onto the generic error boundary ("Algo deu errado"). Most visibly reported on **Accept Invitation** — `better-auth-ui`'s accept card calls `replace(getRedirectTo())` right after `acceptInvitation()` succeeds (confirmed in `node_modules/@daveyplate/better-auth-ui/dist/index.js`), so acceptance itself always "succeeded" server-side but the UI blew up before redirecting.
- Since every better-auth-ui redirect (sign-in, sign-out, accept/reject-invitation, etc.) funnels through these same two props, this single provider bug affected all of them, not just invitations.

## Fix
Use the exported `router` singleton (`@/router`) and call `router.navigate(...)` imperatively instead of the `useNavigate()` hook. The singleton is a plain object method call, not a context lookup, so it works regardless of where in the tree it's invoked from.

## Test plan
- [x] `bun run check` (tsc --noEmit) in `apps/web` — no new type errors (pre-existing, unrelated Tauri module errors only)
- [ ] Manually accept a real pending org invitation end-to-end and confirm it redirects into the org instead of throwing
- [ ] Spot-check sign-in/sign-out redirects still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash on auth redirects (e.g., Accept Invitation) by switching to the app’s router singleton for navigation. Redirects now work reliably across `@daveyplate/better-auth-ui` flows.

- **Bug Fixes**
  - Root cause: `BetterAuthUIProvider` sits above `<RouterProvider>`, so `useNavigate()` resolved to a null router in production.
  - Change: use `router.navigate(...)` from `@/router` for the `navigate` and `replace` props instead of `useNavigate()` from `@tanstack/react-router`.
  - Impact: Accept Invitation, sign-in, sign-out, and other redirects no longer crash.

<sup>Written for commit ceff06b81520725a68470b41ff4599e707d428d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

