### PR TITLE
perf(mcp): drop redundant organization DB lookup in virtual-MCP request path

### DIFF
--- a/apps/api/src/api/routes/virtual-mcp.ts
+++ b/apps/api/src/api/routes/virtual-mcp.ts
@@ -135,20 +135,13 @@ export async function handleVirtualMcpRequest(
     // Note: virtualMcp.id can be null for Decopilot agent, but connectionId should be set for routing
     ctx.connectionId = virtualMcp.id ?? undefined;
 
-    // Set organization context
-    const organization = await ctx.db
-      .selectFrom("organization")
-      .select(["id", "slug", "name"])
-      .where("id", "=", virtualMcp.organization_id)
-      .executeTakeFirst();
-
-    if (organization) {
-      ctx.organization = {
-        id: organization.id,
-        slug: organization.slug,
-        name: organization.name,
-      };
-    }
+    // ctx.organization is already resolved by context-factory and was just
+    // verified above to match virtualMcp.organization_id — every path that
+    // reaches this point has organizationId truthy (see the 400s above), so
+    // re-fetching it here was a redundant DB round trip on every MCP
+    // tool-call request, and it also silently dropped ctx.organization.role
+    // (AuthTransport falls back to the session's active-org role when it's
+    // missing, which can be a different org's role).
 
     // Surface the dev sandbox's tools when the acting user has a running sandbox
     // for this agent. The cheap local pre-filter is just "does the user have a


### PR DESCRIPTION
Follows #2995 ("DB latency amplifies significantly across MCP tool calls") by removing an extra DB round trip from `handleVirtualMcpRequest`, the handler behind `/mcp/gateway/:virtualMcpId` and `/mcp/virtual-mcp/:virtualMcpId` — hit on every single MCP tool call.

**The redundant query.** After looking up the Virtual MCP by id, the handler re-fetched the owning `organization` row from Postgres just to rebuild `ctx.organization`. But by the time execution reaches that line, every path through the function already guarantees `organizationId` is truthy and equals `virtualMcp.organization_id` (enforced by the 400/404 checks directly above it), and `ctx.organization` is already fully resolved (id/slug/name) by `context-factory.ts` before any route handler runs. The query always returned data ctx already had — pure duplicate work on the hottest path in the app.

**A correctness side-effect, fixed for free.** The overwrite also rebuilt `ctx.organization` with only `{ id, slug, name }`, silently dropping the `role` field that `resolveOrgFromPath` may have set. `AuthTransport` (`apps/api/src/mcp-clients/outbound/transports/auth.ts:172`) falls back to `ctx.auth.user?.role` (the session's active-org role) whenever `ctx.organization.role` is missing — the same active-org-vs-target-org role class of bug fixed elsewhere in this repo (#4934, #4996, #5104). Removing the overwrite keeps the path-resolved role intact for any downstream proxied tool calls in this request.

**Net change:** -14/+7 lines, one DB query removed from a hot path, one org-role field no longer silently dropped.

**How to verify:** `cd apps/api && bunx tsc --noEmit` (clean). No behavior change to verify with a test — this is a proven-redundant deletion: `ctx.organization.id` is checked equal to `virtualMcp.organization_id` two lines above the removed block, so the removed query could never have produced different data.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` in `apps/api`. Full CI (lint, unit, e2e) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant organization DB lookup in `handleVirtualMcpRequest` for `/mcp/gateway/:virtualMcpId` and `/mcp/virtual-mcp/:virtualMcpId`. This removes one DB query on every MCP tool call and preserves the path-resolved `ctx.organization.role` instead of overwriting it.

<sup>Written for commit a761f4baf161efd3ec57675b9d184fc4cb23995e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

