### PR TITLE
fix(decopilot): validate DECOPILOT_MAX_CONCURRENT_SUBAGENTS through Settings

### DIFF
--- a/apps/api/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
@@ -9,11 +9,13 @@
  * everything else (pg pool acquires, even signal handlers). This caps how many
  * run at once per process — excess calls queue and start as slots free.
  *
- * DRAFT: limit is read from the environment with a conservative default. If we
- * keep this, move it into Settings (resolve-config.ts) so it's tunable per
- * deployment without an env redeploy, and consider a per-run (not per-process)
- * gate if cross-session head-of-line blocking becomes a concern.
+ * The limit comes from `Settings.decopilotMaxConcurrentSubagents`
+ * (DECOPILOT_MAX_CONCURRENT_SUBAGENTS), validated at startup — a malformed
+ * value fails boot instead of silently coercing here. Consider a per-run (not
+ * per-process) gate if cross-session head-of-line blocking becomes a concern.
  */
+
+import { getSettings } from "@/settings";
 
 export interface ConcurrencyGate {
   /**
@@ -68,7 +70,7 @@ export function createConcurrencyGate(max: number): ConcurrencyGate {
 }
 
 const gate = createConcurrencyGate(
-  Number(process.env.DECOPILOT_MAX_CONCURRENT_SUBAGENTS ?? 4),
+  getSettings().decopilotMaxConcurrentSubagents,
 );
 
 export const acquireSubagentSlot = (): Promise<() => void> => gate.acquire();

--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -388,3 +388,24 @@ describe("resolveConfig topup fee percent", () => {
     ).toThrow("STUDIO_TOPUP_FEE_PERCENT must be a positive integer");
   });
 });
+
+describe("resolveConfig decopilot max concurrent subagents", () => {
+  it("defaults to 4", () => {
+    expect(
+      resolveConfig(flags, {}).settings.decopilotMaxConcurrentSubagents,
+    ).toBe(4);
+  });
+
+  it("honors an override", () => {
+    expect(
+      resolveConfig(flags, { DECOPILOT_MAX_CONCURRENT_SUBAGENTS: "8" }).settings
+        .decopilotMaxConcurrentSubagents,
+    ).toBe(8);
+  });
+
+  it("rejects a non-numeric value at boot (fail-fast, not a silent default)", () => {
+    expect(() =>
+      resolveConfig(flags, { DECOPILOT_MAX_CONCURRENT_SUBAGENTS: "free" }),
+    ).toThrow("DECOPILOT_MAX_CONCURRENT_SUBAGENTS must be a positive integer");
+  });
+});

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -270,6 +270,11 @@ export function resolveConfig(
     ),
     orgFsPublicSetsJson: envVars.ORGFS_PUBLIC_SETS,
     orgFsMountsDisabled: toBool(envVars.DISABLE_ORGFS_MOUNTS),
+    decopilotMaxConcurrentSubagents: toPositiveIntegerOrDefault(
+      "DECOPILOT_MAX_CONCURRENT_SUBAGENTS",
+      envVars.DECOPILOT_MAX_CONCURRENT_SUBAGENTS,
+      4,
+    ),
     // Object Storage (S3-compatible)
     s3Endpoint: envVars.S3_ENDPOINT,
     s3Bucket: envVars.S3_BUCKET,

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -106,6 +106,10 @@ export interface Settings {
    *  (DISABLE_ORGFS_MOUNTS). org-fs is otherwise always mounted; this is
    *  for low-level mount debugging, not a supported org-fs-off mode. */
   orgFsMountsDisabled: boolean;
+  /** Process-wide cap on concurrent `subtask` subagent streams per pod
+   *  (DECOPILOT_MAX_CONCURRENT_SUBAGENTS). Excess calls queue and start as
+   *  slots free — see `subagent-concurrency.ts`. */
+  decopilotMaxConcurrentSubagents: number;
   // Object Storage (S3-compatible)
   s3Endpoint: string | undefined;
   s3Bucket: string | undefined;


### PR DESCRIPTION
Source: hardening follow-up found while hunting the Decopilot hot-reload resilience area (issue #2711). `subagent-concurrency.ts` (the process-wide gate on concurrent `subtask` subagent streams) carried a DRAFT comment explicitly flagging that its env-var read should move into `Settings`/`resolve-config.ts` for validation and per-deployment tuning, matching every other numeric setting in the codebase.

Why a maintainer wants it: today a malformed `DECOPILOT_MAX_CONCURRENT_SUBAGENTS` (e.g. a typo) silently coerces to a cap of 1 instead of failing fast at boot, and reading `process.env` directly at module load bypasses the codebase's one validated Settings pipeline — the repo's `resolve-config.ts` already has a `toPositiveIntegerOrDefault` helper used for the exact same pattern (`DATABASE_POOL_MAX`, `STUDIO_TOPUP_FEE_PERCENT`, etc.), so this closes the gap the DRAFT comment called out.

Change: added `decopilotMaxConcurrentSubagents` to `Settings`, resolved via `toPositiveIntegerOrDefault("DECOPILOT_MAX_CONCURRENT_SUBAGENTS", ..., 4)` (fails boot on a non-numeric value instead of silently defaulting), and pointed the gate's singleton at `getSettings()` instead of `process.env`. `createConcurrencyGate`'s own internal NaN-guard (tested separately) is untouched as defense-in-depth.

Reviewer check: `cd apps/api && bun test src/settings/resolve-config.test.ts` (new `resolveConfig decopilot max concurrent subagents` block: default, override, and fail-on-invalid) and `bun test src/harnesses/decopilot/built-in-tools/subagent-concurrency.test.ts` (unchanged, still green).

Verified locally: `bun run fmt`, `bunx tsc --noEmit` in `apps/api` (clean), and both targeted test files above (64 + 7 passing). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `DECOPILOT_MAX_CONCURRENT_SUBAGENTS` through `Settings` and use it for the Decopilot subagent concurrency gate. Startup now fails on non-numeric values, preventing silent fallback to 1.

- **Bug Fixes**
  - Added `decopilotMaxConcurrentSubagents` to `Settings` via `toPositiveIntegerOrDefault` (default 4).
  - Switched `subagent-concurrency.ts` to `getSettings().decopilotMaxConcurrentSubagents`.
  - Added tests in `resolve-config.test.ts`; existing gate tests remain green.

- **Migration**
  - Ensure `DECOPILOT_MAX_CONCURRENT_SUBAGENTS` is a positive integer, or boot will fail.
  - Default remains 4 if unset.

<sup>Written for commit aa3864ac5d7d66450851c03538a1f8c4d00e0651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

