### PR TITLE
fix(auth): add autocomplete attributes to UnifiedAuthForm inputs

### DIFF
--- a/apps/web/src/components/unified-auth-form.tsx
+++ b/apps/web/src/components/unified-auth-form.tsx
@@ -745,6 +745,7 @@ export function UnifiedAuthForm({
                   onBlur={handleEmailBlur}
                   required
                   disabled={isLoading}
+                  autoComplete="email"
                   aria-invalid={!!emailError}
                   aria-describedby={emailError ? emailErrorId : undefined}
                   className="h-11 rounded-lg"
@@ -855,6 +856,7 @@ export function UnifiedAuthForm({
               onBlur={handleEmailBlur}
               required
               disabled={isLoading}
+              autoComplete="email"
               aria-invalid={!!emailError}
               aria-describedby={emailError ? emailErrorId : undefined}
               className="h-11 rounded-lg"
@@ -900,6 +902,7 @@ export function UnifiedAuthForm({
                 onChange={handleInputChange(setName)}
                 required
                 disabled={isLoading}
+                autoComplete="name"
                 className="h-11 rounded-lg"
               />
             </div>
@@ -920,6 +923,7 @@ export function UnifiedAuthForm({
               onBlur={handleEmailBlur}
               required
               disabled={isLoading}
+              autoComplete="email"
               aria-invalid={!!emailError}
               aria-describedby={emailError ? emailErrorId : undefined}
               className="h-11 rounded-lg"
@@ -960,6 +964,7 @@ export function UnifiedAuthForm({
               onChange={handleInputChange(setPassword)}
               required
               disabled={isLoading}
+              autoComplete={isSignUp ? "new-password" : "current-password"}
               className="h-11 rounded-lg"
             />
           </div>


### PR DESCRIPTION
## What

Follows up on #5443 (label/id association) and #5460 (screen-reader error announcements), both hardening `UnifiedAuthForm`'s accessibility. This pass audited the same component for remaining ARIA/keyboard/announcement gaps and found one: the email, name, and password inputs carry no `autocomplete` attribute — only the OTP field does (`autoComplete="one-time-code"`, added in an earlier pass).

## Failure scenario

Missing `autocomplete` on a field whose purpose is programmatically identifiable fails WCAG 2.1 SC 1.3.5 (Identify Input Purpose, Level AA). Concretely: a screen-reader user relying on autofill/autocomplete hints, or anyone using a password manager, gets no purpose hint on the email/name/password fields across all four views (sign in, sign up, forgot password, OTP) — password managers can't reliably offer to fill or save credentials, and browser-level autofill silently fails.

## Fix

Purely additive `autocomplete` attributes, no behavior/layout change:
- `autoComplete="email"` on all three email inputs (email/password form, forgot-password form, email-OTP form).
- `autoComplete="name"` on the sign-up name field.
- `autoComplete={isSignUp ? "new-password" : "current-password"}` on the password field, so password managers correctly distinguish save-new vs fill-existing.

## To verify
```
cd apps/web && bunx tsc --noEmit
```
Manual check: on `/login`, inspect each input's `autocomplete` attribute matches its purpose; a password manager now offers save/fill appropriately.

## Checks run locally
`bun run fmt` and `bunx tsc --noEmit` (apps/web) — both clean. No test file exists for this presentational component (same as #5443/#5460); this is a JSX-only attribute change. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `autocomplete` attributes to `UnifiedAuthForm` inputs to improve accessibility and allow browsers and password managers to autofill correctly. No layout or behavior changes.

- **Bug Fixes**
  - Set `autoComplete="email"` on all email fields.
  - Set `autoComplete="name"` on the sign-up name field.
  - Set password `autoComplete` to `new-password` on sign-up and `current-password` on sign-in.

<sup>Written for commit 112da66066a756c98d2b0d64a36a9c27f856b895. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

