### PR TITLE
fix(search): treat an empty types filter as "search nothing"

### DIFF
--- a/apps/api/src/tools/search/global-search.integration.test.ts
+++ b/apps/api/src/tools/search/global-search.integration.test.ts
@@ -79,14 +79,7 @@ describe("GLOBAL_SEARCH", () => {
     expect(parsed.items).toHaveLength(0);
   });
 
-  it("honors the `types` filter — empty array of thread results when threads are excluded", async () => {
-    // `types: []` would be filtered out by the input schema if treated as
-    // "none", so use a non-thread (future) type to assert the filter narrows.
-    // Today the only branch is `"thread"`, so passing `types: ["thread"]`
-    // still returns threads. The negative case is: explicitly request a type
-    // that doesn't exist yet — the input schema rejects unknown enum values,
-    // so we instead assert that requesting only `"thread"` works and matches
-    // the unfiltered call.
+  it("honors the `types` filter — matches the unfiltered call when `thread` is requested", async () => {
     const filtered = GLOBAL_SEARCH.outputSchema.parse(
       await GLOBAL_SEARCH.handler(
         { query: "launch", types: ["thread"] },
@@ -99,5 +92,15 @@ describe("GLOBAL_SEARCH", () => {
     expect(filtered.items.map((i) => i.id).sort()).toEqual(
       unfiltered.items.map((i) => i.id).sort(),
     );
+  });
+
+  it("returns no items when `types` is an empty array", async () => {
+    const raw = await GLOBAL_SEARCH.handler(
+      { query: "launch", types: [] },
+      env.ctx,
+    );
+    const parsed = GLOBAL_SEARCH.outputSchema.parse(raw);
+    expect(parsed.items).toHaveLength(0);
+    expect(parsed.totalCount).toBe(0);
   });
 });

--- a/apps/api/src/tools/search/global-search.test.ts
+++ b/apps/api/src/tools/search/global-search.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "bun:test";
-import { GLOBAL_SEARCH, normalizeSearchQuery } from "./global-search";
+import {
+  GLOBAL_SEARCH,
+  normalizeSearchQuery,
+  includesSearchType,
+} from "./global-search";
 
 describe("GLOBAL_SEARCH input schema", () => {
   it("rejects a query longer than 256 characters", () => {
@@ -32,5 +36,23 @@ describe("normalizeSearchQuery", () => {
 
   it("leaves an already-trimmed query unchanged", () => {
     expect(normalizeSearchQuery("foo bar")).toBe("foo bar");
+  });
+});
+
+describe("includesSearchType", () => {
+  it("includes every type when `types` is omitted", () => {
+    expect(includesSearchType(undefined, "thread")).toBe(true);
+  });
+
+  it("includes a type present in the filter", () => {
+    expect(includesSearchType(["thread"], "thread")).toBe(true);
+  });
+
+  it("excludes a type absent from a non-empty filter", () => {
+    expect(includesSearchType(["other"], "thread")).toBe(false);
+  });
+
+  it("excludes every type when `types` is an empty array", () => {
+    expect(includesSearchType([], "thread")).toBe(false);
   });
 });

--- a/apps/api/src/tools/search/global-search.ts
+++ b/apps/api/src/tools/search/global-search.ts
@@ -79,6 +79,18 @@ export function normalizeSearchQuery(query: string): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+/**
+ * Omitting `types` searches every resource type; passing `types: []` (e.g. a
+ * caller unchecked every filter) must narrow to none rather than falling
+ * back to "search everything".
+ */
+export function includesSearchType(
+  types: readonly string[] | undefined,
+  type: string,
+): boolean {
+  return types === undefined || types.includes(type);
+}
+
 export const GLOBAL_SEARCH = defineTool({
   name: "GLOBAL_SEARCH",
   description:
@@ -97,8 +109,7 @@ export const GLOBAL_SEARCH = defineTool({
     requireOrganization(ctx);
 
     const limit = input.limit ?? 20;
-    const requested = input.types?.length ? new Set(input.types) : null;
-    const includeThreads = !requested || requested.has("thread");
+    const includeThreads = includesSearchType(input.types, "thread");
 
     const items: z.infer<typeof SearchResultSchema>[] = [];
     let totalCount = 0;


### PR DESCRIPTION
Bug: `GLOBAL_SEARCH`'s `types` filter used `input.types?.length ? new Set(input.types) : null`, so `types: []` (e.g. a client that unchecked every resource-type filter) was indistinguishable from an omitted filter and silently fell back to searching every resource type instead of returning nothing. The tool's own integration test already called this out as an untested gap in a comment ("`types: []` would be filtered out by the input schema if treated as 'none'" — it isn't, by zod or by the handler).

Why it matters: a caller building a type-filter UI (e.g. "search only threads" checkboxes) that ends up with everything unchecked would get every result back instead of an empty list — a real, surprising correctness gap in a filter primitive other resource types will be added onto per the file's own module doc.

Fix: extracted the inclusion check into a pure `includesSearchType(types, type)` helper — `undefined` still means "search everything", but `[]` now means "search nothing", matching the documented intent of the filter. Net behavior change is scoped to that one edge case; the common paths (omitted filter, `["thread"]`) are unchanged.

Regression test: added unit tests for `includesSearchType` covering omitted/matching/non-matching/empty filters, and replaced the integration test's placeholder comment with a real assertion that `types: []` returns zero items/totalCount against a live search.

Reviewer check: `cd apps/api && bunx tsc --noEmit` and `bun test apps/api/src/tools/search/global-search.test.ts` (the integration test needs Postgres, which full CI covers).

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/api), and the targeted unit test file above — all green. Full CI (including the Postgres-backed integration test) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes global search filtering so an empty `types` array means “search nothing.” Omitting `types` still searches all types. This prevents unexpected results when all type checkboxes are unchecked.

- **Bug Fixes**
  - Added `includesSearchType(types, type)` to distinguish omitted vs empty filters and updated `GLOBAL_SEARCH` to use it.
  - Added unit tests for the helper and an integration test asserting `types: []` returns zero items/totalCount.

<sup>Written for commit 29f80950cb58ac55cca4353380ffe22a0899f642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

