### PR TITLE
fix(task-board): pulse the blocked-task icon in the task dialog too

### DIFF
--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -53,6 +53,7 @@ import {
   PRIORITY_CONFIG,
   STATUS_CONFIG,
   STATUSES,
+  statusIconClassName,
   SUPER_AGENT_ASSIGNEE_ID,
   tagDotColor,
   type Member,
@@ -333,7 +334,11 @@ export function TaskBoardItemDialog({
                   <button type="button" className={PROPERTY_BUTTON}>
                     <StatusIcon
                       size={16}
-                      className={STATUS_CONFIG[status].iconClassName}
+                      className={
+                        item
+                          ? statusIconClassName({ ...item, status })
+                          : STATUS_CONFIG[status].iconClassName
+                      }
                     />
                     {t(STATUS_CONFIG[status].labelKey)}
                   </button>

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -334,11 +334,11 @@ export function TaskBoardItemDialog({
                   <button type="button" className={PROPERTY_BUTTON}>
                     <StatusIcon
                       size={16}
-                      className={
+                      className={cn(
                         item
                           ? statusIconClassName({ ...item, status })
-                          : STATUS_CONFIG[status].iconClassName
-                      }
+                          : STATUS_CONFIG[status].iconClassName,
+                      )}
                     />
                     {t(STATUS_CONFIG[status].labelKey)}
                   </button>


### PR DESCRIPTION
Follows #5436, which added `statusIconClassName()` so an in-progress task waiting on human input (`isTaskBlocked`) shows a `text-warning animate-pulse` icon instead of a spinner — applied to the kanban card and the list row, but the task dialog's own status button still read `STATUS_CONFIG[status].iconClassName` directly.

**Payoff:** a maintainer opening a blocked task's dialog — exactly where they'd go to check why it's stuck — sees the icon still spinning as if the agent were actively working, contradicting the "needs input" signal shown everywhere else on the board.

**Failure scenario:** a task is `in_progress` and blocked (`item.threads.some(t => t.status === "requires_action")`). On the board/list it correctly shows the warning pulse; opening `TaskBoardItemDialog` for that same task shows `text-primary animate-spin` on the property button instead — a visible inconsistency introduced by #5436 only touching two of the three render sites.

**Fix:** the dialog's status trigger now calls `statusIconClassName({ ...item, status })` (merging in the dialog's local `status` state, which starts as `item.status` and is what's actually displayed) when editing an existing item, falling back to the plain config for the create-mode case where there's no `item`/`threads` to check.

**Reviewer check:** open a task board item whose linked thread is `requires_action` while status is `in_progress`, open its dialog, confirm the status icon pulses in warning instead of spinning. `apps/web/src/layouts/task-board/config.test.ts` already covers `statusIconClassName` itself.

**Verified locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bun test apps/web/src/layouts/task-board/config.test.ts` (11 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent status icon in the task dialog: blocked in-progress tasks now show the pulsing warning icon instead of a spinner, matching the board and list.

The dialog now uses `statusIconClassName({ ...item, status })` when editing and falls back to `STATUS_CONFIG[status].iconClassName` in create mode, with the icon class wrapped in `cn`.

<sup>Written for commit 70f68977a9e15e3474c0739afeef243a4433e82f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

