### PR TITLE
fix(chat): don't brick the chat on an orphan tool-input-delta

### DIFF
--- a/apps/web/src/components/chat/store/thread-connection-replay.test.ts
+++ b/apps/web/src/components/chat/store/thread-connection-replay.test.ts
@@ -444,4 +444,85 @@ describe("UI message stream replay (web_search)", () => {
     expect(toolPart).toBeDefined();
     expect((toolPart as { state: string }).state).toBe("output-available");
   });
+
+  // Tail lands mid-`tool-input` streaming: deltas without their
+  // `tool-input-start`.
+  const midInputChunks: UIMessageChunk[] = [
+    {
+      type: "tool-input-delta",
+      toolCallId: TOOL_CALL_ID,
+      inputTextDelta: JSON.stringify({ query: QUERY }),
+    } as UIMessageChunk,
+    {
+      type: "tool-input-available",
+      toolCallId: TOOL_CALL_ID,
+      toolName: "web_search",
+      input: { query: QUERY },
+    },
+    {
+      type: "tool-output-available",
+      toolCallId: TOOL_CALL_ID,
+      output: { success: true, content: REPORT, query: QUERY },
+    },
+    { type: "finish-step" },
+    { type: "finish" },
+  ];
+
+  test("reattach mid-tool-input: unguarded delta without start throws", async () => {
+    const errors: unknown[] = [];
+    const iter = readUIMessageStream({
+      stream: streamOf(midInputChunks),
+      onError: (e) => errors.push(e),
+    });
+
+    const { error } = await drain(iter);
+    const combined =
+      error ??
+      (errors[0] instanceof Error ? errors[0] : new Error(String(errors[0])));
+    expect(String(combined?.message ?? "")).toContain(
+      "Received tool-input-delta for missing tool call",
+    );
+  });
+
+  test("guarded: reattach mid-tool-input folds cleanly, with and without a seed", async () => {
+    for (const seed of [
+      undefined,
+      {
+        id: MESSAGE_ID,
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-web_search",
+            toolCallId: TOOL_CALL_ID,
+            state: "input-available",
+            input: { query: QUERY },
+          },
+        ],
+      } as unknown as UIMessage,
+    ]) {
+      const errors: unknown[] = [];
+      const iter = readUIMessageStream({
+        message: seed ? (structuredClone(seed) as UIMessage) : undefined,
+        stream: guardToolInvariant(streamOf(midInputChunks), seed),
+        onError: (e) => errors.push(e),
+      });
+
+      const { messages, error } = await drain(iter);
+      expect(error).toBeNull();
+      expect(errors).toEqual([]);
+
+      const toolPart = messages
+        .at(-1)
+        ?.parts.find(
+          (p) =>
+            typeof p === "object" &&
+            p !== null &&
+            "type" in p &&
+            (p as { type: string }).type === "tool-web_search",
+        ) as { state: string; output?: { content?: string } } | undefined;
+      expect(toolPart).toBeDefined();
+      expect(toolPart!.state).toBe("output-available");
+      expect(toolPart!.output?.content).toBe(REPORT);
+    }
+  });
 });

--- a/apps/web/src/components/chat/store/tool-invariant-guard.test.ts
+++ b/apps/web/src/components/chat/store/tool-invariant-guard.test.ts
@@ -91,6 +91,36 @@ describe("createToolInvariantGuard", () => {
     ]);
   });
 
+  it("passes a start→delta pair through untouched", () => {
+    const guard = createToolInvariantGuard();
+    const out = flat(guard, [
+      { type: "tool-input-start", toolCallId: "tc", toolName: "x" },
+      { type: "tool-input-delta", toolCallId: "tc", inputTextDelta: "{" },
+    ] as UIMessageChunk[]);
+    expect(out.map((c) => c.type)).toEqual([
+      "tool-input-start",
+      "tool-input-delta",
+    ]);
+  });
+
+  it("drops a delta with no preceding tool-input-start", () => {
+    // Only `tool-input-start` populates the reader's partialToolCalls map —
+    // neither a seeded part nor a `tool-input-available` does.
+    for (const seeded of [[], ["tc"]]) {
+      const guard = createToolInvariantGuard(seeded);
+      const out = flat(guard, [
+        {
+          type: "tool-input-available",
+          toolCallId: "tc",
+          toolName: "x",
+          input: {},
+        },
+        { type: "tool-input-delta", toolCallId: "tc", inputTextDelta: "{" },
+      ] as UIMessageChunk[]);
+      expect(out.map((c) => c.type)).toEqual(["tool-input-available"]);
+    }
+  });
+
   it("leaves non-tool chunks alone", () => {
     const guard = createToolInvariantGuard();
     const out = flat(guard, [

--- a/apps/web/src/components/chat/store/tool-invariant-guard.ts
+++ b/apps/web/src/components/chat/store/tool-invariant-guard.ts
@@ -1,38 +1,27 @@
 /**
  * Tool-invocation invariant guard.
  *
- * The AI SDK's `readUIMessageStream` throws
- * `No tool invocation found for tool call ID "X"` when a `tool-output-available`
- * / `tool-output-error` / `tool-input-delta` chunk references a tool call whose
- * `tool-input-*` part is neither in the seed message nor earlier in the stream.
+ * A tail that starts mid-run (subject purged, retention gap, pod SIGTERM'd
+ * mid-step) delivers a tool's deltas or output without its `tool-input-start`.
+ * `readUIMessageStream` then throws and the whole chat bricks:
+ *   - `No tool invocation found for tool call ID "X"` — output chunk with no
+ *     tool part (from the seed message or an earlier `tool-input-*`).
+ *   - `Received tool-input-delta for missing tool call with ID "X"` — delta with
+ *     no `partialToolCalls` entry, which ONLY `tool-input-start` creates.
  *
- * That invariant breaks whenever a run is reconstructed after abnormal
- * termination — the owning pod is SIGTERM'd mid-step (ghost run force-fail),
- * the JetStream subject is purged mid-window, or a retention gap drops the
- * input seq — so a tool's output survives but its input does not. The whole
- * chat then bricks on reload.
- *
- * The guard sits between the chunk source and the reader: it tracks which tool
- * call ids already have an invocation (seeded from the message's existing
- * parts, then updated as `tool-input-*` chunks flow through) and synthesizes a
- * minimal `tool-input-available` before any orphaned reference. The tool then
- * renders as a completed call with an unknown name instead of aborting the run.
+ * So: synthesize a `tool-input-available` before an orphan output (renders as a
+ * completed call named "unknown"), and drop an orphan delta — deltas carry no
+ * `toolName` and the closing `tool-input-available` carries the full input, so
+ * dropping the partial prefix costs one streaming animation.
  */
 
 import type { UIMessage, UIMessageChunk } from "ai";
 
-/** Chunk types that create a tool invocation the reader can look up later. */
-const CREATES_INVOCATION = new Set([
-  "tool-input-start",
-  "tool-input-available",
-]);
+/** Chunk types that create the tool *part* an output chunk looks up. */
+const CREATES_PART = new Set(["tool-input-start", "tool-input-available"]);
 
-/** Chunk types that require a pre-existing invocation and throw without one. */
-const REQUIRES_INVOCATION = new Set([
-  "tool-input-delta",
-  "tool-output-available",
-  "tool-output-error",
-]);
+/** Chunk types that require a pre-existing part and throw without one. */
+const REQUIRES_PART = new Set(["tool-output-available", "tool-output-error"]);
 
 /** Placeholder name for a tool whose input part was lost. */
 const UNKNOWN_TOOL_NAME = "unknown";
@@ -49,13 +38,17 @@ export function toolCallIdsInMessage(msg: UIMessage | undefined): string[] {
 
 /**
  * Build a stateful guard. Call it once per chunk in stream order; it returns
- * the chunk(s) to forward — either the input unchanged, or a synthetic
- * `tool-input-available` followed by the orphaned chunk.
+ * the chunk(s) to forward — the chunk unchanged, a synthetic
+ * `tool-input-available` followed by an orphan output, or nothing (orphan
+ * delta).
  */
 export function createToolInvariantGuard(
   seedToolCallIds: Iterable<string> = [],
 ): (chunk: UIMessageChunk) => UIMessageChunk[] {
-  const known = new Set(seedToolCallIds);
+  /** Ids with a tool part (seeded, or created by a `tool-input-*` chunk). */
+  const withPart = new Set(seedToolCallIds);
+  /** Ids the reader has a `partialToolCalls` entry for — `tool-input-start` only. */
+  const started = new Set<string>();
 
   return (chunk) => {
     const { type } = chunk;
@@ -63,21 +56,28 @@ export function createToolInvariantGuard(
 
     if (typeof toolCallId !== "string") return [chunk];
 
-    if (CREATES_INVOCATION.has(type)) {
-      known.add(toolCallId);
+    if (CREATES_PART.has(type)) {
+      withPart.add(toolCallId);
+      if (type === "tool-input-start") started.add(toolCallId);
       return [chunk];
     }
 
-    if (REQUIRES_INVOCATION.has(type) && !known.has(toolCallId)) {
-      known.add(toolCallId);
-      const synthetic = {
-        type: "tool-input-available",
-        toolCallId,
-        toolName:
-          (chunk as { toolName?: unknown }).toolName ?? UNKNOWN_TOOL_NAME,
-        input: {},
-      } as UIMessageChunk;
-      return [synthetic, chunk];
+    if (type === "tool-input-delta") {
+      return started.has(toolCallId) ? [chunk] : [];
+    }
+
+    if (REQUIRES_PART.has(type) && !withPart.has(toolCallId)) {
+      withPart.add(toolCallId);
+      return [
+        {
+          type: "tool-input-available",
+          toolCallId,
+          toolName:
+            (chunk as { toolName?: unknown }).toolName ?? UNKNOWN_TOOL_NAME,
+          input: {},
+        } as UIMessageChunk,
+        chunk,
+      ];
     }
 
     return [chunk];


### PR DESCRIPTION
## What

The chat bricks with `Erro ocorreu — Received tool-input-delta for missing tool call with ID "toolu_vrtx_…"` (thread `42f13381-ca35-4e01-a27e-971de7a6ad2e`, org `deco-studio`, run still `in_progress`).

`readUIMessageStream` has **two** orphan-tool throws, not one:

| chunk | lookup | populated by |
| --- | --- | --- |
| `tool-output-available` / `tool-output-error` | tool **part** in `state.message.parts` | seed message, `tool-input-start`, or `tool-input-available` |
| `tool-input-delta` | `state.partialToolCalls[id]` | **`tool-input-start` only** |

`tool-invariant-guard.ts` treated them as one case and synthesized a `tool-input-available` for both. That repairs an orphan output but does nothing for an orphan delta — no `partialToolCalls` entry, so the reader still throws and `failTo()` puts the thread in the error state. A seeded part masks it further: the id is "known" to the guard, so the delta is forwarded untouched.

## Fix

Track the two invariants separately and **drop** orphan deltas rather than synthesizing a start. Deltas carry no `toolName`, so a synthetic start would create a permanently misnamed `tool-unknown` part (the reader never renames an existing part); the `tool-input-available` that closes the call carries the real name and the whole input. Cost of dropping: one input-streaming animation on a stream that was already truncated.

## Upstream cause (not fixed here)

The tail is opened with `deliverPolicy: "all"` when `thread.status === "in_progress"` (`routes.ts`), and the per-thread subject is purged both by the projector after a terminal projection and by `dispatchRun` at turn start. A purge that lands after the current run has begun publishing leaves a subject whose first retained chunk is mid-`tool-input`. Sequencing that purge is a bigger, riskier change; the client should not brick either way — same rationale the guard already shipped with.

## Tests

- `tool-invariant-guard.test.ts` — start→delta passes through; a delta with no start is dropped, seeded or not.
- `thread-connection-replay.test.ts` — mid-`tool-input` reattach through the real `readUIMessageStream`: unguarded reproduces the production error, guarded folds to a complete `tool-web_search` part (with and without a DB seed).

`bun test apps/web/src/components/chat/store/` 135 pass · `bun run check` (apps/web) clean · `bun run fmt` / `lint` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent chat crashes when a `tool-input-delta` arrives without a matching `tool-input-start` by dropping the orphan delta. Also adds a Go sandbox daemon in `packages/sandbox/daemon-go` behind `DAEMON_E2E_CMD`, aligned with the TS daemon and passing the full e2e suite.

- **Bug Fixes**
  - Guard now handles `tool-output-*` vs `tool-input-delta` separately: synthesize start for orphan outputs; drop orphan deltas to avoid `readUIMessageStream` errors.
  - Tests cover start→delta passthrough and mid-`tool-input` replay (unguarded throws; guarded completes), with and without a seeded part.

- **New Features**
  - New Go daemon mirroring the TS daemon’s contract; passes 153/153 conformance tests; not wired into deploy.
  - Adds `/_sandbox/tools/sync` and requires explicit `DAEMON_E2E_CMD` in e2e helpers to select the daemon.

<sup>Written for commit 1e40e0a2f2c48823b2c382d10259befd722c1af3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

