### PR TITLE
fix(sandbox): make the daemon discard route async

### DIFF
--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -1,4 +1,5 @@
 import fs, { mkdtempSync } from "node:fs";
+import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { appendCoAuthorTrailer } from "../../git-co-author";
@@ -749,7 +750,7 @@ export function publish(
   return { pushed: true };
 }
 
-function discard(deps: GitDeps, filepaths: string[]): void {
+async function discard(deps: GitDeps, filepaths: string[]): Promise<void> {
   const repoDir = deps.repoDir;
   const validated = filepaths.map((fp) => resolveRepoRelativePath(deps, fp));
   const status = computeWorkingTreeStatus(repoDir);
@@ -792,7 +793,7 @@ function discard(deps: GitDeps, filepaths: string[]): void {
   for (const fp of toDelete) {
     const abs = path.join(repoDir, fp);
     try {
-      fs.unlinkSync(abs);
+      await unlink(abs);
     } catch {
       // ignore missing files
     }
@@ -924,7 +925,7 @@ export function makeGitDiscardHandler(deps: GitDeps) {
       return jsonResponse({ error: "filepaths is required" }, 400);
     }
     try {
-      discard(deps, filepaths);
+      await discard(deps, filepaths);
       return jsonResponse({ success: true });
     } catch (err) {
       if (err instanceof InvalidDiscardPathError) {


### PR DESCRIPTION
## Summary
Convert the `discard()` helper function from synchronous to asynchronous, replacing `fs.unlinkSync()` with `await unlink()`. This eliminates a blocking filesystem call that stalls the daemon's single-threaded event loop and can cause missed health probes, triggering sandbox teardown.

## Why
Daemon filesystem operations must not block the event loop (see CONTRIBUTING.md rule #1). The `/git/discard` HTTP handler was calling a synchronous function that deleted files using `fs.unlinkSync()`, which could block the health probe Studio polls at ~500ms intervals. A missed probe triggers sandbox destruction.

## Testing
Behavior-preserving change: error handling and file deletion order unchanged, only async conversion. All 51 tests in `daemon/routes/git.test.ts` pass, including 5 discard-specific tests covering:
- Path traversal validation
- Renamed file restoration (original restored before new path deleted)
- Error handling for missing files
- Request validation

**To verify locally:**
```bash
bun test ./packages/sandbox/daemon/routes/git.test.ts
bunx tsc --noEmit -p packages/sandbox/tsconfig.json
```

CI runs the full suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `/git/discard` route non-blocking by converting `discard()` to async. This prevents event loop stalls that could cause missed health probes and sandbox teardown.

- **Bug Fixes**
  - Replaced `fs.unlinkSync()` with `await unlink()` and made `discard()` async.
  - Updated the HTTP handler to `await discard()`; behavior and error handling unchanged.

<sup>Written for commit 3198d9fc1bf67a7e875dfef4be580f10e48dcc06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

