### PR TITLE
fix(chat): stop keyboard focus escaping into the hidden side-panel view

### DIFF
--- a/apps/web/src/components/chat/side-panel-chat.tsx
+++ b/apps/web/src/components/chat/side-panel-chat.tsx
@@ -69,6 +69,8 @@ function ChatSidePanelContent() {
 
       {/* Chat view */}
       <div
+        inert={activePanel !== "chat" ? true : undefined}
+        aria-hidden={activePanel !== "chat"}
         className={cn(
           "absolute inset-0 flex flex-col transition-opacity duration-100 ease-out",
           activePanel !== "chat"
@@ -100,6 +102,8 @@ function ChatSidePanelContent() {
 
       {/* Context view */}
       <div
+        inert={activePanel !== "context" ? true : undefined}
+        aria-hidden={activePanel !== "context"}
         className={cn(
           "absolute inset-0 flex flex-col transition-opacity duration-100 ease-out",
           activePanel === "context"


### PR DESCRIPTION
**Source:** bug found while auditing the chat side-panel empty-state area (no linked issue).

**Why a maintainer wants this:** `ChatSidePanelContent` (apps/web/src/components/chat/side-panel-chat.tsx) keeps both the chat view and the context view mounted at all times inside the same `absolute inset-0` stack, toggling which one is visible with `opacity-0 pointer-events-none` vs `opacity-100`. `pointer-events-none` blocks mouse interaction and `opacity-0` hides it visually, but neither removes the element from the DOM's default tab order or the accessibility tree — a keyboard user pressing Tab (or a screen-reader user navigating linearly) can land on buttons/inputs belonging to whichever view isn't currently shown (e.g. tabbing into the invisible `ChatContextPanel` while the chat view is showing, or vice versa).

**The fix:** add the native `inert` boolean attribute (React 19 supports it directly as a DOM prop) plus `aria-hidden` to whichever of the two panels is not the active one. `inert` removes an element (and its descendants) from focus, tab order, and text selection without any custom focus-trap code — the platform feature the ladder in our house style calls for over hand-rolling one.

**Command a reviewer runs to confirm:** open the Chat side panel, switch between the chat and context views (via `usePanelActions`/`ChatContextPanel`'s back button), and Tab through the page — focus should skip the inactive panel's controls entirely. Reading the diff also confirms the four-line change.

**Checks run locally:**
- `bun run fmt` — clean
- `cd apps/web && bunx tsc --noEmit` — clean
- `npx oxlint apps/web/src/components/chat/side-panel-chat.tsx` — 0 warnings/errors

Full CI (unit tests, full lint, e2e) validates the rest — no Docker/Postgres available in this environment to run more.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents keyboard focus from reaching the hidden side-panel view in chat by making the inactive panel non-interactive. Adds `inert` and `aria-hidden` to the inactive chat/context panel so hidden controls are removed from the tab order and accessibility tree.

<sup>Written for commit 652f6551782464bde56897e95ec1272a2584b7c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

