### PR TITLE
fix(dispatch-queue): validate DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS through Settings

### DIFF
--- a/apps/api/src/dispatch-queue/hosted-run-concurrency.ts
+++ b/apps/api/src/dispatch-queue/hosted-run-concurrency.ts
@@ -20,23 +20,22 @@
  * just delays that step — the workflow's step sequence and recorded I/O are
  * unchanged (recovery-compatible; no DBOS_WORKFLOW_VERSION bump).
  *
- * DRAFT: limit is read from the environment with a conservative default. If we
- * keep this, move it into Settings (resolve-config.ts) so it's tunable per
- * deployment without an env redeploy.
+ * The limit comes from `Settings.decopilotMaxConcurrentHostedRuns`
+ * (DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS), validated at startup like every
+ * other numeric env var in this codebase — a malformed value fails boot
+ * instead of silently coercing to the default.
  */
 
 import { createConcurrencyGate } from "@/harnesses/decopilot/built-in-tools/subagent-concurrency";
+import { getSettings } from "@/settings";
 import { meter } from "@/observability";
 
-// A non-finite / non-positive env value would make the gate never block (fail
-// OPEN — the exact unbounded OOM this file prevents), so guard the default.
 // Default 3: prod worker is 768Mi request / 2Gi limit, run working set p90
 // ~450MB — 3×450≈1.35GB stays under the limit, 4-5 would OOM on p90 alone, and
 // a lower cap just parks more (which the KEDA queue-depth trigger can't see —
 // parked runs are PENDING, not ENQUEUED). The 1.8GB JSON.parse tail can still
 // OOM at any cap≥2; that's recovery's job, not this gate's.
-const parsed = Number(process.env.DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS);
-const MAX = Number.isFinite(parsed) && parsed > 0 ? parsed : 3;
+const MAX = getSettings().decopilotMaxConcurrentHostedRuns;
 
 const gate = createConcurrencyGate(MAX);
 

--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -409,3 +409,26 @@ describe("resolveConfig decopilot max concurrent subagents", () => {
     ).toThrow("DECOPILOT_MAX_CONCURRENT_SUBAGENTS must be a positive integer");
   });
 });
+
+describe("resolveConfig decopilot max concurrent hosted runs", () => {
+  it("defaults to 3", () => {
+    expect(
+      resolveConfig(flags, {}).settings.decopilotMaxConcurrentHostedRuns,
+    ).toBe(3);
+  });
+
+  it("honors an override", () => {
+    expect(
+      resolveConfig(flags, { DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS: "5" })
+        .settings.decopilotMaxConcurrentHostedRuns,
+    ).toBe(5);
+  });
+
+  it("rejects a non-numeric value at boot (fail-fast, not a silent default)", () => {
+    expect(() =>
+      resolveConfig(flags, { DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS: "free" }),
+    ).toThrow(
+      "DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS must be a positive integer",
+    );
+  });
+});

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -275,6 +275,11 @@ export function resolveConfig(
       envVars.DECOPILOT_MAX_CONCURRENT_SUBAGENTS,
       4,
     ),
+    decopilotMaxConcurrentHostedRuns: toPositiveIntegerOrDefault(
+      "DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS",
+      envVars.DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS,
+      3,
+    ),
     // Object Storage (S3-compatible)
     s3Endpoint: envVars.S3_ENDPOINT,
     s3Bucket: envVars.S3_BUCKET,

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -110,6 +110,10 @@ export interface Settings {
    *  (DECOPILOT_MAX_CONCURRENT_SUBAGENTS). Excess calls queue and start as
    *  slots free — see `subagent-concurrency.ts`. */
   decopilotMaxConcurrentSubagents: number;
+  /** Process-wide cap on concurrent top-level hosted agent-loop runs per pod
+   *  (DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS). Excess runs park and start as
+   *  slots free — see `hosted-run-concurrency.ts`. */
+  decopilotMaxConcurrentHostedRuns: number;
   // Object Storage (S3-compatible)
   s3Endpoint: string | undefined;
   s3Bucket: string | undefined;


### PR DESCRIPTION
Source: a bug found while hunting decopilot harness reliability — `hosted-run-concurrency.ts` carried a DRAFT comment flagging it should move into Settings, mirroring the identical fix already applied today to its sibling gate in #5463 (`subagent-concurrency.ts` / `DECOPILOT_MAX_CONCURRENT_SUBAGENTS`).

Why a maintainer wants it: this gate bounds concurrent hosted agent-loop runs per pod specifically to prevent OOM (see the file's own comment: ~450MB working set per run, cap sized to stay under the 2Gi pod limit). It read `process.env.DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS` directly and silently fell back to the default of 3 on a malformed value (e.g. a typo in the deployment config) instead of failing startup — the exact same class of bug the sibling PR fixed, just left as a DRAFT TODO in this file.

Failure scenario: an operator sets `DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS=3ee` (typo) in a deployment manifest; the old code silently used the default of 3 with no indication the override was ignored, masking a misconfiguration until someone investigates why the tuned value never took effect.

Fix: adds `decopilotMaxConcurrentHostedRuns` to `Settings`, validated via the existing `toPositiveIntegerOrDefault` helper (fails boot on a non-numeric value, defaults to 3 — same default as before), and points the gate at `getSettings()` instead of raw `process.env`.

Reviewer command: `cd apps/api && bun test src/settings/resolve-config.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), and the targeted test above (67 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validated `DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS` via Settings and wired it into the hosted-run concurrency gate. This fails fast on bad values and ensures the per-pod cap is respected to avoid OOM.

- **Bug Fixes**
  - Added `decopilotMaxConcurrentHostedRuns` to `Settings`, validated with `toPositiveIntegerOrDefault` (default 3; non-numeric rejects at boot).
  - Updated `hosted-run-concurrency.ts` to read from `getSettings()` instead of `process.env`.
  - Added tests covering default, override, and invalid values in `resolve-config.test.ts`.

<sup>Written for commit 272faad957af42e5499c77b8044e54e8019583f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

