### PR TITLE
fix(native): pin git children to LC_ALL=C in the local-api git route

### DIFF
--- a/apps/native/crates/local-api/src/routes/git.rs
+++ b/apps/native/crates/local-api/src/routes/git.rs
@@ -413,7 +413,15 @@ async fn run_git_raw_with_timeout<S: AsRef<str>>(
         .kill_on_drop(true)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped());
+        .stderr(std::process::Stdio::piped())
+        // `continue_rebase`'s "staged changes in your working tree",
+        // `resolve_conflicts`'s "CONFLICT", and
+        // `force_push_rebased_branch`'s "stale info"/"failed to push some
+        // refs" all read git's ENGLISH message text, and git localizes every
+        // one of them under a translated system locale. Pin the child's
+        // locale so those detectors can't silently miss a known, recoverable
+        // condition — same fix as `setup/clone.rs`'s `run_git`.
+        .env("LC_ALL", "C");
     for (k, v) in env {
         cmd.env(k, v);
     }


### PR DESCRIPTION
Follows #5470's fix.

`routes/git.rs`'s rebase-continue, conflict-resolution, and force-push-retry paths match git's stderr/stdout against fixed English strings: `continue_rebase` checks for `"staged changes in your working tree"`, `resolve_conflicts` checks for `"CONFLICT"`, and `force_push_rebased_branch` checks for `"stale info"` / `"failed to push some refs"`. Under a system git with gettext translations installed (any non-English `LANG`/`LC_ALL`), git localizes every one of these messages, which silently blinds the detectors — the exact bug class #5470 just fixed for `setup/clone.rs`'s matchers (`ref_format_unsupported`, `refetch_after_case_collision`, the "already used by worktree" family), left unfixed in this sibling file.

Failure scenario: a user with a non-English system locale runs a rebase that hits an editor-required commit step; `continue_rebase`'s English-only match on `git rebase --continue`'s error text fails to recognize the recoverable "you have staged changes" case, so the rebase surfaces as a hard failure instead of auto-committing and continuing. Same for conflict-resolution retries and the force-push-with-lease staleness retry, which spin down to a raw error instead of the fetch-and-retry path.

Fix: pin `LC_ALL=C` on every git child this route spawns, mirroring `setup/clone.rs`'s `run_git`, which already does this for the exact same reason.

Reviewer check: `cargo test -p local-api routes::git::` (all 25 existing tests still pass — the change only pins the child's locale, it doesn't touch argv or parsing logic).

Locally verified: `cargo check -p local-api` (clean) and `cargo test -p local-api routes::git::` (25/25 passing). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned git child processes to `LC_ALL=C` in the `local-api` git route so English message matching works across locales. This prevents missed detections for rebase-continue, conflict resolution, and force-push-with-lease retries on non-English systems, restoring the expected auto-retry behavior.

<sup>Written for commit 15e1229856808cb7cee33a17aafe4fa1a6fe0b4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

