### PR TITLE
fix(helm): add missing CPU limit to the studio API container

### DIFF
--- a/deploy/helm/studio/README.md
+++ b/deploy/helm/studio/README.md
@@ -693,6 +693,7 @@ resources:
     cpu: "750m"
   limits:
     memory: "1Gi"
+    cpu: "1"
 
 nginx:
   resources:

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -41,6 +41,7 @@ resources:
     cpu: "750m"
     memory: "1Gi"
   limits:
+    cpu: "1"
     memory: "1Gi"
 
 database:


### PR DESCRIPTION
Follows #5094 (which added CPU limits to nginx and worker containers) — the main API container's `resources` block still had a CPU request (750m) but no CPU limit. The chart README's own Resources section already documented "limits matching requests + headroom (1 CPU per container)" for this container (see the `## Resources` heading and the summary line above it), but `values.yaml` never actually set it, so the doc and the chart had drifted apart.

Why it matters: with the split API/worker topology, the main Deployment runs 2 API containers per pod at `replicaCount: 2` by default. Without a CPU limit, an API container can burst unbounded and starve other workloads on a shared node — the exact class of problem #5094 fixed for the nginx and worker containers in the same pod, just missed for the API container itself.

Change: sets `resources.limits.cpu: "1"` in `deploy/helm/studio/values.yaml`, matching nginx's own request/limit ratio (500m request -> 1 CPU limit) and the value the README already claimed. Also fixes the README's own Resources code sample to include the `cpu` limit line so the doc matches the chart again.

To confirm: `helm template deploy/helm/studio --set database.url=postgresql://x | grep -A5 resources` — both `api-0` and `api-1` containers now render `limits: {cpu: "1", memory: 1Gi}`.

Locally verified: `helm lint deploy/helm/studio` (0 charts failed, only the pre-existing expected `database.url` warning) and `helm template` rendering as above. This is a pure Helm-values change (no code), so no `tsc`/`bun test` applies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a missing CPU limit (`limits.cpu: "1"`) for the Studio API container in `deploy/helm/studio/values.yaml`, aligning with the README and nginx/worker limits. Updates the README example and prevents unbounded CPU bursts that could starve other workloads on shared nodes.

<sup>Written for commit a690cca164cff25a23ceae78fd2c0a83e564adff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

