### PR TITLE
fix(settings): validate DBOS_POOL_SIZE through Settings

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -94,7 +94,7 @@ DBOS.setConfig(
     // SDK default is 10. Cap lower so N replicas don't exhaust RDS slots —
     // bump via `DBOS_POOL_SIZE` if the workflow workload demands more in-flight
     // steps per pod.
-    poolSize: Number(process.env.DBOS_POOL_SIZE ?? 5),
+    poolSize: settings.dbosPoolSize,
     executorID: settings.podName,
     // Pod-role queue filter (see RUN_QUEUES above). undefined => "all".
     listenQueues,

--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -121,6 +121,29 @@ describe("resolveConfig database pool max", () => {
   );
 });
 
+describe("resolveConfig DBOS pool size", () => {
+  it("defaults to 5 when unset", () => {
+    const result = resolveConfig(flags, {});
+
+    expect(result.settings.dbosPoolSize).toBe(5);
+  });
+
+  it("uses DBOS_POOL_SIZE when set", () => {
+    const result = resolveConfig(flags, { DBOS_POOL_SIZE: "20" });
+
+    expect(result.settings.dbosPoolSize).toBe(20);
+  });
+
+  it.each(["abc", "0", "-1", "1.5", "Infinity"])(
+    "throws for invalid pool size %p",
+    (value) => {
+      expect(() => resolveConfig(flags, { DBOS_POOL_SIZE: value })).toThrow(
+        "DBOS_POOL_SIZE must be a positive integer",
+      );
+    },
+  );
+});
+
 describe("resolveConfig port", () => {
   it("defaults to 3000 when unset", () => {
     const result = resolveConfig(flags, {});

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -203,6 +203,11 @@ export function resolveConfig(
       envVars.DATABASE_POOL_MAX,
       5,
     ),
+    dbosPoolSize: toPositiveIntegerOrDefault(
+      "DBOS_POOL_SIZE",
+      envVars.DBOS_POOL_SIZE,
+      5,
+    ),
 
     // Auth & Secrets
     betterAuthSecret: envVars.BETTER_AUTH_SECRET || "",

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -23,6 +23,10 @@ export interface Settings {
   databaseUrl: string;
   databasePgSsl: boolean;
   databasePoolMax: number;
+  /** DBOS's own Postgres connection pool size (DBOS_POOL_SIZE), separate from
+   *  `databasePoolMax` (the app's pool). SDK default is 10; capped lower by
+   *  default so N replicas don't exhaust RDS slots. */
+  dbosPoolSize: number;
 
   // Auth & Secrets
   betterAuthSecret: string;


### PR DESCRIPTION
Source: hunting the settings/resolve-config.ts area right after #5473 (`DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS`) and #5463 (`DECOPILOT_MAX_CONCURRENT_SUBAGENTS`) landed the same fix pattern — `apps/api/src/index.ts` had a sibling raw `process.env` read that never got migrated.

Why a maintainer wants it: `index.ts` reads `Number(process.env.DBOS_POOL_SIZE ?? 5)` directly to size DBOS's own Postgres connection pool. A malformed value (e.g. a typo in a deployment manifest, `DBOS_POOL_SIZE=5O`) evaluates to `NaN`, which is silently swallowed by the pg pool's own `options.max || 10` fallback deep in the DBOS SDK — the operator's tuned value is silently ignored with zero indication, the exact class of bug already fixed twice this week for the decopilot concurrency gates.

Fix: adds `dbosPoolSize` to `Settings`, validated via the existing `toPositiveIntegerOrDefault` helper (fails boot on a non-numeric value, defaults to 5 — same default as before), and points `index.ts`'s DBOS config at `settings.dbosPoolSize` instead of raw `process.env`. Added tests covering default/override/invalid values in `resolve-config.test.ts`, mirroring the existing `DATABASE_POOL_MAX` test block.

Reviewer command: `cd apps/api && bun test src/settings/resolve-config.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), and the targeted test above (74 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `DBOS_POOL_SIZE` through `Settings` to prevent silent fallbacks and ensure the DBOS pool size is a positive integer. Defaults to 5 and fails startup on invalid values.

- **Bug Fixes**
  - Added `dbosPoolSize` to `Settings` using `toPositiveIntegerOrDefault`.
  - Updated `apps/api/src/index.ts` to use `settings.dbosPoolSize` instead of `process.env`.
  - Added tests for default, override, and invalid values in `resolve-config.test.ts`.

<sup>Written for commit 2dcbc58c91dfa722c9882c5cf1338d9c3896398e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

