### PR TITLE
fix(i18n): use a correct plural key for provider-grid's more-providers label

### DIFF
--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -618,5 +618,6 @@ export const settings = {
   "settings.aiProviders.customOpenAiCompatible": "Custom OpenAI-compatible",
   "settings.aiProviders.customOpenAiDescription":
     "Bring your own model server (advanced)",
-  "settings.aiProviders.moreProviders": "{count} more provider{plural}",
+  "settings.aiProviders.moreProvidersSingular": "{count} more provider",
+  "settings.aiProviders.moreProvidersPlural": "{count} more providers",
 } as const;

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -657,5 +657,6 @@ export const settings = {
     "OpenAI-compat\u00edvel personalizado",
   "settings.aiProviders.customOpenAiDescription":
     "Traga seu pr\u00f3prio servidor de modelos (avan\u00e7ado)",
-  "settings.aiProviders.moreProviders": "{count} provedor{plural} adicional",
+  "settings.aiProviders.moreProvidersSingular": "{count} provedor adicional",
+  "settings.aiProviders.moreProvidersPlural": "{count} provedores adicionais",
 } satisfies Record<keyof typeof settingsEn, string>;

--- a/apps/web/src/views/settings/ai-providers/provider-grid.tsx
+++ b/apps/web/src/views/settings/ai-providers/provider-grid.tsx
@@ -183,10 +183,12 @@ export function ProviderGrid({
           {shouldPreview && (
             <SettingsCardItem
               onClick={onShowAll}
-              title={t("settings.aiProviders.moreProviders", {
-                count: hiddenCount,
-                plural: hiddenCount === 1 ? "" : "s",
-              })}
+              title={t(
+                hiddenCount === 1
+                  ? "settings.aiProviders.moreProvidersSingular"
+                  : "settings.aiProviders.moreProvidersPlural",
+                { count: hiddenCount },
+              )}
               action={
                 <ChevronRight size={16} className="text-muted-foreground" />
               }


### PR DESCRIPTION
Follows the recent i18n refactor hardening pass in `apps/web/src/i18n` — found while auditing task-board/library/settings dictionaries for count-based interpolation bugs (assignee-picker and org-connect are already covered by open PRs #5170 / #5382, so this fix targets a different file).

**The bug**: `settings.aiProviders.moreProviders` used a single `{plural}` placeholder filled in JS with a hardcoded English suffix — `plural: hiddenCount === 1 ? "" : "s"`. For the pt-br dictionary entry `"{count} provedor{plural} adicional"`, passing `"s"` renders **"provedors"** — not a real Portuguese word — and also leaves the adjective "adicional" un-pluralized (should be "adicionais"). A Portuguese-speaking user with more than one hidden AI provider sees broken grammar in Settings → AI Providers.

**The fix**: replaced the single interpolated key with explicit `moreProvidersSingular`/`moreProvidersPlural` keys (mirroring the pattern already used elsewhere, e.g. `content-browser.tsx`'s singular/plural ternaries), so each locale's dictionary owns its own correct singular and plural wording instead of assuming an English "append s" rule. pt-br now reads "{count} provedores adicionais" for the plural case.

**To confirm**: open Settings → AI Providers with more than one hidden/collapsed provider tile while the org language is set to Portuguese (Brazil) — the "show more" row should read "N provedores adicionais", not "N provedors adicional".

**Checks run locally**: `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/web` (passes — the pt-br dictionary's `satisfies Record<keyof typeof settingsEn, string>` constraint also catches any key-parity drift at compile time). Full CI runs the broader suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pluralization for the "more providers" label in Settings → AI Providers by replacing a hardcoded English suffix with proper singular/plural i18n keys. Portuguese (Brazil) now shows correct grammar.

- **Bug Fixes**
  - Added `settings.aiProviders.moreProvidersSingular` and `settings.aiProviders.moreProvidersPlural` to `en` and `pt-br` dictionaries.
  - Updated the provider grid to select the correct key based on `hiddenCount` and pass `{count}` only.

<sup>Written for commit 8e6ad366e79928f5948202a8c768725d9989c91d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

