### PR TITLE
fix(sandbox): make golden-cache node-local disk I/O async

### DIFF
--- a/packages/sandbox/daemon/setup/golden-cache.test.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.test.ts
@@ -1,11 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  utimesSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdir, mkdtemp, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -16,8 +10,17 @@ import {
   sameFilesystem,
 } from "./golden-cache";
 
-function tmp(): string {
-  return mkdtempSync(join(tmpdir(), "golden-test-"));
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function tmp(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "golden-test-"));
 }
 
 describe("goldenNodeModulesPath", () => {
@@ -67,35 +70,35 @@ describe("goldenNodeModulesPath", () => {
 });
 
 describe("lockfileHash", () => {
-  it("returns null when no lockfile is present", () => {
-    expect(lockfileHash(tmp(), "bun")).toBeNull();
+  it("returns null when no lockfile is present", async () => {
+    expect(await lockfileHash(await tmp(), "bun")).toBeNull();
   });
 
-  it("returns null for a package manager with no known lockfile", () => {
-    const dir = tmp();
-    writeFileSync(join(dir, "bun.lock"), "x");
-    expect(lockfileHash(dir, "deno")).toBeNull();
+  it("returns null for a package manager with no known lockfile", async () => {
+    const dir = await tmp();
+    await writeFile(join(dir, "bun.lock"), "x");
+    expect(await lockfileHash(dir, "deno")).toBeNull();
   });
 
-  it("hashes lockfile content — same bytes, same hash; different bytes differ", () => {
-    const a = tmp();
-    const b = tmp();
-    const c = tmp();
-    writeFileSync(join(a, "bun.lock"), "lockfile-A");
-    writeFileSync(join(b, "bun.lock"), "lockfile-A");
-    writeFileSync(join(c, "bun.lock"), "lockfile-B");
-    const ha = lockfileHash(a, "bun");
+  it("hashes lockfile content — same bytes, same hash; different bytes differ", async () => {
+    const a = await tmp();
+    const b = await tmp();
+    const c = await tmp();
+    await writeFile(join(a, "bun.lock"), "lockfile-A");
+    await writeFile(join(b, "bun.lock"), "lockfile-A");
+    await writeFile(join(c, "bun.lock"), "lockfile-B");
+    const ha = await lockfileHash(a, "bun");
     expect(ha).toBeTruthy();
-    expect(lockfileHash(b, "bun")).toBe(ha);
-    expect(lockfileHash(c, "bun")).not.toBe(ha);
+    expect(await lockfileHash(b, "bun")).toBe(ha);
+    expect(await lockfileHash(c, "bun")).not.toBe(ha);
   });
 
-  it("picks the pm's lockfile (npm uses package-lock.json)", () => {
-    const dir = tmp();
-    writeFileSync(join(dir, "package-lock.json"), "{}");
-    expect(lockfileHash(dir, "npm")).toBeTruthy();
+  it("picks the pm's lockfile (npm uses package-lock.json)", async () => {
+    const dir = await tmp();
+    await writeFile(join(dir, "package-lock.json"), "{}");
+    expect(await lockfileHash(dir, "npm")).toBeTruthy();
     // bun ignores an npm lockfile
-    expect(lockfileHash(dir, "bun")).toBeNull();
+    expect(await lockfileHash(dir, "bun")).toBeNull();
   });
 });
 
@@ -127,75 +130,87 @@ describe("goldenEnabled (kill switch)", () => {
 });
 
 describe("sameFilesystem", () => {
-  it("true for a path against itself", () => {
-    const dir = tmp();
-    expect(sameFilesystem(dir, dir)).toBe(true);
+  it("true for a path against itself", async () => {
+    const dir = await tmp();
+    expect(await sameFilesystem(dir, dir)).toBe(true);
   });
 
-  it("false when a path does not exist", () => {
-    expect(sameFilesystem("/nonexistent/xyz", tmp())).toBe(false);
+  it("false when a path does not exist", async () => {
+    expect(await sameFilesystem("/nonexistent/xyz", await tmp())).toBe(false);
   });
 });
 
 describe("pruneGoldens", () => {
   // Make a golden dir <root>/golden/<repo>/<name> with a given mtime (ms).
-  function mkGolden(root: string, repo: string, name: string, mtimeMs: number) {
+  async function mkGolden(
+    root: string,
+    repo: string,
+    name: string,
+    mtimeMs: number,
+  ): Promise<string> {
     const dir = join(root, "golden", repo, name);
-    mkdirSync(dir, { recursive: true });
+    await mkdir(dir, { recursive: true });
     const t = new Date(mtimeMs);
-    utimesSync(dir, t, t);
+    await utimes(dir, t, t);
     return dir;
   }
 
-  it("no-ops on a missing cache root / empty store", () => {
-    expect(() => pruneGoldens(undefined)).not.toThrow();
-    expect(() => pruneGoldens(tmp())).not.toThrow();
+  it("no-ops on a missing cache root / empty store", async () => {
+    await expect(pruneGoldens(undefined)).resolves.toBeUndefined();
+    await expect(pruneGoldens(await tmp())).resolves.toBeUndefined();
   });
 
-  it("drops goldens older than the TTL, keeps fresh ones", () => {
-    const root = tmp();
+  it("drops goldens older than the TTL, keeps fresh ones", async () => {
+    const root = await tmp();
     const now = 1_000_000_000_000;
-    const fresh = mkGolden(root, "repoA", "bun-fresh", now - 1000);
-    const stale = mkGolden(root, "repoA", "bun-stale", now - 10 * 86_400_000);
-    pruneGoldens(root, { now, ttlMs: 7 * 86_400_000, maxPerRepo: 99 });
-    expect(existsSync(fresh)).toBe(true);
-    expect(existsSync(stale)).toBe(false);
-  });
-
-  it("caps to the newest maxPerRepo per repo", () => {
-    const root = tmp();
-    const now = 1_000_000_000_000;
-    const dirs = [0, 1, 2, 3].map((i) =>
-      mkGolden(root, "repoB", `bun-${i}`, now - i * 1000),
+    const fresh = await mkGolden(root, "repoA", "bun-fresh", now - 1000);
+    const stale = await mkGolden(
+      root,
+      "repoA",
+      "bun-stale",
+      now - 10 * 86_400_000,
     );
-    pruneGoldens(root, { now, ttlMs: 999 * 86_400_000, maxPerRepo: 2 });
-    // Newest two (i=0,1) survive; older two (i=2,3) are pruned.
-    expect(existsSync(dirs[0])).toBe(true);
-    expect(existsSync(dirs[1])).toBe(true);
-    expect(existsSync(dirs[2])).toBe(false);
-    expect(existsSync(dirs[3])).toBe(false);
+    await pruneGoldens(root, { now, ttlMs: 7 * 86_400_000, maxPerRepo: 99 });
+    expect(await exists(fresh)).toBe(true);
+    expect(await exists(stale)).toBe(false);
   });
 
-  it("never reaps in-flight .tmp. publishes", () => {
-    const root = tmp();
+  it("caps to the newest maxPerRepo per repo", async () => {
+    const root = await tmp();
     const now = 1_000_000_000_000;
-    const tmpPublish = mkGolden(
+    const dirs = await Promise.all(
+      [0, 1, 2, 3].map((i) =>
+        mkGolden(root, "repoB", `bun-${i}`, now - i * 1000),
+      ),
+    );
+    await pruneGoldens(root, { now, ttlMs: 999 * 86_400_000, maxPerRepo: 2 });
+    // Newest two (i=0,1) survive; older two (i=2,3) are pruned.
+    expect(await exists(dirs[0])).toBe(true);
+    expect(await exists(dirs[1])).toBe(true);
+    expect(await exists(dirs[2])).toBe(false);
+    expect(await exists(dirs[3])).toBe(false);
+  });
+
+  it("never reaps in-flight .tmp. publishes", async () => {
+    const root = await tmp();
+    const now = 1_000_000_000_000;
+    const tmpPublish = await mkGolden(
       root,
       "repoC",
       ".tmp.123.node_modules",
       now - 999 * 86_400_000, // ancient, but must be skipped
     );
-    pruneGoldens(root, { now, ttlMs: 1, maxPerRepo: 0 });
-    expect(existsSync(tmpPublish)).toBe(true);
+    await pruneGoldens(root, { now, ttlMs: 1, maxPerRepo: 0 });
+    expect(await exists(tmpPublish)).toBe(true);
   });
 
-  it("prunes each repo independently", () => {
-    const root = tmp();
+  it("prunes each repo independently", async () => {
+    const root = await tmp();
     const now = 1_000_000_000_000;
-    const a = mkGolden(root, "repoA", "bun-1", now);
-    const b = mkGolden(root, "repoB", "bun-1", now);
-    pruneGoldens(root, { now, ttlMs: 999 * 86_400_000, maxPerRepo: 5 });
-    expect(existsSync(a)).toBe(true);
-    expect(existsSync(b)).toBe(true);
+    const a = await mkGolden(root, "repoA", "bun-1", now);
+    const b = await mkGolden(root, "repoB", "bun-1", now);
+    await pruneGoldens(root, { now, ttlMs: 999 * 86_400_000, maxPerRepo: 5 });
+    expect(await exists(a)).toBe(true);
+    expect(await exists(b)).toBe(true);
   });
 });

--- a/packages/sandbox/daemon/setup/golden-cache.ts
+++ b/packages/sandbox/daemon/setup/golden-cache.ts
@@ -28,18 +28,26 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  statSync,
-  utimesSync,
-} from "node:fs";
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  utimes,
+} from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { Config } from "../types";
 import { resolveCloneUrl } from "./install";
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * GC bounds for the golden store (a golden ≈ a full node_modules on the node
@@ -84,13 +92,16 @@ export function repoHash(cloneUrl: string): string {
  * Content hash of the first present lockfile for `pm` under `installRoot`.
  * Null when no lockfile exists (→ golden disabled for this install).
  */
-export function lockfileHash(installRoot: string, pm: string): string | null {
+export async function lockfileHash(
+  installRoot: string,
+  pm: string,
+): Promise<string | null> {
   const names = LOCKFILES[pm];
   if (!names) return null;
   for (const name of names) {
     const path = join(installRoot, name);
     try {
-      const buf = readFileSync(path);
+      const buf = await readFile(path);
       return createHash("sha256").update(buf).digest("hex").slice(0, 32);
     } catch {
       // not this one — try the next
@@ -129,9 +140,10 @@ export function goldenNodeModulesPath(opts: {
  * emptyDir both dev fe01, cp --reflink=always fails). The `cp` exit code is
  * the authoritative test; callers must handle its failure regardless.
  */
-export function sameFilesystem(a: string, b: string): boolean {
+export async function sameFilesystem(a: string, b: string): Promise<boolean> {
   try {
-    return statSync(a).dev === statSync(b).dev;
+    const [sa, sb] = await Promise.all([stat(a), stat(b)]);
+    return sa.dev === sb.dev;
   } catch {
     return false;
   }
@@ -173,17 +185,17 @@ interface GoldenOpts {
   log?: Log;
 }
 
-function resolveGolden(opts: GoldenOpts): {
+async function resolveGolden(opts: GoldenOpts): Promise<{
   golden: string;
   targetNodeModules: string;
-} | null {
+} | null> {
   if (!goldenEnabled()) return null;
   const cacheRoot = opts.cacheRoot ?? process.env.DEPS_CACHE_ROOT;
   const golden = goldenNodeModulesPath({
     cacheRoot,
     cloneUrl: resolveCloneUrl(opts.config),
     pm: opts.pm,
-    lockHash: lockfileHash(opts.installRoot, opts.pm),
+    lockHash: await lockfileHash(opts.installRoot, opts.pm),
   });
   if (!golden) return null;
   return { golden, targetNodeModules: join(opts.installRoot, "node_modules") };
@@ -195,32 +207,32 @@ function resolveGolden(opts: GoldenOpts): {
  */
 export async function tryRestoreGolden(opts: GoldenOpts): Promise<boolean> {
   const log = opts.log ?? (() => {});
-  const paths = resolveGolden(opts);
+  const paths = await resolveGolden(opts);
   if (!paths) return false;
   const { golden, targetNodeModules } = paths;
-  if (!existsSync(golden)) return false;
+  if (!(await exists(golden))) return false;
   // reflink needs golden and the destination parent on one filesystem.
-  if (!sameFilesystem(golden, opts.installRoot)) {
+  if (!(await sameFilesystem(golden, opts.installRoot))) {
     log("[golden] cache and workdir on different filesystems — skipping");
     return false;
   }
   try {
     // A partial node_modules (interrupted prior boot) would make cp nest the
     // clone inside it; start clean.
-    rmSync(targetNodeModules, { recursive: true, force: true });
+    await rm(targetNodeModules, { recursive: true, force: true });
   } catch {
     // best-effort
   }
   const code = await reflinkClone(golden, targetNodeModules);
   if (code !== 0) {
     log(`[golden] restore failed (cp exit ${code}) — falling back to install`);
-    rmSync(targetNodeModules, { recursive: true, force: true });
+    await rm(targetNodeModules, { recursive: true, force: true });
     return false;
   }
   // Mark recently-used so GC's TTL doesn't reap an actively-restored lockfile.
   try {
     const now = new Date();
-    utimesSync(golden, now, now);
+    await utimes(golden, now, now);
   } catch {
     // best-effort
   }
@@ -242,18 +254,18 @@ export async function tryRestoreGolden(opts: GoldenOpts): Promise<boolean> {
 export async function publishGolden(opts: GoldenOpts): Promise<void> {
   const log = opts.log ?? (() => {});
   try {
-    const paths = resolveGolden(opts);
+    const paths = await resolveGolden(opts);
     if (!paths) return;
     const { golden, targetNodeModules } = paths;
-    if (!existsSync(targetNodeModules)) return;
-    if (existsSync(golden)) return; // already published for this lockfile
+    if (!(await exists(targetNodeModules))) return;
+    if (await exists(golden)) return; // already published for this lockfile
 
     const goldenDir = dirname(golden);
-    mkdirSync(goldenDir, { recursive: true });
+    await mkdir(goldenDir, { recursive: true });
     // Now that goldenDir exists, confirm it shares a filesystem with the
     // source (reflink prerequisite) — skip the doomed cp otherwise. (Checked
-    // here, not before mkdir, since statSync on a not-yet-created dir fails.)
-    if (!sameFilesystem(opts.installRoot, goldenDir)) {
+    // here, not before mkdir, since stat on a not-yet-created dir fails.)
+    if (!(await sameFilesystem(opts.installRoot, goldenDir))) {
       log(
         "[golden] cache and workdir on different filesystems — not publishing",
       );
@@ -262,25 +274,25 @@ export async function publishGolden(opts: GoldenOpts): Promise<void> {
     // Unique temp within the same dir (→ same fs → atomic rename). PID keeps
     // concurrent publishers on one node from colliding.
     const tmp = join(goldenDir, `.tmp.${process.pid}.node_modules`);
-    rmSync(tmp, { recursive: true, force: true });
+    await rm(tmp, { recursive: true, force: true });
     const code = await reflinkClone(targetNodeModules, tmp);
     if (code !== 0) {
-      rmSync(tmp, { recursive: true, force: true });
+      await rm(tmp, { recursive: true, force: true });
       log(`[golden] publish reflink failed (cp exit ${code})`);
       return;
     }
     // Strip pod-local runtime caches from the snapshot (cheap — reflink is
     // CoW, so these were near-free to clone and near-free to drop).
     for (const d of RUNTIME_CACHE_DIRS) {
-      rmSync(join(tmp, d), { recursive: true, force: true });
+      await rm(join(tmp, d), { recursive: true, force: true });
     }
     try {
-      renameSync(tmp, golden);
+      await rename(tmp, golden);
       log("[golden] published node_modules to cache");
     } catch {
       // Lost the race (another publisher renamed first) or golden appeared —
       // both fine; drop our temp.
-      rmSync(tmp, { recursive: true, force: true });
+      await rm(tmp, { recursive: true, force: true });
     }
   } catch (e) {
     log(`[golden] publish skipped: ${(e as Error).message}`);
@@ -295,10 +307,10 @@ export async function publishGolden(opts: GoldenOpts): Promise<void> {
  * fails → that pod falls back to install, and already-completed CoW clones are
  * independent of the source.
  */
-export function pruneGoldens(
+export async function pruneGoldens(
   cacheRoot: string | undefined = process.env.DEPS_CACHE_ROOT,
   opts: { ttlMs?: number; maxPerRepo?: number; now?: number } = {},
-): void {
+): Promise<void> {
   if (!cacheRoot) return;
   const ttlMs = opts.ttlMs ?? GOLDEN_TTL_MS;
   const maxPerRepo = opts.maxPerRepo ?? GOLDEN_MAX_PER_REPO;
@@ -306,7 +318,7 @@ export function pruneGoldens(
   const root = join(cacheRoot, "golden");
   let repos: string[];
   try {
-    repos = readdirSync(root);
+    repos = await readdir(root);
   } catch {
     return; // no golden store yet
   }
@@ -314,12 +326,15 @@ export function pruneGoldens(
     const repoDir = join(root, repo);
     let entries: { path: string; mtime: number }[];
     try {
-      entries = readdirSync(repoDir)
-        .filter((name) => !name.startsWith(".tmp.")) // skip in-flight publishes
-        .map((name) => {
+      const names = (await readdir(repoDir)).filter(
+        (name) => !name.startsWith(".tmp."), // skip in-flight publishes
+      );
+      entries = await Promise.all(
+        names.map(async (name) => {
           const path = join(repoDir, name);
-          return { path, mtime: statSync(path).mtimeMs };
-        });
+          return { path, mtime: (await stat(path)).mtimeMs };
+        }),
+      );
     } catch {
       continue;
     }
@@ -328,7 +343,7 @@ export function pruneGoldens(
     for (let i = 0; i < entries.length; i++) {
       const e = entries[i];
       if (i >= maxPerRepo || now - e.mtime > ttlMs) {
-        rmSync(e.path, { recursive: true, force: true });
+        await rm(e.path, { recursive: true, force: true });
       }
     }
   }

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -157,7 +157,7 @@ export class SetupOrchestrator {
       pm: pending.pm,
       log,
     });
-    pruneGoldens();
+    await pruneGoldens();
     // L2 after L1, and only from this same healthy-boot gate. A broken
     // install published to the shared store would poison every node in the
     // fleet, not just this one. No-op when the archive already exists, so the

--- a/packages/sandbox/daemon/setup/remote-golden.ts
+++ b/packages/sandbox/daemon/setup/remote-golden.ts
@@ -93,13 +93,13 @@ export function remoteGoldenPath(opts: {
   );
 }
 
-function resolveRemote(opts: RemoteGoldenOpts): string | null {
+async function resolveRemote(opts: RemoteGoldenOpts): Promise<string | null> {
   if (!remoteEnabled()) return null;
   return remoteGoldenPath({
     remoteRoot: opts.remoteRoot ?? process.env.GOLDEN_CACHE_REMOTE,
     cloneUrl: resolveCloneUrl(opts.config),
     pm: opts.pm,
-    lockHash: lockfileHash(opts.installRoot, opts.pm),
+    lockHash: await lockfileHash(opts.installRoot, opts.pm),
   });
 }
 
@@ -201,7 +201,7 @@ export async function tryRestoreRemoteGolden(
   opts: RemoteGoldenOpts,
 ): Promise<boolean> {
   const log = opts.log ?? (() => {});
-  const archive = resolveRemote(opts);
+  const archive = await resolveRemote(opts);
   if (!archive) return false;
   if (!(await exists(archive))) return false;
 
@@ -260,7 +260,7 @@ export async function publishRemoteGolden(
 ): Promise<void> {
   const log = opts.log ?? (() => {});
   try {
-    const archive = resolveRemote(opts);
+    const archive = await resolveRemote(opts);
     if (!archive) return;
     const source = join(opts.installRoot, "node_modules");
     if (!(await exists(source))) return;


### PR DESCRIPTION
Follows the daemon's async-fs hardening lane (#5333, #5336, #5367, #5370, #5372, #5375) — this is the golden-cache.ts instance of the same bug class.

`golden-cache.ts` used `readFileSync`/`statSync`/`mkdirSync`/`readdirSync`/`rmSync`/`renameSync`/`utimesSync` throughout. `tryRestoreGolden`, `publishGolden`, and `pruneGoldens` all run from a fire-and-forget call (`entry.ts`'s `void orchestrator.publishPendingGolden()`, fired off the `running` health transition) while the daemon's `Bun.serve` is already answering requests — so every sync fs call there parks the single-threaded event loop and can make the daemon miss its own health probe (CONTRIBUTING.md rule #1: a single miss gets the pod marked dead and torn down). `pruneGoldens` is the worst offender: it walks and `stat`s every golden directory on the node.

Why a maintainer wants this: it closes a real, provable liveness gap on the sandbox boot path — one that has already been the subject of ~6 merged PRs elsewhere in this same daemon (routes/fs.ts, discard route, etc.) but was still open here in setup/golden-cache.ts.

Change: converts every blocking call to its `node:fs/promises` equivalent, matching the async style `remote-golden.ts` (the L2 tier) already uses. `resolveRemote` in `remote-golden.ts` now awaits the (now-async) `lockfileHash` it imports from `golden-cache.ts`. `orchestrator.ts`'s one `pruneGoldens()` call site is now awaited. Behavior-preserving: identical logic, fallbacks, and log lines — only the I/O calls changed from sync to async equivalents.

Command a reviewer can run: `bun test packages/sandbox/daemon/setup/golden-cache.test.ts packages/sandbox/daemon/setup/remote-golden.test.ts`

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `packages/sandbox` (clean), and the two targeted test files above (19 + 7 pass). Also ran `packages/sandbox/daemon/setup/orchestrator.test.ts` — one pre-existing failure (`corepack` binary missing in this sandbox) reproduces identically on main before this change, so it's unrelated. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make golden-cache disk I/O async to avoid event-loop blocking during sandbox boot and prevent health probe misses. Replaced sync fs calls with `node:fs/promises` across restore, publish, and prune paths without changing behavior.

- **Bug Fixes**
  - Switched all sync fs calls to async equivalents (`node:fs/promises`).
  - Made `lockfileHash`, `sameFilesystem`, and internal resolvers async; updated callers.
  - `orchestrator` now awaits `pruneGoldens()`; `remote-golden` awaits `lockfileHash` in `resolveRemote`.
  - Updated tests to use async fs and assertions; behavior stays the same.

<sup>Written for commit 02a96aa39b45f1ad4e556c2667e8f9aa81dcd9d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

