### PR TITLE
fix(home): announce pin/unpin state on the shared ToggleButton

### DIFF
--- a/apps/web/src/components/home/toggle-button.tsx
+++ b/apps/web/src/components/home/toggle-button.tsx
@@ -18,6 +18,7 @@ export function ToggleButton({
       onClick={onClick}
       disabled={submitting}
       aria-label={label}
+      aria-pressed={isPinned}
       title={label}
       className={cn(
         "inline-flex size-7 shrink-0 items-center justify-center rounded-md text-xs transition-colors disabled:opacity-50 disabled:cursor-progress",


### PR DESCRIPTION
**Source**: hardening found while auditing the Home dashboard (`apps/web/src/components/home/`) for accessibility gaps, following this repo's proven `aria-label`/`aria-pressed` merge lane (#4903, #5047, #5096, #5226, #5271).

**Why**: `ToggleButton` (`apps/web/src/components/home/toggle-button.tsx`) is the shared pin/unpin control used by the add-tile drawer (agent rows, tool rows, connection rows) and the agent prompt list — three call sites all pass the live `isPinned` state and swap the icon between Plus/Minus. It already carries `aria-label`, but never exposed the *current* state to assistive tech, so a screen-reader user hears the same label regardless of whether the item is pinned or not and can't tell it's a toggle.

**Fix**: add `aria-pressed={isPinned}` alongside the existing `aria-label`. Pure attribute addition — no behavior, layout, or type change.

**Reviewer check**: `cd apps/web && bunx tsc --noEmit` (clean). Inspect the three call sites (`add-tile-drawer.tsx:999`, `add-tile-drawer.tsx:1108`, `agent-prompt-list.tsx:170`) to confirm `isPinned` is always the accurate current-state boolean at render time.

**Verified locally**: `bun run fmt` (no changes needed) and `bunx tsc --noEmit` in `apps/web` (clean). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `aria-pressed={isPinned}` to the shared `ToggleButton` so screen readers announce whether an item is pinned or not. Improves accessibility across the add‑tile drawer and agent prompt list with no behavior or layout changes.

<sup>Written for commit 44097f1c71ba057f61f35796deac3b7681a5e7a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

