### PR TITLE
refactor(chat): remove dead latency prop from ToolCallShell

### DIFF
--- a/apps/web/src/components/chat/message/parts/tool-call-part/common.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/common.tsx
@@ -23,8 +23,6 @@ export interface ToolCallShellProps {
   title: ReactNode;
   /** Usage stats for the operation (optional) */
   usage?: UsageStatsType | null;
-  /** Latency in seconds for the operation (optional) */
-  latency?: number;
   /** Short status text (or node, e.g. a live countdown) shown inline after the label */
   summary?: ReactNode;
   /** Derived UI state computed by caller based on their loading semantics */
@@ -53,7 +51,6 @@ export function ToolCallShell({
   icon,
   title,
   usage,
-  latency: _latency,
   summary,
   state,
   detail,

--- a/apps/web/src/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/generic.tsx
@@ -418,7 +418,6 @@ export function GenericToolCallPart({
           </>
         }
         title={friendlyName}
-        latency={latency}
         summary={summary}
         state={effectiveState}
         detail={detail || null}

--- a/apps/web/src/components/chat/message/thinking-indicator.tsx
+++ b/apps/web/src/components/chat/message/thinking-indicator.tsx
@@ -60,7 +60,6 @@ function ThoughtSummaryShell({
   detail,
   state,
   detailVariant = "prose",
-  latency,
   trailing,
 }: {
   icon: ReactNode;
@@ -69,7 +68,6 @@ function ThoughtSummaryShell({
   detail?: string | null;
   state: "loading" | "error" | "idle";
   detailVariant?: "code" | "prose";
-  latency?: number;
   trailing?: ReactNode;
 }) {
   return (
@@ -80,7 +78,6 @@ function ThoughtSummaryShell({
       detail={detail}
       state={state}
       detailVariant={detailVariant}
-      latency={latency}
       trailing={trailing}
     />
   );
@@ -222,9 +219,6 @@ export function ThoughtSummary({
   const fullText = parts.map((p) => p.text ?? "").join("\n\n");
   const detail = !allPartsRedacted && fullText.trim() ? fullText : null;
 
-  const latency =
-    !isStreaming && duration != null ? duration / 1000 : undefined;
-
   return (
     <ThoughtSummaryShell
       icon={
@@ -241,7 +235,6 @@ export function ThoughtSummary({
       detail={detail}
       state={isStreaming ? "loading" : "idle"}
       detailVariant="prose"
-      latency={latency}
     />
   );
 }


### PR DESCRIPTION
Dead-code deletion found while reviewing `apps/web/src/components/chat/message/parts/tool-call-part/common.tsx` (this tick's focus area).

`ToolCallShell`'s `latency` prop was destructured as `latency: _latency` and never read anywhere in the component body — it has done nothing since at least the current implementation. Only two of its many callers passed it at all:

- `generic.tsx` passed `latency={latency}` to `ToolCallShell`, but that same file already renders the value via `<LatencyBytesBadge latency={latency} .../>` in the `trailing` slot — the direct prop was a fully redundant, inert pass-through.
- `thinking-indicator.tsx`'s `ThoughtSummaryShell` computed a `latency` value and threaded it through to `ToolCallShell`, but that duration is already shown in the title text via `thoughtMessage` ("Thought for Xs") — again nothing rendered from the prop itself.

Net: -11 lines, +0. Removed the prop from `ToolCallShellProps`, its destructuring/doc comment in `common.tsx`, and the two now-pointless pass-through sites. `LatencyLabel` (the component that actually renders a latency badge, used by every other caller) is untouched.

Behavior is unchanged: `rg` confirms no other call site passed `latency` to `ToolCallShell`, and the two removed pass-throughs were provably unread (grep `_latency` had zero usages in the component body).

Reviewer check: `cd apps/web && bunx tsc --noEmit` (green — this is how the dead prop assignment in `thinking-indicator.tsx` surfaced once `common.tsx`'s type dropped it).

Locally ran: `bun run fmt` (clean) and `bunx tsc --noEmit` in `apps/web` (passes). No test added — this is a pure removal of an already-inert prop with a typecheck-verified zero-reference proof, not new logic; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `latency` prop from `ToolCallShell` and its pass-throughs to reduce dead code and simplify types. No UI or behavior changes.

- **Refactors**
  - Dropped `latency` from `ToolCallShellProps` and its destructuring.
  - Removed unused `latency` passes in `generic.tsx` and `thinking-indicator.tsx`.
  - Latency display remains via existing badges/title; type checks pass.

<sup>Written for commit 72e71844dfb693cc1d57b1e8382b72f0b1ab2b9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

