### PR TITLE
fix(settings): fall back to legacy env alias when the new name is an empty string

### DIFF
--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -239,6 +239,18 @@ describe("resolveConfig Studio environment aliases", () => {
     expect(result.settings.studioJwtSecret).toBe("legacy-secret");
     expect(result.settings.dispatchRole).toBe("worker");
   });
+
+  it("falls back to the legacy variables when the Studio ones are set to an empty string", () => {
+    const result = resolveConfig(flags, {
+      STUDIO_JWT_SECRET: "",
+      MESH_JWT_SECRET: "legacy-secret",
+      STUDIO_DISPATCH_ROLE: "",
+      MESH_DISPATCH_ROLE: "worker",
+    });
+
+    expect(result.settings.studioJwtSecret).toBe("legacy-secret");
+    expect(result.settings.dispatchRole).toBe("worker");
+  });
 });
 
 describe("resolveConfig public URL", () => {
@@ -253,6 +265,15 @@ describe("resolveConfig public URL", () => {
 
   it("accepts the legacy MESH_PUBLIC_URL during the compatibility window", () => {
     const result = resolveConfig(flags, {
+      MESH_PUBLIC_URL: "https://legacy.example.com",
+    });
+
+    expect(result.settings.publicUrl).toBe("https://legacy.example.com");
+  });
+
+  it("falls back to MESH_PUBLIC_URL when STUDIO_PUBLIC_URL is an empty string", () => {
+    const result = resolveConfig(flags, {
+      STUDIO_PUBLIC_URL: "",
       MESH_PUBLIC_URL: "https://legacy.example.com",
     });
 
@@ -382,6 +403,20 @@ describe("resolveConfig reports internal API env rename", () => {
 
   it("falls back to the legacy COMMERCE_DISCOVERY_INTERNAL_* names", () => {
     const result = resolveConfig(flags, {
+      COMMERCE_DISCOVERY_INTERNAL_API_URL: "https://reports-old.example.com",
+      COMMERCE_DISCOVERY_INTERNAL_API_KEY: "old-key",
+    });
+
+    expect(result.settings.reportsInternalApiUrl).toBe(
+      "https://reports-old.example.com",
+    );
+    expect(result.settings.reportsInternalApiKey).toBe("old-key");
+  });
+
+  it("falls back to the legacy CD names when the new ones are set to an empty string", () => {
+    const result = resolveConfig(flags, {
+      REPORTS_INTERNAL_API_URL: "",
+      REPORTS_INTERNAL_API_KEY: "",
       COMMERCE_DISCOVERY_INTERNAL_API_URL: "https://reports-old.example.com",
       COMMERCE_DISCOVERY_INTERNAL_API_KEY: "old-key",
     });

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -140,6 +140,19 @@ export function resolveS3ForcePathStyle(raw: string | undefined): boolean {
   return raw === undefined || raw === "" || raw === "true" || raw === "1";
 }
 
+/**
+ * Resolve a "new name first, legacy alias second" env var pair. Uses `||`
+ * (not `??`) so an env var explicitly set to "" — common when a deployment
+ * template renders an unset value as an empty string rather than omitting the
+ * key — falls through to the legacy alias instead of silently winning as "".
+ */
+function resolveAliasedEnv(
+  value: string | undefined,
+  legacyValue: string | undefined,
+): string | undefined {
+  return value || legacyValue;
+}
+
 const SANDBOX_PROVIDER_KINDS = new Set<SandboxProviderKind>([
   "agent-sandbox",
   "user-desktop",
@@ -193,7 +206,10 @@ export function resolveConfig(
     nodeEnv,
     port: toPositiveIntegerOrDefault("PORT", flags.port || envVars.PORT, 3000),
     baseUrl: flags.baseUrl || envVars.BASE_URL,
-    publicUrl: envVars.STUDIO_PUBLIC_URL ?? envVars.MESH_PUBLIC_URL,
+    publicUrl: resolveAliasedEnv(
+      envVars.STUDIO_PUBLIC_URL,
+      envVars.MESH_PUBLIC_URL,
+    ),
     dataDir,
 
     // Database (url resolved after services start)
@@ -212,7 +228,10 @@ export function resolveConfig(
     // Auth & Secrets
     betterAuthSecret: envVars.BETTER_AUTH_SECRET || "",
     encryptionKey: envVars.ENCRYPTION_KEY || "",
-    studioJwtSecret: envVars.STUDIO_JWT_SECRET ?? envVars.MESH_JWT_SECRET,
+    studioJwtSecret: resolveAliasedEnv(
+      envVars.STUDIO_JWT_SECRET,
+      envVars.MESH_JWT_SECRET,
+    ),
     localMode,
     disableRateLimit: toBool(envVars.DISABLE_RATE_LIMIT),
     studioProvisionSecretKey: envVars.STUDIO_PROVISION_SECRET_KEY,
@@ -313,7 +332,10 @@ export function resolveConfig(
     noTui: flags.noTui === true,
     podName: envVars.POD_NAME ?? crypto.randomUUID(),
     dispatchRole: resolveDispatchRole(
-      envVars.STUDIO_DISPATCH_ROLE ?? envVars.MESH_DISPATCH_ROLE,
+      resolveAliasedEnv(
+        envVars.STUDIO_DISPATCH_ROLE,
+        envVars.MESH_DISPATCH_ROLE,
+      ),
     ),
     sandboxProviderKind: resolveSandboxProviderKind(
       envVars.STUDIO_SANDBOX_PROVIDER,
@@ -326,12 +348,14 @@ export function resolveConfig(
     // New name first, legacy Commerce Discovery envs as fallback — one
     // setting, so prod migrates secrets whenever convenient without a
     // coordinated deploy. Drop the fallback once the CD envs are renamed.
-    reportsInternalApiUrl:
-      envVars.REPORTS_INTERNAL_API_URL ??
+    reportsInternalApiUrl: resolveAliasedEnv(
+      envVars.REPORTS_INTERNAL_API_URL,
       envVars.COMMERCE_DISCOVERY_INTERNAL_API_URL,
-    reportsInternalApiKey:
-      envVars.REPORTS_INTERNAL_API_KEY ??
+    ),
+    reportsInternalApiKey: resolveAliasedEnv(
+      envVars.REPORTS_INTERNAL_API_KEY,
       envVars.COMMERCE_DISCOVERY_INTERNAL_API_KEY,
+    ),
 
     // Managed asset storage (shared deco tenant bucket). Defaults match the
     // legacy admin platform so an existing deployment works without new env.


### PR DESCRIPTION
Bug found while auditing `apps/api/src/settings/resolve-config.ts` (the settings-resolution reactive area) for hidden env-fallback bugs, following the recent "resolve X through Settings" hardening lane (#5277, #5463, #5473, #5476).

Every "new name first, legacy alias second" field in this file (`publicUrl`, `studioJwtSecret`, `dispatchRole`, `reportsInternalApiUrl`, `reportsInternalApiKey`) resolved as `envVars.NEW ?? envVars.LEGACY`. Since `??` only treats `null`/`undefined` as absent, an env var explicitly set to `""` (common when a deployment template renders an unset value as an empty string rather than omitting the key) would "win" as `""` instead of falling through to the legacy alias — silently dropping a still-configured legacy value. This is inconsistent with every other optional string field in the same file (`baseUrl`, `configPath`, `duckdbMemoryLimit`, etc.), which all already use `||` for exactly this reason.

Concretely for `publicUrl`: `apps/api/src/core/server-constants.ts`'s `getPublicUrl()` does `getSettings().publicUrl ?? getBaseUrl()` — if `STUDIO_PUBLIC_URL=""` leaked through as `""`, `getPublicUrl()` would return `""` instead of falling back to `getBaseUrl()`, breaking the externally-reachable URL handed to the remote link daemon (its whole documented purpose).

Fix: added one small `resolveAliasedEnv(value, legacyValue)` helper (`value || legacyValue`) and used it at all 5 call sites, replacing the repeated `??` pattern. Behavior is unchanged for every value already covered by existing tests (undefined/set values) — only the empty-string case changes, from "wins as ''" to "falls through to the legacy alias", matching the rest of the file.

Regression tests added: empty-string cases for the JWT-secret/dispatch-role alias pair, the public-URL alias pair, and the reports-internal-API alias pair — each asserting the legacy value is now honored.

Reviewer check: `bun test apps/api/src/settings/resolve-config.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and the targeted test file above (77 pass, up from 74). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes env alias resolution to treat empty strings as absent, so new env vars fall back to their legacy names. Prevents blank values like publicUrl when STUDIO_PUBLIC_URL="" and restores expected behavior.

- **Bug Fixes**
  - Added resolveAliasedEnv helper to prefer value || legacyValue.
  - Applied to publicUrl, studioJwtSecret, dispatchRole, reportsInternalApiUrl, reportsInternalApiKey.
  - Added regression tests for empty-string cases; existing behaviors unchanged for defined values.

<sup>Written for commit 2e7437302ad35133eba4a89941ce1a942a7fc959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

