### PR TITLE
feat(sandbox-env): opt-in <name>-go SandboxTemplate for per-sandbox Go daemon targeting

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,13 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.9.57: opt-in `goTemplate` renders a second SandboxTemplate,
+# `studio-sandbox-<envName>-go`, pinned to the Go image. `daemonImpl` moves the
+# whole env; this moves ONE sandbox, because `spec.sandboxTemplateRef` is the
+# only per-claim lever the operator honors on a warm-poolable claim. Studio
+# points STUDIO_SANDBOX_GO_TEMPLATE_NAME at it; unset there, the org flag and
+# SANDBOX_START's `daemonImpl` prop are both inert. Default render unchanged
+# (enabled: false), and enabling it requires image.goRepository.
 # 0.9.55: the sandbox daemon implementation is now the IMAGE, not a runtime
 # switch. `daemonImpl` (default "ts") selects image.repository vs
 # image.goRepository (studio-sandbox vs studio-sandbox-go), and the pod no
@@ -59,7 +66,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.56
+version: 0.9.57
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.30.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -233,6 +233,8 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `image.goRepository` | `ghcr.io/decocms/studio/studio-sandbox-go` | same image with the Go daemon; used when `daemonImpl: go` |
 | `image.tag` | chart `appVersion` | bump in lockstep with packages/sandbox/package.json; drives BOTH images (released together) |
 | `daemonImpl` | `ts` | which daemon this template's sandboxes run — selects the image, not a runtime switch |
+| `goTemplate.enabled` | `false` | also render `studio-sandbox-<envName>-go`, a twin template pinned to the Go image, so a *single* sandbox can run Go while the env stays on `daemonImpl`. Point Studio's `STUDIO_SANDBOX_GO_TEMPLATE_NAME` at it; requires `image.goRepository` |
+| `goTemplate.warmPoolSize` | `0` | warm pods for that twin; size to the canary (1–2), never the fleet |
 | `resources.*` | 0.5/2 CPU, 1/4Gi RAM | per sandbox pod |
 | `nodeSelector` / `tolerations` / `affinity` | `{}` | for sandbox isolation NodePool |
 | `topologySpreadConstraints` | `[]` | spread sandbox pods across AZs; see `values.yaml` for the recommended config |

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -52,21 +52,46 @@ on the node, instead of here.
 {{- if and (eq $impl "go") (not .Values.image.goRepository) }}
 {{- fail "sandbox-env: daemonImpl=go requires image.goRepository (the studio-sandbox-go image). Set it, or leave daemonImpl=ts." -}}
 {{- end }}
+{{- if and .Values.goTemplate.enabled (not .Values.image.goRepository) }}
+{{- fail "sandbox-env: goTemplate.enabled requires image.goRepository (the studio-sandbox-go image)." -}}
+{{- end }}
 {{- end }}
 
 {{/*
-Sandbox container image, selected by daemonImpl. The daemon implementation is
-the image — `studio-sandbox` runs the TS daemon, `studio-sandbox-go` the Go one
-— so there is no runtime switch to disagree with. One tag drives both: they are
-released together from the same source revision and must never skew.
+Container image for a given daemon impl. The daemon implementation is the image
+— `studio-sandbox` runs the TS daemon, `studio-sandbox-go` the Go one — so there
+is no runtime switch to disagree with. One tag drives both: they are released
+together from the same source revision and must never skew.
+
+Takes a dict: `root` (the chart context) and `impl` ("ts" | "go").
+*/}}
+{{- define "sandbox-env.imageFor" -}}
+{{- $root := .root -}}
+{{- $repo := $root.Values.image.repository -}}
+{{- if eq .impl "go" -}}
+{{- $repo = $root.Values.image.goRepository -}}
+{{- end -}}
+{{- printf "%s:%s" $repo ($root.Values.image.tag | default $root.Chart.AppVersion) -}}
+{{- end }}
+
+{{/*
+The env's default SandboxTemplate name and the impl it runs — what
+STUDIO_SANDBOX_TEMPLATE_NAME must point at.
 */}}
 {{- define "sandbox-env.sandboxImage" -}}
 {{- include "sandbox-env.validateDaemonImpl" . -}}
-{{- $repo := .Values.image.repository -}}
-{{- if eq (.Values.daemonImpl | default "ts") "go" -}}
-{{- $repo = .Values.image.goRepository -}}
-{{- end -}}
-{{- printf "%s:%s" $repo (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- include "sandbox-env.imageFor" (dict "root" . "impl" (.Values.daemonImpl | default "ts")) -}}
+{{- end }}
+
+{{/*
+Name of the opt-in second SandboxTemplate that always runs the Go daemon.
+Studio points STUDIO_SANDBOX_GO_TEMPLATE_NAME at this so a *single* sandbox can
+be routed to Go while every other sandbox in the env keeps the default impl —
+`spec.sandboxTemplateRef` is the only per-claim lever, because the operator
+rejects per-claim `spec.env` on any claim that may bind a warm pod.
+*/}}
+{{- define "sandbox-env.goSandboxName" -}}
+{{- printf "%s-go" (include "sandbox-env.sandboxName" .) -}}
 {{- end }}
 
 {{/*

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -6,10 +6,28 @@
 # default. The template *name* is suffixed with envName so multiple
 # environments' SandboxTemplates coexist; Studio in this env must reference
 # the suffixed name via STUDIO_SANDBOX_TEMPLATE_NAME.
+#
+# Rendered once per variant: the env default (image chosen by daemonImpl) plus,
+# when goTemplate.enabled, a `<name>-go` twin pinned to the Go image. The twin
+# is byte-identical apart from its name, its pod label, and the image — that is
+# the whole point, so a Go canary differs from its neighbours in exactly one
+# dimension. Both stay in THIS release on purpose: a second release would mint a
+# second sentinel Secret that Studio's single STUDIO_SANDBOX_SENTINEL_TOKEN
+# could not authenticate against.
+{{- include "sandbox-env.validateDaemonImpl" . }}
+{{- $variants := list (dict "name" (include "sandbox-env.sandboxName" .) "impl" (.Values.daemonImpl | default "ts")) }}
+{{- if .Values.goTemplate.enabled }}
+{{- $variants = append $variants (dict "name" (include "sandbox-env.goSandboxName" .) "impl" "go") }}
+{{- end }}
+{{- range $i, $v := $variants }}
+{{- if $i }}
+---
+{{- end }}
+{{- with $ }}
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxTemplate
 metadata:
-  name: {{ include "sandbox-env.sandboxName" . }}
+  name: {{ $v.name }}
   namespace: agent-sandbox-system
   labels:
     {{- include "sandbox-env.sandboxLabels" . | nindent 4 }}
@@ -105,7 +123,7 @@ spec:
         # per pod (idempotent). Reuses the sandbox image — already on the
         # node, no extra pull.
         - name: deps-cache-init
-          image: "{{ include "sandbox-env.sandboxImage" . }}"
+          image: "{{ include "sandbox-env.imageFor" (dict "root" $ "impl" $v.impl) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["sh", "-c", "chown 1000:1000 /deps-cache"]
           resources:
@@ -207,7 +225,7 @@ spec:
       {{- end }}
       containers:
         - name: sandbox
-          image: "{{ include "sandbox-env.sandboxImage" . }}"
+          image: "{{ include "sandbox-env.imageFor" (dict "root" $ "impl" $v.impl) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           workingDir: /app
           env:
@@ -374,3 +392,5 @@ spec:
           emptyDir:
             sizeLimit: 1Mi
         {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-warm-pool.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-warm-pool.yaml
@@ -17,3 +17,20 @@ spec:
   sandboxTemplateRef:
     name: {{ include "sandbox-env.sandboxName" . }}
 {{- end }}
+{{- if and .Values.goTemplate.enabled (gt (int .Values.goTemplate.warmPoolSize) 0) }}
+---
+# Warm pods for the opt-in Go template. Independent of warmPool.* on purpose:
+# a Go canary wants 1–2 warm pods regardless of whether the env's default pool
+# is enabled, and turning the canary off must not resize the default pool.
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: {{ include "sandbox-env.goSandboxName" . }}
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "sandbox-env.sandboxLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.goTemplate.warmPoolSize }}
+  sandboxTemplateRef:
+    name: {{ include "sandbox-env.goSandboxName" . }}
+{{- end }}

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -57,6 +57,28 @@ image:
 # affects sandboxes created after the change.
 daemonImpl: ts
 
+# Opt-in SECOND SandboxTemplate (`studio-sandbox-<envName>-go`), identical to
+# the default one except that it always runs the Go image. This is how a
+# *single* sandbox lands on the Go daemon while every other sandbox in the env
+# stays on `daemonImpl`: the operator rejects per-claim `spec.env` whenever the
+# claim may bind a warm pod, so `spec.sandboxTemplateRef` is the only per-claim
+# lever.
+#
+# Wiring on the Studio side (chart-deco-studio configMap.meshConfig):
+#   STUDIO_SANDBOX_GO_TEMPLATE_NAME: "studio-sandbox-<envName>-go"
+# That env var is the global kill switch: unset, Studio ignores both the
+# `sandboxGoDaemon` org flag and SANDBOX_START's `daemonImpl` prop, because
+# there is nothing to point a claim at.
+#
+# Rendering this costs nothing until a claim references it (plus warmPoolSize
+# pods, if any) — deployed is not enabled.
+goTemplate:
+  enabled: false
+  # Warm pods for the Go template. 0 = template only, so a Go claim cold-starts
+  # its own pod. Size to the canary (1–2), never the fleet: every replica costs
+  # a full sandbox resource request, and these pods sit idle until claimed.
+  warmPoolSize: 0
+
 # ── sandbox pod resources (per SandboxClaim) ───────────────────────────
 # Prod ceilings. Adjust per measured workload.
 # memory request = observed p95 of per-pod peak working-set (~2Gi over 7d;


### PR DESCRIPTION
Stacked on #5484 (the Go daemon). Work item 4 of `daemon-go/SPEC.md` §8.5.

## Why a second template and not an env var

`SANDBOX_DAEMON_IMPL` is read by the **image entrypoint at container start**,
so the choice has to be made before the pod exists. In prod the pod usually
already exists — it comes from the warm pool — and `buildClaim` spells out the
constraint: in warm-pool mode the claim carries `spec.env: []` because **the
operator rejects per-claim env when the claim may bind a warm pod**.
Env-based selection is only available on the `warmpool: "none"` path, which
forces a cold pod per claim: fine for a one-off smoke, wrong for a canary
whose whole point is that boot cost stays comparable.

What *is* per-claim is `spec.sandboxTemplateRef`. So selection is by template.

## What ships

- `goTemplate.enabled` → a second `SandboxTemplate`,
  `studio-sandbox-<envName>-go`, identical to the default one except
  `SANDBOX_DAEMON_IMPL=go`.
- `goTemplate.warmPoolSize` → an optional `SandboxWarmPool` bound to it. A pool
  binds exactly one template, and a cold-per-claim Go sandbox would make the
  boot-parity comparison meaningless — so the canary needs its own pool.
- **Same helm release.** A second release would mint a second sentinel Secret
  (`randAlphaNum 64` per install) that Studio's single
  `STUDIO_SANDBOX_SENTINEL_TOKEN` could not authenticate against, and would
  duplicate the preview Gateway, cert, housekeeper and RBAC.
- The template body is **rendered once per impl** instead of copied, so the two
  cannot drift. That is the bulk of the diff — mechanical `.Values` → `$.Values`
  inside a `range`.

Both values default off. Rendering the template costs nothing until a claim
references it.

## Two traps, both handled

- The operator (v0.4.2+) rejects a claim whose `additionalPodMetadata` defines
  a label key already in the template — even with different values. So the
  template must NOT define `studio.decocms.com/daemon-impl` (the runner stamps
  it per claim), same as the existing `role` key. Comment updated to say so.
- The pod's `app.kubernetes.io/name` is deliberately **not** suffixed: both
  impls stay one fleet for anything selecting on it (housekeeper, a future
  NetworkPolicy). Attribution comes from the runner's `daemon-impl` label plus
  each daemon's `impl=` boot line.

## Testing

```
helm lint (defaults, and goTemplate.enabled)                       ✓
helm template, defaults      → render byte-identical to before      ✓
helm template, goTemplate.enabled → 2 SandboxTemplates; diff between
  them is exactly `metadata.name` + the SANDBOX_DAEMON_IMPL env      ✓
helm template, warmPoolSize=2 without enabled → fails at template
  time with a pointed message (silent no-op otherwise)               ✓
```

## Required follow-up outside this repo

Chart bumped to **0.9.52**. `sandbox-env` is pinned by `targetRevision` in
`deco-apps-cd`, so **this will not ship without that bump** — a prior fix
(#4561's 90s grace window) was lost exactly this way. This bump also carries
the `daemonImpl` value added in #5484, which has the same exposure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `studio-sandbox-<envName>-go` SandboxTemplate (with optional warm pool) so a single sandbox can target the Go daemon while others stay on TS. Selection is via `spec.sandboxTemplateRef`; default render remains unchanged.

- **New Features**
  - `goTemplate.enabled` renders `studio-sandbox-<envName>-go` pinned to `image.goRepository` via a new `imageFor` helper.
  - `goTemplate.warmPoolSize` creates an independent warm pool for the Go template.
  - Shared template body via a variant loop; only name and image differ to prevent drift.
  - Validation: require `image.goRepository` when `daemonImpl=go` or `goTemplate.enabled`; defaults render byte-identical to before.

- **Migration**
  - Update `deco-apps-cd` to use `sandbox-env` `0.9.57`.
  - In Studio, set `STUDIO_SANDBOX_GO_TEMPLATE_NAME` to `studio-sandbox-<envName>-go`.
  - Keep `daemonImpl: "ts"` env-wide; enable with `goTemplate.enabled=true` and size `goTemplate.warmPoolSize` for the canary.

<sup>Written for commit 62e6dcf9196b7bdbb9d1b15d3078197736f1493a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

