### PR TITLE
feat(sandbox): target a single sandbox at the Go daemon (org flag + SANDBOX_START prop)

### DIFF
--- a/apps/api/src/sandbox/lifecycle.ts
+++ b/apps/api/src/sandbox/lifecycle.ts
@@ -92,7 +92,7 @@ function readSandboxTemplateName(): string | undefined {
 
 // Name of the sandbox-env chart's opt-in `<name>-go` SandboxTemplate. Presence
 // is the GLOBAL KILL SWITCH for the Go daemon rollout: unset, both the
-// `sandboxGoDaemon` org flag and SANDBOX_START's `daemonImpl` prop are ignored,
+// `sandbox_go_daemon` org flag and SANDBOX_START's `daemonImpl` prop are ignored,
 // because there is no template to point a claim at. Unsetting it routes the next
 // sandbox back to TS with no rebuild; live sandboxes drain on their own binary.
 function readGoSandboxTemplateName(): string | undefined {

--- a/apps/api/src/sandbox/lifecycle.ts
+++ b/apps/api/src/sandbox/lifecycle.ts
@@ -90,6 +90,16 @@ function readSandboxTemplateName(): string | undefined {
   return raw && raw.trim() !== "" ? raw : undefined;
 }
 
+// Name of the sandbox-env chart's opt-in `<name>-go` SandboxTemplate. Presence
+// is the GLOBAL KILL SWITCH for the Go daemon rollout: unset, both the
+// `sandboxGoDaemon` org flag and SANDBOX_START's `daemonImpl` prop are ignored,
+// because there is no template to point a claim at. Unsetting it routes the next
+// sandbox back to TS with no rebuild; live sandboxes drain on their own binary.
+function readGoSandboxTemplateName(): string | undefined {
+  const raw = process.env.STUDIO_SANDBOX_GO_TEMPLATE_NAME;
+  return raw && raw.trim() !== "" ? raw : undefined;
+}
+
 function readEnvName(): string | undefined {
   const raw = process.env.STUDIO_ENV;
   return raw && raw.trim() !== "" ? raw : undefined;
@@ -161,6 +171,7 @@ async function instantiate(
         stateStore,
         previewUrlPattern,
         sandboxTemplateName: readSandboxTemplateName(),
+        goSandboxTemplateName: readGoSandboxTemplateName(),
         envName: readEnvName(),
         previewGateway: readPreviewGateway(),
         sentinelToken: readSandboxSentinelToken(),

--- a/apps/api/src/sandbox/resolve-daemon-impl.test.ts
+++ b/apps/api/src/sandbox/resolve-daemon-impl.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { resolveDaemonImpl } from "./resolve-daemon-impl";
+
+describe("resolveDaemonImpl", () => {
+  it("defaults to ts with no prop and no flag", () => {
+    expect(resolveDaemonImpl({})).toBe("ts");
+    expect(resolveDaemonImpl({ flags: null })).toBe("ts");
+    expect(resolveDaemonImpl({ flags: {} })).toBe("ts");
+  });
+
+  it("honors the org flag", () => {
+    expect(resolveDaemonImpl({ flags: { sandboxGoDaemon: true } })).toBe("go");
+    expect(resolveDaemonImpl({ flags: { sandboxGoDaemon: false } })).toBe("ts");
+  });
+
+  it("lets the explicit prop win in both directions", () => {
+    expect(
+      resolveDaemonImpl({ explicit: "go", flags: { sandboxGoDaemon: false } }),
+    ).toBe("go");
+    // The escape hatch that matters most: pinning one sandbox back to ts
+    // inside an org that is otherwise on Go.
+    expect(
+      resolveDaemonImpl({ explicit: "ts", flags: { sandboxGoDaemon: true } }),
+    ).toBe("ts");
+  });
+});

--- a/apps/api/src/sandbox/resolve-daemon-impl.test.ts
+++ b/apps/api/src/sandbox/resolve-daemon-impl.test.ts
@@ -9,18 +9,25 @@ describe("resolveDaemonImpl", () => {
   });
 
   it("honors the org flag", () => {
-    expect(resolveDaemonImpl({ flags: { sandboxGoDaemon: true } })).toBe("go");
-    expect(resolveDaemonImpl({ flags: { sandboxGoDaemon: false } })).toBe("ts");
+    expect(resolveDaemonImpl({ flags: { sandbox_go_daemon: true } })).toBe(
+      "go",
+    );
+    expect(resolveDaemonImpl({ flags: { sandbox_go_daemon: false } })).toBe(
+      "ts",
+    );
   });
 
   it("lets the explicit prop win in both directions", () => {
     expect(
-      resolveDaemonImpl({ explicit: "go", flags: { sandboxGoDaemon: false } }),
+      resolveDaemonImpl({
+        explicit: "go",
+        flags: { sandbox_go_daemon: false },
+      }),
     ).toBe("go");
     // The escape hatch that matters most: pinning one sandbox back to ts
     // inside an org that is otherwise on Go.
     expect(
-      resolveDaemonImpl({ explicit: "ts", flags: { sandboxGoDaemon: true } }),
+      resolveDaemonImpl({ explicit: "ts", flags: { sandbox_go_daemon: true } }),
     ).toBe("ts");
   });
 });

--- a/apps/api/src/sandbox/resolve-daemon-impl.ts
+++ b/apps/api/src/sandbox/resolve-daemon-impl.ts
@@ -8,7 +8,7 @@
  *   1. **Caller override.** `SANDBOX_START`'s `input.daemonImpl`. The escape
  *      hatch both ways: opt one sandbox in, or pin one back to `ts` inside a
  *      flagged org.
- *   2. **Org flag** `sandboxGoDaemon`. Who gets Go *by default* — what puts a
+ *   2. **Org flag** `sandbox_go_daemon`. Who gets Go *by default* — what puts a
  *      real user's sandboxes on Go without asking them to pass anything.
  *   3. **`ts`.** Deployed is not enabled.
  *
@@ -29,5 +29,5 @@ export function resolveDaemonImpl(args: {
   flags?: OrgFlags | null;
 }): SandboxDaemonImpl {
   if (args.explicit) return args.explicit;
-  return args.flags?.sandboxGoDaemon ? "go" : "ts";
+  return args.flags?.sandbox_go_daemon ? "go" : "ts";
 }

--- a/apps/api/src/sandbox/resolve-daemon-impl.ts
+++ b/apps/api/src/sandbox/resolve-daemon-impl.ts
@@ -1,0 +1,33 @@
+/**
+ * Single source of truth for "which sandbox daemon binary should this sandbox
+ * run?" — the Go-daemon rollout gate. Mirrors how `resolve-provider.ts` resolves
+ * the provider kind.
+ *
+ * Precedence (highest first):
+ *
+ *   1. **Caller override.** `SANDBOX_START`'s `input.daemonImpl`. The escape
+ *      hatch both ways: opt one sandbox in, or pin one back to `ts` inside a
+ *      flagged org.
+ *   2. **Org flag** `sandboxGoDaemon`. Who gets Go *by default* — what puts a
+ *      real user's sandboxes on Go without asking them to pass anything.
+ *   3. **`ts`.** Deployed is not enabled.
+ *
+ * The third layer of control — `STUDIO_SANDBOX_GO_TEMPLATE_NAME`, the global
+ * kill switch — is deliberately NOT read here. It is enforced in the runner
+ * (`resolveClaimTemplate`), which is the only place that knows whether a Go
+ * SandboxTemplate exists to point a claim at, and which persists the impl the
+ * claim actually got. Duplicating the check here would let the two disagree.
+ */
+
+import type { OrgFlags } from "@decocms/shared/organization/schema";
+import type { SandboxDaemonImpl } from "@decocms/sandbox/provider";
+
+export function resolveDaemonImpl(args: {
+  /** `SANDBOX_START`'s `daemonImpl` input, when the caller passed one. */
+  explicit?: SandboxDaemonImpl;
+  /** `organization_settings.flags`. Absent/unset reads as off. */
+  flags?: OrgFlags | null;
+}): SandboxDaemonImpl {
+  if (args.explicit) return args.explicit;
+  return args.flags?.sandboxGoDaemon ? "go" : "ts";
+}

--- a/apps/api/src/tools/sandbox/start.test.ts
+++ b/apps/api/src/tools/sandbox/start.test.ts
@@ -208,6 +208,8 @@ function makeCtx(overrides: {
   /** Row returned by `storage.threads.get` — set `created_by` to exercise the
    *  thread-owner keying (see resolveSandboxUserId). */
   thread?: { created_by: string; metadata: Record<string, unknown> } | null;
+  /** `organization_settings.flags` — drives the `sandboxGoDaemon` rollout flag. */
+  orgFlags?: Record<string, boolean> | null;
 }): StudioContext {
   const {
     orgId = ORG_ID,
@@ -215,6 +217,7 @@ function makeCtx(overrides: {
     virtualMcp,
     updateSpy = mock(async () => {}),
     thread = null,
+    orgFlags = null,
   } = overrides;
 
   const findById = mock(async (_id: string) => virtualMcp ?? null);
@@ -250,6 +253,11 @@ function makeCtx(overrides: {
       threads: {
         get: mock(async (_id: string) => thread),
         update: mock(async () => {}),
+      },
+      // Read once per provision to resolve the `sandboxGoDaemon` rollout flag.
+      // Default: no flags set, so every sandbox lands on the TS daemon.
+      organizationSettings: {
+        get: mock(async (_id: string) => ({ flags: orgFlags })),
       },
     } as never,
     timings: {
@@ -846,6 +854,61 @@ describe("SANDBOX_START", () => {
       updated.sandboxMap[USER_ID]?.[BRANCH] as Record<string, unknown>
     )?.["agent-sandbox"] as SandboxRecord | undefined;
     expect(stored?.sandboxProviderKind).toBe("agent-sandbox");
+  });
+
+  // --- Go-daemon rollout gate (resolveDaemonImpl) ---------------------------
+  // What reaches `runner.ensure` is the contract; whether the pod honors it is
+  // the runner's call (it collapses `go` back to `ts` with no Go template).
+
+  it("sends daemonImpl=ts when the org flag is unset", async () => {
+    const ctx = makeCtx({ virtualMcp: makeVirtualMcp(ORG_ID, BASE_METADATA) });
+    await SANDBOX_START.handler(
+      { virtualMcpId: VMCP_ID, branch: BRANCH } as Parameters<
+        typeof SANDBOX_START.handler
+      >[0],
+      ctx,
+    );
+    const opts = (mockEnsure.mock.calls as unknown[][])[0]![1] as {
+      daemonImpl?: string;
+    };
+    // Explicit rather than omitted: the runner persists whatever it resolved
+    // into the state blob for autonomous recovery, so the value it stores must
+    // never be an inference.
+    expect(opts.daemonImpl).toBe("ts");
+  });
+
+  it("sends daemonImpl=go when the org flag is on", async () => {
+    const ctx = makeCtx({
+      virtualMcp: makeVirtualMcp(ORG_ID, BASE_METADATA),
+      orgFlags: { sandboxGoDaemon: true },
+    });
+    await SANDBOX_START.handler(
+      { virtualMcpId: VMCP_ID, branch: BRANCH } as Parameters<
+        typeof SANDBOX_START.handler
+      >[0],
+      ctx,
+    );
+    const opts = (mockEnsure.mock.calls as unknown[][])[0]![1] as {
+      daemonImpl?: string;
+    };
+    expect(opts.daemonImpl).toBe("go");
+  });
+
+  it("lets an explicit daemonImpl=ts pin one sandbox inside a flagged org", async () => {
+    const ctx = makeCtx({
+      virtualMcp: makeVirtualMcp(ORG_ID, BASE_METADATA),
+      orgFlags: { sandboxGoDaemon: true },
+    });
+    await SANDBOX_START.handler(
+      { virtualMcpId: VMCP_ID, branch: BRANCH, daemonImpl: "ts" } as Parameters<
+        typeof SANDBOX_START.handler
+      >[0],
+      ctx,
+    );
+    const opts = (mockEnsure.mock.calls as unknown[][])[0]![1] as {
+      daemonImpl?: string;
+    };
+    expect(opts.daemonImpl).toBe("ts");
   });
 
   it("throws RECONNECT_ERROR when refreshing an expired token fails", async () => {

--- a/apps/api/src/tools/sandbox/start.test.ts
+++ b/apps/api/src/tools/sandbox/start.test.ts
@@ -208,7 +208,7 @@ function makeCtx(overrides: {
   /** Row returned by `storage.threads.get` — set `created_by` to exercise the
    *  thread-owner keying (see resolveSandboxUserId). */
   thread?: { created_by: string; metadata: Record<string, unknown> } | null;
-  /** `organization_settings.flags` — drives the `sandboxGoDaemon` rollout flag. */
+  /** `organization_settings.flags` — drives the `sandbox_go_daemon` rollout flag. */
   orgFlags?: Record<string, boolean> | null;
 }): StudioContext {
   const {
@@ -254,7 +254,7 @@ function makeCtx(overrides: {
         get: mock(async (_id: string) => thread),
         update: mock(async () => {}),
       },
-      // Read once per provision to resolve the `sandboxGoDaemon` rollout flag.
+      // Read once per provision to resolve the `sandbox_go_daemon` rollout flag.
       // Default: no flags set, so every sandbox lands on the TS daemon.
       organizationSettings: {
         get: mock(async (_id: string) => ({ flags: orgFlags })),
@@ -880,7 +880,7 @@ describe("SANDBOX_START", () => {
   it("sends daemonImpl=go when the org flag is on", async () => {
     const ctx = makeCtx({
       virtualMcp: makeVirtualMcp(ORG_ID, BASE_METADATA),
-      orgFlags: { sandboxGoDaemon: true },
+      orgFlags: { sandbox_go_daemon: true },
     });
     await SANDBOX_START.handler(
       { virtualMcpId: VMCP_ID, branch: BRANCH } as Parameters<
@@ -897,7 +897,7 @@ describe("SANDBOX_START", () => {
   it("lets an explicit daemonImpl=ts pin one sandbox inside a flagged org", async () => {
     const ctx = makeCtx({
       virtualMcp: makeVirtualMcp(ORG_ID, BASE_METADATA),
-      orgFlags: { sandboxGoDaemon: true },
+      orgFlags: { sandbox_go_daemon: true },
     });
     await SANDBOX_START.handler(
       { virtualMcpId: VMCP_ID, branch: BRANCH, daemonImpl: "ts" } as Parameters<

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -115,7 +115,7 @@ export const SANDBOX_START = defineTool({
     daemonImpl: sandboxDaemonImplSchema
       .optional()
       .describe(
-        "Target this one sandbox at a specific sandbox daemon implementation, overriding the org's `sandboxGoDaemon` flag in either direction. Only honored on `agent-sandbox`, and only when the deployment configures a Go SandboxTemplate; otherwise the sandbox lands on `ts`. Applies to a sandbox being created — an existing sandbox keeps the binary it booted with.",
+        "Target this one sandbox at a specific sandbox daemon implementation, overriding the org's `sandbox_go_daemon` flag in either direction. Only honored on `agent-sandbox`, and only when the deployment configures a Go SandboxTemplate; otherwise the sandbox lands on `ts`. Applies to a sandbox being created — an existing sandbox keeps the binary it booted with.",
       ),
   }),
   outputSchema: z.object({

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -17,6 +17,8 @@ import type { SandboxRecord } from "@decocms/shared/sdk";
 import {
   composeSandboxRef,
   normalizeSandboxProviderKind,
+  sandboxDaemonImplSchema,
+  type SandboxDaemonImpl,
   type SandboxProvider,
   type SandboxProviderKind,
   type Workload,
@@ -52,6 +54,7 @@ import {
 import { generateBranchName } from "@decocms/shared/branch-name";
 import { PACKAGE_MANAGER_CONFIG } from "@decocms/shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
+import { resolveDaemonImpl } from "../../sandbox/resolve-daemon-impl";
 import {
   getThreadGithubRepo,
   getThreadHeadRef,
@@ -108,6 +111,11 @@ export const SANDBOX_START = defineTool({
       .optional()
       .describe(
         "Explicit runtime choice. Hosted provider is `agent-sandbox`; legacy `cluster` input is accepted only for compatibility and normalized to `agent-sandbox`. When omitted, defaults to `user-desktop` if the acting user's link daemon is online, else the env kind.",
+      ),
+    daemonImpl: sandboxDaemonImplSchema
+      .optional()
+      .describe(
+        "Target this one sandbox at a specific sandbox daemon implementation, overriding the org's `sandboxGoDaemon` flag in either direction. Only honored on `agent-sandbox`, and only when the deployment configures a Go SandboxTemplate; otherwise the sandbox lands on `ts`. Applies to a sandbox being created — an existing sandbox keeps the binary it booted with.",
       ),
   }),
   outputSchema: z.object({
@@ -201,6 +209,7 @@ export const SANDBOX_START = defineTool({
       existing,
       providerKind,
       runner,
+      daemonImpl: input.daemonImpl,
     });
     return {
       ...entry,
@@ -333,6 +342,9 @@ type StartParams = {
   existing: SandboxRecord | null;
   providerKind: SandboxProviderKind;
   runner: SandboxProvider;
+  /** `SANDBOX_START`'s explicit daemon-impl override, when the caller passed
+   *  one. Absent on the `ensureSandbox` path, which falls back to the org flag. */
+  daemonImpl?: SandboxDaemonImpl;
 };
 
 async function provisionSandbox(
@@ -553,6 +565,22 @@ async function provisionSandbox(
     }
   }
 
+  // Go-daemon rollout gate. Only the hosted runner can honor it (the desktop
+  // daemon is the TS bundle the link spawns), so skip the settings read
+  // entirely elsewhere. `resolveDaemonImpl` applies prop → org flag → `ts`; the
+  // runner then collapses `go` back to `ts` when no Go SandboxTemplate is
+  // configured, and persists whichever one the claim actually got.
+  const daemonImpl =
+    runner.kind === "agent-sandbox"
+      ? resolveDaemonImpl({
+          explicit: params.daemonImpl,
+          flags: params.daemonImpl
+            ? null
+            : ((await ctx.storage.organizationSettings.get(orgId))?.flags ??
+              null),
+        })
+      : undefined;
+
   const sandbox = await runner.ensure(
     { userId: sandboxUserId, projectRef },
     {
@@ -581,6 +609,7 @@ async function provisionSandbox(
           }
         : {}),
       ...(orgFsConfigJson ? { orgFsConfigJson } : {}),
+      ...(daemonImpl ? { daemonImpl } : {}),
     },
   );
 

--- a/packages/sandbox/server/provider/agent-sandbox/claim-template.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/claim-template.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { resolveClaimTemplate } from "./runner";
+
+const TS = "studio-sandbox-stg";
+const GO = "studio-sandbox-stg-go";
+
+describe("resolveClaimTemplate", () => {
+  it("defaults to the ts template", () => {
+    expect(resolveClaimTemplate(undefined, TS, GO)).toEqual({
+      impl: "ts",
+      templateName: TS,
+    });
+    expect(resolveClaimTemplate("ts", TS, GO)).toEqual({
+      impl: "ts",
+      templateName: TS,
+    });
+  });
+
+  it("routes a go request at the go template", () => {
+    expect(resolveClaimTemplate("go", TS, GO)).toEqual({
+      impl: "go",
+      templateName: GO,
+    });
+  });
+
+  it("collapses go back to ts when no go template is configured", () => {
+    // The global kill switch. Pointing a claim at a template that does not
+    // exist fails provisioning outright, so an unconfigured deploy must ignore
+    // the request — and must report `ts`, since that is what the pod will run.
+    expect(resolveClaimTemplate("go", TS, null)).toEqual({
+      impl: "ts",
+      templateName: TS,
+    });
+  });
+});

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -59,6 +59,7 @@ import type {
   EnsureOptions,
   ProxyRequestInit,
   Sandbox,
+  SandboxDaemonImpl,
   SandboxId,
   SandboxProvider,
   Workload,
@@ -309,6 +310,18 @@ export interface AgentSandboxProviderOptions {
   /** SandboxTemplate all claims reference. */
   sandboxTemplateName?: string;
   /**
+   * SandboxTemplate for claims that asked for `daemonImpl: "go"` — the chart's
+   * opt-in `<name>-go` twin, identical except `SANDBOX_DAEMON_IMPL=go`.
+   *
+   * This is the **global kill switch**: leave it unset and `daemonImpl` is
+   * ignored everywhere, because there is nothing to point a claim at. That is
+   * also why the choice can't be per-claim env — the operator rejects
+   * `spec.env` whenever the claim may bind a warm pod, and the entrypoint
+   * reads `SANDBOX_DAEMON_IMPL` at container start, before Studio can talk to
+   * the daemon at all.
+   */
+  goSandboxTemplateName?: string;
+  /**
    * Shared sentinel token baked into the SandboxTemplate's pod env (via the
    * sandbox-env helm chart's Secret). Presence flips the runner into
    * warm-pool mode:
@@ -411,6 +424,8 @@ export class AgentSandboxProvider implements SandboxProvider {
   private readonly portForward: PortForward;
   private readonly namespace: string;
   private readonly sandboxTemplateName: string;
+  /** See {@link AgentSandboxProviderOptions.goSandboxTemplateName}. */
+  private readonly goSandboxTemplateName: string | null;
   private readonly envName: string | null;
   private readonly tokenGenerator: () => string;
   private readonly idleTtlMs: number;
@@ -450,6 +465,9 @@ export class AgentSandboxProvider implements SandboxProvider {
     this.namespace = opts.namespace ?? DEFAULT_NAMESPACE;
     this.sandboxTemplateName =
       opts.sandboxTemplateName ?? DEFAULT_TEMPLATE_NAME;
+    const trimmedGoTemplate = opts.goSandboxTemplateName?.trim() ?? "";
+    this.goSandboxTemplateName =
+      trimmedGoTemplate.length > 0 ? trimmedGoTemplate : null;
     this.envName = normalizeEnvName(opts.envName);
     this.tokenGenerator =
       opts.tokenGenerator ??
@@ -1152,6 +1170,16 @@ export class AgentSandboxProvider implements SandboxProvider {
     // Carried on both the claim and the pod; empty → block omitted entirely.
     const annotations = buildTenantAnnotations(opts);
     const hasAnnotations = Object.keys(annotations).length > 0;
+    const { impl, templateName } = resolveClaimTemplate(
+      opts.daemonImpl,
+      this.sandboxTemplateName,
+      this.goSandboxTemplateName,
+    );
+    if (opts.daemonImpl === "go" && impl !== "go") {
+      console.warn(
+        `[${LOG_LABEL}] daemonImpl=go requested for ${handle} but no Go SandboxTemplate is configured (STUDIO_SANDBOX_GO_TEMPLATE_NAME); landing on ts`,
+      );
+    }
     return {
       apiVersion: `${K8S_CONSTANTS.CLAIM_API_GROUP}/${K8S_CONSTANTS.CLAIM_API_VERSION}`,
       kind: "SandboxClaim",
@@ -1164,13 +1192,14 @@ export class AgentSandboxProvider implements SandboxProvider {
         labels: {
           "app.kubernetes.io/name": "studio-sandbox",
           "app.kubernetes.io/managed-by": "studio",
+          [LABEL_KEYS.daemonImpl]: impl,
           ...(this.envName ? { [LABEL_KEYS.env]: this.envName } : {}),
           ...buildTenantLabels(opts.tenant),
         },
         ...(hasAnnotations ? { annotations } : {}),
       },
       spec: {
-        sandboxTemplateRef: { name: this.sandboxTemplateName },
+        sandboxTemplateRef: { name: templateName },
         // additionalPodMetadata.labels is the operator's pod-label propagation
         // hook (CRD field, not a generic patch). Tenant labels here flow to
         // the pod and become joinable in cAdvisor/kubelet metrics. `role`
@@ -1180,6 +1209,11 @@ export class AgentSandboxProvider implements SandboxProvider {
           labels: buildTenantLabels(opts.tenant, {
             [LABEL_KEYS.role]: "claimed",
             [LABEL_KEYS.sandboxHandle]: handle,
+            // Every panel that splits the Go canary from the TS fleet joins on
+            // this. Must NOT also be set in the SandboxTemplate's podTemplate:
+            // the operator rejects a claim whose additionalPodMetadata repeats a
+            // template label key, even with the same value.
+            [LABEL_KEYS.daemonImpl]: impl,
             ...(this.envName ? { [LABEL_KEYS.env]: this.envName } : {}),
           }),
           ...(hasAnnotations ? { annotations } : {}),
@@ -1348,7 +1382,17 @@ export class AgentSandboxProvider implements SandboxProvider {
       workload: opts.workload ?? null,
       daemonBootId: resolvedBootId,
       tenant: opts.tenant ?? null,
-      ensureOpts: stripEnsureOpts(opts),
+      // Persist the impl the claim actually got, not the one asked for: with the
+      // kill switch off a `go` request lands on ts, and recovery must replay
+      // what ran. Same pure call buildClaim made above.
+      ensureOpts: stripEnsureOpts({
+        ...opts,
+        daemonImpl: resolveClaimTemplate(
+          opts.daemonImpl,
+          this.sandboxTemplateName,
+          this.goSandboxTemplateName,
+        ).impl,
+      }),
     };
   }
 
@@ -2219,7 +2263,29 @@ const LABEL_KEYS = {
   orgId: "studio.decocms.com/org-id",
   userId: "studio.decocms.com/user-id",
   env: "studio.decocms.com/env",
+  daemonImpl: "studio.decocms.com/daemon-impl",
 } as const;
+
+/**
+ * Which SandboxTemplate a claim gets, and therefore which daemon binary its
+ * pod's entrypoint execs. Pure so the rollout gate is testable without a
+ * cluster: it is the one place `go` can collapse back to `ts`.
+ *
+ * `goTemplateName === null` (i.e. `STUDIO_SANDBOX_GO_TEMPLATE_NAME` unset) is
+ * the global kill switch — pointing a claim at a template that doesn't exist
+ * fails provisioning outright, so an unconfigured deploy must ignore the
+ * request rather than honor it.
+ */
+export function resolveClaimTemplate(
+  requested: SandboxDaemonImpl | undefined,
+  tsTemplateName: string,
+  goTemplateName: string | null,
+): { impl: SandboxDaemonImpl; templateName: string } {
+  if (requested === "go" && goTemplateName) {
+    return { impl: "go", templateName: goTemplateName };
+  }
+  return { impl: "ts", templateName: tsTemplateName };
+}
 
 // K8s annotation keys for human-readable ownership/provenance. Unlike labels,
 // annotation values aren't charset-limited, so these carry the identity that
@@ -2409,6 +2475,11 @@ function stripEnsureOpts(opts: EnsureOptions): EnsureOptions | null {
   if (opts.workload) out.workload = opts.workload;
   if (opts.env && Object.keys(opts.env).length > 0) out.env = opts.env;
   if (opts.tenant) out.tenant = opts.tenant;
+  // Stickiness: `resurrectByHandle` re-provisions from these opts with no
+  // SANDBOX_START in the loop, so without this an autonomously recovered
+  // sandbox would silently come back on the other binary — which makes any
+  // incident on it unattributable. Callers persist the *resolved* impl.
+  if (opts.daemonImpl) out.daemonImpl = opts.daemonImpl;
   return Object.keys(out).length > 0 ? out : null;
 }
 

--- a/packages/sandbox/server/provider/index.ts
+++ b/packages/sandbox/server/provider/index.ts
@@ -14,6 +14,7 @@ export type {
   EnsureOptions,
   LegacySandboxProviderKind,
   ProxyRequestInit,
+  SandboxDaemonImpl,
   SandboxProviderKind,
   Sandbox,
   SandboxId,
@@ -23,6 +24,7 @@ export type {
 export type { ClaimFailureReason, ClaimPhase } from "./lifecycle-types";
 export {
   normalizeSandboxProviderKind,
+  sandboxDaemonImplSchema,
   sandboxIdKey,
   sandboxProviderKindSchema,
 } from "./types";

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -138,7 +138,25 @@ export interface EnsureOptions {
    * mount — that's the privileged-sidecar path). Absent → no mounting.
    */
   orgFsConfigJson?: string;
+  /**
+   * Which sandbox daemon binary the pod should run. Both ship in the image and
+   * the entrypoint picks one from `SANDBOX_DAEMON_IMPL` at *container start*, so
+   * this cannot be per-claim env: the operator rejects `spec.env` whenever the
+   * claim may bind a warm pod. `agent-sandbox` therefore honors it by choosing
+   * a per-impl SandboxTemplate (see
+   * `AgentSandboxProviderOptions.goSandboxTemplateName`), and falls back to
+   * `ts` when no Go template is configured. Other runners MUST ignore it.
+   *
+   * Absent → `ts`. The resolved value is persisted in the runner state blob so
+   * autonomous recovery rebuilds the pod on the same binary — a sandbox that
+   * silently changed implementation mid-life makes an incident unattributable.
+   */
+  daemonImpl?: SandboxDaemonImpl;
 }
+
+export const sandboxDaemonImplSchema = z.enum(["ts", "go"]);
+
+export type SandboxDaemonImpl = z.infer<typeof sandboxDaemonImplSchema>;
 
 export interface ProxyRequestInit {
   method: string;

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -137,6 +137,12 @@ export const OrgFlagsSchema = z.object({
     .describe(
       "Curated commerce (reports) look: hides agent navigation, the home Customize button, and the Settings/Automations tabs. Defaulted on for orgs created by commerce onboarding.",
     ),
+  sandboxGoDaemon: z
+    .boolean()
+    .optional()
+    .describe(
+      "Provision this org's new sandboxes on the Go sandbox daemon instead of the TypeScript one. Affects the NEXT sandbox only — live sandboxes drain on the binary they booted with. Ignored unless the deployment sets STUDIO_SANDBOX_GO_TEMPLATE_NAME (the global kill switch); SANDBOX_START's `daemonImpl` overrides it per sandbox in either direction.",
+    ),
 });
 
 export type OrgFlags = z.infer<typeof OrgFlagsSchema>;

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -137,7 +137,7 @@ export const OrgFlagsSchema = z.object({
     .describe(
       "Curated commerce (reports) look: hides agent navigation, the home Customize button, and the Settings/Automations tabs. Defaulted on for orgs created by commerce onboarding.",
     ),
-  sandboxGoDaemon: z
+  sandbox_go_daemon: z
     .boolean()
     .optional()
     .describe(

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -121,7 +121,7 @@ export interface StudioToolIO {
         | {
             demo_mode?: boolean | undefined;
             reports_only?: boolean | undefined;
-            sandboxGoDaemon?: boolean | undefined;
+            sandbox_go_daemon?: boolean | undefined;
           }
         | null
         | undefined;
@@ -184,7 +184,7 @@ export interface StudioToolIO {
         | {
             demo_mode?: boolean | undefined;
             reports_only?: boolean | undefined;
-            sandboxGoDaemon?: boolean | undefined;
+            sandbox_go_daemon?: boolean | undefined;
           }
         | undefined;
       main_agent_id?: string | null | undefined;
@@ -247,7 +247,7 @@ export interface StudioToolIO {
         | {
             demo_mode?: boolean | undefined;
             reports_only?: boolean | undefined;
-            sandboxGoDaemon?: boolean | undefined;
+            sandbox_go_daemon?: boolean | undefined;
           }
         | null
         | undefined;

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -121,6 +121,7 @@ export interface StudioToolIO {
         | {
             demo_mode?: boolean | undefined;
             reports_only?: boolean | undefined;
+            sandboxGoDaemon?: boolean | undefined;
           }
         | null
         | undefined;
@@ -183,6 +184,7 @@ export interface StudioToolIO {
         | {
             demo_mode?: boolean | undefined;
             reports_only?: boolean | undefined;
+            sandboxGoDaemon?: boolean | undefined;
           }
         | undefined;
       main_agent_id?: string | null | undefined;
@@ -245,6 +247,7 @@ export interface StudioToolIO {
         | {
             demo_mode?: boolean | undefined;
             reports_only?: boolean | undefined;
+            sandboxGoDaemon?: boolean | undefined;
           }
         | null
         | undefined;
@@ -6596,6 +6599,7 @@ export interface StudioToolIO {
         | "user-desktop"
         | "cluster"
         | undefined;
+      daemonImpl?: "ts" | "go" | undefined;
     };
     output: {
       previewUrl: string | null;


### PR DESCRIPTION
Studio side of the Go-daemon rollout — work items 1, 2, 3 and the pod label
from 5 of `daemon-go/SPEC.md` §8.5. Independent of the daemon code itself
(#5484) and of the chart (#5485); it only names a template it never has to
contain. Base is `main`.

## Three layers of control

Resolution order **explicit prop → org flag → `ts`**, mirroring how
`resolve-provider.ts` already resolves the provider kind.

| Layer | Where | Purpose |
| --- | --- | --- |
| `STUDIO_SANDBOX_GO_TEMPLATE_NAME` | API deployment env | Global kill switch. Unset → the prop *and* the flag are ignored; there is nothing to point a claim at. |
| `sandboxGoDaemon` | `organization_settings.flags` | Who gets Go by default — what puts a real user's sandboxes on Go without asking them to pass anything. |
| `daemonImpl` | `SANDBOX_START` input | Targets one sandbox. Escape hatch both ways: opt one in, or pin one back to `ts` inside a flagged org. |

Flipping any layer off routes the **next** sandbox to TS; live sandboxes drain
on the binary they booted with. No live workspace is ever migrated.

## Why selection is by template, not by env var

`SANDBOX_DAEMON_IMPL` is read by the image entrypoint **at container start**,
so the choice has to exist before the pod does. In prod the pod comes from the
warm pool, and `buildClaim` already documents the constraint: warm-pool claims
carry `spec.env: []` because **the operator rejects per-claim env when the claim
may bind a warm pod**. `spec.sandboxTemplateRef` is the only per-claim lever, so
the runner picks a per-impl template (`goSandboxTemplateName`, #5485's
`<name>-go`).

The kill switch is enforced in exactly one place — the runner — because that is
the only code that knows whether a Go template exists *and* the code that
persists what the claim actually got. `resolveDaemonImpl` deliberately does not
re-read the env, so the two cannot disagree.

## The two properties the rollout depends on

- **Sticky per sandbox.** The *resolved* impl (post-kill-switch) is persisted in
  the runner state blob's `ensureOpts`, which `resurrectByHandle` replays — so a
  sandbox recovered autonomously, with no `SANDBOX_START` in the loop, rebuilds
  on the same binary. Without this a sandbox could silently change
  implementation mid-life, which makes every incident on it unattributable.
  Uses the existing opaque `state` blob — no migration.
- **Attributable.** `studio.decocms.com/daemon-impl` lands on the claim and, via
  `additionalPodMetadata`, on the pod, so every panel can split canary from
  fleet. It is deliberately **not** in the SandboxTemplate: the operator
  (v0.4.2+) rejects a claim whose `additionalPodMetadata` repeats a template
  label key, even with the same value — the same trap the existing `role` key
  comment documents.

A `daemonImpl: "go"` request on a deploy with no Go template logs a warning and
lands on `ts`. Silently landing on TS is the failure mode that would make a
canary read as "Go is fine".

## Testing

Both decision points are pure functions with unit tests:

- `resolveDaemonImpl` — default, flag on/off, and prop winning in **both**
  directions (pinning back to `ts` inside a flagged org is the case that
  matters).
- `resolveClaimTemplate` — default, go→go-template, and the go→ts collapse when
  the kill switch is off (it must report `ts`, since that is what the pod runs).

`bun run check` (all workspaces), `bun run lint` (no new warnings), `knip`
clean, `generate:tool-contracts` regenerated.

Not yet exercised end to end — that is P0 (kind) and P1 (stg) in SPEC §8.3,
which need a human driving a session.

## Still owner actions after this

- The four alerts + panels split by `daemon-impl`, with a TS baseline recorded
  before any prod traffic (§8.4). Grafana, not this repo.
- `deco-apps-cd` `targetRevision` bump so #5485's chart actually ships.
- Setting `STUDIO_SANDBOX_GO_TEMPLATE_NAME` in the studio release's
  `configMap.meshConfig` for whichever env is canarying.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three-layer control to route hosted sandboxes to the Go daemon: a per-sandbox `SANDBOX_START.daemonImpl`, an org flag default, and a global kill switch via `STUDIO_SANDBOX_GO_TEMPLATE_NAME`. The runner persists the resolved impl and labels resources so sandboxes stick to a binary and are easy to monitor.

- New Features
  - `SANDBOX_START` accepts `daemonImpl` (`"ts"` | `"go"`) for one-off targeting on `agent-sandbox`; desktop ignores it.
  - Org flag `sandbox_go_daemon` sets the default; explicit prop wins.
  - Global kill switch: `STUDIO_SANDBOX_GO_TEMPLATE_NAME`. If unset, `go` collapses to `ts` and logs a warning.
  - Template-based selection (`<name>-go`) instead of per-claim env; avoids warm-pool env rejection.
  - Persist resolved impl in runner state for sticky recovery; add `studio.decocms.com/daemon-impl` on claim and pod.
  - Pure, unit-tested resolution paths (`resolveDaemonImpl`, `resolveClaimTemplate`).
  - `SANDBOX_START` now reads `organization_settings.flags` and always sends an explicit `daemonImpl` to `runner.ensure`; tests cover flag off/on and explicit pinning back to `ts`.

- Refactors
  - Renamed org flag to `sandbox_go_daemon` (snake_case) and regenerated tool contracts.

<sup>Written for commit 2779c8f707de38b7d338330404df9a96e55a6e3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

