### PR TITLE
fix(orgs): use singular/plural i18n keys in the bulk-delete dialog

### DIFF
--- a/apps/web/src/i18n/en/orgs.ts
+++ b/apps/web/src/i18n/en/orgs.ts
@@ -18,10 +18,14 @@ export const orgs = {
   "orgs.automations.loading": "Loading…",
   "orgs.automations.selectPlaceholder": "Select an automation…",
   "orgs.bulkDeleteDialog.cancelButton": "Cancel",
-  "orgs.bulkDeleteDialog.deleteButton": "Delete {count} connection{plural}",
-  "orgs.bulkDeleteDialog.deleteDescription":
-    "This will permanently delete the selected connection{plural}. This action cannot be undone.",
-  "orgs.bulkDeleteDialog.deleteTitle": "Delete {count} connection{plural}?",
+  "orgs.bulkDeleteDialog.deleteButtonSingular": "Delete {count} connection",
+  "orgs.bulkDeleteDialog.deleteButtonPlural": "Delete {count} connections",
+  "orgs.bulkDeleteDialog.deleteDescriptionSingular":
+    "This will permanently delete the selected connection. This action cannot be undone.",
+  "orgs.bulkDeleteDialog.deleteDescriptionPlural":
+    "This will permanently delete the selected connections. This action cannot be undone.",
+  "orgs.bulkDeleteDialog.deleteTitleSingular": "Delete {count} connection?",
+  "orgs.bulkDeleteDialog.deleteTitlePlural": "Delete {count} connections?",
   "orgs.catalogItemCard.cancel": "Cancel",
   "orgs.catalogItemCard.communityMcpServerDescription":
     "This MCP server is from the Community MCP Registry and is not maintained or verified by Deco. Community servers may have varying levels of quality, security, and reliability. Proceed with caution and review the server details before connecting.",

--- a/apps/web/src/i18n/pt-br/orgs.ts
+++ b/apps/web/src/i18n/pt-br/orgs.ts
@@ -21,10 +21,14 @@ export const orgs = {
   "orgs.automations.loading": "Carregando…",
   "orgs.automations.selectPlaceholder": "Selecione uma automação…",
   "orgs.bulkDeleteDialog.cancelButton": "Cancelar",
-  "orgs.bulkDeleteDialog.deleteButton": "Excluir {count} conexão{plural}",
-  "orgs.bulkDeleteDialog.deleteDescription":
-    "Isso excluirá permanentemente a conexão{plural} selecionada(s). Esta ação não pode ser desfeita.",
-  "orgs.bulkDeleteDialog.deleteTitle": "Excluir {count} conexão{plural}?",
+  "orgs.bulkDeleteDialog.deleteButtonSingular": "Excluir {count} conexão",
+  "orgs.bulkDeleteDialog.deleteButtonPlural": "Excluir {count} conexões",
+  "orgs.bulkDeleteDialog.deleteDescriptionSingular":
+    "Isso excluirá permanentemente a conexão selecionada. Esta ação não pode ser desfeita.",
+  "orgs.bulkDeleteDialog.deleteDescriptionPlural":
+    "Isso excluirá permanentemente as conexões selecionadas. Esta ação não pode ser desfeita.",
+  "orgs.bulkDeleteDialog.deleteTitleSingular": "Excluir {count} conexão?",
+  "orgs.bulkDeleteDialog.deleteTitlePlural": "Excluir {count} conexões?",
   "orgs.catalogItemCard.cancel": "Cancelar",
   "orgs.catalogItemCard.communityMcpServerDescription":
     "Este servidor MCP é do Registro MCP da Comunidade e não é mantido ou verificado pela Deco. Os servidores da comunidade podem ter níveis variados de qualidade, segurança e confiabilidade. Proceda com cautela e revise os detalhes do servidor antes de conectar.",

--- a/apps/web/src/routes/orgs/bulk-delete-dialog.tsx
+++ b/apps/web/src/routes/orgs/bulk-delete-dialog.tsx
@@ -27,15 +27,19 @@ export function BulkDeleteDialog({
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>
-            {t("orgs.bulkDeleteDialog.deleteTitle", {
-              count,
-              plural: count !== 1 ? "s" : "",
-            })}
+            {t(
+              count === 1
+                ? "orgs.bulkDeleteDialog.deleteTitleSingular"
+                : "orgs.bulkDeleteDialog.deleteTitlePlural",
+              { count },
+            )}
           </AlertDialogTitle>
           <AlertDialogDescription>
-            {t("orgs.bulkDeleteDialog.deleteDescription", {
-              plural: count !== 1 ? "s" : "",
-            })}
+            {t(
+              count === 1
+                ? "orgs.bulkDeleteDialog.deleteDescriptionSingular"
+                : "orgs.bulkDeleteDialog.deleteDescriptionPlural",
+            )}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
@@ -46,10 +50,12 @@ export function BulkDeleteDialog({
             onClick={onConfirm}
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
           >
-            {t("orgs.bulkDeleteDialog.deleteButton", {
-              count,
-              plural: count !== 1 ? "s" : "",
-            })}
+            {t(
+              count === 1
+                ? "orgs.bulkDeleteDialog.deleteButtonSingular"
+                : "orgs.bulkDeleteDialog.deleteButtonPlural",
+              { count },
+            )}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>


### PR DESCRIPTION
This tick's two merges (settings env-alias fallback #5483, chat latency prop removal #5482) turned out fully clean on re-inspection — `resolve-config.ts`'s alias pairs all now use the safe `resolveAliasedEnv` helper, and `common.tsx`/`generic.tsx` have no leftover dead `latency` references. Widening the hunt to the same i18n plural-interpolation bug class fixed twice very recently in this area (#5477 provider-grid.tsx, #5479 secrets.tsx) turned up one more live instance.

`orgs.bulkDeleteDialog.deleteButton`/`deleteDescription`/`deleteTitle` build their pt-br strings as `"conexão{plural}"`, where the caller (`bulk-delete-dialog.tsx`) always passes a hardcoded English `plural: count !== 1 ? "s" : ""`. For count > 1 this renders "conexãos" instead of the correct pt-br plural "conexões" — an actual, visible grammar bug for any pt-br user bulk-deleting more than one connection.

Fix: replaced the three `{plural}`-templated keys with explicit `Singular`/`Plural` key pairs per locale (matching the pattern used in the #5479 fix), and updated the caller to select the key based on `count === 1` instead of interpolating a suffix.

Failure scenario: a pt-br user selects 2+ connections and opens the bulk-delete dialog — before this fix, the dialog title/button/description read "Excluir 2 conexãos" (not a word) instead of "Excluir 2 conexões".

Reviewer check: `cd apps/web && bunx tsc --noEmit` (passes — `pt-br/orgs.ts` satisfies `Record<keyof typeof en, string>`, so a missing key would be a compile error), and manually open the org connections list, select 2+ connections, and trigger bulk delete with `language` set to pt-br.

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint` on the three changed files (all clean). No dedicated test exists for this component's i18n and none of the other required checks apply (no test file for this component); full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pluralization in the org connections bulk-delete dialog by replacing suffix interpolation with singular/plural i18n keys. This corrects pt-br text (e.g., “conexões”) and avoids similar plural errors.

- **Bug Fixes**
  - Added `...Singular`/`...Plural` keys for delete button, title, and description in `en/orgs.ts` and `pt-br/orgs.ts`.
  - Updated `orgs/bulk-delete-dialog.tsx` to select keys based on `count === 1` and pass `{ count }` only.
  - Removed the hardcoded English `"s"` suffix to produce correct pt-br grammar for counts > 1.

<sup>Written for commit 022f018643e35eba6ea2df40279f0ca4e7f80ccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

