### PR TITLE
fix(registry): block redirect-based SSRF on the primary MCP discovery path

### DIFF
--- a/apps/api/src/tools/registry/discover-tools.test.ts
+++ b/apps/api/src/tools/registry/discover-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  createNoRedirectFetch,
   isPrivateUrl,
   parseToolsListResponse,
   resolvesToPrivateAddress,
@@ -126,6 +127,34 @@ describe("withTimeout", () => {
     await expect(withTimeout(never, 10, "too slow")).rejects.toThrow(
       "too slow",
     );
+  });
+});
+
+describe("createNoRedirectFetch", () => {
+  it("rejects a 3xx redirect instead of letting the caller follow it", async () => {
+    const redirecting = async () =>
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://169.254.169.254/" },
+      });
+    const wrapped = createNoRedirectFetch(redirecting);
+
+    await expect(wrapped("http://example.com/mcp")).rejects.toThrow(
+      "Refusing to follow a redirect",
+    );
+  });
+
+  it("passes through a non-redirect response and forces manual redirect handling", async () => {
+    let seenInit: RequestInit | undefined;
+    const ok = async (_url: string | URL, init?: RequestInit) => {
+      seenInit = init;
+      return new Response("{}", { status: 200 });
+    };
+    const wrapped = createNoRedirectFetch(ok);
+
+    const res = await wrapped("http://example.com/mcp", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(seenInit?.redirect).toBe("manual");
   });
 });
 

--- a/apps/api/src/tools/registry/discover-tools.ts
+++ b/apps/api/src/tools/registry/discover-tools.ts
@@ -249,6 +249,30 @@ export function withTimeout<T>(
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
+/**
+ * Wraps `fetch` to refuse 3xx redirects. `isPrivateUrl` and the DNS check
+ * above only vet the URL we're about to connect to — the MCP SDK's client
+ * transports follow redirects by default, so a malicious/compromised remote
+ * server could 3xx-redirect the `tools/list` request to a private/metadata
+ * address and bypass both checks. `tryRawToolsList` already guards its own
+ * bare fetch this way; this does the same for the primary SDK-client path
+ * (attempted first, for every server).
+ */
+export function createNoRedirectFetch(
+  fetchImpl: (
+    url: string | URL,
+    init?: RequestInit,
+  ) => Promise<Response> = fetch,
+): (url: string | URL, init?: RequestInit) => Promise<Response> {
+  return async (url, init) => {
+    const res = await fetchImpl(url, { ...init, redirect: "manual" });
+    if (res.status >= 300 && res.status < 400) {
+      throw new Error("Refusing to follow a redirect from the remote server");
+    }
+    return res;
+  };
+}
+
 async function tryRawToolsList(
   url: string,
   timeoutMs: number,
@@ -359,6 +383,7 @@ export const REGISTRY_DISCOVER_TOOLS = defineTool({
 
     let lastError: string | null = null;
     let authErrorUrl: string | null = null;
+    const noRedirectFetch = createNoRedirectFetch();
 
     for (const attempt of attempts) {
       let client: Client | null = null;
@@ -372,9 +397,11 @@ export const REGISTRY_DISCOVER_TOOLS = defineTool({
           attempt.transport === "sse"
             ? new SSEClientTransport(new URL(attempt.url), {
                 requestInit: { headers },
+                fetch: noRedirectFetch,
               })
             : new StreamableHTTPClientTransport(new URL(attempt.url), {
                 requestInit: { headers },
+                fetch: noRedirectFetch,
               });
 
         await withTimeout(


### PR DESCRIPTION
**Source**: bug found while auditing `REGISTRY_DISCOVER_TOOLS` (registry discovery hardening focus area). Related prior hardening: #4999 (blocked SSRF via redirect, but only on the *raw* `tools/list` fallback path).

**Why a maintainer wants this**: `REGISTRY_DISCOVER_TOOLS` vets the target URL with `isPrivateUrl` and a DNS-resolution check before connecting, then tries the MCP SDK client transports (`StreamableHTTPClientTransport`/`SSEClientTransport`) first, for every server — that's the primary, always-attempted path. That path's underlying `fetch` followed 3xx redirects by default, so a malicious or compromised remote MCP server could redirect the `tools/list` request to a private/metadata address (e.g. `169.254.169.254`) and completely bypass both the private-URL and DNS checks. Only the secondary raw-fetch fallback (`tryRawToolsList`, used only after an auth error) already guarded against this with `redirect: "manual"` — the comment right above it even warns about the exact bypass, but the fix was never applied to the primary path.

**Failure scenario**: an org member points `REGISTRY_DISCOVER_TOOLS` at an attacker-controlled `https://evil.example/mcp` that responds to the initial connection with a 302 to `http://169.254.169.254/latest/meta-data/`. The SDK transport's fetch follows the redirect transparently, returning cloud metadata contents disguised as (or leaking through) the discovery response — a real SSRF into the deployment's cloud metadata endpoint, from an attacker who only needs to register a domain.

**Fix**: added `createNoRedirectFetch`, a small `fetch` wrapper that forces `redirect: "manual"` and throws on any 3xx response, and passed it via the SDK's public `fetch` transport option to both `StreamableHTTPClientTransport` and `SSEClientTransport` in the discovery loop. Added a regression test (`discover-tools.test.ts`) that asserts `createNoRedirectFetch` rejects a 302 response and forces `redirect: "manual"` on a normal response.

**How a reviewer verifies**: `bun test apps/api/src/tools/registry/discover-tools.test.ts` (20/20 pass, includes the new `createNoRedirectFetch` cases).

**Local checks run**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/tools/registry/discover-tools.test.ts` (20 pass), `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks redirect-based SSRF on the primary MCP discovery path by refusing 3xx redirects in SDK client transports. This hardens `REGISTRY_DISCOVER_TOOLS` to match the raw `tools/list` fallback.

- **Bug Fixes**
  - Added `createNoRedirectFetch` to force `redirect: "manual"` and throw on any 3xx.
  - Passed the wrapper via the `fetch` option to `StreamableHTTPClientTransport` and `SSEClientTransport`.
  - Added tests covering redirect rejection and manual redirect handling.

<sup>Written for commit 24e891a4464eebbdd570ab3ff173a993fc2ef8c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

