### PR TITLE
fix(ai-providers): cap AI_PROVIDER_TOPUP_URL amount at $10,000

### DIFF
--- a/apps/api/src/tools/ai-providers/topup-url.test.ts
+++ b/apps/api/src/tools/ai-providers/topup-url.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { AI_PROVIDER_TOPUP_URL } from "./topup-url";
+
+describe("AI_PROVIDER_TOPUP_URL input validation", () => {
+  it("accepts a normal top-up amount", () => {
+    const result = AI_PROVIDER_TOPUP_URL.inputSchema.safeParse({
+      providerId: "deco",
+      amountCents: 1000,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts the max allowed amount", () => {
+    const result = AI_PROVIDER_TOPUP_URL.inputSchema.safeParse({
+      providerId: "deco",
+      amountCents: 1_000_000,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an amount above the cap", () => {
+    const result = AI_PROVIDER_TOPUP_URL.inputSchema.safeParse({
+      providerId: "deco",
+      amountCents: 1_000_001,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an absurdly large amount that would overflow Stripe's unit_amount limit", () => {
+    const result = AI_PROVIDER_TOPUP_URL.inputSchema.safeParse({
+      providerId: "deco",
+      amountCents: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/tools/ai-providers/topup-url.ts
+++ b/apps/api/src/tools/ai-providers/topup-url.ts
@@ -13,6 +13,13 @@ import { getProviders } from "../../ai-providers/registry";
 import { mintGatewayJwt } from "../../auth/jwt";
 import { getSettings } from "../../settings";
 
+// Ceiling for a single top-up request. Stripe's own `unit_amount` cap is
+// 99999999 (~$999,999.99) and computeTopUpChargeCents() multiplies
+// amountCents up further by the fee percent, so an unbounded amount here can
+// overflow Stripe's limit and surface as an opaque 500 instead of a clean
+// input-validation error.
+const MAX_TOPUP_AMOUNT_CENTS = 1_000_000; // $10,000.00
+
 export const AI_PROVIDER_TOPUP_URL = defineTool({
   name: "AI_PROVIDER_TOPUP_URL",
   description:
@@ -23,7 +30,8 @@ export const AI_PROVIDER_TOPUP_URL = defineTool({
       .number()
       .int()
       .positive()
-      .describe("Amount in cents (e.g. 1000 = $10.00)"),
+      .max(MAX_TOPUP_AMOUNT_CENTS)
+      .describe("Amount in cents (e.g. 1000 = $10.00), max $10,000.00"),
     currency: z.enum(["usd", "brl"]).default("usd"),
   }),
   outputSchema: z.object({


### PR DESCRIPTION
**Source:** bug found while hunting the LLM-governance (cost & limits) focus area — `AI_PROVIDER_TOPUP_URL`'s `amountCents` had no upper bound on either the API schema or the frontend custom-amount input (`deco-credits-hero.tsx` only enforces `>= 1`).

**Why it matters:** `createTopUpCheckoutSession` feeds `amountCents` (after `computeTopUpChargeCents` multiplies it by the org's fee percent) directly into Stripe's `unit_amount`, which Stripe hard-caps at 99999999 (~$999,999.99). An unbounded client-supplied amount currently reaches that boundary with no server-side validation, surfacing as an opaque 500 from Stripe instead of a clean 400 — this is exactly the kind of missing spend-limit groundwork the LLM-governance area calls out.

**Fix:** added `.max(1_000_000)` (a $10,000 ceiling — well under Stripe's limit even after the fee multiplier, and far above the largest existing preset of $500) to the `amountCents` field in `AI_PROVIDER_TOPUP_URL`'s input schema. Pure input-validation tightening; no behavior change for any amount under the cap.

**Regression test:** `apps/api/src/tools/ai-providers/topup-url.test.ts` — asserts the schema accepts a normal amount and the max allowed amount, and rejects amounts just above the cap and an absurdly large one that would have overflowed Stripe's limit.

**To verify:** `bun test apps/api/src/tools/ai-providers/topup-url.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/tools/ai-providers/topup-url.ts apps/api/src/tools/ai-providers/topup-url.test.ts` (0 warnings/errors), and the targeted test above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capped `AI_PROVIDER_TOPUP_URL` top-up `amountCents` at $10,000 to prevent Stripe `unit_amount` overflow and return clear validation errors instead of 500s.

- **Bug Fixes**
  - Added `.max(1_000_000)` to the input schema for `amountCents`.
  - Added tests for normal, max, above-cap, and extreme values.

<sup>Written for commit 1ba138f40c7b45eadbe56b06fed900e2b495d153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

