### PR TITLE
feat(web): add "Install on Mac" entry to the account popover

### DIFF
--- a/apps/web/src/components/account-popover.tsx
+++ b/apps/web/src/components/account-popover.tsx
@@ -21,6 +21,7 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import {
   Copy01,
+  Download01,
   File06,
   Globe01,
   LinkExternal01,
@@ -43,6 +44,11 @@ import { track } from "@/lib/posthog-client";
 import { clearPersistedQueryCache } from "@/lib/query-persist";
 import { usePreferences, type ThemeMode } from "@/hooks/use-preferences.ts";
 import { useDeploymentAdmin } from "@/hooks/use-deployment-admin";
+import { useIsDesktopApp } from "@/hooks/use-is-desktop-app.ts";
+import {
+  DownloadAppDialog,
+  isMacDesktopBrowser,
+} from "@/components/download-app-dialog";
 import { toast } from "@deco/ui/components/sonner.js";
 import { useT } from "@/i18n/use-t.ts";
 
@@ -354,8 +360,10 @@ export function AccountPopover() {
   const [preferences, setPreferences] = usePreferences();
   const isMobile = useIsMobile();
   const { isAdmin: isDeploymentAdmin } = useDeploymentAdmin();
+  const isDesktopApp = useIsDesktopApp();
 
   const [open, setOpen] = useState(false);
+  const [downloadAppOpen, setDownloadAppOpen] = useState(false);
 
   const user = session?.user;
   const userImage = (user as { image?: string } | undefined)?.image;
@@ -392,6 +400,19 @@ export function AccountPopover() {
                 params: { org: currentOrg.slug },
               });
             },
+          } satisfies MenuItem,
+        ]
+      : []),
+    // Same gate as the other DownloadAppDialog triggers: the terminal
+    // installer only works on Mac desktop browsers, and is pointless
+    // inside the desktop app itself.
+    ...(isMacDesktopBrowser() && !isDesktopApp
+      ? [
+          {
+            key: "install-on-mac",
+            label: t("downloadApp.installOnMac"),
+            icon: <Download01 size={16} />,
+            onClick: () => setDownloadAppOpen(true),
           } satisfies MenuItem,
         ]
       : []),
@@ -583,6 +604,10 @@ export function AccountPopover() {
           </PopoverContent>
         </Popover>
       )}
+      <DownloadAppDialog
+        open={downloadAppOpen}
+        onOpenChange={setDownloadAppOpen}
+      />
     </>
   );
 }

--- a/apps/web/src/i18n/en/download-app.ts
+++ b/apps/web/src/i18n/en/download-app.ts
@@ -9,4 +9,5 @@ export const downloadApp = {
   "downloadApp.appleSiliconNote":
     "For Apple Silicon Macs (M1 and newer) — Windows coming soon.",
   "downloadApp.openLabel": "Download the Studio app",
+  "downloadApp.installOnMac": "Install on Mac",
 } as const;

--- a/apps/web/src/i18n/pt-br/download-app.ts
+++ b/apps/web/src/i18n/pt-br/download-app.ts
@@ -11,4 +11,5 @@ export const downloadApp = {
   "downloadApp.appleSiliconNote":
     "Para Macs com Apple Silicon (M1 ou mais novo) — Windows em breve.",
   "downloadApp.openLabel": "Baixar o app do Studio",
+  "downloadApp.installOnMac": "Instalar no Mac",
 } satisfies Record<keyof typeof downloadAppEn, string>;


### PR DESCRIPTION
## Summary
- Adds an **"Install on Mac"** item to the account popover (bottom of the sidebar), right below "Connect to Agents". Clicking it opens the existing `DownloadAppDialog` with the `curl … | sh` terminal install command.
- Web builds only: gated by `isMacDesktopBrowser() && !useIsDesktopApp()` — the same gate as the dialog's other trigger sites. `useIsDesktopApp()` is the build-time `VITE_TAURI_APP` constant, so the item is dead-code-eliminated from the native bundle and can never appear inside the desktop app; the platform check also hides it on Windows/Linux and touch devices.
- New i18n key `downloadApp.installOnMac` in both `en` and `pt-br` dictionaries.

## Testing
- `bun run fmt`, `bun run lint`, and `bun run check` (tsc) all pass.
- No new tests: pure UI wiring of an existing, already-exercised dialog behind an existing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “Install on Mac” item to the account popover in web builds. Clicking it opens the existing `DownloadAppDialog` with the curl | sh install command.

- **New Features**
  - Visible only on Mac desktop browsers and never in the desktop app (gate: `isMacDesktopBrowser()` && `!useIsDesktopApp()`; excluded from native via `VITE_TAURI_APP`).
  - New i18n key `downloadApp.installOnMac` in `en` and `pt-br`.

<sup>Written for commit de148b3b0a79f286814a7c516d6efb5cabac5c8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

