### PR TITLE
fix(settings): fall back to a random pod id when POD_NAME is an empty string

### DIFF
--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -217,6 +217,26 @@ describe("resolveConfig deployment admin emails", () => {
   });
 });
 
+describe("resolveConfig pod name", () => {
+  it("generates a random id when POD_NAME is unset", () => {
+    const result = resolveConfig(flags, {});
+
+    expect(result.settings.podName).toBeTruthy();
+  });
+
+  it("falls back to a random id when POD_NAME is set to an empty string", () => {
+    const result = resolveConfig(flags, { POD_NAME: "" });
+
+    expect(result.settings.podName).toBeTruthy();
+  });
+
+  it("uses POD_NAME when set", () => {
+    const result = resolveConfig(flags, { POD_NAME: "studio-worker-abc123" });
+
+    expect(result.settings.podName).toBe("studio-worker-abc123");
+  });
+});
+
 describe("resolveConfig Studio environment aliases", () => {
   it("prefers Studio JWT and dispatch variables", () => {
     const result = resolveConfig(flags, {

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -330,7 +330,11 @@ export function resolveConfig(
     // Runtime flags
     isCli: true,
     noTui: flags.noTui === true,
-    podName: envVars.POD_NAME ?? crypto.randomUUID(),
+    // `||` (not `??`): an env var explicitly set to "" (a deployment template
+    // rendering an unset POD_NAME as empty rather than omitting the key) must
+    // fall through to a random id instead of every pod sharing "" as its
+    // identity in logs/metrics — see resolveAliasedEnv above for the same trap.
+    podName: envVars.POD_NAME || crypto.randomUUID(),
     dispatchRole: resolveDispatchRole(
       resolveAliasedEnv(
         envVars.STUDIO_DISPATCH_ROLE,


### PR DESCRIPTION
Follows #5483's hardening of the Studio/legacy env-alias fields against the same empty-string trap: `resolveConfig` still resolved `podName: envVars.POD_NAME ?? crypto.randomUUID()`, and `??` only falls through on `null`/`undefined`, not `""`.

A deployment template that renders an unset `POD_NAME` as an empty string (the exact scenario #5483's own comment describes) makes every pod's `podName` silently collapse to `""` instead of getting a unique random id. `podName` backs `getPodId()` (`apps/api/src/core/pod-identity.ts`), used in `dispatch-run.ts` to attribute run-park log lines to a specific pod — with an empty `POD_NAME`, every pod in the fleet logs the same empty pod id, and per-pod attribution in those logs is lost.

Fix: use `||` instead of `??`, matching the pattern already used for `resolveAliasedEnv` in the same file, so an explicit empty string falls through to `crypto.randomUUID()`.

Added a regression test (`resolveConfig pod name` in `resolve-config.test.ts`) covering: unset POD_NAME, POD_NAME="", and a real POD_NAME value.

Reviewer check: `bun test apps/api/src/settings/resolve-config.test.ts` (80 pass).

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pod identity resolution: when `POD_NAME` is empty or unset, we now fall back to a random id so each pod has a unique `podName` and logs are attributed correctly. Added regression tests for unset, empty, and set cases.

<sup>Written for commit bdd868a22788180a6235b82600b4ba3faa8668b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

