### PR TITLE
fix(chat): guard generate_image tool part against non-array images payload

### DIFF
--- a/apps/web/src/components/chat/message/parts/tool-call-part/generate-image.test.ts
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/generate-image.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { getGeneratedImages } from "./generate-image.tsx";
+
+describe("getGeneratedImages", () => {
+  test("returns the array when images is a real array", () => {
+    const images = [{ uri: "a.png", mediaType: "image/png" }];
+    expect(getGeneratedImages({ images })).toBe(images);
+  });
+
+  test("returns undefined when images is missing", () => {
+    expect(getGeneratedImages({})).toBeUndefined();
+    expect(getGeneratedImages(undefined)).toBeUndefined();
+  });
+
+  // A malformed backend/MCP payload could send images as a non-array value
+  // (e.g. an object or string) — without the Array.isArray guard, downstream
+  // `images.map(...)` throws and crashes the message render.
+  test("returns undefined when images is a non-array value", () => {
+    expect(
+      getGeneratedImages({
+        images: { 0: { uri: "a.png" } } as unknown as Array<{
+          mediaType: string;
+        }>,
+      }),
+    ).toBeUndefined();
+    expect(
+      getGeneratedImages({
+        images: "oops" as unknown as Array<{ mediaType: string }>,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/chat/message/parts/tool-call-part/generate-image.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/generate-image.tsx
@@ -45,6 +45,13 @@ interface GenerateImagePartProps {
   latency?: number;
 }
 
+/** Validated `images` array — guards against a malformed (non-array) backend payload. */
+export function getGeneratedImages(
+  result: GenerateImageResult | undefined,
+): GenerateImageResult["images"] {
+  return Array.isArray(result?.images) ? result.images : undefined;
+}
+
 function extractUsage(
   result: GenerateImageResult | undefined,
 ): UsageStats | null {
@@ -102,7 +109,7 @@ export function GenerateImagePart({ part, latency }: GenerateImagePartProps) {
   const state = getEffectiveState(part.state);
   const input = part.input as GenerateImageInput | undefined;
   const result = part.output as GenerateImageResult | undefined;
-  const images = result?.images;
+  const images = getGeneratedImages(result);
   const usage = extractUsage(result);
   const modelLabel = result?.model;
   const refImages = Array.isArray(input?.referenceImages)


### PR DESCRIPTION
**Source:** bug hunt in the chat tool-call-part robustness area (`apps/web/src/components/chat/message/parts/tool-call-part/`).

**Why:** `GenerateImagePart` (generate-image.tsx) read `result?.images` unvalidated. If a backend/MCP tool returns a malformed `generate_image` result where `images` is present but not an array (e.g. an object or a string instead of `Array<{uri, mediaType}>`), the `!images || images.length === 0` guard doesn't catch it (a non-array object/string can still have a `.length`/be truthy), so the code falls into the success branch and calls `images.map(...)`, which throws and crashes that message's render. The file already guards `referenceImages` the same way one field over (`Array.isArray(input?.referenceImages)`), and sibling list components (`agent-list.tsx`, `connection-list.tsx`) use the identical `Array.isArray(result?.items)` pattern — this brings `images` in line with that established convention.

**Failure scenario:** an MCP/backend tool call for `generate_image` returns `{ images: {} }` or `{ images: "oops" }` instead of an array → `GenerateImagePart` renders past the empty-state check and crashes on `images.map`.

**Fix:** added `getGeneratedImages(result)`, a small exported helper that returns `result.images` only when `Array.isArray` is true, and used it in place of the raw field read. `generate-image.test.ts` is the regression test — it exercises `getGeneratedImages` for a valid array, a missing field, and non-array (object/string) shapes, asserting the non-array cases fall back to `undefined` instead of reaching `.map`.

**To verify:** `cd apps/web && bun test src/components/chat/message/parts/tool-call-part/generate-image.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web workspace, clean), the targeted test above (3 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent chat message crashes when a `generate_image` tool returns a non-array `images` payload. `GenerateImagePart` now validates `result.images` via a new `getGeneratedImages` helper and only renders when it's a real array.

- **Bug Fixes**
  - Use `getGeneratedImages(result)` in `generate-image.tsx` to guard `images` before `.map`.
  - Add `generate-image.test.ts` covering valid, missing, and non-array cases.

<sup>Written for commit e5722d03b1a51be6d17de65a8689cbeb8113a01e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

