### PR TITLE
fix(sandbox): make the daemon's publish hooks-dir creation async

### DIFF
--- a/packages/sandbox/daemon/routes/git.ts
+++ b/packages/sandbox/daemon/routes/git.ts
@@ -1,5 +1,5 @@
-import fs, { mkdtempSync } from "node:fs";
-import { readFile, unlink } from "node:fs/promises";
+import fs from "node:fs";
+import { mkdtemp, readFile, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { appendCoAuthorTrailer } from "../../git-co-author";
@@ -478,9 +478,9 @@ function formatGitError(err: unknown): string {
 
 /** Empty dir passed as core.hooksPath so publish commits never run lefthook/husky. */
 let emptyHooksDir: string | null = null;
-function getEmptyHooksDir(): string {
+async function getEmptyHooksDir(): Promise<string> {
   if (!emptyHooksDir) {
-    emptyHooksDir = mkdtempSync(
+    emptyHooksDir = await mkdtemp(
       path.join(tmpdir(), "studio-sandbox-no-hooks-"),
     );
   }
@@ -714,11 +714,12 @@ export async function publish(
     // --no-verify: we may want to run hooks here eventually, but removing it
     // requires surfacing hook failures clearly in the publish UI (which step
     // failed, logs, retry) instead of a generic daemon 500.
+    const hooksDir = await getEmptyHooksDir();
     runGit(
       repoDir,
       [
         "-c",
-        `core.hooksPath=${getEmptyHooksDir()}`,
+        `core.hooksPath=${hooksDir}`,
         "commit",
         "--no-verify",
         "-m",


### PR DESCRIPTION
Continues the daemon's sync-fs → async-fs hardening pass (#5471 discard, #5481 decofile-block validation) for the same reason: any blocking `*Sync` fs call on the daemon's single-threaded Bun event loop stalls the `/health` probe Studio polls, which can get the sandbox marked dead.

**Bug**: `publish()`'s `getEmptyHooksDir()` called `mkdtempSync` (creating the empty `core.hooksPath` dir used to skip lefthook/husky on the publish commit) from inside the already-`async` `publish()` handler, blocking the loop for the syscall's duration on the first publish of the daemon's lifetime.

**Fix**: swap `mkdtempSync` (node:fs) for `mkdtemp` (node:fs/promises), `await`ed at the one call site inside `publish()`. Behavior-preserving — same memoized dir, same path, same commit args; only the creation is now async. Net diff: +6/-5.

**Verify**: `cd packages/sandbox && bunx tsc --noEmit` (clean) and `bun test packages/sandbox/daemon/routes/git.test.ts` (51 pass, including the publish-path tests that exercise this helper).

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in `packages/sandbox`, the single test file above, and `bunx oxlint packages/sandbox/daemon/routes/git.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made hooks directory creation in the sandbox daemon’s publish path async to avoid blocking the Bun event loop. This keeps the `/health` probe responsive and prevents the sandbox from being marked dead.

- **Bug Fixes**
  - Replaced `mkdtempSync` (`node:fs`) with awaited `mkdtemp` (`node:fs/promises`) in `publish()` and passed it to `core.hooksPath`.
  - Behavior preserved: the empty hooks dir is still memoized and used to skip lefthook/husky during publish commits.

<sup>Written for commit 549fe42cec09d2481284af7ad35cbd5e0e7d46c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

