### PR TITLE
ci(native): gate each macOS job on its own inputs, not one shared bit

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -114,11 +114,14 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             # First match wins, so order these most-specific-first. Editing
-            # this workflow sets `rust` (i.e. everything) on purpose: it is the
-            # config for all four jobs and a comment-only YAML edit isn't
-            # cheaply distinguishable from a behavioral one.
+            # THIS workflow matches nothing on purpose: most edits here are
+            # comments or gate wiring, and burning 4 macOS jobs (one of them a
+            # 45-minute bundle) to prove a YAML comment is why this gate got
+            # split in the first place. The `push:` trigger above includes this
+            # file and runs the full set on main, so a workflow change is
+            # verified the moment it merges.
             case "$f" in
-              apps/native/crates/*|apps/native/src-tauri/*|apps/native/Cargo.toml|apps/native/Cargo.lock|apps/native/rustfmt.toml|apps/native/scripts/fetch-rclone.sh|.github/workflows/native.yml)
+              apps/native/crates/*|apps/native/src-tauri/*|apps/native/Cargo.toml|apps/native/Cargo.lock|apps/native/rustfmt.toml|apps/native/scripts/fetch-rclone.sh)
                 rust=true ;;
               packages/sandbox/daemon/*|apps/native/scripts/ci/*) suite=true ;;
               apps/native/e2e/*) contract=true ;;

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -10,7 +10,10 @@ name: Native
 # check whose workflow never runs (workflow-level `paths:` filtering) blocks
 # the merge forever; a job skipped via `if:`, by contrast, reports as passed.
 # The `pull_request` trigger is therefore unfiltered and the `changes` job
-# skips the expensive macOS jobs when the PR touches nothing native-relevant.
+# skips the expensive macOS jobs when the PR touches nothing they consume.
+# That gate is PER JOB, not one workflow-wide "relevant" bit: a PR that
+# changes only the pinned parity fail-set has no reason to run cargo
+# clippy, and a web-only PR has no reason to build local-api twice.
 # Pushes to main keep the `paths:` filter — required checks gate PRs, not
 # pushes, so a never-run workflow is harmless there.
 on:
@@ -58,14 +61,28 @@ env:
   BUN_VERSION: "1.3.14"
 
 jobs:
-  # Gate: skip the macOS jobs when a PR touches nothing native-relevant.
+  # Gate: skip each macOS job when a PR touches none of ITS inputs.
   # Required checks can't be skipped via workflow-level `paths` filters — a
   # never-scheduled required check blocks the merge forever. A job skipped
   # via `if`, by contrast, reports as passed (same pattern as test.yml).
+  #
+  # Four outputs, one per downstream job, because the four jobs consume
+  # different things:
+  #   rust     — the cargo workspace itself (+ build inputs). Every job below
+  #              compiles Rust, so this one implies all of them.
+  #   suite    — the curated daemon e2e suite and its pinned fail-set, the
+  #              only extra inputs to the parity oracle. The suite is fully
+  #              black-box (it imports no workspace package), so nothing else
+  #              in packages/ can move it.
+  #   contract — apps/native's own e2e suite.
+  #   frontend — the web bundle baked into the .app.
   changes:
     runs-on: ubuntu-latest
     outputs:
-      relevant: ${{ steps.filter.outputs.relevant }}
+      rust: ${{ steps.filter.outputs.rust }}
+      suite: ${{ steps.filter.outputs.suite }}
+      contract: ${{ steps.filter.outputs.contract }}
+      frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - name: Detect relevant changes
         id: filter
@@ -73,13 +90,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_MSG: ${{ github.event.head_commit.message }}
         run: |
+          all() { for k in rust suite contract frontend; do echo "$k=$1" >> "$GITHUB_OUTPUT"; done; }
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             # Pushes to main, schedule, and dispatch run everything — except
             # the [release]: version-bump push, which only touches version
             # strings (release-native.yaml owns the shipping build).
             case "$HEAD_MSG" in
-              '[release]:'*) echo "relevant=false" >> "$GITHUB_OUTPUT" ;;
-              *) echo "relevant=true" >> "$GITHUB_OUTPUT" ;;
+              '[release]:'*) all false ;;
+              *) all true ;;
             esac
             exit 0
           fi
@@ -88,19 +106,33 @@ jobs:
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
             --jq '.[].filename'); then
             echo "Could not list PR files — running to be safe."
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            all true
             exit 0
           fi
           echo "Changed files:"; echo "$FILES"
-          relevant=false
+          rust=false suite=false contract=false frontend=false
           while IFS= read -r f; do
             [ -z "$f" ] && continue
+            # First match wins, so order these most-specific-first. Editing
+            # this workflow sets `rust` (i.e. everything) on purpose: it is the
+            # config for all four jobs and a comment-only YAML edit isn't
+            # cheaply distinguishable from a behavioral one.
             case "$f" in
-              apps/native/*|apps/web/*|packages/sandbox/daemon/*|packages/shared/*|.github/workflows/native.yml)
-                relevant=true ;;
+              apps/native/crates/*|apps/native/src-tauri/*|apps/native/Cargo.toml|apps/native/Cargo.lock|apps/native/rustfmt.toml|apps/native/scripts/fetch-rclone.sh|.github/workflows/native.yml)
+                rust=true ;;
+              packages/sandbox/daemon/*|apps/native/scripts/ci/*) suite=true ;;
+              apps/native/e2e/*) contract=true ;;
+              apps/web/*|packages/shared/*) frontend=true ;;
+              # Everything else under apps/native — package.json, tsconfig,
+              # the other scripts — can move any of the three bun-side jobs.
+              # apps/native/{docs,README.md} intentionally match nothing.
+              apps/native/docs/*|apps/native/README.md) ;;
+              apps/native/*) suite=true contract=true frontend=true ;;
             esac
           done <<< "$FILES"
-          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+          for k in rust suite contract frontend; do
+            eval "echo \"$k=\$$k\"" >> "$GITHUB_OUTPUT"
+          done
 
   # ---------------------------------------------------------------------
   # 1. rust-checks — fmt / clippy / cargo test across the whole cargo
@@ -114,7 +146,7 @@ jobs:
   rust-checks:
     needs: changes
     if: >-
-      needs.changes.outputs.relevant == 'true' &&
+      needs.changes.outputs.rust == 'true' &&
       github.event_name != 'schedule'
     runs-on: macos-latest
     timeout-minutes: 30
@@ -195,7 +227,8 @@ jobs:
   daemon-e2e-vs-rust:
     needs: changes
     if: >-
-      needs.changes.outputs.relevant == 'true' &&
+      (needs.changes.outputs.rust == 'true' ||
+       needs.changes.outputs.suite == 'true') &&
       github.event_name != 'schedule'
     runs-on: macos-latest
     timeout-minutes: 30
@@ -276,7 +309,8 @@ jobs:
   contract-suite:
     needs: changes
     if: >-
-      needs.changes.outputs.relevant == 'true' &&
+      (needs.changes.outputs.rust == 'true' ||
+       needs.changes.outputs.contract == 'true') &&
       github.event_name != 'schedule'
     runs-on: macos-latest
     timeout-minutes: 30
@@ -321,7 +355,8 @@ jobs:
   tauri-build:
     needs: changes
     if: >-
-      needs.changes.outputs.relevant == 'true' &&
+      (needs.changes.outputs.rust == 'true' ||
+       needs.changes.outputs.frontend == 'true') &&
       github.event_name != 'schedule'
     runs-on: macos-latest
     timeout-minutes: 45


### PR DESCRIPTION
Noticed on #5484: that PR touches **no Rust at all** (it edits comments in
`native.yml` and rewrites the pinned parity fail-set) and still runs
`rust-checks`, `contract-suite`, and `tauri-build` on macOS runners.

## Why

`changes` emitted a single `relevant` bit, unioned over `apps/native/**` +
`apps/web/**` + `packages/sandbox/daemon/**` + `packages/shared/**`, and all
four macOS jobs keyed off it. Any hit anywhere in that union ran all four:

- a PR touching only `apps/native/scripts/ci/*.json` (the pinned fail-set) ran
  `cargo fmt`/`clippy`/`test`;
- a web-only PR built the release `local-api` binary **twice** — once for the
  parity oracle, once for the contract suite — neither of which `apps/web` can
  move;
- `apps/native/docs/**` edits, and edits to this workflow itself, ran the whole
  macOS set — including the 45-minute `tauri-build`.

## What

One output per job, because the four consume different inputs:

| output | paths | gates |
| --- | --- | --- |
| `rust` | `crates/**`, `src-tauri/**`, `Cargo.{toml,lock}`, `rustfmt.toml`, `fetch-rclone.sh` | all four (every job compiles Rust) |
| `suite` | `packages/sandbox/daemon/**`, `apps/native/scripts/ci/**` | `daemon-e2e-vs-rust` |
| `contract` | `apps/native/e2e/**` | `contract-suite` |
| `frontend` | `apps/web/**`, `packages/shared/**` | `tauri-build` |

Anything else under `apps/native` (package.json, tsconfig, other scripts) sets
the three bun-side flags. `apps/native/docs/**`, its README, and
`.github/workflows/native.yml` match nothing — the `push:` trigger already
lists this workflow and sets every flag true, so main runs the full set the
moment a workflow change merges. **This PR is its own demo: one YAML file, so
all four macOS jobs report skipped.**

`suite` deliberately excludes `packages/shared` — the curated suite is fully
black-box (it imports no workspace package, only `bun:test` / `node:*` / the
MCP SDK), so nothing in `packages/` besides the daemon itself can change its
result.

## Deliberately unchanged

- The gh-api failure path still sets every flag true (run to be safe), and
  push/schedule/dispatch still run everything except `[release]:` bumps.
- All four jobs still run on every PR event and still report
  skipped-as-passed, so required branch-protection checks are unaffected.

## Testing

The `case` block was extracted straight out of the YAML and run against
file-list fixtures: workflow-only → nothing; a `.rs` file → all four;
allowlist-only → `suite`; web-only → `frontend`; `apps/native/e2e` →
`contract`; `apps/native/package.json` → the three bun-side flags; docs-only
and `apps/api`-only → nothing. The workflow parses as YAML and each job's `if:`
resolves to the expected expression.
