### PR TITLE
ci(agents): adopt Bun-style agent guardrails — hooks, comment-cop, PR template

### DIFF
--- a/.claude/hooks/post-edit-format.js
+++ b/.claude/hooks/post-edit-format.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+// PostToolUse hook: format each edited file with Biome so agent commits never
+// need a formatting follow-up. Fail-open — formatting must never block edits.
+import { spawnSync } from "node:child_process";
+import { extname } from "node:path";
+
+const input = await Bun.stdin.json();
+
+const filePath = (input.tool_input || {}).file_path;
+if (!filePath || !["Write", "Edit", "MultiEdit"].includes(input.tool_name)) {
+  process.exit(0);
+}
+
+const BIOME_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".cjs",
+  ".mjs",
+  ".json",
+  ".jsonc",
+  ".css",
+];
+if (BIOME_EXTENSIONS.includes(extname(filePath))) {
+  try {
+    spawnSync("./node_modules/.bin/biome", ["format", "--write", filePath], {
+      cwd: process.env.CLAUDE_PROJECT_DIR || process.cwd(),
+      encoding: "utf-8",
+    });
+  } catch {}
+}
+
+process.exit(0);

--- a/.claude/hooks/pre-guard.js
+++ b/.claude/hooks/pre-guard.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env bun
+// PreToolUse guard: denies known-bad agent commands with a corrective message,
+// and escalates knip config edits to the human (Gotcha #6 in CLAUDE.md).
+
+const input = await Bun.stdin.json();
+
+const toolName = input.tool_name;
+const toolInput = input.tool_input || {};
+const cwd = input.cwd || "";
+const projectDir = process.env.CLAUDE_PROJECT_DIR || "";
+
+function decide(permissionDecision, permissionDecisionReason) {
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision,
+        permissionDecisionReason,
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+// --- knip config edits: ask the human (Gotcha #6) ---
+if (["Write", "Edit", "MultiEdit"].includes(toolName)) {
+  const filePath = toolInput.file_path || "";
+  if (/(^|\/)knip\.(jsonc?|config\.[jt]s)$/.test(filePath)) {
+    decide(
+      "ask",
+      "Gotcha #6: never edit the knip config to silence warnings — delete the dead code/export/dependency instead. If this is a legitimate change (e.g. a new workspace entry point), ask the user to approve.",
+    );
+  }
+  process.exit(0);
+}
+
+if (toolName !== "Bash" || !toolInput.command) {
+  process.exit(0);
+}
+
+// Simple shell parsing: split on spaces respecting quotes, strip inline env prefixes.
+let tokens = (
+  toolInput.command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || []
+).map((t) => t.replace(/^['"]|['"]$/g, ""));
+while (
+  tokens.length &&
+  /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0]) &&
+  !tokens[0].includes("/")
+) {
+  tokens = tokens.slice(1);
+}
+if (tokens.length === 0) {
+  process.exit(0);
+}
+const argv0 = tokens[0].split("/").pop();
+const args = tokens.slice(1);
+
+// --- `git push` to main/master ---
+if (argv0 === "git" && args.includes("push")) {
+  const pushesMain = args.some(
+    (a) => a === "main" || a === "master" || /^[^-].*:(main|master)$/.test(a),
+  );
+  if (pushesMain) {
+    decide(
+      "deny",
+      "error: Don't push to main directly. Create a branch and open a PR (see CLAUDE.md commit guidelines).",
+    );
+  }
+}
+
+// --- bare `bun test` from the repo root runs the entire monorepo suite ---
+if (argv0 === "bun") {
+  const positional = args.filter((a) => !a.startsWith("-"));
+  if (positional[0] === "test") {
+    const hasPath = positional
+      .slice(1)
+      .some((a) => a.includes("/") || a.includes(".test."));
+    const atRepoRoot = !projectDir || cwd === projectDir || cwd === "";
+    if (!hasPath && atRepoRoot) {
+      decide(
+        "deny",
+        "error: Bare `bun test` from the repo root runs every unit test in the monorepo. Run `bun test <path/to/file.test.ts>` for the files you touched instead.",
+      );
+    }
+  }
+}
+
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,27 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-guard.js"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post-edit-format.js"
+          }
+        ]
+      }
+    ],
     "WorktreeCreate": [
       {
         "hooks": [

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
 ## What is this contribution about?
 > Describe your changes and why they're needed.
 
+## How did you verify your code works?
+> Name the tests you ran or added and what you observed. "Verified manually" or "existing tests" without specifics doesn't count.
+
 ## Screenshots/Demonstration
 > Add screenshots or a Loom video if your changes affect the UI.
 

--- a/.github/workflows/auto-label-claude-prs.yml
+++ b/.github/workflows/auto-label-claude-prs.yml
@@ -1,0 +1,28 @@
+name: Auto-label Claude PRs
+
+# PRs authored by coding agents carry the "🤖 Generated with" signature line
+# (mandated by CLAUDE.md). Label them so downstream automation (comment-cop)
+# and reviewers can key off AI provenance.
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-label:
+    if: contains(github.event.pull_request.body, '🤖 Generated with')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Add claude label
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['claude']
+            });

--- a/.github/workflows/comment-cop.yml
+++ b/.github/workflows/comment-cop.yml
@@ -1,0 +1,197 @@
+name: Comment Cop
+
+# Flags multi-line code comments added by claude-labeled PRs and asks for them
+# to be deleted (CLAUDE.md: "a comment that takes a paragraph to justify a
+# workaround is a signal the code is wrong"). Doc comments (/** ... */) are
+# skipped. Runs entirely against the GitHub API — never checks out PR code,
+# which is what makes pull_request_target safe here.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment-cop:
+    if: >
+      github.repository == 'decocms/studio' &&
+      contains(github.event.pull_request.labels.*.name, 'claude') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'claude')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: comment-cop-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Scan diff for added multi-line comments
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const crypto = require('crypto');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+            const headSha = context.payload.pull_request.head.sha;
+
+            const SRC_PREFIX = /^(apps|packages|plugins)\//;
+            const SRC_EXT = /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
+            const MIN_LINES = 2;
+
+            function isCommentLine(line) {
+              const t = line.trimStart();
+              if (t.startsWith('//')) return true;
+              if (t.startsWith('/*')) return true;
+              if (t === '*' || t === '*/' || t.startsWith('* ')) return true;
+              return false;
+            }
+
+            function groupsFromPatch(path, patch) {
+              const out = [];
+              let newLine = 0;
+              let cur = null;
+              const flush = () => {
+                if (cur && cur.lines.length >= MIN_LINES) {
+                  const text = cur.lines.join('\n');
+                  // Doc comments are API documentation, not workaround
+                  // justification — leave them alone.
+                  const isDocBlock = cur.lines[0].trimStart().startsWith('/**');
+                  if (!isDocBlock) out.push({ path, start: cur.start, end: cur.end, text });
+                }
+                cur = null;
+              };
+              for (const raw of patch.split('\n')) {
+                if (raw.startsWith('@@')) {
+                  flush();
+                  const m = /\+(\d+)/.exec(raw);
+                  newLine = m ? parseInt(m[1], 10) : 1;
+                } else if (raw.startsWith('+')) {
+                  const content = raw.slice(1);
+                  if (isCommentLine(content)) {
+                    if (cur) {
+                      cur.end = newLine;
+                      cur.lines.push(content);
+                    } else {
+                      cur = { start: newLine, end: newLine, lines: [content] };
+                    }
+                  } else {
+                    flush();
+                  }
+                  newLine++;
+                } else if (raw.startsWith('-')) {
+                  flush();
+                } else if (raw.startsWith('\\')) {
+                  // "\ No newline at end of file"
+                } else {
+                  // context line (leading space, or blank)
+                  flush();
+                  newLine++;
+                }
+              }
+              flush();
+              return out;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number, per_page: 100,
+            });
+
+            const groups = [];
+            for (const f of files) {
+              if (f.status === 'removed') continue;
+              if (!SRC_PREFIX.test(f.filename)) continue;
+              if (!SRC_EXT.test(f.filename)) continue;
+              if (!f.patch) continue;
+              for (const g of groupsFromPatch(f.filename, f.patch)) groups.push(g);
+            }
+
+            const keyFor = g => `${g.path}:${crypto.createHash('sha256').update(g.text).digest('hex').slice(0, 12)}`;
+            const presentKeys = new Set(groups.map(keyFor));
+
+            // Fetch existing comment-cop review threads (for dedup + auto-resolve).
+            const threads = [];
+            {
+              const q = `
+                query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $pr) {
+                      reviewThreads(first: 100, after: $after) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes { id isResolved comments(first: 1) { nodes { body } } }
+                      }
+                    }
+                  }
+                }`;
+              let after = null;
+              for (;;) {
+                const res = await github.graphql(q, { owner, repo, pr: pull_number, after });
+                const page = res.repository.pullRequest.reviewThreads;
+                for (const t of page.nodes) threads.push(t);
+                if (!page.pageInfo.hasNextPage) break;
+                after = page.pageInfo.endCursor;
+              }
+            }
+
+            const seenKeys = new Set();
+            const toResolve = [];
+            for (const t of threads) {
+              const body = t.comments.nodes[0]?.body || '';
+              const m = /<!-- comment-cop:([^>\s]+) -->/.exec(body);
+              if (!m) continue;
+              const key = m[1];
+              seenKeys.add(key);
+              if (!t.isResolved && !presentKeys.has(key)) toResolve.push(t.id);
+            }
+
+            // Auto-resolve threads whose flagged block is gone from the current diff.
+            if (toResolve.length > 0) {
+              const mut = `
+                mutation($id: ID!) {
+                  resolveReviewThread(input: { threadId: $id }) { thread { id } }
+                }`;
+              for (const id of toResolve) {
+                try {
+                  await github.graphql(mut, { id });
+                } catch (e) {
+                  core.warning(`resolveReviewThread failed for ${id}: ${e.message}`);
+                }
+              }
+              core.info(`Resolved ${toResolve.length} stale comment-cop thread(s).`);
+            }
+
+            // Post new line comments for groups not already flagged.
+            const fresh = groups.filter(g => !seenKeys.has(keyFor(g)));
+            if (fresh.length === 0) {
+              core.info(`No new comment groups to flag (${groups.length} present, all already flagged).`);
+              return;
+            }
+
+            const bodyFor = g =>
+              `<!-- comment-cop:${keyFor(g)} -->\n` +
+              `A comment that takes a paragraph to justify a workaround is a signal the code is wrong, not the comment — fix the code, don't explain it away (CLAUDE.md).\n\n`;
+
+            let posted = 0;
+            for (const g of fresh) {
+              const params = {
+                owner, repo, pull_number,
+                commit_id: headSha,
+                path: g.path,
+                line: g.end,
+                side: 'RIGHT',
+                body: bodyFor(g),
+              };
+              if (g.start < g.end) {
+                params.start_line = g.start;
+                params.start_side = 'RIGHT';
+              }
+              try {
+                await github.rest.pulls.createReviewComment(params);
+                posted++;
+              } catch (e) {
+                core.warning(`createReviewComment failed for ${g.path}:${g.start}-${g.end}: ${e.message}`);
+              }
+            }
+            core.info(`Posted ${posted} review comment(s).`);


### PR DESCRIPTION
## What is this contribution about?

Imports the transferable agent-development practices from studying [oven-sh/bun](https://github.com/oven-sh/bun)'s repo automation. Bun's recurring move: every important rule exists twice — as prose in CLAUDE.md (teaches) and as a hook/workflow (guarantees). This PR adds the mechanism layer for rules our CLAUDE.md already states:

**Claude Code hooks (`.claude/hooks/`)**
- `pre-guard.js` (PreToolUse on Bash/Edit/Write):
  - `git push` to main/master → **deny** with a corrective message
  - bare `bun test` from the repo root (runs the whole monorepo suite) → **deny**, suggests `bun test <path>`
  - edits to `knip.jsonc`/`knip.config.*` → **ask** (escalates to the human, citing Gotcha #6, with an escape hatch for legitimate edits like new workspace entry points)
- `post-edit-format.js` (PostToolUse): runs `biome format --write` on each edited file, fail-open. Removes the "pure-format follow-up" class (e.g. #4461).

**GitHub automation (`.github/workflows/`)**
- `auto-label-claude-prs.yml`: PRs whose body carries the "🤖 Generated with" signature get the `claude` label (label already created on the repo).
- `comment-cop.yml`: on `claude`-labeled PRs, scans the diff via the GitHub API for added multi-line comment blocks in `apps/`, `packages/`, `plugins/` and posts a line review quoting our CLAUDE.md rule ("a comment that takes a paragraph to justify a workaround is a signal the code is wrong"). Marker-based dedupe, auto-resolves its threads when the flagged block disappears from the diff, skips JSDoc blocks. Never checks out PR code — that's what makes `pull_request_target` safe here (property preserved from Bun's original).

**PR template**
- New section: "How did you verify your code works?" — Bun's two-question anti-slop philosophy.

## How did you verify your code works?

- `pre-guard.js`: exercised with simulated hook JSON on stdin — deny on `git push origin main` (incl. env-prefix evasion `FOO=1 git push origin main`), deny on bare `bun test` at repo root, pass on `git push -u origin claude/foo` and `bun test apps/api/src/foo.test.ts`, ask on `knip.jsonc` edit, silent on normal edits.
- `post-edit-format.js`: fed a deliberately misformatted `.ts` file through the hook; Biome rewrote it (quotes/spacing/semicolons).
- `comment-cop` parser: extracted `groupsFromPatch` and ran it against a synthetic patch — the 2-line workaround paragraph is flagged with correct line numbers; JSDoc block and single-line comment are skipped.
- Both workflow YAMLs parse (`Bun.YAML`) with the expected jobs. The workflows themselves only take effect once on main (`pull_request_target`), so end-to-end firing can't be tested from this branch.

## Migration Notes

- The `claude` label was already created on the repo.
- `comment-cop`/`auto-label` only start firing after this lands on main.
- No new dependencies; hooks are zero-dependency Bun scripts.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Bun-style agent guardrails: pre-hooks that block risky commands, post-hooks that auto-format edits, and a workflow that flags workaround-heavy comments. Also updates the PR template to require concrete verification steps.

- **New Features**
  - `.claude` hooks
    - PreToolUse: deny `git push` to main/master; deny bare `bun test` from repo root; ask on `knip` config edits.
    - PostToolUse: run Biome format on edited files (fail-open).
  - GitHub workflows
    - `auto-label-claude-prs.yml`: PRs with the "🤖 Generated with" line get the `claude` label.
    - `comment-cop.yml`: on `claude`-labeled PRs, scans diffs in `apps/`, `packages/`, `plugins/` for added multi-line comment blocks; skips JSDoc; dedupes via markers; auto-resolves when blocks are removed; uses API-only calls (`pull_request_target`-safe).
  - PR template: adds "How did you verify your code works?" section.

- **Migration**
  - No new dependencies; hooks are Bun scripts using local Biome.
  - `claude` label already exists.
  - Workflows start after this lands on `main`.

<sup>Written for commit a202b69e8357a70252e48108f6997419f21c85fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

