### PR TITLE
fix(decopilot): resume a subtask across a transient stream failure

### DIFF
--- a/apps/api/src/harnesses/decopilot/built-in-tools/subtask.test.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/subtask.test.ts
@@ -8,10 +8,42 @@
 import { describe, expect, test } from "bun:test";
 import {
   createSubtaskTool,
+  isTransientStreamError,
   resolveSubtaskCodingWorkspace,
   SubtaskInputSchema,
   type SubtaskParams,
 } from "./subtask";
+
+describe("isTransientStreamError", () => {
+  test("resumes a broken transport", () => {
+    for (const message of [
+      // The prod failure this was written for (thread c12c86aa, 2026-07-31).
+      "The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+      "read ECONNRESET",
+      "write EPIPE",
+      "connect ETIMEDOUT 1.2.3.4:443",
+      "fetch failed",
+      "terminated",
+      "Provider returned error 502",
+      "upstream timed out",
+      "Model is overloaded, please try again",
+    ]) {
+      expect(isTransientStreamError(message)).toBe(true);
+    }
+  });
+
+  test("does not resume a request the provider rejected on its merits", () => {
+    for (const message of [
+      "This endpoint's maximum context length is 200000 tokens",
+      "Invalid API key provided",
+      "No endpoints found that support tool use",
+      "Run aborted before completion.",
+      "messages: at least one message is required",
+    ]) {
+      expect(isTransientStreamError(message)).toBe(false);
+    }
+  });
+});
 
 const mockParams: SubtaskParams = {
   provider: { thinkingModel: {} as never } as never,
@@ -312,7 +344,7 @@ describe("toModelOutput (new runAgentLoop-based contract)", () => {
     expect(result.value).toContain("prompt is too long");
   });
 
-  test("error takes precedence over text", () => {
+  test("error-text carries the partial result instead of discarding it", () => {
     const result = toModelOutput({
       ...baseArgs,
       output: {
@@ -322,6 +354,21 @@ describe("toModelOutput (new runAgentLoop-based contract)", () => {
       } as never,
     }) as { type: string; value: string };
     expect(result.type).toBe("error-text");
+    expect(result.value).toContain("Context window exceeded");
+    // Was previously dropped, which made the parent redo already-applied work.
+    expect(result.value).toContain("Step 1 done.");
+  });
+
+  test("error-text omits the partial section when there is no partial text", () => {
+    const result = toModelOutput({
+      ...baseArgs,
+      output: {
+        text: "",
+        error: "Context window exceeded",
+        finishReason: "error",
+      } as never,
+    }) as { type: string; value: string };
+    expect(result.value).toBe("Subtask failed: Context window exceeded");
   });
 
   test("prefixes text with step-limit notice when finishReason is 'length'", () => {

--- a/apps/api/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -11,7 +11,13 @@
 
 import type { StudioContext, OrganizationScope } from "@/core/studio-context";
 import { resolveSubagent } from "../resolve-subagent";
-import type { ToolSet, UIMessageStreamWriter } from "ai";
+import type {
+  LanguageModelUsage,
+  ModelMessage,
+  StepResult,
+  ToolSet,
+  UIMessageStreamWriter,
+} from "ai";
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { StudioProvider } from "@/ai-providers/types";
@@ -44,6 +50,27 @@ export const SubtaskInputSchema = z.object({
 });
 
 export type SubtaskInput = z.infer<typeof SubtaskInputSchema>;
+
+/**
+ * Does this `runAgentLoop` error message describe a broken transport rather
+ * than a rejected request? Only these resume — a 400/401/context-length error
+ * would fail identically on every attempt.
+ *
+ * Exported for its unit test; the drain loop below is the only caller.
+ */
+export function isTransientStreamError(message: string): boolean {
+  return /socket connection was closed|econnreset|epipe|etimedout|fetch failed|terminated|network error|premature close|\b(429|500|502|503|504)\b|overloaded|rate.?limit|timed? ?out/i.test(
+    message,
+  );
+}
+
+/**
+ * How many times a subagent may resume after a transient stream failure.
+ *
+ * ponytail: fixed at 2 — a third attempt against a provider that dropped twice
+ * is almost always the same outage. Make it a setting only if prod disagrees.
+ */
+const MAX_STREAM_RESUMES = 2;
 
 const SUBTASK_DESCRIPTION =
   "Run a focused task in a fresh subagent that works independently and returns only its conclusion.\n\n" +
@@ -313,56 +340,14 @@ export function createSubtaskTool(
             })()
           : undefined;
 
-        // 3. Call runAgentLoop with subagent kind.
-        const handle = await runAgentLoop({
-          kind: "subagent",
-          ctx,
-          organization,
-          virtualMcp: targetRef,
-          mcpClient,
-          provider,
-          models,
-          messages: [{ role: "user", content: prompt }],
-          // Inherit the parent's thread id so a PR the subagent opens still
-          // moves the linked task board card to In Review via the thread link
-          // (see SubtaskParams.currentThreadId).
-          currentThreadId,
-          systemAgentInstructions: targetRef.instructions,
-          abortSignal: abortSignal ?? new AbortController().signal,
-          stepLimit: SUBAGENT_STEP_LIMIT,
-          toolApprovalLevel: "auto",
-          planMode: false,
-          codingWorkspace: subtaskCodingWorkspace,
-          writer,
-          subtaskParams: {
-            provider,
-            organization,
-            models,
-            needsApproval,
-            codingWorkspace: subtaskCodingWorkspace,
-          },
-          // Subagent inherits the parent's writer for nested chunk routing.
-          // Subagent gets prompts/connections blocks via the MCP client
-          // (which is both the tool source AND the prompts source for the
-          // target agent). This passes through to buildAgentSystemPrompt.
-          passthroughClient: mcpClient,
-          // Full heavy built-ins for the subagent (vm/generate_image/web_search).
-          subagentBuiltInParams,
-          // Fallback only — when no parent params are available (no full-built-in
-          // rebuild), a self-clone still inherits the parent's sandbox tools so
-          // it can run bash / file I/O against the SAME sandbox.
-          extraTools: subagentBuiltInParams
-            ? undefined
-            : isSelf
-              ? vmTools
-              : undefined,
-        });
-
         // Surface the subagent's tool calls in the live stream so the UI shows
         // progress even while the subagent works silently (calling tools, not
         // emitting text). The input STREAMS as it's generated (capped), so a
         // long call (e.g. a file write) reveals progressively rather than
         // popping in whole when the call completes.
+        //
+        // Declared OUTSIDE the resume loop below: a resumed attempt continues
+        // the same transcript instead of restarting the rendered text.
         let streamedText = "";
         // The tool call currently streaming its input (name + accumulated args).
         let pending: { name: string; args: string } | null = null;
@@ -383,52 +368,158 @@ export function createSubtaskTool(
           const sep = streamedText && !streamedText.endsWith("\n") ? "\n" : "";
           return `${streamedText}${sep}↳ ${args ? `${pending.name} ${args}` : pending.name}`;
         };
-        for await (const part of handle.result.fullStream) {
-          const now = performance.now();
-          if (part.type === "text-delta") {
-            commitPending();
-            streamedText += part.text;
-            if (now - lastFlush >= FLUSH_MS) {
+
+        // 3. Drive runAgentLoop, RESUMING across a transient stream failure.
+        //
+        // A provider stream that dies mid-run (socket close, gateway 5xx) used
+        // to end the subagent right there: `handle.error` set, every completed
+        // step discarded, and the parent handed a bare "Subtask failed" — so
+        // the parent had to redo work the subagent had already done, against
+        // side effects it had already applied. Resume instead: replay the
+        // completed steps' response messages, so already-executed tool calls
+        // are NOT re-run, and let the loop carry on from where it broke.
+        // The step budget is shared across attempts, never refreshed.
+        let convo: ModelMessage[] = [{ role: "user", content: prompt }];
+        const steps: StepResult<ToolSet>[] = [];
+        // The LAST attempt's usage object, so the provider's own detail
+        // (`raw`, cache/reasoning token breakdowns) still reaches the metadata
+        // chunk — with the earlier attempts' totals folded into the counts.
+        let usage: LanguageModelUsage | undefined;
+        let error: string | undefined;
+        let finishReason = "unknown";
+        let resumes = 0;
+
+        while (true) {
+          const handle = await runAgentLoop({
+            kind: "subagent",
+            ctx,
+            organization,
+            virtualMcp: targetRef,
+            mcpClient,
+            provider,
+            models,
+            messages: convo,
+            // Inherit the parent's thread id so a PR the subagent opens still
+            // moves the linked task board card to In Review via the thread link
+            // (see SubtaskParams.currentThreadId).
+            currentThreadId,
+            systemAgentInstructions: targetRef.instructions,
+            abortSignal: abortSignal ?? new AbortController().signal,
+            // Budget is shared across resumes — a resumed run gets what's left,
+            // never a fresh 30, so a flapping provider can't multiply the cost.
+            stepLimit: SUBAGENT_STEP_LIMIT - steps.length,
+            toolApprovalLevel: "auto",
+            planMode: false,
+            codingWorkspace: subtaskCodingWorkspace,
+            writer,
+            subtaskParams: {
+              provider,
+              organization,
+              models,
+              needsApproval,
+              codingWorkspace: subtaskCodingWorkspace,
+            },
+            // Subagent inherits the parent's writer for nested chunk routing.
+            // Subagent gets prompts/connections blocks via the MCP client
+            // (which is both the tool source AND the prompts source for the
+            // target agent). This passes through to buildAgentSystemPrompt.
+            passthroughClient: mcpClient,
+            // Full heavy built-ins for the subagent (vm/generate_image/web_search).
+            subagentBuiltInParams,
+            // Fallback only — when no parent params are available (no full-built-in
+            // rebuild), a self-clone still inherits the parent's sandbox tools so
+            // it can run bash / file I/O against the SAME sandbox.
+            extraTools: subagentBuiltInParams
+              ? undefined
+              : isSelf
+                ? vmTools
+                : undefined,
+          });
+
+          for await (const part of handle.result.fullStream) {
+            const now = performance.now();
+            if (part.type === "text-delta") {
+              commitPending();
+              streamedText += part.text;
+              if (now - lastFlush >= FLUSH_MS) {
+                lastFlush = now;
+                yield { text: streamedText };
+              }
+            } else if (part.type === "tool-input-start") {
+              // A new call begins — commit any prior pending line, start streaming.
+              commitPending();
+              pending = { name: part.toolName, args: "" };
+              lastFlush = now;
+              yield { text: render() };
+            } else if (part.type === "tool-input-delta") {
+              if (pending) pending.args += part.delta;
+              if (now - lastFlush >= FLUSH_MS) {
+                lastFlush = now;
+                yield { text: render() };
+              }
+            } else if (part.type === "tool-call") {
+              // Authoritative complete input — finalize with the full (capped) args.
+              const sep =
+                streamedText && !streamedText.endsWith("\n") ? "\n" : "";
+              streamedText += `${sep}↳ ${formatToolCall(part.toolName, part.input)}\n`;
+              pending = null;
               lastFlush = now;
               yield { text: streamedText };
             }
-          } else if (part.type === "tool-input-start") {
-            // A new call begins — commit any prior pending line, start streaming.
-            commitPending();
-            pending = { name: part.toolName, args: "" };
-            lastFlush = now;
-            yield { text: render() };
-          } else if (part.type === "tool-input-delta") {
-            if (pending) pending.args += part.delta;
-            if (now - lastFlush >= FLUSH_MS) {
-              lastFlush = now;
-              yield { text: render() };
-            }
-          } else if (part.type === "tool-call") {
-            // Authoritative complete input — finalize with the full (capped) args.
-            const sep =
-              streamedText && !streamedText.endsWith("\n") ? "\n" : "";
-            streamedText += `${sep}↳ ${formatToolCall(part.toolName, part.input)}\n`;
-            pending = null;
-            lastFlush = now;
-            yield { text: streamedText };
           }
-        }
-        commitPending();
+          commitPending();
 
-        // 5. Collect results from the resolved promises.
-        const error = await handle.error;
-        const finishReason = await handle.result.finishReason;
-        const steps = await handle.result.steps;
+          // 4. Collect this attempt's results from the resolved promises.
+          error = await handle.error;
+          finishReason = await handle.result.finishReason;
+          const attemptSteps = await handle.result.steps;
+          steps.push(...attemptSteps);
+          const attemptUsage = await handle.result.usage;
+          usage = {
+            ...attemptUsage,
+            inputTokens:
+              (usage?.inputTokens ?? 0) + (attemptUsage.inputTokens ?? 0),
+            outputTokens:
+              (usage?.outputTokens ?? 0) + (attemptUsage.outputTokens ?? 0),
+            totalTokens:
+              (usage?.totalTokens ?? 0) + (attemptUsage.totalTokens ?? 0),
+          };
+
+          // 5. Resume only a broken transport, and only while budget remains.
+          //    An abort is the user stopping this subtask — never resume it.
+          if (
+            !error ||
+            !isTransientStreamError(error) ||
+            resumes >= MAX_STREAM_RESUMES ||
+            steps.length >= SUBAGENT_STEP_LIMIT ||
+            abortSignal?.aborted
+          ) {
+            break;
+          }
+          resumes++;
+          console.warn(
+            `[subtask:${targetLabel}${isSelf ? ":self" : ""}] transient stream failure after ${steps.length} step(s), resuming (${resumes}/${MAX_STREAM_RESUMES}): ${error}`,
+          );
+          // Replaying the completed steps' response messages is what makes this
+          // a RESUME and not a restart: every tool call already executed is in
+          // the transcript with its result, so the model continues rather than
+          // re-running it. Empty (the failure landed before step 1) → the same
+          // `convo` is retried, which is the plain-retry case.
+          convo = [
+            ...convo,
+            ...attemptSteps.flatMap((s) => s.response.messages),
+          ];
+          error = undefined;
+        }
+
         const aggregatedText = steps
           .map((s) => s.text ?? "")
           .filter((t) => t.trim().length > 0)
           .join("\n\n")
           .trim();
-        const usage = await handle.result.usage;
 
         console.log(
-          `[subtask:${targetLabel}${isSelf ? ":self" : ""}] completed: finishReason=${finishReason}, steps=${steps.length}, textLength=${aggregatedText.length}, error=${error ? "yes" : "no"}, usage=${JSON.stringify({ inputTokens: usage.inputTokens, outputTokens: usage.outputTokens })}`,
+          `[subtask:${targetLabel}${isSelf ? ":self" : ""}] completed: finishReason=${finishReason}, steps=${steps.length}, resumes=${resumes}, textLength=${aggregatedText.length}, error=${error ? "yes" : "no"}, usage=${JSON.stringify({ inputTokens: usage?.inputTokens, outputTokens: usage?.outputTokens })}`,
         );
 
         // 6. Roll the child's usage into the PARENT run's accumulator so the
@@ -436,9 +527,9 @@ export function createSubtaskTool(
         //    (Task 17 — the kernel sees one number). Per-subtask detail still
         //    rides the `data-tool-subtask-metadata` chunk below.
         onChildUsage?.({
-          inputTokens: usage.inputTokens ?? 0,
-          outputTokens: usage.outputTokens ?? 0,
-          totalTokens: usage.totalTokens ?? 0,
+          inputTokens: usage?.inputTokens ?? 0,
+          outputTokens: usage?.outputTokens ?? 0,
+          totalTokens: usage?.totalTokens ?? 0,
         });
 
         // 6b. Emit metadata chunks to the parent's writer.
@@ -471,9 +562,15 @@ export function createSubtaskTool(
         | { text?: string; error?: string; finishReason?: string }
         | undefined;
       if (o?.error) {
+        // Hand back whatever the subagent DID produce before it died. Dropping
+        // it made the parent redo work that had already run (and whose side
+        // effects had already landed) with no way to know that.
+        const partial = o.text?.trim();
         return {
           type: "error-text" as const,
-          value: `Subtask failed: ${o.error}`,
+          value: partial
+            ? `Subtask failed: ${o.error}\n\nPartial result produced before the failure (its tool calls already ran — do not repeat them blindly):\n\n${partial}`
+            : `Subtask failed: ${o.error}`,
         };
       }
       const text = o?.text?.trim();

--- a/packages/harness/src/decopilot/built-in-tools/local-subtask.ts
+++ b/packages/harness/src/decopilot/built-in-tools/local-subtask.ts
@@ -160,9 +160,15 @@ export function createLocalSubtaskTool(params: LocalSubtaskParams) {
         | { text?: string; error?: string; finishReason?: string }
         | undefined;
       if (o?.error) {
+        // Kept in sync with the cluster `subtask.ts`: hand back whatever the
+        // subagent DID produce before it died, so the parent doesn't redo work
+        // whose side effects already landed.
+        const partial = o.text?.trim();
         return {
           type: "error-text" as const,
-          value: `Subtask failed: ${o.error}`,
+          value: partial
+            ? `Subtask failed: ${o.error}\n\nPartial result produced before the failure (its tool calls already ran — do not repeat them blindly):\n\n${partial}`
+            : `Subtask failed: ${o.error}`,
         };
       }
       const text = o?.text?.trim();


### PR DESCRIPTION
## What broke

Prod thread `c12c86aa-9a70-491b-9245-b2f310af33ee` (deco-studio, 2026-07-31). The agent fanned out 148 image uploads over `subtask`. Two subtasks died like this:

```
[runAgentLoop:subagent:vir_LzBptrEPAU2e_gc5baY_D] Error The socket connection was closed unexpectedly.
[subtask:vir_LzBptrEPAU2e_gc5baY_D:self] completed: finishReason=error, steps=5,  textLength=80,  error=yes, usage={}
[subtask:vir_LzBptrEPAU2e_gc5baY_D:self] completed: finishReason=error, steps=18, textLength=362, error=yes, usage={}
```

The OpenRouter stream socket closed mid-run. Nothing recovered it:

- `runNativeAgentLoopCore` captures the error onto `handle.error` and the loop ends. The AI SDK's `maxRetries` only covers the *initial request* — a body that dies after chunks have arrived is not retried.
- `subtask.ts` then yielded `{ text, error }`, and `toModelOutput` returned only `` `Subtask failed: ${error}` `` — **discarding all 18 steps of accumulated work**, including tool calls whose side effects (asset uploads) had already landed.

So the parent had no result, no partial result, and no signal that work had already been done. The turn stalled.

## Fix

**Resume, don't restart.** `runAgentLoop` now runs in a bounded loop inside `subtask.ts`. On a transient error it replays the completed steps' `response.messages` — every already-executed tool call is in the transcript with its result, so the model continues instead of re-running it — and the stream carries on from where it broke.

Bounds, deliberately tight:
- 2 resumes max (`MAX_STREAM_RESUMES`).
- The 30-step budget is **shared** across attempts (`SUBAGENT_STEP_LIMIT - steps.length`), never refreshed — a flapping provider can't multiply cost.
- `abortSignal.aborted` never resumes (that's the user pressing Stop).
- `isTransientStreamError` gates it: transports only (socket close, ECONNRESET/EPIPE/ETIMEDOUT, `fetch failed`, 429/5xx, overloaded). A context-length or auth error would fail identically on every attempt, so it terminates at once.

**Stop discarding partial work.** `toModelOutput`'s error branch now appends the partial result with an explicit warning that its tool calls already ran. Mirrored into the desktop `local-subtask.ts` copy so the two stay identical.

Usage is folded across attempts while keeping the last attempt's provider detail (`raw`, cache/reasoning breakdowns) so the metadata chunk doesn't regress. `resumes=N` added to the completion log line.

## Testing

- `isTransientStreamError` unit-tested both ways — the exact prod message resumes; context-length/auth/abort do not.
- Inverted the existing `"error takes precedence over text"` test, which encoded the old drop-the-partial behavior, into `"error-text carries the partial result instead of discarding it"`, plus a case for the no-partial-text path.
- `bun test apps/api/src/harnesses/decopilot packages/harness/src/decopilot/built-in-tools` → 207 pass, 1 fail. That one failure (`web_search async-research e2e`) needs Postgres and fails identically on `main`.
- `bun run check` clean, `bun run fmt` applied, `bun run lint` 0 errors.

## Not in scope

The same gap exists in the **parent** run's loop (`hostedHarnessWorkflow` catches the throw and publishes a terminal error). That path at least surfaces the failure and the user can retry; the subagent path had neither. Worth a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resumes subtasks after transient stream failures and preserves partial work, so we don’t redo already-executed tool calls or stall the parent turn. Adds tight bounds and clear error gating to keep behavior safe and predictable.

- **Bug Fixes**
  - Added a resume loop around `runAgentLoop`: on a transient error, replay prior step response messages so the model continues without re-running completed tool calls.
  - Capped at 2 resumes; the 30-step budget is shared across attempts; never resumes if the user aborted.
  - Introduced `isTransientStreamError` to gate resumes (socket close, ECONNRESET/EPIPE/ETIMEDOUT, fetch/network failures, 429/5xx, overloaded). Permanent errors (auth, context length) stop immediately.
  - On failure, return partial text with a clear warning that its tool calls already ran; mirrored in desktop `local-subtask.ts`.
  - Aggregates usage across attempts while keeping the last attempt’s provider detail; logs now include `resumes=N`.

<sup>Written for commit 97c0f3b1de1ff8464d24b270cf1216b802b33e81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

