### PR TITLE
fix(daemon): stop BranchStatusMonitor watchers in branch-status tests

### DIFF
--- a/packages/sandbox/daemon/git/branch-status.test.ts
+++ b/packages/sandbox/daemon/git/branch-status.test.ts
@@ -39,8 +39,13 @@ describe("BranchStatusMonitor", () => {
     name: DaemonEventName;
     payload: DaemonEventPayload<DaemonEventName>;
   }>;
+  // refresh() starts fs.watchers + a 3s poll interval; anything left running
+  // keeps the reused `bun test --parallel` worker's event loop alive and
+  // wedges the whole suite (the job-level 10min timeout is what killed it).
+  let monitors: BranchStatusMonitor[];
 
   beforeEach(() => {
+    monitors = [];
     repo = makeRepo();
     broadcaster = new Broadcaster(1024);
     events = [];
@@ -54,7 +59,11 @@ describe("BranchStatusMonitor", () => {
     }) as Broadcaster["emit"];
   });
 
-  afterEach(() => repo.cleanup());
+  afterEach(() => {
+    // Stop watchers before deleting the watched temp dir.
+    for (const m of monitors) m.stop();
+    repo.cleanup();
+  });
 
   function newMonitor(): BranchStatusMonitor {
     const config = {
@@ -65,7 +74,9 @@ describe("BranchStatusMonitor", () => {
       proxyPort: 0,
       dropPrivileges: false,
     } as never;
-    return new BranchStatusMonitor(config, broadcaster);
+    const m = new BranchStatusMonitor(config, broadcaster);
+    monitors.push(m);
+    return m;
   }
 
   it("starts as 'unknown' on construction", () => {
@@ -212,6 +223,7 @@ describe("BranchStatusMonitor", () => {
         dropPrivileges: false,
       } as never;
       const monitor = new BranchStatusMonitor(config, broadcaster);
+      monitors.push(monitor);
       monitor.refresh();
 
       const last = monitor.getLast();


### PR DESCRIPTION
## Summary

The `test` job in `test.yml` normally finishes in ~40s, but several PR runs have been hanging silently until the 10-minute `timeout-minutes` kills them. Across the 6 timed-out runs in the last 200: the whole suite passes (0 fails), then the runner never prints the final summary — or `packages/sandbox/daemon/git/branch-status.test.ts` never completes at all.

Root cause: `BranchStatusMonitor.refresh()` calls `ensureWatch()`, which starts two recursive `fs.watch`ers and a 3s `setInterval` poll fallback. The test file instantiates monitors in most cases and never calls `stop()`. This always leaked, but was masked while each test file ran in its own force-exited process; since #5292 the unit tier runs under `bun test --parallel`, workers are reused, and the leaked handles keep a worker's event loop alive — wedging the whole job. Bonus rot: the leaked interval keeps running `git status` against a temp repo the `afterEach` already deleted.

## Fix

Track every monitor created by the file and call `m.stop()` in `afterEach`, before the watched temp repo is `rmSync`'d (so no watcher points at a deleted dir).

## Testing

- `bun test packages/sandbox/daemon/git/branch-status.test.ts` — 8 pass.
- Full CI command `bun run test` (parallel runner) — 6449 pass, 0 fail, exits cleanly with the summary in ~31s.
- `bun run fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops leaked watchers and intervals in branch-status tests to prevent the test job from hanging. We now track each `BranchStatusMonitor` and stop it in `afterEach` so `bun test --parallel` workers exit cleanly.

- **Bug Fixes**
  - Track created monitors and call `stop()` in `afterEach` before `repo.cleanup()`.
  - Prevents `refresh()`-spawned `fs.watch`ers and the 3s interval from keeping workers alive and causing 10‑minute timeouts.

<sup>Written for commit 779cefb2d7e90d63659ca551dd1671dada5a4bec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

