### PR TITLE
fix(settings): validate DUCKDB_THREADS instead of silently producing NaN

### DIFF
--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -198,6 +198,29 @@ describe("resolveConfig clickhouse max memory usage", () => {
   );
 });
 
+describe("resolveConfig duckdb threads", () => {
+  it("defaults to undefined when unset", () => {
+    const result = resolveConfig(flags, {});
+
+    expect(result.settings.duckdbThreads).toBeUndefined();
+  });
+
+  it("uses DUCKDB_THREADS when set", () => {
+    const result = resolveConfig(flags, { DUCKDB_THREADS: "4" });
+
+    expect(result.settings.duckdbThreads).toBe(4);
+  });
+
+  it.each(["abc", "0", "-1", "1.5", "Infinity"])(
+    "throws for invalid value %p",
+    (value) => {
+      expect(() => resolveConfig(flags, { DUCKDB_THREADS: value })).toThrow(
+        "DUCKDB_THREADS must be a positive integer",
+      );
+    },
+  );
+});
+
 describe("resolveConfig deployment admin emails", () => {
   it("defaults to an empty list when unset", () => {
     const result = resolveConfig(flags, {});

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -323,9 +323,10 @@ export function resolveConfig(
     duckdbExtensionDirectory:
       envVars.DUCKDB_EXTENSION_DIRECTORY || "/opt/duckdb/extensions",
     duckdbMemoryLimit: envVars.DUCKDB_MEMORY_LIMIT || undefined,
-    duckdbThreads: envVars.DUCKDB_THREADS
-      ? Number(envVars.DUCKDB_THREADS)
-      : undefined,
+    duckdbThreads: toPositiveIntegerOrUndefined(
+      "DUCKDB_THREADS",
+      envVars.DUCKDB_THREADS,
+    ),
 
     // Runtime flags
     isCli: true,


### PR DESCRIPTION
This is the same env-var validation vein as #5473/#5476/#5463/#5379 etc: `DUCKDB_THREADS` was the last remaining hand-rolled `Number(...)` in `resolve-config.ts` with no validation (grepped for `Number(` in the file — the other two hits are already-guarded helpers). A malformed value ("abc", "-1", "1.5") silently produced `NaN` in `Settings.duckdbThreads`, which only surfaces later as an opaque failure wherever the embedded DuckDB monitoring engine consumes it, instead of failing fast at startup with a clear message.

Note: an older open PR (#5130) touched this exact env var, but against the pre-rename `apps/mesh/...` path, which no longer exists in this repo (renamed to `apps/api` months ago) — it can't apply as-is. This PR re-does the fix at the current path.

Fix: route `DUCKDB_THREADS` through the same `toPositiveIntegerOrUndefined` helper already used for `CLICKHOUSE_MAX_MEMORY_USAGE` and other optional numeric env vars in this file, so an invalid value throws `"DUCKDB_THREADS must be a positive integer"` at boot instead of silently becoming NaN.

Failure scenario: an operator sets `DUCKDB_THREADS=4.5` (or any non-integer) in their deployment env — before this fix, `Settings.duckdbThreads` becomes `NaN` and the process boots successfully, only breaking later when the DuckDB monitoring engine reads it. After this fix, `resolveConfig` throws immediately at startup.

Test: added a `resolveConfig duckdb threads` describe block in `resolve-config.test.ts` mirroring the existing `clickhouse max memory usage` test shape — covers unset (undefined default), a valid value, and `it.each` over invalid values ("abc", "0", "-1", "1.5", "Infinity").

Reviewer command: `bun test apps/api/src/settings/resolve-config.test.ts`

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/settings/resolve-config.test.ts` (87 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the DUCKDB_THREADS env var to reject non-integer or non-positive values, so config fails fast with a clear error instead of propagating invalid numbers. Adds targeted tests and follows the existing numeric env var validation pattern.

- **Bug Fixes**
  - Parse `DUCKDB_THREADS` via `toPositiveIntegerOrUndefined` in `resolve-config`, defaulting to `undefined` when unset and accepting integers (e.g., "4").
  - Throw `"DUCKDB_THREADS must be a positive integer"` at startup for invalid values like "abc", "0", "-1", "1.5", "Infinity".
  - Added tests in `apps/api/src/settings/resolve-config.test.ts` covering unset, valid, and invalid cases.

<sup>Written for commit 2e92a9d6f961e087adbe2fd5f2ce73946501f130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

