### PR TITLE
perf(task-board): batch activity-log inserts in TASK_BOARD_ITEM_UPDATE

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -602,6 +602,35 @@ export class TaskBoardStorage {
       .execute();
   }
 
+  /** Append several activity events in one insert — same semantics as
+   *  `recordActivity`, batched so a caller earning multiple timeline entries
+   *  from one change (e.g. a status+assignee+tags update) pays a single DB
+   *  round-trip instead of one per entry. */
+  async recordActivities(
+    entries: {
+      taskBoardItemId: string;
+      action: TaskBoardActivityAction;
+      actorId: string | null;
+      data?: Record<string, unknown>;
+    }[],
+  ): Promise<void> {
+    if (entries.length === 0) return;
+    const now = new Date().toISOString();
+    await this.db
+      .insertInto("task_board_activity")
+      .values(
+        entries.map((params) => ({
+          id: generatePrefixedId("act"),
+          task_board_item_id: params.taskBoardItemId,
+          action: params.action,
+          actor_id: params.actorId,
+          data: params.data ? JSON.stringify(params.data) : null,
+          occurred_at: now,
+        })),
+      )
+      .execute();
+  }
+
   /** A task's activity, oldest first (timeline order). Tenant-scoped through
    *  the task, which is the only thing carrying an org. */
   async listActivity(

--- a/apps/api/src/tools/task-board/activity.ts
+++ b/apps/api/src/tools/task-board/activity.ts
@@ -30,6 +30,26 @@ export async function recordTaskActivity(
   }
 }
 
+/** Same as `recordTaskActivity`, batched into one DB round-trip for a caller
+ *  that earns several timeline entries from a single change (e.g. an update
+ *  touching status, assignee, and tags at once). */
+export async function recordTaskActivities(
+  ctx: StudioContext,
+  entries: {
+    taskBoardItemId: string;
+    action: TaskBoardActivityAction;
+    actorId: string | null;
+    data?: Record<string, unknown>;
+  }[],
+): Promise<void> {
+  if (entries.length === 0) return;
+  try {
+    await ctx.storage.taskBoard.recordActivities(entries);
+  } catch (err) {
+    console.error("[task-board] activity log write failed", err);
+  }
+}
+
 export const TASK_BOARD_ACTIVITY_LIST = defineTool({
   name: "TASK_BOARD_ACTIVITY_LIST",
   description:

--- a/apps/api/src/tools/task-board/update.test.ts
+++ b/apps/api/src/tools/task-board/update.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression coverage for `diffTaskActivityEntries`: the update handler used
+ * to log each changed field with its own sequential `await`ed insert. This
+ * pure diff is what now gets batched into a single write — these tests pin
+ * down exactly which entries a given before/after pair earns, so the batching
+ * change can't silently drop or duplicate one.
+ */
+import { describe, expect, it } from "bun:test";
+import type { TaskBoardItem } from "@/storage/types";
+import { diffTaskActivityEntries } from "./update";
+
+function item(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
+  return {
+    id: "board_1",
+    organizationId: "org_1",
+    title: "Title",
+    description: null,
+    status: "todo",
+    priority: "medium",
+    assigneeId: null,
+    assignedBy: null,
+    dueDate: null,
+    sortOrder: 0,
+    threads: [],
+    tags: [],
+    createdBy: "user_1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedBy: "user_1",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("diffTaskActivityEntries", () => {
+  it("returns nothing when no logged field changed", () => {
+    const previous = item();
+    expect(diffTaskActivityEntries(previous, item())).toEqual([]);
+  });
+
+  it("logs a single changed field", () => {
+    const previous = item({ status: "todo" });
+    const next = item({ status: "in_progress" });
+    expect(diffTaskActivityEntries(previous, next)).toEqual([
+      {
+        action: "status_changed",
+        data: { from: "todo", to: "in_progress" },
+      },
+    ]);
+  });
+
+  it("logs every field that changed in one update, in LOGGED_FIELDS order", () => {
+    const previous = item({ status: "todo", priority: "medium" });
+    const next = item({ status: "in_progress", priority: "high" });
+    expect(diffTaskActivityEntries(previous, next)).toEqual([
+      { action: "status_changed", data: { from: "todo", to: "in_progress" } },
+      { action: "priority_changed", data: { from: "medium", to: "high" } },
+    ]);
+  });
+
+  it("logs a description change without copying its value", () => {
+    const previous = item({ description: "old" });
+    const next = item({ description: "new" });
+    expect(diffTaskActivityEntries(previous, next)).toEqual([
+      { action: "description_changed" },
+    ]);
+  });
+
+  it("logs a tag-set change", () => {
+    const previous = item({ tags: [] });
+    const next = item({
+      tags: [
+        {
+          id: "tag_1",
+          name: "bug",
+          color: null,
+          createdBy: "user_1",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+    expect(diffTaskActivityEntries(previous, next)).toEqual([
+      { action: "tags_changed", data: { from: [], to: next.tags } },
+    ]);
+  });
+
+  it("ignores sortOrder (drag-to-reorder is not logged)", () => {
+    const previous = item({ sortOrder: 0 });
+    const next = item({ sortOrder: 5 });
+    expect(diffTaskActivityEntries(previous, next)).toEqual([]);
+  });
+});

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -10,7 +10,7 @@ import {
 } from "./schema";
 import { assertValidAssignee } from "./validate-assignee";
 import { reactToSuperAgentDelegation } from "./enqueue-super-agent";
-import { recordTaskActivity } from "./activity";
+import { recordTaskActivities } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 
 /**
@@ -31,6 +31,43 @@ const LOGGED_FIELDS: {
   { field: "dueDate", action: "due_date_changed" },
   { field: "title", action: "title_changed" },
 ];
+
+/**
+ * Which activity entries an update earns, diffed against the pre-update item.
+ * Pure — unit-tested — so the one-batched-insert change below can't silently
+ * drop or duplicate an entry the old sequential-await version logged.
+ */
+export function diffTaskActivityEntries(
+  previous: TaskBoardItem,
+  item: TaskBoardItem,
+): { action: TaskBoardActivityAction; data?: Record<string, unknown> }[] {
+  const entries: {
+    action: TaskBoardActivityAction;
+    data?: Record<string, unknown>;
+  }[] = [];
+
+  for (const { field, action } of LOGGED_FIELDS) {
+    if (item[field] === previous[field]) continue;
+    entries.push({ action, data: { from: previous[field], to: item[field] } });
+  }
+
+  if (item.description !== previous.description) {
+    entries.push({ action: "description_changed" });
+  }
+
+  const previousTagIds = new Set(previous.tags.map((t) => t.id));
+  const tagsChanged =
+    item.tags.length !== previous.tags.length ||
+    item.tags.some((t) => !previousTagIds.has(t.id));
+  if (tagsChanged) {
+    entries.push({
+      action: "tags_changed",
+      data: { from: previous.tags, to: item.tags },
+    });
+  }
+
+  return entries;
+}
 
 export const TASK_BOARD_ITEM_UPDATE = defineTool({
   name: "TASK_BOARD_ITEM_UPDATE",
@@ -177,36 +214,20 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
       item = fetched;
     }
 
-    // Log every changed field to the activity timeline. Best-effort.
+    // Log every changed field to the activity timeline in one batched write
+    // instead of one sequential DB round-trip per changed field. Best-effort.
     if (previous) {
       const actorId = getUserId(ctx)!;
-      for (const { field, action } of LOGGED_FIELDS) {
-        if (item[field] === previous[field]) continue;
-        await recordTaskActivity(ctx, {
-          taskBoardItemId: item.id,
-          action,
-          actorId,
-          data: { from: previous[field], to: item[field] },
-        });
-      }
-      if (item.description !== previous.description) {
-        await recordTaskActivity(ctx, {
-          taskBoardItemId: item.id,
-          action: "description_changed",
-          actorId,
-        });
-      }
-      const previousTagIds = new Set(previous.tags.map((t) => t.id));
-      const tagsChanged =
-        item.tags.length !== previous.tags.length ||
-        item.tags.some((t) => !previousTagIds.has(t.id));
-      if (tagsChanged) {
-        await recordTaskActivity(ctx, {
-          taskBoardItemId: item.id,
-          action: "tags_changed",
-          actorId,
-          data: { from: previous.tags, to: item.tags },
-        });
+      const entries = diffTaskActivityEntries(previous, item);
+      if (entries.length > 0) {
+        await recordTaskActivities(
+          ctx,
+          entries.map((entry) => ({
+            taskBoardItemId: item.id,
+            actorId,
+            ...entry,
+          })),
+        );
       }
     }
 


### PR DESCRIPTION
**Source:** DB-latency hunt on the MCP tool-call path (focus area: mcp tool-call DB latency investigation), not tied to a specific issue.

**Payoff:** `TASK_BOARD_ITEM_UPDATE` logged each changed field to the activity timeline with its own sequential `await`ed `INSERT` — `status`, `assigneeId`, `priority`, `dueDate`, `title`, plus `description`/`tags` when those changed. A single tool call that touches several fields at once (a drag-to-reorder that also reassigns, a bulk edit changing status+priority+tags) paid up to 5 serialized DB round-trips before returning, directly inflating that tool call's latency. This collapses them into one batched multi-row insert.

**What changed:** Extracted the field-diffing logic into a pure, unit-tested `diffTaskActivityEntries(previous, item)` in `update.ts` (returns the list of activity entries a change earns, exactly matching the old per-field logic). Added `TaskBoardStorage.recordActivities` (storage) and `recordTaskActivities` (best-effort wrapper, same swallow-on-failure semantics as the existing singular `recordTaskActivity`) to write that list as one `insertInto(...).values([...])` instead of N sequential inserts. Behavior is unchanged: same actions, same `data` payloads, same swallow-on-error semantics — only the number of round-trips changes.

**Regression test:** `apps/api/src/tools/task-board/update.test.ts` pins down `diffTaskActivityEntries` for the no-change, single-field, multi-field, description, tags, and sortOrder-ignored cases, so the batching change can't silently drop or duplicate a timeline entry.

**To verify:** `bun test apps/api/src/tools/task-board/update.test.ts`

**Locally ran:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (6/6 pass), and `bunx oxlint` on all 4 touched files (0 warnings/errors). Full CI validates the rest (this repo has no local Postgres for the storage-layer integration path).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch activity-log inserts in `TASK_BOARD_ITEM_UPDATE` to cut DB round-trips and reduce tool-call latency. Behavior is unchanged; multiple timeline entries now write in one insert.

- **Refactors**
  - Added `diffTaskActivityEntries(previous, item)` to compute activity entries; unit tests cover no-change, single/multi-field, description/tags, and sortOrder ignored cases.
  - Implemented `recordActivities` (storage) and `recordTaskActivities` (wrapper) to batch multi-row inserts with the same best-effort, swallow-on-error semantics and identical `data` payloads/actions.

<sup>Written for commit cedcc1bfa45d2087f5c6daf5b6748f5792d719b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

