### PR TITLE
fix(sandbox): restore renamed files instead of deleting them on Go daemon discard

### DIFF
--- a/packages/sandbox/daemon-go/internal/gitx/porcelain.go
+++ b/packages/sandbox/daemon-go/internal/gitx/porcelain.go
@@ -6,6 +6,9 @@ type PorcelainFile struct {
 	Path       string `json:"path"`
 	Index      string `json:"index"`
 	WorkingDir string `json:"working_dir"`
+	// OrigPath is the pre-rename path, present only for R/C entries (`-z`
+	// emits it as the next null-separated field).
+	OrigPath string `json:"origPath,omitempty"`
 }
 
 func parsePorcelainEntry(entry string) (PorcelainFile, bool) {
@@ -38,10 +41,13 @@ func ParsePorcelainFiles(out string) []PorcelainFile {
 		if !ok {
 			continue
 		}
-		files = append(files, parsed)
 		if parsed.Index == "R" || parsed.Index == "C" {
 			i++
+			if i < len(parts) && parts[i] != "" {
+				parsed.OrigPath = parts[i]
+			}
 		}
+		files = append(files, parsed)
 	}
 	return files
 }

--- a/packages/sandbox/daemon-go/internal/gitx/publish.go
+++ b/packages/sandbox/daemon-go/internal/gitx/publish.go
@@ -296,14 +296,42 @@ func Discard(repoDir string, relPaths []string) error {
 		}
 		return false
 	}
-	var toRestore, toDelete []string
+	filesByPath := map[string]PorcelainFile{}
+	for _, f := range status.Files {
+		filesByPath[f.Path] = f
+	}
+	// A renamed file's new path never existed at HEAD, so the isNew check
+	// below would treat it as untracked and remove it outright — losing the
+	// content entirely, since the original path is already gone from the
+	// working tree too. Discarding a rename must instead restore the
+	// original file from HEAD and unstage + drop the new path.
+	var toRestore, toDelete, toRestoreFromHead, renamedNewPaths []string
 	for _, fp := range relPaths {
+		if origPath := filesByPath[fp].OrigPath; origPath != "" {
+			toRestoreFromHead = append(toRestoreFromHead, origPath)
+			renamedNewPaths = append(renamedNewPaths, fp)
+			toDelete = append(toDelete, fp)
+			continue
+		}
 		isNew := inList(status.NotAdded, fp) || inList(status.Created, fp) ||
 			readRefFile(repoDir, "HEAD", fp) == nil
 		if isNew {
 			toDelete = append(toDelete, fp)
 		} else {
 			toRestore = append(toRestore, fp)
+		}
+	}
+	if len(toRestoreFromHead) > 0 {
+		// Unstage the rename's "new path added" side before restoring the
+		// original — otherwise it survives in the index even after the
+		// working tree file below is deleted.
+		resetArgs := append([]string{"reset", "--"}, renamedNewPaths...)
+		if _, err := runReadGit(repoDir, resetArgs); err != nil {
+			return err
+		}
+		headArgs := append([]string{"checkout", "HEAD", "--"}, toRestoreFromHead...)
+		if _, err := runReadGit(repoDir, headArgs); err != nil {
+			return err
 		}
 	}
 	if len(toRestore) > 0 {

--- a/packages/sandbox/daemon-go/internal/gitx/publish_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/publish_test.go
@@ -82,3 +82,40 @@ func TestInstallProtectedBranchHookWritesTheBranchList(t *testing.T) {
 		// Any other error is expected — this repo has no `origin` to push to.
 	}
 }
+
+// Discarding a staged rename must restore the original file at its original
+// path, not delete it: the new path never existed at HEAD, so treating it as
+// merely "untracked" loses the content entirely once the old path is also
+// gone from the working tree.
+func TestDiscardRestoresRenamedFile(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature/x")
+	if err := os.WriteFile(filepath.Join(repo, "old.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"add", "old.txt"},
+		{"commit", "-q", "-m", "add old.txt"},
+		{"mv", "old.txt", "new.txt"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	if err := Discard(repo, []string{"new.txt"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(repo, "old.txt"))
+	if err != nil {
+		t.Fatalf("old.txt was not restored: %v", err)
+	}
+	if string(got) != "hello\n" {
+		t.Fatalf("old.txt content: got %q, want %q", got, "hello\n")
+	}
+	if _, err := os.Stat(filepath.Join(repo, "new.txt")); !os.IsNotExist(err) {
+		t.Fatalf("new.txt should have been removed, stat err: %v", err)
+	}
+}


### PR DESCRIPTION
**Source:** a real data-loss bug in the newly-added Go sandbox daemon (`packages/sandbox/daemon-go`, dormant behind `SANDBOX_DAEMON_IMPL`/the `sandbox_go_daemon` org flag). This is the same class of bug fixed earlier in the TypeScript daemon's `discard()` (packages/sandbox/daemon/routes/git.ts) and later ported to the native Rust daemon — the fresh Go port shipped without it.

**Why a maintainer wants it:** once the Go daemon rollout flag is flipped on for any org, discarding a renamed file silently destroys the file's content instead of restoring it, with no recovery path.

**Failure scenario:** an agent renames a tracked file (`git mv old.txt new.txt`), then the user discards the change on `new.txt`. `Discard()` parsed `git status --porcelain=v1 -z` but threw away the old-path field that `-z` emits for R/C entries. It then looked up `new.txt` at `HEAD`, found nothing (renames never exist at their new path), classified it as "new", and `os.Remove`'d it — the original content is gone, since `old.txt` is already absent from the working tree too.

**Fix:** `PorcelainFile` now carries `OrigPath` (mirroring the TS parser's `origPath`), and `Discard()` special-cases a path that has one: unstage the rename (`git reset --`) and restore the original file from HEAD at its original path (`git checkout HEAD --`), instead of falling into the generic "new file" deletion path.

**Regression test:** `TestDiscardRestoresRenamedFile` in `internal/gitx/publish_test.go` renames a committed file, discards the new path, and asserts the original file and content come back. Confirmed it fails on the pre-fix code (`old.txt was not restored: ... no such file or directory`) and passes after the fix.

**Reviewer command:** `cd packages/sandbox/daemon-go && go test ./internal/gitx/... -run TestDiscardRestoresRenamedFile -v`

**Locally verified:** `go build ./...`, `go vet ./...`, and the full `go test ./...` in `packages/sandbox/daemon-go` (all packages green). CI's Go workflow (`sandbox-daemon.yml`) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data loss when discarding renamed files in the Go sandbox daemon. Discard now restores the original file from HEAD instead of deleting the new path.

- **Bug Fixes**
  - Parse `git status --porcelain=v1 -z` R/C entries and store the old path as `OrigPath` in `PorcelainFile` (`packages/sandbox/daemon-go/internal/gitx/porcelain.go`).
  - Update `Discard()` to detect renames: unstage the new path, restore the original from HEAD at its old path, and remove the new path (`packages/sandbox/daemon-go/internal/gitx/publish.go`).
  - Add regression test `TestDiscardRestoresRenamedFile` to ensure the original file and content are restored (`packages/sandbox/daemon-go/internal/gitx/publish_test.go`).

<sup>Written for commit c943462718c207e8bed3f2326f5a2ec7b1c51b60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

