### PR TITLE
fix(sandbox): stop auto-start from minting a second branch (and sandbox) per new chat

### DIFF
--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -5,8 +5,9 @@
  * resumes that thread's single sandbox instead of booting a private copy of the
  * same git branch (see `resolveSandboxUserId`).
  * Provider-agnostic — dispatches through the active `SandboxProvider`; this
- * handler only does `sandboxMap` bookkeeping. Branch defaults to a Bayer-style
- * `<greek-letter>-<constellation>` name (e.g. `alpha-centauri`) when omitted.
+ * handler only does `sandboxMap` bookkeeping. Branch is minted from the caller's
+ * slug + a timestamp (`generateBranchName`) when omitted — a fresh identity, so
+ * callers that have a branch must pass it or they get a second sandbox.
  *
  * Different sandbox provider kinds coexist as siblings under the same
  * (user, branch) key — no stale-sandbox teardown is needed on kind change.
@@ -105,7 +106,7 @@ export const SANDBOX_START = defineTool({
       .min(1)
       .optional()
       .describe(
-        "Optional git branch to check out. When omitted the handler generates a Bayer-style `<greek-letter>-<constellation>` name (e.g. `alpha-centauri`) and uses it. The resolved branch is returned in the response so callers can persist it.",
+        "Git branch to check out. Pass the thread's branch whenever the caller has one: when omitted the handler mints a fresh `<user-slug>-<timestamp>` name, which becomes a SEPARATE sandbox from the one the thread's own branch resolves to. The resolved branch is returned in the response so callers can persist it.",
       ),
     sandboxProviderKind: sandboxProviderKindInputSchema
       .optional()

--- a/apps/api/src/tools/thread/create.ts
+++ b/apps/api/src/tools/thread/create.ts
@@ -7,9 +7,13 @@
  *   1. Honor `data.branch` when provided.
  *   2. Otherwise pick the most-recently-touched branch from the user's
  *      `sandboxMap[userId]` so a new task lands on a warm sandbox.
- *   3. Fall back to a freshly generated Bayer-style `<greek>-<constellation>`
- *      name (e.g. `alpha-centauri`) when the user has no sandboxMap entries
- *      for this vMCP.
+ *   3. Fall back to `generateBranchName` (`<user-slug>-<timestamp>`) when the
+ *      user has no sandboxMap entries for this vMCP.
+ *
+ * Step 2 only sees sandboxes that finished provisioning — `setSandboxMapEntry`
+ * runs after `provider.ensure` returns. So a SANDBOX_START in flight is
+ * invisible here and step 3 mints a sibling branch; the frontend must never
+ * auto-start without a branch (see `shouldAutoStart`).
  *
  * Threads created on a vMCP without a githubRepo always get `branch = null`.
  *

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -118,8 +118,11 @@ describe("shouldAutoStart", () => {
     expect(shouldAutoStart({ ...base, userId: null })).toBe(false);
   });
 
-  test("no branch → true (server generates branch on SANDBOX_START)", () => {
-    expect(shouldAutoStart({ ...base, branch: null })).toBe(true);
+  // Inverted from "no branch → true": letting the server mint the branch here
+  // raced COLLECTION_THREADS_CREATE's own mint and leaked an orphan sandbox
+  // (see shouldAutoStart). Only the user-driven start() may go branchless.
+  test("no branch → false (never let SANDBOX_START mint a branch)", () => {
+    expect(shouldAutoStart({ ...base, branch: null })).toBe(false);
   });
 
   test("vmEntry already present → false", () => {

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -41,10 +41,24 @@ export interface ShouldAutoStartArgs {
   attempted: boolean;
 }
 
+/**
+ * `branch` is REQUIRED. Auto-starting without one made `SANDBOX_START` mint a
+ * branch name of its own (`generateBranchName` — a `Date.now()` mint), racing
+ * the one `COLLECTION_THREADS_CREATE` mints for the thread row. Both won: the
+ * thread kept its branch and booted a second sandbox, while the auto-start's
+ * branch was left owning a live pod no thread ever referenced. Observed in
+ * prod as sibling branches minted 8ms apart (`user-fsif89sm` orphaned,
+ * `user-nsif89sm` on the thread), one leaked pod per new chat.
+ *
+ * The agent shell only mounts under `/$org/$taskId` and blocks rendering until
+ * `useEnsureTask` resolves the row, so a missing branch means "the row hasn't
+ * landed yet" — wait a render and start on the branch it carries.
+ */
 export function shouldAutoStart(args: ShouldAutoStartArgs): boolean {
   return (
     args.hasActiveGithubRepo &&
     !!args.userId &&
+    !!args.branch &&
     !args.vmEntry &&
     !args.userStopped &&
     !args.isPending &&
@@ -431,8 +445,8 @@ export function SandboxLifecycleProvider({
   // not already started → fire SANDBOX_START once for this branch."
   // Branch-keyed, not taskId-keyed: that matches useSandboxStart's own
   // dedup and avoids resurrecting a user-killed VM across task switches.
-  // Dedup key: use branch string, or "" for the no-branch (pre-lock) case so a
-  // single auto-start fires even before the server assigns a branch.
+  // `?? ""` only keeps the Set keyed by string — a null branch is never
+  // eligible (shouldAutoStart requires one), so the "" bucket is never written.
   const autoStartDedupKey = branch ?? "";
   const attempted =
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; mutation happens inside effect after add()

--- a/packages/shared/src/branch-name.ts
+++ b/packages/shared/src/branch-name.ts
@@ -5,11 +5,16 @@
  * server-side so it — not the sandbox — decides the branch name and can persist
  * it to sandboxMap before the daemon ever sees it.
  *
- * Format: `<user-slug>-<base36-timestamp>` (e.g. `joao-silva-mabc1x9z`). The
- * slug attributes the branch to whoever created it; the base36-encoded
+ * Format: `<user-slug>-<reversed-base36-timestamp>` (e.g. `joao-silva-z9x1cbam`).
+ * The slug attributes the branch to whoever created it; the base36-encoded
  * `Date.now()` is a monotonic clock, so a given user only collides if two
  * branches are minted within the same millisecond. The suffix is always a valid
  * git ref token (lowercase alphanumeric).
+ *
+ * Every call mints a NEW identity — a new branch, and therefore a new sandbox.
+ * Two callers racing to name the same logical thing produce two sandboxes
+ * (sibling names 8ms apart, one of them orphaned). Only call this where a fresh
+ * branch is the intent; anywhere else, pass the branch you already have.
  */
 
 /**


### PR DESCRIPTION
## Summary

One user request was starting **two** sandboxes. The frontend's sandbox auto-start fires `SANDBOX_START` with **no branch** whenever the thread row hasn't landed yet. With no branch the server mints one (`generateBranchName` — a `Date.now()` mint), which races the branch `COLLECTION_THREADS_CREATE` mints for the thread row. Both mints stick: the thread keeps its own branch and boots a sandbox for it, while the auto-start's branch ends up owning a live pod that no thread ever references.

`shouldAutoStart` already accepted `branch` and **ignored it**. This requires it.

## Evidence (prod, org `wolycasa-com-br`)

`generateBranchName`'s suffix is `Date.now().toString(36)` with its digits reversed, so it decodes back to the exact mint time:

| branch | minted | thread | pod |
|---|---|---|---|
| `user-fsif89sm` | 17:44:32.223 | **none** | `studio-sandbox-prod-jxxd9` |
| `user-nsif89sm` | 17:44:32.231 | `6cef7fbd…` (`created_at` = 32.231) | `studio-sandbox-prod-pt8dj` |

Two names 8 ms apart; the later one is the thread's, the earlier one is an orphan with its own running pod. The same shape repeated two hours earlier on a different agent (`user-kb8449sm` orphaned at 15:43:46.976, `user-sb8449sm` on thread `89acf8e1…` at 15:43:46.984) — so it's the standard new-chat path, not a one-off.

`ensureSandbox` requires `branch: string` and never mints, so `SANDBOX_START` is the only branchless minter and the frontend auto-start is its only branchless caller.

## Why the existing reuse doesn't save us

`COLLECTION_THREADS_CREATE` already tries `pickWarmBranchFromSandboxMap` before minting — it's meant to adopt exactly this warm sandbox. It can't: `setSandboxMapEntry` runs **after** `provider.ensure` returns (~750 ms later), so an in-flight provision is invisible to it. Classic claim-at-completion instead of claim-at-dispatch (CLAUDE.md first-pass checklist #3).

## Changes

- `shouldAutoStart` requires `!!branch` — the one behavioral change.
- Inverted the unit test that encoded the old behavior (`"no branch → true"` → `"no branch → false"`).
- Doc corrections: `SANDBOX_START`, `COLLECTION_THREADS_CREATE` and `branch-name.ts` all described a `<greek>-<constellation>` scheme the code hasn't produced in a while, and none of them said that every `generateBranchName` call is a new *sandbox identity*.

## Testing

- `bun test apps/api/src/tools/sandbox/ apps/web/src/components/sandbox/ packages/shared/src/branch-name.test.ts` → 518 pass, 0 fail
- `bun run check` (all workspaces) → clean · `bun run lint` → 0 errors (16 pre-existing warnings) · `bun run fmt` → clean · `knip` → clean
- Grepped both tiers for other assertions on branchless auto-start; none.

## Deliberately out of scope

- **Legacy branchless threads.** 14 prod threads (of 1708) sit on a repo-backed agent with `branch = null` — a repo attached after the thread was created. They no longer *auto*-start; the user-driven `start()` still allows a branchless start and persists the minted branch via `setCurrentTaskBranch`, so the escape hatch is intact. Fixing the auto path means giving those rows a branch, which is a migration, not this PR.
- **Server-side hardening.** An MCP caller can still call `SANDBOX_START` with no branch and get a fresh sandbox — that's the documented affordance. Making it reuse the caller's warm branch (the `pickWarmBranchFromSandboxMap` policy) would be defence in depth; deferred.
- **The `user-` prefix itself is a second bug.** Both racing mints slugged to the literal fallback `user`, meaning `ctx.auth.user` had neither `name` nor `email`. The same user's other thread that day got `rafael-4i1549sm`, so the identity *is* resolvable on some paths and not others. Worth its own issue.
- **Cleaning up the orphans already running in prod** — that's a write to prod, not done here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate sandboxes on new chats by requiring a branch for auto-start. Auto-start now waits for the thread’s branch instead of calling `SANDBOX_START` without one, which previously minted a second branch and leaked a sandbox.

- **Bug Fixes**
  - Require `branch` in `shouldAutoStart`; no auto-start when the branch is missing.
  - Invert unit test to assert “no branch → false”.
  - Clarify docs/comments for `SANDBOX_START`, thread create, and `generateBranchName` (now noted as `<user-slug>-<reversed-base36-timestamp>` and always a new sandbox identity).
  - Keep user-driven `start()` branchless as an escape hatch for legacy threads.

<sup>Written for commit 71e53b124a7dec5dfb321b0aa6da2fcd23ab2063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

