### PR TITLE
fix(settings): cap STUDIO_TOPUP_FEE_PERCENT at 100

### DIFF
--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -488,6 +488,12 @@ describe("resolveConfig topup fee percent", () => {
       resolveConfig(flags, { STUDIO_TOPUP_FEE_PERCENT: "free" }),
     ).toThrow("STUDIO_TOPUP_FEE_PERCENT must be a positive integer");
   });
+
+  it("rejects a value above 100 instead of silently overcharging top-ups", () => {
+    expect(() =>
+      resolveConfig(flags, { STUDIO_TOPUP_FEE_PERCENT: "150" }),
+    ).toThrow("STUDIO_TOPUP_FEE_PERCENT must be at most 100");
+  });
 });
 
 describe("resolveConfig decopilot max concurrent subagents", () => {

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -82,12 +82,16 @@ function toBoolOrUndefined(value: string | undefined): boolean | undefined {
 function toPositiveIntegerOrUndefined(
   name: string,
   value: string | undefined,
+  max?: number,
 ): number | undefined {
   if (value === undefined || value === "") return undefined;
 
   const numberValue = Number(value);
   if (!Number.isSafeInteger(numberValue) || numberValue <= 0) {
     throw new Error(`${name} must be a positive integer`);
+  }
+  if (max !== undefined && numberValue > max) {
+    throw new Error(`${name} must be at most ${max}`);
   }
   return numberValue;
 }
@@ -96,8 +100,9 @@ function toPositiveIntegerOrDefault(
   name: string,
   value: string | undefined,
   defaultValue: number,
+  max?: number,
 ): number {
-  return toPositiveIntegerOrUndefined(name, value) ?? defaultValue;
+  return toPositiveIntegerOrUndefined(name, value, max) ?? defaultValue;
 }
 
 /** Tri-state flag: unset/empty → `fallback`, otherwise parse as boolean. */
@@ -277,10 +282,15 @@ export function resolveConfig(
     stripeWebhookSecret: envVars.STRIPE_WEBHOOK_SECRET,
     stripeSecretKey: envVars.STRIPE_SECRET_KEY,
     stripeSeatPriceId: envVars.STRIPE_SEAT_PRICE_ID,
+    // Capped at 100: a fee percent above that is a fat-fingered misconfig
+    // (e.g. "150" typed for "15"), and computeTopUpChargeCents() would
+    // otherwise silently charge customers more than double their top-up
+    // amount instead of failing fast at boot.
     topupFeePercent: toPositiveIntegerOrDefault(
       "STUDIO_TOPUP_FEE_PERCENT",
       envVars.STUDIO_TOPUP_FEE_PERCENT,
       15,
+      100,
     ),
 
     // Feature Flags


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/settings/resolve-config.ts` for unchecked env vars (this file has been the target of a long recent series of settings-validation hardening PRs, e.g. #5505, #5494, #5483, #5476).

**Payoff:** `STUDIO_TOPUP_FEE_PERCENT` is validated as a positive integer but has no upper bound. It flows straight into `computeTopUpChargeCents()` (`amountCents * (1 + feePercent / 100)`), which charges the top-up customer's card. A fat-fingered value (e.g. `150` typed for `15`, or `1500` for basis points) would silently overcharge every top-up instead of failing fast at boot — a real money-handling correctness gap, not just a display bug.

**Failure scenario + regression test:** with `STUDIO_TOPUP_FEE_PERCENT=150` set, `resolveConfig` previously accepted it and would have charged customers 250% of their requested top-up amount. Added `resolveConfig.test.ts` case: `rejects a value above 100 instead of silently overcharging top-ups`, asserting `resolveConfig` throws `STUDIO_TOPUP_FEE_PERCENT must be at most 100`.

**Reviewer verification:** `bun test apps/api/src/settings/resolve-config.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/settings/resolve-config.test.ts` (88 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the top-up fee percent at 100 to prevent overcharging and fail fast on misconfiguration. Adds max-bound validation and a regression test in resolve-config.

- **Bug Fixes**
  - Added a max parameter to the positive-integer parsers and applied a 100 cap to topupFeePercent (default 15) in resolveConfig.
  - Added a test that rejects values above 100 with a clear error.

<sup>Written for commit 447d99454dbac9990b341f7eabe4fe58323c158d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

