### PR TITLE
fix(sandbox): empty display name made every branch "user-<stamp>" (?? vs ||)

### DIFF
--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -52,7 +52,10 @@ import {
   detectRepoRuntime,
   detectRepoRuntimeAnonymous,
 } from "../../shared/github-runtime-detect";
-import { generateBranchName } from "@decocms/shared/branch-name";
+import {
+  branchUserLabel,
+  generateBranchName,
+} from "@decocms/shared/branch-name";
 import { PACKAGE_MANAGER_CONFIG } from "@decocms/shared/runtime-defaults";
 import { resolveSandboxProvider } from "../../sandbox/resolve-provider";
 import { resolveDaemonImpl } from "../../sandbox/resolve-daemon-impl";
@@ -132,10 +135,7 @@ export const SANDBOX_START = defineTool({
     const organization = requireOrganization(ctx);
     await ctx.access.check();
     const resolvedBranch =
-      input.branch ??
-      generateBranchName(
-        ctx.auth.user?.name ?? ctx.auth.user?.email?.split("@")[0],
-      );
+      input.branch ?? generateBranchName(branchUserLabel(ctx.auth.user));
 
     // Resolve kind after loading metadata so recorded sandboxMap entries can
     // pin the provider when the caller did not pass an explicit kind.

--- a/apps/api/src/tools/thread/create.ts
+++ b/apps/api/src/tools/thread/create.ts
@@ -34,7 +34,10 @@ import {
   ThreadEntitySchema,
 } from "@decocms/shared/thread/schema";
 import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
-import { generateBranchName } from "@decocms/shared/branch-name";
+import {
+  branchUserLabel,
+  generateBranchName,
+} from "@decocms/shared/branch-name";
 
 const CreateInputSchema = z.object({
   data: ThreadCreateDataSchema.describe(
@@ -134,9 +137,7 @@ export const COLLECTION_THREADS_CREATE = defineTool({
       branch =
         data.branch ??
         pickWarmBranchFromSandboxMap(metadata?.sandboxMap, userId) ??
-        generateBranchName(
-          ctx.auth.user?.name ?? ctx.auth.user?.email?.split("@")[0],
-        );
+        generateBranchName(branchUserLabel(ctx.auth.user));
     }
 
     const result = await ctx.storage.threads.create({

--- a/apps/web/src/components/chat/pills/chat-mode-row.tsx
+++ b/apps/web/src/components/chat/pills/chat-mode-row.tsx
@@ -5,6 +5,7 @@ import { BranchPill } from "./branch-pill";
 import { getActiveGithubRepo } from "@/lib/github-repo";
 import { useProjectContext } from "@/sdk";
 import { authClient } from "@/lib/auth-client";
+import { branchUserLabel } from "@decocms/shared/branch-name";
 
 interface PureProps {
   branchPill: ReactNode;
@@ -50,7 +51,7 @@ export function ChatModeRow({ virtualMcp, currentBranch }: SmartProps) {
 
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id ?? "";
-  const userLabel = session?.user?.name ?? session?.user?.email?.split("@")[0];
+  const userLabel = branchUserLabel(session?.user);
   const { org } = useProjectContext();
 
   const branchPill =

--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -13,7 +13,10 @@ import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client.ts";
 import { coAuthorFromSessionUser } from "@/lib/co-author-identity.ts";
 import { resolveGithubAttachment } from "@/lib/github-repo.ts";
-import { generateBranchName } from "@decocms/shared/branch-name";
+import {
+  branchUserLabel,
+  generateBranchName,
+} from "@decocms/shared/branch-name";
 import { useChatStream } from "../../chat/chat-context.tsx";
 import { useChatTask } from "../../chat/index";
 import { usePanelActions } from "@/layouts/shell-layout";
@@ -305,9 +308,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   };
 
   const switchToFreshBranch = async () => {
-    const nextBranch = generateBranchName(
-      session?.user?.name ?? session?.user?.email?.split("@")[0],
-    );
+    const nextBranch = generateBranchName(branchUserLabel(session?.user));
     await setCurrentTaskBranch(nextBranch);
   };
 

--- a/packages/shared/src/branch-name.test.ts
+++ b/packages/shared/src/branch-name.test.ts
@@ -1,6 +1,43 @@
 import { describe, expect, test } from "bun:test";
 
-import { generateBranchName } from "./branch-name";
+import { branchUserLabel, generateBranchName } from "./branch-name";
+
+describe("branchUserLabel", () => {
+  test("prefers the display name", () => {
+    expect(branchUserLabel({ name: "Rafael", email: "valls@deco.cx" })).toBe(
+      "Rafael",
+    );
+  });
+
+  // The bug this helper exists for: Better Auth stores an unset display name as
+  // "", which `??` treats as present. Every such user's branch slugged to the
+  // literal "user" (171 prod threads) instead of their email local-part.
+  test("an empty display name falls through to the email local-part", () => {
+    expect(branchUserLabel({ name: "", email: "marco@wolycasa.com.br" })).toBe(
+      "marco",
+    );
+  });
+
+  test("null/absent name falls through to the email local-part", () => {
+    expect(branchUserLabel({ name: null, email: "a@b.c" })).toBe("a");
+    expect(branchUserLabel({ email: "a@b.c" })).toBe("a");
+  });
+
+  test("undefined when nothing is usable, so generateBranchName decides", () => {
+    expect(branchUserLabel({ name: "", email: "" })).toBeUndefined();
+    expect(branchUserLabel({})).toBeUndefined();
+    expect(branchUserLabel(null)).toBeUndefined();
+    expect(branchUserLabel(undefined)).toBeUndefined();
+  });
+
+  test("feeds generateBranchName a real slug for a name-less user", () => {
+    expect(
+      generateBranchName(
+        branchUserLabel({ name: "", email: "marco@wolycasa.com.br" }),
+      ),
+    ).toMatch(/^marco-[0-9a-z]+$/);
+  });
+});
 
 describe("generateBranchName", () => {
   test("returns <user-slug>-<base36-timestamp>", () => {

--- a/packages/shared/src/branch-name.ts
+++ b/packages/shared/src/branch-name.ts
@@ -34,9 +34,30 @@ function slugify(label: string | null | undefined): string {
 }
 
 /**
+ * The label to hand `generateBranchName` for a user: their display name, or
+ * their email local-part when there's no usable name.
+ *
+ * Use this instead of writing `user?.name ?? user?.email?.split("@")[0]` at the
+ * call site. `??` is wrong there: Better Auth stores an unset display name as
+ * `""`, which is not nullish, so `??` returns the empty string, never reaches
+ * the email, and `slugify` falls back to the literal `"user"`. Every branch for
+ * such a user was named `user-<stamp>` — 171 prod threads before this existed.
+ * `||` skips the empty string.
+ *
+ * Returns `undefined` (not `""`) when neither field is usable, so
+ * `generateBranchName`'s own fallback stays the single place that decides what
+ * an unidentifiable user's branch looks like.
+ */
+export function branchUserLabel(
+  user: { name?: string | null; email?: string | null } | null | undefined,
+): string | undefined {
+  return user?.name || user?.email?.split("@")[0] || undefined;
+}
+
+/**
  * Build a branch name for `userLabel` (the creator's display name, or their
- * email local-part as a fallback). Callers should pass the most human-readable
- * identity they have; slugification handles the rest.
+ * email local-part as a fallback — see `branchUserLabel`). Callers should pass
+ * the most human-readable identity they have; slugification handles the rest.
  */
 export function generateBranchName(userLabel?: string | null): string {
   const slug = slugify(userLabel);


### PR DESCRIPTION
## Summary

`??` where `||` was needed. Better Auth stores an unset display name as `""`, not `null`, so every branch minted for a user without a display name was called `user-<stamp>` instead of `<their-email-local-part>-<stamp>`.

All four `generateBranchName` call sites picked the label the same way:

```ts
generateBranchName(user?.name ?? user?.email?.split("@")[0])
```

`??` only falls back on nullish, so `name: ""` wins, the email is never reached, and `slugify("")` returns its literal `"user"` fallback.

## Evidence (prod)

The user whose sandboxes I was debugging in #5511:

```
id: brvoCCMqAyA0MU7XWAnSJu79huUNS2eh
name: ""                      ← not null
email: marco@wolycasa.com.br  ← never consulted
```

Their branches: `user-nsif89sm`, `user-fsif89sm`, `user-sb8449sm`. A teammate whose `name` is non-empty, same org, same day: `rafael-4i1549sm`.

Across all prod threads carrying a branch:

| branch shape | count |
|---|---|
| named slug (`rafael-…`) | 3415 |
| thread-scoped (`thread:…`) | 337 |
| **`user-` fallback** | **171** |

Those 171 are all this bug — the fallback is otherwise only reachable by a user with neither a name nor an email.

## Why it matters beyond cosmetics

The branch name is pushed to the customer's repo and is the slug in the sandbox handle (`computeHandle` → `<branch-slug>-<hash16>`), so these branches read as anonymous in git history and in preview hostnames, and two affected users in one org are indistinguishable by branch name.

## Changes

- New `branchUserLabel(user)` in `packages/shared/src/branch-name.ts`, using `||`. Returns `undefined` (not `""`) when nothing is usable, so `generateBranchName`'s own fallback stays the single place that decides what an unidentifiable user's branch looks like.
- All four call sites use it, replacing the duplicated `?? …split("@")[0]` expression: `SANDBOX_START`, `COLLECTION_THREADS_CREATE`, `switchToFreshBranch` (header-actions), `chat-mode-row`'s `userLabel`.
- Tests covering `name: ""` → email local-part, plus the end-to-end `generateBranchName(branchUserLabel({name:"", email:"marco@…"}))` → `marco-…`.

## Testing

- `bun test packages/shared/src/branch-name.test.ts apps/api/src/tools/sandbox/ apps/web/src/components/chat/` → 517 pass, 0 fail
- `bun run check` → clean · `bun run lint` → 0 errors (16 pre-existing warnings) · `bun run fmt` → clean · `knip` → clean

## Out of scope

Existing `user-*` branches are left as they are. Renaming one would orphan the sandbox recorded against it in `sandboxMap` / `sandbox_runner_state`, and the git branch already exists on the customer's remote.

Independent of #5511 (that one is the double-sandbox race); they touch the same two files but different lines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes branch naming for users with empty display names. We now use the email local-part instead of creating anonymous `user-<stamp>` branches, so git history and sandbox handles stay identifiable.

- **Bug Fixes**
  - Added `branchUserLabel(user)` in `@decocms/shared/branch-name` (uses `||` so `""` falls through; returns `undefined` when nothing is usable).
  - Replaced all call sites with `generateBranchName(branchUserLabel(...))` in API and web (`SANDBOX_START`, `COLLECTION_THREADS_CREATE`, header-actions’ `switchToFreshBranch`, `chat-mode-row`), and added tests for empty-name cases. Existing `user-*` branches are unchanged.

<sup>Written for commit ee793a5def9c76eaad24e22ddd67b83b28faab64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

