### PR TITLE
fix(sandbox): make org-fs MountManager's mkdir async

### DIFF
--- a/packages/sandbox/daemon/org-fs/mount-manager.ts
+++ b/packages/sandbox/daemon/org-fs/mount-manager.ts
@@ -16,7 +16,7 @@
  * blocks mounts — desktop links are the target).
  */
 
-import { mkdirSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
 import * as net from "node:net";
 import { join, isAbsolute } from "node:path";
 import { safePath } from "../paths";
@@ -195,7 +195,7 @@ export class MountManager {
         this.log(`skip ${m.volume}: mount path "${m.path}" escapes appRoot`);
         return;
       }
-      mkdirSync(mountPath, { recursive: true });
+      await mkdir(mountPath, { recursive: true });
 
       const client = new OrgFsClient({
         baseUrl: config.baseUrl,


### PR DESCRIPTION
This is a small piece of the recurring "convert blocking sync fs in the sandbox daemon" hardening lane (see #5333, #5336, #5367, #5370, #5372, #5375, #5391, #5403, #5406, #5413, #5442, #5471, #5478, #5481, #5497) applied to `MountManager.mountOne()`, which the lane hadn't reached yet.

`packages/sandbox/daemon/**` runs on a single Bun event loop; per CONTRIBUTING.md rule #4, any sync fs call blocks that loop, and a single missed `/health` probe during the block flips a healthy sandbox to "crashed" and tears the pod down. `MountManager.start()` is invoked fire-and-forget right after the daemon's `Bun.serve()` call in `entry.ts`, so its `mountOne()` (already an `async` function awaiting other I/O) was calling `mkdirSync` synchronously on the daemon's own event loop while org-fs volumes are being mounted at boot.

Fix: swap `mkdirSync` (node:fs) for `await mkdir(...)` (node:fs/promises) — same recursive-create semantics, now off the event loop. Behavior-preserving: `mountOne` was already `async` and this call already sits inside a `try` with the rest of the mount flow awaited after it, so ordering is unchanged.

How to verify: `cd packages/sandbox && bunx tsc --noEmit` (green), `bun test packages/sandbox/daemon/org-fs/mount-manager.test.ts` (12 pass, unchanged), `bunx oxlint packages/sandbox/daemon/org-fs/mount-manager.ts` (0 warnings/errors).

Locally ran: `bun run fmt`, the workspace typecheck above, the targeted test file, and per-file oxlint. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `org-fs` `MountManager.mountOne()` use async `node:fs/promises.mkdir` instead of blocking `node:fs.mkdirSync` when creating mount directories. This avoids blocking the Bun event loop during boot, preventing missed `/health` checks and false "crashed" sandboxes while volumes mount.

<sup>Written for commit 8ef7a3c0e65bd7a1fd470c7386d78b2e701a24dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

