### PR TITLE
fix(native): explain local Git authentication failures

### DIFF
--- a/apps/native/crates/local-api/src/sandbox/manager.rs
+++ b/apps/native/crates/local-api/src/sandbox/manager.rs
@@ -1043,7 +1043,7 @@ impl SandboxManager {
             "sandbox ensure: repository ready"
         );
         if !clone_ok {
-            let message = "git clone/checkout failed; inspect the setup log";
+            let message = "git clone/checkout failed; inspect the setup log, then verify the repository exists and this machine's Git credentials can access it";
             let _ = self
                 .registry
                 .mark_state(&handle, "running", "failed", Some(message));
@@ -2078,6 +2078,10 @@ mod tests {
         assert!(
             error.contains("git clone/checkout failed"),
             "the caller must receive a checkout failure, got: {error}"
+        );
+        assert!(
+            error.contains("this machine's Git credentials"),
+            "the caller must receive actionable credential guidance, got: {error}"
         );
         assert_eq!(
             git_stdout(&sandbox.workdir, &["rev-parse", "--abbrev-ref", "HEAD"]),

--- a/apps/native/crates/local-api/src/setup/clone.rs
+++ b/apps/native/crates/local-api/src/setup/clone.rs
@@ -71,9 +71,13 @@ use crate::tasks::{
 /// the native Git-sandbox contract's "Desktop adaptation" section,
 /// the user is on their OWN machine with their OWN git auth, so cloning
 /// should use exactly what `git clone` would do run by hand: the user's
-/// configured credential helper (macOS Keychain, `gh`, SSH agent, ...).
+/// configured credential helper (for example macOS Keychain, or `gh` after
+/// `gh auth setup-git`). An SSH agent only participates when the configured
+/// `cloneUrl` itself uses SSH; Git does not switch an HTTPS URL to SSH based on
+/// the protocol selected in `gh auth login`.
 /// Clearing `credential.helper` here would silently break every private
-/// repo a desktop user can otherwise already clone from a terminal.
+/// repo a desktop user can otherwise already clone from a terminal with the
+/// same URL.
 /// `GIT_TERMINAL_PROMPT=0` (below, in [`run_git`]) still applies regardless,
 /// so a repo the user's credentials genuinely can't reach fails fast rather
 /// than hanging on an interactive prompt.


### PR DESCRIPTION
## Summary

- make native sandbox clone failures point users to repository visibility and the machine Git credentials
- document that HTTPS clone URLs use the configured credential helper, including gh auth setup-git
- clarify that selecting SSH in gh does not make an HTTPS clone use the SSH agent
- assert the actionable credential guidance in the existing failed-checkout test

## Root cause

The user-desktop sandbox receives the repository HTTPS URL and intentionally clones with the machine ambient Git credentials. It does not receive the short-lived Studio GitHub App installation token. For the reported repository, the setup log showed git ls-remote returning Repository not found, and the active machine GitHub identity could not access the repository.

## Related GitHub App incident

The misleading post-installation redirect was a separate GitHub App registration issue. The optional Setup URL has now been cleared and Redirect on update disabled in the Deco CMS GitHub App settings, so no application landing route is needed in this PR. OAuth callback URLs were left unchanged.

## Testing

- cargo test --manifest-path apps/native/Cargo.toml -p local-api ensure_rejects_a_failed_drift_repair_instead_of_returning_wrong_branch
- bun run --cwd apps/native check
- bun run check
- cargo clippy --manifest-path apps/native/Cargo.toml -- -D warnings
- bun run fmt
- cargo fmt --manifest-path apps/native/Cargo.toml --all --check

Docker-backed resilience and multi-pod suites were not run because Docker is unavailable in this environment.