### PR TITLE
fix(connection): block SSRF on connection create/update tool-fetch

### DIFF
--- a/apps/api/src/tools/connection/fetch-tools.test.ts
+++ b/apps/api/src/tools/connection/fetch-tools.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { fetchToolsFromMCP } from "./fetch-tools";
+
+describe("fetchToolsFromMCP SSRF guard", () => {
+  it("blocks an HTTP connection URL targeting a private/loopback address", async () => {
+    const result = await fetchToolsFromMCP({
+      id: "conn-1",
+      title: "evil",
+      connection_type: "HTTP",
+      connection_url: "http://169.254.169.254/latest/meta-data/",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("blocks an SSE connection URL targeting a private/loopback address", async () => {
+    const result = await fetchToolsFromMCP({
+      id: "conn-2",
+      title: "evil",
+      connection_type: "SSE",
+      connection_url: "http://127.0.0.1:9999/mcp",
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/tools/connection/fetch-tools.ts
+++ b/apps/api/src/tools/connection/fetch-tools.ts
@@ -11,6 +11,10 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { getSettings } from "../../settings";
+import {
+  createNoRedirectFetch,
+  guardAgainstPrivateUrl,
+} from "../registry/discover-tools";
 import type {
   ConnectionParameters,
   HttpConnectionParameters,
@@ -107,6 +111,15 @@ async function fetchToolsFromHttpMCP(
     return null;
   }
 
+  // connection_url is user-supplied — without this guard a connection
+  // create/update call could reach a private/metadata address that the
+  // registry discovery flow already blocks for the same URL.
+  const guardError = await guardAgainstPrivateUrl(connection.connection_url);
+  if (guardError) {
+    console.error(`Blocked HTTP connection ${connection.id}: ${guardError}`);
+    return null;
+  }
+
   let client: Client | null = null;
 
   try {
@@ -127,7 +140,7 @@ async function fetchToolsFromHttpMCP(
 
     const transport = new StreamableHTTPClientTransport(
       new URL(connection.connection_url),
-      { requestInit: { headers } },
+      { requestInit: { headers }, fetch: createNoRedirectFetch() },
     );
 
     client = new Client(
@@ -192,6 +205,12 @@ async function fetchToolsFromSSEMCP(
     return null;
   }
 
+  const guardError = await guardAgainstPrivateUrl(connection.connection_url);
+  if (guardError) {
+    console.error(`Blocked SSE connection ${connection.id}: ${guardError}`);
+    return null;
+  }
+
   let client: Client | null = null;
 
   try {
@@ -211,7 +230,7 @@ async function fetchToolsFromSSEMCP(
 
     const transport = new SSEClientTransport(
       new URL(connection.connection_url),
-      { requestInit: { headers } },
+      { requestInit: { headers }, fetch: createNoRedirectFetch() },
     );
 
     client = new Client(

--- a/apps/api/src/tools/registry/discover-tools.ts
+++ b/apps/api/src/tools/registry/discover-tools.ts
@@ -138,6 +138,44 @@ export async function resolvesToPrivateAddress(
   }
 }
 
+/**
+ * Full SSRF guard for a remote MCP URL: rejects private/loopback/link-local
+ * IP literals synchronously via `isPrivateUrl`, then — for a plain hostname —
+ * resolves DNS and rejects if any resolved address is private. Shared by
+ * every code path that connects to a user-supplied MCP server URL, so a
+ * caller can't bypass the registry discovery guard by hitting a different
+ * entry point (e.g. connection create/update) with the same URL.
+ */
+export async function guardAgainstPrivateUrl(
+  url: string,
+): Promise<string | null> {
+  const blockedMessage = "URLs targeting private networks are not allowed";
+
+  if (isPrivateUrl(url)) {
+    return blockedMessage;
+  }
+
+  // isPrivateUrl already fully vets an IP-literal hostname; only a plain
+  // domain name needs a DNS lookup to catch a domain whose DNS record
+  // points at a private/metadata address.
+  const hostname = new URL(url).hostname;
+  const isIpLiteral =
+    /^\d+\.\d+\.\d+\.\d+$/.test(hostname) ||
+    (hostname.startsWith("[") && hostname.endsWith("]"));
+  if (isIpLiteral) return null;
+
+  try {
+    const blocked = await withTimeout(
+      resolvesToPrivateAddress(hostname),
+      5_000,
+      "DNS resolution timeout",
+    );
+    return blocked ? blockedMessage : null;
+  } catch {
+    return blockedMessage; // can't verify in time — fail closed
+  }
+}
+
 const DiscoverToolsInputSchema = z.object({
   url: z.string().describe("Remote MCP server URL"),
   type: z
@@ -328,42 +366,12 @@ export const REGISTRY_DISCOVER_TOOLS = defineTool({
       return { tools: [], error: "URL is required" };
     }
 
-    if (isPrivateUrl(url)) {
-      return {
-        tools: [],
-        error: "URLs targeting private networks are not allowed",
-      };
+    const guardError = await guardAgainstPrivateUrl(url);
+    if (guardError) {
+      return { tools: [], error: guardError };
     }
 
     const timeoutMs = 10_000;
-
-    // isPrivateUrl already fully vets an IP-literal hostname; only a plain
-    // domain name needs a DNS lookup to catch a domain whose DNS record
-    // points at a private/metadata address.
-    const hostname = new URL(url).hostname;
-    const isIpLiteral =
-      /^\d+\.\d+\.\d+\.\d+$/.test(hostname) ||
-      (hostname.startsWith("[") && hostname.endsWith("]"));
-
-    let blockedByDns = false;
-    if (!isIpLiteral) {
-      try {
-        blockedByDns = await withTimeout(
-          resolvesToPrivateAddress(hostname),
-          5_000,
-          "DNS resolution timeout",
-        );
-      } catch {
-        blockedByDns = true; // can't verify in time — fail closed
-      }
-    }
-
-    if (blockedByDns) {
-      return {
-        tools: [],
-        error: "URLs targeting private networks are not allowed",
-      };
-    }
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",


### PR DESCRIPTION
Follows the SSRF-hardening lineage on `REGISTRY_DISCOVER_TOOLS` (#4999, #5488, and others in the registry SSRF vein) — this closes the same gap on a sibling entry point.

**The gap:** `apps/api/src/tools/connection/fetch-tools.ts` (`fetchToolsFromHttpMCP` / `fetchToolsFromSSEMCP`) is called from `CONNECTION_CREATE` and `CONNECTION_UPDATE` with a user-supplied `connection_url`, and connects to it with the default `fetch` (redirect-following, no private-IP check). This is the exact same trust boundary `discover-tools.ts`'s `isPrivateUrl`/`resolvesToPrivateAddress`/`createNoRedirectFetch` guard was built for, but an org member could bypass that guard entirely just by calling `CONNECTION_CREATE`/`CONNECTION_UPDATE` directly (skipping `REGISTRY_DISCOVER_TOOLS`) with an HTTP/SSE `connection_url` pointing at a private/loopback/cloud-metadata address, or a public URL that 3xx-redirects to one.

**The fix:** extracted the inline private-URL check in `discover-tools.ts`'s handler into a reusable exported `guardAgainstPrivateUrl(url)` (no behavior change there — same logic, same order of checks, existing tests still cover it), then call that guard plus `createNoRedirectFetch()` from both `fetchToolsFromHttpMCP` and `fetchToolsFromSSEMCP` before connecting. STDIO fetch is untouched (already gated by `localMode`, no network URL involved).

**Regression test:** added `apps/api/src/tools/connection/fetch-tools.test.ts` — asserts `fetchToolsFromMCP` returns `null` (its existing failure contract) for an HTTP connection targeting `169.254.169.254` and an SSE connection targeting `127.0.0.1`, without ever attempting a network connection (blocked synchronously by the literal-IP check).

**Reviewer command:** `bun test apps/api/src/tools/connection/fetch-tools.test.ts apps/api/src/tools/registry/discover-tools.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the two test files above (22 pass), and `bunx oxlint` on all three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks SSRF in connection create/update by enforcing the same private-network URL guard and no-redirect fetch used in `REGISTRY_DISCOVER_TOOLS`. HTTP/SSE `connection_url` can no longer target private/loopback/metadata IPs or redirect to them.

- **Bug Fixes**
  - Extracted `guardAgainstPrivateUrl()` from discovery and reused it in `fetch-tools` for `CONNECTION_CREATE` and `CONNECTION_UPDATE`.
  - Applied `createNoRedirectFetch()` to HTTP and SSE transports to prevent redirect-based bypass.
  - Added tests to ensure `fetchToolsFromMCP` returns `null` for private targets (e.g. `169.254.169.254`, `127.0.0.1`) without making network requests.
  - STDIO path unchanged and remains gated by local mode.

<sup>Written for commit 7b7333542a5b908fab3aef95ff1c4251a0e01c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

