### PR TITLE
fix(sandbox): give a loaded repo-backed thread with no branch one, so it can auto-start

### DIFF
--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.test.ts
@@ -3,6 +3,7 @@ import {
   resolveVmEntry,
   selectVmEntry,
   shouldAutoStart,
+  shouldAdoptBranch,
   shouldSelfHeal,
   computeDrawerStatus,
   buildSandboxStartArgs,
@@ -144,6 +145,48 @@ describe("shouldAutoStart", () => {
 
   test("already attempted for this branch → false", () => {
     expect(shouldAutoStart({ ...base, attempted: true })).toBe(false);
+  });
+});
+
+describe("shouldAdoptBranch", () => {
+  const base = {
+    threadLoaded: true,
+    isOwner: true,
+    hasActiveGithubRepo: true,
+    branch: null as string | null,
+    attempted: false,
+  };
+
+  test("loaded repo-backed thread with no branch → true", () => {
+    expect(shouldAdoptBranch(base)).toBe(true);
+  });
+
+  // The whole point: shouldAutoStart refuses to start without a branch, so
+  // without this these threads would never boot a preview at all.
+  test("already has a branch → false", () => {
+    expect(shouldAdoptBranch({ ...base, branch: "rafael-z9x1cbam" })).toBe(
+      false,
+    );
+  });
+
+  // A null branch on an unresolved row means "not known yet", not "none" —
+  // minting here would race COLLECTION_THREADS_CREATE all over again.
+  test("thread row not loaded → false", () => {
+    expect(shouldAdoptBranch({ ...base, threadLoaded: false })).toBe(false);
+  });
+
+  test("teammate's thread → false (their row stays read-only)", () => {
+    expect(shouldAdoptBranch({ ...base, isOwner: false })).toBe(false);
+  });
+
+  test("no repo → false (nothing to clone, so no branch is needed)", () => {
+    expect(shouldAdoptBranch({ ...base, hasActiveGithubRepo: false })).toBe(
+      false,
+    );
+  });
+
+  test("already adopted for this thread → false", () => {
+    expect(shouldAdoptBranch({ ...base, attempted: true })).toBe(false);
   });
 });
 

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -66,6 +66,39 @@ export function shouldAutoStart(args: ShouldAutoStartArgs): boolean {
   );
 }
 
+export interface ShouldAdoptBranchArgs {
+  /** The thread row has resolved. `false` while `useEnsureTask` is still
+   *  fetching/creating, when a null branch means "not known yet". */
+  threadLoaded: boolean;
+  /** The viewer created this thread. A teammate's row stays read-only. */
+  isOwner: boolean;
+  hasActiveGithubRepo: boolean;
+  branch: string | null;
+  /** Already adopted once for this thread in this session. */
+  attempted: boolean;
+}
+
+/**
+ * A loaded thread on a repo-backed agent with no branch gets one assigned, so
+ * the branch-gated auto-start (`shouldAutoStart`) can fire for it.
+ *
+ * Threads only reach this state when the repo was attached to the agent AFTER
+ * they were created — `COLLECTION_THREADS_CREATE` assigns a branch whenever the
+ * agent already has a `githubRepo`. Before the branch gate those threads were
+ * covered by `SANDBOX_START` minting a branch server-side, which is exactly the
+ * race that leaked a sandbox per new chat; minting here instead is safe because
+ * the row already exists, so nothing else is naming it concurrently.
+ */
+export function shouldAdoptBranch(args: ShouldAdoptBranchArgs): boolean {
+  return (
+    args.threadLoaded &&
+    args.isOwner &&
+    args.hasActiveGithubRepo &&
+    !args.branch &&
+    !args.attempted
+  );
+}
+
 export interface ShouldSelfHealArgs {
   notFound: boolean;
   deadVmId: string | null;

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/sdk";
 import type { VirtualMCPEntity, SandboxMap } from "@decocms/shared/sdk/types";
 import { agentHasClonableSource } from "@/lib/agent-capabilities";
+import { generateBranchName } from "@decocms/shared/branch-name";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useIsSandboxStartPending } from "@/components/sandbox/hooks/use-sandbox-start";
 import { useStatusSounds } from "../../hooks/use-status-sounds";
@@ -63,6 +64,7 @@ import {
   SandboxLifecycleProvider,
   resolveVmEntry,
   overlayThreadSandboxMap,
+  shouldAdoptBranch,
   type BranchMapEntryLike,
 } from "@/components/sandbox/hooks/sandbox-lifecycle-context";
 import { useEnsureTask } from "@/hooks/use-ensure-task";
@@ -146,7 +148,7 @@ function VmEventsBridge({
   sandboxMap: SandboxMap | undefined;
   children: ReactNode;
 }) {
-  const { currentBranch, activeTask } = useChatTask();
+  const { currentBranch, activeTask, setCurrentTaskBranch } = useChatTask();
   const { pendingSandboxProviderKind } = useChatPrefs();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
@@ -165,6 +167,37 @@ function VmEventsBridge({
   });
   const effectiveHasGithubRepo =
     hasActiveGithubRepo || agentHasClonableSource(activeTask?.metadata);
+
+  // Assign a branch to a loaded repo-backed thread that has none, so the
+  // branch-gated auto-start can run for it. Only reachable when the repo was
+  // attached to the agent after the thread was created (COLLECTION_THREADS_CREATE
+  // assigns one otherwise). See shouldAdoptBranch.
+  //
+  // Ceiling: two tabs on the same such thread each mint once, and the row keeps
+  // the last write — the loser's sandbox is orphaned. Bounded to one mint per
+  // thread per tab; a shared lock is the fix if that ever shows up in practice.
+  const adoptedBranchForThreadRef = useRef<string | null>(null);
+  const adoptBranchEligible = shouldAdoptBranch({
+    threadLoaded: !!activeTask,
+    isOwner: !!userId && activeTask?.created_by === userId,
+    hasActiveGithubRepo: effectiveHasGithubRepo,
+    branch: currentBranch ?? null,
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; recorded inside the effect after firing
+    attempted: adoptedBranchForThreadRef.current === (activeTask?.id ?? null),
+  });
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- one-shot row write gated on the resolved thread; no render-time equivalent
+  useEffect(() => {
+    if (!adoptBranchEligible || !activeTask) return;
+    // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- record the thread so a re-render can't mint twice
+    adoptedBranchForThreadRef.current = activeTask.id;
+    setCurrentTaskBranch(
+      generateBranchName(
+        // TODO: swap for `branchUserLabel` once decocms/studio#5513 lands — `??`
+        // would let Better Auth's empty display name through and slug to "user".
+        session?.user?.name || session?.user?.email?.split("@")[0],
+      ),
+    );
+  }, [adoptBranchEligible, activeTask, session, setCurrentTaskBranch]);
 
   // Open the events stream only when a sandbox actually exists or a start is
   // in flight — NOT merely because the agent has a GitHub repo configured.


### PR DESCRIPTION
> Follow-up to #5511 (merged). Rebased onto `main`, so this is a single-commit diff.

## Summary

#5511 made `shouldAutoStart` require a branch, which closes the double-sandbox race. The gap it leaves: a thread whose row has `branch = null` on a repo-backed agent now gets **no** auto-start at all. `computePreviewState` with no `previewUrl` and no error is `{ kind: "starting" }`, so the preview would hold its booting overlay indefinitely, and only the user-driven `start()` button would recover it.

This closes that gap by assigning the branch instead of asking the server to invent one mid-flight.

## When a thread ends up branchless

`COLLECTION_THREADS_CREATE` assigns a branch whenever the agent already has a `githubRepo`. So the only way to get `branch = null` with a repo present is: **the repo was attached to the agent after the thread was created.** 14 of 1708 repo-backed prod threads are in that state today, and since attaching a repo to an existing agent is a normal thing to do, it keeps happening — a one-time backfill wouldn't have fixed the class.

## Changes

`VmEventsBridge` mints and persists a branch for exactly that case, then the normal branch-gated auto-start fires on the next render. Guarded by a new pure `shouldAdoptBranch`:

- `threadLoaded` — the row has resolved. A null branch on an *unresolved* row means "not known yet", which is the state #5511 exists to stop us from acting on.
- `isOwner` — a teammate's row stays read-only.
- `hasActiveGithubRepo` — no repo, no branch needed.
- `!branch` / `!attempted` — one mint per thread per tab.

Minting here is safe where the old server-side mint was not: the row already exists, so nothing else is naming it concurrently.

## Testing

- 6 new unit tests on `shouldAdoptBranch`, including the two that matter — `threadLoaded: false → false` (the race guard) and `branch present → false`.
- `bun test apps/web/src/components/sandbox/ apps/web/src/layouts/` → 648 pass, 0 fail
- `bun run check` → clean · `bun run lint` → 0 errors (16 pre-existing warnings) · `bun run fmt` → clean · `knip` → clean

## Known ceiling

Two tabs open on the same branchless thread each mint once; the row keeps the last write and the loser's sandbox is orphaned. Bounded (one mint per thread per tab), noted at the call site, and needs a shared lock to close properly — not worth it unless it shows up in practice.

## Note

The mint inlines `session?.user?.name || session?.user?.email?.split("@")[0]` with a TODO pointing at #5513, which replaces that expression with a `branchUserLabel` helper everywhere. Whichever lands second drops the TODO.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Assigns a branch to loaded repo-backed threads that have none, so previews auto-start instead of hanging on “starting.” The branch is minted client-side once per thread per tab, only when it’s safe.

- **Bug Fixes**
  - Added `shouldAdoptBranch` to gate adoption: loaded thread, owner, active GitHub/clonable repo, no branch, not yet attempted.
  - `VmEventsBridge` now sets a branch via `setCurrentTaskBranch(generateBranchName(...))` from `@decocms/shared/branch-name`, letting `shouldAutoStart` run.
  - Added unit tests for `shouldAdoptBranch`.
  - Note: two tabs on the same thread can each mint; last write wins. Bounded and acceptable for now.

<sup>Written for commit b1c4c64673181fe643a257ebe99a92b6f8e86f8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

