### PR TITLE
feat(sandbox): split sandbox metrics by daemon impl

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/claim-template.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/claim-template.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { resolveClaimTemplate } from "./runner";
+import type { SandboxResource } from "./client";
+import { readClaimDaemonImpl, resolveClaimTemplate } from "./runner";
 
 const TS = "studio-sandbox-stg";
 const GO = "studio-sandbox-stg-go";
+
+const claimWithLabels = (labels: Record<string, string>): SandboxResource =>
+  ({ metadata: { labels } }) as unknown as SandboxResource;
 
 describe("resolveClaimTemplate", () => {
   it("defaults to the ts template", () => {
@@ -31,5 +35,28 @@ describe("resolveClaimTemplate", () => {
       impl: "ts",
       templateName: TS,
     });
+  });
+});
+
+describe("readClaimDaemonImpl", () => {
+  const KEY = "studio.decocms.com/daemon-impl";
+
+  it("recovers the impl a claim was provisioned with", () => {
+    expect(readClaimDaemonImpl(claimWithLabels({ [KEY]: "go" }))).toBe("go");
+    expect(readClaimDaemonImpl(claimWithLabels({ [KEY]: "ts" }))).toBe("ts");
+  });
+
+  it("reports null rather than guessing ts when the label is absent", () => {
+    // Claims provisioned before the rollout gate existed. Defaulting to "ts"
+    // here would be indistinguishable from a real TS sandbox on the dashboard.
+    expect(readClaimDaemonImpl(claimWithLabels({}))).toBeNull();
+    expect(readClaimDaemonImpl({} as SandboxResource)).toBeNull();
+  });
+
+  it("rejects an unrecognized label value", () => {
+    // The label is writable by anything with claim access; an unbounded value
+    // here would land straight in a metric attribute as new cardinality.
+    expect(readClaimDaemonImpl(claimWithLabels({ [KEY]: "rust" }))).toBeNull();
+    expect(readClaimDaemonImpl(claimWithLabels({ [KEY]: "" }))).toBeNull();
   });
 });

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -278,6 +278,17 @@ interface K8sRecord {
    * that case so the caller's normal SANDBOX_START flow can repopulate them.
    */
   ensureOpts: EnsureOptions | null;
+  /**
+   * Which daemon binary this sandbox's pod is actually running — the metric
+   * dimension the Go rollout is compared on. Distinct from
+   * `ensureOpts.daemonImpl` (what the caller *asked* for, which the kill
+   * switch can collapse) and resolvable on paths that have no `ensureOpts` at
+   * all: adopt recovers it from the claim label, which is the cluster-side
+   * source of truth. Null only when neither is available — reported as an
+   * empty attribute rather than defaulting to `ts`, so a Go sandbox can never
+   * be silently counted as a TS one.
+   */
+  daemonImpl: SandboxDaemonImpl | null;
 }
 
 interface PersistedK8sState {
@@ -540,7 +551,7 @@ export class AgentSandboxProvider implements SandboxProvider {
       // Decrement only when we actually held the record — getRecord can be
       // null after restart-without-state-store, in which case the gauge
       // was never incremented for this handle in this process.
-      this.metrics?.active.add(-1, tenantAttrs(rec.tenant));
+      this.metrics?.active.add(-1, tenantAttrs(rec.tenant, rec.daemonImpl));
     }
     // Drop the HTTPRoute first so traffic stops resolving immediately —
     // the operator's claim teardown can take a few seconds, and we don't
@@ -1115,7 +1126,7 @@ export class AgentSandboxProvider implements SandboxProvider {
       );
     }
     if (this.metrics) {
-      const attrs = tenantAttrs(rec.tenant);
+      const attrs = tenantAttrs(rec.tenant, rec.daemonImpl);
       this.metrics.ensureOutcome.add(1, { ...attrs, outcome });
       // Only increment the active gauge on first observation to avoid
       // double-counting when the same handle is rehydrated multiple times
@@ -1236,6 +1247,16 @@ export class AgentSandboxProvider implements SandboxProvider {
     const token = this.tokenGenerator();
     const daemonBootId = randomUUID();
     const workdir = DEFAULT_WORKDIR;
+    // The impl the claim actually gets — `go` collapses back to `ts` here when
+    // the kill switch is off. Resolved once and reused for the record, its
+    // persisted opts, and the claim itself (buildClaim re-derives it from the
+    // same pure function on the same inputs), so the metric attribute can
+    // never disagree with the pod that ran.
+    const { impl: resolvedImpl } = resolveClaimTemplate(
+      opts.daemonImpl,
+      this.sandboxTemplateName,
+      this.goSandboxTemplateName,
+    );
 
     const claim = this.buildClaim(handle, opts, {
       token,
@@ -1382,17 +1403,11 @@ export class AgentSandboxProvider implements SandboxProvider {
       workload: opts.workload ?? null,
       daemonBootId: resolvedBootId,
       tenant: opts.tenant ?? null,
+      daemonImpl: resolvedImpl,
       // Persist the impl the claim actually got, not the one asked for: with the
       // kill switch off a `go` request lands on ts, and recovery must replay
       // what ran. Same pure call buildClaim made above.
-      ensureOpts: stripEnsureOpts({
-        ...opts,
-        daemonImpl: resolveClaimTemplate(
-          opts.daemonImpl,
-          this.sandboxTemplateName,
-          this.goSandboxTemplateName,
-        ).impl,
-      }),
+      ensureOpts: stripEnsureOpts({ ...opts, daemonImpl: resolvedImpl }),
     };
   }
 
@@ -1795,6 +1810,9 @@ export class AgentSandboxProvider implements SandboxProvider {
       daemonBootId: live.bootId,
       tenant: state.tenant ?? null,
       ensureOpts: state.ensureOpts ?? null,
+      // Rows written before the rollout gate existed have no persisted impl;
+      // they are TS sandboxes by construction, but say null rather than guess.
+      daemonImpl: state.ensureOpts?.daemonImpl ?? null,
     };
   }
 
@@ -1870,6 +1888,11 @@ export class AgentSandboxProvider implements SandboxProvider {
       // can't autonomously re-provision; falls back to the caller's
       // SANDBOX_START path.
       ensureOpts: null,
+      // The one thing that IS recoverable without ensureOpts: the claim label
+      // studio stamped at provision time. Without this, every adopted sandbox
+      // would drop out of the impl split during exactly the incident (studio
+      // restarted, state-store empty) you'd be reading the dashboard for.
+      daemonImpl: readClaimDaemonImpl(claim),
     };
   }
 
@@ -1978,7 +2001,7 @@ export class AgentSandboxProvider implements SandboxProvider {
   ): void {
     if (!this.metrics) return;
     this.metrics.proxyDurationMs.record(durationMs, {
-      ...tenantAttrs(rec?.tenant ?? null),
+      ...tenantAttrs(rec?.tenant ?? null, rec?.daemonImpl ?? null),
       source,
       sandbox_handle: rec?.handle ?? fallbackHandle ?? "",
       status_code: statusCode || 0,
@@ -2192,7 +2215,7 @@ function buildRunnerMetrics(meter: Meter): RunnerMetrics {
   return {
     active: meter.createUpDownCounter("studio.sandbox.active", {
       description:
-        "Active sandbox count, by runner kind and owning org. Cross-checks the cAdvisor-derived count from the cluster — divergence between the two indicates orphaned claims (studio deleted but K8s didn't reap) or unattributed pods.",
+        "Active sandbox count, by runner kind, owning org, and daemon impl. Cross-checks the cAdvisor-derived count from the cluster — divergence between the two indicates orphaned claims (studio deleted but K8s didn't reap) or unattributed pods.",
       unit: "{sandbox}",
     }),
     ensureOutcome: meter.createCounter("studio.sandbox.ensure.outcome", {
@@ -2448,19 +2471,43 @@ function readClaimTenant(claim: SandboxResource): RunnerTenant | null {
 }
 
 /**
+ * Which daemon binary a claim's pod runs, per the label studio stamped at
+ * provision time. The cluster-side source of truth, and the only way to
+ * recover the impl on the adopt path (where `ensureOpts` is unrecoverable).
+ * Returns null for claims that predate the label rather than assuming `ts`.
+ */
+export function readClaimDaemonImpl(
+  claim: SandboxResource,
+): SandboxDaemonImpl | null {
+  const value = claim.metadata?.labels?.[LABEL_KEYS.daemonImpl];
+  return value === "go" || value === "ts" ? value : null;
+}
+
+/**
  * Convert tenant struct to OTel attribute keys. `runner_kind` is constant for
  * a given runner instance but included on every attrs set so downstream
  * dashboards can pivot across runners without re-aggregating.
+ *
+ * `daemon_impl` is the Go-rollout comparison dimension: it splits every
+ * sandbox metric by the binary the pod actually ran, so `go` and `ts` can be
+ * read side by side while both are live. Empty when unknown — never defaulted
+ * to `ts`, because a Go sandbox counted as TS is worse than one counted as
+ * neither. Cardinality is bounded at 3 (`go` | `ts` | `""`).
  */
-function tenantAttrs(tenant: RunnerTenant | null): {
+function tenantAttrs(
+  tenant: RunnerTenant | null,
+  daemonImpl: SandboxDaemonImpl | null,
+): {
   org_id: string;
   user_id: string;
   runner_kind: string;
+  daemon_impl: string;
 } {
   return {
     org_id: tenant?.orgId ?? "",
     user_id: tenant?.userId ?? "",
     runner_kind: RUNNER_KIND,
+    daemon_impl: daemonImpl ?? "",
   };
 }
 


### PR DESCRIPTION
Makes the Go-vs-TS rollout readable in Grafana while both daemons are live.

## What was missing

The three sandbox metrics Studio already exports —
`studio.sandbox.active`, `studio.sandbox.ensure.outcome`,
`studio.sandbox.proxy.duration_ms` — carried `org_id`, `user_id` and
`runner_kind`, but nothing identifying which daemon the pod ran. With both
impls live they summed into one series, so a Go regression would show up as a
fleet-wide regression at half amplitude and be unattributable.

`daemon_impl` is now a fourth attribute on all three. Cardinality is bounded at
3 (`go` | `ts` | `""`).

These reach Grafana through the existing path — `PrometheusExporter` on the API
pod's `:8080/metrics`, scraped by vmagent. No new pipeline, no infra change.

## Where the value comes from

Resolution had to survive the paths that have no `EnsureOptions`:

- **Provision** — `resolveClaimTemplate` is now called once in `provision()`
  and the result reused for the record, its persisted opts, and the claim. The
  metric attribute therefore cannot disagree with the pod that ran; previously
  the same pure call was made twice on the same inputs.
- **Rehydrate** — from the persisted `ensureOpts.daemonImpl` (the *resolved*
  impl, already persisted by #5486 for sticky recovery).
- **Adopt** — from the `studio.decocms.com/daemon-impl` claim label, the
  cluster-side source of truth. Without this, every adopted sandbox would drop
  out of the split during exactly the incident (studio restarted, state-store
  empty) you'd be reading the dashboard for.

Unknown reports `""`, never `ts`. A Go sandbox counted as TS is worse than one
counted as neither — it would move the TS baseline you're comparing against.

`readClaimDaemonImpl` rejects any label value that isn't `go`/`ts`: the label
is writable by anything with claim access, and an unbounded value would land
straight in a metric attribute as new cardinality.

## Not in this PR: daemon-internal OTel

The ask that prompted this was to instrument the Go daemon with
`opentelemetry-go` directly. **A sandbox pod cannot export OTLP**, so that
would compile, run, and silently drop every metric.

Verified from inside the live `studio-sandbox-stg-go` pod in stg:

```
collector 10.3.89.87:4318 -> 000     (blocked)
external  https://1.1.1.1  -> 301     (allowed)
```

That is `netinit` (`setup-netpol`) doing its job: it REJECTs RFC1918
destinations — which is every in-cluster service, including the collector — and
allows outbound TCP only on 53/443. The pod runs untrusted user code; that
boundary is the point, not an oversight.

For the record, the TS daemon is not a baseline here either: it imports
`@opentelemetry/api` but registers no MeterProvider or exporter anywhere in
`packages/sandbox`, so its `trace`/`meter` are no-op stubs that exist only to
satisfy the `HarnessContext` shape. Neither daemon emits a metric today.

Getting daemon-internal numbers out needs a transport decision, not a library —
see the PR discussion.

## Testing

`readClaimDaemonImpl` unit tests (recovery, absent label, unrecognized value)
alongside the existing `resolveClaimTemplate` ones. 58 pass in
`provider/agent-sandbox/`, 144 across `packages/sandbox/server`. `bun run check`,
`bun run lint` (no new warnings), `knip` clean.

Not yet observed end to end — the attribute appears on the next provision after
this deploys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `daemon_impl` attribute to sandbox metrics to split Go vs TS daemons so the rollout is readable in Grafana. Impl is resolved at provision and recovered on adopt to avoid mismatched or missing data.

- **New Features**
  - Added `daemon_impl` to `studio.sandbox.active`, `studio.sandbox.ensure.outcome`, and `studio.sandbox.proxy.duration_ms` (`go` | `ts` | `""`).
  - Resolve once during provision and persist on the record; metrics use it across the lifecycle.
  - Recover on adopt from the `studio.decocms.com/daemon-impl` claim label; reject unknown values to bound cardinality.
  - Unknown never defaults to `ts`, preventing TS baseline drift. No infra or pipeline changes.

<sup>Written for commit 5829af784b7c024279832b0148e000e18809531b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

