### PR TITLE
feat(sandbox-env): opt-in OTLP egress for daemon metrics

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -66,7 +66,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.9.62
+version: 0.9.63
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.32.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -240,6 +240,8 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `topologySpreadConstraints` | `[]` | spread sandbox pods across AZs; see `values.yaml` for the recommended config |
 | `readOnlyRootFilesystem` | `true` | RO rootfs + emptyDirs on /app, /tmp, /home |
 | `netinit.enabled` | `true` | installs the iptables egress policy before user code starts |
+| `telemetry.enabled` | `false` | let the daemon export OTLP metrics: opens ONE extra egress destination (the collector) and sets `OTEL_EXPORTER_OTLP_ENDPOINT` |
+| `telemetry.otlp.ip` / `telemetry.otlp.port` | `""` / `4318` | collector **ClusterIP** and port. Must be an IP — sandboxes use `dnsPolicy: None`, so in-cluster DNS names do not resolve. Goes stale if the Service is recreated |
 | `disableFsSidecar` | `false` | debug-only opt-out from the mandatory privileged org-fs sidecar |
 | `depsCache.enabled` / `depsCache.golden` | `false` / `false` | opt-in node-local dependency caches |
 | `depsCache.remote.enabled` / `depsCache.remote.pvcName` | `false` / `""` | opt-in L2 cross-node golden archive on an RWX PVC, mounted read-only |

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -118,6 +118,22 @@ the Gateway/HTTPRoute name so the cert ↔ listener pairing is obvious.
 {{- end }}
 
 {{/*
+OTLP endpoint handed to the daemon, built from the same ip/port the netinit
+ACCEPT rule is built from so the configured destination is by construction the
+reachable one. Fails at template time rather than shipping a sandbox that
+retries into a REJECT for its whole life.
+*/}}
+{{- define "sandbox-env.otlpEndpoint" -}}
+{{- if not .Values.telemetry.otlp.ip }}
+{{- fail "sandbox-env: telemetry.enabled requires telemetry.otlp.ip — the OTLP collector's ClusterIP. A DNS name will NOT work: sandboxes use dnsPolicy: None with public resolvers, so in-cluster names do not resolve. Get it with: kubectl -n opentelemetry-collector get svc gateway-otlp -o jsonpath='{.spec.clusterIP}'" -}}
+{{- end }}
+{{- if not (regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$" .Values.telemetry.otlp.ip) }}
+{{- fail (printf "sandbox-env: telemetry.otlp.ip must be a bare IPv4 address, got %q. It is interpolated into an iptables -d rule; a hostname there fails the init container and the pod never starts." .Values.telemetry.otlp.ip) -}}
+{{- end }}
+{{- printf "http://%s:%v" .Values.telemetry.otlp.ip .Values.telemetry.otlp.port -}}
+{{- end }}
+
+{{/*
 Selector labels for sandbox pods. The runner stamps the same name label
 onto every pod it creates via SandboxClaim.additionalPodMetadata, so the
 NetworkPolicy podSelector can target it. Per-env, so two envs' netpols

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -170,6 +170,16 @@ spec:
               iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT 2>/dev/null \
                 || iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT 2>/dev/null \
                 || { echo "ERROR: neither -m conntrack nor -m state available; cannot install ESTABLISHED,RELATED rule. Preview ingress would silently break. Failing the init container so the pod does not come up." >&2; exit 1; }
+              {{- if .Values.telemetry.enabled }}
+              # The ONE in-cluster destination a sandbox may reach: the OTLP
+              # collector. Must precede the blockCIDR REJECTs below — the
+              # collector's ClusterIP lives inside them (172.20.x is covered by
+              # 172.16.0.0/12), so a rule placed after would never be evaluated.
+              # Scoped to an exact /32 and a single port: this is a hole in the
+              # boundary that keeps user code away from in-cluster services, and
+              # it stays exactly one destination wide.
+              iptables -A OUTPUT -d {{ printf "%s/32" .Values.telemetry.otlp.ip | quote }} -p tcp --dport {{ .Values.telemetry.otlp.port }} -j ACCEPT
+              {{- end }}
               {{- range .Values.netinit.blockCIDRs }}
               iptables -A OUTPUT -d {{ . | quote }} -j REJECT
               {{- end }}
@@ -255,6 +265,19 @@ spec:
             - name: GOLDEN_CACHE_REMOTE
               value: {{ .Values.depsCache.remote.mountPath | quote }}
             {{- end }}
+            {{- end }}
+            {{- if .Values.telemetry.enabled }}
+            # OTLP metrics endpoint for the daemon. Standard OTel variable, so
+            # it reaches whichever daemon the image runs — a daemon with no
+            # exporter wired simply ignores it. Absent → the daemon must not
+            # start an exporter at all (no endpoint is the off switch).
+            #
+            # An IP, never a DNS name: sandboxes run `dnsPolicy: None` against
+            # public resolvers, so `gateway-otlp.opentelemetry-collector` is
+            # NXDOMAIN in here. Same value drives the netinit ACCEPT above, so
+            # the reachable destination and the configured one cannot drift.
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ include "sandbox-env.otlpEndpoint" . | quote }}
             {{- end }}
             - name: DAEMON_PORT
               value: "9000"

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -107,6 +107,35 @@ resources:
 # reclaim notice.
 terminationGracePeriodSeconds: 90
 
+# ── daemon telemetry (OTLP metrics) ───────────────────────────────────
+# Opens exactly ONE in-cluster destination in the sandbox egress boundary —
+# the OTel collector — and hands the daemon the matching
+# OTEL_EXPORTER_OTLP_ENDPOINT. Off by default: rendering costs nothing, and a
+# sandbox with no endpoint starts no exporter.
+#
+# `otlp.ip` MUST be the collector Service's ClusterIP, not a DNS name.
+# Sandboxes run `dnsPolicy: None` against public resolvers (see dnsConfig
+# below), so `gateway-otlp.opentelemetry-collector` is NXDOMAIN inside the pod.
+# Read it with:
+#   kubectl -n opentelemetry-collector get svc gateway-otlp -o jsonpath='{.spec.clusterIP}'
+#
+# KNOWN CEILING: a ClusterIP is stable for the life of a Service but not across
+# a delete/recreate. If the collector is recreated this value goes stale and
+# metrics stop — the daemon logs export failures and keeps serving, because
+# telemetry must never take a sandbox down. Re-read the IP and upgrade.
+#
+# Why a hole here is acceptable when the rest of the boundary is not: the
+# collector is a write-only ingest endpoint with no tenant data behind it. It
+# accepts unauthenticated OTLP, so there is no credential in the pod for user
+# code to steal. User code CAN write junk metrics to it — accepted knowingly;
+# turn `enabled` off to cut it. Do not widen this to a CIDR.
+telemetry:
+  enabled: false
+  otlp:
+    ip: ""
+    # 4318 = OTLP/HTTP. Use 4317 for gRPC (the collector serves both).
+    port: 4318
+
 # ── netinit / sandbox egress enforcement ──────────────────────────────
 # Sandbox pods run user code and must not reach in-cluster services.
 # Enforcement is via an iptables init container rather than a Kubernetes


### PR DESCRIPTION
Chart half of daemon-internal telemetry. Pairs with the Go daemon exporter (next PR); each is inert without the other, and both default off.

## The problem this solves

A sandbox pod's egress is locked to TCP 53/443 with every RFC1918 destination REJECTed — `netinit` exists because the pod runs untrusted user code and must not reach in-cluster services. Verified from a live `studio-sandbox-stg-go` pod:

```
collector 172.20.146.131:4318  ->  000    (blocked)
external  https://1.1.1.1      ->  301    (allowed)
```

So the daemon has no way to export metrics, and its existing stdout telemetry is sampled at **1%** by the log pipeline's `sampling.lua` (info-level, non-`sites-*`) — survivable at fleet volume, useless for a one-sandbox canary.

## What changes

`telemetry.enabled` adds two things and nothing else:

- An iptables `ACCEPT` for the collector, scoped to an exact `/32` and a single port. **It must precede the blockCIDR REJECTs** — the collector's ClusterIP is `172.20.x`, which sits inside `172.16.0.0/12`, so a rule appended after would never be evaluated. Verified in the rendered output (ACCEPT at line 300, first REJECT at 301).
- `OTEL_EXPORTER_OTLP_ENDPOINT` on the sandbox container. Standard variable, so it reaches whichever daemon the image runs; a daemon with no exporter ignores it.

Default render is byte-identical to before.

## Why an IP and not a DNS name

Sandboxes run `dnsPolicy: None` against public resolvers (`1.1.1.1`), so cluster names don't resolve. Confirmed in the same pod:

```
getent hosts gateway-otlp.opentelemetry-collector  ->  NXDOMAIN
```

`telemetry.otlp.ip` is therefore the collector's **ClusterIP**, and the same value builds both the firewall rule and the endpoint — they cannot disagree. Two template-time guards, because both failures are otherwise invisible until a pod is running:

- no `ip` → fails with the `kubectl` command to fetch it
- a hostname → fails pointing out it gets interpolated into `iptables -d`, where it would kill the init container and the pod never starts

## Known ceiling

A ClusterIP is stable for a Service's life but not across delete/recreate. If the collector is recreated this value goes stale and metrics stop. The daemon logs export failures and keeps serving — telemetry never takes a sandbox down. Re-read the IP and upgrade.

## On the security boundary

This is a hole in a boundary that exists for a reason, so its shape is deliberate: one destination, one port, no CIDR. The collector is a write-only ingest endpoint with no tenant data behind it and it accepts unauthenticated OTLP — so unlike a sidecar-plus-external-endpoint design, **there is no credential in the pod for user code to steal**. What user code *can* do is write junk metrics to it. That is a knowing trade (per @nicacio): flip `telemetry.enabled` off to cut it. Do not widen this to a CIDR.

## Testing

```
helm lint, default + telemetry.enabled                              ✓
helm template, default      → no OTEL env, no ACCEPT rule           ✓
helm template, enabled      → ACCEPT before the REJECTs; endpoint
                              http://<ip>:4318 on the container      ✓
helm template, enabled + no ip        → pointed template-time fail   ✓
helm template, enabled + hostname     → pointed template-time fail   ✓
```

Chart bumped to **0.9.63**. `sandbox-env` is pinned by `targetRevision` in `deco-apps-cd`, so this does not ship without that bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an opt-in path for the sandbox daemon to export OTLP metrics by opening a single egress to the collector and wiring `OTEL_EXPORTER_OTLP_ENDPOINT`. Default off; default templates render unchanged.

- **New Features**
  - `telemetry.enabled` (default `false`) adds a strict /32 ACCEPT rule for `telemetry.otlp.ip`:`telemetry.otlp.port` before the blockCIDR REJECTs, and sets `OTEL_EXPORTER_OTLP_ENDPOINT` from the same IP/port so config and reachability can’t drift.
  - Template-time guards require a bare IPv4; missing or DNS input fails with a clear error. Chart bumped to 0.9.63.

- **Migration**
  - To enable: set `telemetry.enabled: true`, set `telemetry.otlp.ip` to the collector ClusterIP (e.g., `kubectl -n opentelemetry-collector get svc gateway-otlp -o jsonpath='{.spec.clusterIP}'`), optionally set `telemetry.otlp.port` (defaults `4318`).
  - ClusterIP may change on Service recreate; update the value if metrics stop.

<sup>Written for commit d03cbc5d5b886fd5c408c6e18a29f3a1ef6dd423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

