### PR TITLE
fix(thread): reject a virtual_mcp_id belonging to another organization

### DIFF
--- a/apps/api/src/tools/thread/create.integration.test.ts
+++ b/apps/api/src/tools/thread/create.integration.test.ts
@@ -210,4 +210,19 @@ describe("COLLECTION_THREADS_CREATE", () => {
     expect(captureSpy).toHaveBeenCalledTimes(1);
     captureSpy.mockRestore();
   });
+
+  it("rejects a virtual_mcp_id belonging to a different organization", async () => {
+    const foreignVmcp = await env.ctx.storage.virtualMcps.create(
+      "org_1",
+      env.userId,
+      { title: "foreign", connections: [], status: "active", pinned: false },
+    );
+
+    await expect(
+      COLLECTION_THREADS_CREATE.handler(
+        { data: { virtual_mcp_id: foreignVmcp.id, title: "t" } },
+        env.ctx,
+      ),
+    ).rejects.toThrow(/Virtual MCP not found/i);
+  });
 });

--- a/apps/api/src/tools/thread/create.ts
+++ b/apps/api/src/tools/thread/create.ts
@@ -123,7 +123,11 @@ export const COLLECTION_THREADS_CREATE = defineTool({
       data.virtual_mcp_id,
       organization.id,
     );
-    if (!vmcp) {
+    // `findById`'s organizationId param only resolves well-known synthetic
+    // ids (decopilot, brand-context-setup) — for a normal row it does NOT
+    // filter by org, so existence alone doesn't prove the vMCP is ours. Must
+    // check explicitly, same as COLLECTION_VIRTUAL_MCP_UPDATE does.
+    if (!vmcp || vmcp.organization_id !== organization.id) {
       throw new Error(`Virtual MCP not found: ${data.virtual_mcp_id}`);
     }
 

--- a/apps/api/src/tools/thread/update.integration.test.ts
+++ b/apps/api/src/tools/thread/update.integration.test.ts
@@ -95,4 +95,32 @@ describe("COLLECTION_THREADS_UPDATE", () => {
     );
     expect(updated.item.branch).toBe("deco/manual-pick");
   });
+
+  it("rejects re-pointing a thread at a virtual_mcp_id from a different organization", async () => {
+    const vmcp = await env.ctx.storage.virtualMcps.create(
+      env.orgId,
+      env.userId,
+      { title: "own", connections: [], status: "active", pinned: false },
+    );
+    const created = await COLLECTION_THREADS_CREATE.handler(
+      { data: { virtual_mcp_id: vmcp.id, title: "t" } },
+      env.ctx,
+    );
+
+    const foreignVmcp = await env.ctx.storage.virtualMcps.create(
+      "org_1",
+      env.userId,
+      { title: "foreign", connections: [], status: "active", pinned: false },
+    );
+
+    await expect(
+      COLLECTION_THREADS_UPDATE.handler(
+        {
+          id: created.item.id,
+          data: { virtual_mcp_id: foreignVmcp.id },
+        },
+        env.ctx,
+      ),
+    ).rejects.toThrow(/Virtual MCP not found/i);
+  });
 });

--- a/apps/api/src/tools/thread/update.ts
+++ b/apps/api/src/tools/thread/update.ts
@@ -64,6 +64,20 @@ export const COLLECTION_THREADS_UPDATE = defineTool({
       throw new Error("Thread not found in organization");
     }
 
+    if (data.virtual_mcp_id !== undefined) {
+      const targetVmcp = await ctx.storage.virtualMcps.findById(
+        data.virtual_mcp_id,
+        organization.id,
+      );
+      // `findById`'s organizationId param only resolves well-known synthetic
+      // ids — for a normal row it does NOT filter by org, so existence alone
+      // doesn't prove the vMCP is ours. Without this, re-pointing a thread
+      // (data.virtual_mcp_id) could target another organization's agent.
+      if (!targetVmcp || targetVmcp.organization_id !== organization.id) {
+        throw new Error(`Virtual MCP not found: ${data.virtual_mcp_id}`);
+      }
+    }
+
     if (data.branch === null && existing.virtual_mcp_id) {
       const vmcp = await ctx.storage.virtualMcps.findById(
         existing.virtual_mcp_id,


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/tools/thread/` for missing validation.

**Why:** `VirtualMCPStorage.findById(id, organizationId)` only uses `organizationId` to resolve well-known synthetic ids (decopilot, brand-context-setup) — for a normal row it does NOT filter the DB query by org (unlike its sibling `connections.findById`, which does). `COLLECTION_THREADS_CREATE` and `COLLECTION_THREADS_UPDATE` treated a non-null `findById` result as proof the vMCP belongs to the caller's org, when it only proves the id exists *somewhere*. `COLLECTION_VIRTUAL_MCP_UPDATE` already guards against this exact gap with an explicit `existing.organization_id !== organization.id` check — the thread tools were missing the same guard.

**Failure scenario:** a user in org A who learns/guesses a virtual MCP id belonging to org B can call `COLLECTION_THREADS_CREATE` (or `COLLECTION_THREADS_UPDATE` with `data.virtual_mcp_id`) with that foreign id. The thread is created/re-pointed at org B's agent — including its `githubRepo`/connections metadata — while still being stored under org A, since only existence was checked, not ownership.

**Fix:** in both `create.ts` and `update.ts`, after `findById`, explicitly reject when `vmcp.organization_id !== organization.id`, mirroring the existing `virtual/update.ts` pattern. Added a regression test per tool (`create.integration.test.ts`, `update.integration.test.ts`) that creates a vMCP under a different seeded org (`org_1`) and asserts the cross-org id is rejected with "Virtual MCP not found".

**Reviewer check:** `bun test apps/api/src/tools/thread/create.integration.test.ts apps/api/src/tools/thread/update.integration.test.ts` (12 pass, including the 2 new cases).

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on the 4 changed files (0 warnings/errors), and the targeted integration test file above (real Postgres, not mocked — this repo bans DB mocks for storage-adjacent tests). Full CI validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects `virtual_mcp_id` from other organizations in thread create/update to enforce org scoping. This closes a security gap where a thread could be pointed at another org’s agent; now we verify ownership and return "Virtual MCP not found".

- **Bug Fixes**
  - In `create.ts` and `update.ts` (`COLLECTION_THREADS_CREATE`, `COLLECTION_THREADS_UPDATE`), check `vmcp.organization_id === organization.id` after `virtualMcps.findById`; otherwise throw.
  - Added integration tests to ensure cross-org IDs are rejected.

<sup>Written for commit 13ea0eb1660f89ea7adcaf5ea7d5470b73477fae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

