### PR TITLE
fix(sections-editor): translate hardcoded "Rule" label in multivariate field wrapper

### DIFF
--- a/apps/web/src/components/sections-editor/fields/multivariate-field-wrapper.tsx
+++ b/apps/web/src/components/sections-editor/fields/multivariate-field-wrapper.tsx
@@ -193,7 +193,9 @@ export function MultivariateFieldWrapper({
 
       <div className="space-y-4 px-2 pt-3">
         <div className="space-y-1.5">
-          <Label className="text-xs text-muted-foreground">Rule</Label>
+          <Label className="text-xs text-muted-foreground">
+            {t("sectionsEditor.multivariateFieldWrapper.ruleLabel")}
+          </Label>
           <MatcherPicker
             currentRt={currentRt}
             currentLabel={formatMatcher(currentRule)}

--- a/apps/web/src/i18n/en/sections-editor.ts
+++ b/apps/web/src/i18n/en/sections-editor.ts
@@ -109,6 +109,7 @@ export const sectionsEditor = {
   "sectionsEditor.mediaTransformControls.mutedLabel": "Muted",
   "sectionsEditor.mediaTransformControls.qualityLabel": "Quality",
   "sectionsEditor.multivariateFieldWrapper.addVariant": "Add variant",
+  "sectionsEditor.multivariateFieldWrapper.ruleLabel": "Rule",
   "sectionsEditor.multivariateFieldWrapper.variantN": "Variant {n}",
   "sectionsEditor.pageJsonDialog.copied": "Copied",
   "sectionsEditor.pageJsonDialog.copy": "Copy",

--- a/apps/web/src/i18n/pt-br/sections-editor.ts
+++ b/apps/web/src/i18n/pt-br/sections-editor.ts
@@ -113,6 +113,7 @@ export const sectionsEditor = {
   "sectionsEditor.mediaTransformControls.mutedLabel": "Mudo",
   "sectionsEditor.mediaTransformControls.qualityLabel": "Qualidade",
   "sectionsEditor.multivariateFieldWrapper.addVariant": "Adicionar variante",
+  "sectionsEditor.multivariateFieldWrapper.ruleLabel": "Regra",
   "sectionsEditor.multivariateFieldWrapper.variantN": "Variante {n}",
   "sectionsEditor.pageJsonDialog.copied": "Copiado",
   "sectionsEditor.pageJsonDialog.copy": "Copiar",


### PR DESCRIPTION
Bug found while auditing sections-editor i18n consistency (per keys/placeholders/pluralization already in sync between en and pt-br dictionaries — `sectionsEditor` in both locales has identical key sets and matching `{placeholder}` tokens, so no gap there).

`multivariate-field-wrapper.tsx` calls `useT()` and translates every other string in the file (`addVariant`, `variantN`, etc.), but the "Rule" label above the matcher picker was left as a raw JSX string, so pt-br users see English there while every sibling label is translated.

Failure scenario: a pt-br user opens a multivariate field's variant rule picker and sees the English word "Rule" instead of "Regra", inconsistent with the fully-translated surrounding UI.

Fix: added `sectionsEditor.multivariateFieldWrapper.ruleLabel` ("Rule" / "Regra") to both `apps/web/src/i18n/en/sections-editor.ts` and `apps/web/src/i18n/pt-br/sections-editor.ts`, and swapped the hardcoded string for `t(...)` in the component.

To verify: open a section field that supports variants (multivariate wrapper) in the sections editor with the app language set to Portuguese, and confirm the label above the rule picker now reads "Regra".

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean — pt-br dict still satisfies `Record<keyof typeof sectionsEditorEn, string>`), and `bunx oxlint` on the three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translated the hardcoded "Rule" label in the multivariate field wrapper to use i18n, so Portuguese users see "Regra" consistently. Added `sectionsEditor.multivariateFieldWrapper.ruleLabel` to `apps/web/src/i18n/en/sections-editor.ts` and `apps/web/src/i18n/pt-br/sections-editor.ts`, and replaced the raw string with `t(...)` in `apps/web/src/components/sections-editor/fields/multivariate-field-wrapper.tsx`.

<sup>Written for commit 56fa44f2be6be170a772bd14201c81d551530e57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

