### PR TITLE
fix(mcp-clients): bound AuthTransport's internal tools/list probe with a timeout

### DIFF
--- a/apps/api/src/mcp-clients/outbound/transports/auth.test.ts
+++ b/apps/api/src/mcp-clients/outbound/transports/auth.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { MCP_LIST_TOOLS_TIMEOUT_MS } from "@/core/constants";
+import { AuthTransport } from "./auth";
+
+describe("AuthTransport", () => {
+  test(
+    "bounds the internal tools/list probe instead of hanging forever when the downstream server never replies",
+    async () => {
+      // Simulates a downstream MCP server that accepts the request but never
+      // sends a response — no onmessage callback is ever invoked.
+      const hangingInner = {
+        send: async () => {},
+        close: async () => {},
+      } as any;
+
+      const ctx = { pendingRevalidations: [], auth: {} } as any;
+      const connection = { id: "conn_test" } as any;
+
+      const transport = new AuthTransport(hangingInner, { ctx, connection });
+
+      const outcome = await Promise.race([
+        transport
+          .send({
+            jsonrpc: "2.0",
+            id: "1",
+            method: "tools/call",
+            params: { name: "SOME_TOOL", arguments: {} },
+          } as any)
+          .then(() => "resolved")
+          .catch(() => "rejected"),
+        new Promise((resolve) =>
+          setTimeout(
+            () => resolve("still-hanging"),
+            MCP_LIST_TOOLS_TIMEOUT_MS + 3000,
+          ),
+        ),
+      ]);
+
+      expect(outcome).not.toBe("still-hanging");
+    },
+    MCP_LIST_TOOLS_TIMEOUT_MS + 5000,
+  );
+});

--- a/apps/api/src/mcp-clients/outbound/transports/auth.ts
+++ b/apps/api/src/mcp-clients/outbound/transports/auth.ts
@@ -7,6 +7,7 @@
  */
 
 import type { StudioContext } from "@/core/studio-context";
+import { MCP_LIST_TOOLS_TIMEOUT_MS } from "@/core/constants";
 import {
   type McpListCache,
   getMcpListCache,
@@ -44,6 +45,9 @@ export class AuthTransport extends WrapperTransport {
   /**
    * Fetch tools by sending a tools/list JSON-RPC request through the inner transport.
    * Single-flighted: concurrent callers share the same in-flight request.
+   * Bounded by MCP_LIST_TOOLS_TIMEOUT_MS — without it, a downstream server that
+   * never replies would leave every subsequent authorized tool call on this
+   * connection hanging forever (the single-flighted promise never resets).
    */
   private fetchToolsFromServer(): Promise<unknown[] | null> {
     if (!this.toolsListPromise) {
@@ -51,17 +55,24 @@ export class AuthTransport extends WrapperTransport {
         const requestId = `auth-tools-${Date.now()}`;
         const prev = this.innerTransport.onmessage;
 
+        const finish = (tools: unknown[] | null) => {
+          clearTimeout(timer);
+          this.innerTransport.onmessage = prev;
+          this.toolsListPromise = null;
+          resolve(tools);
+        };
+
+        const timer = setTimeout(() => finish(null), MCP_LIST_TOOLS_TIMEOUT_MS);
+
         this.innerTransport.onmessage = (message: JSONRPCMessage) => {
           if ("id" in message && message.id === requestId) {
-            this.innerTransport.onmessage = prev;
-            this.toolsListPromise = null;
             if ("result" in message) {
               const tools =
                 (message.result as { tools?: unknown[] })?.tools ?? null;
-              resolve(tools);
+              finish(tools);
             } else {
               // JSON-RPC error response — resolve null so callers degrade gracefully
-              resolve(null);
+              finish(null);
             }
           } else {
             prev?.(message);
@@ -75,11 +86,7 @@ export class AuthTransport extends WrapperTransport {
             method: "tools/list",
             params: {},
           } as JSONRPCMessage)
-          .catch(() => {
-            this.innerTransport.onmessage = prev;
-            this.toolsListPromise = null;
-            resolve(null);
-          });
+          .catch(() => finish(null));
       });
     }
     return this.toolsListPromise;


### PR DESCRIPTION
**Source**: bug found while auditing `apps/api/src/mcp-clients/outbound/transports/auth.ts` (MCP auth-transport hardening focus area).

**Why a maintainer wants this**: every authorized `tools/call` first fetches the connection's tool list (to resolve the public-tool metadata) through `fetchToolsFromServer()`, a single-flighted promise that only resolves when the downstream server replies. A downstream MCP server that accepts the request but never sends a response (hang, dropped connection, etc.) leaves that promise pending forever — and because it's shared (`this.toolsListPromise` is only cleared inside the resolution callback), every *subsequent* authorized tool call on that connection hangs too, until process restart. This is exactly the class of bug the sibling `listToolsWithTimeout` probe (`apps/api/src/mcp-clients/list-tools-with-timeout.ts`, used by the connection-list binding filter) was written to prevent — this internal probe was just missed.

**Fix**: bound the probe with the existing `MCP_LIST_TOOLS_TIMEOUT_MS` constant (already defined in `core/constants.ts` and used by the connection-list tools/list probe). On timeout it resolves `null` and resets the in-flight promise, exactly like the existing JSON-RPC-error and failed-`send()` paths already do — so callers keep degrading gracefully instead of hanging.

**Regression test**: `apps/api/src/mcp-clients/outbound/transports/auth.test.ts` — constructs an `AuthTransport` over a fake inner transport whose `send()` resolves but never invokes `onmessage` (simulating a downstream server that never replies), then asserts the outer `send()` call still settles (resolve or reject) well within `MCP_LIST_TOOLS_TIMEOUT_MS`, rather than hanging indefinitely as it did before this fix.

**To verify**: `cd apps/api && bunx tsc --noEmit` (clean) and `bun test apps/api/src/mcp-clients/outbound/transports/auth.test.ts` (passes in ~5s, bounded by the new timeout).

**Checks run locally**: `bun run fmt`, targeted `tsc --noEmit` in `apps/api`, the one targeted test file above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound `AuthTransport`’s internal tools/list probe with a timeout so a non-responsive MCP server can’t hang authorized `tools/call` requests. If the probe times out, it now resolves to null and resets the in-flight promise.

- **Bug Fixes**
  - Added `MCP_LIST_TOOLS_TIMEOUT_MS` bound to `fetchToolsFromServer()`; on timeout, resolve null and clear the single-flighted promise.
  - Matches existing behavior for JSON-RPC errors and failed `send()`.
  - Added a regression test that simulates a server that never replies and verifies the call settles within the timeout.

<sup>Written for commit cae37ea5ba3cc59bff6643de102cb4281137f1c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

