### PR TITLE
fix(task-board): enforce the review gate server-side in promote-to-production

### DIFF
--- a/apps/api/src/tools/task-board/promote-to-production.test.ts
+++ b/apps/api/src/tools/task-board/promote-to-production.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression coverage for `isReadyToShip`: the server-side gate that
+ * `TASK_BOARD_PROMOTE_TO_PRODUCTION` must enforce so a caller can't merge a
+ * task's PR before it's actually In Review with every enabled reviewer
+ * approved — the board's "Ship to production" button only shows in that
+ * state, but the tool itself used to trust the caller, not the task's status.
+ */
+import { describe, expect, it } from "bun:test";
+import type { ReviewCycleActivity } from "@decocms/shared/task-board";
+import { isReadyToShip } from "./promote-to-production";
+
+function approved(reviewer: "qa" | "code_review"): ReviewCycleActivity {
+  return {
+    action: "review_approved",
+    data: { reviewer },
+    occurredAt: "2026-01-01T00:01:00.000Z",
+  };
+}
+
+describe("isReadyToShip", () => {
+  it("rejects a task that never entered review, even with no reviewers enabled", () => {
+    expect(isReadyToShip("todo", [], [])).toBe(false);
+    expect(isReadyToShip("in_progress", [], [])).toBe(false);
+  });
+
+  it("allows an in_review task straight through when no reviewers are enabled", () => {
+    expect(isReadyToShip("in_review", [], [])).toBe(true);
+  });
+
+  it("rejects an in_review task while a required reviewer hasn't approved", () => {
+    expect(
+      isReadyToShip("in_review", [approved("qa")], ["qa", "code_review"]),
+    ).toBe(false);
+  });
+
+  it("allows an in_review task once every enabled reviewer approved", () => {
+    expect(
+      isReadyToShip(
+        "in_review",
+        [approved("qa"), approved("code_review")],
+        ["qa", "code_review"],
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/tools/task-board/promote-to-production.ts
+++ b/apps/api/src/tools/task-board/promote-to-production.ts
@@ -1,10 +1,35 @@
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { requireAuth } from "@/core/studio-context";
+import type { TaskBoardItem } from "@/storage/types";
+import {
+  allReviewersApproved,
+  REVIEWER_FLAG,
+  REVIEWER_KINDS,
+  type ReviewCycleActivity,
+  type ReviewerKind,
+} from "@decocms/shared/task-board";
 import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { mergeLinkedPr } from "./merge-pr";
+
+/**
+ * The board only shows "Ship to production" once the task is In Review and
+ * every enabled reviewer approved (`reviewsSatisfiedForPromotion` on the web
+ * side) — but that's client-side gating only. Without this check here, any
+ * caller of this tool (a decopilot agent, a stale client, a direct MCP call)
+ * could merge ANY task's linked PR — todo, in_progress, unreviewed — bypassing
+ * the QA Agent / Code Reviewer gate entirely.
+ */
+export function isReadyToShip(
+  status: TaskBoardItem["status"],
+  activity: ReviewCycleActivity[],
+  enabled: ReviewerKind[],
+): boolean {
+  if (status !== "in_review") return false;
+  return enabled.length === 0 || allReviewersApproved(activity, enabled);
+}
 
 export const TASK_BOARD_PROMOTE_TO_PRODUCTION = defineTool({
   name: "TASK_BOARD_PROMOTE_TO_PRODUCTION",
@@ -42,6 +67,21 @@ export const TASK_BOARD_PROMOTE_TO_PRODUCTION = defineTool({
     );
     if (!item) {
       throw new Error(`Task board item not found: ${taskBoardItemId}`);
+    }
+
+    const settings = await ctx.storage.organizationSettings.get(organizationId);
+    const flags = settings?.flags ?? {};
+    const enabled = REVIEWER_KINDS.filter(
+      (k) => flags[REVIEWER_FLAG[k]] === true,
+    );
+    const activity = await ctx.storage.taskBoard.listActivity(
+      taskBoardItemId,
+      organizationId,
+    );
+    if (!isReadyToShip(item.status, activity, enabled)) {
+      throw new Error(
+        "Task is not ready to ship: it must be In Review with every enabled reviewer approved",
+      );
     }
 
     const merged = await mergeLinkedPr(ctx, organizationId, taskBoardItemId);


### PR DESCRIPTION
Regression audit of the just-merged QA Agent + Code Reviewer review flow (#5520).

`TASK_BOARD_PROMOTE_TO_PRODUCTION` (the "Ship to production" action) merged the task's linked PR and moved it to Done for **any** task with a linked PR — regardless of its status or whether the enabled reviewers had approved. The board only shows the "Ship to production" button once the task is In Review and every enabled reviewer approved (`reviewsSatisfiedForPromotion` in `apps/web/src/layouts/task-board/review-status.ts`), but that gating lives entirely in the web client. The MCP tool itself — callable directly by a decopilot agent or any other MCP caller with task-board access, not just the button — never checked task status or reviewer approvals before merging, so it could ship an unreviewed (even `todo`/`in_progress`) task's PR straight to production, completely bypassing the QA Agent / Code Reviewer gate that #5520 introduced.

**Failure scenario:** an org enables both reviewers and auto-merge is off. A task is still `in_progress` with an open draft-ish PR linked. Any caller (an agent given the tool, or a stale/malicious client) invokes `TASK_BOARD_PROMOTE_TO_PRODUCTION` directly — the PR merges and the task flips to Done, with zero reviewer sign-off, silently defeating the whole review feature.

**Fix:** the handler now fetches the org's enabled reviewers and the task's activity log and requires `item.status === "in_review"` plus every enabled reviewer's latest cycle verdict being an approval (reusing the same shared `allReviewersApproved` reducer the auto-merge gate in `review-decision.ts` already uses) before calling `mergeLinkedPr`. Added `promote-to-production.test.ts` covering: rejects non-in_review status, allows when no reviewers are enabled, rejects when a required reviewer hasn't approved, allows once all have.

**To verify:** `bun test apps/api/src/tools/task-board/promote-to-production.test.ts`

**Locally ran:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (4 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the review gate server-side in `TASK_BOARD_PROMOTE_TO_PRODUCTION` to prevent merging unreviewed tasks. Stops direct MCP calls from bypassing QA/Code Review approvals.

- **Bug Fixes**
  - Add `isReadyToShip`: require `status === "in_review"` and approvals from all enabled reviewers (via `allReviewersApproved` from `@decocms/shared/task-board`); allow when no reviewers are enabled.
  - Read org reviewer flags and task activity; reject with a clear error if the gate isn’t satisfied.
  - Add `promote-to-production.test.ts` covering reject/allow scenarios.

<sup>Written for commit c22ce286764774cf59ef995ecfa905cd32316ebd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

