### PR TITLE
fix(web): translate QaAgentIcon alt text instead of hardcoding it

### DIFF
--- a/apps/web/src/components/qa-agent-icon.tsx
+++ b/apps/web/src/components/qa-agent-icon.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@deco/ui/lib/utils.ts";
 import { QA_AGENT_ICON_URL } from "@/sdk";
+import { useT } from "@/i18n/use-t.ts";
 
 /** The QA Agent shield-check glyph, rendered as a round avatar so it sits
  *  alongside the Super Agent and member avatars in the assignee picker. */
@@ -10,10 +11,11 @@ export function QaAgentIcon({
   size?: number;
   className?: string;
 }) {
+  const t = useT();
   return (
     <img
       src={QA_AGENT_ICON_URL}
-      alt="QA Agent"
+      alt={t("taskBoard.taskDialog.qaAgentLabel")}
       width={size}
       height={size}
       style={{ width: size, height: size }}


### PR DESCRIPTION
Follows the repo's i18n rule that every user-facing string in `apps/web/src` (including `alt`/`aria-label` text) must go through `t()` — `QaAgentIcon`'s `alt="QA Agent"` was the one hardcoded string left in this brand-new component from #5520.

Why a maintainer wants it: it's the last hardcoded string in a component two other workers already flagged this convention for elsewhere in the codebase; leaving it means a future locale swap silently misses this screen-reader string.

No new translation content needed — `taskBoard.taskDialog.qaAgentLabel` already exists in both `en` and `pt-br` dictionaries with the exact text "QA Agent" (it's a proper noun, so both locales already agree). The component now reads that key instead of a literal.

How to confirm: render `QaAgentIcon` (used in `task-dialog.tsx`'s review-thread card and reviewer chip) and check the rendered `alt` attribute matches `t("taskBoard.taskDialog.qaAgentLabel")` in both locales.

Locally ran: `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/web` (clean), `bunx oxlint apps/web/src/components/qa-agent-icon.tsx` (0 warnings/errors). No test added — this is a one-line literal-to-lookup swap with no new branch/logic, so no new behavior to pin down. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internationalized the QaAgentIcon alt text by replacing the hardcoded "QA Agent" with t("taskBoard.taskDialog.qaAgentLabel"). Ensures screen reader text is localized and follows the apps/web i18n rule.

<sup>Written for commit ed19e8b7323f296877d64792866c78b25944dbaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

