### PR TITLE
fix(sandbox): re-relay org-fs mount config on recovery paths

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/runner.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import type { EnsureOptions } from "../types";
+import { stripEnsureOpts } from "./runner";
+
+describe("stripEnsureOpts", () => {
+  it("retains orgFsConfigJson so resurrection replays org-fs mounts", () => {
+    const opts: EnsureOptions = { orgFsConfigJson: '{"mounts":[]}' };
+    expect(stripEnsureOpts(opts)).toEqual({ orgFsConfigJson: '{"mounts":[]}' });
+  });
+
+  it("drops orgFsConfigJson along with everything else when unset", () => {
+    expect(stripEnsureOpts({})).toBeNull();
+  });
+});

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1378,11 +1378,7 @@ export class AgentSandboxProvider implements SandboxProvider {
       // (separate endpoint — see postOrgFsConfig). Post-bind on purpose:
       // warm-pool claims reject spec.env. Best-effort: mounts are additive,
       // a relay failure must not fail provisioning.
-      if (opts.orgFsConfigJson) {
-        await postOrgFsConfig(daemonUrl, token, opts.orgFsConfigJson).catch(
-          (err) => console.warn("[org-fs] sidecar config relay failed", err),
-        );
-      }
+      await this.relayOrgFsConfig(daemonUrl, token, opts.orgFsConfigJson);
     } catch (err) {
       this.closeForwarder(daemonForward);
       await this.deleteHttpRouteIfManaged(handle).catch(() => {});
@@ -1430,6 +1426,24 @@ export class AgentSandboxProvider implements SandboxProvider {
       port: opts?.workload?.devPort ?? DEFAULT_DEV_PORT,
       tenant: opts?.tenant ?? undefined,
     });
+  }
+
+  /**
+   * Relay org-fs mount config to the pod's privileged sidecar (separate
+   * endpoint — see `postOrgFsConfig`). Shared by fresh provision and
+   * warm-pool re-bootstrap; a recreated pool pod's sidecar starts unmounted
+   * and must be re-configured the same way a fresh one is. Best-effort:
+   * mounts are additive, a relay failure must not fail provisioning/recovery.
+   */
+  private async relayOrgFsConfig(
+    daemonUrl: string,
+    token: string,
+    orgFsConfigJson: string | undefined,
+  ): Promise<void> {
+    if (!orgFsConfigJson) return;
+    await postOrgFsConfig(daemonUrl, token, orgFsConfigJson).catch((err) =>
+      console.warn("[org-fs] sidecar config relay failed", err),
+    );
   }
 
   /**
@@ -1576,6 +1590,14 @@ export class AgentSandboxProvider implements SandboxProvider {
       await postConfig(daemonUrl, this.sentinelToken, payload, {
         rotateToken: token,
       });
+      // A recreated pool pod boots with an empty sidecar — the org-fs mounts
+      // from the original provision must be re-relayed here too, or a pod
+      // recreated under a live claim silently loses them.
+      await this.relayOrgFsConfig(
+        daemonUrl,
+        token,
+        ensureOpts?.orgFsConfigJson,
+      );
       return true;
     } catch (err) {
       // A 401 means the daemon no longer accepts the sentinel: it was already
@@ -1588,6 +1610,11 @@ export class AgentSandboxProvider implements SandboxProvider {
       if (err instanceof ConfigRequestError && err.status === 401) {
         try {
           await postConfig(daemonUrl, token, payload, { rotateToken: token });
+          await this.relayOrgFsConfig(
+            daemonUrl,
+            token,
+            ensureOpts?.orgFsConfigJson,
+          );
           return true;
         } catch (retryErr) {
           console.warn(
@@ -2516,12 +2543,17 @@ function tenantAttrs(
  * (k8s ignores it — template pins the image) and any nullish entries so the
  * persisted blob stays small.
  */
-function stripEnsureOpts(opts: EnsureOptions): EnsureOptions | null {
+export function stripEnsureOpts(opts: EnsureOptions): EnsureOptions | null {
   const out: EnsureOptions = {};
   if (opts.repo) out.repo = opts.repo;
   if (opts.workload) out.workload = opts.workload;
   if (opts.env && Object.keys(opts.env).length > 0) out.env = opts.env;
   if (opts.tenant) out.tenant = opts.tenant;
+  // Without this, `resurrectByHandle` re-provisioning from these persisted
+  // opts (no SANDBOX_START in that loop) would silently drop the org-fs
+  // mounts a live sandbox had — same class of bug as the daemonImpl
+  // stickiness below, just for mounts instead of the binary.
+  if (opts.orgFsConfigJson) out.orgFsConfigJson = opts.orgFsConfigJson;
   // Stickiness: `resurrectByHandle` re-provisions from these opts with no
   // SANDBOX_START in the loop, so without this an autonomously recovered
   // sandbox would silently come back on the other binary — which makes any


### PR DESCRIPTION
A bug found while auditing `packages/sandbox/server/provider/agent-sandbox/runner.ts` (this area's focus this tick).

**The bug:** `orgFsConfigJson` (the org filesystem mount config relayed to the pod's privileged sidecar via `postOrgFsConfig`, see `EnsureOptions.orgFsConfigJson`) is only ever sent on the fresh-provision path. It never survives a round-trip through the persisted state:

1. `stripEnsureOpts` — the function that decides which `EnsureOptions` fields get persisted for later recovery — silently dropped `orgFsConfigJson`. So `resurrectByHandle` (autonomous recovery after the operator's idle-TTL evicts a claim+pod) re-provisions with everything *except* the org-fs mounts, even though repo/workload/tenant/daemonImpl all correctly survive.
2. `rebootstrapDaemon` — the warm-pool re-bootstrap that runs when a pool pod is recreated under a still-live claim (node churn, idle reap) — re-posts the `/config` workload handshake against the freshly-booted (unmounted) sidecar, but never re-relayed org-fs config either.

**Why a maintainer wants this:** a user's org filesystem silently stops being mounted after any sandbox recovery event, with no error surfaced anywhere — it just quietly disappears from a recreated/resurrected pod.

**Fix:** extracted the existing relay call into a small `relayOrgFsConfig` helper (same best-effort semantics as before — a relay failure never fails provisioning/recovery) and call it from both `provision()` and `rebootstrapDaemon()`'s two success paths; and added `orgFsConfigJson` to the fields `stripEnsureOpts` persists, mirroring the existing `daemonImpl` stickiness comment right below it (same failure class, different field).

**Regression test:** `runner.test.ts` (new file) asserts `stripEnsureOpts` now retains `orgFsConfigJson` — exported it for this purpose, same pattern as `resolveClaimTemplate`/`readClaimDaemonImpl` in `claim-template.test.ts`.

**To confirm:** `cd packages/sandbox && bunx tsc --noEmit`, then `bun test packages/sandbox/server/provider/agent-sandbox/runner.test.ts` and `bun test packages/sandbox/server/provider/agent-sandbox/claim-template.test.ts` (unaffected, still green).

**Locally ran:** `bun run fmt`, targeted `tsc --noEmit` on the `@decocms/sandbox` workspace, the two test files above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure org-fs mounts survive sandbox recovery by persisting `orgFsConfigJson` and re-relaying it during provisioning and warm-pool reboots. This prevents mounts from disappearing after pod resurrection or recreation.

- **Bug Fixes**
  - Persist `orgFsConfigJson` in `stripEnsureOpts` (exported for tests) so `resurrectByHandle` replays mounts.
  - Add `relayOrgFsConfig()` and call it from `provision()` and both success paths in `rebootstrapDaemon()`; best-effort semantics preserved.
  - Add `runner.test.ts` to verify persistence of `orgFsConfigJson`.

<sup>Written for commit a201ec07de9cdca234b68df3fa78b1e59b8b5dba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

