### PR TITLE
fix(auth): fail closed on-behalf-of forwarding when the token has no org scope

### DIFF
--- a/apps/api/src/core/context-factory.on-behalf-of.test.ts
+++ b/apps/api/src/core/context-factory.on-behalf-of.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Unit test for the on-behalf-of cross-org guard used by `resolveOnBehalfOfUser`.
+ * A self/loopback call authenticates with an org-scoped API key but forwards the
+ * real acting user via an `x-studio-token` JWT; this guard decides whether that
+ * forwarded identity is trusted for the org the API key is scoped to.
+ */
+import { describe, expect, it } from "bun:test";
+import { isOnBehalfOfTokenOrgAllowed } from "./context-factory";
+
+describe("isOnBehalfOfTokenOrgAllowed", () => {
+  it("allows a token scoped to the same org as the API key", () => {
+    expect(isOnBehalfOfTokenOrgAllowed("org_1", "org_1")).toBe(true);
+  });
+
+  it("denies a token scoped to a different org (the cross-org leak this blocks)", () => {
+    expect(isOnBehalfOfTokenOrgAllowed("org_1", "org_2")).toBe(false);
+  });
+
+  it("denies a token with no org scope when the API key is org-scoped", () => {
+    expect(isOnBehalfOfTokenOrgAllowed("org_1", undefined)).toBe(false);
+  });
+
+  it("allows any token when the API key itself is not org-scoped", () => {
+    expect(isOnBehalfOfTokenOrgAllowed(undefined, "org_2")).toBe(true);
+    expect(isOnBehalfOfTokenOrgAllowed(undefined, undefined)).toBe(true);
+  });
+});

--- a/apps/api/src/core/context-factory.ts
+++ b/apps/api/src/core/context-factory.ts
@@ -597,6 +597,22 @@ async function resolveAndCacheRole(
 }
 
 /**
+ * Does a forwarded on-behalf-of token's org scope match the API key's org?
+ *
+ * Exported for unit testing — the intent is "a cross-org token is never
+ * honored", so a token minted with no org scope at all must NOT be treated as
+ * a match against an org-scoped API key (an absent `tokenOrgId` is not "any
+ * org"; it fails closed like a genuine mismatch would).
+ */
+export function isOnBehalfOfTokenOrgAllowed(
+  apiKeyOrgId: string | undefined,
+  tokenOrgId: string | undefined,
+): boolean {
+  if (!apiKeyOrgId) return true;
+  return tokenOrgId === apiKeyOrgId;
+}
+
+/**
  * Resolve the on-behalf-of user for a self/loopback call.
  *
  * When studio calls its own management server (the `<org>_self` connection — e.g.
@@ -628,9 +644,11 @@ async function resolveOnBehalfOfUser(
   if (!payload?.sub) return undefined;
 
   // Defensive: only honor a forwarded user scoped to the SAME org the API key
-  // authorizes. A cross-org token (never expected for self calls) is ignored.
+  // authorizes. A cross-org token (never expected for self calls) is ignored —
+  // including one minted with no org scope at all, which is just as untrusted
+  // as a mismatched one here.
   const tokenOrgId = payload.metadata?.organizationId;
-  if (apiKeyOrgId && tokenOrgId && tokenOrgId !== apiKeyOrgId) {
+  if (!isOnBehalfOfTokenOrgAllowed(apiKeyOrgId, tokenOrgId)) {
     return undefined;
   }
 


### PR DESCRIPTION
A bug found while auditing apps/api/src/auth and its context-factory helper.

`resolveOnBehalfOfUser` (apps/api/src/core/context-factory.ts) forwards the real acting user's identity from an `x-studio-token` JWT for self/loopback calls that authenticate with an org-scoped API key (e.g. a Studio Pack agent invoking a tool through the org's `_self` connection). Its own doc comment states the invariant: "a cross-org token (never expected for self calls) is ignored" — but the guard was `apiKeyOrgId && tokenOrgId && tokenOrgId !== apiKeyOrgId`, which only compares orgs when the forwarded token actually carries one. A studio JWT minted with no org scope at all (`metadata.organizationId` unset — possible since `ctx.organization` is optional at mint time in `buildRequestHeaders`) skipped the comparison entirely and had its identity honored for attribution under an unrelated org-scoped API key, contradicting the stated invariant.

**Failure scenario**: a studio JWT is issued without an org scope (e.g. minted during a call not scoped to any org), then presented as `x-studio-token` alongside a different org's API key. Under the old guard, `resolveOnBehalfOfUser` returns the JWT's user as the on-behalf-of actor for that org's request, so any resulting write is attributed (`created_by`/`updated_by`) to a user's identity that was never actually validated against that org.

**Fix**: extracted the check into an exported pure helper `isOnBehalfOfTokenOrgAllowed(apiKeyOrgId, tokenOrgId)` and tightened it so an org-scoped API key requires the forwarded token to carry the *same* org — a missing `tokenOrgId` now fails closed instead of silently passing. Authorization itself is unaffected (it was already decided solely by the API key's stored permissions, not this identity) — this only closes an identity/attribution leak.

**Regression test**: `apps/api/src/core/context-factory.on-behalf-of.test.ts` — covers same-org allow, cross-org deny, missing-token-org deny (the bug), and the unscoped-API-key passthrough case.

**To verify**: `bun test apps/api/src/core/context-factory.on-behalf-of.test.ts`

**Locally ran**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed when forwarding on-behalf-of identity for self calls: org-scoped API keys now only honor `x-studio-token` JWTs scoped to the same org. Tokens with no org scope are rejected to prevent cross-org attribution.

- **Bug Fixes**
  - Tightened guard via `isOnBehalfOfTokenOrgAllowed(apiKeyOrgId, tokenOrgId)` and used it in `resolveOnBehalfOfUser`.
  - No change to authorization; this only fixes identity/attribution.
  - Added unit tests for same-org allow, cross-org deny, missing-token-org deny, and unscoped API key allow.

<sup>Written for commit f55a5dc380203f47ae55c10f12011be2eef7ae9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

