### PR TITLE
fix(task-board): refresh a task's activity feed on live item updates

### DIFF
--- a/apps/web/src/hooks/use-task-board-items.ts
+++ b/apps/web/src/hooks/use-task-board-items.ts
@@ -34,6 +34,12 @@ export function useTaskBoardItems() {
           ? next.map((t) => (t.id === patched.id ? patched : t))
           : [patched, ...next];
       });
+      // Every pushed item change also appends to its timeline — refetch the
+      // activity feed so a task dialog left open during a live transition
+      // (e.g. a Super Agent status/assignee change) doesn't show a stale one.
+      queryClient.invalidateQueries({
+        queryKey: KEYS.taskBoardActivity(locator, item.id),
+      });
     },
     // Live deletes: drop the removed card so it clears on every open board.
     onDelete: (id) => {


### PR DESCRIPTION
Bug found while auditing the task-board activity feed for state-sync issues after the recent activity-feed feature.

A task dialog's Activity feed is driven by a separate itemId-scoped query (`useTaskBoardActivity`), while the item itself (status, assignee, priority, etc.) is kept live via `useTaskBoardEvents`' SSE push in `useTaskBoardItems`, which patches the item straight into the `taskBoardItems` cache. That SSE handler never invalidated the matching `taskBoardActivity` query, so a task dialog left open during a live transition (e.g. a Super Agent status/assignee change pushed over SSE) showed the new status/assignee on the card immediately, but the timeline underneath — which is supposed to log that exact change — stayed stale until the dialog was closed and reopened (or a window refocus happened to trigger a refetch).

Fix: invalidate `KEYS.taskBoardActivity(locator, item.id)` alongside the existing cache patch in the SSE `onUpdate` handler, mirroring the same pairing `TASK_BOARD_ITEM_UPDATE`'s own mutation already does in its `onSettled`.

Failure scenario: open a task dialog, have an agent flip its status/assignee via the Super Agent flow (pushed over SSE) while the dialog stays open — the status pill updates but the activity timeline below it doesn't show the new entry until you close and reopen the dialog.

To confirm: open a task's dialog, trigger a live status/assignee change on it (e.g. via the Super Agent flow) while the dialog stays open, and check the Activity section picks up the new timeline entry without closing the dialog.

Locally verified: `bun run fmt` (no changes needed), `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/hooks/use-task-board-items.ts` (0 warnings/errors). No existing unit test covers this SSE-driven cache-invalidation path (it composes react-query + a mocked SSE subscription, which the repo's testing tiers push toward e2e rather than a unit test) — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stale Activity feed in the task dialog by invalidating the activity query on live item updates. On SSE updates, we now call `queryClient.invalidateQueries({ queryKey: KEYS.taskBoardActivity(locator, item.id) })` so status/assignee changes refresh the timeline without closing the dialog.

<sup>Written for commit a7c4765783b96622b53c14cf6d58b9271309a8d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

