### PR TITLE
fix(runtime): dedupe concurrent TriggerStateManager storage reads

### DIFF
--- a/packages/runtime/src/triggers.test.ts
+++ b/packages/runtime/src/triggers.test.ts
@@ -413,6 +413,78 @@ describe("createTriggers with storage", () => {
     ]);
   });
 
+  it("concurrent enable() calls on an uncached connection don't drop each other's trigger type", async () => {
+    const data = new Map<string, unknown>();
+    data.set("conn-race", {
+      credentials: {
+        callbackUrl: "https://studio.example.com/api/trigger-callback",
+        callbackToken: "prior-token",
+      },
+      activeTriggerTypes: ["existing.type"],
+    });
+
+    // get() resolves only when explicitly triggered, so the test can control
+    // exactly when the (shared) in-flight read completes.
+    const getResolvers: Array<() => void> = [];
+    let getCalls = 0;
+    const storage: TriggerStorage = {
+      get: (id) => {
+        getCalls++;
+        const snapshot = (data.get(id) as any) ?? null;
+        return new Promise((resolve) => {
+          getResolvers.push(() => resolve(snapshot));
+        });
+      },
+      set: async (id, state) => {
+        data.set(id, state);
+      },
+      delete: async (id) => {
+        data.delete(id);
+      },
+    };
+
+    const t = createTriggers({
+      definitions: [
+        ...defs,
+        {
+          type: "github.pull_request.opened" as const,
+          description: "PR opened",
+          params: z.object({ repo: z.string().describe("Repo") }),
+        },
+      ],
+      storage,
+    });
+    const configureTool = t.tools()[1];
+
+    const pA = configureTool.execute({
+      context: { type: "github.push", params: {}, enabled: true },
+      runtimeContext: mockCtx("conn-race"),
+    });
+    const pB = configureTool.execute({
+      context: {
+        type: "github.pull_request.opened",
+        params: {},
+        enabled: true,
+      },
+      runtimeContext: mockCtx("conn-race"),
+    });
+
+    // Both calls share a single in-flight storage read instead of racing
+    // their own reads against each other's writes.
+    expect(getCalls).toBe(1);
+    expect(getResolvers.length).toBe(1);
+
+    getResolvers[0]();
+    await Promise.all([pA, pB]);
+
+    const stored = data.get("conn-race") as any;
+    expect(stored.activeTriggerTypes.sort()).toEqual([
+      "existing.type",
+      "github.pull_request.opened",
+      "github.push",
+    ]);
+  });
+
   it("disable after restart clears persisted credentials from storage", async () => {
     const storage = createMockStorage();
 

--- a/packages/runtime/src/triggers.ts
+++ b/packages/runtime/src/triggers.ts
@@ -70,6 +70,11 @@ class TriggerStateManager {
   private credentials = new Map<string, CallbackCredentials>();
   private activeTriggers = new Map<string, Set<string>>();
   private storage: TriggerStorage | null;
+  // Concurrent enable()/disable() calls for a connection not yet cached must
+  // share one in-flight storage read — otherwise a second call's read (started
+  // before the first's write) can resolve later and overwrite the first
+  // call's in-memory update with stale data, silently dropping it.
+  private loading = new Map<string, Promise<void>>();
 
   constructor(storage?: TriggerStorage) {
     this.storage = storage ?? null;
@@ -81,11 +86,30 @@ class TriggerStateManager {
 
   async loadFromStorage(connectionId: string): Promise<void> {
     if (!this.storage || this.credentials.has(connectionId)) return;
-    const state = await this.storage.get(connectionId);
-    if (state) {
-      this.credentials.set(connectionId, state.credentials);
-      this.activeTriggers.set(connectionId, new Set(state.activeTriggerTypes));
-    }
+
+    const inFlight = this.loading.get(connectionId);
+    if (inFlight) return inFlight;
+
+    const storage = this.storage;
+    const promise = (async () => {
+      try {
+        const state = await storage.get(connectionId);
+        // Skip if a concurrent call already populated this connection while
+        // this read was in flight.
+        if (state && !this.credentials.has(connectionId)) {
+          this.credentials.set(connectionId, state.credentials);
+          this.activeTriggers.set(
+            connectionId,
+            new Set(state.activeTriggerTypes),
+          );
+        }
+      } finally {
+        this.loading.delete(connectionId);
+      }
+    })();
+
+    this.loading.set(connectionId, promise);
+    return promise;
   }
 
   async enable(


### PR DESCRIPTION
Bug found while auditing `packages/runtime/src/trigger-storage.ts` / `triggers.ts` for stale-trigger/race issues (open PR #5386 already covers stale-entry pruning in `trigger-storage.ts`, so this targets the separate in-memory race in `triggers.ts` instead).

**Failure scenario**: `TriggerStateManager.loadFromStorage()` guards against redundant loads by checking `this.credentials.has(connectionId)` *before* awaiting `storage.get()`, but never re-checks after. If two `enable()`/`disable()` calls for the same not-yet-cached connection run concurrently (e.g. two near-simultaneous `TRIGGER_CONFIGURE` requests), both call `storage.get()` independently. If call A's read resolves and finishes its write first, then call B's *stale* read (taken before A's write) resolves afterward, B's `loadFromStorage` unconditionally overwrites `this.activeTriggers` with the stale snapshot — silently dropping the trigger type A just enabled. This exact bug class (a second concurrent load clobbering a first write) was already fixed once in the same file family for `JsonFileStorage.load()` in #5335; this closes the analogous gap in `TriggerStateManager`.

**Fix**: share one in-flight load promise per `connectionId` (same pattern as #5335's disk-storage fix) instead of letting each caller run its own independent read, and re-check `credentials.has()` after the read resolves before writing.

**Regression test** (`triggers.test.ts`): a storage mock with a manually-controlled `get()` resolution proves that before the fix, a concurrent `enable("github.push")` + `enable("github.pull_request.opened")` on the same fresh connection results in only one trigger type surviving; after the fix, only one `storage.get()` call happens (shared) and both trigger types are persisted correctly.

**To verify**: `bun test packages/runtime/src/triggers.test.ts`

**Checks run locally**: `bun run fmt`, `cd packages/runtime && bunx tsc --noEmit`, `bun test packages/runtime/src/triggers.test.ts` (15/15 pass), `bunx oxlint packages/runtime/src/triggers.ts packages/runtime/src/triggers.test.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `TriggerStateManager` where concurrent `enable`/`disable` calls on an uncached connection could overwrite newer state with stale data. Now a single in-flight storage read is shared per `connectionId`, preventing dropped trigger types.

- **Bug Fixes**
  - Share one in-flight `storage.get()` per `connectionId` via a `loading` map.
  - After the read resolves, skip applying state if `credentials` was populated meanwhile.
  - Add a regression test in `packages/runtime/src/triggers.test.ts` that simulates concurrent enables; verifies one read and correct persistence.

<sup>Written for commit a88d0e77c0c02cbaa0822436e29ff82bc4d66701. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

