### PR TITLE
fix(sandbox): make dep-metrics' node_modules existence check async

### DIFF
--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -1,10 +1,19 @@
-import { existsSync } from "node:fs";
+import { stat } from "node:fs/promises";
 import { join } from "node:path";
 import type { PackageManager } from "../types";
 import { repoHash } from "./golden-cache";
 
 // Guard against a pathological node_modules blowing up the log line.
 const MAX_DEPS = 10_000;
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * True when a `package.json` (path relative to node_modules) is a real package
@@ -36,7 +45,7 @@ async function readInstalledDeps(
   // ENOENT into the catch below, which both swallows the countable zero-dep
   // line the denominator needs AND writes a spurious error to stderr on every
   // such boot. Return empty and let the caller emit the line.
-  if (!existsSync(nodeModulesDir)) return [];
+  if (!(await exists(nodeModulesDir))) return [];
   const glob = new Bun.Glob("**/package.json");
   for await (const rel of glob.scan({
     cwd: nodeModulesDir,


### PR DESCRIPTION
Follows the daemon's ongoing async-fs hardening pass (#5333, #5336, #5367, #5370, #5372, #5375, #5391, #5403, #5406, #5413, #5442, #5471, #5478, #5481) — this is another unconverted instance of the same bug class in `packages/sandbox/daemon/setup/dep-metrics.ts`.

`readInstalledDeps` (invoked via `emitInstalledDeps`, fired-and-forgotten from `orchestrator.ts`'s install step on every successful boot that ran a real install) called `existsSync(nodeModulesDir)` before doing its async glob scan. Per CONTRIBUTING.md rule #1, the sandbox daemon runs on a single-threaded Bun event loop, so any sync fs call blocks it from answering its HTTP health probe — Studio polls that probe and tears down/recovers the pod on a single miss.

Fix: replace `existsSync` with an async `stat`-based `exists()` helper (same pattern already used in this daemon's `golden-cache.ts`), so the check no longer blocks the loop.

Behavior-preserving: same true/false result, just non-blocking — verified via the existing `dep-metrics.test.ts` suite (all 7 tests pass unchanged) plus a clean `tsc --noEmit` in `packages/sandbox`.

To confirm: `cd packages/sandbox && bunx tsc --noEmit && bun test daemon/setup/dep-metrics.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (packages/sandbox), targeted `bun test daemon/setup/dep-metrics.test.ts`, `bunx oxlint` on the changed file — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `node_modules` existence check in dep-metrics async to avoid blocking the sandbox daemon’s event loop and prevent health probe timeouts.

- **Bug Fixes**
  - Replaced sync `existsSync` with an async `stat`-based `exists()` helper in `packages/sandbox/daemon/setup/dep-metrics.ts` before the glob scan.
  - Behavior unchanged; non-blocking now. Existing tests pass and typecheck is clean.

<sup>Written for commit ed418d4d48d19b28f1f7be023a894fda2f0b9318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

