### PR TITLE
perf(task-board): enqueue enabled reviewers concurrently

### DIFF
--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -111,30 +111,36 @@ export async function enqueueEnabledReviewers(
   const lastInReviewAt = await lastInReviewTime(ctx, task);
   const cycleAt = new Date(lastInReviewAt);
 
-  for (const kind of enabled) {
-    if (reviewerHandledThisCycle(task, kind, lastInReviewAt)) continue;
-    // Atomically claim the reviewer's slot for this cycle. The claim dedups the
-    // two triggers (projector run-finish + the modal poll) that can fire at the
-    // same instant — the loser's `claimed` is false, so it skips instead of
-    // spawning a duplicate run. The claim's token binds the reviewer's later
-    // decision back to this dispatch.
-    let claimed: boolean;
-    let token: string;
-    try {
-      ({ claimed, token } = await ctx.storage.taskBoard.claimReviewer(
-        task.id,
-        kind,
-        cycleAt,
-      ));
-    } catch (err) {
-      console.error(`[task-board] ${kind} reviewer claim failed`, err);
-      continue;
-    }
-    if (!claimed) continue;
-    await enqueueReviewerForTask(ctx, task, kind, token).catch((err) => {
-      console.error(`[task-board] ${kind} reviewer enqueue failed`, err);
-    });
-  }
+  // Each reviewer's claim + enqueue is independent (a separate DB row keyed by
+  // its own kind), so run them CONCURRENTLY — this is on TASK_BOARD_ITEM_PRS_GET's
+  // synchronous poll path, and serial awaits doubled its latency once both QA
+  // and Code Reviewer are enabled.
+  await Promise.all(
+    enabled.map(async (kind) => {
+      if (reviewerHandledThisCycle(task, kind, lastInReviewAt)) return;
+      // Atomically claim the reviewer's slot for this cycle. The claim dedups
+      // the two triggers (projector run-finish + the modal poll) that can fire
+      // at the same instant — the loser's `claimed` is false, so it skips
+      // instead of spawning a duplicate run. The claim's token binds the
+      // reviewer's later decision back to this dispatch.
+      let claimed: boolean;
+      let token: string;
+      try {
+        ({ claimed, token } = await ctx.storage.taskBoard.claimReviewer(
+          task.id,
+          kind,
+          cycleAt,
+        ));
+      } catch (err) {
+        console.error(`[task-board] ${kind} reviewer claim failed`, err);
+        return;
+      }
+      if (!claimed) return;
+      await enqueueReviewerForTask(ctx, task, kind, token).catch((err) => {
+        console.error(`[task-board] ${kind} reviewer enqueue failed`, err);
+      });
+    }),
+  );
 }
 
 /** True when a reviewer of `kind` already has a live or this-cycle thread — the


### PR DESCRIPTION
Follows #5520 (QA Agent + Code Reviewer review flow).

`enqueueEnabledReviewers` looped over the org's enabled reviewer kinds (`qa`, `code_review`) and `await`ed each one's `claimReviewer` + `enqueueReviewerForTask` sequentially, even though the two are fully independent — each claim is its own DB row keyed by `(task, reviewer, cycle)`, and each enqueue creates its own thread/dispatch. This function is called synchronously from `TASK_BOARD_ITEM_PRS_GET`'s handler (the board's 10s poll), so with both reviewers enabled — the default shape after #5520 — every poll that triggers the hand-off paid two full claim+thread-create+dispatch round-trips back to back instead of one.

Change: run the per-reviewer work via `Promise.all` instead of a `for...await` loop. Behavior is unchanged — each reviewer's claim/enqueue/error-handling is identical, just concurrent instead of serial; no shared mutable state between iterations (each writes to its own claim row and its own thread).

How to verify: `cd apps/api && bunx tsc --noEmit` and `bunx oxlint apps/api/src/tools/task-board/enqueue-reviewer.ts` (both clean). No behavior change to unit-test — `enqueue-reviewer.test.ts`'s existing coverage of `reviewerHandledThisCycle` (the pure guard this loop calls) is untouched and still passes. Full CI validates the rest.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/tools/task-board/enqueue-reviewer.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run QA and Code Reviewer enqueueing in parallel to reduce task board poll latency. Behavior is unchanged; each reviewer still claims and enqueues independently.

- **Refactors**
  - Use `Promise.all` in `enqueueEnabledReviewers` to run per-reviewer claim+enqueue concurrently, reducing `TASK_BOARD_ITEM_PRS_GET` poll path latency.
  - Keep the same claim token flow and error handling; each reviewer writes to its own `(task, reviewer, cycle)` row.

<sup>Written for commit 52a26b476c460b2c881fdfb6413784c5ea12fbfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

