### PR TITLE
fix(automations): reject a trigger-callback token replayed against a mismatched org path

### DIFF
--- a/apps/api/src/api/routes/trigger-callback.test.ts
+++ b/apps/api/src/api/routes/trigger-callback.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+import { Hono } from "hono";
+import type { AutomationEventDispatcher } from "@/automations/automation-event-dispatcher";
+import type { StudioContext } from "@/core/studio-context";
+import type { TriggerCallbackTokenStorage } from "@/storage/trigger-callback-tokens";
+import { createTriggerCallbackRoutes } from "./trigger-callback";
+
+const TOKEN_ORG = "org-a";
+const TOKEN_CONNECTION = "conn-1";
+
+function buildApp(pathOrgId: string | undefined) {
+  const dispatched: unknown[] = [];
+  const tokenStorage: Pick<TriggerCallbackTokenStorage, "validateToken"> = {
+    validateToken: async (token: string) =>
+      token === "valid-token"
+        ? { organizationId: TOKEN_ORG, connectionId: TOKEN_CONNECTION }
+        : null,
+  };
+  const automationEventDispatcher = {
+    dispatchForEvents: (events: unknown[]) => {
+      dispatched.push(...events);
+    },
+  } as unknown as AutomationEventDispatcher;
+
+  const app = new Hono<{
+    Variables: { studioContext?: StudioContext };
+  }>();
+  // Simulates resolveOrgFromPath having already run for the org-scoped mount.
+  // The legacy unscoped mount never sets studioContext.organization, so
+  // pathOrgId is undefined there.
+  app.use("*", async (c, next) => {
+    if (pathOrgId) {
+      c.set("studioContext", {
+        organization: { id: pathOrgId },
+      } as unknown as StudioContext);
+    }
+    await next();
+  });
+  app.route(
+    "/",
+    createTriggerCallbackRoutes({
+      tokenStorage: tokenStorage as TriggerCallbackTokenStorage,
+      automationEventDispatcher,
+    }),
+  );
+  return { app, dispatched };
+}
+
+describe("POST /trigger-callback — cross-org token replay", () => {
+  it("fires the automation when the path org matches the token's org", async () => {
+    const { app, dispatched } = buildApp(TOKEN_ORG);
+    const res = await app.request("/trigger-callback", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer valid-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ type: "issue.opened" }),
+    });
+    expect(res.status).toBe(202);
+    expect(dispatched).toHaveLength(1);
+  });
+
+  it("rejects a valid token replayed against a mismatched org path", async () => {
+    const { app, dispatched } = buildApp("org-b");
+    const res = await app.request("/trigger-callback", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer valid-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ type: "issue.opened" }),
+    });
+    expect(res.status).toBe(401);
+    expect(dispatched).toHaveLength(0);
+  });
+
+  it("still fires on the legacy unscoped mount (no path-resolved org)", async () => {
+    const { app, dispatched } = buildApp(undefined);
+    const res = await app.request("/trigger-callback", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer valid-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ type: "issue.opened" }),
+    });
+    expect(res.status).toBe(202);
+    expect(dispatched).toHaveLength(1);
+  });
+});

--- a/apps/api/src/api/routes/trigger-callback.ts
+++ b/apps/api/src/api/routes/trigger-callback.ts
@@ -5,7 +5,11 @@
  * and fires matching automations via AutomationEventDispatcher.
  *
  * Auth: Bearer token (callback token generated during TRIGGER_CONFIGURE)
- * Route: POST /api/trigger-callback
+ * Routes:
+ *   POST /api/:org/trigger-callback — canonical; ConfigureTrigger mints the
+ *     callback URL with the org's own slug, so a legitimate caller's :org
+ *     always matches the token's bound organization.
+ *   POST /api/trigger-callback — legacy, unscoped, deprecated.
  */
 
 import { Hono } from "hono";
@@ -13,6 +17,7 @@ import { bodyLimit } from "hono/body-limit";
 import { z } from "zod";
 import type { AutomationEventDispatcher } from "@/automations/automation-event-dispatcher";
 import type { DeprecatedRouteAttribution } from "@/api/middleware/log-deprecated-route";
+import type { StudioContext } from "@/core/studio-context";
 import type { TriggerCallbackTokenStorage } from "@/storage/trigger-callback-tokens";
 
 const TriggerCallbackBodySchema = z.object({
@@ -29,7 +34,10 @@ const MAX_BODY_SIZE = 1_048_576; // 1MB
 
 export function createTriggerCallbackRoutes(deps: TriggerCallbackDeps) {
   const app = new Hono<{
-    Variables: { deprecatedRouteAttribution?: DeprecatedRouteAttribution };
+    Variables: {
+      deprecatedRouteAttribution?: DeprecatedRouteAttribution;
+      studioContext?: StudioContext;
+    };
   }>();
 
   app.post(
@@ -55,8 +63,19 @@ export function createTriggerCallbackRoutes(deps: TriggerCallbackDeps) {
         return c.json({ error: "Invalid callback token" }, 401);
       }
 
+      // Under the org-scoped mount, resolveOrgFromPath has already resolved
+      // `:org` onto studioContext.organization. Cross-check it against the
+      // token's bound organization so a token can't be replayed against a
+      // mismatched URL — same defense-in-depth as automation-webhooks.ts.
+      // The legacy unscoped mount has no path-resolved org, so this is a
+      // no-op there.
+      const pathOrgId = c.get("studioContext")?.organization?.id;
+      if (pathOrgId && pathOrgId !== context.organizationId) {
+        return c.json({ error: "Invalid callback token" }, 401);
+      }
+
       // Attribute the legacy-route deprecation log to the token's
-      // org/connection — this route has no session-based studioContext.
+      // org/connection — the legacy mount has no session-based studioContext.
       c.set("deprecatedRouteAttribution", {
         organizationId: context.organizationId,
         connectionId: context.connectionId,


### PR DESCRIPTION
Follows the org-scoped route migration (#3256) that mounted the trigger-callback endpoint at both the canonical `/api/:org/trigger-callback` (via `createOrgScopedApi`, org-scoped.ts) and the legacy unscoped `/api/trigger-callback`.

The route validates the Bearer token (bound to a specific org+connection at `TRIGGER_CONFIGURE` time) but never cross-checked the path-resolved `:org` against the token's bound organization. The sibling `automation-webhooks.ts` route (same trust boundary: an external, unauthenticated caller presenting a bearer credential) already does this exact cross-check for its API-key-based auth (`ctx.organization?.id !== meta.organization.id`) — this route was the one org-scoped-family route missing the analogous guard.

**Why it matters:** `configure-trigger.ts` mints the callback URL with the connection's own org slug (`${ctx.baseUrl}/api/${organizationSlug}/trigger-callback`), so a legitimate caller's `:org` always matches the token's org — this change never affects normal traffic. It closes the gap for a leaked/reused token being replayed against a different org's URL path, matching the established defense-in-depth idiom for org-scoped external-webhook auth in this codebase.

**Regression test** (`trigger-callback.test.ts`, injects fake `tokenStorage`/`studioContext`, no DB/mocking of internals):
- matching path-org + token-org → 202, automation fires
- mismatched path-org vs token-org → 401, automation does NOT fire
- legacy unscoped mount (no path-resolved org) → unaffected, still fires (mirrors current behavior)

**To verify:** `bun test apps/api/src/api/routes/trigger-callback.test.ts`

**Locally ran:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (3 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cross-org replay of trigger-callback tokens on the org-scoped endpoint. A token minted for one org can no longer be used on another org’s URL; normal traffic is unaffected.

- **Bug Fixes**
  - Cross-checks the path org (`studioContext.organization.id`) against the token’s org on `POST /api/:org/trigger-callback`; returns 401 on mismatch (parity with `automation-webhooks.ts`).
  - Legacy unscoped `POST /api/trigger-callback` behavior unchanged.
  - Added tests covering match (202), mismatch (401), and legacy (202).

<sup>Written for commit e8313d4e7550acf038956e0b0609bdc9f83383fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

