### PR TITLE
fix(task-board): translate hardcoded strings in assignee picker

### DIFF
--- a/apps/web/src/layouts/task-board/assignee-picker.tsx
+++ b/apps/web/src/layouts/task-board/assignee-picker.tsx
@@ -10,6 +10,7 @@ import {
 import { User01 } from "@untitledui/icons";
 import { SuperAgentIcon } from "@/components/super-agent-icon";
 import { getInitials } from "@/lib/get-initials";
+import { useT } from "@/i18n/use-t.ts";
 import { SUPER_AGENT_ASSIGNEE_ID, type Member } from "./config";
 
 export function AssigneePickerContent({
@@ -19,30 +20,38 @@ export function AssigneePickerContent({
   members: Member[];
   onSelect: (userId: string | null) => void;
 }) {
+  const t = useT();
   return (
     <Command>
-      <CommandInput placeholder="Assign to…" className="h-9" />
+      <CommandInput
+        placeholder={t("taskBoard.taskDialog.assignToPlaceholder")}
+        className="h-9"
+      />
       <CommandList>
-        <CommandEmpty>No members found.</CommandEmpty>
+        <CommandEmpty>{t("taskBoard.taskDialog.noMembersFound")}</CommandEmpty>
         <CommandGroup>
           <CommandItem
-            value="Super Agent"
+            value={t("taskBoard.taskDialog.superAgentLabel")}
             onSelect={() => onSelect(SUPER_AGENT_ASSIGNEE_ID)}
             className="gap-2"
           >
             <SuperAgentIcon size={16} />
-            <span className="truncate">Super Agent</span>
+            <span className="truncate">
+              {t("taskBoard.taskDialog.superAgentLabel")}
+            </span>
           </CommandItem>
           <CommandItem
-            value="Unassigned"
+            value={t("taskBoard.taskDialog.unassignedLabel")}
             onSelect={() => onSelect(null)}
             className="gap-2"
           >
             <User01 size={16} className="text-muted-foreground" />
-            <span className="truncate">Unassigned</span>
+            <span className="truncate">
+              {t("taskBoard.taskDialog.unassignedLabel")}
+            </span>
           </CommandItem>
         </CommandGroup>
-        <CommandGroup heading="Members">
+        <CommandGroup heading={t("taskBoard.taskDialog.membersGroupHeading")}>
           {members.map((m) => (
             <CommandItem
               key={m.userId}


### PR DESCRIPTION
**Bug**: `AssigneePickerContent` (`apps/web/src/layouts/task-board/assignee-picker.tsx`) hardcoded its placeholder, empty state, "Super Agent", "Unassigned", and "Members" group heading in raw English JSX text instead of routing through `t()`. This component is shared and rendered from both `task-dialog.tsx` and `index.tsx`, so every pt-br user assigning a task saw untranslated English strings in this picker.

**Why a maintainer wants this**: the repo's i18n rule (CLAUDE.md) requires every user-facing string in `apps/web/src` to go through `t()`. The sibling `TagPickerContent` in the same folder already does this correctly, and the exact translation keys needed (`taskBoard.taskDialog.assignToPlaceholder`, `noMembersFound`, `superAgentLabel`, `unassignedLabel`, `membersGroupHeading`) already exist in both `en/task-board.ts` and `pt-br/task-board.ts` (used elsewhere in `task-dialog.tsx`) — this component was simply the one spot that never got wired up to them.

**Fix**: swap the five hardcoded strings for `t(...)` calls using the pre-existing keys. No new i18n keys added, no dictionary changes needed — reused what's already there. Behavior-preserving (same rendered English text for `en`; now correctly localized for `pt-br`).

**How to verify**: switch language to pt-br in the app, open a task, open the assignee picker (from the card menu or the task dialog) — placeholder, empty state, "Super Agent"/"Unassigned" rows, and the "Members" heading should now render in Portuguese instead of English.

**Checks run locally**: `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/web` (clean), `bunx oxlint apps/web/src/layouts/task-board/assignee-picker.tsx` (0 warnings/errors). No test file exists for this presentational component (no branching logic to unit test); full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the Task Board assignee picker by routing its UI strings through `t()` with existing `taskBoard.taskDialog` keys. Placeholder, empty state, "Super Agent", "Unassigned", and "Members" heading now translate correctly (no new i18n keys; behavior unchanged for `en`).

<sup>Written for commit e9ca8f2b33f404a5fff1077dc893f2bac5455ea9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

