### PR TITLE
refactor(storage): dedupe org-fs LIKE-escaping into existing helper

### DIFF
--- a/apps/api/src/storage/org-fs.ts
+++ b/apps/api/src/storage/org-fs.ts
@@ -578,7 +578,7 @@ export class OrgFsEntryStorage {
   }): Promise<OrgFsEntry[]> {
     if (params.volumes && params.volumes.length === 0) return [];
     // Escape LIKE metacharacters so the query is a literal substring.
-    const escaped = params.query.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+    const escaped = escapeLike(params.query);
     let qb = this.db
       .selectFrom("org_fs_entry")
       .where("organization_id", "=", params.organizationId)


### PR DESCRIPTION
**Source:** code reduction (C1) found while auditing `apps/api/src/storage/org-fs.ts` for the org-fs backend focus area.

**What/why:** `OrgFsEntryStorage.searchFiles()` re-implemented the exact same backslash-escape regex that `escapeLike()` (already defined in the same file, used by `tombstoneSubtree`/`listSubtreeFiles`/`listSubtreeDirs`) provides — just spelled with a replacer callback instead of `"\\$&"`. Two copies of the same LIKE-escaping logic in one file risk silently drifting apart if the escaped character set ever changes. Collapsed into the single existing implementation.

**Net change:** -1 / +1 line, behavior-preserving (the two expressions are semantically identical — both escape `\`, `%`, `_` with a leading backslash). No test needed for this one: it's a literal substitution of one escaping implementation for an already-in-use one in the same file, not new logic.

**How a reviewer confirms:** read the diff — `escapeLike(params.query)` produces the exact same output as the regex it replaces for any input.

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (green), `bunx oxlint apps/api/src/storage/org-fs.ts` (0 warnings/errors). `searchFiles()` itself is only covered by `org-fs.integration.test.ts`, which needs a real Postgres unavailable in this sandbox — full CI will run it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped LIKE-escaping in `apps/api/src/storage/org-fs.ts` by using the existing `escapeLike()` in `searchFiles()` instead of re-implementing the regex. Behavior is unchanged and escapes `\`, `%`, and `_` consistently across org-fs operations.

<sup>Written for commit d6ec6d517f08ba753cf6b713bf43f2279558bad9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

