### PR TITLE
fix(sandbox): resolve sticky-head-ref flag through Settings, not raw env

### DIFF
--- a/apps/api/src/sandbox/head-ref.ts
+++ b/apps/api/src/sandbox/head-ref.ts
@@ -94,13 +94,3 @@ export function pickGitBranch(args: {
   if (args.sticky && args.recordedHeadRef) return args.recordedHeadRef;
   return args.derivedRef;
 }
-
-/**
- * Sticky HEAD is a change on the sandbox BOOT path — which branch a sandbox
- * checks out — so it ships behind its own default-off flag rather than
- * piggybacking on a neighbour's. Recording runs regardless, so the data is
- * already there when this is switched on.
- */
-export function isStickyHeadRefEnabled(): boolean {
-  return process.env.SANDBOX_STICKY_HEAD_REF === "true";
-}

--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -45,6 +45,20 @@ describe("resolveConfig sandbox provider kind", () => {
   });
 });
 
+describe("resolveConfig sandbox sticky head ref", () => {
+  it("defaults to disabled when unset", () => {
+    const result = resolveConfig(flags, {});
+    expect(result.settings.sandboxStickyHeadRefEnabled).toBe(false);
+  });
+
+  it("enables via SANDBOX_STICKY_HEAD_REF=true", () => {
+    const result = resolveConfig(flags, {
+      SANDBOX_STICKY_HEAD_REF: "true",
+    });
+    expect(result.settings.sandboxStickyHeadRefEnabled).toBe(true);
+  });
+});
+
 describe("resolveConfig NATS tunnel settings", () => {
   it("enables public tunnel when NATS_PUBLIC_URL is set and flag is unset", () => {
     const result = resolveConfig(flags, {

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -355,6 +355,7 @@ export function resolveConfig(
     sandboxProviderKind: resolveSandboxProviderKind(
       envVars.STUDIO_SANDBOX_PROVIDER,
     ),
+    sandboxStickyHeadRefEnabled: toBool(envVars.SANDBOX_STICKY_HEAD_REF),
 
     // External service credentials
     decoSupabaseUrl: envVars.DECO_SUPABASE_URL,

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -153,6 +153,10 @@ export interface Settings {
   /** Which DBOS run queues this pod dequeues (pod dispatch-role split). */
   dispatchRole: DispatchRole;
   sandboxProviderKind: "agent-sandbox" | "user-desktop";
+  /** Sticky HEAD ref for thread-scoped sandboxes (SANDBOX_STICKY_HEAD_REF).
+   *  Off by default — see `sandbox/head-ref.ts` for the boot-path change this
+   *  gates and why it ships behind its own flag. */
+  sandboxStickyHeadRefEnabled: boolean;
 
   // External service credentials (optional)
   decoSupabaseUrl: string | undefined;

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -67,7 +67,7 @@ import {
   syntheticBranchToGitRef,
   threadIdFromBranch,
 } from "./thread-repo";
-import { isStickyHeadRefEnabled, pickGitBranch } from "../../sandbox/head-ref";
+import { pickGitBranch } from "../../sandbox/head-ref";
 import { deriveOffloadAllowlist } from "../../object-storage/offload-allowlist";
 import { getSettings } from "../../settings";
 import { getPublicUrl } from "../../core/server-constants";
@@ -461,7 +461,7 @@ async function provisionSandbox(
     // derived ref: the derived ref may never have been pushed, in which case
     // cloning it forks from the repo default and the preview serves pre-change
     // code while the work sits on the PR branch. Flagged off by default.
-    const stickyHeadRef = isStickyHeadRefEnabled();
+    const stickyHeadRef = getSettings().sandboxStickyHeadRefEnabled;
     const gitBranch = pickGitBranch({
       branch,
       derivedRef: syntheticBranchToGitRef(branch),


### PR DESCRIPTION
Every other feature flag consumed by SANDBOX_START's provisioning path (e.g. `orgFsMountsDisabled`, `sandboxProviderKind`) is resolved once in `resolve-config.ts` into the frozen `Settings` object and read via `getSettings()`. `SANDBOX_STICKY_HEAD_REF` was the one exception: `sandbox/head-ref.ts`'s `isStickyHeadRefEnabled()` read `process.env.SANDBOX_STICKY_HEAD_REF` directly, bypassing that pipeline entirely (a real, un-CI-enforced convention violation — see repo CLAUDE.md gotcha #1, 'never access environment variables directly').

Why it matters: a raw `process.env` read can't be validated/logged at startup like the rest of `resolveConfig`'s flags, and it can't be deterministically overridden through `getSettings()` mocks the way every other sandbox-provisioning flag can in tests — so this flag's tests-of-record were reduced to only the pure `pickGitBranch`/`pickRecordableHeadRef` helpers, never the flag resolution itself.

Change: added `sandboxStickyHeadRefEnabled` to the `Settings` type, resolved it in `resolve-config.ts` next to `sandboxProviderKind` (`toBool(envVars.SANDBOX_STICKY_HEAD_REF)`, same helper every other boolean flag in that file uses), deleted the raw-env `isStickyHeadRefEnabled()` function from `head-ref.ts`, and updated its single call site in `start.ts` to read `getSettings().sandboxStickyHeadRefEnabled` (it already imports `getSettings` for `orgFsMountsDisabled`).

Behavior is unchanged in production: `toBool` and the old `=== "true"` check both only turn the flag on for the literal string `"true"`, and it stays off by default (unset -> false either way).

How to verify: `cd apps/api && bunx tsc --noEmit`, then `bun test apps/api/src/settings/resolve-config.test.ts apps/api/src/sandbox/head-ref.test.ts apps/api/src/tools/sandbox/start.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the three targeted test files above (all green), and `bunx oxlint` on every changed file (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route the sandbox sticky head ref flag through `Settings` instead of reading `process.env` directly, aligning it with other sandbox flags. This improves startup validation/logging and testability with no behavior change.

- **Refactors**
  - Added `sandboxStickyHeadRefEnabled` to `Settings` and resolve via `toBool` in `resolve-config.ts`.
  - Removed `isStickyHeadRefEnabled()` and read the flag from `getSettings()` in `start.ts`.
  - Added tests for default and enabled cases in `resolve-config.test.ts`.

<sup>Written for commit 32edab980a54f1c2a822980ed768f9c658d0698f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

