### PR TITLE
refactor(thread): dedupe GithubRepoMeta type across create/update tools

### DIFF
--- a/apps/api/src/tools/thread/create.ts
+++ b/apps/api/src/tools/thread/create.ts
@@ -28,7 +28,7 @@ import {
   requireAuth,
   requireOrganization,
 } from "../../core/studio-context";
-import { normalizeThreadForResponse } from "./helpers";
+import { normalizeThreadForResponse, type GithubRepoMeta } from "./helpers";
 import {
   ThreadCreateDataSchema,
   ThreadEntitySchema,
@@ -50,14 +50,6 @@ export type CreateThreadInput = z.infer<typeof CreateInputSchema>;
 const CreateOutputSchema = z.object({
   item: ThreadEntitySchema.describe("The created thread entity"),
 });
-
-type GithubRepoMeta = {
-  githubRepo?: {
-    owner: string;
-    name: string;
-    connectionId?: string;
-  } | null;
-};
 
 type SandboxMapMeta = {
   sandboxMap?: Record<

--- a/apps/api/src/tools/thread/helpers.ts
+++ b/apps/api/src/tools/thread/helpers.ts
@@ -8,6 +8,15 @@
 import type { Thread, ThreadStatus } from "../../storage/types";
 import type { ThreadEntity } from "@decocms/shared/thread/schema";
 
+/** Shape of the `githubRepo` field on a virtual MCP's `metadata` column. */
+export type GithubRepoMeta = {
+  githubRepo?: {
+    owner: string;
+    name: string;
+    connectionId?: string;
+  } | null;
+};
+
 /**
  * Threads stuck in "in_progress" longer than this are surfaced as "expired".
  * This is a virtual status (never stored in the DB) so the thread can

--- a/apps/api/src/tools/thread/update.ts
+++ b/apps/api/src/tools/thread/update.ts
@@ -12,7 +12,7 @@ import {
   requireAuth,
   requireOrganization,
 } from "../../core/studio-context";
-import { normalizeThreadForResponse } from "./helpers";
+import { normalizeThreadForResponse, type GithubRepoMeta } from "./helpers";
 import {
   ThreadEntitySchema,
   ThreadUpdateDataSchema,
@@ -67,15 +67,8 @@ export const COLLECTION_THREADS_UPDATE = defineTool({
     if (data.branch === null && existing.virtual_mcp_id) {
       const vmcp = await ctx.storage.virtualMcps.findById(
         existing.virtual_mcp_id,
-        requireOrganization(ctx).id,
+        organization.id,
       );
-      type GithubRepoMeta = {
-        githubRepo?: {
-          owner: string;
-          name: string;
-          connectionId?: string;
-        } | null;
-      };
       const githubRepo = (vmcp?.metadata as GithubRepoMeta | null | undefined)
         ?.githubRepo;
       if (githubRepo) {


### PR DESCRIPTION
Source: audit of apps/api/src/tools/thread/ for duplicated logic per this tick's focus area (the more substantial cross-org virtual_mcp_id gap in this same pair of files is already covered by open PR #5526, so this targets the remaining real duplication).

`create.ts` and `update.ts` each declared an identical inline `GithubRepoMeta` type (shape of a virtual MCP's `metadata.githubRepo`) used to check whether a thread's agent is GitHub-linked. `update.ts` also called `requireOrganization(ctx)` a second time inside the handler even though the org was already bound to a local `organization` variable at the top.

Change: moved `GithubRepoMeta` into `helpers.ts` (a file both tools already import from) and dropped both duplicate declarations; replaced the redundant `requireOrganization(ctx).id` call with the existing `organization.id`. Pure move/dedupe, no behavior change: net -18/+12 lines.

How to confirm: `cd apps/api && bunx tsc --noEmit` stays clean, and the existing integration tests for both tools still pass unchanged (they exercise the exact `githubRepo` branch-null/branch-switch logic this type feeds).

Local checks run: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/tools/thread/create.integration.test.ts` (7 pass), `bun test apps/api/src/tools/thread/update.integration.test.ts` (3 pass), `bunx oxlint` on all three touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the `GithubRepoMeta` type to `helpers.ts` and removed duplicate declarations in `create.ts` and `update.ts`. Also replaced an extra `requireOrganization(ctx)` call in `update.ts` with the existing `organization.id`. No behavior change.

- **Refactors**
  - Centralized `GithubRepoMeta` in `helpers.ts`; both tools now import it.
  - Dropped redundant `requireOrganization(ctx)` in `update.ts` in favor of `organization.id`.

<sup>Written for commit b12742fd6dd979f77bdd88227f41a94be0fe09db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

