### PR TITLE
fix(web): stop org-fs listing from flashing the previous org's files on org switch

### DIFF
--- a/apps/web/src/hooks/use-org-fs.test.tsx
+++ b/apps/web/src/hooks/use-org-fs.test.tsx
@@ -1,0 +1,98 @@
+import { setupComponentTest } from "../../test/setup";
+setupComponentTest();
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  ProjectContextProvider,
+  type OrganizationData,
+} from "@/sdk/context/project-context";
+import { useOrgFsList, type OrgFsEntry } from "./use-org-fs";
+
+const orgA: OrganizationData = {
+  id: "org-a",
+  name: "A",
+  slug: "a",
+  logo: null,
+};
+const orgB: OrganizationData = {
+  id: "org-b",
+  name: "B",
+  slug: "b",
+  logo: null,
+};
+
+function entriesFor(orgSlug: string) {
+  return [
+    {
+      path: `${orgSlug}-secret.txt`,
+      kind: "file" as const,
+      size: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+  ];
+}
+
+describe("useOrgFsList", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("does not show the previous org's listing as placeholder data after switching orgs", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    // org "b"'s fetch never resolves during the test — any data shown for it
+    // must therefore be a real placeholder, not a fetched result.
+    global.fetch = mock((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/a/")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ entries: entriesFor("a") }), {
+            status: 200,
+          }),
+        );
+      }
+      return new Promise(() => {}); // org "b" — left pending
+    }) as unknown as typeof fetch;
+
+    const latest: {
+      data: OrgFsEntry[] | undefined;
+      isPlaceholderData: boolean;
+    } = { data: undefined, isPlaceholderData: false };
+
+    function Harness() {
+      const list = useOrgFsList("home", "");
+      latest.data = list.data;
+      latest.isPlaceholderData = list.isPlaceholderData;
+      return null;
+    }
+
+    function Tree({ org }: { org: OrganizationData }) {
+      return (
+        <QueryClientProvider client={client}>
+          <ProjectContextProvider
+            org={org}
+            project={{ id: org.id, slug: "_org" }}
+          >
+            <Harness />
+          </ProjectContextProvider>
+        </QueryClientProvider>
+      );
+    }
+
+    const { rerender } = render(<Tree org={orgA} />);
+
+    await waitFor(() => expect(latest.data?.[0]?.path).toBe("a-secret.txt"));
+
+    rerender(<Tree org={orgB} />);
+
+    // Org "b"'s request is still pending — without the org-scoped guard,
+    // `keepPreviousData` would surface org "a"'s entries here.
+    expect(latest.data).toBeUndefined();
+    expect(latest.isPlaceholderData).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/use-org-fs.ts
+++ b/apps/web/src/hooks/use-org-fs.ts
@@ -5,12 +5,7 @@
  * uploads/downloads move raw bytes, which the HTTP routes are built for.
  */
 
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-  keepPreviousData,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useProjectContext } from "@/sdk";
 import { KEYS } from "@/lib/query-keys";
 
@@ -92,8 +87,14 @@ export function useOrgFsList(volume: string, path: string) {
   const { org } = useProjectContext();
   return useQuery({
     queryKey: KEYS.orgFsList(org.id, volume, path),
-    // Keep the previous listing on screen while navigating into a dir.
-    placeholderData: keepPreviousData,
+    // Keep the previous listing on screen while navigating into a dir —
+    // but only within the same org+volume, so switching orgs (which
+    // doesn't remount this hook) never flashes another org's file names.
+    placeholderData: (previousData, previousQuery) =>
+      previousQuery?.queryKey[1] === org.id &&
+      previousQuery.queryKey[2] === volume
+        ? previousData
+        : undefined,
     queryFn: async () => {
       const res = await fsFetch(fsUrl(org.slug, volume, "list", { path }));
       const body = (await res.json()) as { entries: OrgFsEntry[] };
@@ -176,7 +177,11 @@ export function useOrgFsSearch(query: string, limit = 50) {
   return useQuery({
     queryKey: KEYS.orgFsSearch(org.id, query),
     enabled: query.length > 0,
-    placeholderData: keepPreviousData,
+    // Keep previous results on screen between keystrokes, but only within
+    // the same org — switching orgs doesn't remount this hook, so without
+    // this guard the new org's search box would flash the old org's results.
+    placeholderData: (previousData, previousQuery) =>
+      previousQuery?.queryKey[1] === org.id ? previousData : undefined,
     queryFn: async () => {
       const res = await fsFetch(
         `/api/${encodeURIComponent(org.slug)}/fs/search?q=${encodeURIComponent(query)}&limit=${limit}`,


### PR DESCRIPTION
**Source:** bug found while auditing `apps/web/src/hooks/use-org-fs.ts` for stale-state handling across navigation.

**Why:** `useOrgFsList` and `useOrgFsSearch` set `placeholderData: keepPreviousData`, which shows this hook instance's last-seen data while a new query loads — intended for "stay on the current listing while navigating into a subfolder / typing a search query." But switching orgs via the org switcher is an in-app `navigate({ to: "/$org" })` (see `apps/web/src/components/header/org-switcher.tsx:334`), not a hard reload, and the Library route isn't keyed by the `$org` param, so the same `useOrgFsList`/`useOrgFsSearch` hook instance survives the switch with a single, app-wide `QueryClient` (`apps/web/src/providers/providers.tsx`). Right after switching orgs, the Library page briefly renders the *previous* org's file names/search results as placeholder data until the new org's request resolves — a real (if brief) cross-tenant leak of file paths.

**Fix:** both queries now compute `placeholderData` from a function that checks the previous query's `queryKey` — for the listing, org id *and* volume must match; for search, org id must match. A mismatch (org switch) returns `undefined` instead of stale data, so the UI shows a loading state rather than another org's files. In-org navigation (subfolder, new search query) is unaffected since org/volume still match.

**Regression test:** `apps/web/src/hooks/use-org-fs.test.tsx` renders `useOrgFsList` for org "a" (fetch resolves), then rerenders for org "b" (fetch left pending) and asserts `data` is `undefined`, not org "a"'s entries. Confirmed it fails against the pre-fix code (shows org "a"'s entry) and passes with the fix.

**To verify:** `bun test apps/web/src/hooks/use-org-fs.test.tsx`

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint apps/web/src/hooks/use-org-fs.ts apps/web/src/hooks/use-org-fs.test.tsx` (all clean), and the targeted test above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Library from flashing the previous org’s file names and search results after switching orgs, removing a brief cross-tenant leak of paths. Scopes placeholder data to the same org (and volume for listings).

- **Bug Fixes**
  - `useOrgFsList`: `placeholderData` now uses previous data only when both org id and volume match the previous query; otherwise shows loading.
  - `useOrgFsSearch`: `placeholderData` now uses previous data only when org id matches.
  - Added `apps/web/src/hooks/use-org-fs.test.tsx` to verify no stale data is shown after an org switch.

<sup>Written for commit 5cb5ab11068bf3780e1d02c1c24033b3eeb27328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

