### PR TITLE
feat(sandbox): export daemon OTLP metrics from the TS daemon

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/api": {
       "name": "decocms",
-      "version": "4.155.3",
+      "version": "4.158.5",
       "bin": {
         "deco": "./dist/server/cli.js",
       },
@@ -128,7 +128,7 @@
     },
     "apps/native": {
       "name": "@decocms/native",
-      "version": "4.155.3",
+      "version": "4.158.5",
       "dependencies": {
         "@decocms/shared": "workspace:*",
       },
@@ -248,7 +248,7 @@
     },
     "packages/e2e": {
       "name": "@decocms/e2e",
-      "version": "1.26.1",
+      "version": "1.27.0",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/sandbox": "workspace:*",
@@ -329,13 +329,16 @@
     },
     "packages/sandbox": {
       "name": "@decocms/sandbox",
-      "version": "1.31.2",
+      "version": "1.33.0",
       "dependencies": {
         "@decocms/harness": "workspace:*",
         "@decocms/shared": "workspace:*",
         "@kubernetes/client-node": "^1.4.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.211.0",
+        "@opentelemetry/resources": "^2.7.0",
+        "@opentelemetry/sdk-metrics": "^2.7.0",
         "node-pty": "^1.0.0",
         "zod": "4.3.6",
       },
@@ -348,7 +351,7 @@
     },
     "packages/shared": {
       "name": "@decocms/shared",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.1",
         "@modelcontextprotocol/sdk": "1.29.0",
@@ -1014,7 +1017,7 @@
 
     "@opentelemetry/exporter-metrics-otlp-grpc": ["@opentelemetry/exporter-metrics-otlp-grpc@0.207.0", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "2.2.0", "@opentelemetry/exporter-metrics-otlp-http": "0.207.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-grpc-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-6flX89W54gkwmqYShdcTBR1AEF5C1Ob0O8pDgmLPikTKyEv27lByr9yBmO5WrP0+5qJuNPHrLfgFQFYi6npDGA=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fG8FAJmvXOrKXGIRN8+y41U41IfVXxPRVwyB05LoMqYSjugx/FSBkMZUZXUT/wclTdmBKtS5MKoi0bEKkmRhSw=="],
+    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.211.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/otlp-exporter-base": "0.211.0", "@opentelemetry/otlp-transformer": "0.211.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/sdk-metrics": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lfHXElPAoDSPpPO59DJdN5FLUnwi1wxluLTWQDayqrSPfWRnluzxRhD+g7rF8wbj1qCz0sdqABl//ug1IZyWvA=="],
 
     "@opentelemetry/exporter-metrics-otlp-proto": ["@opentelemetry/exporter-metrics-otlp-proto@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/exporter-metrics-otlp-http": "0.207.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-kDBxiTeQjaRlUQzS1COT9ic+et174toZH6jxaVuVAvGqmxOkgjpLOjrI5ff8SMMQE69r03L3Ll3nPKekLopLwg=="],
 
@@ -3662,6 +3665,8 @@
 
     "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
 
+    "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fG8FAJmvXOrKXGIRN8+y41U41IfVXxPRVwyB05LoMqYSjugx/FSBkMZUZXUT/wclTdmBKtS5MKoi0bEKkmRhSw=="],
+
     "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw=="],
 
     "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA=="],
@@ -3670,17 +3675,15 @@
 
     "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.5.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw=="],
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA=="],
-
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
-
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw=="],
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA=="],
 
     "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
+
+    "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fG8FAJmvXOrKXGIRN8+y41U41IfVXxPRVwyB05LoMqYSjugx/FSBkMZUZXUT/wclTdmBKtS5MKoi0bEKkmRhSw=="],
 
     "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw=="],
 
@@ -3763,6 +3766,8 @@
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/sdk-logs": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-JpOh7MguEUls8eRfkVVW3yRhClo5b9LqwWTOg8+i4gjr/+8eiCtquJnC7whvpTIGyff06cLZ2NsEj+CVP3Mjeg=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-proto": ["@opentelemetry/exporter-logs-otlp-proto@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-trace-base": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-RQJEV/K6KPbQrIUbsrRkEe0ufks1o5OGLHy6jbDD8tRjeCsbFHWfg99lYBRqBV33PYZJXsigqMaAbjWGTFYzLw=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.207.0", "@opentelemetry/otlp-transformer": "0.207.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fG8FAJmvXOrKXGIRN8+y41U41IfVXxPRVwyB05LoMqYSjugx/FSBkMZUZXUT/wclTdmBKtS5MKoi0bEKkmRhSw=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/exporter-prometheus": ["@opentelemetry/exporter-prometheus@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-metrics": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Y5p1s39FvIRmU+F1++j7ly8/KSqhMmn6cMfpQqiDCqDjdDHwUtSq0XI0WwL3HYGnZeaR/VV4BNmsYQJ7GAPrhw=="],
 
@@ -4174,14 +4179,6 @@
 
     "@opentelemetry/exporter-metrics-otlp-grpc/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
-
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer/@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-4MEQmn04y+WFe6cyzdrXf58hZxilvY59lzZj2AccuHW/+BxLn/rGVN/Irsi/F0qfBOpMOrrCLKTExoSL2zoQmg=="],
-
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw=="],
-
-    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
-
     "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-transformer/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
 
     "@opentelemetry/exporter-metrics-otlp-proto/@opentelemetry/otlp-transformer/@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-4MEQmn04y+WFe6cyzdrXf58hZxilvY59lzZj2AccuHW/+BxLn/rGVN/Irsi/F0qfBOpMOrrCLKTExoSL2zoQmg=="],
@@ -4233,6 +4230,10 @@
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.207.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.207.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA=="],
 
     "@opentelemetry/sdk-trace-node/@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
@@ -4533,6 +4534,8 @@
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-http/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/exporter-logs-otlp-proto/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
     "@playwright/experimental-ct-core/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 

--- a/packages/sandbox/daemon-go/internal/setup/depmetrics.go
+++ b/packages/sandbox/daemon-go/internal/setup/depmetrics.go
@@ -11,10 +11,11 @@ import (
 	"github.com/decocms/studio/sandbox-daemon/internal/telemetry"
 )
 
-// Dependency telemetry leaves the pod as JSON lines on stdout, NOT OTLP: a
-// sandbox pod's egress is locked to 53/443, so no in-cluster collector is
-// reachable. Shapes here must stay byte-compatible with the TS daemon's
-// setup/dep-metrics.ts or the sandbox dashboard panels stop matching.
+// Dependency telemetry leaves the pod as JSON lines on stdout AND, where
+// sandbox-env's `telemetry.*` opens an ACCEPT to the in-cluster collector, as
+// OTLP metrics (see EmitDepsRestore). Shapes here must stay byte-compatible
+// with the TS daemon's setup/dep-metrics.ts or the sandbox dashboard panels
+// stop matching.
 
 const (
 	maxDeps        = 10_000

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -84,12 +84,17 @@ import {
 import { makeScriptsHandler } from "./routes/scripts";
 import { discoverScripts } from "./process/script-discovery";
 import { SetupOrchestrator } from "./setup/orchestrator";
+import { initTelemetry, recordPhase } from "./telemetry";
 import type { Config, TenantConfig } from "./types";
 import { makeWsUpgrader, type WsProxyData } from "./ws-proxy";
 
 if (!process.env.DAEMON_BOOT_ID) {
   process.env.DAEMON_BOOT_ID = randomUUID();
 }
+
+// Before anything that can finish a phase. No-op unless the deployment set
+// OTEL_EXPORTER_OTLP_ENDPOINT (sandbox-env's `telemetry.*`).
+const otelShutdown = initTelemetry(process.env.DAEMON_BOOT_ID, "ts");
 
 // Corepack walks UP from cwd to find the closest `packageManager` field and
 // rejects mismatched invocations. On host runners the daemon's workdir lives
@@ -184,7 +189,11 @@ lifecycle.transition = (next) => {
 };
 // Per-command history for LLM context (each bash/exec spawned via TaskManager
 // is tracked as a phase). Setup pipeline phases live on `lifecycle` instead.
-const phaseManager = new PhaseManager();
+//
+// One hook covers every phase, so per-phase boot cost needs no per-call-site
+// instrumentation and a phase added later is measured for free. Same wiring as
+// daemon-go's `d.phases.OnFinish` — the two must stay comparable.
+const phaseManager = new PhaseManager({ onFinish: recordPhase });
 const taskManager = new TaskManager({
   logsDir: TMP_DIR,
   phaseManager,
@@ -962,6 +971,12 @@ async function shutdown(): Promise<void> {
   if (mountManager) {
     await mountManager.stop().catch(() => {});
   }
+  // Flush the current export window: a sandbox torn down inside the 30s
+  // interval would otherwise report nothing, and short-lived pods are exactly
+  // the boots a cold-start comparison cares about. Raced, because an
+  // unreachable collector must not spend the SIGTERM grace period we just used
+  // to push the user's work.
+  await Promise.race([otelShutdown().catch(() => {}), sleep(2000)]);
   process.exit(0);
 }
 

--- a/packages/sandbox/daemon/process/phase-manager.test.ts
+++ b/packages/sandbox/daemon/process/phase-manager.test.ts
@@ -35,4 +35,30 @@ describe("PhaseManager", () => {
       "task-499",
     ]);
   });
+
+  test("onFinish reports name, terminal status and a duration per phase", () => {
+    const seen: Array<[string, string, number]> = [];
+    const pm = new PhaseManager({
+      onFinish: (name, status, durationMs) =>
+        seen.push([name, status, durationMs]),
+    });
+    pm.done(pm.begin("clone"));
+    pm.fail(pm.begin("install"), "exit 1");
+    expect(seen.map(([name, status]) => [name, status])).toEqual([
+      ["clone", "done"],
+      ["install", "failed"],
+    ]);
+    expect(seen.every(([, , ms]) => ms >= 0)).toBe(true);
+  });
+
+  test("onFinish fires once per phase — a double done must not double-count", () => {
+    let calls = 0;
+    const pm = new PhaseManager({ onFinish: () => calls++ });
+    const id = pm.begin("install");
+    pm.done(id);
+    pm.done(id);
+    pm.fail(id, "too late");
+    pm.done("never-existed");
+    expect(calls).toBe(1);
+  });
 });

--- a/packages/sandbox/daemon/process/phase-manager.ts
+++ b/packages/sandbox/daemon/process/phase-manager.ts
@@ -11,6 +11,17 @@ export interface Phase {
 
 export interface PhaseManagerDeps {
   onChange?: (phases: Phase[]) => void;
+  /**
+   * Called once per phase that reaches a terminal state, with its wall-clock
+   * duration. Optional so this module keeps no dependency on the telemetry
+   * stack — entry.ts wires it up. Fires only on a real transition: `done`/`fail`
+   * are idempotent by design, and a double `done` must not double-count.
+   */
+  onFinish?: (
+    name: string,
+    status: Exclude<PhaseStatus, "running">,
+    durationMs: number,
+  ) => void;
 }
 
 // A long-lived daemon can run many thousands of tasks (every /exec call
@@ -55,6 +66,7 @@ export class PhaseManager {
     t.doneAt = Date.now();
     this.trim();
     this.emit();
+    this.deps.onFinish?.(t.name, "done", t.doneAt - t.startedAt);
   }
 
   fail(id: string, error?: string): void {
@@ -65,6 +77,7 @@ export class PhaseManager {
     if (error) t.error = error;
     this.trim();
     this.emit();
+    this.deps.onFinish?.(t.name, "failed", t.doneAt - t.startedAt);
   }
 
   list(filter?: { status?: ReadonlyArray<PhaseStatus> }): Phase[] {

--- a/packages/sandbox/daemon/setup/dep-metrics.ts
+++ b/packages/sandbox/daemon/setup/dep-metrics.ts
@@ -1,5 +1,6 @@
 import { stat } from "node:fs/promises";
 import { join } from "node:path";
+import { recordDepsRestore } from "../telemetry";
 import type { PackageManager } from "../types";
 import { repoHash } from "./golden-cache";
 
@@ -110,16 +111,18 @@ export interface DepsRestoreInput {
  * needs the pod to land on a node already warm for its repo, so the hit rate
  * is a property of fleet churn, not of the cache code.
  *
- * A log line rather than a metric, for three reasons:
- *  - it is the only channel that leaves a sandbox pod (see the note on
- *    `emitInstalledDeps` — egress is locked to 53/443, so no in-cluster OTLP
- *    collector is reachable);
+ * Kept as a log line even though the same event is now also a metric (see
+ * `emitDepsRestore`), for two reasons:
  *  - `bootId` is free here and unbounded cardinality as a metric attribute.
  *    Without it a counter cannot tell "one pod installed three times" from
  *    "three pods", and `stepInstall` does re-run within a boot (config change,
  *    reprovision);
  *  - raw durations beat pre-bucketed histograms when the range is unknown,
  *    which is the whole point of measuring.
+ *
+ * The third original reason — that stdout is the only channel out of a sandbox
+ * pod, egress being locked to 53/443 — no longer holds: sandbox-env's
+ * `telemetry.*` opens one ACCEPT to the in-cluster collector.
  *
  * Sized for the pipeline that drops big lines and samples bursts: ~150 bytes,
  * one per boot. Both limits are orders of magnitude away — no chunking, no
@@ -138,6 +141,11 @@ export function buildDepsRestoreLine(input: DepsRestoreInput): string {
 export function emitDepsRestore(input: DepsRestoreInput): void {
   try {
     console.log(buildDepsRestoreLine(input));
+    // Same event, second channel. The stdout line above keeps `bootId` and the
+    // raw duration and is what the existing panels read; the metric is what
+    // survives the log pipeline, which samples info-level lines at 1% and so
+    // cannot be counted on. No-op unless OTLP is configured.
+    recordDepsRestore(input.source, Math.round(input.durationMs));
   } catch {
     // never let telemetry break the install path
   }

--- a/packages/sandbox/daemon/telemetry.e2e.test.ts
+++ b/packages/sandbox/daemon/telemetry.e2e.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The TS twin of daemon-go's TestInitExportsToEndpoint. Runs a real OTLP/HTTP
+ * receiver on localhost and asserts the daemon's three instruments arrive with
+ * the names, units and attributes the Go daemon uses — the export path is what
+ * silently breaks (a resource merge failure, a wrong content type, a histogram
+ * the collector rejects), and none of it shows up in a type check.
+ */
+
+import { afterEach, expect, test } from "bun:test";
+import { initTelemetry, recordDepsRestore, recordPhase } from "./telemetry";
+
+const originalEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+const originalInterval = process.env.OTEL_METRIC_EXPORT_INTERVAL;
+
+afterEach(() => {
+  process.env.OTEL_EXPORTER_OTLP_ENDPOINT = originalEndpoint;
+  process.env.OTEL_METRIC_EXPORT_INTERVAL = originalInterval;
+});
+
+test("exports the daemon instruments to an OTLP endpoint", async () => {
+  const bodies: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      bodies.push(await req.text());
+      return new Response("{}", {
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  try {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = `http://localhost:${server.port}`;
+    // Long enough that only the shutdown flush can produce the export, which is
+    // the path a short-lived sandbox actually takes.
+    process.env.OTEL_METRIC_EXPORT_INTERVAL = "600000";
+
+    const shutdown = initTelemetry("boot-test", "ts");
+    recordPhase("install", "done", 1234);
+    recordDepsRestore("l1", 42);
+    await shutdown();
+
+    const payload = bodies.join("");
+    expect(payload).toContain("sandbox.daemon.phase.duration");
+    expect(payload).toContain("sandbox.daemon.deps.restore");
+    expect(payload).toContain("sandbox.daemon.deps.restore.duration");
+    // The comparison dimension: without it a panel cannot split ts from go.
+    expect(payload).toContain("daemon.impl");
+    expect(payload).toContain("studio-sandbox-daemon");
+    expect(payload).toContain("install");
+    expect(payload).toContain("l1");
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("is a no-op with no endpoint configured", async () => {
+  process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "";
+  const shutdown = initTelemetry("boot-test", "ts");
+  // Recording against an uninitialised pipeline must not throw — every call
+  // site is on the boot path.
+  recordPhase("clone", "failed", 1);
+  recordDepsRestore("miss", 1);
+  await shutdown();
+});

--- a/packages/sandbox/daemon/telemetry.ts
+++ b/packages/sandbox/daemon/telemetry.ts
@@ -1,0 +1,141 @@
+/**
+ * Daemon-internal OTLP metrics — the TS twin of daemon-go's
+ * `internal/telemetry`. Instrument names, units and attributes MUST stay
+ * identical across the two daemons: the whole point is that a panel can split
+ * one series by `daemon.impl` and compare ts against go. A rename on one side
+ * doesn't break anything loudly, it just makes the comparison silently compare
+ * nothing.
+ *
+ * These metrics exist because the equivalent stdout lines are sampled at 1% by
+ * the log pipeline, which is fine for a fleet-wide rate and useless at canary
+ * volume.
+ *
+ * Unlike Go, instruments are created INSIDE `initTelemetry`, not at module
+ * scope: `@opentelemetry/api`'s metrics surface has no proxy meter provider
+ * (only tracing does), so an instrument taken from the global before a real
+ * provider is installed stays a no-op forever.
+ */
+
+import { hostname } from "node:os";
+import type { Counter, Histogram } from "@opentelemetry/api";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import {
+  defaultResource,
+  resourceFromAttributes,
+} from "@opentelemetry/resources";
+import {
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from "@opentelemetry/sdk-metrics";
+
+const SCOPE = "github.com/decocms/studio/sandbox-daemon";
+
+// A sandbox's median life is minutes, so the SDK's 60s default would lose
+// short-lived pods entirely; faster buys nothing, since these instruments fire
+// a handful of times per boot. Read here rather than left to the SDK so the
+// standard OTel knob works regardless of which env vars this SDK version parses.
+const DEFAULT_EXPORT_INTERVAL_MS = 30_000;
+
+let phaseDuration: Histogram | undefined;
+let depsRestore: Counter | undefined;
+let depsRestoreDuration: Histogram | undefined;
+
+const noopShutdown = async (): Promise<void> => {};
+
+/**
+ * Installs the OTLP metric pipeline. Returns a shutdown function that is safe
+ * to call whether or not an exporter was started.
+ *
+ * No endpoint configured is the normal, expected case (desktop, local dev, any
+ * deploy that has not opted in) — it returns a no-op and no error.
+ */
+export function initTelemetry(
+  bootId: string,
+  impl: string,
+): () => Promise<void> {
+  if (!process.env.OTEL_EXPORTER_OTLP_ENDPOINT) return noopShutdown;
+
+  try {
+    // Merge, not replace: the default resource carries telemetry.sdk.* and the
+    // service.name fallback.
+    const resource = defaultResource().merge(
+      resourceFromAttributes({
+        "service.name": "studio-sandbox-daemon",
+        // The pod name is the join key back to the k8s labels Studio stamps
+        // (org, user, sandbox handle, daemon-impl). Carrying tenant identity in
+        // the metric itself would put org and user ids on every series; the pod
+        // name keeps cardinality flat and the join available.
+        "k8s.pod.name": hostname(),
+        // The comparison dimension for the Go rollout. Also on the pod label
+        // and the boot log line; all three must agree.
+        "daemon.impl": impl,
+        "daemon.boot_id": bootId,
+      }),
+    );
+
+    const provider = new MeterProvider({
+      resource,
+      readers: [
+        new PeriodicExportingMetricReader({
+          exporter: new OTLPMetricExporter(),
+          exportIntervalMillis:
+            Number(process.env.OTEL_METRIC_EXPORT_INTERVAL) ||
+            DEFAULT_EXPORT_INTERVAL_MS,
+        }),
+      ],
+    });
+
+    const meter = provider.getMeter(SCOPE);
+
+    phaseDuration = meter.createHistogram("sandbox.daemon.phase.duration", {
+      unit: "ms",
+      description:
+        "Wall-clock duration of each setup phase (clone, install, dev-server start). The per-phase boot cost breakdown, which exists nowhere outside the daemon: Studio sees only the total time until the sandbox answers.",
+    });
+
+    depsRestore = meter.createCounter("sandbox.daemon.deps.restore", {
+      unit: "{step}",
+      description:
+        "Dependency-install outcomes by cache tier (l1 / l2 / miss / no-install). The golden-cache hit rate. Also emitted as a stdout line, but that path is sampled at 1% by the log pipeline and cannot be counted on.",
+    });
+
+    depsRestoreDuration = meter.createHistogram(
+      "sandbox.daemon.deps.restore.duration",
+      {
+        unit: "ms",
+        description:
+          "Wall-clock duration of the dependency step, split by cache tier. A cache hit that is not meaningfully faster than a miss is the signal that the cache is not paying for itself.",
+      },
+    );
+
+    console.log(
+      `[daemon] otlp metrics enabled endpoint=${process.env.OTEL_EXPORTER_OTLP_ENDPOINT} impl=${impl} boot_id=${bootId}`,
+    );
+
+    return () => provider.shutdown();
+  } catch (err) {
+    // Telemetry must never break a boot.
+    console.warn("[daemon] otlp metrics init failed", err);
+    return noopShutdown;
+  }
+}
+
+/**
+ * Reports one finished setup phase. `status` is "done" or "failed" — a failed
+ * phase is a boot that produced a duration but not a sandbox, and averaging the
+ * two together hides exactly the regression a canary looks for.
+ */
+export function recordPhase(
+  name: string,
+  status: string,
+  durationMs: number,
+): void {
+  phaseDuration?.record(durationMs, { phase: name, status });
+}
+
+/** Reports one dependency step and which cache tier served it. */
+export function recordDepsRestore(source: string, durationMs: number): void {
+  const attrs = { source };
+  depsRestore?.add(1, attrs);
+  depsRestoreDuration?.record(durationMs, attrs);
+}

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -33,6 +33,9 @@
     "@kubernetes/client-node": "^1.4.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.211.0",
+    "@opentelemetry/resources": "^2.7.0",
+    "@opentelemetry/sdk-metrics": "^2.7.0",
     "node-pty": "^1.0.0",
     "zod": "4.3.6"
   },


### PR DESCRIPTION
The Go daemon has exported per-phase boot cost and golden-cache hit rate since #5521. The TS daemon exports nothing — no file under `packages/sandbox/daemon/` even reads `OTEL_EXPORTER_OTLP_ENDPOINT`. So the ts-vs-go comparison the canary exists to make has exactly one side, and any dashboard built today would be Go-only.

Confirmed on the live templates before writing this:

```
sandboxtemplate/studio-sandbox-stg      → OTEL_EXPORTER_OTLP_ENDPOINT set (TS image, exports nothing)
sandboxtemplate/studio-sandbox-stg-go   → OTEL_EXPORTER_OTLP_ENDPOINT set, daemon logs "otlp metrics enabled"
```

The TS parity channel — the `sandbox.deps.restore` stdout line — is sampled at 1% by the log pipeline, which is fine for a fleet-wide rate and useless at canary volume. That's the same reason the Go side added metrics.

## What changed

- **`daemon/telemetry.ts`** (new) — the TS twin of `daemon-go/internal/telemetry`. Same three instruments, same names, units, descriptions, attributes (`phase`/`status`, `source`) and resource attributes (`service.name`, `k8s.pod.name`, `daemon.impl`, `daemon.boot_id`). Same 30s export interval and the same "no endpoint configured is the normal case" no-op.
- **`daemon/process/phase-manager.ts`** — optional `onFinish(name, status, durationMs)` dep, fired only on a real transition. Mirrors Go's `PhaseManager.OnFinish`: one hook covers every phase, so a phase added later is measured for free.
- **`daemon/entry.ts`** — init before anything can finish a phase; `onFinish: recordPhase`; a raced 2s flush on shutdown so a sandbox torn down inside the export window still reports (short-lived pods are exactly the boots a cold-start comparison cares about).
- **`daemon/setup/dep-metrics.ts`** — `emitDepsRestore` records the same event on both channels, as Go's `EmitDepsRestore` does. All four call sites funnel through it.
- Both daemons: dropped the now-false comment that stdout is the only channel out of a sandbox pod. `telemetry.*` opens an ACCEPT to the collector, and the Go file asserting it was already calling `telemetry.RecordDepsRestore` three lines below.

## One deliberate difference from Go

Instruments are created **inside** `initTelemetry`, not at module scope. `@opentelemetry/api` has a proxy provider for tracing but not for metrics, so an instrument taken from the global before a real provider is installed stays a no-op forever. Go's package-level instruments work because otel-go's global provider delegates.

## Deps

`@opentelemetry/sdk-metrics`, `@opentelemetry/resources` (both 2.7.0, same majors `apps/api` already runs) and `@opentelemetry/exporter-metrics-otlp-http` 0.211.0. Skipped `semantic-conventions` — the four attribute keys are string constants, and the wire result is identical.

The daemon is bundled (`bun build --target=bun`), so this is bundle size, not install time: **3.20 → 3.30 MB**.

## Testing

- `daemon/telemetry.e2e.test.ts` (new) — the twin of Go's `TestInitExportsToEndpoint`. Runs a real OTLP receiver on localhost, forces the export to come from the shutdown flush (the path a short-lived sandbox takes), and asserts all three instrument names plus `daemon.impl` and the attribute values arrive. Also asserts recording against an uninitialised pipeline doesn't throw — every call site is on the boot path. This is the check that catches what a type check can't: a resource-merge failure, a wrong content type, a histogram the collector rejects.
- `phase-manager.test.ts` — two cases: `onFinish` reports name/terminal status/duration, and fires exactly once per phase (a double `done`, a `fail` after `done`, and an unknown id must not double-count).
- `bun test` over all 87 non-e2e sandbox files: 730 pass, 0 fail. `bun run --workspaces check`, `bun run lint`, `knip` and `bun run fmt` clean.

## Known, shared with the Go side — not fixed here

`PhaseManager.begin` is called with `spec.label ?? spec.command`, so a user's bash command becomes the `phase` attribute value. Unbounded cardinality on both daemons. It lands in ClickHouse as rows rather than a TSDB series explosion, so it's survivable, but capping or normalising the label is worth a follow-up on both sides at once — doing it on one side only would break the comparison this PR exists to enable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OTLP metrics to the TS sandbox daemon to match the Go daemon (phase durations and dependency restore rate/duration) so dashboards can compare ts vs go. Metrics initialize only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set.

- **New Features**
  - Added `daemon/telemetry.ts` with three instruments: `sandbox.daemon.phase.duration`, `sandbox.daemon.deps.restore`, and `sandbox.daemon.deps.restore.duration` (same names, units, attributes, and resource attributes as Go; 30s export interval).
  - `PhaseManager` gains `onFinish(name, status, durationMs)` and is wired in `entry.ts` to record phases; metrics calls are safe no-ops without an endpoint.
  - `emitDepsRestore` now records OTLP metrics in addition to the existing stdout line; added e2e test to validate export and PhaseManager tests.

- **Dependencies**
  - Added `@opentelemetry/exporter-metrics-otlp-http@^0.211.0`, `@opentelemetry/sdk-metrics@^2.7.0`, `@opentelemetry/resources@^2.7.0` (sandbox bundle ~3.20 → 3.30 MB).

<sup>Written for commit add684233d7000bd08fe2bc4361cd70ece0bb697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

