### PR TITLE
feat(sandbox): measure boot, lag, proxy, restarts and shutdown sync on both daemons

### DIFF
--- a/packages/sandbox/daemon-go/internal/proxy/proxy.go
+++ b/packages/sandbox/daemon-go/internal/proxy/proxy.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/decocms/studio/sandbox-daemon/internal/probe"
+	"github.com/decocms/studio/sandbox-daemon/internal/telemetry"
 )
 
 type Deps struct {
@@ -86,11 +87,22 @@ func (p *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	outReq.Header.Del("Authorization")
 	outReq.Host = r.Host
 
+	// Measured to headers, not to the last body byte: SSE / NDJSON / long-poll
+	// responses stream for as long as the client keeps them open, and folding
+	// that into the same histogram would drown the number this exists to show
+	// (how long the dev server took to start answering).
+	upstreamStartedAt := time.Now()
 	upstream, err := p.transport.RoundTrip(outReq)
 	if err != nil {
+		telemetry.RecordProxy(r.Context(), time.Since(upstreamStartedAt).Milliseconds(), "error")
 		p.proxyError(w, r, port, err)
 		return
 	}
+	telemetry.RecordProxy(
+		r.Context(),
+		time.Since(upstreamStartedAt).Milliseconds(),
+		fmt.Sprintf("%dxx", upstream.StatusCode/100),
+	)
 	defer upstream.Body.Close()
 
 	if upstream.StatusCode >= 500 && p.deps.Log != nil {

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"github.com/decocms/studio/sandbox-daemon/internal/lifecycle"
 	"github.com/decocms/studio/sandbox-daemon/internal/paths"
 	"github.com/decocms/studio/sandbox-daemon/internal/proc"
+	"github.com/decocms/studio/sandbox-daemon/internal/telemetry"
 )
 
 type Step string
@@ -68,6 +70,10 @@ func NewOrchestrator(deps OrchestratorDeps) *Orchestrator {
 		if s.LogName == "" || !proc.IsWellKnownStarter(s.LogName) {
 			return
 		}
+		// Counted before the intentional gate below: a restart the daemon asked
+		// for and a user app crashlooping are the same event from outside the
+		// pod, and telling them apart is the whole point of the attribute.
+		telemetry.RecordDevServerExit(context.Background(), s.Intentional)
 		if s.Intentional {
 			return
 		}
@@ -217,6 +223,37 @@ func (o *Orchestrator) rawChunk(data string) {
 }
 
 func (o *Orchestrator) stepClone() bool {
+	return timedPhase("clone", o.stepCloneInner)
+}
+
+func (o *Orchestrator) stepInstall() bool {
+	return timedPhase("install", o.stepInstallInner)
+}
+
+func (o *Orchestrator) stepStart() {
+	timedPhase("start", func() bool { o.stepStartInner(); return true })
+}
+
+// timedPhase times one setup step and reports it under the same instrument the
+// TaskManager phases use. Wrapping the three step methods here rather than
+// threading a timer through their many exit points is what makes `clone` and
+// `install` measurable at all — neither goes through the PhaseManager, so until
+// now sandbox.daemon.phase.duration covered only the dev-server spawn and user
+// commands, despite claiming otherwise.
+//
+// A step signals failure by returning false, which aborts the pipeline.
+func timedPhase(name string, run func() bool) bool {
+	startedAt := time.Now()
+	ok := run()
+	status := "done"
+	if !ok {
+		status = "failed"
+	}
+	telemetry.RecordPhase(context.Background(), name, status, time.Since(startedAt).Milliseconds())
+	return ok
+}
+
+func (o *Orchestrator) stepCloneInner() bool {
 	cfg := o.deps.Store.Read()
 	if cfg == nil {
 		return false
@@ -297,7 +334,7 @@ func (o *Orchestrator) maybeFastForwardToBase() {
 	))
 }
 
-func (o *Orchestrator) stepInstall() bool {
+func (o *Orchestrator) stepInstallInner() bool {
 	cfg := o.deps.Store.Read()
 	if cfg == nil {
 		return false
@@ -390,7 +427,7 @@ func (o *Orchestrator) stepInstall() bool {
 	return true
 }
 
-func (o *Orchestrator) stepStart() {
+func (o *Orchestrator) stepStartInner() {
 	cfg := o.deps.Store.Read()
 	if cfg == nil {
 		return

--- a/packages/sandbox/daemon-go/internal/telemetry/telemetry.go
+++ b/packages/sandbox/daemon-go/internal/telemetry/telemetry.go
@@ -32,6 +32,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strconv"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -76,7 +77,90 @@ var (
 			"Wall-clock duration of the dependency step, split by cache tier. A cache hit that is not meaningfully faster than a miss is the signal that the cache is not paying for itself.",
 		),
 	)
+
+	readyDuration, _ = meter.Int64Histogram(
+		"sandbox.daemon.ready.duration",
+		metric.WithUnit("ms"),
+		metric.WithDescription(
+			"Daemon boot to the dev server answering, recorded once per boot. The in-pod half of cold start: Studio's own claim-to-answering number folds in scheduling and image pull, which no daemon change can move.",
+		),
+	)
+
+	loopLag, _ = meter.Int64Histogram(
+		"sandbox.daemon.loop.lag",
+		metric.WithUnit("ms"),
+		metric.WithDescription(
+			"Scheduling delay of a fixed-interval timer. A blocked loop (TS) or a descheduled process (both) stops the daemon answering its health probe, and Studio tears the sandbox down on a single miss — this is the only signal that says why, while the pod is still alive to say it.",
+		),
+	)
+
+	proxyDuration, _ = meter.Int64Histogram(
+		"sandbox.daemon.proxy.duration",
+		metric.WithUnit("ms"),
+		metric.WithDescription(
+			"Time to proxy one request to the user's dev server. Separates a slow sandbox from a slow app — nothing outside the pod can see this hop.",
+		),
+	)
+
+	devServerExit, _ = meter.Int64Counter(
+		"sandbox.daemon.devserver.exit",
+		metric.WithUnit("{exit}"),
+		metric.WithDescription(
+			"Dev-server process exits, split by whether the daemon asked for it. Unintentional exits are a crashlooping user app, which reads identically to a broken sandbox from the outside.",
+		),
+	)
+
+	publishDuration, _ = meter.Int64Histogram(
+		"sandbox.daemon.publish.duration",
+		metric.WithUnit("ms"),
+		metric.WithDescription(
+			"The SIGTERM git sync — the one irrecoverable step of a teardown, and the reason the pod grace period is 90s. How close this runs to the grace period is how much of the user's work is one slow push from being lost.",
+		),
+	)
 )
+
+// Explicit buckets for the boot-cost histograms, shared verbatim with the TS
+// daemon's telemetry.ts. Two panels can only be compared if their buckets
+// agree, and the OTel default set stops at 10s — a clone or install routinely
+// exceeds that, so on the default every interesting boot lands in +Inf and
+// every percentile above p50 is a fabrication.
+var durationBucketsMs = []float64{
+	50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 20_000, 30_000, 60_000,
+	120_000, 300_000,
+}
+
+// Loop lag lives in a different range entirely — sub-millisecond when healthy,
+// and the interesting question is "did it cross ~1s", not "was it 30s or 60s".
+var lagBucketsMs = []float64{1, 5, 10, 25, 50, 100, 250, 500, 1_000, 5_000, 30_000}
+
+// How often the lag sampler ticks. Cheap enough to leave on always, fine-grained
+// enough to catch the multi-second stalls that make the daemon miss its probe.
+const lagSampleInterval = time.Second
+
+// views pins the histogram boundaries. Split out from Init so a test can assert
+// the bounds off a manual reader: the OTLP exporter here speaks protobuf, so
+// boundaries are binary on the wire and cannot be asserted by inspecting it.
+func views() []sdkmetric.View {
+	return []sdkmetric.View{
+		// Lag first: it must not also match the ms-duration view below, which
+		// would register the same instrument twice.
+		sdkmetric.NewView(
+			sdkmetric.Instrument{Name: "sandbox.daemon.loop.lag"},
+			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+				Boundaries: lagBucketsMs,
+			}},
+		),
+		// Everything else measured in ms. Matched by wildcard so an instrument
+		// added later inherits the shared buckets instead of silently falling
+		// back to the 10s-capped default.
+		sdkmetric.NewView(
+			sdkmetric.Instrument{Name: "sandbox.daemon.*.duration"},
+			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+				Boundaries: durationBucketsMs,
+			}},
+		),
+	}
+}
 
 // Init installs the OTLP metric pipeline. Returns a shutdown func that is safe
 // to call whether or not an exporter was started.
@@ -131,14 +215,47 @@ func Init(ctx context.Context, bootID, impl string) (func(context.Context) error
 	provider := sdkmetric.NewMeterProvider(
 		sdkmetric.WithResource(res),
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, readerOpts...)),
+		sdkmetric.WithView(views()...),
 	)
 	otel.SetMeterProvider(provider)
+
+	stopLag := startLoopLagSampler()
 
 	slog.Info("otlp metrics enabled",
 		"endpoint", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
 		"impl", impl, "boot_id", bootID)
 
-	return provider.Shutdown, nil
+	return func(ctx context.Context) error {
+		stopLag()
+		return provider.Shutdown(ctx)
+	}, nil
+}
+
+// startLoopLagSampler samples how late a fixed-interval ticker actually fires.
+// On a starved node that lateness is the scheduler; on the TS daemon the same
+// instrument catches a blocked event loop. Same failure from the sandbox's
+// point of view, which is why both daemons sample it under one name.
+func startLoopLagSampler() func() {
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(lagSampleInterval)
+		defer ticker.Stop()
+		expected := time.Now().Add(lagSampleInterval)
+		for {
+			select {
+			case <-done:
+				return
+			case now := <-ticker.C:
+				lag := now.Sub(expected).Milliseconds()
+				if lag < 0 {
+					lag = 0
+				}
+				loopLag.Record(context.Background(), lag)
+				expected = now.Add(lagSampleInterval)
+			}
+		}
+	}()
+	return func() { close(done) }
 }
 
 // RecordPhase reports one finished setup phase. `status` is "done" or "failed"
@@ -156,4 +273,32 @@ func RecordDepsRestore(ctx context.Context, source string, durationMs int64) {
 	attrs := metric.WithAttributes(attribute.String("source", source))
 	depsRestore.Add(ctx, 1, attrs)
 	depsRestoreDuration.Record(ctx, durationMs, attrs)
+}
+
+// RecordReady reports the boot that produced a serving sandbox. Called once per
+// boot — a dev server that crashes and comes back is a restart, not a second
+// cold start, and counting it as one would flatter every average.
+func RecordReady(ctx context.Context, durationMs int64) {
+	readyDuration.Record(ctx, durationMs)
+}
+
+// RecordProxy reports one proxied request to the user's dev server.
+func RecordProxy(ctx context.Context, durationMs int64, statusClass string) {
+	proxyDuration.Record(ctx, durationMs, metric.WithAttributes(
+		attribute.String("status_class", statusClass),
+	))
+}
+
+// RecordDevServerExit reports one dev-server process exit.
+func RecordDevServerExit(ctx context.Context, intentional bool) {
+	devServerExit.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("intentional", strconv.FormatBool(intentional)),
+	))
+}
+
+// RecordPublish reports the shutdown git sync. `status` is "done" or "failed".
+func RecordPublish(ctx context.Context, status string, durationMs int64) {
+	publishDuration.Record(ctx, durationMs, metric.WithAttributes(
+		attribute.String("status", status),
+	))
 }

--- a/packages/sandbox/daemon-go/internal/telemetry/telemetry_test.go
+++ b/packages/sandbox/daemon-go/internal/telemetry/telemetry_test.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // The exporter is the whole point of this package and the one part that cannot
@@ -37,6 +41,16 @@ func TestInitExportsToEndpoint(t *testing.T) {
 
 	RecordPhase(context.Background(), "install", "done", 1234)
 	RecordDepsRestore(context.Background(), "no-install", 7)
+	RecordReady(context.Background(), 9876)
+	RecordProxy(context.Background(), 12, "2xx")
+	RecordDevServerExit(context.Background(), false)
+	RecordPublish(context.Background(), "done", 345)
+	// Loop lag has no Record* of its own — Init's sampler is the only producer,
+	// so waiting one tick is what proves the sampler runs. It has to be asserted
+	// here rather than in a test of its own: otel-go binds these package-level
+	// instruments to the FIRST provider installed in the process, so a second
+	// Init in the same binary would record into this test's dead exporter.
+	time.Sleep(lagSampleInterval + 200*time.Millisecond)
 
 	// Shutdown force-flushes, so this asserts on a real export rather than
 	// racing the periodic reader.
@@ -59,6 +73,11 @@ func TestInitExportsToEndpoint(t *testing.T) {
 	for _, want := range []string{
 		"sandbox.daemon.phase.duration",
 		"sandbox.daemon.deps.restore",
+		"sandbox.daemon.ready.duration",
+		"sandbox.daemon.proxy.duration",
+		"sandbox.daemon.devserver.exit",
+		"sandbox.daemon.publish.duration",
+		"sandbox.daemon.loop.lag",
 		"install",
 		"no-install",
 		// The rollout comparison dimension has to reach the wire, not just the
@@ -70,6 +89,57 @@ func TestInitExportsToEndpoint(t *testing.T) {
 			t.Errorf("export missing %q", want)
 		}
 	}
+}
+
+// Bounds are asserted off a manual reader rather than the wire: the OTLP
+// exporter speaks protobuf, so boundaries are binary there and a passing
+// string-match would prove nothing. Getting this wrong is silent — the SDK
+// falls back to a default set that stops at 10s, which buckets a 45s install
+// and a 5-minute one identically, and makes these panels incomparable to the TS
+// daemon's (which pins the same boundaries).
+func TestViewsPinSharedBuckets(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithView(views()...),
+	)
+	meter := provider.Meter(scopeName)
+	phase, _ := meter.Int64Histogram("sandbox.daemon.phase.duration")
+	lag, _ := meter.Int64Histogram("sandbox.daemon.loop.lag")
+	phase.Record(context.Background(), 45_000)
+	lag.Record(context.Background(), 2)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	bounds := map[string][]float64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if h, ok := m.Data.(metricdata.Histogram[int64]); ok && len(h.DataPoints) > 0 {
+				bounds[m.Name] = h.DataPoints[0].Bounds
+			}
+		}
+	}
+
+	if got := bounds["sandbox.daemon.phase.duration"]; !contains(got, 300_000) {
+		t.Errorf("phase duration bounds missing 300000: %v", got)
+	}
+	// Lag must NOT inherit the duration set: on those bounds every healthy
+	// sample sits in the first bucket and the metric says nothing.
+	if got := bounds["sandbox.daemon.loop.lag"]; !contains(got, 1) || contains(got, 300_000) {
+		t.Errorf("loop lag should use the lag bounds, got: %v", got)
+	}
+}
+
+func contains(xs []float64, want float64) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestInitIsNoopWithoutEndpoint(t *testing.T) {

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -60,8 +60,13 @@ func isSandboxPath(pathname string) bool {
 	return false
 }
 
+// Zero for the boot-to-serving measurement. A package var so it is stamped at
+// process start — anything later would silently exclude whatever ran before it.
+var processStartedAt = time.Now()
+
 type daemon struct {
 	mu              sync.Mutex
+	readyOnce       sync.Once
 	token           string
 	bootId          string
 	appRoot         string
@@ -100,6 +105,9 @@ type daemon struct {
 
 	health http.HandlerFunc
 	mux    *http.ServeMux
+
+	// Bounded metric flush on the SIGTERM path; nil when metrics are off.
+	otelShutdown func(context.Context) error
 }
 
 // sandboxHandlers is the daemon API's leaf handlers, built once and mounted
@@ -416,6 +424,7 @@ func (d *daemon) shutdown() {
 
 	cfg := d.store.Read()
 	if cfg != nil && cfg.Branch() != "" {
+		publishStartedAt := time.Now()
 		release := d.treeLock.Acquire()
 		err := gitx.Publish(gitx.PublishDeps{
 			RepoDir:     d.repoDir,
@@ -426,9 +435,23 @@ func (d *daemon) shutdown() {
 			OnInvalidBlock: gitx.InvalidBlockSkip,
 		}, "chore(daemon): sync all local changes to remote on shutdown")
 		release()
+		status := "done"
 		if err != nil {
+			status = "failed"
 			slog.Error("shutdown publish failed", "err", err)
 		}
+		telemetry.RecordPublish(context.Background(), status, time.Since(publishStartedAt).Milliseconds())
+	}
+	// Flush the current export window. os.Exit below skips main's deferred
+	// shutdown, so without this a sandbox torn down inside the 30s interval
+	// reports nothing — and short-lived pods are exactly the boots a cold-start
+	// comparison cares about. Bounded at 2s, AFTER the publish: an unreachable
+	// collector must not spend the grace period that saves the user's work.
+	// The TS daemon races the same 2s budget at the same point.
+	if d.otelShutdown != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = d.otelShutdown(ctx)
+		cancel()
 	}
 	os.Exit(0)
 }
@@ -464,9 +487,9 @@ func main() {
 	// Metrics are opt-in via OTEL_EXPORTER_OTLP_ENDPOINT and best-effort: a
 	// collector that is unreachable, misconfigured or absent must never keep a
 	// sandbox from booting, so a failure here is logged and execution continues
-	// with the no-op provider. No shutdown flush on SIGTERM either — that path
-	// belongs to the git-sync that saves the user's work, and metrics do not get
-	// to spend its grace period.
+	// with the no-op provider. The SIGTERM path flushes too, but only after the
+	// git-sync that saves the user's work and only within a bounded budget — see
+	// daemon.shutdown().
 	otelShutdown, err := telemetry.Init(context.Background(), bootId, "go")
 	if err != nil {
 		slog.Warn("otlp metrics disabled: exporter init failed", "err", err)
@@ -518,6 +541,7 @@ func main() {
 		tmpDir:        tmpDir,
 		currentStatus: events.DaemonStatus{State: "running"},
 		pendingPaths:  map[string]struct{}{},
+		otelShutdown:  otelShutdown,
 	}
 
 	d.broadcaster = events.NewBroadcaster(routes.ReplayBytesCapacity)
@@ -538,6 +562,15 @@ func main() {
 		}
 		if prev.Phase != next.Phase {
 			slog.Info("lifecycle transition", "from", prev.Phase, "to", next.Phase)
+		}
+		// Every path to a serving sandbox ends here, so one hook covers cold
+		// boot, golden restore and resume alike. Once per process: a dev server
+		// that crashes and comes back re-enters `running`, and counting that as
+		// a second cold start would flatter every average it appears in.
+		if next.Phase == events.PhaseRunning {
+			d.readyOnce.Do(func() {
+				telemetry.RecordReady(context.Background(), time.Since(processStartedAt).Milliseconds())
+			})
 		}
 	}
 

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -84,7 +84,7 @@ import {
 import { makeScriptsHandler } from "./routes/scripts";
 import { discoverScripts } from "./process/script-discovery";
 import { SetupOrchestrator } from "./setup/orchestrator";
-import { initTelemetry, recordPhase } from "./telemetry";
+import { initTelemetry, recordPhase, recordPublish } from "./telemetry";
 import type { Config, TenantConfig } from "./types";
 import { makeWsUpgrader, type WsProxyData } from "./ws-proxy";
 
@@ -95,6 +95,10 @@ if (!process.env.DAEMON_BOOT_ID) {
 // Before anything that can finish a phase. No-op unless the deployment set
 // OTEL_EXPORTER_OTLP_ENDPOINT (sandbox-env's `telemetry.*`).
 const otelShutdown = initTelemetry(process.env.DAEMON_BOOT_ID, "ts");
+
+// Zero for the boot-to-serving measurement. Taken here, at the top of the
+// module, because anything later would silently exclude whatever ran before it.
+const BOOTED_AT = Date.now();
 
 // Corepack walks UP from cwd to find the closest `packageManager` field and
 // rejects mismatched invocations. On host runners the daemon's workdir lives
@@ -169,7 +173,7 @@ function setStatus(next: DaemonStatus) {
 
 const store = new TenantConfigStore();
 const installState = new InstallState();
-const lifecycle = new LifecycleManager({ broadcaster });
+const lifecycle = new LifecycleManager({ broadcaster, bootedAt: BOOTED_AT });
 let resetProbeState = (): void => {};
 // Drop the sniffed port whenever we leave `running` — the next dev start
 // may bind somewhere else and we need to re-sniff its announcement.
@@ -952,6 +956,7 @@ async function shutdown(): Promise<void> {
   // could hang on a credential prompt until SIGKILL.
   const branch = store.read()?.git?.repository?.branch;
   if (branch) {
+    const publishStartedAt = Date.now();
     try {
       // "skip" (not "throw"): an invalid decofile block must not abort the whole
       // shutdown sync — that would silently lose the user's other valid work when
@@ -962,7 +967,9 @@ async function shutdown(): Promise<void> {
         "chore(daemon): sync all local changes to remote on shutdown",
         { onInvalidBlock: "skip" },
       );
+      recordPublish("done", Date.now() - publishStartedAt);
     } catch (err) {
+      recordPublish("failed", Date.now() - publishStartedAt);
       console.warn("[daemon] shutdown publish failed", err);
     }
   }

--- a/packages/sandbox/daemon/lifecycle/manager.ts
+++ b/packages/sandbox/daemon/lifecycle/manager.ts
@@ -1,8 +1,14 @@
 import type { Broadcaster } from "../events/broadcast";
 import type { LifecycleState } from "../events/types";
+import { recordReady } from "../telemetry";
 
 export interface LifecycleManagerDeps {
   broadcaster: Broadcaster;
+  /**
+   * Process start, for the boot-to-serving measurement. Injected rather than
+   * read from the module so a test can define "boot" without touching globals.
+   */
+  bootedAt?: number;
 }
 
 /**
@@ -16,6 +22,7 @@ export interface LifecycleManagerDeps {
  */
 export class LifecycleManager {
   private state: LifecycleState = { phase: "idle" };
+  private readySeen = false;
 
   constructor(private readonly deps: LifecycleManagerDeps) {}
 
@@ -28,6 +35,16 @@ export class LifecycleManager {
     if (equal(this.state, next)) return;
     this.state = next;
     this.deps.broadcaster.emit("lifecycle", { state: next });
+    // Every path to a serving sandbox ends here, so one hook covers cold boot,
+    // golden restore and resume alike. Once per process: a dev server that
+    // crashes and comes back re-enters `running`, and counting that as a second
+    // cold start would flatter every average it appears in.
+    if (next.phase === "running" && !this.readySeen) {
+      this.readySeen = true;
+      if (this.deps.bootedAt !== undefined) {
+        recordReady(Date.now() - this.deps.bootedAt);
+      }
+    }
   }
 }
 

--- a/packages/sandbox/daemon/proxy.ts
+++ b/packages/sandbox/daemon/proxy.ts
@@ -1,6 +1,7 @@
 import { BOOTSTRAP_SCRIPT } from "./constants";
 import type { Broadcaster } from "./events/broadcast";
 import { fetchLoopback } from "../proxy/http";
+import { recordProxy } from "./telemetry";
 
 export interface ProxyDeps {
   broadcaster: Broadcaster;
@@ -56,6 +57,11 @@ export function makeProxyHandler({ broadcaster, getDevPort }: ProxyDeps) {
     const onClientAbort = () => upstreamAbort.abort();
     req.signal.addEventListener("abort", onClientAbort, { once: true });
 
+    // Measured to headers, not to the last body byte: SSE / NDJSON / long-poll
+    // responses stream for as long as the client keeps them open, and folding
+    // that into the same histogram would drown the number this exists to show
+    // (how long the dev server took to start answering).
+    const upstreamStartedAt = Date.now();
     let upstream: Response;
     try {
       const init: RequestInit = {
@@ -73,8 +79,13 @@ export function makeProxyHandler({ broadcaster, getDevPort }: ProxyDeps) {
         init,
       );
       clearTimeout(headersTimeout);
+      recordProxy(
+        Date.now() - upstreamStartedAt,
+        `${Math.floor(upstream.status / 100)}xx`,
+      );
     } catch (e) {
       clearTimeout(headersTimeout);
+      recordProxy(Date.now() - upstreamStartedAt, "error");
       req.signal.removeEventListener("abort", onClientAbort);
       const msg = (e as Error).message ?? String(e);
       log("proxy error", req.method, url.pathname, `port=${port}`, msg);

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -37,6 +37,7 @@ import { configureGitIdentity } from "./identity";
 import { denoCacheEnv, resolveCloneUrl, spawnInstall } from "./install";
 import { publishRemoteGolden, tryRestoreRemoteGolden } from "./remote-golden";
 import { spawnSetupStep } from "./spawn-step";
+import { recordDevServerExit, recordPhase } from "../telemetry";
 import { installProtectedBranchHook } from "../git/protect-branch";
 
 const INSTALL_LOG_MAX_BYTES = 10 * 1024 * 1024;
@@ -89,6 +90,10 @@ export class SetupOrchestrator {
         )
       )
         return;
+      // Counted before the intentional gate below: a restart the daemon asked
+      // for and a user app crashlooping are the same event from outside the
+      // pod, and telling them apart is the whole point of the attribute.
+      recordDevServerExit(summary.intentional === true);
       if (summary.intentional) return;
       if (summary.exitCode === 0 || summary.exitCode === null) return;
       const reason = `dev script exited with code ${summary.exitCode}`;
@@ -268,7 +273,46 @@ export class SetupOrchestrator {
    * branch. Then runs idempotent post-source-acquisition steps (git
    * identity, protected-branch hook, fillDefaults).
    */
-  private async stepClone(): Promise<boolean> {
+  /**
+   * Times one setup step and reports it under the same instrument the
+   * TaskManager phases use. Wrapping the three step methods here rather than
+   * threading a timer through their many exit points is what makes `clone` and
+   * `install` measurable at all — neither goes through the PhaseManager, so
+   * until now `sandbox.daemon.phase.duration` covered only the dev-server
+   * spawn and user commands, despite claiming otherwise.
+   *
+   * A step signals failure by returning false, which aborts the pipeline — same
+   * meaning as a throw, so both report "failed".
+   */
+  private async timedPhase<T>(name: string, run: () => Promise<T>): Promise<T> {
+    const startedAt = Date.now();
+    try {
+      const result = await run();
+      recordPhase(
+        name,
+        result === false ? "failed" : "done",
+        Date.now() - startedAt,
+      );
+      return result;
+    } catch (e) {
+      recordPhase(name, "failed", Date.now() - startedAt);
+      throw e;
+    }
+  }
+
+  private stepClone(): Promise<boolean> {
+    return this.timedPhase("clone", () => this.stepCloneInner());
+  }
+
+  private stepInstall(): Promise<boolean> {
+    return this.timedPhase("install", () => this.stepInstallInner());
+  }
+
+  private stepStart(): Promise<void> {
+    return this.timedPhase("start", () => this.stepStartInner());
+  }
+
+  private async stepCloneInner(): Promise<boolean> {
     const config = this.currentConfig();
     if (!config) return false;
     const cloneUrl = config.git?.repository?.cloneUrl;
@@ -392,7 +436,7 @@ export class SetupOrchestrator {
    * Run install. Skips when fingerprint matches (already installed for this
    * config + branch HEAD). Returns true on success/skip, false on failure.
    */
-  private async stepInstall(): Promise<boolean> {
+  private async stepInstallInner(): Promise<boolean> {
     const config = this.currentConfig();
     if (!config) return false;
     if (this.deps.installState.isInstalledFor(config, this.currentBranchHead)) {
@@ -534,7 +578,7 @@ export class SetupOrchestrator {
    * Spawn the dev script. Probe drives the transition from `starting` to
    * `running` once the dev server responds.
    */
-  private async stepStart(): Promise<void> {
+  private async stepStartInner(): Promise<void> {
     const config = this.currentConfig();
     if (!config) return;
     if (this.deps.getStatus().state !== "running") {

--- a/packages/sandbox/daemon/telemetry.e2e.test.ts
+++ b/packages/sandbox/daemon/telemetry.e2e.test.ts
@@ -1,13 +1,22 @@
 /**
  * The TS twin of daemon-go's TestInitExportsToEndpoint. Runs a real OTLP/HTTP
- * receiver on localhost and asserts the daemon's three instruments arrive with
- * the names, units and attributes the Go daemon uses — the export path is what
+ * receiver on localhost and asserts the daemon's instruments arrive with the
+ * names, units, buckets and attributes the Go daemon uses — the export path is what
  * silently breaks (a resource merge failure, a wrong content type, a histogram
  * the collector rejects), and none of it shows up in a type check.
  */
 
 import { afterEach, expect, test } from "bun:test";
-import { initTelemetry, recordDepsRestore, recordPhase } from "./telemetry";
+import { sleep } from "@decocms/shared/std";
+import {
+  initTelemetry,
+  recordDepsRestore,
+  recordDevServerExit,
+  recordPhase,
+  recordProxy,
+  recordPublish,
+  recordReady,
+} from "./telemetry";
 
 const originalEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
 const originalInterval = process.env.OTEL_METRIC_EXPORT_INTERVAL;
@@ -38,17 +47,102 @@ test("exports the daemon instruments to an OTLP endpoint", async () => {
     const shutdown = initTelemetry("boot-test", "ts");
     recordPhase("install", "done", 1234);
     recordDepsRestore("l1", 42);
+    recordReady(9876);
+    recordProxy(12, "2xx");
+    recordDevServerExit(false);
+    recordPublish("done", 345);
     await shutdown();
 
     const payload = bodies.join("");
-    expect(payload).toContain("sandbox.daemon.phase.duration");
-    expect(payload).toContain("sandbox.daemon.deps.restore");
-    expect(payload).toContain("sandbox.daemon.deps.restore.duration");
+    for (const name of [
+      "sandbox.daemon.phase.duration",
+      "sandbox.daemon.deps.restore",
+      "sandbox.daemon.deps.restore.duration",
+      "sandbox.daemon.ready.duration",
+      "sandbox.daemon.proxy.duration",
+      "sandbox.daemon.devserver.exit",
+      "sandbox.daemon.publish.duration",
+    ]) {
+      expect(payload).toContain(name);
+    }
     // The comparison dimension: without it a panel cannot split ts from go.
     expect(payload).toContain("daemon.impl");
     expect(payload).toContain("studio-sandbox-daemon");
     expect(payload).toContain("install");
     expect(payload).toContain("l1");
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("duration histograms carry buckets that reach past a slow boot", async () => {
+  const bodies: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      bodies.push(await req.text());
+      return new Response("{}", {
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  try {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = `http://localhost:${server.port}`;
+    process.env.OTEL_METRIC_EXPORT_INTERVAL = "600000";
+
+    const shutdown = initTelemetry("boot-test", "ts");
+    recordPhase("install", "done", 45_000);
+    await shutdown();
+
+    const phase = JSON.parse(
+      bodies.join(""),
+    ).resourceMetrics[0].scopeMetrics[0].metrics.find(
+      (m: { name: string }) => m.name === "sandbox.daemon.phase.duration",
+    ).histogram.dataPoints[0];
+    // The OTel default set stops at 10s, which would bucket a 45s install into
+    // +Inf together with every other slow boot — and a percentile computed from
+    // that is fiction. These bounds are shared verbatim with daemon-go so the
+    // two impls' panels are comparable at all.
+    expect(phase.explicitBounds).toContain(300_000);
+    expect(phase.bucketCounts.at(-1)).toBe(0);
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("samples loop lag on its own timer", async () => {
+  const bodies: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      bodies.push(await req.text());
+      return new Response("{}", {
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  try {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = `http://localhost:${server.port}`;
+    process.env.OTEL_METRIC_EXPORT_INTERVAL = "600000";
+
+    const shutdown = initTelemetry("boot-test", "ts");
+    // Nothing records lag explicitly — the sampler is the only producer, so
+    // this also proves it was started and survives to the flush. One tick plus
+    // slack; the sampler's interval is 1s.
+    await sleep(1_200);
+    await shutdown();
+
+    const lag = JSON.parse(
+      bodies.join(""),
+    ).resourceMetrics[0].scopeMetrics[0].metrics.find(
+      (m: { name: string }) => m.name === "sandbox.daemon.loop.lag",
+    )?.histogram.dataPoints[0];
+    expect(lag.count).toBeGreaterThan(0);
+    // Lag has its own bucket set — the duration bounds would put every healthy
+    // sample in the first bucket and say nothing.
+    expect(lag.explicitBounds).toContain(1);
   } finally {
     server.stop(true);
   }

--- a/packages/sandbox/daemon/telemetry.ts
+++ b/packages/sandbox/daemon/telemetry.ts
@@ -24,11 +24,38 @@ import {
   resourceFromAttributes,
 } from "@opentelemetry/resources";
 import {
+  AggregationType,
   MeterProvider,
   PeriodicExportingMetricReader,
 } from "@opentelemetry/sdk-metrics";
 
 const SCOPE = "github.com/decocms/studio/sandbox-daemon";
+
+/**
+ * Explicit buckets for the boot-cost histograms, shared verbatim with
+ * daemon-go. Two panels can only be compared if their buckets agree, and the
+ * OTel default set stops at 10s — a clone or install routinely exceeds that, so
+ * on the default every interesting boot lands in `+Inf` and every percentile
+ * above p50 is a fabrication. Range chosen to cover a warm restore (~100ms) to
+ * a cold install on a starved node (minutes).
+ */
+const DURATION_BUCKETS_MS = [
+  50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 20_000, 30_000, 60_000,
+  120_000, 300_000,
+];
+
+/**
+ * Loop lag lives in a different range entirely — sub-millisecond when healthy,
+ * and the interesting question is "did it cross ~1s", not "was it 30s or 60s".
+ */
+const LAG_BUCKETS_MS = [1, 5, 10, 25, 50, 100, 250, 500, 1_000, 5_000, 30_000];
+
+/**
+ * How often the lag sampler ticks. Cheap enough to leave on always (one timer
+ * wake per second), fine-grained enough to catch the multi-second sync blocks
+ * that make the daemon miss its health probe.
+ */
+const LAG_SAMPLE_INTERVAL_MS = 1_000;
 
 // A sandbox's median life is minutes, so the SDK's 60s default would lose
 // short-lived pods entirely; faster buys nothing, since these instruments fire
@@ -39,6 +66,11 @@ const DEFAULT_EXPORT_INTERVAL_MS = 30_000;
 let phaseDuration: Histogram | undefined;
 let depsRestore: Counter | undefined;
 let depsRestoreDuration: Histogram | undefined;
+let readyDuration: Histogram | undefined;
+let loopLag: Histogram | undefined;
+let proxyDuration: Histogram | undefined;
+let devServerExit: Counter | undefined;
+let publishDuration: Histogram | undefined;
 
 const noopShutdown = async (): Promise<void> => {};
 
@@ -75,6 +107,25 @@ export function initTelemetry(
 
     const provider = new MeterProvider({
       resource,
+      views: [
+        {
+          instrumentName: "sandbox.daemon.loop.lag",
+          aggregation: {
+            type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+            options: { boundaries: LAG_BUCKETS_MS },
+          },
+        },
+        // Everything else measured in ms. Listed by wildcard so an instrument
+        // added later inherits the shared buckets instead of silently falling
+        // back to the 10s-capped default.
+        {
+          instrumentName: "sandbox.daemon.*.duration",
+          aggregation: {
+            type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+            options: { boundaries: DURATION_BUCKETS_MS },
+          },
+        },
+      ],
       readers: [
         new PeriodicExportingMetricReader({
           exporter: new OTLPMetricExporter(),
@@ -108,11 +159,46 @@ export function initTelemetry(
       },
     );
 
+    readyDuration = meter.createHistogram("sandbox.daemon.ready.duration", {
+      unit: "ms",
+      description:
+        "Daemon boot to the dev server answering, recorded once per boot. The in-pod half of cold start: Studio's own claim-to-answering number folds in scheduling and image pull, which no daemon change can move.",
+    });
+
+    loopLag = meter.createHistogram("sandbox.daemon.loop.lag", {
+      unit: "ms",
+      description:
+        "Scheduling delay of a fixed-interval timer. A blocked loop (TS) or a descheduled process (both) stops the daemon answering its health probe, and Studio tears the sandbox down on a single miss — this is the only signal that says why, while the pod is still alive to say it.",
+    });
+
+    proxyDuration = meter.createHistogram("sandbox.daemon.proxy.duration", {
+      unit: "ms",
+      description:
+        "Time to proxy one request to the user's dev server. Separates a slow sandbox from a slow app — nothing outside the pod can see this hop.",
+    });
+
+    devServerExit = meter.createCounter("sandbox.daemon.devserver.exit", {
+      unit: "{exit}",
+      description:
+        "Dev-server process exits, split by whether the daemon asked for it. Unintentional exits are a crashlooping user app, which reads identically to a broken sandbox from the outside.",
+    });
+
+    publishDuration = meter.createHistogram("sandbox.daemon.publish.duration", {
+      unit: "ms",
+      description:
+        "The SIGTERM git sync — the one irrecoverable step of a teardown, and the reason the pod grace period is 90s. How close this runs to the grace period is how much of the user's work is one slow push from being lost.",
+    });
+
+    startLoopLagSampler();
+
     console.log(
       `[daemon] otlp metrics enabled endpoint=${process.env.OTEL_EXPORTER_OTLP_ENDPOINT} impl=${impl} boot_id=${bootId}`,
     );
 
-    return () => provider.shutdown();
+    return async () => {
+      stopLoopLagSampler();
+      await provider.shutdown();
+    };
   } catch (err) {
     // Telemetry must never break a boot.
     console.warn("[daemon] otlp metrics init failed", err);
@@ -138,4 +224,52 @@ export function recordDepsRestore(source: string, durationMs: number): void {
   const attrs = { source };
   depsRestore?.add(1, attrs);
   depsRestoreDuration?.record(durationMs, attrs);
+}
+
+/**
+ * Reports the boot that produced a serving sandbox. Called once per boot — a
+ * dev server that crashes and comes back is a restart, not a second cold start,
+ * and counting it as one would flatter every average.
+ */
+export function recordReady(durationMs: number): void {
+  readyDuration?.record(durationMs);
+}
+
+/** Reports one proxied request to the user's dev server. */
+export function recordProxy(durationMs: number, statusClass: string): void {
+  proxyDuration?.record(durationMs, { status_class: statusClass });
+}
+
+/** Reports one dev-server process exit. */
+export function recordDevServerExit(intentional: boolean): void {
+  devServerExit?.add(1, { intentional: String(intentional) });
+}
+
+/** Reports the shutdown git sync. `status` is "done" or "failed". */
+export function recordPublish(status: string, durationMs: number): void {
+  publishDuration?.record(durationMs, { status });
+}
+
+let lagTimer: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * Samples how late a fixed-interval timer actually fires. On the TS daemon that
+ * lateness IS the event-loop block (CONTRIBUTING rule #1); on a starved node it
+ * is the scheduler. Both are the same failure from the sandbox's point of view,
+ * which is why daemon-go samples the same way under the same instrument name.
+ */
+function startLoopLagSampler(): void {
+  let expected = Date.now() + LAG_SAMPLE_INTERVAL_MS;
+  lagTimer = setInterval(() => {
+    const now = Date.now();
+    loopLag?.record(Math.max(0, now - expected));
+    expected = now + LAG_SAMPLE_INTERVAL_MS;
+  }, LAG_SAMPLE_INTERVAL_MS);
+  // Never hold the process open for telemetry.
+  lagTimer.unref?.();
+}
+
+function stopLoopLagSampler(): void {
+  if (lagTimer) clearInterval(lagTimer);
+  lagTimer = undefined;
 }


### PR DESCRIPTION
## The existing instrument was measuring the wrong thing

`sandbox.daemon.phase.duration` says it covers "clone, install, dev-server start". It doesn't. `PhaseManager.begin` has exactly one caller on each daemon — `task-manager.ts:382` / `taskmanager.go:199` — and the orchestrator runs `stepClone`/`stepInstall` through `spawnSetupStep`, which never touches the phase manager. What was actually collected: the dev-server spawn plus every user bash/exec command. **Clone was unmeasured entirely**; install survived only as `deps.restore`'s duration.

Wrapping the three step methods in a `timedPhase` helper fixes it on both daemons and makes the description true. A step signals failure by returning false (aborting the pipeline), same meaning as a throw — both report `failed`.

## Five new instruments, identical on both daemons

| instrument | why the daemon is the only thing that can report it |
|---|---|
| `sandbox.daemon.ready.duration` | boot → dev server answering, once per boot. The in-pod half of cold start; Studio's claim-to-answering folds in scheduling and image pull, which no daemon change can move. Hooked on the lifecycle transition to `running`, so cold boot / golden restore / resume are all covered by one hook. |
| `sandbox.daemon.loop.lag` | lateness of a fixed-interval timer. A blocked loop (TS) or a descheduled process (both) stops the daemon answering its health probe, and Studio tears the sandbox down on a single miss. Today that failure is only visible from the corpse. |
| `sandbox.daemon.proxy.duration` | the in-pod hop, measured to headers (streaming bodies would drown it). Separates "sandbox is slow" from "the user's Vite is slow" — unanswerable from either side today. |
| `sandbox.daemon.devserver.exit` | dev-server exits split by `intentional`. A crashlooping user app and a broken sandbox read identically from outside the pod. |
| `sandbox.daemon.publish.duration` | the SIGTERM git sync — the one irrecoverable teardown step, and the reason the grace period went 30s → 90s (#4561). Tells you whether 90s is actually enough. |

Once-per-boot on `ready` is deliberate: a dev server that crashes and comes back re-enters `running`, and counting that as a second cold start would flatter every average it appears in.

## Panels have to be comparable, so buckets are pinned

Both daemons now pin the same explicit boundaries (50ms → 300s for durations, 1ms → 30s for lag). The OTel spec default stops at **10s** — a clone or install routinely exceeds that, so on the default every interesting boot lands in `+Inf` and every percentile above p50 is fiction. Two histograms can only be compared if their buckets agree, so these are shared verbatim between `telemetry.ts` and `telemetry.go`.

`daemon.impl` stays a resource attribute, so one query splits ts vs go on every instrument.

## Go now flushes on shutdown too

Go's `shutdown()` calls `os.Exit(0)`, so main's deferred flush never ran — short-lived Go sandboxes reported nothing while TS (after #5558) reported. That's an asymmetry in exactly the boots a cold-start comparison cares about. Go now flushes on the same terms as TS: bounded at 2s, **after** the git sync, so an unreachable collector can never spend the grace period that saves the user's work. The comment claiming otherwise is updated.

## Testing

- **TS** — `telemetry.e2e.test.ts` extended: all seven recorded instruments arrive at a real OTLP receiver; a dedicated test asserts a 45s phase lands in a real bucket rather than `+Inf`; another lets the sampler tick and asserts lag exports with its own bounds.
- **Go** — `TestInitExportsToEndpoint` extended with the new instruments and lag. Bounds are asserted off a `ManualReader` in `TestViewsPinSharedBuckets`, **not** off the wire: the Go exporter speaks protobuf, so boundaries are binary there and a string match would prove nothing (my first attempt did exactly that and passed for the wrong reason).
- Full runs: `go build ./... && go vet ./... && go test ./...` all green; `bun test` over 87 non-e2e sandbox files — 730 pass, 0 fail; `bun run --workspaces check`, `lint`, `knip`, `fmt` clean.

Two things worth knowing about otel-go that this turned up: package-level instruments bind to the **first** provider installed in a process (so a second `Init` in one test binary records into a dead exporter — the lag assertion has to live in the first test), and a JS instrument with no data points is omitted from the export entirely.

## Known, unchanged

`PhaseManager.begin` still takes `spec.label ?? spec.command`, so a user's bash command becomes the `phase` attribute value on both daemons. Unbounded cardinality; it lands in ClickHouse as rows rather than a series explosion, so it's survivable. Capping it needs to happen on both sides at once or the comparison breaks, which is its own PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes phase timing to actually measure clone, install, and start, and adds unified performance metrics across both daemons. Also pins shared histogram buckets for comparable panels and ensures Go flushes metrics on shutdown.

- **New Features**
  - Add five instruments on TS and Go: `sandbox.daemon.ready.duration`, `sandbox.daemon.loop.lag`, `sandbox.daemon.proxy.duration`, `sandbox.daemon.devserver.exit`, `sandbox.daemon.publish.duration`.
  - Pin shared buckets for histograms (durations: 50ms–300s; lag: 1ms–30s) in both `telemetry.ts` and `telemetry.go`.
  - Sample `sandbox.daemon.loop.lag` every 1s; measure `sandbox.daemon.proxy.duration` to headers with `status_class`; emit `ready.duration` once when entering `running`.

- **Bug Fixes**
  - `sandbox.daemon.phase.duration` now truly covers clone, install, and start by wrapping these steps in a timed helper on both daemons; failures report `failed`.
  - Go daemon now flushes metrics on SIGTERM after the git sync (2s budget) so short-lived pods are reported.

<sup>Written for commit 6d7c1d5f8eb673f7f1430ff925a9cc9db94559de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

