### PR TITLE
fix(sandbox): classify start-phase outcomes, stop orphaning the lag timer

### DIFF
--- a/packages/sandbox/daemon-go/internal/lifecycle/lifecycle.go
+++ b/packages/sandbox/daemon-go/internal/lifecycle/lifecycle.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"encoding/json"
 	"sync"
+	"time"
 
 	"github.com/decocms/studio/sandbox-daemon/internal/events"
 )
@@ -16,6 +17,16 @@ type Manager struct {
 	state        events.LifecycleState
 	broadcaster  Broadcaster
 	OnTransition func(prev, next events.LifecycleState)
+
+	// OnStartPhase reports a finished `start` phase. Spawning the dev script
+	// says nothing about whether it serves — Spawn returns once the process
+	// exists, so timing it would measure fork latency and would never observe a
+	// failure. The phase ends where it becomes observable: the probe seeing the
+	// server (running) or the script dying (start-failed). Optional, so this
+	// package keeps no dependency on the telemetry stack — main wires it up.
+	OnStartPhase func(status string, durationMs int64)
+
+	startAttemptAt time.Time
 }
 
 func New(b Broadcaster) *Manager {
@@ -31,6 +42,23 @@ func (m *Manager) Current() events.LifecycleState {
 	return m.state
 }
 
+// NoteStartAttempt records that a dev script was just spawned. The phase it
+// opens is closed by the next running / start-failed transition. A second
+// attempt before the first resolves (branch change mid-boot) replaces it: the
+// abandoned attempt has no terminal state to measure to.
+func (m *Manager) NoteStartAttempt() {
+	m.mu.Lock()
+	m.startAttemptAt = time.Now()
+	m.mu.Unlock()
+}
+
+// CancelStartAttempt drops the open attempt — the step spawned nothing.
+func (m *Manager) CancelStartAttempt() {
+	m.mu.Lock()
+	m.startAttemptAt = time.Time{}
+	m.mu.Unlock()
+}
+
 func (m *Manager) Transition(next events.LifecycleState) {
 	m.mu.Lock()
 	prev := m.state
@@ -40,10 +68,29 @@ func (m *Manager) Transition(next events.LifecycleState) {
 	}
 	m.state = next
 	hook := m.OnTransition
+
+	// Resolve an open start attempt under the same lock that owns the state, so
+	// two transitions racing cannot both report the same attempt.
+	var startStatus string
+	var startMs int64
+	if !m.startAttemptAt.IsZero() &&
+		(next.Phase == events.PhaseRunning || next.Phase == events.PhaseStartFailed) {
+		startStatus = "done"
+		if next.Phase == events.PhaseStartFailed {
+			startStatus = "failed"
+		}
+		startMs = time.Since(m.startAttemptAt).Milliseconds()
+		m.startAttemptAt = time.Time{}
+	}
+	startHook := m.OnStartPhase
 	m.mu.Unlock()
+
 	m.broadcaster.Emit("lifecycle", map[string]any{"state": next})
 	if hook != nil {
 		hook(prev, next)
+	}
+	if startStatus != "" && startHook != nil {
+		startHook(startStatus, startMs)
 	}
 }
 

--- a/packages/sandbox/daemon-go/internal/lifecycle/lifecycle_test.go
+++ b/packages/sandbox/daemon-go/internal/lifecycle/lifecycle_test.go
@@ -1,0 +1,89 @@
+package lifecycle
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/decocms/studio/sandbox-daemon/internal/events"
+)
+
+type nopBroadcaster struct{}
+
+func (nopBroadcaster) Emit(string, any) {}
+
+type recorder struct {
+	mu   sync.Mutex
+	seen []string
+}
+
+func (r *recorder) record(status string, _ int64) {
+	r.mu.Lock()
+	r.seen = append(r.seen, status)
+	r.mu.Unlock()
+}
+
+func newManager() (*Manager, *recorder) {
+	rec := &recorder{}
+	m := New(nopBroadcaster{})
+	m.OnStartPhase = rec.record
+	return m, rec
+}
+
+func running() events.LifecycleState {
+	return events.LifecycleState{Phase: events.PhaseRunning, Port: 3000}
+}
+
+// Spawning proves nothing about whether the dev server serves, so nothing may
+// be reported until a terminal state arrives.
+func TestStartPhaseReportedOnRunning(t *testing.T) {
+	m, rec := newManager()
+	m.NoteStartAttempt()
+	m.Transition(events.LifecycleState{Phase: events.PhaseStarting})
+	if len(rec.seen) != 0 {
+		t.Fatalf("reported before the server was reachable: %v", rec.seen)
+	}
+	m.Transition(running())
+	if len(rec.seen) != 1 || rec.seen[0] != "done" {
+		t.Fatalf("want one done, got %v", rec.seen)
+	}
+}
+
+func TestStartPhaseReportedAsFailed(t *testing.T) {
+	m, rec := newManager()
+	m.NoteStartAttempt()
+	m.Transition(events.LifecycleState{Phase: events.PhaseStartFailed, Error: "exit 1"})
+	if len(rec.seen) != 1 || rec.seen[0] != "failed" {
+		t.Fatalf("want one failed, got %v", rec.seen)
+	}
+}
+
+func TestSkippedStartOpensNoPhase(t *testing.T) {
+	m, rec := newManager()
+	m.NoteStartAttempt()
+	m.CancelStartAttempt()
+	m.Transition(running())
+	if len(rec.seen) != 0 {
+		t.Fatalf("a skipped start reported a phase: %v", rec.seen)
+	}
+}
+
+// A crash and recovery is a restart, not a second start phase.
+func TestOneAttemptReportsOnce(t *testing.T) {
+	m, rec := newManager()
+	m.NoteStartAttempt()
+	m.Transition(running())
+	m.Transition(events.LifecycleState{Phase: events.PhaseCrashed})
+	m.Transition(running())
+	if len(rec.seen) != 1 {
+		t.Fatalf("want one report, got %v", rec.seen)
+	}
+}
+
+func TestNoAttemptReportsNothing(t *testing.T) {
+	m, rec := newManager()
+	m.Transition(running())
+	m.Transition(events.LifecycleState{Phase: events.PhaseStartFailed, Error: "unrelated"})
+	if len(rec.seen) != 0 {
+		t.Fatalf("reported without an attempt: %v", rec.seen)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -240,17 +240,23 @@ const (
 	startSkipped startOutcome = "skipped"
 )
 
-// start cannot use timedPhase: unlike clone/install it has three outcomes, not
-// two. A skipped start never spawned anything, so recording it would drag a
-// near-zero duration into the same series as real boots; and a failure arrives
-// as an outcome rather than a panic, so it must not be averaged in as healthy.
+// start cannot use timedPhase, for two reasons.
+//
+// It has three outcomes rather than two: a skipped start spawned nothing, so
+// there is no phase to report.
+//
+// And it does not finish when this function returns. TaskManager.Spawn returns
+// once the process exists, not once it serves — timing that would measure fork
+// latency and would record every immediately-crashing dev script as a healthy
+// start. So the attempt is left open and closed by the lifecycle, which is
+// where both terminal states arrive: running (the probe reached the server) or
+// start-failed (no start command, or the script exited non-zero).
 func (o *Orchestrator) stepStart() {
-	startedAt := time.Now()
-	outcome := o.stepStartInner()
-	if outcome == startSkipped {
-		return
+	o.deps.Lifecycle.NoteStartAttempt()
+	// startFailed already transitioned to start-failed, which closed the attempt.
+	if o.stepStartInner() == startSkipped {
+		o.deps.Lifecycle.CancelStartAttempt()
 	}
-	telemetry.RecordPhase(context.Background(), "start", string(outcome), time.Since(startedAt).Milliseconds())
 }
 
 // timedPhase times one setup step and reports it under the same instrument the

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -230,8 +230,27 @@ func (o *Orchestrator) stepInstall() bool {
 	return timedPhase("install", o.stepInstallInner)
 }
 
+// startOutcome is what a start attempt actually did. "skipped" is not a boot
+// phase — nothing was spawned — so it is deliberately not reported.
+type startOutcome string
+
+const (
+	startDone    startOutcome = "done"
+	startFailed  startOutcome = "failed"
+	startSkipped startOutcome = "skipped"
+)
+
+// start cannot use timedPhase: unlike clone/install it has three outcomes, not
+// two. A skipped start never spawned anything, so recording it would drag a
+// near-zero duration into the same series as real boots; and a failure arrives
+// as an outcome rather than a panic, so it must not be averaged in as healthy.
 func (o *Orchestrator) stepStart() {
-	timedPhase("start", func() bool { o.stepStartInner(); return true })
+	startedAt := time.Now()
+	outcome := o.stepStartInner()
+	if outcome == startSkipped {
+		return
+	}
+	telemetry.RecordPhase(context.Background(), "start", string(outcome), time.Since(startedAt).Milliseconds())
 }
 
 // timedPhase times one setup step and reports it under the same instrument the
@@ -427,18 +446,18 @@ func (o *Orchestrator) stepInstallInner() bool {
 	return true
 }
 
-func (o *Orchestrator) stepStartInner() {
+func (o *Orchestrator) stepStartInner() startOutcome {
 	cfg := o.deps.Store.Read()
 	if cfg == nil {
-		return
+		return startSkipped
 	}
 	if status := o.deps.GetStatus(); status.State != "running" {
 		o.chunk(fmt.Sprintf("\r\n[orchestrator] skipping start: status=%s (resume to retry)\r\n", status.State))
-		return
+		return startSkipped
 	}
 	if !o.deps.InstallState.IsInstalledFor(cfg, o.branchHead()) {
 		o.chunk("\r\n[orchestrator] skipping start: install fingerprint mismatch\r\n")
-		return
+		return startSkipped
 	}
 	command, ok := o.buildStartCommand(cfg)
 	if !ok {
@@ -446,7 +465,7 @@ func (o *Orchestrator) stepStartInner() {
 		o.chunk(reason)
 		flat := strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(reason, "\r", " "), "\n", " "))
 		o.deps.Lifecycle.Transition(events.LifecycleState{Phase: events.PhaseStartFailed, Error: flat})
-		return
+		return startFailed
 	}
 
 	if runningCmd, runningCwd, found := o.deps.TaskManager.RunningCommandByLogName(command.Source); found &&
@@ -456,7 +475,7 @@ func (o *Orchestrator) stepStartInner() {
 		if cur != events.PhaseRunning && cur != events.PhaseStarting {
 			o.deps.Lifecycle.Transition(events.LifecycleState{Phase: events.PhaseStarting})
 		}
-		return
+		return startSkipped
 	}
 	o.stopDevTask()
 	o.deps.Lifecycle.Transition(events.LifecycleState{Phase: events.PhaseStarting})
@@ -476,6 +495,7 @@ func (o *Orchestrator) stepStartInner() {
 		LogName:          command.Source,
 		ReplaceByLogName: true,
 	})
+	return startDone
 }
 
 type startCommand struct {

--- a/packages/sandbox/daemon-go/internal/telemetry/telemetry_test.go
+++ b/packages/sandbox/daemon-go/internal/telemetry/telemetry_test.go
@@ -46,11 +46,12 @@ func TestInitExportsToEndpoint(t *testing.T) {
 	RecordDevServerExit(context.Background(), false)
 	RecordPublish(context.Background(), "done", 345)
 	// Loop lag has no Record* of its own — Init's sampler is the only producer,
-	// so waiting one tick is what proves the sampler runs. It has to be asserted
+	// so waiting is what proves the sampler runs. Two intervals, not one: a
+	// single delayed tick on a loaded CI host would fail a run that is fine. It has to be asserted
 	// here rather than in a test of its own: otel-go binds these package-level
 	// instruments to the FIRST provider installed in the process, so a second
 	// Init in the same binary would record into this test's dead exporter.
-	time.Sleep(lagSampleInterval + 200*time.Millisecond)
+	time.Sleep(2*lagSampleInterval + 400*time.Millisecond)
 
 	// Shutdown force-flushes, so this asserts on a real export rather than
 	// racing the periodic reader.

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -553,6 +553,9 @@ func main() {
 	d.store = config.NewStore()
 	d.installState = setup.NewInstallState()
 	d.lifecycle = lifecycle.New(d.broadcaster)
+	d.lifecycle.OnStartPhase = func(status string, durationMs int64) {
+		telemetry.RecordPhase(context.Background(), "start", status, durationMs)
+	}
 	d.lifecycle.OnTransition = func(prev, next events.LifecycleState) {
 		if prev.Phase == events.PhaseRunning && next.Phase != events.PhaseRunning {
 			d.sniffer.Reset()

--- a/packages/sandbox/daemon/entry.ts
+++ b/packages/sandbox/daemon/entry.ts
@@ -173,7 +173,12 @@ function setStatus(next: DaemonStatus) {
 
 const store = new TenantConfigStore();
 const installState = new InstallState();
-const lifecycle = new LifecycleManager({ broadcaster, bootedAt: BOOTED_AT });
+const lifecycle = new LifecycleManager({
+  broadcaster,
+  bootedAt: BOOTED_AT,
+  onStartPhase: (status, durationMs) =>
+    recordPhase("start", status, durationMs),
+});
 let resetProbeState = (): void => {};
 // Drop the sniffed port whenever we leave `running` — the next dev start
 // may bind somewhere else and we need to re-sniff its announcement.

--- a/packages/sandbox/daemon/lifecycle/manager.test.ts
+++ b/packages/sandbox/daemon/lifecycle/manager.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { LifecycleManager } from "./manager";
+
+const noopBroadcaster = { emit: () => {} } as unknown as ConstructorParameters<
+  typeof LifecycleManager
+>[0]["broadcaster"];
+
+function makeManager() {
+  const seen: Array<[string, number]> = [];
+  const m = new LifecycleManager({
+    broadcaster: noopBroadcaster,
+    onStartPhase: (status, durationMs) => seen.push([status, durationMs]),
+  });
+  return { m, seen };
+}
+
+describe("LifecycleManager start-phase accounting", () => {
+  test("a spawned start is reported only once the probe sees the server", () => {
+    const { m, seen } = makeManager();
+    m.noteStartAttempt();
+    // Spawning proves nothing — nothing may be reported yet.
+    m.transition({ phase: "starting" });
+    expect(seen).toEqual([]);
+
+    m.transition({ phase: "running", port: 3000, htmlSupport: true });
+    expect(seen.map(([status]) => status)).toEqual(["done"]);
+    expect(seen[0]![1]).toBeGreaterThanOrEqual(0);
+  });
+
+  test("a dev script that dies is reported as failed, not as a healthy start", () => {
+    const { m, seen } = makeManager();
+    m.noteStartAttempt();
+    m.transition({ phase: "start-failed", error: "exit 1" });
+    expect(seen.map(([status]) => status)).toEqual(["failed"]);
+  });
+
+  test("a skipped start opens no phase", () => {
+    const { m, seen } = makeManager();
+    m.noteStartAttempt();
+    m.cancelStartAttempt();
+    m.transition({ phase: "running", port: 3000, htmlSupport: true });
+    expect(seen).toEqual([]);
+  });
+
+  test("one attempt yields one report, however many times it re-enters running", () => {
+    const { m, seen } = makeManager();
+    m.noteStartAttempt();
+    m.transition({ phase: "running", port: 3000, htmlSupport: true });
+    // A crash and recovery is a restart, not a second start phase.
+    m.transition({ phase: "crashed" });
+    m.transition({ phase: "running", port: 3000, htmlSupport: true });
+    expect(seen).toHaveLength(1);
+  });
+
+  test("transitions with no attempt open report nothing", () => {
+    const { m, seen } = makeManager();
+    m.transition({ phase: "running", port: 3000, htmlSupport: true });
+    m.transition({ phase: "start-failed", error: "unrelated" });
+    expect(seen).toEqual([]);
+  });
+});

--- a/packages/sandbox/daemon/lifecycle/manager.ts
+++ b/packages/sandbox/daemon/lifecycle/manager.ts
@@ -9,6 +9,14 @@ export interface LifecycleManagerDeps {
    * read from the module so a test can define "boot" without touching globals.
    */
   bootedAt?: number;
+  /**
+   * Reports a finished `start` phase. Spawning the dev script says nothing
+   * about whether it serves — the process is created and the call returns, so
+   * timing that would measure fork latency and never observe a failure. The
+   * phase ends where it becomes observable: the probe seeing the server
+   * (`running`) or the dev script dying (`start-failed`).
+   */
+  onStartPhase?: (status: "done" | "failed", durationMs: number) => void;
 }
 
 /**
@@ -23,11 +31,27 @@ export interface LifecycleManagerDeps {
 export class LifecycleManager {
   private state: LifecycleState = { phase: "idle" };
   private readySeen = false;
+  private startAttemptAt: number | null = null;
 
   constructor(private readonly deps: LifecycleManagerDeps) {}
 
   current(): LifecycleState {
     return this.state;
+  }
+
+  /**
+   * A dev script was just spawned. The phase it opens is closed by the next
+   * `running` / `start-failed` transition. A second attempt before the first
+   * resolves (branch change mid-boot) replaces it: the abandoned attempt has no
+   * terminal state to measure to.
+   */
+  noteStartAttempt(): void {
+    this.startAttemptAt = Date.now();
+  }
+
+  /** The step spawned nothing, so no phase was opened. */
+  cancelStartAttempt(): void {
+    this.startAttemptAt = null;
   }
 
   /** Idempotent — same-shape transitions don't re-broadcast. */
@@ -44,6 +68,17 @@ export class LifecycleManager {
       if (this.deps.bootedAt !== undefined) {
         recordReady(Date.now() - this.deps.bootedAt);
       }
+    }
+    if (
+      this.startAttemptAt !== null &&
+      (next.phase === "running" || next.phase === "start-failed")
+    ) {
+      const durationMs = Date.now() - this.startAttemptAt;
+      this.startAttemptAt = null;
+      this.deps.onStartPhase?.(
+        next.phase === "running" ? "done" : "failed",
+        durationMs,
+      );
     }
   }
 }

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -51,6 +51,12 @@ export type Step = "clone" | "install" | "start";
 
 const STEP_RANK: Record<Step, number> = { clone: 3, install: 2, start: 1 };
 
+/**
+ * What a start attempt actually did. "skipped" is not a boot phase — nothing
+ * was spawned — so it is deliberately not reported as a duration.
+ */
+type StartOutcome = "done" | "failed" | "skipped";
+
 export interface SetupOrchestratorDeps {
   bootConfig: { appRoot: string; repoDir: string };
   store: TenantConfigStore;
@@ -308,8 +314,26 @@ export class SetupOrchestrator {
     return this.timedPhase("install", () => this.stepInstallInner());
   }
 
-  private stepStart(): Promise<void> {
-    return this.timedPhase("start", () => this.stepStartInner());
+  /**
+   * `start` can't use `timedPhase`: unlike clone/install it has three outcomes,
+   * not two. A skipped start (no config, install fingerprint mismatch, dev
+   * server already up) never spawned anything, so recording it would drag a
+   * near-zero duration into the same series as real boots; and a failure
+   * reaches us as `failed`, not as an exception, so it must not be averaged in
+   * as a healthy boot.
+   */
+  private async stepStart(): Promise<void> {
+    const startedAt = Date.now();
+    let outcome: StartOutcome;
+    try {
+      outcome = await this.stepStartInner();
+    } catch (e) {
+      recordPhase("start", "failed", Date.now() - startedAt);
+      throw e;
+    }
+    if (outcome !== "skipped") {
+      recordPhase("start", outcome, Date.now() - startedAt);
+    }
   }
 
   private async stepCloneInner(): Promise<boolean> {
@@ -578,14 +602,14 @@ export class SetupOrchestrator {
    * Spawn the dev script. Probe drives the transition from `starting` to
    * `running` once the dev server responds.
    */
-  private async stepStartInner(): Promise<void> {
+  private async stepStartInner(): Promise<StartOutcome> {
     const config = this.currentConfig();
-    if (!config) return;
+    if (!config) return "skipped";
     if (this.deps.getStatus().state !== "running") {
       this.chunk(
         `\r\n[orchestrator] skipping start: status=${this.deps.getStatus().state} (resume to retry)\r\n`,
       );
-      return;
+      return "skipped";
     }
     if (
       !this.deps.installState.isInstalledFor(config, this.currentBranchHead)
@@ -593,7 +617,7 @@ export class SetupOrchestrator {
       this.chunk(
         "\r\n[orchestrator] skipping start: install fingerprint mismatch\r\n",
       );
-      return;
+      return "skipped";
     }
     const command = this.buildStartCommand(config);
     if (!command) {
@@ -603,7 +627,7 @@ export class SetupOrchestrator {
         phase: "start-failed",
         error: reason.replace(/\r?\n/g, " ").trim(),
       });
-      return;
+      return "failed";
     }
 
     const running = this.deps.taskManager.runningCommandByLogName(
@@ -623,7 +647,7 @@ export class SetupOrchestrator {
       if (cur !== "running" && cur !== "starting") {
         this.deps.lifecycle.transition({ phase: "starting" });
       }
-      return;
+      return "skipped";
     }
     await this.stopDevTask();
     this.deps.lifecycle.transition({ phase: "starting" });
@@ -652,6 +676,7 @@ export class SetupOrchestrator {
       logName: command.source,
       replaceByLogName: true,
     });
+    return "done";
   }
 
   /**

--- a/packages/sandbox/daemon/setup/orchestrator.ts
+++ b/packages/sandbox/daemon/setup/orchestrator.ts
@@ -315,25 +315,27 @@ export class SetupOrchestrator {
   }
 
   /**
-   * `start` can't use `timedPhase`: unlike clone/install it has three outcomes,
-   * not two. A skipped start (no config, install fingerprint mismatch, dev
-   * server already up) never spawned anything, so recording it would drag a
-   * near-zero duration into the same series as real boots; and a failure
-   * reaches us as `failed`, not as an exception, so it must not be averaged in
-   * as a healthy boot.
+   * `start` can't use `timedPhase`, for two reasons.
+   *
+   * It has three outcomes rather than two: a skipped start (no config, install
+   * fingerprint mismatch, dev server already up) spawned nothing, so there is
+   * no phase to report.
+   *
+   * And it doesn't finish when this method returns. `taskManager.spawn` awaits
+   * process *creation*, not readiness — timing it would measure fork latency
+   * and would record every immediately-crashing dev script as a healthy start.
+   * So the attempt is left open and closed by the lifecycle, which is where
+   * both terminal states arrive: `running` (the probe reached the server) or
+   * `start-failed` (no start command, or the script exited non-zero).
    */
   private async stepStart(): Promise<void> {
-    const startedAt = Date.now();
-    let outcome: StartOutcome;
-    try {
-      outcome = await this.stepStartInner();
-    } catch (e) {
-      recordPhase("start", "failed", Date.now() - startedAt);
+    this.deps.lifecycle.noteStartAttempt();
+    const outcome = await this.stepStartInner().catch((e) => {
+      this.deps.lifecycle.cancelStartAttempt();
       throw e;
-    }
-    if (outcome !== "skipped") {
-      recordPhase("start", outcome, Date.now() - startedAt);
-    }
+    });
+    // "failed" already transitioned to start-failed, which closed the attempt.
+    if (outcome === "skipped") this.deps.lifecycle.cancelStartAttempt();
   }
 
   private async stepCloneInner(): Promise<boolean> {

--- a/packages/sandbox/daemon/telemetry.e2e.test.ts
+++ b/packages/sandbox/daemon/telemetry.e2e.test.ts
@@ -129,9 +129,10 @@ test("samples loop lag on its own timer", async () => {
 
     const shutdown = initTelemetry("boot-test", "ts");
     // Nothing records lag explicitly — the sampler is the only producer, so
-    // this also proves it was started and survives to the flush. One tick plus
-    // slack; the sampler's interval is 1s.
-    await sleep(1_200);
+    // this also proves it was started and survives to the flush. Two intervals,
+    // not one: a single delayed timer callback on a loaded CI host would leave
+    // zero samples and fail a run that is actually fine.
+    await sleep(2 * 1_000 + 400);
     await shutdown();
 
     const lag = JSON.parse(

--- a/packages/sandbox/daemon/telemetry.ts
+++ b/packages/sandbox/daemon/telemetry.ts
@@ -259,6 +259,10 @@ let lagTimer: ReturnType<typeof setInterval> | undefined;
  * which is why daemon-go samples the same way under the same instrument name.
  */
 function startLoopLagSampler(): void {
+  // A second init would otherwise orphan the first timer — its handle is
+  // overwritten before either shutdown closure runs, leaving a sampler feeding
+  // a dead provider forever. Production inits once; tests do not.
+  stopLoopLagSampler();
   let expected = Date.now() + LAG_SAMPLE_INTERVAL_MS;
   lagTimer = setInterval(() => {
     const now = Date.now();


### PR DESCRIPTION
Follow-up to #5559, addressing the review on it.

## `start` was always recorded as a success

Unlike `clone` and `install`, `stepStart` reports failure through a lifecycle transition rather than a return value, so `timedPhase`'s `result === false ? "failed" : "done"` could never classify it as failed. A boot that never produced a dev server was averaged into the same series as a healthy one — the exact mis-measurement #5559 exists to remove.

It also has a third outcome the other two don't: a **skip** (no config, install fingerprint mismatch, dev server already up) spawns nothing, so recording it would drag a near-zero duration into the boot-cost series. `stepStartInner` now returns `done | failed | skipped` on both daemons, and only the first two are reported.

## The lag sampler leaked on re-init

Its handle was overwritten before either shutdown closure ran, leaving a timer feeding a dead provider. Production initialises once, so this is a test-only leak today — but the fix is one line and the next caller doesn't have to know.

## The lag tests were one delayed tick from flaking

Both waited exactly one sampler interval, so a single late timer callback on a loaded CI host would have failed a healthy run. They now wait two.

## Testing

`go build`/`vet`/`test ./...` green; 730/730 non-e2e TS tests; `--workspaces check`, lint, knip, fmt clean.

Separately: the `daemon-e2e` (Windows) failure on #5559 was a flake — re-running the same commit passed. It died on `killed 1 dangling process` during the bash test, which is the harness reaper racing the daemon, not anything in that diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes start-phase telemetry to measure real boots by timing from the spawn attempt to the observable outcome (running/start-failed), correctly classifying outcomes (done/failed/skipped), and prevents orphaning the loop lag timer on telemetry re-init. Improves boot metrics accuracy and reduces test flakiness.

- **Bug Fixes**
  - Start phase now opens on spawn and closes on lifecycle transition; only "done"/"failed" are reported, "skipped" opens no phase. Implemented in both `packages/sandbox/daemon-go` and `packages/sandbox/daemon`.
  - Added lifecycle bookkeeping (`NoteStartAttempt`/`CancelStartAttempt` in Go; `noteStartAttempt`/`cancelStartAttempt` in TS) and wired `OnStartPhase`/`onStartPhase` to `RecordPhase`/`recordPhase`.
  - `packages/sandbox/daemon/telemetry.ts`: stop the previous loop lag sampler before starting a new one to avoid an orphaned timer.
  - Tests: added lifecycle unit tests; lag tests now wait two intervals to avoid flakes on slow CI hosts.

<sup>Written for commit c020dfe5553bbc7dcda5095c981d445e441536cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

