### PR TITLE
fix(decopilot): expose load_repo to the super agent only

### DIFF
--- a/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
@@ -262,7 +262,8 @@ async function buildAllTools(
     Object.assign(tools, vmTools);
     // Repo switcher — dynamic description lists the org's imported repos; calling
     // it binds the repo to the thread, eagerly clones its sandbox, and opens the
-    // Preview. Omitted when the org has no imported repos (nothing to switch).
+    // Preview. Returns null (tool omitted) for any agent but the super-agent, and
+    // when the org has no imported repos (nothing to switch).
     const loadRepo = await createLoadRepoTool({
       ctx,
       orgId: organization.id,

--- a/apps/api/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/load-repo.test.ts
@@ -1,9 +1,28 @@
 import { expect, test } from "bun:test";
 import {
   buildDescription,
+  createLoadRepoTool,
   parseCloneProbe,
   selectLoadableRepos,
 } from "./load-repo";
+
+test("createLoadRepoTool is super-agent-only", async () => {
+  // A non-decopilot agent gets no tool — and the check happens before any
+  // storage access, so a bare ctx suffices.
+  const args = {
+    ctx: {} as never,
+    orgId: "org_1",
+    userId: "user_1",
+    threadId: "thread_1",
+    writer: {} as never,
+  };
+  expect(
+    await createLoadRepoTool({ ...args, virtualMcpId: "vm_regular_agent" }),
+  ).toBeNull();
+  await expect(
+    createLoadRepoTool({ ...args, virtualMcpId: "decopilot_org_1" }),
+  ).rejects.toThrow(); // got past the gate, then hit the empty ctx
+});
 
 test("buildDescription lists each repo with its connectionId", () => {
   const desc = buildDescription([

--- a/apps/api/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -8,8 +8,9 @@
  * repo to the THREAD (`threads.metadata.githubRepo` + a dedicated
  * `thread:<id>` branch — real, persisted columns). Sandbox provisioning
  * (`ensureSandbox`) and the fs-tool binding (`tools.ts`) both prefer the
- * thread's repo, so the thread gets its own repo-cloned sandbox. For real
- * repo-agents this is a per-conversation override.
+ * thread's repo, so the thread gets its own repo-cloned sandbox. Only the
+ * super-agent gets this tool — every other agent is scoped to the repo it was
+ * configured with and must not be able to re-point itself at another one.
  *
  * The tool clones EAGERLY and waits: it provisions the repo sandbox and blocks
  * until the git checkout is present before returning, then signals the client
@@ -30,6 +31,7 @@ import { z } from "zod";
 import type { StudioContext } from "@/core/studio-context";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import { getRepoScope } from "@decocms/shared/github-repo-scope";
+import { isDecopilot } from "@decocms/shared/sdk";
 import {
   mergeSandboxMapEntry,
   readSandboxMap,
@@ -149,6 +151,11 @@ export async function createLoadRepoTool(opts: {
   rebindFs?: (branch: string) => Promise<void>;
 }) {
   const { ctx, orgId, virtualMcpId, userId, threadId, writer, rebindFs } = opts;
+  // Super-Agent-only. Every other agent either owns a repo already (repo-agents
+  // get it from `metadata.githubRepo`) or is deliberately scoped to one — letting
+  // them re-point the thread at an arbitrary org repo mid-run isn't an override,
+  // it's an escape from their configured scope.
+  if (!isDecopilot(virtualMcpId)) return null;
   const repos = await listOrgRepos(ctx, orgId);
   // Nothing to switch between — don't expose the tool at all.
   if (repos.length === 0) return null;

--- a/apps/api/src/harnesses/decopilot/tools.ts
+++ b/apps/api/src/harnesses/decopilot/tools.ts
@@ -292,9 +292,9 @@ export async function assembleDecopilotTools(
     const vmMetadata = runContext.virtualMcp.metadata as {
       githubRepo?: GithubRepo | null;
     };
-    // A thread-scoped repo (set by `load_repo`) wins: it's the only place a repo
-    // can persist for the synthetic Decopilot agent, and a per-conversation
-    // override for real repo-agents. When present it pins the thread to a
+    // A thread-scoped repo (set by `load_repo`, super-agent-only) wins: it's the
+    // only place a repo can persist for the synthetic Decopilot agent. Threads of
+    // real repo-agents never carry one. When present it pins the thread to a
     // dedicated `thread:<id>` sandbox branch (not the shared "ephemeral" one).
     const threadRepo = await getThreadGithubRepo(ctx, extras.threadId);
     const effectiveRepo = threadRepo ?? vmMetadata.githubRepo;


### PR DESCRIPTION
## Bug

`load_repo` was registered for **any** agent that had a `vmContext` — the only gate was "does the org have imported repos". So a scoped repo-agent could call it and re-point its own thread at an arbitrary org repo mid-run (it writes `threads.metadata.githubRepo` + a `thread:<id>/<connId>` branch, provisions a new sandbox, and `rebindFs`-swaps the live file tools onto it).

That's not a per-conversation override, it's an escape from the agent's configured scope. The tool only makes sense for the Super Agent, which is synthetic and has no repo of its own — that's why the thread-scoped binding exists in the first place, and it's the only agent whose prompt tells it to use the tool (`enqueue-super-agent.ts`).

## Fix

One gate in `createLoadRepoTool`, next to the existing "no imported repos → return null":

```ts
if (!isDecopilot(virtualMcpId)) return null;
```

Placed before any storage access, so a non-super agent doesn't even pay for the connection list. Stale comments in `built-in-tools/index.ts` and `tools.ts` that described the old repo-agent-override behavior updated to match.

## Testing

- New unit test in `load-repo.test.ts` asserting a non-decopilot `virtualMcpId` gets `null` and a `decopilot_*` one gets past the gate.
- `bun test apps/api/src/harnesses/decopilot/built-in-tools/load-repo.test.ts` — 8 pass.
- `bun run --cwd=apps/api check`, `bun run fmt` clean.

## Affected

Repo-agents / QA / code-reviewer lose a tool they were never meant to have. Super Agent behavior unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts `load_repo` to the Super Agent to stop repo-scoped agents from re-pointing their thread to another org repo. Super Agent behavior is unchanged; scoped agents no longer see the tool.

- **Bug Fixes**
  - Gate `createLoadRepoTool` with `isDecopilot(virtualMcpId)` before any storage access; return `null` for non-super agents or when no imported repos exist.
  - Update comments in `built-in-tools/index.ts` and `tools.ts` to reflect super-agent-only behavior.
  - Add unit test asserting non-decopilot IDs get `null` and `decopilot_*` gets past the gate.

<sup>Written for commit 1ef8a4af467c72ccc293160a722ed27d9984ce4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

