### PR TITLE
fix(github): list forks in the import-from-GitHub picker

### DIFF
--- a/apps/web/src/components/github-repo-picker.tsx
+++ b/apps/web/src/components/github-repo-picker.tsx
@@ -418,22 +418,24 @@ function PickerContent({
       navigateToAgent(virtualMcpId);
     },
     onError: (error, repo) => {
+      console.error("GitHub import failed:", error);
+      const message =
+        error instanceof Error
+          ? error.message
+          : t("common.githubRepoPicker.unknownError");
       // A fork the GitHub App wasn't granted shows up in public search but the
-      // token mint fails — point the user at the installation settings instead
-      // of a raw mint error.
-      if (repo.fork) {
+      // token mint fails (provisionRepoScopedGithubConnection throws a
+      // "…mint a repo-scoped GitHub token…" error) — point the user at the
+      // installation settings. Only do this for the mint failure; other fork
+      // import errors (agent create, rollback, network) keep the real message.
+      if (repo.fork && message.toLowerCase().includes("mint")) {
         toast.error(
           t("common.githubRepoPicker.failedImportFork", { name: repo.name }),
         );
         return;
       }
       toast.error(
-        t("common.githubRepoPicker.failedImport", {
-          error:
-            error instanceof Error
-              ? error.message
-              : t("common.githubRepoPicker.unknownError"),
-        }),
+        t("common.githubRepoPicker.failedImport", { error: message }),
       );
     },
   });

--- a/apps/web/src/components/github-repo-picker.tsx
+++ b/apps/web/src/components/github-repo-picker.tsx
@@ -64,6 +64,7 @@ export interface Repo {
   private: boolean;
   description: string | null;
   updatedAt: string;
+  fork: boolean;
 }
 
 export interface GitHubImportPayload {
@@ -416,7 +417,16 @@ function PickerContent({
       );
       navigateToAgent(virtualMcpId);
     },
-    onError: (error) => {
+    onError: (error, repo) => {
+      // A fork the GitHub App wasn't granted shows up in public search but the
+      // token mint fails — point the user at the installation settings instead
+      // of a raw mint error.
+      if (repo.fork) {
+        toast.error(
+          t("common.githubRepoPicker.failedImportFork", { name: repo.name }),
+        );
+        return;
+      }
       toast.error(
         t("common.githubRepoPicker.failedImport", {
           error:
@@ -841,9 +851,13 @@ function RepoList({
   const githubClient = useMCPClient({ connectionId, orgId, orgSlug });
 
   const qualifier = installation.type === "User" ? "user" : "org";
+  // `fork:true` includes forks alongside non-forks. GitHub's search API omits
+  // forks by default, so without this the picker silently hides every fork the
+  // account owns. Forks the GitHub App wasn't granted still fail at import time
+  // (see importMutation.onError) — that's surfaced with a fork-specific hint.
   const searchQuery = query
-    ? `${qualifier}:${installation.login} ${query} in:name`
-    : `${qualifier}:${installation.login}`;
+    ? `${qualifier}:${installation.login} ${query} in:name fork:true`
+    : `${qualifier}:${installation.login} fork:true`;
 
   const { data: repos } = useSuspenseQuery({
     queryKey: KEYS.githubOrgRepos(
@@ -872,6 +886,7 @@ function RepoList({
           private: boolean;
           description: string | null;
           updated_at: string;
+          fork?: boolean;
         }>;
       };
       return (parsed.items ?? []).map((r) => ({
@@ -882,6 +897,7 @@ function RepoList({
         private: r.private,
         description: r.description,
         updatedAt: r.updated_at,
+        fork: r.fork ?? false,
       }));
     },
   });
@@ -914,6 +930,11 @@ function RepoList({
           <GitHubIcon className="size-4 text-muted-foreground mt-0.5 shrink-0" />
           <div className="flex items-center gap-2 min-w-0 flex-1">
             <span className="text-sm font-medium truncate">{repo.name}</span>
+            {repo.fork && (
+              <span className="text-xs font-medium text-muted-foreground border border-border rounded px-1.5 py-0.5 shrink-0 leading-none">
+                {t("common.githubRepoPicker.forkBadge")}
+              </span>
+            )}
           </div>
           <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground border border-border rounded px-1.5 py-0.5 shrink-0 leading-none">
             {repo.private ? <Lock01 size={10} /> : <LockUnlocked01 size={10} />}

--- a/apps/web/src/i18n/en/common.ts
+++ b/apps/web/src/i18n/en/common.ts
@@ -107,10 +107,13 @@ export const common = {
     "Your GitHub connection may have expired. Reconnect to restore access.",
   "common.githubRepoPicker.connectionFailed": "Connection failed",
   "common.githubRepoPicker.failedImport": "Failed to import repo: {error}",
+  "common.githubRepoPicker.failedImportFork":
+    "Couldn't import the fork {name}. If it isn't shared with the GitHub App, add it under GitHub → Settings → Installations, then try again.",
   "common.githubRepoPicker.failedLoadAccounts":
     "Failed to load GitHub accounts",
   "common.githubRepoPicker.failedReconnect":
     "Failed to reconnect GitHub: {error}",
+  "common.githubRepoPicker.forkBadge": "Fork",
   "common.githubRepoPicker.githubConnected": "GitHub connected",
   "common.githubRepoPicker.importFromGitHub": "Import from GitHub",
   "common.githubRepoPicker.importedRepo": "Imported {name} from GitHub",

--- a/apps/web/src/i18n/pt-br/common.ts
+++ b/apps/web/src/i18n/pt-br/common.ts
@@ -111,10 +111,13 @@ export const common = {
   "common.githubRepoPicker.connectionFailed": "Conexão falhou",
   "common.githubRepoPicker.failedImport":
     "Falha ao importar repositório: {error}",
+  "common.githubRepoPicker.failedImportFork":
+    "Não foi possível importar o fork {name}. Se ele não estiver compartilhado com o aplicativo GitHub, adicione-o em GitHub → Settings → Installations e tente novamente.",
   "common.githubRepoPicker.failedLoadAccounts":
     "Falha ao carregar contas do GitHub",
   "common.githubRepoPicker.failedReconnect":
     "Falha ao reconectar GitHub: {error}",
+  "common.githubRepoPicker.forkBadge": "Fork",
   "common.githubRepoPicker.githubConnected": "GitHub conectado",
   "common.githubRepoPicker.importFromGitHub": "Importar do GitHub",
   "common.githubRepoPicker.importedRepo": "Importado {name} do GitHub",


### PR DESCRIPTION
## Summary

The **Import from GitHub** repo picker didn't list forks. The cause isn't our code — the picker lists repos through the `search_repositories` MCP tool (GitHub's Search API), which **omits forks by default** unless the query contains `fork:true`. The query has been `user:<login> ... in:name` since the picker was first added (#3095), so forks were never surfaced.

This adds `fork:true` and handles the one real caveat behind why forks were left out: a fork the GitHub App wasn't granted access to shows up in public search but **fails at token-mint time** (the installation token can't access it). Instead of a raw mint error, the user gets a clear, actionable message.

## Changes (all in `apps/web/src/components/github-repo-picker.tsx` + i18n)

- **Query**: append `fork:true` to `searchQuery` so forks are listed alongside non-forks.
- **Type/parse**: read the `fork` field from the search result into the `Repo` type.
- **Badge**: render a small "Fork" badge so forks are distinguishable in the list.
- **Error handling**: `importMutation.onError` now inspects the repo and, for a fork whose failure is a **token-mint** error, shows a fork-specific message ("… add it under GitHub → Settings → Installations, then try again.") pointing at the installation settings. Other fork failures (agent-create, rollback, network) keep the real error message, and the raw error is always logged to the console.
- **i18n**: `forkBadge` + `failedImportFork` added to `en/common.ts` and `pt-br/common.ts` (full mirror — `bun run check` proves completeness).

## Notes / out of scope

- Sibling call sites use the same `search_repositories` pattern and also omit `fork:true`, **consciously left untouched**:
  - `hooks/use-github-recent-prs.ts` / `hooks/use-github-contributions.ts` — home-dashboard tiles that summarize *your* activity; pulling in forks would add upstream noise. Correct to exclude by design.
  - `routes/commerce-onboarding/companion-forms/github-config-form.tsx` — a repo selector, but it already has a manual `owner/name` fallback (`OWNER_NAME_RE`), so forks are reachable there even when unlisted. The import picker was the only fallback-less flow, which is why the fix lands here.
- No automated test added: the existing e2e (`packages/e2e/tests/github-import-repo-scope.spec.ts`) deliberately doesn't drive the picker's repo listing, and that path depends on the external mcp-github server.

## Testing

- `bun run fmt`, `bun run check`, `bun run lint` all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)