### PR TITLE
fix(preview): keep iframe interactive after panel resize

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -74,7 +74,7 @@
     "react-dom": "^19.2.6",
     "react-hook-form": "^7.66.0",
     "react-markdown": "^10.1.0",
-    "react-resizable-panels": "^2.1.7",
+    "react-resizable-panels": "^4.12.2",
     "react-syntax-highlighter": "^15.6.1",
     "recharts": "^3.6.0",
     "rehype-raw": "^7.0.0",

--- a/apps/web/src/components/resizable.tsx
+++ b/apps/web/src/components/resizable.tsx
@@ -4,8 +4,8 @@ import type * as React from "react";
 import { DotsGrid } from "@untitledui/icons";
 import * as ResizablePrimitive from "react-resizable-panels";
 export type {
-  ImperativePanelHandle,
-  ImperativePanelGroupHandle,
+  GroupImperativeHandle,
+  PanelImperativeHandle,
 } from "react-resizable-panels";
 
 import { cn } from "@deco/ui/lib/utils.ts";
@@ -14,38 +14,48 @@ function ResizablePanelGroup({
   className,
   ref,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
+}: React.ComponentProps<typeof ResizablePrimitive.Group> & {
+  ref?: React.Ref<ResizablePrimitive.GroupImperativeHandle | null>;
+}) {
   return (
-    <ResizablePrimitive.PanelGroup
-      ref={ref}
+    <ResizablePrimitive.Group
+      groupRef={ref}
       data-slot="resizable-panel-group"
-      className={cn(
-        "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
-        className,
-      )}
+      className={cn("flex h-full w-full", className)}
       {...props}
     />
   );
 }
 
 function ResizablePanel({
+  ref,
+  style,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
-  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />;
+}: React.ComponentProps<typeof ResizablePrimitive.Panel> & {
+  ref?: React.Ref<ResizablePrimitive.PanelImperativeHandle | null>;
+}) {
+  return (
+    <ResizablePrimitive.Panel
+      panelRef={ref}
+      data-slot="resizable-panel"
+      style={{ overflow: "hidden", ...style }}
+      {...props}
+    />
+  );
 }
 
 function ResizableHandle({
   withHandle,
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
   withHandle?: boolean;
 }) {
   return (
-    <ResizablePrimitive.PanelResizeHandle
+    <ResizablePrimitive.Separator
       data-slot="resizable-handle"
       className={cn(
-        "bg-border focus-visible:ring-ring relative flex w-[0.5px] items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        "bg-border focus-visible:ring-ring relative flex w-[0.5px] items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:-translate-y-1/2 aria-[orientation=horizontal]:after:translate-x-0 [&[aria-orientation=horizontal]>div]:rotate-90",
         className,
       )}
       {...props}
@@ -55,7 +65,7 @@ function ResizableHandle({
           <DotsGrid className="size-2.5" />
         </div>
       )}
-    </ResizablePrimitive.PanelResizeHandle>
+    </ResizablePrimitive.Separator>
   );
 }
 

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -132,7 +132,7 @@ import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
-  type ImperativePanelHandle,
+  type PanelImperativeHandle,
 } from "@/components/resizable";
 import {
   shouldAutoOpenCms,
@@ -255,7 +255,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     number | null
   >(null);
   const previewIframeRef = useRef<HTMLIFrameElement>(null);
-  const blocksPanelRef = useRef<ImperativePanelHandle>(null);
+  const blocksPanelRef = useRef<PanelImperativeHandle>(null);
 
   // Pages dropdown in URL bar
   const [pagesOpen, setPagesOpen] = useState(false);
@@ -751,7 +751,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const activateEditingMode = (mode: PreviewEditingMode) => {
     const previousMode = editingMode;
     if (!isMobile && mode !== previousMode) {
-      if (mode === "blocks") blocksPanelRef.current?.resize(30);
+      if (mode === "blocks") blocksPanelRef.current?.resize("30%");
       else blocksPanelRef.current?.collapse();
     }
     setEditingMode(mode);
@@ -1542,15 +1542,17 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             {floatingPreviewControls}
           </div>
         ) : (
-          <ResizablePanelGroup direction="horizontal">
+          <ResizablePanelGroup
+            orientation="horizontal"
+            disabled={effectiveEditingMode !== "blocks"}
+          >
             <ResizablePanel
               ref={blocksPanelRef}
               id="preview-blocks-editor"
-              order={1}
-              defaultSize={effectiveEditingMode === "blocks" ? 30 : 0}
-              minSize={20}
+              defaultSize={effectiveEditingMode === "blocks" ? "30%" : "0%"}
+              minSize="20%"
               collapsible
-              collapsedSize={0}
+              collapsedSize="0%"
               className="min-w-0 overflow-hidden"
             >
               {effectiveEditingMode === "blocks" && (
@@ -1560,15 +1562,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                 />
               )}
             </ResizablePanel>
-            <ResizableHandle
-              withHandle
-              className={cn(effectiveEditingMode !== "blocks" && "hidden")}
-            />
+            {effectiveEditingMode === "blocks" && (
+              <ResizableHandle withHandle />
+            )}
             <ResizablePanel
               id="preview-canvas"
-              order={2}
-              defaultSize={effectiveEditingMode === "blocks" ? 60 : 100}
-              minSize={35}
+              defaultSize={effectiveEditingMode === "blocks" ? "70%" : "100%"}
+              minSize="35%"
               className="min-w-0 overflow-hidden"
             >
               <div

--- a/apps/web/src/hooks/use-panel-width-percent.ts
+++ b/apps/web/src/hooks/use-panel-width-percent.ts
@@ -1,6 +1,6 @@
 import { useLocalStorage } from "@/hooks/use-local-storage";
 
-/** react-resizable-panels requires numeric defaultSize; localStorage may hold strings. */
+/** Stored widths are percentages; legacy localStorage values may be strings. */
 function normalizePanelSizePercent(value: unknown, fallback: number): number {
   const n = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(n) || n <= 0 || n >= 100) return fallback;

--- a/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
@@ -12,17 +12,15 @@
 import {
   useEffect,
   useRef,
-  useTransition,
   type PropsWithChildren,
   type ReactNode,
 } from "react";
 import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
-import { cn } from "@deco/ui/lib/utils.js";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
-  type ImperativePanelGroupHandle,
+  type GroupImperativeHandle,
 } from "@/components/resizable";
 import { useSidePanelWidth } from "@/hooks/use-side-panel-width";
 import { useElementWidth } from "@/hooks/use-element-width";
@@ -51,6 +49,9 @@ import {
   MainPanelHeaderSlot,
   PanelHeader,
 } from "./panel-header";
+
+const SIDE_PANEL_ID = "workspace-side-panel";
+const MAIN_PANEL_ID = "workspace-main-panel";
 
 function PanelCard({
   children,
@@ -118,9 +119,8 @@ export function WorkspacePanelGroup({
   toggleSidePanel,
   chatContent,
 }: WorkspacePanelGroupProps) {
-  const [_isPending, startTransition] = useTransition();
   const [sidePanelWidth, setSidePanelWidth] = useSidePanelWidth();
-  const panelGroupRef = useRef<ImperativePanelGroupHandle>(null);
+  const panelGroupRef = useRef<GroupImperativeHandle>(null);
   const visibility = { sidePanel, mainOpen };
   const sizes = computeWorkspacePanelSizes(visibility);
   const sideSize = sidePanel !== null && mainOpen ? sidePanelWidth : sizes.side;
@@ -164,7 +164,10 @@ export function WorkspacePanelGroup({
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- syncs URL-derived visibility with the resizable panels' imperative layout API
   useEffect(() => {
-    panelGroupRef.current?.setLayout([sideSize, mainSize]);
+    panelGroupRef.current?.setLayout({
+      [SIDE_PANEL_ID]: sideSize,
+      [MAIN_PANEL_ID]: mainSize,
+    });
   }, [sideSize, mainSize]);
 
   const chatHeader = (
@@ -264,27 +267,31 @@ export function WorkspacePanelGroup({
       <ResizablePanelGroup
         ref={panelGroupRef}
         key={`${virtualMcpId}-${taskId}`}
-        direction="horizontal"
-        className="flex-1 min-h-0 pb-1 pr-1 pl-0 pt-0"
+        orientation="horizontal"
+        className="flex-1 min-h-0 pb-1 pr-1 pl-0 pt-0 [&>[data-workspace-panel-open]]:!min-w-[320px]"
         style={{ overflow: "visible" }}
+        onLayoutChanged={(layout, { isUserInteraction }) => {
+          const percentage = layout[SIDE_PANEL_ID];
+          if (
+            isUserInteraction &&
+            sidePanel !== null &&
+            mainOpen &&
+            typeof percentage === "number" &&
+            percentage > 0 &&
+            percentage < 100
+          ) {
+            setSidePanelWidth(percentage);
+          }
+        }}
       >
         <ResizablePanel
-          order={1}
-          defaultSize={sizes.side}
-          minSize={20}
+          id={SIDE_PANEL_ID}
+          defaultSize={`${sizes.side}%`}
+          minSize="20%"
           collapsible
-          collapsedSize={0}
-          className={cn(
-            "overflow-hidden bg-sidebar",
-            sidePanel !== null ? "min-w-[320px]" : "min-w-0",
-          )}
-          onResize={(size) =>
-            startTransition(() => {
-              if (sidePanel !== null && mainOpen && size > 0 && size < 100) {
-                setSidePanelWidth(size);
-              }
-            })
-          }
+          collapsedSize="0%"
+          data-workspace-panel-open={sidePanel !== null ? "" : undefined}
+          className="min-w-0 overflow-hidden bg-sidebar"
         >
           <PanelCard testId="side-panel" header={chatOpen ? chatHeader : null}>
             {chatOpen && <SidePanel chatContent={chatContent} />}
@@ -294,15 +301,13 @@ export function WorkspacePanelGroup({
         <ResizableHandle className="bg-sidebar" />
 
         <ResizablePanel
-          order={2}
-          defaultSize={sizes.main}
-          minSize={20}
+          id={MAIN_PANEL_ID}
+          defaultSize={`${sizes.main}%`}
+          minSize="20%"
           collapsible
-          collapsedSize={0}
-          className={cn(
-            "min-w-0 overflow-hidden bg-sidebar",
-            mainOpen ? "min-w-[320px]" : "min-w-0",
-          )}
+          collapsedSize="0%"
+          data-workspace-panel-open={mainOpen ? "" : undefined}
+          className="min-w-0 overflow-hidden bg-sidebar"
         >
           <PanelCard testId="main-panel" header={mainOpen ? mainHeader : null}>
             <MainPanelWithDrawer taskId={taskId} virtualMcpId={virtualMcpId} />

--- a/bun.lock
+++ b/bun.lock
@@ -198,7 +198,7 @@
         "react-dom": "^19.2.6",
         "react-hook-form": "^7.66.0",
         "react-markdown": "^10.1.0",
-        "react-resizable-panels": "^2.1.7",
+        "react-resizable-panels": "^4.12.2",
         "react-syntax-highlighter": "^15.6.1",
         "recharts": "^3.6.0",
         "rehype-raw": "^7.0.0",
@@ -3029,7 +3029,7 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-resizable-panels": ["react-resizable-panels@2.1.9", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ=="],
+    "react-resizable-panels": ["react-resizable-panels@4.12.2", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-NwY5LCo4WrxVvDh0xoMML6EMLPONP/8ckKcIdpnojxexoatZdjLiRqLJQjQK5CPkd4SYiB/2M5BVrjZBQtOO7Q=="],
 
     "react-smooth": ["react-smooth@4.0.4", "", { "dependencies": { "fast-equals": "^5.0.1", "prop-types": "^15.8.1", "react-transition-group": "^4.4.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q=="],
 

--- a/packages/e2e/tests/deck-preview-edit.spec.ts
+++ b/packages/e2e/tests/deck-preview-edit.spec.ts
@@ -107,12 +107,44 @@ test.describe("deck preview tab", () => {
       await dismissRelease.click();
     }
 
+    // Releasing a workspace resize over an iframe used to leave the panel
+    // group's drag state active forever. The library then kept
+    // `pointer-events: none` on the panels, so the framed page still painted
+    // but no longer accepted clicks or keyboard focus.
+    const resizeHandle = page.locator('[data-slot="resizable-handle"]').first();
+    const iframe = page.locator(`iframe[title="${DECK_PATH}"]`);
+    const mainResizablePanel = page
+      .getByTestId("main-panel")
+      .locator("xpath=ancestor::*[@data-panel][1]");
+    const resizeHandleBox = await resizeHandle.boundingBox();
+    const iframeBox = await iframe.boundingBox();
+    expect(resizeHandleBox).not.toBeNull();
+    expect(iframeBox).not.toBeNull();
+    if (!resizeHandleBox || !iframeBox) {
+      throw new Error("Resize handle and preview iframe must be visible");
+    }
+
+    const resizeX = resizeHandleBox.x + resizeHandleBox.width / 2;
+    const resizeY = iframeBox.y + iframeBox.height / 2;
+    await page.mouse.move(resizeX, resizeY);
+    await page.mouse.down();
+    // Establish the drag while still over the parent document. v4 captures the
+    // pointer on this first movement so the later iframe crossing cannot steal
+    // the release event.
+    await page.mouse.move(resizeX - 4, resizeY);
+    await expect(mainResizablePanel).toHaveCSS("pointer-events", "none");
+    await page.mouse.move(iframeBox.x + 40, resizeY, { steps: 10 });
+    await page.mouse.up();
+    await expect(mainResizablePanel).toHaveCSS("pointer-events", "auto");
+
     // Enter edit mode and delete slide 2 via the rail context menu.
     await page.getByRole("button", { name: "Edit inline" }).click();
-    await expect(frame.locator("section[data-deck-active]")).toHaveAttribute(
-      "contenteditable",
-      "true",
-    );
+    const activeSlide = frame.locator("section[data-deck-active]");
+    await expect(activeSlide).toHaveAttribute("contenteditable", "true");
+    // Prove the iframe is interactive again, not merely that its parent style
+    // changed: a real click must reach and focus its contenteditable slide.
+    await activeSlide.click({ position: { x: 20, y: 20 } });
+    await expect(activeSlide).toBeFocused();
 
     await frame.locator(".thumb").nth(1).click({ button: "right" });
     await frame.locator('[data-act="delete"]').click();


### PR DESCRIPTION
## What is this contribution about?

Fixes the preview iframe becoming unclickable after a panel resize is released over the iframe.

The old `react-resizable-panels` v2 implementation did not capture the drag pointer. When the cursor crossed into the iframe, the iframe could swallow `pointerup`, leaving the panel group in its dragging state with `pointer-events: none` applied to the panels.

This PR:

- Upgrades `react-resizable-panels` to v4.12.2, which captures the pointer during resize.
- Migrates the shared resizable wrappers and consumers to the v4 API.
- Preserves the workspace panel size persistence and 320px visible-panel floor.
- Removes the inactive preview separator outside Blocks mode.
- Adds a browser regression that releases a resize over the iframe and proves clicks and keyboard focus still reach its content.

Upstream context: https://github.com/bvaughn/react-resizable-panels/issues/688

## How did you verify your code works?

- `bun install --frozen-lockfile`
- `bun run fmt:check`
- `bun run lint` — 0 errors
- `bun run --cwd=apps/web check`
- `bun run --cwd=packages/e2e check`
- `bun run --cwd=apps/web build`
- Focused unit suite — 29 passed
- `CI=1 E2E_SKIP_WEB_BUILD=1 ... playwright test tests/deck-preview-edit.spec.ts --workers=1` — 1 Chromium test passed against isolated Postgres, NATS, and MinIO

## Screenshots/Demonstration

No visual change. The new Playwright coverage reproduces the iframe-crossing pointer release and verifies the editable iframe receives focus afterward.

## How to Test

1. Open a chat with a preview iframe in the main panel.
2. Start dragging the workspace separator and release the pointer while it is over the iframe.
3. Click and type inside the iframe.
4. The iframe should remain fully interactive.

## Review Checklist

- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (not needed for this behavior-preserving bug fix)
- [x] No breaking changes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview iframe becoming unclickable after releasing a panel resize over it. Upgrades `react-resizable-panels` to v4 to capture the pointer during drag and keeps the preview fully interactive.

- **Bug Fixes**
  - Capture the pointer on resize to avoid a stuck drag state and `pointer-events: none` on panels.
  - Preserve panel size persistence and a 320px minimum width for open panels.
  - Hide the preview handle outside Blocks mode and add a Playwright test that releases resize over the iframe and verifies click/focus inside.

- **Dependencies**
  - Upgrade `react-resizable-panels` to `^4.12.2` and migrate to the v4 API (use `Group`/`Separator`, percent sizes, `GroupImperativeHandle`/`PanelImperativeHandle`, `orientation`, `onLayoutChanged`).

<sup>Written for commit 2d08cb666105c65ba7b7f8215e97745a6c3666fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

