### PR TITLE
fix(preview): keep iframe interactive in Blocks mode

### DIFF
--- a/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { CMS_EDITOR_SCRIPT } from "./cms-editor-script";
+
+describe("CMS editor iframe interactions", () => {
+  test("observes section clicks without cancelling the page's native click", () => {
+    const handlerStart = CMS_EDITOR_SCRIPT.indexOf(
+      "var clickHandler = function(e)",
+    );
+    const handlerEnd = CMS_EDITOR_SCRIPT.indexOf(
+      'document.addEventListener("click", clickHandler, true)',
+      handlerStart,
+    );
+
+    expect(handlerStart).toBeGreaterThanOrEqual(0);
+    expect(handlerEnd).toBeGreaterThan(handlerStart);
+
+    const clickHandler = CMS_EDITOR_SCRIPT.slice(handlerStart, handlerEnd);
+    expect(clickHandler).toContain('type: "cms-editor::section-clicked"');
+    expect(clickHandler).not.toContain("preventDefault");
+    expect(clickHandler).not.toContain("stopPropagation");
+    expect(clickHandler).not.toContain("stopImmediatePropagation");
+  });
+});

--- a/apps/web/src/components/sandbox/preview/cms-editor-script.ts
+++ b/apps/web/src/components/sandbox/preview/cms-editor-script.ts
@@ -272,9 +272,9 @@ export const CMS_EDITOR_SCRIPT = `(function() {
   };
   document.addEventListener("mouseout", outHandler, true);
 
+  // Blocks observes clicks to select sections in the side panel; it must not
+  // cancel the iframe page's own handlers or native control behavior.
   var clickHandler = function(e) {
-    e.preventDefault();
-    e.stopImmediatePropagation();
     var target = e.target;
     if (!target || target === highlight || target === badge) return;
     var section = findSection(target);


### PR DESCRIPTION
## Summary

- let iframe clicks continue to native controls and application handlers while Blocks is open
- keep the existing CMS section-selection message and click feedback
- add a regression contract preventing the injected click observer from cancelling propagation or default behavior

## Testing

- bun run fmt
- bun run check
- bun run lint (0 errors)
- bun test apps/web/src/components/sandbox/preview/cms-editor-script.test.ts
- real Chromium probe: label focus, keyboard typing, button handler, and Blocks section selection all pass together
- full unit lane: 6,567 passed; two monitoring truncation cases timed out under parallel load and passed 12/12 when rerun in isolation

## Affected area

Preview iframe interaction while the Blocks side panel is open.

## Screenshots

Not applicable; behavior-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the preview iframe interactive while the Blocks panel is open. Section selection still works, and page controls and app handlers continue to fire.

- **Bug Fixes**
  - Stop cancelling iframe clicks in `cms-editor-script` so labels, inputs, buttons, and page handlers work in Blocks mode.
  - Keep section selection messaging and click highlight behavior.
  - Add a regression test to ensure the click observer does not call `preventDefault`, `stopPropagation`, or `stopImmediatePropagation`.

<sup>Written for commit dadf4a76ff930b2a0d36ecabb035926238c3aa63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

