### PR TITLE
feat(sandbox): make the Go daemon the default for every sandbox

### DIFF
--- a/apps/api/src/sandbox/lifecycle.ts
+++ b/apps/api/src/sandbox/lifecycle.ts
@@ -90,11 +90,12 @@ function readSandboxTemplateName(): string | undefined {
   return raw && raw.trim() !== "" ? raw : undefined;
 }
 
-// Name of the sandbox-env chart's opt-in `<name>-go` SandboxTemplate. Presence
-// is the GLOBAL KILL SWITCH for the Go daemon rollout: unset, both the
-// `sandbox_go_daemon` org flag and SANDBOX_START's `daemonImpl` prop are ignored,
-// because there is no template to point a claim at. Unsetting it routes the next
-// sandbox back to TS with no rebuild; live sandboxes drain on their own binary.
+// Name of the sandbox-env chart's `<name>-go` SandboxTemplate. Presence is the
+// GLOBAL KILL SWITCH for the Go daemon: unset, both the `go` default and
+// SANDBOX_START's `daemonImpl` prop are ignored, because there is no template to
+// point a claim at. Now that Go is the default, this is the fleet-wide rollback —
+// unsetting it routes every next sandbox back to TS with no rebuild; live
+// sandboxes drain on their own binary.
 function readGoSandboxTemplateName(): string | undefined {
   const raw = process.env.STUDIO_SANDBOX_GO_TEMPLATE_NAME;
   return raw && raw.trim() !== "" ? raw : undefined;

--- a/apps/api/src/sandbox/resolve-daemon-impl.test.ts
+++ b/apps/api/src/sandbox/resolve-daemon-impl.test.ts
@@ -2,18 +2,18 @@ import { describe, expect, it } from "bun:test";
 import { resolveDaemonImpl } from "./resolve-daemon-impl";
 
 describe("resolveDaemonImpl", () => {
-  it("defaults to ts with no prop and no flag", () => {
-    expect(resolveDaemonImpl({})).toBe("ts");
-    expect(resolveDaemonImpl({ flags: null })).toBe("ts");
-    expect(resolveDaemonImpl({ flags: {} })).toBe("ts");
+  it("defaults to go with no prop and no flag", () => {
+    expect(resolveDaemonImpl({})).toBe("go");
+    expect(resolveDaemonImpl({ flags: null })).toBe("go");
+    expect(resolveDaemonImpl({ flags: {} })).toBe("go");
   });
 
-  it("honors the org flag", () => {
-    expect(resolveDaemonImpl({ flags: { sandbox_go_daemon: true } })).toBe(
-      "go",
-    );
+  it("treats the org flag as an opt-out, not an opt-in", () => {
     expect(resolveDaemonImpl({ flags: { sandbox_go_daemon: false } })).toBe(
       "ts",
+    );
+    expect(resolveDaemonImpl({ flags: { sandbox_go_daemon: true } })).toBe(
+      "go",
     );
   });
 
@@ -24,10 +24,8 @@ describe("resolveDaemonImpl", () => {
         flags: { sandbox_go_daemon: false },
       }),
     ).toBe("go");
-    // The escape hatch that matters most: pinning one sandbox back to ts
-    // inside an org that is otherwise on Go.
-    expect(
-      resolveDaemonImpl({ explicit: "ts", flags: { sandbox_go_daemon: true } }),
-    ).toBe("ts");
+    // The escape hatch that matters most now that Go is the default: pinning
+    // one sandbox back to ts without opting the whole org out.
+    expect(resolveDaemonImpl({ explicit: "ts" })).toBe("ts");
   });
 });

--- a/apps/api/src/sandbox/resolve-daemon-impl.ts
+++ b/apps/api/src/sandbox/resolve-daemon-impl.ts
@@ -6,17 +6,19 @@
  * Precedence (highest first):
  *
  *   1. **Caller override.** `SANDBOX_START`'s `input.daemonImpl`. The escape
- *      hatch both ways: opt one sandbox in, or pin one back to `ts` inside a
- *      flagged org.
- *   2. **Org flag** `sandbox_go_daemon`. Who gets Go *by default* — what puts a
- *      real user's sandboxes on Go without asking them to pass anything.
- *   3. **`ts`.** Deployed is not enabled.
+ *      hatch both ways: pin one sandbox back to `ts`, or force `go` inside an
+ *      org that opted out.
+ *   2. **Org flag** `sandbox_go_daemon`, when explicitly `false`. The per-org
+ *      opt-out — the flag no longer opts *in*, because Go is the default.
+ *   3. **`go`.** Everyone, unless something above says otherwise.
  *
  * The third layer of control — `STUDIO_SANDBOX_GO_TEMPLATE_NAME`, the global
  * kill switch — is deliberately NOT read here. It is enforced in the runner
  * (`resolveClaimTemplate`), which is the only place that knows whether a Go
  * SandboxTemplate exists to point a claim at, and which persists the impl the
  * claim actually got. Duplicating the check here would let the two disagree.
+ * That kill switch is what makes a `go` default safe to ship: unsetting the env
+ * var collapses the whole fleet back to `ts` on the next claim, no code deploy.
  */
 
 import type { OrgFlags } from "@decocms/shared/organization/schema";
@@ -25,9 +27,12 @@ import type { SandboxDaemonImpl } from "@decocms/sandbox/provider";
 export function resolveDaemonImpl(args: {
   /** `SANDBOX_START`'s `daemonImpl` input, when the caller passed one. */
   explicit?: SandboxDaemonImpl;
-  /** `organization_settings.flags`. Absent/unset reads as off. */
+  /**
+   * `organization_settings.flags`. Only an explicit `false` opts out — absent
+   * and unset both read as "go", which is what makes this the default.
+   */
   flags?: OrgFlags | null;
 }): SandboxDaemonImpl {
   if (args.explicit) return args.explicit;
-  return args.flags?.sandbox_go_daemon ? "go" : "ts";
+  return args.flags?.sandbox_go_daemon === false ? "ts" : "go";
 }

--- a/apps/api/src/tools/sandbox/start.test.ts
+++ b/apps/api/src/tools/sandbox/start.test.ts
@@ -208,7 +208,7 @@ function makeCtx(overrides: {
   /** Row returned by `storage.threads.get` — set `created_by` to exercise the
    *  thread-owner keying (see resolveSandboxUserId). */
   thread?: { created_by: string; metadata: Record<string, unknown> } | null;
-  /** `organization_settings.flags` — drives the `sandbox_go_daemon` rollout flag. */
+  /** `organization_settings.flags` — drives the `sandbox_go_daemon` opt-out. */
   orgFlags?: Record<string, boolean> | null;
 }): StudioContext {
   const {
@@ -254,8 +254,8 @@ function makeCtx(overrides: {
         get: mock(async (_id: string) => thread),
         update: mock(async () => {}),
       },
-      // Read once per provision to resolve the `sandbox_go_daemon` rollout flag.
-      // Default: no flags set, so every sandbox lands on the TS daemon.
+      // Read once per provision to resolve the `sandbox_go_daemon` opt-out.
+      // Default: no flags set, so every sandbox lands on the Go daemon.
       organizationSettings: {
         get: mock(async (_id: string) => ({ flags: orgFlags })),
       },
@@ -860,7 +860,7 @@ describe("SANDBOX_START", () => {
   // What reaches `runner.ensure` is the contract; whether the pod honors it is
   // the runner's call (it collapses `go` back to `ts` with no Go template).
 
-  it("sends daemonImpl=ts when the org flag is unset", async () => {
+  it("sends daemonImpl=go when the org flag is unset", async () => {
     const ctx = makeCtx({ virtualMcp: makeVirtualMcp(ORG_ID, BASE_METADATA) });
     await SANDBOX_START.handler(
       { virtualMcpId: VMCP_ID, branch: BRANCH } as Parameters<
@@ -874,13 +874,13 @@ describe("SANDBOX_START", () => {
     // Explicit rather than omitted: the runner persists whatever it resolved
     // into the state blob for autonomous recovery, so the value it stores must
     // never be an inference.
-    expect(opts.daemonImpl).toBe("ts");
+    expect(opts.daemonImpl).toBe("go");
   });
 
-  it("sends daemonImpl=go when the org flag is on", async () => {
+  it("sends daemonImpl=ts when the org flag opts out", async () => {
     const ctx = makeCtx({
       virtualMcp: makeVirtualMcp(ORG_ID, BASE_METADATA),
-      orgFlags: { sandbox_go_daemon: true },
+      orgFlags: { sandbox_go_daemon: false },
     });
     await SANDBOX_START.handler(
       { virtualMcpId: VMCP_ID, branch: BRANCH } as Parameters<
@@ -891,13 +891,12 @@ describe("SANDBOX_START", () => {
     const opts = (mockEnsure.mock.calls as unknown[][])[0]![1] as {
       daemonImpl?: string;
     };
-    expect(opts.daemonImpl).toBe("go");
+    expect(opts.daemonImpl).toBe("ts");
   });
 
-  it("lets an explicit daemonImpl=ts pin one sandbox inside a flagged org", async () => {
+  it("lets an explicit daemonImpl=ts pin one sandbox without opting the org out", async () => {
     const ctx = makeCtx({
       virtualMcp: makeVirtualMcp(ORG_ID, BASE_METADATA),
-      orgFlags: { sandbox_go_daemon: true },
     });
     await SANDBOX_START.handler(
       { virtualMcpId: VMCP_ID, branch: BRANCH, daemonImpl: "ts" } as Parameters<

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -119,7 +119,7 @@ export const SANDBOX_START = defineTool({
     daemonImpl: sandboxDaemonImplSchema
       .optional()
       .describe(
-        "Target this one sandbox at a specific sandbox daemon implementation, overriding the org's `sandbox_go_daemon` flag in either direction. Only honored on `agent-sandbox`, and only when the deployment configures a Go SandboxTemplate; otherwise the sandbox lands on `ts`. Applies to a sandbox being created — an existing sandbox keeps the binary it booted with.",
+        "Target this one sandbox at a specific sandbox daemon implementation, overriding both the `go` default and the org's `sandbox_go_daemon` opt-out. Only honored on `agent-sandbox`, and only when the deployment configures a Go SandboxTemplate; otherwise the sandbox lands on `ts`. Applies to a sandbox being created — an existing sandbox keeps the binary it booted with.",
       ),
   }),
   outputSchema: z.object({
@@ -566,9 +566,9 @@ async function provisionSandbox(
     }
   }
 
-  // Go-daemon rollout gate. Only the hosted runner can honor it (the desktop
-  // daemon is the TS bundle the link spawns), so skip the settings read
-  // entirely elsewhere. `resolveDaemonImpl` applies prop → org flag → `ts`; the
+  // Go-daemon gate. Only the hosted runner can honor it (the desktop daemon is
+  // the TS bundle the link spawns), so skip the settings read entirely
+  // elsewhere. `resolveDaemonImpl` applies prop → org opt-out → `go`; the
   // runner then collapses `go` back to `ts` when no Go SandboxTemplate is
   // configured, and persists whichever one the claim actually got.
   const daemonImpl =

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -159,7 +159,7 @@ export const OrgFlagsSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      "Provision this org's new sandboxes on the Go sandbox daemon instead of the TypeScript one. Affects the NEXT sandbox only — live sandboxes drain on the binary they booted with. Ignored unless the deployment sets STUDIO_SANDBOX_GO_TEMPLATE_NAME (the global kill switch); SANDBOX_START's `daemonImpl` overrides it per sandbox in either direction.",
+      "Which sandbox daemon this org's new sandboxes run. Go is the default, so this is an OPT-OUT: set it to `false` to keep the org on the TypeScript daemon; unset (or `true`) means Go. Affects the NEXT sandbox only — live sandboxes drain on the binary they booted with. Ignored unless the deployment sets STUDIO_SANDBOX_GO_TEMPLATE_NAME (the global kill switch); SANDBOX_START's `daemonImpl` overrides it per sandbox in either direction.",
     ),
 });
 


### PR DESCRIPTION
## Summary

Flips `resolveDaemonImpl` so a sandbox lands on the Go daemon unless something explicitly says otherwise. One line of behavior; the rest is the comments and tests that asserted the old direction.

- `resolve-daemon-impl.ts`: `flags?.sandbox_go_daemon ? "go" : "ts"` → `flags?.sandbox_go_daemon === false ? "ts" : "go"`. Precedence is unchanged (prop → org flag → default); only the default and the flag's polarity move.
- `sandbox_go_daemon` becomes an **opt-out**: absent/unset/`true` → Go, explicit `false` → TS. Schema description updated to say so. No rename — the flag name still reads correctly, and renaming it would orphan whatever rows already set it.
- `SANDBOX_START`'s `daemonImpl` prop is untouched and still wins in both directions, so a single sandbox can be pinned back to `ts` without opting the org out.
- Comment fixes in `lifecycle.ts` and `start.ts` that described Go as an opt-in rollout.

## Rollback

Three levels, cheapest first:

1. **Per sandbox** — `SANDBOX_START { daemonImpl: "ts" }`.
2. **Per org** — `ORGANIZATION_SETTINGS_UPDATE { flags: { sandbox_go_daemon: false } }`.
3. **Fleet** — unset `STUDIO_SANDBOX_GO_TEMPLATE_NAME` in the studio chart. `resolveClaimTemplate` collapses every `go` back to `ts` when there's no Go SandboxTemplate to point a claim at, so the whole fleet reverts on the next claim with no code deploy. Live sandboxes always drain on the binary they booted with.

## Depends on

**decocms/deco-apps-cd#191 must merge and sync first.** It KEDA-scales the `studio-sandbox-{stg,prod}-go` warm pools. Without it those pools are canary-sized at a static 1 replica while KEDA scales only the TS pools — this change would send the whole fleet at a 1-pod pool and cold-start most sandboxes.

## Testing

`bun test` on the three affected files — 32 pass. Inverted the existing assertions rather than appending:

- `resolve-daemon-impl.test.ts`: "defaults to ts" → "defaults to go"; "honors the org flag" → "treats the org flag as an opt-out"; the explicit-prop case now pins `ts` with no flag set, which is the escape hatch that matters once Go is the default.
- `start.test.ts`: the two `daemonImpl` reaching-`runner.ensure` cases swapped, and the "pin inside a flagged org" case became "pin without opting the org out".
- `claim-template.test.ts` needed no change — `resolveClaimTemplate` is downstream of this and its contract (no Go template ⇒ `ts`) is unchanged.

`bun run fmt`, `bun run lint` (0 errors) clean. `generate:tool-contracts` produced no diff for this change — the flag description doesn't reach `tool-io.ts`.

## Caveat worth a second opinion

The prod Go canary has been up ~31h with essentially no real traffic through it — 2 pods, both warm-pool, and no Go `SandboxClaim` live at the time I checked. So this flip is the first meaningful Go traffic in prod rather than a graduation from a proven canary. The three rollback levels above are why I think that's acceptable, but if you'd rather bake stg first, merge decocms/deco-apps-cd#191, then hold this and flip a couple of orgs' `sandbox_go_daemon` by hand for a day.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Go sandbox daemon the default for all new sandboxes. The `sandbox_go_daemon` flag is now an opt-out (`false` pins TS), and `SANDBOX_START`’s `daemonImpl` still overrides per sandbox.

- **Migration**
  - Per sandbox: `SANDBOX_START { daemonImpl: "ts" }`.
  - Per org: set `flags.sandbox_go_daemon = false`.
  - Fleet rollback: unset `STUDIO_SANDBOX_GO_TEMPLATE_NAME` to route new claims to TS; live sandboxes drain on their boot binary.

- **Dependencies**
  - `decocms/deco-apps-cd#191` must merge and sync first to scale `studio-sandbox-{stg,prod}-go` warm pools.

<sup>Written for commit f999e8d8c992315c8db496daa9817fffc1a0b5d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

