### PR TITLE
fix(task-board): show "Ship to production" button when auto-merge is on

### DIFF
--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -952,7 +952,7 @@ function PrCard({
 }: {
   pr: TaskBoardItemPr;
   previewThread?: TaskBoardItemThread;
-  /** Task-level: In Review + every enabled reviewer approved + auto-merge off. */
+  /** Task-level: In Review + every enabled reviewer approved. */
   reviewsReady: boolean;
   shipPending: boolean;
   onShip: () => void;
@@ -1160,7 +1160,6 @@ function LinksSection({
   const { data: activity } = useTaskBoardActivity(item.id);
   const qaEnabled = useOrgFlag("qa_agent_enabled");
   const codeReviewerEnabled = useOrgFlag("code_reviewer_enabled");
-  const autoMerge = useOrgFlag("auto_merge");
   const promote = usePromoteToProduction(item.id);
   const links = extractDescriptionLinks(description);
   // Keep the section up (with a skeleton) while the PR enrichment loads; a
@@ -1171,11 +1170,12 @@ function LinksSection({
   }
 
   // Task-level readiness for the manual ship button: In Review + every enabled
-  // reviewer approved + auto-merge off. The per-card PrCard adds the PR-open +
-  // green-checks gate (so a failing PR never offers the button).
+  // reviewer approved. Shown regardless of auto-merge — it's a manual escape
+  // hatch (a human can ship even while auto-merge is pending/blocked on token
+  // verification). The per-card PrCard adds the PR-open + green-checks gate (so
+  // a failing PR never offers the button).
   const reviewsReady =
     item.status === "in_review" &&
-    !autoMerge &&
     reviewsSatisfiedForPromotion(
       activity ?? [],
       enabledReviewers({ qa: qaEnabled, codeReview: codeReviewerEnabled }),


### PR DESCRIPTION
## Summary

The manual **"Ship to production"** button was hidden whenever the `auto_merge` org flag was enabled. The gate lived in `PrCard`'s `reviewsReady`:

```ts
const reviewsReady =
  item.status === "in_review" &&
  !autoMerge &&                      // ← hid the button
  reviewsSatisfiedForPromotion(...);
```

But the server tool `TASK_BOARD_PROMOTE_TO_PRODUCTION` **never** checked `auto_merge` — it only gates on `isReadyToShip` (In Review + every enabled reviewer approved). So the `!autoMerge` gate was purely cosmetic and removed a valid manual escape hatch: shipping while auto-merge is pending or blocked on token verification.

## Changes

- Removed the `!autoMerge` clause from `reviewsReady` and the now-orphaned `useOrgFlag("auto_merge")` read.
- The button now shows once: task is **In Review**, all enabled reviewers approved, PR open, and CI green (or no checks) — regardless of auto-merge.
- Updated the stale "auto-merge off" comments.

## Testing

- `bun run --cwd=apps/web check` — passes.
- No test inverted: the `!autoMerge` gate was inline in the component; `reviewsSatisfiedForPromotion` unit tests never referenced auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the "Ship to production" button even when auto-merge is enabled, matching the server’s `TASK_BOARD_PROMOTE_TO_PRODUCTION` logic. Restores the manual escape hatch to ship while auto-merge is pending or blocked.

- **Bug Fixes**
  - Removed the `!autoMerge` gate from `reviewsReady` so the button appears when the task is In Review and all required reviewers approved; PR open and CI green are still enforced in `PrCard`.
  - Deleted the unused `useOrgFlag("auto_merge")` read and updated comments to reflect the new behavior.

<sup>Written for commit baa6a57d387c1d87cc88dbb719488b0d74df10f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

