### PR TITLE
fix(decopilot): drop the `?`-in-text heuristic from thread status resolution

### DIFF
--- a/apps/api/src/api/routes/decopilot/project-chunks.ts
+++ b/apps/api/src/api/routes/decopilot/project-chunks.ts
@@ -131,7 +131,7 @@ export interface ProjectChunksResult {
    * The parts of the LAST assistant message the fold produced, taken directly
    * from the onFinish callback's responseMessage. Used by the workflow's
    * terminal branch to call resolveThreadStatus(finishReason, finalParts) so
-   * it can distinguish requires_action (tool-approval pause / question ending)
+   * it can distinguish requires_action (tool-approval pause / pending user_ask)
    * from completed without a round-trip back to the DB.
    */
   finalParts: Array<{ type: string; text?: string; state?: string }>;

--- a/apps/api/src/api/routes/decopilot/status.test.ts
+++ b/apps/api/src/api/routes/decopilot/status.test.ts
@@ -11,32 +11,31 @@ describe("resolveThreadStatus", () => {
     expect(resolveThreadStatus("stop", parts)).toBe("completed");
   });
 
-  test("stop with question -> requires_action", () => {
+  test("stop with a trailing question -> completed (no `?` heuristic)", () => {
+    // A clean stop is a finished turn. Ending prose with a question no longer
+    // implies the agent is waiting on input — that must be signalled
+    // structurally (user_ask / approval-requested, both under `tool-calls`).
     const parts = [
       { type: "text", text: "Here is the answer." },
       { type: "text", text: "Does that help?" },
     ];
-    expect(resolveThreadStatus("stop", parts)).toBe("requires_action");
-  });
-
-  test("stop with question mark only inside URL -> completed", () => {
-    const parts = [
-      {
-        type: "text",
-        text: "Check out https://example.com/page?foo=bar for more info.",
-      },
-    ];
     expect(resolveThreadStatus("stop", parts)).toBe("completed");
   });
 
-  test("stop with question and URL -> requires_action", () => {
+  test("stop with a `?` inside a schemeless URL -> completed (regression)", () => {
+    // Real case: a review agent's summary mentioned `fonts.googleapis.com/css2?...`
+    // (no scheme). The old `?`-substring heuristic only stripped `https://`-scheme
+    // URLs, so this query-string `?` survived and the completed review thread was
+    // wrongly flipped to requires_action — wedging the task board.
     const parts = [
       {
         type: "text",
-        text: "See https://example.com/page?q=1 — does this help?",
+        text:
+          "Decision recorded. The endpoint fonts.googleapis.com/css2?family=" +
+          "Material+Symbols varies by UA, so a static SRI hash cannot work.",
       },
     ];
-    expect(resolveThreadStatus("stop", parts)).toBe("requires_action");
+    expect(resolveThreadStatus("stop", parts)).toBe("completed");
   });
 
   test("tool-calls without user_ask -> completed", () => {

--- a/apps/api/src/api/routes/decopilot/status.test.ts
+++ b/apps/api/src/api/routes/decopilot/status.test.ts
@@ -12,9 +12,6 @@ describe("resolveThreadStatus", () => {
   });
 
   test("stop with a trailing question -> completed (no `?` heuristic)", () => {
-    // A clean stop is a finished turn. Ending prose with a question no longer
-    // implies the agent is waiting on input — that must be signalled
-    // structurally (user_ask / approval-requested, both under `tool-calls`).
     const parts = [
       { type: "text", text: "Here is the answer." },
       { type: "text", text: "Does that help?" },
@@ -22,11 +19,8 @@ describe("resolveThreadStatus", () => {
     expect(resolveThreadStatus("stop", parts)).toBe("completed");
   });
 
+  // Regression: a schemeless URL's query `?` used to false-trip requires_action.
   test("stop with a `?` inside a schemeless URL -> completed (regression)", () => {
-    // Real case: a review agent's summary mentioned `fonts.googleapis.com/css2?...`
-    // (no scheme). The old `?`-substring heuristic only stripped `https://`-scheme
-    // URLs, so this query-string `?` survived and the completed review thread was
-    // wrongly flipped to requires_action — wedging the task board.
     const parts = [
       {
         type: "text",

--- a/apps/api/src/api/routes/decopilot/status.ts
+++ b/apps/api/src/api/routes/decopilot/status.ts
@@ -24,14 +24,8 @@ export function resolveThreadStatus(
   responseParts: ResponsePart[] = [],
 ): Exclude<ThreadStatus, "in_progress"> {
   if (finishReason === "stop") {
-    // A clean stop is a finished turn. An agent that needs input signals it
-    // structurally — a pending `user_ask` or an `approval-requested` tool part,
-    // both handled by the `tool-calls` branch below — never by ending normal
-    // prose with a question. We used to infer `requires_action` from a `?` in
-    // the final text; that false-positived on any summary mentioning a URL
-    // query string (e.g. `fonts.googleapis.com/css2?...`) or a rhetorical
-    // question, wedging completed review threads in `requires_action` and
-    // blocking the task board from advancing them.
+    // Finished turn. "Needs input" comes only from the structured `tool-calls`
+    // signals below (user_ask / approval), never from a `?` in the prose.
     return "completed";
   }
 

--- a/apps/api/src/api/routes/decopilot/status.ts
+++ b/apps/api/src/api/routes/decopilot/status.ts
@@ -9,7 +9,6 @@ import type { ThreadStatus } from "@/storage/types";
 
 type ResponsePart = {
   type: string;
-  text?: string;
   state?: string;
 };
 
@@ -25,14 +24,15 @@ export function resolveThreadStatus(
   responseParts: ResponsePart[] = [],
 ): Exclude<ThreadStatus, "in_progress"> {
   if (finishReason === "stop") {
-    const text = responseParts
-      .filter((p) => p.type === "text" && p.text)
-      .map((p) => p.text!)
-      .join("\n");
-
-    // Strip URLs so their query strings don't trigger a false positive
-    const textWithoutUrls = text.replace(/https?:\/\/[^\s)>\]]+/g, "");
-    return textWithoutUrls.includes("?") ? "requires_action" : "completed";
+    // A clean stop is a finished turn. An agent that needs input signals it
+    // structurally — a pending `user_ask` or an `approval-requested` tool part,
+    // both handled by the `tool-calls` branch below — never by ending normal
+    // prose with a question. We used to infer `requires_action` from a `?` in
+    // the final text; that false-positived on any summary mentioning a URL
+    // query string (e.g. `fonts.googleapis.com/css2?...`) or a rhetorical
+    // question, wedging completed review threads in `requires_action` and
+    // blocking the task board from advancing them.
+    return "completed";
   }
 
   if (finishReason === "tool-calls") {

--- a/apps/web/src/components/chat/store/thread-status.test.ts
+++ b/apps/web/src/components/chat/store/thread-status.test.ts
@@ -4,9 +4,7 @@ import { deriveTerminalThreadStatus } from "./thread-status";
 describe("deriveTerminalThreadStatus", () => {
   it("maps stream finish reasons to non-running thread statuses", () => {
     expect(deriveTerminalThreadStatus("stop", [])).toBe("completed");
-    // A clean stop is completed even when its text ends with a question — the
-    // `?` heuristic is gone; "needs input" comes only from the structural
-    // `tool-calls` signals below.
+    // A stop is completed even when its text ends with a question (no `?` heuristic).
     const stopWithQuestion = [{ type: "text", text: "Ok?" }];
     expect(deriveTerminalThreadStatus("stop", stopWithQuestion)).toBe(
       "completed",

--- a/apps/web/src/components/chat/store/thread-status.test.ts
+++ b/apps/web/src/components/chat/store/thread-status.test.ts
@@ -4,9 +4,13 @@ import { deriveTerminalThreadStatus } from "./thread-status";
 describe("deriveTerminalThreadStatus", () => {
   it("maps stream finish reasons to non-running thread statuses", () => {
     expect(deriveTerminalThreadStatus("stop", [])).toBe("completed");
-    expect(
-      deriveTerminalThreadStatus("stop", [{ type: "text", text: "Ok?" }]),
-    ).toBe("requires_action");
+    // A clean stop is completed even when its text ends with a question — the
+    // `?` heuristic is gone; "needs input" comes only from the structural
+    // `tool-calls` signals below.
+    const stopWithQuestion = [{ type: "text", text: "Ok?" }];
+    expect(deriveTerminalThreadStatus("stop", stopWithQuestion)).toBe(
+      "completed",
+    );
     expect(
       deriveTerminalThreadStatus("tool-calls", [
         { type: "tool-user_ask", state: "input-available" },

--- a/apps/web/src/components/chat/store/thread-status.ts
+++ b/apps/web/src/components/chat/store/thread-status.ts
@@ -5,20 +5,14 @@ type ResponsePart = {
   state?: string;
 };
 
-// Client-side mirror of the server's `resolveThreadStatus`
-// (apps/api/src/api/routes/decopilot/status.ts). `apps/web` can't import from
-// `apps/api/src` (ban-web-server-imports), so the two are kept in lockstep by
-// hand — change both together.
+// Client mirror of the server's `resolveThreadStatus` (status.ts) — keep in sync.
 export function deriveTerminalThreadStatus(
   finishReason: string | undefined,
   responseParts: ResponsePart[] = [],
 ): Exclude<Task["status"], "in_progress"> {
   if (finishReason === "stop") {
-    // A clean stop is a finished turn. An agent that needs input signals it
-    // structurally — a pending `user_ask` or `approval-requested` part, both
-    // handled by the `tool-calls` branch below — never by ending prose with a
-    // question. (We used to infer `requires_action` from a `?` in the text,
-    // which false-positived on any URL query string or rhetorical question.)
+    // Finished turn. "Needs input" comes only from the structured `tool-calls`
+    // signals below (user_ask / approval), never from a `?` in the prose.
     return "completed";
   }
 

--- a/apps/web/src/components/chat/store/thread-status.ts
+++ b/apps/web/src/components/chat/store/thread-status.ts
@@ -2,21 +2,24 @@ import type { Task } from "../task/types";
 
 type ResponsePart = {
   type?: string;
-  text?: string;
   state?: string;
 };
 
+// Client-side mirror of the server's `resolveThreadStatus`
+// (apps/api/src/api/routes/decopilot/status.ts). `apps/web` can't import from
+// `apps/api/src` (ban-web-server-imports), so the two are kept in lockstep by
+// hand — change both together.
 export function deriveTerminalThreadStatus(
   finishReason: string | undefined,
   responseParts: ResponsePart[] = [],
 ): Exclude<Task["status"], "in_progress"> {
   if (finishReason === "stop") {
-    const text = responseParts
-      .filter((part) => part.type === "text" && part.text)
-      .map((part) => part.text!)
-      .join("\n");
-    const textWithoutUrls = text.replace(/https?:\/\/[^\s)>\]]+/g, "");
-    return textWithoutUrls.includes("?") ? "requires_action" : "completed";
+    // A clean stop is a finished turn. An agent that needs input signals it
+    // structurally — a pending `user_ask` or `approval-requested` part, both
+    // handled by the `tool-calls` branch below — never by ending prose with a
+    // question. (We used to infer `requires_action` from a `?` in the text,
+    // which false-positived on any URL query string or rhetorical question.)
+    return "completed";
   }
 
   if (finishReason === "tool-calls") {

--- a/packages/e2e/tests/decopilot-projection.spec.ts
+++ b/packages/e2e/tests/decopilot-projection.spec.ts
@@ -235,8 +235,8 @@ test.describe("decopilot projection — requires_action", () => {
   test.skip(
     true,
     "requires_action is produced when resolveThreadStatus maps finishReason=" +
-      "'tool-calls' + an `approval-requested` part (or finishReason='stop' + a " +
-      "question in the text). Driving this deterministically from e2e requires " +
+      "'tool-calls' + an `approval-requested` part (or a pending `user_ask`). " +
+      "Driving this deterministically from e2e requires " +
       "either a real model that emits tool-calls with a pending approval, or a " +
       "test hook that injects a canned relay body whose finish-step chunk carries " +
       "finishReason='tool-calls' AND a synthesized approval-requested part so the " +


### PR DESCRIPTION
## Summary

Removes the fragile heuristic in `resolveThreadStatus` (`apps/api/src/api/routes/decopilot/status.ts`) that flipped a cleanly-finished (`stop`) turn to `requires_action` whenever its final text contained a `?`.

The heuristic only stripped `https://`-scheme URLs before the `.includes("?")` check, so it false-positived on:
- **schemeless URLs** with a query string — e.g. a review agent writing `` `fonts.googleapis.com/css2?...` `` in its summary, and
- any **rhetorical question** in normal prose.

### Real-world impact (the bug that surfaced this)

A QA / Code Reviewer thread that had already recorded its decision (`TASK_BOARD_REVIEW_DECISION` → task correctly moved to `in_progress`) was nonetheless marked `requires_action` ("Requer entrada") because its summary mentioned `fonts.googleapis.com/css2?...`.

That non-terminal thread status then wedged the task board:
- `shouldAdvanceToReview` (`apps/api/src/storage/task-board.ts`) requires **every** linked thread to be terminal → the task never moved back to **In Review** after the Super Agent's fix.
- `decideStallAction` (`stall-recovery.ts`) deliberately leaves `requires_action` alone, assuming a human owns a `user_ask` that never existed.

Net result: the card sat in **In Progress** indefinitely, waiting on input nobody ever needed to give.

## Fix

A clean `stop` is a finished turn. An agent that needs input signals it **structurally** — a pending `user_ask` or an `approval-requested` tool part, both already handled by the `tool-calls` branch. So `stop` now always maps to `completed`; the `?` text inference is gone (and the now-unused `text` field dropped from the local `ResponsePart` type).

## Testing

- `bun test apps/api/.../status.test.ts` — 14/14 pass.
- Inverted the two unit tests that encoded the old `?` behavior (`stop` + trailing question, `stop` + question-with-URL) to assert `completed`.
- Added a regression test for the real schemeless-URL case (`fonts.googleapis.com/css2?...` → `completed`).
- Updated the e2e skip note in `packages/e2e/tests/decopilot-projection.spec.ts` that referenced the removed `stop`+`?` path.
- `tsc --noEmit` clean in both `apps/api` and `packages/e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dropped the `?`-in-text heuristic in server `resolveThreadStatus` and web `deriveTerminalThreadStatus` so a `stop` finish always maps to `completed`. Fixes false `requires_action` from schemeless URLs and rhetorical questions, and keeps client/server status in sync.

- **Bug Fixes**
  - Server: rely only on structured signals (`user_ask`, `approval-requested` under `tool-calls`); remove `text` from part type; invert tests; add a schemeless-URL regression; update the e2e skip note and a stale `project-chunks.ts` comment.
  - Web: mirror `stop -> completed`; drop `text` from the local type; invert the unit test; add a cross-reference comment to keep server/web logic aligned.

- **Refactors**
  - Trimmed overlong rationale comments across status and thread-status files per `comment-cop`.

<sup>Written for commit 185a930d6f2bab38ab34b21a4e3678710ed3f276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

