### PR TITLE
fix(task-board): cancel the sibling reviewer's run when one requests changes

### DIFF
--- a/apps/api/src/tools/task-board/cancel-sibling-reviewers.test.ts
+++ b/apps/api/src/tools/task-board/cancel-sibling-reviewers.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { inProgressSiblingReviewerThreadIds } from "./cancel-sibling-reviewers";
+
+const thread = (
+  threadId: string,
+  title: string | null,
+  status: string | null,
+) => ({ threadId, title, status });
+
+describe("inProgressSiblingReviewerThreadIds", () => {
+  test("returns the other reviewer's in_progress thread", () => {
+    const threads = [
+      thread("qa", "QA Agent: Add SRI", "completed"),
+      thread("cr", "Code Reviewer: Add SRI", "in_progress"),
+    ];
+    // QA is deciding → cancel the still-running Code Reviewer.
+    expect(inProgressSiblingReviewerThreadIds(threads, "qa")).toEqual(["cr"]);
+  });
+
+  test("never cancels the deciding reviewer's own thread", () => {
+    const threads = [thread("qa", "QA Agent: Add SRI", "in_progress")];
+    expect(inProgressSiblingReviewerThreadIds(threads, "qa")).toEqual([]);
+  });
+
+  test("ignores terminal sibling threads", () => {
+    const threads = [
+      thread("cr1", "Code Reviewer: Add SRI", "completed"),
+      thread("cr2", "Code Reviewer: Add SRI", "failed"),
+      thread("cr3", "Code Reviewer: Add SRI", "expired"),
+    ];
+    expect(inProgressSiblingReviewerThreadIds(threads, "qa")).toEqual([]);
+  });
+
+  test("ignores a sibling paused in requires_action (human owns it)", () => {
+    const threads = [thread("cr", "Code Reviewer: Add SRI", "requires_action")];
+    expect(inProgressSiblingReviewerThreadIds(threads, "qa")).toEqual([]);
+  });
+
+  test("ignores null-status and non-reviewer threads", () => {
+    const threads = [
+      thread("cr", "Code Reviewer: Add SRI", null),
+      thread("sa", "Super Agent: Add SRI", "in_progress"),
+      thread("plain", "Some chat", "in_progress"),
+    ];
+    expect(inProgressSiblingReviewerThreadIds(threads, "qa")).toEqual([]);
+  });
+
+  test("code_review deciding cancels the running QA sibling", () => {
+    const threads = [
+      thread("qa", "QA Agent: Add SRI", "in_progress"),
+      thread("cr", "Code Reviewer: Add SRI", "in_progress"),
+    ];
+    expect(inProgressSiblingReviewerThreadIds(threads, "code_review")).toEqual([
+      "qa",
+    ]);
+  });
+});

--- a/apps/api/src/tools/task-board/cancel-sibling-reviewers.ts
+++ b/apps/api/src/tools/task-board/cancel-sibling-reviewers.ts
@@ -1,0 +1,91 @@
+import { cancelHostedHarness } from "@/dispatch-queue";
+import { cancelThreadGateHead } from "@/dispatch-queue/thread-gate-queue";
+import type { StudioContext } from "@/core/studio-context";
+import type { TaskBoardItem } from "@/storage/types";
+import {
+  isReviewerThreadTitle,
+  REVIEWER_KINDS,
+  REVIEWER_LABEL,
+  type ReviewerKind,
+} from "@decocms/shared/task-board";
+
+/**
+ * The still-running reviewer threads that a `request_changes` decision should
+ * cancel: every OTHER reviewer kind whose thread is currently `in_progress`.
+ *
+ * Scoped to `in_progress` on purpose. A sibling that finished (terminal) needs
+ * no cancel, and one paused in `requires_action` is a genuine approval/user_ask
+ * pause a human owns — leaving it matches `decideStallAction`'s stance and
+ * `markRunFailed`'s `in_progress`-only flip (a requires_action row wouldn't flip
+ * anyway). Restricting to OTHER kinds guarantees we never cancel the deciding
+ * reviewer's own in-flight thread (which is running this very tool call).
+ *
+ * Pure — unit-tested.
+ */
+export function inProgressSiblingReviewerThreadIds(
+  threads: { threadId: string; title: string | null; status: string | null }[],
+  decidingReviewer: ReviewerKind,
+): string[] {
+  const otherKinds = REVIEWER_KINDS.filter((k) => k !== decidingReviewer);
+  return threads
+    .filter(
+      (t) =>
+        t.status === "in_progress" &&
+        otherKinds.some((k) => isReviewerThreadTitle(t.title, k)),
+    )
+    .map((t) => t.threadId);
+}
+
+/**
+ * A reviewer requested changes, so the task is bouncing back to the Super Agent
+ * and this review cycle is abandoned. Any sibling reviewer still running is now
+ * reviewing a stale PR — tear its run down so it can't record a decision for
+ * code that's about to change, and so its thread goes terminal instead of
+ * wedging `shouldAdvanceToReview` (which requires every linked thread terminal
+ * before the fixed task can move back to In Review).
+ *
+ * Mirrors the durable, tool-reachable subset of `cancelActiveThreadRun`
+ * (routes.ts): the durable cancel flag (ingest 409s the next step), the gate
+ * head, and the hosted-harness child. The in-memory abort + NATS fan-out from
+ * the route helper aren't reachable here, but a headless reviewer run has no SSE
+ * tunnel; the durable path is what terminates it. Best-effort per thread — a
+ * teardown hiccup must never fail the review decision itself.
+ */
+export async function cancelSiblingReviewerRuns(
+  ctx: StudioContext,
+  item: TaskBoardItem,
+  decidingReviewer: ReviewerKind,
+): Promise<void> {
+  const organizationId = item.organizationId;
+  const threadIds = inProgressSiblingReviewerThreadIds(
+    item.threads,
+    decidingReviewer,
+  );
+  for (const threadId of threadIds) {
+    try {
+      // Durable cancel flag: the ingest backstop rejects the sibling's next
+      // step with 409, the documented correctness path.
+      await ctx.storage.threads.setCancelRequested(threadId, organizationId);
+      // Free a PENDING gate head so the concurrency=1 partition slot releases.
+      await cancelThreadGateHead(threadId).catch(() => {});
+      // Tear down the hosted-harness child so it can never later report success.
+      const fence = await ctx.storage.threads.getRunFence(threadId);
+      if (fence) {
+        await cancelHostedHarness(threadId, fence).catch(() => {});
+      }
+      // Flip the thread terminal (in_progress → failed) so it stops counting as
+      // live for the advance-to-review gate.
+      await ctx.storage.threads.markRunFailed(
+        threadId,
+        `Superseded: ${REVIEWER_LABEL[decidingReviewer]} requested changes; this review cycle was abandoned.`,
+        "cancelled",
+      );
+    } catch (err) {
+      console.error("[task-board] failed to cancel sibling reviewer run", {
+        taskBoardItemId: item.id,
+        threadId,
+        err,
+      });
+    }
+  }
+}

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -12,6 +12,7 @@ import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
+import { cancelSiblingReviewerRuns } from "./cancel-sibling-reviewers";
 import { mergeLinkedPr } from "./merge-pr";
 
 /**
@@ -139,6 +140,12 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
         data: { reviewer, notes, verified },
       });
       emitTaskBoardUpdated(organizationId, updated);
+      // This review cycle is abandoned — the task goes back to the Super Agent.
+      // Cancel any sibling reviewer still running in parallel so it can't record
+      // a decision for a now-stale PR and its thread goes terminal instead of
+      // wedging the advance-to-review gate. Uses `item` (pre-update) for the
+      // reviewer threads; the status write above only touched the task row.
+      await cancelSiblingReviewerRuns(ctx, item, reviewer);
       // Pass the PR under review so the re-run updates it in place (checks out
       // its branch) instead of opening a second PR. Newest linked PR is the one.
       const prs = await ctx.storage.taskBoard.listPrs(


### PR DESCRIPTION
## Summary

Reviewers (**QA Agent** and **Code Reviewer**) are dispatched **concurrently** when a task reaches In Review with an open PR (`enqueueEnabledReviewers`). When one of them calls `TASK_BOARD_REVIEW_DECISION` with `request_changes`, `review-decision.ts` bounces the task back to the Super Agent and re-enqueues it with feedback — but the **other reviewer kept running**, now reviewing a PR that's about to change.

Two concrete problems with that orphaned run:
1. It can still call `TASK_BOARD_REVIEW_DECISION` and record an approve/request-changes decision for **stale** code.
2. Its still-live thread blocks `shouldAdvanceToReview` (`apps/api/src/storage/task-board.ts`), which requires **every** linked thread to be terminal before the fixed task can move back to In Review — so the card can wedge in In Progress.

## Fix

On `request_changes`, tear down any sibling reviewer still `in_progress`, mirroring the durable, **tool-reachable** subset of `cancelActiveThreadRun` (`routes.ts`):
- `setCancelRequested` (durable cancel flag — ingest 409s the next step),
- `cancelThreadGateHead` (free the PENDING gate partition slot),
- `getRunFence` + `cancelHostedHarness` (tear down the hosted-harness child so it can never report success),
- `markRunFailed` (flip the thread `in_progress → failed` so it stops counting as live).

The route helper's in-memory abort + NATS fan-out aren't reachable from a tool handler, but a headless reviewer run (`source: "background-tool"`) has no SSE tunnel — the durable path is what terminates it.

### Scope decisions
- **Only `in_progress` siblings** are cancelled. A sibling paused in `requires_action` is a genuine, human-owned approval/`user_ask` pause (consistent with `decideStallAction`), and `markRunFailed` only flips `in_progress` anyway.
- **Only OTHER reviewer kinds** are targeted, so the deciding reviewer never cancels its own in-flight thread (the one running this very tool call).
- **Best-effort** per thread — a teardown hiccup never fails the review decision itself.

## Files
- `apps/api/src/tools/task-board/cancel-sibling-reviewers.ts` — pure selector `inProgressSiblingReviewerThreadIds` + `cancelSiblingReviewerRuns`.
- `apps/api/src/tools/task-board/cancel-sibling-reviewers.test.ts` — unit tests for the selector.
- `apps/api/src/tools/task-board/review-decision.ts` — wired into the `request_changes` branch.

## Testing
- `bun test .../cancel-sibling-reviewers.test.ts` — 6/6 pass (sibling selected; own thread never cancelled; terminal / `requires_action` / null-status / non-reviewer threads ignored; both reviewer directions).
- `tsc --noEmit` clean in `apps/api`; `knip` clean; `lint` 0 errors.

## Relationship to #5585
Independent and complementary. #5585 removes the `?`-in-text heuristic that **falsely** marked completed reviewer threads `requires_action`; this PR stops a **genuinely** in-flight sibling from being orphaned by a `request_changes`. Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel the other reviewer’s in-progress run when one requests changes to prevent stale decisions and unblock moving the task back to In Review.

- **Bug Fixes**
  - On `request_changes` in `TASK_BOARD_REVIEW_DECISION`, invoke `cancelSiblingReviewerRuns` to stop the sibling reviewer.
  - Targets only the other reviewer’s `in_progress` thread; ignores `requires_action` and terminal threads.
  - Uses durable teardown: `setCancelRequested` → `cancelThreadGateHead` → `cancelHostedHarness` → `markRunFailed`.
  - Added `cancel-sibling-reviewers.ts` with `inProgressSiblingReviewerThreadIds` and unit tests; wired into `review-decision.ts`.

<sup>Written for commit e4ece09a1e45db7b775e18f27c545499fec82113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

