### PR TITLE
feat(task-board): auto-resolve merge conflicts on approved PRs

### DIFF
--- a/apps/api/migrations/156-task-board-conflict-activity.ts
+++ b/apps/api/migrations/156-task-board-conflict-activity.ts
@@ -1,0 +1,50 @@
+import { type Kysely, sql } from "kysely";
+
+/** Migration 154's action list, plus `merge_conflict_resolution` — logged when
+ *  an approved PR can't auto-merge because of a merge conflict and the task is
+ *  handed back to the Super Agent to resolve it. The CHECK constraint is
+ *  replaced wholesale — 154 may already be live, so editing its list in place
+ *  wouldn't reach a deployed database. A frozen snapshot like its predecessors;
+ *  `activity-actions.test.ts` reads this one (the newest) to prove SQL and
+ *  TypeScript agree. */
+export const ACTIONS = [
+  "created",
+  "status_changed",
+  "assignee_changed",
+  "priority_changed",
+  "due_date_changed",
+  "title_changed",
+  "description_changed",
+  "tags_changed",
+  "review_requested",
+  "review_approved",
+  "review_changes_requested",
+  "merge_conflict_resolution",
+] as const;
+
+const NEW_ACTIONS = new Set(["merge_conflict_resolution"]);
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await replaceActivityActionCheck(db, ACTIONS);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await replaceActivityActionCheck(
+    db,
+    ACTIONS.filter((a) => !NEW_ACTIONS.has(a)),
+  );
+}
+
+/** Swap `task_board_activity`'s action CHECK constraint for one allowing
+ *  exactly `actions`. */
+async function replaceActivityActionCheck(
+  db: Kysely<unknown>,
+  actions: readonly string[],
+): Promise<void> {
+  await sql`ALTER TABLE task_board_activity DROP CONSTRAINT chk_task_board_activity_action`.execute(
+    db,
+  );
+  await sql`ALTER TABLE task_board_activity ADD CONSTRAINT chk_task_board_activity_action CHECK (action IN (${sql.join(
+    actions.map((a) => sql.lit(a)),
+  )}))`.execute(db);
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -154,6 +154,7 @@ import * as migration152repairconnectionslug from "./152-repair-connection-slug.
 import * as migration153taskboardlatestassistantpartindex from "./153-task-board-latest-assistant-part-index.ts";
 import * as migration154taskboardqaactivity from "./154-task-board-qa-activity.ts";
 import * as migration155taskboardreviewclaims from "./155-task-board-review-claims.ts";
+import * as migration156taskboardconflictactivity from "./156-task-board-conflict-activity.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -334,6 +335,7 @@ const migrations: Record<string, Migration> = {
     migration153taskboardlatestassistantpartindex,
   "154-task-board-qa-activity": migration154taskboardqaactivity,
   "155-task-board-review-claims": migration155taskboardreviewclaims,
+  "156-task-board-conflict-activity": migration156taskboardconflictactivity,
 };
 
 export default migrations;

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -446,6 +446,40 @@ export class TaskBoardStorage {
   }
 
   /**
+   * Atomically claim a task for merge-conflict auto-resolution: move it from In
+   * Review to In Progress ONLY if it's still In Review, returning the updated
+   * item to the single winner and null to everyone else. The auto-resolve
+   * reaction fires from two triggers that can coincide — a reviewer's approval
+   * (`review-decision`) and the PR modal's poll (`prs-get`) — so, like
+   * `claimReviewer`, this fence must be atomic: a read-then-write would let both
+   * dispatch a Super Agent run on the same PR. A single conditional UPDATE is
+   * atomic under READ COMMITTED — the second writer re-checks `status` against
+   * the first's committed row and matches nothing.
+   */
+  async claimConflictResolution(
+    id: string,
+    organizationId: string,
+    by: string,
+  ): Promise<TaskBoardItem | null> {
+    const row = await this.db
+      .updateTable("task_board_items")
+      .set({
+        status: "in_progress",
+        updated_by: by,
+        updated_at: new Date().toISOString(),
+      })
+      .where("id", "=", id)
+      .where("organization_id", "=", organizationId)
+      .where("status", "=", "in_review")
+      .returningAll()
+      .executeTakeFirst();
+    if (!row) return null;
+    const item = this.itemFromDbRow(row);
+    await this.attachRefs([item], organizationId);
+    return item;
+  }
+
+  /**
    * Populate each item's `threads` and `tags` — one transaction, so a card
    * can't read its threads from before a concurrent edit and its tags from
    * after.

--- a/apps/api/src/tools/task-board/activity-actions.test.ts
+++ b/apps/api/src/tools/task-board/activity-actions.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { expect, test } from "bun:test";
-import { ACTIONS as MIGRATION_ACTIONS } from "../../../migrations/154-task-board-qa-activity";
+import { ACTIONS as MIGRATION_ACTIONS } from "../../../migrations/156-task-board-conflict-activity";
 import { TASK_BOARD_ACTIVITY_ACTIONS } from "./schema";
 
 test("the DB CHECK constraint allows exactly the actions TypeScript declares", () => {

--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, expect, it } from "bun:test";
 import {
+  conflictFromPrGet,
   extractPreviewUrl,
   extractPreviewUrlFromComments,
   isDecoPreviewHost,
@@ -41,6 +42,36 @@ describe("toChecksStatus", () => {
   it("is null for a missing response or unknown state", () => {
     expect(toChecksStatus(null)).toBeNull();
     expect(toChecksStatus({ state: "weird", total_count: 1 })).toBeNull();
+  });
+});
+
+describe("conflictFromPrGet", () => {
+  it("maps an open PR with mergeable === false → conflict (true)", () => {
+    expect(conflictFromPrGet({ state: "open", mergeable: false })).toBe(true);
+  });
+
+  it("maps an open, mergeable PR → false", () => {
+    expect(conflictFromPrGet({ state: "open", mergeable: true })).toBe(false);
+  });
+
+  it("is null when GitHub hasn't computed mergeability yet (mergeable null/absent)", () => {
+    // GitHub computes `mergeable` asynchronously — it's null right after a push.
+    // An unknown must NEVER read as a conflict (the caller only acts on `true`).
+    expect(conflictFromPrGet({ state: "open", mergeable: null })).toBeNull();
+    expect(conflictFromPrGet({ state: "open" })).toBeNull();
+  });
+
+  it("treats a non-open PR as not-conflicting, never a conflict", () => {
+    // A merged/closed PR reports `mergeable: null` but must not read as a
+    // conflict (guards a just-merged PR from a spurious resolution run).
+    expect(conflictFromPrGet({ state: "closed", mergeable: null })).toBe(false);
+    expect(conflictFromPrGet({ state: "merged", mergeable: false })).toBe(
+      false,
+    );
+  });
+
+  it("is null for a missing response", () => {
+    expect(conflictFromPrGet(null)).toBeNull();
   });
 });
 

--- a/apps/api/src/tools/task-board/conflict-reaction.test.ts
+++ b/apps/api/src/tools/task-board/conflict-reaction.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure logic behind conflict auto-resolution: the per-task dispatch cap. The
+ * orchestration (claim fence, enqueue, gating against real storage) is
+ * integration/e2e; this pins only the bound, where an off-by-one would let a
+ * conflict the agent can't resolve loop forever.
+ */
+import { describe, expect, it } from "bun:test";
+import type { ReviewCycleActivity } from "@decocms/shared/task-board";
+import { conflictResolutionCapReached } from "./conflict-reaction";
+
+const at = "2026-08-03T00:00:00.000Z";
+const resolution = (): ReviewCycleActivity => ({
+  action: "merge_conflict_resolution",
+  occurredAt: at,
+});
+const other = (): ReviewCycleActivity => ({
+  action: "review_approved",
+  occurredAt: at,
+});
+
+describe("conflictResolutionCapReached", () => {
+  it("is false below the cap (0, 1, 2 prior resolutions)", () => {
+    expect(conflictResolutionCapReached([])).toBe(false);
+    expect(conflictResolutionCapReached([resolution()])).toBe(false);
+    expect(conflictResolutionCapReached([resolution(), resolution()])).toBe(
+      false,
+    );
+  });
+
+  it("is true at exactly the cap of 3 (the off-by-one boundary)", () => {
+    expect(
+      conflictResolutionCapReached([resolution(), resolution(), resolution()]),
+    ).toBe(true);
+  });
+
+  it("stays true beyond the cap", () => {
+    expect(
+      conflictResolutionCapReached([
+        resolution(),
+        resolution(),
+        resolution(),
+        resolution(),
+      ]),
+    ).toBe(true);
+  });
+
+  it("counts only merge_conflict_resolution entries, ignoring other actions", () => {
+    expect(
+      conflictResolutionCapReached([
+        other(),
+        resolution(),
+        other(),
+        resolution(),
+        other(),
+      ]),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/tools/task-board/conflict-reaction.ts
+++ b/apps/api/src/tools/task-board/conflict-reaction.ts
@@ -1,0 +1,128 @@
+import type { StudioContext } from "@/core/studio-context";
+import type { TaskBoardItem } from "@/storage/types";
+import {
+  allReviewersApproved,
+  REVIEWER_FLAG,
+  REVIEWER_KINDS,
+  type ReviewCycleActivity,
+  SUPER_AGENT_ASSIGNEE_ID,
+} from "@decocms/shared/task-board";
+import { recordTaskActivity } from "./activity";
+import { emitTaskBoardUpdated } from "./run-reactions";
+import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
+
+/**
+ * How many times a single task may be auto-handed-back to the Super Agent to
+ * resolve a merge conflict, all-time. A bound, not a target: if the agent keeps
+ * failing to resolve (or the base branch keeps moving under it), stop the
+ * automatic churn and leave the PR for a human rather than re-dispatching a run
+ * every poll. Generous — a task rarely conflicts more than once.
+ */
+const MAX_AUTO_CONFLICT_RESOLUTIONS = 3;
+
+/** True once a task has hit its all-time cap of auto conflict-resolution
+ *  dispatches — counted from the `merge_conflict_resolution` activity entries,
+ *  which persist across review cycles (so the cap doesn't reset when the task
+ *  bounces back to In Review). Pure, so the off-by-one is unit-tested. */
+export function conflictResolutionCapReached(
+  activity: ReviewCycleActivity[],
+): boolean {
+  const attempts = activity.filter(
+    (a) => a.action === "merge_conflict_resolution",
+  ).length;
+  return attempts >= MAX_AUTO_CONFLICT_RESOLUTIONS;
+}
+
+/**
+ * When a task's PR is approved by every enabled reviewer but can't merge because
+ * it conflicts with its base branch, hand it back to the Super Agent to resolve
+ * the conflict — the automatic version of what a human would otherwise do
+ * (check out the branch, merge the base, push). Reuses the same machinery as a
+ * reviewer's change request: bounce the task to In Progress and re-enqueue the
+ * Super Agent on the EXISTING PR, so when it finishes the task returns to In
+ * Review, reviewers re-run on the merged result, and (with auto-merge on) it
+ * ships. Keeping it In Review instead would fight `reopenTasksOnThreadRun`,
+ * which pulls a task back to In Progress the moment a run starts on it.
+ *
+ * Gated on the org's `auto_merge` flag — conflict resolution is an extension of
+ * auto-merge (the only thing standing between an approved PR and an automatic
+ * merge is the conflict), so it rides the same opt-in rather than its own knob.
+ * Also gated on the SAME verified all-approved check the auto-merge uses (a
+ * self-asserted approval must not trigger it) and a per-task cap so a conflict
+ * the agent can't resolve doesn't loop forever.
+ *
+ * `opts.pr` is the PR the caller detected the conflict on — the reaction acts on
+ * THAT PR, not a re-derived "newest linked PR", so a task with more than one
+ * linked PR (e.g. a closed one plus the open conflicting one) resolves the right
+ * branch. `opts.conflict` is the mergeability signal: pass the already-known
+ * value from the poll's live-state fetch to avoid a second GitHub round-trip;
+ * the caller is responsible for it being an explicit `true` (a null/unknown must
+ * never act).
+ *
+ * Returns true when it bounced the task and enqueued a resolution run (and has
+ * already emitted the update). Best-effort at the seams; the caller wraps it.
+ */
+export async function reactToApprovedPrConflict(
+  ctx: StudioContext,
+  orgId: string,
+  item: TaskBoardItem,
+  opts: { pr: { number: number; url: string }; conflict: boolean | null },
+): Promise<boolean> {
+  // Only an In Review task delegated to the Super Agent is a candidate — a
+  // human-owned review never gets an automatic run, and a task already moved on
+  // (In Progress, Done) must not be bounced.
+  if (item.status !== "in_review") return false;
+  if (item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID) return false;
+  if (opts.conflict !== true) return false;
+
+  const settings = await ctx.storage.organizationSettings.get(orgId);
+  const flags = settings?.flags ?? {};
+  if (flags.auto_merge !== true) return false;
+
+  // Same gate as the auto-merge: EVERY enabled reviewer must have a
+  // token-verified approval in the current cycle. With no reviewer enabled
+  // `allReviewersApproved` is false, so a conflict never auto-resolves without
+  // an approval standing behind it.
+  const enabled = REVIEWER_KINDS.filter(
+    (k) => flags[REVIEWER_FLAG[k]] === true,
+  );
+  const activity = await ctx.storage.taskBoard.listActivity(item.id, orgId);
+  if (!allReviewersApproved(activity, enabled, { verifiedOnly: true })) {
+    return false;
+  }
+
+  // Cap the automatic churn — a conflict the agent can't resolve mustn't loop.
+  if (conflictResolutionCapReached(activity)) {
+    console.warn(
+      `[task-board] conflict auto-resolve cap (${MAX_AUTO_CONFLICT_RESOLUTIONS}) reached on task ${item.id} — leaving the PR for a human`,
+    );
+    return false;
+  }
+
+  const pr = opts.pr;
+
+  // Atomically bounce to In Progress — this is the dispatch fence. If it returns
+  // null we lost the race to a coinciding trigger (approval + poll), so skip:
+  // the winner already enqueued the resolution run. Everything past here runs
+  // for the single winner only, so the activity log (which feeds the cap count)
+  // stays accurate. No `status_changed` entry — mirrors the request_changes
+  // bounce; the review cycle resets only when the run advances back to In Review.
+  const claimed = await ctx.storage.taskBoard.claimConflictResolution(
+    item.id,
+    orgId,
+    item.updatedBy,
+  );
+  if (!claimed) return false;
+  await recordTaskActivity(ctx, {
+    taskBoardItemId: item.id,
+    action: "merge_conflict_resolution",
+    actorId: null,
+    data: { prNumber: pr.number },
+  });
+  emitTaskBoardUpdated(orgId, claimed);
+  await enqueueSuperAgentForTask(ctx, claimed, {
+    pr: { number: pr.number, url: pr.url },
+    resolveConflict: true,
+  });
+  return true;
+}

--- a/apps/api/src/tools/task-board/enqueue-super-agent.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure branch selection in the Super Agent prompt: a fresh attempt, a reviewer's
+ * change request, or a merge-conflict resolution. The dispatch itself is
+ * integration/e2e; this pins which lead block the prompt leads with — getting
+ * that wrong sends the agent to re-do the task or open a second PR.
+ */
+import { describe, expect, it } from "bun:test";
+import { buildSuperAgentTaskPrompt } from "./enqueue-super-agent";
+
+const task = { id: "board_1", title: "Fix the thing", description: null };
+const pr = { number: 7, url: "https://github.com/x/y/pull/7" };
+
+const CONFLICT_LEAD = "MERGE CONFLICT";
+const FEEDBACK_LEAD = "A reviewer requested changes";
+
+describe("buildSuperAgentTaskPrompt", () => {
+  it("a fresh attempt has neither lead block", () => {
+    const p = buildSuperAgentTaskPrompt(task);
+    expect(p).not.toContain(CONFLICT_LEAD);
+    expect(p).not.toContain(FEEDBACK_LEAD);
+    expect(p).toContain("Fix the thing");
+    expect(p).toContain("(task id: board_1)");
+  });
+
+  it("a conflict re-run leads with the conflict-resolution instruction", () => {
+    const p = buildSuperAgentTaskPrompt(task, { pr, resolveConflict: true });
+    expect(p).toContain(CONFLICT_LEAD);
+    expect(p).toContain("gh pr checkout 7");
+    expect(p).not.toContain(FEEDBACK_LEAD);
+  });
+
+  it("a reviewer change request leads with the feedback block", () => {
+    const p = buildSuperAgentTaskPrompt(task, {
+      pr,
+      feedback: "QA Agent: the button is broken",
+    });
+    expect(p).toContain(FEEDBACK_LEAD);
+    expect(p).toContain("the button is broken");
+    expect(p).not.toContain(CONFLICT_LEAD);
+  });
+
+  it("conflict resolution wins over feedback when both are set", () => {
+    const p = buildSuperAgentTaskPrompt(task, {
+      pr,
+      resolveConflict: true,
+      feedback: "QA Agent: the button is broken",
+    });
+    expect(p).toContain(CONFLICT_LEAD);
+    expect(p).not.toContain(FEEDBACK_LEAD);
+  });
+
+  it("resolveConflict without a PR skips the conflict lead (no PR to check out)", () => {
+    // The callers always pair resolveConflict with a pr; this documents the
+    // guard so a bad call can't emit a conflict instruction with no branch.
+    const p = buildSuperAgentTaskPrompt(task, { resolveConflict: true });
+    expect(p).not.toContain(CONFLICT_LEAD);
+  });
+});

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -31,24 +31,38 @@ export async function reactToSuperAgentDelegation(
  * a single text message, smart tier, no tool allowlist. Iterate on the prompt,
  * model, and metadata from here.
  */
-export async function enqueueSuperAgentForTask(
-  ctx: StudioContext,
-  task: TaskBoardItem,
-  opts?: {
-    /** A reviewer's change request — leads the re-run prompt. */
-    feedback?: string;
-    /** The PR already under review, so the re-run updates it in place instead
-     *  of opening a second PR. */
-    pr?: { number: number; url: string };
-  },
-): Promise<void> {
+/** Options that steer the Super Agent prompt for a re-run on an existing PR. */
+export type SuperAgentPromptOpts = {
+  /** A reviewer's change request — leads the re-run prompt. */
+  feedback?: string;
+  /** The PR already under review, so the re-run updates it in place instead
+   *  of opening a second PR. */
+  pr?: { number: number; url: string };
+  /** This re-run exists to resolve a merge conflict on `pr` (not reviewer
+   *  feedback): the lead instructs a checkout + base merge + push. Requires
+   *  `pr` — without it the conflict lead is skipped (a conflict instruction
+   *  is meaningless with no PR to check out). */
+  resolveConflict?: boolean;
+};
+
+/**
+ * The autonomous Super Agent prompt for a task. Pure (no I/O) so the branch
+ * selection is unit-tested: a fresh attempt, a reviewer's change request, or a
+ * merge-conflict resolution — the last two lead with an instruction to update
+ * the EXISTING PR rather than open a second one. Conflict resolution wins over
+ * feedback when both are set.
+ */
+export function buildSuperAgentTaskPrompt(
+  task: { id: string; title: string; description: string | null },
+  opts?: SuperAgentPromptOpts,
+): string {
   // Guidance tuned from observed runs. First: let the agent judge whether the
   // task even touches a repo — not every task does, and forcing a PR on a
   // research/answer task made it invent code changes. Only when it works on a
   // repo does the commit/push/PR flow apply. Then keep it direct: don't hunt for
   // the dev-server port, don't chase incidental symbols. Keep it tight — a
   // bloated prompt costs tokens every step.
-  const prompt = [
+  return [
     "You've been assigned this task. Complete it.",
     "",
     "You are running AUTONOMOUSLY — no human is watching this run, so drive it " +
@@ -59,25 +73,35 @@ export async function enqueueSuperAgentForTask(
     "",
     `Title: ${task.title}`,
     task.description ? `\nDescription:\n${task.description}\n` : "",
-    // When a reviewer bounced the task back, its feedback is the whole point of
-    // this re-run — lead with it so the model addresses it (and updates the
-    // EXISTING PR), not re-does the task from scratch or opens a second PR.
-    opts?.feedback
+    // A conflict re-run leads with the resolution instruction; a reviewer's
+    // change request leads with its feedback. Either way the whole point is to
+    // update the EXISTING PR, not re-do the task or open a second PR.
+    opts?.resolveConflict && opts.pr
       ? [
-          opts.pr
-            ? `A reviewer requested changes on the existing pull request #${opts.pr.number} (${opts.pr.url}):`
-            : "A reviewer requested changes on your previous work:",
-          opts.feedback,
-          opts.pr
-            ? `Load the repo, then CHECK OUT that PR's branch (e.g. \`gh pr checkout ${opts.pr.number}\`) before editing, address the feedback, commit, and push to update the SAME pull request — do NOT open a new one or start a new branch.`
-            : "Address this feedback.",
+          `Your pull request #${opts.pr.number} (${opts.pr.url}) is approved but can't be merged — it has a MERGE CONFLICT with its base branch.`,
+          `Load the repo, CHECK OUT that PR's branch (e.g. \`gh pr checkout ${opts.pr.number}\`), then merge (or rebase) the base branch into it and resolve the conflicts, and push to update the SAME pull request — do NOT open a new one or start a new branch. Resolve conflicts by preserving BOTH sides' intent; never blindly discard either side. Change only what resolving the conflict requires.`,
           "",
         ].join("\n")
-      : "",
+      : // When a reviewer bounced the task back, its feedback is the whole point
+        // of this re-run — lead with it so the model addresses it (and updates
+        // the EXISTING PR), not re-does the task from scratch or opens a second.
+        opts?.feedback
+        ? [
+            opts.pr
+              ? `A reviewer requested changes on the existing pull request #${opts.pr.number} (${opts.pr.url}):`
+              : "A reviewer requested changes on your previous work:",
+            opts.feedback,
+            opts.pr
+              ? `Load the repo, then CHECK OUT that PR's branch (e.g. \`gh pr checkout ${opts.pr.number}\`) before editing, address the feedback, commit, and push to update the SAME pull request — do NOT open a new one or start a new branch.`
+              : "Address this feedback.",
+            "",
+          ].join("\n")
+        : "",
     "How to work:",
     "- First decide whether this task requires changing code in a repository. Some tasks (research, answering a question, planning) don't. If it doesn't, just do the work directly — don't load a repo or open a PR.",
-    // The reviewer-feedback block above overrides this for a re-run: only a
-    // FIRST attempt opens a new branch + PR; a re-run pushes to the PR's branch.
+    // A re-run's lead block above (reviewer feedback OR conflict resolution)
+    // overrides this: only a FIRST attempt opens a new branch + PR; a re-run
+    // checks out the existing PR's branch and pushes to it.
     "- If it DOES need code changes: use the `load_repo` tool to load the relevant repository, then make the change, commit on a new branch, push, and open a pull request. Only then does a PR apply.",
     "- Prefer the GitHub tool to open the PR. If it errors or targets the wrong repo, fall back to `git push` + the GitHub REST API (the auth token is embedded in the `origin` URL).",
     "- If a dev server is running it hot-reloads your changes — don't restart it, hunt for its port, or run a full typecheck/build just to verify a small edit.",
@@ -86,6 +110,14 @@ export async function enqueueSuperAgentForTask(
     "",
     `(task id: ${task.id})`,
   ].join("\n");
+}
+
+export async function enqueueSuperAgentForTask(
+  ctx: StudioContext,
+  task: TaskBoardItem,
+  opts?: SuperAgentPromptOpts,
+): Promise<void> {
+  const prompt = buildSuperAgentTaskPrompt(task, opts);
 
   await enqueueAgentRunForTask(ctx, task, {
     title: `Super Agent: ${task.title}`,

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -707,16 +707,20 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
     // reviewer approved but the PR can't merge because it conflicts with its
     // base branch, hand it back to the Super Agent to resolve (gated on the
     // org's `auto_merge` flag, checked inside the reaction). This is the
-    // poll-driven safety net —
-    // a conflict often appears AFTER approval (the base branch moved on), which
-    // the merge attempt at approval time can't see. `mergeable === false` is the
-    // definite conflict signal; null/true never triggers. The reaction is
+    // poll-driven safety net — a conflict often appears AFTER approval (the base
+    // branch moved on), which the merge attempt at approval time can't see. Run
+    // the same `conflictFromPrGet` mapping the review-decision path uses (only an
+    // explicit conflict triggers; null/unknown never does). The reaction is
     // idempotent (it bounces the task to In Progress, so the next poll skips).
+    const openPrConflict = openPr
+      ? conflictFromPrGet({ state: openPr.state, mergeable: openPr.mergeable })
+      : null;
     if (
       item &&
       item.status === "in_review" &&
       item.assigneeId === SUPER_AGENT_ASSIGNEE_ID &&
-      openPr?.mergeable === false
+      openPr &&
+      openPrConflict === true
     ) {
       // Act on the PR the conflict was detected on (`openPr`), not a re-derived
       // "newest" — a task can have more than one linked PR.

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -10,6 +10,7 @@ import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import { TaskBoardItemPrSchema } from "./schema";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
+import { reactToApprovedPrConflict } from "./conflict-reaction";
 import { extractPrFromText } from "./pr-extract";
 
 /** Cap a single live PR fetch — the modal shouldn't hang on a slow GitHub. */
@@ -101,6 +102,9 @@ type PrLiveState = {
   state: "open" | "closed" | null;
   draft: boolean | null;
   merged: boolean | null;
+  /** GitHub's `mergeable`: false = conflicts with base, true = clean, null =
+   *  not computed yet / unknown. */
+  mergeable: boolean | null;
   checksStatus: ChecksStatus;
   checks: PrCheck[];
   previewUrl: string | null;
@@ -112,6 +116,7 @@ const NO_LIVE_STATE: PrLiveState = {
   state: null,
   draft: null,
   merged: null,
+  mergeable: null,
   checksStatus: null,
   checks: [],
   previewUrl: null,
@@ -409,6 +414,60 @@ export async function fetchPrChecksStatus(
   }
 }
 
+/** Map a `pull_request_read get` response to whether the PR conflicts with its
+ *  base branch. `true` = conflicts (`mergeable === false`); `false` = mergeable,
+ *  OR the PR is not open (a merged/closed PR reports `mergeable: null` but is
+ *  never "conflicting"); `null` = GitHub hasn't computed mergeability yet (it's
+ *  async) or the read gave nothing — an unknown must NEVER read as a conflict,
+ *  so the caller only acts on an explicit `true`. Pure — unit-tested; the single
+ *  home for the `mergeable` polarity, so the two callers can't drift. */
+export function conflictFromPrGet(
+  obj: Record<string, unknown> | null,
+): boolean | null {
+  if (!obj) return null;
+  if (obj.state !== "open") return false;
+  return typeof obj.mergeable === "boolean" ? !obj.mergeable : null;
+}
+
+/** Whether the PR conflicts with its base branch — the definite "can't merge"
+ *  signal used to gate conflict auto-resolution. Reads the same `get` the
+ *  live-state fetch uses; best-effort (null on any failure). */
+export async function fetchPrConflict(
+  ctx: StudioContext,
+  orgId: string,
+  pr: TaskBoardItemPrRef,
+): Promise<boolean | null> {
+  const conn = await resolveGithubConnection(ctx, orgId, pr.connectionId, {
+    owner: pr.repoOwner,
+    name: pr.repoName,
+  });
+  if (!conn) return null;
+  const client = await clientFromConnection(conn, ctx, true);
+  try {
+    return conflictFromPrGet(
+      toolResultJson(
+        await client.callTool(
+          {
+            name: "pull_request_read",
+            arguments: {
+              method: "get",
+              owner: pr.repoOwner,
+              repo: pr.repoName,
+              pullNumber: pr.number,
+            },
+          },
+          undefined,
+          { timeout: PR_FETCH_TIMEOUT_MS },
+        ),
+      ),
+    );
+  } catch {
+    return null;
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
 /** Fetch the PR's live CI + preview extras via the GitHub MCP
  *  `pull_request_read` tool: the combined Status API AND the Checks API (repos
  *  differ in which they post to), merged into one checks summary, plus the deco
@@ -523,6 +582,10 @@ async function fetchPrLiveState(
       state: rawState === "closed" ? "closed" : isOpen ? "open" : null,
       draft: typeof obj.draft === "boolean" ? obj.draft : null,
       merged: typeof obj.merged === "boolean" ? obj.merged : null,
+      // Mergeability only means something for an open PR (a merged/closed PR
+      // reports `mergeable: null`). Anything but a boolean is "unknown".
+      mergeable:
+        isOpen && typeof obj.mergeable === "boolean" ? obj.mergeable : null,
       // Checks/preview only mean something for an open PR.
       checksStatus: isOpen ? extras.checksStatus : null,
       checks: isOpen ? extras.checks : [],
@@ -637,6 +700,31 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
     ) {
       await enqueueEnabledReviewers(ctx, item).catch((err) => {
         console.error("[task-board] reviewer auto-handoff failed", err);
+      });
+    }
+
+    // Auto-resolve a merge conflict on an approved PR: once every enabled
+    // reviewer approved but the PR can't merge because it conflicts with its
+    // base branch, hand it back to the Super Agent to resolve (gated on the
+    // org's `auto_merge` flag, checked inside the reaction). This is the
+    // poll-driven safety net —
+    // a conflict often appears AFTER approval (the base branch moved on), which
+    // the merge attempt at approval time can't see. `mergeable === false` is the
+    // definite conflict signal; null/true never triggers. The reaction is
+    // idempotent (it bounces the task to In Progress, so the next poll skips).
+    if (
+      item &&
+      item.status === "in_review" &&
+      item.assigneeId === SUPER_AGENT_ASSIGNEE_ID &&
+      openPr?.mergeable === false
+    ) {
+      // Act on the PR the conflict was detected on (`openPr`), not a re-derived
+      // "newest" — a task can have more than one linked PR.
+      await reactToApprovedPrConflict(ctx, organizationId, item, {
+        pr: { number: openPr.number, url: openPr.url },
+        conflict: true,
+      }).catch((err) => {
+        console.error("[task-board] conflict auto-resolve failed", err);
       });
     }
 

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -13,6 +13,8 @@ import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 import { mergeLinkedPr } from "./merge-pr";
+import { fetchPrConflict } from "./prs-get";
+import { reactToApprovedPrConflict } from "./conflict-reaction";
 
 /**
  * True when EVERY enabled reviewer has a token-VERIFIED `approve` as its latest
@@ -184,28 +186,58 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
       ? await mergeLinkedPr(ctx, organizationId, taskBoardItemId)
       : false;
 
-    // A merge ships the task → Done. Without a merge, leave it In Review for a
-    // human to merge.
-    const updated = merged
-      ? await ctx.storage.taskBoard.update(
-          taskBoardItemId,
-          organizationId,
-          { status: "done" },
-          item.updatedBy,
-        )
-      : ((await ctx.storage.taskBoard.getById(
-          taskBoardItemId,
-          organizationId,
-        )) ?? item);
+    // A merge ships the task → Done.
     if (merged) {
+      const done = await ctx.storage.taskBoard.update(
+        taskBoardItemId,
+        organizationId,
+        { status: "done" },
+        item.updatedBy,
+      );
       await recordTaskActivity(ctx, {
         taskBoardItemId,
         action: "status_changed",
         actorId: null,
         data: { from: item.status, to: "done" },
       });
+      emitTaskBoardUpdated(organizationId, done);
+      return { status: done.status, merged: true };
     }
-    emitTaskBoardUpdated(organizationId, updated);
-    return { status: updated.status, merged };
+
+    // No merge — the task is still In Review (we only move it on a merge). When
+    // auto-merge is on and the merge was blocked by a conflict specifically (not
+    // pending CI, not a transient failure), hand the PR back to the Super Agent
+    // to resolve it — the headless counterpart to the poll path in `prs-get`.
+    // The conflict fetch is a GitHub round-trip, so only pay it when auto-merge
+    // is on. Otherwise leave it In Review for a human.
+    const current =
+      (await ctx.storage.taskBoard.getById(taskBoardItemId, organizationId)) ??
+      item;
+    if (autoMerge) {
+      const prs = await ctx.storage.taskBoard.listPrs(
+        taskBoardItemId,
+        organizationId,
+      );
+      // The newest linked PR is the one under review (the same one
+      // `mergeLinkedPr` just tried to merge) — detect and act on it.
+      const pr = prs[0];
+      const resolving = pr
+        ? await reactToApprovedPrConflict(ctx, organizationId, current, {
+            pr: { number: pr.number, url: pr.url },
+            conflict: await fetchPrConflict(ctx, organizationId, pr),
+          })
+        : false;
+      if (resolving) {
+        const bounced =
+          (await ctx.storage.taskBoard.getById(
+            taskBoardItemId,
+            organizationId,
+          )) ?? current;
+        // `reactToApprovedPrConflict` already emitted the update.
+        return { status: bounced.status, merged: false };
+      }
+    }
+    emitTaskBoardUpdated(organizationId, current);
+    return { status: current.status, merged: false };
   },
 });

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -56,6 +56,11 @@ export const TaskBoardItemPrSchema = z.object({
   state: z.enum(["open", "closed"]).nullable(),
   draft: z.boolean().nullable(),
   merged: z.boolean().nullable(),
+  /** GitHub's mergeability for the PR: `false` means it conflicts with its base
+   *  branch and can't be merged; `true` means it's clean. `null` when GitHub
+   *  hasn't computed it yet (it's async) or the fetch failed — an unknown must
+   *  never be read as "conflict". */
+  mergeable: z.boolean().nullable(),
   /** Combined CI check state for the PR's head commit, fetched live from GitHub.
    *  `null` when the PR has no checks or the fetch failed. Best-effort — reads
    *  the combined Status API, so a repo that only uses the Checks API may report
@@ -120,6 +125,7 @@ export const TASK_BOARD_ACTIVITY_ACTIONS = [
   "review_requested",
   "review_approved",
   "review_changes_requested",
+  "merge_conflict_resolution",
 ] as const;
 
 export type TaskBoardActivityAction =

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -382,7 +382,7 @@ export const settings = {
     "Reviews the code using the repository's stack-appropriate review skills.",
   "settings.review.autoMergeTitle": "Enable Auto-merge",
   "settings.review.autoMergeDescription":
-    "When every enabled reviewer approves, merge the pull request automatically instead of waiting for a human.",
+    "When every enabled reviewer approves, merge the pull request automatically instead of waiting for a human. If a conflict blocks the merge, the Super Agent resolves it first.",
   "settings.review.updateError": "Couldn't update the review setting",
   "settings.orgRoleDetail.addMember": "Add Member",
   "settings.orgRoleDetail.addMembersToGrantPermissions":

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -79,6 +79,8 @@ export const taskBoard = {
     "{reviewer} requested changes and handed the task back to the Super Agent",
   "taskBoard.taskDialog.activityReviewChangesRequestedWithNotes":
     "{reviewer} requested changes: {notes}",
+  "taskBoard.taskDialog.activityMergeConflictResolution":
+    "couldn't merge the pull request — resolving a merge conflict",
   "taskBoard.taskDialog.tagsButton": "Tags",
   "taskBoard.taskDialog.removeTagAriaLabel": "Remove tag {name}",
   "taskBoard.taskDialog.addTagButton": "Add tag",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -398,7 +398,7 @@ export const settings = {
     "Revisa o c\u00f3digo usando as skills de review apropriadas \u00e0 stack do reposit\u00f3rio.",
   "settings.review.autoMergeTitle": "Ativar Auto-merge",
   "settings.review.autoMergeDescription":
-    "Quando todos os revisores habilitados aprovam, mescla o pull request automaticamente em vez de esperar por uma pessoa.",
+    "Quando todos os revisores habilitados aprovam, mescla o pull request automaticamente em vez de esperar por uma pessoa. Se um conflito bloquear o merge, o Super Agent resolve antes.",
   "settings.review.updateError":
     "N\u00e3o foi poss\u00edvel atualizar a configura\u00e7\u00e3o de revis\u00e3o",
   "settings.orgRoleDetail.addMember": "Adicionar Membro",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -85,6 +85,8 @@ export const taskBoard = {
     "{reviewer} pediu alterações e devolveu a tarefa ao Super Agent",
   "taskBoard.taskDialog.activityReviewChangesRequestedWithNotes":
     "{reviewer} pediu alterações: {notes}",
+  "taskBoard.taskDialog.activityMergeConflictResolution":
+    "não conseguiu mesclar o pull request — resolvendo um conflito de merge",
   "taskBoard.taskDialog.tagsButton": "Tags",
   "taskBoard.taskDialog.removeTagAriaLabel": "Remover tag {name}",
   "taskBoard.taskDialog.addTagButton": "Adicionar tag",

--- a/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
+++ b/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
@@ -25,6 +25,7 @@ const pr = (o: Partial<TaskBoardItemPr>): TaskBoardItemPr => ({
   state: "open",
   draft: false,
   merged: false,
+  mergeable: null,
   checksStatus: null,
   checks: [],
   previewUrl: null,

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1563,6 +1563,8 @@ function describeActivity(
         : t("taskBoard.taskDialog.activityReviewChangesRequested", {
             reviewer: reviewerName(d.reviewer, t),
           });
+    case "merge_conflict_resolution":
+      return t("taskBoard.taskDialog.activityMergeConflictResolution");
     default: {
       const _exhaustive: never = a.action;
       return String(_exhaustive);

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -153,7 +153,7 @@ export const OrgFlagsSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      "When every enabled reviewer (QA Agent / Code Reviewer) approves a task's pull request, merge it automatically instead of leaving the merge to a human.",
+      "When every enabled reviewer (QA Agent / Code Reviewer) approves a task's pull request, merge it automatically instead of leaving the merge to a human. If the merge is blocked by a conflict with the base branch, hand the PR back to the Super Agent to resolve the conflict (check out the branch, merge the base, push) so it can then merge.",
     ),
 });
 

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -441,6 +441,7 @@ export interface StudioToolIO {
         state: "open" | "closed" | null;
         draft: boolean | null;
         merged: boolean | null;
+        mergeable: boolean | null;
         checksStatus: "pending" | "passing" | "failing" | null;
         checks: {
           name: string;
@@ -490,7 +491,8 @@ export interface StudioToolIO {
           | "tags_changed"
           | "review_requested"
           | "review_approved"
-          | "review_changes_requested";
+          | "review_changes_requested"
+          | "merge_conflict_resolution";
         actorId: string | null;
         data: Record<string, unknown>;
         occurredAt: string;


### PR DESCRIPTION
## Summary

When every enabled reviewer approves a task's PR but **auto-merge is blocked by a conflict** with the base branch, the PR used to sit In Review waiting for a human. This hands it back to the **Super Agent** to resolve the conflict automatically (check out the PR branch, merge the base, resolve, push), so it then merges.

Rides the existing **`auto_merge`** opt-in — **no new settings toggle**. Conflict resolution is just auto-merge finishing the job when the only blocker is a conflict.

## How it works

1. All reviewers approved, but the merge can't happen because `mergeable === false`.
2. The task bounces to **In Progress** and the Super Agent is re-enqueued with a conflict-resolution prompt (checkout the PR branch → merge base → resolve → push the same PR).
3. When it finishes, the task returns to **In Review**, reviewers re-run on the merged result, approve, and auto-merge ships it.

**Two triggers** (shared logic in `conflict-reaction.ts`):
- On the approving reviewer decision — headless, no browser needed.
- On the PR modal's poll — safety net for conflicts that appear *after* approval (the base branch moved on).

## Safety

- **Gated on `auto_merge`** (default off) — only fires when the org already opted into automatic merges.
- **Atomic dispatch fence** (`claimConflictResolution`: conditional `UPDATE ... WHERE status='in_review'`) so two coinciding triggers can't dispatch two runs on the same PR.
- **Token-verified approvals only** — a self-asserted/forged approval can't trigger the autonomous run (same gate as auto-merge).
- **Per-task cap (3)** so a conflict the agent can't resolve doesn't loop forever.
- Acts on the exact PR the conflict was detected on (correct for tasks with more than one linked PR).

## Tests

New unit tests for the extracted pure logic: the `mergeable`→conflict mapping (`conflictFromPrGet`), the cap boundary (`conflictResolutionCapReached`), and the prompt branch selection (`buildSuperAgentTaskPrompt`). All task-board tests pass; `bun run check` and `bun run lint` clean.

## Notes / follow-ups

- New migration **156** replaces the activity-action CHECK constraint to add `merge_conflict_resolution` (run `bun run --cwd=apps/api migrate`).
- Not covered here (needs infra the black-box e2e suite lacks — real GitHub): a storage-integration test for the CAS claim and an end-to-end conflict→resolve→merge test. The pure logic is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-resolve merge conflicts on approved PRs when `auto_merge` is enabled by handing the task back to the Super Agent to check out the PR branch, merge the base, resolve, and push. This removes the last manual step so approved work can ship.

- **New Features**
  - Detects conflicts on approved PRs and re-enqueues the Super Agent to resolve them (on approval and during PR modal poll). Gated by `auto_merge` and token-verified approvals only.
  - Acts on the exact PR where the conflict was found. Adds an atomic `claimConflictResolution` to avoid double dispatches and a per-task cap of 3 runs. Records a `merge_conflict_resolution` activity with UI copy.
  - Adds `mergeable` to PR live state and routes both approval and poll paths through a shared `conflictFromPrGet` mapper. Super Agent prompt gains a conflict-resolution lead that takes precedence over feedback.

- **Migration**
  - Adds and registers migration 156 to include the `merge_conflict_resolution` action (run: `bun run --cwd=apps/api migrate`).

<sup>Written for commit 32b03e683d395d0be96839e3019090259f702b42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

