### PR TITLE
perf(native): eliminate redundant Tauri CI builds

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -375,9 +375,9 @@ jobs:
   # 4. tauri-build — bundles the RELEASE .app (the same profile
   #    release-native.yaml ships; a debug bundle used to be built here but
   #    gated nothing the release profile doesn't, while leaving the shipped
-  #    profile untested until release day), uploads it as an artifact, and
-  #    boot-smokes it. Unsigned always — signing/notarization live in
-  #    release-native.yaml, the secret-gated release job.
+  #    profile untested until release day), boot-smokes it, and uploads the
+  #    exact tested bundle as an artifact. Unsigned always — signing and
+  #    notarization live in release-native.yaml, the secret-gated release job.
   # ---------------------------------------------------------------------
   tauri-build:
     needs: changes
@@ -406,14 +406,14 @@ jobs:
       #   APPLE_ID                       - Apple ID used for notarization
       #   APPLE_PASSWORD                 - app-specific password for APPLE_ID
       #   APPLE_TEAM_ID                  - Developer Team ID
-      # DELIBERATELY NOT WIRED HERE. This job only ever produces a DEBUG
+      # DELIBERATELY NOT WIRED HERE. This job produces an unsigned release
       # bundle for boot-smoke, which runs the binary directly and gains
       # nothing from a Developer ID. Exporting the secrets made the Tauri CLI
-      # attempt `security import` on every build in this job — including the
-      # one boot-smoke launches itself — and it failed with "failed codesign
-      # application: failed to import keychain certificate", from a cert that
-      # is present but not importable. Wiring them cost a green CI and bought
-      # nothing. Signing belongs to the separate, secret-gated release job.
+      # attempt `security import` during this verification build, and it
+      # failed with "failed codesign application: failed to import keychain
+      # certificate", from a cert that is present but not importable. Wiring
+      # them cost a green CI and bought nothing. Signing belongs to the
+      # separate, secret-gated release job.
       # --- Tauri updater artifact signing: NOT wired here, by design.
       #     createUpdaterArtifacts is enabled only by release-native.yaml's
       #     --config overlay (never the committed tauri.conf.json5), so this
@@ -450,58 +450,37 @@ jobs:
           path: apps/native/src-tauri/binaries
           key: rclone-${{ runner.os }}-${{ hashFiles('apps/native/scripts/fetch-rclone.sh') }}
 
-      # Explicit for the same reason as the frontend bundle below:
-      # `beforeBuildCommand` also runs it, but a dedicated step attributes a
+      # `beforeBuildCommand` also runs this, but a dedicated step attributes a
       # download or checksum failure to itself instead of to `tauri build`.
       - name: Fetch bundled rclone
         working-directory: apps/native
         run: ./scripts/fetch-rclone.sh
 
-      # Explicit step (not relying solely on tauri.conf.json5's own
-      # `beforeBuildCommand: bun run build:native`) for a clearer CI step
-      # boundary/log — slightly redundant with that hook, harmless (the
-      # second invocation is a fast no-op rebuild of already-fresh output).
-      - name: Build desktop frontend bundle
-        run: bun run --cwd apps/web build:native
-
-      - name: tauri build
+      # These verification builds are NEVER signed, whether or not the
+      # secrets exist. Boot-smoke runs the binary directly and a Developer ID
+      # buys it nothing, while attempting the import couples this job to the
+      # health of six repo secrets. Signing belongs to release-native.yaml,
+      # the secret-gated release job.
+      #
+      # PRs build only the artifact this job smokes and uploads. Pushes to
+      # main and manual runs retain DMG bundler coverage without adding that
+      # packaging cost to every review cycle.
+      - name: tauri build (.app only)
+        if: github.event_name == 'pull_request'
         working-directory: apps/native
-        # This build is NEVER signed, whether or not the secrets exist.
-        # boot-smoke runs the binary directly and a Developer ID buys it
-        # nothing, while attempting the import couples this job to the health
-        # of six repo secrets — which is exactly how it has been failing:
-        # "failed codesign application: failed to import keychain certificate",
-        # from a cert that is present but not importable. Signing belongs to
-        # release-native.yaml, the secret-gated release job.
-        run: bunx @tauri-apps/cli@latest build
+        run: bunx @tauri-apps/cli@2.11.4 build --bundles app
 
-      - name: Upload .app artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: deco-app
-          path: apps/native/target/release/bundle/macos/deco.app
-          if-no-files-found: error
-          retention-days: 14
+      - name: tauri build (.app + DMG)
+        if: github.event_name != 'pull_request'
+        working-directory: apps/native
+        run: bunx @tauri-apps/cli@2.11.4 build
 
-      # Boot-smoke consideration (the desktop migration contract §5.1): CI macOS runners
-      # are full logged-in GUI VMs (not headless like Linux — no Xvfb
-      # needed), and DESKTOP_SELFTEST=1 builds the "main" window
-      # `.visible(false)` specifically so this never pops a real window
-      # (see the native Tauri integration's "Self-test mode" section) — confirmed
-      # locally: `bun run --cwd apps/native smoke:boot` passes end-to-end
-      # (all 7 self-test checks + the orphan-process check) without ever
-      # showing a window. Included here rather than documented as
-      # local-only. Residual risk not fully provable from a dev machine:
-      # `authStatusInvoke`'s status check touches macOS Keychain via the
-      # `keyring` crate (crates/upstream) — GH's macos-latest runners
-      # provide an unlocked default login keychain so a read-only
-      # "no stored session" status check is expected to work the same way
-      # it does locally, but if this step ever starts failing ONLY in CI
-      # with a Keychain-access error, add a
-      # `security unlock-keychain -p runner ~/Library/Keychains/login.keychain-db`
-      # step immediately before this one rather than reverting it to
-      # local-only.
-      - name: Boot smoke (DESKTOP_SELFTEST=1, hidden window)
+      # GitHub's macOS runners provide a GUI session, so no headless display
+      # shim is needed. Self-test uses an isolated app-data directory and an
+      # in-memory token store, validates the runtime report, and checks for
+      # orphaned child processes. Its window is briefly visible by default to
+      # avoid macOS App Nap stalling the runtime probes.
+      - name: Boot smoke (DESKTOP_SELFTEST=1)
         # DECOCMS_DISABLE_AUTO_UPDATE: this job builds the RELEASE profile at
         # the committed version 0.1.0 — without the kill-switch, a
         # plugin-registered updater would see the prod channel as "newer" and
@@ -510,7 +489,17 @@ jobs:
         # the 0.1.0 placeholder version.
         env:
           DECOCMS_DISABLE_AUTO_UPDATE: "1"
-        run: bun run --cwd apps/native smoke:boot
+        # CI must smoke the bundle produced above without letting the smoke
+        # script replace it with a second build.
+        run: bun run --cwd apps/native smoke:boot --require-existing-bundle
+
+      - name: Upload smoked .app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deco-app
+          path: apps/native/target/release/bundle/macos/deco.app
+          if-no-files-found: error
+          retention-days: 14
 
   # ---------------------------------------------------------------------
   # 5. stub-seam-nightly — keeps the DAEMON_E2E_CMD swap-seam mechanics

--- a/.github/workflows/release-native.yaml
+++ b/.github/workflows/release-native.yaml
@@ -201,10 +201,6 @@ jobs:
         working-directory: apps/native
         run: ./scripts/fetch-rclone.sh
 
-      - name: Build desktop frontend bundle
-        if: steps.guard.outputs.release == 'true'
-        run: bun run --cwd apps/web build:native
-
       # Import the Developer ID certificate only when configured. Kept as its
       # own step (not left to the Tauri CLI env-sniffing) so a broken cert
       # fails HERE with a clear name, not inside `tauri build`.

--- a/apps/native/scripts/boot-smoke-options.test.ts
+++ b/apps/native/scripts/boot-smoke-options.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseBootSmokeOptions,
+  resolveBootSmokeBundleAction,
+} from "./boot-smoke-options";
+
+describe("parseBootSmokeOptions", () => {
+  test("keeps freshness-aware local behavior by default", () => {
+    expect(parseBootSmokeOptions([])).toEqual({
+      bundleMode: "ensure-fresh",
+    });
+  });
+
+  test("selects a forced rebuild", () => {
+    expect(parseBootSmokeOptions(["--rebuild"])).toEqual({
+      bundleMode: "force-rebuild",
+    });
+  });
+
+  test("selects the existing-bundle-only mode", () => {
+    expect(parseBootSmokeOptions(["--require-existing-bundle"])).toEqual({
+      bundleMode: "require-existing",
+    });
+  });
+
+  test("rejects conflicting bundle modes", () => {
+    expect(() =>
+      parseBootSmokeOptions(["--rebuild", "--require-existing-bundle"]),
+    ).toThrow(
+      "--rebuild and --require-existing-bundle cannot be used together",
+    );
+  });
+
+  test("rejects unsupported arguments", () => {
+    expect(() => parseBootSmokeOptions(["--unknown"])).toThrow(
+      "unsupported boot-smoke argument: --unknown",
+    );
+  });
+});
+
+describe("resolveBootSmokeBundleAction", () => {
+  test("never builds when CI requires the existing bundle", () => {
+    expect(resolveBootSmokeBundleAction("require-existing", true)).toBe(
+      "use-existing",
+    );
+    expect(resolveBootSmokeBundleAction("require-existing", false)).toBe(
+      "reject-missing",
+    );
+  });
+
+  test("always builds when a rebuild is forced", () => {
+    expect(resolveBootSmokeBundleAction("force-rebuild", true)).toBe("build");
+    expect(resolveBootSmokeBundleAction("force-rebuild", false)).toBe("build");
+  });
+
+  test("checks freshness only when the default mode finds a bundle", () => {
+    expect(resolveBootSmokeBundleAction("ensure-fresh", true)).toBe(
+      "check-freshness",
+    );
+    expect(resolveBootSmokeBundleAction("ensure-fresh", false)).toBe("build");
+  });
+});

--- a/apps/native/scripts/boot-smoke-options.ts
+++ b/apps/native/scripts/boot-smoke-options.ts
@@ -1,0 +1,58 @@
+export type BootSmokeBundleMode =
+  | "ensure-fresh"
+  | "force-rebuild"
+  | "require-existing";
+
+type BootSmokeBundleAction =
+  | "build"
+  | "check-freshness"
+  | "use-existing"
+  | "reject-missing";
+
+interface BootSmokeOptions {
+  bundleMode: BootSmokeBundleMode;
+}
+
+const REBUILD_FLAG = "--rebuild";
+const REQUIRE_EXISTING_BUNDLE_FLAG = "--require-existing-bundle";
+const SUPPORTED_FLAGS = new Set([REBUILD_FLAG, REQUIRE_EXISTING_BUNDLE_FLAG]);
+
+/**
+ * Parses the boot smoke's small CLI surface independently from any filesystem
+ * or process work, so CI-only bundle selection cannot accidentally trigger a
+ * build before invalid arguments are rejected.
+ */
+export function parseBootSmokeOptions(args: string[]): BootSmokeOptions {
+  const unsupported = args.find((arg) => !SUPPORTED_FLAGS.has(arg));
+  if (unsupported) {
+    throw new Error(`unsupported boot-smoke argument: ${unsupported}`);
+  }
+
+  const forceRebuild = args.includes(REBUILD_FLAG);
+  const requireExisting = args.includes(REQUIRE_EXISTING_BUNDLE_FLAG);
+  if (forceRebuild && requireExisting) {
+    throw new Error(
+      `${REBUILD_FLAG} and ${REQUIRE_EXISTING_BUNDLE_FLAG} cannot be used together`,
+    );
+  }
+
+  if (requireExisting) return { bundleMode: "require-existing" };
+  if (forceRebuild) return { bundleMode: "force-rebuild" };
+  return { bundleMode: "ensure-fresh" };
+}
+
+/**
+ * Chooses whether boot-smoke may build before any filesystem walk or process
+ * spawn. In particular, CI's require-existing mode can only use the artifact
+ * it was handed or reject it as missing; it can never select a build.
+ */
+export function resolveBootSmokeBundleAction(
+  bundleMode: BootSmokeBundleMode,
+  bundleExists: boolean,
+): BootSmokeBundleAction {
+  if (bundleMode === "require-existing") {
+    return bundleExists ? "use-existing" : "reject-missing";
+  }
+  if (bundleMode === "force-rebuild" || !bundleExists) return "build";
+  return "check-freshness";
+}

--- a/apps/native/scripts/boot-smoke.ts
+++ b/apps/native/scripts/boot-smoke.ts
@@ -4,10 +4,13 @@
  *
  * End-to-end boot smoke for the Tauri shell (`apps/native/src-tauri/`):
  *
- *   1. Builds the release `.app` bundle (`bunx @tauri-apps/cli build`) —
- *      the same profile the shipped app uses, so the smoke gates what ships
- *      if it doesn't already exist (pass `--rebuild` to force a fresh
- *      build — useful after touching Rust or frontend source).
+ *   1. By default, ensures the release `.app` bundle exists
+ *      (`bunx @tauri-apps/cli build`) and is newer than its inputs — the same
+ *      profile the shipped app uses, so the smoke gates what ships. Pass
+ *      `--rebuild` to force a fresh build after touching Rust or frontend
+ *      source. CI, which already built the exact artifact it needs to test,
+ *      passes `--require-existing-bundle` to fail when that `.app` is absent
+ *      and never rebuild it.
  *   2. Launches `Contents/MacOS/<bin>` DIRECTLY (not `open -a`, which
  *      detaches from this process's stdio/exit-code and complicates
  *      cleanup) with `DESKTOP_SELFTEST=1`,
@@ -50,6 +53,11 @@ import {
   type BootSmokePaths,
   resolveBootSmokePaths,
 } from "./boot-smoke-paths";
+import {
+  type BootSmokeBundleMode,
+  parseBootSmokeOptions,
+  resolveBootSmokeBundleAction,
+} from "./boot-smoke-options";
 
 const DESKTOP_DIR = fileURLToPath(new URL("..", import.meta.url));
 const APP_BINARY_NAME = "deco";
@@ -57,6 +65,7 @@ const APP_BUNDLE = join(
   DESKTOP_DIR,
   `target/release/bundle/macos/${APP_BINARY_NAME}.app`,
 );
+const TAURI_CLI_VERSION = "2.11.4";
 const SELFTEST_DEADLINE_MS = 60_000;
 const ORPHAN_CHECK_SETTLE_MS = 1000;
 
@@ -132,8 +141,22 @@ function newestMtimeUnder(dir: string): number {
   return newest;
 }
 
-async function ensureBuilt(forceRebuild: boolean): Promise<void> {
-  if (!forceRebuild && existsSync(APP_BUNDLE)) {
+async function ensureBuilt(bundleMode: BootSmokeBundleMode): Promise<void> {
+  const action = resolveBootSmokeBundleAction(
+    bundleMode,
+    existsSync(APP_BUNDLE),
+  );
+  if (action === "reject-missing") {
+    fail(
+      `--require-existing-bundle was passed but ${APP_BUNDLE} does not exist`,
+    );
+  }
+  if (action === "use-existing") {
+    log(`using required existing bundle at ${APP_BUNDLE}`);
+    return;
+  }
+
+  if (action === "check-freshness") {
     // Staleness guard: the bundle bakes the frontend + Rust in at build
     // time, so an existing .app can silently predate both. A stale bundle
     // is exactly how a fixed frontend kept shipping a blank window on
@@ -170,11 +193,11 @@ async function ensureBuilt(forceRebuild: boolean): Promise<void> {
     log("existing bundle is older than its inputs — rebuilding");
   }
   log(
-    "building release app bundle: bunx @tauri-apps/cli@latest build --bundles app",
+    `building release app bundle: bunx @tauri-apps/cli@${TAURI_CLI_VERSION} build --bundles app`,
   );
   const code = await run(
     "bunx",
-    ["@tauri-apps/cli@latest", "build", "--bundles", "app"],
+    [`@tauri-apps/cli@${TAURI_CLI_VERSION}`, "build", "--bundles", "app"],
     { cwd: DESKTOP_DIR },
   );
   if (code !== 0) {
@@ -240,9 +263,9 @@ function livingProcessesMatching(pattern: string): number[] {
 }
 
 async function main(): Promise<void> {
-  const forceRebuild = process.argv.includes("--rebuild");
+  const options = parseBootSmokeOptions(process.argv.slice(2));
 
-  await ensureBuilt(forceRebuild);
+  await ensureBuilt(options.bundleMode);
   const bin = binaryPath();
   log(`binary: ${bin}`);
 


### PR DESCRIPTION
## Summary

- Make the Tauri beforeBuildCommand hook the single owner of the native frontend production build in both verification and release workflows.
- Add a --require-existing-bundle boot-smoke mode so CI tests the exact app produced by the preceding Tauri build and can never replace it with another build.
- Run boot smoke before artifact upload, ensuring the uploaded app is the one that passed.
- Pin the verification and smoke fallback paths to Tauri CLI 2.11.4, matching the release workflow.
- Build only the app bundle on pull requests while retaining app plus DMG coverage on main and manual runs.
- Add pure unit coverage for argument validation and the no-rebuild bundle policy.

## Why this improves build speed

The tauri-build job previously performed work at multiple layers:

1. The workflow built the desktop frontend explicitly.
2. Tauri built the frontend again through beforeBuildCommand.
3. Boot smoke was allowed to invoke another Tauri build instead of being a strict consumer of the artifact already produced.
4. Pull requests packaged a DMG even though this job only smoke-tests and uploads the app bundle.

After this change, the pull-request path builds the frontend once, creates the app once, smoke-tests that exact app, and uploads it. Main and release paths still exercise DMG packaging, so the faster PR loop does not move DMG validation all the way to release day.

Recent successful tauri-build jobs had a median around 10m42s and p90 around 15m58s. Removing the repeated frontend/build boundary and PR-only DMG packaging is expected to move the median toward roughly 6–7 minutes. CI on this PR will provide the definitive measurement.

## Safety and coverage

- --require-existing-bundle fails closed when the app is missing and never selects a build action.
- Default local smoke behavior remains freshness-aware; --rebuild still forces a local rebuild.
- Main and manual verification runs retain app plus DMG bundling.
- The release workflow still produces the app, DMG, updater artifacts, signing, and notarization; it now relies on the same self-contained Tauri build hook for the frontend.
- Artifact upload happens only after boot smoke succeeds.

## Validation

- bun test apps/native/scripts — 24 passed
- bun run check — passed
- bun run lint — passed with 0 errors
- bun run fmt:check — passed
- actionlint -shellcheck= on both changed workflows — passed
- git diff --check — passed
- Missing-bundle black-box invocation exits immediately without printing or starting a Tauri build

## Not run locally

The full Tauri release bundle was not rebuilt locally because it is the expensive path this PR is optimizing. The macOS CI job is the end-to-end validation and timing measurement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up native macOS CI by removing duplicate Tauri builds and smoking the exact bundle we upload. PRs now build only the `.app`, while main/manual runs keep `.app` + DMG coverage; expected PR median drops from ~10m42s to ~6–7m.

- **Refactors**
  - Make Tauri `beforeBuildCommand` the single owner of the production frontend build; remove explicit web build steps from workflows.
  - Build `.app` only on pull requests; keep `.app` + DMG on `main` and manual runs.
  - Run boot smoke before artifact upload to gate the uploaded bundle.
  - Pin verification/smoke builds to `@tauri-apps/cli@2.11.4` to match release.

- **New Features**
  - Add `--require-existing-bundle` boot-smoke mode so CI tests the produced bundle and never rebuilds.
  - Add unit tests for option parsing and the no‑rebuild policy.

<sup>Written for commit 967273d077d6f9a35dd7dc6069e069075f069d8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

