### PR TITLE
refactor(api): dedupe bundle-server-script's three near-identical build functions

### DIFF
--- a/apps/api/scripts/bundle-server-script.ts
+++ b/apps/api/scripts/bundle-server-script.ts
@@ -476,11 +476,14 @@ async function pruneNodeModules(): Promise<Set<string>> {
   return successfullyCopied;
 }
 
-async function buildMigrateScript(packagesToExternalize: Set<string>) {
-  console.log("🔨 Building migrate.js...");
+async function buildScript(
+  sourcePath: string,
+  outputName: string,
+  packagesToExternalize: Set<string>,
+) {
+  console.log(`🔨 Building ${outputName}...`);
 
-  const migrateSourcePath = join(SCRIPT_DIR, "../src/database/migrate.ts");
-  const migrateOutputPath = join(OUTPUT_DIR, "migrate.js");
+  const outputPath = join(OUTPUT_DIR, outputName);
 
   // Ensure output directory exists
   await mkdir(OUTPUT_DIR, { recursive: true });
@@ -488,13 +491,13 @@ async function buildMigrateScript(packagesToExternalize: Set<string>) {
   const commandsParts = [
     "bun",
     "build",
-    migrateSourcePath,
+    sourcePath,
     "--target",
     "bun",
     "--minify",
     "--production",
     "--outfile",
-    migrateOutputPath,
+    outputPath,
   ];
 
   for (const pkg of packagesToExternalize) {
@@ -505,95 +508,34 @@ async function buildMigrateScript(packagesToExternalize: Set<string>) {
   }
 
   console.log(`🔨 Running command: ${commandsParts.join(" ")}`);
-  // Build migrate.js
   await $`${commandsParts}`.quiet();
 
-  if (!existsSync(migrateOutputPath)) {
-    console.error("❌ Failed to build migrate.js");
+  if (!existsSync(outputPath)) {
+    console.error(`❌ Failed to build ${outputName}`);
     process.exit(1);
   }
 
-  console.log(`✅ migrate.js built successfully at ${migrateOutputPath}`);
+  console.log(`✅ ${outputName} built successfully at ${outputPath}`);
 }
 
-async function buildServerScript(packagesToExternalize: Set<string>) {
-  console.log("🔨 Building server.js...");
-
-  const serverSourcePath = join(SCRIPT_DIR, "../src/index.ts");
-  const serverOutputPath = join(OUTPUT_DIR, "server.js");
-
-  // Ensure output directory exists
-  await mkdir(OUTPUT_DIR, { recursive: true });
-
-  const commandsParts = [
-    "bun",
-    "build",
-    serverSourcePath,
-    "--target",
-    "bun",
-    "--minify",
-    "--production",
-    "--outfile",
-    serverOutputPath,
-  ];
-
-  for (const pkg of packagesToExternalize) {
-    commandsParts.push("--external", pkg);
-  }
-  for (const pkg of ALWAYS_EXCLUDE) {
-    commandsParts.push("--external", pkg);
-  }
-
-  console.log(`🔨 Running command: ${commandsParts.join(" ")}`);
-  // Build server.js
-  await $`${commandsParts}`.quiet();
-
-  if (!existsSync(serverOutputPath)) {
-    console.error("❌ Failed to build server.js");
-    process.exit(1);
-  }
-
-  console.log(`✅ server.js built successfully at ${serverOutputPath}`);
+function buildMigrateScript(packagesToExternalize: Set<string>) {
+  return buildScript(
+    join(SCRIPT_DIR, "../src/database/migrate.ts"),
+    "migrate.js",
+    packagesToExternalize,
+  );
 }
 
-async function buildCliScript(packagesToExternalize: Set<string>) {
-  console.log("🔨 Building cli.js...");
+function buildServerScript(packagesToExternalize: Set<string>) {
+  return buildScript(
+    join(SCRIPT_DIR, "../src/index.ts"),
+    "server.js",
+    packagesToExternalize,
+  );
+}
 
-  const cliSourcePath = CLI_ENTRY_POINT;
-  const cliOutputPath = join(OUTPUT_DIR, "cli.js");
-
-  // Ensure output directory exists
-  await mkdir(OUTPUT_DIR, { recursive: true });
-
-  const commandsParts = [
-    "bun",
-    "build",
-    cliSourcePath,
-    "--target",
-    "bun",
-    "--minify",
-    "--production",
-    "--outfile",
-    cliOutputPath,
-  ];
-
-  for (const pkg of packagesToExternalize) {
-    commandsParts.push("--external", pkg);
-  }
-  for (const pkg of ALWAYS_EXCLUDE) {
-    commandsParts.push("--external", pkg);
-  }
-
-  console.log(`🔨 Running command: ${commandsParts.join(" ")}`);
-  // Build cli.js
-  await $`${commandsParts}`.quiet();
-
-  if (!existsSync(cliOutputPath)) {
-    console.error("❌ Failed to build cli.js");
-    process.exit(1);
-  }
-
-  console.log(`✅ cli.js built successfully at ${cliOutputPath}`);
+function buildCliScript(packagesToExternalize: Set<string>) {
+  return buildScript(CLI_ENTRY_POINT, "cli.js", packagesToExternalize);
 }
 
 async function copyRootReadme() {


### PR DESCRIPTION
**Source:** a net code reduction (C1) found while scanning recently-churned files in apps/api/scripts/bundle-server-script.ts.

**Payoff:** `buildMigrateScript`, `buildServerScript`, and `buildCliScript` each repeated the identical `bun build ... --minify --production --outfile ...` invocation plus the identical "exit 1 if the output file is missing" check, differing only by source path and output filename. Collapsed the three into one `buildScript(sourcePath, outputName, packagesToExternalize)` helper that the three thin wrappers now call.

**Behavior preserved:** the emitted console log lines, the exact bun-build command/flag order, the `--external` package list construction, and the exit-on-missing-output logic are byte-identical per entry point — only the source/output strings are now parameters instead of copy-pasted local variables. Net diff: -85 / +27 lines in the one touched file.

**How to confirm:** run `bun run --cwd=apps/api build:server` (or `bun run scripts/bundle-server-script.ts --dist <path>` from apps/api) and diff the resulting `migrate.js`/`server.js`/`cli.js` sizes/behavior against main — they should build identically since the invocation per entry point is unchanged.

**Checks run locally:** `bun run fmt` (no changes needed), `bunx tsc --noEmit` in apps/api (clean), `bunx oxlint apps/api/scripts/bundle-server-script.ts` (0 warnings/errors). No test file exists for this build script (it's a build-time tool, not covered by `bun test`); full CI validates the actual bundling job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated the API bundling script by replacing three near-identical build functions with one `buildScript` helper. Behavior and build outputs are unchanged.

- **Refactors**
  - Converted `buildMigrateScript`, `buildServerScript`, and `buildCliScript` into thin wrappers around `buildScript(sourcePath, outputName, packagesToExternalize)`.
  - Kept the same bun command/flag order, `--external` list construction, logs, and exit-on-missing-output check.
  - Net change: -85 / +27 lines.

<sup>Written for commit 0d1d29955387a2633bc30c5eb600e7e3033c1aa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

