### PR TITLE
refactor(shared): remove dead Links ToolCategory left over from link removal

### DIFF
--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -36,7 +36,6 @@ export type ToolCategory =
   | "Registry"
   | "GitHub"
   | "VM"
-  | "Links"
   | "Search"
   | "Task Board";
 
@@ -1621,7 +1620,6 @@ export function getToolsByCategory(): Record<ToolCategory, ToolMetadata[]> {
     Registry: [],
     GitHub: [],
     VM: [],
-    Links: [],
     Search: [],
     "Task Board": [],
   };


### PR DESCRIPTION
PR #5570 ("chore(link): remove the desktop link feature") deleted the two `Links`-category entries from `MANAGEMENT_TOOLS` in `packages/shared/src/tools/registry-metadata.ts` but left the now-orphaned `"Links"` member in the `ToolCategory` union and the corresponding `Links: []` bucket in `getToolsByCategory()`'s grouping object — dead code from that removal (checklist item: "leave no dead code" after a feature deletion).

Why a maintainer wants it: `rg -n '"Links"'` across `packages/shared`, `apps/api`, and `apps/web` shows zero remaining tool with that category and zero other consumer of the `ToolCategory` type, so the union member and its grouping-object key are unreachable — pure dead code, no functional path exercises it.

Net change: -2 lines, 0 additions. Behavior-preserving: `getToolsByCategory()` still returns exactly the same populated categories as before (the `Links` key was always an empty array since #5570 merged), and no other file references `ToolCategory` or the `"Links"` string, confirmed via repo-wide `rg`.

Reviewer check: `rg -n '"Links"' packages/shared apps/api apps/web` shows only the (now-removed) union member is gone; `cd packages/shared && bunx tsc --noEmit` stays green, as does `apps/api`/`apps/web`'s typecheck (both consume this shared package).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in `packages/shared`, `apps/api`, and `apps/web` (all green), and `bunx oxlint packages/shared/src/tools/registry-metadata.ts` (0 warnings/errors). No test exercises this dead branch, so there's nothing to invert; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove dead `Links` category left over from the link feature removal. Deleted the `Links` member from `ToolCategory` and the empty `Links: []` bucket in `getToolsByCategory()` in `packages/shared/src/tools/registry-metadata.ts`; no behavior change.

<sup>Written for commit 88a19ec7a2683466e59e6b3e432aba83496da973. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

