### PR TITLE
fix(sandbox): reject invalid metadata.runtime.port before use

### DIFF
--- a/apps/api/src/tools/sandbox/helpers.test.ts
+++ b/apps/api/src/tools/sandbox/helpers.test.ts
@@ -88,6 +88,20 @@ describe("resolveRuntimeConfig", () => {
     const result = resolveRuntimeConfig(metadata);
     expect(result.port).toBeNull();
   });
+
+  it("treats a non-numeric, empty, or out-of-range port as unset", () => {
+    for (const port of ["", "abc", "0", "3.14", "70000", "-1", " 3000"]) {
+      const metadata: VmMetadata = { runtime: { selected: "npm", port } };
+      expect(resolveRuntimeConfig(metadata).port).toBeNull();
+    }
+  });
+
+  it("keeps a valid decimal port string in 1-65535", () => {
+    const metadata: VmMetadata = {
+      runtime: { selected: "npm", port: "65535" },
+    };
+    expect(resolveRuntimeConfig(metadata).port).toBe("65535");
+  });
 });
 
 describe("readValidatedSubmoduleCredentials", () => {

--- a/apps/api/src/tools/sandbox/helpers.ts
+++ b/apps/api/src/tools/sandbox/helpers.ts
@@ -141,6 +141,20 @@ export async function requireVmEntry(
 }
 
 /**
+ * A valid dev-server port is a plain decimal string in 1-65535. The metadata
+ * JSON column is untrusted (same rationale as `readValidatedRuntimeEnv`), and
+ * `VIRTUAL_MCP_UPDATE`'s schema only requires a string — "", "0", or garbage
+ * like "abc" all pass validation there. Treating anything but a valid port as
+ * unset keeps `start.ts`'s `Number(port)` from ever producing `0`/`NaN` as a
+ * `devPort` sent to the sandbox provider.
+ */
+function parseValidPort(port: string | null): string | null {
+  if (port === null || !/^\d+$/.test(port)) return null;
+  const n = Number(port);
+  return n >= 1 && n <= 65535 ? port : null;
+}
+
+/**
  * Resolves package manager and runtime config from Virtual MCP metadata.
  * Returns null packageManager/runtime when no package manager is selected
  * (clone-only mode for non-JS repos). `port` is null unless the user
@@ -150,7 +164,7 @@ export function resolveRuntimeConfig(metadata: Record<string, unknown>) {
   const runtime = (metadata as RuntimeConfigMeta).runtime ?? null;
   const selected = runtime?.selected ?? null;
   const pm = selected as PackageManager | null;
-  const port = runtime?.port ?? null;
+  const port = parseValidPort(runtime?.port ?? null);
   const packageManagerPath = runtime?.path ?? null;
 
   if (!pm || !(pm in PACKAGE_MANAGER_CONFIG)) {


### PR DESCRIPTION
**Source**: bug found while auditing `apps/api/src/tools/sandbox/` — no linked issue.

**Why a maintainer wants this**: `VIRTUAL_MCP_UPDATE`'s `runtime.port` schema (`packages/shared/src/sdk/types/virtual-mcp.ts`) only requires a string (`z.string().nullable().optional()`), so any MCP client can set `metadata.runtime.port` to `""`, `"0"`, `"abc"`, or an out-of-range value and it passes validation — only the frontend's `parsePortInput` (apps/web) actually enforces a valid 1-65535 decimal string or `null`. `resolveRuntimeConfig` (apps/api/src/tools/sandbox/helpers.ts) trusted the raw metadata value, so `start.ts`'s `...(port !== null ? { devPort: Number(port) } : {})` could compute `devPort: 0` (from `""`) or `devPort: NaN` (from `"abc"`) and forward it into `runner.ensure()`'s workload — `packages/sandbox/server/provider/agent-sandbox/runner.ts`'s `workloadConfigPayload` does `opts?.workload?.devPort ?? DEFAULT_DEV_PORT`, and neither `0` nor `NaN` is nullish, so the bogus value rides straight into the daemon config instead of falling back to the documented autodetect default.

**Failure scenario**: a caller sets `metadata.runtime.port: ""` (or a non-numeric value) via `VIRTUAL_MCP_UPDATE` directly (bypassing the frontend's normalize-to-null), then calls `SANDBOX_START`. The dev server silently gets pinned to port `0` (OS picks a random port) or the daemon receives `port: null` (JSON.stringify(NaN)) instead of the user's intended autodetect/pinned port, breaking the preview with no validation error surfaced anywhere.

**Fix**: `resolveRuntimeConfig` now validates `port` against the same rule the frontend already enforces (`/^\d+$/`, 1-65535) before returning it, following the file's existing defensive-reader pattern for untrusted JSON metadata (`readValidatedRuntimeEnv`, `readValidatedSubmoduleCredentials`). An invalid port now resolves to `null` (autodetect), matching the schema's own documented "empty/absent = autodetect" contract instead of silently corrupting `devPort`.

**Regression test**: added to `helpers.test.ts` — asserts `""`, `"abc"`, `"0"`, `"3.14"`, `"70000"`, `"-1"`, and `" 3000"` all resolve to `port: null`, and a valid `"65535"` is preserved.

**To verify**: `bun test apps/api/src/tools/sandbox/helpers.test.ts`

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (green), `bun test apps/api/src/tools/sandbox/helpers.test.ts` (14 pass) and `bun test apps/api/src/tools/sandbox/start.test.ts` (20 pass, unaffected), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `metadata.runtime.port` in the sandbox and normalize invalid values to null. This prevents `devPort` 0/NaN and restores the autodetect fallback.

- **Bug Fixes**
  - `resolveRuntimeConfig` now accepts only decimal ports 1–65535; otherwise returns null.
  - Aligns backend validation with the frontend’s `parsePortInput` to avoid bad ports reaching the daemon.
  - Adds tests covering empty, non-numeric, out-of-range, and valid values.

<sup>Written for commit c6873edcf1fb786fb1133501467ecaf842f93a4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

