### PR TITLE
refactor(native): dedupe native e2e task-polling helpers into helpers.ts

### DIFF
--- a/apps/native/e2e/helpers.ts
+++ b/apps/native/e2e/helpers.ts
@@ -20,7 +20,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { sleep } from "@decocms/shared/std";
-import { describe as bunDescribe } from "bun:test";
+import { describe as bunDescribe, expect } from "bun:test";
 
 /** Per-test-run bearer. 32+ chars, matches the daemon suite's convention
  *  (`daemon.e2e.helpers.ts`'s `DAEMON_TOKEN`) so a Rust binary honoring the
@@ -371,6 +371,56 @@ export async function stopLocalApi(
   }
   if (workdir && !opts.keepWorkdir)
     rmSync(workdir, { recursive: true, force: true });
+}
+
+// --- sandbox tasks -----------------------------------------------------------
+
+export interface TaskSummary {
+  id: string;
+  command: string;
+  status: string;
+  logName: string | null;
+}
+
+/** `GET /_sandbox/tasks` scoped to `handle` via the header (or the
+ * process-global registry when `handle` is omitted). */
+export async function listTasks(
+  a: LocalApi,
+  handle?: string,
+): Promise<TaskSummary[]> {
+  const res = await fetch(url(a, "/_sandbox/tasks"), {
+    headers: authHeaders(handle ? { "x-decocms-sandbox-handle": handle } : {}),
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { tasks: TaskSummary[] };
+  return body.tasks;
+}
+
+/** Polls `listTasks(a, handle)` until a RUNNING task named `logName` with an
+ * id different from every id in `excludeIds` shows up — proves a fresh
+ * dev-server task was spawned for THAT specific handle. */
+export async function waitForFreshRunningTask(
+  a: LocalApi,
+  handle: string,
+  logName: string,
+  excludeIds: Set<string>,
+  deadlineMs = 20_000,
+): Promise<TaskSummary> {
+  const deadline = Date.now() + deadlineMs;
+  while (Date.now() < deadline) {
+    const tasks = await listTasks(a, handle);
+    const fresh = tasks.find(
+      (t) =>
+        t.logName === logName &&
+        t.status === "running" &&
+        !excludeIds.has(t.id),
+    );
+    if (fresh) return fresh;
+    await sleep(200);
+  }
+  throw new Error(
+    `no fresh running "${logName}" task appeared for handle ${handle} within ${deadlineMs}ms`,
+  );
 }
 
 // --- SSE ---------------------------------------------------------------------

--- a/apps/native/e2e/sandbox-resolution.e2e.test.ts
+++ b/apps/native/e2e/sandbox-resolution.e2e.test.ts
@@ -24,7 +24,6 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { sleep } from "@decocms/shared/std";
 import { afterAll, beforeAll, expect, it } from "bun:test";
 import { computeHandle, normalizeBranch, repoDirFor } from "./sandbox-handle";
 
@@ -33,9 +32,11 @@ import {
   describeLocalApi,
   HOOK_TIMEOUT_MS,
   jsonAuthHeaders,
+  listTasks,
   startLocalApi,
   stopLocalApi,
   url,
+  waitForFreshRunningTask,
   type LocalApi,
 } from "./helpers";
 
@@ -110,51 +111,6 @@ async function ensureSandbox(
   const body = (await response.json()) as { handle?: string };
   expect(body.handle).toBeString();
   return body.handle!;
-}
-
-interface TaskSummary {
-  id: string;
-  command: string;
-  status: string;
-  logName: string | null;
-}
-
-/** `GET /_sandbox/tasks` scoped to `handle` via the header (or the
- * process-global registry when `handle` is omitted). */
-async function listTasks(a: LocalApi, handle?: string): Promise<TaskSummary[]> {
-  const res = await fetch(url(a, "/_sandbox/tasks"), {
-    headers: authHeaders(handle ? { "x-decocms-sandbox-handle": handle } : {}),
-  });
-  expect(res.status).toBe(200);
-  const body = (await res.json()) as { tasks: TaskSummary[] };
-  return body.tasks;
-}
-
-/** Polls `listTasks(a, handle)` until a RUNNING task named `logName` with an
- * id different from every id in `excludeIds` shows up — proves a fresh
- * dev-server task was spawned for THAT specific handle. */
-async function waitForFreshRunningTask(
-  a: LocalApi,
-  handle: string,
-  logName: string,
-  excludeIds: Set<string>,
-  deadlineMs = 20_000,
-): Promise<TaskSummary> {
-  const deadline = Date.now() + deadlineMs;
-  while (Date.now() < deadline) {
-    const tasks = await listTasks(a, handle);
-    const fresh = tasks.find(
-      (t) =>
-        t.logName === logName &&
-        t.status === "running" &&
-        !excludeIds.has(t.id),
-    );
-    if (fresh) return fresh;
-    await sleep(200);
-  }
-  throw new Error(
-    `no fresh running "${logName}" task appeared for handle ${handle} within ${deadlineMs}ms`,
-  );
 }
 
 describeLocalApi(

--- a/apps/native/e2e/sandbox-restart-resurrection.e2e.test.ts
+++ b/apps/native/e2e/sandbox-restart-resurrection.e2e.test.ts
@@ -43,10 +43,12 @@ import {
   authHeaders,
   describeLocalApi,
   jsonAuthHeaders,
+  listTasks,
   readSseUntil,
   startLocalApi,
   stopLocalApi,
   url,
+  waitForFreshRunningTask,
   type LocalApi,
 } from "./helpers";
 
@@ -103,21 +105,6 @@ function setupFixtureRepo(packageJson = PACKAGE_JSON): {
   return { root, bareDir };
 }
 
-interface TaskSummary {
-  id: string;
-  status: string;
-  logName: string | null;
-}
-
-async function listTasks(a: LocalApi, handle?: string): Promise<TaskSummary[]> {
-  const res = await fetch(url(a, "/_sandbox/tasks"), {
-    headers: authHeaders(handle ? { "x-decocms-sandbox-handle": handle } : {}),
-  });
-  expect(res.status).toBe(200);
-  const body = (await res.json()) as { tasks: TaskSummary[] };
-  return body.tasks;
-}
-
 /** The production UI's desktop control-plane entry point. This route needs no
  * coding-agent session: it materializes the
  * focused repo, durably registers its meaning, and reconciles it to running. */
@@ -146,30 +133,6 @@ async function ensureSandbox(
   const body = (await response.json()) as { handle?: string };
   expect(body.handle).toBeString();
   return body.handle!;
-}
-
-async function waitForFreshRunningTask(
-  a: LocalApi,
-  handle: string,
-  logName: string,
-  excludeIds: Set<string>,
-  deadlineMs = 20_000,
-): Promise<TaskSummary> {
-  const deadline = Date.now() + deadlineMs;
-  while (Date.now() < deadline) {
-    const tasks = await listTasks(a, handle);
-    const fresh = tasks.find(
-      (t) =>
-        t.logName === logName &&
-        t.status === "running" &&
-        !excludeIds.has(t.id),
-    );
-    if (fresh) return fresh;
-    await sleep(200);
-  }
-  throw new Error(
-    `no fresh running "${logName}" task appeared for handle ${handle} within ${deadlineMs}ms`,
-  );
 }
 
 interface LiveSseCapture {


### PR DESCRIPTION
**Source:** code reduction (C1) found while hunting for real work in the native e2e suite (`apps/native/e2e/`).

**Payoff:** `sandbox-resolution.e2e.test.ts` and `sandbox-restart-resurrection.e2e.test.ts` each defined their own byte-identical `TaskSummary` interface, `listTasks()`, and `waitForFreshRunningTask()` polling helper (verified with `diff` — the only difference was one extra `command` field on one file's `TaskSummary`, which the shared version now carries since the other file's `listTasks()` call site never read it). Moving them into the shared `helpers.ts` (which already hosts every other piece of shared harness code for this suite, like `readSseUntil`/`startLocalApi`) removes the duplication and gives future e2e files in this directory one place to reuse this polling logic instead of re-pasting it a third time.

**Net diff:** +55 / -86 (net -31 lines) across 3 files. Behavior-preserving: the moved functions are unchanged verbatim (only the `TaskSummary` interface gained the already-used `command` field so one shared type covers both call sites); each file's now-unused `sleep`/local declarations were removed and its imports updated to pull `listTasks`/`waitForFreshRunningTask` from `./helpers` instead.

**Reviewer check:** `cd apps/native && bunx tsc --noEmit -p .` (green — confirms both test files still typecheck against the shared helpers) and `bun test apps/native/e2e/sandbox-resolution.e2e.test.ts apps/native/e2e/sandbox-restart-resurrection.e2e.test.ts apps/native/e2e/helpers.test.ts` (all pass/skip cleanly; the two e2e suites skip without `LOCAL_API_E2E_CMD` set locally, same as before this change, proving the module still loads and wires up correctly).

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` in `apps/native`, `bunx oxlint` on all 3 changed files (0 warnings/errors), and the 3 targeted `bun test` runs above. Full CI validates the rest (including running these suites against the real Rust `local-api` binary).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped native e2e task-polling helpers by moving `TaskSummary`, `listTasks`, and `waitForFreshRunningTask` into `apps/native/e2e/helpers.ts`. This removes duplication across sandbox tests and centralizes shared logic with no behavior changes.

- **Refactors**
  - Added shared `TaskSummary` (now includes `command`) and exported `listTasks` and `waitForFreshRunningTask` in `helpers.ts`.
  - Updated `sandbox-resolution.e2e.test.ts` and `sandbox-restart-resurrection.e2e.test.ts` to import helpers and removed local copies.

<sup>Written for commit 79579da79d5bf02297c31f3ad24f0f7f845db8c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

