### PR TITLE
feat(commerce-onboarding): add Shopify as a commerce companion source (reland)

### DIFF
--- a/apps/api/src/api/routes/credential-vault.integration.test.ts
+++ b/apps/api/src/api/routes/credential-vault.integration.test.ts
@@ -163,8 +163,7 @@ describe("Credential Vault Routes", () => {
           title: "Static Token Target",
           connection_type: "HTTP",
           connection_url: "https://static-token.example.test/mcp",
-          // Token-auth MCP (e.g. Shopify): the bearer lives on the connection,
-          // never in downstream_tokens.
+          // Token-auth MCP (e.g. Shopify): bearer on the connection only.
           connection_token: await new CredentialVault(
             getSettings().encryptionKey,
           ).encrypt("static-admin-api-token"),

--- a/apps/api/src/api/routes/credential-vault.integration.test.ts
+++ b/apps/api/src/api/routes/credential-vault.integration.test.ts
@@ -156,6 +156,23 @@ describe("Credential Vault Routes", () => {
           created_at: now,
           updated_at: now,
         },
+        {
+          id: "conn_static_token_target",
+          organization_id: "org_1",
+          created_by: "user_1",
+          title: "Static Token Target",
+          connection_type: "HTTP",
+          connection_url: "https://static-token.example.test/mcp",
+          // Token-auth MCP (e.g. Shopify): the bearer lives on the connection,
+          // never in downstream_tokens.
+          connection_token: await new CredentialVault(
+            getSettings().encryptionKey,
+          ).encrypt("static-admin-api-token"),
+          status: "active",
+          pinned: false,
+          created_at: now,
+          updated_at: now,
+        },
       ])
       .execute();
 
@@ -181,6 +198,10 @@ describe("Credential Vault Routes", () => {
         },
         {
           targetConnectionId: "conn_inactive_granted",
+          scope: CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+        },
+        {
+          targetConnectionId: "conn_static_token_target",
           scope: CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
         },
         {
@@ -269,6 +290,37 @@ describe("Credential Vault Routes", () => {
       /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
     );
     expect(body.scope).toBe("read write");
+  });
+
+  it("falls back to the connection's static bearer token when there is no OAuth token", async () => {
+    const res = await app.fetch(
+      new Request(
+        "http://test/api/org_1/vault/connections/conn_static_token_target/access-token",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${workloadToken}` },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Pragma")).toBe("no-cache");
+    const body = (await res.json()) as {
+      type: string;
+      tokenType: string;
+      accessToken: string;
+      expiresAt: string | null;
+      scope: string | null;
+    };
+    expect(Object.keys(body).sort()).toEqual(
+      ["accessToken", "expiresAt", "scope", "tokenType", "type"].sort(),
+    );
+    expect(body.type).toBe("static_token");
+    expect(body.tokenType).toBe("Bearer");
+    expect(body.accessToken).toBe("static-admin-api-token");
+    expect(body.expiresAt).toBeNull();
+    expect(body.scope).toBeNull();
   });
 
   it("exchanges a workload token for a granted downstream MCP configuration", async () => {

--- a/apps/api/src/api/routes/credential-vault.ts
+++ b/apps/api/src/api/routes/credential-vault.ts
@@ -147,13 +147,9 @@ export const createCredentialVaultRoutes = () => {
     });
 
     if (result.state === "missing") {
-      // Fall back to a static bearer token stored on the connection itself
-      // (token-auth MCPs like Shopify that never run an OAuth flow, so nothing
-      // is ever written to downstream_tokens). Mirrors the MCP proxy's own
-      // resolution order — OAuth first, then connection_token (see
-      // mcp-clients/outbound/headers.ts) — so static-token connections are
-      // first-class in the vault too. The response shape is unchanged; only
-      // `type` differs so callers can tell the lanes apart.
+      // Token-auth MCPs (e.g. Shopify) never write downstream_tokens — fall
+      // back to the connection's static bearer, the same OAuth-then-token
+      // order as mcp-clients/outbound/headers.ts.
       if (target.connection_token) {
         c.header("Cache-Control", "no-store");
         c.header("Pragma", "no-cache");

--- a/apps/api/src/api/routes/credential-vault.ts
+++ b/apps/api/src/api/routes/credential-vault.ts
@@ -147,9 +147,7 @@ export const createCredentialVaultRoutes = () => {
     });
 
     if (result.state === "missing") {
-      // Token-auth MCPs (e.g. Shopify) never write downstream_tokens — fall
-      // back to the connection's static bearer, the same OAuth-then-token
-      // order as mcp-clients/outbound/headers.ts.
+      // Static-token MCPs (e.g. Shopify): the bearer lives on connection_token.
       if (target.connection_token) {
         c.header("Cache-Control", "no-store");
         c.header("Pragma", "no-cache");

--- a/apps/api/src/api/routes/credential-vault.ts
+++ b/apps/api/src/api/routes/credential-vault.ts
@@ -147,6 +147,24 @@ export const createCredentialVaultRoutes = () => {
     });
 
     if (result.state === "missing") {
+      // Fall back to a static bearer token stored on the connection itself
+      // (token-auth MCPs like Shopify that never run an OAuth flow, so nothing
+      // is ever written to downstream_tokens). Mirrors the MCP proxy's own
+      // resolution order — OAuth first, then connection_token (see
+      // mcp-clients/outbound/headers.ts) — so static-token connections are
+      // first-class in the vault too. The response shape is unchanged; only
+      // `type` differs so callers can tell the lanes apart.
+      if (target.connection_token) {
+        c.header("Cache-Control", "no-store");
+        c.header("Pragma", "no-cache");
+        return c.json({
+          type: "static_token",
+          tokenType: "Bearer",
+          accessToken: target.connection_token,
+          expiresAt: null,
+          scope: null,
+        });
+      }
       return c.json({ error: "Downstream token not found" }, 409);
     }
     if (

--- a/apps/web/src/i18n/en/commerce-onboarding.ts
+++ b/apps/web/src/i18n/en/commerce-onboarding.ts
@@ -67,4 +67,18 @@ export const commerceOnboarding = {
   "commerceOnboarding.vtexConfigForm.savingButton": "Saving...",
   "commerceOnboarding.vtexConfigForm.savingError":
     "Couldn't save the configuration",
+  "commerceOnboarding.shopifyConfigForm.storeDomainLabel": "Store domain",
+  "commerceOnboarding.shopifyConfigForm.storeDomainPlaceholder":
+    "my-store.myshopify.com",
+  "commerceOnboarding.shopifyConfigForm.accessTokenLabel":
+    "Admin API access token",
+  "commerceOnboarding.shopifyConfigForm.accessTokenPlaceholder": "shpat_...",
+  "commerceOnboarding.shopifyConfigForm.apiVersionLabel":
+    "API version (optional)",
+  "commerceOnboarding.shopifyConfigForm.apiVersionPlaceholder": "2026-07",
+  "commerceOnboarding.shopifyConfigForm.cancelButton": "Cancel",
+  "commerceOnboarding.shopifyConfigForm.saveButton": "Save",
+  "commerceOnboarding.shopifyConfigForm.savingButton": "Saving...",
+  "commerceOnboarding.shopifyConfigForm.savingError":
+    "Couldn't save the configuration",
 } as const;

--- a/apps/web/src/i18n/pt-br/commerce-onboarding.ts
+++ b/apps/web/src/i18n/pt-br/commerce-onboarding.ts
@@ -70,4 +70,18 @@ export const commerceOnboarding = {
   "commerceOnboarding.vtexConfigForm.savingButton": "Salvando...",
   "commerceOnboarding.vtexConfigForm.savingError":
     "Não foi possível salvar a configuração",
+  "commerceOnboarding.shopifyConfigForm.storeDomainLabel": "Domínio da loja",
+  "commerceOnboarding.shopifyConfigForm.storeDomainPlaceholder":
+    "minha-loja.myshopify.com",
+  "commerceOnboarding.shopifyConfigForm.accessTokenLabel":
+    "Access token da Admin API",
+  "commerceOnboarding.shopifyConfigForm.accessTokenPlaceholder": "shpat_...",
+  "commerceOnboarding.shopifyConfigForm.apiVersionLabel":
+    "Versão da API (opcional)",
+  "commerceOnboarding.shopifyConfigForm.apiVersionPlaceholder": "2026-07",
+  "commerceOnboarding.shopifyConfigForm.cancelButton": "Cancelar",
+  "commerceOnboarding.shopifyConfigForm.saveButton": "Salvar",
+  "commerceOnboarding.shopifyConfigForm.savingButton": "Salvando...",
+  "commerceOnboarding.shopifyConfigForm.savingError":
+    "Não foi possível salvar a configuração",
 } satisfies Record<keyof typeof commerceOnboardingEn, string>;

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/registry.ts
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/registry.ts
@@ -1,4 +1,5 @@
 import { VtexConfigForm } from "./vtex-config-form.tsx";
+import { ShopifyConfigForm } from "./shopify-config-form.tsx";
 import { GoogleAnalyticsConfigForm } from "./google-analytics-config-form.tsx";
 import { GoogleSearchConsoleConfigForm } from "./google-search-console-config-form.tsx";
 import { GitHubConfigForm } from "./github-config-form.tsx";
@@ -6,6 +7,7 @@ import type { CompanionFormComponent } from "./types.ts";
 
 export const COMPANION_CONFIG_FORMS: Record<string, CompanionFormComponent> = {
   vtex: VtexConfigForm,
+  shopify: ShopifyConfigForm,
   "google-analytics": GoogleAnalyticsConfigForm,
   "google-search-console": GoogleSearchConsoleConfigForm,
   github: GitHubConfigForm,

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
@@ -22,13 +22,23 @@ import type { CompanionFormProps } from "./types.ts";
 // Shopify MCP); the accessToken is a static bearer that lives on the
 // connection's `connection_token`, never in configuration_state. See
 // use-save-companion-config.ts for the split.
-const schema = z.object({
-  storeDomain: z.string().min(1, "Informe o domínio da loja"),
-  accessToken: z.string().optional(),
-  apiVersion: z.string().optional(),
-});
+// The token is REQUIRED on first configure: `isCompanionConfigured` reads
+// storeDomain as the "configured" signal, so a tokenless save would show a
+// connected card whose every vault lease 409s (no connection_token to fall
+// back to). On edit it stays optional — blank means "keep the existing token".
+const makeSchema = (configured: boolean) =>
+  z
+    .object({
+      storeDomain: z.string().min(1, "Informe o domínio da loja"),
+      accessToken: z.string().optional(),
+      apiVersion: z.string().optional(),
+    })
+    .refine((data) => configured || Boolean(data.accessToken?.trim()), {
+      path: ["accessToken"],
+      message: "Informe o Admin API access token",
+    });
 
-type FormData = z.infer<typeof schema>;
+type FormData = z.infer<ReturnType<typeof makeSchema>>;
 
 export function ShopifyConfigForm({
   card,
@@ -40,7 +50,7 @@ export function ShopifyConfigForm({
 }: CompanionFormProps) {
   const t = useT();
   const form = useForm<FormData>({
-    resolver: zodResolver(schema),
+    resolver: zodResolver(makeSchema(card.configured)),
     defaultValues: {
       storeDomain: (card.configurationState?.storeDomain as string) || "",
       // The token is write-only from the UI (stored on connection_token, not

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
@@ -1,0 +1,183 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useEffect } from "react";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@deco/ui/components/form.tsx";
+import { Input } from "@deco/ui/components/input.tsx";
+import { PasswordInput } from "@deco/ui/components/password-input.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { DialogFooter } from "@deco/ui/components/dialog.tsx";
+import { useT } from "@/i18n/use-t.ts";
+import { useSaveCompanionConfig } from "./use-save-companion-config.ts";
+import type { CompanionFormProps } from "./types.ts";
+
+// storeDomain + apiVersion are the MCP's configuration.state (StateSchema in the
+// Shopify MCP); the accessToken is a static bearer that lives on the
+// connection's `connection_token`, never in configuration_state. See
+// use-save-companion-config.ts for the split.
+const schema = z.object({
+  storeDomain: z.string().min(1, "Informe o domínio da loja"),
+  accessToken: z.string().optional(),
+  apiVersion: z.string().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export function ShopifyConfigForm({
+  card,
+  companionClient: _companionClient,
+  selfClient,
+  org,
+  onDone,
+  onIsPendingChange,
+}: CompanionFormProps) {
+  const t = useT();
+  const form = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      storeDomain: (card.configurationState?.storeDomain as string) || "",
+      // The token is write-only from the UI (stored on connection_token, not
+      // configuration_state) — never prefilled. Left blank on edit preserves it.
+      accessToken: "",
+      apiVersion: (card.configurationState?.apiVersion as string) || "",
+    },
+  });
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- sync form when config changes from server
+  useEffect(() => {
+    form.reset({
+      storeDomain: (card.configurationState?.storeDomain as string) || "",
+      accessToken: "",
+      apiVersion: (card.configurationState?.apiVersion as string) || "",
+    });
+  }, [card.configurationState, form]);
+
+  const { save, isPending, error } = useSaveCompanionConfig({
+    card,
+    selfClient,
+    org,
+    onDone,
+  });
+
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- notify parent of save pending state
+  useEffect(() => {
+    onIsPendingChange?.(isPending);
+  }, [isPending, onIsPendingChange]);
+
+  const handleSubmit = form.handleSubmit(async (data) => {
+    const apiVersion = data.apiVersion?.trim();
+    const accessToken = data.accessToken?.trim();
+    save(
+      {
+        storeDomain: data.storeDomain.trim(),
+        // Only persist apiVersion when set — the MCP defaults it otherwise.
+        ...(apiVersion ? { apiVersion } : {}),
+      },
+      // Omit the token when left blank so an existing one survives an edit.
+      accessToken ? { connectionToken: accessToken } : undefined,
+    );
+  });
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Form {...form}>
+        <FormField
+          control={form.control}
+          name="storeDomain"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                {t("commerceOnboarding.shopifyConfigForm.storeDomainLabel")}
+              </FormLabel>
+              <FormControl>
+                <Input
+                  placeholder={t(
+                    "commerceOnboarding.shopifyConfigForm.storeDomainPlaceholder",
+                  )}
+                  {...field}
+                  disabled={isPending}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="accessToken"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                {t("commerceOnboarding.shopifyConfigForm.accessTokenLabel")}
+              </FormLabel>
+              <FormControl>
+                <PasswordInput
+                  placeholder={t(
+                    "commerceOnboarding.shopifyConfigForm.accessTokenPlaceholder",
+                  )}
+                  {...field}
+                  disabled={isPending}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="apiVersion"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                {t("commerceOnboarding.shopifyConfigForm.apiVersionLabel")}
+              </FormLabel>
+              <FormControl>
+                <Input
+                  placeholder={t(
+                    "commerceOnboarding.shopifyConfigForm.apiVersionPlaceholder",
+                  )}
+                  {...field}
+                  disabled={isPending}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </Form>
+
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error instanceof Error
+            ? error.message
+            : t("commerceOnboarding.shopifyConfigForm.savingError")}
+        </p>
+      )}
+
+      <DialogFooter className="pt-4">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onDone}
+          disabled={isPending}
+        >
+          {t("commerceOnboarding.shopifyConfigForm.cancelButton")}
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending
+            ? t("commerceOnboarding.shopifyConfigForm.savingButton")
+            : t("commerceOnboarding.shopifyConfigForm.saveButton")}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
@@ -51,8 +51,7 @@ export function ShopifyConfigForm({
     resolver: zodResolver(makeSchema(card.configured)),
     defaultValues: {
       storeDomain: (card.configurationState?.storeDomain as string) || "",
-      // The token is write-only from the UI (stored on connection_token, not
-      // configuration_state) — never prefilled. Left blank on edit preserves it.
+      // Write-only: never prefilled; blank on edit keeps the stored token.
       accessToken: "",
       apiVersion: (card.configurationState?.apiVersion as string) || "",
     },

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
@@ -22,10 +22,8 @@ import type { CompanionFormProps } from "./types.ts";
 // Shopify MCP); the accessToken is a static bearer that lives on the
 // connection's `connection_token`, never in configuration_state. See
 // use-save-companion-config.ts for the split.
-// The token is REQUIRED on first configure: `isCompanionConfigured` reads
-// storeDomain as the "configured" signal, so a tokenless save would show a
-// connected card whose every vault lease 409s (no connection_token to fall
-// back to). On edit it stays optional — blank means "keep the existing token".
+// Token required on first configure (a tokenless save reads "connected" but
+// every vault lease 409s); optional on edit — blank keeps the existing token.
 const makeSchema = (configured: boolean) =>
   z
     .object({

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
@@ -22,8 +22,7 @@ import type { CompanionFormProps } from "./types.ts";
 // Shopify MCP); the accessToken is a static bearer that lives on the
 // connection's `connection_token`, never in configuration_state. See
 // use-save-companion-config.ts for the split.
-// Token required on first configure (a tokenless save reads "connected" but
-// every vault lease 409s); optional on edit — blank keeps the existing token.
+// Token: required on first configure; blank on edit keeps the stored one.
 const makeSchema = (configured: boolean) =>
   z
     .object({

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/use-save-companion-config.ts
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/use-save-companion-config.ts
@@ -19,18 +19,32 @@ export function useSaveCompanionConfig({
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: async (formValues: Record<string, unknown>) => {
+    mutationFn: async ({
+      values,
+      connectionToken,
+    }: {
+      values: Record<string, unknown>;
+      connectionToken?: string;
+    }) => {
       const mergedState = {
         ...(card.configurationState ?? {}),
-        ...formValues,
+        ...values,
       };
+      const data: Record<string, unknown> = {
+        configuration_state: mergedState,
+      };
+      // Static-token MCPs (e.g. Shopify) keep the secret on the connection's
+      // encrypted `connection_token`, never in configuration_state. Omitted when
+      // the caller doesn't manage a token, or left blank on edit — so an existing
+      // token survives a domain-only change instead of being wiped.
+      if (connectionToken !== undefined) {
+        data.connection_token = connectionToken;
+      }
       await selfClient.callTool({
         name: "COLLECTION_CONNECTIONS_UPDATE",
         arguments: {
           id: card.linkedConnectionId || card.candidateConnectionId,
-          data: {
-            configuration_state: mergedState,
-          },
+          data,
         },
       });
     },
@@ -45,7 +59,10 @@ export function useSaveCompanionConfig({
     },
   });
 
-  const save = (values: Record<string, unknown>) => mutation.mutate(values);
+  const save = (
+    values: Record<string, unknown>,
+    opts?: { connectionToken?: string },
+  ) => mutation.mutate({ values, connectionToken: opts?.connectionToken });
 
   return { save, isPending: mutation.isPending, error: mutation.error };
 }

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/use-save-companion-config.ts
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/use-save-companion-config.ts
@@ -33,8 +33,7 @@ export function useSaveCompanionConfig({
       const data: Record<string, unknown> = {
         configuration_state: mergedState,
       };
-      // undefined ⇒ leave connection_token untouched (blank on edit keeps the
-      // stored secret; it never lives in configuration_state).
+      // undefined ⇒ keep the stored connection_token.
       if (connectionToken !== undefined) {
         data.connection_token = connectionToken;
       }

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/use-save-companion-config.ts
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/use-save-companion-config.ts
@@ -33,10 +33,8 @@ export function useSaveCompanionConfig({
       const data: Record<string, unknown> = {
         configuration_state: mergedState,
       };
-      // Static-token MCPs (e.g. Shopify) keep the secret on the connection's
-      // encrypted `connection_token`, never in configuration_state. Omitted when
-      // the caller doesn't manage a token, or left blank on edit — so an existing
-      // token survives a domain-only change instead of being wiped.
+      // undefined ⇒ leave connection_token untouched (blank on edit keeps the
+      // stored secret; it never lives in configuration_state).
       if (connectionToken !== undefined) {
         data.connection_token = connectionToken;
       }

--- a/apps/web/src/routes/commerce-onboarding/companions-core.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions-core.ts
@@ -108,8 +108,7 @@ export function isCompanionConfigured(args: {
     case "vtex":
       return isMeaningfulConfigValue(companionConfig?.accountName);
     case "shopify":
-      // The access token lives on connection_token, not configuration_state, so
-      // the store domain (the MCP's other required credential) is the signal.
+      // The token is on connection_token — storeDomain is the visible signal.
       return isMeaningfulConfigValue(companionConfig?.storeDomain);
     case "google-analytics":
       return isMeaningfulConfigValue(companionConfig?.propertyId);

--- a/apps/web/src/routes/commerce-onboarding/companions-core.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions-core.ts
@@ -107,6 +107,10 @@ export function isCompanionConfigured(args: {
   switch (args.bindingType) {
     case "vtex":
       return isMeaningfulConfigValue(companionConfig?.accountName);
+    case "shopify":
+      // The access token lives on connection_token, not configuration_state, so
+      // the store domain (the MCP's other required credential) is the signal.
+      return isMeaningfulConfigValue(companionConfig?.storeDomain);
     case "google-analytics":
       return isMeaningfulConfigValue(companionConfig?.propertyId);
     case "google-search-console":
@@ -132,6 +136,10 @@ function getConnectedDetail(args: {
     case "vtex":
       return typeof companionConfig?.accountName === "string"
         ? companionConfig.accountName
+        : null;
+    case "shopify":
+      return typeof companionConfig?.storeDomain === "string"
+        ? companionConfig.storeDomain
         : null;
     case "google-analytics":
       return typeof companionConfig?.propertyId === "string"
@@ -195,6 +203,7 @@ export function parseBindingRequirements(
  */
 export const FALLBACK_COMPANION_REQUIREMENTS: BindingRequirement[] = [
   { fieldKey: "vtex", bindingType: "vtex" },
+  { fieldKey: "shopify", bindingType: "shopify" },
   { fieldKey: "ga4", bindingType: "google-analytics" },
   { fieldKey: "gsc", bindingType: "google-search-console" },
   { fieldKey: "github", bindingType: "github" },

--- a/apps/web/src/routes/commerce-onboarding/companions.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions.ts
@@ -21,6 +21,11 @@ export const COMMERCE_COMPANION_MCPS: Record<string, CompanionCopy> = {
     area: "Catálogo",
     headline: "Rupturas e PDPs que travam suas vendas.",
   },
+  shopify: {
+    registryAppId: "deco/shopify",
+    area: "Catálogo",
+    headline: "Pedidos, estoque e catálogo direto da sua Shopify.",
+  },
   "google-analytics": {
     registryAppId: "deco/google-analytics",
     area: "Funil",


### PR DESCRIPTION
Relands #5582 (reverted in #5584 after an accidental early merge). Restores the exact original implementation so it can be tested end-to-end before final merge. (Supersedes #5587, auto-closed by a branch rename.)

## Summary

Adds **Shopify** (`deco/shopify`) as a selectable data source in the commerce discovery onboarding modal, alongside VTEX. Studio half of the Shopify diagnostic — plumbs credentials into the vault so `decocms/reports` (commerce-discovery) can read them back.

### Credential split (architecturally-correct lane per credential)

The Shopify MCP declares `auth: { type: "token", header: "Authorization", prefix: "Bearer" }` and a `configuration.state` of `storeDomain` + `apiVersion`. Credentials land in two places, matching how the MCP resolves them:

| Credential | Stored in | Read by reports via |
|---|---|---|
| `storeDomain`, `apiVersion` | `connections.configuration_state` (encrypted) | `getConfiguration()` → `/vault/.../configuration` |
| `accessToken` | `connections.connection_token` (encrypted column — canonical home for token-auth MCPs) | `getAccessToken()` → `/vault/.../access-token` |

The access token is never written to `configuration_state`; it stays in the sensitive `connection_token` column, excluded from serialization and already injected as `Authorization: Bearer` by the MCP proxy.

### Vault change (the dependency for the reports side)

`POST /vault/connections/:id/access-token` was OAuth-only (409 for static-token connections). It now falls back to `connection_token` when there is no OAuth token, returning `{ type: "static_token", tokenType: "Bearer", accessToken, expiresAt: null, scope: null }` — mirroring the MCP proxy's own resolution order (`mcp-clients/outbound/headers.ts`).

## Changes

**API**
- `credential-vault.ts` — static-token fallback in `/access-token`
- `credential-vault.integration.test.ts` — new real-Postgres case for the fallback

**Web**
- `companion-forms/shopify-config-form.tsx` — new form (`storeDomain` + `accessToken` + optional `apiVersion`); blank token on edit preserves the existing one
- `companion-forms/use-save-companion-config.ts` — backward-compatible extension to also write `connection_token`
- `companion-forms/registry.ts`, `companions.ts` — register the Shopify card/form
- `companions-core.ts` — `isCompanionConfigured` / `getConnectedDetail` / `FALLBACK_COMPANION_REQUIREMENTS` gain a `shopify` case (uses `storeDomain` as the "configured" signal)
- i18n en + pt-br

## ⚠️ Requires a coordinated commerce-discovery / `decocms/reports` change

The Shopify card only renders once commerce-discovery advertises the `shopify` binding requirement in its `MCP_CONFIGURATION` (binding `__type: "shopify"`, fieldKey `shopify`), and its resolver reads the token via `getAccessToken()` (the `static_token` lane), not `getConfiguration()`. Ship these together.

## Testing

- `bun run fmt`, `bun run --cwd=apps/api check`, `bun run --cwd=apps/web check`, `bun run lint` — all clean
- `credential-vault.integration.test.ts` — 12 pass / 0 fail against real Postgres (includes the static-token fallback case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Shopify (`deco/shopify`) as a commerce companion in onboarding and adds a static-token fallback in the credential vault so Admin API tokens work without OAuth. Users connect with store domain + Admin API token; the token is required on first setup.

- **New Features**
  - Onboarding: Shopify card and form (`storeDomain`, optional `apiVersion`, write-only Admin API token). Token required on first configure; on edit, leaving it blank keeps the existing token.
  - Vault: `POST /vault/connections/:id/access-token` falls back to `connection_token` and returns `{ type: "static_token", tokenType: "Bearer" }`. Adds an integration test for this path.
  - Registers `shopify` in companions and config checks (uses `storeDomain` as the configured signal). Adds i18n keys (en/pt-br).

- **Migration**
  - Update commerce-discovery/`decocms/reports` to advertise a `shopify` binding in `MCP_CONFIGURATION` and read the Admin API token via `getAccessToken()` (static_token lane), not `getConfiguration()`. Ship together to show the Shopify card and complete auth.

<sup>Written for commit 148c10e4c101575c88ea6730e7f38befeb6403cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

