### PR TITLE
fix(nginx): rotear /report pelo Bun API — SEO/OG nunca chegava em produção

### DIFF
--- a/deploy/helm/studio/files/api-nginx.conf
+++ b/deploy/helm/studio/files/api-nginx.conf
@@ -88,7 +88,12 @@ server {
     return 200 "ok\n";
   }
 
-  location ~ ^/(api|mcp|oauth-proxy|\.well-known|org|health|metrics)(/|$) {
+  # `report` routes to the Bun API (createReportPagesRoutes): the API serves the
+  # same SPA index.html but with the per-report SEO head rewritten (og:image,
+  # title, score) and proxies /report/:domain/og.png from the reports worker.
+  # Without it these fall through to the SPA fallback below — default meta, no
+  # share card.
+  location ~ ^/(api|mcp|oauth-proxy|\.well-known|org|health|metrics|report)(/|$) {
     proxy_pass http://studio_api;
     proxy_http_version 1.1;
     proxy_set_header Host $host;


### PR DESCRIPTION
## Sintoma

#5588 (e o head per-report que já existia) mergeados, mas `studio.decocms.com/report/<site>` segue com meta default e `/report/<site>/og.png` devolve o HTML da SPA.

## Causa raiz — roteamento, não cache

O front-door nginx (`deploy/helm/studio/files/api-nginx.conf`) só proxia `^/(api|mcp|oauth-proxy|\.well-known|org|health|metrics)` para o Bun API. `/report` não está na lista → `try_files $uri /index.html` serve a SPA estática com meta default, e `createReportPagesRoutes` (head rewrite + proxy do og.png) nunca executa. Verificável: a resposta vem `cache-control: no-cache` / `cf-cache-status: DYNAMIC` — origin fresco, não cache.

## Fix

Adiciona `report` ao regex do location proxiado. O Bun API serve o mesmo `index.html` (asset handler + `dist/client` no container da API), com o head per-report reescrito; `/report/:domain/og.png` passa a proxiar o card do worker de reports (decocms/reports#292, já live — `curl reports.decocms.com/api/v2/public/diagnostics/americanas.com.br/og.png` → 200 PNG 404KB).

## Deploy

O conf é **baked na imagem nginx** (comentário no topo do arquivo): precisa de release rebuild + bump do tag — release-tagging observa este dir, então a próxima release já leva.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route `/report` to the Bun API so per-report SEO tags and OG images render correctly in production. Previously these paths fell through to the SPA and returned default meta or HTML.

- **Bug Fixes**
  - Add `report` to the proxied location regex in `deploy/helm/studio/files/api-nginx.conf` to serve the API’s rewritten `index.html` and proxy `/report/:domain/og.png`.

- **Migration**
  - Nginx config is baked into the image; rebuild and release to apply. The next release will include this change.

<sup>Written for commit 75ed2d4ef8aed48a908d08971cc1c0898ede3547. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

