### PR TITLE
feat(reports): mount report-pages under /api/report (og.png without touching nginx)

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -1295,7 +1295,13 @@ export async function createApp(options: CreateAppOptions = {}) {
 
   // Auth-gated report page + domain-derived metadata. API-only/test apps safely
   // return 404 for the HTML shell when no built client directory is supplied.
-  app.route("/report", createReportPagesRoutes(options.clientDir));
+  // Mounted twice: the nginx front door only proxies /api-prefixed paths to
+  // this server (everything else falls through to the static SPA), so the
+  // share-card image URL (og:image → /api/report/:domain/og.png) rides the
+  // /api mount to stay reachable in production without touching nginx.
+  const reportPages = createReportPagesRoutes(options.clientDir);
+  app.route("/report", reportPages);
+  app.route("/api/report", reportPages);
 
   // ============================================================================
   // Better Auth Routes

--- a/apps/api/src/api/routes/report-pages.tsx
+++ b/apps/api/src/api/routes/report-pages.tsx
@@ -11,9 +11,12 @@
  * The share IMAGE is the full cover card (favicon · url · score ring · device
  * frames with the real captured screenshots), rendered by the reports worker
  * (satori/resvg on the edge — see decocms/reports) and PROXIED by the sibling
- * `GET /report/:domain/og.png` route so og:image stays same-origin. The worker
- * always answers 200 with a branded card (even for an unscanned domain); the
- * designed static card remains the fallback for a dead/slow worker only.
+ * `GET /:domain/og.png` route so og:image stays same-origin. og:image points at
+ * the `/api/report` mount of this app (see app.ts): the nginx front door only
+ * proxies /api-prefixed paths here, so the plain /report path would land on the
+ * static SPA fallback. The worker always answers 200 with a branded card (even
+ * for an unscanned domain); the designed static card remains the fallback for a
+ * dead/slow worker only.
  */
 
 import { Hono } from "hono";
@@ -110,8 +113,10 @@ export function buildReportHead(
 
   // The rendered per-report card (favicon + domain + score), or its static
   // fallback for an unscanned domain — both 1200×630, so summary_large_image.
-  // og:image MUST be absolute for every unfurler.
-  const image = `${canonical}/og.png`;
+  // og:image MUST be absolute for every unfurler — and must ride the /api
+  // mount: the nginx front door only proxies /api-prefixed paths to this
+  // server, so `${canonical}/og.png` would land on the SPA fallback instead.
+  const image = `${origin}/api/report/${encodeURIComponent(domain)}/og.png`;
   const imageAlt = `${brand} commerce report by decocms`;
 
   return [
@@ -155,8 +160,9 @@ const OG_PROXY_TIMEOUT_MS = 10_000;
 export function createReportPagesRoutes(clientDir: string | undefined): Hono {
   const app = new Hono();
 
-  // GET /report/:domain/og.png — the per-report share card, proxied from the
-  // reports worker (GET /api/v2/public/diagnostics/:domain/og.png). The worker
+  // GET /:domain/og.png (reachable in prod as /api/report/:domain/og.png) —
+  // the per-report share card, proxied from the reports worker
+  // (GET /api/v2/public/diagnostics/:domain/og.png). The worker
   // renders the full cover card and always answers 200 (branded fallback for an
   // unscanned domain), so the designed static card here only covers a dead/slow
   // worker or a non-image reply. Registered before `/:domain` so the


### PR DESCRIPTION
## Context

The /report/<site> SEO/OG merged in #5588 doesn't show in production. It's not cache: the nginx front door only proxies `^/(api|mcp|oauth-proxy|\.well-known|org|health|metrics)` to the Bun API — `/report` falls through to the static SPA fallback, so `createReportPagesRoutes` never runs. Alternative to changing nginx (PR #5600, closed).

## What changes

- `createReportPagesRoutes` is mounted **twice**: `/report` (as before) and `/api/report` — the latter goes through the front door today, no nginx image rebuild. `report` is already a reserved organization slug, so it can't collide with the `/api/:org` catch-all.
- `og:image` in the head now points at `${origin}/api/report/:domain/og.png` (the `/report/...` path would never reach this server).

Verification: `tsc` and `oxlint` clean; scoped `bun test` (app + routes) has an **identical** failure set to main (local-infra tests), empty diff.

## What's STILL missing for full SEO

The per-report head (title with score, description, og:image) is only emitted when the `/report/:domain` **HTML** reaches this server — and nginx keeps serving the static SPA on that path. Since the front door doesn't change here, close the loop with a **Cloudflare Transform Rule** (studio.decocms.com zone): path rewrite `^/report/(.+)` → `/api/report/$1`. It's origin-side — the browser URL stays `/report/<site>` — and the handler already emits `canonical`/`og:url` pointing at `/report/<site>`. Without it, unfurlers keep seeing the SPA's default meta.