### PR TITLE
fix(nginx): route /report through the Bun API — per-report SEO never reached production

### DIFF
--- a/apps/api/src/api/routes/report-pages.tsx
+++ b/apps/api/src/api/routes/report-pages.tsx
@@ -187,8 +187,8 @@ export function createReportPagesRoutes(clientDir: string | undefined): Hono {
       // Pipe the worker's stream through — never buffer the PNG here.
       return c.body(res.body, 200, {
         "Content-Type": type,
-        // Crawlers cache the bytes; a day is plenty and re-scans are rare.
-        "Cache-Control": "public, max-age=0, s-maxage=86400",
+        // The card only changes on a re-scan (rare) — a week at the edge is safe.
+        "Cache-Control": "public, max-age=0, s-maxage=604800",
       });
     } catch {
       return serveFallback();

--- a/deploy/helm/studio/files/api-nginx.conf
+++ b/deploy/helm/studio/files/api-nginx.conf
@@ -88,7 +88,13 @@ server {
     return 200 "ok\n";
   }
 
-  location ~ ^/(api|mcp|oauth-proxy|\.well-known|org|health|metrics)(/|$) {
+  # `report` routes to the Bun API (createReportPagesRoutes): it serves the
+  # same static SPA index.html but with the per-report SEO head rewritten
+  # (title with score, description, og:image) and proxies /report/:domain/og.png
+  # from the reports worker. No SSR involved — the SPA boots unchanged; only
+  # crawlers/unfurlers read the difference. Without this entry both paths fall
+  # through to the SPA fallback below: default meta, no share card.
+  location ~ ^/(api|mcp|oauth-proxy|\.well-known|org|health|metrics|report)(/|$) {
     proxy_pass http://studio_api;
     proxy_http_version 1.1;
     proxy_set_header Host $host;

--- a/deploy/helm/studio/files/api-nginx.conf
+++ b/deploy/helm/studio/files/api-nginx.conf
@@ -88,12 +88,8 @@ server {
     return 200 "ok\n";
   }
 
-  # `report` routes to the Bun API (createReportPagesRoutes): it serves the
-  # same static SPA index.html but with the per-report SEO head rewritten
-  # (title with score, description, og:image) and proxies /report/:domain/og.png
-  # from the reports worker. No SSR involved — the SPA boots unchanged; only
-  # crawlers/unfurlers read the difference. Without this entry both paths fall
-  # through to the SPA fallback below: default meta, no share card.
+  # `report`: the Bun API serves the SPA index.html with the per-report SEO
+  # head rewritten (createReportPagesRoutes) + the og.png share-card proxy.
   location ~ ^/(api|mcp|oauth-proxy|\.well-known|org|health|metrics|report)(/|$) {
     proxy_pass http://studio_api;
     proxy_http_version 1.1;


### PR DESCRIPTION
## Symptom

#5588 (and the per-report head that predates it) merged, but `studio.decocms.com/report/<site>` still serves the default meta and `/report/<site>/og.png` returns the SPA's HTML.

## Root cause — routing, not cache

The nginx front door (`deploy/helm/studio/files/api-nginx.conf`) only proxies `^/(api|mcp|oauth-proxy|\.well-known|org|health|metrics)` to the Bun API. `/report` isn't in the list → `try_files $uri /index.html` serves the static SPA with default meta, and `createReportPagesRoutes` (head rewrite + og.png proxy) never runs. Verifiable: the response comes back `cache-control: no-cache` / `cf-cache-status: DYNAMIC` — fresh origin, not cache.

## Fix

Add `report` to the proxied location regex. **No SSR involved**: the Bun API serves the same static `index.html` (asset handler + `dist/client` ship in the API container), only rewriting the `<head>` meta (`buildReportHead`/`rewriteHead`). The SPA boots unchanged for users; `/assets/*` keeps being served by nginx with immutable cache. `/report/:domain/og.png` then proxies the share card from the reports worker (decocms/reports#292, already live — `curl reports.decocms.com/api/v2/public/diagnostics/americanas.com.br/og.png` → 200 PNG 404KB).

Config syntax verified: `nginx -t` passes on `nginx:alpine` with this file as `conf.d/default.conf`.

## Deploy note

This conf is **baked into the nginx image** (header comment in the file): it takes effect after a release rebuilds the image and the tag is bumped — release-tagging watches this dir, so the next release picks it up. After deploy, Cloudflare may hold the stale HTML on the og.png path for up to 4h (`max-age=14400` it applied to the misrouted response); purge the path to see it immediately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `/report` through the Bun API so per-report SEO and share images work in production. Also sets a week-long edge cache for the share card.

- **Bug Fixes**
  - Added `report` to the nginx proxy regex to hit the Bun API (per-report head rewrite + `og.png` from the reports worker).
  - Set `s-maxage=604800` for `/report/:domain/og.png` to cache at the edge for a week.
  - No SSR; SPA behavior unchanged. `/assets/*` still served by nginx.

- **Migration**
  - Takes effect after the nginx image is rebuilt and deployed. Purge Cloudflare for affected `og.png` paths if needed.

<sup>Written for commit 4a528e69b9a1370f9a48ce92396488a32fb94811. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

