### PR TITLE
Show report cover before login, gate the rest

### DIFF
--- a/apps/api/src/api/routes/reports.ts
+++ b/apps/api/src/api/routes/reports.ts
@@ -1,10 +1,16 @@
 /**
- * Authenticated Report Routes — `/api/_reports/*`
+ * Report Routes — `/api/_reports/*`
  *
- * Session-gated proxy between the report page (`/report/:domain`) and the
- * reports engine (reports.decocms.com, `/api/v2`). The engine's master API key
- * stays server-side; the caller's session email is the only delivery
- * address accepted when a scan starts.
+ * Proxy between the report page (`/report/:domain`) and the reports engine
+ * (reports.decocms.com, `/api/v2`). The engine's master API key stays
+ * server-side; the caller's session email is the only delivery address
+ * accepted when a scan starts.
+ *
+ * `GET /site/:domain` is the one route that also serves unauthenticated
+ * callers — it returns only the cover slide of an already-completed scan, so
+ * the first card of a report is visible before login. Everything else
+ * (starting a scan, polling it, resolving email links) still requires a
+ * session.
  */
 
 import { Hono } from "hono";
@@ -25,7 +31,8 @@ function engineFetch(path: string, init?: RequestInit): Promise<Response> {
 }
 
 /**
- * Read an already-scanned domain's deck after the route's session gate.
+ * Read an already-scanned domain's deck. Callers without a session get the
+ * full state back too — the route handler truncates it to the cover slide.
  */
 async function fetchReport(
   domain: string,
@@ -61,7 +68,7 @@ const TERMINAL = new Set(["complete", "errored", "terminated", "unknown"]);
 
 type ReportsEnv = {
   Variables: {
-    reportUser: { email: string };
+    reportUser?: { email: string };
   };
 };
 
@@ -69,33 +76,35 @@ const app = new Hono<ReportsEnv>();
 
 app.use("*", async (c, next) => {
   const session = await auth.api.getSession({ headers: c.req.raw.headers });
-  if (!session?.user?.id) {
-    return c.json({ error: "Authentication required" }, 401, {
-      "Cache-Control": "private, no-store",
-      Vary: "Cookie",
-    });
-  }
-
-  c.set("reportUser", {
-    email: session.user.email,
-  });
+  c.set(
+    "reportUser",
+    session?.user?.id ? { email: session.user.email } : undefined,
+  );
   await next();
   c.header("Cache-Control", "private, no-store");
   c.header("Vary", "Cookie");
   return undefined;
 });
 
-/** GET /api/_reports/site/:domain — the deck for an already-scanned domain. */
+/** GET /api/_reports/site/:domain — the deck for an already-scanned domain.
+ *  Unauthenticated callers get the cover slide only; starting a new scan
+ *  still requires signing in (see POST /run). */
 app.get("/site/:domain", async (c) => {
   const domain = c.req.param("domain").trim();
   if (!domain) return c.json({ error: "domain is required" }, 400);
+  const user = c.get("reportUser");
   const key = c.req.query("key")?.trim() || undefined;
   const lang = c.req.query("lang")?.trim() || undefined;
   try {
     const state = await fetchReport(domain, key, lang);
     // Never cached: the deck carries short-lived signed screenshot URLs.
     c.header("Cache-Control", "private, no-store");
-    return c.json(state);
+    if (user || !state.deck) return c.json(state);
+    return c.json({
+      ...state,
+      deck: { ...state.deck, slides: state.deck.slides.slice(0, 1) },
+      truncated: state.status === "ready",
+    });
   } catch {
     return c.json({ error: "report read failed" }, 502);
   }
@@ -108,6 +117,8 @@ app.get("/site/:domain", async (c) => {
  *  optional `distinctId` is the visitor's PostHog id, so the engine's
  *  server-side funnel events attribute to the same person. */
 app.post("/run", async (c) => {
+  const user = c.get("reportUser");
+  if (!user) return c.json({ error: "Authentication required" }, 401);
   let body: { domain?: unknown; distinctId?: unknown };
   try {
     body = await c.req.json();
@@ -116,7 +127,7 @@ app.post("/run", async (c) => {
   }
   const domain = typeof body.domain === "string" ? body.domain.trim() : "";
   if (!domain) return c.json({ error: "domain is required" }, 400);
-  const email = c.get("reportUser").email;
+  const email = user.email;
   const distinctId =
     typeof body.distinctId === "string" &&
     body.distinctId.trim() &&
@@ -155,6 +166,8 @@ app.post("/run", async (c) => {
 
 /** GET /api/_reports/status?id= — poll a durable run (master-key, server-only). */
 app.get("/status", async (c) => {
+  if (!c.get("reportUser"))
+    return c.json({ error: "Authentication required" }, 401);
   const id = c.req.query("id");
   if (!id) return c.json({ error: "id is required" }, 400);
   try {
@@ -176,6 +189,8 @@ app.get("/status", async (c) => {
  *  {domain, run_id} it was minted for. Session auth is still required even
  *  though the engine token itself is unguessable. Null on a 404. */
 app.get("/link-token/:id", async (c) => {
+  if (!c.get("reportUser"))
+    return c.json({ error: "Authentication required" }, 401);
   const id = c.req.param("id");
   try {
     const res = await engineFetch(
@@ -193,6 +208,8 @@ app.get("/link-token/:id", async (c) => {
 /** GET /api/_reports/suggest?q= — typo-tolerant domain suggestions for the URL
  *  input. Fail-soft: suggestions are a hint, never worth surfacing an error. */
 app.get("/suggest", async (c) => {
+  if (!c.get("reportUser"))
+    return c.json({ error: "Authentication required" }, 401);
   const q = (c.req.query("q") ?? "").trim().slice(0, 64);
   if (q.length < 2) return c.json({ suggestions: [] });
   try {

--- a/apps/api/src/api/routes/reports.ts
+++ b/apps/api/src/api/routes/reports.ts
@@ -13,7 +13,7 @@
  * session.
  */
 
-import { Hono } from "hono";
+import { Hono, type MiddlewareHandler } from "hono";
 import { auth } from "@/auth";
 import { resolveApiKey, resolveBaseUrl } from "@/tools/reports/auth-client";
 import {
@@ -86,6 +86,18 @@ app.use("*", async (c, next) => {
   return undefined;
 });
 
+const requireReportUser: MiddlewareHandler<ReportsEnv> = async (c, next) => {
+  if (!c.get("reportUser"))
+    return c.json({ error: "Authentication required" }, 401);
+  await next();
+  return undefined;
+};
+
+app.use("/run", requireReportUser);
+app.use("/status", requireReportUser);
+app.use("/link-token/*", requireReportUser);
+app.use("/suggest", requireReportUser);
+
 /** GET /api/_reports/site/:domain — the deck for an already-scanned domain.
  *  Unauthenticated callers get the cover slide only; starting a new scan
  *  still requires signing in (see POST /run). */
@@ -117,8 +129,7 @@ app.get("/site/:domain", async (c) => {
  *  optional `distinctId` is the visitor's PostHog id, so the engine's
  *  server-side funnel events attribute to the same person. */
 app.post("/run", async (c) => {
-  const user = c.get("reportUser");
-  if (!user) return c.json({ error: "Authentication required" }, 401);
+  const user = c.get("reportUser")!;
   let body: { domain?: unknown; distinctId?: unknown };
   try {
     body = await c.req.json();
@@ -166,8 +177,6 @@ app.post("/run", async (c) => {
 
 /** GET /api/_reports/status?id= — poll a durable run (master-key, server-only). */
 app.get("/status", async (c) => {
-  if (!c.get("reportUser"))
-    return c.json({ error: "Authentication required" }, 401);
   const id = c.req.query("id");
   if (!id) return c.json({ error: "id is required" }, 400);
   try {
@@ -189,8 +198,6 @@ app.get("/status", async (c) => {
  *  {domain, run_id} it was minted for. Session auth is still required even
  *  though the engine token itself is unguessable. Null on a 404. */
 app.get("/link-token/:id", async (c) => {
-  if (!c.get("reportUser"))
-    return c.json({ error: "Authentication required" }, 401);
   const id = c.req.param("id");
   try {
     const res = await engineFetch(
@@ -208,8 +215,6 @@ app.get("/link-token/:id", async (c) => {
 /** GET /api/_reports/suggest?q= — typo-tolerant domain suggestions for the URL
  *  input. Fail-soft: suggestions are a hint, never worth surfacing an error. */
 app.get("/suggest", async (c) => {
-  if (!c.get("reportUser"))
-    return c.json({ error: "Authentication required" }, 401);
   const q = (c.req.query("q") ?? "").trim().slice(0, 64);
   if (q.length < 2) return c.json({ suggestions: [] });
   try {

--- a/apps/web/src/routes/reports.tsx
+++ b/apps/web/src/routes/reports.tsx
@@ -70,6 +70,10 @@ function domainChromeRef(
   };
 }
 
+/** GET /site/:domain shouldn't 401 anymore (see `apps/api/.../reports.ts`),
+ *  but if it ever does — an edge case, not the normal unauthenticated path —
+ *  refresh the session and drop back to the login gate instead of a dead-end
+ *  error screen. */
 function UnauthorizedReportGate({
   domain,
   refreshSession,
@@ -142,14 +146,17 @@ export default function ReportPage() {
   // on unmount via the chrome ref below sharing the same lifecycle.
   setReportReviewerMode(Boolean(key));
 
+  // Unauthenticated too: the backend returns the cover slide of an
+  // already-completed scan without a session — see `ScanGate`/`SignalDeck`
+  // for where navigating past it prompts login.
   const initial = useQuery({
     queryKey: KEYS.report(domain, key, language),
     queryFn: () => getReport(domain, key, language),
-    enabled: authenticated,
     staleTime: Infinity,
     retry: (failureCount, error) =>
       !isReportsUnauthorized(error) && failureCount < 1,
   });
+
   const reportUnauthorized =
     initial.isError && isReportsUnauthorized(initial.error);
 
@@ -191,31 +198,45 @@ export default function ReportPage() {
     });
   };
 
-  const content = session.isPending ? (
-    <ReportAuthGate domain={domain} loading />
-  ) : !session.data?.user ? (
-    <ReportAuthGate domain={domain} />
+  const content = initial.isPending ? (
+    // Bare stage while the (unauthenticated-capable) read resolves —
+    // ScanGate takes over with the full scanning UI, or the deck renders.
+    <div className="fixed inset-0 overflow-hidden" aria-busy="true">
+      <ReportBackdrop domain={domain} />
+      <div className="pointer-events-none absolute inset-0 bg-white/35" />
+    </div>
   ) : reportUnauthorized ? (
     <UnauthorizedReportGate
       domain={domain}
       refreshSession={() => void session.refetch()}
     />
-  ) : initial.isPending ? (
-    // Bare stage while the authenticated read resolves — ScanGate takes over
-    // with the full scanning UI (or the deck renders when ready).
-    <div className="fixed inset-0 overflow-hidden" aria-busy="true">
-      <ReportBackdrop domain={domain} />
-      <div className="pointer-events-none absolute inset-0 bg-white/35" />
-    </div>
   ) : initial.isError ? (
     <ReportLoadError domain={domain} retry={() => void initial.refetch()} />
+  ) : initial.data.status === "ready" ? (
+    // A completed scan exists — render it straight away, even before login
+    // has resolved. Unauthenticated visitors only get the cover slide; see
+    // `SignalDeck`'s `authenticated` gating for what happens past it.
+    <ScanGate
+      domain={domain}
+      initial={initial.data}
+      sessionEmail={session.data?.user?.email ?? ""}
+      sessionUser={session.data?.user}
+      lang={language}
+      authenticated={authenticated}
+    />
+  ) : session.isPending ? (
+    <ReportAuthGate domain={domain} loading />
+  ) : !authenticated ? (
+    // No completed scan yet, and anonymous visitors can't start one.
+    <ReportAuthGate domain={domain} />
   ) : (
     <ScanGate
       domain={domain}
       initial={initial.data}
-      sessionEmail={session.data.user.email}
-      sessionUser={session.data.user}
+      sessionEmail={session.data?.user?.email ?? ""}
+      sessionUser={session.data?.user}
       lang={language}
+      authenticated={authenticated}
     />
   );
 

--- a/apps/web/src/routes/reports/auth-gate.tsx
+++ b/apps/web/src/routes/reports/auth-gate.tsx
@@ -354,13 +354,10 @@ export function ReportBackdrop({ domain }: { domain: string }) {
   );
 }
 
-export function ReportAuthGate({
-  domain,
-  loading = false,
-}: {
-  domain: string;
-  loading?: boolean;
-}) {
+/** The sign-in card itself — brand pill, `AuthEntry`, free-access note, social
+ *  proof. Shared by the full-page `ReportAuthGate` and the in-deck
+ *  `ReportAuthOverlay`, which differ only in what sits behind the card. */
+function ReportAuthCard({ domain }: { domain: string }) {
   const t = useT();
   const handleAuthEvent = (event: AuthFlowEvent) => {
     const provider = "provider" in event ? event.provider : undefined;
@@ -399,7 +396,7 @@ export function ReportAuthGate({
   };
 
   const trackGateRef = (element: HTMLDivElement | null) => {
-    if (!element || loading) return;
+    if (!element) return;
     const attempt = beginReportAuthAttempt(domain);
     if (element.dataset.tracked === "true" || !isPostHogInitialized()) return;
     element.dataset.tracked = "true";
@@ -411,8 +408,66 @@ export function ReportAuthGate({
   };
 
   return (
-    <div
+    <section
       ref={trackGateRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("reports.authGate.accessYourReport")}
+      className="w-full max-w-[440px] rounded-2xl bg-white px-6 py-6 card-shadow sm:rounded-3xl sm:px-8 sm:py-8"
+    >
+      <AuthEntry
+        callbackUrl={callbackUrl(domain)}
+        title={t("reports.authGate.accessYourReport")}
+        subtitle={t("reports.authGate.authSubtitle")}
+        variant="compact"
+        allowedSocialProviders={["google"]}
+        allowPassword={false}
+        onAuthEvent={handleAuthEvent}
+        brand={
+          <div className="flex items-center justify-between gap-4">
+            <div
+              className="inline-flex min-w-0 items-center gap-2 rounded-full border px-3 py-1.5"
+              style={{ borderColor: DECK.border, background: DECK.bg }}
+            >
+              <img
+                src={faviconForDomain(domain)}
+                alt=""
+                className="h-4 w-4 shrink-0 rounded object-contain"
+              />
+              <span
+                className="truncate text-[13px]"
+                style={{ color: DECK.muted }}
+              >
+                {domain}
+              </span>
+            </div>
+            <img
+              src="/logos/deco logo.svg"
+              alt="Deco"
+              className="h-7 w-7 shrink-0"
+            />
+          </div>
+        }
+        copy={getReportAuthCopy(t)}
+      />
+      <p className="mt-4 text-xs leading-5" style={{ color: DECK.faint }}>
+        {t("reports.authGate.freeAccess")}
+      </p>
+      <ReportSocialProof compact />
+    </section>
+  );
+}
+
+export function ReportAuthGate({
+  domain,
+  loading = false,
+}: {
+  domain: string;
+  loading?: boolean;
+}) {
+  const t = useT();
+  return (
+    <div
       className="fixed inset-0 overflow-hidden"
       style={{
         color: DECK.ink,
@@ -430,53 +485,37 @@ export function ReportAuthGate({
             aria-label={t("reports.authGate.loadingSession")}
           />
         ) : (
-          <section
-            role="dialog"
-            aria-modal="true"
-            aria-label={t("reports.authGate.accessYourReport")}
-            className="w-full max-w-[440px] rounded-2xl bg-white px-6 py-6 card-shadow sm:rounded-3xl sm:px-8 sm:py-8"
-          >
-            <AuthEntry
-              callbackUrl={callbackUrl(domain)}
-              title={t("reports.authGate.accessYourReport")}
-              subtitle={t("reports.authGate.authSubtitle")}
-              variant="compact"
-              allowedSocialProviders={["google"]}
-              allowPassword={false}
-              onAuthEvent={handleAuthEvent}
-              brand={
-                <div className="flex items-center justify-between gap-4">
-                  <div
-                    className="inline-flex min-w-0 items-center gap-2 rounded-full border px-3 py-1.5"
-                    style={{ borderColor: DECK.border, background: DECK.bg }}
-                  >
-                    <img
-                      src={faviconForDomain(domain)}
-                      alt=""
-                      className="h-4 w-4 shrink-0 rounded object-contain"
-                    />
-                    <span
-                      className="truncate text-[13px]"
-                      style={{ color: DECK.muted }}
-                    >
-                      {domain}
-                    </span>
-                  </div>
-                  <img
-                    src="/logos/deco logo.svg"
-                    alt="Deco"
-                    className="h-7 w-7 shrink-0"
-                  />
-                </div>
-              }
-              copy={getReportAuthCopy(t)}
-            />
-            <p className="mt-4 text-xs leading-5" style={{ color: DECK.faint }}>
-              {t("reports.authGate.freeAccess")}
-            </p>
-            <ReportSocialProof compact />
-          </section>
+          <ReportAuthCard domain={domain} />
         )}
+      </div>
+    </div>
+  );
+}
+
+/** Shown over the real deck (cover slide still visible behind it) when an
+ *  unauthenticated visitor tries to move past the cover. Unlike
+ *  `ReportAuthGate`, there's no mock backdrop — the actual slide is already
+ *  on screen. Clicking outside the card dismisses it back to the cover. */
+export function ReportAuthOverlay({
+  domain,
+  onClose,
+}: {
+  domain: string;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center px-3 py-5 sm:px-6 sm:py-10"
+      style={{
+        color: DECK.ink,
+        fontFamily: "Switzer, 'Inter var', Helvetica, Arial, sans-serif",
+        WebkitFontSmoothing: "antialiased",
+      }}
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-white/70 backdrop-blur-sm" />
+      <div onClick={(e) => e.stopPropagation()}>
+        <ReportAuthCard domain={domain} />
       </div>
     </div>
   );

--- a/apps/web/src/routes/reports/scan-gate.tsx
+++ b/apps/web/src/routes/reports/scan-gate.tsx
@@ -28,12 +28,14 @@ export default function ScanGate({
   sessionEmail,
   sessionUser,
   lang,
+  authenticated = true,
 }: {
   domain: string;
   initial?: ReportState;
   sessionEmail: string;
   sessionUser?: { name?: string; email?: string; image?: string };
   lang?: string;
+  authenticated?: boolean;
 }) {
   const [deck, setDeck] = useState<TemplateDeck | null>(
     initial?.status === "ready" ? initial.deck : null,
@@ -62,7 +64,14 @@ export default function ScanGate({
     return () => controller.abort();
   };
 
-  if (deck) return <SignalDeck deck={deck} sessionUser={sessionUser} />;
+  if (deck)
+    return (
+      <SignalDeck
+        deck={deck}
+        sessionUser={sessionUser}
+        authenticated={authenticated}
+      />
+    );
   if (phase === "unauthorized") {
     return <ReportAuthGate domain={domain} />;
   }

--- a/apps/web/src/routes/reports/signal-deck.tsx
+++ b/apps/web/src/routes/reports/signal-deck.tsx
@@ -11,6 +11,7 @@ import { VALID_LOCALES } from "@/i18n/locale.ts";
 import { usePreferences } from "@/hooks/use-preferences.ts";
 import { authClient } from "@/lib/auth-client";
 import { resolveEmailLinkToken } from "./api";
+import { ReportAuthOverlay } from "./auth-gate";
 import Icon from "./icon";
 import { onboardingUrl, trackConnectCta } from "./onboarding";
 import { resolveLogoUrl } from "./source-logos";
@@ -28,11 +29,16 @@ const sharerPersonId = () =>
 export default function SignalDeck({
   deck,
   sessionUser,
+  authenticated = true,
 }: {
   deck: TemplateDeck;
   sessionUser?: { name?: string; email?: string; image?: string };
+  /** Unauthenticated visitors see the cover slide only — advancing past it
+   *  prompts login instead of navigating (see `go` below). */
+  authenticated?: boolean;
 }) {
   const t = useT();
+  const [authGateOpen, setAuthGateOpen] = useState(false);
   const [{ language }, setPreferences] = usePreferences();
   const total = deck.slides.length;
   const [index, setIndex] = useState(0);
@@ -60,6 +66,9 @@ export default function SignalDeck({
 
   const ctaHref = onboardingUrl(`https://${deck.meta.domain}/`);
   const slide = deck.slides[index];
+  // Template-based, not `index === total - 1`: a truncated (anonymous) deck
+  // has only the cover slide, which then sits at `total - 1` too.
+  const isCtaSlide = slide?.template.template === "cta";
   const lockRef = useRef(false);
   const sharePopoverRef = useRef<HTMLDivElement>(null);
 
@@ -87,7 +96,9 @@ export default function SignalDeck({
       surface: "deck_v2",
     });
     // Once per mount — revisiting the last slide is not a second completion.
-    if (i === total - 1 && !deckCompletedRef.current) {
+    // Unauthenticated visitors only ever see the cover, so "reaching slide 0"
+    // there isn't a real completion.
+    if (authenticated && i === total - 1 && !deckCompletedRef.current) {
       deckCompletedRef.current = true;
       captureReport("report_deck_completed", {
         domain: deck.meta.domain,
@@ -107,6 +118,12 @@ export default function SignalDeck({
   // Effect Events let the long-lived keyboard/wheel/touch listeners read the
   // latest slide index without render-time ref mutation or listener churn.
   const go = useEffectEvent((i: number) => {
+    // Every navigation path (keyboard, wheel/swipe, rail, footer, in-slide
+    // links) funnels through here, so gating it is enough to gate the deck.
+    if (!authenticated && i > 0) {
+      setAuthGateOpen(true);
+      return;
+    }
     const clamped = Math.min(Math.max(i, 0), total - 1);
     if (clamped === index) return;
     history.pushState({ slideIndex: clamped }, "");
@@ -695,7 +712,7 @@ export default function SignalDeck({
       <footer
         className="flex shrink-0 items-center gap-2 px-4 py-4 sm:px-6"
         style={
-          index === total - 1
+          isCtaSlide
             ? {
                 borderTop: "1px solid rgba(255,255,255,0.14)",
                 background: DECK.forest,
@@ -706,7 +723,7 @@ export default function SignalDeck({
         {/* On the last slide (the CTA): MOBILE shows Share + a full-width action
             (Figma). DESKTOP shows only a slide counter + Share — the primary CTA
             lives inside the slide there, so the footer stays light. */}
-        {index === total - 1 ? (
+        {isCtaSlide ? (
           <>
             {/* desktop: counter (left) */}
             <span
@@ -1134,6 +1151,13 @@ export default function SignalDeck({
         >
           {toast}
         </div>
+      )}
+
+      {authGateOpen && (
+        <ReportAuthOverlay
+          domain={deck.meta.domain}
+          onClose={() => setAuthGateOpen(false)}
+        />
       )}
     </div>
   );

--- a/packages/e2e/tests/report-auth-gate.spec.ts
+++ b/packages/e2e/tests/report-auth-gate.spec.ts
@@ -25,12 +25,11 @@ test("anonymous shared report shows login over a blurred preview", async ({
   await expect(page).toHaveURL(/#overview$/);
 });
 
-test("report data and scan operations reject anonymous callers", async ({
+test("scan operations reject anonymous callers, but reading a report doesn't", async ({
   playwright,
 }) => {
   const anonymous = await newApiContext(playwright);
-  const responses = await Promise.all([
-    anonymous.get("/api/_reports/site/example.com"),
+  const gated = await Promise.all([
     anonymous.post("/api/_reports/run", {
       data: { domain: "example.com", email: "other@example.com" },
     }),
@@ -38,11 +37,18 @@ test("report data and scan operations reject anonymous callers", async ({
     anonymous.get("/api/_reports/link-token/token-id"),
     anonymous.get("/api/_reports/suggest?q=e"),
   ]);
-
-  for (const response of responses) {
+  for (const response of gated) {
     expect(response.status()).toBe(401);
     expect(response.headers()["cache-control"]).toContain("no-store");
   }
+
+  // GET /site is the one route anonymous callers can reach — it's how the
+  // cover slide of an already-completed scan shows before login. There's no
+  // completed scan for this domain, so it comes back "not_found", not a 401.
+  const site = await anonymous.get("/api/_reports/site/example.com");
+  expect(site.status()).toBe(200);
+  expect(site.headers()["cache-control"]).toContain("no-store");
+  expect((await site.json()).status).toBe("not_found");
 
   await anonymous.dispose();
 });

--- a/packages/shared/src/reports/to-deck.ts
+++ b/packages/shared/src/reports/to-deck.ts
@@ -35,6 +35,9 @@ export interface ReportState {
   scanned_at: string | null;
   /** Slides dropped by the contract on this read (for `report_slide_dropped`). */
   drops: SlideDrop[];
+  /** True when `deck.slides` was cut down to the cover slide for an
+   *  unauthenticated caller — the rest requires signing in. */
+  truncated?: boolean;
 }
 
 /** Run response from POST /api/v2/diagnostics/run (idempotent + single-flight). */


### PR DESCRIPTION
## What is this contribution about?
Unauthenticated visitors to `/report/:domain` now see the real cover slide of an already-completed scan instead of a blurred mock, and only hit a login prompt when they try to advance past it. `GET /api/_reports/site/:domain` truncates the deck server-side for anonymous callers so the rest of the deck's data never reaches the client — starting or polling a new scan still requires a session.

## How did you verify your code works?
Ran `bun run check` (typecheck) and `bun run lint` across the repo — both clean. Ran the unit tests under `apps/web/src/routes/reports` — 12 pass. Traced the new gating logic (auth state → deck render → per-slide navigation) by hand across `reports.tsx`, `scan-gate.tsx`, and `signal-deck.tsx`. Could not run the `packages/e2e` Playwright suite in this environment (local Postgres role not provisioned), but updated `report-auth-gate.spec.ts` to match the new `GET /site/:domain` contract (200 + `not_found` for anonymous reads instead of 401).

## Screenshots/Demonstration
No screenshots — not run in a browser in this environment.

## How to Test
1. Sign out and visit `/report/<a domain with a completed scan>`.
2. Confirm the real cover slide renders (not a blurred mock) without logging in.
3. Try to advance to the next slide (arrow key, scroll, or the Next button) — a login overlay should appear over the still-visible cover slide.
4. Log in — navigation to the rest of the deck should now work normally.
5. Visit `/report/<a domain with no completed scan>` while signed out — should show the full-page login gate (no scan can start without a session).

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the real report cover to anonymous visitors and only require login when they try to move past it. Also refactors API auth checks into a single `requireReportUser` middleware for protected routes.

- **New Features**
  - `/report/:domain` shows the actual cover before login; advancing opens a login overlay you can dismiss by clicking outside.
  - `GET /api/_reports/site/:domain` allows anonymous reads and returns a cover-only deck with `truncated: true` when `status: "ready"`; other routes (`POST /run`, `GET /status`, `GET /link-token/:id`, `GET /suggest`) remain auth-only.
  - Deck navigation is gated via an `authenticated` prop; completion events only fire when authenticated.
  - E2E updated to expect 200 + `not_found` for anonymous `/site` reads and 401 for scan operations.

- **Refactors**
  - Deduped per-route auth checks into `requireReportUser` and applied it to `/run`, `/status`, `/link-token/*`, and `/suggest`; `GET /site` stays public.

<sup>Written for commit 44d0980ccfa0e7c6bf2b4dd01076f5f0c1c674dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

